### PR TITLE
feat(document): the one conversation thread in Document mode (DES-MERGE-001 slice 10)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -51,6 +51,14 @@ What "independent" means here, and what this script proves end-to-end:
      swaps the frame to the v1 URL (and Back rewinds it), §7.6's scroll affordance
      is disabled-with-a-reason where the anchor is null, and Fork from v1 creates a
      4th version whose parent is 1 — asserted through the API, labelled in the UI.
+ 13. (DES-MERGE-001 slice 10) the ONE conversation in Document mode, on that same rig:
+     the thread mounts beside the canvas with a single composer; typing while idle
+     creates the doc-generation run (the message and an informative run opening land
+     in the transcript, the anchor id riding with the request); typing while generating
+     injects steering with the chip visible; the whole whimsy list pushed over a
+     generation window renders NOTHING while real narration lands, and no
+     `status.requested` heartbeat is ever emitted; and a landed version tags the
+     message that triggered it (§7.6).
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -63,7 +71,8 @@ studio itself unless SKIP_STUDIO_BUILD=1 (in which case dist/ must already be
 baked for CREW_PORT).
 
 Env knobs: CREW_CLI, CREW_PORT (default 7901), STUDIO_PORT (default 4310),
-DOC_PORT (default 4320, the same-origin rig for §10), SKIP_STUDIO_BUILD.
+DOC_PORT (default 4320, the same-origin rig for §10), SKIP_STUDIO_BUILD,
+SLICE10_WINDOW_S (default 10, the generation window §13 pushes filler across).
 
 Prints a JSON report to stdout (exit 0/1); screenshots land in e2e/shots/.
 Operator-run smoke — though it spends no tokens (stub engine, no real CLI seats).
@@ -890,6 +899,11 @@ try:
     # state (append-only, per INV-4) rather than deriving a fresh list per request.
     doc_versions = {d["name"]: seed_versions(d["name"]) for d in FIXTURE_DOCS}
     versions_lock = threading.Lock()
+    # Slice 10's two composer wires, recorded verbatim so the run can assert WHICH wire
+    # each composer state chose — and that no `status.requested` heartbeat is ever among
+    # them (§3.2's second deletion is a claim about what the client does NOT send).
+    created_docs: list[dict] = []
+    emitted_events: list[dict] = []
     BRIDGE_DOWN_HINT = ("run `npx wicked-interactive serve` in this project's root — "
                         "the bridge could not be started")
     # `data-wid` anchors are what core/instrument.js injects (§5.5) — the fixture carries
@@ -1014,6 +1028,31 @@ try:
                              "created_at": "2026-08-18T12:00:00Z"})
             return self._json(200, {"version": created, "parent": parent})
 
+        def _body(self) -> dict:
+            return json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+
+        def _create_doc(self, project: str) -> None:
+            """`POST /api/docs` — the IDLE composer's wire (§2.2 case 1). The message is
+            the brief; the bridge slugifies the derived name and opens generation."""
+            body = self._body()
+            body["_project_path"] = project
+            created_docs.append(body)
+            slug = re.sub(r"[^a-z0-9]+", "-", (body.get("name") or "untitled").lower()).strip("-")
+            with versions_lock:
+                doc_versions.setdefault(slug, [{
+                    "version": 1, "parent": None, "feedback_file": None, "html_file": "v1.html",
+                    "created_at": "2026-08-18T12:05:00Z",
+                    "meta": {"sourceMessageId": body.get("source_message_id")},
+                }])
+            return self._json(200, {"name": slug, "head": 1, "kind": "doc",
+                                    "generating": True, "project_id": body.get("project")})
+
+        def _emit(self) -> None:
+            """`POST /api/events` — the GENERATING/GATED composer's wire (§2.2 cases 2-3)."""
+            emitted_events.append(self._body())
+            return self._json(200, {"ok": True, "event_id": f"ev-{len(emitted_events)}",
+                                    "correlation_id": "c-doc"})
+
         def do_POST(self):  # noqa: N802
             path = urllib.parse.urlparse(self.path).path
             m = INTERACTIVE_RE.match(path)
@@ -1024,6 +1063,10 @@ try:
                     return self._json(503, {"code": "bridge_unavailable", "hint": BRIDGE_DOWN_HINT})
                 if fork:
                     return self._fork(urllib.parse.unquote(fork.group(1)))
+                if rest == "/api/docs":
+                    return self._create_doc(project)
+                if rest == "/api/events":
+                    return self._emit()
             return self._proxy()
 
     docd = ThreadingHTTPServer(
@@ -1187,8 +1230,6 @@ try:
     _, _, forked_manifest = http_json("GET", doc_api)
     api_v4 = next((v for v in forked_manifest["versions"] if v["version"] == 4), None)
 
-    docd.shutdown()
-
     expected_v1_src = (f"{DOC_ORIGIN}/api/v1/projects/{urllib.parse.quote(doc_project)}"
                        f"/interactive/d/{STRIP_DOC}/doc/1")
     report["steps"]["version_strip"] = {
@@ -1233,6 +1274,179 @@ try:
     }
     if not report["steps"]["version_strip"]["ok"]:
         fail("version_strip_verdict", "slice-9 version-strip assertions did not all hold — see version_strip")
+
+    # ── 14. Slice 10 (DES-MERGE-001 §6.3): the ONE conversation in Document mode ──
+    # Same same-origin rig; the fake bridge now also answers the composer's two wires
+    # and RECORDS what it was sent, so each assertion is about the wire the composer
+    # chose, not about button text. What this proves:
+    #   · the thread mounts BESIDE the canvas with ONE composer (§2.1) — no second input;
+    #   · typing while IDLE creates the doc-generation run, and the thread shows the
+    #     user's message plus the run opening as an informative line with a subject
+    #     (§2.2 case 1, §3.3) — the anchor id travelling with the request (§7.6);
+    #   · typing while GENERATING injects steering with `steering-chip` visible (case 2);
+    #   · over a generation window in which the upstream bridge speaks the WHOLE whimsy
+    #     list, the transcript renders NONE of it while real narration lands (§3.2), and
+    #     the client emits no `status.requested` heartbeat at any point;
+    #   · a landed version tags the message that triggered it (§7.6, client half), which
+    #     is what makes slice 9's scroll targets resolvable going forward.
+    WHIMSY = ["Wiring the harness…", "Pondering the loop…", "Tightening the bolts…",
+              "Consulting the spine…", "Aligning the lanes…", "Reticulating splines…",
+              "Checking the gates…"]
+    FILLER_RE = re.compile(r"reticulating|splines|bolts", re.I)
+    # §6.3 words this as a 60 s window. The filler rotated every 4 s, so the property is
+    # "many rotations, none rendered"; the clock is a knob and the pushes are what count.
+    GEN_WINDOW_S = float(os.environ.get("SLICE10_WINDOW_S", "10"))
+    BRIEF = "a deck for the Q3 review"
+    CREATED_DOC = "a-deck-for-the-q3-review"
+    REAL_STATUS = "Rewriting slide 3 — tightening the headline"
+    STEER = "keep it to five slides"
+    THREAD_TEXT = """() => document.querySelector('[data-testid="thread"]')?.innerText ?? ''"""
+    PUSH_STATUS = """args => window.__pushFrame({ type: 'interactiveEvent', event: {
+         event_type: 'wicked.interactive.status.posted',
+         payload: { project_id: args.project, document_id: args.doc,
+                    state: 'working', message: args.text } } })"""
+    thread_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(WS_TAP)
+        page.on("console", lambda m: thread_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text else None)
+
+        # ── AC: one thread, one composer, beside the canvas — never over it (§2.5) ──
+        page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document", wait_until="networkidle")
+        thread = page.locator('[data-testid="thread"]')
+        thread.wait_for(timeout=30000)
+        page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
+        idle_state = thread.get_attribute("data-composer-state")
+        composers = page.locator('[data-testid="doc-composer"]').count()
+        canvas_beside_thread = page.locator('[data-testid="doc-picker-row"]').first.is_visible()
+        page.screenshot(path=str(SHOTS / "slice10-thread-idle.png"), full_page=True)
+
+        # ── AC: typing while IDLE creates the doc-generation run ───────────────────
+        page.fill('[data-testid="doc-composer"]', BRIEF)
+        page.click('[data-testid="doc-composer-submit"]')
+        created_nav = wait_for_path(page, f"/p/{doc_project}/document/{CREATED_DOC}")
+        page.locator('[data-testid="doc-message"]').first.wait_for(timeout=30000)
+        first_message = page.locator('[data-testid="doc-message"]').first.inner_text()
+        anchor_id = page.locator('[data-testid="doc-message"]').first.get_attribute("data-message-id")
+        opening = page.locator('[data-testid="doc-narration"]').first.inner_text()
+        generating_state = thread.get_attribute("data-composer-state")
+        chip_while_generating = page.locator('[data-testid="steering-chip"]').is_visible()
+        create_body = created_docs[0] if created_docs else {}
+        page.screenshot(path=str(SHOTS / "slice10-thread-created.png"), full_page=True)
+
+        # ── AC: the whimsy never reaches the transcript, and real narration does ───
+        pushed = 0
+        started = time.time()
+        while time.time() - started < GEN_WINDOW_S:
+            page.evaluate(PUSH_STATUS, {"project": doc_project, "doc": CREATED_DOC,
+                                        "text": WHIMSY[pushed % len(WHIMSY)]})
+            pushed += 1
+            page.wait_for_timeout(400)
+        page.evaluate(PUSH_STATUS, {"project": doc_project, "doc": CREATED_DOC,
+                                    "text": REAL_STATUS})
+        real_narration_ok, real_narration_ms = within(
+            page,
+            """text => (document.querySelector('[data-testid="thread"]')?.innerText ?? '')
+                 .includes(text)""",
+            REAL_STATUS,
+        )
+        transcript = page.evaluate(THREAD_TEXT)
+        filler_hit = FILLER_RE.search(transcript)
+        # Filler carried the state it rode in on: dropping the LINE is not dropping the fact.
+        state_after_window = thread.get_attribute("data-composer-state")
+        page.screenshot(path=str(SHOTS / "slice10-thread-narration.png"), full_page=True)
+
+        # ── AC: typing while GENERATING injects steering rather than creating ──────
+        page.fill('[data-testid="doc-composer"]', STEER)
+        page.click('[data-testid="doc-composer-submit"]')
+        steer_rendered, steer_ms = within(
+            page,
+            """text => Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+                 .some(m => m.innerText.includes(text))""",
+            STEER,
+        )
+        chip_after_steer = page.locator('[data-testid="steering-chip"]').is_visible()
+        docs_created_by_steer = len(created_docs)
+        page.screenshot(path=str(SHOTS / "slice10-thread-steering.png"), full_page=True)
+
+        # ── AC (§7.6, client half): the landed version tags the message that caused it ──
+        page.evaluate(
+            """args => window.__pushFrame({ type: 'interactiveEvent', event: {
+                 event_type: 'wicked.interactive.version.created',
+                 payload: { project_id: args.project, document_id: args.doc,
+                            version: 2, parent: 1, kind: 'generated' } } })""",
+            {"project": doc_project, "doc": CREATED_DOC},
+        )
+        tagged_ok, tag_ms = within(
+            page,
+            """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                       return m.length > 0 && m[m.length - 1].getAttribute('data-version') === '2'; }""",
+        )
+        terminal_state = thread.get_attribute("data-composer-state")
+        chip_when_terminal = page.locator('[data-testid="steering-chip"]').count()
+        page.screenshot(path=str(SHOTS / "slice10-thread-version-anchor.png"), full_page=True)
+        browser.close()
+
+    docd.shutdown()
+
+    steers = [e for e in emitted_events if e.get("event_type") == "wicked.interactive.chat.posted"]
+    heartbeats = [e for e in emitted_events
+                  if e.get("event_type") == "wicked.interactive.status.requested"]
+    report["steps"]["doc_thread"] = {
+        "ok": all([
+            idle_state == "idle", composers == 1, canvas_beside_thread,
+            created_nav, len(created_docs) == 1,
+            create_body.get("brief") == BRIEF, create_body.get("project") == doc_project,
+            anchor_id is not None and create_body.get("source_message_id") == anchor_id,
+            BRIEF in first_message, CREATED_DOC in opening,
+            generating_state == "generating", chip_while_generating,
+            pushed >= len(WHIMSY), filler_hit is None,
+            real_narration_ok, state_after_window == "generating",
+            steer_rendered, chip_after_steer, docs_created_by_steer == 1,
+            len(steers) == 1,
+            [(s.get("payload") or {}).get("text") for s in steers] == [STEER],
+            [(s.get("payload") or {}).get("document_id") for s in steers] == [CREATED_DOC],
+            not heartbeats,
+            tagged_ok, terminal_state == "terminal", chip_when_terminal == 0,
+        ]),
+        "project_id": doc_project,
+        "created_doc": CREATED_DOC,
+        "composer_state_idle": idle_state,
+        "composer_count": composers,
+        "canvas_and_thread_both_visible": canvas_beside_thread,
+        "create_navigated_to_doc": created_nav,
+        "create_request_body": create_body,
+        "first_thread_message": first_message,
+        "run_opening_narration": opening,
+        "version_anchor_id": anchor_id,
+        "composer_state_generating": generating_state,
+        "steering_chip_visible_while_generating": chip_while_generating,
+        "whimsy_lines_pushed": pushed,
+        "whimsy_window_seconds": GEN_WINDOW_S,
+        "filler_rendered": filler_hit.group(0) if filler_hit else None,
+        "real_narration_rendered": real_narration_ok,
+        "real_narration_ms": real_narration_ms,
+        "state_survived_filtered_frames": state_after_window,
+        "steer_message_rendered": steer_rendered,
+        "steer_render_ms": steer_ms,
+        "steer_emitted_events": steers,
+        "steer_created_no_new_doc": docs_created_by_steer == 1,
+        "status_requested_heartbeats": heartbeats,
+        "version_tagged_triggering_message": tagged_ok,
+        "version_tag_ms": tag_ms,
+        "composer_state_terminal": terminal_state,
+        "transcript": transcript[:600],
+        "console_errors": thread_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice10-thread-idle.png", "slice10-thread-created.png",
+                         "slice10-thread-narration.png", "slice10-thread-steering.png",
+                         "slice10-thread-version-anchor.png")],
+    }
+    if not report["steps"]["doc_thread"]["ok"]:
+        fail("doc_thread_verdict", "slice-10 document-thread assertions did not all hold — see doc_thread")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { GateNotifications } from './components/GateNotifications.js';
 import { HomeBoard } from './components/HomeBoard.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
 import { DocumentCanvas } from './components/DocumentCanvas.js';
+import { DocumentThread } from './components/DocumentThread.js';
 import { ModePlaceholder } from './components/ModePlaceholder.js';
 import { PolicyManager } from './components/PolicyManager.js';
 import { ProjectShell } from './components/ProjectShell.js';
@@ -31,6 +32,7 @@ import { useElicitationStore } from './store/elicitations.js';
 import { useNotificationStore } from './store/notifications.js';
 import { useRuntimeStore } from './store/runtime.js';
 import { useRunEventStore } from './store/events.js';
+import { useDocThreadStore } from './store/docThread.js';
 import type { CoreEvent, RepoEntry } from './api/types.js';
 import { api } from './api/client.js';
 
@@ -88,6 +90,7 @@ export function App(): React.ReactElement {
   const ingestNotif = useNotificationStore((s) => s.ingest);
   const ingestRuntime = useRuntimeStore((s) => s.ingest);
   const ingestRunEvent = useRunEventStore((s) => s.ingest);
+  const ingestDocThread = useDocThreadStore((s) => s.ingest);
 
   // Dashboard gate callbacks — the CenterDashboard handles the API call + store
   // clearing itself; these callbacks exist for any post-confirmation side-effects
@@ -107,9 +110,12 @@ export function App(): React.ReactElement {
       ingestNotif(event);
       ingestRuntime(event);
       ingestRunEvent(event);
+      // Relayed interactive frames feed BOTH altitudes off the one subscription (§3.4):
+      // the runtime store's board headline above, the doc transcript here.
+      ingestDocThread(event);
       if (LIFECYCLE_EVENTS.has(event.type)) refresh();
     },
-    [ingestGate, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, refresh],
+    [ingestGate, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, refresh],
   );
 
   useEventStream(handleEvent);
@@ -257,13 +263,24 @@ export function App(): React.ReactElement {
     // The document's VERSION rides in the query (`?v=N`, slice 9) — the artifact is the
     // doc, the version is a lens on it — so the strip's selection is a real navigation.
     if (m === 'document') {
+      // Canvas and thread are SIBLINGS, never nested: §1.2's "mode surface + the one
+      // conversation thread, always present" (slice 10). The thread is fixed-width and
+      // dismissible-by-navigation — never force-opened over the canvas (§2.5).
       return (
-        <DocumentCanvas
-          projectId={pid}
-          docId={artifactId}
-          version={routedVersion(search)}
-          navigate={navigate}
-        />
+        <>
+          <DocumentCanvas
+            projectId={pid}
+            docId={artifactId}
+            version={routedVersion(search)}
+            navigate={navigate}
+          />
+          <DocumentThread
+            projectId={pid}
+            docId={artifactId}
+            selectedVersion={routedVersion(search)}
+            navigate={navigate}
+          />
+        </>
       );
     }
     if (m === 'video') return <ModePlaceholder mode={m} />;

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -88,6 +88,9 @@ export interface CreateDocBody {
   /** Crew project binding. Registration is the authority: a doc that cannot be
    *  filed is a loud error with no doc created (DES-PROJECT-001 §2.3). */
   project?: string;
+  /** The thread message this generation came from (§7.6). The bridge writes it into
+   *  the version's `meta.sourceMessageId` at commit; the client only supplies it. */
+  source_message_id?: string;
 }
 
 export interface CreateDocResult {
@@ -202,9 +205,22 @@ export function createDoc(projectId: string, body: CreateDocBody): Promise<Creat
   return iFetch<CreateDocResult>(`${interactiveBase(projectId)}/api/docs`, jsonPost(body));
 }
 
-/** `POST /d/:docId/api/fork` — branch a new version off `version`. */
-export function postFork(projectId: string, docId: string, version: number): Promise<ForkResult> {
-  return iFetch<ForkResult>(`${docBase(projectId, docId)}/api/fork`, jsonPost({ from: version }));
+/**
+ * `POST /d/:docId/api/fork` — branch a new version off `version`. `sourceMessageId`
+ * (§7.6) is the thread message the branch came from, carried for the manifest's
+ * `meta`; it is omitted entirely when the fork had no message behind it (the strip's
+ * own Fork button), rather than sent as null.
+ */
+export function postFork(
+  projectId: string,
+  docId: string,
+  version: number,
+  sourceMessageId?: string,
+): Promise<ForkResult> {
+  return iFetch<ForkResult>(
+    `${docBase(projectId, docId)}/api/fork`,
+    jsonPost({ from: version, ...(sourceMessageId ? { source_message_id: sourceMessageId } : {}) }),
+  );
 }
 
 /** `POST /d/:docId/api/export` — renders the artifact and returns its download URL. */

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useRef, useState } from 'react';
+import { createDoc, getVersions, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { versionPath, type Navigate } from '../hooks/useRoute.js';
+import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
+
+// Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
+//
+// Same thread contract as Build's (`data-testid="thread"` + `data-message-id`, the seam
+// slice 9's version→message cross-link resolves through), one composer, and what Enter
+// DOES is a pure function of the generation's state (§2.2) — the user never picks a verb:
+//
+//   idle       no document in the route → CREATE: `POST /api/docs` seeds the brief and
+//              the doc's generation run opens with this message as its first line.
+//   generating → STEER: `wicked.interactive.chat.posted` injects into the live agent.
+//   gated      → ANSWER: the question is answerable in the transcript, where it was asked.
+//   terminal   → CONTINUE: fork + inject as ONE atomic composer action (§7.10). The thread
+//              renders the linked run as a continuation — a version divider, no new header.
+//
+// There is no dead composer state and no synthetic liveness: no whimsy filler (filtered in
+// the store, §3.2), no `status.requested` heartbeat (never emitted at all).
+
+const S = {
+  panel:  '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.35)',
+  accent: '#ffda19',
+  user:   '#224a5e',
+  card:   '#1b222e',
+  footer: '#161c26',
+  live:   '#79c0ff',
+  danger: '#f85149',
+};
+
+/** What the composer says it will do — the affordance, in words (§2.2, §3.3). */
+const COMPOSER: Record<GenState, { placeholder: string; submit: string }> = {
+  idle:       { placeholder: 'Describe the document you want…',        submit: 'Create' },
+  generating: { placeholder: 'Steer the document agent…',              submit: 'Send' },
+  gated:      { placeholder: 'Answer the question above…',             submit: 'Answer' },
+  terminal:   { placeholder: 'Ask for a change — it lands as a new version…', submit: 'Send' },
+};
+
+// ── Message renderers ────────────────────────────────────────────────────────
+
+function Bubble({ msg, projectId }: { msg: DocMsg; projectId: string }): React.ReactElement | null {
+  if (msg.kind === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div
+          data-testid="doc-message"
+          data-message-id={msg.id}
+          data-version={msg.version === undefined ? undefined : String(msg.version)}
+          className="max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed"
+          style={{ background: S.user, color: S.ink, border: `1px solid ${S.border}` }}
+        >
+          {msg.text}
+        </div>
+      </div>
+    );
+  }
+  if (msg.kind === 'narration') {
+    return (
+      <div className="flex items-start gap-2 text-xs font-mono" data-testid="doc-narration" style={{ color: S.faint }}>
+        <span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0" style={{ background: S.live }} />
+        <span>{msg.text}</span>
+      </div>
+    );
+  }
+  if (msg.kind === 'divider') {
+    // §7.10: the seam between two runs is a version divider, NOT a new thread header.
+    return (
+      <div className="flex items-center gap-2" data-testid="version-divider" data-version={String(msg.version)}>
+        <span className="flex-1 h-px" style={{ background: S.border }} />
+        <span className="text-[10px] font-mono shrink-0" style={{ color: S.faint }}>
+          continues as v{msg.version}
+        </span>
+        <span className="flex-1 h-px" style={{ background: S.border }} />
+      </div>
+    );
+  }
+  if (msg.kind === 'agent' || msg.kind === 'verdict') {
+    return (
+      <div className="self-start max-w-[90%] flex flex-col gap-1" data-testid={`doc-${msg.kind}`}>
+        <span className="text-[10px] font-mono uppercase tracking-wide" style={{ color: S.faint }}>
+          {msg.kind === 'verdict' ? `${msg.author} · review` : msg.author}
+        </span>
+        <div className="rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap"
+             style={{ background: S.card, border: `1px solid ${S.border}`, color: S.ink }}>
+          {msg.text}
+          {msg.kind === 'agent' && msg.href !== undefined && (
+            <a
+              data-testid="doc-artifact-download"
+              href={interactiveUrl(projectId, msg.href)}
+              download
+              className="block mt-2 text-xs font-mono underline"
+              style={{ color: S.accent }}
+            >
+              Download
+            </a>
+          )}
+        </div>
+      </div>
+    );
+  }
+  return null;
+}
+
+/**
+ * §2.2 case 3 — the gate is answered WHERE IT WAS ASKED. Options answer in one click;
+ * free text answers with a steer in the same submit. Either way one bus emit.
+ */
+function GateCard({
+  msg, projectId, docId, onAnswered,
+}: {
+  msg: Extract<DocMsg, { kind: 'gate' }>;
+  projectId: string;
+  docId: string;
+  onAnswered: () => void;
+}): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function answer(text: string): Promise<void> {
+    if (busy || text.trim() === '') return;
+    setBusy(true);
+    setError(null);
+    try {
+      await postEvent(projectId, {
+        event_type: 'wicked.interactive.question.answered',
+        payload: { request_id: msg.requestId, answer: text.trim(), document_id: docId },
+      });
+      onAnswered();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid="doc-gate"
+      data-request-id={msg.requestId}
+      className="rounded-xl px-3.5 py-3 flex flex-col gap-2"
+      style={{ background: 'rgba(255,218,25,0.06)', border: '1px solid rgba(255,218,25,0.2)' }}
+    >
+      <p className="text-sm" style={{ color: S.accent, margin: 0 }}>{msg.question}</p>
+      {msg.options.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {msg.options.map((option) => (
+            <button
+              key={option}
+              type="button"
+              data-testid="doc-gate-option"
+              disabled={busy}
+              onClick={() => void answer(option)}
+              className="rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+              style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      )}
+      {error !== null && (
+        <p data-testid="doc-gate-error" className="text-[11px] font-mono" style={{ color: S.danger, margin: 0 }}>
+          Not sent: {error} — the question is still open; answer again.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── The thread ───────────────────────────────────────────────────────────────
+
+export interface DocumentThreadProps {
+  projectId: string;
+  /** `null` on `/p/:projectId/document` — nothing generated yet, so the composer creates. */
+  docId: string | null;
+  /** The routed `?v=N`; `null` means the head, which fork resolves from the manifest. */
+  selectedVersion: number | null;
+  navigate: Navigate;
+}
+
+export function DocumentThread({ projectId, docId, selectedVersion, navigate }: DocumentThreadProps): React.ReactElement {
+  const key = docId === null ? null : threadKey(projectId, docId);
+  const messages = useDocThreadStore((s) => (key === null ? EMPTY : s.messages[key] ?? EMPTY));
+  const streamed = useDocThreadStore((s) => (key === null ? undefined : s.genState[key]));
+  // A document that exists with nothing in flight IS case 4: complete, and editable (§7.10).
+  const state: GenState = docId === null ? 'idle' : streamed ?? 'terminal';
+
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bottom = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { bottom.current?.scrollIntoView({ block: 'end' }); }, [messages.length]);
+
+  const gate = state === 'gated'
+    ? [...messages].reverse().find((m): m is Extract<DocMsg, { kind: 'gate' }> => m.kind === 'gate') ?? null
+    : null;
+
+  async function submit(): Promise<void> {
+    const body = text.trim();
+    if (body === '' || busy) return;
+    const store = useDocThreadStore.getState();
+    const msgId = nextMsgId();
+    setBusy(true);
+    setError(null);
+    try {
+      // 1 — LAUNCH. The message IS the brief; the doc's generation run opens with it.
+      if (docId === null || key === null) {
+        const created = await createDoc(projectId, {
+          name: docName(body), kind: 'source', brief: body, project: projectId,
+          source_message_id: msgId,
+        });
+        const opened = threadKey(projectId, created.name);
+        store.addUserMsg(opened, msgId, body);
+        store.addNarration(opened, `Generating “${created.name}” from your brief.`);
+        store.setGenState(opened, 'generating');
+        setText('');
+        navigate(versionPath(projectId, created.name, null));
+        return;
+      }
+
+      // 4 — CONTINUE (§7.10). Fork + inject is ONE composer action: the branch lands, the
+      // divider marks it, and the same message steers the run that continues from it. The
+      // seam is hidden in the UI; underneath it is still two governed runs (§2.4).
+      if (state === 'terminal') {
+        const from = selectedVersion ?? (await getVersions(projectId, docId)).head;
+        const forked = await postFork(projectId, docId, from, msgId);
+        store.addDivider(key, forked.version);
+        store.addUserMsg(key, msgId, body);
+        store.setGenState(key, 'generating');
+        await inject(projectId, docId, body, msgId);
+        setText('');
+        navigate(versionPath(projectId, docId, forked.version));
+        return;
+      }
+
+      // 2 / 3 — STEER, and answer a gate WITH a steer in the same submit.
+      store.addUserMsg(key, msgId, body);
+      if (state === 'gated' && gate !== null) {
+        await postEvent(projectId, {
+          event_type: 'wicked.interactive.question.answered',
+          payload: { request_id: gate.requestId, answer: body, document_id: docId },
+        });
+        store.setGenState(key, 'generating');
+      } else {
+        await inject(projectId, docId, body, msgId);
+      }
+      setText('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const { placeholder, submit: label } = COMPOSER[state];
+
+  return (
+    <div
+      data-testid="thread"
+      data-composer-state={state}
+      className="flex flex-col shrink-0"
+      style={{ width: '340px', background: S.panel, borderLeft: `1px solid ${S.border}` }}
+    >
+      <div className="flex-1 overflow-y-auto px-3.5 py-4 flex flex-col gap-3">
+        {messages.length === 0 && (
+          <p className="text-xs leading-relaxed" style={{ color: S.muted }}>
+            {docId === null
+              ? 'Describe the document you want — “a deck for the Q3 review”, “write this up as a report” — and it is created from that message.'
+              : 'Ask for a change and it lands as a new version. Everything the agent says about this document appears here.'}
+          </p>
+        )}
+        {messages.map((m) =>
+          m.kind === 'gate'
+            ? (docId !== null && key !== null && (
+                <GateCard
+                  key={m.id}
+                  msg={m}
+                  projectId={projectId}
+                  docId={docId}
+                  onAnswered={() => useDocThreadStore.getState().setGenState(key, 'generating')}
+                />
+              )) || null
+            : <Bubble key={m.id} msg={m} projectId={projectId} />,
+        )}
+        <div ref={bottom} />
+      </div>
+
+      <div className="shrink-0 px-3.5 py-3 flex flex-col gap-2"
+           style={{ borderTop: `1px solid ${S.border}`, background: S.footer }}>
+        {state === 'generating' && (
+          <span
+            data-testid="steering-chip"
+            className="self-start flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'rgba(121,192,255,0.08)', color: S.live, border: '1px solid rgba(121,192,255,0.2)' }}
+          >
+            <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
+            steering the live document run
+          </span>
+        )}
+        <div className="flex items-end gap-2 rounded-2xl px-3 py-2"
+             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+          <textarea
+            data-testid="doc-composer"
+            className="flex-1 resize-none text-sm outline-none border-0 bg-transparent leading-6"
+            style={{ color: S.ink, fontFamily: 'inherit', minHeight: '28px' }}
+            placeholder={placeholder}
+            value={text}
+            rows={1}
+            disabled={busy}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void submit(); }
+            }}
+          />
+          <button
+            type="button"
+            data-testid="doc-composer-submit"
+            onClick={() => void submit()}
+            disabled={busy || text.trim() === ''}
+            className="shrink-0 rounded-xl px-3 py-1.5 text-xs font-semibold disabled:opacity-40"
+            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+          >
+            {busy ? '…' : label}
+          </button>
+        </div>
+        {error !== null && (
+          <p data-testid="doc-composer-error" className="text-[11px] font-mono" style={{ color: S.danger, margin: 0 }}>
+            {error} — nothing was sent; edit and try again.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Stable identity for "no messages" so the selector never returns a fresh array. */
+const EMPTY: DocMsg[] = [];
+
+/** The doc's name is DERIVED from the ask (§4.1) — the bridge slugifies what it gets. */
+function docName(brief: string): string {
+  return brief.split(/\s+/).slice(0, 6).join(' ').slice(0, 60);
+}
+
+/** Steering = one `chat.posted` carrying the anchor id (§7.6) into the agent's session. */
+function inject(projectId: string, docId: string, text: string, msgId: string): Promise<unknown> {
+  return postEvent(projectId, {
+    event_type: 'wicked.interactive.chat.posted',
+    payload: { role: 'user', text, document_id: docId, source_message_id: msgId },
+  });
+}

--- a/src/components/threadAnchor.ts
+++ b/src/components/threadAnchor.ts
@@ -4,9 +4,10 @@
 // and the anchor is resolved through the DOM by the contract both sides publish —
 // `data-testid="thread"` on the container, `data-message-id` on each message.
 //
-// Slice 9 owns the SCROLL only. Document mode's own thread is slice 10; until it
-// lands the anchor resolves against whatever thread is mounted, and resolves to
-// nothing when none is. A miss is reported, never thrown.
+// Slice 9 owns the SCROLL only; slice 10 mounted Document mode's own thread, which
+// publishes that contract and tags a landed version onto the message that triggered
+// it. A version whose anchor is not on screen (a pre-merge doc, or a message from a
+// session this client never saw) is a reported miss, never a throw.
 
 /** Selector-safe attribute match — a message id may legally contain quotes or spaces. */
 function messageSelector(messageId: string): string {

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -1,0 +1,234 @@
+// The Document-mode conversation (DES-MERGE-001 §2, §6.3 slice 10).
+//
+// One thread per doc, spanning all its versions (§2.4). Frames arrive inside slice 3's
+// relay envelope `{type:"interactiveEvent", event}` and are folded into an ordered
+// transcript keyed `projectId:docId` — the same shape the runtime store folds for the
+// board headline, at the thread's altitude instead of the card's (§3.4).
+//
+// The vocabulary is wicked-interactive's (`service/events.js`) and this repo does not
+// own it, so every payload is read DEFENSIVELY: both spellings of each field, no throw
+// on a shape that does not match, and a frame naming no project+document is dropped
+// rather than rendered under a guessed key.
+
+import { create } from 'zustand';
+import { isWhimsy } from './narration.js';
+import type { CoreEvent } from '../api/types.js';
+
+// ── Transcript ───────────────────────────────────────────────────────────────
+
+export type DocMsg =
+  | { kind: 'user';      id: string; text: string; version?: number }
+  | { kind: 'narration'; id: string; text: string }
+  | { kind: 'agent';     id: string; author: string; text: string; href?: string }
+  | { kind: 'verdict';   id: string; author: string; text: string }
+  | { kind: 'gate';      id: string; requestId: string; question: string; options: string[] }
+  | { kind: 'divider';   id: string; version: number };
+
+/**
+ * The composer's four states (§2.2). `idle` is a fact about the ROUTE — no document
+ * selected — so it is never stored; the other three are what the stream last said.
+ */
+export type GenState = 'idle' | 'generating' | 'gated' | 'terminal';
+
+let seq = 0;
+export function nextMsgId(): string { return `dmsg-${++seq}`; }
+
+// ── Frame parsing ────────────────────────────────────────────────────────────
+
+const STATUS   = 'wicked.interactive.status.posted';
+const CHAT     = 'wicked.interactive.chat.posted';
+const REVIEW   = 'wicked.interactive.review.completed';
+const VERSION  = 'wicked.interactive.version.created';
+const EXPORTED = 'wicked.interactive.export.generated';
+
+/** Version kinds a GENERATION produces. A `fork` is a lineage move the user made, not
+ *  the agent finishing — it neither ends the working state nor consumes the anchor. */
+const GENERATED: ReadonlySet<string> = new Set(['generated', 'structural', 'demo']);
+
+/** First non-empty string among the candidate keys of an untyped bag. */
+function pick(bag: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = bag[key];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return null;
+}
+
+interface Frame { key: string; type: string; payload: Record<string, unknown> }
+
+/** A relayed interactive frame, reduced to `(thread key, event type, payload)`. */
+function frameOf(event: CoreEvent): Frame | null {
+  if (event.type !== 'interactiveEvent') return null;
+  const ev = event.event as Record<string, unknown> | undefined;
+  if (typeof ev !== 'object' || ev === null) return null;
+  const type = pick(ev, 'event_type', 'type');
+  const payload = (typeof ev.payload === 'object' && ev.payload !== null ? ev.payload : ev) as Record<string, unknown>;
+  const docId = pick(payload, 'document_id', 'doc_id', 'document');
+  const projectId = pick(payload, 'project_id', 'project') ?? pick(ev, 'project_id', 'project');
+  if (type === null || docId === null || projectId === null) return null;
+  return { key: threadKey(projectId, docId), type, payload };
+}
+
+/** The one spelling of a thread's identity. Thread id = the doc's lineage (§2.4). */
+export function threadKey(projectId: string, docId: string): string {
+  return `${projectId}:${docId}`;
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+interface DocThreadStore {
+  messages: Record<string, DocMsg[]>;
+  /** What the stream last said the generation is doing, per thread. */
+  genState: Record<string, GenState>;
+  /** The user message a landing version will be tagged with (§7.6, client half). */
+  anchor: Record<string, string>;
+  /** Fold one CoreEvent — every non-interactive frame is ignored. */
+  ingest: (event: CoreEvent) => void;
+  /** Append the user's message and make it the pending version anchor. */
+  addUserMsg: (key: string, id: string, text: string) => void;
+  /** Append a client-authored informative line (§3.3) — an action the user took. */
+  addNarration: (key: string, text: string) => void;
+  /** The version divider a fork+inject continuation renders behind (§7.10). */
+  addDivider: (key: string, version: number) => void;
+  setGenState: (key: string, state: GenState) => void;
+  clear: (key: string) => void;
+}
+
+/** Append one message to a thread. */
+function append(messages: Record<string, DocMsg[]>, key: string, msg: DocMsg): Record<string, DocMsg[]> {
+  return { ...messages, [key]: [...(messages[key] ?? []), msg] };
+}
+
+export const useDocThreadStore = create<DocThreadStore>((set) => ({
+  messages: {},
+  genState: {},
+  anchor: {},
+
+  ingest: (event) => {
+    const frame = frameOf(event);
+    if (frame === null) return;
+    const { key, type, payload } = frame;
+
+    set((s) => {
+      const messages = s.messages;
+      const was = s.genState[key] ?? 'terminal';
+
+      // status.posted carries BOTH narration and the gate: `state:"asking"` is the
+      // question (§2.2 case 3), every other state is a line about the work (§3.3).
+      if (type === STATUS) {
+        const state = pick(payload, 'state') ?? 'working';
+        const text = pick(payload, 'message', 'status', 'text');
+        if (state === 'asking') {
+          const requestId = pick(payload, 'request_id', 'requestId');
+          const question = pick(payload, 'question') ?? text;
+          if (requestId === null || question === null) return s;
+          const options = Array.isArray(payload.options)
+            ? payload.options.filter((o): o is string => typeof o === 'string')
+            : [];
+          return {
+            messages: append(messages, key, { kind: 'gate', id: nextMsgId(), requestId, question, options }),
+            genState: { ...s.genState, [key]: 'gated' },
+          };
+        }
+        const done = state === 'complete' || state === 'error';
+        const next: GenState = done ? 'terminal' : was === 'gated' ? 'gated' : 'generating';
+        // §3.2: filler never reaches the transcript, but a filtered frame still carries
+        // the state transition it rode in on — dropping the LINE is not dropping the fact.
+        if (text === null || isWhimsy(text)) return { genState: { ...s.genState, [key]: next } };
+        return {
+          messages: append(messages, key, { kind: 'narration', id: nextMsgId(), text }),
+          genState: { ...s.genState, [key]: next },
+        };
+      }
+
+      // §2.5: every author is an author. A review verdict is an ordinary message with a
+      // name on it, not a toast and not a `role:"review"` special kind (§4.7).
+      if (type === CHAT) {
+        const role = pick(payload, 'role') ?? 'agent';
+        const text = pick(payload, 'text', 'message', 'content');
+        // Our own submits are echoed back by the bus; the optimistic message is already
+        // in the transcript, so re-rendering the echo would double every user line.
+        if (text === null || role === 'user') return s;
+        const author = pick(payload, 'reviewer', 'author', 'cli') ?? (role === 'review' ? 'reviewer' : 'agent');
+        return {
+          messages: append(messages, key,
+            role === 'review'
+              ? { kind: 'verdict', id: nextMsgId(), author, text }
+              : { kind: 'agent', id: nextMsgId(), author, text }),
+        };
+      }
+
+      if (type === REVIEW) {
+        const author = pick(payload, 'reviewer', 'author') ?? 'reviewer';
+        const text = pick(payload, 'verdict', 'message', 'text') ?? `${author} review complete`;
+        return { messages: append(messages, key, { kind: 'verdict', id: nextMsgId(), author, text }) };
+      }
+
+      // An export is a completed artifact, so it lands IN the thread with its download
+      // (§4.4's merged-UI change — studio's `downloadRunEvidence` pattern), not a toast.
+      if (type === EXPORTED) {
+        const format = pick(payload, 'format') ?? 'file';
+        const file = pick(payload, 'file') ?? format;
+        const href = pick(payload, 'download');
+        return {
+          messages: append(messages, key, {
+            kind: 'agent', id: nextMsgId(), author: 'export',
+            text: `${format.toUpperCase()} export ready — ${file}`,
+            ...(href === null ? {} : { href }),
+          }),
+        };
+      }
+
+      // §7.6, client half: the version the generation just landed is tagged onto the user
+      // message that triggered it, so slice 9's strip has a message to scroll to. The
+      // service half writes the same id into `versions.json`; this is what makes the
+      // anchor resolvable in the session that produced it.
+      if (type === VERSION) {
+        const raw = payload.version;
+        const version = typeof raw === 'number' ? raw : Number(pick(payload, 'version') ?? NaN);
+        const kind = pick(payload, 'kind') ?? '';
+        if (!Number.isInteger(version)) return s;
+        const anchorId = s.anchor[key];
+        const generated = GENERATED.has(kind);
+        const tagged = anchorId === undefined
+          ? messages
+          : {
+              ...messages,
+              [key]: (messages[key] ?? []).map((m) =>
+                m.kind === 'user' && m.id === anchorId ? { ...m, version } : m),
+            };
+        const anchor = { ...s.anchor };
+        if (generated) delete anchor[key];
+        return {
+          messages: tagged,
+          anchor,
+          genState: generated ? { ...s.genState, [key]: 'terminal' } : s.genState,
+        };
+      }
+
+      return s;
+    });
+  },
+
+  addUserMsg: (key, id, text) =>
+    set((s) => ({
+      messages: append(s.messages, key, { kind: 'user', id, text }),
+      anchor: { ...s.anchor, [key]: id },
+    })),
+
+  addNarration: (key, text) =>
+    set((s) => ({ messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text }) })),
+
+  addDivider: (key, version) =>
+    set((s) => ({ messages: append(s.messages, key, { kind: 'divider', id: nextMsgId(), version }) })),
+
+  setGenState: (key, state) => set((s) => ({ genState: { ...s.genState, [key]: state } })),
+
+  clear: (key) =>
+    set((s) => {
+      const messages = { ...s.messages }; delete messages[key];
+      const genState = { ...s.genState }; delete genState[key];
+      const anchor = { ...s.anchor }; delete anchor[key];
+      return { messages, genState, anchor };
+    }),
+}));

--- a/src/store/narration.ts
+++ b/src/store/narration.ts
@@ -1,0 +1,33 @@
+// The one narration rule, in code (DES-MERGE-001 §3.2/§3.3): every status line is
+// either actionable or informative, and rotating flavour text is neither.
+//
+// wicked-interactive's `Thread.jsx` rotates a fixed WHIMSY list every 4 s while the
+// agent works, because its status channel could go silent. Studio relays real output,
+// so the filler is DELETED (§4.9's only outright deletion) — and deleted at the SEAM,
+// not just at its old emit site: an upstream bridge that still speaks it must not put
+// it back on screen. Every surface that renders a relayed status routes through here.
+
+/** The verbatim WHIMSY list, normalized. Matching the phrase (not a keyword) keeps a
+ *  real status that happens to mention a gate or a lane from being swallowed. */
+const FILLER: ReadonlySet<string> = new Set([
+  'wiring the harness',
+  'pondering the loop',
+  'tightening the bolts',
+  'consulting the spine',
+  'aligning the lanes',
+  'reticulating splines',
+  'checking the gates',
+]);
+
+/** Words that cannot name a subject in any real document status, in any phrasing. */
+const NONSENSE = /reticulat|splines/i;
+
+/** Lowercase, one-space, no trailing ellipsis — the filler ships with a trailing `…`. */
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').replace(/[\s….!]+$/u, '').trim();
+}
+
+/** True when this status is flavour text and must never reach a rendering surface. */
+export function isWhimsy(text: string): boolean {
+  return NONSENSE.test(text) || FILLER.has(normalize(text));
+}

--- a/src/store/runtime.ts
+++ b/src/store/runtime.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { isWhimsy } from './narration.js';
 import type { CoreEvent } from '../api/types.js';
 
 /** Cap per (run, unit) output buffer so a chatty CLI can't grow memory unbounded. */
@@ -220,7 +221,9 @@ export function docActivityOf(frame: CoreEvent): { projectId: string; activity: 
       : {};
   const projectId = pick(payload, 'project_id', 'project') ?? pick(event, 'project_id', 'project');
   const message = pick(payload, 'message', 'status', 'text');
-  if (projectId === null || message === null) return null;
+  // §3.2 is a rule about SCREENS, not about one component: filler dropped from the
+  // transcript must not survive as the card's headline either.
+  if (projectId === null || message === null || isWhimsy(message)) return null;
   return {
     projectId,
     activity: {

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -1,0 +1,252 @@
+// The ONE composer in Document mode — DES-MERGE-001 §2.2, §7.10, §6.3 slice 10.
+//
+// What Enter does is a pure function of the generation's state, so each test drives the
+// composer in one state and asserts the WIRE it chose. The §7.10 case is the load-bearing
+// one: editing a complete version is fork + inject as a SINGLE composer action, rendered
+// as a continuation — a version divider, no new thread header.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'launch-deck';
+const KEY = threadKey(PROJECT, DOC);
+
+const createDoc = vi.fn();
+const postFork = vi.fn();
+const postEvent = vi.fn();
+const getVersions = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: (...a: unknown[]) => createDoc(...a),
+  postFork: (...a: unknown[]) => postFork(...a),
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  getVersions: (...a: unknown[]) => getVersions(...a),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+const navigate = vi.fn();
+
+function mount(docId: string | null, version: number | null = null): void {
+  render(
+    <DocumentThread projectId={PROJECT} docId={docId} selectedVersion={version} navigate={navigate} />,
+  );
+}
+
+/** The doc's transcript as the store holds it. */
+function thread(): DocMsg[] {
+  return useDocThreadStore.getState().messages[KEY] ?? [];
+}
+
+/** A message's id, or a sentinel that fails the comparison it is used in. */
+function idOf(msg: DocMsg | undefined): string {
+  return msg?.id ?? '<no message>';
+}
+
+async function send(text: string): Promise<void> {
+  const user = userEvent.setup();
+  await user.type(screen.getByTestId('doc-composer'), text);
+  await user.click(screen.getByTestId('doc-composer-submit'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {} });
+  createDoc.mockResolvedValue({ name: DOC, head: 0, generating: true });
+  postFork.mockResolvedValue({ version: 4, parent: 3 });
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  getVersions.mockResolvedValue({ head: 3, versions: [] });
+});
+
+afterEach(cleanup);
+
+describe('state 1 — idle: typing CREATES the doc-generation run', () => {
+  it('posts the message as the brief and opens the run in the thread', async () => {
+    mount(null);
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'idle');
+
+    await send('a deck for the Q3 review');
+
+    await waitFor(() => expect(createDoc).toHaveBeenCalledTimes(1));
+    // The message is the FIRST line of the new doc's thread, with the run opening
+    // named after it (§3.3 informative — a subject, never a bare spinner).
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: 'a deck for the Q3 review' });
+    expect(thread()[1]).toMatchObject({ kind: 'narration', text: `Generating “${DOC}” from your brief.` });
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}`);
+    // The anchor id travels WITH the request (§7.6) — same id as the message.
+    expect(createDoc).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      kind: 'source', brief: 'a deck for the Q3 review', project: PROJECT,
+      source_message_id: idOf(thread()[0]),
+    }));
+  });
+
+  it('surfaces a refused create without losing the message', async () => {
+    createDoc.mockRejectedValue(new Error('API 409: doc already exists'));
+    mount(null);
+    await send('a deck for the Q3 review');
+    await waitFor(() => expect(screen.getByTestId('doc-composer-error')).toHaveTextContent('409'));
+    expect(screen.getByTestId('doc-composer')).toHaveValue('a deck for the Q3 review');
+  });
+});
+
+describe('state 2 — generating: typing INJECTS steering', () => {
+  beforeEach(() => useDocThreadStore.getState().setGenState(KEY, 'generating'));
+
+  it('shows the steering chip and injects rather than creating anything', async () => {
+    mount(DOC);
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'generating');
+    expect(screen.getByTestId('steering-chip')).toBeInTheDocument();
+
+    await send('keep it to five slides');
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: 'wicked.interactive.chat.posted',
+      payload: expect.objectContaining({ role: 'user', text: 'keep it to five slides', document_id: DOC }),
+    }));
+    expect(createDoc).not.toHaveBeenCalled();
+    expect(postFork).not.toHaveBeenCalled();
+    expect(screen.getByTestId('doc-message')).toHaveTextContent('keep it to five slides');
+  });
+
+  it('the chip is absent in every other state — it names a live run, not a decoration', () => {
+    useDocThreadStore.getState().setGenState(KEY, 'terminal');
+    mount(DOC);
+    expect(screen.queryByTestId('steering-chip')).toBeNull();
+  });
+});
+
+describe('state 3 — gated: the gate is answerable in the thread', () => {
+  beforeEach(() => {
+    useDocThreadStore.getState().ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.status.posted',
+        payload: {
+          project_id: PROJECT, document_id: DOC, state: 'asking',
+          request_id: 'req-7', question: 'Deck or one-pager?', options: ['Deck', 'One-pager'],
+        },
+      },
+    } as never);
+  });
+
+  it('answers with one click on an option, in the transcript', async () => {
+    mount(DOC);
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'gated');
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Deck' }));
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: 'wicked.interactive.question.answered',
+      payload: expect.objectContaining({ request_id: 'req-7', answer: 'Deck', document_id: DOC }),
+    }));
+    await waitFor(() => expect(useDocThreadStore.getState().genState[KEY]).toBe('generating'));
+  });
+
+  it('free text answers the gate AND steers in one submit (§2.2 case 3)', async () => {
+    mount(DOC);
+    await send('a one-pager, but keep the chart');
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: 'wicked.interactive.question.answered',
+      payload: expect.objectContaining({ request_id: 'req-7', answer: 'a one-pager, but keep the chart' }),
+    }));
+    expect(screen.getByTestId('doc-message')).toHaveTextContent('a one-pager, but keep the chart');
+  });
+});
+
+describe('state 4 — terminal: fork + inject is ONE atomic action (§7.10)', () => {
+  it('forks from the shown version, injects with the same message, renders a continuation', async () => {
+    mount(DOC, 3);
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'terminal');
+
+    await send('make the closing slide stronger');
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    // ONE composer action → one fork, one inject, both carrying the same anchor id.
+    const anchorId = screen.getByTestId('doc-message').getAttribute('data-message-id');
+    expect(postFork).toHaveBeenCalledTimes(1);
+    expect(postFork).toHaveBeenCalledWith(PROJECT, DOC, 3, anchorId);
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      payload: expect.objectContaining({
+        text: 'make the closing slide stronger', document_id: DOC, source_message_id: anchorId,
+      }),
+    }));
+
+    // Rendered as a CONTINUATION: a version divider, and no new thread header.
+    const divider = screen.getByTestId('version-divider');
+    expect(divider).toHaveAttribute('data-version', '4');
+    expect(divider).toHaveTextContent('continues as v4');
+    expect(screen.queryByTestId('thread-header')).toBeNull();
+    expect(screen.getAllByTestId('thread')).toHaveLength(1);
+
+    // The divider precedes the message it continues into, and the composer is live again.
+    const order = (useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind);
+    expect(order).toEqual(['divider', 'user']);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=4`);
+  });
+
+  it('with no routed version it forks from the manifest head, never from v1', async () => {
+    mount(DOC, null);
+    await send('tighten the intro');
+    await waitFor(() => expect(postFork).toHaveBeenCalledTimes(1));
+    expect(getVersions).toHaveBeenCalledWith(PROJECT, DOC);
+    expect(postFork).toHaveBeenCalledWith(PROJECT, DOC, 3, expect.any(String));
+  });
+});
+
+describe('the transcript is the record (§2.3, §2.5)', () => {
+  it('renders narration, agent replies, verdicts and export artifacts in arrival order', () => {
+    const store = useDocThreadStore.getState();
+    store.addNarration(KEY, 'Rewriting slide 3 — tightening the headline');
+    store.ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.review.completed',
+        payload: { project_id: PROJECT, document_id: DOC, reviewer: 'a11y', verdict: 'Contrast fails on slide 2' },
+      },
+    } as never);
+    store.ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.export.generated',
+        payload: {
+          project_id: PROJECT, document_id: DOC, format: 'pdf', file: 'launch-deck_v3.pdf',
+          download: '/d/launch-deck/download/launch-deck_v3.pdf',
+        },
+      },
+    } as never);
+    mount(DOC);
+
+    expect(screen.getByTestId('doc-narration')).toHaveTextContent('Rewriting slide 3');
+    expect(screen.getByTestId('doc-verdict')).toHaveTextContent('a11y · review');
+    expect(screen.getByTestId('doc-verdict')).toHaveTextContent('Contrast fails on slide 2');
+    expect(screen.getByTestId('doc-artifact-download')).toHaveAttribute(
+      'href', `/api/v1/projects/${PROJECT}/interactive/d/launch-deck/download/launch-deck_v3.pdf`,
+    );
+  });
+
+  it('a version-tagged message carries the anchor attributes slice 9 scrolls to (§7.6)', () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dmsg-anchor', 'make the intro punchier');
+    store.ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.version.created',
+        payload: { project_id: PROJECT, document_id: DOC, version: 7, parent: 6, kind: 'generated' },
+      },
+    } as never);
+    mount(DOC);
+
+    const message = screen.getByTestId('doc-message');
+    expect(message).toHaveAttribute('data-message-id', 'dmsg-anchor');
+    expect(message).toHaveAttribute('data-version', '7');
+    // The strip resolves the anchor through the DOM contract, so it must be findable.
+    expect(screen.getByTestId('thread').querySelector('[data-message-id="dmsg-anchor"]')).toBe(message);
+  });
+});

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -33,7 +33,7 @@ function messages(): DocMsg[] {
 }
 
 function texts(): string[] {
-  return messages().map((m) => ('text' in m ? m.text : `divider:v${m.version}`));
+  return messages().flatMap((m) => ('text' in m ? [m.text] : []));
 }
 
 function state(): string | undefined {
@@ -56,9 +56,10 @@ describe('composer state mapping (§2.2)', () => {
       state: 'asking', request_id: 'req-7', question: 'Deck or one-pager?', options: ['Deck', 'One-pager'],
     }));
     expect(state()).toBe('gated');
