### PR TITLE
feat(shell): project routes + four-mode switcher (DES-MERGE-001 slice 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ e2e/shots/
 .DS_Store
 *.tgz
 .wicked-vault/
+# Scratch the run harness and the e2e gate write inside the checkout, never source.
+tmp/
+__pycache__/

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -24,6 +24,10 @@ What "independent" means here, and what this script proves end-to-end:
      CoreEvent frames arrive over ws://<daemon>/ws until the run completes
   6. (post-#243) the project surface answers: GET /api/v1/projects returns 200 with
      a list, cross-origin
+  7. (DES-MERGE-001 slice 4) the project shell: /p/:projectId/:mode renders the
+     four-mode switcher, an unavailable mode is disabled with its enabling action in
+     the tooltip, clicking Build is a real (back-button-correct) navigation, and the
+     pre-merge /runs/:id and /projects/:id bookmarks redirect into the new shape
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -44,11 +48,13 @@ Operator-run smoke — though it spends no tokens (stub engine, no real CLI seat
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -260,6 +266,92 @@ try:
     }
     if not report["steps"]["browser_flow"]["ok"]:
         fail("browser_flow_verdict", "run list / WS completion assertions did not all hold — see browser_flow")
+
+    # ── 8. Slice 4 (DES-MERGE-001 §6.2): project shell, mode switcher, redirects ─
+    # File the run under a real project first: run→project resolution is membership-based,
+    # and `default` is the SYNTHESIZED unfiled project, which deliberately never redirects.
+    _, _, created = http_json("POST", f"{API}/projects", {"name": f"slice4-{run_id[:12]}"})
+    project_id = created["project"]["id"]
+    http_json(
+        "POST", f"{API}/projects/{project_id}/members",
+        {"kind": "crew.run", "ref": run_id, "attachedBy": "studio"},
+    )
+
+    def wait_for_path(page, path: str, timeout: float = 30.0) -> bool:
+        """Poll the SPA's path — pushState/replaceState, not document navigations."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if urllib.parse.urlparse(page.url).path == path:
+                return True
+            page.wait_for_timeout(200)
+        return False
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        # Land on a mode whose surface makes no API calls, so this section asserts the
+        # SHELL rather than whatever a live surface happens to be doing.
+        page.goto(f"{STUDIO_ORIGIN}/p/{project_id}/document", wait_until="networkidle")
+        switcher = page.locator('[data-testid="mode-switcher"]')
+        switcher.wait_for(timeout=30000)
+        tabs = switcher.locator('[role="tab"]')
+        tab_labels = [tabs.nth(i).inner_text() for i in range(tabs.count())]
+
+        # AC: an unavailable mode is DISABLED (never hidden) and its tooltip names the
+        # one action that enables it (§1.3 rule 3).
+        video = page.locator('[data-testid="mode-tab-video"]')
+        video_title = video.get_attribute("title") or ""
+        disabled_ok = (
+            video.is_disabled()
+            and re.search(r"install|connect|create", video_title, re.I) is not None
+        )
+        # The deep-linked unavailable mode still states what it is and how to enable it
+        # (§3.3: no bare spinner, every state names a subject).
+        placeholder_ok = page.locator('[data-testid="mode-enabling-action-document"]').is_visible()
+        page.screenshot(path=str(SHOTS / "slice4-mode-switcher.png"), full_page=True)
+
+        # AC: clicking Build changes the URL, and the back button returns.
+        page.locator('[data-testid="mode-tab-build"]').click()
+        build_url_ok = wait_for_path(page, f"/p/{project_id}/build")
+        page.go_back()
+        back_ok = wait_for_path(page, f"/p/{project_id}/document")
+
+        # AC: a legacy bookmark lands on the new shape with the run open.
+        page.goto(f"{STUDIO_ORIGIN}/runs/{run_id}", wait_until="networkidle")
+        redirect_ok = wait_for_path(page, f"/p/{project_id}/build/{run_id}")
+        surface = page.locator('[data-testid="mode-surface"]')
+        surface.wait_for(timeout=30000)
+        run_open = problem[:30] in surface.inner_text()
+        page.screenshot(path=str(SHOTS / "slice4-legacy-redirect.png"), full_page=True)
+
+        # AC: /projects/:id keeps working as a bookmark too.
+        page.goto(f"{STUDIO_ORIGIN}/projects/{project_id}", wait_until="networkidle")
+        project_redirect_ok = wait_for_path(page, f"/p/{project_id}/build")
+
+        browser.close()
+
+    report["steps"]["project_shell"] = {
+        "ok": all([
+            tab_labels == ["Chat", "Build", "Document", "Video"],
+            disabled_ok, placeholder_ok, build_url_ok, back_ok, redirect_ok, run_open,
+            project_redirect_ok,
+        ]),
+        "project_id": project_id,
+        "mode_tabs": tab_labels,
+        "disabled_mode_titles_enabling_action": disabled_ok,
+        "disabled_mode_title": video_title,
+        "unavailable_mode_states_enabling_action": placeholder_ok,
+        "build_click_changed_url": build_url_ok,
+        "back_button_returned": back_ok,
+        "legacy_run_redirected": redirect_ok,
+        "run_open_after_redirect": run_open,
+        "legacy_project_redirected": project_redirect_ok,
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice4-mode-switcher.png", "slice4-legacy-redirect.png")],
+    }
+    if not report["steps"]["project_shell"]["ok"]:
+        fail("project_shell_verdict", "slice-4 shell assertions did not all hold — see project_shell")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,9 @@ import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
 import { GateNotifications } from './components/GateNotifications.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
+import { ModePlaceholder } from './components/ModePlaceholder.js';
 import { PolicyManager } from './components/PolicyManager.js';
+import { ProjectShell } from './components/ProjectShell.js';
 import { ProjectDetailPage } from './components/ProjectDetailPage.js';
 import { ProjectsPage } from './components/ProjectsPage.js';
 import { RepositoriesPanel } from './components/RepositoriesPanel.js';
@@ -19,7 +21,8 @@ import { WorkflowViewer } from './components/WorkflowViewer.js';
 import { WorkPage } from './components/WorkPage.js';
 import { SystemSettings } from './components/SystemSettings.js';
 import { useEventStream } from './hooks/useEventStream.js';
-import { useRoute } from './hooks/useRoute.js';
+import { useLegacyRedirect } from './hooks/useLegacyRedirect.js';
+import { modePath, useRoute, type Mode } from './hooks/useRoute.js';
 import { useRuns } from './hooks/useRuns.js';
 import { useGateStore } from './store/gates.js';
 import { useElicitationStore } from './store/elicitations.js';
@@ -76,7 +79,7 @@ function useKillShortcut(
 }
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, projectId, showLaunch, showRegisterRepo, chatMode, navigate } = useRoute();
+  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate } = useRoute();
   const { runs, refresh } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestElicitation = useElicitationStore((s) => s.ingest);
@@ -108,6 +111,9 @@ export function App(): React.ReactElement {
   );
 
   useEventStream(handleEvent);
+
+  // Pre-merge bookmarks (`/runs/:id`, `/projects/:id`) redirect into the shell (§1.5).
+  useLegacyRedirect({ panel, runId, projectId, mode, showLaunch }, navigate);
 
   // FINDING-013: /ws has no late-join replay, so a page reloaded against a run shows an empty Burn
   // panel even though usage was durably recorded. When the selected run has no frames yet (a reload
@@ -143,20 +149,30 @@ export function App(): React.ReactElement {
     };
   }, [runId]);
 
-  const selectRun = useCallback(
-    (id: string) => navigate(`/runs/${encodeURIComponent(id)}`),
-    [navigate],
+  // Inside the project shell, selecting a run stays in the shell (Chat keeps Chat, every
+  // other mode opens Build) instead of bouncing out to /runs/:id and redirecting back.
+  const runPath = useCallback(
+    (id: string) =>
+      projectId && mode
+        ? modePath(projectId, mode === 'chat' ? 'chat' : 'build', id)
+        : `/runs/${encodeURIComponent(id)}`,
+    [projectId, mode],
   );
+
+  const selectRun = useCallback((id: string) => navigate(runPath(id)), [navigate, runPath]);
 
   const onLaunched = useCallback(
     (id: string) => {
       refresh();
-      navigate(`/runs/${encodeURIComponent(id)}`);
+      navigate(runPath(id));
     },
-    [navigate, refresh],
+    [navigate, refresh, runPath],
   );
 
-  const onNavigateBack = useCallback(() => navigate('/'), [navigate]);
+  const onNavigateBack = useCallback(
+    () => navigate(projectId && mode ? modePath(projectId, mode) : '/'),
+    [navigate, projectId, mode],
+  );
 
   const onKill = useCallback(
     async (id: string) => {
@@ -190,8 +206,66 @@ export function App(): React.ReactElement {
     [repoId],
   );
 
+  // The three center surfaces, rendered by the legacy routes AND by the project shell.
+  // Slice 4 WIRES them; sharing the expression is what keeps "the same surface" literal.
+  const dashboardSurface = (): React.ReactElement => (
+    <div className="flex-1 overflow-y-auto">
+      <CenterDashboard
+        runs={runs}
+        onSelectRun={selectRun}
+        onApproveGate={onDashboardApproveGate}
+        onRejectGate={onDashboardRejectGate}
+        navigate={navigate}
+      />
+    </div>
+  );
+
+  const groupChatSurface = (repo: string | null): React.ReactElement => (
+    <div className="flex-1 overflow-hidden">
+      <GroupChat repoId={repo} onBack={onNavigateBack} />
+    </div>
+  );
+
+  const runSurface = (): React.ReactElement => (
+    <div className="flex-1 overflow-hidden">
+      <ChatPanel
+        view={selected}
+        chatMode={chatMode}
+        onLaunched={onLaunched}
+        onNavigateBack={onNavigateBack}
+        onRefresh={refresh}
+        onKill={onKill}
+        navigate={navigate}
+      />
+    </div>
+  );
+
+  /**
+   * What a mode renders inside the shell (DES-MERGE-001 §6.2, slice 4). Document and
+   * Video state what is coming and the action that enables it; Chat and Build reuse the
+   * existing surfaces above.
+   *
+   * Build with nothing open is the existing run home, UNSCOPED: scoping a project's runs
+   * is the board's data plumbing (slices 5-6) and needs launch to file the run it creates,
+   * so filtering here first would hide a run the user had just launched.
+   */
+  function renderModeSurface(m: Mode): React.ReactElement {
+    if (m === 'document' || m === 'video') return <ModePlaceholder mode={m} />;
+    if (m === 'chat' && !artifactId) return groupChatSurface(null);
+    return artifactId ? runSurface() : dashboardSurface();
+  }
+
   // Center panel content based on route
   function renderCenter(): React.ReactElement {
+    // The project shell owns every `/p/*` route and is checked FIRST — the panel parse
+    // below is untouched and still owns the flat cross-project lists and side panels.
+    if (projectId !== null && mode !== null) {
+      return (
+        <ProjectShell projectId={projectId} mode={mode} artifactId={artifactId} navigate={navigate}>
+          {renderModeSurface(mode)}
+        </ProjectShell>
+      );
+    }
     if (panel === 'coverage') {
       return (
         <div className="flex-1 overflow-y-auto p-6">
@@ -267,6 +341,8 @@ export function App(): React.ReactElement {
         </div>
       );
     }
+    // `/projects/:id` redirects into the shell (§1.5); this renders only for the tick
+    // before the redirect lands, and is the fallback if the redirect never does.
     if (panel === 'project-detail' && projectId) {
       return (
         <div className="flex-1 overflow-y-auto">
@@ -283,40 +359,14 @@ export function App(): React.ReactElement {
     }
     // Home dashboard: no run selected and not launching — three-panel home view + manager controls
     if (panel === 'runs' && !runId && !selected && !showLaunch) {
-      return (
-        <div className="flex-1 overflow-y-auto">
-          <CenterDashboard
-            runs={runs}
-            onSelectRun={selectRun}
-            onApproveGate={onDashboardApproveGate}
-            onRejectGate={onDashboardRejectGate}
-            navigate={navigate}
-          />
-        </div>
-      );
+      return dashboardSurface();
     }
     // NEW CHAT: the group-chat surface (warm seats + fan-out), not a run (crew#165).
     if (chatMode && selected === null) {
-      return (
-        <div className="flex-1 overflow-hidden">
-          <GroupChat repoId={repoId} onBack={onNavigateBack} />
-        </div>
-      );
+      return groupChatSurface(repoId);
     }
     // Run selected or launch form
-    return (
-      <div className="flex-1 overflow-hidden">
-        <ChatPanel
-          view={selected}
-          chatMode={chatMode}
-          onLaunched={onLaunched}
-          onNavigateBack={onNavigateBack}
-          onRefresh={refresh}
-          onKill={onKill}
-          navigate={navigate}
-        />
-      </div>
-    );
+    return runSurface();
   }
 
   return (

--- a/src/components/ModePlaceholder.tsx
+++ b/src/components/ModePlaceholder.tsx
@@ -1,0 +1,47 @@
+import type { Mode } from '../hooks/useRoute.js';
+import { MODE_SPECS } from './ModeSwitcher.js';
+
+const S = {
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  accent: '#ffda19',
+};
+
+/**
+ * The surface a mode shows before its transport lands (Document → slice 8,
+ * Video → slice 13). Deliberately NOT a spinner: §3.3 bans a working state with
+ * no subject, so this states what the mode is, with its subject, and names the
+ * one action that enables it — the same string the disabled tab's tooltip carries.
+ */
+export function ModePlaceholder({ mode }: { mode: Mode }): React.ReactElement {
+  const spec = MODE_SPECS[mode];
+  return (
+    <div style={{ padding: '32px', overflowY: 'auto' }}>
+      <div
+        data-testid={`mode-placeholder-${mode}`}
+        style={{
+          background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+          padding: '20px 22px', maxWidth: '640px',
+        }}
+      >
+        <h2 style={{ fontSize: '15px', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
+          {spec.label} mode is not connected yet
+        </h2>
+        <p style={{ fontSize: '13px', color: S.muted, margin: '0 0 14px', lineHeight: 1.5 }}>
+          {spec.summary}
+        </p>
+        <p
+          data-testid={`mode-enabling-action-${mode}`}
+          style={{
+            fontSize: '13px', color: S.ink, margin: 0, lineHeight: 1.5,
+            borderLeft: `2px solid ${S.accent}`, paddingLeft: '10px',
+          }}
+        >
+          <strong>To enable it:</strong> {spec.enables}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -1,0 +1,118 @@
+import { MODES, type Mode } from '../hooks/useRoute.js';
+
+const S = {
+  bar:      '#161c26',
+  border:   'rgba(230,237,243,0.1)',
+  ink:      '#e6edf3',
+  muted:    'rgba(230,237,243,0.55)',
+  faint:    'rgba(230,237,243,0.3)',
+  accent:   '#ffda19',
+};
+
+export interface ModeSpec {
+  label: string;
+  /**
+   * THE ONE FLAG THIS SLICE IS ALLOWED (DES-MERGE-001 §6.0). An unavailable mode is
+   * DISABLED, never hidden (§1.3 rule 3) — hiding it teaches the user the feature
+   * does not exist. Document flips to `true` in slice 8, Video in slice 13; when both
+   * are `true` this field and its branches delete cleanly.
+   */
+  available: boolean;
+  /**
+   * The ONE action that enables this mode, named as an action (§1.3 rule 3). Rendered
+   * as the disabled tab's `title` and verbatim in the mode's placeholder.
+   */
+  enables: string;
+  /** What this mode is, with its subject — never a bare "coming soon" (§3.3). */
+  summary: string;
+}
+
+export const MODE_SPECS: Record<Mode, ModeSpec> = {
+  chat: {
+    label: 'Chat',
+    available: true,
+    enables: '',
+    summary: 'Talk to an agent with no artifact committed yet — and choose a mode by conversation.',
+  },
+  build: {
+    label: 'Build',
+    available: true,
+    enables: '',
+    summary: 'Governed code work: units, phases, gates and evidence, on a crew run.',
+  },
+  document: {
+    label: 'Document',
+    available: false,
+    enables:
+      'Connect the interactive document service to this project (crew proxies it at '
+      + '/api/v1/projects/:projectId/interactive) to create documents here.',
+    summary:
+      'Document mode is where the interactive canvas lands: an HTML doc, deck or report, '
+      + 'its version strip, and point-and-comment feedback — all against this project’s one thread.',
+  },
+  video: {
+    label: 'Video',
+    available: false,
+    enables:
+      'Install the demo recorder (ffmpeg) and connect the interactive document service to '
+      + 'this project to record demos here.',
+    summary:
+      'Video mode is where the demo storyboard and player land: chapters derived from the '
+      + 'document’s steps, recorded and re-recorded from the same thread.',
+  },
+};
+
+interface Props {
+  mode: Mode;
+  onSelect: (mode: Mode) => void;
+}
+
+/**
+ * The four-mode switcher (DES-MERGE-001 §1.3) — rendered on every `/p/*` route.
+ *
+ * Each mode is a verb on the current project, not a document type, and each is
+ * peer-level: Document is deliberately NOT a tab under Build (§1.3 rule 4).
+ */
+export function ModeSwitcher({ mode, onSelect }: Props): React.ReactElement {
+  return (
+    <div
+      role="tablist"
+      aria-label="Project mode"
+      data-testid="mode-switcher"
+      style={{
+        display: 'flex', gap: '2px', padding: '0 12px', flexShrink: 0,
+        background: S.bar, borderBottom: `1px solid ${S.border}`,
+      }}
+    >
+      {MODES.map((m) => {
+        const spec = MODE_SPECS[m];
+        const active = m === mode;
+        return (
+          <button
+            key={m}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            data-testid={`mode-tab-${m}`}
+            data-mode={m}
+            disabled={!spec.available}
+            title={spec.available ? spec.summary : spec.enables}
+            onClick={() => onSelect(m)}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              borderBottom: `2px solid ${active ? S.accent : 'transparent'}`,
+              color: !spec.available ? S.faint : active ? S.ink : S.muted,
+              cursor: spec.available ? 'pointer' : 'not-allowed',
+              fontSize: '13px',
+              fontWeight: active ? 700 : 500,
+              padding: '10px 14px',
+            }}
+          >
+            {spec.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ProjectShell.tsx
+++ b/src/components/ProjectShell.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { modePath, rememberMode, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { useProjectsStore } from '../store/projects.js';
+import { ModeSwitcher } from './ModeSwitcher.js';
+
+const S = {
+  bar:    '#161c26',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+};
+
+interface Props {
+  projectId: string;
+  mode: Mode;
+  /** What the current mode has open — remembered per mode so a switch never drops it. */
+  artifactId: string | null;
+  navigate: Navigate;
+  /** The mode surface: an existing studio surface for Chat/Build, a placeholder otherwise. */
+  children: React.ReactNode;
+}
+
+/**
+ * The project shell (DES-MERGE-001 §1.2): mode switcher on top, mode surface below.
+ *
+ * The switcher lives OUTSIDE the surface, so switching modes re-renders the surface
+ * without tearing down the shell, and each mode returns to the artifact it was last
+ * showing — §1.3 rule 1, "switching modes never resets the conversation".
+ */
+export function ProjectShell({ projectId, mode, artifactId, navigate, children }: Props): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const loadProjects = useProjectsStore((s) => s.load);
+
+  useEffect(() => {
+    if (projects.length === 0) void loadProjects();
+  }, [projects.length, loadProjects]);
+
+  // Per-mode artifact memory: Build → Chat → Build lands back on the same run rather
+  // than on an empty surface. A ref (not state) because it never drives a render.
+  const lastArtifact = useRef<Partial<Record<Mode, string>>>({});
+  if (artifactId) lastArtifact.current[mode] = artifactId;
+
+  useEffect(() => { rememberMode(projectId, mode); }, [projectId, mode]);
+
+  const onSelectMode = useCallback(
+    (next: Mode) => navigate(modePath(projectId, next, lastArtifact.current[next] ?? null)),
+    [navigate, projectId],
+  );
+
+  const name = projects.find((p) => p.id === projectId)?.name ?? projectId;
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden" data-testid="project-shell" data-project-id={projectId}>
+      <header
+        style={{
+          display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0,
+          padding: '10px 14px 8px', background: S.bar, borderBottom: `1px solid ${S.border}`,
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          title="All projects"
+          style={{ background: 'transparent', border: 'none', color: S.muted, cursor: 'pointer', fontSize: '12px', padding: 0 }}
+        >
+          ‹ Projects
+        </button>
+        <h1 data-testid="project-name" style={{ fontSize: '13px', fontWeight: 700, color: S.ink, margin: 0 }}>
+          {name}
+        </h1>
+      </header>
+
+      <ModeSwitcher mode={mode} onSelect={onSelectMode} />
+
+      <div className="flex flex-1 overflow-hidden" data-testid="mode-surface" data-mode={mode}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import { api } from '../api/client.js';
+import { lastMode, modePath, type Mode, type Navigate } from './useRoute.js';
+
+/** The synthesized "unfiled" project — a run that appears only there has no project. */
+const DEFAULT_PROJECT_ID = 'default';
+
+/** Membership kinds that make a run/thread a member of a project. */
+const RUN_KINDS = new Set(['crew.run', 'crew.chat']);
+
+/**
+ * Resolve the project a run is filed under (DES-MERGE-001 §1.5 back-compat).
+ *
+ * Crew has no reverse lookup, so this scans membership: `GET /projects` then each
+ * project's members, concurrently. `default` is skipped deliberately — it is the
+ * SYNTHESIZED project that holds every unfiled run, so a hit there means "no
+ * project", and the caller keeps the legacy run view rather than inventing a home.
+ * Any project that fails to answer is treated as a miss, never as an error.
+ */
+export async function resolveRunProject(runId: string): Promise<string | null> {
+  const { projects } = await api.listProjects();
+  const hits = await Promise.all(
+    projects
+      .filter((p) => p.id !== DEFAULT_PROJECT_ID)
+      .map(async (p) => {
+        try {
+          const { members } = await api.listProjectMembers(p.id);
+          return members.some((m) => m.member_ref === runId && RUN_KINDS.has(m.member_kind)) ? p.id : null;
+        } catch {
+          return null;
+        }
+      }),
+  );
+  return hits.find((id): id is string => id !== null) ?? null;
+}
+
+interface LegacyRoute {
+  panel: string;
+  runId: string | null;
+  projectId: string | null;
+  mode: Mode | null;
+  showLaunch: boolean;
+}
+
+/**
+ * Client-side redirects from the pre-merge paths into the project shell (§1.5).
+ * Every redirect REPLACES its history entry, so Back leaves the shell instead of
+ * bouncing through the redirect again.
+ *
+ *   /projects/:id  →  /p/:id/<last-used mode>
+ *   /runs/:id      →  /p/<project>/build/:id   (when the run is filed under one)
+ *
+ * A run with no project keeps the existing run view: no bookmark breaks, and no
+ * guessed project binding.
+ */
+export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void {
+  const { panel, runId, projectId, mode, showLaunch } = route;
+
+  useEffect(() => {
+    if (mode !== null) return; // already in the shell
+
+    if (projectId !== null) {
+      // Both `/projects/:id` (legacy panel) and a bare `/p/:id` land on the last-used mode.
+      navigate(modePath(projectId, lastMode(projectId)), { replace: true });
+      return;
+    }
+
+    if (panel !== 'runs' || runId === null || showLaunch) return;
+    let cancelled = false;
+    void resolveRunProject(runId)
+      .then((pid) => {
+        if (!cancelled && pid !== null) navigate(modePath(pid, 'build', runId), { replace: true });
+      })
+      .catch(() => {
+        /* projects surface unreachable — the legacy run view stays, which is the honest fallback */
+      });
+    return () => { cancelled = true; };
+  }, [panel, runId, projectId, mode, showLaunch, navigate]);
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -4,6 +4,19 @@ export type Panel = 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 
 
 const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
 
+/**
+ * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not
+ * app state: `/p/:projectId/:mode[/:artifactId]`, so it is deep-linkable,
+ * back-button-correct and Playwright-addressable.
+ */
+export type Mode = 'chat' | 'build' | 'document' | 'video';
+
+export const MODES: readonly Mode[] = ['chat', 'build', 'document', 'video'] as const;
+
+function asMode(s: string): Mode | null {
+  return (MODES as readonly string[]).includes(s) ? (s as Mode) : null;
+}
+
 interface Route {
   panel: Panel;
   /** Non-null only when panel === 'runs' and a run is selected. */
@@ -16,41 +29,104 @@ interface Route {
   showRegisterRepo: boolean;
   /** True when the launch form is in chat mode (vs. work mode). */
   chatMode: boolean;
-  /** Non-null only when panel === 'project-detail'. */
+  /** Non-null on the legacy `/projects/:id` panel AND on every `/p/*` route. */
   projectId: string | null;
+  /** Non-null only on `/p/:projectId/:mode` — the active mode of the project shell. */
+  mode: Mode | null;
+  /** What the mode has open: run id (Build), thread id (Chat), doc id, demo id. */
+  artifactId: string | null;
+}
+
+/** Route options a caller can override; everything else takes its inert default. */
+const INERT: Route = {
+  panel: 'runs',
+  runId: null,
+  showLaunch: false,
+  repoId: null,
+  showRegisterRepo: false,
+  chatMode: false,
+  projectId: null,
+  mode: null,
+  artifactId: null,
+};
+
+function route(over: Partial<Route>): Route {
+  return { ...INERT, ...over };
 }
 
 function safeDecode(s: string): string {
   try { return decodeURIComponent(s); } catch { return s; }
 }
 
-function parse(pathname: string): Route {
-  const [, first = '', second = ''] = pathname.split('/');
-  if (first === 'repo-detail' && second) {
-    return { panel: 'repo-detail', runId: null, showLaunch: false, repoId: safeDecode(second), showRegisterRepo: false, chatMode: false, projectId: null };
+/** Where `/p/:projectId` (no mode) lands, per project. §1.5: last-used mode, default `chat`. */
+const LAST_MODE_KEY = 'wk.studio.lastMode';
+
+export function lastMode(projectId: string): Mode {
+  try {
+    return asMode(window.localStorage.getItem(`${LAST_MODE_KEY}.${projectId}`) ?? '') ?? 'chat';
+  } catch {
+    return 'chat'; // storage denied (private mode) — the default is still correct
   }
-  if (first === 'repo-detail') {
-    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
-  }
-  if (first === 'repos' && second === 'new') {
-    return { panel: 'repos', runId: null, showLaunch: false, repoId: null, showRegisterRepo: true, chatMode: false, projectId: null };
-  }
-  if (first === 'chat' && second === 'new') {
-    return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: true, projectId: null };
-  }
-  if (first === 'projects' && second) {
-    return { panel: 'project-detail', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: safeDecode(second) };
-  }
-  if ((PANELS as string[]).includes(first) && first !== 'runs') {
-    return { panel: first as Panel, runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
-  }
-  if (second === 'new') return { panel: 'runs', runId: null, showLaunch: true, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
-  if (second) return { panel: 'runs', runId: safeDecode(second), showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
-  return { panel: 'runs', runId: null, showLaunch: false, repoId: null, showRegisterRepo: false, chatMode: false, projectId: null };
 }
 
+export function rememberMode(projectId: string, mode: Mode): void {
+  try {
+    window.localStorage.setItem(`${LAST_MODE_KEY}.${projectId}`, mode);
+  } catch { /* storage denied — the default mode simply stays 'chat' */ }
+}
+
+/** Build a project-shell path. The single spelling of `/p/:projectId/:mode[/:artifactId]`. */
+export function modePath(projectId: string, mode: Mode, artifactId?: string | null): string {
+  const base = `/p/${encodeURIComponent(projectId)}/${mode}`;
+  return artifactId ? `${base}/${encodeURIComponent(artifactId)}` : base;
+}
+
+function parse(pathname: string): Route {
+  const [, first = '', second = '', third = '', fourth = ''] = pathname.split('/');
+  // The project+mode parse runs AHEAD of the panel parse (DES-MERGE-001 §1.5); the
+  // `Panel` union below is untouched and still owns every side panel.
+  if (first === 'p' && second) {
+    const mode = asMode(third);
+    const artifactId = mode !== null && fourth ? safeDecode(fourth) : null;
+    return route({
+      projectId: safeDecode(second),
+      mode,
+      artifactId,
+      // Build and Chat wire straight into the existing run surfaces, so the artifact IS
+      // the run: every run-selected behaviour (event backfill, Ctrl+K kill, RightPanel,
+      // gate toasts) keeps working unchanged inside the shell.
+      runId: mode === 'build' || mode === 'chat' ? artifactId : null,
+      chatMode: mode === 'chat',
+    });
+  }
+  if (first === 'repo-detail' && second) {
+    return route({ panel: 'repo-detail', repoId: safeDecode(second) });
+  }
+  if (first === 'repo-detail') {
+    return route({ panel: 'repos' });
+  }
+  if (first === 'repos' && second === 'new') {
+    return route({ panel: 'repos', showRegisterRepo: true });
+  }
+  if (first === 'chat' && second === 'new') {
+    return route({ panel: 'runs', showLaunch: true, chatMode: true });
+  }
+  if (first === 'projects' && second) {
+    return route({ panel: 'project-detail', projectId: safeDecode(second) });
+  }
+  if ((PANELS as string[]).includes(first) && first !== 'runs') {
+    return route({ panel: first as Panel });
+  }
+  if (second === 'new') return route({ panel: 'runs', showLaunch: true });
+  if (second) return route({ panel: 'runs', runId: safeDecode(second) });
+  return route({ panel: 'runs' });
+}
+
+/** `replace` swaps the current history entry — used by redirects so Back never re-enters them. */
+export type Navigate = (path: string, opts?: { replace?: boolean }) => void;
+
 export function useRoute(): Route & {
-  navigate: (path: string) => void;
+  navigate: Navigate;
   panelPath: (p: Panel) => string;
 } {
   const [pathname, setPathname] = useState(() => window.location.pathname);
@@ -61,8 +137,9 @@ export function useRoute(): Route & {
     return () => window.removeEventListener('popstate', handler);
   }, []);
 
-  const navigate = useCallback((path: string) => {
-    history.pushState(null, '', path);
+  const navigate = useCallback<Navigate>((path, opts) => {
+    if (opts?.replace) history.replaceState(null, '', path);
+    else history.pushState(null, '', path);
     setPathname(path);
   }, []);
 

--- a/tests/ModeSwitcher.test.tsx
+++ b/tests/ModeSwitcher.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MODES } from '../src/hooks/useRoute.js';
+import { MODE_SPECS, ModeSwitcher } from '../src/components/ModeSwitcher.js';
+import { ModePlaceholder } from '../src/components/ModePlaceholder.js';
+
+afterEach(cleanup);
+
+describe('ModeSwitcher (DES-MERGE-001 §1.3)', () => {
+  it('shows exactly four tabs, in mode order', () => {
+    render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
+    const tabs = screen.getByTestId('mode-switcher').querySelectorAll('[role="tab"]');
+    expect(tabs).toHaveLength(4);
+    expect([...tabs].map((t) => t.getAttribute('data-mode'))).toEqual(['chat', 'build', 'document', 'video']);
+    expect([...tabs].map((t) => t.textContent)).toEqual(['Chat', 'Build', 'Document', 'Video']);
+  });
+
+  it('marks the active mode selected', () => {
+    render(<ModeSwitcher mode="build" onSelect={() => {}} />);
+    expect(screen.getByTestId('mode-tab-build')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('mode-tab-chat')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('selects a mode on click', () => {
+    const onSelect = vi.fn();
+    render(<ModeSwitcher mode="chat" onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('mode-tab-build'));
+    expect(onSelect).toHaveBeenCalledWith('build');
+  });
+
+  it('DISABLES an unavailable mode instead of hiding it, and names the enabling action', () => {
+    render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
+    for (const m of MODES) {
+      const tab = screen.getByTestId(`mode-tab-${m}`);
+      // Rule 3: never hidden — every mode is on screen whether or not it is available.
+      expect(tab).toBeInTheDocument();
+      if (MODE_SPECS[m].available) continue;
+      expect(tab).toBeDisabled();
+      expect(tab).toHaveAttribute('title', expect.stringMatching(/install|connect|create/i));
+    }
+  });
+
+  it('does not fire onSelect for a disabled mode', () => {
+    const onSelect = vi.fn();
+    render(<ModeSwitcher mode="chat" onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('mode-tab-video'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('ModePlaceholder (§3.3 — every state names a subject)', () => {
+  it('states what the mode is and the one action that enables it', () => {
+    render(<ModePlaceholder mode="document" />);
+    const card = screen.getByTestId('mode-placeholder-document');
+    expect(card).toHaveTextContent(/interactive canvas/i);
+    expect(screen.getByTestId('mode-enabling-action-document')).toHaveTextContent(/connect/i);
+  });
+
+  it('carries the SAME enabling action as the disabled tab tooltip — one source of truth', () => {
+    render(<ModePlaceholder mode="video" />);
+    expect(screen.getByTestId('mode-enabling-action-video')).toHaveTextContent(MODE_SPECS.video.enables);
+  });
+
+  it('renders no spinner and no subject-less status', () => {
+    const { container } = render(<ModePlaceholder mode="video" />);
+    expect(container.querySelector('[class*="spin"], [class*="animate-"]')).toBeNull();
+    expect(container.textContent).not.toMatch(/^\s*(working|loading)…?\s*$/i);
+  });
+});

--- a/tests/ProjectShell.test.tsx
+++ b/tests/ProjectShell.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ProjectShell } from '../src/components/ProjectShell.js';
+import { useProjectsStore } from '../src/store/projects.js';
+import { lastMode } from '../src/hooks/useRoute.js';
+
+vi.mock('../src/api/client.js', () => ({
+  api: { listProjects: () => Promise.resolve({ projects: [] }) },
+}));
+
+beforeEach(() => {
+  useProjectsStore.setState({
+    projects: [{
+      id: 'proj-1', name: 'Merge the skins', description: null, status: 'active',
+      scope: 'project:proj-1', created_at: 1, updated_at: 1,
+    }],
+    loading: false,
+    error: null,
+  });
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe('ProjectShell (DES-MERGE-001 §1.2)', () => {
+  it('renders the switcher and the mode surface on a /p/* route', () => {
+    render(
+      <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={() => {}}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    expect(screen.getByTestId('mode-switcher')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-surface')).toHaveAttribute('data-mode', 'build');
+    expect(screen.getByTestId('project-name')).toHaveTextContent('Merge the skins');
+  });
+
+  it('falls back to the project id when the project is not loaded — never a blank header', async () => {
+    useProjectsStore.setState({ projects: [] });
+    // The empty store triggers a load; await it inside act so the fetch settles here.
+    await act(async () => {
+      render(
+        <ProjectShell projectId="proj-9" mode="chat" artifactId={null} navigate={() => {}}>
+          <p>surface</p>
+        </ProjectShell>,
+      );
+    });
+    expect(screen.getByTestId('project-name')).toHaveTextContent('proj-9');
+  });
+
+  it('navigates to the mode route on a tab click', () => {
+    const navigate = vi.fn();
+    render(
+      <ProjectShell projectId="proj-1" mode="chat" artifactId={null} navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    fireEvent.click(screen.getByTestId('mode-tab-build'));
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/build');
+  });
+
+  it('remembers each mode\'s artifact, so a switch never drops what was open (§1.3 rule 1)', () => {
+    const navigate = vi.fn();
+    const { rerender } = render(
+      <ProjectShell projectId="proj-1" mode="build" artifactId="run-9" navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    // Build → Chat …
+    fireEvent.click(screen.getByTestId('mode-tab-chat'));
+    expect(navigate).toHaveBeenLastCalledWith('/p/proj-1/chat');
+
+    rerender(
+      <ProjectShell projectId="proj-1" mode="chat" artifactId={null} navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    // … and back to Build lands on run-9 again, not on an empty run list.
+    fireEvent.click(screen.getByTestId('mode-tab-build'));
+    expect(navigate).toHaveBeenLastCalledWith('/p/proj-1/build/run-9');
+  });
+
+  it('records the last-used mode, which is where a bare /p/:projectId lands', () => {
+    render(
+      <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={() => {}}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    expect(lastMode('proj-1')).toBe('build');
+  });
+});

--- a/tests/legacyRedirect.test.ts
+++ b/tests/legacyRedirect.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { Project, ProjectMember } from '../src/api/types.js';
+import { resolveRunProject, useLegacyRedirect } from '../src/hooks/useLegacyRedirect.js';
+import { rememberMode } from '../src/hooks/useRoute.js';
+
+const listProjects = vi.fn();
+const listProjectMembers = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: (...a: unknown[]) => listProjects(...a),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+  },
+}));
+
+function project(id: string, name = id): Project {
+  return { id, name, description: null, status: 'active', scope: `project:${id}`, created_at: 1, updated_at: 1 };
+}
+
+function member(projectId: string, kind: string, ref: string): ProjectMember {
+  return {
+    id: `${projectId}:${kind}:${ref}`, project_id: projectId, member_kind: kind,
+    member_ref: ref, meta: null, attached_at: 1, attached_by: 'studio',
+  };
+}
+
+/** Route shape for a legacy path; `mode: null` is what makes it legacy. */
+const legacy = {
+  runs: (runId: string) => ({ panel: 'runs', runId, projectId: null, mode: null, showLaunch: false }),
+  projects: (projectId: string) => ({ panel: 'project-detail', runId: null, projectId, mode: null, showLaunch: false }),
+};
+
+beforeEach(() => {
+  listProjects.mockReset();
+  listProjectMembers.mockReset();
+  window.localStorage.clear();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('resolveRunProject', () => {
+  it('finds the project a run is filed under', async () => {
+    listProjects.mockResolvedValue({ projects: [project('default', 'Unfiled'), project('proj-1'), project('proj-2')] });
+    listProjectMembers.mockImplementation((id: string) =>
+      Promise.resolve({ members: id === 'proj-2' ? [member('proj-2', 'crew.run', 'run-9')] : [] }));
+
+    await expect(resolveRunProject('run-9')).resolves.toBe('proj-2');
+    // `default` is the SYNTHESIZED unfiled project — never scanned, never a hit.
+    expect(listProjectMembers).not.toHaveBeenCalledWith('default');
+  });
+
+  it('resolves a chat thread too (crew.chat is a member kind)', async () => {
+    listProjects.mockResolvedValue({ projects: [project('proj-1')] });
+    listProjectMembers.mockResolvedValue({ members: [member('proj-1', 'crew.chat', 'chat-3')] });
+    await expect(resolveRunProject('chat-3')).resolves.toBe('proj-1');
+  });
+
+  it('returns null for an unfiled run, and ignores non-run member kinds', async () => {
+    listProjects.mockResolvedValue({ projects: [project('proj-1')] });
+    listProjectMembers.mockResolvedValue({ members: [member('proj-1', 'crew.repo', 'run-9')] });
+    await expect(resolveRunProject('run-9')).resolves.toBeNull();
+  });
+
+  it('treats a project that fails to answer as a miss, not an error', async () => {
+    listProjects.mockResolvedValue({ projects: [project('proj-1'), project('proj-2')] });
+    listProjectMembers.mockImplementation((id: string) =>
+      id === 'proj-1' ? Promise.reject(new Error('API 500')) : Promise.resolve({ members: [member('proj-2', 'crew.run', 'run-9')] }));
+    await expect(resolveRunProject('run-9')).resolves.toBe('proj-2');
+  });
+});
+
+describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () => {
+  it('/runs/:id → /p/<project>/build/:id, replacing the history entry', async () => {
+    listProjects.mockResolvedValue({ projects: [project('proj-1')] });
+    listProjectMembers.mockResolvedValue({ members: [member('proj-1', 'crew.run', 'run-9')] });
+    const navigate = vi.fn();
+
+    renderHook(() => useLegacyRedirect(legacy.runs('run-9'), navigate));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/p/proj-1/build/run-9', { replace: true }));
+  });
+
+  it('leaves an unfiled run on the existing run view', async () => {
+    listProjects.mockResolvedValue({ projects: [project('proj-1')] });
+    listProjectMembers.mockResolvedValue({ members: [] });
+    const navigate = vi.fn();
+
+    renderHook(() => useLegacyRedirect(legacy.runs('run-9'), navigate));
+
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('leaves the run view alone when the projects surface is unreachable', async () => {
+    listProjects.mockRejectedValue(new Error('API 503'));
+    const navigate = vi.fn();
+
+    renderHook(() => useLegacyRedirect(legacy.runs('run-9'), navigate));
+
+    await waitFor(() => expect(listProjects).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('/projects/:id → /p/:id on the last-used mode, with no membership lookup', () => {
+    const navigate = vi.fn();
+    rememberMode('proj-1', 'document');
+
+    renderHook(() => useLegacyRedirect(legacy.projects('proj-1'), navigate));
+
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/document', { replace: true });
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+
+  it('a bare /p/:projectId lands on chat by default', () => {
+    const navigate = vi.fn();
+    renderHook(() => useLegacyRedirect(
+      { panel: 'runs', runId: null, projectId: 'proj-1', mode: null, showLaunch: false }, navigate));
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/chat', { replace: true });
+  });
+
+  it('never redirects a route that is already in the shell, or the launch form', () => {
+    const navigate = vi.fn();
+    renderHook(() => useLegacyRedirect(
+      { panel: 'runs', runId: 'run-9', projectId: 'proj-1', mode: 'build', showLaunch: false }, navigate));
+    renderHook(() => useLegacyRedirect(
+      { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: true }, navigate));
+    renderHook(() => useLegacyRedirect(
+      { panel: 'work', runId: null, projectId: null, mode: null, showLaunch: false }, navigate));
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,3 +4,21 @@ import '@testing-library/jest-dom';
 if (typeof window.HTMLElement.prototype.scrollIntoView !== 'function') {
   window.HTMLElement.prototype.scrollIntoView = () => {};
 }
+
+// This jsdom build exposes no localStorage (opaque-origin / node flag gap), while every
+// browser the SPA ships to does. Stub the same shape so storage-backed behaviour is
+// TESTED rather than silently falling through the production try/catch guards.
+if (!('localStorage' in window) || window.localStorage == null) {
+  const mem = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => mem.get(k) ?? null,
+      setItem: (k: string, v: string) => void mem.set(k, String(v)),
+      removeItem: (k: string) => void mem.delete(k),
+      clear: () => mem.clear(),
+      key: (i: number) => [...mem.keys()][i] ?? null,
+      get length() { return mem.size; },
+    },
+  });
+}

--- a/tests/useRoute.modes.test.ts
+++ b/tests/useRoute.modes.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { MODES, lastMode, modePath, rememberMode, useRoute } from '../src/hooks/useRoute.js';
+
+/** Render the hook against a given path — the parse reads `window.location` at mount. */
+function routeAt(path: string) {
+  window.history.replaceState(null, '', path);
+  return renderHook(() => useRoute()).result;
+}
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/');
+  window.localStorage.clear();
+});
+
+describe('useRoute — project + mode routes (DES-MERGE-001 §1.5)', () => {
+  it('parses /p/:projectId/:mode', () => {
+    const r = routeAt('/p/proj-1/build');
+    expect(r.current.projectId).toBe('proj-1');
+    expect(r.current.mode).toBe('build');
+    expect(r.current.artifactId).toBeNull();
+  });
+
+  it('parses /p/:projectId/:mode/:artifactId for all four modes', () => {
+    for (const mode of MODES) {
+      const r = routeAt(`/p/proj-1/${mode}/art-7`);
+      expect(r.current.mode).toBe(mode);
+      expect(r.current.artifactId).toBe('art-7');
+    }
+  });
+
+  it('maps the Build/Chat artifact onto runId so the existing run surfaces stay wired', () => {
+    expect(routeAt('/p/proj-1/build/run-9').current.runId).toBe('run-9');
+
+    const chat = routeAt('/p/proj-1/chat/run-9').current;
+    expect(chat.runId).toBe('run-9');
+    expect(chat.chatMode).toBe(true);
+
+    // Document/Video artifacts are docs and demos, NOT crew runs — never a runId.
+    expect(routeAt('/p/proj-1/document/doc-3').current.runId).toBeNull();
+    expect(routeAt('/p/proj-1/video/demo-3').current.runId).toBeNull();
+  });
+
+  it('leaves mode null for /p/:projectId and for an unknown mode segment', () => {
+    expect(routeAt('/p/proj-1').current.mode).toBeNull();
+
+    const bogus = routeAt('/p/proj-1/bogus/x').current;
+    expect(bogus.mode).toBeNull();
+    expect(bogus.artifactId).toBeNull();
+    expect(bogus.projectId).toBe('proj-1');
+  });
+
+  it('decodes percent-encoded ids', () => {
+    const r = routeAt('/p/proj%20one/build/run%2F9');
+    expect(r.current.projectId).toBe('proj one');
+    expect(r.current.artifactId).toBe('run/9');
+  });
+});
+
+describe('useRoute — the existing panel routes keep working', () => {
+  it('still parses every legacy shape unchanged', () => {
+    expect(routeAt('/').current).toMatchObject({ panel: 'runs', runId: null, mode: null });
+    expect(routeAt('/runs/run-1').current).toMatchObject({ panel: 'runs', runId: 'run-1' });
+    expect(routeAt('/runs/new').current).toMatchObject({ panel: 'runs', showLaunch: true });
+    expect(routeAt('/chat/new').current).toMatchObject({ showLaunch: true, chatMode: true });
+    expect(routeAt('/work').current.panel).toBe('work');
+    expect(routeAt('/repos/new').current).toMatchObject({ panel: 'repos', showRegisterRepo: true });
+    expect(routeAt('/repo-detail/repo-1').current).toMatchObject({ panel: 'repo-detail', repoId: 'repo-1' });
+    expect(routeAt('/repo-detail').current.panel).toBe('repos');
+    expect(routeAt('/projects').current.panel).toBe('projects');
+    expect(routeAt('/projects/proj-1').current).toMatchObject({ panel: 'project-detail', projectId: 'proj-1' });
+    expect(routeAt('/system').current.panel).toBe('system');
+  });
+
+  it('a legacy route carries no mode, and panelPath is unchanged', () => {
+    const r = routeAt('/runs/run-1');
+    expect(r.current.mode).toBeNull();
+    expect(r.current.panelPath('runs')).toBe('/');
+    expect(r.current.panelPath('coverage')).toBe('/coverage');
+  });
+});
+
+describe('navigate', () => {
+  it('pushes a history entry by default, so Back returns to the previous mode', () => {
+    const r = routeAt('/p/proj-1/chat');
+    const before = window.history.length;
+
+    act(() => r.current.navigate('/p/proj-1/build'));
+
+    expect(window.location.pathname).toBe('/p/proj-1/build');
+    expect(r.current.mode).toBe('build');
+    expect(window.history.length).toBe(before + 1);
+  });
+
+  it('replaces the entry when asked, so a redirect is never a Back-button trap', () => {
+    const r = routeAt('/runs/run-9');
+    const before = window.history.length;
+
+    act(() => r.current.navigate('/p/proj-1/build/run-9', { replace: true }));
+
+    expect(window.location.pathname).toBe('/p/proj-1/build/run-9');
+    expect(r.current.runId).toBe('run-9');
+    expect(window.history.length).toBe(before);
+  });
+});
+
+describe('modePath / last-used mode', () => {
+  it('builds the single spelling of the shell path', () => {
+    expect(modePath('proj-1', 'build')).toBe('/p/proj-1/build');
+    expect(modePath('proj-1', 'build', 'run-9')).toBe('/p/proj-1/build/run-9');
+    expect(modePath('proj one', 'chat', 'run/9')).toBe('/p/proj%20one/chat/run%2F9');
+  });
+
+  it('defaults to chat and remembers per project', () => {
+    expect(lastMode('proj-1')).toBe('chat');
+    rememberMode('proj-1', 'build');
+    expect(lastMode('proj-1')).toBe('build');
+    expect(lastMode('proj-2')).toBe('chat');
+  });
+
+  it('ignores a junk stored value rather than routing to a mode that does not exist', () => {
+    window.localStorage.setItem('wk.studio.lastMode.proj-1', 'sideways');
+    expect(lastMode('proj-1')).toBe('chat');
+  });
+});


### PR DESCRIPTION
Slice 4 — Phase B opens: the first user-visible piece of the merged IA, authored by governed run `29b10e15` (clarify/design/build: claude · adversarial-review/test/review: codex), which read the design from this repo's own main.

- `/p/:projectId/:mode[/:artifactId]` parsed ahead of the existing panel parse; all current routes intact
- `ModeSwitcher` (`data-testid="mode-switcher"`): [ Chat | Build | Document | Video ] — mode is a route segment (deep-linkable, back-button-correct); unavailable modes disabled with a tooltip naming the enabling action, never hidden (§1.3)
- Chat/Build wire the existing surfaces into the shell; Document/Video render informative placeholders that state what is coming (§3.3 — no bare spinners)
- Legacy redirects: `/runs/:id` → `/p/<project>/build/<id>` (project resolved from the run), `/projects/:id` → `/p/:id` — no bookmark breaks
- Playwright slice-4 ACs added to the standalone browser gate; 331/331 unit tests locally (44 files)

Design: `.product/DES-MERGE-001.md` §1.2–1.6, §6.2 slice 4, §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)