### PR TITLE
feat(run view): unit outputs in the main panel; Files open via system default

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -280,6 +280,20 @@ export const api = {
     apiFetch<{ status: string }>(`/terminals/${encodeURIComponent(id)}/close`, { method: 'POST' }),
 
   /**
+   * Ask the daemon to open a file/folder with the OS default application
+   * (crew#273: `POST /open {path, runId?}` → macOS `open` / linux `xdg-open` /
+   * windows `start`, validated daemon-side against the run's workdir + evidence
+   * roots). The open MUST happen daemon-side — the studio is a browser SPA and
+   * cannot spawn a process. A daemon predating the route 404s; callers treat
+   * that as "unsupported" and fall back to copy-path.
+   */
+  openPath: (path: string, runId?: string) =>
+    apiFetch<{ status: string }>('/open', {
+      method: 'POST',
+      body: JSON.stringify(runId === undefined ? { path } : { path, runId }),
+    }),
+
+  /**
    * Inject a message into one or all active agent sessions (POST /runs/:id/inject).
    * `target` is either `"all"` (broadcast) or a session-specific discriminator.
    * Used by the manager dashboard's send-to-agents panel (crew#73).

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { lostQuorum, quorumLabel } from './councilQuorum.js';
 import { api, downloadRunEvidence } from '../api/client.js';
-import type { SessionView, StageKind, UnitStatus } from '../api/types.js';
+import type { SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
 import { executingOrd } from '../api/run-state.js';
 import { useGateStore } from '../store/gates.js';
 import { useElicitationStore } from '../store/elicitations.js';
@@ -174,6 +174,17 @@ const UNIT_STATUS_TEXT: Record<UnitStatus, string> = {
 
 function unitKey(runId: string, unitId: string, ord: number): string {
   return unitId.startsWith(`${runId}:`) ? unitId.slice(runId.length + 1) : `u${ord}`;
+}
+
+/**
+ * The unit's phase name for its output header (crew#272). Workflow units are keyed
+ * `<run>:<phase_id>` (`run-1:survey` → `survey`); free-text units carry only the
+ * synthetic `u<ord>` suffix, so the methodology stage is the closest thing to a
+ * phase name they have.
+ */
+function phaseName(runId: string, unit: WorkUnit): string {
+  const key = unitKey(runId, unit.id, unit.ord);
+  return /^u\d+$/.test(key) ? unit.stage : key;
 }
 
 const SYSTEM_EVENT_TYPES = new Set([
@@ -822,9 +833,33 @@ function RunChat({
                     </div>
                   )}
                   {unit.status === 'done' && (
-                    <div className="flex items-center gap-2 text-sm font-mono" style={{ color: '#3fb950' }}>
-                      <span>✓</span>
-                      <span className="font-medium">{UNIT_STATUS_TEXT[unit.status]}</span>
+                    <div data-testid={`unit-output-${unit.ord}`}>
+                      {/* Output header: phase name + status (crew#272) */}
+                      <div className="flex items-center gap-2 text-sm font-mono">
+                        <span style={{ color: '#3fb950' }}>✓</span>
+                        <span className="font-medium" style={{ color: '#3fb950' }}>{phaseName(session.id, unit)}</span>
+                        <span className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>{UNIT_STATUS_TEXT[unit.status]}</span>
+                        <button
+                          type="button"
+                          data-testid={`unit-output-toggle-${unit.ord}`}
+                          onClick={() => toggleTranscript(unit.ord)}
+                          className="ml-auto text-xs font-medium font-mono hover:underline"
+                          style={{ color: '#79c0ff' }}
+                        >
+                          {tc?.visible ? '▾ Hide output' : '▸ Show output'}
+                        </button>
+                      </div>
+                      {/* The unit's OUTPUT is the primary message body (crew#272): auto-loaded,
+                          expanded, and rendered in the main flow — not buried behind a
+                          transcript toggle the user has to dig for. */}
+                      {tc?.visible && (
+                        <div className="mt-2.5 max-h-[28rem] overflow-y-auto">
+                          {tc.loading
+                            ? <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>Loading output…</span>
+                            : <Markdown className="whitespace-pre-wrap">{tc.text ?? ''}</Markdown>
+                          }
+                        </div>
+                      )}
                     </div>
                   )}
                   {unit.status === 'rejected' && (
@@ -848,30 +883,6 @@ function RunChat({
                     );
                   })()}
 
-                  {/* Transcript toggle */}
-                  {unit.status === 'done' && (
-                    <div className="mt-3">
-                      <button
-                        type="button"
-                        onClick={() => toggleTranscript(unit.ord)}
-                        className="text-xs font-medium font-mono hover:underline"
-                        style={{ color: '#79c0ff' }}
-                      >
-                        {tc?.visible ? '▾ Hide transcript' : '▸ View transcript'}
-                      </button>
-                      {tc?.visible && (
-                        <div
-                          className="mt-2.5 max-h-96 overflow-auto rounded-xl p-4"
-                          style={{ background: '#0d1117' }}
-                        >
-                          {tc.loading
-                            ? <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>Loading…</span>
-                            : <Markdown className="whitespace-pre-wrap">{tc.text ?? ''}</Markdown>
-                          }
-                        </div>
-                      )}
-                    </div>
-                  )}
                 </div>
               </div>
             </div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -50,8 +50,10 @@ const DELETE_TOOLS: ReadonlySet<string> = new Set(['DeleteFile', 'Remove']);
 
 type FileOpKind = 'write' | 'delete';
 
-function FilePath({ path, opKind }: { path: string; opKind?: FileOpKind }): React.ReactElement {
-  const [copied, setCopied] = useState(false);
+type FileFeedback = 'opened' | 'copied' | 'open-failed';
+
+function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; runId: string }): React.ReactElement {
+  const [feedback, setFeedback] = useState<FileFeedback | null>(null);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current); }, []);
   const parts = path.replace(/\\/g, '/').split('/');
