### PR TITLE
feat(settings): seat sign-in terminals, worker config root, launch check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.4.0"
+        "wicked-crew-api-types": "file:../../../../../tmp/wicked-crew-api-types-0.5.0.tgz"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.4.0.tgz",
-      "integrity": "sha512-6i0FGaOkqYxspAasVqvBRcCY5WVzPBa35s95WTJ2Wbw/MdLk7W1qMr1nTt9EDeYK9dt9yRx/gAvG5KHmMifaaQ==",
+      "version": "0.5.0",
+      "resolved": "file:../../../../../tmp/wicked-crew-api-types-0.5.0.tgz",
+      "integrity": "sha512-cGs+qYYVFpP0FPGV0LT8NMk149dXX7a5+8aeTwT7GyfPtJji+NNPFqfIqGd23Nl3ZjVnz+SMj4LwVTuGtftb7w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "file:../../../../../tmp/wicked-crew-api-types-0.5.0.tgz"
+        "wicked-crew-api-types": "^0.5.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7147,8 +7147,8 @@
     },
     "node_modules/wicked-crew-api-types": {
       "version": "0.5.0",
-      "resolved": "file:../../../../../tmp/wicked-crew-api-types-0.5.0.tgz",
-      "integrity": "sha512-cGs+qYYVFpP0FPGV0LT8NMk149dXX7a5+8aeTwT7GyfPtJji+NNPFqfIqGd23Nl3ZjVnz+SMj4LwVTuGtftb7w==",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.5.0.tgz",
+      "integrity": "sha512-yDxxJyQVhG+k4U4hOMS2/AsgCgA1XjL0YT7F6LQx7081weQ8Xmf5na1ylCzj8yJUzFx+Wbb8pefqeppd8iVSDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.4.0"
+    "wicked-crew-api-types": "^0.5.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,6 +301,7 @@ export function App(): React.ReactElement {
           onNavigateBack={onNavigateBack}
           onRefresh={refresh}
           onKill={onKill}
+          navigate={navigate}
         />
       </div>
     );

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -31,6 +31,12 @@ interface Props {
   injectTarget?: string;
   /** Called when the user clears the agent-specific inject target (resets to "all"). */
   onClearInjectTarget?: () => void;
+  /**
+   * App-level route navigation (App.tsx's useRoute().navigate), threaded down so the
+   * seat sign-in warning can jump to Settings (/system). Optional — surfaces without
+   * it just render the warning with no working link.
+   */
+  navigate?: (path: string) => void;
 }
 
 const INJECT_STATUSES = new Set(['executing', 'distributing', 'planning']);
@@ -82,7 +88,7 @@ function ActivePill({
 // Defense-in-depth denylist: catches system workflows that predate the is_system flag.
 const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
 
-export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget }: Props): React.ReactElement {
+export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget, navigate }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
 
   // ── Steer mode state ───────────────────────────────────────────────────────
@@ -466,6 +472,13 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const canSubmit = problem.trim().length > 0 && selectedClis.size > 0 && !submitting;
   const showDetection = detectedWorkflow !== null && !workflowDismissed && !workflow && !workflowOverride;
 
+  // Seats routed to by this launch that the daemon observed as NOT signed in.
+  // Strictly `=== false` — `null`/absent means "unknowable cheaply", not a problem.
+  // A warning only: fallbacks exist, so the launch is never blocked on it.
+  const unsignedSelected = roster.filter(
+    (s) => selectedClis.has(s.key) && s.signed_in === false,
+  );
+
   // Determine whether CLIs differ from the defaults that loaded from the roster
   const defaultCliSet = new Set(
     roster.filter((s) => s.enabled_for_council).map((s) => s.key),
@@ -561,6 +574,33 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             style={{ color: 'rgba(230,237,243,0.35)' }}
           >
             ✕
+          </button>
+        </div>
+      )}
+
+      {/* Seat sign-in warning — selected seats observed as signed_in === false */}
+      {unsignedSelected.length > 0 && (
+        <div
+          data-testid="signin-warning"
+          className="flex items-center gap-2 text-xs rounded-xl px-4 py-2 font-mono"
+          style={{
+            background: 'rgba(248,81,73,0.08)',
+            border: '1px solid rgba(248,81,73,0.3)',
+            color: '#f85149',
+          }}
+        >
+          <span className="flex-1">
+            ⚠ {unsignedSelected.map((s) => s.key).join(', ')}{' '}
+            {unsignedSelected.length === 1 ? "isn't" : "aren't"} signed in — runs routed there
+            will fall back or fail. Sign in in Settings.
+          </span>
+          <button
+            type="button"
+            onClick={() => navigate?.('/system')}
+            className="rounded-lg px-3 py-1 font-semibold text-xs shrink-0"
+            style={{ background: 'rgba(248,81,73,0.15)', color: '#f85149', border: '1px solid rgba(248,81,73,0.35)' }}
+          >
+            Open Settings
           </button>
         </div>
       )}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -23,6 +23,8 @@ interface Props {
   onNavigateBack: () => void;
   onRefresh: () => void;
   onKill?: (runId: string) => void | Promise<void>;
+  /** App-level route navigation — threaded to ChatInput's seat sign-in warning (→ /system). */
+  navigate?: (path: string) => void;
 }
 
 // Per-CLI identity: consistent avatar colours across multi-agent runs
