### PR TITLE
feat(board): attention decay + bands (DES-UXFIX-001 slice 1)

### DIFF
--- a/.product/evidence/uxfix-slice1/checklist.md
+++ b/.product/evidence/uxfix-slice1/checklist.md
@@ -1,0 +1,29 @@
+# DES-UXFIX-001 slice 1 — experience checklist verdicts
+
+**Slice:** attention decay + board bands (answers F3, F5; serves W2, W4)
+**Rubric:** DES-UXFIX-001 §4.1, items mapped to this slice: EC3, EC4, EC5 (EC10 re-read
+opportunistically per the slice design §5.6).
+**Images:** `e2e/shots/uxfix/uxfix-1-messy-board.png` (full W2 board, QUIET collapsed),
+`e2e/shots/uxfix/uxfix-1-quiet-expanded.png` (same board, QUIET expanded) — captured at
+1440×900, `device_scale_factor=1`, per §4.0, by `e2e/uxfix_slice1_test.py` against the
+frozen-`NOW0` W2 fixture (§4.2). The shots are gitignored evidence; the rig's JSON report
+records each shot's path beside the DOM verdicts.
+
+| Item | Verdict | Read from the image |
+|---|---|---|
+| **EC3** — needs-me is distinct from history | **PASS** | In `uxfix-1-messy-board.png`, the accent NEEDS YOU band label and the gate chips (`gate [Approve] [Reject]`, `gate [Answer ›]`) are the highest-contrast elements on screen. The quiet majority is one demoted chip line each (`○ notes · 2d`, `○ legacy-spike · 8d`, …) under its own muted QUIET (24) label. |
+| **EC4** — no stale item leads | **PASS** | Same image: `legacy-spike` (8-day failure) is not in the live band — it appears only as a quiet chip labelled `8d` — while `upload-endpoint` sits in NEEDS YOU streaming its live narration line. The 12-minute failure (`auth-refactor`) still leads it; both gates lead everything. Legible from the ordering alone, without the DOM. |
+| **EC5** — no junk leads | **PASS** | Both images: no band above the real projects belongs to the shelf; "Not in a project" is last in document order, collapsed, absent entirely when nothing is unfiled (DOM-asserted by the rig), and the word "Unfiled" appears nowhere on the surface. |
+| **EC10** — no banned state (opportunistic) | **PASS** | Neither shot contains a bare spinner, a bare "Working…", whimsy, or an error without a next action. Every live line names its subject (`build — Writing the token-bucket middleware for /upload`). |
+
+Not judged here (out of this slice's mapping, per §5.6): EC2 (absence budget) and EC6
+(differentiated verbs) — the expanded QUIET band deliberately shows today's full card,
+including its "No documents yet." lines and the four same-named quick actions; both are
+slice 2's deliverables (D5, R6).
+
+**Mechanism verdicts** (the DOM half, from the rig's JSON report, all true):
+needs-you order `q3-review-deck → api-migration → auth-refactor → upload-endpoint`;
+`legacy-spike` demoted by its 8-day durable-log tail despite a 1-hour-old
+`project.updated_at` (the R3 trap, exercised for real); an 8-day-old gate still scores
+100.00 and leads; band ⇄ threshold agreement on every mounted card; board height 844px ≤
+900, document height 900 ≤ 900, 13 cards mounted of 28 projects with QUIET expanded.

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -112,6 +112,13 @@ What "independent" means here, and what this script proves end-to-end:
      accent-coloured, unanimated), the run chip inside the executing card carries
      the same edge, and under prefers-reduced-motion the animation is replaced by
      a wider solid edge rather than dropped.
+ 20. (DES-UXFIX-001 slice 1) the board renders NEEDS YOU / QUIET bands off the
+     decayed attention score. The board sections above expand the QUIET band
+     wherever they assert a quiet project's card (a run-less project is quiet by
+     construction now); the slice's own W2 messy-reality gate — an 8-day failure
+     demoted, a live run leading, the "Not in a project" shelf last/collapsed/
+     absent-when-empty — runs against a deterministic fixture rig in
+     e2e/uxfix_slice1_test.py, which needs no crew daemon at all.
 
 The daemon is the ONE thing this repo cannot supply. Point CREW_CLI at a built
 crew CLI entry (`.../packages/crew/dist/cli/index.js`); it defaults to the sibling
@@ -516,6 +523,10 @@ try:
         gate_chip_ok = "gate" in first_card.inner_text().lower()
 
         # AC: the empty project's card shows the four quick actions, each pre-bound to it.
+        # Slice 1 (DES-UXFIX-001): a run-less project is QUIET by construction, and its
+        # card mounts only once the band expands. The claim under test is unchanged.
+        page.locator('[data-testid="band-quiet-toggle"]').wait_for(timeout=30000)
+        page.locator('[data-testid="band-quiet-toggle"]').click()
         empty_card = page.locator(f'[data-testid="project-card"][data-project-id="{empty_project}"]')
         empty_card.wait_for(timeout=30000)
         actions = empty_card.locator('[data-testid="quick-action"]')
@@ -540,6 +551,9 @@ try:
             page,
             """() => Number(document.querySelector('[data-testid="project-board"]')?.dataset.total || 0) >= 20""",
         )
+        # Slice 1: mounted-bounded is a claim about CARDS — expand QUIET (the reload
+        # collapsed it again) so the bulk projects are in a grid, then count.
+        page.locator('[data-testid="band-quiet-toggle"]').click()
         total = int(board.get_attribute("data-total") or 0)
         rendered = page.locator('[data-testid="project-card"]').count()
         board_box = board.bounding_box() or {"height": 1e9}
@@ -648,6 +662,12 @@ try:
         # every assertion below is provably about THIS page load.
         page.evaluate("() => { window.__slice6 = 'same page'; }")
 