@@ -72,37 +74,75 @@ function FilePath({ path, opKind }: { path: string; opKind?: FileOpKind }): Reac
         ? '#e6edf3'
         : '#e6edf3';
 
+  function flash(state: FileFeedback): void {
+    setFeedback(state);
+    if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = setTimeout(() => { setFeedback(null); resetTimerRef.current = null; }, 2000);
+  }
+
   function handleCopy(): void {
     void navigator.clipboard.writeText(path).then(() => {
-      setCopied(true);
-      if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current);
-      resetTimerRef.current = setTimeout(() => { setCopied(false); resetTimerRef.current = null; }, 1500);
+      flash('copied');
     }).catch(() => { /* clipboard unavailable — silently ignore */ });
   }
 
+  /**
+   * Open with the OS default application (crew#273). The open happens DAEMON-side
+   * (`POST /open` → `open`/`xdg-open`/`start`) — a browser SPA cannot spawn a
+   * process. A daemon without the route 404s; fall back to copying the path so
+   * the click still hands the operator something actionable.
+   */
+  function handleOpen(): void {
+    api.openPath(path, runId)
+      .then(() => flash('opened'))
+      .catch(() => {
+        void navigator.clipboard.writeText(path).catch(() => { /* clipboard unavailable */ });
+        flash('open-failed');
+      });
+  }
+
   return (
-    <li title={copied ? 'Copied!' : path} className="flex items-start gap-1.5 min-w-0">
+    <li title={path} className="flex items-start gap-1.5 min-w-0">
       <span className="shrink-0 mt-0.5 text-[9px] font-mono select-none" style={{ color: glyphColor }}>
         {glyph}
       </span>
       <button
         type="button"
-        onClick={handleCopy}
-        className="min-w-0 leading-5 font-mono text-[10px] break-all text-left transition-opacity hover:opacity-70"
-        title={copied ? 'Copied!' : `Click to copy: ${path}`}
+        onClick={handleOpen}
+        className="min-w-0 flex-1 leading-5 font-mono text-[10px] break-all text-left transition-opacity hover:opacity-70"
+        title={`Open with system default app: ${path}`}
         style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
       >
         {dir && <span style={{ color: 'rgba(230,237,243,0.3)' }}>{dir}</span>}
         <span style={{ color: nameColor }}>{name}</span>
-        {copied && (
-          <span className="ml-1 text-[9px]" style={{ color: '#3fb950' }}>✓</span>
+        {feedback === 'opened' && (
+          <span className="ml-1 text-[9px]" style={{ color: '#3fb950' }}>✓ opened</span>
         )}
+        {feedback === 'copied' && (
+          <span className="ml-1 text-[9px]" style={{ color: '#3fb950' }}>✓ copied</span>
+        )}
+        {feedback === 'open-failed' && (
+          <span className="ml-1 text-[9px]" style={{ color: '#ffda19' }}>
+            open unavailable — path copied
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={`Copy path ${path}`}
+        title="Copy path"
+        className="shrink-0 mt-0.5 text-[9px] font-mono leading-5 transition-opacity hover:opacity-70"
+        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'rgba(230,237,243,0.35)' }}
+      >
+        ⧉
       </button>
     </li>
   );
 }
 
 function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
+  const runId = model.session.id;
   // Build sets of "write units" and "delete units" from governance hook fires.
   // governanceHookFired events carry toolName but not file paths, so we use a unit's
   // entire filesRead set as a proxy for "files touched by write operations".
@@ -169,10 +209,10 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
           ) : (
             <ul className="flex flex-col gap-1">
               {sortedModified.map((f) => (
-                <FilePath key={f} path={f} opKind="write" />
+                <FilePath key={f} path={f} opKind="write" runId={runId} />
               ))}
               {sortedDeleted.map((f) => (
-                <FilePath key={f} path={f} opKind="delete" />
+                <FilePath key={f} path={f} opKind="delete" runId={runId} />
               ))}
             </ul>
           )}
@@ -187,7 +227,7 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
           </p>
           <ul className="flex flex-col gap-1">
             {sortedReferenced.map((f) => (
-              <FilePath key={f} path={f} />
+              <FilePath key={f} path={f} runId={runId} />
             ))}
           </ul>
         </div>

--- a/tests/ChatPanel.output.test.tsx
+++ b/tests/ChatPanel.output.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+});
+
+describe('ChatPanel unit outputs in the main panel (crew#272)', () => {
+  it('auto-renders each completed unit output as a primary block, in ord order', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockImplementation(
+      async (_id: string, unitKey: string) => ({ output: `output of ${unitKey}` }),
+    );
+    render(
+      <ChatPanel
+        view={makeView({ status: 'completed' }, [
+          // Deliberately out of ord order — the panel must sort by ord.
+          makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'done', assigned_cli: 'claude' }),
+          makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+        ])}
+        onLaunched={vi.fn()}
+        onNavigateBack={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    // Outputs load with NO click and render in the main flow (crew#272).
+    const first = await screen.findByTestId('unit-output-1');
+    const second = await screen.findByTestId('unit-output-2');
+    expect(await within(first).findByText('output of survey')).toBeInTheDocument();
+    expect(await within(second).findByText('output of build')).toBeInTheDocument();
+
+    // The header carries the phase name + the unit's status.
+    expect(first).toHaveTextContent('survey');
+    expect(first).toHaveTextContent('done');
+    expect(second).toHaveTextContent('build');
+
+    // ord order in the DOM: unit 1's block precedes unit 2's.
+    expect(
+      first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // The output endpoint was addressed by the phase-id unit key.
+    expect(client.api.getUnitOutput).toHaveBeenCalledWith('run-1', 'survey');
+    expect(client.api.getUnitOutput).toHaveBeenCalledWith('run-1', 'build');
+  });
+
+  it('falls back to the stage as the phase name for a free-text (u<ord>) unit', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'free-text result' });
+    render(
+      <ChatPanel
+        view={makeView({ status: 'completed' }, [
+          makeUnit({ id: 'run-1:u0', ord: 0, stage: 'build', status: 'done' }),
+        ])}
+        onLaunched={vi.fn()}
+        onNavigateBack={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+    const block = await screen.findByTestId('unit-output-0');
+    expect(await within(block).findByText('free-text result')).toBeInTheDocument();
+    // 'u0' is not a phase name — the stage is the closest thing a free-text unit has.
+    expect(block).toHaveTextContent('build');
+    expect(block).not.toHaveTextContent('u0');
+  });
+
+  it('hides and re-shows the output via the toggle (secondary layer)', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'collapsible body' });
+    render(
+      <ChatPanel
+        view={makeView({ status: 'completed' }, [
+          makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done' }),
+        ])}
+        onLaunched={vi.fn()}
+        onNavigateBack={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText('collapsible body')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('unit-output-toggle-1'));
+    expect(screen.queryByText('collapsible body')).not.toBeInTheDocument();
+    // The header (phase name + status) stays even while the body is collapsed.
+    expect(screen.getByTestId('unit-output-1')).toHaveTextContent('survey');
+
+    await user.click(screen.getByTestId('unit-output-toggle-1'));
+    expect(await screen.findByText('collapsible body')).toBeInTheDocument();
+  });
+
+  it('renders the daemon-stated reason when a done unit has no stored output', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({
+      output: null,
+      outputUnavailable: 'Unit 1 is recorded as done (approved) but the transcript read returned nothing.',
+    });
+    render(
+      <ChatPanel
+        view={makeView({ status: 'completed' }, [
+          makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done' }),
+        ])}
+        onLaunched={vi.fn()}
+        onNavigateBack={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(
+      await screen.findByText(/recorded as done \(approved\) but the transcript read returned nothing/),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/RightPanel.files.test.tsx
+++ b/tests/RightPanel.files.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RightPanel } from '../src/components/RightPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+import type { SessionView } from '../src/api/types.js';
+
+const FILE = '/work/report.md';
+
+function seededView(): SessionView {
+  return makeView({ status: 'completed' }, [
+    makeUnit({ id: 'run-1:u0', ord: 0, status: 'done', assigned_cli: 'claude' }),
+  ]);
+}
+
+let writeText: Mock;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Seed the run's event log with a dataUsed frame so the Files panel has a file.
+  useRunEventStore.setState({ byRun: {} });
+  useRunEventStore.getState().hydrate('run-1', [
+    { type: 'dataUsed', session: 'run-1', ord: 0, files: [FILE] },
+  ]);
+  // jsdom has no clipboard — install a spyable stub (fireEvent, not userEvent, so
+  // user-event's own clipboard stub never replaces this one).
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  vi.spyOn(client.api, 'getRun').mockResolvedValue({ run: seededView() });
+});
+
+async function renderFilesTab(): Promise<HTMLElement> {
+  render(<RightPanel view={seededView()} />);
+  fireEvent.click(screen.getByRole('button', { name: /files/i }));
+  return await screen.findByTitle(`Open with system default app: ${FILE}`);
+}
+
+describe('RightPanel Files tab — open with the system default app (crew#273)', () => {
+  it('clicking a file asks the daemon to open it with the OS default application', async () => {
+    const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
+    const row = await renderFilesTab();
+
+    fireEvent.click(row);
+    expect(openPath).toHaveBeenCalledWith(FILE, 'run-1');
+    expect(await screen.findByText('✓ opened')).toBeInTheDocument();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('falls back to copying the path when the daemon has no /open route', async () => {
+    vi.spyOn(client.api, 'openPath').mockRejectedValue(new Error('API 404: Not Found'));
+    const row = await renderFilesTab();
+
+    fireEvent.click(row);
+    expect(await screen.findByText(/open unavailable — path copied/)).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalledWith(FILE);
+  });
+
+  it('the explicit copy button copies the path without attempting an open', async () => {
+    const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
+    await renderFilesTab();
+
+    fireEvent.click(screen.getByRole('button', { name: `Copy path ${FILE}` }));
+    expect(await screen.findByText('✓ copied')).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalledWith(FILE);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implements crew#272 and the studio half of crew#273.

- **crew#272** — each done unit's output renders as the primary message body of its chat block in the run view (phase-name header + status, show/hide toggle), auto-loaded via `GET /runs/:id/units/:unitKey/output`; a null output still shows the daemon's `outputUnavailable` reason. Existing panels untouched.
- **crew#273** — Files rows call `POST /api/v1/open {path, runId}` (system-default open, server-side); on a daemon without the route it degrades to copy-path + notice. Explicit ⧉ copy button added. The crew-side endpoint ships separately on crew's seat-health branch with path validation (inside run workdir/extra roots/repo roots only) and a no-shell spawn.
- +7 RTL tests (253 total green); lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn