### PR TITLE
feat(ui): breathing live-edge for executing work (operator UX request)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -1530,6 +1530,16 @@ try:
             [edge_busy, edge_gate],
         )
         page.screenshot(path=str(SHOTS / "liveedge-board-executing-vs-gate.png"), full_page=True)
+        # A second shot with the executing card actually on screen. Attention order puts
+        # every gate-waiting card above it — which is the point — so the first shot alone
+        # shows a reviewer only the treatment that was already there.
+        page.evaluate(
+            """id => document.querySelector(
+                 `[data-testid="project-card"][data-project-id="${id}"]`
+               )?.scrollIntoView({ block: 'center' })""",
+            edge_busy,
+        )
+        page.screenshot(path=str(SHOTS / "liveedge-board-executing.png"), full_page=True)
         browser.close()
 
         # AC (rule 4): prefers-reduced-motion substitutes a STATIC, higher-contrast
@@ -1595,7 +1605,8 @@ try:
         "reduced_motion_ms": reduced_ms,
         "console_errors": edge_console[:10],
         "screenshots": [str(SHOTS / n) for n in
-                        ("liveedge-board-executing-vs-gate.png", "liveedge-reduced-motion.png")],
+                        ("liveedge-board-executing-vs-gate.png", "liveedge-board-executing.png",
+                         "liveedge-reduced-motion.png")],
     }
     if not report["steps"]["live_edge"]["ok"]:
         fail("live_edge_verdict", "live-edge assertions did not all hold — see live_edge")

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -59,6 +59,13 @@ What "independent" means here, and what this script proves end-to-end:
      generation window renders NOTHING while real narration lands, and no
      `status.requested` heartbeat is ever emitted; and a landed version tags the
      message that triggered it (§7.6).
+ 14. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
+     ranked: in one DOM snapshot an executing card carries the breathing 2px
+     `live-edge` element while a gate-waiting card carries a treatment that is
+     present at the same time and different in computed pixels (wider, solid,
+     accent-coloured, unanimated), the run chip inside the executing card carries
+     the same edge, and under prefers-reduced-motion the animation is replaced by
+     a wider solid edge rather than dropped.
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -1447,6 +1454,151 @@ try:
     }
     if not report["steps"]["doc_thread"]["ok"]:
         fail("doc_thread_verdict", "slice-10 document-thread assertions did not all hold — see doc_thread")
+
+    # ── 15. Operator UX directive: the live edge on the board ──────────────────
+    # The ACTIVE-WORK signal is a breathing 2px strip along the leading edge of the
+    # element doing work, and the thing that has to hold is the RANKING: a busy card
+    # must be visible without out-shouting a card that needs a human. So both states
+    # are asserted in ONE DOM snapshot, and asserted to be DIFFERENT — same testid,
+    # different state, different computed pixels.
+    #
+    # The gate side is the real daemon (a run genuinely parked on a human gate). The
+    # executing side pins `GET /runs` for ONE run's status word, the same discipline
+    # slice 7 used for its complex gate: the run is real and filed, the payload
+    # travels the full app path (fetch → useRuns → board → card), and the assertion
+    # is about the treatment rather than about whether the stub engine happens to
+    # still be mid-unit when the browser looks.
+    edge_gate = new_project(f"edge-gate-{tag}")
+    attach_run(edge_gate, await_gate(launch("live edge: parks on a gate", "all")))
+    edge_busy = new_project(f"edge-busy-{tag}")
+    edge_busy_run = launch("live edge: executing while the board is watched", "none")
+    attach_run(edge_busy, edge_busy_run)
+
+    def pin_executing(route):
+        """Hold ONE run at `executing` in the run list; pass every other run through."""
+        response = route.fetch()
+        body = response.json()
+        for view in body.get("runs", []):
+            if view["session"]["id"] == edge_busy_run:
+                view["session"]["status"] = "executing"
+        route.fulfill(response=response, json=body)
+
+    # Everything the browser needs to know about one card's edge, in one snapshot.
+    EDGE = """id => {
+      const card = document.querySelector(`[data-testid="project-card"][data-project-id="${id}"]`);
+      if (!card) return null;
+      const own = card.querySelector(':scope > [data-testid="live-edge"]');
+      const chip = card.querySelector('[data-testid="run-chip"] [data-testid="live-edge"]');
+      const read = (el) => {
+        if (!el) return null;
+        const cs = getComputedStyle(el);
+        return { state: el.dataset.edgeState, className: el.className,
+                 animation: cs.animationName, duration: cs.animationDuration,
+                 width: cs.width, background: cs.backgroundColor, opacity: cs.opacity };
+      };
+      return { attention: card.dataset.attention, own: read(own), chip: read(chip) };
+    }"""
+
+    edge_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.on("console", lambda m: edge_console.append(m.text) if m.type == "error" else None)
+        page.route(f"{API}/runs", pin_executing)
+
+        page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        # AC: an executing card exposes the live-edge element.
+        busy_edge_ok, busy_edge_ms = within(
+            page,
+            """id => { const c = document.querySelector(
+                         `[data-testid="project-card"][data-project-id="${id}"]`);
+                       return c?.querySelector(
+                         ':scope > [data-testid="live-edge"]')?.dataset.edgeState === 'executing'; }""",
+            edge_busy,
+            budget_ms=30000,
+        )
+        # AC: the gate-waiting card's treatment is present AT THE SAME TIME — one
+        # snapshot, both cards, so this cannot pass by the two states taking turns.
+        page.evaluate(f"() => {{ window.__readEdge = {EDGE}; }}")
+        busy = page.evaluate("id => window.__readEdge(id)", edge_busy)
+        gate = page.evaluate("id => window.__readEdge(id)", edge_gate)
+        simultaneous = page.evaluate(
+            """ids => ids.every(id => !!document.querySelector(
+                 `[data-testid="project-card"][data-project-id="${id}"] [data-testid="live-edge"]`))""",
+            [edge_busy, edge_gate],
+        )
+        page.screenshot(path=str(SHOTS / "liveedge-board-executing-vs-gate.png"), full_page=True)
+        browser.close()
+
+        # AC (rule 4): prefers-reduced-motion substitutes a STATIC, higher-contrast
+        # edge. Asserted in a real CSS engine, which is the only place the media
+        # query exists — the unit tests pin the class the component maps to.
+        reduced_browser = p.chromium.launch()
+        reduced_page = reduced_browser.new_page()
+        reduced_page.emulate_media(reduced_motion="reduce")
+        reduced_page.route(f"{API}/runs", pin_executing)
+        reduced_page.goto(f"{STUDIO_ORIGIN}/", wait_until="networkidle")
+        reduced_page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        reduced_ok, reduced_ms = within(
+            reduced_page,
+            """id => { const c = document.querySelector(
+                         `[data-testid="project-card"][data-project-id="${id}"]`);
+                       return c?.querySelector(
+                         ':scope > [data-testid="live-edge"]')?.dataset.edgeState === 'executing'; }""",
+            edge_busy,
+            budget_ms=30000,
+        )
+        reduced_page.evaluate(f"() => {{ window.__readEdge = {EDGE}; }}")
+        reduced = reduced_page.evaluate("id => window.__readEdge(id)", edge_busy)
+        reduced_page.screenshot(path=str(SHOTS / "liveedge-reduced-motion.png"), full_page=True)
+        reduced_browser.close()
+
+    busy_own = (busy or {}).get("own") or {}
+    gate_own = (gate or {}).get("own") or {}
+    busy_chip = (busy or {}).get("chip") or {}
+    reduced_own = (reduced or {}).get("own") or {}
+    report["steps"]["live_edge"] = {
+        "ok": all([
+            busy_edge_ok, simultaneous,
+            busy_own.get("state") == "executing",
+            gate_own.get("state") == "gate",
+            # Distinct, and distinct in PIXELS rather than only in a class name.
+            busy_own.get("className") != gate_own.get("className"),
+            busy_own.get("background") != gate_own.get("background"),
+            busy_own.get("width") != gate_own.get("width"),
+            # Motion is what catches the eye — and only executing gets it. A gate is
+            # louder by contrast, so a wall of busy cards cannot drown it out.
+            busy_own.get("animation") == "wk-live-pulse",
+            busy_own.get("duration") == "2s",
+            gate_own.get("animation") == "none",
+            gate_own.get("opacity") == "1",
+            # Rule 5: the same treatment on the run chip inside the card.
+            busy_chip.get("state") == "executing",
+            # Rule 4: no animation, and MORE contrast than the breath it replaced.
+            reduced_ok,
+            reduced_own.get("animation") == "none",
+            reduced_own.get("opacity") == "1",
+            reduced_own.get("width") != busy_own.get("width"),
+        ]),
+        "gate_project": edge_gate,
+        "busy_project": edge_busy,
+        "busy_run": edge_busy_run,
+        "executing_card_exposes_live_edge": busy_edge_ok,
+        "executing_edge_ms": busy_edge_ms,
+        "both_treatments_present_at_once": simultaneous,
+        "executing_edge": busy_own,
+        "gate_edge": gate_own,
+        "executing_run_chip_edge": busy_chip,
+        "reduced_motion_edge": reduced_own,
+        "reduced_motion_ms": reduced_ms,
+        "console_errors": edge_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("liveedge-board-executing-vs-gate.png", "liveedge-reduced-motion.png")],
+    }
+    if not report["steps"]["live_edge"]["ok"]:
+        fail("live_edge_verdict", "live-edge assertions did not all hold — see live_edge")
 
     report["ok"] = True
     print(json.dumps(report, indent=2))

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { useGateStore } from '../store/gates.js';
 import { useElicitationStore } from '../store/elicitations.js';
 import { ElicitationPrompt } from './ElicitationPrompt.js';
 import { useRuntimeStore, outputKey, type CouncilStatus } from '../store/runtime.js';
+import { LiveEdge } from './LiveEdge.js';
 import { STATUS_STYLE } from './RunCard.js';
 import { SteeringGate } from './SteeringGate.js';
 import { ChatInput } from './ChatInput.js';
@@ -89,11 +90,17 @@ function routingSummary(unit: WorkUnit): string | null {
 /** A phase's place in the run: finished, judged-and-rejected, running now, or still to come. */
 type StepState = 'done' | 'rejected' | 'active' | 'queued';
 
+/**
+ * `active` is link-blue, not accent-yellow: yellow is the colour of a gate — the state
+ * that needs a human — and spending it on "a phase is running" left the two ranked the
+ * same. Executing now carries the same blue live edge it carries on the board, and the
+ * attention colour is free to mean only one thing.
+ */
 const STEP_STYLE: Record<StepState, { color: string; background: string; border: string }> = {
-  done:     { color: '#3fb950',               background: 'rgba(63,185,80,0.1)',   border: '1px solid rgba(63,185,80,0.25)' },
-  rejected: { color: '#f85149',               background: 'rgba(248,81,73,0.1)',   border: '1px solid rgba(248,81,73,0.3)' },
-  active:   { color: '#ffda19',               background: 'rgba(255,218,25,0.12)', border: '1px solid rgba(255,218,25,0.35)' },
-  queued:   { color: 'rgba(230,237,243,0.3)', background: 'transparent',           border: '1px solid rgba(230,237,243,0.08)' },
+  done:     { color: '#3fb950',               background: 'rgba(63,185,80,0.1)',    border: '1px solid rgba(63,185,80,0.25)' },
+  rejected: { color: '#f85149',               background: 'rgba(248,81,73,0.1)',    border: '1px solid rgba(248,81,73,0.3)' },
+  active:   { color: '#79c0ff',               background: 'rgba(121,192,255,0.12)', border: '1px solid rgba(121,192,255,0.35)' },
+  queued:   { color: 'rgba(230,237,243,0.3)', background: 'transparent',            border: '1px solid rgba(230,237,243,0.08)' },
 };
 
 /**
@@ -154,16 +161,16 @@ function ProcessStepper({
               data-testid={`stepper-phase-${unit.ord}`}
               data-state={state}
               title={tooltip}
-              className="rounded-full px-2.5 py-0.5 flex items-center gap-1.5 whitespace-nowrap"
+              className="rounded-full px-2.5 py-0.5 flex items-center gap-1.5 whitespace-nowrap relative"
               style={{ background: s.background, border: s.border, color: s.color }}
             >
               {state === 'done' && <span aria-hidden="true">✓</span>}
               {state === 'rejected' && <span aria-hidden="true">✗</span>}
+              {/* The breathing edge is the signal; the dot stays only for colour
+                  continuity with the run's status, so it no longer pulses too. */}
+              {state === 'active' && <LiveEdge state="executing" pill />}
               {state === 'active' && (
-                <span
-                  className="inline-block w-1.5 h-1.5 rounded-full animate-pulse shrink-0"
-                  style={{ background: '#ffda19' }}
-                />
+                <span className="inline-block w-1.5 h-1.5 rounded-full shrink-0" style={{ background: '#79c0ff' }} />
               )}
               {phaseName(runId, unit)}
             </span>

--- a/src/components/LiveEdge.tsx
+++ b/src/components/LiveEdge.tsx
@@ -1,29 +1,74 @@
+import type { SessionStatus } from '../api/types.js';
+
 /**
- * A 2 px accent strip placed along the leading (left) edge of an executing element.
- * The parent must have `position: relative` and `overflow: hidden` so the strip is
- * clipped by the parent's border-radius.  Never rendered for gate-waiting, failed,
- * or terminal states — those carry their own distinct treatments.
+ * The live edge — the PRIMARY signal that an element is doing work (operator UX
+ * directive). A blinking status dot was the old signal and was too easy to miss: 5px
+ * of colour in a card header does not reach peripheral vision. A 2px strip running the
+ * full leading edge of the card does, because it is long, and it *moves* — a slow
+ * opacity breath (0.5→1 over 2s) rather than a blink, so a wall of 20 cards reads as
+ * calm rather than as an alarm panel.
  *
- * Motion: slow opacity breath (0.5→1, 2 s ease-in-out, via .wk-live-edge in index.css).
- * Reduced-motion: animation is suppressed by the CSS media query; the strip stays at
- * full opacity so the state is still obvious.  The component also reads matchMedia and
- * sets data-reduced="true" so unit tests can assert the reduced-motion branch without
- * a real CSS engine.
+ * Ranking is the constraint that shapes the rest (rule 2). GATE-WAITING needs a human
+ * and must out-rank executing, so the two treatments are deliberately asymmetric:
+ *
+ *   executing    2px, link-blue, breathing 0.5→1, faint glow  — "something is happening"
+ *   gate-waiting 3px, accent-yellow, SOLID at full opacity     — "you are the blocker"
+ *
+ * The gate edge does not breathe. Motion is a limited resource on this surface: if both
+ * states moved, the wall of executing cards would drown out the one card that needs a
+ * decision. The gate's own urgency is carried by contrast (wider, brighter, unwavering)
+ * plus the controls beside it — the answerable `GateChip`, whose badge already pulses.
+ *
+ * Placement contract: the parent must be `position: relative`, and should be
+ * `overflow: hidden` so the parent's border-radius clips the strip's ends.
  */
 
-function prefersReducedMotion(): boolean {
-  return typeof window !== 'undefined' &&
+/** Statuses in which a run is moving under its own power — all of them get the edge. */
+const WORKING: ReadonlySet<SessionStatus> = new Set(['planning', 'distributing', 'executing']);
+
+export type EdgeState = 'gate' | 'executing' | 'none';
+
+/**
+ * The status → state reduction, gate-dominant. Takes a list so one function serves a
+ * single run (`edgeStateOf([session.status])` — a chip, a run card, a stepper phase)
+ * and a whole board card (every run on it) with the same ranking rule. `failed` and the
+ * terminal statuses get no edge: they are not doing work, and they already carry their
+ * own colour on the status dot and in `FailureBanner`.
+ */
+export function edgeStateOf(statuses: readonly SessionStatus[]): EdgeState {
+  if (statuses.includes('awaiting_human')) return 'gate';
+  if (statuses.some((s) => WORKING.has(s))) return 'executing';
+  return 'none';
+}
+
+/** True when the OS asks for no animation. Guarded: jsdom and SSR have no `matchMedia`. */
+export function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-export function LiveEdge(): React.ReactElement {
-  const reduced = prefersReducedMotion();
-  return (
-    <span
-      data-testid="live-edge"
-      aria-hidden="true"
-      className="wk-live-edge"
-      {...(reduced ? { 'data-reduced': 'true' } : {})}
-    />
-  );
+/**
+ * The state → class mapping (see `index.css` for what each class does).
+ *
+ * `reduced` swaps the executing treatment for `--static`: no animation, and a wider
+ * solid edge at full opacity, so removing the motion makes the state *more* obvious
+ * rather than less (rule 4). The gate treatment is already static, so it is unchanged.
+ *
+ * `pill` insets the strip for a fully-rounded container (the stepper's phase chips),
+ * where an edge at `left: 0` would land on the cap's curve.
+ */
+export function liveEdgeClass(state: EdgeState, reduced: boolean, pill = false): string | null {
+  if (state === 'none') return null;
+  const base = state === 'gate'
+    ? 'wk-live-edge wk-live-edge--gate'
+    : reduced ? 'wk-live-edge wk-live-edge--static' : 'wk-live-edge';
+  return pill ? `${base} wk-live-edge--pill` : base;
+}
+
+export function LiveEdge({ state, pill = false }: { state: EdgeState; pill?: boolean }): React.ReactElement | null {
+  // Read per render rather than through a media-query listener: every consumer already
+  // re-renders on store updates, so a mid-session preference change self-corrects.
+  const className = liveEdgeClass(state, prefersReducedMotion(), pill);
+  if (className === null) return null;
+  return <span data-testid="live-edge" data-edge-state={state} aria-hidden="true" className={className} />;
 }

--- a/src/components/LiveEdge.tsx
+++ b/src/components/LiveEdge.tsx
@@ -1,0 +1,29 @@
+/**
+ * A 2 px accent strip placed along the leading (left) edge of an executing element.
+ * The parent must have `position: relative` and `overflow: hidden` so the strip is
+ * clipped by the parent's border-radius.  Never rendered for gate-waiting, failed,
+ * or terminal states — those carry their own distinct treatments.
+ *
+ * Motion: slow opacity breath (0.5→1, 2 s ease-in-out, via .wk-live-edge in index.css).
+ * Reduced-motion: animation is suppressed by the CSS media query; the strip stays at
+ * full opacity so the state is still obvious.  The component also reads matchMedia and
+ * sets data-reduced="true" so unit tests can assert the reduced-motion branch without
+ * a real CSS engine.
+ */
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function LiveEdge(): React.ReactElement {
+  const reduced = prefersReducedMotion();
+  return (
+    <span
+      data-testid="live-edge"
+      aria-hidden="true"
+      className="wk-live-edge"
+      {...(reduced ? { 'data-reduced': 'true' } : {})}
+    />
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -5,6 +5,7 @@ import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
 import { GateChip } from './GateChip.js';
+import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 import { STATUS_STYLE } from './RunCard.js';
 
 /**
@@ -63,6 +64,8 @@ const CSS = {
     height: `${CARD_H}px`, boxSizing: 'border-box', overflow: 'hidden', background: '#161b22',
     border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
     display: 'flex', flexDirection: 'column',
+    // Anchors the live edge, and the radius above clips its ends (see LiveEdge).
+    position: 'relative',
   },
   header: { display: 'flex', alignItems: 'center', gap: '8px' },
   name: {
@@ -181,7 +184,13 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
 
   return (
     <section data-testid="project-card" data-project-id={project.id} data-attention={attention} style={CSS.card}>
-      {/* Header — name, repo binding, status dot */}
+      {/* The card's own state signal, read from the RUNS rather than from `attention`:
+          a project bucketed as `failing` can still have something executing on it, and
+          the edge answers "is work moving here", not "which bucket did this sort into". */}
+      <LiveEdge state={edgeStateOf(runs.map((v) => v.session.status))} />
+
+      {/* Header — name, repo binding, status dot. The dot stays for colour continuity
+          with the sort bucket; it is no longer the thing that catches the eye. */}
       <div style={CSS.header}>
         <span
           data-testid="project-status-dot"
@@ -262,11 +271,14 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
                     data-run-id={session.id}
                     data-status={session.status}
                     style={{
-                      ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden',
+                      ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden', position: 'relative',
+                      // Clears the strip so a phase label never sits on top of it.
+                      paddingLeft: '10px',
                       border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
                       background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
                     }}
                   >
+                    <LiveEdge state={edgeStateOf([session.status])} />
                     <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
                     {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
                         has no `started_at`, so a gate's daemon-cached `receivedAt` is the one

--- a/src/components/RunCard.tsx
+++ b/src/components/RunCard.tsx
@@ -1,4 +1,5 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
+import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 
 // Status metadata — className uses wicked semantic colors
 export const STATUS_STYLE: Record<SessionStatus, { label: string; className: string; color: string }> = {
@@ -30,7 +31,7 @@ export function RunCard({ view, selected, onSelect }: Props): React.ReactElement
       data-run-id={session.id}
       data-status={session.status}
       aria-pressed={selected}
-      className="w-full text-left rounded-lg p-4 transition"
+      className="w-full text-left rounded-lg p-4 transition relative overflow-hidden"
       style={{
         background: selected ? '#1b222e' : '#161c26',
         border: selected
@@ -39,6 +40,8 @@ export function RunCard({ view, selected, onSelect }: Props): React.ReactElement
         boxShadow: selected ? '0 0 0 1px rgba(121,192,255,0.1)' : 'none',
       }}
     >
+      {/* Same treatment as the board card, so a run reads identically on both surfaces. */}
+      <LiveEdge state={edgeStateOf([session.status])} />
       <div className="flex justify-between items-start gap-2 mb-1">
         <p className="font-semibold text-sm line-clamp-2 flex-1 font-mono" style={{ color: '#e6edf3' }}>
           {session.problem}

--- a/src/index.css
+++ b/src/index.css
@@ -54,41 +54,57 @@ code, pre, .font-mono {
   background-repeat: no-repeat, no-repeat, no-repeat;
 }
 
-/* Live edge — slow breathing accent strip for the EXECUTING state (operator UX directive).
-   Applied via .wk-live-edge on an absolutely-positioned child inside a position:relative
-   container with overflow:hidden.  The parent's border-radius clips the strip's corners.
+/* Live edge — the leading-edge strip that marks the element doing work, and the one
+   waiting on a human (see components/LiveEdge.tsx for the ranking rationale). Rendered
+   on an absolutely-positioned child of a position:relative container; an overflow:hidden
+   parent clips the strip's ends to its border-radius.
 
-   Gate-waiting keeps its yellow treatment (higher visual priority) and never shows this strip.
-
-   prefers-reduced-motion: animation is removed; the strip stays fully opaque so the state
-   remains obvious without motion.  The JS component also sets data-reduced="true" on the
-   element when window.matchMedia matches, so unit tests can assert the reduced branch without
-   a real CSS engine. */
+   Selector order matters here — every rule below is one class deep, so the variants win
+   by coming last. Keep --gate and --pill after the reduced-motion block. */
 
 @keyframes wk-live-pulse {
   0%, 100% { opacity: 0.5; }
-  50%       { opacity: 1;   }
+  50%      { opacity: 1;   }
 }
 
+/* EXECUTING: 2px, breathing, faint matching glow. Slow and low-contrast on purpose. */
 .wk-live-edge {
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
   width: 2px;
-  background: #79c0ff;
+  background: var(--wk-link);
   box-shadow: 0 0 8px rgba(121, 192, 255, 0.2);
   animation: wk-live-pulse 2s ease-in-out infinite;
+  pointer-events: none;
 }
+
+/* Reduced motion: no animation, and MORE contrast than the breath averaged — a solid
+   edge at full opacity, one pixel wider. Set twice on purpose: the media query is the
+   real behaviour in a browser, the --static class is what LiveEdge maps the state to so
+   the branch is assertable in a unit test without a CSS engine. */
+.wk-live-edge--static { animation: none; opacity: 1; width: 3px; }
 
 @media (prefers-reduced-motion: reduce) {
-  .wk-live-edge {
-    animation: none;
-    opacity: 1;
-  }
+  .wk-live-edge { animation: none; opacity: 1; width: 3px; }
 }
 
-.wk-live-edge[data-reduced="true"] {
+/* GATE-WAITING: out-ranks executing — wider, accent-yellow, solid, never breathing. */
+.wk-live-edge--gate {
+  width: 3px;
+  background: var(--wk-accent);
+  box-shadow: 0 0 10px rgba(255, 218, 25, 0.3);
   animation: none;
   opacity: 1;
+}
+
+/* Fully-rounded containers (the stepper's phase chips): inset clear of the cap curve. */
+.wk-live-edge--pill {
+  left: 3px;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  border-radius: 1px;
+  box-shadow: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -53,3 +53,42 @@ code, pre, .font-mono {
   background-position: 0 0, 0 0, center;
   background-repeat: no-repeat, no-repeat, no-repeat;
 }
+
+/* Live edge — slow breathing accent strip for the EXECUTING state (operator UX directive).
+   Applied via .wk-live-edge on an absolutely-positioned child inside a position:relative
+   container with overflow:hidden.  The parent's border-radius clips the strip's corners.
+
+   Gate-waiting keeps its yellow treatment (higher visual priority) and never shows this strip.
+
+   prefers-reduced-motion: animation is removed; the strip stays fully opaque so the state
+   remains obvious without motion.  The JS component also sets data-reduced="true" on the
+   element when window.matchMedia matches, so unit tests can assert the reduced branch without
+   a real CSS engine. */
+
+@keyframes wk-live-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%       { opacity: 1;   }
+}
+
+.wk-live-edge {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #79c0ff;
+  box-shadow: 0 0 8px rgba(121, 192, 255, 0.2);
+  animation: wk-live-pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-live-edge {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+.wk-live-edge[data-reduced="true"] {
+  animation: none;
+  opacity: 1;
+}

--- a/tests/ChatPanel.stepper.test.tsx
+++ b/tests/ChatPanel.stepper.test.tsx
@@ -63,6 +63,25 @@ describe('ChatPanel process stepper (workflow map at the top of the thread)', ()
     expect(await screen.findByText('clarify output')).toBeInTheDocument();
   });
 
+  // Rule 5 of the live-edge directive: the stepper's active phase gets the same
+  // treatment the board does, and only it — a queued or done phase is not doing work.
+  it('gives the active phase the live edge, and no other phase one', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
+    render(<ChatPanel view={workflowView()} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+    // Let the done phase's transcript land, so no fetch settles after teardown.
+    expect(await screen.findByText('clarify output')).toBeInTheDocument();
+
+    const stepper = screen.getByTestId('process-stepper');
+    const edge = within(within(stepper).getByTestId('stepper-phase-2')).getByTestId('live-edge');
+    expect(edge).toHaveAttribute('data-edge-state', 'executing');
+    // Inset variant: an edge at left:0 would land on a fully-rounded pill's cap curve.
+    expect(edge.className).toContain('wk-live-edge--pill');
+    expect(within(stepper).getAllByTestId('live-edge')).toHaveLength(1);
+
+    // The dot stays for colour continuity but no longer competes: it does not pulse.
+    expect(within(stepper).getByTestId('stepper-phase-2').querySelector('.animate-pulse')).toBeNull();
+  });
+
   it('keeps queued phases OUT of the timeline: no empty blocks, no per-unit meta rows', async () => {
     vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'clarify output' });
     render(<ChatPanel view={workflowView()} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);

--- a/tests/LiveEdge.test.tsx
+++ b/tests/LiveEdge.test.tsx
@@ -1,0 +1,121 @@
+// The live edge — the primary EXECUTING signal that replaced the blinking status dot
+// (operator UX directive). These cases pin the two things that make the treatment
+// correct rather than merely present:
+//
+//   1. the state → class MAPPING, including the prefers-reduced-motion branch, where
+//      the animation must be swapped for a *higher-contrast* static edge, not dropped;
+//   2. the RANKING — a gate-waiting element never gets the executing treatment, and its
+//      own treatment is distinct, because a card that needs a human must not be
+//      out-shouted by a wall of cards that are merely busy.
+//
+// The mapping is asserted as classes rather than computed style on purpose: jsdom has no
+// CSS engine, so `@media (prefers-reduced-motion)` is inert here. The component maps the
+// preference to `--static` for exactly this reason (index.css carries both).
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { SessionStatus } from '../src/api/types.js';
+import { edgeStateOf, LiveEdge, liveEdgeClass } from '../src/components/LiveEdge.js';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+/** Force the OS preference for the duration of one case. */
+function stubReducedMotion(reduce: boolean): void {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: reduce && query.includes('prefers-reduced-motion'),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+}
+
+describe('edgeStateOf — status → edge state', () => {
+  it('gives every under-its-own-power status the executing edge', () => {
+    for (const s of ['planning', 'distributing', 'executing'] as SessionStatus[]) {
+      expect(edgeStateOf([s])).toBe('executing');
+    }
+  });
+
+  it('gives a parked run the gate edge', () => {
+    expect(edgeStateOf(['awaiting_human'])).toBe('gate');
+  });
+
+  it('leaves terminal runs unmarked — they are not doing work', () => {
+    for (const s of ['completed', 'cancelled', 'failed'] as SessionStatus[]) {
+      expect(edgeStateOf([s])).toBe('none');
+    }
+    expect(edgeStateOf([])).toBe('none');
+  });
+
+  it('ranks a gate above any amount of executing (rule 2)', () => {
+    expect(edgeStateOf(['executing', 'awaiting_human', 'executing'])).toBe('gate');
+    expect(edgeStateOf(['completed', 'executing'])).toBe('executing');
+  });
+});
+
+describe('liveEdgeClass — state → class', () => {
+  it('breathes for executing when motion is allowed', () => {
+    expect(liveEdgeClass('executing', false)).toBe('wk-live-edge');
+  });
+
+  it('swaps the breath for a static edge under prefers-reduced-motion (rule 4)', () => {
+    expect(liveEdgeClass('executing', true)).toBe('wk-live-edge wk-live-edge--static');
+  });
+
+  it('keeps the gate edge identical either way — it never animated', () => {
+    expect(liveEdgeClass('gate', false)).toBe('wk-live-edge wk-live-edge--gate');
+    expect(liveEdgeClass('gate', true)).toBe('wk-live-edge wk-live-edge--gate');
+  });
+
+  it('renders nothing for a state with no treatment', () => {
+    expect(liveEdgeClass('none', false)).toBeNull();
+    expect(liveEdgeClass('none', true)).toBeNull();
+  });
+
+  it('adds the pill inset for fully-rounded containers, in every state', () => {
+    expect(liveEdgeClass('executing', false, true)).toBe('wk-live-edge wk-live-edge--pill');
+    expect(liveEdgeClass('executing', true, true)).toBe('wk-live-edge wk-live-edge--static wk-live-edge--pill');
+    expect(liveEdgeClass('gate', false, true)).toBe('wk-live-edge wk-live-edge--gate wk-live-edge--pill');
+    expect(liveEdgeClass('none', false, true)).toBeNull();
+  });
+
+  it('never marks the gate treatment as executing, or the reverse', () => {
+    const gate = liveEdgeClass('gate', false) ?? '';
+    const executing = liveEdgeClass('executing', false) ?? '';
+    expect(gate).not.toBe(executing);
+    expect(gate.split(' ')).toContain('wk-live-edge--gate');
+    expect(executing.split(' ')).not.toContain('wk-live-edge--gate');
+  });
+});
+
+describe('<LiveEdge>', () => {
+  it('exposes the state on the element and hides it from assistive tech', () => {
+    stubReducedMotion(false);
+    render(<LiveEdge state="executing" />);
+    const edge = screen.getByTestId('live-edge');
+    expect(edge).toHaveAttribute('data-edge-state', 'executing');
+    expect(edge).toHaveAttribute('aria-hidden', 'true');
+    expect(edge.className).toBe('wk-live-edge');
+  });
+
+  it('reads the OS preference and takes the reduced-motion branch', () => {
+    stubReducedMotion(true);
+    render(<LiveEdge state="executing" />);
+    expect(screen.getByTestId('live-edge').className).toBe('wk-live-edge wk-live-edge--static');
+  });
+
+  it('renders no element at all when there is nothing to signal', () => {
+    stubReducedMotion(false);
+    render(<LiveEdge state="none" />);
+    expect(screen.queryByTestId('live-edge')).toBeNull();
+  });
+
+  it('survives an environment with no matchMedia (SSR / bare jsdom)', () => {
+    vi.stubGlobal('matchMedia', undefined);
+    render(<LiveEdge state="executing" />);
+    expect(screen.getByTestId('live-edge').className).toBe('wk-live-edge');
+  });
+});

--- a/tests/liveEdge.surfaces.test.tsx
+++ b/tests/liveEdge.surfaces.test.tsx
@@ -1,0 +1,103 @@
+// "Executing" must look the same wherever it renders (operator UX directive, rule 5):
+// board cards, the run chips on them, the run list's cards, and the run view's stepper
+// active phase. These cases pin the treatment on each surface, and — the point of the
+// whole change — that a gate-waiting element on the SAME board carries a DISTINCT
+// treatment at the same time, so the one card that needs a human still wins the eye.
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { ProjectCard } from '../src/components/ProjectCard.js';
+import { RunCard } from '../src/components/RunCard.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { Project, SessionStatus } from '../src/api/types.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { makeUnit, makeView } from './factories.js';
+
+beforeEach(() => {
+  useGateStore.setState({ gates: {} });
+  useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {} });
+});
+afterEach(cleanup);
+
+function project(id: string): Project {
+  return {
+    id, name: id, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at: 1,
+  };
+}
+
+function card(id: string, statuses: SessionStatus[], attention: BoardProject['attention']): BoardProject {
+  return {
+    project: project(id),
+    repo: null,
+    runs: statuses.map((status, i) =>
+      makeView({ id: `${id}-run-${i}`, status }, [makeUnit({ id: `${id}-u${i}`, stage: 'build' })]),
+    ),
+    docs: [],
+    attention,
+  };
+}
+
+/** The card's OWN edge — chips carry their own, so only the direct child counts. */
+function cardEdge(el: HTMLElement): HTMLElement | null {
+  return el.querySelector<HTMLElement>(':scope > [data-testid="live-edge"]');
+}
+
+describe('the live edge on the board', () => {
+  it('marks an executing card with the breathing edge', () => {
+    render(<ProjectCard item={card('busy', ['executing'], 'running')} navigate={() => {}} />);
+    const edge = cardEdge(screen.getByTestId('project-card'));
+    expect(edge).not.toBeNull();
+    expect(edge).toHaveAttribute('data-edge-state', 'executing');
+    expect(edge?.className).toContain('wk-live-edge');
+    expect(edge?.className).not.toContain('wk-live-edge--gate');
+  });
+
+  it('marks a gate-waiting card DISTINCTLY, and both read at once on one board', () => {
+    render(
+      <>
+        <ProjectCard item={card('busy', ['executing'], 'running')} navigate={() => {}} />
+        <ProjectCard item={card('gated', ['awaiting_human'], 'gate')} navigate={() => {}} />
+      </>,
+    );
+    const [busy, gated] = screen.getAllByTestId('project-card');
+    const busyEdge = cardEdge(busy as HTMLElement);
+    const gateEdge = cardEdge(gated as HTMLElement);
+    expect(busyEdge).toHaveAttribute('data-edge-state', 'executing');
+    expect(gateEdge).toHaveAttribute('data-edge-state', 'gate');
+    expect(gateEdge?.className).not.toBe(busyEdge?.className);
+  });
+
+  it('lets a gate on the card out-rank the executing run beside it', () => {
+    render(<ProjectCard item={card('mixed', ['executing', 'awaiting_human'], 'gate')} navigate={() => {}} />);
+    expect(cardEdge(screen.getByTestId('project-card'))).toHaveAttribute('data-edge-state', 'gate');
+  });
+
+  it('leaves a quiet card unmarked — no edge, nothing to signal', () => {
+    render(<ProjectCard item={card('quiet', ['completed'], 'quiet')} navigate={() => {}} />);
+    expect(cardEdge(screen.getByTestId('project-card'))).toBeNull();
+  });
+
+  it('carries the edge on the individual run chips too, per run state', () => {
+    render(<ProjectCard item={card('mixed', ['executing', 'awaiting_human'], 'gate')} navigate={() => {}} />);
+    const chips = screen.getAllByTestId('run-chip');
+    expect(within(chips[0] as HTMLElement).getByTestId('live-edge'))
+      .toHaveAttribute('data-edge-state', 'executing');
+    expect(within(chips[1] as HTMLElement).getByTestId('live-edge'))
+      .toHaveAttribute('data-edge-state', 'gate');
+  });
+});
+
+describe('the live edge on the run list and the run view', () => {
+  it('marks an executing run card, and a parked one distinctly', () => {
+    const { rerender } = render(
+      <RunCard view={makeView({ status: 'executing' })} selected={false} onSelect={() => {}} />,
+    );
+    expect(screen.getByTestId('live-edge')).toHaveAttribute('data-edge-state', 'executing');
+    rerender(<RunCard view={makeView({ status: 'awaiting_human' })} selected={false} onSelect={() => {}} />);
+    expect(screen.getByTestId('live-edge')).toHaveAttribute('data-edge-state', 'gate');
+    rerender(<RunCard view={makeView({ status: 'completed' })} selected={false} onSelect={() => {}} />);
+    expect(screen.queryByTestId('live-edge')).toBeNull();
+  });
+});


### PR DESCRIPTION
Operator-requested UX slice, authored and delivered by governed run `7dc215ab`.

Executing work now announces itself with a slow-breathing accent strip along the leading edge (cards, run chips, ProcessStepper active phase) instead of relying on the blinking dot. Gate-waiting keeps its distinct treatment and visually outranks executing; `prefers-reduced-motion` gets a static high-contrast edge. `data-testid="live-edge"` pinned in unit + Playwright coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)