### PR TITLE
feat(board): the orchestrator home board, static (DES-MERGE-001 slice 5)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -28,6 +28,10 @@ What "independent" means here, and what this script proves end-to-end:
      four-mode switcher, an unavailable mode is disabled with its enabling action in
      the tooltip, clicking Build is a real (back-button-correct) navigation, and the
      pre-merge /runs/:id and /projects/:id bookmarks redirect into the new shape
+  8. (DES-MERGE-001 slice 5) the orchestrator board at /: the gate-waiting project
+     sorts first, an empty project's card IS its four quick actions (each pre-bound
+     to that project), doc tiles are placeholders rather than iframes (§7.5), and
+     20+ projects stay windowed inside a viewport-bounded board
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -352,6 +356,129 @@ try:
     }
     if not report["steps"]["project_shell"]["ok"]:
         fail("project_shell_verdict", "slice-4 shell assertions did not all hold — see project_shell")
+
+    # ── 9. Slice 5 (DES-MERGE-001 §6.2): the orchestrator board at / ──────────
+    def new_project(name: str) -> str:
+        _, _, created = http_json("POST", f"{API}/projects", {"name": name})
+        return created["project"]["id"]
+
+    def attach_run(project: str, run: str) -> None:
+        http_json(
+            "POST", f"{API}/projects/{project}/members",
+            {"kind": "crew.run", "ref": run, "attachedBy": "studio"},
+        )
+
+    def launch(problem: str, human_confirm: str) -> str:
+        _, _, body = http_json("POST", f"{API}/runs", {"problem": problem, "humanConfirm": human_confirm})
+        return body["runId"]
+
+    def await_gate(rid: str) -> str:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            _, _, body = http_json("GET", f"{API}/runs/{rid}")
+            if body["run"]["session"]["status"] == "awaiting_human":
+                return rid
+            time.sleep(0.5)
+        fail("board_seed", f"run {rid} never parked on a human gate")
+        return rid  # unreachable — fail() exits
+
+    tag = run_id[:8]
+    gate_project = new_project(f"board-gate-{tag}")
+    attach_run(gate_project, await_gate(launch("board seed: parks on a gate", "all")))
+    busy_project = new_project(f"board-busy-{tag}")
+    busy_run = launch("board seed: runs unattended", "none")
+    attach_run(busy_project, busy_run)
+    empty_project = new_project(f"board-empty-{tag}")
+
+    def settled(page, expr: str, arg=None) -> bool:
+        """The board sorts once memberships land — poll for the settled state, not the first paint."""
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=30000)
+            return True
+        except Exception:
+            return False
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        viewport = page.viewport_size
+
+        # AC: with a gate-waiting, a running and an empty project seeded, the FIRST card
+        # is the gate-waiting one (§1.4 — sorted by attention, not recency).
+        page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        gate_first_ok = settled(
+            page,
+            """id => { const c = document.querySelector('[data-testid="project-card"]');
+                       return !!c && c.dataset.projectId === id && c.dataset.attention === 'gate'; }""",
+            gate_project,
+        )
+        first_card = page.locator('[data-testid="project-card"]').first
+        gate_chip_ok = "gate" in first_card.inner_text().lower()
+
+        # AC: the empty project's card shows the four quick actions, each pre-bound to it.
+        empty_card = page.locator(f'[data-testid="project-card"][data-project-id="{empty_project}"]')
+        empty_card.wait_for(timeout=30000)
+        actions = empty_card.locator('[data-testid="quick-action"]')
+        modes = [actions.nth(i).get_attribute("data-mode") for i in range(actions.count())]
+        empty_actions_ok = modes == ["chat", "build", "document", "video"]
+        prebound_ok = all(
+            actions.nth(i).get_attribute("href") == f"/p/{empty_project}/{m}"
+            for i, m in enumerate(modes)
+        )
+        # §7.5: doc tiles are PLACEHOLDERS — no card mounts a live document.
+        no_iframes = page.locator('[data-testid="project-card"] iframe').count() == 0
+        page.screenshot(path=str(SHOTS / "slice5-board-attention.png"), full_page=True)
+
+        # AC: 20 more projects stay windowed — the board is bounded by the viewport, and
+        # what is MOUNTED is bounded with it (§1.4: legible at ~20 cards).
+        for i in range(20):
+            new_project(f"board-bulk-{tag}-{i:02d}")
+        page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        board = page.locator('[data-testid="project-board"]')
+        board.wait_for(timeout=30000)
+        bulk_loaded = settled(
+            page,
+            """() => Number(document.querySelector('[data-testid="project-board"]')?.dataset.total || 0) >= 20""",
+        )
+        total = int(board.get_attribute("data-total") or 0)
+        rendered = page.locator('[data-testid="project-card"]').count()
+        board_box = board.bounding_box() or {"height": 1e9}
+        doc_height = page.evaluate("() => document.documentElement.scrollHeight")
+        board_bounded = board_box["height"] <= viewport["height"] + 1
+        page_bounded = doc_height <= viewport["height"] + 1
+        windowed = rendered < total
+        page.screenshot(path=str(SHOTS / "slice5-board-windowed.png"), full_page=True)
+
+        browser.close()
+
+    report["steps"]["orchestrator_board"] = {
+        "ok": all([
+            gate_first_ok, gate_chip_ok, empty_actions_ok, prebound_ok, no_iframes,
+            bulk_loaded, board_bounded, page_bounded, windowed,
+        ]),
+        "gate_project": gate_project,
+        "busy_project": busy_project,
+        "busy_run": busy_run,
+        "empty_project": empty_project,
+        "gate_waiting_sorted_first": gate_first_ok,
+        "gate_state_on_card": gate_chip_ok,
+        "empty_card_quick_actions": modes,
+        "quick_actions_prebound_to_project": prebound_ok,
+        "doc_tiles_are_placeholders_no_iframe": no_iframes,
+        "projects_total": total,
+        "cards_mounted": rendered,
+        "board_height_px": board_box["height"],
+        "viewport_height_px": viewport["height"],
+        "document_scroll_height_px": doc_height,
+        "board_height_bounded_by_viewport": board_bounded,
+        "page_does_not_grow_with_projects": page_bounded,
+        "virtualized_fewer_cards_than_projects": windowed,
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice5-board-attention.png", "slice5-board-windowed.png")],
+    }
+    if not report["steps"]["orchestrator_board"]["ok"]:
+        fail("orchestrator_board_verdict", "slice-5 board assertions did not all hold — see orchestrator_board")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ChatsPage } from './components/ChatsPage.js';
 import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
 import { GateNotifications } from './components/GateNotifications.js';
