### PR TITLE
feat(document): learn-a-theme + sources attach (DES-MERGE-001 slice 16)

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -87,7 +87,17 @@ What "independent" means here, and what this script proves end-to-end:
      origin; and a PPTX export with python-pptx absent renders the service's 400 as an
      actionable message carrying the install command verbatim, with the document still
      framed at v3 and its composer still taking input (§4.4).
- 17. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
+ 17. (DES-MERGE-001 slice 16) learn-a-theme and sources attach on that same rig,
+     where two of the three claims are about what the browser does NOT do: the
+     theme library lists learned themes and picking one is a composer chip;
+     submitting `http://169.254.169.254/` shows the SERVICE's stated refusal
+     verbatim with a next action beside it while `page.on('request')` sees NO
+     request to that address from the SPA (the SSRF guard is in the bridge, where
+     §4.6 puts it, and the client never resolves or pre-judges a host); and
+     attaching a local folder shows it as a context chip while no
+     `multipart/form-data` body leaves the page — the one request that does
+     carries the PATH as JSON, because the service reads it in place (§4.9).
+ 18. (operator UX directive) the LIVE EDGE is the active-work signal, and it is
      ranked: in one DOM snapshot an executing card carries the breathing 2px
      `live-edge` element while a gate-waiting card carries a treatment that is
      present at the same time and different in computed pixels (wider, solid,
@@ -1022,6 +1032,24 @@ try:
     DOWNLOAD_RE = re.compile(r"^/d/([^/]+)/download/(.+)$")
     PPTX_HINT = "pip install python-pptx (PPTX export needs it; HTML and PDF do not)"
     export_requests: list[dict] = []
+    # Slice 16 (§4.6, §4.9): the theme library, the learn endpoint, and sources attach.
+    # THE SSRF GUARD LIVES HERE, in the service, and nowhere else — this fixture refuses
+    # exactly as the real one does (resolve the host, reject link-local/loopback/private,
+    # state the reason) and NEVER fetches the target. The client's only job is to show the
+    # refusal, which is what §19 asserts; a client that pre-rejected the address would be
+    # answering with its own opinion and this AC would pass without the guard existing.
+    THEME_LEARN = "/api/theme/learn"
+    SOURCES_RE = re.compile(r"^/d/([^/]+)/api/sources$")
+    BLOCKED_HOST_RE = re.compile(r"^(127\.|169\.254\.|10\.|192\.168\.|localhost$|\[?::1)")
+    SSRF_REASON = ("refused http://169.254.169.254/: the host resolves to 169.254.169.254, "
+                   "a link-local address — a theme source must be publicly reachable")
+    FIXTURE_THEMES = [
+        {"name": "stripe-ish", "source": "url", "learned_at": "2026-08-18T09:00:00Z"},
+        {"name": "brand-deck", "source": "pdf", "learned_at": "2026-08-17T09:00:00Z"},
+        {"name": "corporate"},  # a built-in: learned from nothing, so no source
+    ]
+    learn_requests: list[dict] = []
+    source_requests: list[dict] = []
     WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
     class DocFixtureHandler(SimpleHTTPRequestHandler):
@@ -1083,6 +1111,10 @@ try:
                 # Video mode is what narrows them to `kind: "demo"`.
                 self._json(200, FIXTURE_DOCS + FIXTURE_DEMOS
                            if project == demo_project else FIXTURE_DOCS)
+                return True
+            if rest == "/api/themes":
+                # The envelope shape (§4.6's library = built-ins + everything learned).
+                self._json(200, {"themes": FIXTURE_THEMES})
                 return True
             m = DEMO_SPEC_RE.match(rest)
             if m:
@@ -1208,6 +1240,37 @@ try:
             return self._json(200, {"format": fmt, "path": f"/exports/{file}", "file": file,
                                     "download": f"/d/{name}/download/{file}"})
 
+        def _learn(self) -> None:
+            """`POST /api/theme/learn` — §4.6's guard, server-side, exactly where the
+            design puts it: http(s) only, resolve the host, reject loopback/link-local/
+            private, and REFUSE WITH A REASON. Nothing is fetched on the refusal path —
+            the address is never contacted by anyone, client or service."""
+            raw = self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}"
+            body = json.loads(raw)
+            learn_requests.append({"body": body, "raw": raw.decode("utf-8", "replace"),
+                                   "content_type": self.headers.get("Content-Type", "")})
+            if body.get("kind") == "url":
+                host = urllib.parse.urlparse(str(body.get("url") or "")).hostname or ""
+                if BLOCKED_HOST_RE.match(host):
+                    return self._json(400, {"error": SSRF_REASON})
+                slug = re.sub(r"[^a-z0-9]+", "-", host.lower()).strip("-") or "theme"
+                return self._json(200, {"theme_id": slug, "status": "queued",
+                                        "message": f"Capturing {body.get('url')} in a headless "
+                                                   "browser — the agent reads the design back."})
+            stem = Path(str(body.get("path") or "theme")).stem
+            return self._json(200, {"theme_id": stem, "status": "queued"})
+
+        def _attach_source(self, name: str) -> None:
+            """`POST /d/:docId/api/sources` — the service reads the path IN PLACE (§4.9).
+            The raw body is retained verbatim so §19 can assert what the browser sent: a
+            JSON path, never a multipart part with bytes in it."""
+            raw = self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}"
+            source_requests.append({"doc": name, "raw": raw.decode("utf-8", "replace"),
+                                    "content_type": self.headers.get("Content-Type", "")})
+            path = json.loads(raw).get("path")
+            return self._json(200, {"path": path, "note": "", "status": "indexing",
+                                    "added_at": "2026-08-18T15:00:00Z", "indexed_at": None})
+
         def _emit(self) -> None:
             """`POST /api/events` — the GENERATING/GATED composer's wire (§2.2 cases 2-3)
             and both of the feedback batch's writes (§7.7)."""
@@ -1262,6 +1325,11 @@ try:
                 exporting = EXPORT_RE.match(rest)
                 if exporting:
                     return self._export(urllib.parse.unquote(exporting.group(1)))
+                if rest == THEME_LEARN:
+                    return self._learn()
+                sources = SOURCES_RE.match(rest)
+                if sources:
+                    return self._attach_source(urllib.parse.unquote(sources.group(1)))
                 if rest == "/api/docs":
                     return self._create_doc(project)
                 if rest == "/api/events":
@@ -2306,8 +2374,6 @@ try:
         page.screenshot(path=str(SHOTS / "slice15-pptx-absent.png"), full_page=True)
         browser.close()
 
-    docd.shutdown()  # last section on the same-origin rig
-
     new_exports = export_requests[exports_before:]
     expected_href = (f"/api/v1/projects/{urllib.parse.quote(doc_project)}"
                      f"/interactive/d/{STRIP_DOC}/download/{EXPORT_FILE}")
@@ -2356,7 +2422,144 @@ try:
     if not report["steps"]["exports"]["ok"]:
         fail("exports_verdict", "slice-15 export assertions did not all hold — see exports")
 
-    # ── 19. Operator UX directive: the live edge on the board ──────────────────
+    # ── 19. Slice 16 (DES-MERGE-001 §4.6, §4.9, §6.4): themes + sources attach ──
+    # Still the same-origin rig. Three claims, and two of them are about what the browser
+    # does NOT do — which is why this section watches `page.on("request")` rather than
+    # reading the DOM for reassurance:
+    #
+    #   · SSRF: submitting `http://169.254.169.254/` shows the SERVICE's stated reason,
+    #     verbatim, with a next action beside it — and the SPA makes NO request to that
+    #     address. The guard is in the fixture bridge where the real one lives (§4.6);
+    #     the client never resolves, never fetches, and never pre-judges the host, so a
+    #     regression that moved the guard client-side would fail the request assertion
+    #     rather than quietly pass the DOM one.
+    #   · Sources: attaching a local folder shows it as a context chip and UPLOADS
+    #     NOTHING — no `multipart/form-data` body leaves the page, and the one request
+    #     that does carries the PATH as JSON (§4.9's "read in place" guarantee, which is
+    #     what "it uses your actual numbers" rests on).
+    #   · The library: learned themes list and picking one is a chip on the composer.
+    SSRF_TARGET = "http://169.254.169.254/"
+    SOURCE_PATH = "/Users/operator/finance/q3-actuals"
+    learn_console: list[str] = []
+    spa_requests: list[dict] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        # Same filter policy as §18: this section DRIVES a 400 (the guard's refusal) and
+        # chromium logs every failed fetch at error level. The claim is that the app turns
+        # that 400 into an actionable message — asserted directly below.
+        page.on("console", lambda m: learn_console.append(m.text)
+                if m.type == "error" and "fonts.g" not in m.text
+                and "status of 400" not in m.text else None)
+        page.on("request", lambda r: spa_requests.append({
+            "url": r.url, "method": r.method,
+            "content_type": (r.headers.get("content-type") or ""),
+            "post_data": (r.post_data or ""),
+        }))
+
+        page.goto(f"{DOC_ORIGIN}/p/{doc_project}/document/{STRIP_DOC}",
+                  wait_until="domcontentloaded")
+        page.locator('[data-testid="thread-context"]').wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+        # ── AC: the theme library lists themes, and picking one is a composer chip ──
+        page.click('[data-testid="context-library"]')
+        page.locator('[data-testid="theme-row"]').first.wait_for(timeout=30000)
+        rows = page.locator('[data-testid="theme-row"]')
+        library_themes = [rows.nth(i).get_attribute("data-theme") for i in range(rows.count())]
+        page.click('[data-testid="theme-row"][data-theme="stripe-ish"]')
+        theme_chip = page.locator('[data-testid="context-chip"][data-chip-kind="theme"]')
+        theme_chip.wait_for(timeout=10000)
+        theme_chip_value = theme_chip.get_attribute("data-chip-value")
+        page.screenshot(path=str(SHOTS / "slice16-theme-chip.png"), full_page=True)
+
+        # ── AC: the SSRF refusal is the service's, shown verbatim, with no outbound req ──
+        page.click('[data-testid="context-learn"]')
+        page.fill('[data-testid="learn-input"]', SSRF_TARGET)
+        page.click('[data-testid="learn-submit"]')
+        refusal = page.locator('[data-testid="doc-actionable"]').last
+        refusal.wait_for(timeout=30000)
+        refusal_text = refusal.inner_text()
+        refusal_hint = page.locator('[data-testid="doc-actionable-hint"]').last.inner_text()
+        # The ask stays in the transcript (§2.3): a refused theme is still a record of
+        # what was tried and why it did not happen.
+        thread_text = page.evaluate(
+            """() => document.querySelector('[data-testid="thread"]')?.innerText ?? ''""")
+        page.screenshot(path=str(SHOTS / "slice16-ssrf-refused.png"), full_page=True)
+
+        # ── AC: attaching a folder shows the chip and uploads nothing ──────────────
+        page.click('[data-testid="context-sources"]')
+        page.fill('[data-testid="source-input"]', SOURCE_PATH)
+        page.click('[data-testid="source-attach"]')
+        source_chip = page.locator('[data-testid="context-chip"][data-chip-kind="source"]')
+        source_chip.wait_for(timeout=30000)
+        source_chip_value = source_chip.get_attribute("data-chip-value")
+        source_thread_text = page.evaluate(
+            """() => document.querySelector('[data-testid="thread"]')?.innerText ?? ''""")
+        # The document is untouched by either action — the composer still takes input.
+        page.fill('[data-testid="doc-composer"]', "now apply that theme to the summary")
+        composer_after = page.input_value('[data-testid="doc-composer"]')
+        page.screenshot(path=str(SHOTS / "slice16-source-chip.png"), full_page=True)
+        browser.close()
+
+    docd.shutdown()  # last section on the same-origin rig
+
+    # What the browser did, and did not, put on the wire.
+    ssrf_outbound = [r for r in spa_requests if "169.254.169.254" in r["url"]]
+    multipart = [r for r in spa_requests
+                 if "multipart" in r["content_type"].lower()
+                 or "multipart/form-data" in r["post_data"][:200].lower()]
+    learn_sent = learn_requests[-1] if learn_requests else None
+    source_sent = source_requests[-1] if source_requests else None
+    report["steps"]["themes_and_sources"] = {
+        "ok": all([
+            # The library, and the pick that becomes context for the next generation.
+            library_themes == ["stripe-ish", "brand-deck", "corporate"],
+            theme_chip_value == "stripe-ish",
+            # The SSRF refusal: the SERVICE's sentence, verbatim, with a next action.
+            SSRF_REASON in refusal_text,
+            refusal_hint.strip() != "",
+            SSRF_TARGET in thread_text,
+            # …and the SPA never went near the address. This is the whole claim.
+            ssrf_outbound == [],
+            learn_sent is not None and learn_sent["body"] == {"kind": "url", "url": SSRF_TARGET},
+            learn_sent is not None and "json" in learn_sent["content_type"],
+            # Sources: a chip for the path, and NOTHING uploaded from the page.
+            source_chip_value == SOURCE_PATH,
+            SOURCE_PATH in source_thread_text,
+            multipart == [],
+            source_sent is not None and json.loads(source_sent["raw"]) == {"path": SOURCE_PATH},
+            source_sent is not None and "json" in source_sent["content_type"],
+            source_sent is not None and len(source_sent["raw"]) < len(SOURCE_PATH) + 32,
+            # Neither action disturbed the document.
+            composer_after == "now apply that theme to the summary",
+            not learn_console,
+        ]),
+        "library_themes": library_themes,
+        "picked_theme_chip": theme_chip_value,
+        "ssrf_target": SSRF_TARGET,
+        "ssrf_reason_expected": SSRF_REASON,
+        "ssrf_reason_rendered": refusal_text,
+        "ssrf_next_action_rendered": refusal_hint,
+        "spa_requests_to_the_target": ssrf_outbound,
+        "learn_request_seen_by_bridge": learn_sent,
+        "source_path": SOURCE_PATH,
+        "source_chip": source_chip_value,
+        "source_request_seen_by_bridge": source_sent,
+        "multipart_bodies_that_left_the_page": multipart,
+        "spa_request_count": len(spa_requests),
+        "composer_still_accepts_input": composer_after,
+        "console_errors": learn_console[:10],
+        "screenshots": [str(SHOTS / n) for n in
+                        ("slice16-theme-chip.png", "slice16-ssrf-refused.png",
+                         "slice16-source-chip.png")],
+    }
+    if not report["steps"]["themes_and_sources"]["ok"]:
+        fail("themes_and_sources_verdict",
+             "slice-16 theme/sources assertions did not all hold — see themes_and_sources")
+
+    # ── 20. Operator UX directive: the live edge on the board ──────────────────
     # The ACTIVE-WORK signal is a breathing 2px strip along the leading edge of the
     # element doing work, and the thing that has to hold is the RANKING: a busy card
     # must be visible without out-shouting a card that needs a human. So both states

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -107,6 +107,8 @@ export interface CreateDocBody {
   /** The thread message this generation came from (§7.6). The bridge writes it into
    *  the version's `meta.sourceMessageId` at commit; the client only supplies it. */
   source_message_id?: string;
+  /** A learned theme to apply to this generation (§4.6, slice 16). */
+  theme_id?: string;
 }
 
 export interface CreateDocResult {
@@ -290,6 +292,71 @@ export function postEvent(projectId: string, evt: InteractiveEvent): Promise<Eve
   );
 }
 
+// ── Theme types (§4.6, §6.4 slice 16) ────────────────────────────────────────
+
+export type LearnKind = 'url' | 'pdf' | 'image';
+
+/**
+ * One row of `GET /api/themes` — the library, which is `src/themes/*.json` plus everything
+ * the agent has learned (§4.6). `name` is the slug id, exactly as `DocSummary.name` is:
+ * one spelling of "the id of a thing in a registry" across the whole seam. It is what
+ * `CreateDocBody.theme_id` carries back.
+ */
+export interface ThemeSummary {
+  name: string;
+  /** Absent on the built-in themes, which were not learned from anything. */
+  source?: LearnKind;
+  learned_at?: string;
+}
+
+export interface LearnThemeBody {
+  kind: LearnKind;
+  /** Live URL to capture via headless chrome (kind: 'url'). Never fetched by the SPA —
+   *  the bridge proxy owns the SSRF guard (§4.6: reject loopback, private, link-local). */
+  url?: string;
+  /** Absolute path of a local PDF or image (kind: 'pdf' | 'image'). Read server-side;
+   *  the client sends the PATH ONLY — nothing is uploaded from the browser. */
+  path?: string;
+}
+
+/** The bridge queues immediately and the agent runs async. */
+export interface LearnThemeResult {
+  theme_id: string;
+  status: 'queued';
+  /** An informative message the bridge authored — show it in the thread, never paraphrase. */
+  message?: string;
+}
+
+/** `GET /api/themes` — the theme library (built-ins + everything learned, §4.6). */
+export function listThemes(projectId: string): Promise<ThemeSummary[]> {
+  return iFetch<{ themes: ThemeSummary[] } | ThemeSummary[]>(
+    `${interactiveBase(projectId)}/api/themes`,
+  ).then((r) => (Array.isArray(r) ? r : r.themes));
+}
+
+/**
+ * `POST /api/theme/learn { kind, url? | path? }` — submit one source for the agent to learn.
+ *
+ * The SSRF guard lives entirely server-side (§4.6: reject loopback/link-local/private, resolve
+ * every address and pin the validated IP). The SPA sends the URL to the bridge proxy, NEVER to
+ * the target itself — `page.on('request')` in the E2E AC confirms this.
+ */
+export function learnTheme(projectId: string, body: LearnThemeBody): Promise<LearnThemeResult> {
+  return iFetch<LearnThemeResult>(
+    `${interactiveBase(projectId)}/api/theme/learn`, jsonPost(body));
+}
+
+/**
+ * `POST /d/:docId/api/sources { path }` — attach a local reference path (§4.9).
+ *
+ * The body is `application/json` carrying only the path string — the service reads the files
+ * server-side. Nothing is uploaded from the browser. The E2E AC uses `page.on('request')` to
+ * confirm no `multipart/form-data` body leaves the page.
+ */
+export function attachSource(projectId: string, docId: string, path: string): Promise<SourceEntry> {
+  return iFetch<SourceEntry>(`${docBase(projectId, docId)}/api/sources`, jsonPost({ path }));
+}
+
 // ── Demo types (§4.5, §6.4 slice 13) ────────────────────────────────────────
 
 /** One chapter of a demo spec — the agent authors the spec; the service executes it. */
@@ -375,9 +442,16 @@ export function injectDocMessage(
   docId: string,
   text: string,
   sourceMessageId: string,
+  /** The theme the composer had picked when this message was sent (§4.6, slice 16).
+   *  Carried on the message rather than set on the document, because a pick applies to
+   *  the GENERATION the message starts — the same reason `CreateDocBody` carries it. */
+  themeId?: string,
 ): Promise<EventAck> {
   return postEvent(projectId, {
     event_type: 'wicked.interactive.chat.posted',
-    payload: { role: 'user', text, document_id: docId, source_message_id: sourceMessageId },
+    payload: {
+      role: 'user', text, document_id: docId, source_message_id: sourceMessageId,
+      ...(themeId === undefined || themeId === '' ? {} : { theme_id: themeId }),
+    },
   });
 }

--- a/src/components/ComposerContext.tsx
+++ b/src/components/ComposerContext.tsx
@@ -7,8 +7,8 @@ import { contextKey, useDocContextStore } from '../store/docContext.js';
 
 // The composer's context row (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
 //
-// Three actions and the chips they produce, all in the footer beside the composer,
-// because what they change is what the NEXT message generates:
+// Three actions and the chips they produce, in the footer beside the composer, because
+// what they change is what the NEXT message generates:
 //
 //   Style   — teach the agent a theme from a website, a PDF or an image (§4.6). The
 //             submission is a message (§2.3) and the learning narrates in the thread.
@@ -33,43 +33,49 @@ const S = {
 };
 
 const CHIP: React.CSSProperties = {
-  background: 'rgba(255,218,25,0.1)', color: S.accent,
-  border: '1px solid rgba(255,218,25,0.25)',
+  background: 'rgba(255,218,25,0.1)', color: S.accent, border: '1px solid rgba(255,218,25,0.25)',
 };
-
 const ACTION: React.CSSProperties = {
-  background: 'transparent', color: S.muted,
-  border: `1px solid ${S.border}`, cursor: 'pointer',
+  background: 'transparent', color: S.muted, border: `1px solid ${S.border}`, cursor: 'pointer',
 };
-
 const FIELD: React.CSSProperties = {
   background: 'transparent', color: S.ink, border: `1px solid ${S.border}`,
   borderRadius: '8px', outline: 'none',
 };
+const SUBMIT: React.CSSProperties = {
+  background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer',
+};
+const BOX: React.CSSProperties = { background: S.card, border: `1px solid ${S.border}` };
+const PANEL = 'flex flex-col gap-1.5 rounded-xl px-2.5 py-2';
+const PILL = 'rounded-full px-2.5 py-0.5 text-[10px] font-mono';
+const INPUT = 'px-2 py-1 text-[11px] font-mono';
+const GO = 'self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40';
+const NOTE = 'text-[10px] font-mono';
 
 type Panel = 'learn' | 'library' | 'sources';
+
+/** The three actions, in §4.6/§4.9's order. `needsDoc` marks the ones that render as
+ *  MESSAGES: a message needs a transcript, so they wait for a document to exist. */
+const ACTIONS: ReadonlyArray<{ panel: Panel; testId: string; label: string; title: string; needsDoc: boolean }> = [
+  { panel: 'learn', testId: 'context-learn', label: 'learn a theme', needsDoc: true,
+    title: 'Teach the agent a theme from a website, a PDF or an image' },
+  { panel: 'library', testId: 'context-library', label: 'theme library', needsDoc: false,
+    title: 'Pick a theme for the next generation' },
+  { panel: 'sources', testId: 'context-sources', label: 'attach sources', needsDoc: true,
+    title: 'Point at a folder or file the service reads in place — nothing uploads' },
+];
 
 /** One context chip: what is in effect, and the control that takes it back out. */
 function Chip({
   kind, value, label, onRemove,
 }: { kind: string; value: string; label: string; onRemove: () => void }): React.ReactElement {
   return (
-    <span
-      data-testid="context-chip"
-      data-chip-kind={kind}
-      data-chip-value={value}
-      className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-mono max-w-full"
-      style={CHIP}
-    >
+    <span data-testid="context-chip" data-chip-kind={kind} data-chip-value={value}
+          className={`flex items-center gap-1 max-w-full ${PILL}`} style={CHIP}>
       <span className="truncate">{label}</span>
-      <button
-        type="button"
-        data-testid="context-chip-remove"
-        aria-label={`Remove ${label}`}
-        onClick={onRemove}
-        className="shrink-0 leading-none"
-        style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }}
-      >
+      <button type="button" data-testid="context-chip-remove" aria-label={`Remove ${label}`}
+              onClick={onRemove} className="shrink-0 leading-none"
+              style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }}>
         ×
       </button>
     </span>
@@ -126,6 +132,18 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
     setPath(''); setPanel(null);
   }
 
+  // §3.3: the library says what it is doing or why it cannot, and a library that failed
+  // to load picks nothing rather than silently offering the default as if it were chosen.
+  const status = libraryError !== null
+    ? { testId: 'theme-library-error', danger: true,
+        text: `${libraryError} — no theme was picked; the next generation uses the default.` }
+    : themes === null
+      ? { testId: 'theme-library-loading', danger: false, text: 'Loading the theme library…' }
+      : themes.length === 0
+        ? { testId: 'theme-library-empty', danger: false,
+            text: 'No themes yet — learn one from a website, a PDF or an image.' }
+        : null;
+
   return (
     <div data-testid="thread-context" className="flex flex-col gap-1.5">
       {(theme !== undefined || sources.length > 0) && (
@@ -142,99 +160,59 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
       )}
 
       <div className="flex flex-wrap gap-1.5">
-        {docId !== null && (
-          <button type="button" data-testid="context-learn" onClick={() => toggle('learn')}
-                  className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
-                  title="Teach the agent a theme from a website, a PDF or an image">
-            learn a theme
+        {ACTIONS.filter((a) => docId !== null || !a.needsDoc).map((a) => (
+          <button key={a.panel} type="button" data-testid={a.testId} title={a.title}
+                  aria-expanded={panel === a.panel} onClick={() => toggle(a.panel)}
+                  className={PILL} style={ACTION}>
+            {a.label}
           </button>
-        )}
-        <button type="button" data-testid="context-library" onClick={() => toggle('library')}
-                className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
-                title="Pick a theme for the next generation">
-          theme library
-        </button>
-        {docId !== null && (
-          <button type="button" data-testid="context-sources" onClick={() => toggle('sources')}
-                  className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
-                  title="Point at a folder or file the service reads in place — nothing uploads">
-            attach sources
-          </button>
-        )}
+        ))}
       </div>
 
       {panel === 'learn' && docId !== null && (
-        <div data-testid="learn-panel" className="flex flex-col gap-1.5 rounded-xl px-2.5 py-2"
-             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+        <div data-testid="learn-panel" className={PANEL} style={BOX}>
           <div className="flex gap-1.5">
             {LEARN_KINDS.map((k) => (
-              <button
-                key={k}
-                type="button"
-                data-testid="learn-kind"
-                data-kind={k}
-                aria-pressed={kind === k}
-                onClick={() => setKind(k)}
-                className="rounded-full px-2 py-0.5 text-[10px] font-mono"
-                style={kind === k ? CHIP : ACTION}
-              >
+              <button key={k} type="button" data-testid="learn-kind" data-kind={k}
+                      aria-pressed={kind === k} onClick={() => setKind(k)}
+                      className="rounded-full px-2 py-0.5 text-[10px] font-mono"
+                      style={kind === k ? CHIP : ACTION}>
                 {k}
               </button>
             ))}
           </div>
           <input
-            data-testid="learn-input"
+            data-testid="learn-input" className={INPUT} style={FIELD}
             aria-label={`Theme source ${LEARN_LABEL[kind].noun}`}
-            className="px-2 py-1 text-[11px] font-mono"
-            style={FIELD}
             placeholder={LEARN_LABEL[kind].placeholder}
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitLearn(); } }}
           />
-          {/* §4.6 requires this said in the UI, not just honoured on the wire. */}
+          {/* §4.6 asks for this to be SAID in the UI, not only honoured on the wire. */}
           {kind !== 'url' && (
-            <p data-testid="learn-no-upload" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+            <p data-testid="learn-no-upload" className={NOTE} style={{ color: S.faint, margin: 0 }}>
               Read in place — the file is not uploaded.
             </p>
           )}
-          <button
-            type="button"
-            data-testid="learn-submit"
-            disabled={busy || !learnReady(kind, value)}
-            onClick={() => void submitLearn()}
-            className="self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40"
-            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
-          >
+          <button type="button" data-testid="learn-submit" className={GO} style={SUBMIT}
+                  disabled={busy || !learnReady(kind, value)} onClick={() => void submitLearn()}>
             {busy ? 'Submitting…' : `Learn from this ${LEARN_LABEL[kind].noun}`}
           </button>
         </div>
       )}
 
       {panel === 'library' && (
-        <div data-testid="theme-library" className="flex flex-col gap-1 rounded-xl px-2.5 py-2 max-h-40 overflow-y-auto"
-             style={{ background: S.card, border: `1px solid ${S.border}` }}>
-          {libraryError !== null && (
-            <p data-testid="theme-library-error" className="text-[10px] font-mono" style={{ color: S.danger, margin: 0 }}>
-              {libraryError} — no theme was picked; the next generation uses the default.
-            </p>
-          )}
-          {libraryError === null && themes === null && (
-            <p className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
-              Loading the theme library…
-            </p>
-          )}
-          {themes !== null && themes.length === 0 && (
-            <p data-testid="theme-library-empty" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
-              No themes yet — learn one from a website, a PDF or an image.
+        <div data-testid="theme-library" className={`${PANEL} gap-1 max-h-40 overflow-y-auto`} style={BOX}>
+          {status !== null && (
+            <p data-testid={status.testId} className={NOTE}
+               style={{ color: status.danger ? S.danger : S.faint, margin: 0 }}>
+              {status.text}
             </p>
           )}
           {(themes ?? []).map((t) => (
             <button
-              key={t.name}
-              type="button"
-              data-testid="theme-row"
-              data-theme={t.name}
+              key={t.name} type="button" data-testid="theme-row" data-theme={t.name}
               aria-pressed={theme === t.name}
               onClick={() => { useDocContextStore.getState().pickTheme(key, t.name); setPanel(null); }}
               className="flex items-baseline justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11px] font-mono"
@@ -242,38 +220,27 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
                        color: S.ink, border: 'none', cursor: 'pointer' }}
             >
               <span className="truncate">{t.name}</span>
-              <span className="shrink-0 text-[10px]" style={{ color: S.faint }}>
-                {t.source ?? 'built-in'}
-              </span>
+              <span className="shrink-0 text-[10px]" style={{ color: S.faint }}>{t.source ?? 'built-in'}</span>
             </button>
           ))}
         </div>
       )}
 
       {panel === 'sources' && docId !== null && (
-        <div data-testid="sources-panel" className="flex flex-col gap-1.5 rounded-xl px-2.5 py-2"
-             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+        <div data-testid="sources-panel" className={PANEL} style={BOX}>
           <input
-            data-testid="source-input"
+            data-testid="source-input" className={INPUT} style={FIELD}
             aria-label="Reference folder or file path"
-            className="px-2 py-1 text-[11px] font-mono"
-            style={FIELD}
             placeholder="/path/to/reference-folder"
             value={path}
             onChange={(e) => setPath(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitSource(); } }}
           />
-          <p data-testid="source-no-upload" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+          <p data-testid="source-no-upload" className={NOTE} style={{ color: S.faint, margin: 0 }}>
             The service reads it where it is — nothing is uploaded from this page.
           </p>
-          <button
-            type="button"
-            data-testid="source-attach"
-            disabled={busy || path.trim() === ''}
-            onClick={() => void submitSource()}
-            className="self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40"
-            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
-          >
+          <button type="button" data-testid="source-attach" className={GO} style={SUBMIT}
+                  disabled={busy || path.trim() === ''} onClick={() => void submitSource()}>
             {busy ? 'Attaching…' : 'Attach'}
           </button>
         </div>

--- a/src/components/ComposerContext.tsx
+++ b/src/components/ComposerContext.tsx
@@ -1,0 +1,286 @@
+import { useState } from 'react';
+import { listThemes, type LearnKind, type ThemeSummary } from '../api/interactive.js';
+import {
+  attachSourceFromThread, learnReady, learnThemeFromThread, LEARN_KINDS, LEARN_LABEL,
+} from '../interactive/themeWire.js';
+import { contextKey, useDocContextStore } from '../store/docContext.js';
+
+// The composer's context row (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
+//
+// Three actions and the chips they produce, all in the footer beside the composer,
+// because what they change is what the NEXT message generates:
+//
+//   Style   — teach the agent a theme from a website, a PDF or an image (§4.6). The
+//             submission is a message (§2.3) and the learning narrates in the thread.
+//   Theme   — the library (built-ins + everything learned). Picking one is a chip, and
+//             the chip rides with the next generation as `theme_id`.
+//   Sources — attach a folder or file the service reads IN PLACE (§4.9). The chip is a
+//             path, never a payload: this component has no file input and builds no
+//             FormData, so attaching context uploads nothing.
+//
+// The two thread actions require an open document, for the same reason the storyboard's
+// Record button does: they render as messages, and a message needs a thread to land in.
+// Picking a theme does not — it is context for a generation that has not started yet.
+
+const S = {
+  ink:    '#e6edf3',
+  faint:  'rgba(230,237,243,0.35)',
+  muted:  'rgba(230,237,243,0.55)',
+  accent: '#ffda19',
+  card:   '#1b222e',
+  border: 'rgba(230,237,243,0.1)',
+  danger: '#f85149',
+};
+
+const CHIP: React.CSSProperties = {
+  background: 'rgba(255,218,25,0.1)', color: S.accent,
+  border: '1px solid rgba(255,218,25,0.25)',
+};
+
+const ACTION: React.CSSProperties = {
+  background: 'transparent', color: S.muted,
+  border: `1px solid ${S.border}`, cursor: 'pointer',
+};
+
+const FIELD: React.CSSProperties = {
+  background: 'transparent', color: S.ink, border: `1px solid ${S.border}`,
+  borderRadius: '8px', outline: 'none',
+};
+
+type Panel = 'learn' | 'library' | 'sources';
+
+/** One context chip: what is in effect, and the control that takes it back out. */
+function Chip({
+  kind, value, label, onRemove,
+}: { kind: string; value: string; label: string; onRemove: () => void }): React.ReactElement {
+  return (
+    <span
+      data-testid="context-chip"
+      data-chip-kind={kind}
+      data-chip-value={value}
+      className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-mono max-w-full"
+      style={CHIP}
+    >
+      <span className="truncate">{label}</span>
+      <button
+        type="button"
+        data-testid="context-chip-remove"
+        aria-label={`Remove ${label}`}
+        onClick={onRemove}
+        className="shrink-0 leading-none"
+        style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+export interface ComposerContextProps {
+  projectId: string;
+  /** `null` on the doc-less composer — the theme picker still works; the two thread
+   *  actions do not, because there is no transcript for their message yet. */
+  docId: string | null;
+}
+
+export function ComposerContext({ projectId, docId }: ComposerContextProps): React.ReactElement {
+  const key = contextKey(projectId, docId);
+  const theme = useDocContextStore((s) => s.theme[key]);
+  const sources = useDocContextStore((s) => s.sources[key] ?? EMPTY);
+
+  const [panel, setPanel] = useState<Panel | null>(null);
+  const [kind, setKind] = useState<LearnKind>('url');
+  const [value, setValue] = useState('');
+  const [path, setPath] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [themes, setThemes] = useState<ThemeSummary[] | null>(null);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
+
+  function toggle(next: Panel): void {
+    const opening = panel !== next;
+    setPanel(opening ? next : null);
+    if (!opening || next !== 'library') return;
+    setLibraryError(null);
+    listThemes(projectId)
+      .then(setThemes)
+      .catch((e: unknown) => setLibraryError(e instanceof Error ? e.message : String(e)));
+  }
+
+  async function submitLearn(): Promise<void> {
+    if (docId === null || busy || !learnReady(kind, value)) return;
+    setBusy(true);
+    // Both outcomes are already IN the thread (informative, or actionable with the
+    // service's own reason) — the panel's job is only to stop offering the same submit.
+    const outcome = await learnThemeFromThread({ projectId, docId, kind, value });
+    setBusy(false);
+    if (outcome.ok) { setValue(''); setPanel(null); setThemes(null); }
+  }
+
+  async function submitSource(): Promise<void> {
+    if (docId === null || busy || path.trim() === '') return;
+    setBusy(true);
+    const outcome = await attachSourceFromThread({ projectId, docId, path });
+    setBusy(false);
+    if (!outcome.ok) return;
+    useDocContextStore.getState().addSource(key, outcome.entry.path);
+    setPath(''); setPanel(null);
+  }
+
+  return (
+    <div data-testid="thread-context" className="flex flex-col gap-1.5">
+      {(theme !== undefined || sources.length > 0) && (
+        <div className="flex flex-wrap gap-1.5">
+          {theme !== undefined && (
+            <Chip kind="theme" value={theme} label={`theme: ${theme}`}
+                  onRemove={() => useDocContextStore.getState().pickTheme(key, null)} />
+          )}
+          {sources.map((p) => (
+            <Chip key={p} kind="source" value={p} label={p}
+                  onRemove={() => useDocContextStore.getState().removeSource(key, p)} />
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-1.5">
+        {docId !== null && (
+          <button type="button" data-testid="context-learn" onClick={() => toggle('learn')}
+                  className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
+                  title="Teach the agent a theme from a website, a PDF or an image">
+            learn a theme
+          </button>
+        )}
+        <button type="button" data-testid="context-library" onClick={() => toggle('library')}
+                className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
+                title="Pick a theme for the next generation">
+          theme library
+        </button>
+        {docId !== null && (
+          <button type="button" data-testid="context-sources" onClick={() => toggle('sources')}
+                  className="rounded-full px-2.5 py-0.5 text-[10px] font-mono" style={ACTION}
+                  title="Point at a folder or file the service reads in place — nothing uploads">
+            attach sources
+          </button>
+        )}
+      </div>
+
+      {panel === 'learn' && docId !== null && (
+        <div data-testid="learn-panel" className="flex flex-col gap-1.5 rounded-xl px-2.5 py-2"
+             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+          <div className="flex gap-1.5">
+            {LEARN_KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                data-testid="learn-kind"
+                data-kind={k}
+                aria-pressed={kind === k}
+                onClick={() => setKind(k)}
+                className="rounded-full px-2 py-0.5 text-[10px] font-mono"
+                style={kind === k ? CHIP : ACTION}
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+          <input
+            data-testid="learn-input"
+            aria-label={`Theme source ${LEARN_LABEL[kind].noun}`}
+            className="px-2 py-1 text-[11px] font-mono"
+            style={FIELD}
+            placeholder={LEARN_LABEL[kind].placeholder}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitLearn(); } }}
+          />
+          {/* §4.6 requires this said in the UI, not just honoured on the wire. */}
+          {kind !== 'url' && (
+            <p data-testid="learn-no-upload" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+              Read in place — the file is not uploaded.
+            </p>
+          )}
+          <button
+            type="button"
+            data-testid="learn-submit"
+            disabled={busy || !learnReady(kind, value)}
+            onClick={() => void submitLearn()}
+            className="self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40"
+            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+          >
+            {busy ? 'Submitting…' : `Learn from this ${LEARN_LABEL[kind].noun}`}
+          </button>
+        </div>
+      )}
+
+      {panel === 'library' && (
+        <div data-testid="theme-library" className="flex flex-col gap-1 rounded-xl px-2.5 py-2 max-h-40 overflow-y-auto"
+             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+          {libraryError !== null && (
+            <p data-testid="theme-library-error" className="text-[10px] font-mono" style={{ color: S.danger, margin: 0 }}>
+              {libraryError} — no theme was picked; the next generation uses the default.
+            </p>
+          )}
+          {libraryError === null && themes === null && (
+            <p className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+              Loading the theme library…
+            </p>
+          )}
+          {themes !== null && themes.length === 0 && (
+            <p data-testid="theme-library-empty" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+              No themes yet — learn one from a website, a PDF or an image.
+            </p>
+          )}
+          {(themes ?? []).map((t) => (
+            <button
+              key={t.name}
+              type="button"
+              data-testid="theme-row"
+              data-theme={t.name}
+              aria-pressed={theme === t.name}
+              onClick={() => { useDocContextStore.getState().pickTheme(key, t.name); setPanel(null); }}
+              className="flex items-baseline justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11px] font-mono"
+              style={{ background: theme === t.name ? 'rgba(255,218,25,0.1)' : 'transparent',
+                       color: S.ink, border: 'none', cursor: 'pointer' }}
+            >
+              <span className="truncate">{t.name}</span>
+              <span className="shrink-0 text-[10px]" style={{ color: S.faint }}>
+                {t.source ?? 'built-in'}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {panel === 'sources' && docId !== null && (
+        <div data-testid="sources-panel" className="flex flex-col gap-1.5 rounded-xl px-2.5 py-2"
+             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+          <input
+            data-testid="source-input"
+            aria-label="Reference folder or file path"
+            className="px-2 py-1 text-[11px] font-mono"
+            style={FIELD}
+            placeholder="/path/to/reference-folder"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitSource(); } }}
+          />
+          <p data-testid="source-no-upload" className="text-[10px] font-mono" style={{ color: S.faint, margin: 0 }}>
+            The service reads it where it is — nothing is uploaded from this page.
+          </p>
+          <button
+            type="button"
+            data-testid="source-attach"
+            disabled={busy || path.trim() === ''}
+            onClick={() => void submitSource()}
+            className="self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40"
+            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+          >
+            {busy ? 'Attaching…' : 'Attach'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Stable identity for "no sources" so the selector never returns a fresh array. */
+const EMPTY: string[] = [];

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { createDoc, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { ComposerContext } from './ComposerContext.js';
 import { DemoWizard } from './DemoWizard.js';
 import { recordFromThread } from '../interactive/demoWire.js';
 import { runExport } from '../interactive/exportWire.js';
 import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
+import { contextKey, useDocContextStore } from '../store/docContext.js';
 import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
 
 // Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
@@ -309,6 +311,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   const streamed = useDocThreadStore((s) => (key === null ? undefined : s.genState[key]));
   // A document that exists with nothing in flight IS case 4: complete, and editable (§7.10).
   const state: GenState = docId === null ? 'idle' : streamed ?? 'terminal';
+  // §4.6: a picked theme is composer CONTEXT, so it rides with whatever the next submit
+  // turns out to be — the create body in case 1, the injected message in cases 2-4. It is
+  // never a separate action, because applying a theme is something a GENERATION does.
+  const theme = useDocContextStore((s) => s.theme[contextKey(projectId, docId)]);
 
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
@@ -347,6 +353,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         const created = await createDoc(projectId, {
           name: docName(body), kind: 'source', brief: body, project: projectId,
           source_message_id: msgId,
+          ...(theme === undefined ? {} : { theme_id: theme }),
         });
         const opened = threadKey(projectId, created.name);
         store.addUserMsg(opened, msgId, body);
@@ -366,7 +373,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         store.addDivider(key, forked.version);
         store.addUserMsg(key, msgId, body);
         store.setGenState(key, 'generating');
-        await injectDocMessage(projectId, docId, body, msgId);
+        await injectDocMessage(projectId, docId, body, msgId, theme);
         setText('');
         navigate(versionPath(projectId, docId, forked.version));
         return;
@@ -381,7 +388,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         });
         store.setGenState(key, 'generating');
       } else {
-        await injectDocMessage(projectId, docId, body, msgId);
+        await injectDocMessage(projectId, docId, body, msgId, theme);
       }
       setText('');
     } catch (e: unknown) {
@@ -468,6 +475,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
             record this demo
           </button>
         )}
+        {/* §4.6/§4.9: what the next generation is MADE OF — the learned theme in effect and
+            the folders the service reads in place — stated where the message is composed.
+            Document mode only: a demo's look comes from the site it records (§4.5). */}
+        {mode === 'document' && <ComposerContext projectId={projectId} docId={docId} />}
         {state === 'generating' && (
           <span
             data-testid="steering-chip"

--- a/src/interactive/themeWire.ts
+++ b/src/interactive/themeWire.ts
@@ -83,6 +83,18 @@ export function serviceReason(e: unknown): string {
   return message.replace(/^API \d{3}: /, '');
 }
 
+/**
+ * A refusal, as the transcript reads it. The service's reason is carried WHOLE and the
+ * client only supplies a subject where the reason has not already named one — a guard
+ * that says "refused http://…: link-local" needs no "the service refused http://…"
+ * bolted in front of it, and stacking the two would make the message look paraphrased
+ * when the point is that it is not.
+ */
+export function refusalText(target: string, reason: string, verb: string): string {
+  const subject = target.trim();
+  return reason.includes(subject) ? reason : `${subject} ${verb}: ${reason}`;
+}
+
 /** §3.3: an error with no next action is banned. The service's named fix wins whenever
  *  it gave one; otherwise the next action is the other way to learn the same theme. */
 export function learnFix(kind: LearnKind, e: unknown): string {
@@ -126,11 +138,7 @@ export async function learnThemeFromThread(
     return { ok: true, themeId: res.theme_id };
   } catch (e: unknown) {
     const reason = serviceReason(e);
-    store.addActionable(
-      key,
-      `The service refused to learn from ${value.trim()}: ${reason}`,
-      learnFix(kind, e),
-    );
+    store.addActionable(key, refusalText(value, reason, 'was not learned from'), learnFix(kind, e));
     return { ok: false, reason };
   }
 }
@@ -188,7 +196,7 @@ export async function attachSourceFromThread(
     const reason = serviceReason(e);
     store.addActionable(
       key,
-      `${path.trim()} was not attached: ${reason}`,
+      refusalText(path, reason, 'was not attached'),
       e instanceof ServiceHintError ? e.hint
         : 'Check the path exists and the service can read it, then attach it again.',
     );

--- a/src/interactive/themeWire.ts
+++ b/src/interactive/themeWire.ts
@@ -1,0 +1,197 @@
+// Learn-a-theme and sources attach (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
+//
+// Both are non-text inputs, so both are MESSAGES (§2.3): a theme learned from a website
+// and a folder attached as reference are two of the clearest cases of a change whose
+// reason is unreconstructable if it never reached the transcript.
+//
+// Two guarantees this module keeps, and both of them are ABSENCES:
+//
+//   1. NOTHING UPLOADS (§4.6, §4.9). A PDF, an image and a reference folder are all
+//      submitted as a PATH the service reads in place. There is no `FormData`, no `File`
+//      and no `Blob` in this file and no file input behind it — which is what makes
+//      "it uses your actual numbers" a property rather than a promise.
+//   2. THE SPA NEVER FETCHES THE TARGET. A learn-from-URL submission goes to the bridge
+//      proxy and only there. The SSRF guard stays server-side and untouched (§4.6: http(s)
+//      only, reject metadata/loopback/link-local/private/ULA/CGNAT, resolve every address
+//      for the host and pin the validated one) — re-implementing any of it here would be a
+//      second, weaker guard that drifts from the real one. So when the service refuses,
+//      the client's whole job is to show the service's OWN reason, verbatim.
+
+import {
+  attachSource, learnTheme, ServiceHintError,
+  type LearnKind, type LearnThemeBody, type SourceEntry,
+} from '../api/interactive.js';
+import { nextMsgId, threadKey, useDocThreadStore } from '../store/docThread.js';
+
+/** Offered in §4.6's own order: the live URL first, then the two local kinds. */
+export const LEARN_KINDS: readonly LearnKind[] = ['url', 'pdf', 'image'];
+
+/** What the user is being asked for, per kind — the input's label and its placeholder. */
+export const LEARN_LABEL: Record<LearnKind, { noun: string; placeholder: string }> = {
+  url:   { noun: 'website',    placeholder: 'https://example.com' },
+  pdf:   { noun: 'PDF file',   placeholder: '/path/to/brand-guide.pdf' },
+  image: { noun: 'image file', placeholder: '/path/to/screenshot.png' },
+};
+
+/**
+ * The submission, per kind: a URL travels as `url`, a local file as `path` — never as
+ * bytes. The shapes differ because the SERVICE does different things with them (headless
+ * capture vs. reading the file in place), so the client says which it means rather than
+ * making the bridge guess from the string.
+ */
+export function learnBody(kind: LearnKind, value: string): LearnThemeBody {
+  const trimmed = value.trim();
+  return kind === 'url' ? { kind, url: trimmed } : { kind, path: trimmed };
+}
+
+/**
+ * Submittable. Deliberately SHALLOW for URLs: `http(s)://` + a host is the shape check,
+ * and nothing more — deciding whether an address is allowed is the server-side guard's
+ * job, and a client that pre-rejects `169.254.169.254` would be answering with its own
+ * opinion instead of the guard's stated reason (§4.6).
+ */
+export function learnReady(kind: LearnKind, value: string): boolean {
+  const trimmed = value.trim();
+  return kind === 'url' ? /^https?:\/\/\S+/i.test(trimmed) : trimmed !== '';
+}
+
+/** The ask, as the message it is (§2.3). */
+export function learnAsk(kind: LearnKind, value: string): string {
+  return kind === 'url'
+    ? `Learn a theme from ${value.trim()}.`
+    : `Learn a theme from the ${kind === 'pdf' ? 'PDF' : 'image'} at ${value.trim()}.`;
+}
+
+/**
+ * §3.3 informative: the subject is WHAT is being learned from, and what is happening to
+ * it. The local kinds also say the thing the UI is required to say (§4.6: "nothing
+ * uploads — preserve that guarantee and say so in the UI").
+ */
+export function learnSubject(kind: LearnKind, value: string): string {
+  const target = value.trim();
+  return kind === 'url'
+    ? `Learning a theme from ${target} — the service opens it in a headless browser and `
+      + 'the agent reads the design back from what rendered.'
+    : `Learning a theme from ${target} — read in place on this machine. `
+      + 'The file is not uploaded.';
+}
+
+/** The service's own sentence, unwrapped from the client's `API <status>: ` framing so
+ *  the refusal a human reads is the refusal the guard wrote (§4.6). */
+export function serviceReason(e: unknown): string {
+  const message = e instanceof Error ? e.message : String(e);
+  return message.replace(/^API \d{3}: /, '');
+}
+
+/** §3.3: an error with no next action is banned. The service's named fix wins whenever
+ *  it gave one; otherwise the next action is the other way to learn the same theme. */
+export function learnFix(kind: LearnKind, e: unknown): string {
+  if (e instanceof ServiceHintError) return e.hint;
+  return kind === 'url'
+    ? 'Use a public http(s) address the service can reach, or learn the theme from a '
+      + 'PDF or image instead — those are read from this machine.'
+    : 'Check the path exists and the service can read it, then submit it again.';
+}
+
+export interface LearnArgs {
+  projectId: string;
+  docId: string;
+  kind: LearnKind;
+  value: string;
+}
+
+export type LearnOutcome =
+  | { ok: true; themeId: string }
+  | { ok: false; reason: string };
+
+/**
+ * Submit one source for the agent to learn, and put the whole of it in the conversation.
+ * Never throws: a refusal is a message (§3.3 actionable), because the document is
+ * untouched either way and a refused theme is exactly the kind of thing a reader
+ * scrolling back needs to find.
+ */
+export async function learnThemeFromThread(
+  { projectId, docId, kind, value }: LearnArgs,
+): Promise<LearnOutcome> {
+  const key = threadKey(projectId, docId);
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(key, nextMsgId(), learnAsk(kind, value));
+  store.addNarration(key, learnSubject(kind, value));
+  try {
+    const res = await learnTheme(projectId, learnBody(kind, value));
+    // The bridge's own line wins where it wrote one — it knows what the agent is doing
+    // with this source; we only know that it took it.
+    store.addNarration(key, res.message ?? `Queued “${res.theme_id}” — it joins the theme `
+      + 'library once the agent has read the design.');
+    return { ok: true, themeId: res.theme_id };
+  } catch (e: unknown) {
+    const reason = serviceReason(e);
+    store.addActionable(
+      key,
+      `The service refused to learn from ${value.trim()}: ${reason}`,
+      learnFix(kind, e),
+    );
+    return { ok: false, reason };
+  }
+}
+
+// ── Sources attach (§4.9) ────────────────────────────────────────────────────
+
+/** The ask, as the message it is (§2.3). */
+export function sourceAsk(path: string): string {
+  return `Use ${path.trim()} as reference.`;
+}
+
+/** §3.3 informative, and §4.9's headline guarantee stated where the user can read it. */
+export function sourceSubject(path: string): string {
+  return `Attaching ${path.trim()} as a reference source — the service reads it in place `
+    + 'on this machine. Nothing is uploaded.';
+}
+
+/** Where the attach got to, in the service's terms. Every branch names its subject. */
+export function sourceStatusLine(entry: SourceEntry): string {
+  return entry.status === 'indexed'
+    ? `“${entry.path}” is indexed — the next generation can use what is in it.`
+    : `“${entry.path}” is being indexed on the service — it becomes usable as it lands.`;
+}
+
+export type AttachOutcome =
+  | { ok: true; entry: SourceEntry }
+  | { ok: false; reason: string };
+
+/**
+ * Attach one reference path. The chip is the caller's to add and it is added only on
+ * success — a chip for a folder the service could not read would claim context the
+ * generation does not actually have.
+ */
+export async function attachSourceFromThread(
+  { projectId, docId, path }: { projectId: string; docId: string; path: string },
+): Promise<AttachOutcome> {
+  const key = threadKey(projectId, docId);
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(key, nextMsgId(), sourceAsk(path));
+  store.addNarration(key, sourceSubject(path));
+  try {
+    const entry = await attachSource(projectId, docId, path.trim());
+    if (entry.status === 'error') {
+      store.addActionable(
+        key,
+        `“${entry.path}” was attached but could not be read, so nothing in it is available `
+        + 'to the next generation.',
+        'Check the path exists and the service can read it, then attach it again.',
+      );
+      return { ok: false, reason: 'the service could not read it' };
+    }
+    store.addNarration(key, sourceStatusLine(entry));
+    return { ok: true, entry };
+  } catch (e: unknown) {
+    const reason = serviceReason(e);
+    store.addActionable(
+      key,
+      `${path.trim()} was not attached: ${reason}`,
+      e instanceof ServiceHintError ? e.hint
+        : 'Check the path exists and the service can read it, then attach it again.',
+    );
+    return { ok: false, reason };
+  }
+}

--- a/src/store/docContext.ts
+++ b/src/store/docContext.ts
@@ -1,0 +1,66 @@
+// What the composer is carrying (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
+//
+// A picked theme and an attached reference folder are CONTEXT, not actions: they change
+// what the next generation is made of, so they belong on the composer as chips — studio's
+// existing `ContextPopover` pattern (§4.9) — rather than in a modal that closes and leaves
+// no trace of what is in effect.
+//
+// Two properties this store is shaped by:
+//
+//   - a chip is a REFERENCE, never a payload. A source chip holds the path the service
+//     reads in place; there is no File, no ArrayBuffer and no FormData anywhere in this
+//     module, which is the client half of §4.9's "nothing uploads" guarantee.
+//   - context is keyed to the composer the user is looking at, including the one with no
+//     document yet (§2.2 case 1) — a theme picked before the first message must ride with
+//     the generation that message opens, so `docId: null` is a real key, not a gap.
+
+import { create } from 'zustand';
+
+/** The composer's identity. Mirrors `threadKey`, extended to the doc-less case 1. */
+export function contextKey(projectId: string, docId: string | null): string {
+  return `${projectId}:${docId ?? ''}`;
+}
+
+interface DocContextStore {
+  /** The picked theme's slug (`ThemeSummary.name`), per composer. */
+  theme: Record<string, string>;
+  /** Attached reference paths, per composer, in the order they were attached. */
+  sources: Record<string, string[]>;
+  /** Pick a theme, or clear the chip by passing `null`. One theme at a time (§4.6). */
+  pickTheme: (key: string, themeId: string | null) => void;
+  /** Record an attached path. Idempotent: attaching the same folder twice is one chip. */
+  addSource: (key: string, path: string) => void;
+  removeSource: (key: string, path: string) => void;
+  clear: (key: string) => void;
+}
+
+export const useDocContextStore = create<DocContextStore>((set) => ({
+  theme: {},
+  sources: {},
+
+  pickTheme: (key, themeId) =>
+    set((s) => {
+      const theme = { ...s.theme };
+      if (themeId === null || themeId === '') delete theme[key];
+      else theme[key] = themeId;
+      return { theme };
+    }),
+
+  addSource: (key, path) =>
+    set((s) => {
+      const had = s.sources[key] ?? [];
+      return had.includes(path) ? s : { sources: { ...s.sources, [key]: [...had, path] } };
+    }),
+
+  removeSource: (key, path) =>
+    set((s) => ({
+      sources: { ...s.sources, [key]: (s.sources[key] ?? []).filter((p) => p !== path) },
+    })),
+
+  clear: (key) =>
+    set((s) => {
+      const theme = { ...s.theme }; delete theme[key];
+      const sources = { ...s.sources }; delete sources[key];
+      return { theme, sources };
+    }),
+}));

--- a/tests/ComposerContext.test.tsx
+++ b/tests/ComposerContext.test.tsx
@@ -1,0 +1,310 @@
+// The composer's context row — DES-MERGE-001 §4.6, §4.9, §2.3, §6.4 slice 16.
+//
+// What is asserted here is the SURFACE half of the slice: a picked theme becomes a chip
+// and that chip rides with the next generation, an attached folder becomes a chip and
+// uploads nothing, and a refusal from the service reaches the transcript with the
+// service's own words in it. The wire half lives in `themeWire.test.ts`.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposerContext } from '../src/components/ComposerContext.js';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { contextKey, useDocContextStore } from '../src/store/docContext.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
+
+const listThemes = vi.fn();
+const learnTheme = vi.fn();
+const attachSource = vi.fn();
+const createDoc = vi.fn();
+const postEvent = vi.fn();
+const getVersions = vi.fn();
+const postFork = vi.fn();
+
+vi.mock('../src/api/interactive.js', async (importOriginal) => {
+  // The error classes are real: `learnFix` narrows on `ServiceHintError`, and a stubbed
+  // class would make that branch untestable.
+  const actual = await importOriginal<typeof import('../src/api/interactive.js')>();
+  return {
+    ServiceHintError: actual.ServiceHintError,
+    BridgeUnavailableError: actual.BridgeUnavailableError,
+    listThemes: (...a: unknown[]) => listThemes(...a),
+    learnTheme: (...a: unknown[]) => learnTheme(...a),
+    attachSource: (...a: unknown[]) => attachSource(...a),
+    createDoc: (...a: unknown[]) => createDoc(...a),
+    postEvent: (...a: unknown[]) => postEvent(...a),
+    getVersions: (...a: unknown[]) => getVersions(...a),
+    postFork: (...a: unknown[]) => postFork(...a),
+    injectDocMessage: (p: string, d: string, text: string, id: string, themeId?: string) =>
+      postEvent(p, {
+        event_type: 'wicked.interactive.chat.posted',
+        payload: {
+          role: 'user', text, document_id: d, source_message_id: id,
+          ...(themeId === undefined ? {} : { theme_id: themeId }),
+        },
+      }),
+    interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+  };
+});
+
+const navigate = vi.fn();
+
+const THEMES = [
+  { name: 'stripe-ish', source: 'url' as const, learned_at: '2026-08-18T10:00:00Z' },
+  { name: 'corporate', learned_at: undefined },
+];
+
+function mountContext(docId: string | null = DOC): ReturnType<typeof render> {
+  return render(<ComposerContext projectId={PROJECT} docId={docId} />);
+}
+
+function mountThread(docId: string | null): void {
+  render(<DocumentThread projectId={PROJECT} docId={docId} selectedVersion={null} navigate={navigate} />);
+}
+
+function thread(key = KEY): DocMsg[] {
+  return useDocThreadStore.getState().messages[key] ?? [];
+}
+
+function chips(): HTMLElement[] {
+  return screen.queryAllByTestId('context-chip');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocContextStore.setState({ theme: {}, sources: {} });
+  listThemes.mockResolvedValue(THEMES);
+  learnTheme.mockResolvedValue({ theme_id: 'stripe-ish', status: 'queued' });
+  attachSource.mockResolvedValue({
+    path: '/Users/me/finance/q3', note: '', status: 'indexing',
+    added_at: '2026-08-18T10:00:00Z', indexed_at: null,
+  });
+  createDoc.mockResolvedValue({ name: DOC, head: 1 });
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  getVersions.mockResolvedValue({ head: 3, versions: [] });
+  postFork.mockResolvedValue({ version: 4, parent: 3 });
+});
+afterEach(cleanup);
+
+// ── AC: theme pick → chip ────────────────────────────────────────────────────
+
+describe('the theme library', () => {
+  it('lists the learned themes and picking one renders the context chip', async () => {
+    const user = userEvent.setup();
+    mountContext();
+    expect(chips()).toHaveLength(0);
+
+    await user.click(screen.getByTestId('context-library'));
+    const rows = await screen.findAllByTestId('theme-row');
+    expect(rows.map((r) => r.getAttribute('data-theme'))).toEqual(['stripe-ish', 'corporate']);
+    expect(listThemes).toHaveBeenCalledWith(PROJECT);
+
+    await user.click(rows[0]!);
+    await waitFor(() => expect(chips()).toHaveLength(1));
+    expect(chips()[0]).toHaveAttribute('data-chip-kind', 'theme');
+    expect(chips()[0]).toHaveAttribute('data-chip-value', 'stripe-ish');
+    expect(chips()[0]).toHaveTextContent('stripe-ish');
+  });
+
+  it('picking a second theme REPLACES the first — one theme at a time (§4.6)', async () => {
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-library'));
+    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
+    await user.click(screen.getByTestId('context-library'));
+    await user.click((await screen.findAllByTestId('theme-row'))[1]!);
+    await waitFor(() => expect(chips()).toHaveLength(1));
+    expect(chips()[0]).toHaveAttribute('data-chip-value', 'corporate');
+  });
+
+  it('the chip is removable, and removing it clears the pick', async () => {
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-library'));
+    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
+    await waitFor(() => expect(chips()).toHaveLength(1));
+
+    await user.click(screen.getByTestId('context-chip-remove'));
+    await waitFor(() => expect(chips()).toHaveLength(0));
+    expect(useDocContextStore.getState().theme[contextKey(PROJECT, DOC)]).toBeUndefined();
+  });
+
+  it('is pickable with NO document open — it is context for a generation not yet started', async () => {
+    const user = userEvent.setup();
+    mountContext(null);
+    // The two THREAD actions need a transcript for their message; the pick does not.
+    expect(screen.queryByTestId('context-learn')).toBeNull();
+    expect(screen.queryByTestId('context-sources')).toBeNull();
+    await user.click(screen.getByTestId('context-library'));
+    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
+    await waitFor(() => expect(chips()).toHaveLength(1));
+  });
+
+  it('a library that cannot be read says so and picks nothing (§3.3)', async () => {
+    listThemes.mockRejectedValue(new Error('API 503: bridge down'));
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-library'));
+    expect(await screen.findByTestId('theme-library-error')).toHaveTextContent('bridge down');
+    expect(chips()).toHaveLength(0);
+  });
+});
+
+// ── AC: the chip rides with the next generation ─────────────────────────────
+
+describe('the picked theme is what the next generation is made with', () => {
+  it('case 1 — the create body carries `theme_id`', async () => {
+    const user = userEvent.setup();
+    useDocContextStore.getState().pickTheme(contextKey(PROJECT, null), 'stripe-ish');
+    mountThread(null);
+
+    await user.type(screen.getByTestId('doc-composer'), 'a deck for the Q3 review');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+
+    await waitFor(() => expect(createDoc).toHaveBeenCalled());
+    expect(createDoc.mock.calls[0]![1]).toMatchObject({ theme_id: 'stripe-ish' });
+  });
+
+  it('case 2 — a steer carries the theme on the injected message', async () => {
+    const user = userEvent.setup();
+    useDocContextStore.getState().pickTheme(contextKey(PROJECT, DOC), 'corporate');
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    mountThread(DOC);
+
+    await user.type(screen.getByTestId('doc-composer'), 'make the headings tighter');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalled());
+    expect(postEvent.mock.calls[0]![1]).toMatchObject({
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { theme_id: 'corporate' },
+    });
+  });
+
+  it('no pick means no `theme_id` — an absent chip sends an absent field, never null', async () => {
+    const user = userEvent.setup();
+    mountThread(null);
+    await user.type(screen.getByTestId('doc-composer'), 'a deck for the Q3 review');
+    await user.click(screen.getByTestId('doc-composer-submit'));
+    await waitFor(() => expect(createDoc).toHaveBeenCalled());
+    expect(createDoc.mock.calls[0]![1]).not.toHaveProperty('theme_id');
+  });
+});
+
+// ── AC: sources attach → chip, and NOTHING uploads ──────────────────────────
+
+describe('attaching a reference folder', () => {
+  const PATH = '/Users/me/finance/q3';
+
+  it('shows the path as a context chip and submits the PATH, not the files', async () => {
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-sources'));
+    await user.type(screen.getByTestId('source-input'), PATH);
+    await user.click(screen.getByTestId('source-attach'));
+
+    await waitFor(() => expect(chips()).toHaveLength(1));
+    expect(chips()[0]).toHaveAttribute('data-chip-kind', 'source');
+    expect(chips()[0]).toHaveAttribute('data-chip-value', PATH);
+    expect(attachSource).toHaveBeenCalledWith(PROJECT, DOC, PATH);
+    // Every argument is a string. Nothing file-shaped is even constructed.
+    for (const arg of attachSource.mock.calls[0]!) expect(typeof arg).toBe('string');
+  });
+
+  it('offers NO file input anywhere — there is nothing to upload from (§4.9)', async () => {
+    const user = userEvent.setup();
+    const { container } = mountContext();
+    await user.click(screen.getByTestId('context-sources'));
+    expect(container.querySelectorAll('input[type="file"]')).toHaveLength(0);
+    // …and the panel SAYS so, which §4.9 asks of the UI rather than just of the wire.
+    expect(screen.getByTestId('source-no-upload')).toHaveTextContent('nothing is uploaded');
+
+    await user.click(screen.getByTestId('context-learn'));
+    expect(container.querySelectorAll('input[type="file"]')).toHaveLength(0);
+  });
+
+  it('the attach lands in the thread as a message (§2.3)', async () => {
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-sources'));
+    await user.type(screen.getByTestId('source-input'), PATH);
+    await user.click(screen.getByTestId('source-attach'));
+
+    await waitFor(() => expect(thread().length).toBeGreaterThan(0));
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: `Use ${PATH} as reference.` });
+    expect(thread().some((m) => m.kind === 'narration' && m.text.includes('Nothing is uploaded'))).toBe(true);
+  });
+
+  it('a refused attach leaves NO chip — a chip would claim context the generation lacks', async () => {
+    attachSource.mockRejectedValue(new Error('API 400: path is outside the project root'));
+    const user = userEvent.setup();
+    mountContext();
+    await user.click(screen.getByTestId('context-sources'));
+    await user.type(screen.getByTestId('source-input'), '/etc');
+    await user.click(screen.getByTestId('source-attach'));
+
+    await waitFor(() => expect(thread().some((m) => m.kind === 'actionable')).toBe(true));
+    expect(chips()).toHaveLength(0);
+  });
+});
+
+// ── AC: the service's refusal, surfaced verbatim, in the thread ─────────────
+
+describe('learn-a-theme in the thread', () => {
+  const REASON = 'refused: 169.254.169.254 resolves to a link-local address';
+
+  it('renders the SERVICE reason verbatim as an actionable message', async () => {
+    learnTheme.mockRejectedValue(new Error(`API 400: ${REASON}`));
+    const user = userEvent.setup();
+    mountThread(DOC);
+
+    await user.click(screen.getByTestId('context-learn'));
+    await user.type(screen.getByTestId('learn-input'), 'http://169.254.169.254/');
+    await user.click(screen.getByTestId('learn-submit'));
+
+    const actionable = await screen.findByTestId('doc-actionable');
+    expect(actionable).toHaveTextContent(REASON);
+    // The SPA submitted to the bridge and nowhere else — the guard is the only thing
+    // that ever resolved that address.
+    expect(learnTheme).toHaveBeenCalledWith(PROJECT, { kind: 'url', url: 'http://169.254.169.254/' });
+    expect(screen.getByTestId('doc-actionable-hint').textContent?.trim()).not.toBe('');
+  });
+
+  it('submits the picked KIND: switching to PDF sends a path, and says nothing uploads', async () => {
+    const user = userEvent.setup();
+    mountThread(DOC);
+    await user.click(screen.getByTestId('context-learn'));
+    await user.click(screen.getByTestId('learn-input'));
+
+    const pdf = screen.getAllByTestId('learn-kind').find((b) => b.getAttribute('data-kind') === 'pdf')!;
+    await user.click(pdf);
+    expect(screen.getByTestId('learn-no-upload')).toHaveTextContent('not uploaded');
+
+    await user.type(screen.getByTestId('learn-input'), '/brand/guide.pdf');
+    await user.click(screen.getByTestId('learn-submit'));
+    await waitFor(() => expect(learnTheme).toHaveBeenCalled());
+    expect(learnTheme).toHaveBeenCalledWith(PROJECT, { kind: 'pdf', path: '/brand/guide.pdf' });
+  });
+
+  it('a malformed URL is not submittable, but an address the GUARD owns is', async () => {
+    const user = userEvent.setup();
+    mountThread(DOC);
+    await user.click(screen.getByTestId('context-learn'));
+    await user.type(screen.getByTestId('learn-input'), 'stripe.com');
+    expect(screen.getByTestId('learn-submit')).toBeDisabled();
+
+    await user.clear(screen.getByTestId('learn-input'));
+    await user.type(screen.getByTestId('learn-input'), 'http://169.254.169.254/');
+    expect(screen.getByTestId('learn-submit')).toBeEnabled();
+  });
+
+  it('the context row is Document mode only — a demo looks like the site it records', () => {
+    render(<DocumentThread projectId={PROJECT} docId={DOC} selectedVersion={null}
+                           navigate={navigate} mode="video" />);
+    expect(screen.queryByTestId('thread-context')).toBeNull();
+  });
+});

--- a/tests/themeWire.test.ts
+++ b/tests/themeWire.test.ts
@@ -1,0 +1,268 @@
+// Learn-a-theme + sources attach, at the WIRE (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
+//
+// These tests drive the REAL client (`src/api/interactive.ts`) against a stubbed `fetch`,
+// not a mocked module, because two of the four ACs are claims about what does and does not
+// leave the page — and a mocked client cannot prove either one:
+//
+//   - nothing uploads: every submission body is a JSON string carrying a PATH. No
+//     `FormData`, no `File`, no `Blob`, no `multipart/*` content type (§4.6, §4.9).
+//   - the SPA never fetches the target: a learn-from-URL submission goes to the bridge
+//     proxy and only there, so the SSRF guard (§4.6) is the only thing that ever resolves
+//     that address. When it refuses, its reason reaches the transcript verbatim.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  attachSourceFromThread, learnBody, learnFix, learnReady, learnThemeFromThread,
+  serviceReason, sourceStatusLine,
+} from '../src/interactive/themeWire.js';
+import { listThemes } from '../src/api/interactive.js';
+import { apiBase } from '../src/api/client.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
+
+/** The metadata endpoint §6.4's AC names. The guard is server-side; this address must
+ *  never appear in a request the SPA itself makes. */
+const METADATA = 'http://169.254.169.254/';
+
+interface Call { url: string; init: RequestInit | undefined }
+
+/** Stub fetch with one queued response per call; returns the log it received. */
+function stubFetch(responses: Array<{ body: unknown; status?: number }>): Call[] {
+  const calls: Call[] = [];
+  const queue = [...responses];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const next = queue.shift() ?? { body: {}, status: 200 };
+    const status = next.status ?? 200;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: String(status),
+      text: () => Promise.resolve(JSON.stringify(next.body)),
+      json: () => Promise.resolve(next.body),
+    });
+  }));
+  return calls;
+}
+
+function thread(): DocMsg[] {
+  return useDocThreadStore.getState().messages[KEY] ?? [];
+}
+
+/** Every message body, flattened — what a human scrolling the transcript would read. */
+function transcript(): string {
+  return thread().map((m) => ('text' in m ? m.text : '')).join('\n');
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_API_HOST', '');
+  Object.defineProperty(window, 'location', {
+    value: new URL('http://127.0.0.1:7788/'), writable: true, configurable: true,
+  });
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+});
+afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+// ── AC: submission shapes, per kind ──────────────────────────────────────────
+
+describe('submission shape per kind (url / pdf / image)', () => {
+  it('a URL travels as `url`; a PDF and an image travel as `path`', () => {
+    expect(learnBody('url', ' https://stripe.com ')).toEqual({ kind: 'url', url: 'https://stripe.com' });
+    expect(learnBody('pdf', ' /brand/guide.pdf ')).toEqual({ kind: 'pdf', path: '/brand/guide.pdf' });
+    expect(learnBody('image', '/shots/home.png')).toEqual({ kind: 'image', path: '/shots/home.png' });
+  });
+
+  it('a local kind sends NO url field, so the service never treats a path as fetchable', () => {
+    for (const kind of ['pdf', 'image'] as const) {
+      expect(learnBody(kind, '/x.pdf')).not.toHaveProperty('url');
+    }
+    expect(learnBody('url', 'https://x.dev')).not.toHaveProperty('path');
+  });
+
+  it('readiness is a SHAPE check only — an address the guard will refuse is submittable', () => {
+    // Deliberate (§4.6): pre-rejecting here would answer with the client's opinion
+    // instead of the guard's stated reason, and the two would drift.
+    expect(learnReady('url', METADATA)).toBe(true);
+    expect(learnReady('url', 'stripe.com')).toBe(false);   // not http(s) — a typo, not a policy
+    expect(learnReady('pdf', '   ')).toBe(false);
+    expect(learnReady('image', '/shots/home.png')).toBe(true);
+  });
+
+  it.each(['url', 'pdf', 'image'] as const)(
+    '%s: POSTs the kind to the proxied learn endpoint as a JSON body — never a form',
+    async (kind) => {
+      const calls = stubFetch([{ body: { theme_id: 't1', status: 'queued' } }]);
+      const value = kind === 'url' ? 'https://stripe.com' : '/brand/guide.pdf';
+      await learnThemeFromThread({ projectId: PROJECT, docId: DOC, kind, value });
+
+      expect(calls).toHaveLength(1);
+      const { url, init } = calls[0]!;
+      expect(url).toBe(`${apiBase()}/projects/${PROJECT}/interactive/api/theme/learn`);
+      expect(init?.method).toBe('POST');
+      expect(typeof init?.body).toBe('string');
+      expect(JSON.parse(init?.body as string)).toEqual(learnBody(kind, value));
+      expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    },
+  );
+
+  it('the submission is a MESSAGE, and the learning narrates informatively (§2.3, §3.3)', async () => {
+    stubFetch([{ body: { theme_id: 'stripe', status: 'queued' } }]);
+    await learnThemeFromThread({
+      projectId: PROJECT, docId: DOC, kind: 'url', value: 'https://stripe.com',
+    });
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: 'Learn a theme from https://stripe.com.' });
+    const narration = thread().filter((m) => m.kind === 'narration');
+    expect(narration.length).toBeGreaterThanOrEqual(2);
+    // Informative means it names its subject AND what is happening to it — never bare.
+    expect(narration[0]!.text).toContain('https://stripe.com');
+    expect(narration[0]!.text).not.toBe('Working…');
+  });
+
+  it('the local kinds SAY the no-upload guarantee, as §4.6 requires of the UI', async () => {
+    stubFetch([{ body: { theme_id: 't', status: 'queued' } }]);
+    await learnThemeFromThread({
+      projectId: PROJECT, docId: DOC, kind: 'pdf', value: '/brand/guide.pdf',
+    });
+    expect(transcript()).toContain('not uploaded');
+  });
+
+  it("the bridge's own progress line wins over ours when it wrote one", async () => {
+    stubFetch([{ body: { theme_id: 't', status: 'queued', message: 'Reading the palette from 12 captured pages.' } }]);
+    await learnThemeFromThread({
+      projectId: PROJECT, docId: DOC, kind: 'url', value: 'https://stripe.com',
+    });
+    expect(transcript()).toContain('Reading the palette from 12 captured pages.');
+  });
+});
+
+// ── AC: the SSRF refusal is the SERVICE's, surfaced verbatim ─────────────────
+
+describe('SSRF rejection surfacing (§4.6 — the guard stays server-side)', () => {
+  const REASON = 'refused: 169.254.169.254 resolves to a link-local address';
+
+  it('shows the reason VERBATIM and makes no request to the address itself', async () => {
+    const calls = stubFetch([{ body: { error: REASON }, status: 400 }]);
+    const outcome = await learnThemeFromThread({
+      projectId: PROJECT, docId: DOC, kind: 'url', value: METADATA,
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: REASON });
+    // ONE request, to the bridge proxy — never to the target. This is the unit-level
+    // twin of the Playwright `page.on('request')` assertion.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${apiBase()}/projects/${PROJECT}/interactive/api/theme/learn`);
+    for (const call of calls) expect(call.url).not.toContain('169.254.169.254');
+
+    const actionable = thread().find((m) => m.kind === 'actionable');
+    expect(actionable).toBeDefined();
+    // Verbatim: the guard's own sentence, not a paraphrase and not an HTTP status.
+    expect((actionable as Extract<DocMsg, { kind: 'actionable' }>).text).toContain(REASON);
+    expect((actionable as Extract<DocMsg, { kind: 'actionable' }>).text).not.toContain('API 400');
+  });
+
+  it('a refusal still carries a next action — §3.3 bans an error without one', async () => {
+    stubFetch([{ body: { error: REASON }, status: 400 }]);
+    await learnThemeFromThread({ projectId: PROJECT, docId: DOC, kind: 'url', value: METADATA });
+    const actionable = thread().find((m) => m.kind === 'actionable') as Extract<DocMsg, { kind: 'actionable' }>;
+    expect(actionable.hint.trim()).not.toBe('');
+    expect(actionable.hint).toContain('PDF or image');
+  });
+
+  it("the service's own named fix wins over ours whenever it gave one", async () => {
+    const hint = 'set WI_ALLOW_PRIVATE_THEME_HOSTS=1 to allow this host';
+    stubFetch([{ body: { error: REASON, hint }, status: 400 }]);
+    await learnThemeFromThread({ projectId: PROJECT, docId: DOC, kind: 'url', value: METADATA });
+    const actionable = thread().find((m) => m.kind === 'actionable') as Extract<DocMsg, { kind: 'actionable' }>;
+    expect(actionable.hint).toBe(hint);
+  });
+
+  it('the ask stays in the transcript after a refusal — a rejected theme is a record', async () => {
+    stubFetch([{ body: { error: REASON }, status: 400 }]);
+    await learnThemeFromThread({ projectId: PROJECT, docId: DOC, kind: 'url', value: METADATA });
+    expect(thread()[0]).toMatchObject({ kind: 'user' });
+    expect(transcript()).toContain(METADATA);
+  });
+
+  it('serviceReason unwraps the client framing; learnFix always names something to do', () => {
+    expect(serviceReason(new Error('API 400: not an http(s) URL'))).toBe('not an http(s) URL');
+    expect(serviceReason(new Error('connection refused'))).toBe('connection refused');
+    expect(learnFix('pdf', new Error('boom')).trim()).not.toBe('');
+  });
+});
+
+// ── AC: sources attach uploads NOTHING ───────────────────────────────────────
+
+describe('sources attach (§4.9 — the service reads it in place)', () => {
+  const PATH = '/Users/me/finance/q3';
+
+  it('sends the PATH as JSON: no FormData, no File, no multipart body', async () => {
+    const calls = stubFetch([{ body: { path: PATH, note: '', status: 'indexing', added_at: 'now', indexed_at: null } }]);
+    const outcome = await attachSourceFromThread({ projectId: PROJECT, docId: DOC, path: PATH });
+
+    expect(outcome.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    const { url, init } = calls[0]!;
+    expect(url).toBe(`${apiBase()}/projects/${PROJECT}/interactive/d/${DOC}/api/sources`);
+    expect(init?.method).toBe('POST');
+    // The whole of the no-upload guarantee, at the only place it can be broken.
+    expect(init?.body).toBeTypeOf('string');
+    expect(init?.body).not.toBeInstanceOf(FormData);
+    expect(JSON.parse(init?.body as string)).toEqual({ path: PATH });
+    const ctype = (init?.headers as Record<string, string>)['Content-Type'];
+    expect(ctype).toBe('application/json');
+    expect(ctype).not.toContain('multipart');
+    // The body carries the path and nothing else — no bytes, no file name list.
+    expect((init?.body as string).length).toBeLessThan(PATH.length + 32);
+  });
+
+  it('the attach is a message, and says where the reading happens (§2.3, §4.9)', async () => {
+    stubFetch([{ body: { path: PATH, note: '', status: 'indexed', added_at: 'now', indexed_at: 'now' } }]);
+    await attachSourceFromThread({ projectId: PROJECT, docId: DOC, path: PATH });
+    expect(thread()[0]).toMatchObject({ kind: 'user', text: `Use ${PATH} as reference.` });
+    expect(transcript()).toContain('Nothing is uploaded.');
+    expect(transcript()).toContain('is indexed');
+  });
+
+  it('a source the service could not read is ACTIONABLE and does not claim context', async () => {
+    stubFetch([{ body: { path: PATH, note: '', status: 'error', added_at: 'now', indexed_at: null } }]);
+    const outcome = await attachSourceFromThread({ projectId: PROJECT, docId: DOC, path: PATH });
+    expect(outcome.ok).toBe(false);
+    const actionable = thread().find((m) => m.kind === 'actionable') as Extract<DocMsg, { kind: 'actionable' }>;
+    expect(actionable.text).toContain(PATH);
+    expect(actionable.hint).toContain('attach it again');
+  });
+
+  it('a refused attach surfaces the service reason verbatim', async () => {
+    stubFetch([{ body: { error: 'path is outside the project root' }, status: 400 }]);
+    const outcome = await attachSourceFromThread({ projectId: PROJECT, docId: DOC, path: '/etc' });
+    expect(outcome).toEqual({ ok: false, reason: 'path is outside the project root' });
+    expect(transcript()).toContain('path is outside the project root');
+  });
+
+  it('every status line names its subject (§3.3)', () => {
+    const base = { path: PATH, note: '', added_at: 'now', indexed_at: null };
+    for (const status of ['pending', 'indexing', 'indexed'] as const) {
+      expect(sourceStatusLine({ ...base, status })).toContain(PATH);
+    }
+  });
+});
+
+// ── The library, as the bridge may spell it ──────────────────────────────────
+
+describe('theme library', () => {
+  it('reads a bare array and a `{themes}` envelope the same way', async () => {
+    const rows = [{ name: 'stripe', source: 'url' as const, learned_at: 'now' }];
+    stubFetch([{ body: rows }]);
+    await expect(listThemes(PROJECT)).resolves.toEqual(rows);
+    stubFetch([{ body: { themes: rows } }]);
+    await expect(listThemes(PROJECT)).resolves.toEqual(rows);
+  });
+
+  it('is fetched through the project-scoped proxy mount — no second origin', async () => {
+    const calls = stubFetch([{ body: [] }]);
+    await listThemes(PROJECT);
+    expect(calls[0]!.url).toBe(`${apiBase()}/projects/${PROJECT}/interactive/api/themes`);
+  });
+});

--- a/tests/themeWire.test.ts
+++ b/tests/themeWire.test.ts
@@ -12,7 +12,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   attachSourceFromThread, learnBody, learnFix, learnReady, learnThemeFromThread,
-  serviceReason, sourceStatusLine,
+  refusalText, serviceReason, sourceStatusLine,
 } from '../src/interactive/themeWire.js';
 import { listThemes } from '../src/api/interactive.js';
 import { apiBase } from '../src/api/client.js';
@@ -155,11 +155,21 @@ describe('SSRF rejection surfacing (§4.6 — the guard stays server-side)', () 
     expect(calls[0]!.url).toBe(`${apiBase()}/projects/${PROJECT}/interactive/api/theme/learn`);
     for (const call of calls) expect(call.url).not.toContain('169.254.169.254');
 
-    const actionable = thread().find((m) => m.kind === 'actionable');
+    const actionable = thread().find((m) => m.kind === 'actionable') as Extract<DocMsg, { kind: 'actionable' }>;
     expect(actionable).toBeDefined();
-    // Verbatim: the guard's own sentence, not a paraphrase and not an HTTP status.
-    expect((actionable as Extract<DocMsg, { kind: 'actionable' }>).text).toContain(REASON);
-    expect((actionable as Extract<DocMsg, { kind: 'actionable' }>).text).not.toContain('API 400');
+    // Verbatim: the guard's own sentence, carried WHOLE — not a paraphrase, not summarised
+    // and not an HTTP status. This reason names no URL, so the client supplies the subject
+    // (and only then); the reason itself is untouched.
+    expect(actionable.text).toContain(REASON);
+    expect(actionable.text).toBe(`${METADATA} was not learned from: ${REASON}`);
+    expect(actionable.text).not.toContain('API 400');
+  });
+
+  it('supplies a subject only when the service reason has not already named one', () => {
+    expect(refusalText('http://x.dev', 'refused http://x.dev: private range', 'was not learned from'))
+      .toBe('refused http://x.dev: private range');
+    expect(refusalText('http://x.dev', 'not reachable', 'was not learned from'))
+      .toBe('http://x.dev was not learned from: not reachable');
   });
 
   it('a refusal still carries a next action — §3.3 bans an error without one', async () => {


### PR DESCRIPTION
Slice 16, authored and delivered by governed run `95c568d7-5c9f-4fd9-845a-652b61aca49d`.

Learn-a-theme (URL / PDF / image) as thread actions with narrated progress; theme library + composer context chip; sources attach as a chip with NOTHING uploaded (asserted — no multipart body leaves the page); the service's SSRF rejection surfaces verbatim, with Playwright proving no client-side request to the rejected address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)