-    const gate = messages()[0];
-    expect(gate).toMatchObject({ kind: 'gate', requestId: 'req-7', question: 'Deck or one-pager?' });
-    expect(gate.kind === 'gate' && gate.options).toEqual(['Deck', 'One-pager']);
+    expect(messages()[0]).toMatchObject({
+      kind: 'gate', requestId: 'req-7', question: 'Deck or one-pager?',
+      options: ['Deck', 'One-pager'],
+    });
   });
 
   it('a status arriving DURING a gate narrates without clearing the gate', () => {

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -1,0 +1,191 @@
+// The Document-mode transcript store — DES-MERGE-001 §6.3 slice 10.
+//
+// Four concerns, one per AC:
+//   1. Composer state mapping: the four §2.2 states, derived from the relayed stream.
+//   2. The whimsy filter (§3.2): filler never becomes a message, at either altitude.
+//   3. Authorship (§2.5): review verdicts and export completions are ORDINARY messages.
+//   4. Version anchors (§7.6, client half): a landed version tags the message that
+//      triggered it, so slice 9's strip has something to scroll to.
+import { beforeEach, describe, expect, it } from 'vitest';
+import { nextMsgId, threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+import { isWhimsy } from '../src/store/narration.js';
+import { docActivityOf } from '../src/store/runtime.js';
+import type { CoreEvent } from '../src/api/types.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'launch-deck';
+const KEY = threadKey(PROJECT, DOC);
+
+/** One frame as crew relays it (slice 3's envelope). */
+function frame(eventType: string, payload: Record<string, unknown>): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: { event_type: eventType, payload: { project_id: PROJECT, document_id: DOC, ...payload } },
+  } as unknown as CoreEvent;
+}
+
+function ingest(event: CoreEvent): void {
+  useDocThreadStore.getState().ingest(event);
+}
+
+function messages(): DocMsg[] {
+  return useDocThreadStore.getState().messages[KEY] ?? [];
+}
+
+function texts(): string[] {
+  return messages().map((m) => ('text' in m ? m.text : `divider:v${m.version}`));
+}
+
+function state(): string | undefined {
+  return useDocThreadStore.getState().genState[KEY];
+}
+
+beforeEach(() => {
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {} });
+});
+
+describe('composer state mapping (§2.2)', () => {
+  it('a status while working puts the thread in GENERATING', () => {
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Planning 4 slides' }));
+    expect(state()).toBe('generating');
+    expect(texts()).toEqual(['Planning 4 slides']);
+  });
+
+  it('state:"asking" is a GATE, answerable in the thread with its options', () => {
+    ingest(frame('wicked.interactive.status.posted', {
+      state: 'asking', request_id: 'req-7', question: 'Deck or one-pager?', options: ['Deck', 'One-pager'],
+    }));
+    expect(state()).toBe('gated');
+    const gate = messages()[0];
+    expect(gate).toMatchObject({ kind: 'gate', requestId: 'req-7', question: 'Deck or one-pager?' });
+    expect(gate.kind === 'gate' && gate.options).toEqual(['Deck', 'One-pager']);
+  });
+
+  it('a status arriving DURING a gate narrates without clearing the gate', () => {
+    ingest(frame('wicked.interactive.status.posted', { state: 'asking', request_id: 'r1', question: 'Which theme?' }));
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Waiting on your answer' }));
+    expect(state()).toBe('gated');
+  });
+
+  it('state:"complete" and state:"error" are both TERMINAL — the composer continues', () => {
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Drafting' }));
+    ingest(frame('wicked.interactive.status.posted', { state: 'complete', message: 'Draft landed' }));
+    expect(state()).toBe('terminal');
+    ingest(frame('wicked.interactive.status.posted', { state: 'error', message: 'Could not read the source file' }));
+    expect(state()).toBe('terminal');
+  });
+
+  it('a generated version ends the working state; a fork does not', () => {
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    ingest(frame('wicked.interactive.version.created', { version: 4, parent: 3, kind: 'fork' }));
+    expect(state()).toBe('generating');
+    ingest(frame('wicked.interactive.version.created', { version: 5, parent: 4, kind: 'generated' }));
+    expect(state()).toBe('terminal');
+  });
+
+  it('ignores frames that are not relayed interactive events, and unkeyable ones', () => {
+    ingest({ type: 'unitOutputDelta', session: 's1', ord: 0, text: 'hi' } as unknown as CoreEvent);
+    ingest({
+      type: 'interactiveEvent',
+      event: { event_type: 'wicked.interactive.status.posted', payload: { message: 'no ids here' } },
+    } as unknown as CoreEvent);
+    expect(useDocThreadStore.getState().messages).toEqual({});
+  });
+});
+
+describe('whimsy filter (§3.2)', () => {
+  const WHIMSY = [
+    'Wiring the harness…', 'Pondering the loop…', 'Tightening the bolts…', 'Consulting the spine…',
+    'Aligning the lanes…', 'Reticulating splines…', 'Checking the gates…',
+  ];
+
+  it('recognizes every line of interactive\'s WHIMSY list, ellipsis or not', () => {
+    for (const line of WHIMSY) {
+      expect(isWhimsy(line)).toBe(true);
+      expect(isWhimsy(line.replace('…', ''))).toBe(true);
+    }
+  });
+
+  it('keeps real narration that merely mentions a filler word', () => {
+    expect(isWhimsy('Checking the gates on run 4 — 2 of 3 approved')).toBe(false);
+    expect(isWhimsy('Rewriting slide 3 — tightening the headline')).toBe(false);
+  });
+
+  it('drops filler from the transcript while keeping the state it rode in on', () => {
+    for (const line of WHIMSY) {
+      ingest(frame('wicked.interactive.status.posted', { state: 'working', message: line }));
+    }
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Rewriting slide 3' }));
+    expect(texts()).toEqual(['Rewriting slide 3']);
+    expect(state()).toBe('generating');
+  });
+
+  it('drops filler from the board headline too — one rule, both altitudes (§3.4)', () => {
+    expect(docActivityOf(frame('wicked.interactive.status.posted', { message: 'Reticulating splines…' }))).toBeNull();
+    expect(docActivityOf(frame('wicked.interactive.status.posted', { message: 'Planning: 4 units' })))
+      .toMatchObject({ projectId: PROJECT, activity: { message: 'Planning: 4 units' } });
+  });
+});
+
+describe('ordinary messages, not toasts (§2.5 / §4.4)', () => {
+  it('a review verdict is a message with its reviewer as the author', () => {
+    ingest(frame('wicked.interactive.review.completed', { reviewer: 'a11y', verdict: 'Contrast fails on slide 2' }));
+    expect(messages()[0]).toMatchObject({ kind: 'verdict', author: 'a11y', text: 'Contrast fails on slide 2' });
+  });
+
+  it('a chat line with role:"review" collapses into the same verdict shape', () => {
+    ingest(frame('wicked.interactive.chat.posted', { role: 'review', reviewer: 'copy', text: 'Headline is vague' }));
+    expect(messages()[0]).toMatchObject({ kind: 'verdict', author: 'copy', text: 'Headline is vague' });
+  });
+
+  it('an agent reply lands as an agent message; our own echoed user line does not', () => {
+    ingest(frame('wicked.interactive.chat.posted', { role: 'agent', text: 'Reworked the intro' }));
+    ingest(frame('wicked.interactive.chat.posted', { role: 'user', text: 'make it shorter' }));
+    expect(messages()).toHaveLength(1);
+    expect(messages()[0]).toMatchObject({ kind: 'agent', text: 'Reworked the intro' });
+  });
+
+  it('a completed export lands in the thread as a downloadable message', () => {
+    ingest(frame('wicked.interactive.export.generated', {
+      version: 3, format: 'pdf', file: 'launch-deck_v3.pdf', download: '/d/launch-deck/api/download/launch-deck_v3.pdf',
+    }));
+    expect(messages()[0]).toMatchObject({
+      kind: 'agent', author: 'export', text: 'PDF export ready — launch-deck_v3.pdf',
+      href: '/d/launch-deck/api/download/launch-deck_v3.pdf',
+    });
+  });
+});
+
+describe('version anchors (§7.6, client half)', () => {
+  it('tags the triggering user message with the version the generation landed', () => {
+    const id = nextMsgId();
+    useDocThreadStore.getState().addUserMsg(KEY, id, 'make the intro punchier');
+    ingest(frame('wicked.interactive.version.created', { version: 7, parent: 6, kind: 'generated' }));
+    expect(messages()[0]).toMatchObject({ kind: 'user', id, version: 7 });
+  });
+
+  it('tags the LAST user message before generation started, not an earlier one', () => {
+    const first = nextMsgId();
+    useDocThreadStore.getState().addUserMsg(KEY, first, 'first ask');
+    const second = nextMsgId();
+    useDocThreadStore.getState().addUserMsg(KEY, second, 'actually, do this instead');
+    ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
+    const tagged = messages().filter((m) => m.kind === 'user' && m.version !== undefined);
+    expect(tagged).toHaveLength(1);
+    expect(tagged[0]).toMatchObject({ id: second, version: 2 });
+  });
+
+  it('a fork version tags the message but leaves it anchored for the generation to come', () => {
+    const id = nextMsgId();
+    useDocThreadStore.getState().addUserMsg(KEY, id, 'try a darker theme');
+    ingest(frame('wicked.interactive.version.created', { version: 4, parent: 1, kind: 'fork' }));
+    expect(messages()[0]).toMatchObject({ version: 4 });
+    ingest(frame('wicked.interactive.version.created', { version: 5, parent: 4, kind: 'generated' }));
+    expect(messages()[0]).toMatchObject({ version: 5 });
+  });
+
+  it('a version with no message behind it tags nothing and throws nothing', () => {
+    ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
+    expect(messages()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Slice 10, authored and delivered by governed run `06931571` (feature-pr workflow — the run opened this PR).

Document mode mounts the single conversation thread beside the canvas: the §2.2 composer states mapped to document wires (idle→generate, generating→inject with steering chip, gated→answer in thread, terminal→fork+inject as ONE atomic continuation with a version divider per §7.10). `interactiveEvent` narration renders as informative subject-lines; whimsy filler is filtered dead (`/reticulating|splines|bolts/i` never renders); review verdicts and exports arrive as ordinary messages; completed generations tag their triggering message with the version (client half of §7.6, feeding slice 9's anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)