### PR TITLE
feat(video): record and re-record from the thread (DES-MERGE-001 slice 14)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -949,6 +949,10 @@ try:
         {"index": 3, "title": "Confirm the order", "timestamp": 21.25},
         {"index": 4, "title": "Land on the receipt", "timestamp": 27},
     ]
+    # Slice 14 re-authors a spec at ONE step, so the fixture holds the spec as STATE:
+    # "the new version's spec differs at step 2" has to be read back off the service,
+    # not predicted by the client that asked for it.
+    demo_specs = {d["name"]: [dict(s) for s in DEMO_STEPS] for d in FIXTURE_DEMOS}
     DEMO_GIF_PATH = f"/d/{RECORDED_DEMO}/demo/v2.gif"
     # A real 1×1 GIF: the player must render the SERVICE's bytes, fetched through the
     # proxy on the page's own origin — not a data: URL the SPA could have invented.
@@ -974,6 +978,13 @@ try:
     # The manifest is the SERVICE's, and fork mutates it — so the fixture holds real
     # state (append-only, per INV-4) rather than deriving a fresh list per request.
     doc_versions = {d["name"]: seed_versions(d["name"]) for d in FIXTURE_DOCS}
+    # A demo is a doc, so its lineage lives in the SAME manifest state (§4.5) — which is
+    # what slice 14's step feedback appends to when the agent re-authors a step.
+    for demo in FIXTURE_DEMOS:
+        doc_versions[demo["name"]] = [
+            {"version": v, "parent": v - 1 or None, "feedback_file": None,
+             "html_file": f"v{v}.html", "created_at": f"2026-08-1{v}T09:00:00Z"}
+            for v in range(1, demo["head"] + 1)]
     versions_lock = threading.Lock()
     # Slice 10's two composer wires, recorded verbatim so the run can assert WHICH wire
     # each composer state chose — and that no `status.requested` heartbeat is ever among
@@ -1061,17 +1072,24 @@ try:
                 return True
             m = DEMO_SPEC_RE.match(rest)
             if m:
-                self._json(200, {"steps": DEMO_STEPS, "target_url": "https://shop.example/"})
+                name = urllib.parse.unquote(m.group(1))
+                with versions_lock:
+                    steps = [dict(s) for s in demo_specs.get(name, [])]
+                self._json(200, {"steps": steps, "target_url": "https://shop.example/"})
                 return True
             m = DEMO_REC_RE.match(rest)
             if m:
-                # Two demos, two states: one recorded (gif only — ffmpeg produced no mp4
-                # on this box either, which is the common case), one whose post-process
-                # found no ffmpeg at all. Both are 200s: the VERSION landed regardless.
-                self._json(200,
-                           {"version": 1, "ffmpeg_absent": True, "ffmpeg_hint": FFMPEG_HINT}
-                           if urllib.parse.unquote(m.group(1)) == FFMPEG_DEMO
-                           else {"version": 2, "gif_url": DEMO_GIF_PATH})
+                # Three demos, three states: one recorded (gif only — ffmpeg produced no
+                # mp4 on this box either, which is the common case), one whose post-process
+                # found no ffmpeg at all, and one just authored and never recorded. All are
+                # 200s: the VERSION landed regardless (§4.5).
+                name = urllib.parse.unquote(m.group(1))
+                if name == FFMPEG_DEMO:
+                    self._json(200, {"version": 1, "ffmpeg_absent": True, "ffmpeg_hint": FFMPEG_HINT})
+                elif name == RECORDED_DEMO:
+                    self._json(200, {"version": 2, "gif_url": DEMO_GIF_PATH})
+                else:
+                    self._json(200, {"version": 1})
                 return True
             if rest == DEMO_GIF_PATH:
                 self._send(200, TINY_GIF, "image/gif")
@@ -1135,13 +1153,21 @@ try:
             body["_project_path"] = project
             created_docs.append(body)
             slug = re.sub(r"[^a-z0-9]+", "-", (body.get("name") or "untitled").lower()).strip("-")
+            kind = "demo" if body.get("kind") == "demo" else "doc"
             with versions_lock:
                 doc_versions.setdefault(slug, [{
                     "version": 1, "parent": None, "feedback_file": None, "html_file": "v1.html",
                     "created_at": "2026-08-18T12:05:00Z",
                     "meta": {"sourceMessageId": body.get("source_message_id")},
                 }])
-            return self._json(200, {"name": slug, "head": 1, "kind": "doc",
+                # Slice 14's wizard: the agent authors the spec FROM the ordered steps it
+                # was given, so the storyboard that comes back is the order authored.
+                if kind == "demo":
+                    demo_specs.setdefault(slug, [
+                        {"index": s.get("index"), "timestamp": 0,
+                         "title": f"{s.get('subject')} — {s.get('action')}"}
+                        for s in (body.get("demo_steps") or [])])
+            return self._json(200, {"name": slug, "head": 1, "kind": kind,
                                     "generating": True, "project_id": body.get("project")})
 
         def _emit(self) -> None:
@@ -1156,6 +1182,26 @@ try:
             if (body.get("event_type") == "wicked.interactive.chat.posted"
                     and INJECT_FAIL_MARK in str(payload.get("text") or "")):
                 return self._json(500, {"error": "run not found"})
+            # Slice 14 (§4.5): feedback aimed at `demo_step` is a request to RE-AUTHOR the
+            # spec, so the model-free service applies it at the named step and lands a new
+            # version — the same append-only manifest a document generation writes (INV-4).
+            if (body.get("event_type") == FEEDBACK_EVENT
+                    and payload.get("target") == "demo_step"):
+                name = str(payload.get("document_id") or "")
+                with versions_lock:
+                    steps = demo_specs.get(name)
+                    rows = doc_versions.get(name)
+                    if steps is not None and rows:
+                        for item in payload.get("items") or []:
+                            at = re.match(r"^step-(\d+)$", str(item.get("wid") or ""))
+                            if at and int(at.group(1)) < len(steps):
+                                steps[int(at.group(1))]["title"] = str(item.get("comment") or "")
+                        created = max(r["version"] for r in rows) + 1
+                        rows.append({"version": created, "parent": created - 1,
+                                     "feedback_file": f"feedback-v{created}.json",
+                                     "html_file": f"v{created}.html",
+                                     "created_at": "2026-08-18T14:00:00Z",
+                                     "meta": {"sourceMessageId": payload.get("source_message_id")}})
             return self._json(200, {"ok": True, "event_id": f"ev-{len(emitted_events)}",
                                     "correlation_id": "c-doc"})
 
@@ -1900,13 +1946,255 @@ try:
                         ("slice13-demo-picker.png", "slice13-storyboard.png",
                          "slice13-chapter-seek.png", "slice13-ffmpeg-absent.png")],
     }
-    docd.shutdown()  # last section on the same-origin rig
-
     if not report["steps"]["video_storyboard"]["ok"]:
         fail("video_storyboard_verdict",
              "slice-13 Video-mode assertions did not all hold — see video_storyboard")
 
-    # ── 17. Operator UX directive: the live edge on the board ──────────────────
+    # ── 17. Slice 14 (DES-MERGE-001 §4.5, §6.4): record + re-record from the thread ──
+    # Same same-origin rig, one section later; the fake bridge now holds each demo's SPEC
+    # as state and applies a step diff when feedback names one, so every claim below is
+    # read back off the service rather than predicted by the client that asked for it.
+    #
+    #   · the ordered wizard (§4.1/§4.5): the composer's ask opens it, steps are authored
+    #     in order, and the demo the service creates carries those steps IN THAT ORDER —
+    #     then the surface it lands on is the one that offers to record it (§3.3);
+    #   · commenting on storyboard step 2 and submitting produces a NEW VERSION whose
+    #     spec differs at step 2 and nowhere else, shown as a continuation (§7.10) and
+    #     offering the re-record a new spec needs to become a new video;
+    #   · the recording status is INFORMATIVE — it names the demo and its step — and is
+    #     never a bare `Working…`, asserted with the bridge streaming exactly that (§3.3).
+    WIZARD_ASK = "a walkthrough of the checkout flow"
+    WIZARD_DEMO = "a-walkthrough-of-the-checkout-flow"
+    WIZARD_STEPS = [("the storefront", "open it"), ("the cart", "add a hoodie to it")]
+    # "Step 2" as the user sees it — the card labelled `2.`, which is spec index 1.
+    COMMENT_INDEX = 1
+    STEP_COMMENT = "Add TWO hoodies to the cart, not one"
+    BARE_STATUS = "Working…"
+    REAL_RECORD_STATUS = "Step 2 of 5 — Add a hoodie to the cart"
+    STATUS_TEXT = """() => document.querySelector('[data-testid="demo-record-status"]')?.innerText ?? ''"""
+    record_before = list(record_requests)
+    versions_before = len(doc_versions[RECORDED_DEMO])
+    spec_before = [dict(s) for s in demo_specs[RECORDED_DEMO]]
+    rec_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.add_init_script(WS_TAP)
+        page.on("console", lambda m: rec_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text else None)
+
+        # ── AC: the composer's ask opens the ORDERED wizard; nothing is created yet ──
+        page.goto(f"{DOC_ORIGIN}/p/{demo_project}/video", wait_until="domcontentloaded")
+        page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
+        docs_created_before = len(created_docs)
+        page.fill('[data-testid="doc-composer"]', WIZARD_ASK)
+        page.click('[data-testid="doc-composer-submit"]')
+        wizard = page.locator('[data-testid="demo-wizard"]')
+        wizard.wait_for(timeout=30000)
+        wizard_stage_first = wizard.get_attribute("data-stage")
+        docs_created_by_ask = len(created_docs) - docs_created_before
+        page.screenshot(path=str(SHOTS / "slice14-wizard-target.png"), full_page=True)
+
+        # ── AC: steps are authored IN ORDER, and submitted in that order ───────────
+        page.fill('[data-testid="wizard-target"]', "https://shop.example/")
+        page.wait_for_function(
+            """() => document.querySelector('[data-testid="demo-wizard"]')
+                 ?.getAttribute('data-stage') === 'steps'""", timeout=30000)
+        wizard_stage_second = wizard.get_attribute("data-stage")
+        for n, (subject, action) in enumerate(WIZARD_STEPS, start=1):
+            page.fill('[data-testid="wizard-step-subject"]', subject)
+            page.fill('[data-testid="wizard-step-action"]', action)
+            page.click('[data-testid="wizard-step-add"]')
+            page.wait_for_function(
+                """n => document.querySelector('[data-testid="demo-wizard"]')
+                     ?.getAttribute('data-steps') === String(n)""", arg=n, timeout=30000)
+        listed = page.locator('[data-testid="wizard-step"]')
+        wizard_order = [listed.nth(i).get_attribute("data-index") for i in range(listed.count())]
+        wizard_labels = [listed.nth(i).inner_text() for i in range(listed.count())]
+        page.screenshot(path=str(SHOTS / "slice14-wizard-steps.png"), full_page=True)
+        page.click('[data-testid="wizard-create"]')
+        wizard_nav_ok = wait_for_path(page, f"/p/{demo_project}/video/{WIZARD_DEMO}")
+        created_demo = created_docs[-1] if created_docs else {}
+
+        # ── AC: completion lands on the surface that OFFERS to record it ───────────
+        authored = page.locator('[data-testid="chapter-card"]')
+        authored.first.wait_for(timeout=30000)
+        authored_titles = [authored.nth(i).inner_text() for i in range(authored.count())]
+        record_offered = page.locator('[data-testid="demo-record"]').is_visible()
+        page.screenshot(path=str(SHOTS / "slice14-authored-demo.png"), full_page=True)
+
+        # ── AC: recording status is INFORMATIVE, never a bare "Working…" (§3.3) ────
+        page.click('[data-testid="demo-record"]')
+        status_el = page.locator('[data-testid="demo-record-status"]')
+        status_el.wait_for(timeout=30000)
+        status_on_request = page.evaluate(STATUS_TEXT)
+        # The bridge speaks the banned line; the seam is what must refuse to render it.
+        page.evaluate(
+            """args => window.__pushFrame({ type: 'interactiveEvent', event: {
+                 event_type: 'wicked.interactive.status.posted',
+                 payload: { project_id: args.project, document_id: args.doc,
+                            state: 'working', message: args.text } } })""",
+            {"project": demo_project, "doc": WIZARD_DEMO, "text": BARE_STATUS})
+        page.wait_for_timeout(500)
+        status_after_bare = page.evaluate(STATUS_TEXT)
+        bare_in_thread = BARE_STATUS in page.evaluate(
+            """() => document.querySelector('[data-testid="thread"]')?.innerText ?? ''""")
+        # …and a line that DOES name its subject wins over the fallback (§3.4 rule 1).
+        page.evaluate(
+            """args => window.__pushFrame({ type: 'interactiveEvent', event: {
+                 event_type: 'wicked.interactive.status.posted',
+                 payload: { project_id: args.project, document_id: args.doc,
+                            state: 'working', message: args.text } } })""",
+            {"project": demo_project, "doc": WIZARD_DEMO, "text": REAL_RECORD_STATUS})
+        real_status_ok, real_status_ms = within(
+            page,
+            """text => (document.querySelector('[data-testid="demo-record-status"]')?.innerText ?? '')
+                 .includes(text)""",
+            REAL_RECORD_STATUS,
+        )
+        page.screenshot(path=str(SHOTS / "slice14-record-status.png"), full_page=True)
+
+        # ── AC: commenting on step 2 produces a new version whose spec differs there ──
+        page.goto(f"{DOC_ORIGIN}/p/{demo_project}/video/{RECORDED_DEMO}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        cards = page.locator('[data-testid="chapter-card"]')
+        cards.first.wait_for(timeout=30000)
+        commented_label = cards.nth(COMMENT_INDEX).inner_text()
+        cards.nth(COMMENT_INDEX).click()
+        page.click('[data-testid="step-comment-open"]')
+        page.fill('[data-testid="step-comment-input"]', STEP_COMMENT)
+        page.click('[data-testid="step-comment-add"]')
+        commented_card_marks = cards.nth(COMMENT_INDEX).get_attribute("data-comments")
+        page.screenshot(path=str(SHOTS / "slice14-step-comment.png"), full_page=True)
+        page.click('[data-testid="step-feedback-submit"]')
+
+        # The storyboard re-reads the SERVICE and shows the step that came back (§7.10).
+        spec_shown_ok, spec_shown_ms = within(
+            page,
+            """text => Array.from(document.querySelectorAll('[data-testid="chapter-card"]'))
+                 .some(c => c.innerText.includes(text))""",
+            STEP_COMMENT,
+            budget_ms=15000,
+        )
+        # …as a CONTINUATION: one message with its deep-linkable target, no new thread.
+        batch_msg = page.locator('[data-testid="doc-message"]').last
+        batch_items = batch_msg.get_attribute("data-items")
+        batch_text = batch_msg.inner_text()
+        rerecord_offered = page.locator('[data-testid="demo-rerecord"]').is_visible()
+        page.screenshot(path=str(SHOTS / "slice14-respec.png"), full_page=True)
+
+        # ── AC: the offer is real — re-recording goes through the proxied service ──
+        page.click('[data-testid="demo-rerecord"]')
+        rerecord_status_ok, _ = within(
+            page,
+            """demo => (document.querySelector('[data-testid="demo-record-status"]')?.innerText ?? '')
+                 .includes(demo)""",
+            RECORDED_DEMO,
+            budget_ms=15000,
+        )
+        page.screenshot(path=str(SHOTS / "slice14-rerecord.png"), full_page=True)
+        browser.close()
+
+    spec_after = demo_specs[RECORDED_DEMO]
+    versions_after = doc_versions[RECORDED_DEMO]
+    new_records = [r for r in record_requests if r not in record_before or record_requests.count(r) > record_before.count(r)]
+    feedback_events = [e for e in emitted_events
+                       if e.get("event_type") == FEEDBACK_EVENT
+                       and (e.get("payload") or {}).get("target") == "demo_step"]
+    report["steps"]["video_record"] = {
+        "ok": all([
+            # The wizard: ordered, and nothing created until it submits.
+            wizard_stage_first == "target", wizard_stage_second == "steps",
+            docs_created_by_ask == 0,
+            wizard_order == ["0", "1"],
+            wizard_nav_ok,
+            created_demo.get("kind") == "demo",
+            created_demo.get("url") == "https://shop.example/",
+            [s.get("index") for s in created_demo.get("demo_steps") or []] == [0, 1],
+            [s.get("subject") for s in created_demo.get("demo_steps") or []]
+                == [s[0] for s in WIZARD_STEPS],
+            # …and the demo the SERVICE authored carries those steps, in that order.
+            len(authored_titles) == len(WIZARD_STEPS),
+            all(f"{subject} — {action}" in title
+                for (subject, action), title in zip(WIZARD_STEPS, authored_titles)),
+            record_offered,
+            # The status: informative, and never the banned line (the slice's AC).
+            WIZARD_DEMO in status_on_request,
+            status_after_bare.strip() != BARE_STATUS,
+            BARE_STATUS not in status_after_bare,
+            not bare_in_thread,
+            real_status_ok,
+            # Step feedback: ONE event, aimed at the step, and a version that landed.
+            len(feedback_events) == 1,
+            [i.get("wid") for i in (feedback_events[0].get("payload") or {}).get("items") or []]
+                == [f"step-{COMMENT_INDEX}"] if feedback_events else False,
+            commented_card_marks == "1",
+            len(versions_after) == versions_before + 1,
+            # The spec differs AT step 2 — and nowhere else.
+            spec_after[COMMENT_INDEX]["title"] == STEP_COMMENT,
+            [s["title"] for i, s in enumerate(spec_after) if i != COMMENT_INDEX]
+                == [s["title"] for i, s in enumerate(spec_before) if i != COMMENT_INDEX],
+            spec_shown_ok,
+            batch_items == "1", STEP_COMMENT in batch_text,
+            # The re-record: offered, and a real request through the proxy.
+            rerecord_offered,
+            WIZARD_DEMO in new_records, RECORDED_DEMO in new_records,
+            rerecord_status_ok,
+            not rec_console,
+        ]),
+        "project_id": demo_project,
+        "wizard": {
+            "stage_before_target": wizard_stage_first,
+            "stage_after_target": wizard_stage_second,
+            "docs_created_by_the_ask": docs_created_by_ask,
+            "step_order": wizard_order,
+            "step_labels": wizard_labels,
+            "submitted_steps": created_demo.get("demo_steps"),
+            "created_kind": created_demo.get("kind"),
+            "navigated": wizard_nav_ok,
+            "storyboard_titles": authored_titles,
+            "offers_record": record_offered,
+        },
+        "recording_status": {
+            "on_request": status_on_request,
+            "after_bare_working_pushed": status_after_bare,
+            "bare_line_reached_the_thread": bare_in_thread,
+            "real_streamed_line_won": real_status_ok,
+            "real_streamed_line_ms": real_status_ms,
+        },
+        "step_feedback": {
+            "commented_card": commented_label,
+            "commented_spec_index": COMMENT_INDEX,
+            "card_marked_pending": commented_card_marks,
+            "events_emitted": len(feedback_events),
+            "event_payload": (feedback_events[0].get("payload") if feedback_events else None),
+            "versions_before": versions_before,
+            "versions_after": len(versions_after),
+            "landed_version": versions_after[-1] if versions_after else None,
+            "spec_before": [s["title"] for s in spec_before],
+            "spec_after": [s["title"] for s in spec_after],
+            "spec_rendered_ms": spec_shown_ms,
+            "thread_message_items": batch_items,
+            "offers_rerecord": rerecord_offered,
+        },
+        "record_requests_seen_by_bridge": record_requests,
+        "console_errors": rec_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice14-wizard-target.png", "slice14-wizard-steps.png",
+                         "slice14-authored-demo.png", "slice14-record-status.png",
+                         "slice14-step-comment.png", "slice14-respec.png",
+                         "slice14-rerecord.png")],
+    }
+    docd.shutdown()  # last section on the same-origin rig
+
+    if not report["steps"]["video_record"]["ok"]:
+        fail("video_record_verdict",
+             "slice-14 record/re-record assertions did not all hold — see video_record")
+
+    # ── 18. Operator UX directive: the live edge on the board ──────────────────
     # The ACTIVE-WORK signal is a breathing 2px strip along the leading edge of the
     # element doing work, and the thing that has to hold is the RANKING: a busy card
     # must be visible without out-shouting a card that needs a human. So both states

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,6 +296,7 @@ export function App(): React.ReactElement {
             docId={artifactId}
             selectedVersion={null}
             navigate={navigate}
+            mode="video"
           />
         </>
       );

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -77,6 +77,19 @@ export interface ExportResult {
   download: string;
 }
 
+/**
+ * One step as the ordered wizard authored it (§4.5, §4.1: the demo path is the one path
+ * with genuinely ordered steps, so the wizard survives there). `index` is the AUTHORING
+ * position and is what the service's spec order must agree with; a step is a `subject`
+ * (what the step is about) plus an `action` (what happens to it) — never a bare label,
+ * for the same reason a status line is never bare (§3.3).
+ */
+export interface DemoStepDraft {
+  index: number;
+  subject: string;
+  action: string;
+}
+
 export interface CreateDocBody {
   name: string;
   html?: string;
@@ -84,6 +97,9 @@ export interface CreateDocBody {
   source_paths?: string[];
   brief?: string;
   url?: string;
+  /** `kind: "demo"` only — the wizard's ordered steps, which the agent authors the
+   *  deterministic spec from (ADR-0018: the agent authors, the service records). */
+  demo_steps?: DemoStepDraft[];
   style?: 'web' | 'ppt' | 'brochure' | 'doc';
   /** Crew project binding. Registration is the authority: a doc that cannot be
    *  filed is a loud error with no doc created (DES-PROJECT-001 §2.3). */

--- a/src/components/DemoWizard.tsx
+++ b/src/components/DemoWizard.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { createDemoFromDraft, draftReady, stepReady, stepTitle, type DemoDraft } from '../interactive/demoWire.js';
+import { S } from './SurfaceState.js';
+
+// The ordered demo wizard (DES-MERGE-001 §4.5, §4.1, §6.4 slice 14).
+//
+// §4.1 retired `CreationWizard.jsx` as REPLACED-BY-BETTER for every document kind but
+// one: the demo path has genuinely ordered steps, and an ordered thing authored through
+// a single free-text composer loses the ordering that makes it work. So the wizard
+// survives HERE, and only here — reached from the composer (§2.2 case 1), never as a
+// second front door: the message the user typed seeds the name, and completion opens the
+// demo's conversation with the authored spec as its first line.
+//
+// Two stages, because there are exactly two questions: WHERE the demo runs, and WHAT
+// happens in it, in order. Each step is a subject plus an action — a step that names one
+// without the other is not authored, for the same reason a status line is never bare.
+
+const FIELD: React.CSSProperties = {
+  background: 'rgba(13,17,23,0.6)', border: `1px solid ${S.border}`, borderRadius: '6px',
+  color: S.ink, fontFamily: 'inherit', fontSize: '12px', padding: '6px 8px', width: '100%',
+};
+
+const BTN: React.CSSProperties = {
+  border: 'none', borderRadius: '7px', cursor: 'pointer',
+  fontSize: '11px', fontWeight: 600, padding: '5px 11px',
+};
+
+export interface DemoWizardProps {
+  projectId: string;
+  /** The composer message that opened it. §4.1: the name is DERIVED from the ask — the
+   *  wizard asks only what the ask could not have said, which is the ordering. */
+  seed: string;
+  /** The thread message id this authoring is anchored to (§7.6). */
+  msgId: string;
+  onCancel: () => void;
+  /** The demo exists and its conversation has opened; the surface offers to record it. */
+  onCreated: (demoId: string) => void;
+}
+
+export function DemoWizard({ projectId, seed, msgId, onCancel, onCreated }: DemoWizardProps): React.ReactElement {
+  const [draft, setDraft] = useState<DemoDraft>({ name: seed, targetUrl: '', steps: [] });
+  const [step, setStep] = useState({ subject: '', action: '' });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const staged = draft.targetUrl.trim() !== '';
+
+  function addStep(): void {
+    if (!stepReady(step)) return;
+    // Append: the order steps are authored in IS the spec's order (`demoDraftBody`
+    // assigns `index` from position), so there is no separate ordering to get wrong.
+    setDraft((d) => ({ ...d, steps: [...d.steps, { ...step }] }));
+    setStep({ subject: '', action: '' });
+  }
+
+  async function create(): Promise<void> {
+    if (!draftReady(draft) || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { name } = await createDemoFromDraft(projectId, draft, msgId);
+      onCreated(name);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid="demo-wizard"
+      data-stage={staged ? 'steps' : 'target'}
+      data-steps={String(draft.steps.length)}
+      className="absolute inset-0 z-10 flex flex-col gap-2.5 overflow-y-auto p-3.5"
+      style={{ background: S.card }}
+    >
+      <p className="text-xs font-semibold" style={{ color: S.ink, margin: 0 }}>
+        Author the demo — the service records exactly these steps, in this order.
+      </p>
+
+      {/* Stage 1 — where it runs. Nothing can be authored against an unknown target. */}
+      <label className="text-[10px] font-mono uppercase tracking-wide" style={{ color: S.label }}>
+        Target URL
+        <input data-testid="wizard-target" style={FIELD} placeholder="https://shop.example/"
+               value={draft.targetUrl}
+               onChange={(e) => setDraft((d) => ({ ...d, targetUrl: e.target.value }))} />
+      </label>
+
+      {/* Stage 2 — what happens, in order. */}
+      {staged && (
+        <>
+          <ol data-testid="wizard-steps" className="flex flex-col gap-1 pl-0" style={{ listStyle: 'none', margin: 0 }}>
+            {draft.steps.map((s, i) => (
+              <li key={`${s.subject}-${i}`} data-testid="wizard-step" data-index={String(i)}
+                  className="flex items-center gap-2 rounded-md px-2 py-1 text-[11px]"
+                  style={{ background: 'rgba(13,17,23,0.6)', border: `1px solid ${S.border}`, color: S.ink }}>
+                <span className="font-mono" style={{ color: S.accent }}>{i + 1}</span>
+                <span className="flex-1">{stepTitle(s)}</span>
+                <button type="button" data-testid="wizard-step-remove"
+                        onClick={() => setDraft((d) => ({ ...d, steps: d.steps.filter((_, n) => n !== i) }))}
+                        style={{ ...BTN, background: 'transparent', color: S.muted, padding: '2px 6px' }}>
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ol>
+
+          <div className="flex flex-col gap-1.5">
+            <input data-testid="wizard-step-subject" style={FIELD} placeholder="Subject — “the cart”"
+                   value={step.subject} onChange={(e) => setStep((s) => ({ ...s, subject: e.target.value }))} />
+            <input data-testid="wizard-step-action" style={FIELD} placeholder="Action — “add a hoodie to it”"
+                   value={step.action}
+                   onChange={(e) => setStep((s) => ({ ...s, action: e.target.value }))}
+                   onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addStep(); } }} />
+            <button type="button" data-testid="wizard-step-add" disabled={!stepReady(step)} onClick={addStep}
+                    className="self-start disabled:opacity-40"
+                    style={{ ...BTN, background: 'transparent', border: `1px solid ${S.border}`, color: S.ink }}>
+              Add step {draft.steps.length + 1}
+            </button>
+          </div>
+        </>
+      )}
+
+      <div className="mt-auto flex items-center gap-2 pt-2">
+        <button type="button" data-testid="wizard-create" disabled={!draftReady(draft) || busy}
+                onClick={() => void create()} className="disabled:opacity-40"
+                style={{ ...BTN, background: S.accent, color: '#0d1117' }}>
+          {busy ? 'Authoring…' : `Create demo (${draft.steps.length} steps)`}
+        </button>
+        <button type="button" data-testid="wizard-cancel" onClick={onCancel}
+                style={{ ...BTN, background: 'transparent', border: `1px solid ${S.border}`, color: S.muted }}>
+          Cancel
+        </button>
+      </div>
+      {error !== null && (
+        <p data-testid="wizard-error" className="text-[11px] font-mono" style={{ color: '#f85149', margin: 0 }}>
+          {error} — nothing was created; fix it and submit again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { createDoc, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { DemoWizard } from './DemoWizard.js';
+import { recordFromThread } from '../interactive/demoWire.js';
 import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
-import { versionPath, type Navigate } from '../hooks/useRoute.js';
+import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
 
 // Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
@@ -240,9 +242,16 @@ export interface DocumentThreadProps {
   /** The routed `?v=N`; `null` means the head, which fork resolves from the manifest. */
   selectedVersion: number | null;
   navigate: Navigate;
+  /**
+   * Which artifact this thread's composer is launching (§6.4 slice 14). A demo IS a
+   * document, so this is the SAME thread with the same four states — what differs is
+   * only case 1: a demo's steps are ordered, so the launch discloses the wizard (§4.1)
+   * instead of taking the message as a brief. Default keeps Document mode untouched.
+   */
+  mode?: 'document' | 'video';
 }
 
-export function DocumentThread({ projectId, docId, selectedVersion, navigate }: DocumentThreadProps): React.ReactElement {
+export function DocumentThread({ projectId, docId, selectedVersion, navigate, mode = 'document' }: DocumentThreadProps): React.ReactElement {
   const key = docId === null ? null : threadKey(projectId, docId);
   const messages = useDocThreadStore((s) => (key === null ? EMPTY : s.messages[key] ?? EMPTY));
   const streamed = useDocThreadStore((s) => (key === null ? undefined : s.genState[key]));
@@ -252,6 +261,11 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The demo path's ordered disclosure (§4.1), seeded by the message that opened it. The
+  // anchor id is minted BEFORE the wizard so the version it lands tags the same message
+  // the transcript shows (§7.6) — the wizard is a longer way to write case 1, not a
+  // different case.
+  const [wizard, setWizard] = useState<{ seed: string; msgId: string } | null>(null);
   const bottom = useRef<HTMLDivElement>(null);
 
   useEffect(() => { bottom.current?.scrollIntoView({ block: 'end' }); }, [messages.length]);
@@ -268,6 +282,14 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
     setBusy(true);
     setError(null);
     try {
+      // 1 — LAUNCH, the demo path (§4.5): the ask names the demo, and the wizard collects
+      // the steps it is made of, in order. Nothing is created until the wizard submits.
+      if ((docId === null || key === null) && mode === 'video') {
+        setWizard({ seed: body, msgId });
+        setText('');
+        return;
+      }
+
       // 1 — LAUNCH. The message IS the brief; the doc's generation run opens with it.
       if (docId === null || key === null) {
         const created = await createDoc(projectId, {
@@ -318,19 +340,39 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
   }
 
   const { placeholder, submit: label } = COMPOSER[state];
+  // Case 1 is the only state whose words differ by artifact — what the composer DOES is
+  // the same function of run state either way (§2.2), it just says what it will make.
+  const prompt = mode === 'video' && state === 'idle'
+    ? 'Describe the demo you want to record…' : placeholder;
 
   return (
     <div
       data-testid="thread"
       data-composer-state={state}
-      className="flex flex-col shrink-0"
+      className="flex flex-col shrink-0 relative"
       style={{ width: '340px', background: S.panel, borderLeft: `1px solid ${S.border}` }}
     >
+      {wizard !== null && (
+        <DemoWizard
+          projectId={projectId}
+          seed={wizard.seed}
+          msgId={wizard.msgId}
+          onCancel={() => setWizard(null)}
+          onCreated={(name) => {
+            setWizard(null);
+            // The demo exists with its spec and no recording — so the surface it opens on
+            // is the one that OFFERS to record it (§3.3: the control beside the statement).
+            navigate(modePath(projectId, 'video', name));
+          }}
+        />
+      )}
       <div className="flex-1 overflow-y-auto px-3.5 py-4 flex flex-col gap-3">
         {messages.length === 0 && (
           <p className="text-xs leading-relaxed" style={{ color: S.muted }}>
             {docId === null
-              ? 'Describe the document you want — “a deck for the Q3 review”, “write this up as a report” — and it is created from that message.'
+              ? mode === 'video'
+                ? 'Describe the demo you want — “a walkthrough of the checkout flow” — and its steps are authored from there, in order.'
+                : 'Describe the document you want — “a deck for the Q3 review”, “write this up as a report” — and it is created from that message.'
               : 'Ask for a change and it lands as a new version. Everything the agent says about this document appears here.'}
           </p>
         )}
@@ -352,6 +394,28 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
 
       <div className="shrink-0 px-3.5 py-3 flex flex-col gap-2"
            style={{ borderTop: `1px solid ${S.border}`, background: S.footer }}>
+        {/* §2.3: asking for a recording is an input like any other, so it is a MESSAGE —
+            the same wire the storyboard's own Record button uses, offered here because
+            the composer is where the user already is when they decide to re-run it. */}
+        {mode === 'video' && docId !== null && state !== 'generating' && (
+          <button
+            type="button"
+            data-testid="thread-record"
+            disabled={busy}
+            onClick={() => {
+              setBusy(true);
+              setError(null);
+              void recordFromThread({ projectId, demoId: docId, ask: `Record “${docId}”.` })
+                .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+                .finally(() => setBusy(false));
+            }}
+            className="self-start rounded-full px-2.5 py-0.5 text-[10px] font-mono disabled:opacity-40"
+            style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
+                     border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+          >
+            record this demo
+          </button>
+        )}
         {state === 'generating' && (
           <span
             data-testid="steering-chip"
@@ -359,7 +423,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
             style={{ background: 'rgba(121,192,255,0.08)', color: S.live, border: '1px solid rgba(121,192,255,0.2)' }}
           >
             <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
-            steering the live document run
+            steering the live {mode === 'video' ? 'demo' : 'document'} run
           </span>
         )}
         <div className="flex items-end gap-2 rounded-2xl px-3 py-2"
@@ -368,7 +432,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate }: 
             data-testid="doc-composer"
             className="flex-1 resize-none text-sm outline-none border-0 bg-transparent leading-6"
             style={{ color: S.ink, fontFamily: 'inherit', minHeight: '28px' }}
-            placeholder={placeholder}
+            placeholder={prompt}
             value={text}
             rows={1}
             disabled={busy}

--- a/src/components/VideoStoryboard.tsx
+++ b/src/components/VideoStoryboard.tsx
@@ -1,9 +1,12 @@
 import { useRef, useState } from 'react';
 import {
-  getDemoSpec, getLatestRecording, interactiveUrl, listDemos, requestRecord,
+  getDemoSpec, getLatestRecording, getVersions, interactiveUrl, listDemos,
 } from '../api/interactive.js';
 import type { DemoRecording, DemoStep, DocSummary } from '../api/interactive.js';
+import { recordFromThread, recordingSubject, submitStepFeedback, type StepComment } from '../interactive/demoWire.js';
 import { modePath, type Navigate } from '../hooks/useRoute.js';
+import { statusLine } from '../store/narration.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../store/docThread.js';
 import { Failed, Loading, PANEL, S, useLoad, type Failure } from './SurfaceState.js';
 
 // Video mode's surface (DES-MERGE-001 §1.3, §4.5, §6.4 slice 13): storyboard + player.
@@ -81,6 +84,19 @@ export function playerState(
   return { kind: 'missing', ffmpeg: false };
 }
 
+/** Stable identity for "this thread has said nothing", so the selector never re-renders. */
+const NO_MESSAGES: DocMsg[] = [];
+
+const ACTION: React.CSSProperties = {
+  border: 'none', borderRadius: '6px', cursor: 'pointer', flexShrink: 0,
+  fontSize: '11px', fontWeight: 600, padding: '5px 11px',
+};
+
+const BAR: React.CSSProperties = {
+  alignItems: 'center', background: '#0f1419', borderTop: `1px solid ${S.border}`,
+  display: 'flex', flexShrink: 0, gap: '8px', padding: '8px 12px',
+};
+
 // ── Demo picker — the mode with no `:demoId` in the route ────────────────────
 
 /** Most-recent first, same rule as the slice-8 doc picker. A null `updated_at` sinks. */
@@ -148,17 +164,20 @@ function DemoPicker({ projectId, navigate }: { projectId: string; navigate: Navi
 // ── The missing-recording panel — §3.3 actionable, never a dead end ──────────
 
 function MissingRecording({
-  projectId, demoId, state,
-}: { projectId: string; demoId: string; state: Extract<PlayerState, { kind: 'missing' }> }): React.ReactElement {
+  demoId, state, record,
+}: {
+  demoId: string; record: (ask: string) => Promise<void>;
+  state: Extract<PlayerState, { kind: 'missing' }>;
+}): React.ReactElement {
   const [queued, setQueued] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function record(): Promise<void> {
+  async function go(): Promise<void> {
     setBusy(true);
     setError(null);
     try {
-      await requestRecord(projectId, demoId);
+      await record(`Record “${demoId}”.`);
       setQueued(true);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
@@ -197,7 +216,7 @@ function MissingRecording({
           type="button"
           data-testid="demo-record"
           disabled={busy || queued}
-          onClick={() => void record()}
+          onClick={() => void go()}
           style={{
             background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
             color: queued ? S.muted : S.ink, cursor: busy || queued ? 'default' : 'pointer',
@@ -224,13 +243,30 @@ function MissingRecording({
 // ── Player + storyboard — the demo surface itself ────────────────────────────
 
 function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string }): React.ReactElement {
-  // Two INDEPENDENT loads on purpose: the spec is what makes the storyboard, and a
+  const key = threadKey(projectId, demoId);
+  // A re-authored spec is a NEW VERSION of the same demo (§7.10's continuation), so the
+  // surface re-reads the service when one lands rather than showing the steps it was fed
+  // at mount. `reloads` is the same read on the near side of the stream: a submitted
+  // batch asks for a re-authoring now, and the frame confirming it may be seconds behind.
+  const landed = useDocThreadStore((s) => s.landed[key]);
+  const recording = useDocThreadStore((s) => s.genState[key]) === 'generating';
+  const messages = useDocThreadStore((s) => s.messages[key] ?? NO_MESSAGES);
+  const [reloads, setReloads] = useState(0);
+  const nonce = `${landed ?? 0}:${reloads}`;
+
+  // Three INDEPENDENT loads on purpose: the spec is what makes the storyboard, and a
   // recording that 404s, errors, or reports a missing ffmpeg must leave the chapters
   // standing (§4.5 — degradation is required behaviour, not a nicety).
-  const [spec, specFailure, retrySpec] = useLoad(() => getDemoSpec(projectId, demoId), [projectId, demoId]);
-  const [rec, recFailure] = useLoad(() => getLatestRecording(projectId, demoId), [projectId, demoId]);
+  const [spec, specFailure, retrySpec] = useLoad(() => getDemoSpec(projectId, demoId), [projectId, demoId, nonce]);
+  const [rec, recFailure] = useLoad(() => getLatestRecording(projectId, demoId), [projectId, demoId, nonce]);
+  const [manifest] = useLoad(() => getVersions(projectId, demoId), [projectId, demoId, nonce]);
   const [chapter, setChapter] = useState(0);
   const [at, setAt] = useState(0);
+  const [draft, setDraft] = useState<StepComment | null>(null);
+  const [items, setItems] = useState<StepComment[]>([]);
+  const [sent, setSent] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const video = useRef<HTMLVideoElement>(null);
 
   const subject = `“${demoId}”`;
@@ -241,6 +277,21 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
   // arrive: `index` IS the chapter number the user sees, so the two cannot disagree.
   const steps = [...(spec.steps ?? [])].sort((a, b) => a.index - b.index);
   const player = playerState(projectId, rec, recFailure);
+  const version = manifest?.head ?? rec?.version ?? null;
+
+  /** §3.4's two altitudes, one stream: the thread keeps the transcript, this keeps the
+   *  headline. Rule 1 (a real streamed line) wins; rule 3 — the demo and its first step —
+   *  is why a bare `Working…` is never needed and never rendered here. */
+  const status = statusLine(
+    messages.filter((m): m is Extract<DocMsg, { kind: 'narration' }> => m.kind === 'narration').map((m) => m.text),
+    recordingSubject(demoId, steps.length, steps[0]?.title),
+  );
+
+  /** Both record paths are the same wire (§2.3): the ask lands in the thread first. */
+  async function record(ask: string): Promise<void> {
+    setSent(false);
+    await recordFromThread({ projectId, demoId, ask, steps: steps.length, first: steps[0]?.title });
+  }
 
   /** Clicking chapter N seeks the player there; with no seekable recording it puts the
    *  step itself in focus instead, so the click always resolves to something visible. */
@@ -251,6 +302,31 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
     setAt(seconds);
     if (el) el.currentTime = seconds;
     else card?.scrollIntoView?.({ block: 'nearest', inline: 'center' });
+  }
+
+  /** One comment queued against one step. Batched, never sent per comment (§4.3). */
+  function commit(): void {
+    if (draft === null || draft.text.trim() === '') return;
+    setItems((prev) => [...prev, { index: draft.index, text: draft.text.trim() }]);
+    setDraft(null);
+  }
+
+  /** §4.3's batch, aimed at the spec: N step comments → one message, one re-authoring. */
+  async function send(): Promise<void> {
+    if (items.length === 0 || version === null || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await submitStepFeedback(projectId, demoId, version, items);
+      setItems([]);
+      setDraft(null);
+      setSent(true);
+      setReloads((n) => n + 1);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
@@ -285,7 +361,7 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
             </p>
           </div>
         ) : (
-          <MissingRecording projectId={projectId} demoId={demoId} state={player} />
+          <MissingRecording demoId={demoId} state={player} record={record} />
         )}
       </div>
 
@@ -310,11 +386,12 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
             data-index={String(step.index)}
             data-timestamp={String(step.timestamp)}
             data-selected={String(step.index === chapter)}
+            data-comments={String(items.filter((i) => i.index === step.index).length)}
             title={`Chapter ${step.index + 1}: ${step.title} — ${player.kind === 'video' ? 'seeks to' : 'starts at'} ${mmss(step.timestamp)}`}
             onClick={(e) => onChapter(step, e.currentTarget)}
             style={{
               background: step.index === chapter ? 'rgba(255,218,25,0.1)' : 'transparent',
-              border: `1px solid ${step.index === chapter ? S.accent : S.border}`,
+              border: `1px solid ${step.index === chapter || items.some((i) => i.index === step.index) ? S.accent : S.border}`,
               borderRadius: '8px', color: S.ink, cursor: 'pointer', flexShrink: 0,
               padding: '8px', textAlign: 'left', width: '160px',
             }}
@@ -334,6 +411,101 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
           </button>
         ))}
       </div>
+
+      {/*
+        The one action bar under the storyboard. It is one bar and not four because the
+        four things it says are the same thing at different moments of one loop — what
+        the recorder is doing, what you are commenting on, what is queued, and what to do
+        with the version that came back — and §3.3 wants each of them stated WITH its
+        control rather than scattered around the surface.
+
+        Commenting targets the SELECTED chapter, which is the chapter the player is
+        already parked on: a step is picked by clicking it, exactly as a document element
+        is picked by clicking it (§4.3), and the click keeps its existing meaning.
+      */}
+      {steps.length > 0 && (
+        <div data-testid="demo-actions" style={BAR}>
+          {recording ? (
+            <span data-testid="demo-record-status" style={{ color: S.ink, fontSize: '12px' }}>{status}</span>
+          ) : draft !== null ? (
+            <>
+              <span style={{ color: S.muted, fontFamily: 'monospace', fontSize: '10px', flexShrink: 0 }}>
+                step {draft.index + 1}
+              </span>
+              <textarea
+                data-testid="step-comment-input"
+                autoFocus
+                rows={1}
+                value={draft.text}
+                placeholder={`What should “${steps.find((s) => s.index === draft.index)?.title ?? ''}” do instead?`}
+                onChange={(e) => setDraft({ index: draft.index, text: e.target.value })}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); }
+                  if (e.key === 'Escape') setDraft(null);
+                }}
+                style={{
+                  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
+                  color: S.ink, flex: 1, fontFamily: 'inherit', fontSize: '12px', padding: '5px 7px', resize: 'none',
+                }}
+              />
+              <button type="button" data-testid="step-comment-add" onClick={commit}
+                      disabled={draft.text.trim() === ''}
+                      style={{ ...ACTION, background: S.accent, color: '#0d1117' }}>
+                Add to batch
+              </button>
+              <button type="button" data-testid="step-comment-cancel" onClick={() => setDraft(null)}
+                      style={{ ...ACTION, background: 'transparent', border: `1px solid ${S.border}`, color: S.muted }}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                data-testid="step-comment-open"
+                data-index={String(chapter)}
+                onClick={() => { setDraft({ index: chapter, text: '' }); setSent(false); }}
+                style={{ ...ACTION, background: 'transparent', border: `1px solid ${S.border}`, color: S.ink }}
+              >
+                Comment on step {chapter + 1}
+              </button>
+              {sent && (
+                <>
+                  <span style={{ color: S.ink, fontSize: '12px' }}>
+                    “{demoId}” was re-authored from your comments — record it again to see the change.
+                  </span>
+                  <button
+                    type="button"
+                    data-testid="demo-rerecord"
+                    onClick={() => void record(`Re-record “${demoId}” with the updated steps.`)}
+                    style={{ ...ACTION, background: S.accent, color: '#0d1117' }}
+                  >
+                    Re-record
+                  </button>
+                </>
+              )}
+              {items.length > 0 && (
+                <button
+                  type="button"
+                  data-testid="step-feedback-submit"
+                  data-count={String(items.length)}
+                  disabled={busy || version === null}
+                  title={version === null ? 'This demo has no version to comment on yet.' : 'One message, one re-authoring'}
+                  onClick={() => void send()}
+                  style={{ ...ACTION, background: S.accent, color: '#0d1117', marginLeft: 'auto' }}
+                >
+                  {busy ? 'Sending…' : `Send ${items.length} comment${items.length === 1 ? '' : 's'}`}
+                </button>
+              )}
+            </>
+          )}
+          {error !== null && (
+            <span data-testid="step-feedback-error" style={{ color: '#f85149', fontFamily: 'monospace', fontSize: '11px' }}>
+              {error} — nothing was sent; try again.
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/interactive/demoWire.ts
+++ b/src/interactive/demoWire.ts
@@ -1,0 +1,184 @@
+// Video mode's wires (DES-MERGE-001 §4.5, §6.4 slice 14): authoring a demo, recording
+// one, and commenting on a step.
+//
+// ADR-0018's split is the constraint everything here is shaped by — the agent authors
+// the spec, the MODEL-FREE service executes and records it. So nothing in this module
+// decides what to click: it submits an ordered authoring intent, asks the service to
+// run it, or asks for one STEP to be re-authored. Deterministic replay is what makes
+// "change step 3" mean anything, and it only holds while the spec stays the authority.
+//
+// Both user-visible actions go through the thread, because a non-text input is a message
+// too (§2.3): a recording the user asked for that leaves no trace in the transcript makes
+// the transcript stop being the record of why v4 became v5.
+
+import { createDoc, requestRecord, type CreateDocBody, type DemoStepDraft } from '../api/interactive.js';
+import { nextMsgId, threadKey, useDocThreadStore } from '../store/docThread.js';
+import { submitFeedbackBatch, type SubmitBatchResult } from './feedbackBatch.js';
+
+// ── Step anchors ─────────────────────────────────────────────────────────────
+
+/**
+ * A storyboard step's stable anchor, in the same shape a document element's `data-wid`
+ * carries (INV-1). Same spelling on both sides of the seam means step feedback rides the
+ * batch contract unchanged (§7.7) and its thread message deep-links back to the step.
+ */
+export function stepWid(index: number): string {
+  return `step-${index}`;
+}
+
+// ── The ordered wizard (§4.5, §4.1) ──────────────────────────────────────────
+
+/** What the wizard collects, in authoring order. */
+export interface DemoDraft {
+  name: string;
+  targetUrl: string;
+  steps: { subject: string; action: string }[];
+}
+
+/** A step is only authored once it says WHAT and TO WHAT — both halves, or neither. */
+export function stepReady(step: { subject: string; action: string }): boolean {
+  return step.subject.trim() !== '' && step.action.trim() !== '';
+}
+
+/** Submittable: a target to open, and at least one complete step to run against it. */
+export function draftReady(draft: DemoDraft): boolean {
+  return draft.name.trim() !== ''
+    && /^https?:\/\/\S+/i.test(draft.targetUrl.trim())
+    && draft.steps.length > 0
+    && draft.steps.every(stepReady);
+}
+
+/** One step, in the transcript's words. The subject leads because it is what the user
+ *  recognizes — the same reason a status line leads with its subject (§3.3). */
+export function stepTitle(step: { subject: string; action: string }): string {
+  return `${step.subject.trim()} — ${step.action.trim()}`;
+}
+
+/**
+ * The draft as the thread reads it. This is the message the demo's conversation OPENS
+ * with (§2.2 case 1), so it has to be the spec a human can check against the storyboard.
+ */
+export function demoBrief(draft: DemoDraft): string {
+  return [
+    `Record a demo of ${draft.targetUrl.trim()}:`,
+    ...draft.steps.map((step, i) => `${i + 1}. ${stepTitle(step)}`),
+  ].join('\n');
+}
+
+/**
+ * The draft as the SERVICE reads it. `index` is assigned from the array position rather
+ * than carried on the step, so the order the user authored is the order the spec has —
+ * the two cannot disagree, which is the property the storyboard's chapter numbers rest on.
+ */
+export function demoDraftBody(
+  projectId: string, draft: DemoDraft, sourceMessageId: string,
+): CreateDocBody {
+  const steps: DemoStepDraft[] = draft.steps.map((step, index) => ({
+    index,
+    subject: step.subject.trim(),
+    action: step.action.trim(),
+  }));
+  return {
+    name: draft.name.trim(),
+    kind: 'demo',
+    url: draft.targetUrl.trim(),
+    brief: demoBrief(draft),
+    demo_steps: steps,
+    project: projectId,
+    source_message_id: sourceMessageId,
+  };
+}
+
+/**
+ * Wizard completion (§2.2 case 1, for the demo path). The demo's conversation opens with
+ * the authored spec as its first line, exactly as a document's opens with its brief —
+ * one thread per artifact, spanning every version (§2.4).
+ */
+export async function createDemoFromDraft(
+  projectId: string, draft: DemoDraft, msgId: string,
+): Promise<{ name: string; text: string }> {
+  const text = demoBrief(draft);
+  const created = await createDoc(projectId, demoDraftBody(projectId, draft, msgId));
+  const key = threadKey(projectId, created.name);
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(key, msgId, text);
+  store.addNarration(
+    key,
+    `Authored “${created.name}” — ${draft.steps.length} `
+    + `${draft.steps.length === 1 ? 'step' : 'steps'} against ${draft.targetUrl.trim()}. `
+    + 'Recording runs them in a real browser.',
+  );
+  return { name: created.name, text };
+}
+
+// ── Recording (§4.5, §2.3) ───────────────────────────────────────────────────
+
+/** The line the thread opens a recording with. Informative means it names its subject
+ *  AND what is happening to it — the fallback the surface falls back TO (§3.4 rule 3). */
+export function recordingSubject(demoId: string, steps?: number, first?: string): string {
+  // The composer can ask for a recording without having read the spec, so the count is
+  // optional — but the SUBJECT never is: every branch names the demo and what is
+  // happening to it, which is the whole of rule 3 (§3.4).
+  if (steps === undefined) return `Recording “${demoId}” — running its authored steps in a real browser.`;
+  const count = `${steps} ${steps === 1 ? 'step' : 'steps'}`;
+  return first === undefined
+    ? `Recording “${demoId}” — ${count}, in a real browser.`
+    : `Recording “${demoId}” — ${count}, starting at “${first}”.`;
+}
+
+export interface RecordArgs {
+  projectId: string;
+  demoId: string;
+  /** The user's ask, as the message it is (§2.3). */
+  ask: string;
+  /** Named so the opening narration has a subject before the service says anything.
+   *  Absent when the caller has not read the spec (the composer's Record action). */
+  steps?: number | undefined;
+  first?: string | undefined;
+}
+
+/**
+ * Queue a recording AND put it in the conversation. The order matters: the message and
+ * its narration land FIRST so a request the service refuses still shows what was asked —
+ * then the working state is retired and the caller renders the failure with its retry
+ * (§3.3: an error with no next action is banned, and the button is that action).
+ */
+export async function recordFromThread(
+  { projectId, demoId, ask, steps, first }: RecordArgs,
+): Promise<void> {
+  const key = threadKey(projectId, demoId);
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(key, nextMsgId(), ask);
+  store.addNarration(key, recordingSubject(demoId, steps, first));
+  store.setGenState(key, 'generating');
+  try {
+    await requestRecord(projectId, demoId);
+  } catch (e: unknown) {
+    store.setGenState(key, 'terminal');
+    throw e;
+  }
+}
+
+// ── Step-targeted feedback (§4.3's batch, aimed at the spec) ─────────────────
+
+export interface StepComment { index: number; text: string }
+
+/**
+ * Comment on N storyboard steps → ONE message, ONE regeneration (§4.3: N submits would
+ * be N versions and N runs for what the user experienced as one round of edits), through
+ * §7.7's two client-authored writes unchanged. What differs from a document batch is only
+ * what the agent is being asked to re-author: `target: "demo_step"` says the diff belongs
+ * in the SPEC, which is what makes the re-record deterministic rather than a fresh take.
+ */
+export function submitStepFeedback(
+  projectId: string, demoId: string, version: number, comments: StepComment[],
+): Promise<SubmitBatchResult> {
+  return submitFeedbackBatch({
+    projectId,
+    docId: demoId,
+    version,
+    items: comments.map((c) => ({ wid: stepWid(c.index), text: c.text.trim() })),
+    subject: 'this demo',
+    target: 'demo_step',
+  });
+}

--- a/src/interactive/feedbackBatch.ts
+++ b/src/interactive/feedbackBatch.ts
@@ -23,10 +23,10 @@ export const FEEDBACK_EVENT = 'wicked.interactive.feedback.submitted';
  * it is the same anchor the item's deep-link resolves through, so the message a human
  * reads and the target the agent edits are provably the same element.
  */
-export function composeBatchMessage(items: FeedbackItem[]): string {
+export function composeBatchMessage(items: FeedbackItem[], subject = 'this document'): string {
   const where = items.length === 1 ? '1 place' : `${items.length} places`;
   return [
-    `Feedback on ${where} in this document:`,
+    `Feedback on ${where} in ${subject}:`,
     ...items.map((item, i) => `${i + 1}. [${item.wid}] ${item.text}`),
   ].join('\n');
 }
@@ -36,6 +36,12 @@ export interface SubmitBatchArgs {
   docId: string;
   version: number;
   items: FeedbackItem[];
+  /** What the batch is feedback ON, in the message's own words. */
+  subject?: string;
+  /** What the agent must re-author. Omitted for document elements (the default the
+   *  contract has always carried); `"demo_step"` for a storyboard step, whose edit is a
+   *  SPEC diff rather than an HTML fragment (§4.5 — the spec is what gets re-recorded). */
+  target?: string;
 }
 
 export interface SubmitBatchResult {
@@ -48,9 +54,9 @@ export interface SubmitBatchResult {
 
 /** Write 1 then write 2. Throws only when write 1 fails — nothing was submitted then. */
 export async function submitFeedbackBatch(
-  { projectId, docId, version, items }: SubmitBatchArgs,
+  { projectId, docId, version, items, subject, target }: SubmitBatchArgs,
 ): Promise<SubmitBatchResult> {
-  const text = composeBatchMessage(items);
+  const text = composeBatchMessage(items, subject);
   const msgId = nextMsgId();
   const key = threadKey(projectId, docId);
 
@@ -60,6 +66,7 @@ export async function submitFeedbackBatch(
       document_id: docId,
       version,
       source_message_id: msgId,
+      ...(target === undefined ? {} : { target }),
       items: items.map((item) => ({ wid: item.wid, comment: item.text })),
     },
   });

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -11,7 +11,7 @@
 // rather than rendered under a guessed key.
 
 import { create } from 'zustand';
-import { isWhimsy } from './narration.js';
+import { isFiller } from './narration.js';
 import type { CoreEvent } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
@@ -94,6 +94,13 @@ interface DocThreadStore {
   genState: Record<string, GenState>;
   /** The user message a landing version will be tagged with (§7.6, client half). */
   anchor: Record<string, string>;
+  /**
+   * The newest version the stream has landed, per thread. The transcript tags its anchor
+   * message (§7.6) and does not otherwise care; a mode SURFACE does — a re-authored demo
+   * spec is a new version of the same artifact (§7.10's continuation rhythm), so the
+   * storyboard re-reads the service rather than showing the steps it was fed at mount.
+   */
+  landed: Record<string, number>;
   /** Fold one CoreEvent — every non-interactive frame is ignored. */
   ingest: (event: CoreEvent) => void;
   /** Append the user's message and make it the pending version anchor. */
@@ -117,6 +124,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   messages: {},
   genState: {},
   anchor: {},
+  landed: {},
 
   ingest: (event) => {
     const frame = frameOf(event);
@@ -146,9 +154,11 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         }
         const done = state === 'complete' || state === 'error';
         const next: GenState = done ? 'terminal' : was === 'gated' ? 'gated' : 'generating';
-        // §3.2: filler never reaches the transcript, but a filtered frame still carries
-        // the state transition it rode in on — dropping the LINE is not dropping the fact.
-        if (text === null || isWhimsy(text)) return { genState: { ...s.genState, [key]: next } };
+        // §3.2/§3.3: filler never reaches the transcript — rotating flavour text and a
+        // subject-less `Working…` are both dropped AT THE SEAM, so an upstream bridge that
+        // still speaks either cannot put it on screen. A filtered frame still carries the
+        // state transition it rode in on: dropping the LINE is not dropping the fact.
+        if (text === null || isFiller(text)) return { genState: { ...s.genState, [key]: next } };
         return {
           messages: append(messages, key, { kind: 'narration', id: nextMsgId(), text }),
           genState: { ...s.genState, [key]: next },
@@ -216,6 +226,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         return {
           messages: tagged,
           anchor,
+          landed: { ...s.landed, [key]: version },
           genState: generated ? { ...s.genState, [key]: 'terminal' } : s.genState,
         };
       }
@@ -252,6 +263,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       const messages = { ...s.messages }; delete messages[key];
       const genState = { ...s.genState }; delete genState[key];
       const anchor = { ...s.anchor }; delete anchor[key];
-      return { messages, genState, anchor };
+      const landed = { ...s.landed }; delete landed[key];
+      return { messages, genState, anchor, landed };
     }),
 }));

--- a/src/store/narration.ts
+++ b/src/store/narration.ts
@@ -50,7 +50,11 @@ export function isFiller(text: string): boolean {
 }
 
 /**
- * §3.4's derivation, for one line: the last streamed status that actually names
+ * §3.4's derivation, for one line, over a doc/demo thread's streamed statuses. The crew
+ * side of the same rule is `useBoardHeadline`'s `deriveHeadline`, which reads a run's
+ * delta buffer instead — one rule, two streams, deliberately not one function.
+ *
+ * The last streamed status that actually names
  * something, and otherwise the caller's derived subject (rule 3 — there is always a
  * truthful subject available from state the client already has, which is precisely why
  * a bare `Working…` is never needed).

--- a/src/store/narration.ts
+++ b/src/store/narration.ts
@@ -22,6 +22,13 @@ const FILLER: ReadonlySet<string> = new Set([
 /** Words that cannot name a subject in any real document status, in any phrasing. */
 const NONSENSE = /reticulat|splines/i;
 
+/**
+ * §3.3's other banned shape: a status with no subject. "Working…" is not informative —
+ * it says nothing about THIS run — and it is not actionable. The whole phrase is matched,
+ * anchored: "Working on the hero section" names its subject and must survive untouched.
+ */
+const BARE = /^(working|processing|thinking|running|busy|loading|please wait|one moment)$/u;
+
 /** Lowercase, one-space, no trailing ellipsis — the filler ships with a trailing `…`. */
 function normalize(text: string): string {
   return text.toLowerCase().replace(/\s+/g, ' ').replace(/[\s….!]+$/u, '').trim();
@@ -30,4 +37,28 @@ function normalize(text: string): string {
 /** True when this status is flavour text and must never reach a rendering surface. */
 export function isWhimsy(text: string): boolean {
   return NONSENSE.test(text) || FILLER.has(normalize(text));
+}
+
+/** True when this status names no subject — §3.3's bare `Working…`, in any casing. */
+export function isBare(text: string): boolean {
+  return BARE.test(normalize(text));
+}
+
+/** Neither informative nor actionable, so it never reaches a surface (§3.2's deletion). */
+export function isFiller(text: string): boolean {
+  return isWhimsy(text) || isBare(text);
+}
+
+/**
+ * §3.4's derivation, for one line: the last streamed status that actually names
+ * something, and otherwise the caller's derived subject (rule 3 — there is always a
+ * truthful subject available from state the client already has, which is precisely why
+ * a bare `Working…` is never needed).
+ */
+export function statusLine(streamed: readonly string[], subject: string): string {
+  for (let i = streamed.length - 1; i >= 0; i -= 1) {
+    const text = (streamed[i] ?? '').trim();
+    if (text !== '' && !isFiller(text)) return text;
+  }
+  return subject;
 }

--- a/src/store/runtime.ts
+++ b/src/store/runtime.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { isWhimsy } from './narration.js';
+import { isFiller } from './narration.js';
 import type { CoreEvent } from '../api/types.js';
 
 /** Cap per (run, unit) output buffer so a chatty CLI can't grow memory unbounded. */
@@ -221,9 +221,10 @@ export function docActivityOf(frame: CoreEvent): { projectId: string; activity: 
       : {};
   const projectId = pick(payload, 'project_id', 'project') ?? pick(event, 'project_id', 'project');
   const message = pick(payload, 'message', 'status', 'text');
-  // §3.2 is a rule about SCREENS, not about one component: filler dropped from the
-  // transcript must not survive as the card's headline either.
-  if (projectId === null || message === null || isWhimsy(message)) return null;
+  // §3.2/§3.3 are rules about SCREENS, not about one component: what is dropped from the
+  // transcript — flavour text, and a subject-less `Working…` — must not survive as the
+  // card's headline either, where rule 3 already has a truthful subject to fall back on.
+  if (projectId === null || message === null || isFiller(message)) return null;
   return {
     projectId,
     activity: {

--- a/tests/DocumentThread.video.test.tsx
+++ b/tests/DocumentThread.video.test.tsx
@@ -1,0 +1,187 @@
+// The composer in Video mode — DES-MERGE-001 §2.2, §4.1, §4.5, §6.4 slice 14.
+//
+// Same thread, same four states, same rule that what Enter DOES is a pure function of run
+// state (slice 10). Exactly one case differs, and only in how it collects: a demo's steps
+// are ORDERED, so case 1 discloses the wizard (§4.1) instead of taking the message as a
+// brief. Everything asserted here is the WIRE the composer chose, not the button's label.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const PROJECT = 'proj-abc';
+const DEMO = 'checkout-walkthrough';
+const KEY = threadKey(PROJECT, DEMO);
+
+const createDoc = vi.fn();
+const requestRecord = vi.fn();
+const postEvent = vi.fn();
+const getVersions = vi.fn();
+const postFork = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: (...a: unknown[]) => createDoc(...a),
+  requestRecord: (...a: unknown[]) => requestRecord(...a),
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  getVersions: (...a: unknown[]) => getVersions(...a),
+  postFork: (...a: unknown[]) => postFork(...a),
+  injectDocMessage: (p: string, d: string, text: string, id: string) =>
+    postEvent(p, {
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { role: 'user', text, document_id: d, source_message_id: id },
+    }),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+const navigate = vi.fn();
+
+function mount(docId: string | null): void {
+  render(
+    <DocumentThread projectId={PROJECT} docId={docId} selectedVersion={null}
+                    navigate={navigate} mode="video" />,
+  );
+}
+
+function thread(key = KEY): DocMsg[] {
+  return useDocThreadStore.getState().messages[key] ?? [];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  createDoc.mockResolvedValue({ name: DEMO, head: 1, kind: 'demo' });
+  requestRecord.mockResolvedValue({ queued: true });
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  getVersions.mockResolvedValue({ head: 1, versions: [] });
+});
+afterEach(cleanup);
+
+// ── Case 1, the demo path: the composer opens the ordered wizard ─────────────
+
+describe('case 1 — the ask opens the wizard, and nothing is created until it submits', () => {
+  it('AC: typing while idle discloses the wizard instead of posting a brief', async () => {
+    const user = userEvent.setup();
+    mount(null);
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'idle');
+    expect(screen.getByTestId('doc-composer')).toHaveAttribute(
+      'placeholder', 'Describe the demo you want to record…');
+
+    await user.type(screen.getByTestId('doc-composer'), 'a walkthrough of the checkout flow');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+
+    const wizard = await screen.findByTestId('demo-wizard');
+    // §4.5's first ordered question: nothing can be authored against an unknown target.
+    expect(wizard).toHaveAttribute('data-stage', 'target');
+    expect(createDoc).not.toHaveBeenCalled();
+  });
+
+  it('AC: steps are authored IN ORDER and submitted in that order', async () => {
+    const user = userEvent.setup();
+    mount(null);
+    await user.type(screen.getByTestId('doc-composer'), 'a walkthrough of the checkout flow');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+    await screen.findByTestId('demo-wizard');
+
+    await user.type(screen.getByTestId('wizard-target'), 'https://shop.example/');
+    expect(screen.getByTestId('demo-wizard')).toHaveAttribute('data-stage', 'steps');
+
+    // Authored one at a time; the wizard cannot accept a half-named step.
+    await user.type(screen.getByTestId('wizard-step-subject'), 'the storefront');
+    expect(screen.getByTestId('wizard-step-add')).toBeDisabled();
+    await user.type(screen.getByTestId('wizard-step-action'), 'open it');
+    await user.click(screen.getByTestId('wizard-step-add'));
+
+    await user.type(screen.getByTestId('wizard-step-subject'), 'the cart');
+    await user.type(screen.getByTestId('wizard-step-action'), 'add a hoodie to it');
+    await user.click(screen.getByTestId('wizard-step-add'));
+
+    const listed = screen.getAllByTestId('wizard-step');
+    expect(listed.map((el) => el.getAttribute('data-index'))).toEqual(['0', '1']);
+    expect(listed[0]).toHaveTextContent('the storefront — open it');
+    expect(listed[1]).toHaveTextContent('the cart — add a hoodie to it');
+
+    await user.click(screen.getByTestId('wizard-create'));
+
+    await waitFor(() => expect(createDoc).toHaveBeenCalledTimes(1));
+    const [project, body] = createDoc.mock.calls[0] as [string, {
+      kind: string; url: string; name: string; project: string; source_message_id: string;
+      demo_steps: { index: number; subject: string; action: string }[];
+    }];
+    expect(project).toBe(PROJECT);
+    expect(body.kind).toBe('demo');
+    expect(body.url).toBe('https://shop.example/');
+    // §4.1: the name is DERIVED from the ask — the wizard only asks what the ask couldn't say.
+    expect(body.name).toBe('a walkthrough of the checkout flow');
+    expect(body.demo_steps).toEqual([
+      { index: 0, subject: 'the storefront', action: 'open it' },
+      { index: 1, subject: 'the cart', action: 'add a hoodie to it' },
+    ]);
+
+    // Completion opens the demo's conversation and lands on the surface that OFFERS to
+    // record it — the demo exists with a spec and no recording (§3.3: control adjacent).
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/video/${DEMO}`));
+    expect(screen.queryByTestId('demo-wizard')).toBeNull();
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: expect.stringContaining('1. the storefront — open it') });
+    expect(thread()[1]?.kind).toBe('narration');
+    // §7.6: the message the composer minted BEFORE the wizard is the version's anchor.
+    expect(useDocThreadStore.getState().anchor[KEY]).toBe(thread()[0]?.id);
+  });
+
+  it('cancelling creates nothing and leaves the composer where it was', async () => {
+    const user = userEvent.setup();
+    mount(null);
+    await user.type(screen.getByTestId('doc-composer'), 'a walkthrough');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+    await user.click(await screen.findByTestId('wizard-cancel'));
+
+    expect(screen.queryByTestId('demo-wizard')).toBeNull();
+    expect(createDoc).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Recording from the composer (§2.3) ───────────────────────────────────────
+
+describe('the composer can ask for a recording, and the ask is a message', () => {
+  it('AC: the request goes through the proxied service and lands in the transcript', async () => {
+    const user = userEvent.setup();
+    mount(DEMO);
+
+    await user.click(screen.getByTestId('thread-record'));
+
+    await waitFor(() => expect(requestRecord).toHaveBeenCalledWith(PROJECT, DEMO));
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: `Record “${DEMO}”.` });
+    // §3.3: the opening line names the demo and what is happening to it, never bare.
+    expect(thread()[1]).toMatchObject({
+      kind: 'narration',
+      text: `Recording “${DEMO}” — running its authored steps in a real browser.`,
+    });
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('retires the offer while the recorder is running, and says so with the demo named', async () => {
+    mount(DEMO);
+    act(() => useDocThreadStore.getState().setGenState(KEY, 'generating'));
+
+    await waitFor(() => expect(screen.queryByTestId('thread-record')).toBeNull());
+    expect(screen.getByTestId('steering-chip')).toHaveTextContent('steering the live demo run');
+  });
+
+  it('a refused request states the failure — the composer never swallows it (§3.3)', async () => {
+    const user = userEvent.setup();
+    requestRecord.mockRejectedValueOnce(new Error('API 503: recorder unavailable'));
+    mount(DEMO);
+
+    await user.click(screen.getByTestId('thread-record'));
+
+    expect(await screen.findByTestId('doc-composer-error')).toHaveTextContent('recorder unavailable');
+    // The ask stays in the transcript: what was asked is not erased by the refusal.
+    expect(thread().filter((m) => m.kind === 'user')).toHaveLength(1);
+  });
+
+  it('a demo with no route (the picker) offers no record action — there is nothing to record', () => {
+    mount(null);
+    expect(screen.queryByTestId('thread-record')).toBeNull();
+  });
+});

--- a/tests/VideoStoryboard.slice14.test.tsx
+++ b/tests/VideoStoryboard.slice14.test.tsx
@@ -1,0 +1,227 @@
+// Video mode's surface, slice 14 — DES-MERGE-001 §4.5, §3.3/§3.4, §7.10, §6.4.
+//
+// Three claims, each of which the Playwright AC also drives end-to-end:
+//   1. a step is a feedback target: commenting on step 2 and submitting asks for the SPEC
+//      to be re-authored at step 2, and the surface re-reads what came back (§7.10);
+//   2. a submitted batch OFFERS the re-record, because a new spec is not a new video;
+//   3. the recording status is informative — it names the demo and the step — and is
+//      never a bare `Working…`, even when the bridge streams exactly that.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VideoStoryboard } from '../src/components/VideoStoryboard.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+import type { CoreEvent } from '../src/api/types.js';
+
+const PROJECT = 'proj-abc-123';
+const DEMO = 'checkout-walkthrough';
+const KEY = threadKey(PROJECT, DEMO);
+
+const STEPS = [
+  { index: 0, title: 'Open the storefront', timestamp: 0 },
+  { index: 1, title: 'Add a hoodie to the cart', timestamp: 6.5 },
+  { index: 2, title: 'Enter the card details', timestamp: 12 },
+];
+
+interface Call { url: string; method: string; body: unknown }
+
+/**
+ * The fake bridge, in miniature: it holds the spec as STATE and applies a step diff when
+ * the feedback event names one — so "the spec differs at step 2" is asserted against what
+ * the service came back with, not against what the client hoped it would say.
+ */
+function stubBridge(): { calls: Call[]; spec: () => typeof STEPS } {
+  const calls: Call[] = [];
+  let steps = STEPS.map((s) => ({ ...s }));
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    const body: unknown = init?.body === undefined ? undefined : JSON.parse(String(init.body));
+    calls.push({ url, method: init?.method ?? 'GET', body });
+
+    if (url.includes('/api/demo/spec')) return json({ steps, target_url: 'https://shop.example/' });
+    if (url.includes('/api/demo/recordings')) return json({ version: 2, gif_url: '/d/x/demo/v2.gif' });
+    if (url.includes('/api/demo/record')) return json({ queued: true });
+    if (url.includes('/api/versions')) return json({ head: 2, kind: 'demo', versions: [] });
+    if (url.includes('/api/events')) {
+      const payload = (body as { payload?: Record<string, unknown> })?.payload ?? {};
+      for (const item of (payload.items as { wid: string; comment: string }[] | undefined) ?? []) {
+        const at = Number(/^step-(\d+)$/.exec(item.wid)?.[1] ?? NaN);
+        if (Number.isInteger(at)) steps = steps.map((s) => (s.index === at ? { ...s, title: item.comment } : s));
+      }
+      return json({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+    }
+    return Promise.reject(new Error(`unstubbed fetch: ${url}`));
+  }));
+  return { calls, spec: () => steps };
+}
+
+function json(body: unknown): Promise<unknown> {
+  return Promise.resolve({
+    ok: true, status: 200, statusText: 'OK',
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  });
+}
+
+/** A relayed status frame, as slice 3's envelope delivers it. */
+function status(message: string): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: {
+      event_type: 'wicked.interactive.status.posted',
+      payload: { project_id: PROJECT, document_id: DEMO, state: 'working', message },
+    },
+  } as unknown as CoreEvent;
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_API_HOST', '');
+  Object.defineProperty(window, 'location', {
+    value: new URL('http://127.0.0.1:7788/'), writable: true, configurable: true,
+  });
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+function mount(): void {
+  render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
+}
+
+// ── 1 + 2. Step feedback → a spec diff → the offer to re-record ──────────────
+
+describe('commenting on a storyboard step re-authors the spec at that step', () => {
+  it('AC: commenting on step 2 submits a step-2 spec diff and the surface shows it', async () => {
+    const user = userEvent.setup();
+    const { calls, spec } = stubBridge();
+    mount();
+
+    // A step is picked by clicking it, exactly as a document element is (§4.3) — the
+    // click keeps its existing meaning, and the action bar follows the selection.
+    const cards = await screen.findAllByTestId('chapter-card');
+    await user.click(cards[1]!);
+    expect(screen.getByTestId('step-comment-open')).toHaveAttribute('data-index', '1');
+
+    await user.click(screen.getByTestId('step-comment-open'));
+    await user.type(screen.getByTestId('step-comment-input'), 'Add TWO hoodies to the cart');
+    await user.click(screen.getByTestId('step-comment-add'));
+    expect(cards[1]).toHaveAttribute('data-comments', '1');
+
+    await user.click(screen.getByTestId('step-feedback-submit'));
+
+    // The request: one bus event naming the version, the step anchor and the target.
+    const emitted = calls.filter((c) => c.url.includes('/api/events'));
+    const feedback = emitted.find((c) =>
+      (c.body as { event_type?: string }).event_type === 'wicked.interactive.feedback.submitted');
+    expect(feedback?.body).toMatchObject({
+      payload: {
+        document_id: DEMO,
+        version: 2,
+        target: 'demo_step',
+        items: [{ wid: 'step-1', comment: 'Add TWO hoodies to the cart' }],
+      },
+    });
+
+    // The result: the SERVICE's spec now differs at that step, and the storyboard shows
+    // the spec that came back rather than the one it mounted with (§7.10's continuation).
+    expect(spec()[1]?.title).toBe('Add TWO hoodies to the cart');
+    expect(spec()[0]?.title).toBe('Open the storefront');
+    await waitFor(() => expect(screen.getAllByTestId('chapter-card')[1])
+      .toHaveTextContent('Add TWO hoodies to the cart'));
+    expect(screen.getAllByTestId('chapter-card')[0]).toHaveTextContent('Open the storefront');
+  });
+
+  it('AC: a submitted batch offers the RE-RECORD — a new spec is not a new video', async () => {
+    const user = userEvent.setup();
+    const { calls } = stubBridge();
+    mount();
+
+    const cards = await screen.findAllByTestId('chapter-card');
+    await user.click(cards[1]!);
+    await user.click(screen.getByTestId('step-comment-open'));
+    await user.type(screen.getByTestId('step-comment-input'), 'two hoodies');
+    await user.click(screen.getByTestId('step-comment-add'));
+    await user.click(screen.getByTestId('step-feedback-submit'));
+
+    const offer = await screen.findByTestId('demo-rerecord');
+    expect(screen.getByTestId('demo-actions')).toHaveTextContent('was re-authored from your comments');
+    await user.click(offer);
+
+    await waitFor(() => expect(calls.some((c) =>
+      c.method === 'POST' && /\/api\/demo\/record$/.test(c.url))).toBe(true));
+    // §2.3: the re-record ask is a message, and the recorder is now the live state.
+    const messages = useDocThreadStore.getState().messages[KEY] ?? [];
+    expect(messages.some((m) => m.kind === 'user' && m.text.includes('Re-record'))).toBe(true);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('N comments across steps go as ONE message, and the batch clears on submit', async () => {
+    const user = userEvent.setup();
+    const { calls } = stubBridge();
+    mount();
+
+    const cards = await screen.findAllByTestId('chapter-card');
+    for (const [i, text] of [[1, 'two hoodies'], [2, 'slow down here']] as [number, string][]) {
+      await user.click(cards[i]!);
+      await user.click(screen.getByTestId('step-comment-open'));
+      await user.type(screen.getByTestId('step-comment-input'), text);
+      await user.click(screen.getByTestId('step-comment-add'));
+    }
+    expect(screen.getByTestId('step-feedback-submit')).toHaveAttribute('data-count', '2');
+
+    await user.click(screen.getByTestId('step-feedback-submit'));
+
+    await waitFor(() => expect(screen.queryByTestId('step-feedback-submit')).toBeNull());
+    const feedback = calls.filter((c) =>
+      (c.body as { event_type?: string })?.event_type === 'wicked.interactive.feedback.submitted');
+    expect(feedback).toHaveLength(1);
+    expect((feedback[0]?.body as { payload: { items: unknown[] } }).payload.items).toHaveLength(2);
+  });
+});
+
+// ── 3. The recording status (§3.3, §3.4) ────────────────────────────────────
+
+describe('the recording status names what is happening (§3.3)', () => {
+  it('AC: it is never a bare "Working…" — the streamed line is filtered at the seam', async () => {
+    stubBridge();
+    mount();
+    await screen.findAllByTestId('chapter-card');
+
+    act(() => {
+      useDocThreadStore.getState().ingest(status('Working…'));
+      useDocThreadStore.getState().ingest(status('Working'));
+    });
+
+    const line = await screen.findByTestId('demo-record-status');
+    expect(line).not.toHaveTextContent('Working…');
+    // Rule 3: the fallback is the demo and its first step — a subject the client already
+    // holds, which is exactly why the bare line is never needed.
+    expect(line).toHaveTextContent(`Recording “${DEMO}” — 3 steps, starting at “Open the storefront”.`);
+  });
+
+  it('a real streamed line WINS over the fallback, and the newest one is shown', async () => {
+    stubBridge();
+    mount();
+    await screen.findAllByTestId('chapter-card');
+
+    act(() => {
+      useDocThreadStore.getState().ingest(status('Step 1 of 3 — Open the storefront'));
+      useDocThreadStore.getState().ingest(status('Working…'));
+      useDocThreadStore.getState().ingest(status('Step 2 of 3 — Add a hoodie to the cart'));
+    });
+
+    expect(await screen.findByTestId('demo-record-status'))
+      .toHaveTextContent('Step 2 of 3 — Add a hoodie to the cart');
+  });
+
+  it('the status shows only while the recorder is running, and editing is not offered then', async () => {
+    stubBridge();
+    mount();
+    await screen.findAllByTestId('chapter-card');
+    expect(screen.queryByTestId('demo-record-status')).toBeNull();
+    expect(screen.getByTestId('step-comment-open')).toBeInTheDocument();
+
+    act(() => { useDocThreadStore.getState().ingest(status('Step 1 of 3 — Open the storefront')); });
+
+    expect(await screen.findByTestId('demo-record-status')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-comment-open')).toBeNull();
+  });
+});

--- a/tests/VideoStoryboard.test.tsx
+++ b/tests/VideoStoryboard.test.tsx
@@ -140,8 +140,10 @@ describe('storyboard chapters (§4.5)', () => {
     render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
     await screen.findByTestId('demo-gif');
 
+    // Spec, recording AND the version manifest slice 14 reads to know what a step
+    // comment is commenting ON — every one of them under the project's proxy mount.
     for (const url of seen) {
-      expect(url).toContain(`/api/v1/projects/${PROJECT}/interactive/d/${DEMO}/api/demo/`);
+      expect(url).toContain(`/api/v1/projects/${PROJECT}/interactive/d/${DEMO}/api/`);
       expect(url).not.toContain('4400');
     }
     expect((screen.getByTestId('demo-gif') as HTMLImageElement).getAttribute('src'))

--- a/tests/demoWire.test.ts
+++ b/tests/demoWire.test.ts
@@ -1,0 +1,228 @@
+// Video mode's wires — DES-MERGE-001 §4.5, §2.3, §7.7, §6.4 slice 14.
+//
+// Everything here is a claim about a REQUEST SHAPE or about what lands in the thread,
+// because those are the two things the merge is made of: the service is model-free and
+// must be told exactly what to record (ADR-0018), and an action the user took that leaves
+// no trace in the transcript makes the transcript stop being the record (§2.3).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDemoFromDraft, demoBrief, demoDraftBody, draftReady, recordFromThread,
+  recordingSubject, stepReady, stepTitle, stepWid, submitStepFeedback, type DemoDraft,
+} from '../src/interactive/demoWire.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const createDoc = vi.fn();
+const requestRecord = vi.fn();
+const postEvent = vi.fn();
+const injectDocMessage = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: (...a: unknown[]) => createDoc(...a),
+  requestRecord: (...a: unknown[]) => requestRecord(...a),
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (...a: unknown[]) => injectDocMessage(...a),
+}));
+
+const PROJECT = 'proj-abc-123';
+const DEMO = 'checkout-walkthrough';
+const KEY = threadKey(PROJECT, DEMO);
+
+const DRAFT: DemoDraft = {
+  name: 'a demo of the checkout flow',
+  targetUrl: 'https://shop.example/ ',
+  steps: [
+    { subject: 'the storefront', action: 'open it' },
+    { subject: 'the cart', action: 'add a hoodie to it' },
+    { subject: 'the card form', action: 'fill it in' },
+  ],
+};
+
+function messages(key = KEY): DocMsg[] {
+  return useDocThreadStore.getState().messages[key] ?? [];
+}
+
+beforeEach(() => {
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  createDoc.mockResolvedValue({ name: DEMO, head: 1, kind: 'demo' });
+  requestRecord.mockResolvedValue({ queued: true });
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  injectDocMessage.mockResolvedValue({ ok: true, event_id: 'e2', correlation_id: 'c1' });
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+// ── 1. The ordered wizard (§4.5, §4.1) ───────────────────────────────────────
+
+describe('the ordered demo wizard — order is the thing it exists to carry', () => {
+  it('AC: `index` is the AUTHORING position, so spec order cannot drift from wizard order', () => {
+    const body = demoDraftBody(PROJECT, DRAFT, 'dmsg-7');
+
+    expect(body.demo_steps?.map((s) => s.index)).toEqual([0, 1, 2]);
+    expect(body.demo_steps?.map((s) => s.subject))
+      .toEqual(['the storefront', 'the cart', 'the card form']);
+    // Re-ordering the draft re-numbers the spec — position IS the index, always.
+    const swapped = demoDraftBody(
+      PROJECT, { ...DRAFT, steps: [DRAFT.steps[2]!, DRAFT.steps[0]!, DRAFT.steps[1]!] }, 'dmsg-7',
+    );
+    expect(swapped.demo_steps?.map((s) => s.subject))
+      .toEqual(['the card form', 'the storefront', 'the cart']);
+    expect(swapped.demo_steps?.map((s) => s.index)).toEqual([0, 1, 2]);
+  });
+
+  it('AC: the submission is a demo, bound to its project, with its target and anchor', () => {
+    const body = demoDraftBody(PROJECT, DRAFT, 'dmsg-7');
+
+    expect(body).toMatchObject({
+      name: 'a demo of the checkout flow',
+      kind: 'demo',
+      url: 'https://shop.example/',      // trimmed — the service gets what it can open
+      project: PROJECT,
+      source_message_id: 'dmsg-7',       // §7.6: the version this lands tags this message
+    });
+    expect(body.demo_steps).toHaveLength(3);
+    expect(body.demo_steps?.[1]).toEqual({ index: 1, subject: 'the cart', action: 'add a hoodie to it' });
+  });
+
+  it('a step names WHAT and TO WHAT, or it is not authored', () => {
+    expect(stepReady({ subject: 'the cart', action: 'add a hoodie' })).toBe(true);
+    expect(stepReady({ subject: 'the cart', action: '   ' })).toBe(false);
+    expect(stepReady({ subject: '', action: 'click it' })).toBe(false);
+    expect(stepTitle({ subject: ' the cart ', action: ' add a hoodie ' })).toBe('the cart — add a hoodie');
+  });
+
+  it('is submittable only with a real target and at least one complete step', () => {
+    expect(draftReady(DRAFT)).toBe(true);
+    expect(draftReady({ ...DRAFT, steps: [] })).toBe(false);
+    expect(draftReady({ ...DRAFT, targetUrl: 'shop.example' })).toBe(false);   // no scheme to open
+    expect(draftReady({ ...DRAFT, targetUrl: '' })).toBe(false);
+    expect(draftReady({ ...DRAFT, name: '  ' })).toBe(false);
+    expect(draftReady({ ...DRAFT, steps: [...DRAFT.steps, { subject: 'x', action: '' }] })).toBe(false);
+  });
+
+  it('AC: completion opens the demo conversation with the authored spec as its first line', async () => {
+    const { name, text } = await createDemoFromDraft(PROJECT, DRAFT, 'dmsg-7');
+
+    expect(name).toBe(DEMO);
+    expect(text).toBe(demoBrief(DRAFT));
+    expect(text).toBe([
+      'Record a demo of https://shop.example/:',
+      '1. the storefront — open it',
+      '2. the cart — add a hoodie to it',
+      '3. the card form — fill it in',
+    ].join('\n'));
+
+    // The thread the messages land in is the CREATED demo's, not the typed name's.
+    const thread = messages();
+    expect(thread[0]).toMatchObject({ kind: 'user', id: 'dmsg-7', text });
+    expect(thread[1]?.kind).toBe('narration');
+    // §3.3: the line names the demo, the count, and the target — never a bare status.
+    expect((thread[1] as Extract<DocMsg, { kind: 'narration' }>).text)
+      .toBe(`Authored “${DEMO}” — 3 steps against https://shop.example/. `
+        + 'Recording runs them in a real browser.');
+    // §7.6: the version this generation lands tags the message that triggered it.
+    expect(useDocThreadStore.getState().anchor[KEY]).toBe('dmsg-7');
+  });
+});
+
+// ── 2. Recording (§2.3, §3.3) ────────────────────────────────────────────────
+
+describe('recording is a message, not a side channel (§2.3)', () => {
+  it('AC: the ask and an INFORMATIVE opening line land, then the proxied wire is called', async () => {
+    await recordFromThread({
+      projectId: PROJECT, demoId: DEMO, ask: `Record “${DEMO}”.`, steps: 5, first: 'Open the storefront',
+    });
+
+    expect(requestRecord).toHaveBeenCalledWith(PROJECT, DEMO);
+    const thread = messages();
+    expect(thread[0]).toMatchObject({ kind: 'user', text: `Record “${DEMO}”.` });
+    expect(thread[1]).toMatchObject({
+      kind: 'narration',
+      text: `Recording “${DEMO}” — 5 steps, starting at “Open the storefront”.`,
+    });
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('every opening line names its subject, with or without a spec in hand', () => {
+    expect(recordingSubject(DEMO)).toBe(`Recording “${DEMO}” — running its authored steps in a real browser.`);
+    expect(recordingSubject(DEMO, 1)).toBe(`Recording “${DEMO}” — 1 step, in a real browser.`);
+    expect(recordingSubject(DEMO, 4)).toBe(`Recording “${DEMO}” — 4 steps, in a real browser.`);
+  });
+
+  it('a refused request retires the working state and rethrows for its retry (§3.3)', async () => {
+    requestRecord.mockRejectedValueOnce(new Error('API 503: recorder busy'));
+
+    await expect(recordFromThread({ projectId: PROJECT, demoId: DEMO, ask: 'Record it.', steps: 2 }))
+      .rejects.toThrow('recorder busy');
+
+    // The ask STAYS: what was asked is not erased by the service refusing it.
+    expect(messages().filter((m) => m.kind === 'user')).toHaveLength(1);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('terminal');
+  });
+});
+
+// ── 3. Step-targeted feedback → a SPEC diff (§4.3, §4.5, §7.7) ───────────────
+
+describe('commenting on a step asks for the SPEC to be re-authored', () => {
+  it('AC: the request names the version, the step anchors, and demo_step as the target', async () => {
+    await submitStepFeedback(PROJECT, DEMO, 2, [
+      { index: 1, text: '  add TWO hoodies, not one  ' },
+      { index: 3, text: 'pause on the receipt' },
+    ]);
+
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    const [project, event] = postEvent.mock.calls[0] as [string, {
+      event_type: string; payload: Record<string, unknown>;
+    }];
+    expect(project).toBe(PROJECT);
+    expect(event.event_type).toBe('wicked.interactive.feedback.submitted');
+    expect(event.payload).toMatchObject({
+      document_id: DEMO,
+      version: 2,
+      // What makes this a spec diff rather than an HTML fragment edit — and therefore
+      // what keeps the re-record deterministic instead of a fresh take (ADR-0018).
+      target: 'demo_step',
+      items: [
+        { wid: 'step-1', comment: 'add TWO hoodies, not one' },
+        { wid: 'step-3', comment: 'pause on the receipt' },
+      ],
+    });
+    expect(stepWid(1)).toBe('step-1');
+  });
+
+  it('AC: N step comments are ONE message and ONE regeneration (§4.3)', async () => {
+    await submitStepFeedback(PROJECT, DEMO, 2, [
+      { index: 1, text: 'two hoodies' }, { index: 3, text: 'pause here' },
+    ]);
+
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(injectDocMessage).toHaveBeenCalledTimes(1);
+    const user = messages().filter((m) => m.kind === 'user');
+    expect(user).toHaveLength(1);
+    expect(user[0]?.text).toBe([
+      'Feedback on 2 places in this demo:',
+      '1. [step-1] two hoodies',
+      '2. [step-3] pause here',
+    ].join('\n'));
+    // Each item stays deep-linkable to the step it targets (§4.3's jump-to affordance).
+    expect((user[0] as Extract<DocMsg, { kind: 'user' }>).items?.map((i) => i.wid))
+      .toEqual(['step-1', 'step-3']);
+  });
+
+  it('a failed inject leaves the batch standing with its retry (§7.7) — the spec still changed', async () => {
+    injectDocMessage.mockRejectedValueOnce(new Error('API 500: run not found'));
+
+    const { recorded } = await submitStepFeedback(PROJECT, DEMO, 2, [{ index: 1, text: 'two hoodies' }]);
+
+    expect(recorded).toBe(false);
+    expect(postEvent).toHaveBeenCalledTimes(1);   // write 1 landed: the demo IS re-authoring
+    expect(messages()[0]).toMatchObject({ kind: 'user', notRecorded: true });
+  });
+
+  it('a failed bus event writes NOTHING — nothing was submitted', async () => {
+    postEvent.mockRejectedValueOnce(new Error('API 403: not emittable'));
+
+    await expect(submitStepFeedback(PROJECT, DEMO, 2, [{ index: 1, text: 'two hoodies' }]))
+      .rejects.toThrow('not emittable');
+    expect(injectDocMessage).not.toHaveBeenCalled();
+    expect(messages()).toHaveLength(0);
+  });
+});

--- a/tests/narration.bare.test.ts
+++ b/tests/narration.bare.test.ts
@@ -1,0 +1,104 @@
+// The other banned status shape — DES-MERGE-001 §3.3, §3.4, §6.4 slice 14.
+//
+// §3.2 got the whimsy out at the seam (slice 10). §3.3 bans a second shape for exactly
+// the same reason, and slice 14's AC pins it: a bare `Working…` is neither actionable
+// (there is nothing to do) nor informative (it says nothing about THIS run). The reason
+// it is never needed is rule 3 — there is always a truthful subject available from state
+// the client already holds — so this file asserts both halves: the bare line never
+// reaches a surface, and something with a subject is always there in its place.
+import { describe, expect, it } from 'vitest';
+import { isBare, isFiller, isWhimsy, statusLine } from '../src/store/narration.js';
+import { useDocThreadStore } from '../src/store/docThread.js';
+import { docActivityOf } from '../src/store/runtime.js';
+import type { CoreEvent } from '../src/api/types.js';
+
+const PROJECT = 'proj-abc';
+const DEMO = 'checkout-walkthrough';
+const KEY = `${PROJECT}:${DEMO}`;
+
+/** The bare shapes an agent falls back to when it has nothing specific to say. */
+const BARE = ['Working…', 'Working', 'working...', 'WORKING …', 'Processing…', 'Thinking…',
+  'Running…', 'Busy…', 'Loading…', 'Please wait…', 'One moment…'];
+
+/** …and the lines that merely START like one, which are real narration (§3.3). */
+const REAL = [
+  'Working on the hero section',
+  'Processing step 2 of 5 — Add a hoodie to the cart',
+  'Running the checkout spec in a real browser',
+  'Loading the storefront',
+];
+
+function frame(payload: Record<string, unknown>): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: {
+      event_type: 'wicked.interactive.status.posted',
+      payload: { project_id: PROJECT, document_id: DEMO, ...payload },
+    },
+  } as unknown as CoreEvent;
+}
+
+describe('a status with no subject is filler (§3.3)', () => {
+  it('recognizes the bare shapes, in any casing or punctuation', () => {
+    for (const line of BARE) {
+      expect(isBare(line), line).toBe(true);
+      expect(isFiller(line), line).toBe(true);
+    }
+  });
+
+  it('keeps every line that names what it is working ON', () => {
+    for (const line of REAL) {
+      expect(isBare(line), line).toBe(false);
+      expect(isFiller(line), line).toBe(false);
+    }
+  });
+
+  it('is a SECOND rule, not a renaming of the first', () => {
+    expect(isWhimsy('Working…')).toBe(false);        // not on interactive's WHIMSY list
+    expect(isBare('Reticulating splines…')).toBe(false);  // not subject-less, just nonsense
+    expect(isFiller('Reticulating splines…')).toBe(true);
+    expect(isFiller('Rewriting slide 3 — tightening the headline')).toBe(false);
+  });
+});
+
+describe('the filter is applied at the seam, so no surface can render it', () => {
+  it('AC: a bare status never reaches the transcript — but its state transition does', () => {
+    const { ingest } = useDocThreadStore.getState();
+    useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+
+    for (const line of BARE) ingest(frame({ state: 'working', message: line }));
+    expect(useDocThreadStore.getState().messages[KEY] ?? []).toEqual([]);
+    // Dropping the LINE is not dropping the FACT that the recorder is running.
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+
+    ingest(frame({ state: 'working', message: 'Step 2 of 5 — Add a hoodie to the cart' }));
+    expect((useDocThreadStore.getState().messages[KEY] ?? [])
+      .map((m) => (m.kind === 'narration' ? m.text : m.kind)))
+      .toEqual(['Step 2 of 5 — Add a hoodie to the cart']);
+  });
+
+  it('drops it from the board headline too — one rule, both altitudes (§3.4)', () => {
+    expect(docActivityOf(frame({ message: 'Working…' }))).toBeNull();
+    expect(docActivityOf(frame({ message: 'Recording “checkout-walkthrough” — step 2' })))
+      .toMatchObject({ projectId: PROJECT });
+  });
+});
+
+describe('statusLine — §3.4 in its stated priority order', () => {
+  const SUBJECT = 'Recording “checkout-walkthrough” — 5 steps, starting at “Open the storefront”.';
+
+  it('takes the NEWEST line that names something', () => {
+    expect(statusLine(['Opened the storefront', 'Step 2 — Add a hoodie to the cart'], SUBJECT))
+      .toBe('Step 2 — Add a hoodie to the cart');
+  });
+
+  it('AC: never returns a bare "Working…" — it falls back to the derived subject (rule 3)', () => {
+    expect(statusLine(BARE, SUBJECT)).toBe(SUBJECT);
+    expect(statusLine(['Reticulating splines…', 'Working…'], SUBJECT)).toBe(SUBJECT);
+    expect(statusLine([], SUBJECT)).toBe(SUBJECT);
+    expect(statusLine(['   '], SUBJECT)).toBe(SUBJECT);
+    // A real line followed by filler still resolves to the real line, not the fallback.
+    expect(statusLine(['Step 3 — Enter the card details', 'Working…'], SUBJECT))
+      .toBe('Step 3 — Enter the card details');
+  });
+});


### PR DESCRIPTION
Slice 14, authored by governed run `eb3793c7-90c0-4e2f-a148-36062914ee0a` (deliver phase misfired on a HEAD-on-main worktree — hardened in the overlay, tracked in crew#293; PR opened by the operator from the run branch).

Recording wired through the thread with informative narration (bare 'Working…' banned by test), the §4.5 ordered wizard for new demos, and step-targeted feedback producing a spec-diffed version + re-record offer, rendered as a §7.10 continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)