### PR TITLE
release: 0.2.0 — the merged interactive layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
-  "version": "0.1.1",
-  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "version": "0.2.0",
+  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump for the DES-MERGE-001 wave (slices 2, 4–17 + live-edge; 23 commits since v0.1.1). Tag `v0.2.0` after merge triggers the trusted-publish workflow; wicked-crew 0.6.0 bundles this dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)