+import { HomeBoard } from './components/HomeBoard.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
 import { ModePlaceholder } from './components/ModePlaceholder.js';
 import { PolicyManager } from './components/PolicyManager.js';
@@ -169,8 +170,10 @@ export function App(): React.ReactElement {
     [navigate, refresh, runPath],
   );
 
+  // Outside the project shell, "back" belongs to the list the run was opened from —
+  // `/runs`, not the board (§1.5): `/` is now a different surface, not this one's parent.
   const onNavigateBack = useCallback(
-    () => navigate(projectId && mode ? modePath(projectId, mode) : '/'),
+    () => navigate(projectId && mode ? modePath(projectId, mode) : '/runs'),
     [navigate, projectId, mode],
   );
 
@@ -265,6 +268,11 @@ export function App(): React.ReactElement {
           {renderModeSurface(mode)}
         </ProjectShell>
       );
+    }
+    // `/` is the orchestrator board (§1.4, slice 5); the flat run list it replaced is
+    // still at `/runs`, which the `panel === 'runs'` fallback below keeps rendering.
+    if (panel === 'home') {
+      return <HomeBoard runs={runs} navigate={navigate} />;
     }
     if (panel === 'coverage') {
       return (

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SessionView } from '../api/types.js';
+import { useBoardModel } from '../hooks/useBoardModel.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { CARD_H, ProjectCard } from './ProjectCard.js';
+
+/**
+ * The orchestrator home board (DES-MERGE-001 §1.2/§1.4, slice 5) — the route `/`.
+ *
+ * A wall of what is happening across many unrelated projects at once, sorted by
+ * attention needed rather than recency. "Many projects at once is the default case"
+ * (§1.4), so the grid is WINDOWED: cards are a fixed height, and only the rows the
+ * viewport can show (plus one row of overscan) are mounted. Twenty projects mount a
+ * dozen cards, not twenty, and the container never grows past the viewport.
+ *
+ * Static in this slice: the model reads REST on load. Live card updates are slice 6.
+ */
+
+const GAP = 14;
+/** Below this the grid drops a column rather than squeezing a card unreadable. */
+const MIN_COL = 320;
+/** One row above and below the viewport, so a scroll never shows a gap. */
+const OVERSCAN = 1;
+/** Used when the container has not been measured yet (first paint, jsdom). */
+const FALLBACK_W = 1200;
+const FALLBACK_H = 900;
+
+const S = {
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.3)',
+  red:    '#f85149',
+};
+
+interface Props {
+  runs: SessionView[];
+  navigate: Navigate;
+}
+
+export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
+  const { items, loading, error } = useBoardModel(runs);
+  const scroller = useRef<HTMLDivElement>(null);
+  const [box, setBox] = useState({ w: 0, h: 0 });
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useEffect(() => {
+    const el = scroller.current;
+    if (el === null) return;
+    const measure = (): void => setBox({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
+  const onScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  const columns = Math.max(1, Math.floor((box.w || FALLBACK_W) / (MIN_COL + GAP)));
+  const rowH = CARD_H + GAP;
+  const rows = Math.ceil(items.length / columns);
+  const viewH = box.h || FALLBACK_H;
+  const firstRow = Math.max(0, Math.floor(scrollTop / rowH) - OVERSCAN);
+  const lastRow = Math.min(rows - 1, Math.ceil((scrollTop + viewH) / rowH) + OVERSCAN);
+  const visible = items.slice(firstRow * columns, (lastRow + 1) * columns);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <header
+        style={{
+          display: 'flex', alignItems: 'baseline', gap: '12px', flexShrink: 0,
+          padding: '20px 24px 12px',
+        }}
+      >
+        <h1 style={{ fontSize: '16px', fontWeight: 700, color: S.ink, margin: 0 }}>Projects</h1>
+        <p style={{ fontSize: '12px', color: S.muted, margin: 0 }}>
+          Sorted by what needs you first.
+        </p>
+        {/* The flat run list this board replaced stays reachable (§1.5 escape hatch). */}
+        <a
+          href="/runs"
+          onClick={(e) => { e.preventDefault(); navigate('/runs'); }}
+          data-testid="all-runs-link"
+          style={{ marginLeft: 'auto', fontSize: '12px', color: S.muted }}
+        >
+          All runs ›
+        </a>
+      </header>
+
+      <div
+        ref={scroller}
+        onScroll={onScroll}
+        data-testid="project-board"
+        data-total={items.length}
+        data-rendered={visible.length}
+        style={{ flex: 1, overflowY: 'auto', padding: '0 24px 24px' }}
+      >
+        {loading && (
+          <p style={{ fontSize: '13px', color: S.faint, fontFamily: 'monospace' }}>Loading projects…</p>
+        )}
+        {!loading && error !== null && (
+          <p style={{ fontSize: '13px', color: S.red }}>Could not load projects: {error}</p>
+        )}
+        {!loading && error === null && items.length === 0 && (
+          <div style={{ padding: '40px 0' }}>
+            <p style={{ fontSize: '14px', color: S.muted, margin: '0 0 4px' }}>No projects yet</p>
+            <a
+              href="/projects"
+              onClick={(e) => { e.preventDefault(); navigate('/projects'); }}
+              data-testid="create-first-project"
+              style={{ fontSize: '12px', color: S.ink }}
+            >
+              Create your first project ›
+            </a>
+          </div>
+        )}
+        {items.length > 0 && (
+          <div style={{ position: 'relative', height: `${rows * rowH}px` }}>
+            <div
+              style={{
+                position: 'absolute', top: `${firstRow * rowH}px`, left: 0, right: 0,
+                display: 'grid', gap: `${GAP}px`,
+                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+              }}
+            >
+              {visible.map((item) => (
+                <ProjectCard key={item.project.id} item={item} navigate={navigate} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,249 @@
+import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
+import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
+import { useGateStore } from '../store/gates.js';
+import { STATUS_STYLE } from './RunCard.js';
+
+/**
+ * One orchestrator-board card (DES-MERGE-001 §1.4). All four regions are ALWAYS
+ * present; an empty region renders an invitation, never a blank. The height is
+ * FIXED (`CARD_H`) so the board stays legible at 20+ cards — nothing here may grow
+ * with the run or doc count, which is why every list is capped with an overflow
+ * count instead of scrolling.
+ */
+
+/** Fixed card height in px. The board's windowing math depends on it. */
+export const CARD_H = 264;
+
+const MAX_TILES = 3;
+const MAX_CHIPS = 2;
+
+const S = {
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.3)',
+  accent: '#ffda19',
+};
+
+const DOT: Record<Attention, string> = {
+  gate:    '#ffda19',
+  failing: '#f85149',
+  running: '#79c0ff',
+  drafts:  'rgba(230,237,243,0.45)',
+  quiet:   'rgba(230,237,243,0.2)',
+};
+
+const ACTIONS: { mode: Mode; label: string; glyph: string }[] = [
+  { mode: 'chat',     label: 'New chat',    glyph: '💬' },
+  { mode: 'build',    label: 'Do work',     glyph: '⚙' },
+  { mode: 'document', label: 'New doc',     glyph: '▤' },
+  { mode: 'video',    label: 'Record demo', glyph: '▶' },
+];
+
+/** Coarse, honest relative time — the board never needs second precision. */
+export function ago(from: number, now: number = Date.now()): string {
+  const secs = Math.max(0, Math.round((now - from) / 1000));
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
+  return `${Math.floor(secs / 86400)}d`;
+}
+
+function Region({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <div style={{ marginTop: '10px', minHeight: '46px' }}>
+      <p style={{ fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint, margin: '0 0 4px' }}>
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function Invitation({ text }: { text: string }): React.ReactElement {
+  return <p style={{ fontSize: '11px', color: S.faint, margin: 0 }}>{text}</p>;
+}
+
+/**
+ * A doc tile is a PLACEHOLDER — title, kind glyph, updated-at (§7.5). Live-rendered
+ * thumbnails were explicitly deferred: 20 cards × 3 iframes is a browser's worth of
+ * documents to keep mounted for a surface the user is only scanning.
+ */
+function DocTile({ name, kind, updatedAt }: { name: string; kind: string; updatedAt: string | null }): React.ReactElement {
+  const when = updatedAt === null ? null : Date.parse(updatedAt);
+  return (
+    <div
+      data-testid="doc-tile"
+      data-doc-kind={kind}
+      style={{
+        flex: 1, minWidth: 0, background: 'rgba(230,237,243,0.04)', border: `1px solid ${S.border}`,
+        borderRadius: '6px', padding: '5px 7px',
+      }}
+    >
+      <p style={{ fontSize: '11px', color: S.ink, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <span aria-hidden style={{ marginRight: '4px' }}>{kind === 'demo' ? '▶' : '▤'}</span>
+        {name}
+      </p>
+      <p style={{ fontSize: '10px', color: S.faint, margin: '2px 0 0', fontFamily: 'monospace' }}>
+        {when !== null && !Number.isNaN(when) ? `${ago(when)} ago` : 'not yet edited'}
+      </p>
+    </div>
+  );
+}
+
+interface Props {
+  item: BoardProject;
+  navigate: Navigate;
+}
+
+export function ProjectCard({ item, navigate }: Props): React.ReactElement {
+  const { project, repo, runs, docs, attention } = item;
+  const gates = useGateStore((s) => s.gates);
+  const empty = runs.length === 0 && docs.length === 0;
+
+  function go(path: string, e: React.MouseEvent): void {
+    e.preventDefault();
+    navigate(path);
+  }
+
+  const action = (a: (typeof ACTIONS)[number], large: boolean): React.ReactElement => {
+    const path = modePath(project.id, a.mode);
+    return (
+      <a
+        key={a.mode}
+        href={path}
+        onClick={(e) => go(path, e)}
+        data-testid="quick-action"
+        data-mode={a.mode}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: large ? 'flex-start' : 'center',
+          gap: '6px', textDecoration: 'none', background: 'rgba(230,237,243,0.05)',
+          border: `1px solid ${S.border}`, borderRadius: '6px', color: S.ink,
+          padding: large ? '10px 12px' : '6px 8px', fontSize: large ? '12px' : '11px',
+          fontWeight: large ? 600 : 400,
+        }}
+      >
+        <span aria-hidden>{a.glyph}</span> {a.label}
+      </a>
+    );
+  };
+
+  return (
+    <section
+      data-testid="project-card"
+      data-project-id={project.id}
+      data-attention={attention}
+      style={{
+        height: `${CARD_H}px`, boxSizing: 'border-box', overflow: 'hidden',
+        background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
+        display: 'flex', flexDirection: 'column',
+      }}
+    >
+      {/* Header — name, repo binding, status dot */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <span
+          data-testid="project-status-dot"
+          aria-hidden
+          style={{ width: '8px', height: '8px', borderRadius: '50%', background: DOT[attention], flexShrink: 0 }}
+        />
+        <a
+          href={modePath(project.id, 'build')}
+          onClick={(e) => go(modePath(project.id, 'build'), e)}
+          style={{
+            fontSize: '13px', fontWeight: 700, color: S.ink, textDecoration: 'none',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}
+        >
+          {project.name}
+        </a>
+        <span
+          data-testid="project-repo"
+          style={{ marginLeft: 'auto', fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 }}
+        >
+          {repo ?? 'no repo'}
+        </span>
+      </div>
+
+      {/* Documents — placeholder tiles only (§7.5), capped so the card cannot grow */}
+      <Region title="Documents">
+        {docs.length === 0 ? (
+          <Invitation text="No documents yet." />
+        ) : (
+          <div style={{ display: 'flex', gap: '6px', alignItems: 'stretch' }}>
+            {docs.slice(0, MAX_TILES).map((d) => (
+              <DocTile key={d.name} name={d.name} kind={d.kind} updatedAt={d.updated_at} />
+            ))}
+            {docs.length > MAX_TILES && (
+              <span data-testid="doc-overflow" style={{ alignSelf: 'center', fontSize: '11px', color: S.muted, flexShrink: 0 }}>
+                {docs.length - MAX_TILES} more
+              </span>
+            )}
+          </div>
+        )}
+      </Region>
+
+      {/* Crew runs — phase, gate state, elapsed */}
+      <Region title="Crew runs">
+        {runs.length === 0 ? (
+          <Invitation text="No runs yet." />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            {runs.slice(0, MAX_CHIPS).map(({ session, units }) => {
+              const style = STATUS_STYLE[session.status];
+              const gate = gates[session.id];
+              const phase = units[session.unit_ix]?.stage ?? units[units.length - 1]?.stage ?? 'planning';
+              const waiting = session.status === 'awaiting_human';
+              return (
+                <a
+                  key={session.id}
+                  href={modePath(project.id, 'build', session.id)}
+                  onClick={(e) => go(modePath(project.id, 'build', session.id), e)}
+                  data-testid="run-chip"
+                  data-run-id={session.id}
+                  data-status={session.status}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
+                    fontSize: '11px', fontFamily: 'monospace', color: S.muted,
+                    border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
+                    background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
+                    borderRadius: '5px', padding: '3px 7px',
+                  }}
+                >
+                  <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
+                  {waiting && <span style={{ color: S.accent, fontWeight: 700 }}>gate</span>}
+                  {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
+                      has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
+                      honest clock on this surface. */}
+                  {waiting && gate && <span style={{ marginLeft: 'auto' }}>waiting {ago(gate.receivedAt)}</span>}
+                  {!waiting && <span style={{ marginLeft: 'auto' }}>{style?.label ?? session.status}</span>}
+                </a>
+              );
+            })}
+            {runs.length > MAX_CHIPS && (
+              <span data-testid="run-overflow" style={{ fontSize: '11px', color: S.muted }}>
+                {runs.length - MAX_CHIPS} more
+              </span>
+            )}
+          </div>
+        )}
+      </Region>
+
+      {/* Quick actions — large when the card IS the empty state (§1.4) */}
+      {empty && (
+        <p style={{ fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint, margin: '10px 0 0' }}>
+          Start here
+        </p>
+      )}
+      <div
+        data-testid="quick-actions"
+        style={{
+          marginTop: 'auto', paddingTop: empty ? '4px' : '10px', display: 'grid', gap: '6px',
+          gridTemplateColumns: empty ? '1fr 1fr' : 'repeat(4, minmax(0,1fr))',
+        }}
+      >
+        {ACTIONS.map((a) => action(a, empty))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -11,8 +11,15 @@ import { STATUS_STYLE } from './RunCard.js';
  * count instead of scrolling.
  */
 
-/** Fixed card height in px. The board's windowing math depends on it. */
-export const CARD_H = 264;
+/**
+ * Fixed card height in px — the board's windowing math depends on it.
+ *
+ * Sized by the TALLEST variant, the empty card: header + two regions + the 2×2
+ * quick-action grid. The actions are bottom-anchored (`marginTop: auto`) inside an
+ * `overflow: hidden` box, so a height that merely fits would clip the primary
+ * affordance the moment a font metric moved. This carries ~16px of slack.
+ */
+export const CARD_H = 280;
 
 const MAX_TILES = 3;
 const MAX_CHIPS = 2;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -18,7 +18,6 @@ const MAX_TILES = 3;
 const MAX_CHIPS = 2;
 
 const S = {
-  card:   '#161b22',
   border: 'rgba(230,237,243,0.1)',
   ink:    '#e6edf3',
   muted:  'rgba(230,237,243,0.55)',
@@ -41,6 +40,35 @@ const ACTIONS: { mode: Mode; label: string; glyph: string }[] = [
   { mode: 'video',    label: 'Record demo', glyph: '▶' },
 ];
 
+const CSS = {
+  card: {
+    height: `${CARD_H}px`, boxSizing: 'border-box', overflow: 'hidden', background: '#161b22',
+    border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
+    display: 'flex', flexDirection: 'column',
+  },
+  header: { display: 'flex', alignItems: 'center', gap: '8px' },
+  name: {
+    fontSize: '13px', fontWeight: 700, color: S.ink, textDecoration: 'none',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  repo: { marginLeft: 'auto', fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 },
+  label: { fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint },
+  tile: {
+    flex: 1, minWidth: 0, background: 'rgba(230,237,243,0.04)',
+    border: `1px solid ${S.border}`, borderRadius: '6px', padding: '5px 7px',
+  },
+  tileName: { fontSize: '11px', color: S.ink, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  chip: {
+    display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
+    fontSize: '11px', fontFamily: 'monospace', color: S.muted, borderRadius: '5px', padding: '3px 7px',
+  },
+  quick: {
+    display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
+    background: 'rgba(230,237,243,0.05)', border: `1px solid ${S.border}`,
+    borderRadius: '6px', color: S.ink,
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
 /** Coarse, honest relative time — the board never needs second precision. */
 export function ago(from: number, now: number = Date.now()): string {
   const secs = Math.max(0, Math.round((now - from) / 1000));
@@ -53,9 +81,7 @@ export function ago(from: number, now: number = Date.now()): string {
 function Region({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
   return (
     <div style={{ marginTop: '10px', minHeight: '46px' }}>
-      <p style={{ fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint, margin: '0 0 4px' }}>
-        {title}
-      </p>
+      <p style={{ ...CSS.label, margin: '0 0 4px' }}>{title}</p>
       {children}
     </div>
   );
@@ -71,22 +97,15 @@ function Invitation({ text }: { text: string }): React.ReactElement {
  * documents to keep mounted for a surface the user is only scanning.
  */
 function DocTile({ name, kind, updatedAt }: { name: string; kind: string; updatedAt: string | null }): React.ReactElement {
-  const when = updatedAt === null ? null : Date.parse(updatedAt);
+  const when = updatedAt === null ? NaN : Date.parse(updatedAt);
   return (
-    <div
-      data-testid="doc-tile"
-      data-doc-kind={kind}
-      style={{
-        flex: 1, minWidth: 0, background: 'rgba(230,237,243,0.04)', border: `1px solid ${S.border}`,
-        borderRadius: '6px', padding: '5px 7px',
-      }}
-    >
-      <p style={{ fontSize: '11px', color: S.ink, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+    <div data-testid="doc-tile" data-doc-kind={kind} style={CSS.tile}>
+      <p style={CSS.tileName}>
         <span aria-hidden style={{ marginRight: '4px' }}>{kind === 'demo' ? '▶' : '▤'}</span>
         {name}
       </p>
       <p style={{ fontSize: '10px', color: S.faint, margin: '2px 0 0', fontFamily: 'monospace' }}>
-        {when !== null && !Number.isNaN(when) ? `${ago(when)} ago` : 'not yet edited'}
+        {Number.isNaN(when) ? 'not yet edited' : `${ago(when)} ago`}
       </p>
     </div>
   );
@@ -102,74 +121,28 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   const gates = useGateStore((s) => s.gates);
   const empty = runs.length === 0 && docs.length === 0;
 
-  function go(path: string, e: React.MouseEvent): void {
-    e.preventDefault();
-    navigate(path);
-  }
-
-  const action = (a: (typeof ACTIONS)[number], large: boolean): React.ReactElement => {
-    const path = modePath(project.id, a.mode);
-    return (
-      <a
-        key={a.mode}
-        href={path}
-        onClick={(e) => go(path, e)}
-        data-testid="quick-action"
-        data-mode={a.mode}
-        style={{
-          display: 'flex', alignItems: 'center', justifyContent: large ? 'flex-start' : 'center',
-          gap: '6px', textDecoration: 'none', background: 'rgba(230,237,243,0.05)',
-          border: `1px solid ${S.border}`, borderRadius: '6px', color: S.ink,
-          padding: large ? '10px 12px' : '6px 8px', fontSize: large ? '12px' : '11px',
-          fontWeight: large ? 600 : 400,
-        }}
-      >
-        <span aria-hidden>{a.glyph}</span> {a.label}
-      </a>
-    );
-  };
+  /** Every affordance on the card is a real link — deep-linkable, middle-clickable. */
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
 
   return (
-    <section
-      data-testid="project-card"
-      data-project-id={project.id}
-      data-attention={attention}
-      style={{
-        height: `${CARD_H}px`, boxSizing: 'border-box', overflow: 'hidden',
-        background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
-        display: 'flex', flexDirection: 'column',
-      }}
-    >
+    <section data-testid="project-card" data-project-id={project.id} data-attention={attention} style={CSS.card}>
       {/* Header — name, repo binding, status dot */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <div style={CSS.header}>
         <span
           data-testid="project-status-dot"
           aria-hidden
           style={{ width: '8px', height: '8px', borderRadius: '50%', background: DOT[attention], flexShrink: 0 }}
         />
-        <a
-          href={modePath(project.id, 'build')}
-          onClick={(e) => go(modePath(project.id, 'build'), e)}
-          style={{
-            fontSize: '13px', fontWeight: 700, color: S.ink, textDecoration: 'none',
-            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-          }}
-        >
-          {project.name}
-        </a>
-        <span
-          data-testid="project-repo"
-          style={{ marginLeft: 'auto', fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 }}
-        >
-          {repo ?? 'no repo'}
-        </span>
+        <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
+        <span data-testid="project-repo" style={CSS.repo}>{repo ?? 'no repo'}</span>
       </div>
 
       {/* Documents — placeholder tiles only (§7.5), capped so the card cannot grow */}
       <Region title="Documents">
-        {docs.length === 0 ? (
-          <Invitation text="No documents yet." />
-        ) : (
+        {docs.length === 0 ? <Invitation text="No documents yet." /> : (
           <div style={{ display: 'flex', gap: '6px', alignItems: 'stretch' }}>
             {docs.slice(0, MAX_TILES).map((d) => (
               <DocTile key={d.name} name={d.name} kind={d.kind} updatedAt={d.updated_at} />
@@ -185,9 +158,7 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
 
       {/* Crew runs — phase, gate state, elapsed */}
       <Region title="Crew runs">
-        {runs.length === 0 ? (
-          <Invitation text="No runs yet." />
-        ) : (
+        {runs.length === 0 ? <Invitation text="No runs yet." /> : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
             {runs.slice(0, MAX_CHIPS).map(({ session, units }) => {
               const style = STATUS_STYLE[session.status];
@@ -197,17 +168,14 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
               return (
                 <a
                   key={session.id}
-                  href={modePath(project.id, 'build', session.id)}
-                  onClick={(e) => go(modePath(project.id, 'build', session.id), e)}
+                  {...link(modePath(project.id, 'build', session.id))}
                   data-testid="run-chip"
                   data-run-id={session.id}
                   data-status={session.status}
                   style={{
-                    display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
-                    fontSize: '11px', fontFamily: 'monospace', color: S.muted,
+                    ...CSS.chip,
                     border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
                     background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
-                    borderRadius: '5px', padding: '3px 7px',
                   }}
                 >
                   <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
@@ -215,8 +183,9 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
                   {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
                       has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
                       honest clock on this surface. */}
-                  {waiting && gate && <span style={{ marginLeft: 'auto' }}>waiting {ago(gate.receivedAt)}</span>}
-                  {!waiting && <span style={{ marginLeft: 'auto' }}>{style?.label ?? session.status}</span>}
+                  <span style={{ marginLeft: 'auto' }}>
+                    {waiting ? (gate ? `waiting ${ago(gate.receivedAt)}` : 'needs you') : style?.label ?? session.status}
+                  </span>
                 </a>
               );
             })}
@@ -230,11 +199,7 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
       </Region>
 
       {/* Quick actions — large when the card IS the empty state (§1.4) */}
-      {empty && (
-        <p style={{ fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint, margin: '10px 0 0' }}>
-          Start here
-        </p>
-      )}
+      {empty && <p style={{ ...CSS.label, margin: '10px 0 0' }}>Start here</p>}
       <div
         data-testid="quick-actions"
         style={{
@@ -242,7 +207,21 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
           gridTemplateColumns: empty ? '1fr 1fr' : 'repeat(4, minmax(0,1fr))',
         }}
       >
-        {ACTIONS.map((a) => action(a, empty))}
+        {ACTIONS.map((a) => (
+          <a
+            key={a.mode}
+            {...link(modePath(project.id, a.mode))}
+            data-testid="quick-action"
+            data-mode={a.mode}
+            style={{
+              ...CSS.quick, justifyContent: empty ? 'flex-start' : 'center',
+              padding: empty ? '10px 12px' : '6px 8px',
+              fontSize: empty ? '12px' : '11px', fontWeight: empty ? 600 : 400,
+            }}
+          >
+            <span aria-hidden>{a.glyph}</span> {a.label}
+          </a>
+        ))}
       </div>
     </section>
   );

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import { listDocs, type DocSummary } from '../api/interactive.js';
+import type { Project, ProjectMember, SessionView } from '../api/types.js';
+
+/**
+ * The orchestrator board's data model (DES-MERGE-001 §1.4, slice 5).
+ *
+ * STATIC by design: everything here comes from the REST surface on load — `GET
+ * /projects`, `GET /runs` (owned by `useRuns`, passed in), each project's members,
+ * and the interactive `listDocs` for projects bound to an interactive root. The
+ * board goes live in slice 6; no WS subscription belongs in this file.
+ *
+ * Runs are joined to projects through MEMBERSHIP (`crew.run` / `crew.chat` refs) —
+ * `AgentSession` carries no project id, so this is the only binding that exists.
+ */
+
+/** Attention buckets, most-urgent first — §1.4's sort key, spelled once. */
+export type Attention = 'gate' | 'failing' | 'running' | 'drafts' | 'quiet';
+
+const ORDER: readonly Attention[] = ['gate', 'failing', 'running', 'drafts', 'quiet'];
+
+/** Statuses that mean the run is moving under its own power. */
+const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+/** Membership kinds that make a run/thread a member of a project. */
+const RUN_KINDS: ReadonlySet<string> = new Set(['crew.run', 'crew.chat']);
+
+export interface BoardProject {
+  project: Project;
+  /** Display name of the bound repo (`crew.repo` member), or `null` when unbound. */
+  repo: string | null;
+  runs: SessionView[];
+  docs: DocSummary[];
+  attention: Attention;
+}
+
+/**
+ * The nullable per-project setting that maps a project onto a wicked-interactive
+ * root (§7.1). It rides `Project`'s forward-additive index signature, so it is read
+ * defensively: no root, no `listDocs` call, and a card with no doc tiles.
+ */
+export function interactiveRootOf(p: Project): string | null {
+  const v = p.interactiveRoot ?? p.interactive_root;
+  return typeof v === 'string' && v.trim() !== '' ? v : null;
+}
+
+/** §1.4's sort key. Gate-waiting first; ties break newest-updated, then by name. */
+export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attention {
+  if (runs.some((v) => v.session.status === 'awaiting_human')) return 'gate';
+  if (runs.some((v) => v.session.status === 'failed')) return 'failing';
+  if (runs.some((v) => ACTIVE.has(v.session.status))) return 'running';
+  if (docs.length > 0) return 'drafts';
+  return 'quiet';
+}
+
+export function sortByAttention(items: BoardProject[]): BoardProject[] {
+  return [...items].sort(
+    (a, b) =>
+      ORDER.indexOf(a.attention) - ORDER.indexOf(b.attention) ||
+      b.project.updated_at - a.project.updated_at ||
+      a.project.name.localeCompare(b.project.name),
+  );
+}
+
+/** Everything about a project that the run list itself cannot answer. */
+interface Bindings {
+  runIds: ReadonlySet<string>;
+  repo: string | null;
+  docs: DocSummary[];
+}
+
+const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [] };
+
+async function loadBindings(p: Project, repoNames: Map<string, string>): Promise<Bindings> {
+  const [members, docs] = await Promise.all([
+    api.listProjectMembers(p.id).then((r) => r.members).catch((): ProjectMember[] => []),
+    // No interactive root ⇒ no bridge to ask. A project WITH one whose bridge cannot be
+    // started (§7.12) simply shows no tiles rather than failing the whole board.
+    interactiveRootOf(p) ? listDocs(p.id).catch((): DocSummary[] => []) : Promise.resolve([]),
+  ]);
+  const repoRef = members.find((m) => m.member_kind === 'crew.repo')?.member_ref ?? null;
+  return {
+    runIds: new Set(members.filter((m) => RUN_KINDS.has(m.member_kind)).map((m) => m.member_ref)),
+    repo: repoRef === null ? null : repoNames.get(repoRef) ?? repoRef,
+    docs,
+  };
+}
+
+export interface BoardModel {
+  items: BoardProject[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useBoardModel(runs: SessionView[]): BoardModel {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [bindings, setBindings] = useState<Record<string, Bindings>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      let active: Project[];
+      let repoNames: Map<string, string>;
+      try {
+        const [{ projects: all }, repos] = await Promise.all([
+          api.listProjects(),
+          api.listRepos().then((r) => r.repos).catch(() => []),
+        ]);
+        active = all.filter((p) => p.status === 'active');
+        repoNames = new Map(repos.map((r) => [r.id, r.name]));
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setLoading(false);
+        }
+        return;
+      }
+      if (cancelled) return;
+      // Cards render as soon as the projects are known; tiles and chips fill in behind
+      // them, so a slow bridge never holds the whole board on a spinner (§3.3).
+      setProjects(active);
+      setLoading(false);
+      const entries = await Promise.all(
+        active.map(async (p) => [p.id, await loadBindings(p, repoNames)] as const),
+      );
+      if (!cancelled) setBindings(Object.fromEntries(entries));
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const items = useMemo(
+    () =>
+      sortByAttention(
+        projects.map((project) => {
+          const b = bindings[project.id] ?? EMPTY;
+          const mine = runs.filter((v) => b.runIds.has(v.session.id));
+          return { project, repo: b.repo, runs: mine, docs: b.docs, attention: deriveAttention(mine, b.docs) };
+        }),
+      ),
+    [projects, bindings, runs],
+  );
+
+  return { items, loading, error };
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Panel = 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
 
 const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
 
@@ -83,6 +83,11 @@ export function modePath(projectId: string, mode: Mode, artifactId?: string | nu
 
 function parse(pathname: string): Route {
   const [, first = '', second = '', third = '', fourth = ''] = pathname.split('/');
+  // `/` is the orchestrator board (DES-MERGE-001 §1.5, slice 5). The flat run list it
+  // replaced keeps its own route, `/runs` — the power-user escape hatch, not a redirect.
+  if (first === '') {
+    return route({ panel: 'home' });
+  }
   // The project+mode parse runs AHEAD of the panel parse (DES-MERGE-001 §1.5); the
   // `Panel` union below is untouched and still owns every side panel.
   if (first === 'p' && second) {
@@ -143,7 +148,7 @@ export function useRoute(): Route & {
     setPathname(path);
   }, []);
 
-  const panelPath = useCallback((p: Panel) => (p === 'runs' ? '/' : `/${p}`), []);
+  const panelPath = useCallback((p: Panel) => (p === 'home' ? '/' : `/${p}`), []);
 
   return { ...parse(pathname), navigate, panelPath };
 }

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { DocSummary } from '../src/api/interactive.js';
+import type { Project, ProjectMember } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * The orchestrator board (DES-MERGE-001 §1.4, slice 5). These cases pin the four
+ * ACs of §6.2 slice 5 that do not need a browser: attention order, the empty card
+ * being the four quick actions, placeholder-only doc tiles (§7.5), and the board
+ * windowing so 20 projects do not mount 20 cards.
+ */
+
+let projects: Project[] = [];
+let members: Record<string, ProjectMember[]> = {};
+let docs: Record<string, DocSummary[]> = {};
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects }),
+    listRepos: () => Promise.resolve({ repos: [{ id: 'repo-1', name: 'wicked-studio' }] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: members[id] ?? [] }),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: (id: string) => Promise.resolve(docs[id] ?? []),
+}));
+
+const { HomeBoard } = await import('../src/components/HomeBoard.js');
+
+function project(over: Partial<Project> & { id: string; name: string }): Project {
+  return {
+    description: null,
+    status: 'active',
+    scope: `project:${over.id}`,
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  };
+}
+
+function member(project_id: string, member_kind: string, member_ref: string): ProjectMember {
+  return {
+    id: `${project_id}:${member_kind}:${member_ref}`,
+    project_id,
+    member_kind,
+    member_ref,
+    meta: null,
+    attached_at: 1,
+    attached_by: 'studio',
+  };
+}
+
+/** Wait for the async project + member + doc loads to settle into the board. */
+async function boardWith(runs = [] as ReturnType<typeof makeView>[]): Promise<void> {
+  render(<HomeBoard runs={runs} navigate={() => {}} />);
+  await screen.findByTestId('project-board');
+  // The bindings (members/docs) land one microtask-chain after the projects do.
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+  });
+}
+
+describe('HomeBoard — the orchestrator board', () => {
+  beforeEach(() => {
+    projects = [];
+    members = {};
+    docs = {};
+  });
+
+  it('sorts by attention: gate-waiting before running before empty', async () => {
+    projects = [
+      project({ id: 'p-quiet', name: 'Quiet' }),
+      project({ id: 'p-run', name: 'Running' }),
+      project({ id: 'p-gate', name: 'Gated' }),
+    ];
+    members = {
+      'p-gate': [member('p-gate', 'crew.run', 'run-gate')],
+      'p-run': [member('p-run', 'crew.run', 'run-exec')],
+    };
+    await boardWith([
+      makeView({ id: 'run-exec', status: 'executing' }),
+      makeView({ id: 'run-gate', status: 'awaiting_human' }),
+    ]);
+
+    await vi.waitFor(() => {
+      const cards = screen.getAllByTestId('project-card');
+      expect(cards.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-gate', 'p-run', 'p-quiet']);
+    });
+    // AC: the first card IS the gate-waiting one, and says so.
+    const first = screen.getAllByTestId('project-card')[0];
+    expect(first).toHaveAttribute('data-attention', 'gate');
+    expect(first).toHaveTextContent('gate');
+  });
+
+  it('a project with nothing in it renders the four quick actions — the card IS the empty state', async () => {
+    projects = [project({ id: 'p-empty', name: 'Empty' })];
+    await boardWith();
+
+    const card = await screen.findByTestId('project-card');
+    const actions = within(card).getAllByTestId('quick-action');
+    expect(actions).toHaveLength(4);
+    expect(actions.map((a) => a.getAttribute('data-mode'))).toEqual(['chat', 'build', 'document', 'video']);
+    // Each launches INTO that project, pre-bound to a slice-4 mode route.
+    expect(actions.map((a) => a.getAttribute('href'))).toEqual([
+      '/p/p-empty/chat', '/p/p-empty/build', '/p/p-empty/document', '/p/p-empty/video',
+    ]);
+    // Never a dead tile: the empty regions invite rather than showing nothing.
+    expect(card).toHaveTextContent('No documents yet');
+    expect(card).toHaveTextContent('No runs yet');
+  });
+
+  it('a quick action navigates into the project shell', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    projects = [project({ id: 'p-1', name: 'One' })];
+    render(<HomeBoard runs={[]} navigate={navigate} />);
+
+    const card = await screen.findByTestId('project-card');
+    await user.click(within(card).getByText(/Do work/));
+    expect(navigate).toHaveBeenCalledWith('/p/p-1/build');
+  });
+
+  it('doc tiles are PLACEHOLDERS — title, kind glyph, updated-at, never an iframe (§7.5)', async () => {
+    projects = [project({ id: 'p-docs', name: 'Docs', interactiveRoot: '/tmp/wi' })];
+    docs = {
+      'p-docs': [
+        { name: 'launch-deck', kind: 'doc', head: 2, versions: 2, updated_at: new Date(Date.now() - 3600_000).toISOString() },
+        { name: 'demo-reel', kind: 'demo', head: 1, versions: 1, updated_at: null },
+        { name: 'brief', kind: 'doc', head: 1, versions: 1, updated_at: null },
+        { name: 'overflow-one', kind: 'doc', head: 1, versions: 1, updated_at: null },
+      ],
+    };
+    await boardWith();
+
+    const card = await screen.findByTestId('project-card');
+    await vi.waitFor(() => expect(within(card).getAllByTestId('doc-tile')).toHaveLength(3));
+    expect(within(card).getByTestId('doc-overflow')).toHaveTextContent('1 more');
+    expect(card).toHaveTextContent('launch-deck');
+    expect(card).toHaveTextContent('1h ago');
+    expect(card.querySelector('iframe')).toBeNull();
+  });
+
+  it('does not ask the interactive bridge about a project with no interactive root', async () => {
+    projects = [project({ id: 'p-none', name: 'None' })];
+    docs = { 'p-none': [{ name: 'never-shown', kind: 'doc', head: 1, versions: 1, updated_at: null }] };
+    await boardWith();
+
+    const card = await screen.findByTestId('project-card');
+    expect(card).toHaveTextContent('No documents yet');
+    expect(within(card).queryByTestId('doc-tile')).toBeNull();
+  });
+
+  it('windows the grid: what is mounted is bounded by the viewport, not by the project count', async () => {
+    const seed = (n: number): void => {
+      projects = Array.from({ length: n }, (_, i) =>
+        project({ id: `p-${i}`, name: `Project ${i}`, updated_at: 100 - i }),
+      );
+    };
+
+    seed(20);
+    await boardWith();
+    const at20 = screen.getAllByTestId('project-card').length;
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '20');
+    expect(at20).toBeGreaterThan(0);
+    expect(at20).toBeLessThan(20);
+    cleanup();
+
+    // Tripling the board does NOT triple what is mounted — that is the whole point of
+    // windowing, and it is what keeps 20+ cards legible (§1.4).
+    seed(60);
+    await boardWith();
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '60');
+    expect(screen.getAllByTestId('project-card')).toHaveLength(at20);
+  });
+
+  it('states what is missing rather than showing a blank board', async () => {
+    await boardWith();
+    expect(screen.getByTestId('project-board')).toHaveTextContent('No projects yet');
+    expect(screen.getByTestId('create-first-project')).toBeTruthy();
+  });
+});

--- a/tests/boardModel.test.ts
+++ b/tests/boardModel.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { DocSummary } from '../src/api/interactive.js';
+import type { Project, SessionView } from '../src/api/types.js';
+import {
+  deriveAttention,
+  interactiveRootOf,
+  sortByAttention,
+  type Attention,
+  type BoardProject,
+} from '../src/hooks/useBoardModel.js';
+import { ago } from '../src/components/ProjectCard.js';
+import { makeView } from './factories.js';
+
+const doc: DocSummary = { name: 'deck', kind: 'doc', head: 1, versions: 1, updated_at: null };
+
+function project(over: Partial<Project> & { id: string }): Project {
+  return {
+    name: over.id,
+    description: null,
+    status: 'active',
+    scope: `project:${over.id}`,
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  };
+}
+
+function item(id: string, attention: Attention, updated_at = 1, name = id): BoardProject {
+  return { project: project({ id, name, updated_at }), repo: null, runs: [], docs: [], attention };
+}
+
+describe('deriveAttention (DES-MERGE-001 §1.4 sort key)', () => {
+  const cases: [string, SessionView[], DocSummary[], Attention][] = [
+    ['a waiting gate outranks everything', [makeView({ id: 'r1', status: 'executing' }), makeView({ id: 'r2', status: 'awaiting_human' })], [doc], 'gate'],
+    ['a failure outranks a live run', [makeView({ id: 'r1', status: 'executing' }), makeView({ id: 'r2', status: 'failed' })], [], 'failing'],
+    ['planning counts as running', [makeView({ id: 'r1', status: 'planning' })], [], 'running'],
+    ['finished runs plus a doc are idle-with-drafts', [makeView({ id: 'r1', status: 'completed' })], [doc], 'drafts'],
+    ['nothing anywhere is quiet', [], [], 'quiet'],
+    ['a completed run with no docs is still quiet', [makeView({ id: 'r1', status: 'completed' })], [], 'quiet'],
+  ];
+
+  for (const [why, runs, docs, expected] of cases) {
+    it(why, () => expect(deriveAttention(runs, docs)).toBe(expected));
+  }
+});
+
+describe('sortByAttention', () => {
+  it('orders gate > failing > running > drafts > quiet', () => {
+    const sorted = sortByAttention([
+      item('quiet', 'quiet'),
+      item('drafts', 'drafts'),
+      item('running', 'running'),
+      item('failing', 'failing'),
+      item('gate', 'gate'),
+    ]);
+    expect(sorted.map((i) => i.project.id)).toEqual(['gate', 'failing', 'running', 'drafts', 'quiet']);
+  });
+
+  it('breaks ties on recency, then name — never on list position', () => {
+    const sorted = sortByAttention([
+      item('old', 'quiet', 10, 'zulu'),
+      item('new', 'quiet', 20, 'alpha'),
+      item('same-b', 'quiet', 20, 'bravo'),
+    ]);
+    expect(sorted.map((i) => i.project.id)).toEqual(['new', 'same-b', 'old']);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [item('quiet', 'quiet'), item('gate', 'gate')];
+    sortByAttention(input);
+    expect(input.map((i) => i.project.id)).toEqual(['quiet', 'gate']);
+  });
+});
+
+describe('interactiveRootOf', () => {
+  it('reads either spelling of the forward-additive project setting', () => {
+    expect(interactiveRootOf(project({ id: 'a', interactiveRoot: '/tmp/wi' }))).toBe('/tmp/wi');
+    expect(interactiveRootOf(project({ id: 'b', interactive_root: '/tmp/wi' }))).toBe('/tmp/wi');
+  });
+
+  it('treats an absent, blank, or non-string root as unbound', () => {
+    expect(interactiveRootOf(project({ id: 'c' }))).toBeNull();
+    expect(interactiveRootOf(project({ id: 'd', interactiveRoot: '   ' }))).toBeNull();
+    expect(interactiveRootOf(project({ id: 'e', interactiveRoot: 42 }))).toBeNull();
+  });
+});
+
+describe('ago', () => {
+  const now = 1_000_000_000_000;
+  it('is coarse and never negative', () => {
+    expect(ago(now, now)).toBe('0s');
+    expect(ago(now + 5_000, now)).toBe('0s'); // a clock skew reads as "just now", not "-5s"
+    expect(ago(now - 45_000, now)).toBe('45s');
+    expect(ago(now - 90_000, now)).toBe('1m');
+    expect(ago(now - 7_200_000, now)).toBe('2h');
+    expect(ago(now - 3 * 86_400_000, now)).toBe('3d');
+  });
+});

--- a/tests/useRoute.modes.test.ts
+++ b/tests/useRoute.modes.test.ts
@@ -59,7 +59,9 @@ describe('useRoute — project + mode routes (DES-MERGE-001 §1.5)', () => {
 
 describe('useRoute — the existing panel routes keep working', () => {
   it('still parses every legacy shape unchanged', () => {
-    expect(routeAt('/').current).toMatchObject({ panel: 'runs', runId: null, mode: null });
+    // `/` became the orchestrator board in slice 5; the run list moved to `/runs`.
+    expect(routeAt('/').current).toMatchObject({ panel: 'home', runId: null, mode: null });
+    expect(routeAt('/runs').current).toMatchObject({ panel: 'runs', runId: null });
     expect(routeAt('/runs/run-1').current).toMatchObject({ panel: 'runs', runId: 'run-1' });
     expect(routeAt('/runs/new').current).toMatchObject({ panel: 'runs', showLaunch: true });
     expect(routeAt('/chat/new').current).toMatchObject({ showLaunch: true, chatMode: true });
@@ -75,7 +77,8 @@ describe('useRoute — the existing panel routes keep working', () => {
   it('a legacy route carries no mode, and panelPath is unchanged', () => {
     const r = routeAt('/runs/run-1');
     expect(r.current.mode).toBeNull();
-    expect(r.current.panelPath('runs')).toBe('/');
+    expect(r.current.panelPath('home')).toBe('/');
+    expect(r.current.panelPath('runs')).toBe('/runs');
     expect(r.current.panelPath('coverage')).toBe('/coverage');
   });
 });


### PR DESCRIPTION
Slice 5, authored by governed run `e63d5dbd` (clarify/design/build: claude · adversarial-review/test/review: codex).

`/` becomes the orchestrator board: one card per project, attention-ordered (gate-waiting > failing > running > idle-with-drafts > quiet), fixed card height, windowed at 20+ cards. Card anatomy per §1.4: header + placeholder doc tiles (§7.5 — no live iframes) + run chips + four quick actions that launch pre-bound into `/p/<id>/<mode>`. An empty project's card renders the quick actions large — the card is the empty state. Old run list stays at `/runs`. Static data only; live WS wiring is slice 6.

Playwright board ACs in the standalone gate; 380/380 unit tests locally (47 files).

Design: `.product/DES-MERGE-001.md` §1.2/§1.4, §6.2 slice 5, §7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)