### PR TITLE
fix(GateNotifications): pointer-events none on container, auto on buttons

### DIFF
--- a/src/components/GateNotifications.tsx
+++ b/src/components/GateNotifications.tsx
@@ -14,6 +14,7 @@ export function GateNotifications({ onSelect }: Props): React.ReactElement {
     <div
       className="fixed bottom-4 right-4 flex flex-col gap-2 z-50"
       data-testid="gate-notification"
+      style={{ pointerEvents: 'none' }}
     >
       {open.map((gate) => (
         <button
@@ -27,6 +28,7 @@ export function GateNotifications({ onSelect }: Props): React.ReactElement {
             background: '#1b222e',
             border: '1px solid rgba(255,218,25,0.35)',
             boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            pointerEvents: 'auto',
           }}
           onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.55)'; }}
           onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.35)'; }}


### PR DESCRIPTION
## Summary

- The `GateNotifications` overlay container (`fixed bottom-4 right-4 z-50`) had no `pointer-events` restriction, so it intercepted clicks on elements behind it whenever a gate notification was visible.
- Add `pointer-events: none` to the container div; `pointer-events: auto` on each button (children inherit `none` from the parent without this explicit override).

## Reproduces as

Found by `e2e/burn_cov_test.py` (Playwright): after 58 retries, a click near the bottom-right of the page failed because the gate-notification container was catching the event first.

Fixes #8.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` (239 unit tests) passes
- [ ] Manual: clicking elements near the bottom-right works when a gate notification is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)