### PR TITLE
fix(run-thread): live streaming render + process-stepper layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,14 +114,26 @@ export function App(): React.ReactElement {
   // with no live socket history), backfill from the persisted event trail. Guarded on emptiness (and
   // again inside the store) so a live run's streamed frames are never double-counted; a 503 (engine
   // with no event-log binding) or a run with no history simply leaves the panels as they are.
+  //
+  // The same replay gap hid the run thread's live narration: the runtime store's `outputs` buffers
+  // were fed ONLY by live `unitOutputDelta`/`cliOutputDelta` frames (the structured-event hydrate
+  // above deliberately drops them), so opening an already-executing run showed a bare "Working…"
+  // even though the streamed text was durably recorded. The same fetch now also seeds those
+  // buffers, per-key guarded inside the store so live frames are never double-counted.
   useEffect(() => {
     if (!runId) return;
-    if ((useRunEventStore.getState().byRun[runId] ?? []).length > 0) return;
+    const hasFrames = (useRunEventStore.getState().byRun[runId] ?? []).length > 0;
+    const hasOutputs = Object.keys(useRuntimeStore.getState().outputs).some((k) =>
+      k.startsWith(`${runId}:u`),
+    );
+    if (hasFrames && hasOutputs) return;
     let cancelled = false;
     api
       .getRunEvents(runId)
       .then(({ events }) => {
-        if (!cancelled) useRunEventStore.getState().hydrate(runId, events);
+        if (cancelled) return;
+        useRunEventStore.getState().hydrate(runId, events);
+        useRuntimeStore.getState().hydrateOutputs(runId, events);
       })
       .catch(() => {
         /* no event-log binding, or the run has no persisted history — no backfill */

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { lostQuorum, quorumLabel } from './councilQuorum.js';
 import { api, downloadRunEvidence } from '../api/client.js';
 import type { SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
@@ -6,7 +6,7 @@ import { executingOrd } from '../api/run-state.js';
 import { useGateStore } from '../store/gates.js';
 import { useElicitationStore } from '../store/elicitations.js';
 import { ElicitationPrompt } from './ElicitationPrompt.js';
-import { useRuntimeStore, outputKey } from '../store/runtime.js';
+import { useRuntimeStore, outputKey, type CouncilStatus } from '../store/runtime.js';
 import { STATUS_STYLE } from './RunCard.js';
 import { SteeringGate } from './SteeringGate.js';
 import { ChatInput } from './ChatInput.js';
@@ -43,17 +43,17 @@ function cliInitials(key: string): string {
 }
 
 /**
- * Live council deliberation status for a pending unit, derived from the
+ * Live council deliberation status for a not-yet-started unit, derived from the
  * councilConvened / councilSeatFailed / councilDeliberated (below-bar runoff) / councilVoted
- * frames.
+ * frames. Rendered as the queued phase's stepper tooltip (operator UX directive: routing
+ * chatter for future work belongs in the stepper, not as standalone thread blocks).
  *
- * Seats that failed are shown alongside the agreement percentage, not instead of it. A council
+ * Seats that failed are named alongside the agreement percentage, not instead of it. A council
  * that convened three seats and heard from one still reports 100% agreement — true of the votes
  * cast, and misleading on its own.
  */
-function CouncilDeliberation({ runId, ord }: { runId: string; ord: number }): React.ReactElement {
-  const status = useRuntimeStore((s) => s.councilStatus[`${runId}:${ord}`]);
-  const label = !status
+function councilLabel(status: CouncilStatus | undefined): string {
+  const line = !status
     ? 'Council deliberating…'
     : status.state === 'convened'
       ? `Council convened — polling ${status.clis?.length ?? '?'} CLI${(status.clis?.length ?? 0) === 1 ? '' : 's'}…`
@@ -61,26 +61,115 @@ function CouncilDeliberation({ runId, ord }: { runId: string; ord: number }): Re
         ? `Ballot ${status.round ?? '?'}: ${status.agreementPct ?? '?'}% — below the ${status.neededPct ?? 75}% bar, runoff in progress…`
         : `Council voted — ${status.agreementPct ?? '?'}% agreement (${status.votes ?? '?'} votes)`;
   const failed = status?.failedSeats ?? [];
+  if (failed.length === 0) return line;
+  // `why` is CRLF-normalized in the store, so a Windows seat's stderr does not put stray
+  // carriage returns into the tooltip.
+  return `${line}\n${failed.length} seat${failed.length === 1 ? '' : 's'} did not vote — ${failed
+    .map((f) => `${f.cli} (${f.kind})`)
+    .join(', ')}`;
+}
+
+/** One line of routing provenance for a phase's stepper tooltip. */
+function routingSummary(unit: WorkUnit): string | null {
+  if (unit.routing === null) return unit.assigned_cli ? `→ ${unit.assigned_cli}` : null;
+  switch (unit.routing.method) {
+    case 'council':
+      return `Council → ${unit.assigned_cli ?? '?'} · ${quorumLabel(unit.routing)} · ${
+        unit.routing.agreement_pct
+      }% agree · ${unit.routing.dissent} dissent${lostQuorum(unit.routing) ? ' · quorum lost' : ''}`;
+    case 'evaluator_distinct':
+      return `Evaluator-distinct → ${unit.assigned_cli ?? '?'} (was: ${unit.routing.was})`;
+    case 'degraded':
+      return `Degraded routing: ${unit.routing.reason}`;
+    default:
+      return unit.assigned_cli ? `→ ${unit.assigned_cli}` : null;
+  }
+}
+
+/** A phase's place in the run: finished, judged-and-rejected, running now, or still to come. */
+type StepState = 'done' | 'rejected' | 'active' | 'queued';
+
+const STEP_STYLE: Record<StepState, { color: string; background: string; border: string }> = {
+  done:     { color: '#3fb950',               background: 'rgba(63,185,80,0.1)',   border: '1px solid rgba(63,185,80,0.25)' },
+  rejected: { color: '#f85149',               background: 'rgba(248,81,73,0.1)',   border: '1px solid rgba(248,81,73,0.3)' },
+  active:   { color: '#ffda19',               background: 'rgba(255,218,25,0.12)', border: '1px solid rgba(255,218,25,0.35)' },
+  queued:   { color: 'rgba(230,237,243,0.3)', background: 'transparent',           border: '1px solid rgba(230,237,243,0.08)' },
+};
+
+/**
+ * Compact process stepper at the top of the run thread (operator UX directive): every phase
+ * of the workflow in ord order — done phases checked, the executing one highlighted, future
+ * ones dimmed. This is the run's map; the conversational timeline below it carries only the
+ * phases that have actually run (or are running), so queued work no longer renders as a
+ * column of tall empty "Not started" blocks. Routing provenance and live council chatter for
+ * a queued phase live here, in the phase's tooltip, until the phase starts.
+ */
+function ProcessStepper({
+  runId,
+  units,
+  executingUnitOrd,
+}: {
+  runId: string;
+  /** Already ord-sorted (the caller's memoized `ordered`). */
+  units: WorkUnit[];
+  executingUnitOrd: number | null;
+}): React.ReactElement | null {
+  const councilStatus = useRuntimeStore((s) => s.councilStatus);
+  if (units.length === 0) return null;
   return (
     <div
-      className="flex flex-col gap-1 text-xs font-mono rounded-lg px-3 py-2"
-      style={{ background: 'rgba(139,92,246,0.08)', border: '1px solid rgba(139,92,246,0.18)', color: '#a78bfa' }}
+      data-testid="process-stepper"
+      aria-label="Workflow phases"
+      className="flex items-center gap-1.5 flex-wrap px-6 py-2.5 shrink-0 font-mono text-[11px]"
+      style={{ borderBottom: '1px solid rgba(230,237,243,0.05)', background: '#161c26' }}
     >
-      <div className="flex items-center gap-2">
-        <span
-          className={`inline-block w-1.5 h-1.5 rounded-full ${status?.state === 'voted' ? '' : 'animate-pulse'}`}
-          style={{ background: '#a78bfa' }}
-        />
-        <span>{label}</span>
-      </div>
-      {failed.length > 0 && (
-        // `why` is CRLF-normalized in the store, so a Windows seat's stderr does not put stray
-        // carriage returns into the tooltip.
-        <div className="pl-3.5" style={{ color: '#fca5a5' }} title={failed.map((f) => `${f.cli}: ${f.why}`).join('\n')}>
-          {failed.length} seat{failed.length === 1 ? '' : 's'} did not vote —{' '}
-          {failed.map((f) => `${f.cli} (${f.kind})`).join(', ')}
-        </div>
-      )}
+      {units.map((unit, i) => {
+        const state: StepState =
+          unit.status === 'done'
+            ? 'done'
+            : unit.status === 'rejected'
+              ? 'rejected'
+              : unit.ord === executingUnitOrd
+                ? 'active'
+                : 'queued';
+        const live = councilStatus[`${runId}:${unit.ord}`];
+        const tooltip = [
+          unit.description,
+          routingSummary(unit),
+          // Live deliberation chatter only matters while the phase has not produced anything
+          // else to look at; once it starts, the phase entry in the thread takes over.
+          state === 'queued' && unit.status === 'pending' ? councilLabel(live) : null,
+        ]
+          .filter((line): line is string => line !== null && line.length > 0)
+          .join('\n');
+        const s = STEP_STYLE[state];
+        return (
+          <Fragment key={unit.id}>
+            {i > 0 && (
+              <span aria-hidden="true" style={{ color: 'rgba(230,237,243,0.15)' }}>
+                ›
+              </span>
+            )}
+            <span
+              data-testid={`stepper-phase-${unit.ord}`}
+              data-state={state}
+              title={tooltip}
+              className="rounded-full px-2.5 py-0.5 flex items-center gap-1.5 whitespace-nowrap"
+              style={{ background: s.background, border: s.border, color: s.color }}
+            >
+              {state === 'done' && <span aria-hidden="true">✓</span>}
+              {state === 'rejected' && <span aria-hidden="true">✗</span>}
+              {state === 'active' && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full animate-pulse shrink-0"
+                  style={{ background: '#ffda19' }}
+                />
+              )}
+              {phaseName(runId, unit)}
+            </span>
+          </Fragment>
+        );
+      })}
     </div>
   );
 }
@@ -97,7 +186,7 @@ const NARRATION_TAIL = 4096;
  * worker never grows the thread's DOM unbounded (the store keeps its own
  * larger cap for the full-output consumers).
  */
-function LiveNarration({ runId, ord }: { runId: string; ord: number }): React.ReactElement {
+function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phase: string }): React.ReactElement {
   const live = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
   const [visible, setVisible] = useState(true);
   const scrollRef = useRef<HTMLPreElement>(null);
@@ -116,6 +205,8 @@ function LiveNarration({ runId, ord }: { runId: string; ord: number }): React.Re
     <div data-testid={`live-narration-${ord}`}>
       <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
         <span className="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: '#79c0ff' }} />
+        {/* Phase label leads the entry (operator UX directive) — mirrors the done-unit header. */}
+        <span className="font-medium" style={{ color: '#79c0ff' }}>{phase}</span>
         <span>{hasText ? 'Working — live output' : 'Working…'}</span>
         {hasText && (
           <button
@@ -619,10 +710,22 @@ function RunChat({
   // happen per unit, each call re-sorting the plan from inside the loop (PR #179 review).
   const ordered = useMemo(() => [...units].sort((a, b) => a.ord - b.ord), [units]);
   const executingUnitOrd = useMemo(() => executingOrd(session, units), [session, units]);
+  // The conversational timeline holds ONLY phases that have run or are running (rejected counts:
+  // it ran far enough to be judged). Future work is the stepper's job — a queued unit used to
+  // render one tall, empty "Not started" block per phase, which is what the operator flagged.
+  const timeline = useMemo(
+    () =>
+      ordered.filter(
+        (u) =>
+          u.status === 'done' ||
+          u.status === 'rejected' ||
+          (u.status === 'distributed' && u.ord === executingUnitOrd),
+      ),
+    [ordered, executingUnitOrd],
+  );
   const gate = useGateStore((s) => s.gates[session.id]);
   const elicitation = useElicitationStore((s) => s.elicitations[session.id]);
   const log = useRuntimeStore((s) => s.logs[session.id]) ?? [];
-  const executorTypes = useRuntimeStore((s) => s.executorTypes);
   /** "all" broadcasts; any other value is a CLI key (set by clicking an agent card). */
   const [injectTarget, setInjectTarget] = useState<string>('all');
   const terminalIds = useRuntimeStore((s) => s.terminalIds);
@@ -636,7 +739,7 @@ function RunChat({
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [units.length, log.length]);
+  }, [timeline.length, log.length]);
 
   useEffect(() => {
     for (const unit of units) {
@@ -733,6 +836,10 @@ function RunChat({
         )}
       </div>
 
+      {/* Process stepper — the run's map: every phase, in order, with its state at a glance.
+          The timeline below renders only the phases that have entered the conversation. */}
+      <ProcessStepper runId={session.id} units={ordered} executingUnitOrd={executingUnitOrd} />
+
       {/* Message thread */}
       <div className="flex-1 overflow-y-auto px-4 py-6 flex flex-col gap-6 max-w-3xl w-full mx-auto">
         {/* An open MCP elicitation suspends the agent's turn, so it leads the stream (DES-002).
@@ -754,8 +861,9 @@ function RunChat({
           </div>
         </div>
 
-        {/* Unit messages — gate panel injected inline before the unit it blocks */}
-        {ordered.flatMap((unit) => {
+        {/* Phase entries — only phases that have run or are running; gate panel injected
+            inline before the unit it blocks when that unit has already entered the thread */}
+        {timeline.flatMap((unit) => {
           const tc = transcripts[unit.ord];
           const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'rgba(230,237,243,0.08)', color: 'rgba(230,237,243,0.5)' };
           const gateBeforeThis = session.status === 'awaiting_human' && gate?.ord === unit.ord;
@@ -861,16 +969,11 @@ function RunChat({
                   className="rounded-2xl px-5 py-4"
                   style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.08)' }}
                 >
-                  {unit.status === 'distributed' && unit.ord === executingUnitOrd && (
-                    <LiveNarration runId={session.id} ord={unit.ord} />
-                  )}
-                  {/* Routed but not dispatched. `isTerminal` used to be the test here, which made
-                      every queued unit of a merely PAUSED run claim to be working (FINDING-052). */}
-                  {unit.status === 'distributed' && unit.ord !== executingUnitOrd && (
-                    <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
-                      <span>—</span>
-                      <span>Not started</span>
-                    </div>
+                  {/* A `distributed` unit is in the timeline ONLY as the cursor unit of an
+                      executing run (FINDING-052: distributed = routed, not running — queued
+                      units live in the stepper now, never as thread blocks). */}
+                  {unit.status === 'distributed' && (
+                    <LiveNarration runId={session.id} ord={unit.ord} phase={phaseName(session.id, unit)} />
                   )}
                   {unit.status === 'done' && (
                     <div data-testid={`unit-output-${unit.ord}`}>
@@ -907,22 +1010,6 @@ function RunChat({
                       Rejected{unit.denial_reason ? `: ${unit.denial_reason}` : ''}
                     </div>
                   )}
-                  {unit.status === 'pending' && (() => {
-                    // Unknown executor type (late join — unitPlanned fired before the WS
-                    // connected, and there is no replay) defaults to agent: council units
-                    // dominate, and tool units correct themselves on the next live frame.
-                    const executorType = executorTypes[`${session.id}:${unit.ord}`];
-                    const isAgent = executorType ? executorType === 'agent' : true;
-                    return isAgent ? (
-                      <CouncilDeliberation runId={session.id} ord={unit.ord} />
-                    ) : (
-                      <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
-                        <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: 'rgba(230,237,243,0.2)' }} />
-                        <span>Queued</span>
-                      </div>
-                    );
-                  })()}
-
                 </div>
               </div>
             </div>
@@ -974,8 +1061,11 @@ function RunChat({
           );
         })}
 
-        {/* Steering gate — fallback position when gate.ord doesn't match any planned unit */}
-        {session.status === 'awaiting_human' && !units.some((u) => gate?.ord === u.ord) && (
+        {/* Steering gate — fallback position when the gated unit has no timeline entry. This is
+            now the COMMON path: awaiting_human pauses BEFORE a not-yet-started unit, and queued
+            units no longer render as thread blocks, so the card lands here — after everything
+            that has already run, which is exactly where the pause chronologically is. */}
+        {session.status === 'awaiting_human' && !timeline.some((u) => gate?.ord === u.ord) && (
           <div className="self-center w-full max-w-lg">
             <SteeringGate
               runId={session.id}

--- a/src/store/runtime.ts
+++ b/src/store/runtime.ts
@@ -107,6 +107,21 @@ function summarize(event: CoreEvent): string {
   }
 }
 
+/**
+ * The streamed text a frame carries, or null when it is not an output delta.
+ * `unitOutputDelta` is the delta-relay spelling (shared contract 0.5.1, `text`);
+ * `cliOutputDelta` is the legacy spelling (`chunk`). Identical append semantics,
+ * one shared buffer, so every consumer reads the same text whichever frame the
+ * daemon emits — live (`ingest`) or replayed (`hydrateOutputs`).
+ */
+function deltaTextOf(event: CoreEvent): string | null {
+  return event.type === 'unitOutputDelta' && typeof event.text === 'string'
+    ? event.text
+    : event.type === 'cliOutputDelta' && typeof event.chunk === 'string'
+      ? event.chunk
+      : null;
+}
+
 /** One structured assumption parsed from a unit's output (assumptionRecorded). */
 export interface RecordedAssumption {
   ord: number;
@@ -173,6 +188,17 @@ interface RuntimeStore {
   seq: number;
   /** Fold one CoreEvent: append output deltas, log every other run-scoped frame. */
   ingest: (event: CoreEvent) => void;
+  /**
+   * Seed a run's live-output buffers from the durably-persisted event trail
+   * (`GET /runs/:id/events`). `/ws` has no late-join replay, and `outputs` was fed
+   * ONLY by live frames — so a page opened (or reloaded) after a unit started
+   * showed a bare "Working…" for a unit whose streamed text already existed, until
+   * the next live delta happened to arrive. Same backfill idea as the run-event
+   * store's `hydrate` (FINDING-013), with the guard moved per-key: a buffer that a
+   * live `/ws` frame has already started is never touched, so replayed deltas are
+   * never double-appended to live ones.
+   */
+  hydrateOutputs: (session: string, events: CoreEvent[]) => void;
   /** Drop a run's accumulated output + log. */
   clear: (session: string) => void;
 }
@@ -194,19 +220,9 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
     set((s) => {
       const seq = s.seq + 1;
 
-      // Live output delta -> append to the (run, unit) buffer (§11.4).
-      // `unitOutputDelta` is the delta-relay spelling of the same frame (see the
-      // temporary UnitOutputDeltaEvent extension in api/types.ts): identical
-      // append semantics, one shared buffer, so ChatPanel's live narration and
-      // the older LiveOutput consumers read the same text whichever frame the
-      // daemon emits.
-      // unitOutputDelta carries `text` (shared contract 0.5.1); cliOutputDelta carries `chunk`.
-      const deltaText =
-        event.type === 'unitOutputDelta' && typeof event.text === 'string'
-          ? event.text
-          : event.type === 'cliOutputDelta' && typeof event.chunk === 'string'
-            ? event.chunk
-            : null;
+      // Live output delta -> append to the (run, unit) buffer (§11.4). ChatPanel's
+      // live narration and the older LiveOutput consumers read the same buffer.
+      const deltaText = deltaTextOf(event);
       if (deltaText !== null && typeof event.ord === 'number') {
         const key = outputKey(session, event.ord);
         const prev = s.outputs[key] ?? '';
@@ -366,6 +382,28 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
       return { seq, logs: { ...s.logs, [session]: nextLog } };
     });
   },
+
+  hydrateOutputs: (session, events) =>
+    set((s) => {
+      // Fold the trail's deltas per key first, then merge — one state write, and the
+      // per-key liveness check stays atomic with it (a live frame that lands between
+      // the fetch and this set() wins wholesale; skipping the key loses the older
+      // replayed text but can never double-count, mirroring FINDING-013's guard).
+      const folded: Record<string, string> = {};
+      for (const event of events) {
+        if (event.session !== session) continue;
+        const deltaText = deltaTextOf(event);
+        if (deltaText === null || typeof event.ord !== 'number') continue;
+        const key = outputKey(session, event.ord);
+        if (s.outputs[key] !== undefined) continue; // live buffer already started
+        let combined = (folded[key] ?? '') + deltaText;
+        if (combined.length > OUTPUT_CAP) combined = combined.slice(combined.length - OUTPUT_CAP);
+        folded[key] = combined;
+      }
+      if (Object.keys(folded).length === 0) return s;
+      // Spread order matters: existing (live) buffers win over the replayed fold.
+      return { outputs: { ...folded, ...s.outputs } };
+    }),
 
   clear: (session) =>
     set((s) => {

--- a/tests/ChatPanel.narration.test.tsx
+++ b/tests/ChatPanel.narration.test.tsx
@@ -96,7 +96,7 @@ describe('ChatPanel live narration (unitOutputDelta → active unit block)', () 
     expect(text).not.toContain('HEAD-');
   });
 
-  it('shows narration only on the ACTIVE unit — queued distributed units stay "Not started"', () => {
+  it('shows narration only on the ACTIVE unit — queued units get no thread block at all', () => {
     const view = makeView({ status: 'executing', unit_ix: 0 }, [
       makeUnit({ id: 'run-1:u0', ord: 0, status: 'distributed', assigned_cli: 'claude' }),
       makeUnit({ id: 'run-1:u1', ord: 1, status: 'distributed', assigned_cli: 'codex' }),
@@ -109,7 +109,47 @@ describe('ChatPanel live narration (unitOutputDelta → active unit block)', () 
     expect(screen.getByTestId('live-narration-0')).toBeInTheDocument();
     expect(screen.queryByTestId('live-narration-1')).not.toBeInTheDocument();
     expect(screen.queryByText('should not render')).not.toBeInTheDocument();
-    expect(screen.getByText('Not started')).toBeInTheDocument();
+    // The queued phase is the stepper's job now — no tall empty block in the timeline.
+    expect(screen.queryByText('Not started')).not.toBeInTheDocument();
+    expect(screen.getByTestId('stepper-phase-1')).toHaveAttribute('data-state', 'queued');
+  });
+
+  it('streams live text for the real daemon shape: 1-based ords, cursor unit_ix into the ord order', () => {
+    // Mirrors the live governed run: unit 1 done, unit 2 distributed + executing under
+    // unit_ix=1 (a 0-based index into the ord-ordered plan, NOT an ord).
+    const view = makeView({ status: 'executing', unit_ix: 1 }, [
+      makeUnit({ id: 'run-1:clarify', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+      makeUnit({ id: 'run-1:design', ord: 2, stage: 'recon', status: 'distributed', assigned_cli: 'claude' }),
+      makeUnit({ id: 'run-1:build', ord: 3, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+    ]);
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
+    render(<ChatPanel view={view} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    act(() => {
+      useRuntimeStore.getState().ingest(relayDelta('run-1', 2, 'Studying both repos'));
+    });
+    expect(screen.getByTestId('live-narration-text-2')).toHaveTextContent('Studying both repos');
+    // The entry names its phase (the unit-id suffix), not just a status word.
+    expect(screen.getByTestId('live-narration-2')).toHaveTextContent('design');
+    // The queued build phase has no block; the done clarify phase keeps its output entry.
+    expect(screen.queryByTestId('live-narration-3')).not.toBeInTheDocument();
+  });
+
+  it('renders text already hydrated from the persisted trail (late-join reload, no live frame yet)', () => {
+    // The render-gap root cause: /ws has no replay, so a page opened after the unit began
+    // showed a bare "Working…" until the NEXT live delta. hydrateOutputs backfills the buffer
+    // from GET /runs/:id/events; the block must render that text with zero live frames.
+    act(() => {
+      useRuntimeStore.getState().hydrateOutputs('run-1', [
+        relayDelta('run-1', 0, 'recorded before '),
+        relayDelta('run-1', 0, 'the page opened'),
+      ]);
+    });
+    render(
+      <ChatPanel view={executingView()} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />,
+    );
+    expect(screen.getByTestId('live-narration-text-0')).toHaveTextContent(
+      'recorded before the page opened',
+    );
   });
 
   it('legacy cliOutputDelta frames feed the same narration block', () => {

--- a/tests/ChatPanel.stepper.test.tsx
+++ b/tests/ChatPanel.stepper.test.tsx
@@ -1,0 +1,139 @@
+// Process-stepper layout for the run thread (fix/run-thread-ux, operator UX directive):
+// a compact stepper at the top of the thread maps EVERY workflow phase (done checked,
+// current highlighted, future dimmed), and the conversational timeline below carries ONLY
+// phases that have run or are running. Queued units no longer render tall empty
+// "Not started" blocks, and council/routing chatter for not-yet-started units folds into
+// the stepper tooltip instead of standalone thread blocks.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { useGateStore } from '../src/store/gates.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRuntimeStore.setState({
+    outputs: {}, councilStatus: {}, assumptions: {}, logs: {}, executorTypes: {}, terminalIds: {}, seq: 0,
+  });
+  useGateStore.setState({ gates: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+});
+
+/** The live governed-run shape: 1-based ords, unit_ix 1 → ord 2 executing. */
+function workflowView(status: 'executing' | 'awaiting_human' = 'executing'): ReturnType<typeof makeView> {
+  return makeView({ status, unit_ix: 1 }, [
+    makeUnit({ id: 'run-1:clarify', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:design', ord: 2, stage: 'recon', status: 'distributed', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:build', ord: 3, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:review', ord: 4, stage: 'review', status: 'distributed', assigned_cli: 'codex' }),
+  ]);
+}
+
+describe('ChatPanel process stepper (workflow map at the top of the thread)', () => {
+  it('renders every phase in ord order: done checked, current highlighted, future dimmed', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
+    render(<ChatPanel view={workflowView()} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+
+    const stepper = screen.getByTestId('process-stepper');
+    expect(within(stepper).getByTestId('stepper-phase-1')).toHaveAttribute('data-state', 'done');
+    expect(within(stepper).getByTestId('stepper-phase-2')).toHaveAttribute('data-state', 'active');
+    expect(within(stepper).getByTestId('stepper-phase-3')).toHaveAttribute('data-state', 'queued');
+    expect(within(stepper).getByTestId('stepper-phase-4')).toHaveAttribute('data-state', 'queued');
+
+    // Phase NAMES, not status words: the workflow's own vocabulary.
+    expect(within(stepper).getByTestId('stepper-phase-1')).toHaveTextContent('clarify');
+    expect(within(stepper).getByTestId('stepper-phase-2')).toHaveTextContent('design');
+    expect(within(stepper).getByTestId('stepper-phase-3')).toHaveTextContent('build');
+    expect(within(stepper).getByTestId('stepper-phase-4')).toHaveTextContent('review');
+
+    // Done phases carry the check mark.
+    expect(within(stepper).getByTestId('stepper-phase-1')).toHaveTextContent('✓');
+
+    // DOM order follows ord order.
+    const done = within(stepper).getByTestId('stepper-phase-1');
+    const active = within(stepper).getByTestId('stepper-phase-2');
+    expect(done.compareDocumentPosition(active) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Output test's concern, but pin the pairing here too: the done phase still shows output.
+    expect(await screen.findByText('clarify output')).toBeInTheDocument();
+  });
+
+  it('keeps queued phases OUT of the timeline: no empty blocks, no per-unit meta rows', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
+    render(<ChatPanel view={workflowView()} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+
+    // Timeline entries: done clarify (output block) + active design (live narration). Nothing else.
+    expect(await screen.findByTestId('unit-output-1')).toBeInTheDocument();
+    expect(screen.getByTestId('live-narration-2')).toBeInTheDocument();
+    expect(screen.queryByText('Not started')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('live-narration-3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('unit-output-3')).not.toBeInTheDocument();
+    // The queued review unit's codex avatar row must not render as a thread entry.
+    expect(screen.queryByRole('button', { name: /send message to codex only/i })).not.toBeInTheDocument();
+  });
+
+  it('folds live council deliberation for a pending unit into the stepper tooltip, not a thread block', () => {
+    const view = makeView({ status: 'executing', unit_ix: 0 }, [
+      makeUnit({ id: 'run-1:u0', ord: 0, status: 'distributed', assigned_cli: 'claude' }),
+      makeUnit({ id: 'run-1:u1', ord: 1, status: 'pending' }),
+    ]);
+    render(<ChatPanel view={view} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    act(() => {
+      useRuntimeStore.getState().ingest({
+        type: 'councilConvened', session: 'run-1', ord: 1, clis: ['claude', 'codex', 'antigravity'],
+      } as CoreEvent);
+    });
+    // No standalone council block in the conversation…
+    expect(screen.queryByText(/Council convened/)).not.toBeInTheDocument();
+    // …the stepper phase carries it as its tooltip instead.
+    expect(screen.getByTestId('stepper-phase-1').getAttribute('title')).toContain(
+      'Council convened — polling 3 CLIs',
+    );
+  });
+
+  it('folds a routed-but-queued unit\'s council provenance into the tooltip, not a routing pill', () => {
+    const view = makeView({ status: 'executing', unit_ix: 0 }, [
+      makeUnit({ id: 'run-1:u0', ord: 0, status: 'distributed', assigned_cli: 'claude' }),
+      makeUnit({
+        id: 'run-1:u1', ord: 1, status: 'distributed', assigned_cli: 'codex',
+        routing: { method: 'council', winner: 'codex', agreement_pct: 67, returned: 3, seated: 3, dissent: 1 },
+      }),
+    ]);
+    render(<ChatPanel view={view} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    // The council pill used to render as its own block for every routed unit.
+    expect(screen.queryByText(/Council → codex/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('stepper-phase-1').getAttribute('title')).toContain('Council → codex');
+    expect(screen.getByTestId('stepper-phase-1').getAttribute('title')).toContain('67% agree');
+  });
+
+  it('still shows the steering gate card when the run pauses before a queued phase', () => {
+    act(() => {
+      useGateStore.setState({
+        gates: { 'run-1': { runId: 'run-1', ord: 2, prompt: 'Approve the design phase?', lifecycle: 'open', receivedAt: 0 } },
+      });
+    });
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
+    // awaiting_human = paused BEFORE the not-yet-started unit: no unit is executing, the
+    // gated unit has no timeline entry, and the gate card must still render (fallback slot).
+    render(<ChatPanel view={workflowView('awaiting_human')} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId('steering-gate')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Approve the design phase?');
+    // Paused: nothing is "working", and the paused phase sits queued in the stepper.
+    expect(screen.queryByTestId('live-narration-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('stepper-phase-2')).toHaveAttribute('data-state', 'queued');
+  });
+
+  it('renders no stepper for a legacy chat run (LegacyChatHistory keeps its own layout)', () => {
+    const view = makeView({ workflow_id: 'chat', status: 'completed' }, [
+      makeUnit({ id: 'run-1:u0', ord: 0, status: 'done' }),
+    ]);
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'chat answer' });
+    render(<ChatPanel view={view} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    expect(screen.queryByTestId('process-stepper')).not.toBeInTheDocument();
+  });
+});

--- a/tests/runtime.store.test.ts
+++ b/tests/runtime.store.test.ts
@@ -82,6 +82,58 @@ describe('runtime store (§11.4 — live output + per-run event log)', () => {
     expect(log[0]).toMatchObject({ type: 'crashRecoveryRedrive', detail: 'attempt 3', attempt: 3 });
   });
 
+  // hydrateOutputs: the late-join replay for `outputs`. /ws has no replay, so a page opened
+  // after a unit started never saw the already-streamed text (the run-thread render gap) —
+  // the persisted trail (GET /runs/:id/events) backfills it, per-key guarded against
+  // double-counting frames the live socket already appended.
+  describe('hydrateOutputs (persisted-trail backfill)', () => {
+    const relay = (session: string, ord: number, text: string): CoreEvent =>
+      ({ type: 'unitOutputDelta', session, ord, attempt: 0, text } as CoreEvent);
+
+    it('folds persisted deltas (both spellings) into the per-(run, unit) buffers', () => {
+      useRuntimeStore.getState().hydrateOutputs('run-1', [
+        relay('run-1', 1, 'hello '),
+        { type: 'unitDone', session: 'run-1', ord: 1 } as CoreEvent,
+        relay('run-1', 2, 'world'),
+        delta('run-1', 2, '!'),
+      ]);
+      expect(useRuntimeStore.getState().outputs[outputKey('run-1', 1)]).toBe('hello ');
+      expect(useRuntimeStore.getState().outputs[outputKey('run-1', 2)]).toBe('world!');
+    });
+
+    it('never touches a buffer a live frame already started (no double-count, live wins)', () => {
+      useRuntimeStore.getState().ingest(relay('run-1', 2, 'live text'));
+      useRuntimeStore.getState().hydrateOutputs('run-1', [
+        relay('run-1', 1, 'replayed u1'),
+        relay('run-1', 2, 'replayed u2'), // same delta the socket already delivered
+      ]);
+      const { outputs } = useRuntimeStore.getState();
+      expect(outputs[outputKey('run-1', 2)]).toBe('live text');
+      expect(outputs[outputKey('run-1', 1)]).toBe('replayed u1');
+    });
+
+    it('ignores other runs\' frames and non-delta frames', () => {
+      useRuntimeStore.getState().hydrateOutputs('run-1', [
+        relay('run-2', 1, 'someone else'),
+        { type: 'unitExecuting', session: 'run-1', ord: 1 } as CoreEvent,
+        relay('run-1', 1, 'mine'),
+      ]);
+      const { outputs } = useRuntimeStore.getState();
+      expect(outputs[outputKey('run-1', 1)]).toBe('mine');
+      expect(outputs[outputKey('run-2', 1)]).toBeUndefined();
+    });
+
+    it('caps a replayed buffer at the same limit as the live path', () => {
+      useRuntimeStore.getState().hydrateOutputs('run-1', [
+        relay('run-1', 1, 'HEAD-' + 'x'.repeat(250_000) + '-TAIL'),
+      ]);
+      const buf = useRuntimeStore.getState().outputs[outputKey('run-1', 1)] ?? '';
+      expect(buf).toHaveLength(200_000);
+      expect(buf.endsWith('-TAIL')).toBe(true);
+      expect(buf).not.toContain('HEAD-');
+    });
+  });
+
   it('clear() drops a run\'s output and log', () => {
     const ingest = useRuntimeStore.getState().ingest;
     ingest(delta('run-1', 0, 'x'));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
     // Playwright suite (site/tests/e2e, run by the Site E2E workflow).
     // Without this, vitest's default include sweeps those *.spec.ts files
     // and fails resolving @playwright/test (installed only under site/).
-    exclude: [...configDefaults.exclude, 'site/**'],
+    // wicked-worktrees/ holds governed-run worktrees (gitignored checkouts a
+    // crew run makes INSIDE this repo) — same sweep problem, foreign suites.
+    exclude: [...configDefaults.exclude, 'site/**', 'wicked-worktrees/**'],
   },
 });


### PR DESCRIPTION
Fixes the two operator-reported defects on the live run page (ChatPanel/RunChat), verified against a real executing governed run (`8aa1cd42`, daemon at :7701).

## 1. Streaming render gap (bug)

**Root cause: no late-join replay for the live-output buffers.** `unitOutputDelta` frames do flow over `/ws` and fold into the runtime store's per-`(run, ord)` `outputs` buffer, and the active unit's block does subscribe to it — but that buffer was fed **only** by live socket frames. The FINDING-013 backfill (`GET /runs/:id/events` → run-event store `hydrate`) deliberately drops delta frames (`IGNORED` set in `src/store/events.ts`), and the runtime store had no hydrate path at all. So opening or reloading the run page after a unit began execution rendered only the bare status word: the already-streamed text was durably recorded (verified: the trail carries `unitOutputDelta` events with `text`) but never replayed, and sparse ACP relays can go many minutes between assistant chunks — indistinguishable from "never streams".

**Fix:** `hydrateOutputs(session, events)` on the runtime store seeds the buffers from the persisted trail. Per-key guard: a buffer a live `/ws` frame has already started is never touched, so replay + live can never double-count a delta (same tradeoff FINDING-013 pinned). `App.tsx`'s existing backfill effect now feeds both stores from the one fetch. The active unit's block streams the growing text (phase label + collapsible-open-by-default, autoscrolled, trailing ~4KB).

## 2. Process-stepper layout (operator UX directive)

Credit to the operator's UX feedback from driving a real governed run: every queued unit rendered as a tall, empty "Not started" block, burying the conversation in placeholder.

- **Process stepper** heads the run thread: every workflow phase in ord order — done ✓, rejected ✗, the executing one highlighted (pulse), future ones dimmed. Tooltips carry each phase's description, routing provenance (council/evaluator-distinct/degraded), and live council deliberation status for pending units.
- **Timeline below carries ONLY phases that have run or are running**: live narration while active, the substantive output when done (unchanged crew#272 rendering), gate cards where they occur (a gate pausing before a queued phase renders in the fallback slot after everything that ran — chronologically where the pause is).
- Council/routing rows for not-yet-started units no longer render as standalone thread blocks — folded into the stepper tooltip.
- Gate/elicitation cards, steering, and composer behavior untouched.

## Tests

296 passing across 40 files (was ~284). New pins: active-unit live text renders (incl. the real daemon shape — 1-based ords, `unit_ix` cursor — and the hydrated late-join case); queued phases absent from the timeline but present in the stepper; done phases still show output; council chatter in tooltip not thread; gate card on pause-before-queued-phase. Also excludes `wicked-worktrees/**` from vitest — governed-run worktrees inside the repo carry foreign suites the default include swept up.

typecheck + lint + build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)