### PR TITLE
feat(document): exports as thread artifacts + board quick action (DES-MERGE-001 slice 15)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -80,7 +80,14 @@ What "independent" means here, and what this script proves end-to-end:
      recording bytes fetched through the proxy, and the ffmpeg-absent demo shows the
      service's install command VERBATIM while still rendering its full storyboard —
      degradation, not a crash (§4.5).
- 16. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
+ 16. (DES-MERGE-001 slice 15) exports are thread artifacts: the version strip offers
+     all three formats for the version it has SELECTED — v3, while the head is the v4
+     §13 forked — a PDF export lands in the transcript as an ordinary downloadable
+     message and really downloads, named `<doc-slug>_v3.pdf`, from the page's own
+     origin; and a PPTX export with python-pptx absent renders the service's 400 as an
+     actionable message carrying the install command verbatim, with the document still
+     framed at v3 and its composer still taking input (§4.4).
+ 17. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
      ranked: in one DOM snapshot an executing card carries the breathing 2px
      `live-edge` element while a gate-waiting card carries a treatment that is
      present at the same time and different in computed pixels (wider, solid,
@@ -1008,6 +1015,13 @@ try:
     VERSIONS_RE = re.compile(r"^/d/([^/]+)/api/versions$")
     RENDER_RE = re.compile(r"^/d/([^/]+)/doc/(\d+)$")
     FORK_RE = re.compile(r"^/d/([^/]+)/api/fork$")
+    # Slice 15 (§4.4): all three exports are the SERVICE's, and PPTX's python-pptx is a
+    # LAZY dependency — absent on this box, as on most — so it answers a clean 400 naming
+    # the command that fixes it. HTML and PDF depend on nothing optional and still render.
+    EXPORT_RE = re.compile(r"^/d/([^/]+)/api/export$")
+    DOWNLOAD_RE = re.compile(r"^/d/([^/]+)/download/(.+)$")
+    PPTX_HINT = "pip install python-pptx (PPTX export needs it; HTML and PDF do not)"
+    export_requests: list[dict] = []
     WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
     class DocFixtureHandler(SimpleHTTPRequestHandler):
@@ -1111,6 +1125,14 @@ try:
                                 .replace("__V__", m.group(2)))
                 self._send(200, html.encode(), "text/html; charset=utf-8")
                 return True
+            m = DOWNLOAD_RE.match(rest)
+            if m:
+                # Deliberately NO Content-Disposition. The name the browser saves under has
+                # to come from the SPA's own `download` attribute (§4.4's doc-slug naming),
+                # or the AC would be asserting this fixture's header instead of the client.
+                self._send(200, f"%PDF-1.4 {urllib.parse.unquote(m.group(2))}".encode(),
+                           "application/octet-stream")
+                return True
             return False
 
         def do_GET(self):  # noqa: N802 (stdlib naming)
@@ -1170,6 +1192,22 @@ try:
             return self._json(200, {"name": slug, "head": 1, "kind": kind,
                                     "generating": True, "project_id": body.get("project")})
 
+        def _export(self, name: str) -> None:
+            """`POST /d/:docId/api/export` — render ONE version in ONE format (§4.4).
+            `downloadBase(dir, version)`'s naming is the service's: doc-slug, never
+            `export_v3.*`."""
+            body = self._body()
+            fmt, version = str(body.get("format") or ""), body.get("version")
+            export_requests.append({"doc": name, "format": fmt, "version": version})
+            if fmt == "pptx":
+                # A clean 400 with the install hint — not a 500, and not the install gate
+                # that blocks ordinary documents. The document is untouched.
+                return self._json(400, {"error": "pptx export unavailable: python-pptx is not importable",
+                                        "hint": PPTX_HINT})
+            file = f"{name}_v{version}.{fmt}"
+            return self._json(200, {"format": fmt, "path": f"/exports/{file}", "file": file,
+                                    "download": f"/d/{name}/download/{file}"})
+
         def _emit(self) -> None:
             """`POST /api/events` — the GENERATING/GATED composer's wire (§2.2 cases 2-3)
             and both of the feedback batch's writes (§7.7)."""
@@ -1221,6 +1259,9 @@ try:
                     return self._json(200, {"queued": True})
                 if fork:
                     return self._fork(urllib.parse.unquote(fork.group(1)))
+                exporting = EXPORT_RE.match(rest)
+                if exporting:
+                    return self._export(urllib.parse.unquote(exporting.group(1)))
                 if rest == "/api/docs":
                     return self._create_doc(project)
                 if rest == "/api/events":
@@ -2188,13 +2229,134 @@ try:
                          "slice14-step-comment.png", "slice14-respec.png",
                          "slice14-rerecord.png")],
     }
-    docd.shutdown()  # last section on the same-origin rig
-
     if not report["steps"]["video_record"]["ok"]:
         fail("video_record_verdict",
              "slice-14 record/re-record assertions did not all hold — see video_record")
 
-    # ── 18. Operator UX directive: the live edge on the board ──────────────────
+    # ── 18. Slice 15 (DES-MERGE-001 §4.4, §6.4): exports as thread artifacts ──
+    # Same same-origin rig; the fake bridge now renders exports and serves them back
+    # through the proxy. Two claims, and the second is the one that decides whether the
+    # merged app is safe to put in front of someone:
+    #
+    #   · a PDF export from the version strip yields a real DOWNLOAD, named
+    #     `<doc-slug>_v<N>.pdf` for the version the strip has selected — which is NOT the
+    #     head here, because §13 forked this document to v4, so "export what is shown"
+    #     and "export the latest" cannot pass for each other;
+    #   · a PPTX export with python-pptx absent renders the service's 400 as an
+    #     ACTIONABLE message carrying the install command verbatim, and the document
+    #     stays usable — the frame is still live and the composer still takes input.
+    #
+    # The download is asserted through the browser's own download event, on the PAGE's
+    # origin: §5.3's "no second origin" has to hold for artifacts too.
+    EXPORT_VERSION = 3
+    EXPORT_FILE = f"{STRIP_DOC}_v{EXPORT_VERSION}.pdf"
+    IN_FLIGHT = f"Exporting “{STRIP_DOC}” v{EXPORT_VERSION} as PDF"
+    exports_before = len(export_requests)
+    export_console: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(accept_downloads=True)
+        # This section DRIVES a 400 (§4.4's pptx refusal) and chromium logs every failed
+        # fetch at error level. The claim under test is that the APP turns that 400 into an
+        # actionable message — asserted directly, below — so the browser's own network log
+        # is filtered here in the same spirit as the fonts CDN. Every other error counts.
+        page.on("console", lambda m: export_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text
+                and "status of 400" not in m.text else None)
+        page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document/{STRIP_DOC}?v={EXPORT_VERSION}",
+                  wait_until="domcontentloaded")
+        menu = page.locator('[data-testid="export-menu"]')
+        menu.wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        menu_version = menu.get_attribute("data-version")
+        offered = page.locator('[data-testid="export-format"]')
+        offered_formats = [offered.nth(i).get_attribute("data-format") for i in range(offered.count())]
+
+        # ── AC: a PDF export yields a download named <doc-slug>_v<N>.pdf ───────────
+        page.click('[data-testid="export-menu"] [data-format="pdf"]')
+        link = page.locator('[data-testid="doc-artifact-download"]').last
+        link.wait_for(timeout=30000)
+        # The in-flight line stays in the transcript, so it is read back rather than
+        # raced: §3.3 informative means it named its format and its version, not "…".
+        thread_text = page.evaluate(
+            """() => document.querySelector('[data-testid="thread"]')?.innerText ?? ''""")
+        download_attr = link.get_attribute("download")
+        # RESOLVED, not the attribute: §5.3's "no second origin" is a claim about where the
+        # browser actually goes for the bytes, and only the resolved href says that.
+        download_href = link.evaluate("el => el.href")
+        with page.expect_download() as pending:
+            link.click()
+        suggested = pending.value.suggested_filename
+        page.screenshot(path=str(SHOTS / "slice15-export-download.png"), full_page=True)
+
+        # ── AC: PPTX with python-pptx absent — actionable hint, document still usable ──
+        page.click('[data-testid="export-menu"] [data-format="pptx"]')
+        actionable = page.locator('[data-testid="doc-actionable"]')
+        actionable.wait_for(timeout=30000)
+        hint_text = page.locator('[data-testid="doc-actionable-hint"]').inner_text()
+        retry_offered = page.locator('[data-testid="doc-actionable-retry"]').is_visible()
+        # "Leaves the doc usable" is not a claim about the absence of a crash: the frame is
+        # still rendering the version that was selected, and the composer still takes input.
+        canvas_after = page.locator('[data-testid="doc-canvas"]').get_attribute("data-version")
+        frame_after = page.frame_locator('[data-testid="doc-canvas"]').locator(
+            "[data-wid='h1']").inner_text()
+        page.fill('[data-testid="doc-composer"]', "and now make the intro punchier")
+        composer_after = page.input_value('[data-testid="doc-composer"]')
+        page.screenshot(path=str(SHOTS / "slice15-pptx-absent.png"), full_page=True)
+        browser.close()
+
+    docd.shutdown()  # last section on the same-origin rig
+
+    new_exports = export_requests[exports_before:]
+    expected_href = (f"/api/v1/projects/{urllib.parse.quote(doc_project)}"
+                     f"/interactive/d/{STRIP_DOC}/download/{EXPORT_FILE}")
+    report["steps"]["exports"] = {
+        "ok": all([
+            # All three formats, per version, from the surface that owns the selection.
+            offered_formats == ["html", "pdf", "pptx"],
+            menu_version == str(EXPORT_VERSION),
+            # The request named the SELECTED version — v4 exists and is the head.
+            new_exports == [{"doc": STRIP_DOC, "format": "pdf", "version": EXPORT_VERSION},
+                            {"doc": STRIP_DOC, "format": "pptx", "version": EXPORT_VERSION}],
+            # The artifact: in the thread, named, and downloadable on the page's origin.
+            IN_FLIGHT in thread_text,
+            EXPORT_FILE in thread_text,
+            download_attr == EXPORT_FILE,
+            download_href == f"{DOC_ORIGIN}{expected_href}",
+            suggested == EXPORT_FILE,
+            # The refusal: the service's command, verbatim, with the retry beside it.
+            hint_text.strip() == PPTX_HINT,
+            retry_offered,
+            # …and the document did not go anywhere.
+            canvas_after == str(EXPORT_VERSION),
+            f"version {EXPORT_VERSION}" in frame_after,
+            composer_after == "and now make the intro punchier",
+            not export_console,
+        ]),
+        "doc": STRIP_DOC,
+        "exported_version": EXPORT_VERSION,
+        "head_version_at_the_time": 4,
+        "formats_offered": offered_formats,
+        "requests_seen_by_bridge": new_exports,
+        "in_flight_line_in_thread": IN_FLIGHT in thread_text,
+        "download_attribute": download_attr,
+        "download_href": download_href,
+        "downloaded_filename": suggested,
+        "pptx_hint_rendered": hint_text,
+        "pptx_hint_expected": PPTX_HINT,
+        "pptx_retry_offered": retry_offered,
+        "doc_still_framed_at": canvas_after,
+        "doc_frame_heading": frame_after,
+        "composer_still_accepts_input": composer_after,
+        "console_errors": export_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice15-export-download.png", "slice15-pptx-absent.png")],
+    }
+    if not report["steps"]["exports"]["ok"]:
+        fail("exports_verdict", "slice-15 export assertions did not all hold — see exports")
+
+    # ── 19. Operator UX directive: the live edge on the board ──────────────────
     # The ACTIVE-WORK signal is a breathing 2px strip along the leading edge of the
     # element doing work, and the thing that has to hold is the RANKING: a busy card
     # must be visible without out-shouting a card that needs a human. So both states

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -150,6 +150,22 @@ export class BridgeUnavailableError extends Error {
   }
 }
 
+/**
+ * A 4xx the service answered with a NAMED fix. §4.4's lazy dependency is the case this
+ * exists for: a PPTX export on a box without python-pptx is a clean 400 carrying its
+ * install command — never a crash, and never the install gate that blocks ordinary
+ * documents. `hint` is carried verbatim so the UI renders an *actionable* message rather
+ * than a bare failure (§3.3), exactly as `BridgeUnavailableError` does for the 503.
+ */
+export class ServiceHintError extends Error {
+  readonly hint: string;
+  constructor(message: string, hint: string) {
+    super(message);
+    this.name = 'ServiceHintError';
+    this.hint = hint;
+  }
+}
+
 // ── URL resolution ──────────────────────────────────────────────────────────
 
 /** The proxy mount for one project: `<apiBase>/projects/:projectId/interactive`. */
@@ -197,6 +213,10 @@ async function iFetch<T>(url: string, init?: RequestInit): Promise<T> {
     const raw = body?.error ?? body?.message ?? text;
     const msg = (typeof raw === 'string' ? raw : JSON.stringify(raw))
       || res.statusText || String(res.status);
+    // A refusal that NAMED its fix keeps that name typed all the way to the surface.
+    if (typeof body?.hint === 'string' && body.hint.trim() !== '') {
+      throw new ServiceHintError(`API ${res.status}: ${msg}`, body.hint.trim());
+    }
     throw new Error(`API ${res.status}: ${msg}`);
   }
   return res.json() as Promise<T>;

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createDoc, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
 import { DemoWizard } from './DemoWizard.js';
 import { recordFromThread } from '../interactive/demoWire.js';
+import { runExport } from '../interactive/exportWire.js';
 import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
@@ -108,6 +109,9 @@ function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; doc
       </div>
     );
   }
+  if (msg.kind === 'actionable') {
+    return <ActionableCard msg={msg} projectId={projectId} docId={docId} />;
+  }
   if (msg.kind === 'agent' || msg.kind === 'verdict') {
     return (
       <div className="self-start max-w-[90%] flex flex-col gap-1" data-testid={`doc-${msg.kind}`}>
@@ -118,14 +122,17 @@ function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; doc
              style={{ background: S.card, border: `1px solid ${S.border}`, color: S.ink }}>
           {msg.text}
           {msg.kind === 'agent' && msg.href !== undefined && (
+            // Served THROUGH the proxy, on the page's own origin (§5.3) — there is no
+            // second origin to download from. `download` names the file the service named
+            // (§4.4's doc-slug naming), so what lands on disk is what the message says.
             <a
               data-testid="doc-artifact-download"
               href={interactiveUrl(projectId, msg.href)}
-              download
+              download={msg.file ?? true}
               className="block mt-2 text-xs font-mono underline"
               style={{ color: S.accent }}
             >
-              Download
+              Download {msg.file ?? ''}
             </a>
           )}
         </div>
@@ -133,6 +140,51 @@ function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; doc
     );
   }
   return null;
+}
+
+/**
+ * §3.3's ACTIONABLE kind, rendered: what happened, the service's own fix NAMED verbatim,
+ * and the control that runs it again — all in the same block. Both halves are mandatory
+ * on purpose: a hint with no button is a dead end, and a button with no command is a
+ * retry that fails identically. §4.4's PPTX case is what this exists for — python-pptx
+ * absent is a stated install command and a document that never stopped being usable.
+ */
+function ActionableCard({
+  msg, projectId, docId,
+}: {
+  msg: Extract<DocMsg, { kind: 'actionable' }>; projectId: string; docId: string | null;
+}): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+  const retry = msg.retry;
+  return (
+    <div
+      data-testid="doc-actionable"
+      className="rounded-xl px-3.5 py-3 flex flex-col gap-2"
+      style={{ background: 'rgba(255,218,25,0.06)', border: '1px solid rgba(255,218,25,0.2)' }}
+    >
+      <p className="text-sm leading-relaxed" style={{ color: S.ink, margin: 0 }}>{msg.text}</p>
+      <code data-testid="doc-actionable-hint" className="text-[11px] font-mono whitespace-pre-wrap"
+            style={{ color: S.accent }}>
+        {msg.hint}
+      </code>
+      {retry !== undefined && docId !== null && (
+        <button
+          type="button"
+          data-testid="doc-actionable-retry"
+          disabled={busy}
+          onClick={() => {
+            setBusy(true);
+            void runExport({ projectId, docId, version: retry.version, format: retry.format })
+              .finally(() => setBusy(false));
+          }}
+          className="self-start rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+          style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+        >
+          {busy ? 'Exporting…' : `Export ${retry.format.toUpperCase()} again`}
+        </button>
+      )}
+    </div>
+  );
 }
 
 /**

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import type { ExportFormat } from '../api/interactive.js';
+import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
+
+// The export control (DES-MERGE-001 §4.4, §6.4 slice 15) — ONE component in both places
+// the design puts it: per-version on the document's version strip, and as a quick action
+// on the board card's doc tile (§1.4). "Export this document at this version" is one
+// action wherever it is offered; what differs is only how loud it is on a surface the
+// user is scanning, which is what `compact` is.
+//
+// Everything a READER needs lands in the thread (§4.4, §2.5): the in-flight line, the
+// downloadable artifact, and the install hint of an export that could not run. What stays
+// here is only what the pressed button owes the finger that pressed it — which format is
+// running, and, on the board where no thread is on screen, the reason it stopped.
+
+const S = {
+  border: 'rgba(230,237,243,0.1)',
+  muted:  'rgba(230,237,243,0.55)',
+  faint:  'rgba(230,237,243,0.3)',
+  accent: '#ffda19',
+};
+
+const BUTTON: React.CSSProperties = {
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '5px',
+  color: S.muted, cursor: 'pointer', fontSize: '10px', lineHeight: 1.6, padding: '1px 6px',
+};
+
+/** The tile variant: bare text, because a card is scanned and a box is a claim on the eye. */
+const COMPACT: React.CSSProperties = {
+  background: 'none', border: 'none', color: S.muted, cursor: 'pointer',
+  fontFamily: 'monospace', fontSize: '9px', padding: 0,
+};
+
+export interface ExportMenuProps {
+  projectId: string;
+  docId: string;
+  /** The version to export — the strip's selection, or the tile's head. Never "latest":
+   *  §4.2 addresses versions explicitly, and a download is a thing you keep. */
+  version: number;
+  compact?: boolean;
+}
+
+export function ExportMenu({ projectId, docId, version, compact = false }: ExportMenuProps): React.ReactElement {
+  const [busy, setBusy] = useState<ExportFormat | null>(null);
+  const [hint, setHint] = useState<string | null>(null);
+
+  function run(format: ExportFormat): void {
+    setBusy(format);
+    setHint(null);
+    void runExport({ projectId, docId, version, format })
+      .then((outcome) => { if (!outcome.ok) setHint(outcome.hint); })
+      .finally(() => setBusy(null));
+  }
+
+  return (
+    <div
+      data-testid="export-menu"
+      data-doc-id={docId}
+      data-version={version}
+      style={{ alignSelf: 'center', display: 'flex', flexDirection: 'column',
+               flexShrink: 0, gap: '2px', minWidth: 0 }}
+    >
+      <div style={{ alignItems: 'center', display: 'flex', gap: compact ? '7px' : '5px' }}>
+        {!compact && (
+          <span style={{ color: S.faint, fontSize: '10px', letterSpacing: '0.06em',
+                         textTransform: 'uppercase' }}>
+            Export v{version}
+          </span>
+        )}
+        {EXPORT_FORMATS.map((format) => (
+          <button
+            key={format}
+            type="button"
+            data-testid="export-format"
+            data-format={format}
+            disabled={busy !== null}
+            onClick={() => run(format)}
+            title={`Export “${docId}” v${version} as ${format.toUpperCase()} — it lands in the thread as a download`}
+            style={{ ...(compact ? COMPACT : BUTTON),
+                     color: busy === format ? S.accent : S.muted,
+                     opacity: busy !== null && busy !== format ? 0.4 : 1 }}
+          >
+            {busy === format ? `${format}…` : compact ? format : format.toUpperCase()}
+          </button>
+        ))}
+      </div>
+      {/* §3.3: the reason is stated and the control that retries it is the row above —
+          adjacent, not a toast that takes the fix away with it when it fades. */}
+      {hint !== null && (
+        <span
+          data-testid="export-hint"
+          title={hint}
+          style={{ color: S.accent, fontSize: '9px', fontFamily: 'monospace',
+                   overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {hint}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -57,8 +57,10 @@ export function ExportMenu({ projectId, docId, version, compact = false }: Expor
       data-testid="export-menu"
       data-doc-id={docId}
       data-version={version}
+      // Capped: the hint below can be a whole install command, and a control that grows to
+      // fit its own error message would push the surface it sits on out of the way.
       style={{ alignSelf: 'center', display: 'flex', flexDirection: 'column',
-               flexShrink: 0, gap: '2px', minWidth: 0 }}
+               flexShrink: 0, gap: '2px', maxWidth: '220px', minWidth: 0 }}
     >
       <div style={{ alignItems: 'center', display: 'flex', gap: compact ? '7px' : '5px' }}>
         {!compact && (

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -4,6 +4,7 @@ import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
+import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 import { STATUS_STYLE } from './RunCard.js';
@@ -121,7 +122,9 @@ function Invitation({ text }: { text: string }): React.ReactElement {
 }
 
 /**
- * A doc tile is a PLACEHOLDER — title, kind glyph, updated-at (§7.5). Live-rendered
+ * A doc tile is a PLACEHOLDER — title, kind glyph, updated-at (§7.5) — plus §4.4's quick
+ * action: exporting is the one thing worth doing to a document without opening it, and it
+ * belongs to the DOCUMENT rather than to the project, so it lives on the tile. Live-rendered
  * thumbnails were explicitly deferred: 20 cards × 3 iframes is a browser's worth of
  * documents to keep mounted for a surface the user is only scanning.
  *
@@ -129,7 +132,9 @@ function Invitation({ text }: { text: string }): React.ReactElement {
  * doc dates the tile from the frame, because between `listDocs` calls that event IS
  * the document changing.
  */
-function DocTile({ name, kind, when }: { name: string; kind: string; when: number }): React.ReactElement {
+function DocTile({ projectId, name, kind, head, when }: {
+  projectId: string; name: string; kind: string; head: number; when: number;
+}): React.ReactElement {
   return (
     <div data-testid="doc-tile" data-doc-kind={kind} style={CSS.tile}>
       <p style={CSS.tileName}>
@@ -139,6 +144,8 @@ function DocTile({ name, kind, when }: { name: string; kind: string; when: numbe
       <p style={{ fontSize: '10px', color: S.faint, margin: '2px 0 0', fontFamily: 'monospace' }}>
         {Number.isNaN(when) ? 'not yet edited' : `${ago(when)} ago`}
       </p>
+      {/* The card exports the HEAD — the only version a surface that shows none can mean. */}
+      <ExportMenu projectId={projectId} docId={name} version={head} compact />
     </div>
   );
 }
@@ -208,8 +215,10 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             {docs.slice(0, MAX_TILES).map((d) => (
               <DocTile
                 key={d.name}
+                projectId={project.id}
                 name={d.name}
                 kind={d.kind}
+                head={d.head}
                 when={
                   activity !== undefined && activity.docId === d.name
                     ? activity.at

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { postFork } from '../api/interactive.js';
 import type { ForkResult, VersionEntry, VersionManifest } from '../api/interactive.js';
 import { versionPath, type Navigate } from '../hooks/useRoute.js';
+import { ExportMenu } from './ExportMenu.js';
 import { scrollThreadToMessage } from './threadAnchor.js';
 
 // The rewind / compare / fork surface (DES-MERGE-001 §4.2, §6.3 slice 9). The version
@@ -111,9 +112,13 @@ export function VersionStrip({
       data-testid="version-strip"
       style={{
         alignItems: 'stretch', background: S.bar, borderTop: `1px solid ${S.border}`,
-        display: 'flex', flexShrink: 0, gap: '8px', overflowX: 'auto', padding: '10px 12px',
+        display: 'flex', flexShrink: 0, gap: '8px', padding: '10px 12px',
       }}
     >
+      {/* The versions scroll; the export control does NOT — a doc with 20 versions must
+          not push its own export off the right edge of the surface that addresses it. */}
+      <div style={{ alignItems: 'stretch', display: 'flex', flex: 1, gap: '8px',
+                    minWidth: 0, overflowX: 'auto' }}>
       <span style={{
         alignSelf: 'center', color: S.faint, flexShrink: 0, fontSize: '10px', fontWeight: 600,
         letterSpacing: '0.06em', paddingRight: '2px', textTransform: 'uppercase',
@@ -203,6 +208,12 @@ export function VersionStrip({
           Fork failed: {error} — the document is unchanged; try again.
         </span>
       )}
+      </div>
+
+      {/* §4.4: export is PER-VERSION, so it belongs to the surface that owns which version
+          is addressed. The selection is the subject — exporting "the document" would be
+          exporting whichever version happened to be head when the button was pressed. */}
+      <ExportMenu projectId={projectId} docId={docId} version={selected} />
     </div>
   );
 }

--- a/src/interactive/exportWire.ts
+++ b/src/interactive/exportWire.ts
@@ -1,0 +1,92 @@
+// Exports as thread artifacts (DES-MERGE-001 §4.4, §6.4 slice 15).
+//
+// All three renderers are EMBEDDED in wicked-interactive — cheerio inlining for the
+// self-contained HTML, headless chrome for the PDF, vendored python-pptx for the PPTX —
+// so nothing in this module renders anything. This is the CONVERSATION half of an export:
+//
+//   1. before the artifact exists, an INFORMATIVE line naming its subject — which
+//      document, which version, which format (§3.3: never a bare spinner);
+//   2. when it exists, an ordinary downloadable message authored by the service (§2.5,
+//      §4.4's merged-UI change — studio's `downloadRunEvidence` pattern), served back
+//      through the proxy so there is still exactly one origin (§5.3);
+//   3. when it does not, an ACTIONABLE message carrying the service's own install command
+//      verbatim. §4.4 names PPTX's lazy dependency as the case: missing python-pptx is a
+//      clean 400 with a hint, never a crash, and the document stays usable — so a failed
+//      export changes nothing about the document and this module says exactly that.
+//
+// HTML depends on no optional dependency at all, which is why it is always offered.
+
+import { postExport, ServiceHintError } from '../api/interactive.js';
+import type { ExportFormat, ExportResult } from '../api/interactive.js';
+import { threadKey, useDocThreadStore } from '../store/docThread.js';
+
+/** Offered in §4.4's own order. Parity is all three, from every surface that exports. */
+export const EXPORT_FORMATS: readonly ExportFormat[] = ['html', 'pdf', 'pptx'];
+
+/**
+ * `downloadBase(dir, version)`'s naming rule, client-side: doc-SLUG names (`roadmap_v3.pdf`),
+ * never `export_v3.*` (§4.4). The service is the authority — its `file` is taken verbatim
+ * whenever it answers with one — and this derivation names the artifact before the reply
+ * exists, and names the saved file when a proxied response carries no disposition of its own.
+ */
+export function exportFilename(
+  docId: string, version: number, format: ExportFormat, file?: string | null,
+): string {
+  if (typeof file === 'string' && file.trim() !== '') return file.trim();
+  const slug = docId.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return `${slug === '' ? 'document' : slug}_v${version}.${format}`;
+}
+
+/** §3.3 informative: the subject is WHICH document, at WHICH version, in WHICH format. */
+export function exportSubject(docId: string, version: number, format: ExportFormat): string {
+  return `Exporting “${docId}” v${version} as ${format.toUpperCase()} — rendering it on the service.`;
+}
+
+/** The service's fix, verbatim where it named one (§3.3: show it, never paraphrase it).
+ *  A failure that named none still says what failed, which is the least it can do. */
+export function exportHint(e: unknown): string {
+  if (e instanceof ServiceHintError) return e.hint;
+  return e instanceof Error ? e.message : String(e);
+}
+
+export interface ExportArgs {
+  projectId: string;
+  docId: string;
+  version: number;
+  format: ExportFormat;
+}
+
+/** What the pressed control needs back. Everything a READER needs is in the thread. */
+export type ExportOutcome =
+  | { ok: true; file: string; result: ExportResult }
+  | { ok: false; hint: string };
+
+/**
+ * Export one version and put the whole of it in the conversation. Never throws: a refused
+ * export is a message, not an exception to route around — the document is untouched either
+ * way, and both outcomes are things the transcript is supposed to remember.
+ */
+export async function runExport(
+  { projectId, docId, version, format }: ExportArgs,
+): Promise<ExportOutcome> {
+  const key = threadKey(projectId, docId);
+  const store = useDocThreadStore.getState();
+  store.addNarration(key, exportSubject(docId, version, format));
+  try {
+    const result = await postExport(projectId, docId, version, format);
+    const file = exportFilename(docId, version, format, result.file);
+    store.addAgentMsg(key, 'export', `${format.toUpperCase()} export ready — ${file}`,
+                      { href: result.download, file });
+    return { ok: true, file, result };
+  } catch (e: unknown) {
+    const hint = exportHint(e);
+    store.addActionable(
+      key,
+      `${format.toUpperCase()} export of “${docId}” v${version} did not run. `
+      + 'The document is unchanged and still editable.',
+      hint,
+      { format, version },
+    );
+    return { ok: false, hint };
+  }
+}

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -12,6 +12,7 @@
 
 import { create } from 'zustand';
 import { isFiller } from './narration.js';
+import type { ExportFormat } from '../api/interactive.js';
 import type { CoreEvent } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
@@ -23,6 +24,9 @@ import type { CoreEvent } from '../api/types.js';
  */
 export interface FeedbackItem { wid: string; text: string }
 
+/** What a failed export offers to run again — the same format, at the same version. */
+export interface ExportRetry { format: ExportFormat; version: number }
+
 export type DocMsg =
   // `items` is set only for a submitted feedback batch: ONE message, N targets (§4.3 —
   // sending each comment separately would produce N versions and N runs). `notRecorded`
@@ -31,7 +35,12 @@ export type DocMsg =
   | { kind: 'user';      id: string; text: string; version?: number;
       items?: FeedbackItem[]; notRecorded?: boolean }
   | { kind: 'narration'; id: string; text: string }
-  | { kind: 'agent';     id: string; author: string; text: string; href?: string }
+  // `href` + `file` make an agent message DOWNLOADABLE (§4.4): an export is an ordinary
+  // message from the service, carrying its artifact — never a toast, never a second origin.
+  | { kind: 'agent';     id: string; author: string; text: string; href?: string; file?: string }
+  // §3.3's actionable kind: what happened, the fix NAMED verbatim, and — where the action
+  // repeats — what to retry. An error with no next action is banned, so `hint` is required.
+  | { kind: 'actionable'; id: string; text: string; hint: string; retry?: ExportRetry }
   | { kind: 'verdict';   id: string; author: string; text: string }
   | { kind: 'gate';      id: string; requestId: string; question: string; options: string[] }
   | { kind: 'divider';   id: string; version: number };
@@ -109,6 +118,17 @@ interface DocThreadStore {
   markNotRecorded: (key: string, id: string, notRecorded: boolean) => void;
   /** Append a client-authored informative line (§3.3) — an action the user took. */
   addNarration: (key: string, text: string) => void;
+  /**
+   * Append a service-authored agent message, optionally carrying a downloadable artifact.
+   * The export wire (§4.4, slice 15) adds the finished export from the HTTP response it
+   * already has, so the download is offered the moment it exists rather than whenever the
+   * bus echo arrives. `ingest`'s EXPORTED handler deduplicates on `href`, so the echo that
+   * follows never doubles the entry.
+   */
+  addAgentMsg: (key: string, author: string, text: string,
+                artifact?: { href: string; file?: string }) => void;
+  /** Append an §3.3 ACTIONABLE line — a failure that names its fix, and what to retry. */
+  addActionable: (key: string, text: string, hint: string, retry?: ExportRetry) => void;
   /** The version divider a fork+inject continuation renders behind (§7.10). */
   addDivider: (key: string, version: number) => void;
   setGenState: (key: string, state: GenState) => void;
@@ -190,15 +210,20 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
 
       // An export is a completed artifact, so it lands IN the thread with its download
       // (§4.4's merged-UI change — studio's `downloadRunEvidence` pattern), not a toast.
+      // ExportMenu adds the message immediately from the HTTP response; this WS echo
+      // deduplicates on `href` so the same download never appears twice.
       if (type === EXPORTED) {
         const format = pick(payload, 'format') ?? 'file';
         const file = pick(payload, 'file') ?? format;
         const href = pick(payload, 'download');
+        if (href !== null && (messages[key] ?? []).some(
+          (m) => m.kind === 'agent' && m.href === href,
+        )) return s;
         return {
           messages: append(messages, key, {
             kind: 'agent', id: nextMsgId(), author: 'export',
             text: `${format.toUpperCase()} export ready — ${file}`,
-            ...(href === null ? {} : { href }),
+            ...(href === null ? {} : { href, file }),
           }),
         };
       }
@@ -252,6 +277,23 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
 
   addNarration: (key, text) =>
     set((s) => ({ messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text }) })),
+
+  addAgentMsg: (key, author, text, artifact) =>
+    set((s) => ({
+      messages: append(s.messages, key, {
+        kind: 'agent', id: nextMsgId(), author, text,
+        ...(artifact === undefined ? {} : { href: artifact.href }),
+        ...(artifact?.file === undefined ? {} : { file: artifact.file }),
+      }),
+    })),
+
+  addActionable: (key, text, hint, retry) =>
+    set((s) => ({
+      messages: append(s.messages, key, {
+        kind: 'actionable', id: nextMsgId(), text, hint,
+        ...(retry === undefined ? {} : { retry }),
+      }),
+    })),
 
   addDivider: (key, version) =>
     set((s) => ({ messages: append(s.messages, key, { kind: 'divider', id: nextMsgId(), version }) })),

--- a/tests/DocumentThread.export.test.tsx
+++ b/tests/DocumentThread.export.test.tsx
@@ -1,0 +1,120 @@
+// Exports IN the transcript — DES-MERGE-001 §4.4, §2.5, §3.3, §6.4 slice 15.
+//
+// §4.4's merged-UI change is a rendering claim as much as a wire one: a completed export
+// is an ordinary message that happens to carry a download, and a refused one is an
+// ACTIONABLE message that carries the fix and the control that runs it. Both are asserted
+// here against the real thread, because the transcript is where a user goes looking for
+// an artifact they asked for an hour ago.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { runExport } from '../src/interactive/exportWire.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+
+const postExport = vi.fn();
+
+const { ServiceHintError } = vi.hoisted(() => ({
+  ServiceHintError: class ServiceHintError extends Error {
+    readonly hint: string;
+    constructor(message: string, hint: string) {
+      super(message);
+      this.name = 'ServiceHintError';
+      this.hint = hint;
+    }
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: vi.fn(),
+  postFork: vi.fn(),
+  postEvent: vi.fn(),
+  getVersions: vi.fn(),
+  injectDocMessage: vi.fn(),
+  postExport: (...a: unknown[]) => postExport(...a),
+  ServiceHintError,
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+const PROJECT = 'proj-abc';
+const DOC = 'launch-deck';
+const KEY = threadKey(PROJECT, DOC);
+const PPTX_HINT = 'pip install python-pptx (PPTX export needs it; HTML and PDF do not)';
+
+function mount(): void {
+  render(
+    <DocumentThread projectId={PROJECT} docId={DOC} selectedVersion={3} navigate={() => {}} />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+});
+afterEach(cleanup);
+
+describe('a completed export renders as a download (§4.4, §2.5)', () => {
+  it('AC: the link is served THROUGH the proxy and saves under `<doc-slug>_v<N>.<ext>`', async () => {
+    postExport.mockResolvedValue({
+      format: 'pdf', path: '/exports/launch-deck_v3.pdf', file: 'launch-deck_v3.pdf',
+      download: '/d/launch-deck/download/launch-deck_v3.pdf',
+    });
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+    mount();
+
+    const link = screen.getByTestId('doc-artifact-download');
+    expect(link).toHaveAttribute(
+      'href', `/api/v1/projects/${PROJECT}/interactive/d/launch-deck/download/launch-deck_v3.pdf`,
+    );
+    expect(link).toHaveAttribute('download', 'launch-deck_v3.pdf');
+    // The line above it says which format and which file, in the service's name (§2.5).
+    expect(screen.getByTestId('doc-agent')).toHaveTextContent('PDF export ready — launch-deck_v3.pdf');
+    expect(screen.getByTestId('doc-agent')).toHaveTextContent('export');
+  });
+
+  it('the in-flight line is on screen while it renders, naming its subject (§3.3)', async () => {
+    postExport.mockImplementation(() => new Promise(() => {}));  // never settles
+    void runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+    mount();
+
+    const narration = screen.getByTestId('doc-narration');
+    expect(narration).toHaveTextContent('Exporting “launch-deck” v3 as PDF');
+    expect(narration).not.toHaveTextContent(/^Working…?$/);
+  });
+});
+
+describe('PPTX with python-pptx absent (§4.4, §3.3)', () => {
+  beforeEach(() => {
+    postExport.mockRejectedValue(new ServiceHintError('API 400: pptx export unavailable', PPTX_HINT));
+  });
+
+  it('AC: the install command is rendered VERBATIM and the doc stays interactive', async () => {
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pptx' });
+    mount();
+
+    expect(screen.getByTestId('doc-actionable-hint')).toHaveTextContent(PPTX_HINT);
+    expect(screen.getByTestId('doc-actionable')).toHaveTextContent('still editable');
+    // "The doc stays usable": the composer is live, so the next ask still lands.
+    expect(screen.getByTestId('doc-composer')).toBeEnabled();
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'terminal');
+    expect(screen.queryByTestId('doc-artifact-download')).toBeNull();
+  });
+
+  it('AC: the retry beside it re-runs the SAME format at the SAME version', async () => {
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pptx' });
+    mount();
+    postExport.mockResolvedValue({
+      format: 'pptx', path: '/exports/launch-deck_v3.pptx', file: 'launch-deck_v3.pptx',
+      download: '/d/launch-deck/download/launch-deck_v3.pptx',
+    });
+
+    await userEvent.setup().click(screen.getByTestId('doc-actionable-retry'));
+
+    await waitFor(() => expect(postExport).toHaveBeenLastCalledWith(PROJECT, DOC, 3, 'pptx'));
+    await waitFor(() => expect(screen.getByTestId('doc-artifact-download'))
+      .toHaveAttribute('download', 'launch-deck_v3.pptx'));
+    // The failure stays in the transcript: it is what happened, and it is why the retry exists.
+    expect(useDocThreadStore.getState().messages[KEY]?.filter((m) => m.kind === 'actionable'))
+      .toHaveLength(1);
+  });
+});

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -1,0 +1,147 @@
+// Export from the two surfaces the design puts it on — DES-MERGE-001 §4.4, §1.4, §6.4
+// slice 15: per-version on Document mode's version strip, and as a quick action on the
+// board card's doc tile. The wire underneath is REAL in these cases (only `postExport`
+// is stubbed), because the claim being made is that pressing a control on either surface
+// produces the same request and the same transcript.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProjectCard } from '../src/components/ProjectCard.js';
+import { VersionStrip } from '../src/components/VersionStrip.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const postExport = vi.fn();
+const postFork = vi.fn();
+
+const { ServiceHintError } = vi.hoisted(() => ({
+  ServiceHintError: class ServiceHintError extends Error {
+    readonly hint: string;
+    constructor(message: string, hint: string) {
+      super(message);
+      this.name = 'ServiceHintError';
+      this.hint = hint;
+    }
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  postExport: (...a: unknown[]) => postExport(...a),
+  postFork: (...a: unknown[]) => postFork(...a),
+  ServiceHintError,
+}));
+
+const PROJECT = 'proj-abc';
+const DOC = 'roadmap';
+const PPTX_HINT = 'pip install python-pptx and export again';
+
+const MANIFEST = {
+  head: 3,
+  versions: [1, 2, 3].map((version) => ({
+    version, parent: version - 1 || null, feedback_file: null,
+    html_file: `v${version}.html`, created_at: `2026-08-1${version}T11:30:00Z`,
+  })),
+};
+
+function reply(file: string, format = 'pdf'): Record<string, string> {
+  return { format, path: `/exports/${file}`, file, download: `/d/${DOC}/download/${file}` };
+}
+
+function messages(docId = DOC): DocMsg[] {
+  return useDocThreadStore.getState().messages[threadKey(PROJECT, docId)] ?? [];
+}
+
+function strip(selected = 3): void {
+  render(
+    <VersionStrip
+      projectId={PROJECT}
+      docId={DOC}
+      manifest={MANIFEST}
+      selected={selected}
+      navigate={() => {}}
+      onForked={() => {}}
+    />,
+  );
+}
+
+/** One board card carrying one document — §1.4's card, at the tile that owns the export. */
+function card(): void {
+  const item = {
+    project: {
+      id: PROJECT, name: 'Wicked', description: null, status: 'active',
+      scope: `project:${PROJECT}`, created_at: 1, updated_at: 1,
+    },
+    repo: null,
+    runs: [],
+    docs: [{ name: DOC, kind: 'doc' as const, head: 3, versions: 3, updated_at: '2026-08-18T11:30:00Z' }],
+    attention: 'drafts' as const,
+  } as unknown as BoardProject;
+  render(<ProjectCard item={item} navigate={() => {}} />);
+}
+
+/** Press one format button inside the menu on screen. */
+async function press(format: string, scope?: HTMLElement): Promise<void> {
+  const root = scope ?? screen.getByTestId('export-menu');
+  const button = within(root).getAllByTestId('export-format')
+    .find((b) => b.getAttribute('data-format') === format);
+  await userEvent.setup().click(button as HTMLElement);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  postExport.mockResolvedValue(reply('roadmap_v3.pdf'));
+});
+afterEach(cleanup);
+
+describe('the version strip exports the SELECTED version (§4.4, §4.2)', () => {
+  it('AC: all three formats are offered, per version', () => {
+    strip();
+    const menu = screen.getByTestId('export-menu');
+    expect(menu).toHaveAttribute('data-version', '3');
+    expect(within(menu).getAllByTestId('export-format').map((b) => b.getAttribute('data-format')))
+      .toEqual(['html', 'pdf', 'pptx']);
+  });
+
+  it('exports the version the strip has selected, not the manifest head', async () => {
+    strip(1);
+    await press('pdf');
+    await waitFor(() => expect(postExport).toHaveBeenCalledWith(PROJECT, DOC, 1, 'pdf'));
+  });
+
+  it('the artifact lands in the thread as a download — the strip itself reports nothing', async () => {
+    strip();
+    await press('html');
+    postExport.mockResolvedValue(reply('roadmap_v3.html', 'html'));
+
+    await waitFor(() => expect(messages().some((m) => m.kind === 'agent')).toBe(true));
+    expect(screen.queryByTestId('export-hint')).toBeNull();
+  });
+});
+
+describe('the board card exports without opening the document (§1.4, §4.4)', () => {
+  it('AC: the doc tile offers export at that document’s head version', async () => {
+    card();
+    const menu = within(screen.getByTestId('doc-tile')).getByTestId('export-menu');
+    expect(menu).toHaveAttribute('data-doc-id', DOC);
+    expect(menu).toHaveAttribute('data-version', '3');
+
+    await press('pdf', menu);
+    await waitFor(() => expect(postExport).toHaveBeenCalledWith(PROJECT, DOC, 3, 'pdf'));
+    // The transcript is still where it lands, even though no thread is on screen (§2.5).
+    await waitFor(() => expect(messages()[1]).toMatchObject({ kind: 'agent', author: 'export' }));
+  });
+
+  it('AC: a refusal names its fix ON THE CARD, with the control that retries it adjacent', async () => {
+    postExport.mockRejectedValue(new ServiceHintError('API 400: no python-pptx', PPTX_HINT));
+    card();
+    const menu = within(screen.getByTestId('doc-tile')).getByTestId('export-menu');
+
+    await press('pptx', menu);
+
+    await waitFor(() => expect(within(menu).getByTestId('export-hint')).toHaveTextContent(PPTX_HINT));
+    // §3.3: the control is in the same block, so the retry is one press away.
+    expect(within(menu).getAllByTestId('export-format')).toHaveLength(3);
+    expect(within(menu).getAllByTestId('export-format')[2]).toBeEnabled();
+  });
+});

--- a/tests/exportWire.test.ts
+++ b/tests/exportWire.test.ts
@@ -1,0 +1,200 @@
+// Exports as thread artifacts — DES-MERGE-001 §4.4, §2.5, §3.3, §6.4 slice 15.
+//
+// Two kinds of claim, matching the two things this wire is responsible for: the REQUEST
+// SHAPE it sends (format × version, because a download is a thing you keep and "the
+// latest" is not a version), and what lands in the TRANSCRIPT either way — the artifact
+// when the service renders it, and the service's own install command when it cannot.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EXPORT_FORMATS, exportFilename, exportHint, exportSubject, runExport,
+} from '../src/interactive/exportWire.js';
+import { isFiller } from '../src/store/narration.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const postExport = vi.fn();
+
+/** The real class, mirrored ONCE and shared with the mocked module: `exportHint` narrows
+ *  on it, so a test that constructed a different class would pass for the wrong reason. */
+const { ServiceHintError } = vi.hoisted(() => ({
+  ServiceHintError: class ServiceHintError extends Error {
+    readonly hint: string;
+    constructor(message: string, hint: string) {
+      super(message);
+      this.name = 'ServiceHintError';
+      this.hint = hint;
+    }
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  postExport: (...a: unknown[]) => postExport(...a),
+  ServiceHintError,
+}));
+
+const PROJECT = 'proj-abc';
+const DOC = 'launch-deck';
+const KEY = threadKey(PROJECT, DOC);
+
+/** §4.4's own words: missing python-pptx is a clean 400 with an install hint. */
+const PPTX_HINT = 'pip install python-pptx (PPTX export needs it; HTML and PDF do not)';
+
+function messages(): DocMsg[] {
+  return useDocThreadStore.getState().messages[KEY] ?? [];
+}
+
+function reply(file: string): Record<string, string> {
+  return { format: 'pdf', path: `/exports/${file}`, file, download: `/d/${DOC}/download/${file}` };
+}
+
+beforeEach(() => {
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  postExport.mockResolvedValue(reply('launch-deck_v3.pdf'));
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+// ── 1. Request shapes: format × version ──────────────────────────────────────
+
+describe('the export request names both the format and the version (§4.4, §4.2)', () => {
+  it('AC: every format is offered, and each posts its own format at the routed version', async () => {
+    expect([...EXPORT_FORMATS]).toEqual(['html', 'pdf', 'pptx']);
+
+    for (const format of EXPORT_FORMATS) {
+      await runExport({ projectId: PROJECT, docId: DOC, version: 3, format });
+    }
+
+    expect(postExport.mock.calls).toEqual([
+      [PROJECT, DOC, 3, 'html'],
+      [PROJECT, DOC, 3, 'pdf'],
+      [PROJECT, DOC, 3, 'pptx'],
+    ]);
+  });
+
+  it('exports the version it was given, not the head — a rewound doc exports what is shown', async () => {
+    await runExport({ projectId: PROJECT, docId: DOC, version: 1, format: 'pdf' });
+    await runExport({ projectId: PROJECT, docId: DOC, version: 17, format: 'pdf' });
+
+    expect(postExport.mock.calls.map((c) => c[2])).toEqual([1, 17]);
+  });
+});
+
+// ── 2. Filename derivation (§4.4: doc-slug names, never `export_v17.*`) ──────
+
+describe('filename derivation', () => {
+  it('AC: `<doc-slug>_v<N>.<ext>` for every format', () => {
+    expect(exportFilename('roadmap', 3, 'pdf')).toBe('roadmap_v3.pdf');
+    expect(exportFilename('roadmap', 3, 'html')).toBe('roadmap_v3.html');
+    expect(exportFilename('agent-harness', 17, 'pptx')).toBe('agent-harness_v17.pptx');
+  });
+
+  it('takes the SERVICE’s filename verbatim where it answered with one', () => {
+    expect(exportFilename('roadmap', 3, 'pdf', 'roadmap-final_v3.pdf')).toBe('roadmap-final_v3.pdf');
+    // Blank is not an answer — the service said nothing, so the derivation stands.
+    expect(exportFilename('roadmap', 3, 'pdf', '   ')).toBe('roadmap_v3.pdf');
+    expect(exportFilename('roadmap', 3, 'pdf', null)).toBe('roadmap_v3.pdf');
+  });
+
+  it('slugifies a name that never went through the registry, and never emits a bare `_v3`', () => {
+    expect(exportFilename('Q3 Review Deck!', 3, 'pdf')).toBe('q3-review-deck_v3.pdf');
+    expect(exportFilename('!!!', 3, 'pdf')).toBe('document_v3.pdf');
+  });
+});
+
+// ── 3. What lands in the thread when it works (§2.5, §3.3) ──────────────────
+
+describe('a completed export is an ordinary downloadable message (§2.5, §4.4)', () => {
+  it('AC: the in-flight line is INFORMATIVE — it names the document, version and format', async () => {
+    const subject = exportSubject(DOC, 3, 'pdf');
+    expect(subject).toContain(DOC);
+    expect(subject).toContain('v3');
+    expect(subject).toContain('PDF');
+    // §3.3's banned shape: this is never a bare `Working…`, in any casing.
+    expect(isFiller(subject)).toBe(false);
+
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+    expect(messages()[0]).toMatchObject({ kind: 'narration', text: subject });
+  });
+
+  it('the in-flight line lands BEFORE the reply — progress, not a report after the fact', async () => {
+    let release = (): void => {};
+    postExport.mockImplementation(() => new Promise((resolve) => {
+      release = () => resolve(reply('launch-deck_v3.pdf'));
+    }));
+
+    const running = runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+    expect(messages()).toHaveLength(1);
+    expect(messages()[0]).toMatchObject({ kind: 'narration' });
+
+    release();
+    await running;
+    expect(messages()).toHaveLength(2);
+  });
+
+  it('the artifact is authored by the SERVICE and carries its download and filename', async () => {
+    const outcome = await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+
+    expect(outcome).toMatchObject({ ok: true, file: 'launch-deck_v3.pdf' });
+    expect(messages()[1]).toMatchObject({
+      kind: 'agent', author: 'export',
+      text: 'PDF export ready — launch-deck_v3.pdf',
+      href: `/d/${DOC}/download/launch-deck_v3.pdf`,
+      file: 'launch-deck_v3.pdf',
+    });
+  });
+
+  it('the bus echo of the same export does not double the download', async () => {
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pdf' });
+    useDocThreadStore.getState().ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.export.generated',
+        payload: {
+          project_id: PROJECT, document_id: DOC, format: 'pdf',
+          file: 'launch-deck_v3.pdf', download: `/d/${DOC}/download/launch-deck_v3.pdf`,
+        },
+      },
+    } as never);
+
+    expect(messages().filter((m) => m.kind === 'agent')).toHaveLength(1);
+  });
+});
+
+// ── 4. The one failure §4.4 names: PPTX without python-pptx ─────────────────
+
+describe('a PPTX export with python-pptx absent is ACTIONABLE, not a crash (§4.4, §3.3)', () => {
+  beforeEach(() => {
+    postExport.mockRejectedValue(new ServiceHintError('API 400: pptx export unavailable', PPTX_HINT));
+  });
+
+  it('AC: the service’s 400 becomes a message naming the install command VERBATIM', async () => {
+    const outcome = await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pptx' });
+
+    expect(outcome).toEqual({ ok: false, hint: PPTX_HINT });
+    expect(messages()[1]).toMatchObject({ kind: 'actionable', hint: PPTX_HINT });
+  });
+
+  it('AC: the document is left usable — the failure says so, and offers the retry', async () => {
+    await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'pptx' });
+
+    const msg = messages()[1];
+    expect(msg).toMatchObject({ retry: { format: 'pptx', version: 3 } });
+    expect(msg?.kind === 'actionable' && msg.text).toContain('still editable');
+    // Nothing downloadable was invented, and the export never threw at the caller.
+    expect(messages().some((m) => m.kind === 'agent')).toBe(false);
+  });
+
+  it('HTML never depends on the optional dependency the PPTX renderer needs (§4.4)', async () => {
+    postExport.mockResolvedValue(reply('launch-deck_v3.html'));
+    const outcome = await runExport({ projectId: PROJECT, docId: DOC, version: 3, format: 'html' });
+
+    expect(outcome.ok).toBe(true);
+    expect(messages().some((m) => m.kind === 'actionable')).toBe(false);
+  });
+
+  it('a refusal that named no command still names what failed — never a silent one', async () => {
+    postExport.mockRejectedValue(new Error('API 500: renderer crashed'));
+    await runExport({ projectId: PROJECT, docId: DOC, version: 2, format: 'pdf' });
+
+    expect(messages()[1]).toMatchObject({ kind: 'actionable', hint: 'API 500: renderer crashed' });
+    expect(exportHint(new ServiceHintError('API 400: nope', PPTX_HINT))).toBe(PPTX_HINT);
+  });
+});

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BridgeUnavailableError,
+  ServiceHintError,
   createDoc,
   getDemoSpec,
   getLatestRecording,
@@ -179,6 +180,55 @@ describe('BridgeUnavailableError', () => {
   it("surfaces the bridge's {error} message on ordinary failures", async () => {
     stubFetch({ error: 'doc already exists' }, 409);
     await expect(createDoc(PROJECT, { name: DOC })).rejects.toThrow('API 409: doc already exists');
+  });
+});
+
+// ── 2b. ServiceHintError (§4.4, §3.3) ───────────────────────────────────────
+//
+// The typed 4xx that carries a NAMED fix — §4.4's lazy-dependency case (a PPTX
+// export with python-pptx absent is a clean 400 with an install hint). slice 15's
+// actionable-message path depends on `iFetch` producing THIS error from the wire,
+// so the branch is pinned here directly rather than only through the mocked
+// `postExport` in the export-wire tests.
+
+describe('ServiceHintError', () => {
+  beforeEach(prodOrigin);
+
+  it('a 400 carrying {error, hint} rejects with the typed error', async () => {
+    stubFetch({ error: 'pptx export unavailable', hint: 'pip install python-pptx' }, 400);
+    await expect(postExport(PROJECT, DOC, 3, 'pptx')).rejects.toBeInstanceOf(ServiceHintError);
+  });
+
+  it('carries the install command verbatim and states the status in the message', async () => {
+    const hint = 'pip install python-pptx (PPTX export needs it; HTML and PDF do not)';
+    stubFetch({ error: 'pptx export unavailable: python-pptx is not importable', hint }, 400);
+    const err = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ServiceHintError);
+    expect((err as ServiceHintError).hint).toBe(hint);
+    // The message keeps the status and the service's own reason for a bare render.
+    expect((err as ServiceHintError).message).toBe(
+      'API 400: pptx export unavailable: python-pptx is not importable');
+  });
+
+  it('trims the hint, and a whitespace-only hint is no hint — stays a generic Error', async () => {
+    stubFetch({ error: 'nope', hint: '  pip install python-pptx  ' }, 400);
+    const trimmed = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
+    expect((trimmed as ServiceHintError).hint).toBe('pip install python-pptx');
+
+    stubFetch({ error: 'nope', hint: '   ' }, 400);
+    const blank = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
+    expect(blank).not.toBeInstanceOf(ServiceHintError);
+    expect(blank).toBeInstanceOf(Error);
+    expect((blank as Error).message).toBe('API 400: nope');
+  });
+
+  it('the 503 bridge_unavailable branch wins even when a hint is present', async () => {
+    // A hint does not downgrade the bridge-down signal: the UI must still route this
+    // to the bridge-unavailable surface, not the per-export actionable one.
+    stubFetch({ code: 'bridge_unavailable', hint: 'npm i -g wicked-interactive' }, 503);
+    const err = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BridgeUnavailableError);
+    expect(err).not.toBeInstanceOf(ServiceHintError);
   });
 });
 


### PR DESCRIPTION
Slice 15, authored and delivered by governed run `7eec57b3-d08b-446e-9d54-e0765ace4e15` (hardened deliver phase: branch derived from run identity).

HTML/PDF/PPTX exports from Document mode (per-version) and the board card, through the proxy; completed exports land as downloadable thread messages (`<doc-slug>_v<N>.<ext>`); python-pptx absence surfaces the service's 400 as an actionable install hint with the doc left usable; in-flight exports narrate format + version, never a bare spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)