### PR TITLE
feat(board): answerable gate chips (DES-MERGE-001 slice 7)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -37,6 +37,10 @@ What "independent" means here, and what this script proves end-to-end:
      `unitOutputDelta` updates that card's headline within 2 s while its neighbour
      is untouched, and a relayed `wicked.interactive.status.posted` adds a doc
      activity line — all over the page's ONE existing socket
+ 10. (DES-MERGE-001 slice 7) gate chips on that board are ANSWERABLE: a SIMPLE gate
+     (§7.11) is approved inline and the run advances on the same page with no
+     navigation, while a COMPLEX one deep-links to the thread with the gate message
+     scrolled into view and focused
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -687,6 +691,136 @@ try:
     }
     if not report["steps"]["board_live"]["ok"]:
         fail("board_live_verdict", "slice-6 live-board assertions did not all hold — see board_live")
+
+    # ── 11. Slice 7 (DES-MERGE-001 §6.2): answerable gate chips on the board ──
+    # Two gates, two shapes (§7.11 — "the AC asserts both shapes via fixtures"):
+    #   - SIMPLE is the gate crew actually raises: a prompt-only payload, whose two
+    #     answers are the two `POST /runs/:id/gate` accepts. Answered inline, on `/`.
+    #   - COMPLEX is a payload that names more than two choices. Crew does not send
+    #     one yet, so it is delivered through the same WebSocket tap slice 6 uses —
+    #     a real `awaitingHuman` frame for a run that IS genuinely parked on a gate,
+    #     travelling the full app path (onmessage → gate store → card).
+    simple_project = new_project(f"slice7-simple-{tag}")
+    simple_run = await_gate(launch("slice7: a simple gate, answered from the board", "all"))
+    attach_run(simple_project, simple_run)
+    complex_project = new_project(f"slice7-complex-{tag}")
+    complex_run = await_gate(launch("slice7: a gate that needs the thread", "all"))
+    attach_run(complex_project, complex_run)
+
+    slice7_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(WS_TAP)
+        page.on("console", lambda m: slice7_console.append(m.text) if m.type == "error" else None)
+
+        page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
+        # Same sentinel discipline as slice 6: any navigation or reload wipes it.
+        page.evaluate("() => { window.__slice7 = 'same page'; }")
+
+        # ── AC: a simple gate is answered ON the board, and the run advances there ─
+        approve = page.locator(f'[data-testid="gate-approve-{simple_run}"]')
+        approve.wait_for(timeout=30000)
+        # §1.4: the chip is a CONTROL, not a badge — and a simple gate never sends the
+        # user to the thread to answer it.
+        inline_ok = (
+            page.locator(f'[data-testid="gate-reject-{simple_run}"]').count() == 1
+            and page.locator(f'[data-testid="gate-open-{simple_run}"]').count() == 0
+        )
+        approve.click()
+        # Disabled while the POST is open — the double-submit guard, visible (§3.3).
+        disabled_ok, _ = within(
+            page,
+            """id => { const b = document.querySelector(`[data-testid="gate-approve-${id}"]`);
+                       return b === null || b.disabled; }""",
+            simple_run,
+            budget_ms=3000,
+        )
+        advanced_ok, advance_ms = within(
+            page,
+            """id => { const chip = document.querySelector(`[data-testid="run-chip"][data-run-id="${id}"]`);
+                       return !!chip && chip.dataset.status !== 'awaiting_human'; }""",
+            simple_run,
+            budget_ms=20000,  # gate decision → resume → run-list reconcile (400 ms debounce)
+        )
+        chip_status = page.evaluate(
+            """id => document.querySelector(
+                 `[data-testid="run-chip"][data-run-id="${id}"]`)?.dataset.status ?? null""",
+            simple_run,
+        )
+        no_nav_ok = (
+            page.evaluate("() => window.__slice7 === 'same page'")
+            and urllib.parse.urlparse(page.url).path == "/"
+        )
+        _, _, simple_final = http_json("GET", f"{API}/runs/{simple_run}")
+        simple_rest_status = simple_final["run"]["session"]["status"]
+        page.screenshot(path=str(SHOTS / "slice7-board-gate-answered.png"), full_page=True)
+
+        # ── AC: a complex gate's chip navigates to the thread, message focused ────
+        page.evaluate(
+            """args => window.__pushFrame({ type: 'awaitingHuman', session: args.run, ord: args.ord,
+                 prompt: args.prompt, choices: ['ship it', 'rework the plan', 'split the slice'] })""",
+            {"run": complex_run, "ord": 0, "prompt": "Which way should this go?"},
+        )
+        open_chip = page.locator(f'[data-testid="gate-open-{complex_run}"]')
+        open_chip.wait_for(timeout=30000)
+        deep_link = open_chip.get_attribute("href")
+        # A card cannot answer a question that needs prose — so it does not offer to.
+        complex_shape_ok = (
+            page.locator(f'[data-testid="gate-approve-{complex_run}"]').count() == 0
+            and deep_link == f"/p/{complex_project}/build/{complex_run}#gate"
+        )
+        open_chip.click()
+        deep_link_ok = wait_for_path(page, f"/p/{complex_project}/build/{complex_run}")
+        focus_ok, focus_ms = within(
+            page,
+            """() => document.activeElement?.dataset?.testid === 'steering-prompt'""",
+            budget_ms=30000,
+        )
+        # Focused AND in view (§6.2: "scrolled into view and focused"), and the one-shot
+        # intent is consumed so the live thread cannot keep yanking focus back.
+        in_view = page.evaluate(
+            """() => { const el = document.querySelector('[data-testid="steering-prompt"]');
+                       if (!el) return false;
+                       const r = el.getBoundingClientRect();
+                       return r.top >= 0 && r.bottom <= window.innerHeight; }""")
+        hash_consumed = page.evaluate("() => window.location.hash === ''")
+        page.screenshot(path=str(SHOTS / "slice7-gate-deep-link.png"), full_page=True)
+        browser.close()
+
+    report["steps"]["gate_chips"] = {
+        "ok": all([
+            inline_ok, disabled_ok, advanced_ok, no_nav_ok,
+            simple_rest_status != "awaiting_human",
+            complex_shape_ok, deep_link_ok, focus_ok, in_view, hash_consumed,
+        ]),
+        "simple_project": simple_project,
+        "simple_run": simple_run,
+        "complex_project": complex_project,
+        "complex_run": complex_run,
+        "simple_gate_answerable_inline": inline_ok,
+        "chip_disabled_in_flight": disabled_ok,
+        "run_advanced_on_the_board": advanced_ok,
+        "advance_ms": advance_ms,
+        "chip_status_after_approve": chip_status,
+        "status_via_rest_after_approve": simple_rest_status,
+        "no_navigation_or_reload": no_nav_ok,
+        "complex_gate_deep_links_only": complex_shape_ok,
+        "complex_gate_href": deep_link,
+        "navigated_to_thread": deep_link_ok,
+        "gate_message_focused": focus_ok,
+        "focus_ms": focus_ms,
+        "gate_message_in_view": in_view,
+        "focus_intent_consumed": hash_consumed,
+        "console_errors": slice7_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice7-board-gate-answered.png", "slice7-gate-deep-link.png")],
+    }
+    if not report["steps"]["gate_chips"]["ok"]:
+        fail("gate_chips_verdict", "slice-7 gate-chip assertions did not all hold — see gate_chips")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,8 +395,11 @@ export function App(): React.ReactElement {
         <RightPanel view={selected} />
       )}
 
-      {/* Gate toasts — always mounted, renders above everything; scoped to the current run */}
-      <GateNotifications onSelect={selectRun} runId={runId} />
+      {/* Gate toasts — renders above everything; scoped to the current run. NOT on the
+          orchestrator board: there every waiting gate is already an answerable chip on
+          its project's card, sorted to the front (§1.4, slice 7), and the unscoped stack
+          would both duplicate those chips and physically cover the cards holding them. */}
+      {panel !== 'home' && <GateNotifications onSelect={selectRun} runId={runId} />}
 
       {/* Repo graph modal — opened from RepoDetailPage */}
       {graphModalRepo !== null && (

--- a/src/components/GateChip.tsx
+++ b/src/components/GateChip.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { api } from '../api/client.js';
+import { modePath, type Navigate } from '../hooks/useRoute.js';
+import { isSimpleGate, useGateStore, type OpenGate } from '../store/gates.js';
+
+/**
+ * A waiting gate on a board card, rendered as an ANSWERABLE chip rather than a
+ * badge (DES-MERGE-001 §1.4: "answering a simple gate must not require entering
+ * the project").
+ *
+ * Which of the two shapes it takes is §7.11's heuristic, `isSimpleGate`:
+ *
+ * - **simple** (≤2 choices, no free text) — approve/reject right here, through the
+ *   same `POST /runs/:id/gate` the thread's `SteeringGate` uses. Answering NEVER
+ *   navigates: the card reflects the run advancing in place, because the daemon's
+ *   `resumed` / `runCancelled` frame lands on the shared socket the board already
+ *   subscribes to (slice 6) and takes the run off `awaiting_human`;
+ * - **complex** — a deep link into the thread with `#gate`, where the full card
+ *   (steer text, coverage stats, the footnote) is. Nothing on a fixed-height board
+ *   card can answer a question that needs prose.
+ *
+ * Both states obey §3.3: in flight, the chip says what it is doing; on failure it
+ * NAMES the error with the controls still adjacent — clicking again is the retry.
+ */
+
+/** One-shot focus intent for the thread's gate card, read by `SteeringGate`. */
+export const GATE_HASH = '#gate';
+
+const S = {
+  accent: '#ffda19',
+  green:  '#3fb950',
+  red:    '#f85149',
+  muted:  'rgba(230,237,243,0.55)',
+};
+
+const BTN: React.CSSProperties = {
+  fontSize: '10px', fontFamily: 'monospace', borderRadius: '4px', padding: '2px 6px',
+  border: '1px solid transparent', cursor: 'pointer', flexShrink: 0,
+};
+
+const CSS = {
+  wrap: { display: 'flex', alignItems: 'center', gap: '4px', flexShrink: 0, flexWrap: 'nowrap' },
+  label: { fontSize: '10px', fontFamily: 'monospace', color: S.accent, fontWeight: 700 },
+  approve: { ...BTN, background: 'rgba(63,185,80,0.15)', borderColor: 'rgba(63,185,80,0.35)', color: S.green },
+  reject:  { ...BTN, background: 'rgba(248,81,73,0.12)', borderColor: 'rgba(248,81,73,0.3)', color: S.red },
+  open: {
+    ...BTN, textDecoration: 'none', background: 'rgba(255,218,25,0.12)',
+    borderColor: 'rgba(255,218,25,0.35)', color: S.accent,
+  },
+  error: {
+    fontSize: '10px', fontFamily: 'monospace', color: S.red, maxWidth: '92px', flexShrink: 1,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+interface Props {
+  runId: string;
+  projectId: string;
+  /** The cached gate, or `undefined` when the daemon restarted (§3.3 known limit). */
+  gate: OpenGate | undefined;
+  navigate: Navigate;
+}
+
+export function GateChip({ runId, projectId, gate, navigate }: Props): React.ReactElement {
+  const clearGate = useGateStore((s) => s.clearGate);
+  const [busy, setBusy] = useState(false);
+  const [answered, setAnswered] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isSimpleGate(gate)) {
+    // The gate MESSAGE is the destination, not just the run — the hash is what tells
+    // the thread's gate card to scroll itself in and take focus.
+    const path = `${modePath(projectId, 'build', runId)}${GATE_HASH}`;
+    return (
+      <span style={CSS.wrap}>
+        <span style={CSS.label}>gate</span>
+        <a
+          href={path}
+          onClick={(e) => { e.preventDefault(); navigate(path); }}
+          data-testid={`gate-open-${runId}`}
+          title={gate?.prompt ?? 'Open this gate in the thread'}
+          style={CSS.open}
+        >
+          Answer ›
+        </a>
+      </span>
+    );
+  }
+
+  async function answer(approve: boolean): Promise<void> {
+    // The one double-submit guard: a second click while the first POST is open, or
+    // after it landed, is dropped rather than sent (a re-sent gate decision is a 409
+    // at best and a second, unintended decision at worst).
+    if (busy || answered !== null) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await api.confirmGate(runId, { approve });
+      setAnswered(approve ? 'approved' : 'rejected');
+      // Prune the local gate immediately; the run's own status follows from the
+      // daemon's frame, which is what actually moves the card (§1.4 live).
+      clearGate(runId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (answered !== null) {
+    return (
+      <span style={CSS.wrap} data-testid={`gate-answered-${runId}`}>
+        <span style={{ ...CSS.label, color: S.muted, fontWeight: 400 }}>{answered} · advancing…</span>
+      </span>
+    );
+  }
+
+  return (
+    <span style={CSS.wrap} data-testid={`gate-chip-${runId}`}>
+      <span style={CSS.label}>{busy ? 'answering…' : 'gate'}</span>
+      {error !== null && (
+        <span data-testid={`gate-error-${runId}`} title={`Could not answer the gate: ${error} — try again`} style={CSS.error}>
+          {error}
+        </span>
+      )}
+      <button
+        type="button"
+        data-testid={`gate-approve-${runId}`}
+        onClick={() => void answer(true)}
+        disabled={busy}
+        title={error !== null ? 'Retry approve' : gate?.prompt ?? 'Approve this gate'}
+        style={{ ...CSS.approve, opacity: busy ? 0.5 : 1 }}
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        data-testid={`gate-reject-${runId}`}
+        onClick={() => void answer(false)}
+        disabled={busy}
+        title={error !== null ? 'Retry reject' : 'Reject this gate'}
+        style={{ ...CSS.reject, opacity: busy ? 0.5 : 1 }}
+      >
+        Reject
+      </button>
+    </span>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -4,6 +4,7 @@ import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
+import { GateChip } from './GateChip.js';
 import { STATUS_STYLE } from './RunCard.js';
 
 /**
@@ -251,27 +252,33 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
               const phase = units[session.unit_ix]?.stage ?? units[units.length - 1]?.stage ?? 'planning';
               const waiting = session.status === 'awaiting_human';
               return (
-                <a
-                  key={session.id}
-                  {...link(modePath(project.id, 'build', session.id))}
-                  data-testid="run-chip"
-                  data-run-id={session.id}
-                  data-status={session.status}
-                  style={{
-                    ...CSS.chip,
-                    border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
-                    background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
-                  }}
-                >
-                  <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
-                  {waiting && <span style={{ color: S.accent, fontWeight: 700 }}>gate</span>}
-                  {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
-                      has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
-                      honest clock on this surface. */}
-                  <span style={{ marginLeft: 'auto' }}>
-                    {waiting ? (gate ? `waiting ${ago(gate.receivedAt)}` : 'needs you') : style?.label ?? session.status}
-                  </span>
-                </a>
+                // A waiting gate is ANSWERABLE, not a badge (§1.4) — so the row is a row:
+                // the run link, and beside it a chip carrying its own controls. Nesting
+                // buttons inside the link would be neither valid nor operable.
+                <div key={session.id} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  <a
+                    {...link(modePath(project.id, 'build', session.id))}
+                    data-testid="run-chip"
+                    data-run-id={session.id}
+                    data-status={session.status}
+                    style={{
+                      ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden',
+                      border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
+                      background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
+                    }}
+                  >
+                    <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
+                    {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
+                        has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
+                        honest clock on this surface. */}
+                    <span style={{ marginLeft: 'auto', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {waiting ? (gate ? `waiting ${ago(gate.receivedAt)}` : 'needs you') : style?.label ?? session.status}
+                    </span>
+                  </a>
+                  {waiting && (
+                    <GateChip runId={session.id} projectId={project.id} gate={gate} navigate={navigate} />
+                  )}
+                </div>
               );
             })}
             {runs.length > MAX_CHIPS && (

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api, type GateDecision } from '../api/client.js';
 import type { CoverageReport } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
+import { GATE_HASH } from './GateChip.js';
 
 interface Props {
   runId: string;
@@ -37,6 +38,20 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [coverage, setCoverage] = useState<CoverageReport | null>(null);
+  const message = useRef<HTMLParagraphElement>(null);
+
+  // Arrived from a board gate chip (§1.4 complex gate): put the MESSAGE in view and
+  // give it focus, so a keyboard lands on the question rather than wherever the
+  // thread happened to leave it. One-shot — the hash is consumed on arrival, or the
+  // next render (this thread re-renders on every frame) would yank focus back.
+  useEffect(() => {
+    if (window.location.hash !== GATE_HASH) return;
+    const el = message.current;
+    if (el === null) return;
+    el.scrollIntoView({ block: 'center' });
+    el.focus({ preventScroll: true });
+    window.history.replaceState(null, '', window.location.pathname);
+  }, [runId]);
 
   useEffect(() => {
     if (!repoRef) return;
@@ -116,8 +131,11 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
 
       {/* Headline prompt — the actionable part only */}
       <p
+        ref={message}
+        // Focusable only programmatically: the deep-link target, never a tab stop.
+        tabIndex={-1}
         className="text-xs mb-1 leading-relaxed font-mono"
-        style={{ color: 'rgba(230,237,243,0.85)' }}
+        style={{ color: 'rgba(230,237,243,0.85)', outline: 'none' }}
         data-testid="steering-prompt"
       >
         {headline}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -145,7 +145,10 @@ export function useRoute(): Route & {
   const navigate = useCallback<Navigate>((path, opts) => {
     if (opts?.replace) history.replaceState(null, '', path);
     else history.pushState(null, '', path);
-    setPathname(path);
+    // A path may carry a hash (the board's gate deep-link ends `#gate`, §6.2 slice 7)
+    // or a query. The parse below is pathname-only, so keep the route state that way —
+    // otherwise `#gate` would ride along as part of the artifact id.
+    setPathname(new URL(path, window.location.origin).pathname);
   }, []);
 
   const panelPath = useCallback((p: Panel) => (p === 'home' ? '/' : `/${p}`), []);

--- a/src/hooks/useRuns.ts
+++ b/src/hooks/useRuns.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { useConnectionStore } from '../store/connection.js';
-import { useGateStore } from '../store/gates.js';
+import { choicesOf, useGateStore } from '../store/gates.js';
 import { useElicitationStore } from '../store/elicitations.js';
 
 /**
@@ -73,12 +73,16 @@ export function useRuns(): { runs: SessionView[]; refresh: () => void } {
         try {
           const g = await api.getGate(id);
           if (cancelled) return;
+          // The daemon-cached gate carries whatever the payload named; `GateInfo` is a
+          // closed interface, so the additive answer shape (§7.11) is read off the bag.
+          const choices = choicesOf(g as unknown as Record<string, unknown>);
           setGate({
             runId: g.runId,
             ord: g.ord,
             prompt: g.prompt,
             lifecycle: g.lifecycle,
             receivedAt: Date.parse(g.receivedAt) || Date.now(),
+            ...(choices !== undefined ? { choices } : {}),
           });
         } catch {
           /* no cached prompt — id-only gate still works */

--- a/src/store/gates.ts
+++ b/src/store/gates.ts
@@ -15,6 +15,48 @@ export interface OpenGate {
   /** From the daemon cache on late join; live events default to `open`. */
   lifecycle: string;
   receivedAt: number;
+  /**
+   * The answers the gate's payload ENUMERATES, when it names any.
+   *
+   * `undefined` = the payload names none, i.e. the plain workflow gate, whose
+   * answers are the two the daemon's `POST /runs/:id/gate` always accepts;
+   * `null` = the payload demands free text (the `options: string[] | null`
+   * vocabulary `ElicitationInfo` already uses on this wire).
+   */
+  choices?: string[] | null;
+}
+
+/**
+ * The answer shape a gate payload names, read defensively off an untyped bag.
+ *
+ * Crew's gate payload is prompt-only today, so this reads `undefined` for every
+ * gate the daemon currently sends — deliberately. The prompt TEXT is never
+ * parsed: a heuristic over prose would sooner or later call a real workflow gate
+ * complex because its explanation happened to list three things, and §7.11's
+ * escape hatch is an additive payload field, not a better regex.
+ */
+export function choicesOf(bag: Record<string, unknown>): string[] | null | undefined {
+  for (const key of ['choices', 'options']) {
+    const value = bag[key];
+    if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
+    if (value === null) return null;
+  }
+  return bag.freeText === true ? null : undefined;
+}
+
+/**
+ * §7.11's simple-vs-complex heuristic — client-side, testable, spelled once: a
+ * gate is SIMPLE iff its payload offers ≤2 choices and requires no free text.
+ * Everything else is complex and belongs in the thread, where the full gate card
+ * (steer text, coverage stats, the why-this-fired footnote) already lives.
+ *
+ * No cached gate (`undefined`, the daemon-restarted case of §3.3) is simple: the
+ * prompt is what was lost, not the two answers the endpoint still accepts.
+ */
+export function isSimpleGate(gate: OpenGate | undefined): boolean {
+  if (gate === undefined) return true;
+  if (gate.choices === null) return false;
+  return (gate.choices ?? ['approve', 'reject']).length <= 2;
 }
 
 interface GateStore {
@@ -50,6 +92,7 @@ export const useGateStore = create<GateStore>((set) => ({
       switch (event.type) {
         case 'awaitingHuman': {
           if (typeof event.ord === 'number' && typeof event.prompt === 'string') {
+            const choices = choicesOf(event as unknown as Record<string, unknown>);
             return {
               gates: {
                 ...s.gates,
@@ -59,6 +102,8 @@ export const useGateStore = create<GateStore>((set) => ({
                   prompt: event.prompt,
                   lifecycle: 'open',
                   receivedAt: Date.now(),
+                  // Omitted rather than set to `undefined`: `exactOptionalPropertyTypes`.
+                  ...(choices !== undefined ? { choices } : {}),
                 },
               },
             };

--- a/tests/GateChip.test.tsx
+++ b/tests/GateChip.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProjectCard } from '../src/components/ProjectCard.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { Project, SessionStatus } from '../src/api/types.js';
+import * as client from '../src/api/client.js';
+import { useGateStore, type OpenGate } from '../src/store/gates.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * Answerable gate chips on the board (DES-MERGE-001 §6.2 slice 7). These pin the
+ * ACs that need no browser: a simple gate answered inline WITHOUT navigating, the
+ * in-flight/error contract of §3.3, the double-submit guard, and a complex gate
+ * (§7.11) deep-linking to the thread's gate message instead of pretending a
+ * fixed-height card can hold it.
+ */
+
+const RUN = 'run-7';
+const PROJECT = 'proj-7';
+
+const project: Project = {
+  id: PROJECT, name: 'the merge', description: null, status: 'active',
+  scope: `project:${PROJECT}`, created_at: 1, updated_at: 1,
+};
+
+function item(status: SessionStatus = 'awaiting_human'): BoardProject {
+  return {
+    project,
+    repo: null,
+    runs: [makeView({ id: RUN, status, unit_ix: 0 }, [makeUnit({ id: `${RUN}:u0`, session_id: RUN, ord: 0, stage: 'build' })])],
+    docs: [],
+    attention: status === 'awaiting_human' ? 'gate' : 'running',
+  };
+}
+
+function openGate(over: Partial<OpenGate> = {}): void {
+  useGateStore.setState({
+    gates: { [RUN]: { runId: RUN, ord: 0, prompt: 'Approve the acceptance criteria?', lifecycle: 'open', receivedAt: Date.now(), ...over } },
+  });
+}
+
+const card = (navigate = vi.fn(), status: SessionStatus = 'awaiting_human'): typeof navigate => {
+  render(<ProjectCard item={item(status)} navigate={navigate} />);
+  return navigate;
+};
+
+describe('board gate chips (§1.4 — answerable, not a badge)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('a waiting simple gate renders approve/reject ON the card', () => {
+    openGate();
+    card();
+    expect(screen.getByTestId(`gate-approve-${RUN}`)).toBeEnabled();
+    expect(screen.getByTestId(`gate-reject-${RUN}`)).toBeEnabled();
+  });
+
+  it('a run that is not waiting has no chip at all', () => {
+    card(vi.fn(), 'executing');
+    expect(screen.queryByTestId(`gate-approve-${RUN}`)).toBeNull();
+  });
+
+  it('approve posts the decision and does NOT navigate', async () => {
+    const user = userEvent.setup();
+    openGate();
+    const navigate = card();
+    await user.click(screen.getByTestId(`gate-approve-${RUN}`));
+    expect(client.api.confirmGate).toHaveBeenCalledWith(RUN, { approve: true });
+    expect(navigate).not.toHaveBeenCalled();
+    // The gate is pruned locally; the card then follows the run's status (slice 6).
+    expect(useGateStore.getState().gates[RUN]).toBeUndefined();
+    expect(screen.getByTestId(`gate-answered-${RUN}`)).toHaveTextContent('approved');
+  });
+
+  it('reject posts {approve:false}', async () => {
+    const user = userEvent.setup();
+    openGate();
+    card();
+    await user.click(screen.getByTestId(`gate-reject-${RUN}`));
+    expect(client.api.confirmGate).toHaveBeenCalledWith(RUN, { approve: false });
+  });
+
+  it('the card reflects the run advancing in place — the chip goes with the status', async () => {
+    const user = userEvent.setup();
+    openGate();
+    const { rerender } = render(<ProjectCard item={item()} navigate={vi.fn()} />);
+    await user.click(screen.getByTestId(`gate-approve-${RUN}`));
+    // What a `resumed` frame does: the run list reconciles off `awaiting_human`.
+    rerender(<ProjectCard item={item('executing')} navigate={vi.fn()} />);
+    expect(screen.queryByTestId(`gate-approve-${RUN}`)).toBeNull();
+    expect(screen.getByTestId('run-chip')).toHaveAttribute('data-status', 'executing');
+  });
+
+  it('disables the chip in flight and never double-submits', async () => {
+    const user = userEvent.setup();
+    let release = (): void => {};
+    vi.spyOn(client.api, 'confirmGate').mockReturnValue(
+      new Promise((resolve) => { release = () => resolve({ status: 'ok' }); }),
+    );
+    openGate();
+    card();
+    const approve = screen.getByTestId(`gate-approve-${RUN}`);
+    await user.click(approve);
+    expect(approve).toBeDisabled();
+    expect(screen.getByTestId(`gate-reject-${RUN}`)).toBeDisabled();
+    // A click on a disabled button is dropped by the DOM; the guard covers the
+    // programmatic path too (a queued event landing after the first POST opened).
+    approve.click();
+    await act(async () => { release(); });
+    expect(screen.getByTestId(`gate-answered-${RUN}`)).toBeInTheDocument();
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(1);
+  });
+
+  it('names the failure on the chip and re-enables it — clicking again is the retry (§3.3)', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(client.api, 'confirmGate')
+      .mockRejectedValueOnce(new Error('409 gate already decided'))
+      .mockResolvedValueOnce({ status: 'ok' });
+    openGate();
+    card();
+    await user.click(screen.getByTestId(`gate-approve-${RUN}`));
+    const error = await screen.findByTestId(`gate-error-${RUN}`);
+    expect(error).toHaveTextContent('409 gate already decided');
+    expect(screen.getByTestId(`gate-approve-${RUN}`)).toBeEnabled();
+    await user.click(screen.getByTestId(`gate-approve-${RUN}`));
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId(`gate-answered-${RUN}`)).toBeInTheDocument();
+  });
+
+  it('a complex gate deep-links to the thread instead of answering inline (§7.11)', async () => {
+    const user = userEvent.setup();
+    openGate({ choices: ['ship it', 'rework the plan', 'split the slice'] });
+    const navigate = card();
+    expect(screen.queryByTestId(`gate-approve-${RUN}`)).toBeNull();
+    const open = screen.getByTestId(`gate-open-${RUN}`);
+    expect(open).toHaveAttribute('href', `/p/${PROJECT}/build/${RUN}#gate`);
+    await user.click(open);
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/build/${RUN}#gate`);
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+
+  it('a gate that demands free text is complex too', () => {
+    openGate({ choices: null });
+    card();
+    expect(screen.queryByTestId(`gate-approve-${RUN}`)).toBeNull();
+    expect(screen.getByTestId(`gate-open-${RUN}`)).toBeInTheDocument();
+  });
+
+  it('a gate whose prompt the daemon lost is still answerable inline (§3.3 known limit)', () => {
+    useGateStore.setState({ gates: {} });
+    card();
+    expect(screen.getByTestId(`gate-approve-${RUN}`)).toBeEnabled();
+  });
+});

--- a/tests/SteeringGate.test.tsx
+++ b/tests/SteeringGate.test.tsx
@@ -83,6 +83,29 @@ describe('SteeringGate (§11.1 — the three/four distinct actions)', () => {
     expect(useGateStore.getState().gates['run-42']).toBeUndefined();
   });
 
+  // Arriving from a board gate chip (slice 7): the `#gate` hash is the focus intent.
+  describe('deep-linked from the board (§6.2 slice 7)', () => {
+    beforeEach(() => window.history.replaceState(null, '', '/p/proj-1/build/run-42'));
+
+    it('scrolls the gate message into view, focuses it, and consumes the hash', () => {
+      window.history.replaceState(null, '', '/p/proj-1/build/run-42#gate');
+      const scrollIntoView = vi.fn();
+      vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+      render(<SteeringGate runId="run-42" ord={3} prompt="Approve the acceptance criteria?" />);
+      expect(document.activeElement).toBe(screen.getByTestId('steering-prompt'));
+      expect(scrollIntoView).toHaveBeenCalled();
+      // One-shot: the path survives, the intent does not — the thread re-renders on
+      // every frame and must not keep yanking focus back.
+      expect(window.location.hash).toBe('');
+      expect(window.location.pathname).toBe('/p/proj-1/build/run-42');
+    });
+
+    it('leaves focus alone without the hash', () => {
+      render(<SteeringGate runId="run-42" ord={3} prompt="?" />);
+      expect(document.activeElement).toBe(document.body);
+    });
+  });
+
   it('works id-only when the prompt is unavailable (daemon restart, §3.3)', async () => {
     const user = userEvent.setup();
     render(<SteeringGate runId="run-42" />);

--- a/tests/gates.store.test.ts
+++ b/tests/gates.store.test.ts
@@ -1,6 +1,36 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useGateStore } from '../src/store/gates.js';
+import { choicesOf, isSimpleGate, useGateStore, type OpenGate } from '../src/store/gates.js';
 import type { CoreEvent } from '../src/api/types.js';
+
+const gate = (over: Partial<OpenGate> = {}): OpenGate =>
+  ({ runId: 'run-1', ord: 0, prompt: '?', lifecycle: 'open', receivedAt: 0, ...over });
+
+describe('simple vs. complex gates (§7.11 — ≤2 choices and no free text)', () => {
+  it('the plain workflow gate is simple — its two answers are approve and reject', () => {
+    expect(isSimpleGate(gate())).toBe(true);
+  });
+
+  it('an uncached gate is simple: the prompt was lost, not the two answers', () => {
+    expect(isSimpleGate(undefined)).toBe(true);
+  });
+
+  it.each([
+    ['two named choices', ['approve', 'send back'], true],
+    ['three named choices', ['ship', 'rework', 'split'], false],
+    ['free text (null options)', null, false],
+  ])('%s → simple=%s', (_label, choices, simple) => {
+    expect(isSimpleGate(gate({ choices: choices as string[] | null }))).toBe(simple);
+  });
+
+  it('reads either spelling off the payload, and nothing off the prompt text', () => {
+    expect(choicesOf({ choices: ['a', 'b'] })).toEqual(['a', 'b']);
+    expect(choicesOf({ options: ['a', 'b', 'c'] })).toEqual(['a', 'b', 'c']);
+    expect(choicesOf({ options: null })).toBeNull();
+    expect(choicesOf({ freeText: true })).toBeNull();
+    // A prompt that merely LISTS things is not a payload that offers choices.
+    expect(choicesOf({ prompt: 'Pick one: a, b or c' })).toBeUndefined();
+  });
+});
 
 const reset = (): void => useGateStore.setState({ gates: {} });
 
@@ -37,6 +67,19 @@ describe('gate cache (§3.3 — event-sourced, self-healing, keyed by run id)', 
   it('ignores frames with no run scope (e.g. heartbeat)', () => {
     useGateStore.getState().ingest({ type: 'heartbeat' } as CoreEvent);
     expect(Object.keys(useGateStore.getState().gates)).toHaveLength(0);
+  });
+
+  it('captures the answer shape a payload names (§7.11)', () => {
+    useGateStore.getState().ingest({
+      type: 'awaitingHuman', session: 'run-1', ord: 0, prompt: 'Which plan?',
+      choices: ['ship', 'rework', 'split'],
+    } as CoreEvent);
+    expect(useGateStore.getState().gates['run-1']?.choices).toEqual(['ship', 'rework', 'split']);
+  });
+
+  it('leaves `choices` absent for the plain workflow gate the daemon sends today', () => {
+    useGateStore.getState().ingest({ type: 'awaitingHuman', session: 'run-1', ord: 0, prompt: 'Proceed?' } as CoreEvent);
+    expect(useGateStore.getState().gates['run-1']).not.toHaveProperty('choices');
   });
 
   it('reconcile keeps only still-awaiting runs (self-healing)', () => {


### PR DESCRIPTION
Slice 7 — Phase B closes, authored by governed run `593d4044` (clarify/design/build: claude · adversarial-review/test/review: codex).

A waiting gate renders as an answerable chip on the card, not a badge. Simple gates (§7.11: ≤2 choices, no free text) approve/reject inline via the existing gate client — no navigation, chip disabled while the POST is in flight, errors named on the chip, the card advances in place through the live store. Complex gates deep-link to `/p/<id>/build/<runId>` with the gate message scrolled into view and focused.

425/425 unit tests locally (50 files); Playwright ACs assert same-page advance and complex-gate deep-link.

Design: `.product/DES-MERGE-001.md` §1.4, §6.2 slice 7, §7.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)