### PR TITLE
fix(chips): seat-health chips on the live launch-form roster

### DIFF
--- a/src/components/LaunchForm.tsx
+++ b/src/components/LaunchForm.tsx
@@ -226,6 +226,16 @@ export function LaunchForm({ onLaunched, onCancel }: Props): React.ReactElement 
               />
               <span>{seat.display_name}</span>
               <span className="font-mono text-gray-400">{seat.key}</span>
+              {seat.health?.status === 'inactive' && (
+                <span
+                  className="rounded-full border px-1.5 text-[10px] font-mono"
+                  style={{ color: '#f85149', borderColor: 'rgba(248,81,73,0.5)' }}
+                  title={seat.health.message ?? 'marked inactive by the platform'}
+                  data-testid={`seat-health-${seat.key}`}
+                >
+                  inactive
+                </span>
+              )}
             </label>
           ))
         )}


### PR DESCRIPTION
Follow-up to PR#18: the chips landed in `Dashboard.tsx`, which turns out to be unrouted legacy (nothing imports it — same trap as `RunDetail.tsx`). The operator-facing seat list is the LAUNCH FORM roster, so the `inactive` pill (tooltip = detection message, `data-testid=seat-health-<key>`) now renders there. 253 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn