### PR TITLE
docs(.product): add REQ-001, DES-001, RAID for wicked-studio (P9 DoD blocker)

### DIFF
--- a/.product/DES-001-technical-design.md
+++ b/.product/DES-001-technical-design.md
@@ -1,0 +1,182 @@
+---
+name: DES-001-technical-design
+title: wicked-studio — Technical Design
+status: approved
+version: 0.1
+date: 2026-08-12
+author: mike.parcewski@gmail.com
+review-required: false
+---
+
+# DES-001 — Technical Design
+
+## 1. Architecture Position
+
+wicked-studio is the **coder skin** of the experience plane. It sits at the top of the four-plane
+dependency stack and has the narrowest coupling of any product: it imports only
+`wicked-crew-api-types` (the published wire contract) and speaks HTTP + WebSocket to the crew
+daemon. No Rust, no engine code, no SQLite.
+
+```
+┌─────────────────────────────────────┐
+│ EXPERIENCE PLANE                    │
+│  wicked-studio  wicked-interactive  │  ← this product
+└──────────────┬──────────────────────┘
+               │ HTTP /api/v1 + WS /ws
+               ▼
+┌─────────────────────────────────────┐
+│ CONTROL PLANE                       │
+│  wicked-crew (daemon + wicked-core) │
+└─────────────────────────────────────┘
+```
+
+---
+
+## 2. Key Decisions
+
+### ADR-001 — Own repository, not crew package
+
+**Context**: studio v2 started as `wicked-crew/packages/studio` (pre-2026-08 consolidation).
+
+**Decision**: Carved out as a standalone repo (`wicked-studio`) with its own version, CI, npm
+package, and GitHub Pages site. wicked-crew declares `wicked-studio` as a `devDependency` and
+copies `dist/` into the daemon's serving tree via `build:with-studio`.
+
+**Rationale**: Independent versioning; studio can ship ahead of crew; avoids workspace coupling.
+The design principle "one binary per product, one repo per product" applies here.
+
+**Consequence**: crew's release build must install devDeps to get studio's dist. Circular risk is
+managed by the dependency direction: crew depends on studio's *build artifact*, never on its
+source or types — studio depends on crew's wire contract package, never on crew's source.
+
+### ADR-002 — Wire contract via npm package, not shared source
+
+**Context**: Studio needs types for the API responses it consumes from crew.
+
+**Decision**: `wicked-crew-api-types` is the only cross-repo import. It is a separate package
+published from `wicked-crew/packages/crew-api-types`. Studio pins it as a dependency.
+
+**Rationale**: Decouples studio from crew release cadence. The type contract is versioned
+independently; drift is caught at compile time by the wire-contract test in crew.
+
+**Consequence**: When crew's API shape changes, `crew-api-types` must be bumped and studio must
+re-pin. This is intentional friction that forces explicit contract negotiation.
+
+### ADR-003 — Same-origin serve, no baked host
+
+**Context**: In production (crew bundling studio's dist), studio and the daemon share the same
+origin. In development, they run on different ports.
+
+**Decision**: In production, use `window.location.origin` as the daemon URL — no host is baked
+into the bundle. In development, use `VITE_API_HOST` (`.env.development` defaults to
+`127.0.0.1:7701`).
+
+**Rationale**: Same-origin production avoids CORS configuration entirely. The dev split is
+explicit and local.
+
+**Consequence**: A standalone build for a non-localhost host requires setting `VITE_API_HOST` at
+build time.
+
+### ADR-004 — Terminal access requires operator trust
+
+**Context**: Studio opens `/ws/terminals/:id` to stream live PTY output from agent worker
+processes. The WebSocket upgrade uses HTTP GET, but inbound frames are raw PTY stdin.
+
+**Decision**: The crew auth hook (`requiredTrust`) treats `/ws/terminals/` paths as `operator`
+regardless of method — before the GET/HEAD blanket observer rule.
+
+**Rationale**: An observer with stdin injection capability can steer a running agent. The trust
+ladder guarantees observer = read-only. Terminal channels are write-capable.
+
+**Consequence**: Studio must present an operator-or-higher token to open a terminal WS.
+
+---
+
+## 3. Module Map
+
+```
+src/
+  api/
+    client.ts          # HTTP wrapper: base URL, auth header, error handling
+    ws.ts              # WebSocket manager: connect, reconnect, event fan-out
+  components/
+    RunList.tsx         # run cards with live status badges
+    RunDetail.tsx       # phase graph, event feed, gate card
+    GateCard.tsx        # HITL gate: artifact + approve/reject/modify
+    Terminal.tsx        # xterm.js instance, backed by /ws/terminals/:id
+    Projects.tsx        # project browser + create/archive
+    Evidence.tsx        # evidence record list + expandable detail
+  hooks/
+    useRuns.ts          # TanStack Query: GET /api/v1/runs, invalidate on events
+    useCoreEvents.ts    # WebSocket /ws fan-out → React events
+    useAuth.ts          # token management, trust level display
+  store/
+    ui.ts               # Zustand: selected run, panel state, filter state
+  types/
+    index.ts            # re-exports from wicked-crew-api-types
+```
+
+---
+
+## 4. Data Flow
+
+```
+                  ┌──────────────┐
+  CoreEvents      │  /ws WebSocket│ → useCoreEvents hook → event bus
+  (read-only fan) └──────────────┘
+                                           │
+                                   invalidate TanStack Query cache
+                                           │
+  REST (read)     ┌──────────────┐         ▼
+  GET /api/v1/*   │  Fastify API  │ → RunList / RunDetail / Evidence
+                  └──────────────┘
+  REST (write)    ┌──────────────┐
+  POST /api/v1/*  │  (same API)  │ ← GateCard / LaunchDialog / Projects
+                  └──────────────┘
+
+  PTY stdin       ┌──────────────────────┐
+  GET /ws/        │  /ws/terminals/:id   │ → Terminal component (xterm.js)
+  terminals/:id   │  (operator trust req)│ ← keystroke frames
+                  └──────────────────────┘
+```
+
+---
+
+## 5. Auth Integration
+
+Studio reads auth config from crew's `GET /api/v1/settings` on startup (or infers `authMode:
+'off'` from a 401-free root). When auth is required:
+
+- Token sourced from `localStorage` (user pastes it from `wicked-crew token print`)
+- Sent as `Authorization: Bearer <token>` on REST calls
+- Sent as `?access_token=<token>` on WS upgrade (RFC 6750 §2.3; browser WebSocket cannot set headers)
+
+---
+
+## 6. Deployment
+
+### Bundled with crew (default)
+
+`wicked-crew build:with-studio` runs `npm install && npm run build` in wicked-studio, then copies
+`dist/` to `packages/crew/dist/studio`. The daemon's static-file handler serves it at `/`.
+
+### Standalone
+
+Any static server works. SPA fallback to `index.html` required for client-side routing.
+
+### GitHub Pages (`ws.wickedagile.com`)
+
+Marketing/deep-dive site lives in `site/`. Separate build from the SPA. Deploys on merge to main.
+
+---
+
+## 7. Test Strategy
+
+| Level | Tool | What it covers |
+|---|---|---|
+| Unit | vitest + testing-library | Component render, hook logic, client module |
+| Type | tsc --noEmit | Wire contract alignment with crew-api-types |
+| e2e | studio_standalone_test.py (Python/Playwright) | Full flow against live crew daemon |
+
+CI runs unit tests + typecheck + lint on every PR. The standalone e2e is run locally before each
+release (or in CI with a crew daemon available).

--- a/.product/RAID.md
+++ b/.product/RAID.md
@@ -1,0 +1,40 @@
+---
+name: RAID
+title: wicked-studio — Risks, Assumptions, Issues, Decisions
+status: live
+date: 2026-08-12
+---
+
+# RAID — wicked-studio
+
+## Risks
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R-01 | crew API shape changes break studio without version bump | Medium | High | Wire-contract test in crew catches drift at compile time; ADR-002 makes bumps explicit |
+| R-02 | `wicked-studio` devDep in crew creates a build-time circular cycle | Low | High | Direction is one-way: crew depends on studio's dist artifact only; studio never imports crew source |
+| R-03 | crew-api-types git-ref pin becomes stale if tag is deleted | Low | Medium | Migrate pin to npm registry version (tracked as conditional in P9 review) |
+
+## Assumptions
+
+| ID | Assumption |
+|---|---|
+| A-01 | The crew daemon is always the auth authority; studio never manages tokens or users |
+| A-02 | PTY terminal access via `/ws/terminals/:id` requires operator trust or higher (see ADR-004) |
+| A-03 | Studio runs in modern Chromium; no IE/legacy browser support required |
+| A-04 | The bundled-with-crew deploy model (same-origin, one port) is the primary production mode |
+
+## Issues
+
+| ID | Issue | Status |
+|---|---|---|
+| I-01 | crew-api-types pinned as git ref (tag `api-types-v0.1.0`) rather than npm registry version | Open — crew is at v0.2.0; studio pin needs update and registry publish |
+| I-02 | `'system'` ActorKind absent from crew-api-types ActorKind union | Open — needs explicit decision: out-of-scope or add to contract + validation |
+
+## Decisions
+
+| ID | Decision | Date | Rationale |
+|---|---|---|---|
+| D-01 | Carved out as standalone repo from `wicked-crew/packages/studio` | 2026-08 | Independent versioning; own CI; "one repo per product" principle |
+| D-02 | Ship marketing/deep-dive site at `ws.wickedagile.com` via `site/` subdir | 2026-08 | Consistent with all other wicked-* products |
+| D-03 | Terminal WS requires operator trust (not observer) | 2026-08 | Stdin-inject capability is a write operation; trust ladder must be upheld |

--- a/.product/REQ-001-application-overview.md
+++ b/.product/REQ-001-application-overview.md
@@ -1,0 +1,129 @@
+---
+name: REQ-001-application-overview
+title: wicked-studio — Application Overview
+status: approved
+version: 0.1
+date: 2026-08-12
+author: mike.parcewski@gmail.com
+review-required: false
+---
+
+# REQ-001 — Application Overview
+
+## 1. Purpose
+
+wicked-studio is the **coder-facing skin of the wicked experience plane**. It is a React SPA — a
+pure HTTP/WS client of the [wicked-crew](https://github.com/mikeparcewski/wicked-crew) daemon —
+for launching and steering governed agent runs, answering human-in-the-loop gates, and watching
+live CoreEvent streams.
+
+The core problem it solves: the wicked-crew daemon is fully headless and powerful, but a
+terminal-only UX makes it inaccessible during live runs. wicked-studio gives operators a reactive,
+evidence-grounded window into every run without adding coupling to the control plane.
+
+---
+
+## 2. What wicked-studio IS
+
+- **An experience-plane skin**: One of two interchangeable front doors (wicked-interactive is the creator skin; wicked-studio is the coder skin).
+- **A pure HTTP/WS client**: All data and actions go through `/api/v1` REST and `/ws` WebSocket. Zero access to crew source code or SQLite.
+- **A human gate interface**: When a run pauses for human approval, studio surfaces the artifact, governance findings, and approve/reject controls.
+- **A live run monitor**: CoreEvent fan-out over `/ws` drives a real-time phase progress view, event log, and coverage/evidence panel.
+- **A projects interface**: Browse, create, and archive projects; scope runs by project.
+- **A decisions ledger browser**: Reads the audit trail from `/api/v1/audit` and governance evidence from `/api/v1/runs/:id/evidence`.
+- **Bundled with crew**: `wicked-crew`'s release build copies studio's `dist/` into the daemon's serving tree so `npx wicked-crew serve` ships the UI same-origin on one port.
+
+---
+
+## 3. What wicked-studio IS NOT
+
+- Not wicked-crew. It does not own the engine, gates, or evidence. The daemon is fully headless.
+- Not an AI coding agent. It does not invoke LLMs or write code.
+- Not a cloud app. Localhost-first: the `VITE_API_HOST` env var points it at a daemon.
+- Not the wicked-interactive creator skin (that is a separate product for non-coder audiences).
+
+---
+
+## 4. Actors and Primary Flows
+
+### Actor: developer / operator (the person running wicked-crew)
+
+**Flow 1 — Launch a governed run**
+1. Open studio. Select or create a project.
+2. Enter goal text, select workflow definition.
+3. Click "Start run". Studio calls `POST /api/v1/runs`.
+4. Run card appears in the run list; live CoreEvents start arriving via `/ws`.
+
+**Flow 2 — Approve a human gate**
+1. Crew pauses at a `wicked.crew.gate.awaiting_human` event.
+2. Studio surfaces a gate card: artifact text, governance findings, approve/reject/modify controls.
+3. Operator reads, decides, submits. Studio calls `POST /api/v1/runs/:id/gate` with `{approve: true/false}`.
+4. Crew advances (or denies) the phase. Studio shows updated state within 2 seconds.
+
+**Flow 3 — Monitor a live run**
+1. Run detail view shows: current phase, phase graph, last event, worker PTY output via `/ws/terminals/:id`.
+2. Evidence panel populates as phases complete (`GET /api/v1/runs/:id/evidence`).
+3. Coverage report visible once the domain-extraction phase completes.
+
+---
+
+## 5. Constraints
+
+- **Wire contract only**: Studio imports `wicked-crew-api-types` for types; no crew source. No Rust.
+- **No auth required in local mode**: Crew defaults to `authMode: 'off'` for local use. Studio passes a bearer token when auth is configured.
+- **Same-origin default**: Bundled with crew, the SPA uses `window.location.origin` for the daemon URL. Split-dev uses `VITE_API_HOST`.
+- **Browser only**: No Node.js runtime. Built with Vite; output is static HTML/JS/CSS.
+
+---
+
+## 6. Success Criteria
+
+- **SC-S01**: Studio connects and shows the run list within 3 seconds of page load (crew daemon running on localhost).
+- **SC-S02**: Gate notification appears within 2 seconds of the `wicked.crew.gate.awaiting_human` WebSocket event.
+- **SC-S03**: Approving a gate via studio advances the run in crew within 3 seconds.
+- **SC-S04**: Run list and detail view reflect CoreEvents within 2 seconds without page reload.
+- **SC-S05**: Graceful disconnected state when daemon is unavailable (no crash, auto-reconnect).
+- **SC-S06**: Works in Chrome on macOS at ≥1280px. Dark and light themes.
+
+---
+
+## 7. Technology Choices
+
+| Concern | Choice | Why |
+|---|---|---|
+| Framework | React 18 + TypeScript | Crew uses TypeScript; React is the dominant SPA ecosystem for this use case |
+| Build | Vite 7 | Fast HMR; compatible with crew's bundling step for same-origin serve |
+| Styling | Tailwind CSS | Utility-first, no design-system coupling to crew |
+| State | TanStack Query (server) + Zustand (UI) | TQ handles REST cache invalidation; Zustand handles ephemeral UI state |
+| Icons | lucide-react | Consistent with wicked-interactive |
+| Tests | vitest + testing-library | Standard for Vite/React; matches garden's test toolchain |
+
+---
+
+## 8. Relationship to wicked-crew
+
+| wicked-crew provides | wicked-studio uses |
+|---|---|
+| `GET /api/v1/runs` | Run list |
+| `GET /api/v1/runs/:id` | Run detail + phase graph |
+| `POST /api/v1/runs` | Launch a new run |
+| `POST /api/v1/runs/:id/gate` | HITL gate decision |
+| `GET /api/v1/runs/:id/evidence` | Evidence browser |
+| `GET /api/v1/projects` | Project browser |
+| `WS /ws` | Live CoreEvent stream |
+| `WS /ws/terminals/:id` | Live PTY output (read) |
+| `wicked-crew-api-types` | Type-safe wire contract |
+
+---
+
+## 9. Definition of Done
+
+- SC-S01..SC-S06 verified against a running crew daemon
+- HITL gate flow exercised end-to-end (studio → API → crew → phase advance)
+- Test suite passes (`npm test`)
+- TypeScript strict-mode clean (`npm run typecheck`)
+- Lint clean (`npm run lint`)
+- Build succeeds (`npm run build`)
+- Standalone e2e test (`e2e/studio_standalone_test.py`) PASS
+- npm package published (`wicked-studio@0.x.x`)
+- Live site at `ws.wickedagile.com`

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+    "wicked-web": "github:mikeparcewski/wicked-web#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1"


### PR DESCRIPTION
## Summary

- Creates `.product/` directory with per-product artifact record required by ecosystem DoD
- **REQ-001**: Purpose, actors (developer/operator), 3 primary flows (launch run, approve gate, monitor), constraints, success criteria, technology choices, relationship table to crew, DoD criteria
- **DES-001**: Architecture position in the four-plane stack, 4 ADRs (standalone repo, wire-contract package, same-origin serve, terminal operator trust), module map, data flow diagram, auth integration, test strategy
- **RAID**: 3 risks, 4 assumptions, 2 open issues (crew-api-types git pin, system ActorKind), 3 locked decisions

## Why

P9 DoD adversarial review flagged wicked-studio as a hard blocker: the only wicked-* product without a `.product/` directory and formal per-product artifact record.

## Test plan

- [ ] `.product/` directory present with 3 files + `evidence/` dir
- [ ] REQ-001 and DES-001 are coherent with the README and the current codebase
- [ ] RAID open issues match crew-api-types' actual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)