### PR TITLE
feat(document): the document canvas iframe (DES-MERGE-001 slice 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+# The same-origin build the slice-8 canvas gate serves (e2e/studio_standalone_test.py §10).
+dist-sameorigin/
 coverage/
 .astro/
 playwright-report/

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -41,6 +41,11 @@ What "independent" means here, and what this script proves end-to-end:
      (§7.11) is approved inline and the run advances on the same page with no
      navigation, while a COMPLEX one deep-links to the thread with the gate message
      scrolled into view and focused
+ 11. (DES-MERGE-001 slice 8) Document mode renders the canvas: a seeded doc frames
+     with a non-empty contentDocument, the frame carries the §5.5 sandbox, its
+     request shares the PAGE's origin, the picker orders most-recent-first and
+     navigates, and a bridge_unavailable 503 shows its hint verbatim. This one
+     section runs against a SECOND, same-origin build (see §12 in the body).
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -53,12 +58,14 @@ studio itself unless SKIP_STUDIO_BUILD=1 (in which case dist/ must already be
 baked for CREW_PORT).
 
 Env knobs: CREW_CLI, CREW_PORT (default 7901), STUDIO_PORT (default 4310),
-SKIP_STUDIO_BUILD.
+DOC_PORT (default 4320, the same-origin rig for §10), SKIP_STUDIO_BUILD.
 
 Prints a JSON report to stdout (exit 0/1); screenshots land in e2e/shots/.
 Operator-run smoke — though it spends no tokens (stub engine, no real CLI seats).
 """
 
+import base64
+import hashlib
 import json
 import os
 import re
@@ -78,6 +85,7 @@ REPO = Path(__file__).resolve().parent.parent
 SHOTS = REPO / "e2e" / "shots"
 CREW_PORT = int(os.environ.get("CREW_PORT", "7901"))
 STUDIO_PORT = int(os.environ.get("STUDIO_PORT", "4310"))
+DOC_PORT = int(os.environ.get("DOC_PORT", "4320"))
 CREW_CLI = Path(
     os.environ.get(
         "CREW_CLI",
@@ -86,6 +94,7 @@ CREW_CLI = Path(
 )
 CREW_ORIGIN = f"http://127.0.0.1:{CREW_PORT}"
 STUDIO_ORIGIN = f"http://127.0.0.1:{STUDIO_PORT}"
+DOC_ORIGIN = f"http://127.0.0.1:{DOC_PORT}"
 API = f"{CREW_ORIGIN}/api/v1"
 NPM = "npm.cmd" if os.name == "nt" else "npm"
 
@@ -304,8 +313,9 @@ try:
         page = browser.new_page()
 
         # Land on a mode whose surface makes no API calls, so this section asserts the
-        # SHELL rather than whatever a live surface happens to be doing.
-        page.goto(f"{STUDIO_ORIGIN}/p/{project_id}/document", wait_until="networkidle")
+        # SHELL rather than whatever a live surface happens to be doing. Document became
+        # a live surface in slice 8 (§10 below owns it), so Video is that mode now.
+        page.goto(f"{STUDIO_ORIGIN}/p/{project_id}/video", wait_until="networkidle")
         switcher = page.locator('[data-testid="mode-switcher"]')
         switcher.wait_for(timeout=30000)
         tabs = switcher.locator('[role="tab"]')
@@ -321,14 +331,14 @@ try:
         )
         # The deep-linked unavailable mode still states what it is and how to enable it
         # (§3.3: no bare spinner, every state names a subject).
-        placeholder_ok = page.locator('[data-testid="mode-enabling-action-document"]').is_visible()
+        placeholder_ok = page.locator('[data-testid="mode-enabling-action-video"]').is_visible()
         page.screenshot(path=str(SHOTS / "slice4-mode-switcher.png"), full_page=True)
 
         # AC: clicking Build changes the URL, and the back button returns.
         page.locator('[data-testid="mode-tab-build"]').click()
         build_url_ok = wait_for_path(page, f"/p/{project_id}/build")
         page.go_back()
-        back_ok = wait_for_path(page, f"/p/{project_id}/document")
+        back_ok = wait_for_path(page, f"/p/{project_id}/video")
 
         # AC: a legacy bookmark lands on the new shape with the run open.
         page.goto(f"{STUDIO_ORIGIN}/runs/{run_id}", wait_until="networkidle")
@@ -821,6 +831,246 @@ try:
     }
     if not report["steps"]["gate_chips"]["ok"]:
         fail("gate_chips_verdict", "slice-7 gate-chip assertions did not all hold — see gate_chips")
+
+    # ── 12. Slice 8 (DES-MERGE-001 §6.3): the Document-mode canvas ────────────
+    # This slice's AC is an ORIGIN claim — "the frame's request URL shares the page's
+    # origin" — and the cross-origin rig above cannot express it: that dist has
+    # VITE_API_HOST baked, so `apiBase()` points at the daemon (:7901) while the page is
+    # served from :4310. So this section stands up the PRODUCTION posture §5.3 describes:
+    # a second build with NO VITE_API_HOST (so `apiBase()` derives from window.location)
+    # served from ONE origin that also answers the project-scoped interactive paths with a
+    # FAKE BRIDGE — fixture docs, fixture manifests, a fixture rendered document, and a
+    # `bridge_unavailable` project — and forwards every other /api/v1 call to the REAL
+    # daemon. Nothing about the merged crew proxy is stubbed away except the bridge itself.
+    same_origin_dist = REPO / "dist-sameorigin"
+    if os.environ.get("SKIP_STUDIO_BUILD") == "1":
+        if not (same_origin_dist / "index.html").is_file():
+            fail("doc_canvas_build",
+                 f"SKIP_STUDIO_BUILD=1 but {same_origin_dist}/index.html is missing — "
+                 "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
+    else:
+        env = dict(os.environ, VITE_API_HOST="")  # empty ⇒ the resolver falls back to window.location
+        r = subprocess.run(
+            [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
+            cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
+        )
+        if r.returncode != 0:
+            fail("doc_canvas_build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+
+    doc_project = new_project(f"doc-canvas-{tag}")
+    down_project = new_project(f"doc-bridge-down-{tag}")
+
+    # Deliberately NOT in recency order — the picker must sort, not echo (§6.3).
+    FIXTURE_DOCS = [
+        {"name": "stale-brief", "kind": "doc", "head": 1, "versions": 1, "updated_at": "2026-08-10T08:00:00Z"},
+        {"name": "launch-deck", "kind": "doc", "head": 2, "versions": 2, "updated_at": "2026-08-18T11:30:00Z"},
+        {"name": "q3-report", "kind": "doc", "head": 1, "versions": 1, "updated_at": "2026-08-17T16:00:00Z"},
+    ]
+    BRIDGE_DOWN_HINT = ("run `npx wicked-interactive serve` in this project's root — "
+                        "the bridge could not be started")
+    # `data-wid` anchors are what core/instrument.js injects (§5.5) — the fixture carries
+    # them so slice 11+12 inherits a document shaped like the real thing.
+    DOC_HTML = (
+        "<!doctype html><html><head><meta charset='utf-8'><title>__DOC__ v__V__</title></head>"
+        "<body style='font-family:system-ui;padding:24px;background:#fff;color:#111'>"
+        "<h1 data-wid='h1'>__DOC__ — version __V__</h1>"
+        "<p data-wid='p1'>Seeded fixture document, served by the fake interactive bridge.</p>"
+        "<script>document.body.setAttribute('data-scripts-ran','1');</script>"
+        "</body></html>"
+    )
+    INTERACTIVE_RE = re.compile(r"^/api/v1/projects/([^/]+)/interactive(/.*)$")
+    VERSIONS_RE = re.compile(r"^/d/([^/]+)/api/versions$")
+    RENDER_RE = re.compile(r"^/d/([^/]+)/doc/(\d+)$")
+    WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+    class DocFixtureHandler(SimpleHTTPRequestHandler):
+        """SPA + fake bridge + daemon passthrough, all on ONE origin."""
+
+        def log_message(self, *_args):  # keep stdout JSON-clean
+            pass
+
+        def _send(self, status: int, body: bytes, ctype: str) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _json(self, status: int, payload) -> None:
+            self._send(status, json.dumps(payload).encode(), "application/json")
+
+        def _ws_idle(self) -> None:
+            """Accept the SPA's /ws upgrade and hold it open. This section asserts that
+            the canvas produces NO console errors, and a refused handshake is one."""
+            key = self.headers.get("Sec-WebSocket-Key", "")
+            accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+            self.wfile.write(
+                ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+                 f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
+            self.wfile.flush()
+            try:
+                while self.rfile.read(1):
+                    pass
+            except OSError:
+                pass
+            self.close_connection = True
+
+        def _proxy(self) -> None:
+            """Everything the fake bridge does not own is the REAL daemon's."""
+            length = int(self.headers.get("Content-Length") or 0)
+            req = urllib.request.Request(
+                CREW_ORIGIN + self.path, data=self.rfile.read(length) if length else None,
+                method=self.command)
+            if self.headers.get("Content-Type"):
+                req.add_header("Content-Type", self.headers["Content-Type"])
+            try:
+                with urllib.request.urlopen(req, timeout=30) as res:
+                    self._send(res.status, res.read(),
+                               res.headers.get("Content-Type", "application/json"))
+            except urllib.error.HTTPError as e:
+                self._send(e.code, e.read(), e.headers.get("Content-Type", "application/json"))
+            except Exception as e:  # noqa: BLE001 — surface it as a body, not a traceback
+                self._json(502, {"error": str(e)})
+
+        def _bridge(self, project: str, rest: str) -> bool:
+            # §7.12: a project whose bridge cannot start answers 503 with a NAMED command.
+            if project == down_project:
+                self._json(503, {"code": "bridge_unavailable", "hint": BRIDGE_DOWN_HINT})
+                return True
+            if rest == "/api/docs":
+                self._json(200, FIXTURE_DOCS)
+                return True
+            m = VERSIONS_RE.match(rest)
+            if m:
+                name = urllib.parse.unquote(m.group(1))
+                head = next((d["head"] for d in FIXTURE_DOCS if d["name"] == name), None)
+                if head is None:
+                    self._json(404, {"error": f"no such doc: {name}"})
+                else:
+                    self._json(200, {"head": head, "kind": "doc", "versions": [
+                        {"version": v, "parent": v - 1 or None, "feedback_file": None,
+                         "html_file": f"v{v}.html", "created_at": "2026-08-18T11:30:00Z"}
+                        for v in range(1, head + 1)]})
+                return True
+            m = RENDER_RE.match(rest)
+            if m:
+                html = (DOC_HTML.replace("__DOC__", urllib.parse.unquote(m.group(1)))
+                                .replace("__V__", m.group(2)))
+                self._send(200, html.encode(), "text/html; charset=utf-8")
+                return True
+            return False
+
+        def do_GET(self):  # noqa: N802 (stdlib naming)
+            if self.headers.get("Upgrade", "").lower() == "websocket":
+                return self._ws_idle()
+            path = urllib.parse.urlparse(self.path).path
+            m = INTERACTIVE_RE.match(path)
+            if m and self._bridge(urllib.parse.unquote(m.group(1)), m.group(2)):
+                return None
+            if path.startswith("/api/v1/"):
+                return self._proxy()
+            if not Path(self.translate_path(self.path)).is_file():
+                self.path = "/index.html"  # client-side routes resolve to the shell
+            return super().do_GET()
+
+        def do_POST(self):  # noqa: N802
+            return self._proxy()
+
+    docd = ThreadingHTTPServer(
+        ("127.0.0.1", DOC_PORT), partial(DocFixtureHandler, directory=str(same_origin_dist)))
+    threading.Thread(target=docd.serve_forever, daemon=True).start()
+
+    doc_console: list[str] = []
+    doc_requests: list[str] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        # The fonts in index.html are a third-party CDN; a sandboxed/offline runner's
+        # failure to reach them is not this slice's surface. Everything else counts.
+        page.on("console", lambda m: doc_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text else None)
+        page.on("request", lambda r: doc_requests.append(r.url))
+
+        # ── AC: the picker (no :docId) lists docs MOST-RECENT FIRST and navigates ──
+        page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document", wait_until="networkidle")
+        rows = page.locator('[data-testid="doc-picker-row"]')
+        rows.first.wait_for(timeout=30000)
+        picker_order = [rows.nth(i).get_attribute("data-doc-id") for i in range(rows.count())]
+        page.screenshot(path=str(SHOTS / "slice8-doc-picker.png"), full_page=True)
+        rows.first.click()
+        picker_nav_ok = wait_for_path(page, f"/p/{doc_project}/document/launch-deck")
+
+        # ── AC: the seeded doc renders, with a non-empty contentDocument ───────────
+        frame = page.locator('[data-testid="doc-canvas"]')
+        frame.wait_for(timeout=30000)
+        page.frame_locator('[data-testid="doc-canvas"]').locator("[data-wid='h1']").wait_for(timeout=30000)
+        sandbox = frame.get_attribute("sandbox")
+        frame_src = frame.get_attribute("src")
+        content_text = frame.evaluate(
+            "el => (el.contentDocument && el.contentDocument.body.innerText || '').trim()")
+        scripts_ran = frame.evaluate(
+            "el => !!el.contentDocument && el.contentDocument.body.dataset.scriptsRan === '1'")
+        page.screenshot(path=str(SHOTS / "slice8-doc-canvas.png"), full_page=True)
+
+        # ── AC: the frame's REQUEST url shares the page's origin ───────────────────
+        page_origin = "{u.scheme}://{u.netloc}".format(u=urllib.parse.urlparse(page.url))
+        rendered = [u for u in doc_requests if "/interactive/d/" in u and "/doc/" in u]
+        frame_request_origins = sorted({
+            "{u.scheme}://{u.netloc}".format(u=urllib.parse.urlparse(u)) for u in rendered})
+
+        # AC: "no console errors" is a claim about the WORKING canvas — snapshot it before
+        # the deliberate 503 below, whose failed request chromium logs as a console error.
+        canvas_console = list(doc_console)
+
+        # ── AC (§7.12): a bridge that cannot start shows its hint VERBATIM ─────────
+        page.goto(f"{DOC_ORIGIN}/p/{down_project}/document/launch-deck", wait_until="networkidle")
+        hint_el = page.locator('[data-testid="doc-bridge-hint"]')
+        hint_el.wait_for(timeout=30000)
+        hint_text = hint_el.inner_text()
+        retry_visible = page.locator('[data-testid="doc-canvas-retry"]').is_visible()
+        no_frame_on_failure = page.locator('[data-testid="doc-canvas"]').count() == 0
+        page.screenshot(path=str(SHOTS / "slice8-bridge-unavailable.png"), full_page=True)
+        browser.close()
+
+    docd.shutdown()
+
+    report["steps"]["doc_canvas"] = {
+        "ok": all([
+            picker_order == ["launch-deck", "q3-report", "stale-brief"],
+            picker_nav_ok,
+            sandbox == "allow-scripts allow-same-origin",
+            len(content_text) > 0,
+            scripts_ran,
+            frame_src is not None and frame_src.endswith("/doc/2"),
+            frame_request_origins == [page_origin],
+            BRIDGE_DOWN_HINT in hint_text,
+            retry_visible, no_frame_on_failure,
+            not canvas_console,
+        ]),
+        "same_origin_rig": {"origin": DOC_ORIGIN, "dist": str(same_origin_dist),
+                            "vite_api_host": "", "fake_bridge": True},
+        "project_id": doc_project,
+        "picker_order_most_recent_first": picker_order,
+        "picker_navigated_to_doc": picker_nav_ok,
+        "frame_src": frame_src,
+        "frame_sandbox": sandbox,
+        "frame_content_document_text": content_text[:120],
+        "frame_scripts_executed": scripts_ran,
+        "page_origin": page_origin,
+        "frame_request_origins": frame_request_origins,
+        "frame_requests": rendered[:5],
+        "bridge_unavailable_hint_verbatim": BRIDGE_DOWN_HINT in hint_text,
+        "bridge_unavailable_hint_rendered": hint_text,
+        "bridge_unavailable_offers_retry": retry_visible,
+        "bridge_unavailable_shows_no_frame": no_frame_on_failure,
+        "console_errors_rendering_canvas": canvas_console[:10],
+        "console_errors_including_seeded_503": doc_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice8-doc-picker.png", "slice8-doc-canvas.png",
+                         "slice8-bridge-unavailable.png")],
+    }
+    if not report["steps"]["doc_canvas"]["ok"]:
+        fail("doc_canvas_verdict", "slice-8 document-canvas assertions did not all hold — see doc_canvas")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { DomainModelBrowser } from './components/DomainModelBrowser.js';
 import { GateNotifications } from './components/GateNotifications.js';
 import { HomeBoard } from './components/HomeBoard.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
+import { DocumentCanvas } from './components/DocumentCanvas.js';
 import { ModePlaceholder } from './components/ModePlaceholder.js';
 import { PolicyManager } from './components/PolicyManager.js';
 import { ProjectShell } from './components/ProjectShell.js';
@@ -244,16 +245,17 @@ export function App(): React.ReactElement {
   );
 
   /**
-   * What a mode renders inside the shell (DES-MERGE-001 §6.2, slice 4). Document and
-   * Video state what is coming and the action that enables it; Chat and Build reuse the
-   * existing surfaces above.
+   * What a mode renders inside the shell (DES-MERGE-001 §6.2, slice 4). Document is the
+   * interactive canvas (§6.3, slice 8); Video still states what is coming and the action
+   * that enables it; Chat and Build reuse the existing surfaces above.
    *
    * Build with nothing open is the existing run home, UNSCOPED: scoping a project's runs
    * is the board's data plumbing (slices 5-6) and needs launch to file the run it creates,
    * so filtering here first would hide a run the user had just launched.
    */
-  function renderModeSurface(m: Mode): React.ReactElement {
-    if (m === 'document' || m === 'video') return <ModePlaceholder mode={m} />;
+  function renderModeSurface(m: Mode, pid: string): React.ReactElement {
+    if (m === 'document') return <DocumentCanvas projectId={pid} docId={artifactId} navigate={navigate} />;
+    if (m === 'video') return <ModePlaceholder mode={m} />;
     if (m === 'chat' && !artifactId) return groupChatSurface(null);
     return artifactId ? runSurface() : dashboardSurface();
   }
@@ -265,7 +267,7 @@ export function App(): React.ReactElement {
     if (projectId !== null && mode !== null) {
       return (
         <ProjectShell projectId={projectId} mode={mode} artifactId={artifactId} navigate={navigate}>
-          {renderModeSurface(mode)}
+          {renderModeSurface(mode, projectId)}
         </ProjectShell>
       );
     }

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  BridgeUnavailableError,
+  getVersions,
+  interactiveUrl,
+  listDocs,
+} from '../api/interactive.js';
+import type { DocSummary } from '../api/interactive.js';
+import { modePath, type Navigate } from '../hooks/useRoute.js';
+
+// The Document-mode canvas (DES-MERGE-001 §1.3, §6.3 slice 8). Replaces the slice-4
+// placeholder: with a doc in the route we frame it, without one we let the user pick.
+//
+// The frame carries the RENDERED DOCUMENT, never the interactive app (§5.3) — its src
+// is built by the slice-2 client from `apiBase()`, so it resolves onto the page's own
+// origin through crew's project-scoped proxy (§7.2). That is what keeps
+// `contentDocument` reachable for the slice 11+12 overlay.
+
+const S = {
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  accent: '#ffda19',
+  label:  'rgba(230,237,243,0.3)',
+};
+
+const PANEL: React.CSSProperties = {
+  background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+  padding: '20px 22px', maxWidth: '640px',
+};
+
+/** What the client failed with, flattened to the two things the UI renders (§3.3). */
+interface Failure { message: string; hint?: string }
+
+function asFailure(e: unknown): Failure {
+  return e instanceof BridgeUnavailableError
+    ? { message: e.message, hint: e.hint }
+    : { message: e instanceof Error ? e.message : String(e) };
+}
+
+/** §3.3: a working state names its subject. Never a bare spinner, never "Loading…". */
+function Loading({ subject }: { subject: string }): React.ReactElement {
+  return (
+    <div data-testid="doc-canvas-loading" style={{ padding: '32px', color: S.muted, fontSize: '13px' }}>
+      Loading {subject}…
+    </div>
+  );
+}
+
+/**
+ * §3.3: an error with no next action is banned. A `bridge_unavailable` 503 carries a
+ * named install/fix command (§7.12) and it is shown VERBATIM — retyping it would be
+ * retyping a command the user has to run. Everything else at least offers Retry.
+ */
+function Failed({
+  subject, failure, onRetry,
+}: { subject: string; failure: Failure; onRetry: () => void }): React.ReactElement {
+  return (
+    <div data-testid="doc-canvas-error" style={{ padding: '32px' }}>
+      <div style={PANEL}>
+        <p style={{ fontSize: '13px', color: S.ink, margin: '0 0 10px' }}>Could not load {subject}.</p>
+        <p
+          data-testid={failure.hint ? 'doc-bridge-hint' : 'doc-error-detail'}
+          style={{
+            fontSize: '13px', color: failure.hint ? S.ink : S.muted, margin: '0 0 14px',
+            lineHeight: 1.5, borderLeft: `2px solid ${S.accent}`, paddingLeft: '10px',
+          }}
+        >
+          {failure.hint ? <><strong>To fix:</strong> {failure.hint}</> : failure.message}
+        </p>
+        <button
+          type="button"
+          data-testid="doc-canvas-retry"
+          onClick={onRetry}
+          style={{
+            background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
+            color: S.ink, cursor: 'pointer', fontSize: '12px', padding: '6px 12px',
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** One async load, re-runnable by Retry. Returns `[value, failure, retry]`. */
+function useLoad<T>(load: () => Promise<T>, deps: React.DependencyList): [T | null, Failure | null, () => void] {
+  const [attempt, setAttempt] = useState(0);
+  const [value, setValue] = useState<T | null>(null);
+  const [failure, setFailure] = useState<Failure | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setValue(null);
+    setFailure(null);
+    load().then(
+      (v) => { if (!cancelled) setValue(v); },
+      (e: unknown) => { if (!cancelled) setFailure(asFailure(e)); },
+    );
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `load` is re-created per render; the caller declares the real deps
+  }, [...deps, attempt]);
+  return [value, failure, useCallback(() => setAttempt((n) => n + 1), [])];
+}
+
+// ── Doc picker — the mode with no `:docId` in the route ──────────────────────
+
+/** Most-recent first (§6.3). The bridge already sorts; a null `updated_at` sinks. */
+function byRecency(a: DocSummary, b: DocSummary): number {
+  return (b.updated_at ?? '').localeCompare(a.updated_at ?? '');
+}
+
+function DocPicker({ projectId, navigate }: { projectId: string; navigate: Navigate }): React.ReactElement {
+  const [docs, failure, retry] = useLoad(() => listDocs(projectId), [projectId]);
+
+  if (failure) return <Failed subject="this project's documents" failure={failure} onRetry={retry} />;
+  if (docs === null) return <Loading subject="this project's documents" />;
+
+  // §1.4's rule, applied to a surface: an empty region renders an invitation, never a
+  // blank. Creation itself is slice 10, so the invitation points at the thread.
+  if (docs.length === 0) {
+    return (
+      <div data-testid="doc-picker-empty" style={{ padding: '32px' }}>
+        <div style={PANEL}>
+          <h2 style={{ fontSize: '15px', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
+            No documents in this project yet
+          </h2>
+          <p style={{ fontSize: '13px', color: S.muted, margin: 0, lineHeight: 1.5 }}>
+            Ask for one in the thread — “make me a deck for the Q3 review”, “write this up as a
+            report” — and it appears here, with its versions, as soon as it exists.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '32px', overflowY: 'auto' }}>
+      <p style={{
+        fontSize: '11px', fontWeight: 600, color: S.label, margin: '0 0 10px',
+        textTransform: 'uppercase', letterSpacing: '0.06em',
+      }}>
+        Documents
+      </p>
+      <div data-testid="doc-picker" style={{ ...PANEL, padding: 0, overflow: 'hidden' }}>
+        {[...docs].sort(byRecency).map((doc, i, sorted) => (
+          <button
+            key={doc.name}
+            type="button"
+            data-testid="doc-picker-row"
+            data-doc-id={doc.name}
+            onClick={() => navigate(modePath(projectId, 'document', doc.name))}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '12px', width: '100%', textAlign: 'left',
+              background: 'transparent', border: 'none',
+              borderBottom: i < sorted.length - 1 ? `1px solid ${S.border}` : 'none',
+              color: S.ink, cursor: 'pointer', fontSize: '13px', padding: '12px 16px',
+            }}
+          >
+            <span style={{ flex: 1, fontWeight: 500 }}>{doc.name}</span>
+            <span style={{ color: S.muted, flexShrink: 0, fontSize: '12px' }}>
+              {doc.kind} · v{doc.head}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Doc frame — the canvas itself ───────────────────────────────────────────
+
+function DocFrame({ projectId, docId }: { projectId: string; docId: string }): React.ReactElement {
+  const [manifest, failure, retry] = useLoad(
+    () => getVersions(projectId, docId), [projectId, docId],
+  );
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => { setLoaded(false); }, [projectId, docId]);
+
+  const subject = `“${docId}”`;
+  if (failure) return <Failed subject={subject} failure={failure} onRetry={retry} />;
+  if (manifest === null) return <Loading subject={subject} />;
+
+  // Version-addressed: slice 9's VersionStrip swaps this number, nothing else.
+  const src = interactiveUrl(
+    projectId,
+    `/d/${encodeURIComponent(docId)}/doc/${manifest.head}`,
+  );
+
+  return (
+    <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+      <iframe
+        data-testid="doc-canvas"
+        data-doc-id={docId}
+        data-version={manifest.head}
+        src={src}
+        title={`Document ${docId}, version ${manifest.head}`}
+        onLoad={() => setLoaded(true)}
+        // §5.5 status quo: `allow-scripts` because documents ARE interactive HTML, and
+        // `allow-same-origin` only until the slice 11+12 instrument bridge replaces the
+        // overlay's contentDocument reads with postMessage — then this drops to
+        // `allow-scripts` alone. Tracked there, not "someday".
+        sandbox="allow-scripts allow-same-origin"
+        style={{ border: 'none', display: 'block', height: '100%', width: '100%' }}
+      />
+      {/* The frame is in the DOM while it loads, so the named status sits over it. */}
+      {loaded ? null : (
+        <div style={{ background: '#0d1117', inset: 0, position: 'absolute' }}>
+          <Loading subject={subject} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface DocumentCanvasProps {
+  projectId: string;
+  /** `null` on `/p/:projectId/document` — no doc chosen yet, so the picker shows. */
+  docId: string | null;
+  navigate: Navigate;
+}
+
+export function DocumentCanvas({ projectId, docId, navigate }: DocumentCanvasProps): React.ReactElement {
+  return (
+    <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
+      {docId === null
+        ? <DocPicker projectId={projectId} navigate={navigate} />
+        : <DocFrame key={`${projectId}/${docId}`} projectId={projectId} docId={docId} />}
+    </div>
+  );
+}

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -14,8 +14,8 @@ export interface ModeSpec {
   /**
    * THE ONE FLAG THIS SLICE IS ALLOWED (DES-MERGE-001 §6.0). An unavailable mode is
    * DISABLED, never hidden (§1.3 rule 3) — hiding it teaches the user the feature
-   * does not exist. Document flips to `true` in slice 8, Video in slice 13; when both
-   * are `true` this field and its branches delete cleanly.
+   * does not exist. Document flipped to `true` in slice 8; Video follows in slice 13,
+   * and when it does this field and its branches delete cleanly.
    */
   available: boolean;
   /**
@@ -42,10 +42,10 @@ export const MODE_SPECS: Record<Mode, ModeSpec> = {
   },
   document: {
     label: 'Document',
-    available: false,
-    enables:
-      'Connect the interactive document service to this project (crew proxies it at '
-      + '/api/v1/projects/:projectId/interactive) to create documents here.',
+    // Flipped by slice 8 (§6.3): the canvas is wired, so the tab is live and the
+    // placeholder is unreachable for this mode. Video is the last `false` left.
+    available: true,
+    enables: '',
     summary:
       'Document mode is where the interactive canvas lands: an HTML doc, deck or report, '
       + 'its version strip, and point-and-comment feedback — all against this project’s one thread.',

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -38,9 +38,9 @@ function stubFetch(routes: Record<string, Reply>): string[] {
   const seen: string[] = [];
   vi.stubGlobal('fetch', vi.fn((url: string) => {
     seen.push(url);
-    const key = Object.keys(routes).find((k) => url.includes(k));
-    if (key === undefined) return Promise.reject(new Error(`unrouted fetch: ${url}`));
-    const { status = 200, body } = routes[key];
+    const hit = Object.entries(routes).find(([k]) => url.includes(k));
+    if (hit === undefined) return Promise.reject(new Error(`unrouted fetch: ${url}`));
+    const { status = 200, body } = hit[1];
     return Promise.resolve({
       ok: status >= 200 && status < 300,
       status,
@@ -206,7 +206,7 @@ describe('DocumentCanvas — the picker (§6.3: no :docId in the route)', () => 
     render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={navigate} />);
 
     await screen.findByTestId('doc-picker');
-    await userEvent.click(screen.getAllByTestId('doc-picker-row')[0]);
+    await userEvent.click(screen.getAllByTestId('doc-picker-row')[0]!);
     expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/launch-deck`);
   });
 

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -1,0 +1,241 @@
+// Unit tests for the Document-mode canvas — DES-MERGE-001 §6.3 slice 8.
+//
+// Three concerns, one per AC:
+//   1. Canvas src derivation: origin-relative (never a second origin, never a port
+//      literal) and version-addressed, through the slice-2 client's `apiBase()`.
+//   2. A 503 {code:"bridge_unavailable", hint} surfaces the hint VERBATIM, with its
+//      named command intact (§7.12 / §3.3 — actionable, not a bare failure).
+//   3. The picker orders most-recent first and navigates into /p/<id>/document/<docId>;
+//      empty invites creation rather than rendering blank.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentCanvas } from '../src/components/DocumentCanvas.js';
+import type { DocSummary, VersionManifest } from '../src/api/interactive.js';
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+
+/** Point jsdom's window.location at an arbitrary origin (as client.resolver does). */
+function setLocation(url: string): void {
+  Object.defineProperty(window, 'location', {
+    value: new URL(url),
+    writable: true,
+    configurable: true,
+  });
+}
+
+/** Prod default: same-origin, no dev split — the posture §5.3's frame relies on. */
+function prodOrigin(): void {
+  vi.stubEnv('VITE_API_HOST', '');
+  setLocation('http://127.0.0.1:7788/');
+}
+
+type Reply = { status?: number; body: unknown };
+
+/** Route stubbed fetch by URL substring; unmatched URLs are a loud test failure. */
+function stubFetch(routes: Record<string, Reply>): string[] {
+  const seen: string[] = [];
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    seen.push(url);
+    const key = Object.keys(routes).find((k) => url.includes(k));
+    if (key === undefined) return Promise.reject(new Error(`unrouted fetch: ${url}`));
+    const { status = 200, body } = routes[key];
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: String(status),
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    });
+  }));
+  return seen;
+}
+
+const MANIFEST: VersionManifest = {
+  head: 3,
+  versions: [
+    { version: 1, parent: null, feedback_file: null, html_file: 'v1.html', created_at: '2026-08-16T09:00:00Z' },
+    { version: 2, parent: 1, feedback_file: 'f2.json', html_file: 'v2.html', created_at: '2026-08-17T09:00:00Z' },
+    { version: 3, parent: 2, feedback_file: null, html_file: 'v3.html', created_at: '2026-08-18T09:00:00Z' },
+  ],
+};
+
+function doc(name: string, updated_at: string | null, head = 1): DocSummary {
+  return { name, kind: 'doc', head, versions: head, updated_at };
+}
+
+const BRIDGE_DOWN: Reply = {
+  status: 503,
+  body: {
+    code: 'bridge_unavailable',
+    hint: 'run `npm i -g wicked-interactive` then retry — the bridge could not be started',
+  },
+};
+
+beforeEach(prodOrigin);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('DocumentCanvas — the frame (§5.3, §6.3)', () => {
+  it('AC: derives the src from apiBase(), on the PAGE ORIGIN, under the project-scoped proxy', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    const frame = await screen.findByTestId('doc-canvas');
+    const src = frame.getAttribute('src') ?? '';
+    expect(src).toBe(`http://127.0.0.1:7788/api/v1/projects/${PROJECT}/interactive/d/${DOC}/doc/3`);
+    // The property the overlay (slice 11+12) depends on: one origin, the page's own.
+    expect(new URL(src).origin).toBe(window.location.origin);
+    // No bridge port literal ever reaches the bundle (§5.3, slice 1's grep AC).
+    expect(src).not.toMatch(/44\d\d/);
+  });
+
+  it('AC: the src is VERSION-ADDRESSED — it pins the manifest head, not a bare /doc', async () => {
+    stubFetch({ '/api/versions': { body: { ...MANIFEST, head: 2 } } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    const frame = await screen.findByTestId('doc-canvas');
+    expect(frame.getAttribute('src')).toMatch(/\/doc\/2$/);
+    expect(frame).toHaveAttribute('data-version', '2');
+  });
+
+  it('percent-encodes a doc id that would otherwise escape its path segment', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(<DocumentCanvas projectId={PROJECT} docId="a/b c" navigate={() => {}} />);
+
+    const frame = await screen.findByTestId('doc-canvas');
+    expect(frame.getAttribute('src')).toContain('/d/a%2Fb%20c/doc/3');
+  });
+
+  it('AC: carries the §5.5 status-quo sandbox — allow-scripts + allow-same-origin', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    const frame = await screen.findByTestId('doc-canvas');
+    expect(frame).toHaveAttribute('sandbox', 'allow-scripts allow-same-origin');
+  });
+
+  it('§3.3: while the doc loads the surface NAMES it — never a bare spinner', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<never>(() => {})));
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    const loading = await screen.findByTestId('doc-canvas-loading');
+    expect(loading).toHaveTextContent(DOC);
+    expect(loading.textContent).not.toMatch(/^\s*(working|loading)…?\s*$/i);
+  });
+});
+
+describe('DocumentCanvas — bridge_unavailable (§7.12, §3.3)', () => {
+  it('AC: surfaces the 503 hint VERBATIM, with its named command intact', async () => {
+    stubFetch({ '/api/versions': BRIDGE_DOWN });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    const hint = await screen.findByTestId('doc-bridge-hint');
+    const expected = (BRIDGE_DOWN.body as { hint: string }).hint;
+    expect(hint.textContent).toContain(expected);
+    expect(hint.textContent).toContain('npm i -g wicked-interactive');
+    // The failure names its subject and offers the next action, per §3.3.
+    expect(screen.getByTestId('doc-canvas-error')).toHaveTextContent(DOC);
+    expect(screen.getByTestId('doc-canvas-retry')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-canvas')).toBeNull();
+  });
+
+  it('surfaces the same hint from the PICKER path, not only the frame', async () => {
+    stubFetch({ '/api/docs': BRIDGE_DOWN });
+    render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}} />);
+
+    const hint = await screen.findByTestId('doc-bridge-hint');
+    expect(hint.textContent).toContain('npm i -g wicked-interactive');
+  });
+
+  it('a non-bridge failure still states what happened and offers Retry', async () => {
+    stubFetch({ '/api/versions': { status: 500, body: { error: 'versions.json is corrupt' } } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    expect(await screen.findByTestId('doc-error-detail')).toHaveTextContent('versions.json is corrupt');
+    expect(screen.getByTestId('doc-canvas-retry')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-bridge-hint')).toBeNull();
+  });
+
+  it('Retry re-issues the load, and a now-healthy bridge renders the frame', async () => {
+    let attempt = 0;
+    vi.stubGlobal('fetch', vi.fn(() => {
+      attempt += 1;
+      const reply: Reply = attempt === 1 ? BRIDGE_DOWN : { body: MANIFEST };
+      return Promise.resolve({
+        ok: (reply.status ?? 200) < 300,
+        status: reply.status ?? 200,
+        statusText: String(reply.status ?? 200),
+        text: () => Promise.resolve(JSON.stringify(reply.body)),
+        json: () => Promise.resolve(reply.body),
+      });
+    }));
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    await userEvent.click(await screen.findByTestId('doc-canvas-retry'));
+    expect(await screen.findByTestId('doc-canvas')).toBeInTheDocument();
+    expect(attempt).toBe(2);
+  });
+});
+
+describe('DocumentCanvas — the picker (§6.3: no :docId in the route)', () => {
+  const DOCS: DocSummary[] = [
+    doc('stale-brief', '2026-08-10T08:00:00Z'),
+    doc('launch-deck', '2026-08-18T11:30:00Z', 4),
+    doc('never-touched', null),
+    doc('q3-report', '2026-08-17T16:00:00Z', 2),
+  ];
+
+  it('AC: lists the project’s docs MOST-RECENT FIRST (a null updated_at sinks)', async () => {
+    stubFetch({ '/api/docs': { body: DOCS } });
+    render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}} />);
+
+    await screen.findByTestId('doc-picker');
+    const rows = screen.getAllByTestId('doc-picker-row');
+    expect(rows.map((r) => r.getAttribute('data-doc-id')))
+      .toEqual(['launch-deck', 'q3-report', 'stale-brief', 'never-touched']);
+  });
+
+  it('AC: selecting a doc navigates to /p/<id>/document/<docId>', async () => {
+    const navigate = vi.fn();
+    stubFetch({ '/api/docs': { body: DOCS } });
+    render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={navigate} />);
+
+    await screen.findByTestId('doc-picker');
+    await userEvent.click(screen.getAllByTestId('doc-picker-row')[0]);
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/launch-deck`);
+  });
+
+  it('encodes both segments so an odd project or doc id still round-trips', async () => {
+    const navigate = vi.fn();
+    stubFetch({ '/api/docs': { body: [doc('a/b', '2026-08-18T00:00:00Z')] } });
+    render(<DocumentCanvas projectId="p 1" docId={null} navigate={navigate} />);
+
+    await screen.findByTestId('doc-picker');
+    await userEvent.click(screen.getByTestId('doc-picker-row'));
+    expect(navigate).toHaveBeenCalledWith('/p/p%201/document/a%2Fb');
+  });
+
+  it('§1.4: an empty project INVITES creation rather than rendering blank', async () => {
+    stubFetch({ '/api/docs': { body: [] } });
+    render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}} />);
+
+    const empty = await screen.findByTestId('doc-picker-empty');
+    expect(empty).toHaveTextContent(/no documents/i);
+    // Informative, not blank: it names where a document comes from (the thread).
+    expect(empty).toHaveTextContent(/thread/i);
+    expect(screen.queryByTestId('doc-picker')).toBeNull();
+  });
+
+  it('reads the doc registry through the project-scoped proxy path (§7.2)', async () => {
+    const seen = stubFetch({ '/api/docs': { body: [] } });
+    render(<DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}} />);
+
+    await waitFor(() => expect(seen.length).toBe(1));
+    expect(seen[0]).toBe(`http://127.0.0.1:7788/api/v1/projects/${PROJECT}/interactive/api/docs`);
+  });
+});

--- a/tests/ModeSwitcher.test.tsx
+++ b/tests/ModeSwitcher.test.tsx
@@ -49,11 +49,12 @@ describe('ModeSwitcher (DES-MERGE-001 §1.3)', () => {
 });
 
 describe('ModePlaceholder (§3.3 — every state names a subject)', () => {
+  // Document left the placeholder in slice 8 (§6.3) — Video is the only mode still on it.
   it('states what the mode is and the one action that enables it', () => {
-    render(<ModePlaceholder mode="document" />);
-    const card = screen.getByTestId('mode-placeholder-document');
-    expect(card).toHaveTextContent(/interactive canvas/i);
-    expect(screen.getByTestId('mode-enabling-action-document')).toHaveTextContent(/connect/i);
+    render(<ModePlaceholder mode="video" />);
+    const card = screen.getByTestId('mode-placeholder-video');
+    expect(card).toHaveTextContent(/storyboard/i);
+    expect(screen.getByTestId('mode-enabling-action-video')).toHaveTextContent(/install/i);
   });
 
   it('carries the SAME enabling action as the disabled tab tooltip — one source of truth', () => {


### PR DESCRIPTION
Slice 8 — Phase C opens, authored by governed run `f3d720c7` (creator: claude · evaluators: codex). Process note: the design unit implemented the slice end-to-end (build confirmed a finished worktree) — the phase-collapse defect filed as core#283; evaluator≠creator held at seat level and all review gates ran on the finished work.

Document mode replaces its placeholder: `DocumentCanvas` renders the proxied doc for the selected version in an origin-shared iframe (`sandbox="allow-scripts allow-same-origin"` per §5.5 status quo — the merged slice 11+12 tightens it), a most-recent-first doc picker when no `:docId` is routed, loading states that name the subject, and `bridge_unavailable` hints surfaced verbatim (§3.3).

419/419 unit tests on the branch; Playwright AC drives a seeded doc through a fake bridge (non-empty `contentDocument`, sandbox attr present, same-origin frame URL, no console errors).

Design: `.product/DES-MERGE-001.md` §1.3, §5.3/§5.5, §6.3 slice 8, §7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)