### PR TITLE
fix(GateNotifications): scope gate toasts to the currently viewed run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -308,8 +308,8 @@ export function App(): React.ReactElement {
         <RightPanel view={selected} />
       )}
 
-      {/* Gate toasts — always mounted, renders above everything */}
-      <GateNotifications onSelect={selectRun} />
+      {/* Gate toasts — always mounted, renders above everything; scoped to the current run */}
+      <GateNotifications onSelect={selectRun} runId={runId} />
 
       {/* Repo graph modal — opened from RepoDetailPage */}
       {graphModalRepo !== null && (

--- a/src/components/GateNotifications.tsx
+++ b/src/components/GateNotifications.tsx
@@ -14,6 +14,7 @@ export function GateNotifications({ onSelect }: Props): React.ReactElement {
     <div
       className="fixed bottom-4 right-4 flex flex-col gap-2 z-50"
       data-testid="gate-notification"
+      style={{ pointerEvents: 'none' }}
     >
       {open.map((gate) => (
         <button
@@ -27,6 +28,7 @@ export function GateNotifications({ onSelect }: Props): React.ReactElement {
             background: '#1b222e',
             border: '1px solid rgba(255,218,25,0.35)',
             boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            pointerEvents: 'auto',
           }}
           onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.55)'; }}
           onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.35)'; }}

--- a/src/components/GateNotifications.tsx
+++ b/src/components/GateNotifications.tsx
@@ -2,11 +2,14 @@ import { useGateStore } from '../store/gates.js';
 
 interface Props {
   onSelect: (runId: string) => void;
+  /** When set, only show the gate toast for this run (fixes studio#10). */
+  runId?: string | null;
 }
 
-export function GateNotifications({ onSelect }: Props): React.ReactElement {
+export function GateNotifications({ onSelect, runId }: Props): React.ReactElement {
   const gates = useGateStore((s) => s.gates);
-  const open = Object.values(gates);
+  const all = Object.values(gates);
+  const open = runId ? all.filter((g) => g.runId === runId) : all;
 
   if (open.length === 0) return <></>;
 

--- a/tests/GateNotifications.test.tsx
+++ b/tests/GateNotifications.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GateNotifications } from '../src/components/GateNotifications.js';
+import { useGateStore } from '../src/store/gates.js';
+
+const noop = () => {};
+
+const seed = () =>
+  useGateStore.setState({
+    gates: {
+      'run-1': { runId: 'run-1', ord: 1, prompt: 'gate for run-1', lifecycle: 'open', receivedAt: 0 },
+      'run-2': { runId: 'run-2', ord: 2, prompt: 'gate for run-2', lifecycle: 'open', receivedAt: 0 },
+    },
+  });
+
+describe('GateNotifications runId scope (studio#10)', () => {
+  beforeEach(() => useGateStore.setState({ gates: {} }));
+
+  it('shows all gates when no runId is provided', () => {
+    seed();
+    render(<GateNotifications onSelect={noop} />);
+    const toasts = screen.getAllByTestId('gate-toast');
+    expect(toasts).toHaveLength(2);
+  });
+
+  it('shows only the matching gate when runId is provided', () => {
+    seed();
+    render(<GateNotifications onSelect={noop} runId="run-1" />);
+    const toasts = screen.getAllByTestId('gate-toast');
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toHaveAttribute('data-run-id', 'run-1');
+  });
+
+  it('shows nothing when runId matches no gate', () => {
+    seed();
+    render(<GateNotifications onSelect={noop} runId="run-99" />);
+    expect(screen.queryByTestId('gate-toast')).toBeNull();
+  });
+
+  it('shows nothing when store is empty', () => {
+    render(<GateNotifications onSelect={noop} runId="run-1" />);
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes studio#10: `GateNotifications` was showing gate toasts for ALL `awaiting_human` runs, not just the currently viewed one
- When a `runId` is active in the route, only the toast for that run is rendered; gates for other runs are still stored in the gate store but not displayed
- Prevents 18 stale-run toasts from stacking and blocking UI elements (Burn accordion, Cov button, Term button)

## Implementation

Option A from the issue: pass `runId` from `useRoute()` in `App.tsx` as a new optional prop; `GateNotifications` filters `open` to `all.filter(g => g.runId === runId)` when a run is active. No store or WS changes required.

## Test plan
- [x] `npm run typecheck` → clean
- [x] `npm test` → 239 tests, 0 failures
- [x] Fix scopes toasts correctly: when viewing a run, only that run's gate appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)