@@ -558,6 +560,7 @@ function RunChat({
   onNavigateBack,
   onRefresh,
   onKill,
+  navigate,
 }: {
   view: SessionView;
   mode: RunMode;
@@ -566,6 +569,7 @@ function RunChat({
   onNavigateBack: () => void;
   onRefresh: () => void;
   onKill?: (runId: string) => void | Promise<void>;
+  navigate?: (path: string) => void;
 }): React.ReactElement {
   const { session, units } = view;
   // `ord` order is what `unit_ix` indexes into, so both the render order and the cursor derive from
@@ -964,6 +968,7 @@ function RunChat({
         onLaunched={onLaunched}
         injectTarget={injectTarget}
         onClearInjectTarget={() => setInjectTarget('all')}
+        {...(navigate !== undefined ? { navigate } : {})}
       />
     </div>
   );
@@ -974,11 +979,13 @@ function NewRunView({
   mode,
   onModeChange,
   onLaunched,
+  navigate,
 }: {
   chatMode: boolean;
   mode: RunMode;
   onModeChange: (m: RunMode) => void;
   onLaunched: (id: string) => void;
+  navigate?: (path: string) => void;
 }): React.ReactElement {
   const heading = chatMode
     ? 'What do you want to explore?'
@@ -1001,13 +1008,19 @@ function NewRunView({
         <div className="flex justify-center">
           <ModePill mode={mode} onChange={onModeChange} />
         </div>
-        <ChatInput embedded mode={mode} onLaunched={onLaunched} {...(chatMode ? { workflowOverride: 'chat' } : {})} />
+        <ChatInput
+          embedded
+          mode={mode}
+          onLaunched={onLaunched}
+          {...(chatMode ? { workflowOverride: 'chat' } : {})}
+          {...(navigate !== undefined ? { navigate } : {})}
+        />
       </div>
     </div>
   );
 }
 
-export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill }: Props): React.ReactElement {
+export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill, navigate }: Props): React.ReactElement {
   const [mode, setMode] = useState<RunMode>('balanced');
 
   if (view) {
@@ -1036,6 +1049,7 @@ export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefres
         onNavigateBack={onNavigateBack}
         onRefresh={onRefresh}
         {...(onKill !== undefined ? { onKill } : {})}
+        {...(navigate !== undefined ? { navigate } : {})}
       />
     );
   }
@@ -1045,6 +1059,7 @@ export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefres
       mode={mode}
       onModeChange={setMode}
       onLaunched={onLaunched}
+      {...(navigate !== undefined ? { navigate } : {})}
     />
   );
 }

--- a/src/components/ContextPopover.tsx
+++ b/src/components/ContextPopover.tsx
@@ -184,6 +184,16 @@ export function ContextPopover({
                     inactive
                   </span>
                 )}
+                {seat.signed_in === false && (
+                  <span
+                    className="rounded-full border px-1.5 text-[10px] font-mono"
+                    style={{ color: '#f85149', borderColor: 'rgba(248,81,73,0.5)' }}
+                    title={`${seat.key} isn't signed in — runs routed there will fall back or fail. Sign in in Settings.`}
+                    data-testid={`seat-signin-${seat.key}`}
+                  >
+                    sign in needed
+                  </span>
+                )}
               </label>
             ))}
           </div>

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -1,8 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
+import { Modal } from './Modal.js';
+import { Terminal } from './Terminal.js';
 
 const CLI_DEFAULTS_KEY = 'wicked_default_clis';
