### PR TITLE
feat(studio): projects UI — list, detail, create, archive (DES-PROJECT-001)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { DomainModelBrowser } from './components/DomainModelBrowser.js';
 import { GateNotifications } from './components/GateNotifications.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
 import { PolicyManager } from './components/PolicyManager.js';
+import { ProjectDetailPage } from './components/ProjectDetailPage.js';
+import { ProjectsPage } from './components/ProjectsPage.js';
 import { RepositoriesPanel } from './components/RepositoriesPanel.js';
 import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
@@ -74,7 +76,7 @@ function useKillShortcut(
 }
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, showLaunch, showRegisterRepo, chatMode, navigate } = useRoute();
+  const { panel, runId, repoId, projectId, showLaunch, showRegisterRepo, chatMode, navigate } = useRoute();
   const { runs, refresh } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestElicitation = useElicitationStore((s) => s.ingest);
@@ -243,6 +245,20 @@ export function App(): React.ReactElement {
       return (
         <div className="flex-1 overflow-y-auto">
           <WorkPage runs={runs} selectedRunId={runId} onSelect={selectRun} navigate={navigate} />
+        </div>
+      );
+    }
+    if (panel === 'projects') {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <ProjectsPage navigate={navigate} />
+        </div>
+      );
+    }
+    if (panel === 'project-detail' && projectId) {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <ProjectDetailPage projectId={projectId} navigate={navigate} />
         </div>
       );
     }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,15 +1,22 @@
 import type {
+  ActivityPage,
+  AttachMemberBody,
   CoreEvent,
+  CreateProjectBody,
   GateDecision,
   GateInfo,
   LaunchRunBody,
   OnboardRef,
   OpenTerminalBody,
+  Project,
+  ProjectDetail,
+  ProjectMember,
   RepoEntry,
   RosterSeat,
   SessionView,
   ElicitationInfo,
   ElicitationResponse,
+  UpdateProjectBody,
 } from './types.js';
 
 export type * from './types.js';
@@ -420,4 +427,50 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify(patch),
     }),
+
+  // ── Projects (DES-PROJECT-001) ───────────────────────────────────────────────
+
+  /** All projects; `status=active` (default) or `archived` filters. Includes the synthesized "Unfiled" default. */
+  listProjects: (status?: 'active' | 'archived') => {
+    const qs = status ? `?status=${status}` : '';
+    return apiFetch<{ projects: Project[] }>(`/projects${qs}`);
+  },
+
+  /** One project's detail (project + members). */
+  getProject: (id: string) =>
+    apiFetch<ProjectDetail>(`/projects/${encodeURIComponent(id)}`),
+
+  /** Create a project. 409 when name collides with an active project. */
+  createProject: (body: CreateProjectBody) =>
+    apiFetch<{ project: Project }>('/projects', { method: 'POST', body: JSON.stringify(body) }),
+
+  /** Rename / describe / archive / restore a project. Rejects the `default` project. */
+  updateProject: (id: string, body: UpdateProjectBody) =>
+    apiFetch<{ project: Project }>(`/projects/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+
+  /** Members of a project. */
+  listProjectMembers: (id: string) =>
+    apiFetch<{ members: ProjectMember[] }>(`/projects/${encodeURIComponent(id)}/members`),
+
+  /** Attach a member (run, chat, repo, doc …) to a project. */
+  attachProjectMember: (id: string, body: AttachMemberBody) =>
+    apiFetch<{ member: ProjectMember }>(`/projects/${encodeURIComponent(id)}/members`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  /** Detach a member by its id. */
+  detachProjectMember: (id: string, memberId: string) =>
+    apiFetch<{ ok: boolean }>(`/projects/${encodeURIComponent(id)}/members/${encodeURIComponent(memberId)}`, {
+      method: 'DELETE',
+    }),
+
+  /** Activity feed (newest-first, cursor-paginated). `cursor` is opaque. */
+  getProjectActivity: (id: string, cursor?: string) => {
+    const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+    return apiFetch<ActivityPage>(`/projects/${encodeURIComponent(id)}/activity${qs}`);
+  },
 };

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -369,6 +369,13 @@ export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Prop
               </div>
             )}
 
+            {/* ── Projects section ── */}
+            <SectionLabel
+              label="Projects"
+              asLink
+              onClick={() => navigate('/projects')}
+            />
+
             {/* ── Repositories section ── */}
             <SectionLabel
               label="Repositories"

--- a/src/components/ProjectDetailPage.tsx
+++ b/src/components/ProjectDetailPage.tsx
@@ -1,0 +1,395 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../api/client.js';
+import type { ActivityEntry, ProjectDetail, ProjectMember } from '../api/types.js';
+import { useProjectsStore } from '../store/projects.js';
+
+const S = {
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.3)',
+  accent: '#ffda19',
+  green:  '#3fb950',
+  red:    '#f85149',
+  hover:  'rgba(230,237,243,0.04)',
+};
+
+function IconBack(): React.ReactElement {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  );
+}
+
+function Pill({ label, color }: { label: string; color: string }): React.ReactElement {
+  return (
+    <span style={{
+      fontSize: '10px', fontFamily: 'monospace', color,
+      border: `1px solid ${color}`, borderRadius: '4px', padding: '1px 5px',
+    }}>
+      {label}
+    </span>
+  );
+}
+
+function MemberKindLabel({ kind }: { kind: string }): React.ReactElement {
+  const colors: Record<string, string> = {
+    'crew.run': '#79c0ff',
+    'crew.chat': '#a5d6ff',
+    'crew.repo': '#7ee787',
+    'crew.workflow': '#ffa657',
+    'interactive.doc': '#d2a8ff',
+  };
+  const color = colors[kind] ?? S.faint;
+  return <Pill label={kind} color={color} />;
+}
+
+function ActivityRow({ entry }: { entry: ActivityEntry }): React.ReactElement {
+  const ts = new Date(entry.ts);
+  return (
+    <div style={{
+      display: 'flex', gap: '12px', padding: '10px 0',
+      borderBottom: `1px solid ${S.border}`, alignItems: 'flex-start',
+    }}>
+      <span style={{ fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0, paddingTop: '1px' }}>
+        {ts.toLocaleTimeString()}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ fontSize: '12px', color: S.muted, margin: 0, marginBottom: '2px' }}>
+          <span style={{ color: S.faint, fontFamily: 'monospace' }}>{entry.kind}</span>
+          {' '}
+          <span style={{ color: S.ink }}>{entry.summary}</span>
+        </p>
+        <span style={{ fontSize: '10px', fontFamily: 'monospace', color: S.faint }}>{entry.ref}</span>
+      </div>
+      <span style={{
+        fontSize: '10px', fontFamily: 'monospace', flexShrink: 0,
+        color: entry.source === 'crew' ? '#79c0ff' : '#d2a8ff',
+      }}>
+        {entry.source}
+      </span>
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  onDetach,
+}: {
+  member: ProjectMember;
+  onDetach: (id: string) => void;
+}): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  async function detach(): Promise<void> {
+    setBusy(true);
+    onDetach(member.id);
+  }
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: '10px', padding: '10px 12px',
+        borderRadius: '7px', background: hovered ? S.hover : 'transparent',
+        transition: 'background 0.1s',
+      }}
+    >
+      <MemberKindLabel kind={member.member_kind} />
+      <span style={{ fontSize: '12px', fontFamily: 'monospace', color: S.muted, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {member.member_ref}
+      </span>
+      <span style={{ fontSize: '10px', color: S.faint, flexShrink: 0 }}>
+        {member.attached_by} · {new Date(member.attached_at).toLocaleDateString()}
+      </span>
+      {hovered && (
+        <button
+          type="button"
+          onClick={() => void detach()}
+          disabled={busy}
+          style={{
+            background: 'transparent', border: `1px solid ${S.red}`, color: S.red,
+            borderRadius: '5px', padding: '3px 8px', fontSize: '11px', cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          {busy ? '…' : 'Detach'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface Props {
+  projectId: string;
+  navigate: (path: string) => void;
+}
+
+export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactElement {
+  const { updateProject } = useProjectsStore();
+  const [detail, setDetail] = useState<ProjectDetail | null>(null);
+  const [activity, setActivity] = useState<ActivityEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+  const [editBusy, setEditBusy] = useState(false);
+  const [editErr, setEditErr] = useState<string | null>(null);
+
+  const [archiveBusy, setArchiveBusy] = useState(false);
+
+  const isDefault = projectId === 'default';
+  const project = detail?.project ?? null;
+  const members = detail?.members ?? [];
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [det, act] = await Promise.all([
+        api.getProject(projectId),
+        api.getProjectActivity(projectId).catch(() => ({ entries: [], nextCursor: null, projectId })),
+      ]);
+      setDetail(det);
+      setActivity(act.entries);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  function startEdit(): void {
+    if (!project) return;
+    setEditName(project.name);
+    setEditDesc(project.description ?? '');
+    setEditErr(null);
+    setEditing(true);
+  }
+
+  async function saveEdit(): Promise<void> {
+    if (!project) return;
+    const trimName = editName.trim();
+    if (!trimName) return;
+    setEditBusy(true);
+    setEditErr(null);
+    try {
+      const { project: updated } = await api.updateProject(project.id, {
+        name: trimName,
+        description: editDesc.trim(),
+      });
+      setDetail((d) => d ? { ...d, project: updated } : d);
+      updateProject(updated);
+      setEditing(false);
+    } catch (e) {
+      setEditErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setEditBusy(false);
+    }
+  }
+
+  async function toggleArchive(): Promise<void> {
+    if (!project || isDefault) return;
+    setArchiveBusy(true);
+    try {
+      const newStatus = project.status === 'active' ? 'archived' : 'active';
+      const { project: updated } = await api.updateProject(project.id, { status: newStatus });
+      setDetail((d) => d ? { ...d, project: updated } : d);
+      updateProject(updated);
+    } catch {
+      /* show nothing, the button will re-enable */
+    } finally {
+      setArchiveBusy(false);
+    }
+  }
+
+  function handleDetach(memberId: string): void {
+    if (!project) return;
+    void api.detachProjectMember(project.id, memberId).catch(() => {});
+    setDetail((d) => d ? { ...d, members: d.members.filter((m) => m.id !== memberId) } : d);
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: '28px 32px' }}>
+        <p style={{ fontSize: '13px', color: S.faint, fontFamily: 'monospace' }}>Loading…</p>
+      </div>
+    );
+  }
+
+  if (error || !project) {
+    return (
+      <div style={{ padding: '28px 32px' }}>
+        <button
+          type="button"
+          onClick={() => navigate('/projects')}
+          style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'transparent', border: 'none', cursor: 'pointer', color: S.muted, fontSize: '13px', marginBottom: '16px', padding: 0 }}
+        >
+          <IconBack /> Projects
+        </button>
+        <p style={{ fontSize: '13px', color: S.red }}>{error ?? 'Project not found.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '800px' }}>
+      {/* Back */}
+      <button
+        type="button"
+        onClick={() => navigate('/projects')}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '6px', background: 'transparent',
+          border: 'none', cursor: 'pointer', color: S.muted, fontSize: '12px',
+          marginBottom: '20px', padding: 0,
+        }}
+      >
+        <IconBack /> All projects
+      </button>
+
+      {/* Header */}
+      {editing ? (
+        <div style={{ marginBottom: '24px' }}>
+          <input
+            type="text"
+            value={editName}
+            maxLength={120}
+            onChange={(e) => setEditName(e.target.value)}
+            autoFocus
+            style={{
+              width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+              borderRadius: '6px', padding: '8px 10px', fontSize: '18px', fontWeight: 700,
+              color: S.ink, outline: 'none', marginBottom: '8px', boxSizing: 'border-box',
+            }}
+          />
+          <textarea
+            value={editDesc}
+            onChange={(e) => setEditDesc(e.target.value)}
+            rows={2}
+            placeholder="Description (optional)"
+            style={{
+              width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+              borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
+              outline: 'none', resize: 'vertical', marginBottom: '10px', boxSizing: 'border-box',
+              fontFamily: 'inherit',
+            }}
+          />
+          {editErr && <p style={{ fontSize: '12px', color: S.red, marginBottom: '8px' }}>{editErr}</p>}
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              type="button"
+              onClick={() => void saveEdit()}
+              disabled={editBusy || !editName.trim()}
+              style={{
+                background: S.accent, color: '#0d1117', border: 'none', borderRadius: '6px',
+                padding: '6px 14px', fontSize: '12px', fontWeight: 700, cursor: 'pointer',
+                opacity: editBusy ? 0.5 : 1,
+              }}
+            >
+              {editBusy ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              style={{
+                background: 'transparent', color: S.muted, border: `1px solid ${S.border}`,
+                borderRadius: '6px', padding: '6px 12px', fontSize: '12px', cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '24px', gap: '16px' }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
+              <h1 style={{ fontSize: '20px', fontWeight: 700, color: S.ink, margin: 0 }}>
+                {project.name}
+              </h1>
+              {project.status === 'archived' && <Pill label="archived" color={S.faint} />}
+              {isDefault && <Pill label="default" color={S.faint} />}
+            </div>
+            {project.description && (
+              <p style={{ fontSize: '13px', color: S.muted, margin: 0 }}>{project.description}</p>
+            )}
+            {project.created_at > 0 && (
+              <p style={{ fontSize: '11px', color: S.faint, margin: 0, marginTop: '6px', fontFamily: 'monospace' }}>
+                Created {new Date(project.created_at).toLocaleDateString()}
+                {project.updated_at !== project.created_at && (
+                  <> · Updated {new Date(project.updated_at).toLocaleDateString()}</>
+                )}
+              </p>
+            )}
+          </div>
+          {!isDefault && (
+            <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+              <button
+                type="button"
+                onClick={startEdit}
+                style={{
+                  background: 'transparent', color: S.muted, border: `1px solid ${S.border}`,
+                  borderRadius: '6px', padding: '6px 12px', fontSize: '12px', cursor: 'pointer',
+                }}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => void toggleArchive()}
+                disabled={archiveBusy}
+                style={{
+                  background: 'transparent', color: S.faint, border: `1px solid ${S.border}`,
+                  borderRadius: '6px', padding: '6px 12px', fontSize: '12px', cursor: 'pointer',
+                  opacity: archiveBusy ? 0.5 : 1,
+                }}
+              >
+                {project.status === 'active' ? 'Archive' : 'Restore'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Members */}
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '13px', fontWeight: 600, color: S.muted, margin: 0, marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.06em', fontFamily: 'monospace' }}>
+          Members ({members.length})
+        </h2>
+        {members.length === 0 ? (
+          <p style={{ fontSize: '13px', color: S.faint }}>No members attached yet.</p>
+        ) : (
+          <div style={{ background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px', overflow: 'hidden', padding: '4px' }}>
+            {members.map((m) => (
+              <MemberRow key={m.id} member={m} onDetach={handleDetach} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Activity */}
+      <section>
+        <h2 style={{ fontSize: '13px', fontWeight: 600, color: S.muted, margin: 0, marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.06em', fontFamily: 'monospace' }}>
+          Activity
+        </h2>
+        {activity.length === 0 ? (
+          <p style={{ fontSize: '13px', color: S.faint }}>No activity yet.</p>
+        ) : (
+          <div style={{ background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px', padding: '0 12px' }}>
+            {activity.map((e) => (
+              <ActivityRow key={e.id} entry={e} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/ProjectsPage.tsx
+++ b/src/components/ProjectsPage.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+import type { Project } from '../api/types.js';
+import { useProjectsStore } from '../store/projects.js';
+
+const S = {
+  bg:     '#0d1117',
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.3)',
+  accent: '#ffda19',
+  hover:  'rgba(230,237,243,0.05)',
+  green:  '#3fb950',
+  red:    '#f85149',
+};
+
+function IconFolder(): React.ReactElement {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
+    </svg>
+  );
+}
+
+function IconArchive(): React.ReactElement {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M20 3H4c-1.1 0-2 .9-2 2v2c0 .75.41 1.39 1 1.73V19c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8.73c.59-.34 1-.99 1-1.73V5c0-1.1-.9-2-2-2zm-5 12H9v-2h6v2zm5-7H4V5h16v3z" />
+    </svg>
+  );
+}
+
+function IconPlus(): React.ReactElement {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M19 11h-6V5a1 1 0 0 0-2 0v6H5a1 1 0 0 0 0 2h6v6a1 1 0 0 0 2 0v-6h6a1 1 0 0 0 0-2z" />
+    </svg>
+  );
+}
+
+function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) => void; onCancel: () => void }): React.ReactElement {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  async function submit(): Promise<void> {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const body = description.trim()
+        ? { name: trimmed, description: description.trim() }
+        : { name: trimmed };
+      const { project } = await api.createProject(body);
+      onCreated(project);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        background: S.card,
+        border: `1px solid ${S.border}`,
+        borderRadius: '10px',
+        padding: '20px',
+        marginBottom: '16px',
+      }}
+    >
+      <p style={{ fontSize: '13px', fontWeight: 600, color: S.ink, marginBottom: '14px' }}>New project</p>
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Project name"
+        value={name}
+        maxLength={120}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') void submit(); if (e.key === 'Escape') onCancel(); }}
+        style={{
+          width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+          borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
+          outline: 'none', marginBottom: '8px', boxSizing: 'border-box',
+        }}
+      />
+      <textarea
+        placeholder="Description (optional)"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={2}
+        style={{
+          width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+          borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
+          outline: 'none', resize: 'vertical', marginBottom: '12px', boxSizing: 'border-box',
+          fontFamily: 'inherit',
+        }}
+      />
+      {err && <p style={{ fontSize: '12px', color: S.red, marginBottom: '10px' }}>{err}</p>}
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={busy || !name.trim()}
+          style={{
+            background: S.accent, color: '#0d1117', border: 'none', borderRadius: '6px',
+            padding: '7px 16px', fontSize: '12px', fontWeight: 700, cursor: busy ? 'default' : 'pointer',
+            opacity: busy || !name.trim() ? 0.5 : 1,
+          }}
+        >
+          {busy ? 'Creating…' : 'Create project'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            background: 'transparent', color: S.muted, border: `1px solid ${S.border}`,
+            borderRadius: '6px', padding: '7px 14px', fontSize: '12px', cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ProjectCard({ project, onClick }: { project: Project; onClick: () => void }): React.ReactElement {
+  const [hovered, setHovered] = useState(false);
+  const isArchived = project.status === 'archived';
+  const isDefault = project.id === 'default';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'block', width: '100%', textAlign: 'left',
+        background: hovered ? 'rgba(230,237,243,0.04)' : S.card,
+        border: `1px solid ${S.border}`,
+        borderRadius: '10px', padding: '16px', cursor: 'pointer',
+        transition: 'background 0.1s',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+        <span style={{ color: isArchived ? S.faint : S.accent, marginTop: '1px', flexShrink: 0 }}>
+          <IconFolder />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+            <span style={{
+              fontSize: '14px', fontWeight: 600, color: isArchived ? S.muted : S.ink,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              {project.name}
+            </span>
+            {isArchived && (
+              <span style={{
+                fontSize: '10px', fontFamily: 'monospace', color: S.faint,
+                border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '1px 5px',
+                flexShrink: 0,
+              }}>
+                archived
+              </span>
+            )}
+            {isDefault && (
+              <span style={{
+                fontSize: '10px', fontFamily: 'monospace', color: S.faint,
+                border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '1px 5px',
+                flexShrink: 0,
+              }}>
+                default
+              </span>
+            )}
+          </div>
+          {project.description && (
+            <p style={{
+              fontSize: '12px', color: S.muted, margin: 0,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              {project.description}
+            </p>
+          )}
+          {project.created_at > 0 && (
+            <p style={{ fontSize: '11px', color: S.faint, margin: 0, marginTop: '6px', fontFamily: 'monospace' }}>
+              Created {new Date(project.created_at).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+interface Props {
+  navigate: (path: string) => void;
+}
+
+export function ProjectsPage({ navigate }: Props): React.ReactElement {
+  const { projects, loading, error, load, addProject } = useProjectsStore();
+  const [showCreate, setShowCreate] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const active = projects.filter((p) => p.status === 'active');
+  const archived = projects.filter((p) => p.status === 'archived');
+
+  function handleCreated(p: Project): void {
+    addProject(p);
+    setShowCreate(false);
+  }
+
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '760px' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px' }}>
+        <div>
+          <h1 style={{ fontSize: '20px', fontWeight: 700, color: S.ink, margin: 0, marginBottom: '4px' }}>Projects</h1>
+          <p style={{ fontSize: '13px', color: S.muted, margin: 0 }}>
+            Group runs, chats, and repos into named containers.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          style={{
+            display: 'flex', alignItems: 'center', gap: '6px',
+            background: S.accent, color: '#0d1117', border: 'none', borderRadius: '7px',
+            padding: '8px 14px', fontSize: '12px', fontWeight: 700, cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          <IconPlus /> New project
+        </button>
+      </div>
+
+      {showCreate && (
+        <CreateProjectForm
+          onCreated={handleCreated}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {loading && (
+        <p style={{ fontSize: '13px', color: S.faint, fontFamily: 'monospace' }}>Loading…</p>
+      )}
+
+      {!loading && error && (
+        <p style={{ fontSize: '13px', color: S.red }}>{error}</p>
+      )}
+
+      {!loading && !error && active.length === 0 && !showCreate && (
+        <div style={{
+          textAlign: 'center', padding: '48px 24px',
+          background: S.card, border: `1px solid ${S.border}`, borderRadius: '12px',
+        }}>
+          <span style={{ color: S.faint, display: 'block', marginBottom: '10px' }}>
+            <IconFolder />
+          </span>
+          <p style={{ fontSize: '14px', color: S.muted, margin: 0, marginBottom: '4px' }}>No projects yet</p>
+          <p style={{ fontSize: '12px', color: S.faint, margin: 0 }}>
+            Create a project to group your runs, chats, and repos.
+          </p>
+        </div>
+      )}
+
+      {active.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
+          {active.map((p) => (
+            <ProjectCard
+              key={p.id}
+              project={p}
+              onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
+            />
+          ))}
+        </div>
+      )}
+
+      {archived.length > 0 && (
+        <div style={{ marginTop: '16px' }}>
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '6px',
+              background: 'transparent', border: 'none', cursor: 'pointer',
+              fontSize: '12px', color: S.faint, padding: '4px 0', marginBottom: '8px',
+            }}
+          >
+            <IconArchive />
+            {showArchived ? 'Hide' : 'Show'} {archived.length} archived project{archived.length !== 1 ? 's' : ''}
+          </button>
+          {showArchived && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {archived.map((p) => (
+                <ProjectCard
+                  key={p.id}
+                  project={p}
+                  onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Panel = 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'chats' | 'work' | 'repo-detail';
+export type Panel = 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'chats', 'work', 'repo-detail'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
 
 interface Route {
   panel: Panel;
@@ -16,6 +16,8 @@ interface Route {
   showRegisterRepo: boolean;
   /** True when the launch form is in chat mode (vs. work mode). */
   chatMode: boolean;
+  /** Non-null only when panel === 'project-detail'. */
+  projectId: string | null;
 }
 
 function safeDecode(s: string): string {
@@ -25,23 +27,26 @@ function safeDecode(s: string): string {
 function parse(pathname: string): Route {
   const [, first = '', second = ''] = pathname.split('/');
   if (first === 'repo-detail' && second) {
-    return { panel: 'repo-detail', runId: null, showLaunch: false, repoId: safeDecode(second), showRegisterRepo: false, chatMode: false };
+    return { panel: 'repo-detail', runId: null, showLaunch: false, repoId: safeDecode(second), showRegisterRepo: false, chatMode: false, projectId: null };
   }
   if (first === 'repo-detail') {
-    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false };
+    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
   }
   if (first === 'repos' && second === 'new') {
-    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: true, chatMode: false };
+    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: true, chatMode: false, projectId: null };
   }
   if (first === 'chat' && second === 'new') {
-    return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: true };
+    return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: true, projectId: null };
+  }
+  if (first === 'projects' && second) {
+    return { panel: 'project-detail', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: safeDecode(second) };
   }
   if ((PANELS as string[]).includes(first) && first !== 'runs') {
-    return { panel: first as Panel, runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false };
+    return { panel: first as Panel, runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
   }
-  if (second === 'new') return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: false };
-  if (second) return { panel: 'runs', runId: safeDecode(second), showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false };
-  return { panel: 'runs', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false };
+  if (second === 'new') return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
+  if (second) return { panel: 'runs', runId: safeDecode(second), showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
+  return { panel: 'runs', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
 }
 
 export function useRoute(): Route & {

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+import type { Project } from '../api/types.js';
+
+interface ProjectsStore {
+  projects: Project[];
+  loading: boolean;
+  error: string | null;
+  /** Fetch the active project list and replace store state. */
+  load: () => Promise<void>;
+  /** Optimistically add a newly-created project. */
+  addProject: (p: Project) => void;
+  /** Optimistically update a project in-place (rename, archive, restore). */
+  updateProject: (p: Project) => void;
+}
+
+export const useProjectsStore = create<ProjectsStore>((set) => ({
+  projects: [],
+  loading: false,
+  error: null,
+
+  load: async () => {
+    set({ loading: true, error: null });
+    try {
+      const { projects } = await api.listProjects();
+      set({ projects, loading: false });
+    } catch (e) {
+      set({ loading: false, error: e instanceof Error ? e.message : String(e) });
+    }
+  },
+
+  addProject: (p) =>
+    set((s) => ({ projects: [p, ...s.projects.filter((x) => x.id !== p.id)] })),
+
+  updateProject: (p) =>
+    set((s) => ({ projects: s.projects.map((x) => (x.id === p.id ? p : x)) })),
+}));


### PR DESCRIPTION
## Summary

- **ProjectsPage** — active/archived list with inline create form and "New project" CTA
- **ProjectDetailPage** — header with edit/archive toggle, members table with detach, activity feed (crew + interactive sources)
- **API client** — 8 new project methods mirroring the 9 crew routes (listProjects, getProject, createProject, updateProject, listProjectMembers, attachProjectMember, detachProjectMember, getProjectActivity)
- **Zustand store** (`projects.ts`) — load, optimistic addProject/updateProject
- **useRoute** — adds `'projects'` and `'project-detail'` panels, `projectId` param; `/projects` and `/projects/:id` parse correctly
- **LeftSidebar** — clickable "Projects" section label navigates to `/projects`

Zero crew source dependency: all interaction is through `/api/v1/projects`. Types are from the published `wicked-crew-api-types` contract.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm test` — 243 tests / 31 files all pass
- [ ] Navigate to `/projects` — list renders, "New project" button opens inline create form
- [ ] Create a project — appears in list; sidebar nav entry navigates to list
- [ ] Click a project — detail page loads with members table and activity feed
- [ ] Edit name/description and save — updates in place
- [ ] Archive/restore toggle — status pill updates
- [ ] Detach a member — row removed optimistically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn