### PR TITLE
feat(dashboard): runtime seat-health chips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.3.0"
+        "wicked-crew-api-types": "^0.4.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.3.0.tgz",
-      "integrity": "sha512-LZOAe3kd1Ii3IPEFyzMMuXp4M/6a4+UkNiIzbW6QVScAn4oByZ8yxw1dmpVXbc1Fuy9OZfFntIpgLQjqugwdPw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.4.0.tgz",
+      "integrity": "sha512-6i0FGaOkqYxspAasVqvBRcCY5WVzPBa35s95WTJ2Wbw/MdLk7W1qMr1nTt9EDeYK9dt9yRx/gAvG5KHmMifaaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
   "version": "0.1.1",
-  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.3.0"
+    "wicked-crew-api-types": "^0.4.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -537,14 +537,28 @@ export function Dashboard({ runs, navigate }: Props): React.ReactElement {
                       >
                         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                           <span
+                            title={
+                              seat.health?.status === 'inactive'
+                                ? `inactive — ${seat.health.message ?? 'no detail'}`
+                                : seat.enabled_for_council
+                                  ? 'active'
+                                  : 'not on the council'
+                            }
                             style={{
                               display: 'inline-block',
                               width: '7px',
                               height: '7px',
                               borderRadius: '50%',
-                              background: seat.enabled_for_council
-                                ? '#3fb950'
-                                : 'rgba(230,237,243,0.18)',
+                              // Runtime seat health outranks static council membership
+                              // (crew#274): red = the platform detected quota/auth/worker
+                              // errors; green = council-enabled and healthy; dim = not
+                              // council-enabled.
+                              background:
+                                seat.health?.status === 'inactive'
+                                  ? '#f85149'
+                                  : seat.enabled_for_council
+                                    ? '#3fb950'
+                                    : 'rgba(230,237,243,0.18)',
                               flexShrink: 0,
                             }}
                           />
@@ -557,6 +571,21 @@ export function Dashboard({ runs, navigate }: Props): React.ReactElement {
                           >
                             {seat.display_name}
                           </span>
+                          {seat.health?.status === 'inactive' && (
+                            <span
+                              title={seat.health.message ?? ''}
+                              style={{
+                                fontSize: '10px',
+                                color: '#f85149',
+                                border: '1px solid rgba(248,81,73,0.4)',
+                                borderRadius: '9999px',
+                                padding: '0 6px',
+                                ...monoText,
+                              }}
+                            >
+                              inactive
+                            </span>
+                          )}
                         </div>
                         <span
                           style={{


### PR DESCRIPTION
The studio half of crew#274 (the crew half — health fold + GET /roster `health` + recovery probe — merged as crew PR#279; `wicked-crew-api-types@0.4.0` published).

Dashboard's CLI list dots now read runtime health: red dot + `inactive` pill with the detection message (tooltip) when the platform marked the seat unhealthy; green for council-enabled healthy seats; dim for non-council. 253 tests green, typecheck clean against 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn