### PR TITLE
chore(deps): consume wicked-crew-api-types from npm (^0.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "github:mikeparcewski/wicked-crew#api-types-v0.1.0"
+        "wicked-crew-api-types": "^0.1.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7147,7 +7147,8 @@
     },
     "node_modules/wicked-crew-api-types": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-crew.git#b0ac6fa9c4ed4efb5c74bdae50e41ff07a945c45",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.1.0.tgz",
+      "integrity": "sha512-3sbcCRzE5mGBMdhdLulQSE31zqUb9VE1/Uuvts+2AZhRy29LV7OOjj3kDPt0Hcsrx7zH7RWL/TsNxvYRaGLK3w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "github:mikeparcewski/wicked-crew#api-types-v0.1.0"
+    "wicked-crew-api-types": "^0.1.0"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## What

Flips the interim gitpkg dependency to the published npm package:

- `wicked-crew-api-types`: `github:mikeparcewski/wicked-crew#api-types-v0.1.0` → `^0.1.0` (devDependencies)

`wicked-crew-api-types@0.1.0` is now on the registry (`npm view wicked-crew-api-types version` → `0.1.0`), so the git-tag workaround is no longer needed. Lockfile rebuilt — the entry now resolves to `registry.npmjs.org` with an integrity hash instead of a git SHA.

## Verification

- `npm run typecheck` — clean
- `npm test` — 30 files, 239 tests passed
- `npm run build` (tsc + vite) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)