### PR TITLE
fix(chips): seat-health chips on the live context popover

### DIFF
--- a/src/components/ContextPopover.tsx
+++ b/src/components/ContextPopover.tsx
@@ -174,6 +174,16 @@ export function ContextPopover({
                   data-testid={`launch-seat-${seat.key}`}
                 />
                 <span>{seat.key}</span>
+                {seat.health?.status === 'inactive' && (
+                  <span
+                    className="rounded-full border px-1.5 text-[10px] font-mono"
+                    style={{ color: '#f85149', borderColor: 'rgba(248,81,73,0.5)' }}
+                    title={seat.health.message ?? 'marked inactive by the platform'}
+                    data-testid={`seat-health-${seat.key}`}
+                  >
+                    inactive
+                  </span>
+                )}
               </label>
             ))}
           </div>


### PR DESCRIPTION
Dashboard.tsx (PR#18) and LaunchForm.tsx (PR#19) both turned out to be unrouted legacy — verified by driving the deployed UI in Playwright: the chat-first composer is the launch surface, and its `ContextPopover` renders the seat toggles. The `inactive` pill (tooltip = detection message, `data-testid=seat-health-<key>`) now renders beside each seat there. A follow-up should delete the legacy components (Dashboard/LaunchForm/RunDetail) so the next feature doesn't land in them — noted below.

253 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn