### PR TITLE
feat(work): Archived chip — write-off view for finished history (crew#265)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.1.0"
+        "wicked-crew-api-types": "^0.3.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.1.0.tgz",
-      "integrity": "sha512-3sbcCRzE5mGBMdhdLulQSE31zqUb9VE1/Uuvts+2AZhRy29LV7OOjj3kDPt0Hcsrx7zH7RWL/TsNxvYRaGLK3w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.3.0.tgz",
+      "integrity": "sha512-LZOAe3kd1Ii3IPEFyzMMuXp4M/6a4+UkNiIzbW6QVScAn4oByZ8yxw1dmpVXbc1Fuy9OZfFntIpgLQjqugwdPw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.1.0"
+    "wicked-crew-api-types": "^0.3.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -121,8 +121,19 @@ export async function downloadRunEvidence(runId: string): Promise<void> {
  * daemon endpoint backed by one core-ts method.
  */
 export const api = {
-  /** Run list, actionable-first (daemon-sorted). Reconciles the daemon gate cache. */
-  listRuns: () => apiFetch<{ runs: SessionView[] }>('/runs'),
+  /** Run list, actionable-first (daemon-sorted). Reconciles the daemon gate cache.
+   *  Archived runs are excluded server-side by default (crew#265); pass `includeArchived`
+   *  to get the complete history. */
+  listRuns: (includeArchived?: boolean) =>
+    apiFetch<{ runs: SessionView[] }>(includeArchived ? '/runs?include=archived' : '/runs'),
+
+  /** Archive (or unarchive) a TERMINAL run (crew#265) — write-off, not delete.
+   *  404 unknown; 409 when the run is non-terminal. */
+  archiveRun: (id: string, archived: boolean, note?: string) =>
+    apiFetch<{ runId: string; archived: boolean }>(`/runs/${encodeURIComponent(id)}/archive`, {
+      method: 'POST',
+      body: JSON.stringify(note === undefined ? { archived } : { archived, note }),
+    }),
 
   /** One run's detail (`SessionView`). */
   getRun: (id: string) => apiFetch<{ run: SessionView }>(`/runs/${encodeURIComponent(id)}`),

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { RunLink } from './RunLink.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
@@ -30,6 +31,35 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
   const [tab, setTab] = useState<StatusTab>('all');
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
+  // Archived runs (crew#265) are WRITTEN OFF: excluded from the default list server-side, so the
+  // chip fetches the complete history on demand rather than always paying for it. `null` = not
+  // yet fetched; refetch on toggle-on so an unarchive elsewhere is reflected.
+  const [showArchived, setShowArchived] = useState(false);
+  const [archivedRuns, setArchivedRuns] = useState<SessionView[] | null>(null);
+  useEffect(() => {
+    if (!showArchived) return;
+    let cancelled = false;
+    api
+      .listRuns(true)
+      .then(({ runs: all }) => {
+        if (cancelled) return;
+        setArchivedRuns(all.filter((v) => v.session.archived_at != null));
+      })
+      .catch(() => {
+        if (!cancelled) setArchivedRuns([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showArchived]);
+  async function unarchive(id: string): Promise<void> {
+    try {
+      await api.archiveRun(id, false);
+      setArchivedRuns((prev) => (prev ? prev.filter((v) => v.session.id !== id) : prev));
+    } catch {
+      /* surfaced on next fetch; the row simply stays */
+    }
+  }
 
   const allWorkRuns = useMemo(
     () => runs.filter((v) => !!v.session.workflow_id && v.session.workflow_id !== 'chat'),
@@ -194,6 +224,21 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
             {t.label} {counts[t.id]}
           </button>
         ))}
+        <div className="flex-1" />
+        {/* Archived is orthogonal to status: a write-off toggle, not a fifth status tab. */}
+        <button
+          type="button"
+          aria-pressed={showArchived}
+          onClick={() => setShowArchived(s => !s)}
+          className="rounded-full px-3 py-1 text-xs font-mono"
+          style={
+            showArchived
+              ? { background: 'rgba(230,237,243,0.1)', color: '#e6edf3', border: '1px dashed rgba(230,237,243,0.3)' }
+              : { color: 'rgba(230,237,243,0.4)', border: '1px dashed rgba(230,237,243,0.15)' }
+          }
+        >
+          Archived{archivedRuns !== null ? ` ${archivedRuns.length}` : ''}
+        </button>
       </div>
 
       {/* List */}
@@ -238,6 +283,32 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
             ) : (
               filtered.map(v => (
                 <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+              ))
+            )}
+          </>
+        )}
+        {showArchived && archivedRuns !== null && (
+          <>
+            <GroupLabel>Archived</GroupLabel>
+            {archivedRuns.length === 0 ? (
+              <p className="px-3 py-3 text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                Nothing archived.
+              </p>
+            ) : (
+              archivedRuns.map(v => (
+                <div key={v.session.id} className="flex items-center gap-2">
+                  <div className="flex-1 min-w-0" style={{ opacity: 0.55 }}>
+                    <RunLink view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void unarchive(v.session.id)}
+                    className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
+                    style={{ color: 'rgba(230,237,243,0.55)', border: '1px solid rgba(230,237,243,0.15)' }}
+                  >
+                    Unarchive
+                  </button>
+                </div>
               ))
             )}
           </>

--- a/tests/WorkPage.archived.test.tsx
+++ b/tests/WorkPage.archived.test.tsx
@@ -1,0 +1,72 @@
+// crew#265 — the Archived chip: a write-off view, off by default.
+//
+// Default: archived runs are simply absent (the daemon excludes them; WorkPage adds nothing).
+// Chip ON: fetches the complete list, shows ONLY the archived remainder under an "Archived"
+// group, with an Unarchive action that removes the row optimistically on success.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkPage } from '../src/components/WorkPage.js';
+import { makeView } from './factories.js';
+
+const listRuns = vi.fn();
+const archiveRun = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRuns: (...a: unknown[]) => listRuns(...a),
+    archiveRun: (...a: unknown[]) => archiveRun(...a),
+  },
+}));
+
+const live = makeView({ id: 'live-1', workflow_id: 'feature', problem: 'live work', status: 'completed' });
+const archived = makeView({
+  id: 'old-1',
+  workflow_id: 'feature',
+  problem: 'campaign leftover',
+  status: 'failed',
+  archived_at: 1786700000000,
+});
+
+beforeEach(() => {
+  listRuns.mockReset();
+  archiveRun.mockReset();
+});
+
+function renderPage() {
+  return render(
+    <WorkPage runs={[live]} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />,
+  );
+}
+
+describe('WorkPage — Archived chip (crew#265)', () => {
+  it('is off by default: no fetch, no Archived group', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /^Archived/ })).toHaveAttribute('aria-pressed', 'false');
+    expect(listRuns).not.toHaveBeenCalled();
+    expect(screen.queryByText('campaign leftover')).toBeNull();
+  });
+
+  it('toggling on fetches the complete list and shows only the archived remainder', async () => {
+    listRuns.mockResolvedValue({ runs: [live, archived] });
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /^Archived/ }));
+    await waitFor(() => expect(screen.getByText('campaign leftover')).toBeInTheDocument());
+    expect(listRuns).toHaveBeenCalledWith(true);
+    // The live run appears once (its normal group), not duplicated into the archived group.
+    expect(screen.getAllByText('live work')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /^Archived 1$/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('Unarchive calls the API and drops the row', async () => {
+    listRuns.mockResolvedValue({ runs: [live, archived] });
+    archiveRun.mockResolvedValue({ runId: 'old-1', archived: false });
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /^Archived/ }));
+    await waitFor(() => expect(screen.getByText('campaign leftover')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Unarchive' }));
+    expect(archiveRun).toHaveBeenCalledWith('old-1', false);
+    await waitFor(() => expect(screen.queryByText('campaign leftover')).toBeNull());
+  });
+});

--- a/tests/factories.ts
+++ b/tests/factories.ts
@@ -14,6 +14,9 @@ export function makeSession(overrides: Partial<AgentSession> = {}): AgentSession
     attempt: 0,
     workdir: null,
     repo_ref: null,
+  extra_write_roots: [],
+  archived_at: null,
+  archive_note: null,
     ...overrides,
   };
 }

--- a/tests/run-state.test.ts
+++ b/tests/run-state.test.ts
@@ -36,6 +36,9 @@ function session(status: SessionStatus, unit_ix: number): AgentSession {
     attempt: 0,
     workdir: null,
     repo_ref: null,
+  extra_write_roots: [],
+  archived_at: null,
+  archive_note: null,
   };
 }
 


### PR DESCRIPTION
## What

The studio half of run archival (wicked-crew#265; daemon routes merged in wicked-crew#266, wire fields in `wicked-crew-api-types@0.3.0`):

- **Archived chip** on the Work page, off by default — and free when off: the daemon already excludes archived runs from `GET /runs`, so the default view needs no fetch and no filtering.
- Toggling on fetches `?include=archived` and renders **only the archived remainder** under an "Archived" group — dimmed, below the status groups, deliberately *not* a fifth status tab (a write-off is orthogonal to status).
- Each archived row has an **Unarchive** action (optimistic removal on success; a failure leaves the row for the next fetch to reconcile).
- `client.listRuns(includeArchived?)` + `client.archiveRun(id, archived, note?)`; api-types bumped to `^0.3.0`; test factories updated for the new wire fields.

## Evidence

- 3 new tests: default-off (no fetch, no group), toggle-on (fetch called with `true`, archived-only remainder, no duplication of live rows, count in the chip), unarchive (API called, row dropped).
- Full suite: **32 files / 246 tests pass**; `tsc --noEmit` clean; production build clean.

Closes the studio follow-up from wicked-crew#266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn