### PR TITLE
feat(document): point-and-comment on the sandboxed instrument bridge (DES-MERGE-001 slice 11+12)

### DIFF
--- a/e2e/fixtures/doc-fixture.html
+++ b/e2e/fixtures/doc-fixture.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>__DOC__ v__V__</title></head>
+<body style="font-family:system-ui;padding:24px;background:#fff;color:#111;margin:0">
+  <!-- The FIXTURE BRIDGE (DES-MERGE-001 §5.5, slices 11+12).
+
+       In production `core/instrument.js` (wicked-interactive, the sibling slice)
+       injects the `data-wid` anchors AND the bridge script below into every rendered
+       document. This fixture is the same contract, hand-written, so studio's half can
+       be built and proven against the CONTRACT before the injector ships.
+
+       If the two ever disagree, instrument-protocol.ts is the arbiter — it is the one
+       module that defines the envelope, and both ends validate against it. -->
+
+  <h1 data-wid="h1">__DOC__ — version __V__</h1>
+  <p data-wid="p1">Seeded fixture document, served by the fake interactive bridge.</p>
+  <p data-wid="p2">A second commentable paragraph, so a batch can hold more than one item.</p>
+  <div style="height:1400px"></div>
+  <p data-wid="tail">Far enough down the page that scroll-to-wid has somewhere to go.</p>
+  <pre id="isolation" data-testid="isolation-probe" style="font-size:12px;color:#555"></pre>
+
+  <script>
+    document.body.setAttribute('data-scripts-ran', '1');
+
+    // ── §5.5 isolation probe ────────────────────────────────────────────────
+    // With `allow-same-origin` dropped this frame has an OPAQUE origin, so reaching
+    // into the parent must throw. The verdict is written into the DOM because the
+    // parent can no longer evaluate anything in here to ask.
+    var verdict = 'REACHED-PARENT-STORAGE';
+    try {
+      void parent.localStorage.length;
+    } catch (e) {
+      verdict = 'THREW: ' + ((e && e.name) || 'Error');
+    }
+    document.getElementById('isolation').textContent = verdict;
+    document.body.setAttribute('data-parent-localstorage', verdict);
+
+    // ── The instrument bridge ───────────────────────────────────────────────
+    function inventory() {
+      var widMap = {};
+      var nodes = document.querySelectorAll('[data-wid]');
+      for (var i = 0; i < nodes.length; i++) {
+        var r = nodes[i].getBoundingClientRect();
+        widMap[nodes[i].getAttribute('data-wid')] = {
+          x: r.x, y: r.y, width: r.width, height: r.height,
+          top: r.top, left: r.left, right: r.right, bottom: r.bottom
+        };
+      }
+      return { v: 1, type: 'wid-inventory', widMap: widMap,
+               scrollX: window.scrollX, scrollY: window.scrollY };
+    }
+
+    // The parent is cross-origin from here (opaque origin), so "*" is the only
+    // targetOrigin that reaches it. Rects and scroll offsets carry nothing private.
+    function post(msg) { parent.postMessage(msg, '*'); }
+
+    window.addEventListener('message', function (e) {
+      var m = e.data;
+      if (!m || m.v !== 1) return;
+      if (m.type === 'request-inventory') {
+        post(inventory());
+      } else if (m.type === 'scroll-to-wid' && typeof m.wid === 'string') {
+        var el = document.querySelector('[data-wid="' + m.wid.replace(/["\\]/g, '') + '"]');
+        if (el) el.scrollIntoView({ block: 'center' });
+        post({ v: 1, type: 'scroll-ack', wid: m.wid });
+      }
+    });
+
+    window.addEventListener('scroll', function () {
+      post({ v: 1, type: 'scroll-state', scrollX: window.scrollX, scrollY: window.scrollY });
+    });
+    window.addEventListener('resize', function () { post(inventory()); });
+
+    // Unprompted first post: the parent asks on load anyway, but a document that
+    // volunteers its inventory shortens the handshake by a round trip.
+    post(inventory());
+  </script>
+</body>
+</html>

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -41,11 +41,14 @@ What "independent" means here, and what this script proves end-to-end:
      (§7.11) is approved inline and the run advances on the same page with no
      navigation, while a COMPLEX one deep-links to the thread with the gate message
      scrolled into view and focused
- 11. (DES-MERGE-001 slice 8) Document mode renders the canvas: a seeded doc frames
-     with a non-empty contentDocument, the frame carries the §5.5 sandbox, its
-     request shares the PAGE's origin, the picker orders most-recent-first and
-     navigates, and a bridge_unavailable 503 shows its hint verbatim. This one
-     section runs against a SECOND, same-origin build (see §12 in the body).
+ 11. (DES-MERGE-001 slice 8, as tightened by slice 12) Document mode renders the
+     canvas: a seeded doc frames and its scripts run — re-derived from the browser's
+     FRAME TREE, because slice 12 made `contentDocument` null on purpose and the
+     parent asserting that null IS the security claim — the frame carries the §5.5
+     sandbox with `allow-same-origin` gone, its request shares the PAGE's origin, the
+     picker orders most-recent-first and navigates, and a bridge_unavailable 503 shows
+     its hint verbatim. This one section runs against a SECOND, same-origin build
+     (see §12 in the body).
  12. (DES-MERGE-001 slice 9) the version strip on that same rig: a 3-version doc
      shows 3 entries oldest→newest with the routed one highlighted, selecting v1
      swaps the frame to the v1 URL (and Back rewinds it), §7.6's scroll affordance
@@ -59,7 +62,17 @@ What "independent" means here, and what this script proves end-to-end:
      generation window renders NOTHING while real narration lands, and no
      `status.requested` heartbeat is ever emitted; and a landed version tags the
      message that triggered it (§7.6).
- 14. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
+ 14. (DES-MERGE-001 slices 11+12, merged per §7.3) point-and-comment, on a frame the
+     overlay could never have shipped without: `sandbox="allow-scripts"` and nothing
+     else, with a fixture document that speaks the postMessage instrument bridge. A
+     script inside that document reaching for `parent.localStorage` THROWS (isolation
+     proven from the inside, not asserted from outside); clicking a `[data-wid]`
+     heading opens the comment box within 4 px of the rect the browser's own frame
+     tree reports; two comments submit as ONE thread message carrying both, ONE
+     `feedback.submitted` event and ONE inject; each submitted item deep-links back to
+     its element over the protocol; and an inject the bridge refuses leaves the batch
+     standing with a retryable "not recorded" chip (§7.7).
+ 15. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
      ranked: in one DOM snapshot an executing card carries the breathing 2px
      `live-edge` element while a gate-waiting card carries a treatment that is
      present at the same time and different in computed pixels (wider, solid,
@@ -913,16 +926,17 @@ try:
     emitted_events: list[dict] = []
     BRIDGE_DOWN_HINT = ("run `npx wicked-interactive serve` in this project's root — "
                         "the bridge could not be started")
-    # `data-wid` anchors are what core/instrument.js injects (§5.5) — the fixture carries
-    # them so slice 11+12 inherits a document shaped like the real thing.
-    DOC_HTML = (
-        "<!doctype html><html><head><meta charset='utf-8'><title>__DOC__ v__V__</title></head>"
-        "<body style='font-family:system-ui;padding:24px;background:#fff;color:#111'>"
-        "<h1 data-wid='h1'>__DOC__ — version __V__</h1>"
-        "<p data-wid='p1'>Seeded fixture document, served by the fake interactive bridge.</p>"
-        "<script>document.body.setAttribute('data-scripts-ran','1');</script>"
-        "</body></html>"
-    )
+    # A phrase the fake bridge refuses to inject, so §15 can drive §7.7's failure path.
+    INJECT_FAIL_MARK = "unrecordable"
+    # The bus event interactive's feedbackStore.js has always emitted — contract unchanged
+    # by the merge (§7.7); what changed is that the CLIENT authors it alongside the inject.
+    FEEDBACK_EVENT = "wicked.interactive.feedback.submitted"
+    # The FIXTURE BRIDGE (slices 11+12): `data-wid` anchors plus the postMessage bridge
+    # that core/instrument.js injects in production (§5.5), kept in a real .html file so
+    # the browser fixture is one artifact rather than a Python string literal. It also
+    # carries the isolation probe: a script reaching for `parent.localStorage`, whose
+    # verdict it writes into its own DOM — the parent can no longer evaluate in here to ask.
+    DOC_HTML = (REPO / "e2e" / "fixtures" / "doc-fixture.html").read_text(encoding="utf-8")
     INTERACTIVE_RE = re.compile(r"^/api/v1/projects/([^/]+)/interactive(/.*)$")
     VERSIONS_RE = re.compile(r"^/d/([^/]+)/api/versions$")
     RENDER_RE = re.compile(r"^/d/([^/]+)/doc/(\d+)$")
@@ -1055,8 +1069,17 @@ try:
                                     "generating": True, "project_id": body.get("project")})
 
         def _emit(self) -> None:
-            """`POST /api/events` — the GENERATING/GATED composer's wire (§2.2 cases 2-3)."""
-            emitted_events.append(self._body())
+            """`POST /api/events` — the GENERATING/GATED composer's wire (§2.2 cases 2-3)
+            and both of the feedback batch's writes (§7.7)."""
+            body = self._body()
+            emitted_events.append(body)
+            # §7.7: a failing INJECT must not block the batch. One marker phrase fails the
+            # `chat.posted` wire while the `feedback.submitted` event that actually drives
+            # the document still succeeds — which is exactly the split the chip describes.
+            payload = body.get("payload") or {}
+            if (body.get("event_type") == "wicked.interactive.chat.posted"
+                    and INJECT_FAIL_MARK in str(payload.get("text") or "")):
+                return self._json(500, {"error": "run not found"})
             return self._json(200, {"ok": True, "event_id": f"ev-{len(emitted_events)}",
                                     "correlation_id": "c-doc"})
 
@@ -1100,16 +1123,21 @@ try:
         rows.first.click()
         picker_nav_ok = wait_for_path(page, f"/p/{doc_project}/document/launch-deck")
 
-        # ── AC: the seeded doc renders, with a non-empty contentDocument ───────────
+        # ── AC: the seeded doc renders, and IS a document ─────────────────────────
+        # Slice 12 supersedes slice 8's original wording here. `contentDocument` was the
+        # evidence when the frame was same-origin; it is null now, BY DESIGN, and that is
+        # the point of the slice. The claim is unchanged — the document rendered and its
+        # scripts ran — so it is re-derived from the browser's FRAME TREE (Playwright
+        # reaches into a cross-origin frame; the page's own JS cannot).
         frame = page.locator('[data-testid="doc-canvas"]')
         frame.wait_for(timeout=30000)
         page.frame_locator('[data-testid="doc-canvas"]').locator("[data-wid='h1']").wait_for(timeout=30000)
         sandbox = frame.get_attribute("sandbox")
         frame_src = frame.get_attribute("src")
-        content_text = frame.evaluate(
-            "el => (el.contentDocument && el.contentDocument.body.innerText || '').trim()")
-        scripts_ran = frame.evaluate(
-            "el => !!el.contentDocument && el.contentDocument.body.dataset.scriptsRan === '1'")
+        content_document_readable = frame.evaluate("el => el.contentDocument !== null")
+        rendered_frame = next(f for f in page.frames if f.url and "/doc/" in f.url)
+        content_text = rendered_frame.evaluate("() => (document.body.innerText || '').trim()")
+        scripts_ran = rendered_frame.evaluate("() => document.body.dataset.scriptsRan === '1'")
         page.screenshot(path=str(SHOTS / "slice8-doc-canvas.png"), full_page=True)
 
         # ── AC: the frame's REQUEST url shares the page's origin ───────────────────
@@ -1136,7 +1164,11 @@ try:
         "ok": all([
             picker_order == ["launch-deck", "q3-report", "stale-brief", "roadmap"],
             picker_nav_ok,
-            sandbox == "allow-scripts allow-same-origin",
+            # §5.5/§7.3, closed: the sandbox is allow-scripts and NOTHING else, and the
+            # parent can no longer read the frame back. Both halves asserted.
+            sandbox == "allow-scripts",
+            "allow-same-origin" not in (sandbox or ""),
+            content_document_readable is False,
             len(content_text) > 0,
             scripts_ran,
             frame_src is not None and frame_src.endswith("/doc/2"),
@@ -1152,7 +1184,8 @@ try:
         "picker_navigated_to_doc": picker_nav_ok,
         "frame_src": frame_src,
         "frame_sandbox": sandbox,
-        "frame_content_document_text": content_text[:120],
+        "frame_content_document_readable_by_parent": content_document_readable,
+        "frame_rendered_text": content_text[:120],
         "frame_scripts_executed": scripts_ran,
         "page_origin": page_origin,
         "frame_request_origins": frame_request_origins,
@@ -1397,8 +1430,8 @@ try:
         page.screenshot(path=str(SHOTS / "slice10-thread-version-anchor.png"), full_page=True)
         browser.close()
 
-    docd.shutdown()
-
+    # Slice 10's assertions are made below, but the fixture server stays up: §15 runs on
+    # the same rig, and its wire assertions are made against the same recorded lists.
     steers = [e for e in emitted_events if e.get("event_type") == "wicked.interactive.chat.posted"]
     heartbeats = [e for e in emitted_events
                   if e.get("event_type") == "wicked.interactive.status.requested"]
@@ -1455,7 +1488,183 @@ try:
     if not report["steps"]["doc_thread"]["ok"]:
         fail("doc_thread_verdict", "slice-10 document-thread assertions did not all hold — see doc_thread")
 
-    # ── 15. Operator UX directive: the live edge on the board ──────────────────
+    # ── 15. Slices 11+12 (§6.3, merged per §7.3): point-and-comment, SANDBOXED ──
+    # §7.3 merged these two slices so that the overlay could never exist against a
+    # same-origin frame. This section is where that merge is cashed: every assertion
+    # below is made about a frame carrying `sandbox="allow-scripts"` and nothing else,
+    # against a fixture document that implements the postMessage instrument bridge the
+    # way core/instrument.js will (`e2e/fixtures/doc-fixture.html`).
+    #
+    #   · ISOLATION, proven not asserted: a script inside the document reaches for
+    #     `parent.localStorage` and records what happened. It must have THROWN — that is
+    #     §5.5's whole risk (agent-authored HTML with the app's ambient authority) shut.
+    #   · ANCHORING: clicking a `[data-wid]` heading opens the comment box within 4 px of
+    #     that element's real on-screen rect — measured through the browser's frame tree,
+    #     which is the only remaining way to learn where anything in there is.
+    #   · BATCHING: two comments submit as ONE thread message carrying both, ONE
+    #     `feedback.submitted` event, and ONE inject (§4.3: N submits would be N runs and
+    #     N versions for one round of edits).
+    #   · DEEP-LINK: clicking a submitted item scrolls the frame back to its element —
+    #     over the protocol, since the parent cannot touch the document to do it itself.
+    #   · §7.7's failure split: an inject the bridge refuses leaves the batch standing
+    #     with a retryable "not recorded" chip, and the feedback event still went.
+    FB_DOC = "launch-deck"
+    FB_ONE = "make this title punchier"
+    FB_TWO = "cut this paragraph in half"
+    FB_FAIL = f"this one is {INJECT_FAIL_MARK}"
+    overlay_console: list[str] = []
+
+    def centre(box: dict) -> tuple[float, float]:
+        return box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.on("console", lambda m: overlay_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text else None)
+
+        page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document/{FB_DOC}", wait_until="networkidle")
+        page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+        doc_frame = page.frame_locator('[data-testid="doc-canvas"]')
+        doc_frame.locator("[data-wid='h1']").wait_for(timeout=30000)
+        overlay_sandbox = page.locator('[data-testid="doc-canvas"]').get_attribute("sandbox")
+
+        # ── AC: a script in the doc reaching for parent.localStorage THREW ─────────
+        isolation_verdict = doc_frame.locator('[data-testid="isolation-probe"]').inner_text()
+
+        # ── AC: the frame answered the instrument bridge, so the overlay is live ───
+        page.locator('[data-testid="feedback-overlay"][data-ready="true"]').wait_for(timeout=30000)
+        toggle = page.locator('[data-testid="feedback-toggle"]')
+        overlay_enabled = toggle.is_enabled()
+        toggle.click()
+        page.locator('[data-testid="feedback-hitlayer"]').wait_for(timeout=10000)
+        page.screenshot(path=str(SHOTS / "slice12-overlay-ready.png"), full_page=True)
+
+        # ── AC: clicking a [data-wid] heading anchors the box within 4 px ──────────
+        # The heading's rect comes from the BROWSER's frame tree, in page coordinates —
+        # an independent measurement of the same element the bridge reported to the app.
+        h1_box = doc_frame.locator("[data-wid='h1']").bounding_box()
+        page.mouse.click(*centre(h1_box))
+        card = page.locator('[data-testid="feedback-comment"]')
+        card.wait_for(timeout=10000)
+        card_wid = card.get_attribute("data-wid")
+        card_box = card.bounding_box()
+        anchor_dx = abs(card_box["x"] - h1_box["x"])
+        anchor_dy = card_box["y"] - (h1_box["y"] + h1_box["height"])
+        page.screenshot(path=str(SHOTS / "slice12-comment-anchored.png"), full_page=True)
+
+        # ── AC: two comments batch, then submit as ONE message ────────────────────
+        page.locator('[data-testid="feedback-comment-input"]').fill(FB_ONE)
+        page.locator('[data-testid="feedback-comment-add"]').click()
+
+        p1_box = doc_frame.locator("[data-wid='p1']").bounding_box()
+        page.mouse.click(*centre(p1_box))
+        page.locator('[data-testid="feedback-comment-input"]').fill(FB_TWO)
+        page.locator('[data-testid="feedback-comment-add"]').click()
+        pins_before_submit = page.locator('[data-testid="feedback-pin"]').count()
+        # Nothing may have gone anywhere yet: batching is the point (§4.3).
+        emitted_before_submit = len([e for e in emitted_events
+                                     if e.get("event_type") == FEEDBACK_EVENT])
+        page.screenshot(path=str(SHOTS / "slice12-batch-of-two.png"), full_page=True)
+
+        messages_before = page.locator('[data-testid="doc-message"]').count()
+        page.locator('[data-testid="feedback-submit"]').click()
+        page.locator('[data-testid="doc-message"][data-items="2"]').wait_for(timeout=15000)
+        messages_added = page.locator('[data-testid="doc-message"]').count() - messages_before
+        batch_msg = page.locator('[data-testid="doc-message"][data-items="2"]')
+        batch_text = batch_msg.inner_text()
+        page.screenshot(path=str(SHOTS / "slice12-batch-submitted.png"), full_page=True)
+
+        # ── AC: each item DEEP-LINKS back to its element, over the protocol ────────
+        # Scroll the document away first, so "came back" is observable rather than vacuous.
+        frame_obj = next(f for f in page.frames if f.url and "/doc/" in f.url)
+        frame_obj.evaluate("() => window.scrollTo(0, 900)")
+        scrolled_away = frame_obj.evaluate("() => window.scrollY")
+        batch_msg.locator('[data-testid="feedback-item-link"][data-wid="h1"]').click()
+        page.wait_for_timeout(600)
+        scrolled_back = frame_obj.evaluate("() => window.scrollY")
+        page.screenshot(path=str(SHOTS / "slice12-deep-link.png"), full_page=True)
+
+        # ── AC (§7.7): a refused inject does NOT block the batch ───────────────────
+        frame_obj.evaluate("() => window.scrollTo(0, 0)")
+        page.wait_for_timeout(300)
+        toggle.click()  # back into commenting
+        page.locator('[data-testid="feedback-hitlayer"]').wait_for(timeout=10000)
+        page.mouse.click(*centre(doc_frame.locator("[data-wid='h1']").bounding_box()))
+        page.locator('[data-testid="feedback-comment-input"]').fill(FB_FAIL)
+        page.locator('[data-testid="feedback-comment-add"]').click()
+        page.locator('[data-testid="feedback-submit"]').click()
+        chip = page.locator('[data-testid="feedback-not-recorded"]')
+        chip.wait_for(timeout=15000)
+        chip_retryable = chip.is_enabled()
+        # The batch itself STANDS: the message is in the transcript and the bus event went.
+        unrecordable_rendered = page.locator(
+            f'[data-testid="doc-message"]:has-text("{INJECT_FAIL_MARK}")').count()
+        page.screenshot(path=str(SHOTS / "slice12-not-recorded-chip.png"), full_page=True)
+        browser.close()
+
+    docd.shutdown()
+
+    feedback_events = [e for e in emitted_events if e.get("event_type") == FEEDBACK_EVENT]
+    batch_event = (feedback_events[0].get("payload") or {}) if feedback_events else {}
+    batch_injects = [e for e in emitted_events
+                     if e.get("event_type") == "wicked.interactive.chat.posted"
+                     and FB_ONE in str((e.get("payload") or {}).get("text") or "")]
+    report["steps"]["feedback_overlay"] = {
+        "ok": all([
+            # §5.5/§7.3: the frame the overlay ran against was FULLY sandboxed…
+            overlay_sandbox == "allow-scripts",
+            # …and the document proved it, from the inside.
+            isolation_verdict.startswith("THREW"),
+            overlay_enabled,
+            # §4.3's anchoring budget, both axes.
+            card_wid == "h1", anchor_dx <= 4, 0 <= anchor_dy <= 4,
+            # Batched, not streamed: two pins, nothing emitted until Submit.
+            pins_before_submit == 2, emitted_before_submit == 0,
+            # ONE message with BOTH items, ONE bus event, ONE inject.
+            messages_added == 1,
+            FB_ONE in batch_text, FB_TWO in batch_text,
+            len(feedback_events) == 2,  # the batch of two, then the unrecordable one
+            [i.get("wid") for i in (batch_event.get("items") or [])] == ["h1", "p1"],
+            [i.get("comment") for i in (batch_event.get("items") or [])] == [FB_ONE, FB_TWO],
+            batch_event.get("version") == 2,
+            len(batch_injects) == 1,
+            # The deep-link brought the element back over the protocol.
+            scrolled_away > 400, scrolled_back < 100,
+            # §7.7: the refused inject is a retryable chip, not a lost batch.
+            chip_retryable, unrecordable_rendered == 1,
+            not overlay_console,
+        ]),
+        "project_id": doc_project,
+        "doc": FB_DOC,
+        "frame_sandbox": overlay_sandbox,
+        "parent_localstorage_from_inside_frame": isolation_verdict,
+        "overlay_enabled_after_handshake": overlay_enabled,
+        "heading_rect_from_frame_tree": h1_box,
+        "comment_box_rect": card_box,
+        "comment_box_wid": card_wid,
+        "anchor_error_px": {"x": anchor_dx, "y": anchor_dy},
+        "pins_before_submit": pins_before_submit,
+        "feedback_events_before_submit": emitted_before_submit,
+        "thread_messages_added_by_submit": messages_added,
+        "batch_message_text": batch_text[:400],
+        "feedback_events": feedback_events,
+        "injects_carrying_the_batch": batch_injects,
+        "frame_scroll_before_deep_link": scrolled_away,
+        "frame_scroll_after_deep_link": scrolled_back,
+        "not_recorded_chip_retryable": chip_retryable,
+        "unrecordable_batch_still_in_transcript": unrecordable_rendered == 1,
+        "console_errors": overlay_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice12-overlay-ready.png", "slice12-comment-anchored.png",
+                         "slice12-batch-of-two.png", "slice12-batch-submitted.png",
+                         "slice12-deep-link.png", "slice12-not-recorded-chip.png")],
+    }
+    if not report["steps"]["feedback_overlay"]["ok"]:
+        fail("feedback_overlay_verdict",
+             "slice-11+12 point-and-comment assertions did not all hold — see feedback_overlay")
+
+    # ── 16. Operator UX directive: the live edge on the board ──────────────────
     # The ACTIVE-WORK signal is a breathing 2px strip along the leading edge of the
     # element doing work, and the thing that has to hold is the RANKING: a busy card
     # must be visible without out-shouting a card that needs a human. So both states

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -135,6 +135,12 @@ NPM = "npm.cmd" if os.name == "nt" else "npm"
 report: dict = {"ok": False, "steps": {}}
 
 
+# Gate toasts from the runs earlier sections seeded are pinned bottom-right and overlap
+# the Document-mode composer. They are not this section's surface — same spirit as the
+# `fonts.g` console filter — so the doc sections suppress them rather than fight them.
+# Hiding is display-only: nothing about the asserted behaviour changes.
+HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
+
 def fail(step: str, why: str) -> None:
     report["steps"][step] = {"ok": False, "error": why}
     print(json.dumps(report, indent=2))
@@ -1248,7 +1254,11 @@ try:
             "[data-wid='h1']").inner_text()
         page.screenshot(path=str(SHOTS / "slice9-version-selected.png"), full_page=True)
 
-        # The version lives in the URL, so Back rewinds the rewind (not app state).
+        # The version lives in the URL, so Back rewinds the rewind (not app state) — in
+        # ONE press. That holds only because a version swap REPLACES the frame element
+        # rather than navigating it: mutating `src` navigates the frame, a frame
+        # navigation lands in the JOINT session history, and Back then undoes the frame's
+        # move instead of the route's. (Independent of the sandbox — verified both ways.)
         page.go_back()
         back_ok = page.wait_for_function(frame_at % "3", timeout=30000) is not None
         back_query = urllib.parse.urlparse(page.url).query
@@ -1356,6 +1366,7 @@ try:
 
         # ── AC: one thread, one composer, beside the canvas — never over it (§2.5) ──
         page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document", wait_until="networkidle")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
         thread = page.locator('[data-testid="thread"]')
         thread.wait_for(timeout=30000)
         page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
@@ -1524,6 +1535,7 @@ try:
                 if m.type == "error" and "fonts.g" not in m.text else None)
 
         page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document/{FB_DOC}", wait_until="networkidle")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
         page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
         doc_frame = page.frame_locator('[data-testid="doc-canvas"]')
         doc_frame.locator("[data-wid='h1']").wait_for(timeout=30000)
@@ -1585,6 +1597,11 @@ try:
         scrolled_back = frame_obj.evaluate("() => window.scrollY")
         page.screenshot(path=str(SHOTS / "slice12-deep-link.png"), full_page=True)
 
+        # "No console errors" is a claim about the WORKING overlay — snapshot it before
+        # the deliberate 500 below, whose failed request chromium logs as a console error.
+        # Same discipline slice 8 uses for its seeded 503.
+        overlay_console_clean = list(overlay_console)
+
         # ── AC (§7.7): a refused inject does NOT block the batch ───────────────────
         frame_obj.evaluate("() => window.scrollTo(0, 0)")
         page.wait_for_timeout(300)
@@ -1633,7 +1650,7 @@ try:
             scrolled_away > 400, scrolled_back < 100,
             # §7.7: the refused inject is a retryable chip, not a lost batch.
             chip_retryable, unrecordable_rendered == 1,
-            not overlay_console,
+            not overlay_console_clean,
         ]),
         "project_id": doc_project,
         "doc": FB_DOC,
@@ -1654,7 +1671,8 @@ try:
         "frame_scroll_after_deep_link": scrolled_back,
         "not_recorded_chip_retryable": chip_retryable,
         "unrecordable_batch_still_in_transcript": unrecordable_rendered == 1,
-        "console_errors": overlay_console[:10],
+        "console_errors_driving_the_overlay": overlay_console_clean[:10],
+        "console_errors_including_seeded_500": overlay_console[:10],
         "screenshots": [str(SHOTS / n) for n in
                         ("slice12-overlay-ready.png", "slice12-comment-anchored.png",
                          "slice12-batch-of-two.png", "slice12-batch-submitted.png",

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -253,3 +253,21 @@ export function postEvent(projectId: string, evt: InteractiveEvent): Promise<Eve
     jsonPost({ event_type: evt.event_type, payload: evt.payload ?? {} }),
   );
 }
+
+/**
+ * The INJECT wire (§2.2 case 2, §7.7): one `chat.posted` carrying the anchor id into the
+ * live agent's session. Both authors of a user message use it — the composer's steer and
+ * the feedback overlay's submitted batch — so there is one spelling of "put this in the
+ * run" rather than two payloads that drift.
+ */
+export function injectDocMessage(
+  projectId: string,
+  docId: string,
+  text: string,
+  sourceMessageId: string,
+): Promise<EventAck> {
+  return postEvent(projectId, {
+    event_type: 'wicked.interactive.chat.posted',
+    payload: { role: 'user', text, document_id: docId, source_message_id: sourceMessageId },
+  });
+}

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -226,6 +226,12 @@ function DocFrame({
     <>
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
       <iframe
+        // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
+        // src. Mutating it navigates the frame, and a frame navigation lands in the
+        // joint session history — so Back undid the frame's move rather than the route's
+        // (§4.2: the version lives in the URL, and Back must rewind it in one press).
+        // A freshly created frame's first load replaces its own entry instead.
+        key={shown}
         ref={setFrameEl}
         data-testid="doc-canvas"
         data-doc-id={docId}

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -7,15 +7,21 @@ import {
 } from '../api/interactive.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
+import { FeedbackOverlay } from './FeedbackOverlay.js';
 import { VersionStrip } from './VersionStrip.js';
 
-// The Document-mode canvas (DES-MERGE-001 §1.3, §6.3 slice 8). Replaces the slice-4
-// placeholder: with a doc in the route we frame it, without one we let the user pick.
+// The Document-mode canvas (DES-MERGE-001 §1.3, §6.3 slice 8, tightened by slices 11+12).
+// With a doc in the route we frame it, without one we let the user pick.
 //
 // The frame carries the RENDERED DOCUMENT, never the interactive app (§5.3) — its src
 // is built by the slice-2 client from `apiBase()`, so it resolves onto the page's own
-// origin through crew's project-scoped proxy (§7.2). That is what keeps
-// `contentDocument` reachable for the slice 11+12 overlay.
+// origin through crew's project-scoped proxy (§7.2).
+//
+// §5.5, closed: agent-authored HTML is influenced by untrusted input (attached sources,
+// scraped pages), so the frame is FULLY sandboxed — `allow-scripts` and nothing else. It
+// cannot read `localStorage`, cannot call `/api/v1` with the user's ambient authority,
+// and the parent cannot read `contentDocument` back. Everything the overlay needs comes
+// over the instrument bridge instead (§7.3: the overlay never shipped without it).
 
 const S = {
   card:   '#161b22',
@@ -190,6 +196,11 @@ function DocFrame({
     () => getVersions(projectId, docId), [projectId, docId],
   );
   const [loaded, setLoaded] = useState(false);
+  // The overlay's instrumentation handshake is keyed to LOADS, not to renders: every
+  // swapped version is a different document with a different inventory (§4.3 / INV-1
+  // guarantees a wid survives WITHIN a document's lineage, not that rects do).
+  const [frameEl, setFrameEl] = useState<HTMLIFrameElement | null>(null);
+  const [loadNonce, setLoadNonce] = useState(0);
   useEffect(() => { setLoaded(false); }, [projectId, docId, version]);
 
   const subject = `“${docId}”`;
@@ -215,17 +226,17 @@ function DocFrame({
     <>
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
       <iframe
+        ref={setFrameEl}
         data-testid="doc-canvas"
         data-doc-id={docId}
         data-version={shown}
         src={src}
         title={`Document ${docId}, version ${shown}`}
-        onLoad={() => setLoaded(true)}
-        // §5.5 status quo: `allow-scripts` because documents ARE interactive HTML, and
-        // `allow-same-origin` only until the slice 11+12 instrument bridge replaces the
-        // overlay's contentDocument reads with postMessage — then this drops to
-        // `allow-scripts` alone. Tracked there, not "someday".
-        sandbox="allow-scripts allow-same-origin"
+        onLoad={() => { setLoaded(true); setLoadNonce((n) => n + 1); }}
+        // §5.5, §7.3: `allow-scripts` because documents ARE interactive HTML, and NOTHING
+        // else. `allow-same-origin` is not "not yet" here — it is gone, and the overlay
+        // below is what made removing it possible. Pinned by a regression test.
+        sandbox="allow-scripts"
         style={{ border: 'none', display: 'block', height: '100%', width: '100%' }}
       />
       {/* The frame is in the DOM while it loads, so the named status sits over it. */}
@@ -234,6 +245,15 @@ function DocFrame({
           <Loading subject={subject} />
         </div>
       )}
+      {/* Point-and-comment (§4.3). A document whose bridge never answers leaves this
+          disabled-with-a-reason; the canvas above is unaffected either way. */}
+      <FeedbackOverlay
+        frame={frameEl}
+        loadNonce={loadNonce}
+        projectId={projectId}
+        docId={docId}
+        version={shown}
+      />
       </div>
       <VersionStrip
         projectId={projectId}

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -149,7 +149,12 @@ function NotRecordedChip({
       disabled={busy}
       onClick={() => {
         setBusy(true);
-        void retryBatchInject(projectId, docId, msgId, text).finally(() => setBusy(false));
+        // A retry that fails again is not a new failure to report — the chip IS the
+        // report, and it stays up. Swallowed deliberately rather than left to reject
+        // unhandled into the console.
+        void retryBatchInject(projectId, docId, msgId, text)
+          .catch(() => {})
+          .finally(() => setBusy(false));
       }}
       className="mt-2 block rounded-full px-2 py-0.5 text-[10px] font-mono disabled:opacity-40"
       style={{ background: 'rgba(248,81,73,0.1)', color: S.danger,

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { createDoc, getVersions, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { createDoc, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { retryBatchInject } from '../interactive/feedbackBatch.js';
+import { scrollToWid } from '../interactive/widScroller.js';
 import { versionPath, type Navigate } from '../hooks/useRoute.js';
 import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
 
@@ -43,7 +45,7 @@ const COMPOSER: Record<GenState, { placeholder: string; submit: string }> = {
 
 // ── Message renderers ────────────────────────────────────────────────────────
 
-function Bubble({ msg, projectId }: { msg: DocMsg; projectId: string }): React.ReactElement | null {
+function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; docId: string | null }): React.ReactElement | null {
   if (msg.kind === 'user') {
     return (
       <div className="flex justify-end">
@@ -51,10 +53,35 @@ function Bubble({ msg, projectId }: { msg: DocMsg; projectId: string }): React.R
           data-testid="doc-message"
           data-message-id={msg.id}
           data-version={msg.version === undefined ? undefined : String(msg.version)}
-          className="max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed"
+          data-items={msg.items === undefined ? undefined : String(msg.items.length)}
+          className="max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap"
           style={{ background: S.user, color: S.ink, border: `1px solid ${S.border}` }}
         >
           {msg.text}
+          {/* §4.3: each batched item DEEP-LINKS back to its element — the frame scrolls
+              it into view over the same protocol that reported its rect. */}
+          {msg.items !== undefined && msg.items.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {msg.items.map((item, i) => (
+                <button
+                  key={`${item.wid}-${i}`}
+                  type="button"
+                  data-testid="feedback-item-link"
+                  data-wid={item.wid}
+                  title={`Show “${item.wid}” in the document`}
+                  onClick={() => scrollToWid(item.wid)}
+                  className="rounded-full px-2 py-0.5 text-[10px] font-mono"
+                  style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
+                           border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+                >
+                  {i + 1}. {item.wid}
+                </button>
+              ))}
+            </div>
+          )}
+          {msg.notRecorded === true && docId !== null && (
+            <NotRecordedChip projectId={projectId} docId={docId} msgId={msg.id} text={msg.text} />
+          )}
         </div>
       </div>
     );
@@ -104,6 +131,33 @@ function Bubble({ msg, projectId }: { msg: DocMsg; projectId: string }): React.R
     );
   }
   return null;
+}
+
+/**
+ * §7.7's failure shape, made actionable (§3.3). The bus event landed — the document IS
+ * regenerating — so this never blocks the batch or offers to "undo" it. It says exactly
+ * what did not happen (the run has no record of the message) and retries that one wire.
+ */
+function NotRecordedChip({
+  projectId, docId, msgId, text,
+}: { projectId: string; docId: string; msgId: string; text: string }): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+  return (
+    <button
+      type="button"
+      data-testid="feedback-not-recorded"
+      disabled={busy}
+      onClick={() => {
+        setBusy(true);
+        void retryBatchInject(projectId, docId, msgId, text).finally(() => setBusy(false));
+      }}
+      className="mt-2 block rounded-full px-2 py-0.5 text-[10px] font-mono disabled:opacity-40"
+      style={{ background: 'rgba(248,81,73,0.1)', color: S.danger,
+               border: '1px solid rgba(248,81,73,0.3)', cursor: 'pointer' }}
+    >
+      {busy ? 'retrying…' : 'not recorded in the run — retry'}
+    </button>
+  );
 }
 
 /**
@@ -233,7 +287,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
         store.addDivider(key, forked.version);
         store.addUserMsg(key, msgId, body);
         store.setGenState(key, 'generating');
-        await inject(projectId, docId, body, msgId);
+        await injectDocMessage(projectId, docId, body, msgId);
         setText('');
         navigate(versionPath(projectId, docId, forked.version));
         return;
@@ -248,7 +302,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
         });
         store.setGenState(key, 'generating');
       } else {
-        await inject(projectId, docId, body, msgId);
+        await injectDocMessage(projectId, docId, body, msgId);
       }
       setText('');
     } catch (e: unknown) {
@@ -286,7 +340,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
                   onAnswered={() => useDocThreadStore.getState().setGenState(key, 'generating')}
                 />
               )) || null
-            : <Bubble key={m.id} msg={m} projectId={projectId} />,
+            : <Bubble key={m.id} msg={m} projectId={projectId} docId={docId} />,
         )}
         <div ref={bottom} />
       </div>
@@ -347,10 +401,3 @@ function docName(brief: string): string {
   return brief.split(/\s+/).slice(0, 6).join(' ').slice(0, 60);
 }
 
-/** Steering = one `chat.posted` carrying the anchor id (§7.6) into the agent's session. */
-function inject(projectId: string, docId: string, text: string, msgId: string): Promise<unknown> {
-  return postEvent(projectId, {
-    event_type: 'wicked.interactive.chat.posted',
-    payload: { role: 'user', text, document_id: docId, source_message_id: msgId },
-  });
-}

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -192,7 +192,9 @@ export function FeedbackOverlay({
             data-wid={item.wid}
             title={item.text}
             style={{
-              position: 'absolute', left: `${box.left}px`, top: `${box.top}px`,
+              // Just OUTSIDE the element's left edge where there is room, so the pin
+              // marks the target without sitting on top of the text being commented on.
+              position: 'absolute', left: `${Math.max(0, box.left - 18)}px`, top: `${box.top}px`,
               background: S.accent, borderRadius: '9px', color: '#0d1117',
               fontSize: '10px', fontWeight: 700, padding: '1px 6px', pointerEvents: 'none',
             }}

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { hitTest, overlayBox, type OverlayBox, type ScrollState } from '../interactive/anchoring.js';
+import {
+  REQUEST_INVENTORY, makeScrollToWid, parseInbound,
+  type OverlayToBridgeMsg, type WidRect,
+} from '../interactive/instrument-protocol.js';
+import { submitFeedbackBatch } from '../interactive/feedbackBatch.js';
+import { registerWidScroller } from '../interactive/widScroller.js';
+import type { FeedbackItem } from '../store/docThread.js';
+
+// Point-and-comment over the SANDBOXED document frame (DES-MERGE-001 §4.3, §5.5,
+// slices 11+12 merged per §7.3).
+//
+// The frame is `sandbox="allow-scripts"` — no `allow-same-origin` — so `contentDocument`
+// is null and every coordinate in here arrives as a validated postMessage payload. That
+// is the whole point of §7.3's merge: the overlay never existed against a same-origin
+// frame, so there is no version of it that could regress into reading the document.
+//
+// Two consequences the code has to own rather than wish away:
+//   · a frame that never answers is NORMAL (an old document, a bridge-less render), so
+//     the overlay disables itself with a title that says why and leaves the canvas alone;
+//   · hit-testing cannot pass through an iframe, so commenting is a MODE. Off by default,
+//     because documents are interactive HTML and clicking them must click them.
+
+const S = {
+  card:   '#161b22',
+  border: 'rgba(230,237,243,0.1)',
+  ink:    '#e6edf3',
+  muted:  'rgba(230,237,243,0.55)',
+  accent: '#ffda19',
+  live:   '#79c0ff',
+  danger: '#f85149',
+};
+
+/** The bridge script runs on the frame's load; ask a few times before giving up. */
+const ASK_AT_MS = [0, 250, 750, 1500];
+const GIVE_UP_MS = 3000;
+/** Comment card footprint, used only to decide below-vs-above (§4.3's 4 px anchoring). */
+const CARD_H = 132;
+const CARD_W = 260;
+/** The anchoring budget the AC pins: the box sits within this of the element's rect. */
+const GAP = 4;
+
+const DEGRADED_TITLE =
+  'Point-and-comment is unavailable: this document did not answer the instrument bridge. '
+  + 'The document still renders, versions and exports normally.';
+
+interface Inventory { widMap: Record<string, WidRect>; measured: ScrollState }
+
+export interface FeedbackOverlayProps {
+  /** The framed document. Null until React attaches the ref. */
+  frame: HTMLIFrameElement | null;
+  /** Bumped on every frame load — a new render is a new inventory and a new batch. */
+  loadNonce: number;
+  projectId: string;
+  docId: string;
+  /** The version being commented ON; rides with the bus event so the agent edits it. */
+  version: number;
+}
+
+export function FeedbackOverlay({
+  frame, loadNonce, projectId, docId, version,
+}: FeedbackOverlayProps): React.ReactElement {
+  const [inventory, setInventory] = useState<Inventory | null>(null);
+  const [scroll, setScroll] = useState<ScrollState>({ scrollX: 0, scrollY: 0 });
+  const [timedOut, setTimedOut] = useState(false);
+  const [active, setActive] = useState(false);
+  const [hover, setHover] = useState<string | null>(null);
+  const [draft, setDraft] = useState<{ wid: string; text: string } | null>(null);
+  const [items, setItems] = useState<FeedbackItem[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const layer = useRef<HTMLDivElement>(null);
+
+  // `sandbox="allow-scripts"` gives the frame an OPAQUE origin, so "*" is the only
+  // targetOrigin that can reach it. Safe by construction: these payloads are a request
+  // for rects and a wid to scroll to — no secrets, nothing the document did not give us.
+  const post = useCallback((msg: OverlayToBridgeMsg): void => {
+    frame?.contentWindow?.postMessage(msg, '*');
+  }, [frame]);
+
+  useEffect(() => {
+    if (frame === null) return;
+    setInventory(null); setTimedOut(false); setScroll({ scrollX: 0, scrollY: 0 });
+    setActive(false); setHover(null); setDraft(null); setItems([]); setError(null);
+
+    function onMessage(e: MessageEvent): void {
+      // Identity, not origin: a sandboxed frame's origin is the string "null", which any
+      // other sandboxed frame on the page would also present. The window IS the identity.
+      if (frame === null || e.source !== frame.contentWindow) return;
+      const msg = parseInbound(e.data);
+      if (msg === null) return;
+      if (msg.type === 'wid-inventory') {
+        const at = { scrollX: msg.scrollX, scrollY: msg.scrollY };
+        setInventory({ widMap: msg.widMap, measured: at });
+        setScroll(at);
+      } else if (msg.type === 'scroll-state') {
+        setScroll({ scrollX: msg.scrollX, scrollY: msg.scrollY });
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+    const asks = ASK_AT_MS.map((ms) => window.setTimeout(() => post(REQUEST_INVENTORY), ms));
+    const giveUp = window.setTimeout(() => setTimedOut(true), GIVE_UP_MS);
+    return () => {
+      window.removeEventListener('message', onMessage);
+      asks.forEach(window.clearTimeout);
+      window.clearTimeout(giveUp);
+    };
+  }, [frame, loadNonce, post]);
+
+  // The thread's half of the deep-link (§4.3): clicking a submitted item asks THIS frame
+  // to bring its element back into view. One active overlay at a time, by construction.
+  useEffect(() => registerWidScroller((wid) => post(makeScrollToWid(wid))), [post]);
+
+  const ready = inventory !== null;
+  const boxOf = (wid: string): OverlayBox | null => {
+    const rect = inventory?.widMap[wid];
+    return rect === undefined || inventory === null
+      ? null : overlayBox(rect, inventory.measured, scroll);
+  };
+  const pointIn = (e: React.MouseEvent<HTMLDivElement>): { x: number; y: number } => {
+    const r = e.currentTarget.getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  };
+  const widAt = (e: React.MouseEvent<HTMLDivElement>): string | null =>
+    inventory === null ? null : hitTest(inventory.widMap, inventory.measured, scroll, pointIn(e));
+
+  function commit(): void {
+    if (draft === null || draft.text.trim() === '') return;
+    setItems((prev) => [...prev, { wid: draft.wid, text: draft.text.trim() }]);
+    setDraft(null);
+  }
+
+  async function submit(): Promise<void> {
+    if (items.length === 0 || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await submitFeedbackBatch({ projectId, docId, version, items });
+      setItems([]); setDraft(null); setActive(false);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const hoverBox = hover === null || draft !== null ? null : boxOf(hover);
+  const draftBox = draft === null ? null : boxOf(draft.wid);
+
+  return (
+    <div
+      data-testid="feedback-overlay"
+      data-ready={String(ready)}
+      style={{ inset: 0, pointerEvents: 'none', position: 'absolute', zIndex: 2 }}
+    >
+      {/* The hit layer only exists while commenting — otherwise the document is the
+          document, and a click on a deck's next-slide button is that click (§4.3). */}
+      {active && ready && (
+        <div
+          ref={layer}
+          data-testid="feedback-hitlayer"
+          style={{ cursor: 'crosshair', inset: 0, pointerEvents: 'auto', position: 'absolute' }}
+          onMouseMove={(e) => setHover(widAt(e))}
+          onMouseLeave={() => setHover(null)}
+          onClick={(e) => {
+            const wid = widAt(e);
+            if (wid !== null) { setDraft({ wid, text: '' }); setHover(null); }
+          }}
+        />
+      )}
+
+      {hoverBox !== null && (
+        <div
+          data-testid="feedback-hover"
+          data-wid={hover}
+          style={{
+            ...px(hoverBox), position: 'absolute', pointerEvents: 'none',
+            border: `2px solid ${S.accent}`, borderRadius: '3px',
+            background: 'rgba(255,218,25,0.08)',
+          }}
+        />
+      )}
+
+      {items.map((item, i) => {
+        const box = boxOf(item.wid);
+        return box === null ? null : (
+          <span
+            key={`${item.wid}-${i}`}
+            data-testid="feedback-pin"
+            data-wid={item.wid}
+            title={item.text}
+            style={{
+              position: 'absolute', left: `${box.left}px`, top: `${box.top}px`,
+              background: S.accent, borderRadius: '9px', color: '#0d1117',
+              fontSize: '10px', fontWeight: 700, padding: '1px 6px', pointerEvents: 'none',
+            }}
+          >
+            {i + 1}
+          </span>
+        );
+      })}
+
+      {draft !== null && draftBox !== null && (
+        <div
+          data-testid="feedback-comment"
+          data-wid={draft.wid}
+          style={{
+            ...cardAt(draftBox, frame?.clientHeight ?? 0),
+            position: 'absolute', pointerEvents: 'auto', width: `${CARD_W}px`,
+            background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+            display: 'flex', flexDirection: 'column', gap: '6px', padding: '10px',
+          }}
+        >
+          <span style={{ color: S.muted, fontFamily: 'monospace', fontSize: '10px' }}>
+            {draft.wid}
+          </span>
+          <textarea
+            data-testid="feedback-comment-input"
+            autoFocus
+            rows={3}
+            value={draft.text}
+            placeholder="What should change here?"
+            onChange={(e) => setDraft({ wid: draft.wid, text: e.target.value })}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); }
+              if (e.key === 'Escape') setDraft(null);
+            }}
+            style={{
+              background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
+              color: S.ink, fontFamily: 'inherit', fontSize: '12px', padding: '6px', resize: 'none',
+            }}
+          />
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <button
+              type="button" data-testid="feedback-comment-add" onClick={commit}
+              disabled={draft.text.trim() === ''}
+              style={{ ...btn, background: S.accent, color: '#0d1117' }}
+            >
+              Add to batch
+            </button>
+            <button
+              type="button" data-testid="feedback-comment-cancel" onClick={() => setDraft(null)}
+              style={{ ...btn, background: 'transparent', border: `1px solid ${S.border}`, color: S.muted }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div
+        data-testid="feedback-toolbar"
+        style={{
+          position: 'absolute', top: '10px', right: '10px', pointerEvents: 'auto',
+          display: 'flex', alignItems: 'center', gap: '6px',
+        }}
+      >
+        {error !== null && (
+          <span data-testid="feedback-error" style={{ color: S.danger, fontFamily: 'monospace', fontSize: '10px' }}>
+            {error}
+          </span>
+        )}
+        {items.length > 0 && (
+          <button
+            type="button" data-testid="feedback-submit" onClick={() => void submit()} disabled={busy}
+            title={`Send all ${items.length} comments as one message`}
+            style={{ ...btn, background: S.accent, color: '#0d1117' }}
+          >
+            {busy ? '…' : `Send ${items.length} comment${items.length === 1 ? '' : 's'}`}
+          </button>
+        )}
+        <button
+          type="button"
+          data-testid="feedback-toggle"
+          data-active={String(active)}
+          data-count={String(items.length)}
+          disabled={!ready}
+          title={ready ? 'Point at anything in the document and comment on it'
+            : timedOut ? DEGRADED_TITLE : 'Connecting to the document…'}
+          onClick={() => { setActive((a) => !a); setDraft(null); setHover(null); }}
+          style={{
+            ...btn,
+            background: active ? S.live : 'rgba(13,17,23,0.75)',
+            border: `1px solid ${active ? S.live : S.border}`,
+            color: active ? '#0d1117' : ready ? S.ink : S.muted,
+            cursor: ready ? 'pointer' : 'not-allowed',
+            opacity: ready ? 1 : 0.5,
+          }}
+        >
+          {active ? 'Done' : 'Comment'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const btn: React.CSSProperties = {
+  border: 'none', borderRadius: '7px', cursor: 'pointer',
+  fontSize: '11px', fontWeight: 600, padding: '4px 10px',
+};
+
+function px(box: OverlayBox): React.CSSProperties {
+  return {
+    left: `${box.left}px`, top: `${box.top}px`,
+    width: `${box.width}px`, height: `${box.height}px`,
+  };
+}
+
+/**
+ * The comment card sits GAP px below its element — or GAP px above when there is no room
+ * below, which keeps it on screen without ever leaving the 4 px anchoring budget the AC
+ * pins. Left edge is the element's own, so the card visibly belongs to what was clicked.
+ */
+function cardAt(box: OverlayBox, frameHeight: number): React.CSSProperties {
+  const below = box.top + box.height + GAP;
+  const fits = frameHeight === 0 || below + CARD_H <= frameHeight;
+  return {
+    left: `${box.left}px`,
+    top: `${fits ? below : Math.max(0, box.top - CARD_H - GAP)}px`,
+  };
+}

--- a/src/interactive/anchoring.ts
+++ b/src/interactive/anchoring.ts
@@ -1,0 +1,60 @@
+// Overlay anchoring math (DES-MERGE-001 §4.3, slices 11+12).
+//
+// The parent cannot measure anything inside a `sandbox="allow-scripts"` frame, so every
+// number here comes from the bridge's `wid-inventory`: rects measured with
+// `getBoundingClientRect()` INSIDE the frame's viewport, plus the scroll offset they
+// were measured at. Re-projecting them is pure arithmetic on that payload — which is
+// what makes the 4 px anchoring AC a unit test rather than a browser-only claim.
+//
+// Coordinates are relative to the OVERLAY LAYER, which is `inset: 0` over the iframe.
+// Layer origin === frame viewport origin, so no frame-position term appears at all.
+
+import type { WidRect } from './instrument-protocol.js';
+
+export interface ScrollState { scrollX: number; scrollY: number }
+export interface Point { x: number; y: number }
+export interface OverlayBox { left: number; top: number; width: number; height: number }
+
+/**
+ * Project one reported rect into overlay-layer coordinates.
+ *
+ * A rect measured at scroll S is viewport-relative AT S. When the frame has since
+ * scrolled to S', the element has moved by exactly -(S' - S) on screen. Re-requesting
+ * the whole inventory on every scroll frame would be the alternative; a single
+ * `scroll-state` message plus this subtraction is the cheap, exact one.
+ */
+export function overlayBox(rect: WidRect, measured: ScrollState, current: ScrollState): OverlayBox {
+  return {
+    left: rect.left - (current.scrollX - measured.scrollX),
+    top: rect.top - (current.scrollY - measured.scrollY),
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+/**
+ * The instrumented element under a point — interactive's `nearestReviewable`, rebuilt
+ * on payloads instead of DOM traversal. Nested anchors overlap (a `data-wid` heading
+ * inside a `data-wid` section), so the SMALLEST containing box wins: pointing at a
+ * heading must comment on the heading, never on the section that contains it.
+ *
+ * Returns null when the point is over no instrumented element — clicking whitespace
+ * opens nothing rather than guessing a target.
+ */
+export function hitTest(
+  widMap: Record<string, WidRect>,
+  measured: ScrollState,
+  current: ScrollState,
+  point: Point,
+): string | null {
+  let best: string | null = null;
+  let bestArea = Infinity;
+  for (const [wid, rect] of Object.entries(widMap)) {
+    const box = overlayBox(rect, measured, current);
+    if (point.x < box.left || point.x > box.left + box.width) continue;
+    if (point.y < box.top || point.y > box.top + box.height) continue;
+    const area = box.width * box.height;
+    if (area < bestArea) { best = wid; bestArea = area; }
+  }
+  return best;
+}

--- a/src/interactive/feedbackBatch.ts
+++ b/src/interactive/feedbackBatch.ts
@@ -1,0 +1,84 @@
+// Submitting a point-and-comment batch (DES-MERGE-001 §4.3, §7.7, slices 11+12).
+//
+// §7.7 is explicit that THE CLIENT AUTHORS BOTH WRITES — no crew bus-listener is
+// introduced — and it names their order of importance:
+//
+//   1. the bus event (`feedback.submitted`, contract unchanged) is what makes the
+//      DOCUMENT update, so it goes first and its failure fails the submit;
+//   2. the inject is what makes the batch VISIBLE IN THE THREAD as a user message.
+//      A failed inject must not block the batch: the document is already regenerating,
+//      so the message stays in the transcript wearing a retryable "not recorded" chip.
+//
+// The batch is ONE message with N targets, never N messages (§4.3): N submits would be
+// N runs and N versions for what the user experienced as one round of edits.
+
+import { injectDocMessage, postEvent } from '../api/interactive.js';
+import { nextMsgId, threadKey, useDocThreadStore, type FeedbackItem } from '../store/docThread.js';
+
+/** The bus event type interactive's `feedbackStore.js` has always emitted. Unchanged. */
+export const FEEDBACK_EVENT = 'wicked.interactive.feedback.submitted';
+
+/**
+ * The batch, as the one line of conversation it is. The `[wid]` tag is not decoration:
+ * it is the same anchor the item's deep-link resolves through, so the message a human
+ * reads and the target the agent edits are provably the same element.
+ */
+export function composeBatchMessage(items: FeedbackItem[]): string {
+  const where = items.length === 1 ? '1 place' : `${items.length} places`;
+  return [
+    `Feedback on ${where} in this document:`,
+    ...items.map((item, i) => `${i + 1}. [${item.wid}] ${item.text}`),
+  ].join('\n');
+}
+
+export interface SubmitBatchArgs {
+  projectId: string;
+  docId: string;
+  version: number;
+  items: FeedbackItem[];
+}
+
+export interface SubmitBatchResult {
+  /** The thread message the batch landed as — also the version anchor (§7.6). */
+  msgId: string;
+  text: string;
+  /** False when write 2 failed; the message carries the retryable chip instead. */
+  recorded: boolean;
+}
+
+/** Write 1 then write 2. Throws only when write 1 fails — nothing was submitted then. */
+export async function submitFeedbackBatch(
+  { projectId, docId, version, items }: SubmitBatchArgs,
+): Promise<SubmitBatchResult> {
+  const text = composeBatchMessage(items);
+  const msgId = nextMsgId();
+  const key = threadKey(projectId, docId);
+
+  await postEvent(projectId, {
+    event_type: FEEDBACK_EVENT,
+    payload: {
+      document_id: docId,
+      version,
+      source_message_id: msgId,
+      items: items.map((item) => ({ wid: item.wid, comment: item.text })),
+    },
+  });
+
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(key, msgId, text, items);
+  try {
+    await injectDocMessage(projectId, docId, text, msgId);
+    return { msgId, text, recorded: true };
+  } catch {
+    store.markNotRecorded(key, msgId, true);
+    return { msgId, text, recorded: false };
+  }
+}
+
+/** The chip's action. Same wire, same message id — a retry, not a second message. */
+export async function retryBatchInject(
+  projectId: string, docId: string, msgId: string, text: string,
+): Promise<void> {
+  await injectDocMessage(projectId, docId, text, msgId);
+  useDocThreadStore.getState().markNotRecorded(threadKey(projectId, docId), msgId, false);
+}

--- a/src/interactive/instrument-protocol.ts
+++ b/src/interactive/instrument-protocol.ts
@@ -1,0 +1,129 @@
+// Typed, versioned postMessage contract for the sandboxed instrument bridge
+// (DES-MERGE-001 §5.5, slices 11+12).
+//
+// The parent overlay asks the frame for element rects and scroll state via
+// `postMessage`; the frame replies with the same mechanism. The parent NEVER reads
+// `contentDocument` — the entire hit-testing flow is driven by the bridge's payloads.
+//
+// Every inbound payload (bridge → overlay) MUST go through `parseInbound` before use.
+// The bridge lives inside `sandbox="allow-scripts"` — it has an opaque origin — and
+// its postMessage payloads must not be trusted raw. Outbound messages (overlay → bridge)
+// are authored here; we trust ourselves.
+//
+// Version field (`v`) is explicit on every envelope so the overlay can silently drop
+// frames from a stale or incompatible bridge rather than misreading them.
+
+// ── Rect ─────────────────────────────────────────────────────────────────────
+
+/** JSON-serializable DOMRect subset. The bridge computes via getBoundingClientRect()
+ *  so values are viewport-relative within the frame's own viewport at measurement time. */
+export interface WidRect {
+  x: number; y: number;
+  width: number; height: number;
+  top: number; left: number;
+  right: number; bottom: number;
+}
+
+// ── Bridge → Overlay (inbound; MUST validate before use) ─────────────────────
+
+/** Full inventory: all [data-wid] rects plus current frame scroll. Posted in
+ *  response to `request-inventory` and whenever the inventory changes substantially. */
+export interface WidInventoryMsg {
+  v: 1; type: 'wid-inventory';
+  widMap: Record<string, WidRect>;
+  scrollX: number; scrollY: number;
+}
+
+/** Posted by the bridge on every frame scroll event so the overlay can recompute
+ *  displayed rects without re-requesting the full inventory. */
+export interface ScrollStateMsg {
+  v: 1; type: 'scroll-state';
+  scrollX: number; scrollY: number;
+}
+
+/** Confirmation that a `scroll-to-wid` request was handled by the frame. */
+export interface ScrollAckMsg {
+  v: 1; type: 'scroll-ack'; wid: string;
+}
+
+export type BridgeToOverlayMsg = WidInventoryMsg | ScrollStateMsg | ScrollAckMsg;
+
+// ── Overlay → Bridge (outbound; authored here, sent via postMessage) ──────────
+
+/** Ask the bridge to post a fresh `wid-inventory`. */
+export interface RequestInventoryMsg { v: 1; type: 'request-inventory' }
+
+/** Ask the bridge to scroll the [data-wid=wid] element into view. */
+export interface ScrollToWidMsg { v: 1; type: 'scroll-to-wid'; wid: string }
+
+export type OverlayToBridgeMsg = RequestInventoryMsg | ScrollToWidMsg;
+
+// ── Runtime validation ────────────────────────────────────────────────────────
+
+function isFiniteNum(x: unknown): x is number {
+  return typeof x === 'number' && isFinite(x);
+}
+
+function isWidRect(x: unknown): x is WidRect {
+  if (typeof x !== 'object' || x === null) return false;
+  const r = x as Record<string, unknown>;
+  return (
+    isFiniteNum(r['x']) && isFiniteNum(r['y']) &&
+    isFiniteNum(r['width']) && isFiniteNum(r['height']) &&
+    isFiniteNum(r['top']) && isFiniteNum(r['left']) &&
+    isFiniteNum(r['right']) && isFiniteNum(r['bottom'])
+  );
+}
+
+/**
+ * Parse and validate one inbound postMessage data payload from the bridge.
+ *
+ * Returns `null` for any frame that does not match the v1 protocol exactly:
+ * wrong version, unknown type, missing fields, non-finite numbers, or a widMap
+ * entry whose rect is malformed. Partial trust is worse than no trust — a single
+ * bad entry in the widMap invalidates the entire inventory.
+ */
+export function parseInbound(data: unknown): BridgeToOverlayMsg | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const d = data as Record<string, unknown>;
+  if (d['v'] !== 1) return null;
+  const type = d['type'];
+
+  if (type === 'wid-inventory') {
+    const raw = d['widMap'];
+    const scrollX = d['scrollX'];
+    const scrollY = d['scrollY'];
+    if (typeof raw !== 'object' || raw === null) return null;
+    if (!isFiniteNum(scrollX) || !isFiniteNum(scrollY)) return null;
+    const widMap: Record<string, WidRect> = {};
+    for (const [wid, rect] of Object.entries(raw as Record<string, unknown>)) {
+      if (!isWidRect(rect)) return null;
+      widMap[wid] = rect;
+    }
+    return { v: 1, type: 'wid-inventory', widMap, scrollX, scrollY };
+  }
+
+  if (type === 'scroll-state') {
+    const scrollX = d['scrollX'];
+    const scrollY = d['scrollY'];
+    if (!isFiniteNum(scrollX) || !isFiniteNum(scrollY)) return null;
+    return { v: 1, type: 'scroll-state', scrollX, scrollY };
+  }
+
+  if (type === 'scroll-ack') {
+    const wid = d['wid'];
+    if (typeof wid !== 'string' || wid === '') return null;
+    return { v: 1, type: 'scroll-ack', wid };
+  }
+
+  return null;
+}
+
+// ── Outbound helpers ──────────────────────────────────────────────────────────
+
+/** Frozen singleton — safe to compare by reference in tests. */
+export const REQUEST_INVENTORY: RequestInventoryMsg = Object.freeze({ v: 1 as const, type: 'request-inventory' as const });
+
+export function makeScrollToWid(wid: string): ScrollToWidMsg {
+  return { v: 1, type: 'scroll-to-wid', wid };
+}

--- a/src/interactive/widScroller.ts
+++ b/src/interactive/widScroller.ts
@@ -1,0 +1,27 @@
+// Thin register/call bridge for scroll-to-wid deep-links (DES-MERGE-001 slices 11+12).
+//
+// FeedbackOverlay registers the active frame's postMessage sender when it mounts;
+// DocumentThread calls scrollToWid() when the user clicks a feedback item's wid link.
+// No prop drilling, no context — the two are document-mode siblings and this is the
+// only cross-component link between them.
+
+type ScrollFn = (wid: string) => void;
+let _fn: ScrollFn | null = null;
+
+/**
+ * Register the handler for scroll-to-wid requests. Returns a cleanup that removes
+ * the handler. Registering a new handler replaces the previous one — at most one
+ * overlay is active at a time, matching the single-frame Document-mode contract.
+ */
+export function registerWidScroller(fn: ScrollFn): () => void {
+  _fn = fn;
+  return () => { if (_fn === fn) _fn = null; };
+}
+
+/**
+ * Ask the currently active frame to scroll the given [data-wid] element into view.
+ * No-ops gracefully when no overlay is registered (frame still loading, navigated away).
+ */
+export function scrollToWid(wid: string): void {
+  _fn?.(wid);
+}

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -16,8 +16,20 @@ import type { CoreEvent } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
 
+/**
+ * One targeted comment from the point-and-comment overlay (§4.3, slices 11+12). `wid`
+ * is the document's own stable anchor (INV-1), which is what makes the item deep-linkable
+ * back to its element for as long as the element exists.
+ */
+export interface FeedbackItem { wid: string; text: string }
+
 export type DocMsg =
-  | { kind: 'user';      id: string; text: string; version?: number }
+  // `items` is set only for a submitted feedback batch: ONE message, N targets (§4.3 —
+  // sending each comment separately would produce N versions and N runs). `notRecorded`
+  // is §7.7's failure shape: the bus event landed and the document still updates, but the
+  // inject that puts this message in the run did not — retryable, never silent.
+  | { kind: 'user';      id: string; text: string; version?: number;
+      items?: FeedbackItem[]; notRecorded?: boolean }
   | { kind: 'narration'; id: string; text: string }
   | { kind: 'agent';     id: string; author: string; text: string; href?: string }
   | { kind: 'verdict';   id: string; author: string; text: string }
@@ -85,7 +97,9 @@ interface DocThreadStore {
   /** Fold one CoreEvent — every non-interactive frame is ignored. */
   ingest: (event: CoreEvent) => void;
   /** Append the user's message and make it the pending version anchor. */
-  addUserMsg: (key: string, id: string, text: string) => void;
+  addUserMsg: (key: string, id: string, text: string, items?: FeedbackItem[]) => void;
+  /** Flag/clear §7.7's "not recorded in the run" chip on one already-rendered message. */
+  markNotRecorded: (key: string, id: string, notRecorded: boolean) => void;
   /** Append a client-authored informative line (§3.3) — an action the user took. */
   addNarration: (key: string, text: string) => void;
   /** The version divider a fork+inject continuation renders behind (§7.10). */
@@ -210,10 +224,19 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
     });
   },
 
-  addUserMsg: (key, id, text) =>
+  addUserMsg: (key, id, text, items) =>
     set((s) => ({
-      messages: append(s.messages, key, { kind: 'user', id, text }),
+      messages: append(s.messages, key, { kind: 'user', id, text, ...(items ? { items } : {}) }),
       anchor: { ...s.anchor, [key]: id },
+    })),
+
+  markNotRecorded: (key, id, notRecorded) =>
+    set((s) => ({
+      messages: {
+        ...s.messages,
+        [key]: (s.messages[key] ?? []).map((m) =>
+          m.kind === 'user' && m.id === id ? { ...m, notRecorded } : m),
+      },
     })),
 
   addNarration: (key, text) =>

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -111,12 +111,22 @@ describe('DocumentCanvas — the frame (§5.3, §6.3)', () => {
     expect(frame.getAttribute('src')).toContain('/d/a%2Fb%20c/doc/3');
   });
 
-  it('AC: carries the §5.5 status-quo sandbox — allow-scripts + allow-same-origin', async () => {
+  // ── REGRESSION PIN (§5.5, §7.3) ────────────────────────────────────────────
+  // Agent-authored HTML is influenced by untrusted input. With `allow-same-origin` it
+  // executes on the app's origin with the user's ambient authority — it could read
+  // localStorage and call /api/v1. §7.3 merged slices 11+12 precisely so that the
+  // overlay could never be the reason someone put this back "just for now". If this
+  // test ever needs changing, the change is a security decision, not a refactor.
+  it('AC: the frame is FULLY sandboxed — allow-scripts, and never allow-same-origin', async () => {
     stubFetch({ '/api/versions': { body: MANIFEST } });
     render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
 
     const frame = await screen.findByTestId('doc-canvas');
-    expect(frame).toHaveAttribute('sandbox', 'allow-scripts allow-same-origin');
+    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    const sandbox = frame.getAttribute('sandbox') ?? '';
+    expect(sandbox.split(/\s+/)).not.toContain('allow-same-origin');
+    // Neither by any other spelling of "give the document the app's authority".
+    expect(sandbox).not.toMatch(/allow-(same-origin|top-navigation|popups-to-escape-sandbox)/);
   });
 
   it('§3.3: while the doc loads the surface NAMES it — never a bare spinner', async () => {

--- a/tests/DocumentThread.feedback.test.tsx
+++ b/tests/DocumentThread.feedback.test.tsx
@@ -1,0 +1,117 @@
+// The thread's half of point-and-comment — DES-MERGE-001 §4.3, §7.7, slices 11+12.
+//
+// The batch lands in the transcript as ONE ordinary user message (§2.3: non-text inputs
+// are messages too). What makes it more than text is that each item still knows which
+// element it came from — clicking one asks the frame to bring that element back.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { registerWidScroller } from '../src/interactive/widScroller.js';
+import { threadKey, useDocThreadStore, type FeedbackItem } from '../src/store/docThread.js';
+
+const postEvent = vi.fn();
+const injectDocMessage = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: vi.fn(),
+  postFork: vi.fn(),
+  getVersions: vi.fn(),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (...a: unknown[]) => injectDocMessage(...a),
+}));
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
+const ITEMS: FeedbackItem[] = [
+  { wid: 'slide-2-heading-1', text: 'make this title punchier' },
+  { wid: 'slide-4-body-2',    text: 'cut this paragraph in half' },
+];
+const TEXT = 'Feedback on 2 places in this document:\n1. [slide-2-heading-1] …\n2. [slide-4-body-2] …';
+
+function mount(): void {
+  render(<DocumentThread projectId={PROJECT} docId={DOC} selectedVersion={3} navigate={vi.fn()} />);
+}
+
+beforeEach(() => {
+  useDocThreadStore.getState().clear(KEY);
+  injectDocMessage.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('DocumentThread — a submitted feedback batch (§4.3)', () => {
+  it('renders the batch as ONE message, not one per comment', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'dm-1', TEXT, ITEMS);
+    mount();
+
+    const messages = screen.getAllByTestId('doc-message');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toHaveAttribute('data-items', '2');
+  });
+
+  it('AC: each item DEEP-LINKS back to its element through the protocol', async () => {
+    const scrolled: string[] = [];
+    const unregister = registerWidScroller((wid) => scrolled.push(wid));
+    useDocThreadStore.getState().addUserMsg(KEY, 'dm-1', TEXT, ITEMS);
+    mount();
+
+    const links = screen.getAllByTestId('feedback-item-link');
+    expect(links.map((l) => l.getAttribute('data-wid'))).toEqual(
+      ['slide-2-heading-1', 'slide-4-body-2']);
+
+    await userEvent.click(links[1]!);
+    expect(scrolled).toEqual(['slide-4-body-2']);
+    unregister();
+  });
+
+  it('a plain composer message carries no item links', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'dm-1', 'make the closing slide stronger');
+    mount();
+
+    expect(screen.getByTestId('doc-message')).not.toHaveAttribute('data-items');
+    expect(screen.queryAllByTestId('feedback-item-link')).toHaveLength(0);
+  });
+});
+
+describe('DocumentThread — the not-recorded chip (§7.7, §3.3)', () => {
+  it('shows a RETRYABLE chip when the inject failed — the batch itself stands', () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dm-1', TEXT, ITEMS);
+    store.markNotRecorded(KEY, 'dm-1', true);
+    mount();
+
+    // The message is still there: the document is already regenerating off the bus event.
+    expect(screen.getByTestId('doc-message')).toHaveTextContent('Feedback on 2 places');
+    expect(screen.getByTestId('feedback-not-recorded')).toHaveTextContent(/retry/i);
+  });
+
+  it('the retry re-sends the SAME message id and clears the chip on success', async () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dm-1', TEXT, ITEMS);
+    store.markNotRecorded(KEY, 'dm-1', true);
+    mount();
+
+    await userEvent.click(screen.getByTestId('feedback-not-recorded'));
+
+    await waitFor(() => expect(screen.queryByTestId('feedback-not-recorded')).toBeNull());
+    expect(injectDocMessage).toHaveBeenCalledWith(PROJECT, DOC, TEXT, 'dm-1');
+    // One message throughout — a retry is a retry, never a second message.
+    expect(screen.getAllByTestId('doc-message')).toHaveLength(1);
+  });
+
+  it('a retry that fails again leaves the chip up', async () => {
+    injectDocMessage.mockRejectedValue(new Error('API 500: run not found'));
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dm-1', TEXT, ITEMS);
+    store.markNotRecorded(KEY, 'dm-1', true);
+    mount();
+
+    await userEvent.click(screen.getByTestId('feedback-not-recorded'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('feedback-not-recorded')).toHaveTextContent(/retry/i));
+    expect(screen.getByTestId('feedback-not-recorded')).toBeEnabled();
+  });
+});

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -23,6 +23,14 @@ vi.mock('../src/api/interactive.js', () => ({
   createDoc: (...a: unknown[]) => createDoc(...a),
   postFork: (...a: unknown[]) => postFork(...a),
   postEvent: (...a: unknown[]) => postEvent(...a),
+  // The real wrapper, mirrored: `injectDocMessage` IS one `postEvent` (slices 11+12
+  // shared the steer wire with the feedback batch), so slice 10's assertions about the
+  // emitted event stay assertions about the emitted event.
+  injectDocMessage: (p: string, d: string, text: string, id: string) =>
+    postEvent(p, {
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { role: 'user', text, document_id: d, source_message_id: id },
+    }),
   getVersions: (...a: unknown[]) => getVersions(...a),
   interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
 }));

--- a/tests/FeedbackOverlay.test.tsx
+++ b/tests/FeedbackOverlay.test.tsx
@@ -1,0 +1,273 @@
+// The point-and-comment overlay against a FIXTURE BRIDGE — DES-MERGE-001 §4.3, §5.5,
+// slices 11+12 (merged per §7.3).
+//
+// Every number the overlay renders here arrived as a postMessage payload and went
+// through `parseInbound` on the way in. Nothing in this file reads `contentDocument`,
+// because in production nothing can: the frame is `sandbox="allow-scripts"`.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FeedbackOverlay } from '../src/components/FeedbackOverlay.js';
+import { scrollToWid } from '../src/interactive/widScroller.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+import { makeFixtureBridge, rect, type FixtureBridge } from './fixtures/fixtureBridge.js';
+
+const postEvent = vi.fn();
+const injectDocMessage = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (...a: unknown[]) => injectDocMessage(...a),
+}));
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
+
+/** A document shaped like the fixtures: a containing section, a heading, two paragraphs. */
+const WIDS = {
+  section: rect(0, 0, 1200, 900),
+  h1:      rect(120, 64, 480, 56),
+  p1:      rect(120, 160, 480, 90),
+};
+
+function mount(bridge: FixtureBridge, version = 3): void {
+  render(
+    <FeedbackOverlay
+      frame={bridge.frame}
+      loadNonce={1}
+      projectId={PROJECT}
+      docId={DOC}
+      version={version}
+    />,
+  );
+}
+
+/** The overlay layer is `inset: 0`, so its client rect is the origin jsdom reports (0,0). */
+async function clickAt(x: number, y: number): Promise<void> {
+  const layer = screen.getByTestId('feedback-hitlayer');
+  await userEvent.pointer([{ target: layer, coords: { clientX: x, clientY: y } },
+                           { keys: '[MouseLeft]', target: layer, coords: { clientX: x, clientY: y } }]);
+}
+
+function boxOf(testId: string): { left: number; top: number } {
+  const el = screen.getByTestId(testId);
+  return { left: parseFloat(el.style.left), top: parseFloat(el.style.top) };
+}
+
+/** Turn commenting on — it is a MODE, because hit-testing cannot pass through an iframe. */
+async function startCommenting(): Promise<void> {
+  await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+  await userEvent.click(screen.getByTestId('feedback-toggle'));
+}
+
+async function comment(x: number, y: number, text: string): Promise<void> {
+  await clickAt(x, y);
+  await userEvent.type(screen.getByTestId('feedback-comment-input'), text);
+  await userEvent.click(screen.getByTestId('feedback-comment-add'));
+}
+
+beforeEach(() => {
+  useDocThreadStore.getState().clear(KEY);
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  injectDocMessage.mockResolvedValue({ ok: true, event_id: 'e2', correlation_id: 'c1' });
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('FeedbackOverlay — the instrumentation handshake (§5.5)', () => {
+  it('asks the frame for its inventory on load, over the protocol', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+
+    await waitFor(() => expect(bridge.sent[0]).toEqual({ v: 1, type: 'request-inventory' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('feedback-overlay')).toHaveAttribute('data-ready', 'true'));
+  });
+
+  it('AC: a frame that NEVER answers degrades gracefully — disabled, with the reason', async () => {
+    vi.useFakeTimers();
+    const bridge = makeFixtureBridge({ widMap: WIDS, silent: true });
+    mount(bridge);
+    await act(async () => { vi.advanceTimersByTime(5000); });
+    vi.useRealTimers();
+
+    const toggle = screen.getByTestId('feedback-toggle');
+    expect(toggle).toBeDisabled();
+    // §3.3: a disabled control says WHY, and says the canvas is still fine.
+    expect(toggle.getAttribute('title')).toMatch(/did not answer the instrument bridge/i);
+    expect(toggle.getAttribute('title')).toMatch(/still renders/i);
+    expect(screen.getByTestId('feedback-overlay')).toHaveAttribute('data-ready', 'false');
+    // And nothing was rendered over the document that could swallow a click.
+    expect(screen.queryByTestId('feedback-hitlayer')).toBeNull();
+  });
+
+  it('drops malformed inbound payloads instead of anchoring against them', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, silent: true });
+    mount(bridge);
+
+    // Hostile / stale / broken — every one must leave the overlay un-ready.
+    bridge.postRaw({ v: 2, type: 'wid-inventory', widMap: WIDS, scrollX: 0, scrollY: 0 });
+    bridge.postRaw({ v: 1, type: 'wid-inventory', widMap: { h1: { top: 'up' } }, scrollX: 0, scrollY: 0 });
+    bridge.postRaw({ v: 1, type: 'exec', code: 'alert(1)' });
+    bridge.postRaw('wid-inventory');
+    bridge.postRaw(null);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('feedback-overlay')).toHaveAttribute('data-ready', 'false'));
+  });
+
+  it('ignores a well-formed inventory from a DIFFERENT window', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, silent: true });
+    const impostor = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+
+    // Same payload, same shape, wrong source. A sandboxed frame's origin is the string
+    // "null" for every such frame, so identity is the only check that can work.
+    impostor.postRaw({ v: 1, type: 'wid-inventory', widMap: WIDS, scrollX: 0, scrollY: 0 });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('feedback-overlay')).toHaveAttribute('data-ready', 'false'));
+  });
+});
+
+describe('FeedbackOverlay — pointing (§4.3)', () => {
+  it('AC: hovering an instrumented element highlights it WITHIN 4 px of its rect', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+
+    const layer = screen.getByTestId('feedback-hitlayer');
+    await userEvent.pointer({ target: layer, coords: { clientX: 300, clientY: 90 } });
+
+    const hover = await screen.findByTestId('feedback-hover');
+    expect(hover).toHaveAttribute('data-wid', 'h1');
+    const box = boxOf('feedback-hover');
+    expect(Math.abs(box.left - WIDS.h1.left)).toBeLessThanOrEqual(4);
+    expect(Math.abs(box.top - WIDS.h1.top)).toBeLessThanOrEqual(4);
+    expect(hover.style.width).toBe(`${WIDS.h1.width}px`);
+    expect(hover.style.height).toBe(`${WIDS.h1.height}px`);
+  });
+
+  it('AC: clicking a heading anchors the comment box within 4 px of its rect', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+    await clickAt(300, 90);
+
+    const card = await screen.findByTestId('feedback-comment');
+    expect(card).toHaveAttribute('data-wid', 'h1');
+    const box = boxOf('feedback-comment');
+    expect(Math.abs(box.left - WIDS.h1.left)).toBeLessThanOrEqual(4);
+    // Anchored just under the element — the gap IS the budget, never more.
+    expect(box.top - (WIDS.h1.top + WIDS.h1.height)).toBeLessThanOrEqual(4);
+    expect(box.top).toBeGreaterThanOrEqual(WIDS.h1.top);
+  });
+
+  it('a click on nothing instrumented opens nothing', async () => {
+    const bridge = makeFixtureBridge({ widMap: { h1: WIDS.h1 } });
+    mount(bridge);
+    await startCommenting();
+    await clickAt(1000, 800);
+
+    expect(screen.queryByTestId('feedback-comment')).toBeNull();
+  });
+
+  it('commenting is a MODE — with it off the document keeps every click', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    expect(screen.queryByTestId('feedback-hitlayer')).toBeNull();
+    expect(screen.getByTestId('feedback-overlay').style.pointerEvents).toBe('none');
+  });
+
+  it('a scroll-state message re-projects the boxes without a new inventory', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+    await clickAt(300, 90);
+    expect(boxOf('feedback-comment').top).toBeGreaterThan(0);
+
+    const asked = bridge.sent.length;
+    act(() => { bridge.scrollTo(0, 100); });
+
+    // The pinned card followed the element up by exactly the scroll delta…
+    await waitFor(() =>
+      expect(boxOf('feedback-comment').top).toBe(WIDS.h1.top + WIDS.h1.height + 4 - 100));
+    // …and no re-inventory round trip was spent to learn that.
+    expect(bridge.sent.length).toBe(asked);
+  });
+});
+
+describe('FeedbackOverlay — batching and submit (§4.3, §7.7)', () => {
+  it('AC: two comments submit as ONE thread message carrying both items', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+
+    await comment(300, 90, 'make this title punchier');
+    await comment(300, 200, 'cut this in half');
+
+    // Batched, not sent: nothing has gone anywhere yet.
+    expect(postEvent).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId('feedback-pin')).toHaveLength(2);
+
+    await userEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    const user = (useDocThreadStore.getState().messages[KEY] ?? []).filter((m) => m.kind === 'user');
+    expect(user).toHaveLength(1);
+    expect(user[0]!.text).toContain('make this title punchier');
+    expect(user[0]!.text).toContain('cut this in half');
+    expect(user[0]!.kind === 'user' && user[0]!.items).toEqual([
+      { wid: 'h1', text: 'make this title punchier' },
+      { wid: 'p1', text: 'cut this in half' },
+    ]);
+    expect(injectDocMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('the submit button appears only with a batch, and clears the batch on success', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+    expect(screen.queryByTestId('feedback-submit')).toBeNull();
+
+    await comment(300, 90, 'punchier');
+    expect(screen.getByTestId('feedback-submit')).toHaveTextContent('Send 1 comment');
+
+    await userEvent.click(screen.getByTestId('feedback-submit'));
+    await waitFor(() => expect(screen.queryByTestId('feedback-submit')).toBeNull());
+    expect(screen.queryAllByTestId('feedback-pin')).toHaveLength(0);
+  });
+
+  it('a failed BUS EVENT keeps the batch so it can be sent again', async () => {
+    postEvent.mockRejectedValue(new Error('API 503: bridge_unavailable'));
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await startCommenting();
+    await comment(300, 90, 'punchier');
+    await userEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('feedback-error')).toHaveTextContent(/503/));
+    expect(screen.getByTestId('feedback-submit')).toBeInTheDocument();
+    expect(screen.getAllByTestId('feedback-pin')).toHaveLength(1);
+  });
+});
+
+describe('FeedbackOverlay — deep-linking back to the element (§4.3)', () => {
+  it('AC: asking for a wid posts scroll-to-wid INTO the frame, over the protocol', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    // This is precisely what a thread item's click does (`widScroller`).
+    act(() => { scrollToWid('slide-4-body-2'); });
+
+    expect(bridge.sent).toContainEqual({ v: 1, type: 'scroll-to-wid', wid: 'slide-4-body-2' });
+  });
+
+  it('a deep-link with no overlay mounted no-ops rather than throwing', () => {
+    cleanup();
+    expect(() => scrollToWid('h1')).not.toThrow();
+  });
+});

--- a/tests/feedbackAnchoring.test.ts
+++ b/tests/feedbackAnchoring.test.ts
@@ -1,0 +1,87 @@
+// Overlay anchoring math — DES-MERGE-001 §4.3, slices 11+12.
+//
+// The AC is "the overlay box lands within 4 px of the element's rect". Because the
+// parent can no longer measure anything inside the sandboxed frame, that budget is
+// spent entirely on arithmetic over the bridge's payload — so it is provable here,
+// exactly, rather than only in a browser.
+import { describe, expect, it } from 'vitest';
+import { hitTest, overlayBox } from '../src/interactive/anchoring.js';
+import { rect } from './fixtures/fixtureBridge.js';
+
+const AT_ORIGIN = { scrollX: 0, scrollY: 0 };
+/** The AC's budget, asserted as the budget rather than as an incidental equality. */
+const BUDGET = 4;
+
+describe('overlayBox — projecting a reported rect into the overlay layer', () => {
+  it('with no scroll since measurement, the box IS the rect (0 px of error)', () => {
+    const box = overlayBox(rect(120, 64, 300, 48), AT_ORIGIN, AT_ORIGIN);
+    expect(box).toEqual({ left: 120, top: 64, width: 300, height: 48 });
+    expect(Math.abs(box.left - 120)).toBeLessThanOrEqual(BUDGET);
+    expect(Math.abs(box.top - 64)).toBeLessThanOrEqual(BUDGET);
+  });
+
+  it('a frame that scrolled DOWN since measurement moves the box UP by the delta', () => {
+    // Measured at scrollY 0, frame now at 200 → the element sits 200 px higher.
+    const box = overlayBox(rect(10, 500, 100, 40), AT_ORIGIN, { scrollX: 0, scrollY: 200 });
+    expect(box.top).toBe(300);
+    expect(box.left).toBe(10);
+  });
+
+  it('re-measurement at a non-zero scroll is the identity, not a double subtraction', () => {
+    // The regression this pins: treating `measured` as always-zero would put the box
+    // 900 px off for any document the user had already scrolled before commenting.
+    const measured = { scrollX: 0, scrollY: 900 };
+    expect(overlayBox(rect(10, 50, 100, 40), measured, measured))
+      .toEqual({ left: 10, top: 50, width: 100, height: 40 });
+  });
+
+  it('horizontal scroll moves the box on x — decks scroll sideways', () => {
+    expect(overlayBox(rect(800, 10, 200, 100), AT_ORIGIN, { scrollX: 640, scrollY: 0 }).left)
+      .toBe(160);
+  });
+
+  it('size is never rescaled — only the origin moves', () => {
+    const box = overlayBox(rect(0, 0, 333, 77), AT_ORIGIN, { scrollX: 40, scrollY: 90 });
+    expect([box.width, box.height]).toEqual([333, 77]);
+  });
+});
+
+describe('hitTest — resolving a click to one instrumented element', () => {
+  const WIDS = {
+    section: rect(0, 0, 800, 600),      // contains everything
+    h1:      rect(40, 40, 400, 60),
+    p1:      rect(40, 140, 400, 80),
+  };
+
+  it('picks the INNERMOST element — pointing at a heading comments on the heading', () => {
+    expect(hitTest(WIDS, AT_ORIGIN, AT_ORIGIN, { x: 200, y: 70 })).toBe('h1');
+    expect(hitTest(WIDS, AT_ORIGIN, AT_ORIGIN, { x: 200, y: 180 })).toBe('p1');
+  });
+
+  it('falls back to the containing element where nothing smaller is under the point', () => {
+    expect(hitTest(WIDS, AT_ORIGIN, AT_ORIGIN, { x: 700, y: 500 })).toBe('section');
+  });
+
+  it('returns null outside every anchor — a click on nothing opens nothing', () => {
+    expect(hitTest(WIDS, AT_ORIGIN, AT_ORIGIN, { x: 900, y: 900 })).toBeNull();
+    expect(hitTest({}, AT_ORIGIN, AT_ORIGIN, { x: 10, y: 10 })).toBeNull();
+  });
+
+  it('edges are INCLUSIVE — a click on an element’s border hits it', () => {
+    expect(hitTest({ h1: WIDS.h1 }, AT_ORIGIN, AT_ORIGIN, { x: 40, y: 40 })).toBe('h1');
+    expect(hitTest({ h1: WIDS.h1 }, AT_ORIGIN, AT_ORIGIN, { x: 440, y: 100 })).toBe('h1');
+    expect(hitTest({ h1: WIDS.h1 }, AT_ORIGIN, AT_ORIGIN, { x: 441, y: 100 })).toBeNull();
+  });
+
+  it('hit-testing follows the SCROLL, not the measurement', () => {
+    const scrolled = { scrollX: 0, scrollY: 100 };
+    // Before scrolling, y=70 is inside h1 (40..100). After scrolling 100 the heading has
+    // moved to -60..0 and p1 has taken its place at 40..120 — so the same point now
+    // resolves to a DIFFERENT element. Comment on what is under the cursor, not on what
+    // was under it when the inventory was taken.
+    expect(hitTest(WIDS, AT_ORIGIN, AT_ORIGIN, { x: 200, y: 70 })).toBe('h1');
+    expect(hitTest(WIDS, AT_ORIGIN, scrolled, { x: 200, y: 70 })).toBe('p1');
+    // The scrolled-away heading is unreachable at any y its old rect covered.
+    expect(hitTest({ h1: WIDS.h1 }, AT_ORIGIN, scrolled, { x: 200, y: 70 })).toBeNull();
+  });
+});

--- a/tests/feedbackBatch.test.ts
+++ b/tests/feedbackBatch.test.ts
@@ -1,0 +1,157 @@
+// Batch → ONE message, and §7.7's two writes — DES-MERGE-001 §4.3, §7.7, slices 11+12.
+//
+// The load-bearing claim of this file is a COUNT: N comments produce exactly one thread
+// message and exactly one bus event. Sending each comment separately would produce N
+// regenerations and N versions for what the user experienced as one round of edits (§4.3).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  FEEDBACK_EVENT, composeBatchMessage, retryBatchInject, submitFeedbackBatch,
+} from '../src/interactive/feedbackBatch.js';
+import { threadKey, useDocThreadStore, type FeedbackItem } from '../src/store/docThread.js';
+
+const postEvent = vi.fn();
+const injectDocMessage = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (...a: unknown[]) => injectDocMessage(...a),
+}));
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
+
+const ITEMS: FeedbackItem[] = [
+  { wid: 'slide-2-heading-1', text: 'make this title punchier' },
+  { wid: 'slide-4-body-2',    text: 'cut this paragraph in half' },
+];
+
+function messages() {
+  return useDocThreadStore.getState().messages[KEY] ?? [];
+}
+
+beforeEach(() => {
+  useDocThreadStore.getState().clear(KEY);
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  injectDocMessage.mockResolvedValue({ ok: true, event_id: 'e2', correlation_id: 'c1' });
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('composeBatchMessage — N targets, one line of conversation', () => {
+  it('names every item and tags each with the wid its deep-link resolves through', () => {
+    const text = composeBatchMessage(ITEMS);
+    expect(text).toBe([
+      'Feedback on 2 places in this document:',
+      '1. [slide-2-heading-1] make this title punchier',
+      '2. [slide-4-body-2] cut this paragraph in half',
+    ].join('\n'));
+  });
+
+  it('reads correctly for a single comment — no "1 places"', () => {
+    expect(composeBatchMessage([ITEMS[0]!])).toContain('Feedback on 1 place in this document:');
+  });
+});
+
+describe('submitFeedbackBatch — §7.7: the client authors BOTH writes', () => {
+  it('AC: two comments submit as ONE thread message containing BOTH items', async () => {
+    await submitFeedbackBatch({ projectId: PROJECT, docId: DOC, version: 3, items: ITEMS });
+
+    const user = messages().filter((m) => m.kind === 'user');
+    expect(user).toHaveLength(1);
+    expect(user[0]!.text).toContain('make this title punchier');
+    expect(user[0]!.text).toContain('cut this paragraph in half');
+    // The items ride ON the message, which is what makes each one deep-linkable (§4.3).
+    expect(user[0]!.kind === 'user' && user[0]!.items).toEqual(ITEMS);
+  });
+
+  it('write 1 is the bus event, carrying the version and every target', async () => {
+    await submitFeedbackBatch({ projectId: PROJECT, docId: DOC, version: 3, items: ITEMS });
+
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: FEEDBACK_EVENT,
+      payload: expect.objectContaining({
+        document_id: DOC,
+        version: 3,
+        items: [
+          { wid: 'slide-2-heading-1', comment: 'make this title punchier' },
+          { wid: 'slide-4-body-2',    comment: 'cut this paragraph in half' },
+        ],
+      }),
+    }));
+  });
+
+  it('write 2 is ONE inject carrying the same text and the message id as anchor', async () => {
+    const { msgId, text } = await submitFeedbackBatch({
+      projectId: PROJECT, docId: DOC, version: 3, items: ITEMS,
+    });
+
+    expect(injectDocMessage).toHaveBeenCalledTimes(1);
+    expect(injectDocMessage).toHaveBeenCalledWith(PROJECT, DOC, text, msgId);
+    // §7.6: the same id is the pending version anchor, so the version this feedback
+    // produces tags the message that asked for it.
+    expect(useDocThreadStore.getState().anchor[KEY]).toBe(msgId);
+  });
+
+  it('a batch of one is still one message and one event', async () => {
+    await submitFeedbackBatch({ projectId: PROJECT, docId: DOC, version: 1, items: [ITEMS[0]!] });
+    expect(messages().filter((m) => m.kind === 'user')).toHaveLength(1);
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(injectDocMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('submitFeedbackBatch — failures (§7.7, §3.3)', () => {
+  it('AC: a failed inject does NOT block the batch — the message stays, chip-flagged', async () => {
+    injectDocMessage.mockRejectedValue(new Error('API 500: run not found'));
+
+    const result = await submitFeedbackBatch({
+      projectId: PROJECT, docId: DOC, version: 3, items: ITEMS,
+    });
+
+    // It did not throw: the document is already regenerating off the bus event.
+    expect(result.recorded).toBe(false);
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    const user = messages().find((m) => m.kind === 'user');
+    expect(user?.kind === 'user' && user.notRecorded).toBe(true);
+    expect(user?.text).toContain('make this title punchier');
+  });
+
+  it('a failed BUS EVENT throws and writes nothing — nothing was submitted', async () => {
+    postEvent.mockRejectedValue(new Error('API 503: bridge_unavailable'));
+
+    await expect(submitFeedbackBatch({
+      projectId: PROJECT, docId: DOC, version: 3, items: ITEMS,
+    })).rejects.toThrow(/503/);
+
+    expect(messages()).toHaveLength(0);
+    expect(injectDocMessage).not.toHaveBeenCalled();
+  });
+
+  it('the chip is RETRYABLE — the same message id, not a second message', async () => {
+    injectDocMessage.mockRejectedValueOnce(new Error('API 500: run not found'));
+    const { msgId, text } = await submitFeedbackBatch({
+      projectId: PROJECT, docId: DOC, version: 3, items: ITEMS,
+    });
+
+    await retryBatchInject(PROJECT, DOC, msgId, text);
+
+    expect(injectDocMessage).toHaveBeenCalledTimes(2);
+    expect(injectDocMessage).toHaveBeenLastCalledWith(PROJECT, DOC, text, msgId);
+    expect(messages().filter((m) => m.kind === 'user')).toHaveLength(1);
+    const user = messages().find((m) => m.kind === 'user');
+    expect(user?.kind === 'user' && user.notRecorded).toBe(false);
+  });
+
+  it('a retry that fails again leaves the chip up rather than clearing it', async () => {
+    injectDocMessage.mockRejectedValue(new Error('API 500: still gone'));
+    const { msgId, text } = await submitFeedbackBatch({
+      projectId: PROJECT, docId: DOC, version: 3, items: ITEMS,
+    });
+
+    await expect(retryBatchInject(PROJECT, DOC, msgId, text)).rejects.toThrow(/still gone/);
+
+    const user = messages().find((m) => m.kind === 'user');
+    expect(user?.kind === 'user' && user.notRecorded).toBe(true);
+  });
+});

--- a/tests/fixtures/fixtureBridge.ts
+++ b/tests/fixtures/fixtureBridge.ts
@@ -1,0 +1,83 @@
+// A tiny document fixture that SPEAKS THE INSTRUMENT PROTOCOL (DES-MERGE-001 §5.5,
+// slices 11+12) — the jsdom twin of `e2e/fixtures/doc-fixture.html`.
+//
+// jsdom lays nothing out, so a real iframe would report every rect as 0×0 and the
+// anchoring assertions would be vacuous. Instead the fixture IS the frame: it owns a
+// stand-in `contentWindow`, answers `request-inventory` with rects the test declares,
+// and delivers replies as real `message` events carrying that window as `source` —
+// which is the exact identity check the overlay filters on.
+//
+// What this deliberately does NOT do is bypass the protocol. Every byte the overlay
+// consumes in these tests went through `postMessage` shape and `parseInbound`.
+
+import type { WidRect } from '../../src/interactive/instrument-protocol.js';
+
+export interface FixtureBridgeOptions {
+  /** Rects the fixture reports, as measured at `scrollY`. */
+  widMap: Record<string, WidRect>;
+  scrollX?: number;
+  scrollY?: number;
+  /** A frame that never answers — the graceful-degradation path (§7.12-shaped). */
+  silent?: boolean;
+}
+
+export interface FixtureBridge {
+  /** Pass as `FeedbackOverlay`'s `frame` prop. */
+  frame: HTMLIFrameElement;
+  /** Everything the overlay posted INTO the frame, in order. */
+  sent: unknown[];
+  /** Push a scroll the way a real document would, without a new inventory. */
+  scrollTo: (scrollX: number, scrollY: number) => void;
+  /** Post a raw payload the overlay must survive — malformed, stale, or hostile. */
+  postRaw: (data: unknown) => void;
+  dispose: () => void;
+}
+
+/** A rect the way `getBoundingClientRect()` reports one. */
+export function rect(left: number, top: number, width: number, height: number): WidRect {
+  return {
+    x: left, y: top, width, height,
+    left, top, right: left + width, bottom: top + height,
+  };
+}
+
+export function makeFixtureBridge(opts: FixtureBridgeOptions): FixtureBridge {
+  const { widMap, scrollX = 0, scrollY = 0, silent = false } = opts;
+  const sent: unknown[] = [];
+
+  // Identity is what the overlay checks (a sandboxed frame's origin is the string
+  // "null" for every such frame, so origin could never distinguish them).
+  const contentWindow = { postMessage: (data: unknown) => { sent.push(data); reply(data); } };
+  const frame = {
+    contentWindow: contentWindow as unknown as Window,
+    clientHeight: 900,
+    clientWidth: 1200,
+  } as unknown as HTMLIFrameElement;
+
+  function deliver(data: unknown): void {
+    const event = new MessageEvent('message', { data });
+    // jsdom will not accept a non-Window `source` through the init dict; the overlay
+    // only ever compares it by reference, so defining it directly is faithful.
+    Object.defineProperty(event, 'source', { value: contentWindow });
+    window.dispatchEvent(event);
+  }
+
+  function reply(data: unknown): void {
+    if (silent) return;
+    const msg = data as { v?: number; type?: string; wid?: string };
+    if (msg?.v !== 1) return;
+    if (msg.type === 'request-inventory') {
+      deliver({ v: 1, type: 'wid-inventory', widMap, scrollX, scrollY });
+    } else if (msg.type === 'scroll-to-wid') {
+      deliver({ v: 1, type: 'scroll-ack', wid: msg.wid });
+    }
+  }
+
+  return {
+    frame,
+    sent,
+    scrollTo: (x, y) => deliver({ v: 1, type: 'scroll-state', scrollX: x, scrollY: y }),
+    postRaw: deliver,
+    dispose: () => { sent.length = 0; },
+  };
+}

--- a/tests/instrumentProtocol.test.ts
+++ b/tests/instrumentProtocol.test.ts
@@ -1,0 +1,99 @@
+// The instrument protocol's runtime validation — DES-MERGE-001 §5.5, slices 11+12.
+//
+// The bridge lives inside `sandbox="allow-scripts"`. Its payloads are authored by
+// AGENT-WRITTEN HTML that was itself influenced by untrusted input (attached source
+// files, scraped pages). "Never trust frame payloads" is therefore not a style rule —
+// it is the reason the sandbox is closeable at all, and these are its teeth.
+import { describe, expect, it } from 'vitest';
+import {
+  REQUEST_INVENTORY, makeScrollToWid, parseInbound,
+} from '../src/interactive/instrument-protocol.js';
+
+const RECT = { x: 10, y: 20, width: 100, height: 40, top: 20, left: 10, right: 110, bottom: 60 };
+
+describe('parseInbound — well-formed v1 frames', () => {
+  it('accepts a wid-inventory and returns it NARROWED, not the raw object', () => {
+    const parsed = parseInbound({
+      v: 1, type: 'wid-inventory', widMap: { h1: RECT }, scrollX: 0, scrollY: 120,
+      // Extra keys are the bridge's business; they must not survive into our state.
+      cookies: 'nope', __proto__: { polluted: true },
+    });
+    expect(parsed).toEqual({
+      v: 1, type: 'wid-inventory', widMap: { h1: RECT }, scrollX: 0, scrollY: 120,
+    });
+    expect(parsed).not.toHaveProperty('cookies');
+  });
+
+  it('accepts scroll-state and scroll-ack', () => {
+    expect(parseInbound({ v: 1, type: 'scroll-state', scrollX: 5, scrollY: 6 }))
+      .toEqual({ v: 1, type: 'scroll-state', scrollX: 5, scrollY: 6 });
+    expect(parseInbound({ v: 1, type: 'scroll-ack', wid: 'h1' }))
+      .toEqual({ v: 1, type: 'scroll-ack', wid: 'h1' });
+  });
+
+  it('an empty inventory is VALID — a document with no anchors is a real document', () => {
+    expect(parseInbound({ v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 }))
+      .toEqual({ v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 });
+  });
+});
+
+describe('parseInbound — malformed inbound messages are DROPPED', () => {
+  const junk: [string, unknown][] = [
+    ['null',                    null],
+    ['a bare string',           'wid-inventory'],
+    ['a number',                42],
+    ['no version',              { type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 }],
+    ['a future version',        { v: 2, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 }],
+    ['a string version',        { v: '1', type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 }],
+    ['an unknown type',         { v: 1, type: 'eval-this', code: 'alert(1)' }],
+    ['no type at all',          { v: 1, widMap: {}, scrollX: 0, scrollY: 0 }],
+    ['widMap missing',          { v: 1, type: 'wid-inventory', scrollX: 0, scrollY: 0 }],
+    ['widMap not an object',    { v: 1, type: 'wid-inventory', widMap: 'h1', scrollX: 0, scrollY: 0 }],
+    ['widMap is null',          { v: 1, type: 'wid-inventory', widMap: null, scrollX: 0, scrollY: 0 }],
+    ['scroll missing',          { v: 1, type: 'wid-inventory', widMap: {} }],
+    ['scroll not finite',       { v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: NaN }],
+    ['scroll is Infinity',      { v: 1, type: 'wid-inventory', widMap: {}, scrollX: Infinity, scrollY: 0 }],
+    ['scroll is a string',      { v: 1, type: 'scroll-state', scrollX: '0', scrollY: '0' }],
+    ['ack with no wid',         { v: 1, type: 'scroll-ack' }],
+    ['ack with an empty wid',   { v: 1, type: 'scroll-ack', wid: '' }],
+    ['ack with a non-string',   { v: 1, type: 'scroll-ack', wid: { toString: () => 'h1' } }],
+  ];
+  it.each(junk)('drops %s', (_label, data) => {
+    expect(parseInbound(data)).toBeNull();
+  });
+
+  // The strict rule §5.5 asks for: partial trust is worse than no trust. One bad rect
+  // in a hundred means the frame is not speaking the protocol, and a half-applied
+  // inventory would anchor comments to the WRONG elements — silently.
+  it('ONE malformed rect invalidates the WHOLE inventory, not just that entry', () => {
+    const parsed = parseInbound({
+      v: 1, type: 'wid-inventory', scrollX: 0, scrollY: 0,
+      widMap: { h1: RECT, p1: { ...RECT, width: 'wide' } },
+    });
+    expect(parsed).toBeNull();
+  });
+
+  it.each([
+    ['a missing field',   { x: 0, y: 0, width: 1, height: 1, top: 0, left: 0, right: 1 }],
+    ['a NaN field',       { ...RECT, top: NaN }],
+    ['a null rect',       null],
+    ['a string rect',     '0,0,1,1'],
+    ['an array rect',     [0, 0, 1, 1]],
+  ])('rejects an inventory whose rect has %s', (_label, bad) => {
+    expect(parseInbound({
+      v: 1, type: 'wid-inventory', widMap: { h1: bad }, scrollX: 0, scrollY: 0,
+    })).toBeNull();
+  });
+});
+
+describe('outbound messages', () => {
+  it('the inventory request is a frozen v1 singleton', () => {
+    expect(REQUEST_INVENTORY).toEqual({ v: 1, type: 'request-inventory' });
+    expect(Object.isFrozen(REQUEST_INVENTORY)).toBe(true);
+  });
+
+  it('scroll-to-wid carries the version so a stale bridge can drop it', () => {
+    expect(makeScrollToWid('slide-2-heading-1'))
+      .toEqual({ v: 1, type: 'scroll-to-wid', wid: 'slide-2-heading-1' });
+  });
+});


### PR DESCRIPTION
Slices 11+12 merged into one PR per §7.3 — the overlay never ships against a same-origin frame. Authored and delivered by governed run `a4ac9f44`.

Typed, versioned postMessage instrument protocol (runtime-validated inbound, frame payloads never trusted); `DocumentCanvas` drops `allow-same-origin` (sandbox regression pinned so it can't return); hover/click overlay anchored to protocol-reported rects (≤4px); batched comments post as ONE thread message (§7.7 dual-write: inject + bus emit, retryable not-recorded chip on inject failure); per-item deep-links scroll the element in-frame. Fixture bridge proves isolation: a script inside the doc reaching for `parent.localStorage` throws.

The §5.5 security window is now closed structurally. wicked-interactive's production `instrument.js` half is the sibling slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)