### PR TITLE
feat(board): the orchestrator board goes live (DES-MERGE-001 slice 6)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -32,6 +32,11 @@ What "independent" means here, and what this script proves end-to-end:
      sorts first, an empty project's card IS its four quick actions (each pre-bound
      to that project), doc tiles are placeholders rather than iframes (§7.5), and
      20+ projects stay windowed inside a viewport-bounded board
+  9. (DES-MERGE-001 slice 6) that board is LIVE: while the page sits on `/` and
+     never reloads, a real gate arrival re-sorts a card ahead of another, a
+     `unitOutputDelta` updates that card's headline within 2 s while its neighbour
+     is untouched, and a relayed `wicked.interactive.status.posted` adds a doc
+     activity line — all over the page's ONE existing socket
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -479,6 +484,209 @@ try:
     }
     if not report["steps"]["orchestrator_board"]["ok"]:
         fail("orchestrator_board_verdict", "slice-5 board assertions did not all hold — see orchestrator_board")
+
+    # ── 10. Slice 6 (DES-MERGE-001 §6.2): the board goes LIVE ─────────────────
+    # Every assertion below happens on ONE page load: the browser lands on `/` once
+    # and is never navigated or reloaded again, which is the property slice 6 exists
+    # to prove ("a card updates in place while the user is looking at a different
+    # card", §1.4).
+    #
+    # Two frame sources, deliberately:
+    #   - the GATE re-sort is driven by the real daemon (a run genuinely parks on a
+    #     human gate while the page watches), because attention order is derived from
+    #     run state and a faked frame would prove nothing about it;
+    #   - the DELTA and the relayed interactive frame are delivered into the page's
+    #     own socket handler through a WebSocket tap installed as an init script. The
+    #     page still opens exactly one real socket to the daemon (asserted), and the
+    #     frame travels the full app path — onmessage → runtime store → card. The tap
+    #     is how a *specific* frame gets delivered on demand: the stub engine's own
+    #     deltas are not addressable, and crew's `interactiveEvent` relay (slice 3)
+    #     is not merged yet, so this is the only way to exercise its envelope.
+    WS_TAP = """
+      (() => {
+        const Real = window.WebSocket;
+        class TapWS extends Real {
+          constructor(...args) {
+            super(...args);
+            window.__pushFrame = (frame) =>
+              this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(frame) }));
+          }
+        }
+        window.WebSocket = TapWS;
+      })();
+    """
+
+    CARD_INDEX = """id => Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+                             .findIndex(c => c.dataset.projectId === id)"""
+    LIVE_LINE = """id => { const c = document.querySelector(
+                             `[data-testid="project-card"][data-project-id="${id}"]`);
+                           return c?.querySelector('[data-testid="live-line"]')?.textContent ?? null; }"""
+
+    def within(page, expr, arg=None, budget_ms: int = 2000):
+        """Assert a DOM condition holds within `budget_ms`, and report what it took."""
+        started = time.time()
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=budget_ms)
+            return True, round((time.time() - started) * 1000)
+        except Exception:
+            return False, round((time.time() - started) * 1000)
+
+    # A is created FIRST and parks on a gate; B is created SECOND (so it wins the
+    # updated_at tiebreak once it too has a gate) and starts with no runs at all.
+    live_a = new_project(f"live-a-{tag}")
+    attach_run(live_a, await_gate(launch("slice6: parks on a gate and stays there", "all")))
+    live_b = new_project(f"live-b-{tag}")
+
+    live_ws_urls: list[str] = []
+    live_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(WS_TAP)
+        page.on("websocket", lambda ws: live_ws_urls.append(ws.url))
+        page.on("console", lambda m: live_console.append(m.text) if m.type == "error" else None)
+
+        page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
+        # A sentinel on the window: any navigation or reload from here on wipes it, so
+        # every assertion below is provably about THIS page load.
+        page.evaluate("() => { window.__slice6 = 'same page'; }")
+
+        both_visible = settled(
+            page,
+            """ids => ids.every(id => document.querySelector(
+                 `[data-testid="project-card"][data-project-id="${id}"]`))""",
+            [live_a, live_b],
+        )
+        a_before = page.evaluate(CARD_INDEX, live_a)
+        b_before = page.evaluate(CARD_INDEX, live_b)
+        board_scroll_before = page.evaluate(
+            """() => document.querySelector('[data-testid="project-board"]').scrollTop""")
+
+        # ── AC: a gate arrival re-sorts the board, no navigation, no reload ────
+        # The run is launched and filed while the page watches; the board has to pick
+        # up both the new membership and, moments later, the gate it parks on.
+        rb = launch("slice6: gates while the board is watching", "all")
+        attach_run(live_b, rb)
+        chip_ok = settled(
+            page,
+            """id => !!document.querySelector(
+                 `[data-testid="project-card"][data-project-id="${id}"] [data-testid="run-chip"]`)""",
+            live_b,
+        )
+        await_gate(rb)
+        resorted, resort_ms = within(
+            page,
+            """ids => { const cards = Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+                          .map(c => c.dataset.projectId);
+                        const [a, b] = ids;
+                        return cards.indexOf(b) >= 0 && cards.indexOf(b) < cards.indexOf(a); }""",
+            [live_a, live_b],
+            budget_ms=5000,  # includes the run-list reconcile the gate frame triggers
+        )
+        a_after_gate = page.evaluate(CARD_INDEX, live_a)
+        b_after_gate = page.evaluate(CARD_INDEX, live_b)
+        page.screenshot(path=str(SHOTS / "slice6-board-gate-resort.png"), full_page=True)
+
+        # ── AC: a delta for B updates B's headline within 2 s; A is unchanged ──
+        _, _, rb_view = http_json("GET", f"{API}/runs/{rb}")
+        units = rb_view["run"]["units"]
+        ix = rb_view["run"]["session"]["unit_ix"]
+        ord_ = units[ix]["ord"] if ix < len(units) else 0
+        headline = "Writing the acceptance criteria for AC-3"
+        a_line_before = page.evaluate(LIVE_LINE, live_a)
+        b_line_before = page.evaluate(LIVE_LINE, live_b)
+        page.evaluate(
+            """args => window.__pushFrame(
+                 { type: 'unitOutputDelta', session: args.run, ord: args.ord, text: args.text + '\\n' })""",
+            {"run": rb, "ord": ord_, "text": headline},
+        )
+        headline_ok, headline_ms = within(
+            page,
+            """args => { const c = document.querySelector(
+                           `[data-testid="project-card"][data-project-id="${args.id}"]`);
+                         return (c?.querySelector('[data-testid="live-line"]')?.textContent ?? '')
+                           .includes(args.text); }""",
+            {"id": live_b, "text": headline},
+        )
+        a_line_after = page.evaluate(LIVE_LINE, live_a)
+        a_card_text = page.evaluate(
+            """id => document.querySelector(
+                 `[data-testid="project-card"][data-project-id="${id}"]`)?.innerText ?? ''""",
+            live_a,
+        )
+        a_untouched = a_line_after == a_line_before and headline not in a_card_text
+        page.screenshot(path=str(SHOTS / "slice6-board-live-headline.png"), full_page=True)
+
+        # ── AC: a relayed wicked.interactive.status.posted lands on its project ─
+        doc_status = "Rewriting slide 3 — tightening the headline"
+        page.evaluate(
+            """args => window.__pushFrame({ type: 'interactiveEvent', event: {
+                 event_type: 'wicked.interactive.status.posted',
+                 payload: { project_id: args.id, document_id: 'launch-deck', message: args.text } } })""",
+            {"id": live_b, "text": doc_status},
+        )
+        doc_ok, doc_ms = within(
+            page,
+            """args => { const c = document.querySelector(
+                           `[data-testid="project-card"][data-project-id="${args.id}"]`);
+                         return (c?.querySelector('[data-testid="doc-activity"]')?.textContent ?? '')
+                           .includes(args.text); }""",
+            {"id": live_b, "text": doc_status},
+        )
+
+        # The live region is new furniture inside a FIXED-height card, and the quick
+        # actions are bottom-anchored inside `overflow: hidden` — so a height that
+        # merely fit would silently clip the primary affordance. Measured, not eyeballed.
+        clipped = page.evaluate(
+            """() => Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+                 .filter(c => c.scrollHeight > c.clientHeight + 1)
+                 .map(c => `${c.dataset.projectId}:${c.scrollHeight}>${c.clientHeight}`)""")
+        same_page = page.evaluate("() => window.__slice6 === 'same page'")
+        board_scroll_after = page.evaluate(
+            """() => document.querySelector('[data-testid="project-board"]').scrollTop""")
+        page.screenshot(path=str(SHOTS / "slice6-board-doc-activity.png"), full_page=True)
+        browser.close()
+
+    # One socket for the whole surface (§3.5) — the board did not open its own.
+    one_socket = len([u for u in live_ws_urls if "/ws" in u]) == 1
+
+    report["steps"]["board_live"] = {
+        "ok": all([
+            both_visible, chip_ok, resorted, b_after_gate < a_after_gate, b_before > a_before,
+            headline_ok, a_untouched, doc_ok, same_page, one_socket,
+            board_scroll_before == board_scroll_after, not clipped,
+        ]),
+        "project_a": live_a,
+        "project_b": live_b,
+        "run_b": rb,
+        "both_cards_mounted": both_visible,
+        "card_order_before_gate": {"a": a_before, "b": b_before},
+        "launched_run_reached_card_without_reload": chip_ok,
+        "gate_moved_b_ahead_of_a": resorted,
+        "card_order_after_gate": {"a": a_after_gate, "b": b_after_gate},
+        "gate_resort_ms": resort_ms,
+        "b_headline_before": b_line_before,
+        "b_headline_updated_within_2s": headline_ok,
+        "headline_update_ms": headline_ms,
+        "card_a_unchanged": a_untouched,
+        "card_a_headline": a_line_after,
+        "doc_activity_within_2s": doc_ok,
+        "doc_activity_ms": doc_ms,
+        "no_navigation_or_reload": same_page,
+        "cards_clipped_by_fixed_height": clipped,
+        "board_scroll_unchanged": board_scroll_before == board_scroll_after,
+        "one_ws_subscription": one_socket,
+        "ws_urls": live_ws_urls,
+        "console_errors": live_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice6-board-gate-resort.png", "slice6-board-live-headline.png",
+                         "slice6-board-doc-activity.png")],
+    }
+    if not report["steps"]["board_live"]["ok"]:
+        fail("board_live_verdict", "slice-6 live-board assertions did not all hold — see board_live")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -27,7 +27,7 @@ import { STATUS_STYLE } from './RunCard.js';
  * `overflow: hidden` box, so a height that merely fits would clip the primary
  * affordance the moment a font metric moved. This carries ~16px of slack.
  */
-export const CARD_H = 340;
+export const CARD_H = 352;
 
 const MAX_TILES = 3;
 const MAX_CHIPS = 2;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,28 +1,38 @@
+import type { SessionView } from '../api/types.js';
+import { isLive, useRunHeadline } from '../hooks/useBoardHeadline.js';
 import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
+import { useRuntimeStore } from '../store/runtime.js';
 import { STATUS_STYLE } from './RunCard.js';
 
 /**
- * One orchestrator-board card (DES-MERGE-001 §1.4). All four regions are ALWAYS
+ * One orchestrator-board card (DES-MERGE-001 §1.4). All regions are ALWAYS
  * present; an empty region renders an invitation, never a blank. The height is
  * FIXED (`CARD_H`) so the board stays legible at 20+ cards — nothing here may grow
  * with the run or doc count, which is why every list is capped with an overflow
  * count instead of scrolling.
+ *
+ * Live activity and the run chips subscribe to the SHARED runtime + gate stores
+ * (slice 6) — the same stores the run view reads, fed by the app's ONE `/ws`
+ * subscription (§3.5). A card therefore updates in place while the user is looking
+ * at a different card, with no second socket and no polling anywhere on this route.
  */
 
 /**
  * Fixed card height in px — the board's windowing math depends on it.
  *
- * Sized by the TALLEST variant, the empty card: header + two regions + the 2×2
+ * Sized by the TALLEST variant, the empty card: header + three regions + the 2×2
  * quick-action grid. The actions are bottom-anchored (`marginTop: auto`) inside an
  * `overflow: hidden` box, so a height that merely fits would clip the primary
  * affordance the moment a font metric moved. This carries ~16px of slack.
  */
-export const CARD_H = 280;
+export const CARD_H = 340;
 
 const MAX_TILES = 3;
 const MAX_CHIPS = 2;
+/** Live lines per card. Fixed height, so extra runs report as a count, not a list. */
+const MAX_LINES = 2;
 
 const S = {
   border: 'rgba(230,237,243,0.1)',
@@ -74,6 +84,14 @@ const CSS = {
     background: 'rgba(230,237,243,0.05)', border: `1px solid ${S.border}`,
     borderRadius: '6px', color: S.ink,
   },
+  line: {
+    display: 'flex', alignItems: 'center', gap: '6px', margin: '0 0 2px',
+    fontSize: '11px', color: S.muted,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  pulse: {
+    width: '5px', height: '5px', borderRadius: '50%', background: '#79c0ff', flexShrink: 0,
+  },
 } as const satisfies Record<string, React.CSSProperties>;
 
 /** Coarse, honest relative time — the board never needs second precision. */
@@ -102,9 +120,12 @@ function Invitation({ text }: { text: string }): React.ReactElement {
  * A doc tile is a PLACEHOLDER — title, kind glyph, updated-at (§7.5). Live-rendered
  * thumbnails were explicitly deferred: 20 cards × 3 iframes is a browser's worth of
  * documents to keep mounted for a surface the user is only scanning.
+ *
+ * `when` is epoch millis (NaN = never edited): a relayed `status.posted` for this
+ * doc dates the tile from the frame, because between `listDocs` calls that event IS
+ * the document changing.
  */
-function DocTile({ name, kind, updatedAt }: { name: string; kind: string; updatedAt: string | null }): React.ReactElement {
-  const when = updatedAt === null ? NaN : Date.parse(updatedAt);
+function DocTile({ name, kind, when }: { name: string; kind: string; when: number }): React.ReactElement {
   return (
     <div data-testid="doc-tile" data-doc-kind={kind} style={CSS.tile}>
       <p style={CSS.tileName}>
@@ -118,6 +139,26 @@ function DocTile({ name, kind, updatedAt }: { name: string; kind: string; update
   );
 }
 
+/**
+ * One run's newest narration line (§1.4 live activity, derived per §3.4(b)). One
+ * line, ellipsised, never scrolling — the card is scanned, not watched; the thread
+ * is where a user goes to watch.
+ */
+function LiveLine({ view }: { view: SessionView }): React.ReactElement {
+  const headline = useRunHeadline(view);
+  return (
+    <p
+      data-testid="live-line"
+      data-run-id={view.session.id}
+      title={headline}
+      style={CSS.line}
+    >
+      <span aria-hidden style={CSS.pulse} />
+      {headline}
+    </p>
+  );
+}
+
 interface Props {
   item: BoardProject;
   navigate: Navigate;
@@ -126,6 +167,9 @@ interface Props {
 export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   const { project, repo, runs, docs, attention } = item;
   const gates = useGateStore((s) => s.gates);
+  // Relayed interactive status for THIS project — one line, plus the tile date it implies.
+  const activity = useRuntimeStore((s) => s.docActivity[project.id]);
+  const live = runs.filter(isLive);
   const empty = runs.length === 0 && docs.length === 0;
 
   /** Every affordance on the card is a real link — deep-linkable, middle-clickable. */
@@ -152,11 +196,45 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
         {docs.length === 0 ? <Invitation text="No documents yet." /> : (
           <div style={{ display: 'flex', gap: '6px', alignItems: 'stretch' }}>
             {docs.slice(0, MAX_TILES).map((d) => (
-              <DocTile key={d.name} name={d.name} kind={d.kind} updatedAt={d.updated_at} />
+              <DocTile
+                key={d.name}
+                name={d.name}
+                kind={d.kind}
+                when={
+                  activity !== undefined && activity.docId === d.name
+                    ? activity.at
+                    : d.updated_at === null ? NaN : Date.parse(d.updated_at)
+                }
+              />
             ))}
             {docs.length > MAX_TILES && (
               <span data-testid="doc-overflow" style={{ alignSelf: 'center', fontSize: '11px', color: S.muted, flexShrink: 0 }}>
                 {docs.length - MAX_TILES} more
+              </span>
+            )}
+          </div>
+        )}
+      </Region>
+
+      {/* Live activity — the newest narration line per in-flight run (§1.4, §3.4(b)),
+          plus the newest relayed doc status. Both arrive on the shared `/ws` stream. */}
+      <Region title="Live activity">
+        {live.length === 0 && activity === undefined ? (
+          <Invitation text="Nothing running." />
+        ) : (
+          <div data-testid="live-activity">
+            {live.slice(0, MAX_LINES).map((v) => (
+              <LiveLine key={v.session.id} view={v} />
+            ))}
+            {activity !== undefined && (
+              <p data-testid="doc-activity" title={activity.message} style={CSS.line}>
+                <span aria-hidden style={{ flexShrink: 0 }}>▤</span>
+                {activity.message}
+              </p>
+            )}
+            {live.length > MAX_LINES && (
+              <span data-testid="live-overflow" style={{ fontSize: '11px', color: S.muted }}>
+                {live.length - MAX_LINES} more running
               </span>
             )}
           </div>

--- a/src/hooks/useBoardHeadline.ts
+++ b/src/hooks/useBoardHeadline.ts
@@ -1,0 +1,119 @@
+import type { SessionView, WorkUnit } from '../api/types.js';
+import { outputKey, useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+
+/**
+ * The board card's narration altitude (DES-MERGE-001 §3.4(b)).
+ *
+ * The thread and the board card read the SAME `unitOutputDelta` stream out of the
+ * same runtime store, but they are not the same component and must not render the
+ * same thing: the thread shows a 4 KB scrolling tail, the card gets ONE line and
+ * no scroll. This module is that reduction — the last *meaningful* line, never a
+ * raw dump, and never a bare "Working…" (§3.3: every status names its subject).
+ */
+
+/** Statuses in which a run has stopped narrating — a terminal run has no live line. */
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'cancelled', 'failed']);
+
+/** Is this run still in flight? A gated run is: it is paused, not finished. */
+export function isLive(view: SessionView): boolean {
+  return !TERMINAL.has(view.session.status);
+}
+
+/**
+ * Frames that name a phase transition — §3.4(b) rule 1's "explicit structured
+ * status". Their `detail` is already the store's one-line summary of the frame.
+ */
+const STRUCTURED: ReadonlySet<string> = new Set([
+  'sessionStarted',
+  'unitPlanned',
+  'unitDistributed',
+  'unitExecuting',
+  'unitDone',
+  'unitDenied',
+  'awaitingHuman',
+  'resumed',
+  'workerStalled',
+  'stepFailed',
+]);
+
+/** One card line, so a chatty worker cannot widen or wrap the fixed-height card. */
+const HEADLINE_CAP = 110;
+
+/** CSI escapes (colour, cursor moves) — invisible in a terminal, noise on a card. */
+const ANSI = /\u001B\[[0-9;?]*[ -\u002F]*[@-~]/g;
+/** Progress-bar redraws: block-glyph runs and ASCII bars say nothing (§3.4(b) rule 2). */
+const PROGRESS = /[█▉▊▋▌▍▎▏▁▂▃▄▅▆▇░▒▓]{2,}|[=#*.-]{6,}/;
+
+function clamp(line: string): string {
+  return line.length > HEADLINE_CAP ? `${line.slice(0, HEADLINE_CAP - 1)}…` : line;
+}
+
+/**
+ * The newest line of a delta buffer worth showing, or `null` when the buffer holds
+ * only noise. ANSI is stripped; `\r` counts as a line break because a progress bar
+ * redraws in place — the segment after the last `\r` is that line's newest state,
+ * not a continuation of it.
+ */
+export function lastMeaningfulLine(text: string | undefined): string | null {
+  if (text === undefined || text === '') return null;
+  const lines = text.replace(ANSI, '').split(/[\r\n]+/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = (lines[i] ?? '').trim();
+    // Pure punctuation / box drawing / bars carry no subject, so they are not a status.
+    if (line === '' || !/[\p{L}\p{N}]/u.test(line) || PROGRESS.test(line)) continue;
+    return clamp(line);
+  }
+  return null;
+}
+
+/** The unit the run is on — the one whose buffer and phase the card is about. */
+export function activeUnit(view: SessionView): WorkUnit | undefined {
+  return view.units[view.session.unit_ix] ?? view.units[view.units.length - 1];
+}
+
+export interface HeadlineInput {
+  view: SessionView;
+  /** The active unit's accumulated delta buffer. */
+  text: string | undefined;
+  /** The run's structured event log (deltas are deliberately absent from it). */
+  log: LoggedEvent[] | undefined;
+  /** Arrival `seq` of this run's newest delta; `-1` when none has arrived. */
+  deltaSeq: number;
+}
+
+/**
+ * §3.4(b)'s derivation, in its stated priority order, always rendered as
+ * `<phase> — <what>` so the line carries a subject the user recognises:
+ *
+ *   1. a structured status, when it is NEWER than the delta buffer;
+ *   2. otherwise the last meaningful line of that buffer;
+ *   3. otherwise the unit's title.
+ *
+ * Rule 3 is why a bare "Working…" is never needed: the client already holds a
+ * truthful subject for every state a run can be in.
+ */
+export function deriveHeadline({ view, text, log, deltaSeq }: HeadlineInput): string {
+  const unit = activeUnit(view);
+  const phase = unit?.stage ?? view.session.status;
+  const structured = [...(log ?? [])].reverse().find((e) => STRUCTURED.has(e.type));
+  const what =
+    (structured !== undefined && structured.seq > deltaSeq ? structured.detail || null : null) ??
+    lastMeaningfulLine(text) ??
+    unit?.description ??
+    view.session.problem;
+  return `${phase} — ${clamp(what.trim())}`;
+}
+
+/**
+ * The live headline for one run, subscribed to the SHARED runtime store — the same
+ * store the run view reads, fed by the one `/ws` subscription (§3.5). Each selector
+ * returns a primitive, so a card re-renders only when its own run's slice moves.
+ */
+export function useRunHeadline(view: SessionView): string {
+  const runId = view.session.id;
+  const ord = activeUnit(view)?.ord ?? 0;
+  const text = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
+  const log = useRuntimeStore((s) => s.logs[runId]);
+  const deltaSeq = useRuntimeStore((s) => s.deltaSeq[runId] ?? -1);
+  return deriveHeadline({ view, text, log, deltaSeq });
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -142,7 +142,9 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   // so the unfiled runs that legitimately belong to no project cost exactly one pass
   // each rather than one per `GET /runs` reconcile.
   useEffect(() => {
-    if (projects.length === 0) return;
+    // Nothing is "unplaced" until the first membership read has landed — without this
+    // the initial run list would fan out a second, identical read behind the first.
+    if (projects.length === 0 || Object.keys(bindings).length === 0) return;
     const known = new Set(Object.values(bindings).flatMap((b) => [...b.runIds]));
     const unplaced = runs.filter((v) => !known.has(v.session.id) && !placed.current.has(v.session.id));
     if (unplaced.length === 0) return;

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -1,18 +1,22 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { listDocs, type DocSummary } from '../api/interactive.js';
 import type { Project, ProjectMember, SessionView } from '../api/types.js';
 
 /**
- * The orchestrator board's data model (DES-MERGE-001 §1.4, slice 5).
+ * The orchestrator board's data model (DES-MERGE-001 §1.4).
  *
- * STATIC by design: everything here comes from the REST surface on load — `GET
- * /projects`, `GET /runs` (owned by `useRuns`, passed in), each project's members,
- * and the interactive `listDocs` for projects bound to an interactive root. The
- * board goes live in slice 6; no WS subscription belongs in this file.
+ * The REST half: `GET /projects`, `GET /runs` (owned by `useRuns`, passed in),
+ * each project's members, and the interactive `listDocs` for projects bound to an
+ * interactive root. The LIVE half is not here and must not move here — narration
+ * and doc status come from the shared runtime store, which the cards subscribe to
+ * directly (§3.5: one socket, one store, no polling).
  *
  * Runs are joined to projects through MEMBERSHIP (`crew.run` / `crew.chat` refs) —
  * `AgentSession` carries no project id, so this is the only binding that exists.
+ * Memberships are re-read when a run the board has never placed shows up in the
+ * run list (slice 6): a run launched from a card's quick action, or by any other
+ * client, must land on its project's card without a reload.
  */
 
 /** Attention buckets, most-urgent first — §1.4's sort key, spelled once. */
@@ -98,19 +102,21 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   const [bindings, setBindings] = useState<Record<string, Bindings>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const repoNames = useRef<Map<string, string>>(new Map());
+  /** Run ids the board has already tried to place — one re-read per run, ever. */
+  const placed = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       let active: Project[];
-      let repoNames: Map<string, string>;
       try {
         const [{ projects: all }, repos] = await Promise.all([
           api.listProjects(),
           api.listRepos().then((r) => r.repos).catch(() => []),
         ]);
         active = all.filter((p) => p.status === 'active');
-        repoNames = new Map(repos.map((r) => [r.id, r.name]));
+        repoNames.current = new Map(repos.map((r) => [r.id, r.name]));
       } catch (e) {
         if (!cancelled) {
           setError(e instanceof Error ? e.message : String(e));
@@ -124,12 +130,32 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
       setProjects(active);
       setLoading(false);
       const entries = await Promise.all(
-        active.map(async (p) => [p.id, await loadBindings(p, repoNames)] as const),
+        active.map(async (p) => [p.id, await loadBindings(p, repoNames.current)] as const),
       );
       if (!cancelled) setBindings(Object.fromEntries(entries));
     })();
     return () => { cancelled = true; };
   }, []);
+
+  // A run the board cannot place yet (launched from a quick action, or by another
+  // client) means the membership snapshot is stale — re-read it. Guarded per run id,
+  // so the unfiled runs that legitimately belong to no project cost exactly one pass
+  // each rather than one per `GET /runs` reconcile.
+  useEffect(() => {
+    if (projects.length === 0) return;
+    const known = new Set(Object.values(bindings).flatMap((b) => [...b.runIds]));
+    const unplaced = runs.filter((v) => !known.has(v.session.id) && !placed.current.has(v.session.id));
+    if (unplaced.length === 0) return;
+    for (const v of unplaced) placed.current.add(v.session.id);
+    let cancelled = false;
+    void (async () => {
+      const entries = await Promise.all(
+        projects.map(async (p) => [p.id, await loadBindings(p, repoNames.current)] as const),
+      );
+      if (!cancelled) setBindings(Object.fromEntries(entries));
+    })();
+    return () => { cancelled = true; };
+  }, [runs, projects, bindings]);
 
   const items = useMemo(
     () =>

--- a/src/store/runtime.ts
+++ b/src/store/runtime.ts
@@ -168,9 +168,83 @@ export interface FailedSeat {
   why: string;
 }
 
+/**
+ * One interactive doc-status line, keyed by the project that owns the document
+ * (DES-MERGE-001 §1.4 live activity, §5.4 one stream).
+ *
+ * The board renders this as a single informative line on the owning project's
+ * card, and dates that document's tile from `at` — a `status.posted` IS the
+ * document changing, which is the only "updated at" signal the board gets
+ * between `listDocs` calls.
+ */
+export interface DocActivity {
+  /** The doc the status is about, when the frame named one (`document_id`). */
+  docId: string | null;
+  /** The agent's own words — informative, never filler (§3.3). */
+  message: string;
+  /** Arrival time (epoch millis). */
+  at: number;
+}
+
+/** The one relayed interactive event the board reads (§3.4(b) rule 1). */
+const STATUS_POSTED = 'wicked.interactive.status.posted';
+
+/** First non-empty string among the candidate keys of an untyped bag. */
+function pick(bag: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = bag[key];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return null;
+}
+
+/**
+ * A `wicked.interactive.status.posted` frame reduced to the line the board shows,
+ * or `null` for every other frame.
+ *
+ * Crew relays interactive's bus frames onto `/ws` inside slice 3's envelope,
+ * `{type:'interactiveEvent', event}` — a foreign vocabulary crossing a seam this
+ * repo does not own, so the payload is read DEFENSIVELY (both spellings of each
+ * field, no throw on a shape that does not match). A frame that names no project
+ * or carries no message is dropped rather than rendered as an empty status.
+ */
+export function docActivityOf(frame: CoreEvent): { projectId: string; activity: DocActivity } | null {
+  if (frame.type !== 'interactiveEvent' || typeof frame.event !== 'object' || frame.event === null) {
+    return null;
+  }
+  const event = frame.event as Record<string, unknown>;
+  if (pick(event, 'event_type', 'type') !== STATUS_POSTED) return null;
+  const payload =
+    typeof event.payload === 'object' && event.payload !== null
+      ? (event.payload as Record<string, unknown>)
+      : {};
+  const projectId = pick(payload, 'project_id', 'project') ?? pick(event, 'project_id', 'project');
+  const message = pick(payload, 'message', 'status', 'text');
+  if (projectId === null || message === null) return null;
+  return {
+    projectId,
+    activity: {
+      docId: pick(payload, 'document_id', 'doc_id', 'document'),
+      message,
+      at: Date.now(),
+    },
+  };
+}
+
 interface RuntimeStore {
   /** Accumulated live CLI output, keyed `<run>:u<ord>` (§11.4). */
   outputs: Record<string, string>;
+  /**
+   * Arrival `seq` of the newest output delta per run.
+   *
+   * Deltas stream into `outputs` and are deliberately NOT logged, so nothing else
+   * orders scraped text against the structured frames in `logs`. The board's
+   * headline needs exactly that comparison — §3.4(b) rule 1 lets a phase
+   * transition win over the delta buffer only when it is the newer of the two.
+   */
+  deltaSeq: Record<string, number>;
+  /** Newest relayed interactive doc status per project id (§5.4). */
+  docActivity: Record<string, DocActivity>;
   /** Live council deliberation per unit, keyed `<session>:<ord>`. */
   councilStatus: Record<string, CouncilStatus>;
   /** Structured assumptions per run (assumptionRecorded events, arrival order). */
@@ -205,6 +279,8 @@ interface RuntimeStore {
 
 export const useRuntimeStore = create<RuntimeStore>((set) => ({
   outputs: {},
+  deltaSeq: {},
+  docActivity: {},
   councilStatus: {},
   assumptions: {},
   logs: {},
@@ -213,6 +289,14 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
   seq: 0,
 
   ingest: (event) => {
+    // Relayed interactive frames are PROJECT-scoped, not run-scoped, so they are
+    // folded before the run guard below drops everything without a `session`.
+    const doc = docActivityOf(event);
+    if (doc !== null) {
+      set((s) => ({ seq: s.seq + 1, docActivity: { ...s.docActivity, [doc.projectId]: doc.activity } }));
+      return;
+    }
+
     const session = typeof event.session === 'string' ? event.session : undefined;
     // Frames with no run scope (heartbeat, repoRegistered, terminal*) aren't run-owned.
     if (session === undefined) return;
@@ -228,7 +312,11 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
         const prev = s.outputs[key] ?? '';
         let combined = prev + deltaText;
         if (combined.length > OUTPUT_CAP) combined = combined.slice(combined.length - OUTPUT_CAP);
-        return { seq, outputs: { ...s.outputs, [key]: combined } };
+        return {
+          seq,
+          outputs: { ...s.outputs, [key]: combined },
+          deltaSeq: { ...s.deltaSeq, [session]: seq },
+        };
       }
 
       // Heartbeats would flood the log and carry no run detail.
@@ -427,6 +515,8 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
       }
       const logs = { ...s.logs };
       delete logs[session];
-      return { outputs, councilStatus, assumptions, executorTypes, terminalIds, logs };
+      const deltaSeq = { ...s.deltaSeq };
+      delete deltaSeq[session];
+      return { outputs, deltaSeq, councilStatus, assumptions, executorTypes, terminalIds, logs };
     }),
 }));

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import type { DocSummary } from '../src/api/interactive.js';
+import type { CoreEvent, Project, ProjectMember, SessionStatus, SessionView } from '../src/api/types.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The board goes LIVE (DES-MERGE-001 §6.2 slice 6). These pin the ACs that do not
+ * need a browser: a card updating in place from the shared runtime store while the
+ * user sits on `/`, its neighbour left alone, a gate arrival re-sorting the board,
+ * and a relayed interactive status landing on the owning project's card.
+ *
+ * Everything here goes through the store's real `ingest` — the same call `App`
+ * makes for every `/ws` frame — so what is under test is the wiring, not a mock.
+ */
+
+let projects: Project[] = [];
+let members: Record<string, ProjectMember[]> = {};
+let docs: Record<string, DocSummary[]> = {};
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: members[id] ?? [] }),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: (id: string) => Promise.resolve(docs[id] ?? []),
+}));
+
+const { HomeBoard } = await import('../src/components/HomeBoard.js');
+
+function project(id: string, name: string, over: Partial<Project> = {}): Project {
+  return {
+    id, name, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at: 1, ...over,
+  };
+}
+
+function member(project_id: string, member_ref: string): ProjectMember {
+  return {
+    id: `${project_id}:crew.run:${member_ref}`, project_id, member_kind: 'crew.run',
+    member_ref, meta: null, attached_at: 1, attached_by: 'studio',
+  };
+}
+
+/** One in-flight run, on a unit whose phase + title is the rule-3 fallback line. */
+const running = (id: string, status: SessionStatus = 'executing'): SessionView =>
+  makeView({ id, status, unit_ix: 0 }, [makeUnit({ id: `${id}:u0`, session_id: id, ord: 0, stage: 'build', description: 'wire the board' })]);
+
+const cardIds = (): (string | null)[] =>
+  screen.getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
+
+const card = (id: string): HTMLElement =>
+  document.querySelector(`[data-testid="project-card"][data-project-id="${id}"]`) as HTMLElement;
+
+/** Push a frame the way `App` does: straight into the shared store's fold. */
+const push = (event: CoreEvent): void => {
+  act(() => { useRuntimeStore.getState().ingest(event); });
+};
+
+async function board(runs: SessionView[]): Promise<void> {
+  render(<HomeBoard runs={runs} navigate={() => {}} />);
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+    expect(screen.getAllByTestId('project-card')).toHaveLength(projects.length);
+  });
+}
+
+describe('HomeBoard — live activity (slice 6)', () => {
+  beforeEach(() => {
+    projects = [];
+    members = {};
+    docs = {};
+    useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
+  });
+
+  it('a unitOutputDelta for B updates B\'s headline in place and leaves A untouched', async () => {
+    projects = [project('p-a', 'Ay'), project('p-b', 'Bee')];
+    members = { 'p-a': [member('p-a', 'run-a')], 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-a'), running('run-b')]);
+
+    // Before: both cards state their subject from phase + title (§3.4(b) rule 3) —
+    // no card is ever blank, and neither says "Working…".
+    const before = within(card('p-a')).getByTestId('live-line').textContent;
+    expect(before).toBe('build — wire the board');
+    expect(within(card('p-b')).getByTestId('live-line')).toHaveTextContent('build — wire the board');
+
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Writing the acceptance criteria for AC-3\n' } as CoreEvent);
+
+    expect(within(card('p-b')).getByTestId('live-line'))
+      .toHaveTextContent('build — Writing the acceptance criteria for AC-3');
+    // The AC's other half: the card the user was NOT looking at is unchanged.
+    expect(within(card('p-a')).getByTestId('live-line').textContent).toBe(before);
+  });
+
+  it('keeps streaming: the newest line replaces the previous one, no scroll, no dump', async () => {
+    projects = [project('p-b', 'Bee')];
+    members = { 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-b')]);
+
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Reading src/App.tsx\n' } as CoreEvent);
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Rewriting slide 3\n' } as CoreEvent);
+
+    const line = within(card('p-b')).getByTestId('live-line');
+    expect(line).toHaveTextContent('build — Rewriting slide 3');
+    expect(line.textContent).not.toContain('Reading src/App.tsx');
+  });
+
+  it('a terminal run has no live line — the region invites instead of narrating a finished run', async () => {
+    projects = [project('p-done', 'Done')];
+    members = { 'p-done': [member('p-done', 'run-done')] };
+    await board([running('run-done', 'completed')]);
+
+    expect(within(card('p-done')).queryByTestId('live-line')).toBeNull();
+    expect(card('p-done')).toHaveTextContent('Nothing running.');
+  });
+
+  it('a gate arrival re-sorts the board without remounting the unaffected card', async () => {
+    // A sorts first while both are quiet (newer `updated_at` breaks the tie).
+    projects = [project('p-a', 'Ay', { updated_at: 200 }), project('p-b', 'Bee', { updated_at: 100 })];
+    members = { 'p-a': [member('p-a', 'run-a')], 'p-b': [member('p-b', 'run-b')] };
+    const { rerender } = render(
+      <HomeBoard runs={[running('run-a', 'completed'), running('run-b', 'completed')]} navigate={() => {}} />,
+    );
+    await vi.waitFor(() => expect(cardIds()).toEqual(['p-a', 'p-b']));
+    const untouched = card('p-a');
+
+    // The gate lands: `useRuns` reconciles the run list, and attention re-sorts B first.
+    rerender(
+      <HomeBoard runs={[running('run-a', 'completed'), running('run-b', 'awaiting_human')]} navigate={() => {}} />,
+    );
+
+    await vi.waitFor(() => expect(cardIds()).toEqual(['p-b', 'p-a']));
+    expect(card('p-b')).toHaveAttribute('data-attention', 'gate');
+    // Keyed by project id, so the card that did not change is MOVED, not rebuilt —
+    // which is what keeps a re-sort from throwing away the unaffected cards' state.
+    expect(card('p-a')).toBe(untouched);
+  });
+
+  it('a relayed status.posted adds a doc line and dates that doc\'s tile', async () => {
+    projects = [project('p-doc', 'Docs', { interactiveRoot: '/tmp/wi' })];
+    docs = { 'p-doc': [{ name: 'launch-deck', kind: 'doc', head: 1, versions: 1, updated_at: null }] };
+    await board([]);
+    await vi.waitFor(() => expect(screen.getByTestId('doc-tile')).toHaveTextContent('not yet edited'));
+
+    push({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.status.posted',
+        payload: {
+          project_id: 'p-doc',
+          document_id: 'launch-deck',
+          message: 'Rewriting slide 3 — tightening the headline',
+        },
+      },
+    } as CoreEvent);
+
+    expect(within(card('p-doc')).getByTestId('doc-activity'))
+      .toHaveTextContent('Rewriting slide 3 — tightening the headline');
+    expect(screen.getByTestId('doc-tile')).toHaveTextContent('0s ago');
+  });
+
+  it('ignores a relayed status for a project that is not on this board', async () => {
+    projects = [project('p-mine', 'Mine')];
+    await board([]);
+
+    push({
+      type: 'interactiveEvent',
+      event: { event_type: 'wicked.interactive.status.posted', payload: { project_id: 'p-other', message: 'elsewhere' } },
+    } as CoreEvent);
+
+    expect(within(card('p-mine')).queryByTestId('doc-activity')).toBeNull();
+    expect(card('p-mine')).not.toHaveTextContent('elsewhere');
+  });
+
+  it('picks up a run attached after first paint — no reload to see a launched run', async () => {
+    projects = [project('p-a', 'Ay')];
+    const { rerender } = render(<HomeBoard runs={[]} navigate={() => {}} />);
+    await vi.waitFor(() => expect(card('p-a')).toHaveTextContent('No runs yet.'));
+
+    // The run is launched and filed while the user sits on the board.
+    members = { 'p-a': [member('p-a', 'run-new')] };
+    rerender(<HomeBoard runs={[running('run-new')]} navigate={() => {}} />);
+
+    await vi.waitFor(() => expect(within(card('p-a')).getByTestId('run-chip')).toHaveAttribute('data-run-id', 'run-new'));
+    expect(within(card('p-a')).getByTestId('live-line')).toHaveTextContent('build — wire the board');
+  });
+});

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -91,8 +91,12 @@ describe('HomeBoard — live activity (slice 6)', () => {
 
     push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Writing the acceptance criteria for AC-3\n' } as CoreEvent);
 
-    expect(within(card('p-b')).getByTestId('live-line'))
-      .toHaveTextContent('build — Writing the acceptance criteria for AC-3');
+    // The AC is "within 2s", not "synchronously": on a loaded runner the store->card
+    // flush can land a beat after act() returns, so wait for it the way a user would.
+    await vi.waitFor(() => {
+      expect(within(card('p-b')).getByTestId('live-line'))
+        .toHaveTextContent('build — Writing the acceptance criteria for AC-3');
+    });
     // The AC's other half: the card the user was NOT looking at is unchanged.
     expect(within(card('p-a')).getByTestId('live-line').textContent).toBe(before);
   });

--- a/tests/boardHeadline.test.ts
+++ b/tests/boardHeadline.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  activeUnit,
+  deriveHeadline,
+  isLive,
+  lastMeaningfulLine,
+} from '../src/hooks/useBoardHeadline.js';
+import type { LoggedEvent } from '../src/store/runtime.js';
+import type { AgentSession, SessionView, WorkUnit } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The board card's narration altitude (DES-MERGE-001 §3.4(b)) — the reduction from
+ * the shared delta stream to ONE meaningful line. The banned states of §3.3 are
+ * pinned here as assertions, not left to review: no bare "Working…", no subject-less
+ * status, no raw dump on a card.
+ */
+
+const view = (
+  over: Partial<AgentSession> = {},
+  units: WorkUnit[] = [makeUnit({ ord: 0, stage: 'recon', description: 'acceptance criteria' })],
+): SessionView => makeView({ status: 'executing', unit_ix: 0, ...over }, units);
+
+const logged = (over: Partial<LoggedEvent> & { type: string; seq: number }): LoggedEvent => ({
+  ts: 1, detail: '', ...over,
+});
+
+describe('lastMeaningfulLine — §3.4(b) rule 2', () => {
+  it('takes the LAST non-empty line, trimmed to one line', () => {
+    expect(lastMeaningfulLine('planning\nWriting the acceptance criteria for AC-3\n\n'))
+      .toBe('Writing the acceptance criteria for AC-3');
+  });
+
+  it('drops ANSI colour/cursor escapes', () => {
+    expect(lastMeaningfulLine('\u001B[2K\u001B[32mTightening the headline\u001B[0m'))
+      .toBe('Tightening the headline');
+  });
+
+  it('treats a \\r redraw as a line break and takes the newest segment', () => {
+    expect(lastMeaningfulLine('step 1\rstep 2\rReading src/App.tsx')).toBe('Reading src/App.tsx');
+  });
+
+  it('skips progress-bar redraws and pure-punctuation lines', () => {
+    expect(lastMeaningfulLine('Indexing sources\n████████░░ 80%\n')).toBe('Indexing sources');
+    expect(lastMeaningfulLine('Indexing sources\n-------------\n>>> ...')).toBe('Indexing sources');
+  });
+
+  it('is null for an empty or noise-only buffer — the card then falls through, never blanks', () => {
+    expect(lastMeaningfulLine(undefined)).toBeNull();
+    expect(lastMeaningfulLine('')).toBeNull();
+    expect(lastMeaningfulLine('\n  \n***\n')).toBeNull();
+  });
+
+  it('caps a long line so one chatty chunk cannot widen the fixed-height card', () => {
+    const line = lastMeaningfulLine('x'.repeat(400));
+    expect(line).not.toBeNull();
+    expect(line!.length).toBeLessThanOrEqual(110);
+    expect(line!.endsWith('…')).toBe(true);
+  });
+});
+
+describe('deriveHeadline — §3.4(b) priority order', () => {
+  it('uses the delta buffer when it is newer than the last structured status', () => {
+    const line = deriveHeadline({
+      view: view(),
+      text: 'Writing the acceptance criteria for AC-3\n',
+      log: [logged({ type: 'unitExecuting', seq: 4, detail: 'executing' })],
+      deltaSeq: 9,
+    });
+    expect(line).toBe('recon — Writing the acceptance criteria for AC-3');
+  });
+
+  it('a structured status that arrived AFTER the last delta wins over the scraped text', () => {
+    const line = deriveHeadline({
+      view: view(),
+      text: 'Writing the acceptance criteria for AC-3\n',
+      log: [logged({ type: 'awaitingHuman', seq: 12, detail: 'awaiting human: approve the plan?' })],
+      deltaSeq: 9,
+    });
+    expect(line).toBe('recon — awaiting human: approve the plan?');
+  });
+
+  it('ignores non-phase frames when looking for the structured status', () => {
+    const line = deriveHeadline({
+      view: view(),
+      text: 'Reading src/App.tsx\n',
+      // cliUsage/heartbeat-ish frames are logged but name no phase transition.
+      log: [logged({ type: 'cliUsage', seq: 30, detail: '1200 tokens' })],
+      deltaSeq: 9,
+    });
+    expect(line).toBe('recon — Reading src/App.tsx');
+  });
+
+  it('falls back to phase + title — never a bare "Working…" (§3.3)', () => {
+    const line = deriveHeadline({ view: view(), text: undefined, log: undefined, deltaSeq: -1 });
+    expect(line).toBe('recon — acceptance criteria');
+    expect(line).not.toMatch(/working/i);
+  });
+
+  it('falls back to the run problem when the unit list has not landed yet', () => {
+    const line = deriveHeadline({
+      view: view({ status: 'planning', problem: 'ship the board' }, []),
+      text: undefined,
+      log: undefined,
+      deltaSeq: -1,
+    });
+    expect(line).toBe('planning — ship the board');
+  });
+
+  it('reads the unit the run is ON, not the first one', () => {
+    const v = view({ unit_ix: 1 }, [
+      makeUnit({ ord: 0, stage: 'recon', description: 'first' }),
+      makeUnit({ ord: 1, stage: 'build', description: 'second' }),
+    ]);
+    expect(activeUnit(v)?.ord).toBe(1);
+    expect(deriveHeadline({ view: v, text: undefined, log: undefined, deltaSeq: -1 }))
+      .toBe('build — second');
+  });
+});
+
+describe('isLive — which runs get a live line', () => {
+  it('counts a gated run as in flight (paused, not finished) and terminal runs as not', () => {
+    expect(isLive(makeView({ status: 'awaiting_human' }))).toBe(true);
+    expect(isLive(makeView({ status: 'executing' }))).toBe(true);
+    expect(isLive(makeView({ status: 'completed' }))).toBe(false);
+    expect(isLive(makeView({ status: 'failed' }))).toBe(false);
+    expect(isLive(makeView({ status: 'cancelled' }))).toBe(false);
+  });
+});

--- a/tests/runtime.store.test.ts
+++ b/tests/runtime.store.test.ts
@@ -3,7 +3,10 @@ import { useRuntimeStore, outputKey } from '../src/store/runtime.js';
 import type { CoreEvent } from '../src/api/types.js';
 
 const reset = (): void =>
-  useRuntimeStore.setState({ outputs: {}, logs: {}, executorTypes: {}, terminalIds: {}, councilStatus: {}, seq: 0 });
+  useRuntimeStore.setState({
+    outputs: {}, logs: {}, executorTypes: {}, terminalIds: {}, councilStatus: {},
+    deltaSeq: {}, docActivity: {}, seq: 0,
+  });
 const delta = (session: string, ord: number, chunk: string): CoreEvent =>
   ({ type: 'cliOutputDelta', session, ord, chunk } as CoreEvent);
 
@@ -131,6 +134,76 @@ describe('runtime store (§11.4 — live output + per-run event log)', () => {
       expect(buf).toHaveLength(200_000);
       expect(buf.endsWith('-TAIL')).toBe(true);
       expect(buf).not.toContain('HEAD-');
+    });
+  });
+
+  // The board's headline has to know whether the newest thing it knows about a run is a
+  // structured frame or scraped text; deltas are not logged, so the store records their
+  // arrival seq (DES-MERGE-001 §3.4(b) rule 1).
+  it('records the arrival seq of the newest delta per run', () => {
+    const ingest = useRuntimeStore.getState().ingest;
+    ingest({ type: 'unitExecuting', session: 'run-1', ord: 0 } as CoreEvent);
+    ingest(delta('run-1', 0, 'x'));
+    ingest({ type: 'unitExecuting', session: 'run-2', ord: 0 } as CoreEvent);
+    const { deltaSeq, logs } = useRuntimeStore.getState();
+    expect(deltaSeq['run-1']).toBeGreaterThan(logs['run-1']?.[0]?.seq ?? 0);
+    expect(deltaSeq['run-2']).toBeUndefined();
+    useRuntimeStore.getState().clear('run-1');
+    expect(useRuntimeStore.getState().deltaSeq['run-1']).toBeUndefined();
+  });
+
+  // Slice 3 relays interactive's bus frames onto the SAME /ws stream inside an
+  // `{type:'interactiveEvent', event}` envelope (§5.4). They are project-scoped, so they
+  // are folded before the run guard, and read defensively across a seam this repo
+  // does not own.
+  describe('relayed interactive frames (§5.4)', () => {
+    const posted = (payload: Record<string, unknown>): CoreEvent =>
+      ({
+        type: 'interactiveEvent',
+        event: { event_type: 'wicked.interactive.status.posted', payload },
+      } as CoreEvent);
+
+    it('folds status.posted into per-project doc activity', () => {
+      useRuntimeStore.getState().ingest(posted({
+        project_id: 'p-1',
+        document_id: 'launch-deck',
+        message: 'Rewriting slide 3 — tightening the headline',
+      }));
+      expect(useRuntimeStore.getState().docActivity['p-1']).toMatchObject({
+        docId: 'launch-deck',
+        message: 'Rewriting slide 3 — tightening the headline',
+      });
+      expect(useRuntimeStore.getState().docActivity['p-1']?.at).toBeGreaterThan(0);
+    });
+
+    it('accepts the alternate field spellings and a doc-less status', () => {
+      useRuntimeStore.getState().ingest({
+        type: 'interactiveEvent',
+        event: { type: 'wicked.interactive.status.posted', payload: { project: 'p-2', status: 'Learning the theme' } },
+      } as CoreEvent);
+      expect(useRuntimeStore.getState().docActivity['p-2']).toMatchObject({
+        docId: null,
+        message: 'Learning the theme',
+      });
+    });
+
+    it('drops frames with no project, no message, or another event type', () => {
+      const ingest = useRuntimeStore.getState().ingest;
+      ingest(posted({ document_id: 'd', message: 'no project' }));
+      ingest(posted({ project_id: 'p-3', message: '   ' }));
+      ingest({ type: 'interactiveEvent', event: { event_type: 'wicked.interactive.doc.created', payload: { project_id: 'p-3' } } } as CoreEvent);
+      ingest({ type: 'interactiveEvent' } as CoreEvent);
+      ingest({ type: 'interactiveEvent', event: 'not an object' } as CoreEvent);
+      expect(Object.keys(useRuntimeStore.getState().docActivity)).toHaveLength(0);
+      // …and none of them landed in a run log either (they carry no run).
+      expect(Object.keys(useRuntimeStore.getState().logs)).toHaveLength(0);
+    });
+
+    it('keeps only the newest status per project', () => {
+      const ingest = useRuntimeStore.getState().ingest;
+      ingest(posted({ project_id: 'p-4', message: 'first' }));
+      ingest(posted({ project_id: 'p-4', message: 'second' }));
+      expect(useRuntimeStore.getState().docActivity['p-4']?.message).toBe('second');
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -22,3 +22,16 @@ if (!('localStorage' in window) || window.localStorage == null) {
     },
   });
 }
+
+// jsdom implements no canvas backend; components that probe a 2D context (and any
+// dependency that measures text through one) throw "Not implemented" on CI where the
+// optional native canvas package is absent. Stub only when missing, same policy as above.
+if (typeof window.HTMLCanvasElement.prototype.getContext !== 'function' ||
+    (() => { try { return document.createElement('canvas').getContext('2d') == null; } catch { return true; } })()) {
+  window.HTMLCanvasElement.prototype.getContext = (() => ({
+    measureText: (t: string) => ({ width: String(t).length * 7 }),
+    fillText: () => {}, clearRect: () => {}, fillRect: () => {},
+    beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
+    save: () => {}, restore: () => {}, scale: () => {}, translate: () => {},
+  })) as unknown as typeof window.HTMLCanvasElement.prototype.getContext;
+}


### PR DESCRIPTION
Slice 6, authored by governed run `a6e56d59` (clarify/design/build: claude · adversarial-review/test/review: codex).

Cards subscribe to the shared runtime store — the same `/ws` feed as the run view, no second socket, no polling. Per-card live narration headline derived per §3.4(b) (subject line from the newest `unitOutputDelta`, never a bare 'Working…'); run chips update in place within 2s; a gate arrival re-sorts the board by attention without touching unaffected cards; `interactiveEvent` frames freshen doc tiles.

405/405 unit tests locally (49 files) plus a real-browser Playwright AC: delta for project B updates B's card without reload while A is untouched, and a gate moves B ahead in DOM order.

Design: `.product/DES-MERGE-001.md` §1.4, §3.4, §6.2 slice 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)