### PR TITLE
site: ws.wickedagile.com — the coder's front door (deep-dive site + e2e + Pages)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy site to GitHub Pages
+
+# Auto-deploys the site on every push to main; also runnable by hand.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least-privilege token: read the repo, write the Pages deployment, and mint the
+# OIDC token actions/deploy-pages needs to claim the github-pages environment.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; let an in-progress run finish so a live deploy
+# is never cancelled mid-flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Configure GitHub Pages
+        # enablement: true turns Pages on the first time this runs — Pages is not
+        # yet enabled on the repo, so the deploy job would otherwise 404.
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+        with:
+          enablement: true
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install dependencies
+        # The site is an Astro app under site/ that consumes the shared
+        # github:mikeparcewski/wicked-web chrome (pinned in site/package-lock.json).
+        run: npm ci
+        working-directory: site
+      - name: Build
+        run: npm run build
+        working-directory: site
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: ./site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -1,0 +1,49 @@
+name: Site E2E
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - ".github/workflows/site-e2e.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: site
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: site
+      - name: Build site
+        run: npm run build
+        working-directory: site
+      - name: Run e2e smoke suite
+        run: npm run test:e2e
+        working-directory: site
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-report
+          path: site/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
 coverage/
+.astro/
+playwright-report/
+test-results/
 e2e/shots/
 *.log
 .DS_Store

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from 'astro/config';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Shared chrome lives in the `wicked-web` package. Develop against the local
+// source when it sits beside this repo (../../wicked-web from this site dir),
+// otherwise (CI) resolve the installed github:mikeparcewski/wicked-web package
+// from node_modules.
+const localUI = fileURLToPath(new URL('../../wicked-web/src', import.meta.url));
+const alias = existsSync(localUI) ? { 'wicked-web': localUI } : {};
+
+// https://astro.build/config
+export default defineConfig({
+  // Served at ws.wickedagile.com (custom domain, root path). No base prefix —
+  // assets resolve from '/', so the CNAME root serves CSS/JS correctly.
+  site: 'https://ws.wickedagile.com',
+  output: 'static',
+  vite: { resolve: { alias } },
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,4381 @@
+{
+  "name": "wicked-studio-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wicked-studio-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "astro": "^7.1.3",
+        "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.62.1"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
+      "integrity": "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@astrojs/compiler-binding-darwin-arm64": "0.3.2",
+        "@astrojs/compiler-binding-darwin-x64": "0.3.2",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.3.2",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.3.2",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
+      "integrity": "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-rs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
+      "integrity": "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-binding": "0.3.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+      "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "satteri": "^0.9.1"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+      "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.4.0",
+        "dset": "^3.1.4",
+        "is-docker": "^4.0.0",
+        "package-manager-detector": "^1.6.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
+      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
+      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/am-i-vibing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+      "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
+      "license": "MIT",
+      "dependencies": {
+        "process-ancestry": "^0.1.0"
+      },
+      "bin": {
+        "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/astro": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.3.tgz",
+      "integrity": "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-rs": "^0.3.1",
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/markdown-satteri": "0.3.4",
+        "@astrojs/telemetry": "3.3.3",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "am-i-vibing": "^0.4.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^2.0.1",
+        "devalue": "^5.8.1",
+        "diff": "^8.0.3",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.28.0",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^1.0.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.4",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.4",
+        "unstorage": "^1.17.5",
+        "vite": "^8.0.13",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0 || ^0.35.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "7.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process-ancestry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+      "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/satteri": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.9.5",
+        "@bruits/satteri-darwin-x64": "0.9.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+        "@bruits/satteri-linux-arm64-musl": "0.9.5",
+        "@bruits/satteri-linux-x64-gnu": "0.9.5",
+        "@bruits/satteri-linux-x64-musl": "0.9.5",
+        "@bruits/satteri-wasm32-wasi": "0.9.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/wicked-web": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#cf770de0a151d46837ae8b3369606b005bb8473c",
+      "integrity": "sha512-uc0gE4B6fQPztbCF+Ix4X6yhR9DnS8eKjAD5F+JquDXRe7B1LHixr5HdyKZFr8pibbtSZod283yMCVvxPEfp/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "astro": ">=4.0.0"
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wicked-studio-site",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "astro": "^7.1.3",
+    "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
+  }
+}

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+const rawPort = process.env.E2E_PORT ?? '4335';
+const PORT = Number.parseInt(rawPort, 10);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
+  throw new Error(`E2E_PORT must be a port number (1-65535), got "${rawPort}"`);
+}
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: { baseURL: `http://127.0.0.1:${PORT}`, trace: 'on-first-retry' },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // --host 127.0.0.1 forces an IPv4 bind: bare `astro preview` binds only ::1,
+    // which the 127.0.0.1 readiness probe (and baseURL) can never reach.
+    command: `npm run preview -- --host 127.0.0.1 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+ws.wickedagile.com

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#0d1117"/><path d="M7 10l7 6-7 6" stroke="#ffda19" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M17 22h8" stroke="#ffda19" stroke-width="2.5" fill="none" stroke-linecap="round"/></svg>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,0 +1,742 @@
+---
+/**
+ * index.astro — the wicked-studio landing page (ws.wickedagile.com).
+ *
+ * POSITIONING (four-plane era): wicked-studio is the CODER'S FRONT DOOR of the
+ * wicked platform's EXPERIENCE plane — the run board for governed agent
+ * delivery. A Vite/React SPA that is a PURE HTTP/WS client of the wicked-crew
+ * daemon: launch and steer governed runs, answer human gates, watch live
+ * CoreEvent streams, drive terminals — everything the daemon exposes on
+ * /api/v1 and /ws, and nothing else. Its sibling front door is
+ * wicked-interactive (the creator skin); both are pure clients of the same
+ * control plane.
+ *
+ * HONEST BOUNDARIES honored on this page:
+ *  - Studio imports ZERO crew source. The only artifact the two products share
+ *    is the published wire contract, wicked-crew-api-types. Every capability
+ *    shown here rides GET/POST /api/v1/… + the /ws CoreEvent stream — real
+ *    routes from src/api/client.ts, never invented ones.
+ *  - Two ship modes, both real: BUNDLED (crew's release build copies studio's
+ *    built dist into the daemon's serving tree — `npx wicked-crew serve`,
+ *    same-origin, one port) and STANDALONE (VITE_API_HOST baked at build time,
+ *    dist/ served from any static server; the daemon's loopback CORS admits
+ *    localhost origins). The standalone mode is proven by a scripted e2e
+ *    (e2e/studio_standalone_test.py) that drives a real browser against a
+ *    live daemon.
+ *  - The Project model is SHIPPED in the control plane (/api/v1/projects,
+ *    nine routes; a project's activity feed merges crew core events with
+ *    wicked.interactive.* bus events carrying the same project_id). The
+ *    studio's DEDICATED project browser is the next surface to land in this
+ *    skin — say "landing in this skin", never "shipped here".
+ *  - Governance vocabulary (deny-dominates, evaluator ≠ creator, gates) is
+ *    crew's — studio SURFACES it, it does not own it. The skin never grades
+ *    anything.
+ *  - Panels named on the board are the SPA's real routes (useRoute.ts):
+ *    runs, work, chats, coverage, workflows, domain, policies, rules, repos.
+ */
+import Base from 'wicked-web/layouts/Base.astro';
+import Topbar from 'wicked-web/components/Topbar.astro';
+import Footer from 'wicked-web/components/Footer.astro';
+import SameGarden from 'wicked-web/components/SameGarden.astro';
+import '../styles/studio.css';
+
+const title = 'wicked-studio — the coder’s front door: launch, watch, steer, verified';
+const description =
+  'wicked-studio is the coder-facing skin of the wicked platform’s experience plane — the run board for governed agent delivery. Launch a run from a plain-text brief, watch live CoreEvents stream over WebSocket, answer the human gates that hold it, and drive a real terminal into the worker’s worktree. A pure HTTP/WS client of the wicked-crew daemon’s /api/v1: zero crew source imported, the wire contract (wicked-crew-api-types) is the only shared artifact. Ships bundled inside `npx wicked-crew serve` or standalone against any daemon via VITE_API_HOST. One project model, two skins: the same projects the creator skin (wicked-interactive) drives.';
+const repo = 'https://github.com/mikeparcewski/wicked-studio';
+
+// The run board: the SPA's real panels (src/hooks/useRoute.ts), each fed by a
+// real /api/v1 route (src/api/client.ts). The board auto-cycles; click to pin.
+const PANELS = [
+  { id: 'runs',       api: 'GET /runs · WS /ws',            line: 'The run board itself: launch from a brief, watch the phase ladder and unit list move, read live output, answer the steering timeline.' },
+  { id: 'work',       api: 'GET /runs/:id/events',           line: 'Every work unit across every run in one queue — what’s streaming, what’s held at a gate, what landed.' },
+  { id: 'chats',      api: 'POST /chats',                    line: 'Group chat with your whole roster: fan one question out, watch each seat answer side by side.' },
+  { id: 'coverage',   api: 'GET /governance/coverage?repo=', line: 'Repo-scoped coverage with a graph view — scoped to the repo you asked about, never a vacuous store-wide 1.0.' },
+  { id: 'workflows',  api: 'GET /workflows',                 line: 'The WorkflowDef JSON that will drive a run — phases, gates, validation — inspected before you commit a brief to it.' },
+  { id: 'domain',     api: 'GET /domain-graph',              line: 'The domain-model browser: requirements and their graph, per repo — what the record actually knows about your problem space.' },
+  { id: 'policies',   api: 'GET /governance/policies',       line: 'Policies and conformance rules — the deterministic floor a run must clear. The skin surfaces the gate; it never grades.' },
+  { id: 'repos',      api: 'POST /repos',                    line: 'Registered repos, their onboarding runs, and code-graph summaries — the ground the workers stand on.' },
+];
+
+// The insight rail: the per-run panels fed by the CoreEvent stream.
+const RAIL = [
+  { id: 'Burn',        line: 'Tokens, cost, and rework per CLI — live during the run, not on the invoice.' },
+  { id: 'Decisions',   line: 'Every human call on the record: who approved what, when, and why.' },
+  { id: 'Governance',  line: 'The audit view: which policies were checked, which verdicts held the run.' },
+  { id: 'Assumptions', line: 'External transforms recorded with honest confidence — needs-research is badged for you.' },
+  { id: 'Steering',    line: 'The timeline of gates raised and answered — approve, amend, reject.' },
+  { id: 'Files',       line: 'The diffs each unit produced, straight from the worktree.' },
+  { id: 'Term',        line: 'A real PTY into the worker’s worktree — raw bytes over /ws/terminals/:id.' },
+  { id: 'Cov',         line: 'Repo-scoped coverage, one click from the run that changed it.' },
+];
+---
+
+<Base title={title} description={description} favicon="/favicon.svg">
+  <Topbar pkg="wicked-studio" repo={repo} />
+
+  <!-- ── Hero: the console IS the product — launch, watch, steer ─────────── -->
+  <section class="hero">
+    <div class="amber-floor" aria-hidden="true"></div>
+    <div class="wrap hero-head">
+      <div class="kicker kicker--plane">wicked-studio · the coder’s front door of the wicked platform</div>
+      <h1>Launch. Watch. Steer.<br><span class="y">Verified.</span></h1>
+      <p class="lede">
+        The run board for governed agent delivery. Describe the problem, watch the live
+        event stream phase by phase, and answer the gates that hold it — <b>the decision
+        is always yours</b>. This is not a mock of the product: it <b>is</b> the interface,
+        and the one below is live. Drive it.
+      </p>
+    </div>
+
+    <div class="wrap hero-console-wrap">
+      <!-- A hands-on mirror of the real SPA (LaunchForm → the brief input,
+           LiveOutput → the feed, SteeringGate → the gate, AgentTerminal → the
+           term line, InsightRail → the chips). Auto-runs on scroll-in, then
+           hands you the wheel at the gate. Vocabulary = real /api/v1 routes. -->
+      <div class="console" data-console aria-label="wicked-studio — launch, watch, and steer a governed run">
+        <div class="mock-bar">
+          <span class="mock-dots"><i></i><i></i><i></i></span>
+          <span class="mock-url">127.0.0.1:7701 · served by your crew daemon · same-origin</span>
+        </div>
+        <div class="console-body">
+          <form class="console-launch" data-console-launch>
+            <label class="cl-k" for="console-brief">launch a run</label>
+            <input id="console-brief" class="cl-input" data-console-input type="text"
+                   value="add rate-limiting to the public API" autocomplete="off" spellcheck="false"
+                   aria-label="Brief — launch a governed run from a plain-text problem" />
+            <button type="submit" class="cl-go" data-console-go>Launch ↵</button>
+          </form>
+          <div class="console-cols">
+            <div class="console-feed" data-console-feed role="log" aria-live="polite" aria-label="live CoreEvent feed">
+              <span class="cf-k">live events · ws /ws</span>
+            </div>
+            <div class="console-gate" data-console-gate hidden>
+              <span class="cg-k">steering gate · awaiting your decision</span>
+              <span class="cg-stamp" data-cg-stamp>DENY</span>
+              <span class="cg-t" data-cg-t>schema-drift · re-verified against the worktree</span>
+              <div class="cg-actions">
+                <button type="button" class="cg-btn cg-btn--ok" data-cg-action="approve">Approve</button>
+                <button type="button" class="cg-btn" data-cg-action="steer">Approve with steer</button>
+                <button type="button" class="cg-btn" data-cg-action="reject">Reject</button>
+              </div>
+            </div>
+          </div>
+          <div class="console-term">
+            <span class="ct-line" data-console-term><span class="ct-p">studio ›</span> term attach r-7c19 <span class="ct-c"># real PTY · /ws/terminals/:id</span></span>
+          </div>
+          <!-- The insight rail — click a chip to read what that panel answers. -->
+          <div class="console-rail" data-rail aria-label="Insight rail panels">
+            <span class="cr-k">insight rail</span>
+            {RAIL.map((r, i) => (
+              <button type="button" class:list={['cr-chip', { 'is-active': i === 0 }]} data-rail-chip data-i={i}>{r.id}</button>
+            ))}
+          </div>
+          <p class="console-rail-line" data-rail-line aria-live="polite">{RAIL[0].line}</p>
+        </div>
+      </div>
+
+      <!-- Phone-native console: the live console is a desktop affordance. On a
+           phone we hide it and tell the same launch → watch → steer story as a
+           compact static list. -->
+      <div class="console-static">
+        <ol class="cs-steps">
+          <li><span class="cs-n">1</span><div><b>Launch</b> a run from a plain-text brief: <code>add rate-limiting to the public API</code></div></li>
+          <li><span class="cs-n">2</span><div><b>Watch</b> live CoreEvents stream over <code>/ws</code> — phase ladder, unit list, burn, diffs</div></li>
+          <li><span class="cs-n">3</span><div><b>Steer</b> the gate — approve, amend, or reject. <span class="cs-chip">schema-drift · DENY → held for you</span></div></li>
+        </ol>
+      </div>
+    </div>
+
+    <div class="wrap hero-foot">
+      <div class="hero-tags" role="list">
+        <span role="listitem">pure client of /api/v1 + /ws</span>
+        <span role="listitem">zero crew source imported</span>
+        <span role="listitem">bundled or standalone</span>
+        <span role="listitem">the decision is yours</span>
+        <span role="listitem">dark / light</span>
+        <span role="listitem">local-first</span>
+      </div>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#get">Get it</a>
+        <a class="btn btn-ghost" href="#client">See the seam</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── The run board — every daemon surface, one skin ──────────────────── -->
+  <section class="board" aria-labelledby="board-h">
+    <div class="wrap">
+      <div class="sec-head sec-head--wide">
+        <div class="kicker">The run board · the SPA’s real panels</div>
+        <h2 id="board-h">If the daemon exposes it, the board shows it.</h2>
+        <p class="sec-sub">
+          Every panel below is a real route in the SPA, fed by a real route on the daemon —
+          <b>nothing rendered here is privileged</b>. The governance vocabulary you’ll meet
+          (deny-dominates gates, evaluator ≠ creator) is <a href="https://wc.wickedagile.com">crew’s</a>;
+          the skin surfaces it and never grades anything. The board auto-cycles — click a panel to pin it.
+        </p>
+      </div>
+
+      <div class="board-layout">
+        <div class="board-list" data-board role="tablist" aria-label="Studio panels">
+          {PANELS.map((p, i) => (
+            <button type="button" role="tab" class:list={['board-item', { 'is-active': i === 0 }]} data-board-item data-i={i} aria-selected={i === 0 ? 'true' : 'false'}>
+              <span class="bi-dot" aria-hidden="true"></span>
+              <span class="bi-name">{p.id}</span>
+            </button>
+          ))}
+        </div>
+        <div class="board-stage" data-board-stage>
+          <div class="board-stage-bar">
+            <span class="bs-name" data-bs-name>runs</span>
+            <code class="bs-api" data-bs-api>{PANELS[0].api}</code>
+          </div>
+          <p class="bs-line" data-bs-line>{PANELS[0].line}</p>
+        </div>
+      </div>
+      <div class="board-status">
+        <button type="button" class="board-status-btn is-playing" data-board-toggle aria-live="polite">
+          <span class="bs-ic" aria-hidden="true">▶</span>
+          <span class="bs-txt" data-board-status-txt>auto-cycling · click a panel to pin it</span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── One project, two skins — the experience-plane story ─────────────── -->
+  <section class="proj" aria-labelledby="proj-h">
+    <div class="wrap">
+      <div class="sec-head sec-head--wide">
+        <div class="kicker kicker--plane">The experience plane · one project model</div>
+        <h2 id="proj-h">One project. Two front doors.</h2>
+        <p class="sec-sub">
+          The Project model lives in the <b>control plane</b> — <code>/api/v1/projects</code>, nine
+          routes — and both skins are pure clients of it. A project groups runs, chats, and docs;
+          its activity feed <b>merges</b> crew’s durable core events with
+          <a href="https://wi.wickedagile.com">wicked-interactive</a>’s bus events carrying the same
+          <code>project_id</code>. The coder’s door and the creator’s door open onto the
+          <b>same room</b> — flip the skin below and watch the same project re-render.
+        </p>
+      </div>
+
+      <div class="proj-card" data-proj data-skin="studio">
+        <div class="proj-bar">
+          <span class="proj-id">project · <b>payments-refresh</b></span>
+          <div class="proj-skins" role="tablist" aria-label="Which skin renders this project">
+            <button type="button" role="tab" class="proj-skin is-active" data-proj-skin="studio" aria-selected="true">studio · coder</button>
+            <button type="button" role="tab" class="proj-skin" data-proj-skin="interactive" aria-selected="false">interactive · creator</button>
+          </div>
+        </div>
+
+        <!-- The STUDIO rendering: the merged activity feed as a run board log. -->
+        <ol class="proj-feed proj-feed--studio" aria-label="The project as the coder’s skin renders it">
+          <li><span class="pf-src pf-src--crew">crew</span><code>run r-7c19</code><span class="pf-note">feature workflow · build → adversarial-review → test — held once, steered, landed</span></li>
+          <li><span class="pf-src pf-src--crew">crew</span><code>gate decision</code><span class="pf-note">schema-drift DENY → approved with steer · on the decisions ledger</span></li>
+          <li><span class="pf-src pf-src--int">interactive</span><code>doc payments-deck</code><span class="pf-note">the creator skin’s deck, in this same feed — created, drafted, delivered</span></li>
+          <li><span class="pf-src pf-src--crew">crew</span><code>chat c-2214</code><span class="pf-note">roster fan-out: “what breaks if we shard the ledger?” — three seats answered</span></li>
+        </ol>
+
+        <!-- The INTERACTIVE rendering: the same project as the creator's canvas. -->
+        <ol class="proj-feed proj-feed--interactive" aria-label="The project as the creator’s skin renders it">
+          <li><span class="pf-src pf-src--int">interactive</span><code>wicked.interactive.doc.created</code><span class="pf-note">the deck asks for a first draft — over the bus</span></li>
+          <li><span class="pf-src pf-src--crew">crew</span><code>governed run answers</code><span class="pf-note">a crew run drafts it — heartbeats stream while it works</span></li>
+          <li><span class="pf-src pf-src--int">interactive</span><code>wicked.interactive.draft.completed</code><span class="pf-note">a real draft, idempotency-keyed — replays can’t double-deliver</span></li>
+          <li><span class="pf-src pf-src--crew">crew</span><code>run r-7c19 · evidence</code><span class="pf-note">the coder’s run sits in the creator’s view too — same feed, other door</span></li>
+        </ol>
+
+        <div class="proj-foot">
+          <code class="proj-call">GET /api/v1/projects/payments-refresh/activity</code>
+          <span class="proj-same" data-proj-same>same project · same feed · rendered by the <b data-proj-skin-label>coder’s</b> skin</span>
+        </div>
+      </div>
+
+      <p class="honest-note">
+        <b>Where this stands:</b> the Project model is <b>shipped in the control plane</b> — nine
+        routes, the merged activity feed, durable gate prompts across member runs
+        (<code>GET /projects/:id/prompts</code>). The studio’s <b>dedicated project browser is
+        landing in this skin next</b>; the run board you saw above already rides the same daemon.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── The client seam — a pure client, nothing privileged ─────────────── -->
+  <section class="pair" id="client" aria-labelledby="pair-h">
+    <div class="wrap">
+      <div class="sec-head sec-head--wide">
+        <div class="kicker">One API · zero private seams</div>
+        <h2 id="pair-h">If the skin can show it, the API serves it.</h2>
+        <p class="sec-sub">
+          Studio imports <b>zero</b> crew source. The only artifact the two products share is the
+          published wire contract — <code>wicked-crew-api-types</code>. Everything on this page rides
+          <code>/api/v1</code> and the <code>/ws</code> CoreEvent stream; there is no back channel.
+          How the SPA finds its daemon is one deliberate seam — flip it.
+        </p>
+      </div>
+
+      <div class="pair-panel" data-pair data-mode="bundled">
+        <div class="pair-modes" role="tablist" aria-label="How the SPA finds the daemon">
+          <button type="button" role="tab" class="pair-mode is-active" data-pair-mode="bundled" aria-selected="true">bundled · same-origin</button>
+          <button type="button" role="tab" class="pair-mode" data-pair-mode="standalone" aria-selected="false">standalone · VITE_API_HOST</button>
+        </div>
+
+        <div class="pair-stage pair-stage--bundled">
+          <pre class="pair-code"><code>$ npx wicked-crew serve            <span class="c"># UI + API · one port · same origin</span>
+
+apiBase() → window.location.origin + '/api/v1'
+wsBase()  → wss? + window.location.host          <span class="c"># /ws CoreEvents</span></code></pre>
+          <p class="pair-note">
+            Crew’s release build copies studio’s built <code>dist/</code> into the daemon’s serving
+            tree — one command, one port. No host is baked into the bundle:
+            <code>--port</code> / <code>CREW_PORT</code> just work.
+          </p>
+        </div>
+
+        <div class="pair-stage pair-stage--standalone">
+          <pre class="pair-code"><code>$ VITE_API_HOST=127.0.0.1:7701 npm run build
+$ npx serve dist                   <span class="c"># any static server · SPA fallback</span>
+
+apiBase() → http://127.0.0.1:7701/api/v1
+wsBase()  → ws://127.0.0.1:7701                  <span class="c"># same contract, other origin</span></code></pre>
+          <p class="pair-note">
+            The daemon’s loopback CORS admits any <code>localhost</code> origin, so a standalone
+            studio on its own port drives a local daemon out of the box — the daemon stays fully
+            functional headless either way.
+          </p>
+        </div>
+
+        <div class="pair-proof">
+          <span class="pair-proof-k">the carve, proven</span>
+          <span class="pair-proof-t"><code>e2e/studio_standalone_test.py</code> builds the SPA, serves <code>dist/</code> from a plain
+          static server, points it at a live daemon, and drives a real browser through a real flow —
+          list runs → open a run → approve a human gate → watch CoreEvents over WS.</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Where studio sits: THE four-plane map (shared chrome, canonical) ──
+       current="wicked-studio" renders this product's card as the
+       "you are here" marker — the map stays complete, the site never
+       promotes itself. -->
+  <SameGarden current="wicked-studio" />
+
+  <!-- ── Get it ───────────────────────────────────────────────────────────── -->
+  <div class="finale">
+    <section class="get" id="get">
+      <div class="wrap get-grid">
+        <div class="get-intro">
+          <div class="kicker">Get it</div>
+          <h2>One command. The studio is already in it.</h2>
+          <p>
+            The studio ships <b>bundled inside wicked-crew</b>: <code>npx wicked-crew serve</code>
+            starts the daemon and serves this skin same-origin on one port — nothing else to
+            install. Running the skin <b>standalone</b> against any daemon is equally supported;
+            it’s the same build, pointed by one env var.
+          </p>
+          <p class="get-alt">
+            Prefer the whole family? <code>npx wicked-installer</code> is the interactive,
+            cross-CLI installer for every wicked-* product.
+          </p>
+        </div>
+        <div class="install-stack">
+          <div class="install install--primary" role="group" aria-label="Run the studio bundled with wicked-crew">
+            <div class="install__bar">
+              <span class="install__label"><span class="install__star" aria-hidden="true">★</span> Recommended · bundled with crew</span>
+              <button class="install__copy" type="button" aria-label="Copy the bundled serve command"
+                onclick="navigator.clipboard&&navigator.clipboard.writeText('npx wicked-crew serve').then(()=>{this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1400);})">Copy</button>
+            </div>
+            <pre class="install__code"><code>npx wicked-crew serve   <span class="c"># daemon + this studio · one port · same origin</span></code></pre>
+            <p class="install__note">Node ≥ 22. The daemon serves the studio at its own origin — open the printed URL and launch a run. <span class="install__ver">wicked-studio npm v0.1.0</span></p>
+          </div>
+
+          <div class="install-or" aria-hidden="true"><span>or run the skin standalone</span></div>
+
+          <div class="install install--secondary" role="group" aria-label="Run wicked-studio standalone against a daemon">
+            <div class="install__bar">
+              <span class="install__label">Standalone · your own daemon</span>
+              <button class="install__copy" type="button" aria-label="Copy the standalone build commands"
+                onclick="navigator.clipboard&&navigator.clipboard.writeText('VITE_API_HOST=127.0.0.1:7701 npm run build\nnpx serve dist').then(()=>{this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1400);})">Copy</button>
+            </div>
+            <pre class="install__code"><code>VITE_API_HOST=127.0.0.1:7701 npm run build
+npx serve dist          <span class="c"># any static server · SPA fallback to index.html</span></code></pre>
+          </div>
+        </div>
+        <a class="gh-pill" href="https://github.com/mikeparcewski/wicked-studio#readme" target="_blank" rel="noopener" aria-label="View wicked-studio on GitHub">
+          <svg viewBox="0 0 16 16" width="42" height="42" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.02-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </section>
+
+    <Footer repo={repo} />
+  </div>
+
+  <!-- ── The console: launch → the feed streams → the gate is yours ──────── -->
+  <script is:inline>
+    (function () {
+      var root = document.querySelector('[data-console]');
+      if (!root) return;
+      var feed = root.querySelector('[data-console-feed]');
+      var gate = root.querySelector('[data-console-gate]');
+      var stamp = root.querySelector('[data-cg-stamp]');
+      var gateT = root.querySelector('[data-cg-t]');
+      var termEl = root.querySelector('[data-console-term]');
+      var form = root.querySelector('[data-console-launch]');
+      var input = root.querySelector('[data-console-input]');
+      if (!feed || !gate || !stamp) return;
+
+      var reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var STEP = 700;
+      var timer = null;
+      var resolved = false;
+      var runSeq = 0;      // guards a stale stream after a relaunch
+      var workerFlip = 0;  // cycles the dispatched worker on relaunch
+
+      function escapeHtml(s) {
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      }
+      function clearFeed() {
+        var rows = feed.querySelectorAll('.cf-row');
+        for (var i = 0; i < rows.length; i++) rows[i].parentNode.removeChild(rows[i]);
+      }
+      function addRow(html, cls) {
+        var row = document.createElement('span');
+        row.className = 'cf-row' + (cls ? ' ' + cls : '');
+        row.innerHTML = html;
+        feed.appendChild(row);
+        feed.scrollTop = feed.scrollHeight;
+        return row;
+      }
+      function setTerm(cmd, comment) {
+        if (!termEl) return;
+        termEl.innerHTML = '<span class="ct-p">studio ›</span> ' + cmd +
+          (comment ? ' <span class="ct-c"># ' + comment + '</span>' : '');
+      }
+      function setButtons(enabled) {
+        var btns = gate.querySelectorAll('[data-cg-action]');
+        for (var i = 0; i < btns.length; i++) btns[i].disabled = !enabled;
+      }
+      function hideCue() {
+        var cue = gate.querySelector('[data-cg-cue]');
+        if (cue) cue.parentNode.removeChild(cue);
+      }
+      function dropAmend() {
+        var amend = gate.querySelector('.cg-amend');
+        if (amend) amend.parentNode.removeChild(amend);
+      }
+      function hideGate() {
+        hideCue(); dropAmend();
+        gate.hidden = true;
+        gate.removeAttribute('data-verdict');
+        stamp.textContent = 'DENY';
+        if (gateT) gateT.textContent = 'schema-drift · re-verified against the worktree';
+        setButtons(true);
+        resolved = false;
+      }
+      function showGate() {
+        gate.hidden = false;
+        gate.setAttribute('data-verdict', 'deny');
+        stamp.textContent = 'DENY';
+        if (gateT) gateT.textContent = 'schema-drift · re-verified against the worktree';
+        setButtons(true);
+        resolved = false;
+        hideCue();
+        var cue = document.createElement('span');
+        cue.className = 'cg-cue';
+        cue.setAttribute('data-cg-cue', '');
+        cue.textContent = '☝ The decision is yours';
+        gate.appendChild(cue);
+      }
+
+      // Feed steps in the daemon's real vocabulary: POST /runs launches, /ws
+      // streams CoreEvents, the gate holds until POST /runs/:id/gate answers it.
+      function steps(worker) {
+        return [
+          { h: 'run <b>r-7c19</b> launched · workflow <b>feature</b> · <b>POST /api/v1/runs</b>' },
+          { h: 'ws <b>/ws</b> subscribed · CoreEvents streaming · phase ladder live' },
+          { h: 'unit <b>2/6</b> build · <b>' + worker + '</b> session · usage 38k in / 5k out' },
+          { h: 'diff captured · Files panel updated · Burn ticking per CLI' },
+          { h: 'evaluator ≠ creator · review unit routed to a <b>different CLI</b>' },
+          { h: 'policy <b>schema-drift</b> · <b>FAIL</b> — migration ≠ checked-in schema', c: 'cf-row--gate' },
+          { h: 'gate raised · <b>held for your decision</b>', c: 'cf-row--gate' }
+        ];
+      }
+      function stream(worker) {
+        if (timer) { clearTimeout(timer); timer = null; }
+        runSeq++;
+        var seq = runSeq;
+        clearFeed();
+        hideGate();
+        setTerm('term attach r-7c19', 'real PTY · /ws/terminals/:id');
+        var list = steps(worker);
+        if (reduced) {
+          for (var i = 0; i < list.length; i++) addRow(list[i].h, list[i].c);
+          showGate();
+          return;
+        }
+        var idx = 0;
+        (function tick() {
+          if (seq !== runSeq) return;
+          if (idx >= list.length) { showGate(); return; }
+          addRow(list[idx].h, list[idx].c);
+          idx++;
+          timer = setTimeout(tick, STEP);
+        })();
+      }
+
+      // --- gate resolutions: the human takes the wheel (the skin never grades) ---
+      function resolveApprove() {
+        if (resolved) return;
+        resolved = true; setButtons(false); hideCue(); dropAmend();
+        addRow('you approved · override recorded on the decisions ledger', 'cf-row--ok');
+        addRow('transition <b>allowed</b> → ship', 'cf-row--ok');
+        gate.setAttribute('data-verdict', 'allow');
+        stamp.textContent = 'ALLOW';
+        if (gateT) gateT.textContent = 'your call · recorded in the steering timeline';
+        setTerm('gate approve r-7c19', 'POST /api/v1/runs/r-7c19/gate');
+      }
+      function resolveReject() {
+        if (resolved) return;
+        resolved = true; setButtons(false); hideCue(); dropAmend();
+        addRow('run <b>rejected</b> · returned to build', 'cf-row--gate');
+        addRow('unit 2 reopened · awaiting a new diff');
+        gate.setAttribute('data-verdict', 'deny');
+        stamp.textContent = 'DENY';
+        if (gateT) gateT.textContent = 'gate stands · nothing shipped';
+        setTerm('gate reject r-7c19', 'held at build · nothing ships');
+      }
+      function resolveSteer(text) {
+        if (resolved) return;
+        resolved = true; setButtons(false); hideCue(); dropAmend();
+        addRow('amendment applied · <b>' + escapeHtml(text) + '</b>');
+        addRow('re-running build · the amendment rides the next prompt');
+        addRow('policy <b>schema-drift</b> · <b>PASS</b>', 'cf-row--ok');
+        addRow('gate <b>build → ship</b> · <b>PASS</b>', 'cf-row--ok');
+        gate.setAttribute('data-verdict', 'allow');
+        stamp.textContent = 'ALLOW';
+        if (gateT) gateT.textContent = 'steered · re-verified against the worktree · PASS';
+        setTerm('run resume r-7c19', 'POST /api/v1/runs/r-7c19/resume');
+      }
+      function openAmend() {
+        if (resolved) return;
+        var existing = gate.querySelector('.cg-amend input');
+        if (existing) { existing.focus(); existing.select(); return; }
+        hideCue();
+        var wrap = document.createElement('div');
+        wrap.className = 'cg-amend';
+        var amInput = document.createElement('input');
+        amInput.type = 'text';
+        amInput.value = 'add rollback migration + regen schema';
+        amInput.setAttribute('aria-label', 'Amendment to steer the next unit');
+        var apply = document.createElement('button');
+        apply.type = 'button';
+        apply.className = 'cg-btn cg-btn--ok';
+        apply.textContent = 'Apply ↵';
+        wrap.appendChild(amInput);
+        wrap.appendChild(apply);
+        gate.appendChild(wrap);
+        amInput.focus();
+        amInput.select();
+        function submit() {
+          var text = amInput.value.trim();
+          if (text) resolveSteer(text);
+        }
+        apply.addEventListener('click', submit);
+        amInput.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter') { e.preventDefault(); submit(); }
+        });
+      }
+
+      gate.addEventListener('click', function (e) {
+        var btn = e.target && e.target.closest ? e.target.closest('[data-cg-action]') : null;
+        if (!btn || btn.disabled) return;
+        var action = btn.getAttribute('data-cg-action');
+        if (action === 'approve') resolveApprove();
+        else if (action === 'reject') resolveReject();
+        else if (action === 'steer') openAmend();
+      });
+
+      // Relaunch from the brief — reset + re-stream a fresh run that ends again
+      // at the gate, so a visitor can drive their own problem in.
+      if (form) {
+        form.addEventListener('submit', function (e) {
+          e.preventDefault();
+          workerFlip = (workerFlip + 1) % 2;
+          stream(workerFlip === 0 ? 'codex' : 'claude');
+          if (input) input.blur();
+        });
+      }
+
+      // Auto-play the run when the console scrolls into view.
+      // Reduced-motion renders it fully, instantly.
+      var started = false;
+      function startOnce() {
+        if (started) return; started = true;
+        stream('claude');
+      }
+      if ('IntersectionObserver' in window) {
+        var io = new IntersectionObserver(function (entries) {
+          entries.forEach(function (en) {
+            if (en.isIntersecting) { startOnce(); io.disconnect(); }
+          });
+        }, { threshold: 0.3 });
+        io.observe(root);
+      } else {
+        startOnce();
+      }
+    })();
+  </script>
+
+  <!-- ── The insight rail chips: click a panel, read what it answers ─────── -->
+  <script is:inline>
+    (function () {
+      var chips = Array.prototype.slice.call(document.querySelectorAll('[data-rail-chip]'));
+      var line = document.querySelector('[data-rail-line]');
+      if (!chips.length || !line) return;
+      var LINES = [
+        'Tokens, cost, and rework per CLI — live during the run, not on the invoice.',
+        'Every human call on the record: who approved what, when, and why.',
+        'The audit view: which policies were checked, which verdicts held the run.',
+        'External transforms recorded with honest confidence — needs-research is badged for you.',
+        'The timeline of gates raised and answered — approve, amend, reject.',
+        'The diffs each unit produced, straight from the worktree.',
+        'A real PTY into the worker’s worktree — raw bytes over /ws/terminals/:id.',
+        'Repo-scoped coverage, one click from the run that changed it.'
+      ];
+      chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+          var i = parseInt(chip.getAttribute('data-i'), 10);
+          if (isNaN(i) || !LINES[i]) return;
+          chips.forEach(function (c) { c.classList.remove('is-active'); });
+          chip.classList.add('is-active');
+          line.textContent = LINES[i];
+        });
+      });
+    })();
+  </script>
+
+  <!-- ── The run board: auto-cycling panel switcher (click to pin) ───────── -->
+  <script is:inline>
+    (function () {
+      var items = Array.prototype.slice.call(document.querySelectorAll('[data-board-item]'));
+      var stage = document.querySelector('[data-board-stage]');
+      var nameEl = document.querySelector('[data-bs-name]');
+      var apiEl = document.querySelector('[data-bs-api]');
+      var lineEl = document.querySelector('[data-bs-line]');
+      var toggle = document.querySelector('[data-board-toggle]');
+      var statusTxt = document.querySelector('[data-board-status-txt]');
+      if (!items.length || !stage || !nameEl || !apiEl || !lineEl) return;
+
+      var PANELS = [
+        { id: 'runs',      api: 'GET /runs · WS /ws',            line: 'The run board itself: launch from a brief, watch the phase ladder and unit list move, read live output, answer the steering timeline.' },
+        { id: 'work',      api: 'GET /runs/:id/events',           line: 'Every work unit across every run in one queue — what’s streaming, what’s held at a gate, what landed.' },
+        { id: 'chats',     api: 'POST /chats',                    line: 'Group chat with your whole roster: fan one question out, watch each seat answer side by side.' },
+        { id: 'coverage',  api: 'GET /governance/coverage?repo=', line: 'Repo-scoped coverage with a graph view — scoped to the repo you asked about, never a vacuous store-wide 1.0.' },
+        { id: 'workflows', api: 'GET /workflows',                 line: 'The WorkflowDef JSON that will drive a run — phases, gates, validation — inspected before you commit a brief to it.' },
+        { id: 'domain',    api: 'GET /domain-graph',              line: 'The domain-model browser: requirements and their graph, per repo — what the record actually knows about your problem space.' },
+        { id: 'policies',  api: 'GET /governance/policies',       line: 'Policies and conformance rules — the deterministic floor a run must clear. The skin surfaces the gate; it never grades.' },
+        { id: 'repos',     api: 'POST /repos',                    line: 'Registered repos, their onboarding runs, and code-graph summaries — the ground the workers stand on.' }
+      ];
+      var reduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var current = 0;
+      var timer = null;
+      var pinned = false;
+
+      function render(i) {
+        current = i;
+        var p = PANELS[i];
+        nameEl.textContent = p.id;
+        apiEl.textContent = p.api;
+        lineEl.textContent = p.line;
+        items.forEach(function (it, j) {
+          it.classList.toggle('is-active', j === i);
+          it.setAttribute('aria-selected', j === i ? 'true' : 'false');
+        });
+      }
+      function play() {
+        if (timer || reduced) return;
+        timer = setInterval(function () { render((current + 1) % PANELS.length); }, 3000);
+        if (toggle) toggle.classList.add('is-playing');
+        if (statusTxt) statusTxt.textContent = 'auto-cycling · click a panel to pin it';
+      }
+      function pause(msg) {
+        if (timer) { clearInterval(timer); timer = null; }
+        if (toggle) toggle.classList.remove('is-playing');
+        if (statusTxt) statusTxt.textContent = msg || 'paused · click to resume';
+      }
+      items.forEach(function (it) {
+        it.addEventListener('click', function () {
+          var i = parseInt(it.getAttribute('data-i'), 10);
+          if (isNaN(i)) return;
+          pinned = true;
+          pause('pinned · ' + PANELS[i].id + ' — click ▶ to resume');
+          render(i);
+        });
+      });
+      if (toggle) {
+        toggle.addEventListener('click', function () {
+          if (timer) { pinned = true; pause(); }
+          else { pinned = false; play(); }
+        });
+      }
+      render(0);
+      if (!reduced) {
+        if ('IntersectionObserver' in window) {
+          var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (en) {
+              if (en.isIntersecting && !pinned) { play(); }
+              else if (!en.isIntersecting) { if (timer) { clearInterval(timer); timer = null; } }
+            });
+          }, { threshold: 0.3 });
+          io.observe(stage);
+        } else {
+          play();
+        }
+      }
+    })();
+  </script>
+
+  <!-- ── One project, two skins: flip which door renders the same room ───── -->
+  <script is:inline>
+    (function () {
+      var card = document.querySelector('[data-proj]');
+      if (!card) return;
+      var buttons = Array.prototype.slice.call(card.querySelectorAll('[data-proj-skin]'));
+      var label = card.querySelector('[data-proj-skin-label]');
+      buttons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var skin = btn.getAttribute('data-proj-skin');
+          if (!skin) return;
+          card.setAttribute('data-skin', skin);
+          buttons.forEach(function (b) {
+            var active = b === btn;
+            b.classList.toggle('is-active', active);
+            b.setAttribute('aria-selected', active ? 'true' : 'false');
+          });
+          if (label) label.textContent = skin === 'studio' ? 'coder’s' : 'creator’s';
+        });
+      });
+    })();
+  </script>
+
+  <!-- ── The client seam: bundled ↔ standalone pairing modes ─────────────── -->
+  <script is:inline>
+    (function () {
+      var panel = document.querySelector('[data-pair]');
+      if (!panel) return;
+      var buttons = Array.prototype.slice.call(panel.querySelectorAll('[data-pair-mode]'));
+      buttons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var mode = btn.getAttribute('data-pair-mode');
+          if (!mode) return;
+          panel.setAttribute('data-mode', mode);
+          buttons.forEach(function (b) {
+            var active = b === btn;
+            b.classList.toggle('is-active', active);
+            b.setAttribute('aria-selected', active ? 'true' : 'false');
+          });
+        });
+      });
+    })();
+  </script>
+</Base>

--- a/site/src/styles/studio.css
+++ b/site/src/styles/studio.css
@@ -1,0 +1,452 @@
+/* wicked-studio content styles (ws.wickedagile.com) — THE CODER'S FRONT DOOR.
+   Positioning: studio is the coder-facing skin of the wicked platform's
+   EXPERIENCE plane — the run board for governed agent delivery. Launch a run
+   from a plain-text brief, watch live CoreEvents stream over /ws, answer the
+   human gates that hold it, drive a real terminal into the worker's worktree.
+   A PURE HTTP/WS client of the wicked-crew daemon's /api/v1 — zero crew
+   source imported; the wire contract (wicked-crew-api-types) is the only
+   shared artifact.
+
+   Aesthetic: a coder's console. The site voice is the EXPERIENCE plane's
+   AMBER (--plane-experience in the shared tokens — the same plane its sibling
+   skin, wicked-interactive, fronts), while brand yellow (--accent) stays the
+   energy color: CTAs, ALLOW, the launch button. Signal green = ok rows,
+   terracotta = DENY/holds. Where interactive is a warm paper canvas, studio
+   is dark console panels and monospace-forward — two front doors, one plane.
+
+   The shared wicked-web chrome (Base/Topbar/Footer + tokens.css) owns theming
+   via [data-theme]; the family palette is inherited. Only studio-specific
+   rules live here. Each major section is viewport-sized and the document
+   scroll locks section-to-section (scroll-snap; mobile falls back to natural
+   scroll). */
+
+body { padding-top: var(--topbar-h); }
+
+/* Base reset: the `hidden` attribute must win over any component `display`.
+   The steering-gate panel uses `display:flex` AND ships with the `hidden`
+   attribute, toggled from JS via `.hidden = true/false`. Without this,
+   `display:flex` overrides the UA default `[hidden]{display:none}` and the
+   DENY gate renders VISIBLE on load. */
+[hidden] { display: none !important; }
+
+/* Width container (canonical family values). */
+.wrap { width: 100%; max-width: 1240px; margin-inline: auto; padding-inline: 28px; }
+@media (max-width: 560px) { .wrap { padding-inline: 18px; } }
+
+/* ── Scroll-lock to section + per-section viewport sizing ────────────────── */
+html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
+.hero, .board, .proj, .pair, .get {
+  min-height: calc(100svh - var(--topbar-h));
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  justify-content: safe center;
+}
+/* Alternating section bands — translucent darkening so the background art
+   shows THROUGH instead of being painted over. */
+.board, .pair { background: color-mix(in oklab, #000 7%, transparent); }
+@media (max-width: 760px) {
+  html { scroll-snap-type: none; }
+  .hero, .board, .proj, .pair, .get { min-height: 0; }
+}
+
+/* ── Studio background — ITS OWN motif: the CODER'S FRONT DOOR ─────────────
+   Same engine + spirit as the siblings (crew's harness schematic, garden's
+   trellis): ONE fixed, low-opacity, --ink-tinted MASKED layer of faint,
+   recognizable ICON line-art. Themed to what studio IS (the run board you
+   steer from): an open FRONT DOOR, a BROWSER run board with sidebar + rows,
+   a TERMINAL, a PHASE LADDER with a check, a WS wave, a PLUG→SOCKET pair
+   (the pure-client seam), a gate SWITCH, and a STEERING wheel — wired by
+   dashed connectors + arrowheads. Fixed at z-index:-1 behind all content,
+   low-contrast so it reads through the section bands and never fights text.
+   Theme-aware via --ink. Inline data-URI mask → no base-path issues. */
+body::before {
+  content: ''; position: fixed; inset: 0; z-index: -1; pointer-events: none;
+  background-color: var(--ink);
+  background-image: none; /* fully override the shared line-grid blueprint */
+  opacity: 0.08;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='1600' height='900' viewBox='0 0 1600 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='black' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M300 170 H540' stroke-dasharray='5 9'/%3E%3Cpath d='M532 164 l8 6 l-8 6'/%3E%3Cpath d='M760 170 H1010' stroke-dasharray='5 9'/%3E%3Cpath d='M1002 164 l8 6 l-8 6'/%3E%3Cpath d='M1210 170 H1400' stroke-dasharray='5 9'/%3E%3Cpath d='M1392 164 l8 6 l-8 6'/%3E%3Cpath d='M320 470 H560' stroke-dasharray='5 9'/%3E%3Cpath d='M552 464 l8 6 l-8 6'/%3E%3Cpath d='M790 480 H1060' stroke-dasharray='5 9'/%3E%3Cpath d='M1052 474 l8 6 l-8 6'/%3E%3Cpath d='M260 790 H460' stroke-dasharray='5 9'/%3E%3Cpath d='M452 784 l8 6 l-8 6'/%3E%3Cpath d='M640 790 H860' stroke-dasharray='5 9'/%3E%3Cpath d='M852 784 l8 6 l-8 6'/%3E%3Cpath d='M1060 790 H1280' stroke-dasharray='5 9'/%3E%3Cpath d='M1272 784 l8 6 l-8 6'/%3E%3Cpath d='M220 240 V430' stroke-dasharray='6 10'/%3E%3Cpath d='M700 230 V430' stroke-dasharray='6 10'/%3E%3Cpath d='M1150 240 V440' stroke-dasharray='6 10'/%3E%3Cpath d='M240 560 V720' stroke-dasharray='6 10'/%3E%3Cpath d='M840 560 V700' stroke-dasharray='6 10'/%3E%3Cpath d='M1360 540 V680' stroke-dasharray='6 10'/%3E%3Ccircle cx='220' cy='435' r='5'/%3E%3Ccircle cx='700' cy='435' r='5'/%3E%3Ccircle cx='1150' cy='445' r='5'/%3E%3Cpath d='M500 300 l9 10 l16 -22'/%3E%3Cpath d='M950 590 l9 10 l16 -22'/%3E%3Cpath d='M1300 300 l9 10 l16 -22'/%3E%3Cg transform='translate(120 110)'%3E%3Crect width='104' height='148' rx='9' stroke-width='1.8'/%3E%3Cpath d='M22 12 L82 28 V142 L22 136 Z'/%3E%3Ccircle cx='70' cy='86' r='4'/%3E%3Cpath d='M104 40 h14 M104 74 h20 M104 108 h14'/%3E%3C/g%3E%3Cg transform='translate(560 90)'%3E%3Crect width='180' height='118' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 26 H180'/%3E%3Ccircle cx='16' cy='13' r='3'/%3E%3Ccircle cx='29' cy='13' r='3'/%3E%3Ccircle cx='42' cy='13' r='3'/%3E%3Cpath d='M46 26 V118'/%3E%3Cpath d='M10 46 H36 M10 64 H36 M10 82 H36'/%3E%3Cpath d='M60 50 H150 M60 70 H166 M60 90 H130'/%3E%3Crect x='140' y='84' width='28' height='13' rx='4'/%3E%3C/g%3E%3Cg transform='translate(1040 100)'%3E%3Crect width='150' height='92' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 24 H150'/%3E%3Ccircle cx='16' cy='12' r='3'/%3E%3Ccircle cx='29' cy='12' r='3'/%3E%3Cpath d='M20 44 l16 13 l-16 13'/%3E%3Cpath d='M46 70 H92'/%3E%3C/g%3E%3Cg transform='translate(1420 120)'%3E%3Ccircle cx='50' cy='50' r='34'/%3E%3Ccircle cx='50' cy='50' r='9'/%3E%3Cpath d='M50 16 V41 M50 59 V84 M16 50 H41 M59 50 H84'/%3E%3C/g%3E%3Cg transform='translate(180 480)'%3E%3Ccircle cx='16' cy='10' r='7'/%3E%3Cpath d='M16 17 V52'/%3E%3Ccircle cx='16' cy='59' r='7'/%3E%3Cpath d='M16 66 V101'/%3E%3Ccircle cx='16' cy='108' r='7'/%3E%3Cpath d='M11 106 l4 5 l8 -10'/%3E%3Cpath d='M30 10 H74 M30 59 H74 M30 108 H74'/%3E%3C/g%3E%3Cg transform='translate(620 470)'%3E%3Crect width='64' height='44' rx='10' stroke-width='1.8'/%3E%3Cpath d='M64 14 h12 M64 30 h12'/%3E%3Crect x='94' y='0' width='64' height='44' rx='10' stroke-width='1.8'/%3E%3Ccircle cx='112' cy='14' r='3'/%3E%3Ccircle cx='112' cy='30' r='3'/%3E%3C/g%3E%3Cg transform='translate(1060 460)'%3E%3Cpath d='M0 30 l22 -18 l22 18 l22 -18 l22 18 l22 -18 l22 18' stroke-width='1.8'/%3E%3Cpath d='M126 24 l10 6 l-10 6'/%3E%3C/g%3E%3Cg transform='translate(1400 470)'%3E%3Crect width='100' height='46' rx='23' stroke-width='1.8'/%3E%3Ccircle cx='72' cy='23' r='15'/%3E%3C/g%3E%3Cg transform='translate(160 700)'%3E%3Crect width='150' height='92' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 24 H150'/%3E%3Ccircle cx='16' cy='12' r='3'/%3E%3Ccircle cx='29' cy='12' r='3'/%3E%3Cpath d='M20 44 l16 13 l-16 13'/%3E%3Cpath d='M46 70 H92'/%3E%3C/g%3E%3Cg transform='translate(520 660)'%3E%3Crect width='180' height='118' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 26 H180'/%3E%3Ccircle cx='16' cy='13' r='3'/%3E%3Ccircle cx='29' cy='13' r='3'/%3E%3Ccircle cx='42' cy='13' r='3'/%3E%3Cpath d='M46 26 V118'/%3E%3Cpath d='M10 46 H36 M10 64 H36 M10 82 H36'/%3E%3Cpath d='M60 50 H150 M60 70 H166 M60 90 H130'/%3E%3Crect x='140' y='84' width='28' height='13' rx='4'/%3E%3C/g%3E%3Cg transform='translate(920 660)'%3E%3Ccircle cx='50' cy='50' r='34'/%3E%3Ccircle cx='50' cy='50' r='9'/%3E%3Cpath d='M50 16 V41 M50 59 V84 M16 50 H41 M59 50 H84'/%3E%3C/g%3E%3Cg transform='translate(1320 680)'%3E%3Crect width='104' height='148' rx='9' stroke-width='1.8'/%3E%3Cpath d='M22 12 L82 28 V142 L22 136 Z'/%3E%3Ccircle cx='70' cy='86' r='4'/%3E%3C/g%3E%3C/g%3E%3Cg fill='black'%3E%3Ccircle cx='420' cy='620' r='2.5'/%3E%3Ccircle cx='433' cy='620' r='2.5'/%3E%3Ccircle cx='446' cy='620' r='2.5'/%3E%3Ccircle cx='1180' cy='860' r='2.5'/%3E%3Ccircle cx='1193' cy='860' r='2.5'/%3E%3Ccircle cx='1206' cy='860' r='2.5'/%3E%3Ccircle cx='1290' cy='420' r='2.5'/%3E%3Ccircle cx='1303' cy='420' r='2.5'/%3E%3Ccircle cx='1316' cy='420' r='2.5'/%3E%3C/g%3E%3C/svg%3E");
+          mask-image: url("data:image/svg+xml,%3Csvg width='1600' height='900' viewBox='0 0 1600 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='black' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M300 170 H540' stroke-dasharray='5 9'/%3E%3Cpath d='M532 164 l8 6 l-8 6'/%3E%3Cpath d='M760 170 H1010' stroke-dasharray='5 9'/%3E%3Cpath d='M1002 164 l8 6 l-8 6'/%3E%3Cpath d='M1210 170 H1400' stroke-dasharray='5 9'/%3E%3Cpath d='M1392 164 l8 6 l-8 6'/%3E%3Cpath d='M320 470 H560' stroke-dasharray='5 9'/%3E%3Cpath d='M552 464 l8 6 l-8 6'/%3E%3Cpath d='M790 480 H1060' stroke-dasharray='5 9'/%3E%3Cpath d='M1052 474 l8 6 l-8 6'/%3E%3Cpath d='M260 790 H460' stroke-dasharray='5 9'/%3E%3Cpath d='M452 784 l8 6 l-8 6'/%3E%3Cpath d='M640 790 H860' stroke-dasharray='5 9'/%3E%3Cpath d='M852 784 l8 6 l-8 6'/%3E%3Cpath d='M1060 790 H1280' stroke-dasharray='5 9'/%3E%3Cpath d='M1272 784 l8 6 l-8 6'/%3E%3Cpath d='M220 240 V430' stroke-dasharray='6 10'/%3E%3Cpath d='M700 230 V430' stroke-dasharray='6 10'/%3E%3Cpath d='M1150 240 V440' stroke-dasharray='6 10'/%3E%3Cpath d='M240 560 V720' stroke-dasharray='6 10'/%3E%3Cpath d='M840 560 V700' stroke-dasharray='6 10'/%3E%3Cpath d='M1360 540 V680' stroke-dasharray='6 10'/%3E%3Ccircle cx='220' cy='435' r='5'/%3E%3Ccircle cx='700' cy='435' r='5'/%3E%3Ccircle cx='1150' cy='445' r='5'/%3E%3Cpath d='M500 300 l9 10 l16 -22'/%3E%3Cpath d='M950 590 l9 10 l16 -22'/%3E%3Cpath d='M1300 300 l9 10 l16 -22'/%3E%3Cg transform='translate(120 110)'%3E%3Crect width='104' height='148' rx='9' stroke-width='1.8'/%3E%3Cpath d='M22 12 L82 28 V142 L22 136 Z'/%3E%3Ccircle cx='70' cy='86' r='4'/%3E%3Cpath d='M104 40 h14 M104 74 h20 M104 108 h14'/%3E%3C/g%3E%3Cg transform='translate(560 90)'%3E%3Crect width='180' height='118' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 26 H180'/%3E%3Ccircle cx='16' cy='13' r='3'/%3E%3Ccircle cx='29' cy='13' r='3'/%3E%3Ccircle cx='42' cy='13' r='3'/%3E%3Cpath d='M46 26 V118'/%3E%3Cpath d='M10 46 H36 M10 64 H36 M10 82 H36'/%3E%3Cpath d='M60 50 H150 M60 70 H166 M60 90 H130'/%3E%3Crect x='140' y='84' width='28' height='13' rx='4'/%3E%3C/g%3E%3Cg transform='translate(1040 100)'%3E%3Crect width='150' height='92' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 24 H150'/%3E%3Ccircle cx='16' cy='12' r='3'/%3E%3Ccircle cx='29' cy='12' r='3'/%3E%3Cpath d='M20 44 l16 13 l-16 13'/%3E%3Cpath d='M46 70 H92'/%3E%3C/g%3E%3Cg transform='translate(1420 120)'%3E%3Ccircle cx='50' cy='50' r='34'/%3E%3Ccircle cx='50' cy='50' r='9'/%3E%3Cpath d='M50 16 V41 M50 59 V84 M16 50 H41 M59 50 H84'/%3E%3C/g%3E%3Cg transform='translate(180 480)'%3E%3Ccircle cx='16' cy='10' r='7'/%3E%3Cpath d='M16 17 V52'/%3E%3Ccircle cx='16' cy='59' r='7'/%3E%3Cpath d='M16 66 V101'/%3E%3Ccircle cx='16' cy='108' r='7'/%3E%3Cpath d='M11 106 l4 5 l8 -10'/%3E%3Cpath d='M30 10 H74 M30 59 H74 M30 108 H74'/%3E%3C/g%3E%3Cg transform='translate(620 470)'%3E%3Crect width='64' height='44' rx='10' stroke-width='1.8'/%3E%3Cpath d='M64 14 h12 M64 30 h12'/%3E%3Crect x='94' y='0' width='64' height='44' rx='10' stroke-width='1.8'/%3E%3Ccircle cx='112' cy='14' r='3'/%3E%3Ccircle cx='112' cy='30' r='3'/%3E%3C/g%3E%3Cg transform='translate(1060 460)'%3E%3Cpath d='M0 30 l22 -18 l22 18 l22 -18 l22 18 l22 -18 l22 18' stroke-width='1.8'/%3E%3Cpath d='M126 24 l10 6 l-10 6'/%3E%3C/g%3E%3Cg transform='translate(1400 470)'%3E%3Crect width='100' height='46' rx='23' stroke-width='1.8'/%3E%3Ccircle cx='72' cy='23' r='15'/%3E%3C/g%3E%3Cg transform='translate(160 700)'%3E%3Crect width='150' height='92' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 24 H150'/%3E%3Ccircle cx='16' cy='12' r='3'/%3E%3Ccircle cx='29' cy='12' r='3'/%3E%3Cpath d='M20 44 l16 13 l-16 13'/%3E%3Cpath d='M46 70 H92'/%3E%3C/g%3E%3Cg transform='translate(520 660)'%3E%3Crect width='180' height='118' rx='12' stroke-width='1.8'/%3E%3Cpath d='M0 26 H180'/%3E%3Ccircle cx='16' cy='13' r='3'/%3E%3Ccircle cx='29' cy='13' r='3'/%3E%3Ccircle cx='42' cy='13' r='3'/%3E%3Cpath d='M46 26 V118'/%3E%3Cpath d='M10 46 H36 M10 64 H36 M10 82 H36'/%3E%3Cpath d='M60 50 H150 M60 70 H166 M60 90 H130'/%3E%3Crect x='140' y='84' width='28' height='13' rx='4'/%3E%3C/g%3E%3Cg transform='translate(920 660)'%3E%3Ccircle cx='50' cy='50' r='34'/%3E%3Ccircle cx='50' cy='50' r='9'/%3E%3Cpath d='M50 16 V41 M50 59 V84 M16 50 H41 M59 50 H84'/%3E%3C/g%3E%3Cg transform='translate(1320 680)'%3E%3Crect width='104' height='148' rx='9' stroke-width='1.8'/%3E%3Cpath d='M22 12 L82 28 V142 L22 136 Z'/%3E%3Ccircle cx='70' cy='86' r='4'/%3E%3C/g%3E%3C/g%3E%3Cg fill='black'%3E%3Ccircle cx='420' cy='620' r='2.5'/%3E%3Ccircle cx='433' cy='620' r='2.5'/%3E%3Ccircle cx='446' cy='620' r='2.5'/%3E%3Ccircle cx='1180' cy='860' r='2.5'/%3E%3Ccircle cx='1193' cy='860' r='2.5'/%3E%3Ccircle cx='1206' cy='860' r='2.5'/%3E%3Ccircle cx='1290' cy='420' r='2.5'/%3E%3Ccircle cx='1303' cy='420' r='2.5'/%3E%3Ccircle cx='1316' cy='420' r='2.5'/%3E%3C/g%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+  -webkit-mask-position: center;  mask-position: center;
+  -webkit-mask-size: cover;       mask-size: cover;
+}
+/* bursts of light — studio's two signals: experience-plane AMBER entering at
+   the front door (top-left) + brand-yellow launch energy (bottom-right). */
+body::after {
+  content: ''; position: fixed; inset: 0; z-index: -2; pointer-events: none;
+  background:
+    radial-gradient(ellipse 50% 42% at 3% 5%,
+      color-mix(in oklab, var(--amb) 16%, transparent), transparent 60%),
+    radial-gradient(ellipse 46% 46% at 97% 95%,
+      color-mix(in oklab, var(--accent) 10%, transparent), transparent 62%);
+  background-position: 0 0, 0 0;
+}
+/* Motion is opt-IN and OFF by default. Where allowed, only the entering-amber
+   glow drifts very slowly. The icon line-art never moves. */
+@media (prefers-reduced-motion: no-preference) {
+  body::after { animation: studio-door 22s var(--ease) infinite alternate; }
+}
+@keyframes studio-door {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 2% 1.5%, -2% -1.5%; }
+}
+
+:root {
+  --ok: #3fb950;
+  --deny: #f85149;
+  /* The EXPERIENCE-plane hue from the shared chrome (tokens.css): amber marks
+     the plane this product fronts — the same voice its sibling skin
+     (wicked-interactive) speaks. Brand yellow (--accent) stays the energy
+     color: Launch, ALLOW, CTAs. */
+  --amb: var(--plane-experience, #f0a868);
+}
+
+/* Section kickers speak in the experience plane's voice (amber). SameGarden's
+   own kicker keeps its accent rule. */
+.kicker { color: color-mix(in oklab, var(--amb) 82%, var(--ink)); }
+.kicker--plane::before {
+  content: ''; display: inline-block; width: 9px; height: 9px; border-radius: 50%;
+  margin-right: 9px; margin-bottom: 1px; vertical-align: baseline;
+  border: 2px solid var(--amb);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--amb) 16%, transparent);
+}
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-stretch: 125%;
+  letter-spacing: -0.02em;
+  line-height: 0.98;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.y { color: var(--accent); }
+code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: color-mix(in oklab, var(--ink) 8%, transparent);
+  border: 1px solid var(--hairline);
+  border-radius: 5px;
+  padding: 0.08em 0.4em;
+  color: var(--ink);
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 0.8rem; letter-spacing: 0.02em;
+  padding: 11px 20px; border-radius: 999px; border: 1px solid var(--hairline-strong);
+  text-decoration: none; cursor: pointer;
+  transition: border-color .22s var(--ease), background .22s var(--ease), color .22s var(--ease), transform .22s var(--ease);
+}
+.btn-primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); font-weight: 700; }
+.btn-primary:hover { transform: translateY(-2px); }
+.btn-ghost { color: var(--ink); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Section heads: left-aligned, spanning the container. */
+.sec-head { max-width: none; margin: 0 0 clamp(26px, 4svh, 46px); }
+.sec-head--wide { text-align: left; }
+.sec-head h2 { font-size: clamp(1.9rem, 3.6vw, 3rem); margin: 12px 0 0; }
+.sec-head h2 code { font-size: 0.82em; }
+.sec-sub { margin: 16px 0 0; max-width: 74ch; font-size: 1rem; line-height: 1.62; color: color-mix(in oklab, var(--ink) 76%, transparent); }
+.sec-sub b { color: var(--ink); }
+.sec-sub a { color: var(--link); }
+
+/* ── Hero ─────────────────────────────────────────────────────────────── */
+.hero { position: relative; overflow: hidden; padding: clamp(44px, 8svh, 96px) 0 clamp(36px, 6svh, 72px); }
+.amber-floor {
+  position: absolute; inset: 0; z-index: -1; pointer-events: none;
+  background: radial-gradient(ellipse 60% 60% at 82% 8%, color-mix(in oklab, var(--amb) 15%, transparent), transparent 60%);
+}
+.hero-head { text-align: center; }
+.hero-head h1 { font-size: clamp(2.3rem, 5.2vw, 4rem); margin: 14px 0 0; }
+.lede { margin: 18px auto 0; font-size: clamp(0.98rem, 1.35vw, 1.1rem); line-height: 1.6; color: color-mix(in oklab, var(--ink) 80%, transparent); max-width: 62%; }
+.lede b { color: var(--ink); font-weight: 700; }
+.hero-foot { margin-top: clamp(18px, 3svh, 30px); display: flex; flex-direction: column; align-items: center; gap: 15px; }
+.hero-tags { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; }
+.hero-tags span {
+  font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--muted); border: 1px solid var(--hairline-strong); border-radius: 999px; padding: 5px 12px;
+}
+.hero-cta { display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; }
+
+/* ── The console (the hero visual IS the product) ─────────────────────── */
+.hero-console-wrap { margin-top: clamp(20px, 3.6svh, 40px); }
+.console {
+  border: 1px solid var(--hairline-strong); border-radius: 16px; overflow: hidden;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
+  box-shadow: 0 30px 60px -44px rgba(0,0,0,.7);
+}
+.mock-bar { display: flex; align-items: center; gap: 12px; padding: 9px 14px; border-bottom: 1px solid var(--hairline); background: color-mix(in oklab, var(--canvas) 45%, transparent); }
+.mock-dots { display: inline-flex; gap: 6px; flex-shrink: 0; }
+.mock-dots i { width: 10px; height: 10px; border-radius: 50%; background: color-mix(in oklab, var(--ink) 22%, transparent); }
+.mock-url { font-family: var(--font-mono); font-size: 0.66rem; color: color-mix(in oklab, var(--ink) 70%, transparent); border: 1px solid var(--hairline-strong); border-radius: 999px; padding: 3px 12px; background: color-mix(in oklab, var(--canvas) 40%, transparent); flex: 1; text-align: center; }
+
+.console-body { padding: 14px; display: flex; flex-direction: column; gap: 11px; }
+.console-launch { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 11px 14px; background: color-mix(in oklab, var(--canvas) 35%, transparent); }
+.console-launch:focus-within { border-color: color-mix(in oklab, var(--accent) 45%, var(--hairline-strong)); }
+.cl-k { font-family: var(--font-mono); font-size: 0.58rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); }
+.cl-input { flex: 1; min-width: 180px; font-family: var(--font-mono); font-size: 0.82rem; color: var(--ink); background: transparent; border: none; outline: none; }
+.cl-input::placeholder { color: var(--faint); }
+.cl-go { font-family: var(--font-mono); font-size: 0.72rem; font-weight: 700; color: var(--accent-ink); background: var(--accent); border: none; border-radius: 7px; padding: 6px 13px; cursor: pointer; transition: transform .2s var(--ease); }
+.cl-go:hover { transform: translateY(-1px); }
+
+.console-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 11px; align-items: stretch; }
+.console-feed, .console-gate { display: flex; flex-direction: column; gap: 8px; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 13px 14px; background: color-mix(in oklab, var(--surface) 60%, transparent); }
+.cf-k, .cg-k { font-family: var(--font-mono); font-size: 0.58rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); }
+.console-feed { height: clamp(120px, 21svh, 180px); overflow-y: auto; }
+.console-gate { overflow-y: auto; }
+.cf-row { font-family: var(--font-mono); font-size: 0.72rem; color: color-mix(in oklab, var(--ink) 74%, transparent); animation: row-in .28s var(--ease) backwards; }
+.cf-row b { color: var(--ink); }
+.cf-row--gate { color: var(--deny); }
+.cf-row--gate b { color: var(--deny); }
+.cf-row--ok { color: var(--ok); }
+.cf-row--ok b { color: var(--ok); }
+@keyframes row-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+
+.cg-stamp { font-family: var(--font-mono); font-weight: 700; font-size: 0.86rem; letter-spacing: 0.12em; width: max-content; color: #fff; background: var(--deny); border-radius: 6px; padding: 5px 12px; }
+.console-gate[data-verdict="allow"] .cg-stamp { color: var(--accent-ink); background: var(--accent); }
+.cg-t { font-family: var(--font-mono); font-size: 0.7rem; color: color-mix(in oklab, var(--ink) 70%, transparent); }
+.cg-actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 2px; }
+.cg-btn { font-family: var(--font-mono); font-size: 0.68rem; padding: 6px 12px; border-radius: 7px; border: 1px solid var(--hairline-strong); color: color-mix(in oklab, var(--ink) 78%, transparent); background: color-mix(in oklab, var(--surface) 70%, transparent); cursor: pointer; transition: border-color .2s var(--ease), color .2s var(--ease), background .2s var(--ease); }
+.cg-btn:hover { border-color: var(--accent); color: var(--accent); }
+.cg-btn--ok { color: var(--accent-ink); background: var(--accent); border-color: var(--accent); font-weight: 700; }
+.cg-btn--ok:hover { color: var(--accent-ink); background: color-mix(in oklab, var(--accent) 88%, #000 6%); border-color: var(--accent); }
+.cg-btn:disabled { opacity: 0.5; cursor: default; }
+.cg-amend { display: flex; gap: 8px; margin-top: 6px; }
+.cg-amend input {
+  flex: 1; min-width: 0; font-family: var(--font-mono); font-size: 0.72rem; color: var(--ink);
+  background: color-mix(in oklab, var(--canvas) 35%, transparent);
+  border: 1px solid var(--hairline-strong); border-radius: 7px; padding: 6px 10px; outline: none;
+}
+.cg-amend input:focus { border-color: var(--accent); }
+.cg-amend button { flex-shrink: 0; border: none; cursor: pointer; }
+.cg-cue {
+  width: max-content; margin-top: 2px;
+  font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.03em; font-weight: 700;
+  color: var(--accent-ink); background: var(--accent); border-radius: 999px; padding: 4px 11px;
+  animation: cue-pulse 1.7s var(--ease) infinite;
+}
+@keyframes cue-pulse { 50% { transform: translateY(-2px); opacity: .85; } }
+
+.console-term { display: flex; flex-direction: column; gap: 5px; border: 1px solid var(--hairline); border-radius: 10px; padding: 11px 14px; background: color-mix(in oklab, var(--surface-2) 70%, #000 6%); }
+.ct-line { font-family: var(--font-mono); font-size: 0.74rem; color: var(--ink); white-space: nowrap; overflow-x: auto; }
+.ct-p { color: var(--accent); font-weight: 700; margin-right: 8px; }
+.ct-c { color: color-mix(in oklab, var(--ink) 46%, transparent); }
+
+/* the insight rail: interactive chips + one caption line */
+.console-rail {
+  display: flex; align-items: center; gap: 7px; flex-wrap: wrap;
+  border: 1px solid var(--hairline); border-radius: 10px; padding: 9px 14px;
+  background: color-mix(in oklab, var(--surface) 45%, transparent);
+}
+.cr-k { font-family: var(--font-mono); font-size: 0.56rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--faint); margin-right: 3px; }
+.cr-chip {
+  font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.04em;
+  color: color-mix(in oklab, var(--ink) 72%, transparent);
+  border: 1px solid var(--hairline-strong); border-radius: 999px; padding: 3px 10px;
+  background: transparent; cursor: pointer;
+  transition: border-color .2s var(--ease), color .2s var(--ease), background .2s var(--ease);
+}
+.cr-chip:hover { border-color: var(--amb); color: var(--amb); }
+.cr-chip.is-active { color: var(--accent-ink); background: var(--amb); border-color: var(--amb); font-weight: 700; }
+.console-rail-line { margin: 0; padding: 0 4px; font-family: var(--font-mono); font-size: 0.68rem; line-height: 1.5; color: var(--muted); min-height: 1.5em; }
+
+/* ── The run board (panel switcher) ───────────────────────────────────── */
+.board { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.board-layout { display: grid; grid-template-columns: minmax(200px, 280px) minmax(0, 1fr); gap: clamp(14px, 2vw, 26px); align-items: start; }
+.board-list { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.board-item {
+  display: flex; align-items: center; gap: 9px; padding: 11px 13px;
+  border: 1px solid var(--hairline-strong); border-radius: 10px;
+  background: color-mix(in oklab, var(--surface) 55%, transparent);
+  color: var(--ink); cursor: pointer; text-align: left;
+  transition: border-color .2s var(--ease), background .2s var(--ease), transform .2s var(--ease);
+}
+.board-item:hover { border-color: color-mix(in oklab, var(--amb) 55%, var(--hairline-strong)); transform: translateY(-1px); }
+.board-item.is-active { border-color: var(--amb); background: color-mix(in oklab, var(--amb) 12%, transparent); }
+.bi-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--hairline-strong); flex-shrink: 0; transition: background .2s var(--ease), box-shadow .2s var(--ease); }
+.board-item.is-active .bi-dot { background: var(--amb); box-shadow: 0 0 8px -1px var(--amb); }
+.bi-name { font-family: var(--font-mono); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.02em; }
+.board-stage {
+  border: 1px solid var(--hairline-strong); border-radius: 14px; overflow: hidden;
+  background: color-mix(in oklab, var(--surface-2) 78%, transparent);
+  min-height: 150px; display: flex; flex-direction: column;
+}
+.board-stage-bar { display: flex; align-items: center; justify-content: space-between; gap: 8px 14px; flex-wrap: wrap; padding: 12px 16px; border-bottom: 1px solid var(--hairline); background: color-mix(in oklab, var(--canvas) 45%, transparent); }
+.bs-name { font-family: var(--font-display); font-weight: 900; font-stretch: 110%; font-size: 1.2rem; letter-spacing: -0.01em; color: var(--ink); }
+.bs-api { font-size: 0.72rem; color: color-mix(in oklab, var(--amb) 80%, var(--ink)); background: color-mix(in oklab, var(--amb) 10%, transparent); border-color: color-mix(in oklab, var(--amb) 30%, var(--hairline)); }
+.bs-line { margin: 0; padding: 16px; font-size: 0.94rem; line-height: 1.6; color: color-mix(in oklab, var(--ink) 78%, transparent); }
+.board-status { margin-top: 14px; }
+.board-status-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.04em;
+  color: var(--muted); background: transparent; border: 1px solid var(--hairline-strong);
+  border-radius: 999px; padding: 6px 14px; cursor: pointer;
+  transition: border-color .2s var(--ease), color .2s var(--ease);
+}
+.board-status-btn:hover { border-color: var(--amb); color: var(--amb); }
+.board-status-btn .bs-ic { font-size: 0.6rem; }
+.board-status-btn.is-playing .bs-ic { color: var(--amb); }
+
+/* ── One project, two skins ───────────────────────────────────────────── */
+.proj { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.proj-card {
+  border: 1px solid var(--hairline-strong); border-radius: 16px; overflow: hidden;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
+  box-shadow: 0 30px 60px -44px rgba(0,0,0,.7);
+}
+.proj-bar { display: flex; align-items: center; justify-content: space-between; gap: 10px 16px; flex-wrap: wrap; padding: 12px 16px; border-bottom: 1px solid var(--hairline); background: color-mix(in oklab, var(--canvas) 45%, transparent); }
+.proj-id { font-family: var(--font-mono); font-size: 0.76rem; color: color-mix(in oklab, var(--ink) 74%, transparent); }
+.proj-id b { color: var(--ink); }
+.proj-skins { display: inline-flex; gap: 6px; }
+.proj-skin {
+  font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.03em;
+  color: color-mix(in oklab, var(--ink) 72%, transparent);
+  border: 1px solid var(--hairline-strong); border-radius: 999px; padding: 5px 13px;
+  background: transparent; cursor: pointer;
+  transition: border-color .2s var(--ease), color .2s var(--ease), background .2s var(--ease);
+}
+.proj-skin:hover { border-color: var(--amb); color: var(--amb); }
+.proj-skin.is-active { color: var(--accent-ink); background: var(--amb); border-color: var(--amb); font-weight: 700; }
+.proj-feed { list-style: none; margin: 0; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
+.proj-feed li { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; font-family: var(--font-mono); font-size: 0.74rem; }
+.pf-src { font-size: 0.56rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; border-radius: 999px; padding: 2px 9px; flex-shrink: 0; }
+.pf-src--crew { color: var(--plane-control, #d2a8ff); border: 1px solid color-mix(in oklab, var(--plane-control, #d2a8ff) 45%, transparent); }
+.pf-src--int { color: var(--amb); border: 1px solid color-mix(in oklab, var(--amb) 50%, transparent); }
+.proj-feed code { background: none; border: none; padding: 0; color: var(--ink); font-size: 0.74rem; }
+.pf-note { color: var(--muted); font-size: 0.7rem; }
+/* the skin toggle: both renderings are in the DOM; data-skin picks one */
+.proj-card[data-skin="studio"] .proj-feed--interactive { display: none; }
+.proj-card[data-skin="interactive"] .proj-feed--studio { display: none; }
+/* the two renderings carry their door's flavor */
+.proj-feed--studio { border-left: 3px solid color-mix(in oklab, var(--plane-control, #d2a8ff) 40%, transparent); margin: 12px 16px; padding: 4px 0 4px 14px; }
+.proj-feed--interactive { border-left: 3px solid color-mix(in oklab, var(--amb) 55%, transparent); margin: 12px 16px; padding: 4px 0 4px 14px; }
+.proj-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px 16px; flex-wrap: wrap; padding: 11px 16px; border-top: 1px solid var(--hairline); }
+.proj-call { font-size: 0.68rem; }
+.proj-same { font-family: var(--font-mono); font-size: 0.64rem; color: var(--muted); }
+.proj-same b { color: var(--amb); }
+
+.honest-note {
+  margin: clamp(20px, 3svh, 34px) 0 0; font-family: var(--font-mono); font-size: 0.72rem; line-height: 1.6;
+  color: color-mix(in oklab, var(--ink) 62%, transparent); max-width: 74ch;
+  border-left: 2px solid var(--hairline-strong); padding-left: 16px;
+}
+.honest-note b { color: var(--ink); }
+
+/* ── The client seam (pairing modes) ──────────────────────────────────── */
+.pair { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.pair-panel {
+  border: 1px solid var(--hairline-strong); border-radius: 16px; overflow: hidden;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
+}
+.pair-modes { display: flex; gap: 6px; padding: 12px 16px; border-bottom: 1px solid var(--hairline); background: color-mix(in oklab, var(--canvas) 45%, transparent); flex-wrap: wrap; }
+.pair-mode {
+  font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.03em;
+  color: color-mix(in oklab, var(--ink) 72%, transparent);
+  border: 1px solid var(--hairline-strong); border-radius: 999px; padding: 6px 14px;
+  background: transparent; cursor: pointer;
+  transition: border-color .2s var(--ease), color .2s var(--ease), background .2s var(--ease);
+}
+.pair-mode:hover { border-color: var(--amb); color: var(--amb); }
+.pair-mode.is-active { color: var(--accent-ink); background: var(--amb); border-color: var(--amb); font-weight: 700; }
+.pair-stage { padding: 16px; }
+.pair-panel[data-mode="bundled"] .pair-stage--standalone { display: none; }
+.pair-panel[data-mode="standalone"] .pair-stage--bundled { display: none; }
+.pair-code { margin: 0; padding: 14px 16px; border: 1px solid var(--hairline); border-radius: 10px; background: color-mix(in oklab, var(--canvas) 40%, transparent); overflow-x: auto; }
+.pair-code code { display: block; background: none; border: none; padding: 0; font-family: var(--font-mono); font-size: 0.78rem; line-height: 1.75; color: var(--ink); white-space: pre; }
+.pair-code .c { color: var(--faint); }
+.pair-note { margin: 12px 0 0; font-size: 0.9rem; line-height: 1.6; color: color-mix(in oklab, var(--ink) 74%, transparent); max-width: 74ch; }
+.pair-proof {
+  display: flex; flex-direction: column; gap: 6px; margin: 0 16px 16px; padding: 13px 16px;
+  border: 1px dashed color-mix(in oklab, var(--amb) 40%, var(--hairline-strong)); border-radius: 10px;
+}
+.pair-proof-k { font-family: var(--font-mono); font-size: 0.58rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--amb); font-weight: 700; }
+.pair-proof-t { font-size: 0.84rem; line-height: 1.6; color: color-mix(in oklab, var(--ink) 74%, transparent); }
+
+/* ── Get it / finale ──────────────────────────────────────────────────── */
+.get { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.get-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: clamp(24px, 3vw, 48px); align-items: center; }
+.get-intro { min-width: 0; }
+.get-intro h2 { font-size: clamp(1.8rem, 3.4vw, 2.8rem); margin: 12px 0 0; }
+.get-intro p { margin: 18px 0 0; font-size: 1.02rem; line-height: 1.65; color: color-mix(in oklab, var(--ink) 78%, transparent); max-width: 50ch; }
+.get-intro p b { color: var(--ink); }
+.get-alt { font-size: 0.86rem !important; color: var(--muted) !important; }
+
+.install { min-width: 0; width: 100%; border: 1px solid var(--hairline-strong); border-radius: 12px; overflow: hidden; background: var(--surface-2); }
+.install__bar { display: flex; align-items: center; justify-content: space-between; gap: 8px 12px; flex-wrap: wrap; padding: 10px 14px; border-bottom: 1px solid var(--hairline); background: color-mix(in oklab, var(--canvas) 50%, transparent); }
+.install__label { min-width: 0; font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.install__copy { font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 0.06em; color: var(--muted); background: transparent; border: 1px solid var(--hairline-strong); border-radius: 6px; padding: 4px 12px; cursor: pointer; transition: border-color .2s var(--ease), color .2s var(--ease); }
+.install__copy:hover { border-color: var(--accent); color: var(--accent); }
+.install__code { min-width: 0; margin: 0; padding: 16px; overflow-x: auto; }
+.install__code code { display: block; background: none; border: none; padding: 0; font-family: var(--font-mono); font-size: 0.82rem; line-height: 1.8; color: var(--ink); white-space: pre; }
+.install__code .c { color: var(--faint); }
+.install-stack { min-width: 0; display: flex; flex-direction: column; gap: 12px; }
+.install--primary { border-color: color-mix(in oklab, var(--accent) 55%, var(--hairline-strong)); box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 18%, transparent), 0 24px 48px -34px rgba(0,0,0,.6); }
+.install--primary .install__bar { background: color-mix(in oklab, var(--accent) 12%, transparent); }
+.install--primary .install__label { color: var(--ink); }
+.install__star { color: var(--accent); }
+.install__note { margin: 0; padding: 10px 16px 14px; font-family: var(--font-mono); font-size: 0.68rem; line-height: 1.5; color: var(--muted); border-top: 1px solid var(--hairline); }
+.install__ver { color: var(--accent); }
+.install--secondary { background: color-mix(in oklab, var(--surface-2) 70%, transparent); }
+.install-or { display: flex; align-items: center; gap: 12px; margin: 2px 0; }
+.install-or::before, .install-or::after { content: ''; flex: 1; height: 1px; background: var(--hairline-strong); }
+.install-or span { font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); }
+
+.gh-pill { grid-column: 1 / -1; justify-self: start; display: inline-flex; align-items: center; gap: 14px; margin-top: 8px; padding: 12px 22px 12px 14px; border: 1px solid var(--hairline-strong); border-radius: 999px; color: var(--ink); text-decoration: none; transition: border-color .22s var(--ease), color .22s var(--ease), transform .22s var(--ease); }
+.gh-pill:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-2px); }
+.gh-pill span { font-family: var(--font-mono); font-size: 0.82rem; letter-spacing: 0.04em; }
+
+/* ── Responsive ───────────────────────────────────────────────────────── */
+@media (max-width: 940px) {
+  .get-grid { grid-template-columns: 1fr; }
+  .lede, .get-intro p { max-width: none; }
+  .console-cols { grid-template-columns: 1fr; }
+  .board-layout { grid-template-columns: 1fr; }
+  .board-list { grid-template-columns: repeat(4, 1fr); }
+}
+@media (max-width: 640px) {
+  .board-list { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ── Phone DENSITY (<=600px) ──────────────────────────────────────────────
+   The live console is a desktop affordance — on a phone we hide it and show
+   the static launch → watch → steer story instead. Board tiles compress. */
+@media (max-width: 600px) {
+  .console { display: none; }
+  .console-static { display: block; }
+  .lede { max-width: none; }
+  .board-item { padding: 9px 11px; }
+  .bi-name { font-size: 0.7rem; }
+  .proj-feed li { font-size: 0.68rem; }
+  .pair-code code { font-size: 0.68rem; }
+}
+/* Phone-native static console: hidden on desktop (min-width guard so the
+   ≤600px display:block above wins on phones). */
+@media (min-width: 601px) { .console-static { display: none; } }
+
+.console-static {
+  border: 1px solid var(--hairline-strong); border-radius: 14px; overflow: hidden;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%); padding: 16px;
+}
+.cs-steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 14px; }
+.cs-steps li { display: flex; gap: 12px; align-items: flex-start; font-size: 0.88rem; line-height: 1.55; color: color-mix(in oklab, var(--ink) 78%, transparent); }
+.cs-steps b { color: var(--ink); }
+.cs-n {
+  flex-shrink: 0; width: 24px; height: 24px; display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 0.7rem; font-weight: 700;
+  color: var(--accent-ink); background: var(--amb); border-radius: 50%;
+}
+.cs-chip { display: inline-block; margin-top: 4px; font-family: var(--font-mono); font-size: 0.62rem; color: var(--deny); border: 1px solid color-mix(in oklab, var(--deny) 45%, transparent); border-radius: 999px; padding: 2px 9px; }
+
+/* ── Reduced motion: keep every state, drop the animation ─────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .cf-row { animation: none; }
+  .cg-cue { animation: none; }
+  .btn, .cg-btn, .cl-go, .board-item, .gh-pill { transition: none; }
+  .btn-primary:hover, .cl-go:hover, .board-item:hover, .gh-pill:hover { transform: none; }
+  html { scroll-behavior: auto; }
+}

--- a/site/tests/e2e/board.spec.ts
+++ b/site/tests/e2e/board.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The run board [data-board] — the SPA's real panels as an auto-cycling
+ * switcher. Clicking a panel pins it (stage swaps name + API route + line);
+ * the status button resumes the cycle.
+ */
+test.describe('the run board [data-board]', () => {
+  test('eight real panels render; clicking one pins the stage to it', async ({ page }) => {
+    await page.goto('/');
+    const board = page.locator('[data-board]');
+    await bringIntoView(board);
+    await expect(board.locator('[data-board-item]')).toHaveCount(8);
+
+    // Pin the workflows panel: the stage swaps to its name + real route.
+    await board.getByRole('tab', { name: 'workflows' }).click();
+    await expect(page.locator('[data-bs-name]')).toHaveText('workflows');
+    await expect(page.locator('[data-bs-api]')).toHaveText('GET /workflows');
+    await expect(page.locator('[data-bs-line]')).toContainText('WorkflowDef');
+    await expect(board.getByRole('tab', { name: 'workflows' })).toHaveAttribute('aria-selected', 'true');
+
+    // Pinning pauses the auto-cycle and says so.
+    await expect(page.locator('[data-board-status-txt]')).toContainText('pinned');
+
+    // Pin policies: honest line — the skin surfaces the gate, never grades.
+    await board.getByRole('tab', { name: 'policies' }).click();
+    await expect(page.locator('[data-bs-api]')).toHaveText('GET /governance/policies');
+    await expect(page.locator('[data-bs-line]')).toContainText('never grades');
+
+    // The status button resumes the auto-cycle.
+    await page.locator('[data-board-toggle]').click();
+    await expect(page.locator('[data-board-status-txt]')).toContainText('auto-cycling');
+  });
+});

--- a/site/tests/e2e/chrome.spec.ts
+++ b/site/tests/e2e/chrome.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * wicked-web chrome (Topbar) — theme toggle (#themeBtn ↔ data-theme on <html>,
+ * persisted under localStorage 'wa-theme') and the ecosystem dropdown
+ * (#projectsBtn → #projectsMenu), which lists studio as a first-class
+ * experience-plane product with a SITE link.
+ */
+test.describe('site chrome (wicked-web topbar)', () => {
+  test('theme toggle flips data-theme on <html> and persists across reload', async ({ page }) => {
+    await page.goto('/');
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('data-theme', 'light');
+
+    await page.locator('#themeBtn').click();
+    await expect(html).toHaveAttribute('data-theme', 'dark');
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('wa-theme')))
+      .toBe('dark');
+
+    // Persists: the no-flash init re-applies the stored theme on reload.
+    await page.reload();
+    await expect(html).toHaveAttribute('data-theme', 'dark');
+
+    // And toggles back.
+    await page.locator('#themeBtn').click();
+    await expect(html).toHaveAttribute('data-theme', 'light');
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('wa-theme')))
+      .toBe('light');
+  });
+
+  test('ecosystem dropdown opens, lists studio as a site, closes on Escape', async ({ page }) => {
+    await page.goto('/');
+    const btn = page.locator('#projectsBtn');
+    const menu = page.locator('#projectsMenu');
+
+    await expect(menu).toBeHidden();
+    await btn.click();
+    await expect(menu).toBeVisible();
+    await expect(btn).toHaveAttribute('aria-expanded', 'true');
+
+    // Studio is a first-class product: its row is a SITE link to ws.wickedagile.com.
+    const studioRow = menu.getByRole('link', { name: /studio/ });
+    await expect(studioRow).toBeVisible();
+    await expect(studioRow).toHaveAttribute('href', 'https://ws.wickedagile.com');
+    await expect(studioRow).toContainText('site');
+
+    await expect(menu.getByRole('link', { name: /garden/ })).toBeVisible();
+    await expect(menu.getByRole('link', { name: /estate/ })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(menu).toBeHidden();
+    await expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/site/tests/e2e/console.spec.ts
+++ b/site/tests/e2e/console.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The hero console [data-console] — the page's signature: this IS the product.
+ * Launch → the CoreEvent feed streams (700ms/step) → the steering gate raises →
+ * the human resolves it. The submit handler resets + re-streams a fresh run,
+ * which makes the flow deterministic regardless of the scroll-in auto-play.
+ */
+test.describe('the console [data-console]', () => {
+  test('launch streams the feed, raises the gate, approve advances the run', async ({ page }) => {
+    await page.goto('/');
+    const console_ = page.locator('[data-console]');
+    await bringIntoView(console_);
+
+    // Relaunch deterministically (the widget also auto-runs on scroll-in;
+    // submitting resets the feed and streams a fresh run).
+    await console_.locator('[data-console-go]').click();
+
+    const feed = console_.locator('[data-console-feed]');
+    await expect(feed.locator('.cf-row').first()).toBeVisible();
+
+    // The stream ends held at the gate: 7 feed rows, gate visible, verdict DENY.
+    const gate = console_.locator('[data-console-gate]');
+    await expect(gate).toBeVisible({ timeout: 15_000 });
+    await expect(feed.locator('.cf-row')).toHaveCount(7);
+    await expect(feed.locator('.cf-row').first()).toContainText('POST /api/v1/runs');
+    await expect(feed.locator('.cf-row').last()).toContainText('held for your decision');
+    const stamp = console_.locator('[data-cg-stamp]');
+    await expect(stamp).toHaveText('DENY');
+
+    // All three steering actions are offered and live.
+    const approve = gate.locator('[data-cg-action="approve"]');
+    await expect(approve).toBeEnabled();
+    await expect(gate.locator('[data-cg-action="steer"]')).toBeEnabled();
+    await expect(gate.locator('[data-cg-action="reject"]')).toBeEnabled();
+
+    // Approve advances the flow: verdict flips, the override is logged on the
+    // decisions ledger, the terminal posts the gate decision, buttons retire.
+    await approve.click();
+    await expect(stamp).toHaveText('ALLOW');
+    await expect(gate).toHaveAttribute('data-verdict', 'allow');
+    await expect(feed.locator('.cf-row').last()).toContainText('allowed');
+    await expect(console_.locator('[data-console-term]')).toContainText('POST /api/v1/runs/r-7c19/gate');
+    await expect(approve).toBeDisabled();
+  });
+
+  test('approve-with-steer opens the amendment and re-verifies to PASS', async ({ page }) => {
+    await page.goto('/');
+    const console_ = page.locator('[data-console]');
+    await bringIntoView(console_);
+    await console_.locator('[data-console-go]').click();
+
+    const gate = console_.locator('[data-console-gate]');
+    await expect(gate).toBeVisible({ timeout: 15_000 });
+
+    // Steer opens an amendment input pre-filled with a real fix.
+    await gate.locator('[data-cg-action="steer"]').click();
+    const amend = gate.locator('.cg-amend input');
+    await expect(amend).toBeVisible();
+    await amend.fill('add rollback migration + regen schema');
+    await amend.press('Enter');
+
+    // The amendment rides the next prompt; the gate re-verifies to ALLOW and
+    // the terminal resumes the run over the real route.
+    await expect(console_.locator('[data-cg-stamp]')).toHaveText('ALLOW');
+    const feed = console_.locator('[data-console-feed]');
+    await expect(feed.locator('.cf-row').last()).toContainText('PASS');
+    await expect(console_.locator('[data-console-term]')).toContainText('POST /api/v1/runs/r-7c19/resume');
+  });
+
+  test('reject holds the run — nothing ships', async ({ page }) => {
+    await page.goto('/');
+    const console_ = page.locator('[data-console]');
+    await bringIntoView(console_);
+    await console_.locator('[data-console-go]').click();
+
+    const gate = console_.locator('[data-console-gate]');
+    await expect(gate).toBeVisible({ timeout: 15_000 });
+
+    await gate.locator('[data-cg-action="reject"]').click();
+    await expect(console_.locator('[data-cg-stamp]')).toHaveText('DENY');
+    await expect(gate).toHaveAttribute('data-verdict', 'deny');
+    const feed = console_.locator('[data-console-feed]');
+    await expect(feed.locator('.cf-row').last()).toContainText('awaiting a new diff');
+    await expect(console_.locator('[data-console-term]')).toContainText('gate reject');
+  });
+});

--- a/site/tests/e2e/copy.spec.ts
+++ b/site/tests/e2e/copy.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The install copy buttons + the page's honest-boundary copy.
+ * Clipboard permissions granted; 127.0.0.1 is a secure context.
+ */
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+test.describe('install copy buttons', () => {
+  test('bundled serve copy button copies the command and shows feedback', async ({ page }) => {
+    await page.goto('/');
+    const btn = page.getByRole('button', { name: 'Copy the bundled serve command' });
+    await bringIntoView(btn);
+    await btn.click();
+
+    await expect(btn).toHaveText('Copied');
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe('npx wicked-crew serve');
+
+    // Feedback resets after ~1.4s.
+    await expect(btn).toHaveText('Copy');
+  });
+
+  test('standalone copy button copies both commands', async ({ page }) => {
+    await page.goto('/');
+    const btn = page.getByRole('button', { name: 'Copy the standalone build commands' });
+    await bringIntoView(btn);
+    await btn.click();
+
+    await expect(btn).toHaveText('Copied');
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe('VITE_API_HOST=127.0.0.1:7701 npm run build\nnpx serve dist');
+
+    await expect(btn).toHaveText('Copy');
+  });
+});
+
+test.describe('honest boundaries', () => {
+  test('the page claims pure-client status, never governance ownership', async ({ page }) => {
+    await page.goto('/');
+
+    // The seam section owns the honesty headline: zero crew source, one contract.
+    const pair = page.locator('.pair');
+    await bringIntoView(pair);
+    await expect(pair).toContainText('zero');
+    await expect(pair).toContainText('wicked-crew-api-types');
+    await expect(pair).toContainText('there is no back channel');
+
+    // The board credits governance to crew — the skin surfaces, never grades.
+    const board = page.locator('.board');
+    await bringIntoView(board);
+    await expect(board).toContainText('never grades');
+    await expect(board.getByRole('link', { name: 'crew’s' })).toHaveAttribute(
+      'href',
+      'https://wc.wickedagile.com'
+    );
+  });
+});

--- a/site/tests/e2e/mobile.spec.ts
+++ b/site/tests/e2e/mobile.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, devices } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * Phone-native fallbacks (≤600px): the live console is a desktop affordance —
+ * a phone gets the static launch → watch → steer story (.console-static)
+ * instead, and the page never scrolls horizontally.
+ */
+// iPhone 12 geometry/UA only — the full descriptor carries
+// defaultBrowserType: 'webkit', which would switch away from the cached Chromium.
+const iphone12 = devices['iPhone 12'];
+test.use({
+  viewport: iphone12.viewport,
+  userAgent: iphone12.userAgent,
+  deviceScaleFactor: iphone12.deviceScaleFactor,
+  isMobile: iphone12.isMobile,
+  hasTouch: iphone12.hasTouch,
+});
+
+test.describe('mobile (390×844)', () => {
+  test('the static console fallback replaces the live console', async ({ page }) => {
+    await page.goto('/');
+
+    // Live console hidden, static launch → watch → steer story shown.
+    await expect(page.locator('[data-console]')).toBeHidden();
+    const staticConsole = page.locator('.console-static');
+    await expect(staticConsole).toBeVisible();
+    await expect(staticConsole.locator('.cs-steps li')).toHaveCount(3);
+    await expect(staticConsole).toContainText('Launch');
+    await expect(staticConsole).toContainText('Steer');
+    await expect(staticConsole).toContainText('DENY');
+  });
+
+  test('no horizontal overflow anywhere on the page', async ({ page }) => {
+    await page.goto('/');
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
+  });
+
+  test('the projects card, seam panel, and four-plane map render on a phone', async ({ page }) => {
+    await page.goto('/');
+
+    // One project, two skins: the toggle still works with touch targets.
+    const card = page.locator('[data-proj]');
+    await bringIntoView(card);
+    await expect(card).toBeVisible();
+    await card.getByRole('tab', { name: /interactive · creator/ }).click();
+    await expect(card).toHaveAttribute('data-skin', 'interactive');
+
+    // The seam panel keeps both modes reachable.
+    const pair = page.locator('[data-pair]');
+    await bringIntoView(pair);
+    await expect(pair).toBeVisible();
+    await pair.getByRole('tab', { name: /standalone/ }).click();
+    await expect(pair).toHaveAttribute('data-mode', 'standalone');
+
+    // SameGarden is CSS-only and degrades — all four planes visible.
+    const map = page.locator('.same-garden');
+    await bringIntoView(map);
+    await expect(map).toBeVisible();
+    await expect(map.locator('.sg-plane')).toHaveCount(4);
+    await expect(map.locator('.sg-card--here')).toBeVisible();
+  });
+
+  test('the hamburger menu lists studio as a site link', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#menuBtn').click();
+    const menu = page.locator('#mobileMenu');
+    await expect(menu).toBeVisible();
+    const studioRow = menu.getByRole('link', { name: /studio/ });
+    await expect(studioRow).toHaveAttribute('href', 'https://ws.wickedagile.com');
+  });
+});

--- a/site/tests/e2e/pairing.spec.ts
+++ b/site/tests/e2e/pairing.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The client seam [data-pair] — how the SPA finds its daemon. Two modes,
+ * both real (src/api/client.ts): bundled/same-origin (window.location.origin)
+ * and standalone (VITE_API_HOST baked at build time). The standalone proof
+ * strip cites the scripted e2e.
+ */
+test.describe('the client seam [data-pair]', () => {
+  test('defaults to bundled; flipping shows the standalone pairing', async ({ page }) => {
+    await page.goto('/');
+    const panel = page.locator('[data-pair]');
+    await bringIntoView(panel);
+    await expect(panel).toHaveAttribute('data-mode', 'bundled');
+
+    // Bundled: same-origin resolution, one command.
+    const bundled = panel.locator('.pair-stage--bundled');
+    await expect(bundled).toBeVisible();
+    await expect(bundled).toContainText('npx wicked-crew serve');
+    await expect(bundled).toContainText("window.location.origin + '/api/v1'");
+    await expect(panel.locator('.pair-stage--standalone')).toBeHidden();
+
+    // Flip to standalone: VITE_API_HOST pairing against any daemon.
+    await panel.getByRole('tab', { name: /standalone/ }).click();
+    await expect(panel).toHaveAttribute('data-mode', 'standalone');
+    const standalone = panel.locator('.pair-stage--standalone');
+    await expect(standalone).toBeVisible();
+    await expect(standalone).toContainText('VITE_API_HOST=127.0.0.1:7701');
+    await expect(standalone).toContainText('http://127.0.0.1:7701/api/v1');
+    await expect(bundled).toBeHidden();
+
+    // The proof strip stays put in either mode: the carve's scripted e2e.
+    const proof = panel.locator('.pair-proof');
+    await expect(proof).toBeVisible();
+    await expect(proof).toContainText('e2e/studio_standalone_test.py');
+    await expect(proof).toContainText('approve a human gate');
+  });
+});

--- a/site/tests/e2e/planes.spec.ts
+++ b/site/tests/e2e/planes.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The shared-chrome SameGarden map (.same-garden) with wicked-studio's card
+ * as the "you are here" marker — the map stays complete, the site never
+ * promotes itself, and the sibling skin (wicked-interactive) stays linked.
+ */
+test.describe('SameGarden four-plane map (.same-garden)', () => {
+  test('all four planes render with wicked-studio as "you are here"', async ({ page }) => {
+    await page.goto('/');
+    const map = page.locator('.same-garden');
+    await bringIntoView(map);
+    await expect(map).toBeVisible();
+
+    // Four plane bands, three contract seams between them.
+    await expect(map.locator('.sg-plane')).toHaveCount(4);
+    await expect(map.locator('.sg-contract')).toHaveCount(3);
+
+    // Studio's card is the non-link "you are here" marker.
+    const here = map.locator('.sg-card--here');
+    await expect(here).toHaveCount(1);
+    await expect(here).toContainText('wicked-studio');
+    await expect(here.locator('.sg-here-chip')).toHaveText('you are here');
+
+    // The sibling skin shares the experience plane and stays linked.
+    const experience = map.locator('.sg-plane--experience');
+    await expect(experience.locator('.sg-card')).toHaveCount(2);
+    await expect(map.getByRole('link', { name: 'Visit wicked-interactive' })).toBeVisible();
+
+    // The rest of the family stays complete and linked.
+    await expect(map.getByRole('link', { name: 'Visit wicked-crew' })).toBeVisible();
+    await expect(map.getByRole('link', { name: 'Visit wicked-garden' })).toBeVisible();
+    await expect(map.getByRole('link', { name: 'Visit wicked-estate' })).toBeVisible();
+  });
+});

--- a/site/tests/e2e/projects.spec.ts
+++ b/site/tests/e2e/projects.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * One project, two skins [data-proj] — the experience-plane interchangeability
+ * story. The same project (payments-refresh) re-renders under either skin;
+ * the API call in the foot never changes, and the honest note keeps the
+ * studio's own project browser labeled as landing.
+ */
+test.describe('one project, two skins [data-proj]', () => {
+  test('defaults to the coder skin; flipping renders the same project as the creator skin', async ({ page }) => {
+    await page.goto('/');
+    const card = page.locator('[data-proj]');
+    await bringIntoView(card);
+    await expect(card).toHaveAttribute('data-skin', 'studio');
+
+    // The studio rendering shows; the interactive one is hidden.
+    await expect(card.locator('.proj-feed--studio')).toBeVisible();
+    await expect(card.locator('.proj-feed--interactive')).toBeHidden();
+    await expect(card.locator('.proj-feed--studio li').first()).toContainText('run r-7c19');
+    await expect(card.locator('[data-proj-skin-label]')).toHaveText('coder’s');
+
+    // Flip to the creator skin — same project, other door.
+    await card.getByRole('tab', { name: /interactive · creator/ }).click();
+    await expect(card).toHaveAttribute('data-skin', 'interactive');
+    await expect(card.locator('.proj-feed--studio')).toBeHidden();
+    const intFeed = card.locator('.proj-feed--interactive');
+    await expect(intFeed).toBeVisible();
+    // The real bus vocabulary rides the creator rendering.
+    await expect(intFeed.locator('li').first()).toContainText('wicked.interactive.doc.created');
+    await expect(intFeed).toContainText('wicked.interactive.draft.completed');
+    await expect(card.locator('[data-proj-skin-label]')).toHaveText('creator’s');
+
+    // The project id and the API call never change — one room, two doors.
+    await expect(card.locator('.proj-id')).toContainText('payments-refresh');
+    await expect(card.locator('.proj-call')).toHaveText('GET /api/v1/projects/payments-refresh/activity');
+
+    // And back.
+    await card.getByRole('tab', { name: /studio · coder/ }).click();
+    await expect(card).toHaveAttribute('data-skin', 'studio');
+    await expect(card.locator('.proj-feed--studio')).toBeVisible();
+  });
+
+  test('the honest note ships: model shipped in the control plane, browser landing in the skin', async ({ page }) => {
+    await page.goto('/');
+    const note = page.locator('.proj .honest-note');
+    await bringIntoView(note);
+    await expect(note).toContainText('shipped in the control plane');
+    await expect(note).toContainText('landing in this skin');
+  });
+});

--- a/site/tests/e2e/rail.spec.ts
+++ b/site/tests/e2e/rail.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * The insight rail [data-rail] — 8 chips (Burn, Decisions, Governance,
+ * Assumptions, Steering, Files, Term, Cov); clicking one swaps the caption
+ * line to that panel's answer.
+ */
+test.describe('insight rail [data-rail]', () => {
+  test('eight chips render; clicking one swaps the caption', async ({ page }) => {
+    await page.goto('/');
+    const rail = page.locator('[data-rail]');
+    await bringIntoView(rail);
+    await expect(rail.locator('[data-rail-chip]')).toHaveCount(8);
+
+    // Burn is the default active chip and its caption shows.
+    const line = page.locator('[data-rail-line]');
+    await expect(rail.locator('[data-rail-chip].is-active')).toHaveText('Burn');
+    await expect(line).toContainText('Tokens, cost, and rework');
+
+    // Click Term → the PTY caption, with the real WS route.
+    await rail.getByRole('button', { name: 'Term', exact: true }).click();
+    await expect(line).toContainText('/ws/terminals/:id');
+    await expect(rail.locator('[data-rail-chip].is-active')).toHaveText('Term');
+
+    // Click Decisions → the ledger caption.
+    await rail.getByRole('button', { name: 'Decisions' }).click();
+    await expect(line).toContainText('who approved what');
+  });
+});

--- a/site/tests/e2e/reduced-motion.spec.ts
+++ b/site/tests/e2e/reduced-motion.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * prefers-reduced-motion: the page must load with zero pageerror events and
+ * every key section visible. The console renders its run fully and instantly
+ * (no 700ms streaming), ending at the gate; the board does not auto-cycle.
+ */
+test.use({ contextOptions: { reducedMotion: 'reduce' } });
+
+test.describe('reduced motion', () => {
+  test('page loads clean and every key section renders', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    await page.goto('/');
+    await expect(page.locator('.hero h1')).toBeVisible();
+
+    // The console's reduced path renders the whole run at once — all 7 rows
+    // and the gate, with no waiting on the stream.
+    const console_ = page.locator('[data-console]');
+    await bringIntoView(console_);
+    await expect(console_.locator('[data-console-gate]')).toBeVisible();
+    await expect(console_.locator('.cf-row')).toHaveCount(7);
+
+    // Every key section is present and visible.
+    for (const sel of ['[data-board]', '[data-proj]', '[data-pair]', '.same-garden', '.install--primary']) {
+      const loc = page.locator(sel);
+      await bringIntoView(loc);
+      await expect(loc).toBeVisible();
+    }
+
+    // The board stays put (no auto-cycle under reduced motion): the stage
+    // still answers a click.
+    await page.locator('[data-board]').getByRole('tab', { name: 'repos' }).click();
+    await expect(page.locator('[data-bs-name]')).toHaveText('repos');
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/site/tests/e2e/utils.ts
+++ b/site/tests/e2e/utils.ts
@@ -1,0 +1,14 @@
+import type { Locator } from '@playwright/test';
+
+/**
+ * Instant JS scroll that skips Playwright's "stable bounding box" wait.
+ *
+ * The page runs independent autoplay intervals (the console feed 0.7s/step,
+ * the run-board cycle 3s) that keep shifting layout, so
+ * `scrollIntoViewIfNeeded()` can starve on its stability check. Scrolling is
+ * only needed to trigger the IntersectionObserver-armed widgets; subsequent
+ * clicks/assertions perform their own actionability checks.
+ */
+export async function bringIntoView(loc: Locator): Promise<void> {
+  await loc.evaluate((el) => el.scrollIntoView({ block: 'center' }));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -9,5 +9,10 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
+    // site/ is the marketing site — its own app with its own deps and a
+    // Playwright suite (site/tests/e2e, run by the Site E2E workflow).
+    // Without this, vitest's default include sweeps those *.spec.ts files
+    // and fails resolving @playwright/test (installed only under site/).
+    exclude: [...configDefaults.exclude, 'site/**'],
   },
 });


### PR DESCRIPTION
The wicked-studio deep-dive site, following the family pattern: Astro under `site/`, shared [wicked-web](https://github.com/mikeparcewski/wicked-web) chrome pinned to **cf770de** (the studio-first-class chrome from wicked-web#24), CNAME `ws.wickedagile.com`, dark/light themes, mobile-native fallbacks, reduced-motion support.

## The story
studio is the **coder-facing skin** of the experience plane — the run board for governed agent delivery, a **pure HTTP/WS client** of the crew daemon's `/api/v1` + `/ws`.

| Section | Interactive | Grounded in |
|---|---|---|
| **Hero — THE CONSOLE** | launch a run from a plain-text brief → CoreEvent feed streams → steering gate (approve / approve-with-steer / reject) → governed terminal posts the decision | real routes from `src/api/client.ts`: `POST /runs`, `POST /runs/:id/gate`, `POST /runs/:id/resume`, `/ws/terminals/:id` |
| Insight rail | 8 clickable chips (Burn, Decisions, Governance, Assumptions, Steering, Files, Term, Cov) swap the caption | the SPA's InsightRail panels |
| **The run board** | auto-cycling panel switcher, click to pin | the SPA's real panels (`useRoute.ts`) + their real routes (`/workflows`, `/governance/policies`, `/domain-graph`, …) |
| **One project, two skins** | skin toggle re-renders the same project (same `GET /projects/:id/activity`) | the shipped control-plane Project model + the `wicked.interactive.*` bus vocabulary; the studio's own project browser is honestly labeled **landing in this skin** |
| **The client seam** | bundled/same-origin ↔ standalone/`VITE_API_HOST` pairing toggle | `src/api/client.ts` origin resolution + the carve proof `e2e/studio_standalone_test.py` |
| Get it | copy buttons | `npx wicked-crew serve` (bundled dist) or the standalone build |
| SameGarden | `current="wicked-studio"` — you-are-here card | shared chrome |

## E2E
**19 Playwright tests / 10 spec files** (chrome, console ×3, rail, board, projects ×2, pairing, planes, copy ×3, mobile ×4, reduced-motion) — all green locally against the pinned chrome.

## Workflows
- `pages.yml` — Pages deploy on push to main (enablement: true for first run), modeled on crew's
- `site-e2e.yml` — PR smoke on `site/**`

## Notes
- astro pinned **7.1.3** (family-consistent): 7.2 daemonizes `astro preview`, which breaks Playwright's webServer readiness probe.
- `.gitignore` gains `.astro/`, `playwright-report/`, `test-results/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)