+
+/**
+ * Client-side mirror of the daemon's worker_config_root rule (empty or absolute).
+ * The daemon stays authoritative — this only pre-warns; a 400 still renders inline.
+ */
+function isAbsolutePathLike(p: string): boolean {
+  return p.startsWith('/') || p.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(p);
+}
 
 interface SettingRowProps {
   label: string;
@@ -45,6 +55,11 @@ export function SystemSettings(): React.ReactElement {
   const [defaultClis, setDefaultClis] = useState<Set<string>>(new Set());
   const [clisSaved, setClisSaved] = useState(false);
   const clisSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** Seat whose sign-in terminal modal is open, or null. */
+  const [signInSeat, setSignInSeat] = useState<RosterSeat | null>(null);
+  /** Daemon 400 from a save whose patch included worker_config_root — rendered inline at the field. */
+  const [workerRootError, setWorkerRootError] = useState<string | null>(null);
 
   useEffect(() => {
     api.getSettings()
@@ -94,6 +109,7 @@ export function SystemSettings(): React.ReactElement {
     if (Object.keys(dirty).length === 0) return;
     setSaving(true);
     setError(null);
+    setWorkerRootError(null);
     try {
       const { settings: next } = await api.updateSettings(dirty);
       setSettings(next);
@@ -102,7 +118,11 @@ export function SystemSettings(): React.ReactElement {
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setSaved(false), 2500);
     } catch (e: unknown) {
-      setError(String(e));
+      // A rejected patch that touched worker_config_root (the daemon 400s a
+      // non-absolute path) belongs at the field, not the page banner.
+      const msg = e instanceof Error ? e.message : String(e);
+      if ('worker_config_root' in dirty) setWorkerRootError(msg);
+      else setError(msg);
     } finally {
       setSaving(false);
     }
@@ -110,6 +130,8 @@ export function SystemSettings(): React.ReactElement {
 
   const merged: Settings = { graphNodeLimit: 150, ...settings, ...dirty };
   const hasDirty = Object.keys(dirty).length > 0;
+  const workerRoot = merged.worker_config_root ?? '';
+  const workerRootInvalid = workerRoot !== '' && !isAbsolutePathLike(workerRoot);
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -166,6 +188,52 @@ export function SystemSettings(): React.ReactElement {
         </SettingRow>
       </section>
 
+      <section
+        className="rounded-xl px-5 mb-6"
+        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+      >
+        <h2
+          className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
+          style={{ color: 'rgba(230,237,243,0.4)' }}
+        >
+          Workers
+        </h2>
+
+        <SettingRow
+          label="Worker config root"
+          description="Base directory for the engine-owned worker CLI config homes (e.g. the claude worker home is <root>/claude). Empty = the engine default ~/.wicked-worker. Must be an absolute path; takes effect on the next worker spawn."
+        >
+          <div className="flex flex-col items-end gap-1">
+            <input
+              type="text"
+              aria-label="Worker config root"
+              placeholder="~/.wicked-worker"
+              value={workerRoot}
+              onChange={(e) => {
+                setWorkerRootError(null);
+                patch('worker_config_root', e.target.value);
+              }}
+              className="w-56 rounded px-2 py-1 text-sm font-mono focus:outline-none"
+              style={{
+                background: '#161c26',
+                border: `1px solid ${workerRootInvalid || workerRootError ? 'rgba(248,81,73,0.5)' : 'rgba(230,237,243,0.12)'}`,
+                color: '#e6edf3',
+              }}
+            />
+            {workerRootInvalid && (
+              <p className="text-xs" style={{ color: '#f85149' }} data-testid="worker-root-invalid">
+                Must be empty or an absolute path.
+              </p>
+            )}
+            {workerRootError && (
+              <p className="text-xs" style={{ color: '#f85149' }} data-testid="worker-root-error">
+                {workerRootError}
+              </p>
+            )}
+          </div>
+        </SettingRow>
+      </section>
+
       <div className="flex items-center gap-3 mb-8">
         <button
           type="button"
@@ -182,7 +250,7 @@ export function SystemSettings(): React.ReactElement {
         {saved && <span className="text-xs font-medium" style={{ color: '#3fb950' }}>Saved</span>}
       </div>
 
-      {/* ── CLIs section ──────────────────────────────────────────────────── */}
+      {/* ── CLI seats & sign-in ───────────────────────────────────────────── */}
       <section
         className="rounded-xl px-5 mb-6"
         style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
@@ -191,30 +259,65 @@ export function SystemSettings(): React.ReactElement {
           className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
           style={{ color: 'rgba(230,237,243,0.4)' }}
         >
-          Default CLIs
+          CLI seats &amp; sign-in
         </h2>
         <p className="text-xs mb-4" style={{ color: 'rgba(230,237,243,0.4)' }}>
-          Which CLIs are pre-selected when you open the launch form. Changes take effect on the next new session.
+          Checked CLIs are pre-selected when you open the launch form (takes effect on the next new
+          session). The status shows whether each seat looks signed in; Sign in opens that CLI&apos;s
+          own login flow in a terminal.
         </p>
         {roster.length === 0 ? (
           <p className="text-xs italic pb-4 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>Loading roster…</p>
         ) : (
           <div className="flex flex-col gap-2 pb-4">
             {roster.map((seat) => (
-              <label key={seat.key} className="flex items-center gap-3 cursor-pointer group">
-                <input
-                  type="checkbox"
-                  checked={defaultClis.has(seat.key)}
-                  onChange={() => toggleDefaultCli(seat.key)}
-                  className="accent-[#ffda19] w-3.5 h-3.5 shrink-0"
-                />
-                <span className="text-sm font-mono flex-1" style={{ color: '#e6edf3' }}>
-                  {seat.display_name}
-                </span>
+              <div key={seat.key} className="flex items-center gap-3">
+                {/* The label wraps ONLY the checkbox + name so the status/sign-in
+                    controls on the row never toggle the default-CLI checkbox. */}
+                <label className="flex items-center gap-3 cursor-pointer group flex-1 min-w-0">
+                  <input
+                    type="checkbox"
+                    checked={defaultClis.has(seat.key)}
+                    onChange={() => toggleDefaultCli(seat.key)}
+                    className="accent-[#ffda19] w-3.5 h-3.5 shrink-0"
+                  />
+                  <span className="text-sm font-mono truncate" style={{ color: '#e6edf3' }}>
+                    {seat.display_name}
+                  </span>
+                </label>
                 <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
                   {seat.key}
                 </span>
-              </label>
+                {seat.signed_in === true && (
+                  <span
+                    className="text-xs font-mono"
+                    style={{ color: '#3fb950' }}
+                    data-testid={`seat-signin-${seat.key}`}
+                  >
+                    ✓ signed in
+                  </span>
+                )}
+                {seat.signed_in === false && (
+                  <span
+                    className="text-xs font-mono"
+                    style={{ color: '#f85149' }}
+                    data-testid={`seat-signin-${seat.key}`}
+                  >
+                    sign in needed
+                  </span>
+                )}
+                {seat.login_invocation !== undefined && seat.login_invocation !== '' && seat.signed_in !== true && (
+                  <button
+                    type="button"
+                    onClick={() => setSignInSeat(seat)}
+                    aria-label={`Sign in ${seat.display_name}`}
+                    className="px-2.5 py-1 rounded-lg text-xs font-medium shrink-0"
+                    style={{ background: 'rgba(255,218,25,0.15)', color: '#ffda19', border: '1px solid rgba(255,218,25,0.3)' }}
+                  >
+                    Sign in
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         )}
@@ -235,6 +338,37 @@ export function SystemSettings(): React.ReactElement {
           </div>
         )}
       </section>
+
+      {/* ── Seat sign-in terminal ─────────────────────────────────────────────
+          An interactive login shell (NO cmd — `login_invocation` is a SHELL LINE,
+          not an argv) into which Terminal types the line + "\n" over the terminal
+          WS once the PTY is up. The operator completes the CLI's URL/paste flow
+          right here. Keyed by seat so switching seats starts a fresh session. */}
+      {signInSeat !== null && (
+        <Modal
+          title={`Sign in — ${signInSeat.display_name}`}
+          onClose={() => setSignInSeat(null)}
+          disableEscapeKey
+        >
+          <div className="flex flex-col gap-3">
+            <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
+              Running{' '}
+              <code
+                className="rounded px-1 py-0.5"
+                style={{ background: 'rgba(230,237,243,0.06)', color: '#e6edf3' }}
+              >
+                {signInSeat.login_invocation}
+              </code>{' '}
+              in your shell — complete the sign-in flow below, then close this panel.
+            </p>
+            <Terminal
+              key={signInSeat.key}
+              cwd="."
+              initialInput={`${signInSeat.login_invocation ?? ''}\n`}
+            />
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -14,6 +14,14 @@ interface Props {
    * surfaced as ungoverned in the UI. Omitted / `true` = the safe governed default.
    */
   governed?: boolean;
+  /**
+   * Bytes to type into the PTY as soon as the stdin channel is up — sent ONCE over
+   * the dedicated terminal WS, the exact same text-frame path keystrokes take
+   * (`ws.send` → daemon `writeTerminal`). Used by seat sign-in: the roster's
+   * `login_invocation` + `"\n"` runs in the operator's own interactive login shell,
+   * echoing visibly so they can complete the CLI's URL/paste flow in this terminal.
+   */
+  initialInput?: string;
 }
 
 /**
@@ -29,11 +37,11 @@ interface Props {
  * A terminal is a stateful session: it opens ONCE for the component's lifetime.
  * Remount with a React `key` to start a fresh terminal (e.g. a different cwd).
  */
-export function Terminal({ cwd, cmd, governed = true }: Props): React.ReactElement {
+export function Terminal({ cwd, cmd, governed = true, initialInput }: Props): React.ReactElement {
   const hostRef = useRef<HTMLDivElement>(null);
   // Snapshot the open-time props; the session opens once (see effect deps: []).
-  const propsRef = useRef({ cwd, cmd, governed });
-  propsRef.current = { cwd, cmd, governed };
+  const propsRef = useRef({ cwd, cmd, governed, initialInput });
+  propsRef.current = { cwd, cmd, governed, initialInput };
 
   useEffect(() => {
     const host = hostRef.current;
@@ -112,6 +120,14 @@ export function Terminal({ cwd, cmd, governed = true }: Props): React.ReactEleme
 
         const ws = new WebSocket(terminalWsUrl(id));
         ws.binaryType = 'arraybuffer';
+        // Type `initialInput` into the PTY the moment the stdin channel is up —
+        // once, over the same WS text-frame path as keystrokes. The PTY's input is
+        // kernel-buffered, so sending at open is safe even before the shell prompts.
+        const line = propsRef.current.initialInput;
+        if (line !== undefined && line.length > 0) {
+          if (ws.readyState === WebSocket.OPEN) ws.send(line);
+          else ws.onopen = () => ws.send(line);
+        }
         ws.onmessage = (ev: MessageEvent) => {
           // Raw PTY output: binary frame → exact bytes; text frame → string.
           if (typeof ev.data === 'string') term.write(ev.data);

--- a/tests/ChatInput.signin.test.tsx
+++ b/tests/ChatInput.signin.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import * as client from '../src/api/client.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+function seat(overrides: Partial<RosterSeat> & { key: string }): RosterSeat {
+  return {
+    display_name: overrides.key,
+    binary: overrides.key,
+    enabled_for_council: true,
+    ...overrides,
+  };
+}
+
+// This jsdom setup exposes no localStorage (ChatInput guards reads with try/catch);
+// stub one so the stored-default-selection path is exercisable.
+function stubLocalStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  stubLocalStorage(); // empty store → default selection = enabled_for_council seats
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ChatInput seat sign-in warning (launch check)', () => {
+  it('warns when a SELECTED seat has signed_in === false, naming only that seat', async () => {
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [
+        seat({ key: 'claude', signed_in: true }),
+        seat({ key: 'codex', signed_in: false }),
+        seat({ key: 'antigravity' }), // absent → no warning contribution
+        seat({ key: 'cursor', enabled_for_council: false, signed_in: false }), // not selected
+      ],
+    });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    const warning = await screen.findByTestId('signin-warning');
+    expect(warning).toHaveTextContent(
+      "⚠ codex isn't signed in — runs routed there will fall back or fail. Sign in in Settings.",
+    );
+    expect(warning).not.toHaveTextContent('cursor');
+    expect(warning).not.toHaveTextContent('antigravity');
+    expect(warning).not.toHaveTextContent('claude');
+  });
+
+  it('navigates to Settings (/system) from the warning', async () => {
+    const navigate = vi.fn();
+    const user = userEvent.setup();
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [seat({ key: 'codex', signed_in: false })],
+    });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} navigate={navigate} />);
+
+    await screen.findByTestId('signin-warning');
+    await user.click(screen.getByRole('button', { name: 'Open Settings' }));
+    expect(navigate).toHaveBeenCalledWith('/system');
+  });
+
+  it('does NOT block the launch — Send stays available with the warning up', async () => {
+    const user = userEvent.setup();
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [seat({ key: 'codex', signed_in: false })],
+    });
+    const launch = vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-1' });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await screen.findByTestId('signin-warning');
+
+    await user.type(screen.getByTestId('launch-problem'), 'build the thing');
+    const send = screen.getByTestId('launch-submit');
+    expect(send).toBeEnabled();
+    await user.click(send);
+    await waitFor(() => expect(launch).toHaveBeenCalledTimes(1));
+  });
+
+  it('null / absent signed_in produces no warning', async () => {
+    const user = userEvent.setup();
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [
+        seat({ key: 'claude', signed_in: null }),
+        seat({ key: 'antigravity' }),
+      ],
+    });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    // Prove the roster actually landed (seats visible in the popover) before
+    // asserting the negative — otherwise "no warning yet" would pass vacuously.
+    await user.click(screen.getByRole('button', { name: /open launch options/i }));
+    await screen.findByTestId('launch-seat-claude');
+    expect(screen.queryByTestId('signin-warning')).toBeNull();
+  });
+
+  it('a signed-out seat that is DESELECTED does not warn (stored default selection)', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('wicked_default_clis', JSON.stringify(['claude']));
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [
+        seat({ key: 'claude', signed_in: true }),
+        seat({ key: 'codex', signed_in: false }),
+      ],
+    });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /open launch options/i }));
+    await screen.findByTestId('launch-seat-codex');
+    expect(screen.queryByTestId('signin-warning')).toBeNull();
+
+    // Selecting it flips the warning on — the check is selection-scoped, live.
+    await user.click(screen.getByTestId('launch-seat-codex'));
+    expect(await screen.findByTestId('signin-warning')).toHaveTextContent("codex isn't signed in");
+  });
+
+  it('marks the signed-out seat in the launch popover', async () => {
+    const user = userEvent.setup();
+    vi.mocked(client.api.getRoster).mockResolvedValue({
+      roster: [
+        seat({ key: 'claude', signed_in: true }),
+        seat({ key: 'codex', signed_in: false }),
+      ],
+    });
+
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await screen.findByTestId('signin-warning');
+
+    await user.click(screen.getByRole('button', { name: /open launch options/i }));
+    expect(await screen.findByTestId('seat-signin-codex')).toHaveTextContent('sign in needed');
+    expect(screen.queryByTestId('seat-signin-claude')).toBeNull();
+  });
+});

--- a/tests/SystemSettings.seats.test.tsx
+++ b/tests/SystemSettings.seats.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SystemSettings } from '../src/components/SystemSettings.js';
+import * as client from '../src/api/client.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+// The real Terminal drags in xterm.js (no jsdom renderer) and opens a PTY on
+// mount; the seats section only needs to prove the terminal is MOUNTED with the
+// right stdin payload, so stub it and inspect its props.
+vi.mock('../src/components/Terminal.js', () => ({
+  Terminal: (props: { cwd: string; cmd?: string[]; initialInput?: string }) => (
+    <div
+      data-testid="mock-terminal"
+      data-cwd={props.cwd}
+      data-cmd={props.cmd === undefined ? '' : props.cmd.join(' ')}
+      data-initial-input={props.initialInput ?? ''}
+    />
+  ),
+}));
+
+function seat(overrides: Partial<RosterSeat> & { key: string }): RosterSeat {
+  return {
+    display_name: overrides.key,
+    binary: overrides.key,
+    enabled_for_council: true,
+    ...overrides,
+  };
+}
+
+const ROSTER: RosterSeat[] = [
+  // Signed in, has a login flow → status ✓, NO sign-in button.
+  seat({ key: 'claude', display_name: 'Claude Code', login_invocation: 'claude login', signed_in: true }),
+  // Not signed in, has a login flow → red status + sign-in button.
+  seat({ key: 'codex', display_name: 'Codex', login_invocation: 'codex auth login', signed_in: false }),
+  // Unknowable (null) but has a login flow → neutral (no status), button offered.
+  seat({ key: 'antigravity', display_name: 'Antigravity', login_invocation: 'antigravity login', signed_in: null }),
+  // Not signed in but no known login flow → status only, no button.
+  seat({ key: 'cursor', display_name: 'Cursor', signed_in: false }),
+  // Field absent entirely (older daemon) → nothing.
+  seat({ key: 'localonly', display_name: 'Local' }),
+];
+
+// This jsdom setup exposes no localStorage (components guard reads with try/catch);
+// stub one so the default-CLI selection path behaves deterministically.
+function stubLocalStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  stubLocalStorage();
+  vi.spyOn(client.api, 'getSettings').mockResolvedValue({ settings: { graphNodeLimit: 150 } });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: ROSTER });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SystemSettings — CLI seats & sign-in', () => {
+  it('renders per-seat sign-in status: ✓ for true, "sign in needed" for false, nothing for null/absent', async () => {
+    render(<SystemSettings />);
+    await screen.findByText('Claude Code');
+
+    expect(screen.getByTestId('seat-signin-claude')).toHaveTextContent('✓ signed in');
+    expect(screen.getByTestId('seat-signin-codex')).toHaveTextContent('sign in needed');
+    expect(screen.getByTestId('seat-signin-cursor')).toHaveTextContent('sign in needed');
+    // null and absent produce NO marker at all.
+    expect(screen.queryByTestId('seat-signin-antigravity')).toBeNull();
+    expect(screen.queryByTestId('seat-signin-localonly')).toBeNull();
+  });
+
+  it('offers Sign in only when the seat has a login_invocation AND signed_in !== true', async () => {
+    render(<SystemSettings />);
+    await screen.findByText('Claude Code');
+
+    // signed_in: false + invocation → button.
+    expect(screen.getByRole('button', { name: 'Sign in Codex' })).toBeInTheDocument();
+    // signed_in: null + invocation → button (state unknowable, let the operator re-auth).
+    expect(screen.getByRole('button', { name: 'Sign in Antigravity' })).toBeInTheDocument();
+    // signed_in: true → no button even with an invocation.
+    expect(screen.queryByRole('button', { name: 'Sign in Claude Code' })).toBeNull();
+    // No invocation → no button even when not signed in.
+    expect(screen.queryByRole('button', { name: 'Sign in Cursor' })).toBeNull();
+  });
+
+  it('Sign in opens a terminal modal with NO cmd and the login line + newline as initial stdin', async () => {
+    const user = userEvent.setup();
+    render(<SystemSettings />);
+    await screen.findByText('Claude Code');
+
+    await user.click(screen.getByRole('button', { name: 'Sign in Codex' }));
+
+    // Modal with the seat's name; terminal mounted inside it.
+    expect(screen.getByRole('dialog', { name: 'Sign in — Codex' })).toBeInTheDocument();
+    const term = screen.getByTestId('mock-terminal');
+    // CONTRACT: login_invocation is a SHELL LINE — interactive login shell (no cmd),
+    // the line + "\n" written into the PTY's stdin stream.
+    expect(term).toHaveAttribute('data-cmd', '');
+    expect(term).toHaveAttribute('data-initial-input', 'codex auth login\n');
+  });
+
+  it('the modal close button dismisses the sign-in terminal', async () => {
+    const user = userEvent.setup();
+    render(<SystemSettings />);
+    await screen.findByText('Claude Code');
+
+    await user.click(screen.getByRole('button', { name: 'Sign in Codex' }));
+    expect(screen.getByTestId('mock-terminal')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() => expect(screen.queryByTestId('mock-terminal')).toBeNull());
+  });
+
+  it('clicking Sign in does not toggle the seat default-CLI checkbox', async () => {
+    const user = userEvent.setup();
+    render(<SystemSettings />);
+    await screen.findByText('Claude Code');
+
+    const row = screen.getByText('Codex').closest('div');
+    const checkbox = row?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).toBeTruthy();
+    const before = checkbox.checked;
+
+    await user.click(screen.getByRole('button', { name: 'Sign in Codex' }));
+    expect(checkbox.checked).toBe(before);
+  });
+});

--- a/tests/SystemSettings.workerRoot.test.tsx
+++ b/tests/SystemSettings.workerRoot.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SystemSettings } from '../src/components/SystemSettings.js';
+import * as client from '../src/api/client.js';
+
+// Terminal drags in xterm.js; this suite never opens it, but SystemSettings
+// imports it at module level, so stub it out of the graph.
+vi.mock('../src/components/Terminal.js', () => ({ Terminal: () => <div data-testid="mock-terminal" /> }));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getSettings').mockResolvedValue({ settings: { graphNodeLimit: 150 } });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+});
+
+describe('SystemSettings — worker config root', () => {
+  it('renders the field with the persisted value and the ~/.wicked-worker placeholder', async () => {
+    vi.mocked(client.api.getSettings).mockResolvedValue({
+      settings: { graphNodeLimit: 150, worker_config_root: '/srv/workers' },
+    });
+    render(<SystemSettings />);
+
+    const input = await screen.findByLabelText('Worker config root');
+    await waitFor(() => expect(input).toHaveValue('/srv/workers'));
+    expect(input).toHaveAttribute('placeholder', '~/.wicked-worker');
+  });
+
+  it('saves through PUT /settings alongside the existing settings path', async () => {
+    const user = userEvent.setup();
+    const updated = vi
+      .spyOn(client.api, 'updateSettings')
+      .mockResolvedValue({ settings: { graphNodeLimit: 150, worker_config_root: '/abs/workers' } });
+    render(<SystemSettings />);
+
+    const input = await screen.findByLabelText('Worker config root');
+    await user.type(input, '/abs/workers');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(updated).toHaveBeenCalledWith({ worker_config_root: '/abs/workers' }),
+    );
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
+  });
+
+  it('mirrors the daemon rule client-side: a relative path shows the inline hint', async () => {
+    const user = userEvent.setup();
+    render(<SystemSettings />);
+
+    const input = await screen.findByLabelText('Worker config root');
+    await user.type(input, 'relative/path');
+
+    expect(screen.getByTestId('worker-root-invalid')).toHaveTextContent(
+      'Must be empty or an absolute path.',
+    );
+
+    // Emptying the field clears the mirror hint (empty is valid).
+    await user.clear(input);
+    expect(screen.queryByTestId('worker-root-invalid')).toBeNull();
+  });
+
+  it("shows the daemon's 400 inline at the field, not in the page banner", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(client.api, 'updateSettings').mockRejectedValue(
+      new Error('API 400: worker_config_root must be empty or an absolute path'),
+    );
+    render(<SystemSettings />);
+
+    const input = await screen.findByLabelText('Worker config root');
+    await user.type(input, 'not-absolute');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const inline = await screen.findByTestId('worker-root-error');
+    expect(inline).toHaveTextContent('API 400: worker_config_root must be empty or an absolute path');
+  });
+});

--- a/tests/Terminal.test.tsx
+++ b/tests/Terminal.test.tsx
@@ -171,6 +171,44 @@ describe('Terminal (DES-TERMINAL-001 §6 — the web bridge)', () => {
     await waitFor(() => expect(client.api.closeTerminal).toHaveBeenCalledWith('term-xyz'));
   });
 
+  it('initialInput: opens a plain login shell (no cmd) and types the line into the PTY over the WS', async () => {
+    render(<Terminal cwd="/work" initialInput={'codex auth login\n'} />);
+    await waitFor(() => expect(FakeWebSocket.last).toBeTruthy());
+
+    // Seat sign-in contract: login_invocation is a SHELL LINE, so the PTY is the
+    // user's interactive login shell — cmd is NOT forwarded to openTerminal.
+    expect(client.api.openTerminal).toHaveBeenCalledWith({
+      cwd: '/work',
+      cols: 80,
+      rows: 24,
+      governed: true,
+    });
+    // ...and the line goes down the SAME stdin path keystrokes use: a WS text frame.
+    expect(FakeWebSocket.last?.send).toHaveBeenCalledWith('codex auth login\n');
+  });
+
+  it('initialInput: waits for ws.onopen when the socket is still connecting', async () => {
+    // Force the CONNECTING path — the component must defer the write to onopen.
+    class ConnectingWebSocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        this.readyState = FakeWebSocket.CONNECTING;
+      }
+    }
+    vi.stubGlobal('WebSocket', ConnectingWebSocket);
+
+    render(<Terminal cwd="/work" initialInput={'claude login\n'} />);
+    await waitFor(() => expect(FakeWebSocket.last).toBeTruthy());
+    const ws = FakeWebSocket.last!;
+    expect(ws.send).not.toHaveBeenCalled();
+
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({});
+    });
+    expect(ws.send).toHaveBeenCalledWith('claude login\n');
+  });
+
   it('surfaces the ungoverned operator shell loudly in the UI (§7)', () => {
     const { rerender } = render(<Terminal cwd="/work" governed />);
     expect(screen.getByTestId('terminal-governed')).toHaveTextContent('governed');


### PR DESCRIPTION
Studio half of the seat sign-in design (core PR#278 + crew PR#281, both merged; `wicked-crew-api-types@0.5.0` published):

- **Settings → CLI seats & sign-in**: each seat shows ✓ signed in / red *sign in needed* / neutral-unknown, with a **Sign in** button (gated on `login_invocation` + not-signed-in) that opens the interactive terminal: PTY spawns the operator's own login shell and the seat's `login_invocation` line is written over the existing WS stdin path — the operator sees the exact command run in their own shell and completes the CLI's URL/paste flow there. No platform credential custody, no per-provider auth code.
- **Settings → Workers**: `worker_config_root` field (absolute or empty = `~/.wicked-worker`), saved through the existing settings path; daemon 400s render inline at the field.
- **Launch check**: the composer warns when a SELECTED seat has `signed_in === false` — '<seat> isn't signed in…' with an Open Settings jump — and never blocks the launch (fallbacks exist; test pins Send still firing).

270 tests (+17), typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132g8U2sMJ4x21UMAkT1fgn