### PR TITLE
feat(brand): the product is wicked-studio

### DIFF
--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -925,7 +925,7 @@ export function CenterDashboard({
         >
           <div>
             <h1 style={{ fontSize: '20px', fontWeight: 600, color: '#e6edf3', margin: 0, ...mono }}>
-              wicked-crew studio
+              wicked-studio
             </h1>
             <p style={{ fontSize: '11px', color: 'rgba(230,237,243,0.38)', margin: '4px 0 0', ...mono }}>
               cross-session control

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -317,7 +317,7 @@ export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Prop
             className="flex-1 text-left text-sm font-semibold font-mono truncate transition-opacity hover:opacity-70"
             style={{ color: S.ink, background: 'transparent' }}
           >
-            wicked-crew studio
+            wicked-studio
           </button>
         )}
         <button

--- a/tests/productName.test.tsx
+++ b/tests/productName.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * The merged product (DES-MERGE-001) ships under its own name. These cases pin the
+ * two places a user actually reads it — the sidebar wordmark and the browser tab —
+ * so a rename back to the old "wicked-crew studio" wordmark fails the suite.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ ok: true, version: '0.2.0' }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+}));
+
+const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+
+describe('visible product name', () => {
+  it('the sidebar wordmark reads wicked-studio', async () => {
+    render(
+      <LeftSidebar runs={[]} selectedRunId={null} onSelectRun={() => {}} navigate={() => {}} />,
+    );
+
+    // The wordmark is the home button next to the logo. `findByRole` also settles the
+    // health/repos fetches the sidebar kicks off on mount. Matched exactly, so the old
+    // "wicked-crew studio" (which contains this text) cannot satisfy it.
+    const wordmark = await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(wordmark.textContent?.trim()).toBe('wicked-studio');
+  });
+
+  it('the document title reads wicked-studio', () => {
+    const html = readFileSync(join(process.cwd(), 'index.html'), 'utf8');
+    expect(html).toMatch(/<title>\s*wicked-studio\s*<\/title>/);
+  });
+});


### PR DESCRIPTION
Operator-requested rebrand, authored and delivered by governed run `7598bf14-8c68-4194-ac43-175c2835d517`: every user-visible "wicked-crew studio" (wordmark, document title, labels) now reads "wicked-studio". Package names, API paths, and daemon references untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)