+        # Slice 1 (DES-UXFIX-001): live_b starts run-less, i.e. QUIET — expand the
+        # band so its card mounts. A toggle click is not a navigation; the sentinel
+        # set above survives it, which `same_page` still proves at the end.
+        page.locator('[data-testid="band-quiet-toggle"]').wait_for(timeout=30000)
+        page.locator('[data-testid="band-quiet-toggle"]').click()
+
         both_visible = settled(
             page,
             """ids => ids.every(id => document.querySelector(
@@ -682,6 +702,13 @@ try:
         )
         a_after_gate = page.evaluate(CARD_INDEX, live_a)
         b_after_gate = page.evaluate(CARD_INDEX, live_b)
+        # Slice 1 strengthens the claim: the gated card did not just sort first — it
+        # moved INTO the NEEDS YOU band (DES-UXFIX-001 §5.5: a gate never decays).
+        b_in_needs_you = page.evaluate(
+            """id => !!document.querySelector(
+                 `[data-testid="band-needs-you"] [data-testid="project-card"][data-project-id="${id}"]`)""",
+            live_b,
+        )
         page.screenshot(path=str(SHOTS / "slice6-board-gate-resort.png"), full_page=True)
 
         # ── AC: a delta for B updates B's headline within 2 s; A is unchanged ──
@@ -750,9 +777,11 @@ try:
     report["steps"]["board_live"] = {
         "ok": all([
             both_visible, chip_ok, resorted, b_after_gate < a_after_gate, b_before > a_before,
+            b_in_needs_you,
             headline_ok, a_untouched, doc_ok, same_page, one_socket,
             board_scroll_before == board_scroll_after, not clipped,
         ]),
+        "gated_card_in_needs_you_band": b_in_needs_you,
         "project_a": live_a,
         "project_b": live_b,
         "run_b": rb,
@@ -810,6 +839,12 @@ try:
         page.wait_for_function("() => typeof window.__pushFrame === 'function'", timeout=30000)
         # Same sentinel discipline as slice 6: any navigation or reload wipes it.
         page.evaluate("() => { window.__slice7 = 'same page'; }")
+
+        # Slice 1: keep quiet cards reachable for the whole flow — an approved run
+        # eventually completes and its project demotes out of the live band; with
+        # QUIET expanded, its chip stays queryable instead of unmounting mid-poll.
+        if page.locator('[data-testid="band-quiet-toggle"]').count() > 0:
+            page.locator('[data-testid="band-quiet-toggle"]').click()
 
         # ── AC: a simple gate is answered ON the board, and the run advances there ─
         approve = page.locator(f'[data-testid="gate-approve-{simple_run}"]')

--- a/e2e/uxfix_slice1_test.py
+++ b/e2e/uxfix_slice1_test.py
@@ -412,11 +412,12 @@ with sync_playwright() as p:
     mounted = page.locator('[data-testid="project-card"]').count()
     invariants_ok = board_h <= 900 and doc_h <= 900 + 1 and 0 < mounted < total
 
-    # Assertion 1's second half: legacy-spike's card carries the verdict. It sits
-    # deep in the quiet grid, so scroll it into the window first.
-    page.evaluate(
-        """() => { const b = document.querySelector('[data-testid="project-board"]');
-                   b.scrollTop = b.scrollHeight; }""")
+    # Assertion 1's second half: legacy-spike's card carries the verdict. Its
+    # epsilon score (≈3e-13, still > the clones' 0) puts it in the quiet band's
+    # FIRST row, so at scrollTop 0 it is co-mounted with the whole NEEDS YOU band
+    # — no scrolling. (Scrolling to the bottom here would race: once the scroll
+    # event's re-render lands, the quiet window moves past row 0 and unmounts the
+    # very card under assertion.)
     legacy_card_ok = settled(
         """() => { const c = document.querySelector(
                      '[data-testid="project-card"][data-project-id="legacy-spike"]');

--- a/e2e/uxfix_slice1_test.py
+++ b/e2e/uxfix_slice1_test.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+uxfix_slice1_test.py — the DES-UXFIX-001 slice-1 gate: attention decay + board
+bands, proven in a real browser against the W2 messy-reality fixture (§4.2).
+
+The daemon cannot produce an 8-day-old failure — its durable log is stamped at
+emit and `POST /runs` starts now — so the fixture is served by a DETERMINISTIC
+FIXTURE SERVER, the same pattern the doc rig in studio_standalone_test.py §12
+uses: a ThreadingHTTPServer that serves the `dist-sameorigin/` build (the
+no-VITE_API_HOST build — `apiBase()` derives from window.location, so the page,
+the API and the `/ws` handshake share ONE origin, no rebuild) plus every
+endpoint the home route reads, with all timestamps computed from a single NOW0
+captured at start.  No crew daemon is involved anywhere.
+
+What it asserts (design §5.5, the slice-1 DOM AC):
+  1. `legacy-spike` (failed 8 DAYS ago, but its project touched an hour ago —
+     the R3 trap) is NOT inside band-needs-you; its card carries
+     data-band="quiet". This exercises the `runEvents` backfill for real.
+  2. `upload-endpoint` (live, streaming narration over the rig's /ws) IS inside
+     band-needs-you and precedes legacy-spike in document order.
+  3. The full expected NEEDS YOU order: q3-review-deck (gate 30s) →
+     api-migration (gate 2m) → auth-refactor (failed 12m) → upload-endpoint.
+  4. A gate whose receivedAt is 8 days old STILL leads (∞ half-life, in the
+     browser) — driven by flipping the fixture's gate age and reloading.
+  5. `band-not-in-project` is last in document order, collapsed, its count
+     matches the orphan run; with the orphan removed it is absent entirely.
+  6. No card inside band-needs-you has data-score < 20; no mounted card outside
+     it has one >= 20.
+  7. The bounded-page invariants hold with the 20 quiet clones: board height <=
+     viewport, document height <= viewport, cards mounted < data-total.
+
+Captures (§4.0 contract: 1440x900, device_scale_factor=1, waits on data-testid,
+never a sleep) into e2e/shots/uxfix/ — gitignored evidence, referenced by path
+from the JSON report this script prints:
+  uxfix-1-messy-board.png     the full W2 board, QUIET collapsed
+  uxfix-1-quiet-expanded.png  the same board, QUIET expanded via its toggle
+
+Prereqs: Python Playwright (`pip install playwright && playwright install
+chromium`). Builds dist-sameorigin/ itself unless SKIP_STUDIO_BUILD=1.
+Env knobs: W2_PORT (default 4330), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SHOTS = REPO / "e2e" / "shots" / "uxfix"
+W2_PORT = int(os.environ.get("W2_PORT", "4330"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+NPM = "npm.cmd" if os.name == "nt" else "npm"
+
+# Same rule as the main harness: gate toasts are not this surface (and the home
+# route does not render them), but the suppression is cheap and display-only.
+HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared with the doc rig — no third studio build) ─
+dist = REPO / "dist-sameorigin"
+if os.environ.get("SKIP_STUDIO_BUILD") == "1":
+    if not (dist / "index.html").is_file():
+        fail("build", f"SKIP_STUDIO_BUILD=1 but {dist}/index.html is missing — "
+             "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
+elif not (dist / "index.html").is_file():
+    env = dict(os.environ, VITE_API_HOST="")
+    r = subprocess.run(
+        [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
+        cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
+    )
+    if r.returncode != 0:
+        fail("build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The W2 fixture (§4.2), every age from ONE frozen NOW0 ───────────────────
+NOW0 = int(time.time() * 1000)
+SEC, MIN, HOUR, DAY = 1_000, 60_000, 3_600_000, 86_400_000
+
+
+def iso(ms: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ms / 1000)) + f".{ms % 1000:03d}Z"
+
+
+# Mutable fixture switches, flipped over POST /__fixture between page loads.
+state = {"orphan": True, "q3_gate_age_ms": 30 * SEC}
+state_lock = threading.Lock()
+
+
+def project(pid: str, name: str, updated_at: int, **extra) -> dict:
+    return {"id": pid, "name": name, "description": None, "status": "active",
+            "scope": f"project:{pid}" if pid != "default" else "",
+            "created_at": updated_at, "updated_at": updated_at, **extra}
+
+
+# §4.2's rows. `legacy-spike`'s project was touched an HOUR ago while its run
+# failed 8 DAYS ago — the exact R3 trap the runEvents backfill exists to defuse.
+QUIET_CLONES = [project(f"quiet-{i:02d}", f"quiet-clone-{i:02d}", NOW0 - 3 * DAY - i * 7 * HOUR)
+                for i in range(20)]
+PROJECTS = [
+    project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
+    project("legacy-spike", "legacy-spike", NOW0 - HOUR),
+    project("upload-endpoint", "upload-endpoint", NOW0),
+    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
+    project("api-migration", "api-migration", NOW0 - 2 * MIN),
+    project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
+    project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
+    project("notes", "notes", NOW0 - 2 * DAY, interactiveRoot="/tmp/wi-notes"),
+    project("scratch", "scratch", NOW0),
+] + QUIET_CLONES
+
+MEMBERS = {
+    "legacy-spike": ["r-legacy"],
+    "upload-endpoint": ["r-upload"],
+    "q3-review-deck": ["r-q3"],
+    "api-migration": ["r-api"],
+    "auth-refactor": ["r-auth"],
+    "smoke-tests": ["r-smoke1", "r-smoke2"],
+}
+
+
+def session(rid: str, status: str, problem: str, unit_desc: str) -> dict:
+    return {"session": {
+        "id": rid, "workflow_id": "wf-w2", "problem": problem, "entity_mode": "shared",
+        "collection_scope": None, "clis": ["claude"], "status": status,
+        "human_confirm": "all" if status == "awaiting_human" else "none",
+        "unit_ix": 0, "attempt": 0, "workdir": None, "repo_ref": None,
+        "extra_write_roots": [], "archived_at": None, "archive_note": None,
+    }, "units": [{
+        "id": f"{rid}:u0", "session_id": rid, "ord": 0, "description": unit_desc,
+        "stage": "build", "assigned_cli": None, "assigned_invocation": None,
+        "council_task_ref": None, "routing": None, "denial_reason": None,
+        "phase_ref": None, "conformance_ref": None, "phase_status": None,
+        "collection_scope": None, "status": "pending",
+    }]}
+
+
+RUNS = [
+    session("r-q3", "awaiting_human", "make the Q3 review deck", "author the deck outline"),
+    session("r-api", "awaiting_human", "migrate the auth tables", "plan the migration"),
+    session("r-upload", "executing", "add rate-limiting to the upload endpoint",
+            "add rate-limiting to the upload endpoint"),
+    session("r-auth", "failed", "refactor the auth middleware", "refactor the auth middleware"),
+    session("r-legacy", "failed", "spike the legacy importer", "spike the legacy importer"),
+    session("r-smoke1", "completed", "smoke: login flow", "smoke the login flow"),
+    session("r-smoke2", "completed", "smoke: checkout flow", "smoke the checkout flow"),
+]
+ORPHAN = session("r-orphan", "executing", "stranded work from another client",
+                 "stranded work from another client")
+
+# The durable-log tails (D3 step 2): the ONE honest clock for a failure's age.
+RUN_EVENTS = {
+    "r-legacy": [{"type": "sessionStarted", "session": "r-legacy", "ts": NOW0 - 8 * DAY - MIN},
+                 {"type": "sessionFailed", "session": "r-legacy", "ts": NOW0 - 8 * DAY}],
+    "r-auth": [{"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 13 * MIN},
+               {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 12 * MIN}],
+}
+
+NOTES_DOCS = [
+    {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
+    {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
+]
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+NARRATION = "Writing the token-bucket middleware for /upload"
+
+
+def ws_frame(payload: dict) -> bytes:
+    data = json.dumps(payload).encode()
+    if len(data) < 126:
+        head = bytes([0x81, len(data)])
+    else:
+        head = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
+    return head + data
+
+
+class W2Handler(SimpleHTTPRequestHandler):
+    """SPA + the whole /api/v1 surface the home route reads + /ws, one origin."""
+
+    def log_message(self, *_args):  # keep stdout JSON-clean
+        pass
+
+    def _json(self, status: int, payload) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _ws(self) -> None:
+        """Accept the upgrade, then stream `unitOutputDelta` frames for the live
+        run — `useRuns` gates its first fetch on a connected socket, so the
+        handshake is mandatory, and the narration keeps the headline honest."""
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+        self.wfile.write(
+            ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+             f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
+        self.wfile.flush()
+        try:
+            while True:
+                self.wfile.write(ws_frame({
+                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                    "text": NARRATION + "\n",
+                }))
+                self.wfile.flush()
+                time.sleep(1.0)
+        except OSError:
+            pass
+        self.close_connection = True
+
+    def _api(self, path: str) -> bool:
+        if path == "/api/v1/health":
+            self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
+            return True
+        if path == "/api/v1/runs":
+            with state_lock:
+                runs = RUNS + ([ORPHAN] if state["orphan"] else [])
+            self._json(200, {"runs": runs})
+            return True
+        if path == "/api/v1/projects":
+            self._json(200, {"projects": PROJECTS})
+            return True
+        if path == "/api/v1/repos":
+            self._json(200, {"repos": []})
+            return True
+        parts = path.split("/")
+        # /api/v1/projects/<id>/members
+        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
+            pid = urllib.parse.unquote(parts[4])
+            self._json(200, {"members": [
+                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
+                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
+                for ref in MEMBERS.get(pid, [])
+            ]})
+            return True
+        # /api/v1/projects/<id>/interactive/api/docs — the notes project's registry
+        if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
+            pid = urllib.parse.unquote(path.split("/")[4])
+            self._json(200, NOTES_DOCS if pid == "notes" else [])
+            return True
+        # /api/v1/runs/<id>/gate
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
+            rid = urllib.parse.unquote(parts[4])
+            if rid == "r-q3":
+                with state_lock:
+                    age = state["q3_gate_age_ms"]
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "Approve the deck outline?",
+                                 "receivedAt": iso(NOW0 - age)})
+            elif rid == "r-api":
+                # `options: null` = free text ⇒ the COMPLEX gate shape (§7.11).
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "How should the tables move?",
+                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
+            else:
+                self._json(404, {"error": f"no gate cached for {rid}"})
+            return True
+        # /api/v1/runs/<id>/events
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
+            rid = urllib.parse.unquote(parts[4])
+            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
+            return True
+        if path.startswith("/api/v1/"):
+            self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+            return True
+        return False
+
+    def do_GET(self):  # noqa: N802 (stdlib naming)
+        if self.headers.get("Upgrade", "").lower() == "websocket":
+            return self._ws()
+        path = urllib.parse.urlparse(self.path).path
+        if self._api(path):
+            return None
+        if not Path(self.translate_path(self.path)).is_file():
+            self.path = "/index.html"  # client-side routes resolve to the shell
+        return super().do_GET()
+
+    def do_POST(self):  # noqa: N802 (stdlib naming)
+        path = urllib.parse.urlparse(self.path).path
+        if path == "/__fixture":
+            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+            with state_lock:
+                state.update({k: v for k, v in body.items() if k in state})
+                snapshot = dict(state)
+            return self._json(200, {"ok": True, "state": snapshot})
+        return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+
+
+httpd = ThreadingHTTPServer(("127.0.0.1", W2_PORT), partial(W2Handler, directory=str(dist)))
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+
+def set_fixture(**kwargs) -> None:
+    req = urllib.request.Request(f"{ORIGIN}/__fixture", method="POST",
+                                 data=json.dumps(kwargs).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        res.read()
+
+
+# ── 3. The browser gate ───────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+NEEDS_YOU_IDS = """() => Array.from(document.querySelectorAll(
+    '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+    .map(c => c.dataset.projectId)"""
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    # §4.0's capture contract, verbatim: 1440x900, device_scale_factor=1.
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # Settle on the DECAYED verdict, not the first paint: legacy-spike enters the
+    # live band on its fresh `updated_at` and leaves it when the 8-day durable-log
+    # tail lands (D3 step 2) — the wait is on that final state.
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    # The live headline is streaming from the rig's own /ws before the shot.
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+
+    needs_you = page.evaluate(NEEDS_YOU_IDS)
+    legacy_not_leading = "legacy-spike" not in needs_you
+    upload_leading = "upload-endpoint" in needs_you
+
+    # Band order in the document: needs-you < quiet < not-in-project, shelf LAST.
+    band_order_ok = page.evaluate(
+        """() => { const b = document.querySelector('[data-testid="project-board"]');
+                   const kids = Array.from(b.children).map(el => el.dataset.testid || '');
+                   const iN = kids.indexOf('band-needs-you'), iQ = kids.indexOf('band-quiet'),
+                         iU = kids.indexOf('band-not-in-project');
+                   return iN >= 0 && iQ > iN && iU > iQ
+                       && b.lastElementChild.dataset.testid === 'band-not-in-project'; }""")
+    shelf_collapsed = page.evaluate(
+        """() => { const s = document.querySelector('[data-testid="band-not-in-project"]');
+                   return !!s && s.dataset.expanded === 'false' && s.dataset.count === '1'
+                       && document.querySelectorAll('[data-testid="unfiled-run"]').length === 0; }""")
+    # F5/V18: the junk bucket neither renders as a card nor by its old name.
+    no_default_card = page.evaluate(
+        """() => !document.querySelector('[data-project-id="default"]')
+              && !document.body.innerText.includes('Unfiled')""")
+
+    # ── Capture 1: the default first impression — QUIET collapsed (§4.0) ──────
+    page.locator('[data-testid="band-quiet"][data-expanded="false"]').wait_for(timeout=10000)
+    page.screenshot(path=str(SHOTS / "uxfix-1-messy-board.png"))
+
+    # ── Expand QUIET; capture 2; then read the decay verdict off legacy's card ─
+    page.locator('[data-testid="band-quiet-toggle"]').click()
+    page.locator('[data-testid="band-quiet"][data-expanded="true"]').wait_for(timeout=10000)
+    page.locator('[data-testid="band-quiet"] [data-testid="project-card"]').first.wait_for(timeout=10000)
+    page.screenshot(path=str(SHOTS / "uxfix-1-quiet-expanded.png"))
+
+    # Assertion 6, over every card the two windows currently mount.
+    scores_ok = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+             .every(c => (c.closest('[data-testid="band-needs-you"]') !== null)
+                       === (Number(c.dataset.score) >= 20))""")
+
+    # Assertion 7: the bounded-page invariants, with the 20 clones expanded.
+    board_h = page.evaluate(
+        """() => document.querySelector('[data-testid="project-board"]').clientHeight""")
+    doc_h = page.evaluate("() => document.documentElement.scrollHeight")
+    total = int(page.locator('[data-testid="project-board"]').get_attribute("data-total") or 0)
+    mounted = page.locator('[data-testid="project-card"]').count()
+    invariants_ok = board_h <= 900 and doc_h <= 900 + 1 and 0 < mounted < total
+
+    # Assertion 1's second half: legacy-spike's card carries the verdict. It sits
+    # deep in the quiet grid, so scroll it into the window first.
+    page.evaluate(
+        """() => { const b = document.querySelector('[data-testid="project-board"]');
+                   b.scrollTop = b.scrollHeight; }""")
+    legacy_card_ok = settled(
+        """() => { const c = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="legacy-spike"]');
+                   return !!c && c.dataset.band === 'quiet' && c.dataset.signal === 'failing'
+                       && Number(c.dataset.score) < 1; }""")
+    # …and upload-endpoint precedes it in document order (EC4, read from the DOM).
+    precedes_ok = page.evaluate(
+        """() => { const up = document.querySelector('[data-project-id="upload-endpoint"]');
+                   const legacy = document.querySelector('[data-project-id="legacy-spike"]');
+                   return !!up && !!legacy &&
+                     !!(up.compareDocumentPosition(legacy) & Node.DOCUMENT_POSITION_FOLLOWING); }""")
+
+    # ── Assertion 4: an 8-day-old GATE still leads — flip the age, reload ──────
+    set_fixture(q3_gate_age_ms=8 * DAY)
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    ancient_gate_ok = settled(
+        """() => { const ids = Array.from(document.querySelectorAll(
+                     '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+                     .map(c => c.dataset.projectId);
+                   // still present, still ahead of every non-gate signal
+                   return ids.includes('q3-review-deck')
+                       && ids.indexOf('q3-review-deck') < ids.indexOf('auth-refactor'); }""")
+    ancient_gate_score = page.evaluate(
+        """() => document.querySelector('[data-project-id="q3-review-deck"]')?.dataset.score ?? null""")
+
+    # ── Assertion 5's second half: no orphan ⇒ no shelf in the DOM at all ──────
+    set_fixture(orphan=False)
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    settled("""() => document.querySelectorAll(
+                 '[data-testid="band-needs-you"] [data-testid="project-card"]').length === 4""")
+    shelf_absent = page.evaluate(
+        """() => document.querySelector('[data-testid="band-not-in-project"]') === null""")
+
+    ctx.close()
+    browser.close()
+
+report["steps"]["w2_board"] = {
+    "ok": all([
+        order_ok, narration_ok, legacy_not_leading, upload_leading, band_order_ok,
+        shelf_collapsed, no_default_card, scores_ok, invariants_ok, legacy_card_ok,
+        precedes_ok, ancient_gate_ok, shelf_absent,
+    ]),
+    "needs_you_order": needs_you,
+    "expected_order": EXPECTED_ORDER,
+    "needs_you_order_ok": order_ok,
+    "live_narration_streamed": narration_ok,
+    "legacy_spike_not_in_needs_you": legacy_not_leading,
+    "upload_endpoint_in_needs_you": upload_leading,
+    "upload_precedes_legacy_in_document": precedes_ok,
+    "legacy_card_quiet_failing_decayed": legacy_card_ok,
+    "band_order_needs_quiet_shelf": band_order_ok,
+    "shelf_last_collapsed_counted": shelf_collapsed,
+    "shelf_absent_without_orphan": shelf_absent,
+    "no_default_card_no_unfiled_word": no_default_card,
+    "score_threshold_matches_band": scores_ok,
+    "ancient_gate_still_leads": ancient_gate_ok,
+    "ancient_gate_score": ancient_gate_score,
+    "board_height_px": board_h,
+    "document_scroll_height_px": doc_h,
+    "projects_total": total,
+    "cards_mounted_expanded": mounted,
+    "bounded_page_invariants": invariants_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(SHOTS / n) for n in
+                    ("uxfix-1-messy-board.png", "uxfix-1-quiet-expanded.png")],
+}
+if not report["steps"]["w2_board"]["ok"]:
+    fail("w2_board_verdict", "slice-1 W2 assertions did not all hold — see w2_board")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/board/boardAttention.ts
+++ b/src/board/boardAttention.ts
@@ -1,0 +1,104 @@
+/**
+ * The board's attention score model (DES-UXFIX-001 §2.1.3, slice 1).
+ *
+ * Attention is a DECAYED SCORE over signals, not a fixed bucket over projects —
+ * the F3 fix. A signal's base severity is discounted by how long it has sat
+ * unattended; a project scores as the MAX over its signals ("projects whose top
+ * score falls below a triage threshold" — §2.1.3), and the signal that set that
+ * max is what the card labels itself with.
+ *
+ * Everything here is a pure function of its arguments, INCLUDING `now` — no
+ * clock of its own, no React — which is what makes the decay curve pinnable at
+ * exact ages in `boardAttention.test.ts`.
+ *
+ * The numbers are tuning constants; the SHAPE (gate ∞, everything else
+ * half-life-decayed) is the design commitment.
+ */
+
+export type SignalKind = 'gate' | 'failing' | 'running' | 'drafts';
+
+/** One thing about a project that could want attention, and when it last said so. */
+export interface Signal {
+  kind: SignalKind;
+  /** Epoch millis of the signal's OWN clock (the D3 source ladder), never Date.now() at call time. */
+  at: number;
+  /** The run this signal came from, when it came from one — the card's headline subject. */
+  runId?: string;
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Base severity per signal kind (§2.1.3's table). */
+export const SEVERITY: Record<SignalKind, number> = {
+  gate: 100,
+  failing: 70,
+  running: 40,
+  drafts: 15,
+};
+
+/**
+ * Half-lives, in millis. `gate` is Infinity — a waiting gate is a person
+ * blocked, and it must NOT decay (it stays top until answered). `failing` ages
+ * out over hours (the exact F3 fix: a fresh failure is urgent, a week-old one
+ * is history); `running` over minutes (a run silent for a half-life is suspect,
+ * not urgent); `drafts` over days (a draft is a nudge, never a demand).
+ */
+export const HALF_LIFE: Record<SignalKind, number> = {
+  gate: Infinity,
+  running: 30 * MINUTE,
+  failing: 4 * HOUR,
+  drafts: 7 * DAY,
+};
+
+/**
+ * Scores at or above this lead the board (NEEDS YOU); below it they drop into
+ * the QUIET band. 20 sits just above the `drafts` base (15) — that is the rule,
+ * not the number: no draft of any age can enter the live band (D2).
+ */
+export const TRIAGE_THRESHOLD = 20;
+
+/** `base × 0.5^(Δ/halfLife)`, Δ clamped at 0 so a skewed clock (a daemon slightly
+ *  ahead of the browser) reads as "just now", never as a future signal scoring
+ *  above its own base. An Infinity half-life means no decay at all. */
+export function scoreOf(signal: Signal, now: number): number {
+  const base = SEVERITY[signal.kind];
+  const halfLife = HALF_LIFE[signal.kind];
+  if (halfLife === Infinity) return base;
+  const age = Math.max(0, now - signal.at);
+  return base * Math.pow(0.5, age / halfLife);
+}
+
+/** The project's score and the signal that set it; no signals ⇒ score 0, signal null. */
+export function topSignal(
+  signals: Signal[],
+  now: number,
+): { score: number; signal: Signal | null } {
+  let signal: Signal | null = null;
+  let score = 0;
+  for (const s of signals) {
+    const v = scoreOf(s, now);
+    if (signal === null || v > score) {
+      signal = s;
+      score = v;
+    }
+  }
+  return signal === null ? { score: 0, signal: null } : { score, signal };
+}
+
+export type Band = 'needs-you' | 'quiet';
+
+/** Which band a score renders in. Exactly the threshold is still NEEDS YOU. */
+export function bandOf(score: number): Band {
+  return score >= TRIAGE_THRESHOLD ? 'needs-you' : 'quiet';
+}
+
+/** Score desc → newest signal first → name asc — the parent's deterministic tail,
+ *  so the board never orders on list position. */
+export function compareScored<T extends { score: number; at: number; name: string }>(
+  a: T,
+  b: T,
+): number {
+  return b.score - a.score || b.at - a.at || a.name.localeCompare(b.name);
+}

--- a/src/board/boardWindow.ts
+++ b/src/board/boardWindow.ts
@@ -1,0 +1,40 @@
+/**
+ * The board's windowing math (DES-MERGE-001 §1.4: 20+ cards stay legible), pure
+ * and extracted so two bands can use it against ONE shared scroller
+ * (DES-UXFIX-001 slice 1, D6). Each band computes its own visible row range;
+ * the page keeps its invariants — board height bounded by the viewport, and
+ * cards mounted < projects total.
+ */
+
+/** One row above and below the viewport, so a scroll never shows a gap. */
+export const OVERSCAN = 1;
+
+export interface RowWindow {
+  firstRow: number;
+  /** Inclusive. `-1` (only when `count` is 0) means nothing to mount. */
+  lastRow: number;
+}
+
+/**
+ * The rows of a `count`-item grid worth mounting, given the shared scroller's
+ * `scrollTop`/`viewH` and this section's own top (`offsetTop`) inside it.
+ *
+ * Never returns a negative or out-of-range row for a non-empty grid: a section
+ * scrolled fully past (or not yet reached) clamps to its nearest edge row, so
+ * the cost of an off-screen band is one overscan row, not a mount of everything.
+ */
+export function windowRows(
+  count: number,
+  columns: number,
+  rowH: number,
+  scrollTop: number,
+  viewH: number,
+  offsetTop: number,
+): RowWindow {
+  const rows = Math.ceil(count / Math.max(1, columns));
+  if (rows === 0) return { firstRow: 0, lastRow: -1 };
+  const local = scrollTop - offsetTop;
+  const firstRow = Math.min(rows - 1, Math.max(0, Math.floor(local / rowH) - OVERSCAN));
+  const lastRow = Math.min(rows - 1, Math.max(firstRow, Math.ceil((local + viewH) / rowH) + OVERSCAN));
+  return { firstRow, lastRow };
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -1,40 +1,97 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SessionView } from '../api/types.js';
-import { useBoardModel } from '../hooks/useBoardModel.js';
+import { windowRows } from '../board/boardWindow.js';
+import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
-import { CARD_H, ProjectCard } from './ProjectCard.js';
+import { modePath } from '../hooks/useRoute.js';
+import { ago, CARD_H, ProjectCard } from './ProjectCard.js';
 
 /**
- * The orchestrator home board (DES-MERGE-001 §1.2/§1.4, slice 5) — the route `/`.
+ * The orchestrator home board (DES-MERGE-001 §1.2/§1.4; bands per DES-UXFIX-001
+ * §2.1.4, slice 1) — the route `/`.
  *
- * A wall of what is happening across many unrelated projects at once, sorted by
- * attention needed rather than recency. "Many projects at once is the default case"
- * (§1.4), so the grid is WINDOWED: cards are a fixed height, and only the rows the
- * viewport can show (plus one row of overscan) are mounted. Twenty projects mount a
- * dozen cards, not twenty, and the container never grows past the viewport.
+ * A wall of what is happening across many unrelated projects at once, in TWO
+ * bands read off each project's decayed attention score (§2.1.3):
  *
- * Static in this slice: the model reads REST on load. Live card updates are slice 6.
+ *   NEEDS YOU — score at or above the triage threshold, score-ordered. Full
+ *   cards. This is what a returning operator scans first.
+ *   QUIET (N) — the calm majority, collapsed to a header + a preview strip of
+ *   one-line chips; expandable into a second windowed grid of full cards.
+ *
+ * "Many projects at once is the default case" (§1.4), so both grids are
+ * WINDOWED against the ONE shared scroller (`boardWindow.ts`): cards are a
+ * fixed height, only the rows the viewport can show (plus overscan) are
+ * mounted, and the container never grows past the viewport.
  */
 
 const GAP = 14;
 /** Below this the grid drops a column rather than squeezing a card unreadable. */
 const MIN_COL = 320;
-/** One row above and below the viewport, so a scroll never shows a gap. */
-const OVERSCAN = 1;
 /** Used when the container has not been measured yet (first paint, jsdom). */
 const FALLBACK_W = 1200;
 const FALLBACK_H = 900;
+/** Nominal height of a band's header row — only windowing precision, not layout:
+ *  an error here is absorbed by the grids' overscan row. */
+const BAND_H = 34;
+/** Collapsed QUIET shows at most this many one-line chips (D5). */
+const QUIET_PREVIEW = 6;
 
 const S = {
   ink:    '#e6edf3',
   muted:  'rgba(230,237,243,0.55)',
   faint:  'rgba(230,237,243,0.3)',
   red:    '#f85149',
+  accent: '#ffda19',
+  border: 'rgba(230,237,243,0.1)',
 };
+
+const CSS = {
+  bandLabel: {
+    fontSize: '10px', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase',
+    margin: '0 0 10px',
+  },
+  toggle: {
+    background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+    fontSize: '11px', fontFamily: 'monospace', color: S.muted,
+  },
+  chip: {
+    display: 'inline-flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
+    fontSize: '11px', color: S.muted, border: `1px solid ${S.border}`, borderRadius: '6px',
+    padding: '4px 10px', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
 
 interface Props {
   runs: SessionView[];
   navigate: Navigate;
+}
+
+/** One band's windowed grid — same math as the pre-band board, used twice (D6). */
+function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate }: {
+  items: BoardProject[];
+  columns: number;
+  rowH: number;
+  firstRow: number;
+  lastRow: number;
+  navigate: Navigate;
+}): React.ReactElement {
+  const rows = Math.ceil(items.length / columns);
+  const visible = lastRow < firstRow ? [] : items.slice(firstRow * columns, (lastRow + 1) * columns);
+  return (
+    <div style={{ position: 'relative', height: `${rows * rowH}px` }}>
+      <div
+        style={{
+          position: 'absolute', top: `${firstRow * rowH}px`, left: 0, right: 0,
+          display: 'grid', gap: `${GAP}px`,
+          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        }}
+      >
+        {visible.map((item) => (
+          <ProjectCard key={item.project.id} item={item} navigate={navigate} />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
@@ -42,6 +99,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   const scroller = useRef<HTMLDivElement>(null);
   const [box, setBox] = useState({ w: 0, h: 0 });
   const [scrollTop, setScrollTop] = useState(0);
+  const [quietOpen, setQuietOpen] = useState(false);
 
   useEffect(() => {
     const el = scroller.current;
@@ -56,13 +114,37 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     setScrollTop(e.currentTarget.scrollTop);
   }, []);
 
+  const needsYou = items.filter((i) => i.band === 'needs-you');
+  const quiet = items.filter((i) => i.band === 'quiet');
+
   const columns = Math.max(1, Math.floor((box.w || FALLBACK_W) / (MIN_COL + GAP)));
   const rowH = CARD_H + GAP;
-  const rows = Math.ceil(items.length / columns);
   const viewH = box.h || FALLBACK_H;
-  const firstRow = Math.max(0, Math.floor(scrollTop / rowH) - OVERSCAN);
-  const lastRow = Math.min(rows - 1, Math.ceil((scrollTop + viewH) / rowH) + OVERSCAN);
-  const visible = items.slice(firstRow * columns, (lastRow + 1) * columns);
+
+  // Each band's own top inside the shared scroller (D6). Coarse is fine: any
+  // header-height error is smaller than the overscan row that absorbs it.
+  const needsTop = BAND_H;
+  const needsH = needsYou.length === 0 ? BAND_H : Math.ceil(needsYou.length / columns) * rowH;
+  const quietGridTop = needsTop + needsH + BAND_H;
+
+  const needsWin = windowRows(needsYou.length, columns, rowH, scrollTop, viewH, needsTop);
+  const quietWin = quietOpen
+    ? windowRows(quiet.length, columns, rowH, scrollTop, viewH, quietGridTop)
+    : null;
+
+  const mounted =
+    (needsWin.lastRow < needsWin.firstRow
+      ? 0
+      : Math.min(needsYou.length, (needsWin.lastRow + 1) * columns) - needsWin.firstRow * columns) +
+    (quietWin === null || quietWin.lastRow < quietWin.firstRow
+      ? 0
+      : Math.min(quiet.length, (quietWin.lastRow + 1) * columns) - quietWin.firstRow * columns);
+
+  /** Every affordance is a real link — deep-linkable, middle-clickable. */
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -92,7 +174,9 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
         onScroll={onScroll}
         data-testid="project-board"
         data-total={items.length}
-        data-rendered={visible.length}
+        data-needs-you={needsYou.length}
+        data-quiet={quiet.length}
+        data-rendered={mounted}
         style={{ flex: 1, overflowY: 'auto', padding: '0 24px 24px' }}
       >
         {loading && (
@@ -114,20 +198,80 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
             </a>
           </div>
         )}
+
         {items.length > 0 && (
-          <div style={{ position: 'relative', height: `${rows * rowH}px` }}>
-            <div
-              style={{
-                position: 'absolute', top: `${firstRow * rowH}px`, left: 0, right: 0,
-                display: 'grid', gap: `${GAP}px`,
-                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-              }}
-            >
-              {visible.map((item) => (
-                <ProjectCard key={item.project.id} item={item} navigate={navigate} />
-              ))}
+          <section data-testid="band-needs-you" data-count={needsYou.length}>
+            <p style={{ ...CSS.bandLabel, color: S.accent }}>Needs you</p>
+            {needsYou.length === 0 ? (
+              // The all-quiet state (§3.1): calm is one line, not a wall of absence.
+              <p data-testid="board-all-quiet" style={{ fontSize: '12px', color: S.muted, margin: '0 0 6px' }}>
+                Nothing needs you right now.
+              </p>
+            ) : (
+              <BandGrid
+                items={needsYou}
+                columns={columns}
+                rowH={rowH}
+                firstRow={needsWin.firstRow}
+                lastRow={needsWin.lastRow}
+                navigate={navigate}
+              />
+            )}
+          </section>
+        )}
+
+        {quiet.length > 0 && (
+          <section
+            data-testid="band-quiet"
+            data-count={quiet.length}
+            data-expanded={quietOpen}
+            style={{ marginTop: '18px' }}
+          >
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
+              <p style={{ ...CSS.bandLabel, color: S.faint, margin: 0 }}>Quiet ({quiet.length})</p>
+              <button
+                type="button"
+                data-testid="band-quiet-toggle"
+                onClick={() => setQuietOpen((v) => !v)}
+                style={CSS.toggle}
+              >
+                {quietOpen ? '[ collapse ▴ ]' : '[ expand ▾ ]'}
+              </button>
             </div>
-          </div>
+            {quietOpen && quietWin !== null ? (
+              <div style={{ marginTop: '10px' }}>
+                <BandGrid
+                  items={quiet}
+                  columns={columns}
+                  rowH={rowH}
+                  firstRow={quietWin.firstRow}
+                  lastRow={quietWin.lastRow}
+                  navigate={navigate}
+                />
+              </div>
+            ) : (
+              // The §2.1.4 wireframe's own representation of the calm majority:
+              // one demoted line per project, capped — never a grid of absence.
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginTop: '10px' }}>
+                {quiet.slice(0, QUIET_PREVIEW).map((i) => (
+                  <a
+                    key={i.project.id}
+                    {...link(modePath(i.project.id, 'build'))}
+                    data-testid="quiet-chip"
+                    data-project-id={i.project.id}
+                    data-score={i.score.toFixed(2)}
+                    style={CSS.chip}
+                  >
+                    <span aria-hidden style={{ color: S.faint }}>○</span>
+                    {i.project.name}
+                    <span style={{ color: S.faint }}>
+                      · {ago(i.signal?.at ?? i.project.updated_at)}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </section>
         )}
       </div>
     </div>

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -95,11 +95,12 @@ function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate }: {
 }
 
 export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
-  const { items, loading, error } = useBoardModel(runs);
+  const { items, unfiled, loading, error } = useBoardModel(runs);
   const scroller = useRef<HTMLDivElement>(null);
   const [box, setBox] = useState({ w: 0, h: 0 });
   const [scrollTop, setScrollTop] = useState(0);
   const [quietOpen, setQuietOpen] = useState(false);
+  const [shelfOpen, setShelfOpen] = useState(false);
 
   useEffect(() => {
     const el = scroller.current;
@@ -267,6 +268,48 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                     <span style={{ color: S.faint }}>
                       · {ago(i.signal?.at ?? i.project.updated_at)}
                     </span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* The ex-"Unfiled" shelf (F5, V18): LAST, collapsed, and absent entirely
+            when nothing is unfiled — it can never lead, or even appear above, a
+            real project. The word "Unfiled" appears nowhere. */}
+        {unfiled.length > 0 && (
+          <section
+            data-testid="band-not-in-project"
+            data-count={unfiled.length}
+            data-expanded={shelfOpen}
+            style={{ marginTop: '18px' }}
+          >
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
+              <p style={{ ...CSS.bandLabel, color: S.faint, margin: 0 }}>
+                Not in a project ({unfiled.length})
+              </p>
+              <button
+                type="button"
+                data-testid="band-not-in-project-toggle"
+                onClick={() => setShelfOpen((v) => !v)}
+                style={CSS.toggle}
+              >
+                {shelfOpen ? '[ collapse ▴ ]' : '[ expand ▾ ]'}
+              </button>
+            </div>
+            {shelfOpen && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '10px' }}>
+                {unfiled.map((v) => (
+                  <a
+                    key={v.session.id}
+                    {...link(`/runs/${v.session.id}`)}
+                    data-testid="unfiled-run"
+                    data-run-id={v.session.id}
+                    style={{ ...CSS.chip, alignSelf: 'flex-start', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                  >
+                    {v.session.problem}
+                    <span style={{ color: S.faint }}>· {v.session.status}</span>
                   </a>
                 ))}
               </div>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -176,7 +176,7 @@ interface Props {
 }
 
 export function ProjectCard({ item, navigate }: Props): React.ReactElement {
-  const { project, repo, runs, docs, attention } = item;
+  const { project, repo, runs, docs, attention, band, score, signal } = item;
   const gates = useGateStore((s) => s.gates);
   // Relayed interactive status for THIS project — one line, plus the tile date it implies.
   const activity = useRuntimeStore((s) => s.docActivity[project.id]);
@@ -190,7 +190,17 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   });
 
   return (
-    <section data-testid="project-card" data-project-id={project.id} data-attention={attention} style={CSS.card}>
+    <section
+      data-testid="project-card"
+      data-project-id={project.id}
+      data-attention={attention}
+      // The decay verdict, readable off the DOM (DES-UXFIX-001 slice-1 AC): which
+      // band this card sorted into, the score that put it there, and the top signal.
+      data-band={band}
+      data-score={score.toFixed(2)}
+      {...(signal !== null ? { 'data-signal': signal.kind } : {})}
+      style={CSS.card}
+    >
       {/* The card's own state signal, read from the RUNS rather than from `attention`:
           a project bucketed as `failing` can still have something executing on it, and
           the edge answers "is work moving here", not "which bucket did this sort into". */}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -2,9 +2,19 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { listDocs, type DocSummary } from '../api/interactive.js';
 import type { Project, ProjectMember, SessionView } from '../api/types.js';
+import {
+  bandOf,
+  compareScored,
+  topSignal,
+  type Band,
+  type Signal,
+} from '../board/boardAttention.js';
+import { useGateStore, type OpenGate } from '../store/gates.js';
+import { useRuntimeStore } from '../store/runtime.js';
 
 /**
- * The orchestrator board's data model (DES-MERGE-001 §1.4).
+ * The orchestrator board's data model (DES-MERGE-001 §1.4; sort + bands per
+ * DES-UXFIX-001 §2.1.3–§2.1.4, slice 1).
  *
  * The REST half: `GET /projects`, `GET /runs` (owned by `useRuns`, passed in),
  * each project's members, and the interactive `listDocs` for projects bound to an
@@ -17,18 +27,29 @@ import type { Project, ProjectMember, SessionView } from '../api/types.js';
  * Memberships are re-read when a run the board has never placed shows up in the
  * run list (slice 6): a run launched from a card's quick action, or by any other
  * client, must land on its project's card without a reload.
+ *
+ * Ordering is by DECAYED attention score (`boardAttention.ts`), not by a fixed
+ * bucket — the F3 fix: a failure from last week no longer outranks a run that is
+ * executing now. `deriveAttention`'s bucket survives as a LABELLING concern (the
+ * status dot, `data-attention`); it is no longer the sort key.
  */
 
-/** Attention buckets, most-urgent first — §1.4's sort key, spelled once. */
+/** Attention buckets — §1.4's vocabulary, kept for the card's dot + label (D8). */
 export type Attention = 'gate' | 'failing' | 'running' | 'drafts' | 'quiet';
-
-const ORDER: readonly Attention[] = ['gate', 'failing', 'running', 'drafts', 'quiet'];
 
 /** Statuses that mean the run is moving under its own power. */
 const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
 
 /** Membership kinds that make a run/thread a member of a project. */
 const RUN_KINDS: ReadonlySet<string> = new Set(['crew.run', 'crew.chat']);
+
+/** How often decayed scores are re-read (D7). Coarse on purpose: slow enough that
+ *  the board never reorders under a cursor, fast enough that a demotion point is
+ *  honoured without waiting for unrelated data to arrive. */
+const TICK_MS = 60_000;
+
+/** At most this many `runEvents` backfills per board load (D3 step 2 / R2). */
+const MAX_BACKFILL = 12;
 
 export interface BoardProject {
   project: Project;
@@ -37,6 +58,11 @@ export interface BoardProject {
   runs: SessionView[];
   docs: DocSummary[];
   attention: Attention;
+  /** Decayed attention (§2.1.3): the max over the project's signals at the last tick. */
+  score: number;
+  band: Band;
+  /** The signal that set the score — `null` when the project has none at all. */
+  signal: Signal | null;
 }
 
 /**
@@ -49,7 +75,7 @@ export function interactiveRootOf(p: Project): string | null {
   return typeof v === 'string' && v.trim() !== '' ? v : null;
 }
 
-/** §1.4's sort key. Gate-waiting first; ties break newest-updated, then by name. */
+/** §1.4's bucket, demoted from sort key to label (D8): what the dot means. */
 export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attention {
   if (runs.some((v) => v.session.status === 'awaiting_human')) return 'gate';
   if (runs.some((v) => v.session.status === 'failed')) return 'failing';
@@ -58,13 +84,47 @@ export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attent
   return 'quiet';
 }
 
-export function sortByAttention(items: BoardProject[]): BoardProject[] {
-  return [...items].sort(
-    (a, b) =>
-      ORDER.indexOf(a.attention) - ORDER.indexOf(b.attention) ||
-      b.project.updated_at - a.project.updated_at ||
-      a.project.name.localeCompare(b.project.name),
-  );
+/**
+ * The D3 source ladder: each signal is stamped with the most honest clock the
+ * client can already reach, degrading source by source down to the project's
+ * own `updated_at`. `AgentSession` carries no timestamps, so the ladder is the
+ * whole reason the decay arithmetic has something true to decay FROM.
+ *
+ *   gate    → the gate store's `receivedAt` (server ISO on reconcile, arrival live)
+ *   failing → the run's durable-log tail `ts` (backfilled once per run id, capped)
+ *   running → the newest structured frame the runtime store has logged for the run
+ *   drafts  → the newest doc's `updated_at`
+ *   any     → `project.updated_at`
+ */
+function signalsOf(
+  project: Project,
+  runs: SessionView[],
+  docs: DocSummary[],
+  gates: Record<string, OpenGate>,
+  logTail: (runId: string) => number | undefined,
+  failedAt: Record<string, number>,
+): Signal[] {
+  const fallback = project.updated_at;
+  const signals: Signal[] = [];
+  for (const v of runs) {
+    const id = v.session.id;
+    const status = v.session.status;
+    if (status === 'awaiting_human') {
+      signals.push({ kind: 'gate', at: gates[id]?.receivedAt ?? fallback, runId: id });
+    } else if (status === 'failed') {
+      signals.push({ kind: 'failing', at: failedAt[id] ?? fallback, runId: id });
+    } else if (ACTIVE.has(status)) {
+      signals.push({ kind: 'running', at: logTail(id) ?? fallback, runId: id });
+    }
+  }
+  if (docs.length > 0) {
+    const newest = docs.reduce((acc, d) => {
+      const t = d.updated_at === null ? NaN : Date.parse(d.updated_at);
+      return Number.isNaN(t) ? acc : Math.max(acc, t);
+    }, -Infinity);
+    signals.push({ kind: 'drafts', at: Number.isFinite(newest) ? newest : fallback });
+  }
+  return signals;
 }
 
 /** Everything about a project that the run list itself cannot answer. */
@@ -92,6 +152,7 @@ async function loadBindings(p: Project, repoNames: Map<string, string>): Promise
 }
 
 export interface BoardModel {
+  /** Score-ordered board cards. */
   items: BoardProject[];
   loading: boolean;
   error: string | null;
@@ -102,9 +163,28 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   const [bindings, setBindings] = useState<Record<string, Bindings>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  /** The decay clock (D7): scores are recomputed on this coarse tick. */
+  const [now, setNow] = useState(() => Date.now());
+  /** Backfilled durable-log tail per FAILED run id — the one age the client
+   *  cannot otherwise know, and the one F3 is about (D3 step 2). */
+  const [failedAt, setFailedAt] = useState<Record<string, number>>({});
+  const gates = useGateStore((s) => s.gates);
   const repoNames = useRef<Map<string, string>>(new Map());
   /** Run ids the board has already tried to place — one re-read per run, ever. */
   const placed = useRef<Set<string>>(new Set());
+  /** Run ids whose event tail has been asked for — once per run id, ever (R2). */
+  const backfilled = useRef<Set<string>>(new Set());
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(t);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -159,16 +239,61 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
     return () => { cancelled = true; };
   }, [runs, projects, bindings]);
 
+  // D3 step 2: a FAILED run's age lives only in its durable event log, so it is
+  // fetched — after first paint, once per run id ever, capped per board load, and
+  // failure-tolerant (a failed fetch is a miss, never an error: the fallback clock
+  // stands). Without this, a recently-touched project with a week-old failure
+  // would read as fresh (R3).
+  useEffect(() => {
+    if (loading) return;
+    for (const v of runs) {
+      if (v.session.status !== 'failed' || backfilled.current.has(v.session.id)) continue;
+      if (backfilled.current.size >= MAX_BACKFILL) break;
+      const id = v.session.id;
+      backfilled.current.add(id);
+      void api.getRunEvents(id)
+        .then(({ events }) => {
+          const ts = events[events.length - 1]?.ts;
+          if (mounted.current && typeof ts === 'number') {
+            setFailedAt((m) => ({ ...m, [id]: ts }));
+          }
+        })
+        .catch(() => { /* no durable log — the fallback clock stands */ });
+    }
+  }, [runs, loading]);
+
   const items = useMemo(
-    () =>
-      sortByAttention(
-        projects.map((project) => {
+    () => {
+      // Live-frame clocks are read NON-reactively: the tick and every run/binding/
+      // gate change already recompute this memo, and subscribing to `logs` would
+      // re-render the whole board once per streamed frame.
+      const logs = useRuntimeStore.getState().logs;
+      const logTail = (id: string): number | undefined => {
+        const log = logs[id];
+        return log !== undefined && log.length > 0 ? log[log.length - 1]?.ts : undefined;
+      };
+      return projects
+        .map((project): BoardProject => {
           const b = bindings[project.id] ?? EMPTY;
           const mine = runs.filter((v) => b.runIds.has(v.session.id));
-          return { project, repo: b.repo, runs: mine, docs: b.docs, attention: deriveAttention(mine, b.docs) };
-        }),
-      ),
-    [projects, bindings, runs],
+          const { score, signal } = topSignal(
+            signalsOf(project, mine, b.docs, gates, logTail, failedAt),
+            now,
+          );
+          return {
+            project, repo: b.repo, runs: mine, docs: b.docs,
+            attention: deriveAttention(mine, b.docs),
+            score, band: bandOf(score), signal,
+          };
+        })
+        .sort((a, b) =>
+          compareScored(
+            { score: a.score, at: a.signal?.at ?? a.project.updated_at, name: a.project.name },
+            { score: b.score, at: b.signal?.at ?? b.project.updated_at, name: b.project.name },
+          ),
+        );
+    },
+    [projects, bindings, runs, gates, failedAt, now],
   );
 
   return { items, loading, error };

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -154,6 +154,8 @@ async function loadBindings(p: Project, repoNames: Map<string, string>): Promise
 export interface BoardModel {
   /** Score-ordered board cards. */
   items: BoardProject[];
+  /** Runs no non-default project claims — the "Not in a project" shelf (D4). */
+  unfiled: SessionView[];
   loading: boolean;
   error: string | null;
 }
@@ -195,7 +197,11 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
           api.listProjects(),
           api.listRepos().then((r) => r.repos).catch(() => []),
         ]);
-        active = all.filter((p) => p.status === 'active');
+        // The synthesized "Unfiled" bucket is NOT a project and never renders as a
+        // card (F5, D4) — the same exclusion `useLegacyRedirect` applies, for the
+        // same reason: a hit there means *no project*. Its runs surface through
+        // `unfiled` below, as the last, collapsed shelf.
+        active = all.filter((p) => p.status === 'active' && p.id !== 'default');
         repoNames.current = new Map(repos.map((r) => [r.id, r.name]));
       } catch (e) {
         if (!cancelled) {
@@ -296,5 +302,14 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
     [projects, bindings, runs, gates, failedAt, now],
   );
 
-  return { items, loading, error };
+  // The unfiled set (F5): what the run list holds that no membership claims. Held
+  // back until the first membership read lands — before that, EVERY run would look
+  // unfiled and the shelf would flash into existence on each load.
+  const unfiled = useMemo(() => {
+    if (loading || (projects.length > 0 && Object.keys(bindings).length === 0)) return [];
+    const known = new Set(Object.values(bindings).flatMap((b) => [...b.runIds]));
+    return runs.filter((v) => !known.has(v.session.id));
+  }, [runs, projects, bindings, loading]);
+
+  return { items, unfiled, loading, error };
 }

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -75,6 +75,10 @@ function card(): void {
     runs: [],
     docs: [{ name: DOC, kind: 'doc' as const, head: 3, versions: 3, updated_at: '2026-08-18T11:30:00Z' }],
     attention: 'drafts' as const,
+    // Slice-1 score fields — the export path never reads them, they just render.
+    score: 0,
+    band: 'quiet' as const,
+    signal: null,
   } as unknown as BoardProject;
   render(<ProjectCard item={item} navigate={() => {}} />);
 }

--- a/tests/GateChip.test.tsx
+++ b/tests/GateChip.test.tsx
@@ -31,6 +31,11 @@ function item(status: SessionStatus = 'awaiting_human'): BoardProject {
     runs: [makeView({ id: RUN, status, unit_ix: 0 }, [makeUnit({ id: `${RUN}:u0`, session_id: RUN, ord: 0, stage: 'build' })])],
     docs: [],
     attention: status === 'awaiting_human' ? 'gate' : 'running',
+    // Slice-1 score fields: the chip is driven by run status + the gate store,
+    // so a nominal score/band is enough to typecheck.
+    score: 100,
+    band: 'needs-you',
+    signal: null,
   };
 }
 

--- a/tests/HomeBoard.bands.test.tsx
+++ b/tests/HomeBoard.bands.test.tsx
@@ -104,10 +104,10 @@ const needsYouIds = (): (string | null)[] =>
   [...screen.getByTestId('band-needs-you').querySelectorAll('[data-testid="project-card"]')]
     .map((c) => c.getAttribute('data-project-id'));
 
-async function board(runs: SessionView[]): Promise<void> {
+async function board(runs: SessionView[], expectedTotal = projects.length): Promise<void> {
   render(<HomeBoard runs={runs} navigate={() => {}} />);
   await vi.waitFor(() => {
-    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(expectedTotal));
   });
 }
 
@@ -233,6 +233,49 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
     expect(screen.getByTestId('board-all-quiet')).toHaveTextContent('Nothing needs you right now.');
     expect(screen.getByTestId('band-needs-you').querySelectorAll('[data-testid="project-card"]')).toHaveLength(0);
     expect(screen.getAllByTestId('quiet-chip')).toHaveLength(2);
+  });
+
+  it('the synthesized "default" project never renders — as a card, a chip, or a count (F5)', async () => {
+    const now = Date.now();
+    projects = [
+      project('default', now, { name: 'Unfiled', scope: '' }),
+      project('real-work', now - 3 * DAY),
+    ];
+    // `data-total` means non-default projects (unchanged meaning) — 1, not 2.
+    await board([], 1);
+    fireEvent.click(screen.getByTestId('band-quiet-toggle'));
+    expect(document.querySelector('[data-project-id="default"]')).toBeNull();
+    // V18: the word "Unfiled" appears nowhere on this surface.
+    expect(screen.queryByText(/Unfiled/)).toBeNull();
+  });
+
+  it('the shelf is absent with nothing unfiled, and last + collapsed with one orphan run', async () => {
+    const now = Date.now();
+    projects = [project('filed', now)];
+    members = { filed: [member('filed', 'r-filed')] };
+
+    // Every run claimed ⇒ no shelf in the DOM at all.
+    await board([makeView({ id: 'r-filed', status: 'executing' })]);
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-project-id="filed"]')).not.toBeNull();
+    });
+    expect(screen.queryByTestId('band-not-in-project')).toBeNull();
+    cleanup();
+
+    // One orphan ⇒ the shelf exists: LAST in document order, collapsed, counted.
+    await board([
+      makeView({ id: 'r-filed', status: 'executing' }),
+      makeView({ id: 'r-orphan', status: 'executing', problem: 'stranded work' }),
+    ]);
+    const shelf = await screen.findByTestId('band-not-in-project');
+    expect(shelf).toHaveAttribute('data-count', '1');
+    expect(shelf).toHaveAttribute('data-expanded', 'false');
+    expect(screen.queryByTestId('unfiled-run')).toBeNull();
+    const boardEl = screen.getByTestId('project-board');
+    expect(boardEl.lastElementChild).toBe(shelf);
+
+    fireEvent.click(screen.getByTestId('band-not-in-project-toggle'));
+    expect(screen.getByTestId('unfiled-run')).toHaveAttribute('data-run-id', 'r-orphan');
   });
 
   it('the 60s tick demotes a running project silent for a half-life — no new data needed', async () => {

--- a/tests/HomeBoard.bands.test.tsx
+++ b/tests/HomeBoard.bands.test.tsx
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { DocSummary } from '../src/api/interactive.js';
+import type { CoreEvent, Project, ProjectMember, SessionView } from '../src/api/types.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * The NEEDS YOU / QUIET bands over the W2 messy-reality fixture (DES-UXFIX-001
+ * §4.2, slice-1 DOM AC): the 8-day failure does NOT lead, the live run does, a
+ * gate leads regardless of age, drafts never leave QUIET, and the quiet band is
+ * collapsed by default. The fixture shape is §4.2's table, ages computed from a
+ * frozen `now`.
+ */
+
+let projects: Project[] = [];
+let members: Record<string, ProjectMember[]> = {};
+let docs: Record<string, DocSummary[]> = {};
+let runEvents: Record<string, CoreEvent[]> = {};
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: members[id] ?? [] }),
+    getRunEvents: (id: string) => Promise.resolve({ events: runEvents[id] ?? [] }),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: (id: string) => Promise.resolve(docs[id] ?? []),
+}));
+
+const { HomeBoard } = await import('../src/components/HomeBoard.js');
+
+const SEC = 1_000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+function project(id: string, updated_at: number, over: Partial<Project> = {}): Project {
+  return {
+    id, name: id, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at, ...over,
+  };
+}
+
+function member(project_id: string, member_ref: string): ProjectMember {
+  return {
+    id: `${project_id}:crew.run:${member_ref}`, project_id, member_kind: 'crew.run',
+    member_ref, meta: null, attached_at: 1, attached_by: 'studio',
+  };
+}
+
+function doc(name: string, at: number): DocSummary {
+  return { name, kind: 'doc', head: 1, versions: 1, updated_at: new Date(at).toISOString() };
+}
+
+/** §4.2's rows, ages relative to `now`. Returns the run list the board receives. */
+function seedW2(now: number): SessionView[] {
+  projects = [
+    // Touched an HOUR ago but failed 8 DAYS ago — the ladder's durable-log tail
+    // (D3 step 2) must beat the fresh `updated_at` fallback, or this row leads.
+    project('legacy-spike', now - HOUR),
+    project('upload-endpoint', now),
+    project('q3-review-deck', now - 30 * SEC),
+    project('api-migration', now - 2 * MIN),
+    project('auth-refactor', now - 12 * MIN),
+    project('smoke-tests', now - 6 * DAY),
+    project('notes', now - 2 * DAY, { interactiveRoot: '/tmp/wi' }),
+    project('scratch', now),
+  ];
+  members = {
+    'legacy-spike': [member('legacy-spike', 'r-legacy')],
+    'upload-endpoint': [member('upload-endpoint', 'r-upload')],
+    'q3-review-deck': [member('q3-review-deck', 'r-q3')],
+    'api-migration': [member('api-migration', 'r-api')],
+    'auth-refactor': [member('auth-refactor', 'r-auth')],
+    'smoke-tests': [member('smoke-tests', 'r-smoke')],
+  };
+  docs = { notes: [doc('ideas', now - 2 * DAY), doc('todo', now - 3 * DAY)] };
+  runEvents = {
+    'r-legacy': [{ type: 'sessionFailed', session: 'r-legacy', ts: now - 8 * DAY }],
+    'r-auth': [{ type: 'sessionFailed', session: 'r-auth', ts: now - 12 * MIN }],
+  };
+  useGateStore.setState({
+    gates: {
+      'r-q3': { runId: 'r-q3', ord: 0, prompt: 'Approve the plan?', lifecycle: 'open', receivedAt: now - 30 * SEC },
+      'r-api': { runId: 'r-api', ord: 0, prompt: 'Pick a migration', lifecycle: 'open', receivedAt: now - 2 * MIN, choices: null },
+    },
+  });
+  return [
+    makeView({ id: 'r-legacy', status: 'failed' }),
+    makeView({ id: 'r-upload', status: 'executing' }),
+    makeView({ id: 'r-q3', status: 'awaiting_human' }),
+    makeView({ id: 'r-api', status: 'awaiting_human' }),
+    makeView({ id: 'r-auth', status: 'failed' }),
+    makeView({ id: 'r-smoke', status: 'completed' }),
+  ];
+}
+
+const needsYouIds = (): (string | null)[] =>
+  [...screen.getByTestId('band-needs-you').querySelectorAll('[data-testid="project-card"]')]
+    .map((c) => c.getAttribute('data-project-id'));
+
+async function board(runs: SessionView[]): Promise<void> {
+  render(<HomeBoard runs={runs} navigate={() => {}} />);
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+  });
+}
+
+describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
+  beforeEach(() => {
+    projects = [];
+    members = {};
+    docs = {};
+    runEvents = {};
+    useGateStore.setState({ gates: {} });
+    useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
+  });
+  afterEach(cleanup);
+
+  it('the 8d failure is NOT in NEEDS YOU and the live run IS — the F3 proof in the DOM', async () => {
+    const runs = seedW2(Date.now());
+    await board(runs);
+
+    // The demotion waits on the durable-log backfill (D3 step 2): once the 8-day
+    // `ts` lands, legacy-spike falls out of the live band despite its fresh
+    // `updated_at` — exactly the trap R3 names.
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('band-quiet')).toBeTruthy();
+      expect(
+        within(screen.getByTestId('band-quiet')).getByText('legacy-spike', { exact: false }),
+      ).toBeTruthy();
+    });
+    expect(needsYouIds()).not.toContain('legacy-spike');
+    expect(needsYouIds()).toContain('upload-endpoint');
+
+    // Its card (mounted once QUIET expands) carries the decay verdict.
+    fireEvent.click(screen.getByTestId('band-quiet-toggle'));
+    const legacy = document.querySelector('[data-testid="project-card"][data-project-id="legacy-spike"]');
+    expect(legacy).not.toBeNull();
+    expect(legacy).toHaveAttribute('data-band', 'quiet');
+    expect(legacy).toHaveAttribute('data-signal', 'failing');
+  });
+
+  it('orders NEEDS YOU by decayed score: gates, then the fresh failure, then the live run', async () => {
+    const runs = seedW2(Date.now());
+    await board(runs);
+
+    await vi.waitFor(() => {
+      expect(needsYouIds()).toEqual([
+        'q3-review-deck',   // gate, 30s — no decay
+        'api-migration',    // gate, 2m — no decay, older than q3
+        'auth-refactor',    // failing, 12m — ≈67.6, still urgent
+        'upload-endpoint',  // running now — 40
+      ]);
+    });
+    // The band boundary, off the DOM: nothing below the threshold leads, nothing
+    // above it hides (slice-1 AC / §5.5 assertion 6).
+    const cards = [...document.querySelectorAll('[data-testid="project-card"]')];
+    for (const c of cards) {
+      const score = Number(c.getAttribute('data-score'));
+      const inBand = c.closest('[data-testid="band-needs-you"]') !== null;
+      expect(inBand).toBe(score >= 20);
+    }
+  });
+
+  it('a gate leads regardless of age — even one older than the failure it outranks', async () => {
+    const now = Date.now();
+    projects = [project('ancient-gate', now - 8 * DAY), project('fresh-failure', now - 12 * MIN)];
+    members = {
+      'ancient-gate': [member('ancient-gate', 'r-gate')],
+      'fresh-failure': [member('fresh-failure', 'r-fail')],
+    };
+    runEvents = { 'r-fail': [{ type: 'sessionFailed', session: 'r-fail', ts: now - 12 * MIN }] };
+    useGateStore.setState({
+      gates: {
+        'r-gate': { runId: 'r-gate', ord: 0, prompt: 'Still waiting…', lifecycle: 'open', receivedAt: now - 8 * DAY },
+      },
+    });
+    await board([
+      makeView({ id: 'r-gate', status: 'awaiting_human' }),
+      makeView({ id: 'r-fail', status: 'failed' }),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(needsYouIds()).toEqual(['ancient-gate', 'fresh-failure']);
+    });
+    const gateCard = document.querySelector('[data-project-id="ancient-gate"]');
+    expect(gateCard).toHaveAttribute('data-score', '100.00');
+    expect(gateCard).toHaveAttribute('data-signal', 'gate');
+  });
+
+  it('drafts are a nudge, never a demand: notes (2 docs, 2d) sits in QUIET', async () => {
+    const runs = seedW2(Date.now());
+    await board(runs);
+
+    await vi.waitFor(() => {
+      expect(
+        within(screen.getByTestId('band-quiet')).getByText('notes', { exact: false }),
+      ).toBeTruthy();
+    });
+    expect(needsYouIds()).not.toContain('notes');
+  });
+
+  it('QUIET is collapsed by default; its cards mount only after the toggle', async () => {
+    const runs = seedW2(Date.now());
+    await board(runs);
+    await vi.waitFor(() => expect(screen.getByTestId('band-quiet')).toHaveAttribute('data-expanded', 'false'));
+
+    const quietCards = (): number =>
+      screen.getByTestId('band-quiet').querySelectorAll('[data-testid="project-card"]').length;
+    expect(quietCards()).toBe(0);
+    // Collapsed, the calm majority is one demoted line each — the preview chips.
+    expect(screen.getAllByTestId('quiet-chip').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByTestId('band-quiet-toggle'));
+    expect(screen.getByTestId('band-quiet')).toHaveAttribute('data-expanded', 'true');
+    await vi.waitFor(() => expect(quietCards()).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByTestId('band-quiet-toggle'));
+    expect(quietCards()).toBe(0);
+  });
+
+  it('with every project quiet, the board states it and no card leads', async () => {
+    const now = Date.now();
+    projects = [project('sleepy', now - 3 * DAY), project('dormant', now - 5 * DAY)];
+    await board([]);
+
+    expect(screen.getByTestId('board-all-quiet')).toHaveTextContent('Nothing needs you right now.');
+    expect(screen.getByTestId('band-needs-you').querySelectorAll('[data-testid="project-card"]')).toHaveLength(0);
+    expect(screen.getAllByTestId('quiet-chip')).toHaveLength(2);
+  });
+
+  it('the 60s tick demotes a running project silent for a half-life — no new data needed', async () => {
+    vi.useFakeTimers();
+    try {
+      const t0 = Date.now();
+      projects = [project('silent', t0)];
+      members = { silent: [member('silent', 'r-silent')] };
+      render(
+        <HomeBoard runs={[makeView({ id: 'r-silent', status: 'executing' })]} navigate={() => {}} />,
+      );
+      // Flush the project + binding loads (microtask chains, no timers involved).
+      for (let i = 0; i < 6; i++) await act(async () => { await Promise.resolve(); });
+      expect(needsYouIds()).toEqual(['silent']);
+
+      // 31 minutes of narration silence: one half-life past 40 → ~19.5, under the
+      // threshold. The tick alone must carry the card out of the live band (D7).
+      await act(async () => { vi.advanceTimersByTime(31 * MIN); });
+      expect(needsYouIds()).toEqual([]);
+      expect(screen.getByTestId('quiet-chip')).toHaveAttribute('data-project-id', 'silent');
+      expect(screen.getByTestId('board-all-quiet')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import type { DocSummary } from '../src/api/interactive.js';
 import type { CoreEvent, Project, ProjectMember, SessionStatus, SessionView } from '../src/api/types.js';
 import { useRuntimeStore } from '../src/store/runtime.js';
@@ -62,10 +62,21 @@ const push = (event: CoreEvent): void => {
   act(() => { useRuntimeStore.getState().ingest(event); });
 };
 
+/** Slice 1 bands: quiet projects mount as cards only once QUIET is expanded, so
+ *  "all cards mounted" is band-aware — expand the quiet band when it is there. */
+async function expandQuiet(): Promise<void> {
+  const toggle = screen.queryByTestId('band-quiet-toggle');
+  if (toggle !== null) fireEvent.click(toggle);
+  return Promise.resolve();
+}
+
 async function board(runs: SessionView[]): Promise<void> {
   render(<HomeBoard runs={runs} navigate={() => {}} />);
   await vi.waitFor(() => {
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+  });
+  await expandQuiet();
+  await vi.waitFor(() => {
     expect(screen.getAllByTestId('project-card')).toHaveLength(projects.length);
   });
 }
@@ -130,6 +141,8 @@ describe('HomeBoard — live activity (slice 6)', () => {
     const { rerender } = render(
       <HomeBoard runs={[running('run-a', 'completed'), running('run-b', 'completed')]} navigate={() => {}} />,
     );
+    await vi.waitFor(() => expect(screen.queryByTestId('band-quiet-toggle')).not.toBeNull());
+    await expandQuiet();
     await vi.waitFor(() => expect(cardIds()).toEqual(['p-a', 'p-b']));
     const untouched = card('p-a');
 
@@ -140,6 +153,10 @@ describe('HomeBoard — live activity (slice 6)', () => {
 
     await vi.waitFor(() => expect(cardIds()).toEqual(['p-b', 'p-a']));
     expect(card('p-b')).toHaveAttribute('data-attention', 'gate');
+    // Slice 1 strengthens the claim: the gated card did not just sort first, it
+    // moved INTO the NEEDS YOU band (a gate never decays, so it always leads).
+    expect(within(screen.getByTestId('band-needs-you')).getByTestId('project-card'))
+      .toHaveAttribute('data-project-id', 'p-b');
     // Keyed by project id, so the card that did not change is MOVED, not rebuilt —
     // which is what keeps a re-sort from throwing away the unaffected cards' state.
     expect(card('p-a')).toBe(untouched);
@@ -184,6 +201,9 @@ describe('HomeBoard — live activity (slice 6)', () => {
   it('picks up a run attached after first paint — no reload to see a launched run', async () => {
     projects = [project('p-a', 'Ay')];
     const { rerender } = render(<HomeBoard runs={[]} navigate={() => {}} />);
+    // A run-less project is quiet by construction (slice 1) — expand to its card.
+    await vi.waitFor(() => expect(screen.queryByTestId('band-quiet-toggle')).not.toBeNull());
+    await expandQuiet();
     await vi.waitFor(() => expect(card('p-a')).toHaveTextContent('No runs yet.'));
 
     // The run is launched and filed while the user sits on the board.

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -73,7 +73,9 @@ describe('HomeBoard — the orchestrator board', () => {
   it('sorts by attention: gate-waiting before running before empty', async () => {
     projects = [
       project({ id: 'p-quiet', name: 'Quiet' }),
-      project({ id: 'p-run', name: 'Running' }),
+      // Under decay (DES-UXFIX-001 §2.1.3) a live run's clock is what ranks it, so
+      // the fixture is honest about it: a project executing NOW was touched now.
+      project({ id: 'p-run', name: 'Running', updated_at: Date.now() }),
       project({ id: 'p-gate', name: 'Gated' }),
     ];
     members = {

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -63,6 +63,11 @@ async function boardWith(runs = [] as ReturnType<typeof makeView>[]): Promise<vo
   });
 }
 
+/** Slice 1 bands: a quiet project's CARD mounts only once QUIET is expanded. */
+async function expandQuiet(): Promise<void> {
+  await userEvent.setup().click(await screen.findByTestId('band-quiet-toggle'));
+}
+
 describe('HomeBoard — the orchestrator board', () => {
   beforeEach(() => {
     projects = [];
@@ -87,19 +92,26 @@ describe('HomeBoard — the orchestrator board', () => {
       makeView({ id: 'run-gate', status: 'awaiting_human' }),
     ]);
 
+    // Slice 1 bands: the projects that need a human are CARDS inside NEEDS YOU,
+    // score-ordered; the quiet one is a one-line preview chip, not a card.
     await vi.waitFor(() => {
-      const cards = screen.getAllByTestId('project-card');
-      expect(cards.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-gate', 'p-run', 'p-quiet']);
+      const band = screen.getByTestId('band-needs-you');
+      const cards = within(band).getAllByTestId('project-card');
+      expect(cards.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-gate', 'p-run']);
     });
+    expect(screen.getByTestId('quiet-chip')).toHaveAttribute('data-project-id', 'p-quiet');
     // AC: the first card IS the gate-waiting one, and says so.
     const first = screen.getAllByTestId('project-card')[0];
     expect(first).toHaveAttribute('data-attention', 'gate');
+    expect(first).toHaveAttribute('data-band', 'needs-you');
     expect(first).toHaveTextContent('gate');
   });
 
   it('a project with nothing in it renders the four quick actions — the card IS the empty state', async () => {
     projects = [project({ id: 'p-empty', name: 'Empty' })];
     await boardWith();
+    // An empty project is quiet by construction now (slice 1) — expand to reach its card.
+    await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
     const actions = within(card).getAllByTestId('quick-action');
@@ -119,6 +131,7 @@ describe('HomeBoard — the orchestrator board', () => {
     const navigate = vi.fn();
     projects = [project({ id: 'p-1', name: 'One' })];
     render(<HomeBoard runs={[]} navigate={navigate} />);
+    await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
     await user.click(within(card).getByText(/Do work/));
@@ -136,6 +149,8 @@ describe('HomeBoard — the orchestrator board', () => {
       ],
     };
     await boardWith();
+    // Docs alone are a drafts nudge, never a demand (D2) — the card lives in QUIET.
+    await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
     await vi.waitFor(() => expect(within(card).getAllByTestId('doc-tile')).toHaveLength(3));
@@ -149,6 +164,7 @@ describe('HomeBoard — the orchestrator board', () => {
     projects = [project({ id: 'p-none', name: 'None' })];
     docs = { 'p-none': [{ name: 'never-shown', kind: 'doc', head: 1, versions: 1, updated_at: null }] };
     await boardWith();
+    await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
     expect(card).toHaveTextContent('No documents yet');
@@ -162,8 +178,13 @@ describe('HomeBoard — the orchestrator board', () => {
       );
     };
 
+    // Twenty quiet projects mount as CHIPS while collapsed (a capped preview strip),
+    // and as a WINDOWED grid once expanded — the intent (mounted bounded by the
+    // viewport, not the project count) holds across both bands (D6).
     seed(20);
     await boardWith();
+    expect(screen.getAllByTestId('quiet-chip').length).toBeLessThan(20);
+    await expandQuiet();
     const at20 = screen.getAllByTestId('project-card').length;
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '20');
     expect(at20).toBeGreaterThan(0);
@@ -174,6 +195,7 @@ describe('HomeBoard — the orchestrator board', () => {
     // windowing, and it is what keeps 20+ cards legible (§1.4).
     seed(60);
     await boardWith();
+    await expandQuiet();
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '60');
     expect(screen.getAllByTestId('project-card')).toHaveLength(at20);
   });

--- a/tests/boardAttention.test.ts
+++ b/tests/boardAttention.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bandOf,
+  compareScored,
+  scoreOf,
+  topSignal,
+  TRIAGE_THRESHOLD,
+  type Signal,
+} from '../src/board/boardAttention.js';
+
+/**
+ * Pins the decay curve (DES-UXFIX-001 §2.1.3, slice-1 AC) at the exact ages the
+ * design names — 30 s, 12 min, 8 d — from a frozen `now`, so the F3 fix is
+ * proven in arithmetic before anything renders it.
+ */
+
+const NOW = 1_700_000_000_000;
+const S = 1_000;
+const MIN = 60 * S;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+const at = (age: number): number => NOW - age;
+const sig = (kind: Signal['kind'], age: number): Signal => ({ kind, at: at(age) });
+
+describe('scoreOf — the decay curve at the AC ages', () => {
+  it('a gate at 30s scores exactly 100 — no decay', () => {
+    expect(scoreOf(sig('gate', 30 * S), NOW)).toBe(100);
+  });
+
+  it('a gate at 8d STILL scores exactly 100 — the ∞ half-life, asserted not assumed', () => {
+    expect(scoreOf(sig('gate', 8 * DAY), NOW)).toBe(100);
+  });
+
+  it('a failure at 12min scores ≈67.62 — fresh, still above the threshold', () => {
+    const score = scoreOf(sig('failing', 12 * MIN), NOW);
+    expect(score).toBeCloseTo(70 * Math.pow(0.5, 12 / 240), 6);
+    expect(Math.abs(score - 67.62)).toBeLessThan(0.01);
+    expect(score).toBeGreaterThanOrEqual(TRIAGE_THRESHOLD);
+  });
+
+  it('a failure at 8d has decayed to ~0 — the F3 proof, in arithmetic', () => {
+    // 8 d = 48 half-lives of 4 h: effectively zero, far below any live run.
+    expect(scoreOf(sig('failing', 8 * DAY), NOW)).toBeLessThan(1e-6);
+  });
+
+  it('running scores 40 now and 20 after one 30-min half-life', () => {
+    expect(scoreOf(sig('running', 0), NOW)).toBe(40);
+    expect(scoreOf(sig('running', 30 * MIN), NOW)).toBeCloseTo(20, 9);
+  });
+
+  it('drafts at 2d score ≈12.31 and band as quiet — a draft never demands (D2)', () => {
+    const score = scoreOf(sig('drafts', 2 * DAY), NOW);
+    expect(Math.abs(score - 12.31)).toBeLessThan(0.01);
+    expect(bandOf(score)).toBe('quiet');
+  });
+
+  it('clamps a negative Δ (clock skew) to 0 — never above the base', () => {
+    expect(scoreOf({ kind: 'running', at: NOW + 5 * MIN }, NOW)).toBe(40);
+    expect(scoreOf({ kind: 'failing', at: NOW + 5 * MIN }, NOW)).toBe(70);
+  });
+});
+
+describe('topSignal', () => {
+  it('picks the max over a mixed set and returns its signal', () => {
+    const gate = sig('gate', 8 * DAY);
+    const { score, signal } = topSignal(
+      [sig('failing', 12 * MIN), gate, sig('running', 0), sig('drafts', 0)],
+      NOW,
+    );
+    expect(score).toBe(100);
+    expect(signal).toBe(gate);
+  });
+
+  it('an empty set scores 0 with a null signal', () => {
+    expect(topSignal([], NOW)).toEqual({ score: 0, signal: null });
+  });
+});
+
+describe('bandOf', () => {
+  it('exactly the threshold is still needs-you', () => {
+    expect(bandOf(TRIAGE_THRESHOLD)).toBe('needs-you');
+    expect(bandOf(TRIAGE_THRESHOLD - 0.001)).toBe('quiet');
+  });
+});
+
+describe('compareScored', () => {
+  const item = (score: number, at: number, name: string): { score: number; at: number; name: string } =>
+    ({ score, at, name });
+
+  it('orders by score descending', () => {
+    const sorted = [item(0, 9, 'quiet'), item(100, 1, 'gated'), item(40, 5, 'busy')].sort(compareScored);
+    expect(sorted.map((i) => i.name)).toEqual(['gated', 'busy', 'quiet']);
+  });
+
+  it('breaks ties newest-signal-first, then name — never on list position', () => {
+    const sorted = [item(0, 10, 'zulu'), item(0, 20, 'alpha'), item(0, 20, 'bravo')].sort(compareScored);
+    expect(sorted.map((i) => i.name)).toEqual(['alpha', 'bravo', 'zulu']);
+  });
+});

--- a/tests/boardModel.test.ts
+++ b/tests/boardModel.test.ts
@@ -4,9 +4,7 @@ import type { Project, SessionView } from '../src/api/types.js';
 import {
   deriveAttention,
   interactiveRootOf,
-  sortByAttention,
   type Attention,
-  type BoardProject,
 } from '../src/hooks/useBoardModel.js';
 import { ago } from '../src/components/ProjectCard.js';
 import { makeView } from './factories.js';
@@ -25,10 +23,6 @@ function project(over: Partial<Project> & { id: string }): Project {
   };
 }
 
-function item(id: string, attention: Attention, updated_at = 1, name = id): BoardProject {
-  return { project: project({ id, name, updated_at }), repo: null, runs: [], docs: [], attention };
-}
-
 describe('deriveAttention (DES-MERGE-001 §1.4 sort key)', () => {
   const cases: [string, SessionView[], DocSummary[], Attention][] = [
     ['a waiting gate outranks everything', [makeView({ id: 'r1', status: 'executing' }), makeView({ id: 'r2', status: 'awaiting_human' })], [doc], 'gate'],
@@ -44,33 +38,9 @@ describe('deriveAttention (DES-MERGE-001 §1.4 sort key)', () => {
   }
 });
 
-describe('sortByAttention', () => {
-  it('orders gate > failing > running > drafts > quiet', () => {
-    const sorted = sortByAttention([
-      item('quiet', 'quiet'),
-      item('drafts', 'drafts'),
-      item('running', 'running'),
-      item('failing', 'failing'),
-      item('gate', 'gate'),
-    ]);
-    expect(sorted.map((i) => i.project.id)).toEqual(['gate', 'failing', 'running', 'drafts', 'quiet']);
-  });
-
-  it('breaks ties on recency, then name — never on list position', () => {
-    const sorted = sortByAttention([
-      item('old', 'quiet', 10, 'zulu'),
-      item('new', 'quiet', 20, 'alpha'),
-      item('same-b', 'quiet', 20, 'bravo'),
-    ]);
-    expect(sorted.map((i) => i.project.id)).toEqual(['new', 'same-b', 'old']);
-  });
-
-  it('does not mutate its input', () => {
-    const input = [item('quiet', 'quiet'), item('gate', 'gate')];
-    sortByAttention(input);
-    expect(input.map((i) => i.project.id)).toEqual(['quiet', 'gate']);
-  });
-});
+// The fixed-bucket `sortByAttention` is gone (DES-UXFIX-001 slice 1): ordering is
+// the decayed-score comparator, pinned in `boardAttention.test.ts`. The bucket
+// itself survives above as a labelling concern (D8), tests kept as-is.
 
 describe('interactiveRootOf', () => {
   it('reads either spelling of the forward-additive project setting', () => {

--- a/tests/boardWindow.test.ts
+++ b/tests/boardWindow.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { OVERSCAN, windowRows } from '../src/board/boardWindow.js';
+
+/**
+ * The extracted windowing math (DES-UXFIX-001 slice 1, D6): one pure function,
+ * used once per band against the shared scroller. What it must never do is
+ * return a negative or out-of-range row for a non-empty grid — the band grids
+ * slice with its answer verbatim.
+ */
+
+const ROW_H = 366; // CARD_H + GAP, as the board computes it
+const VIEW_H = 900;
+
+describe('windowRows', () => {
+  it('at offset 0 mounts the viewport rows plus overscan, no more', () => {
+    const w = windowRows(60, 3, ROW_H, 0, VIEW_H, 0);
+    expect(w.firstRow).toBe(0);
+    expect(w.lastRow).toBe(Math.ceil(VIEW_H / ROW_H) + OVERSCAN);
+    expect(w.lastRow).toBeLessThan(20); // 60 items / 3 columns = 20 rows total
+  });
+
+  it('a section offset shifts the window: scrolled to the section start, row 0 leads', () => {
+    const offset = 2 * ROW_H + 100;
+    const w = windowRows(30, 3, ROW_H, offset, VIEW_H, offset);
+    expect(w.firstRow).toBe(0);
+    expect(w.lastRow).toBe(Math.ceil(VIEW_H / ROW_H) + OVERSCAN);
+  });
+
+  it('count 0 is the one empty window: lastRow -1, nothing to slice', () => {
+    expect(windowRows(0, 3, ROW_H, 0, VIEW_H, 0)).toEqual({ firstRow: 0, lastRow: -1 });
+  });
+
+  it('count smaller than one row clamps to the single row that exists', () => {
+    expect(windowRows(2, 3, ROW_H, 0, VIEW_H, 0)).toEqual({ firstRow: 0, lastRow: 0 });
+  });
+
+  it('scrollTop past the end clamps to the last row — never negative, never out of range', () => {
+    const w = windowRows(6, 3, ROW_H, 1_000_000, VIEW_H, 0); // 2 rows total
+    expect(w).toEqual({ firstRow: 1, lastRow: 1 });
+  });
+
+  it('a section entirely below the viewport keeps only its edge row mounted', () => {
+    const w = windowRows(30, 3, ROW_H, 0, VIEW_H, 5_000);
+    expect(w).toEqual({ firstRow: 0, lastRow: 0 });
+  });
+});

--- a/tests/liveEdge.surfaces.test.tsx
+++ b/tests/liveEdge.surfaces.test.tsx
@@ -28,6 +28,8 @@ function project(id: string): Project {
 }
 
 function card(id: string, statuses: SessionStatus[], attention: BoardProject['attention']): BoardProject {
+  // The edge is derived from run STATUS, not from the score — the slice-1 fields
+  // only need to typecheck here, so a neutral score/band/signal is enough.
   return {
     project: project(id),
     repo: null,
@@ -36,6 +38,9 @@ function card(id: string, statuses: SessionStatus[], attention: BoardProject['at
     ),
     docs: [],
     attention,
+    score: attention === 'quiet' ? 0 : 100,
+    band: attention === 'quiet' ? 'quiet' : 'needs-you',
+    signal: null,
   };
 }
 


### PR DESCRIPTION
Slice 1 of the experience redesign: the board now answers 'what needs me'. Pure decayed-attention score model (gate ∞ / running 30min / failing 4h / drafts 7d half-lives, triage threshold), NEEDS YOU / QUIET / not-in-project bands, the 24-quiet-project wall collapsed to one chip row, 8-day-old failures demoted while an 8-day-old GATE still leads. W2 messy-reality fixture + deterministic e2e rig; 757/757 tests; decay pins mutation-verified.

Screenshot gate exercised as designed: the verifier and the operator both judged the named 1440×900 captures against the §4.1 checklist (EC3/EC4/EC5 pass; evidence committed at .product/evidence/uxfix-slice1/). Workflow-authored (governed run bfde85c0 authored the implementation design; its build was lost to core#291's reap gap — implementation by verified workflow agents against that spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)