### PR TITLE
feat(board): card variants + empty-state budget + mode-spine actions (DES-UXFIX-001 slice 2)

### DIFF
--- a/.product/evidence/uxfix-slice2/checklist.md
+++ b/.product/evidence/uxfix-slice2/checklist.md
@@ -1,0 +1,77 @@
+# DES-UXFIX-001 — Slice 2 experience-checklist verdicts (§4.1)
+
+**Slice:** 2 — card variants + empty-state budget + differentiated actions
+**Date:** 2026-08-20
+**Build:** branch `uxfix/slice-2-card-variants` (on top of slice 1, `3893e71`)
+**Rig:** `e2e/uxfix_slice2_test.py` — the W2 messy-reality fixture (§4.2) served by
+the deterministic fixture server (same pattern as the slice-1 rig), captured per
+the §4.0 contract: 1440×900, `device_scale_factor=1`, every capture waits on a
+`data-testid`, never a sleep. The DOM ACs backing each verdict all passed in the
+same run (JSON report printed by the rig; `banned_strings_found: []`,
+`clipped_cards: []`).
+
+**Screenshots judged** (uncommitted evidence, `e2e/shots/uxfix/`):
+
+| Scene | File |
+|---|---|
+| ACTIVE card (q3-review-deck: gate pill, live line, answerable chip) | `uxfix-2-active-card.png` |
+| QUIET card (smoke-tests: one line + compact actions) | `uxfix-2-quiet-card.png` |
+| First-run card (scratch: invitation + four differentiated verbs) | `uxfix-2-actions.png` |
+
+Judged from the pixels alone, per §4.1 ("if you cannot tell from the image, it
+fails").
+
+---
+
+## EC1 — one obvious next action · **PASS**
+
+On the first-run card (`uxfix-2-actions.png`), the invitation — *"Start by
+describing what you want →"* — is the single accent-coloured (yellow), bolded
+element on the card; it is unambiguously the thing to click. The four mode
+actions sit below it as visibly subordinate muted boxes with faint sublabels.
+Nothing else on the card competes. On the quiet card the summary line is plain
+and the compact actions are uniform — no false primary is manufactured where
+none exists.
+
+## EC2 — absence is at most one line · **PASS**
+
+- The quiet card (`uxfix-2-quiet-card.png`) is exactly one line of absence —
+  *"Quiet — last active 6d ago"* — plus the compact action row. Nothing else.
+  The card is one-line tall (~64px rendered), not a 352px shell of three
+  "nothing" regions.
+- The active card (`uxfix-2-active-card.png`) shows ZERO absence lines:
+  q3-review-deck has no documents and its Documents region is simply not there
+  — omitted, not narrated. No "No documents yet", "Nothing running", or
+  "No runs yet" appears in any capture (the rig asserts the strings are absent
+  from the whole page text, and passed).
+- The first-run card's single line is the invitation — §2.1.2's one sanctioned
+  exception, still one line.
+
+## EC6 — verbs are differentiable · **PASS**
+
+The four actions read as four different things in every capture: each carries
+its own glyph (💬 ⚙ ▤ ▶ — the same four the mode switcher uses) and a mode name
+(Chat / Build / Document / Video), and on the first-run card each also carries a
+producing-artifact sublabel ("think out loud with an agent" / "ship code, with
+checks" / "a deck, page, or report" / "record a demo"). None of the labels are
+near-synonyms; "New chat" vs "Do work" is gone. The DOM AC backing this
+(distinct `data-mode`, labels matching `MODE_SPECS`) passed on every mounted
+card.
+
+---
+
+## Notes / caveats (honest, not blocking)
+
+1. Two first-run sublabels ellipsise at the fixture's 3-column card width
+   ("think out loud with a…", "a deck, page, …"). The full text survives on
+   hover (`title`) and the verbs stay differentiable via glyph + label, so EC6
+   holds — but a narrower board will truncate more.
+2. Cards are content-sized inside fixed windowing slots, so a NEEDS YOU band of
+   short cards shows slot whitespace *between* bands (visible in
+   `uxfix-1-messy-board.png`). That whitespace is layout air, not absence copy
+   — EC2 is judged on "nothing" lines, and there are none — but a later slice
+   could tighten band offsets if it grates.
+3. The first-run invitation is gated on `created_at` newer than 24h
+   (`FIRST_RUN_MS`): an empty project older than that reads as debris
+   ("Quiet — last active Nd ago"), per W2. The 24h window is a defensible
+   default, not a measured one.

--- a/e2e/uxfix_slice2_test.py
+++ b/e2e/uxfix_slice2_test.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+uxfix_slice2_test.py — the DES-UXFIX-001 slice-2 gate: card variants, the
+empty-state budget, and the mode-spine quick actions, proven in a real browser
+against the W2 messy-reality fixture (§4.2).
+
+Same rig pattern as uxfix_slice1_test.py (which stays the slice-1 gate): a
+deterministic ThreadingHTTPServer serves the `dist-sameorigin/` build plus every
+endpoint the home route reads, all timestamps computed from one frozen NOW0, the
+live run narrating over the rig's own /ws. No crew daemon is involved anywhere.
+
+What it asserts (design §4.3, the slice-2 DOM AC):
+  1. Every mounted card in band-needs-you carries data-variant="active"; an
+     active card with no documents renders NO doc tile — the region is OMITTED
+     (auth-refactor and q3-review-deck are the fixture's proof).
+  2. Every mounted card in band-quiet (expanded) carries data-variant="quiet",
+     exactly ONE data-testid="quiet-summary" line, and none of the region
+     furniture (doc-tile / live-line / run-chip).
+  3. The banned absence strings appear NOWHERE in the page text: "No documents
+     yet", "Nothing running", "No runs yet", "Start here" (F1, §3.7).
+  4. The four data-testid="quick-action" per card have distinct data-mode
+     (chat/build/document/video) and labels matching MODE_SPECS (Chat / Build /
+     Document / Video) — the old near-synonyms ("New chat", "Do work") are gone.
+  5. `scratch` (brand-new, empty) shows the first-run invitation as its ONE
+     line and the 2×2 sublabelled action grid, sublabels matching MODE_SPECS.
+  6. No mounted card is clipped (scrollHeight <= clientHeight + 1): the fixed
+     variant heights actually fit their fullest content.
+
+Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
+data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
+  uxfix-2-active-card.png   q3-review-deck: pill, live gate chip, no dead regions
+  uxfix-2-quiet-card.png    smoke-tests: the one-line QUIET variant
+  uxfix-2-actions.png       scratch: invitation + the four differentiated verbs
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4331), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SHOTS = REPO / "e2e" / "shots" / "uxfix"
+W2_PORT = int(os.environ.get("W2_PORT", "4331"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+NPM = "npm.cmd" if os.name == "nt" else "npm"
+
+HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared with the slice-1 rig — same dist dir) ─────
+dist = REPO / "dist-sameorigin"
+if os.environ.get("SKIP_STUDIO_BUILD") == "1":
+    if not (dist / "index.html").is_file():
+        fail("build", f"SKIP_STUDIO_BUILD=1 but {dist}/index.html is missing — "
+             "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
+elif not (dist / "index.html").is_file():
+    env = dict(os.environ, VITE_API_HOST="")
+    r = subprocess.run(
+        [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
+        cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
+    )
+    if r.returncode != 0:
+        fail("build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The W2 fixture (§4.2), every age from ONE frozen NOW0 ───────────────────
+NOW0 = int(time.time() * 1000)
+SEC, MIN, HOUR, DAY = 1_000, 60_000, 3_600_000, 86_400_000
+
+
+def iso(ms: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ms / 1000)) + f".{ms % 1000:03d}Z"
+
+
+def project(pid: str, name: str, updated_at: int, **extra) -> dict:
+    return {"id": pid, "name": name, "description": None, "status": "active",
+            "scope": f"project:{pid}" if pid != "default" else "",
+            "created_at": updated_at, "updated_at": updated_at, **extra}
+
+
+QUIET_CLONES = [project(f"quiet-{i:02d}", f"quiet-clone-{i:02d}", NOW0 - 3 * DAY - i * 7 * HOUR)
+                for i in range(20)]
+PROJECTS = [
+    project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
+    project("legacy-spike", "legacy-spike", NOW0 - HOUR),
+    project("upload-endpoint", "upload-endpoint", NOW0),
+    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
+    project("api-migration", "api-migration", NOW0 - 2 * MIN),
+    project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
+    project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
+    project("notes", "notes", NOW0 - 2 * DAY, interactiveRoot="/tmp/wi-notes"),
+    project("scratch", "scratch", NOW0),
+] + QUIET_CLONES
+
+MEMBERS = {
+    "legacy-spike": ["r-legacy"],
+    "upload-endpoint": ["r-upload"],
+    "q3-review-deck": ["r-q3"],
+    "api-migration": ["r-api"],
+    "auth-refactor": ["r-auth"],
+    "smoke-tests": ["r-smoke1", "r-smoke2"],
+}
+
+
+def session(rid: str, status: str, problem: str, unit_desc: str) -> dict:
+    return {"session": {
+        "id": rid, "workflow_id": "wf-w2", "problem": problem, "entity_mode": "shared",
+        "collection_scope": None, "clis": ["claude"], "status": status,
+        "human_confirm": "all" if status == "awaiting_human" else "none",
+        "unit_ix": 0, "attempt": 0, "workdir": None, "repo_ref": None,
+        "extra_write_roots": [], "archived_at": None, "archive_note": None,
+    }, "units": [{
+        "id": f"{rid}:u0", "session_id": rid, "ord": 0, "description": unit_desc,
+        "stage": "build", "assigned_cli": None, "assigned_invocation": None,
+        "council_task_ref": None, "routing": None, "denial_reason": None,
+        "phase_ref": None, "conformance_ref": None, "phase_status": None,
+        "collection_scope": None, "status": "pending",
+    }]}
+
+
+RUNS = [
+    session("r-q3", "awaiting_human", "make the Q3 review deck", "author the deck outline"),
+    session("r-api", "awaiting_human", "migrate the auth tables", "plan the migration"),
+    session("r-upload", "executing", "add rate-limiting to the upload endpoint",
+            "add rate-limiting to the upload endpoint"),
+    session("r-auth", "failed", "refactor the auth middleware", "refactor the auth middleware"),
+    session("r-legacy", "failed", "spike the legacy importer", "spike the legacy importer"),
+    session("r-smoke1", "completed", "smoke: login flow", "smoke the login flow"),
+    session("r-smoke2", "completed", "smoke: checkout flow", "smoke the checkout flow"),
+    session("r-orphan", "executing", "stranded work from another client",
+            "stranded work from another client"),
+]
+
+RUN_EVENTS = {
+    "r-legacy": [{"type": "sessionStarted", "session": "r-legacy", "ts": NOW0 - 8 * DAY - MIN},
+                 {"type": "sessionFailed", "session": "r-legacy", "ts": NOW0 - 8 * DAY}],
+    "r-auth": [{"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 13 * MIN},
+               {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 12 * MIN}],
+}
+
+NOTES_DOCS = [
+    {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
+    {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
+]
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+NARRATION = "Writing the token-bucket middleware for /upload"
+
+
+def ws_frame(payload: dict) -> bytes:
+    data = json.dumps(payload).encode()
+    if len(data) < 126:
+        head = bytes([0x81, len(data)])
+    else:
+        head = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
+    return head + data
+
+
+class W2Handler(SimpleHTTPRequestHandler):
+    """SPA + the whole /api/v1 surface the home route reads + /ws, one origin."""
+
+    def log_message(self, *_args):  # keep stdout JSON-clean
+        pass
+
+    def _json(self, status: int, payload) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _ws(self) -> None:
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+        self.wfile.write(
+            ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+             f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
+        self.wfile.flush()
+        try:
+            while True:
+                self.wfile.write(ws_frame({
+                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                    "text": NARRATION + "\n",
+                }))
+                self.wfile.flush()
+                time.sleep(1.0)
+        except OSError:
+            pass
+        self.close_connection = True
+
+    def _api(self, path: str) -> bool:
+        if path == "/api/v1/health":
+            self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
+            return True
+        if path == "/api/v1/runs":
+            self._json(200, {"runs": RUNS})
+            return True
+        if path == "/api/v1/projects":
+            self._json(200, {"projects": PROJECTS})
+            return True
+        if path == "/api/v1/repos":
+            self._json(200, {"repos": []})
+            return True
+        parts = path.split("/")
+        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
+            pid = urllib.parse.unquote(parts[4])
+            self._json(200, {"members": [
+                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
+                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
+                for ref in MEMBERS.get(pid, [])
+            ]})
+            return True
+        if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
+            pid = urllib.parse.unquote(path.split("/")[4])
+            self._json(200, NOTES_DOCS if pid == "notes" else [])
+            return True
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
+            rid = urllib.parse.unquote(parts[4])
+            if rid == "r-q3":
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "Approve the deck outline?",
+                                 "receivedAt": iso(NOW0 - 30 * SEC)})
+            elif rid == "r-api":
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "How should the tables move?",
+                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
+            else:
+                self._json(404, {"error": f"no gate cached for {rid}"})
+            return True
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
+            rid = urllib.parse.unquote(parts[4])
+            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
+            return True
+        if path.startswith("/api/v1/"):
+            self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+            return True
+        return False
+
+    def do_GET(self):  # noqa: N802 (stdlib naming)
+        if self.headers.get("Upgrade", "").lower() == "websocket":
+            return self._ws()
+        path = urllib.parse.urlparse(self.path).path
+        if self._api(path):
+            return None
+        if not Path(self.translate_path(self.path)).is_file():
+            self.path = "/index.html"  # client-side routes resolve to the shell
+        return super().do_GET()
+
+
+httpd = ThreadingHTTPServer(("127.0.0.1", W2_PORT), partial(W2Handler, directory=str(dist)))
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ───────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# The §1 spine, verbatim from MODE_SPECS — labels and first-run sublabels.
+MODE_LABELS = ["Chat", "Build", "Document", "Video"]
+MODE_KEYS = ["chat", "build", "document", "video"]
+SUBLABELS = [
+    "think out loud with an agent",
+    "ship code, with checks",
+    "a deck, page, or report",
+    "record a demo",
+]
+BANNED = ["No documents yet", "Nothing running", "No runs yet", "Start here", "Unfiled"]
+
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    # §4.0's capture contract, verbatim: 1440x900, device_scale_factor=1.
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # Settle on the DECAYED verdict (the slice-1 order), so every later read and
+    # shot is against the final board, not the first paint.
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    # The live headline is streaming from the rig's own /ws before the shot.
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+
+    # ── AC 3: the banned absence strings appear nowhere on the surface ─────────
+    body_text = page.evaluate("() => document.body.innerText")
+    banned_hits = [s for s in BANNED if s in body_text]
+
+    # ── AC 1: every NEEDS YOU card is the ACTIVE variant; empty regions omitted ─
+    active_ok = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+              '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+              .every(c => c.dataset.variant === 'active'
+                       && c.querySelectorAll('[data-testid="quiet-summary"]').length === 0)""")
+    # auth-refactor (failed, docless) and q3-review-deck (gated, docless): the
+    # Documents region is OMITTED — no tile, no invitation, nothing.
+    docless_ok = page.evaluate(
+        """() => ['auth-refactor', 'q3-review-deck'].every(id => {
+               const c = document.querySelector(`[data-testid="project-card"][data-project-id="${id}"]`);
+               return !!c && c.querySelectorAll('[data-testid="doc-tile"]').length === 0; })""")
+    # The gate chip is live on the q3 card (§2.1.5 weight — it is why the card leads).
+    gate_chip_ok = page.evaluate(
+        """() => { const c = document.querySelector('[data-project-id="q3-review-deck"]');
+                   return !!c && !!c.querySelector('[data-testid="gate-approve-r-q3"]')
+                       && !!c.querySelector('[data-testid="gate-reject-r-q3"]'); }""")
+    # The header pill names the signal in user words (V3: 'working', not 'distributing').
+    pill_ok = page.evaluate(
+        """() => { const kind = id => document.querySelector(
+                     `[data-project-id="${id}"] [data-testid="attention-pill"]`)?.textContent ?? '';
+                   return kind('q3-review-deck') === 'gate'
+                       && kind('auth-refactor') === 'failed'
+                       && kind('upload-endpoint') === 'working'; }""")
+
+    # ── AC 4: the mode-spine actions, on every mounted card ────────────────────
+    actions_ok = page.evaluate(
+        """spine => Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+              .every(c => {
+                const acts = Array.from(c.querySelectorAll('[data-testid="quick-action"]'));
+                const modes = acts.map(a => a.dataset.mode);
+                const labels = acts.map(a => a.textContent);
+                return acts.length === 4
+                    && JSON.stringify(modes) === JSON.stringify(spine.keys)
+                    && new Set(modes).size === 4
+                    && spine.labels.every((l, i) => labels[i].includes(l));
+              })""",
+        {"keys": MODE_KEYS, "labels": MODE_LABELS},
+    )
+
+    # ── Capture 1: the ACTIVE card (q3-review-deck — pill, gate chip, no dead regions)
+    q3 = page.locator('[data-testid="project-card"][data-project-id="q3-review-deck"]')
+    q3.locator('[data-testid="gate-approve-r-q3"]').wait_for(timeout=10000)
+    q3.screenshot(path=str(SHOTS / "uxfix-2-active-card.png"))
+
+    # ── AC 2 + 5: expand QUIET; the one-line variant and the first-run card ────
+    page.locator('[data-testid="band-quiet-toggle"]').click()
+    page.locator('[data-testid="band-quiet"][data-expanded="true"]').wait_for(timeout=10000)
+    page.locator('[data-testid="band-quiet"] [data-testid="project-card"]').first.wait_for(timeout=10000)
+
+    quiet_ok = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+              '[data-testid="band-quiet"] [data-testid="project-card"]'))
+              .every(c => c.dataset.variant === 'quiet'
+                       && c.querySelectorAll('[data-testid="quiet-summary"]').length === 1
+                       && c.querySelectorAll('[data-testid="doc-tile"]').length === 0
+                       && c.querySelectorAll('[data-testid="live-line"]').length === 0
+                       && c.querySelectorAll('[data-testid="run-chip"]').length === 0
+                       && c.clientHeight <= 110)""")
+
+    # `scratch` (brand-new, empty): the invitation IS its one line, and the
+    # sublabelled grid teaches what each verb produces (§2.2, EC6).
+    scratch = page.locator('[data-testid="project-card"][data-project-id="scratch"]')
+    scratch.wait_for(timeout=10000)
+    firstrun_ok = page.evaluate(
+        """subs => { const c = document.querySelector('[data-project-id="scratch"]');
+               if (!c) return false;
+               const line = c.querySelector('[data-testid="quiet-summary"]');
+               const got = Array.from(c.querySelectorAll('[data-testid="quick-action-sublabel"]'))
+                   .map(s => s.textContent);
+               return !!line && line.dataset.invitation === 'true'
+                   && (line.textContent ?? '').includes('Start by describing what you want')
+                   && c.querySelector('[data-testid="quick-actions"]')?.dataset.detail === 'true'
+                   && JSON.stringify(got) === JSON.stringify(subs); }""",
+        SUBLABELS,
+    )
+    # …and it is the ONLY invitation: every other quiet card says "Quiet — last active".
+    others_calm_ok = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+              '[data-testid="band-quiet"] [data-testid="project-card"]'))
+              .filter(c => c.dataset.projectId !== 'scratch')
+              .every(c => /Quiet — last active \\d+[smhd] ago/.test(
+                  c.querySelector('[data-testid="quiet-summary"]')?.textContent ?? ''))""")
+
+    # ── Capture 3: the first-run card — invitation + four differentiated verbs ─
+    scratch.screenshot(path=str(SHOTS / "uxfix-2-actions.png"))
+
+    # ── Capture 2: a stale-debris QUIET card. smoke-tests (6d) may sit past the
+    # mounted window, so scroll the quiet band up and let the window re-mount. ──
+    page.evaluate(
+        """() => { const b = document.querySelector('[data-testid="project-board"]');
+                   b.scrollTop = document.querySelector('[data-testid="band-quiet"]').offsetTop; }""")
+    smoke = page.locator('[data-testid="project-card"][data-project-id="smoke-tests"]')
+    smoke.wait_for(timeout=10000)
+    smoke_summary = smoke.locator('[data-testid="quiet-summary"]').text_content() or ""
+    smoke.screenshot(path=str(SHOTS / "uxfix-2-quiet-card.png"))
+    smoke_ok = "Quiet — last active 6d ago" in smoke_summary
+
+    # ── AC 6: nothing is clipped — each variant's fixed height fits its content ─
+    clipped = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="project-card"]'))
+             .filter(c => c.scrollHeight > c.clientHeight + 1)
+             .map(c => `${c.dataset.projectId}:${c.scrollHeight}>${c.clientHeight}`)""")
+
+    ctx.close()
+    browser.close()
+
+report["steps"]["slice2_board"] = {
+    "ok": all([
+        order_ok, narration_ok, not banned_hits, active_ok, docless_ok, gate_chip_ok,
+        pill_ok, actions_ok, quiet_ok, firstrun_ok, others_calm_ok, smoke_ok, not clipped,
+    ]),
+    "needs_you_order_ok": order_ok,
+    "live_narration_streamed": narration_ok,
+    "banned_strings_found": banned_hits,
+    "needs_you_cards_all_active_variant": active_ok,
+    "docless_active_cards_omit_documents_region": docless_ok,
+    "gate_chip_answerable_on_card": gate_chip_ok,
+    "attention_pill_user_words": pill_ok,
+    "quick_actions_mode_spine_on_every_card": actions_ok,
+    "quiet_cards_one_line_no_furniture": quiet_ok,
+    "first_run_invitation_and_sublabels": firstrun_ok,
+    "other_quiet_cards_say_last_active": others_calm_ok,
+    "smoke_tests_summary": smoke_summary,
+    "smoke_tests_summary_ok": smoke_ok,
+    "clipped_cards": clipped,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(SHOTS / n) for n in
+                    ("uxfix-2-active-card.png", "uxfix-2-quiet-card.png", "uxfix-2-actions.png")],
+}
+if not report["steps"]["slice2_board"]["ok"]:
+    fail("slice2_verdict", "slice-2 assertions did not all hold — see slice2_board")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -4,7 +4,7 @@ import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { modePath } from '../hooks/useRoute.js';
-import { ago, CARD_H, ProjectCard } from './ProjectCard.js';
+import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 
 /**
  * The orchestrator home board (DES-MERGE-001 §1.2/§1.4; bands per DES-UXFIX-001
@@ -119,18 +119,21 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   const quiet = items.filter((i) => i.band === 'quiet');
 
   const columns = Math.max(1, Math.floor((box.w || FALLBACK_W) / (MIN_COL + GAP)));
-  const rowH = CARD_H + GAP;
+  // Each band windows over its OWN variant's fixed height (DES-UXFIX-001 §2.1.1,
+  // slice 2): NEEDS YOU mounts rich ACTIVE cards, QUIET mounts one-line cards.
+  const activeRowH = ACTIVE_CARD_H + GAP;
+  const quietRowH = QUIET_CARD_H + GAP;
   const viewH = box.h || FALLBACK_H;
 
   // Each band's own top inside the shared scroller (D6). Coarse is fine: any
   // header-height error is smaller than the overscan row that absorbs it.
   const needsTop = BAND_H;
-  const needsH = needsYou.length === 0 ? BAND_H : Math.ceil(needsYou.length / columns) * rowH;
+  const needsH = needsYou.length === 0 ? BAND_H : Math.ceil(needsYou.length / columns) * activeRowH;
   const quietGridTop = needsTop + needsH + BAND_H;
 
-  const needsWin = windowRows(needsYou.length, columns, rowH, scrollTop, viewH, needsTop);
+  const needsWin = windowRows(needsYou.length, columns, activeRowH, scrollTop, viewH, needsTop);
   const quietWin = quietOpen
-    ? windowRows(quiet.length, columns, rowH, scrollTop, viewH, quietGridTop)
+    ? windowRows(quiet.length, columns, quietRowH, scrollTop, viewH, quietGridTop)
     : null;
 
   const mounted =
@@ -212,7 +215,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
               <BandGrid
                 items={needsYou}
                 columns={columns}
-                rowH={rowH}
+                rowH={activeRowH}
                 firstRow={needsWin.firstRow}
                 lastRow={needsWin.lastRow}
                 navigate={navigate}
@@ -244,7 +247,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                 <BandGrid
                   items={quiet}
                   columns={columns}
-                  rowH={rowH}
+                  rowH={quietRowH}
                   firstRow={quietWin.firstRow}
                   lastRow={quietWin.lastRow}
                   navigate={navigate}

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -11,8 +11,14 @@ const S = {
 
 export interface ModeSpec {
   label: string;
+  /** The mode's glyph — the SAME four symbols everywhere (switcher, board quick
+   *  actions, doc tiles), so the spine reads as one vocabulary (DES-UXFIX-001 §2.5). */
+  glyph: string;
   /** What this mode is, with its subject — never a bare "coming soon" (§3.3). */
   summary: string;
+  /** What the verb PRODUCES, in a phrase (DES-UXFIX-001 §2.2) — shown on
+   *  first-run and on hover so the four actions never read as synonyms (F2). */
+  sublabel: string;
 }
 
 /**
@@ -27,23 +33,31 @@ export interface ModeSpec {
 export const MODE_SPECS: Record<Mode, ModeSpec> = {
   chat: {
     label: 'Chat',
+    glyph: '💬',
     summary: 'Talk to an agent with no artifact committed yet — and choose a mode by conversation.',
+    sublabel: 'think out loud with an agent',
   },
   build: {
     label: 'Build',
+    glyph: '⚙',
     summary: 'Governed code work: units, phases, gates and evidence, on a crew run.',
+    sublabel: 'ship code, with checks',
   },
   document: {
     label: 'Document',
+    glyph: '▤',
     summary:
       'Document mode is where the interactive canvas lands: an HTML doc, deck or report, '
       + 'its version strip, and point-and-comment feedback — all against this project’s one thread.',
+    sublabel: 'a deck, page, or report',
   },
   video: {
     label: 'Video',
+    glyph: '▶',
     summary:
       'Video mode is the demo storyboard and player: chapters derived from the spec’s steps, '
       + 'recorded and re-recorded from the same thread.',
+    sublabel: 'record a demo',
   },
 };
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,20 +1,30 @@
 import type { SessionView } from '../api/types.js';
+import type { SignalKind } from '../board/boardAttention.js';
 import { isLive, useRunHeadline } from '../hooks/useBoardHeadline.js';
-import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { modePath, MODES, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
 import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
+import { MODE_SPECS } from './ModeSwitcher.js';
 import { STATUS_STYLE } from './RunCard.js';
 
 /**
- * One orchestrator-board card (DES-MERGE-001 §1.4). All regions are ALWAYS
- * present; an empty region renders an invitation, never a blank. The height is
- * FIXED (`CARD_H`) so the board stays legible at 20+ cards — nothing here may grow
- * with the run or doc count, which is why every list is capped with an overflow
- * count instead of scrolling.
+ * One orchestrator-board card, in TWO variants chosen by the decayed attention
+ * band (DES-UXFIX-001 §2.1.1, slice 2):
+ *
+ *   ACTIVE (band `needs-you`) — rich: header + attention pill, live headline,
+ *   answerable run/gate chips, doc tiles. A region with no content is OMITTED,
+ *   never filled with a "nothing" line — the empty-state budget (§2.1.2, F1).
+ *   QUIET (band `quiet`) — calm, not empty: ONE line of absence
+ *   (`quiet-summary`) plus a compact action row. A brand-new empty project's
+ *   one line is the first-run invitation instead (§2.1.2's single exception).
+ *
+ * Heights stay FIXED per variant so each band's windowing math holds — nothing
+ * here may grow with the run or doc count, which is why every list is capped
+ * with an overflow count instead of scrolling.
  *
  * Live activity and the run chips subscribe to the SHARED runtime + gate stores
  * (slice 6) — the same stores the run view reads, fed by the app's ONE `/ws`
@@ -22,15 +32,15 @@ import { STATUS_STYLE } from './RunCard.js';
  * at a different card, with no second socket and no polling anywhere on this route.
  */
 
-/**
- * Fixed card height in px — the board's windowing math depends on it.
- *
- * Sized by the TALLEST variant, the empty card: header + three regions + the 2×2
- * quick-action grid. The actions are bottom-anchored (`marginTop: auto`) inside an
- * `overflow: hidden` box, so a height that merely fits would clip the primary
- * affordance the moment a font metric moved. This carries ~16px of slack.
- */
-export const CARD_H = 352;
+/** Fixed ACTIVE-card height in px — the NEEDS YOU band's windowing depends on it.
+ *  Sized by the fullest card the caps allow (2 live lines + doc activity + 2 run
+ *  chips + a tile row + the action row), so the bottom-anchored actions inside
+ *  `overflow: hidden` are never clipped. */
+export const ACTIVE_CARD_H = 330;
+
+/** Fixed QUIET-card height in px — one summary line plus the action row, with
+ *  room for the first-run 2×2 sublabelled grid (§2.2) in the same slot. */
+export const QUIET_CARD_H = 104;
 
 const MAX_TILES = 3;
 const MAX_CHIPS = 2;
@@ -53,28 +63,29 @@ const DOT: Record<Attention, string> = {
   quiet:   'rgba(230,237,243,0.2)',
 };
 
-const ACTIONS: { mode: Mode; label: string; glyph: string }[] = [
-  { mode: 'chat',     label: 'New chat',    glyph: '💬' },
-  { mode: 'build',    label: 'Do work',     glyph: '⚙' },
-  { mode: 'document', label: 'New doc',     glyph: '▤' },
-  { mode: 'video',    label: 'Record demo', glyph: '▶' },
-];
+/** The pill's word for the signal that put the card in NEEDS YOU — user words
+ *  (V3: an executing run reads "working", never a scheduler word). */
+const PILL: Record<SignalKind, string> = {
+  gate: 'gate',
+  failing: 'failed',
+  running: 'working',
+  drafts: 'draft',
+};
 
 const CSS = {
   card: {
-    height: `${CARD_H}px`, boxSizing: 'border-box', overflow: 'hidden', background: '#161b22',
+    boxSizing: 'border-box', overflow: 'hidden', background: '#161b22',
     border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
     display: 'flex', flexDirection: 'column',
     // Anchors the live edge, and the radius above clips its ends (see LiveEdge).
     position: 'relative',
   },
-  header: { display: 'flex', alignItems: 'center', gap: '8px' },
+  header: { display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 },
   name: {
     fontSize: '13px', fontWeight: 700, color: S.ink, textDecoration: 'none',
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
-  repo: { marginLeft: 'auto', fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 },
-  label: { fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: S.faint },
+  repo: { fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 },
   tile: {
     flex: 1, minWidth: 0, background: 'rgba(230,237,243,0.04)',
     border: `1px solid ${S.border}`, borderRadius: '6px', padding: '5px 7px',
@@ -85,9 +96,10 @@ const CSS = {
     fontSize: '11px', fontFamily: 'monospace', color: S.muted, borderRadius: '5px', padding: '3px 7px',
   },
   quick: {
-    display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
+    display: 'flex', alignItems: 'center', gap: '5px', textDecoration: 'none',
     background: 'rgba(230,237,243,0.05)', border: `1px solid ${S.border}`,
-    borderRadius: '6px', color: S.ink,
+    borderRadius: '6px', color: S.ink, fontSize: '11px',
+    overflow: 'hidden', whiteSpace: 'nowrap', minWidth: 0,
   },
   line: {
     display: 'flex', alignItems: 'center', gap: '6px', margin: '0 0 2px',
@@ -108,17 +120,59 @@ export function ago(from: number, now: number = Date.now()): string {
   return `${Math.floor(secs / 86400)}d`;
 }
 
-function Region({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
+type Link = (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+
+/**
+ * The four quick actions, relabelled to the mode spine (§2.2, V9/V10/V23): each
+ * action IS a mode the user can already see in the switcher, with the switcher's
+ * glyph, so the verbs are differentiable (F2) — no more "New chat" vs "Do work".
+ * `detail` (the first-run card) lays them out 2×2 with the sublabel visible;
+ * elsewhere the sublabel survives on hover via `title`.
+ */
+function QuickActions({ projectId, link, detail }: {
+  projectId: string;
+  link: Link;
+  detail: boolean;
+}): React.ReactElement {
   return (
-    <div style={{ marginTop: '10px', minHeight: '46px' }}>
-      <p style={{ ...CSS.label, margin: '0 0 4px' }}>{title}</p>
-      {children}
+    <div
+      data-testid="quick-actions"
+      data-detail={detail ? 'true' : undefined}
+      style={{
+        marginTop: 'auto', display: 'grid', gap: detail ? '4px' : '6px',
+        gridTemplateColumns: detail ? '1fr 1fr' : 'repeat(4, minmax(0,1fr))',
+      }}
+    >
+      {MODES.map((m) => {
+        const spec = MODE_SPECS[m];
+        return (
+          <a
+            key={m}
+            {...link(modePath(projectId, m))}
+            data-testid="quick-action"
+            data-mode={m}
+            title={`${spec.label} — ${spec.sublabel}`}
+            style={{
+              ...CSS.quick,
+              justifyContent: detail ? 'flex-start' : 'center',
+              padding: detail ? '4px 8px' : '5px 8px',
+            }}
+          >
+            <span aria-hidden style={{ flexShrink: 0 }}>{spec.glyph}</span>
+            <span style={{ fontWeight: 600, flexShrink: 0 }}>{spec.label}</span>
+            {detail && (
+              <span
+                data-testid="quick-action-sublabel"
+                style={{ color: S.faint, fontSize: '10px', overflow: 'hidden', textOverflow: 'ellipsis' }}
+              >
+                {spec.sublabel}
+              </span>
+            )}
+          </a>
+        );
+      })}
     </div>
   );
-}
-
-function Invitation({ text }: { text: string }): React.ReactElement {
-  return <p style={{ fontSize: '11px', color: S.faint, margin: 0 }}>{text}</p>;
 }
 
 /**
@@ -182,170 +236,203 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   const activity = useRuntimeStore((s) => s.docActivity[project.id]);
   const live = runs.filter(isLive);
   const empty = runs.length === 0 && docs.length === 0;
+  const quiet = band === 'quiet';
 
   /** Every affordance on the card is a real link — deep-linkable, middle-clickable. */
-  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+  const link: Link = (path) => ({
     href: path,
     onClick: (e) => { e.preventDefault(); navigate(path); },
   });
 
+  const cardData = {
+    'data-testid': 'project-card',
+    'data-project-id': project.id,
+    'data-attention': attention,
+    // The decay verdict, readable off the DOM (slice-1 AC): which band this card
+    // sorted into, the score that put it there, the top signal — and, new in
+    // slice 2, the variant the band chose.
+    'data-band': band,
+    'data-variant': quiet ? 'quiet' : 'active',
+    'data-score': score.toFixed(2),
+    ...(signal !== null ? { 'data-signal': signal.kind } : {}),
+  } as const;
+
+  // The dot stays for colour continuity with the sort bucket; on an ACTIVE card
+  // the pill beside the repo is what names the signal.
+  const dot = (
+    <span
+      data-testid="project-status-dot"
+      aria-hidden
+      style={{ width: '8px', height: '8px', borderRadius: '50%', background: DOT[attention], flexShrink: 0 }}
+    />
+  );
+  const name = <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>;
+  const repoTag = repo != null
+    ? <span data-testid="project-repo" style={CSS.repo}>{repo}</span>
+    : null;
+
+  // ── QUIET (§2.1.1): calm is ONE line, not three announcements of absence ──
+  if (quiet) {
+    return (
+      <section {...cardData} style={{ ...CSS.card, height: `${QUIET_CARD_H}px` }}>
+        <LiveEdge state={edgeStateOf(runs.map((v) => v.session.status))} />
+        <div style={CSS.header}>
+          {dot}
+          {name}
+          {repoTag}
+          {/* The empty-state budget (§2.1.2): the ONE line of absence. A brand-new
+              empty project gets the first-run invitation instead — the sole
+              exception, and it is still one line. */}
+          {empty ? (
+            <a
+              {...link(modePath(project.id, 'chat'))}
+              data-testid="quiet-summary"
+              data-invitation="true"
+              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', color: S.ink, textDecoration: 'none' }}
+            >
+              Start by describing what you want →
+            </a>
+          ) : (
+            <p
+              data-testid="quiet-summary"
+              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', color: S.faint, margin: 0 }}
+            >
+              Quiet — last active {ago(signal?.at ?? project.updated_at)} ago
+            </p>
+          )}
+        </div>
+        {/* Compact on a quiet card — a calm board is scanned, not operated (W2);
+            the first-run card is where the sublabelled grid teaches (W1). */}
+        <QuickActions projectId={project.id} link={link} detail={empty} />
+      </section>
+    );
+  }
+
+  // ── ACTIVE (§2.1.1): rich, but a region with no content is OMITTED (F1) ──
   return (
-    <section
-      data-testid="project-card"
-      data-project-id={project.id}
-      data-attention={attention}
-      // The decay verdict, readable off the DOM (DES-UXFIX-001 slice-1 AC): which
-      // band this card sorted into, the score that put it there, and the top signal.
-      data-band={band}
-      data-score={score.toFixed(2)}
-      {...(signal !== null ? { 'data-signal': signal.kind } : {})}
-      style={CSS.card}
-    >
+    <section {...cardData} style={{ ...CSS.card, height: `${ACTIVE_CARD_H}px` }}>
       {/* The card's own state signal, read from the RUNS rather than from `attention`:
           a project bucketed as `failing` can still have something executing on it, and
           the edge answers "is work moving here", not "which bucket did this sort into". */}
       <LiveEdge state={edgeStateOf(runs.map((v) => v.session.status))} />
 
-      {/* Header — name, repo binding, status dot. The dot stays for colour continuity
-          with the sort bucket; it is no longer the thing that catches the eye. */}
+      {/* Header — name, repo binding, and the pill naming why this card needs you. */}
       <div style={CSS.header}>
-        <span
-          data-testid="project-status-dot"
-          aria-hidden
-          style={{ width: '8px', height: '8px', borderRadius: '50%', background: DOT[attention], flexShrink: 0 }}
-        />
-        <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
-        {repo != null && <span data-testid="project-repo" style={CSS.repo}>{repo}</span>}
-      </div>
-
-      {/* Documents — placeholder tiles only (§7.5), capped so the card cannot grow */}
-      <Region title="Documents">
-        {docs.length === 0 ? <Invitation text="No documents yet." /> : (
-          <div style={{ display: 'flex', gap: '6px', alignItems: 'stretch' }}>
-            {docs.slice(0, MAX_TILES).map((d) => (
-              <DocTile
-                key={d.name}
-                projectId={project.id}
-                name={d.name}
-                kind={d.kind}
-                head={d.head}
-                when={
-                  activity !== undefined && activity.docId === d.name
-                    ? activity.at
-                    : d.updated_at === null ? NaN : Date.parse(d.updated_at)
-                }
-              />
-            ))}
-            {docs.length > MAX_TILES && (
-              <span data-testid="doc-overflow" style={{ alignSelf: 'center', fontSize: '11px', color: S.muted, flexShrink: 0 }}>
-                {docs.length - MAX_TILES} more
-              </span>
-            )}
-          </div>
+        {dot}
+        {name}
+        {repoTag}
+        {signal !== null && (
+          <span
+            data-testid="attention-pill"
+            data-kind={signal.kind}
+            style={{
+              marginLeft: 'auto', flexShrink: 0, fontSize: '10px', fontWeight: 700,
+              letterSpacing: '0.06em', textTransform: 'uppercase', color: DOT[attention],
+              border: `1px solid ${S.border}`, borderRadius: '999px', padding: '1px 8px',
+            }}
+          >
+            {PILL[signal.kind]}
+          </span>
         )}
-      </Region>
+      </div>
 
       {/* Live activity — the newest narration line per in-flight run (§1.4, §3.4(b)),
           plus the newest relayed doc status. Both arrive on the shared `/ws` stream. */}
-      <Region title="Live activity">
-        {live.length === 0 && activity === undefined ? (
-          <Invitation text="Nothing running." />
-        ) : (
-          <div data-testid="live-activity">
-            {live.slice(0, MAX_LINES).map((v) => (
-              <LiveLine key={v.session.id} view={v} />
-            ))}
-            {activity !== undefined && (
-              <p data-testid="doc-activity" title={activity.message} style={CSS.line}>
-                <span aria-hidden style={{ flexShrink: 0 }}>▤</span>
-                {activity.message}
-              </p>
-            )}
-            {live.length > MAX_LINES && (
-              <span data-testid="live-overflow" style={{ fontSize: '11px', color: S.muted }}>
-                {live.length - MAX_LINES} more running
-              </span>
-            )}
-          </div>
-        )}
-      </Region>
+      {(live.length > 0 || activity !== undefined) && (
+        <div data-testid="live-activity" style={{ marginTop: '10px' }}>
+          {live.slice(0, MAX_LINES).map((v) => (
+            <LiveLine key={v.session.id} view={v} />
+          ))}
+          {activity !== undefined && (
+            <p data-testid="doc-activity" title={activity.message} style={CSS.line}>
+              <span aria-hidden style={{ flexShrink: 0 }}>▤</span>
+              {activity.message}
+            </p>
+          )}
+          {live.length > MAX_LINES && (
+            <span data-testid="live-overflow" style={{ fontSize: '11px', color: S.muted }}>
+              {live.length - MAX_LINES} more running
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Crew runs — phase, gate state, elapsed */}
-      <Region title="Crew runs">
-        {runs.length === 0 ? <Invitation text="No runs yet." /> : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            {runs.slice(0, MAX_CHIPS).map(({ session, units }) => {
-              const style = STATUS_STYLE[session.status];
-              const gate = gates[session.id];
-              const phase = units[session.unit_ix]?.stage ?? units[units.length - 1]?.stage ?? 'planning';
-              const waiting = session.status === 'awaiting_human';
-              return (
-                // A waiting gate is ANSWERABLE, not a badge (§1.4) — so the row is a row:
-                // the run link, and beside it a chip carrying its own controls. Nesting
-                // buttons inside the link would be neither valid nor operable.
-                <div key={session.id} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                  <a
-                    {...link(modePath(project.id, 'build', session.id))}
-                    data-testid="run-chip"
-                    data-run-id={session.id}
-                    data-status={session.status}
-                    style={{
-                      ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden', position: 'relative',
-                      // Clears the strip so a phase label never sits on top of it.
-                      paddingLeft: '10px',
-                      border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
-                      background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
-                    }}
-                  >
-                    <LiveEdge state={edgeStateOf([session.status])} />
-                    <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
-                    {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
-                        has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
-                        honest clock on this surface. */}
-                    <span style={{ marginLeft: 'auto', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                      {waiting ? (gate ? `waiting ${ago(gate.receivedAt)}` : 'needs you') : style?.label ?? session.status}
-                    </span>
-                  </a>
-                  {waiting && (
-                    <GateChip runId={session.id} projectId={project.id} gate={gate} navigate={navigate} />
-                  )}
-                </div>
-              );
-            })}
-            {runs.length > MAX_CHIPS && (
-              <span data-testid="run-overflow" style={{ fontSize: '11px', color: S.muted }}>
-                {runs.length - MAX_CHIPS} more
-              </span>
-            )}
-          </div>
-        )}
-      </Region>
+      {runs.length > 0 && (
+        <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          {runs.slice(0, MAX_CHIPS).map(({ session, units }) => {
+            const style = STATUS_STYLE[session.status];
+            const gate = gates[session.id];
+            const phase = units[session.unit_ix]?.stage ?? units[units.length - 1]?.stage ?? 'planning';
+            const waiting = session.status === 'awaiting_human';
+            return (
+              // A waiting gate is ANSWERABLE, not a badge (§1.4) — so the row is a row:
+              // the run link, and beside it a chip carrying its own controls. Nesting
+              // buttons inside the link would be neither valid nor operable.
+              <div key={session.id} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <a
+                  {...link(modePath(project.id, 'build', session.id))}
+                  data-testid="run-chip"
+                  data-run-id={session.id}
+                  data-status={session.status}
+                  style={{
+                    ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden', position: 'relative',
+                    // Clears the strip so a phase label never sits on top of it.
+                    paddingLeft: '10px',
+                    border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
+                    background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
+                  }}
+                >
+                  <LiveEdge state={edgeStateOf([session.status])} />
+                  <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
+                  {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
+                      has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
+                      honest clock on this surface. */}
+                  <span style={{ marginLeft: 'auto', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {waiting ? (gate ? `waiting ${ago(gate.receivedAt)}` : 'needs you') : style?.label ?? session.status}
+                  </span>
+                </a>
+                {waiting && (
+                  <GateChip runId={session.id} projectId={project.id} gate={gate} navigate={navigate} />
+                )}
+              </div>
+            );
+          })}
+          {runs.length > MAX_CHIPS && (
+            <span data-testid="run-overflow" style={{ fontSize: '11px', color: S.muted }}>
+              {runs.length - MAX_CHIPS} more
+            </span>
+          )}
+        </div>
+      )}
 
-      {/* Quick actions — large when the card IS the empty state (§1.4) */}
-      {empty && <p style={{ ...CSS.label, margin: '10px 0 0' }}>Start here</p>}
-      <div
-        data-testid="quick-actions"
-        style={{
-          marginTop: 'auto', paddingTop: empty ? '4px' : '10px', display: 'grid', gap: '6px',
-          gridTemplateColumns: empty ? '1fr 1fr' : 'repeat(4, minmax(0,1fr))',
-        }}
-      >
-        {ACTIONS.map((a) => (
-          <a
-            key={a.mode}
-            {...link(modePath(project.id, a.mode))}
-            data-testid="quick-action"
-            data-mode={a.mode}
-            style={{
-              ...CSS.quick, justifyContent: empty ? 'flex-start' : 'center',
-              padding: empty ? '10px 12px' : '6px 8px',
-              fontSize: empty ? '12px' : '11px', fontWeight: empty ? 600 : 400,
-            }}
-          >
-            <span aria-hidden>{a.glyph}</span> {a.label}
-          </a>
-        ))}
-      </div>
+      {/* Documents — placeholder tiles only (§7.5), capped so the card cannot grow.
+          No docs ⇒ no region: omitted, never "No documents yet" (§2.1.2). */}
+      {docs.length > 0 && (
+        <div style={{ marginTop: '10px', display: 'flex', gap: '6px', alignItems: 'stretch' }}>
+          {docs.slice(0, MAX_TILES).map((d) => (
+            <DocTile
+              key={d.name}
+              projectId={project.id}
+              name={d.name}
+              kind={d.kind}
+              head={d.head}
+              when={
+                activity !== undefined && activity.docId === d.name
+                  ? activity.at
+                  : d.updated_at === null ? NaN : Date.parse(d.updated_at)
+              }
+            />
+          ))}
+          {docs.length > MAX_TILES && (
+            <span data-testid="doc-overflow" style={{ alignSelf: 'center', fontSize: '11px', color: S.muted, flexShrink: 0 }}>
+              {docs.length - MAX_TILES} more
+            </span>
+          )}
+        </div>
+      )}
+
+      <QuickActions projectId={project.id} link={link} detail={false} />
     </section>
   );
 }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -32,15 +32,24 @@ import { STATUS_STYLE } from './RunCard.js';
  * at a different card, with no second socket and no polling anywhere on this route.
  */
 
-/** Fixed ACTIVE-card height in px — the NEEDS YOU band's windowing depends on it.
+/** ACTIVE-card slot height in px — the NEEDS YOU band's windowing depends on it.
  *  Sized by the fullest card the caps allow (2 live lines + doc activity + 2 run
  *  chips + a tile row + the action row), so the bottom-anchored actions inside
- *  `overflow: hidden` are never clipped. */
+ *  `overflow: hidden` are never clipped. The card itself sizes to content and
+ *  treats this as a `maxHeight`, so a light card is short, not hollow — the
+ *  SLOT stays fixed for the windowing math, the pixels do not. */
 export const ACTIVE_CARD_H = 330;
 
-/** Fixed QUIET-card height in px — one summary line plus the action row, with
- *  room for the first-run 2×2 sublabelled grid (§2.2) in the same slot. */
-export const QUIET_CARD_H = 104;
+/** QUIET-card slot height in px — one summary line plus the action row, with
+ *  room for the first-run 2×2 sublabelled grid (§2.2) in the same slot. Also a
+ *  `maxHeight`: a compact quiet card renders at its natural ~one-line height. */
+export const QUIET_CARD_H = 112;
+
+/** How recently a project must have been created for its empty card to read as
+ *  "a genuinely brand-new project a user just created" (§2.1.2) and show the
+ *  first-run invitation. An empty project OLDER than this is debris, not a
+ *  beginning — it gets the plain quiet line so the eye can skip it (W2). */
+export const FIRST_RUN_MS = 24 * 3_600_000;
 
 const MAX_TILES = 3;
 const MAX_CHIPS = 2;
@@ -236,6 +245,8 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   const activity = useRuntimeStore((s) => s.docActivity[project.id]);
   const live = runs.filter(isLive);
   const empty = runs.length === 0 && docs.length === 0;
+  /** The §2.1.2 exception: empty AND just created — not merely empty. */
+  const firstRun = empty && Date.now() - project.created_at < FIRST_RUN_MS;
   const quiet = band === 'quiet';
 
   /** Every affordance on the card is a real link — deep-linkable, middle-clickable. */
@@ -274,7 +285,7 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   // ── QUIET (§2.1.1): calm is ONE line, not three announcements of absence ──
   if (quiet) {
     return (
-      <section {...cardData} style={{ ...CSS.card, height: `${QUIET_CARD_H}px` }}>
+      <section {...cardData} style={{ ...CSS.card, maxHeight: `${QUIET_CARD_H}px` }}>
         <LiveEdge state={edgeStateOf(runs.map((v) => v.session.status))} />
         <div style={CSS.header}>
           {dot}
@@ -283,12 +294,13 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
           {/* The empty-state budget (§2.1.2): the ONE line of absence. A brand-new
               empty project gets the first-run invitation instead — the sole
               exception, and it is still one line. */}
-          {empty ? (
+          {firstRun ? (
             <a
               {...link(modePath(project.id, 'chat'))}
               data-testid="quiet-summary"
               data-invitation="true"
-              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', color: S.ink, textDecoration: 'none' }}
+              // EC1: the ONE obvious next action — the brightest thing on the card.
+              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', fontWeight: 600, color: S.accent, textDecoration: 'none' }}
             >
               Start by describing what you want →
             </a>
@@ -303,14 +315,14 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
         </div>
         {/* Compact on a quiet card — a calm board is scanned, not operated (W2);
             the first-run card is where the sublabelled grid teaches (W1). */}
-        <QuickActions projectId={project.id} link={link} detail={empty} />
+        <QuickActions projectId={project.id} link={link} detail={firstRun} />
       </section>
     );
   }
 
   // ── ACTIVE (§2.1.1): rich, but a region with no content is OMITTED (F1) ──
   return (
-    <section {...cardData} style={{ ...CSS.card, height: `${ACTIVE_CARD_H}px` }}>
+    <section {...cardData} style={{ ...CSS.card, maxHeight: `${ACTIVE_CARD_H}px` }}>
       {/* The card's own state signal, read from the RUNS rather than from `attention`:
           a project bucketed as `failing` can still have something executing on it, and
           the edge answers "is work moving here", not "which bucket did this sort into". */}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -92,7 +92,10 @@ export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attent
  *
  *   gate    → the gate store's `receivedAt` (server ISO on reconcile, arrival live)
  *   failing → the run's durable-log tail `ts` (backfilled once per run id, capped)
- *   running → the newest structured frame the runtime store has logged for the run
+ *   running → the newest structured frame the runtime store has logged for the run,
+ *             or a relayed interactive `status.posted` (a document being edited NOW
+ *             is live work — it is what puts the doc-activity line on an ACTIVE
+ *             card now that a quiet card renders no activity at all, slice 2)
  *   drafts  → the newest doc's `updated_at`
  *   any     → `project.updated_at`
  */
@@ -103,9 +106,11 @@ function signalsOf(
   gates: Record<string, OpenGate>,
   logTail: (runId: string) => number | undefined,
   failedAt: Record<string, number>,
+  activityAt: number | undefined,
 ): Signal[] {
   const fallback = project.updated_at;
   const signals: Signal[] = [];
+  if (activityAt !== undefined) signals.push({ kind: 'running', at: activityAt });
   for (const v of runs) {
     const id = v.session.id;
     const status = v.session.status;
@@ -171,6 +176,10 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
    *  cannot otherwise know, and the one F3 is about (D3 step 2). */
   const [failedAt, setFailedAt] = useState<Record<string, number>>({});
   const gates = useGateStore((s) => s.gates);
+  // Relayed doc statuses (slice 6) — REACTIVE, unlike `logs`: a `status.posted`
+  // is rare (one per doc edit, not one per streamed frame) and it must be able
+  // to promote its project into NEEDS YOU without waiting for the next tick.
+  const docActivity = useRuntimeStore((s) => s.docActivity);
   const repoNames = useRef<Map<string, string>>(new Map());
   /** Run ids the board has already tried to place — one re-read per run, ever. */
   const placed = useRef<Set<string>>(new Set());
@@ -283,7 +292,7 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
           const b = bindings[project.id] ?? EMPTY;
           const mine = runs.filter((v) => b.runIds.has(v.session.id));
           const { score, signal } = topSignal(
-            signalsOf(project, mine, b.docs, gates, logTail, failedAt),
+            signalsOf(project, mine, b.docs, gates, logTail, failedAt, docActivity[project.id]?.at),
             now,
           );
           return {
@@ -299,7 +308,7 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
           ),
         );
     },
-    [projects, bindings, runs, gates, failedAt, now],
+    [projects, bindings, runs, gates, docActivity, failedAt, now],
   );
 
   // The unfiled set (F5): what the run list holds that no membership claims. Held

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -64,7 +64,9 @@ function strip(selected = 3): void {
   );
 }
 
-/** One board card carrying one document — §1.4's card, at the tile that owns the export. */
+/** One board card carrying one document — §1.4's card, at the tile that owns the export.
+ *  Doc tiles are ACTIVE-variant furniture (DES-UXFIX-001 §2.1.1, slice 2): a quiet
+ *  card is one line and no tiles, so this card is pinned into NEEDS YOU. */
 function card(): void {
   const item = {
     project: {
@@ -75,10 +77,9 @@ function card(): void {
     runs: [],
     docs: [{ name: DOC, kind: 'doc' as const, head: 3, versions: 3, updated_at: '2026-08-18T11:30:00Z' }],
     attention: 'drafts' as const,
-    // Slice-1 score fields — the export path never reads them, they just render.
-    score: 0,
-    band: 'quiet' as const,
-    signal: null,
+    score: 40,
+    band: 'needs-you' as const,
+    signal: { kind: 'running' as const, at: Date.now() },
   } as unknown as BoardProject;
   render(<ProjectCard item={item} navigate={() => {}} />);
 }

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -90,7 +90,9 @@ describe('HomeBoard — live activity (slice 6)', () => {
   });
 
   it('a unitOutputDelta for B updates B\'s headline in place and leaves A untouched', async () => {
-    projects = [project('p-a', 'Ay'), project('p-b', 'Bee')];
+    // Fresh `updated_at`: an executing run's clock is what ranks it (slice 1), and
+    // the ACTIVE variant with the live line is what a NEEDS YOU card is (slice 2).
+    projects = [project('p-a', 'Ay', { updated_at: Date.now() }), project('p-b', 'Bee', { updated_at: Date.now() })];
     members = { 'p-a': [member('p-a', 'run-a')], 'p-b': [member('p-b', 'run-b')] };
     await board([running('run-a'), running('run-b')]);
 
@@ -113,7 +115,7 @@ describe('HomeBoard — live activity (slice 6)', () => {
   });
 
   it('keeps streaming: the newest line replaces the previous one, no scroll, no dump', async () => {
-    projects = [project('p-b', 'Bee')];
+    projects = [project('p-b', 'Bee', { updated_at: Date.now() })];
     members = { 'p-b': [member('p-b', 'run-b')] };
     await board([running('run-b')]);
 
@@ -125,13 +127,16 @@ describe('HomeBoard — live activity (slice 6)', () => {
     expect(line.textContent).not.toContain('Reading src/App.tsx');
   });
 
-  it('a terminal run has no live line — the region invites instead of narrating a finished run', async () => {
+  it('a terminal run has no live line — the card is the QUIET one-liner, not "Nothing running"', async () => {
     projects = [project('p-done', 'Done')];
     members = { 'p-done': [member('p-done', 'run-done')] };
     await board([running('run-done', 'completed')]);
 
     expect(within(card('p-done')).queryByTestId('live-line')).toBeNull();
-    expect(card('p-done')).toHaveTextContent('Nothing running.');
+    // Slice 2's empty-state budget: absence is the ONE quiet-summary line.
+    expect(card('p-done')).toHaveAttribute('data-variant', 'quiet');
+    expect(within(card('p-done')).getAllByTestId('quiet-summary')).toHaveLength(1);
+    expect(card('p-done')).not.toHaveTextContent('Nothing running');
   });
 
   it('a gate arrival re-sorts the board without remounting the unaffected card', async () => {
@@ -162,11 +167,14 @@ describe('HomeBoard — live activity (slice 6)', () => {
     expect(card('p-a')).toBe(untouched);
   });
 
-  it('a relayed status.posted adds a doc line and dates that doc\'s tile', async () => {
+  it('a relayed status.posted promotes the card to ACTIVE, adds a doc line and dates the tile', async () => {
     projects = [project('p-doc', 'Docs', { interactiveRoot: '/tmp/wi' })];
     docs = { 'p-doc': [{ name: 'launch-deck', kind: 'doc', head: 1, versions: 1, updated_at: null }] };
     await board([]);
-    await vi.waitFor(() => expect(screen.getByTestId('doc-tile')).toHaveTextContent('not yet edited'));
+    // Docs alone are a drafts nudge (D2): the card idles as the QUIET one-liner,
+    // whose budget shows no tiles and no activity region (slice 2).
+    expect(card('p-doc')).toHaveAttribute('data-variant', 'quiet');
+    expect(within(card('p-doc')).queryByTestId('doc-tile')).toBeNull();
 
     push({
       type: 'interactiveEvent',
@@ -180,6 +188,11 @@ describe('HomeBoard — live activity (slice 6)', () => {
       },
     } as CoreEvent);
 
+    // A doc being edited NOW is live work: the signal promotes the project into
+    // NEEDS YOU, where the ACTIVE card carries the activity line and the tile.
+    await vi.waitFor(() => {
+      expect(card('p-doc')).toHaveAttribute('data-variant', 'active');
+    });
     expect(within(card('p-doc')).getByTestId('doc-activity'))
       .toHaveTextContent('Rewriting slide 3 — tightening the headline');
     expect(screen.getByTestId('doc-tile')).toHaveTextContent('0s ago');
@@ -199,12 +212,14 @@ describe('HomeBoard — live activity (slice 6)', () => {
   });
 
   it('picks up a run attached after first paint — no reload to see a launched run', async () => {
-    projects = [project('p-a', 'Ay')];
+    projects = [project('p-a', 'Ay', { updated_at: Date.now() })];
     const { rerender } = render(<HomeBoard runs={[]} navigate={() => {}} />);
-    // A run-less project is quiet by construction (slice 1) — expand to its card.
+    // A run-less project is quiet by construction (slice 1) — expand to its card,
+    // which is the one-line QUIET variant (slice 2), never "No runs yet".
     await vi.waitFor(() => expect(screen.queryByTestId('band-quiet-toggle')).not.toBeNull());
     await expandQuiet();
-    await vi.waitFor(() => expect(card('p-a')).toHaveTextContent('No runs yet.'));
+    await vi.waitFor(() => expect(within(card('p-a')).getAllByTestId('quiet-summary')).toHaveLength(1));
+    expect(card('p-a')).not.toHaveTextContent('No runs yet');
 
     // The run is launched and filed while the user sits on the board.
     members = { 'p-a': [member('p-a', 'run-new')] };

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -107,13 +107,14 @@ describe('HomeBoard — the orchestrator board', () => {
     expect(first).toHaveTextContent('gate');
   });
 
-  it('a project with nothing in it renders the four quick actions — the card IS the empty state', async () => {
+  it('a brand-new project is ONE invitation line + four differentiated actions (slice 2)', async () => {
     projects = [project({ id: 'p-empty', name: 'Empty' })];
     await boardWith();
     // An empty project is quiet by construction now (slice 1) — expand to reach its card.
     await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
+    expect(card).toHaveAttribute('data-variant', 'quiet');
     const actions = within(card).getAllByTestId('quick-action');
     expect(actions).toHaveLength(4);
     expect(actions.map((a) => a.getAttribute('data-mode'))).toEqual(['chat', 'build', 'document', 'video']);
@@ -121,9 +122,20 @@ describe('HomeBoard — the orchestrator board', () => {
     expect(actions.map((a) => a.getAttribute('href'))).toEqual([
       '/p/p-empty/chat', '/p/p-empty/build', '/p/p-empty/document', '/p/p-empty/video',
     ]);
-    // Never a dead tile: the empty regions invite rather than showing nothing.
-    expect(card).toHaveTextContent('No documents yet');
-    expect(card).toHaveTextContent('No runs yet');
+    // The empty-state budget (§2.1.2): ONE line — the first-run invitation — and
+    // never a region of "nothing".
+    const summaries = within(card).getAllByTestId('quiet-summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toHaveTextContent('Start by describing what you want');
+    expect(card).not.toHaveTextContent('No documents yet');
+    expect(card).not.toHaveTextContent('Nothing running');
+    expect(card).not.toHaveTextContent('No runs yet');
+    // First-run is where the sublabels teach what each verb PRODUCES (§2.2, F2).
+    const sublabels = within(card).getAllByTestId('quick-action-sublabel');
+    expect(sublabels.map((s) => s.textContent)).toEqual([
+      'think out loud with an agent', 'ship code, with checks',
+      'a deck, page, or report', 'record a demo',
+    ]);
   });
 
   it('a quick action navigates into the project shell', async () => {
@@ -134,12 +146,15 @@ describe('HomeBoard — the orchestrator board', () => {
     await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
-    await user.click(within(card).getByText(/Do work/));
+    await user.click(within(card).getByText('Build'));
     expect(navigate).toHaveBeenCalledWith('/p/p-1/build');
   });
 
   it('doc tiles are PLACEHOLDERS — title, kind glyph, updated-at, never an iframe (§7.5)', async () => {
-    projects = [project({ id: 'p-docs', name: 'Docs', interactiveRoot: '/tmp/wi' })];
+    // Tiles live on the ACTIVE variant (slice 2): a live run puts the card in
+    // NEEDS YOU, and the docs it carries render as placeholder tiles there.
+    projects = [project({ id: 'p-docs', name: 'Docs', interactiveRoot: '/tmp/wi', updated_at: Date.now() })];
+    members = { 'p-docs': [member('p-docs', 'crew.run', 'run-docs')] };
     docs = {
       'p-docs': [
         { name: 'launch-deck', kind: 'doc', head: 2, versions: 2, updated_at: new Date(Date.now() - 3600_000).toISOString() },
@@ -148,12 +163,11 @@ describe('HomeBoard — the orchestrator board', () => {
         { name: 'overflow-one', kind: 'doc', head: 1, versions: 1, updated_at: null },
       ],
     };
-    await boardWith();
-    // Docs alone are a drafts nudge, never a demand (D2) — the card lives in QUIET.
-    await expandQuiet();
+    await boardWith([makeView({ id: 'run-docs', status: 'executing' })]);
 
     const card = await screen.findByTestId('project-card');
     await vi.waitFor(() => expect(within(card).getAllByTestId('doc-tile')).toHaveLength(3));
+    expect(card).toHaveAttribute('data-variant', 'active');
     expect(within(card).getByTestId('doc-overflow')).toHaveTextContent('1 more');
     expect(card).toHaveTextContent('launch-deck');
     expect(card).toHaveTextContent('1h ago');
@@ -167,8 +181,11 @@ describe('HomeBoard — the orchestrator board', () => {
     await expandQuiet();
 
     const card = await screen.findByTestId('project-card');
-    expect(card).toHaveTextContent('No documents yet');
     expect(within(card).queryByTestId('doc-tile')).toBeNull();
+    expect(card).not.toHaveTextContent('never-shown');
+    // Slice 2: absence is the one quiet line, never a "No documents yet" region.
+    expect(within(card).getAllByTestId('quiet-summary')).toHaveLength(1);
+    expect(card).not.toHaveTextContent('No documents yet');
   });
 
   it('windows the grid: what is mounted is bounded by the viewport, not by the project count', async () => {
@@ -179,8 +196,8 @@ describe('HomeBoard — the orchestrator board', () => {
     };
 
     // Twenty quiet projects mount as CHIPS while collapsed (a capped preview strip),
-    // and as a WINDOWED grid once expanded — the intent (mounted bounded by the
-    // viewport, not the project count) holds across both bands (D6).
+    // and as a WINDOWED grid once expanded. Slice-2 quiet cards are one line tall,
+    // so 20 may genuinely fit the viewport — the invariant is about the CEILING.
     seed(20);
     await boardWith();
     expect(screen.getAllByTestId('quiet-chip').length).toBeLessThan(20);
@@ -188,16 +205,18 @@ describe('HomeBoard — the orchestrator board', () => {
     const at20 = screen.getAllByTestId('project-card').length;
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '20');
     expect(at20).toBeGreaterThan(0);
-    expect(at20).toBeLessThan(20);
+    expect(at20).toBeLessThanOrEqual(20);
     cleanup();
 
-    // Tripling the board does NOT triple what is mounted — that is the whole point of
-    // windowing, and it is what keeps 20+ cards legible (§1.4).
+    // Tripling the board does NOT triple what is mounted — what mounts is bounded
+    // by the viewport's row capacity (plus overscan), never by the project count.
+    // That is the whole point of windowing; it keeps 20+ cards legible (§1.4).
     seed(60);
     await boardWith();
     await expandQuiet();
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '60');
-    expect(screen.getAllByTestId('project-card')).toHaveLength(at20);
+    const at60 = screen.getAllByTestId('project-card').length;
+    expect(at60).toBeLessThan(30);
   });
 
   it('states what is missing rather than showing a blank board', async () => {

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -108,7 +108,8 @@ describe('HomeBoard — the orchestrator board', () => {
   });
 
   it('a brand-new project is ONE invitation line + four differentiated actions (slice 2)', async () => {
-    projects = [project({ id: 'p-empty', name: 'Empty' })];
+    // "Just created" is literal (§2.1.2): the invitation needs a fresh created_at.
+    projects = [project({ id: 'p-empty', name: 'Empty', created_at: Date.now() })];
     await boardWith();
     // An empty project is quiet by construction now (slice 1) — expand to reach its card.
     await expandQuiet();

--- a/tests/ProjectCard.variants.test.tsx
+++ b/tests/ProjectCard.variants.test.tsx
@@ -26,10 +26,12 @@ beforeEach(() => {
 });
 afterEach(cleanup);
 
-function project(id: string): Project {
+const THREE_DAYS = 3 * 86_400_000;
+
+function project(id: string, created_at: number = Date.now() - THREE_DAYS): Project {
   return {
     id, name: id, description: null, status: 'active', scope: `project:${id}`,
-    created_at: 1, updated_at: Date.now() - 3 * 86_400_000,
+    created_at, updated_at: Date.now() - THREE_DAYS,
   };
 }
 
@@ -64,7 +66,7 @@ describe('the QUIET variant — calm is one line, not a wall of absence (F1)', (
       />,
     );
     expect(card()).toHaveAttribute('data-variant', 'quiet');
-    expect(card().style.height).toBe(`${QUIET_CARD_H}px`);
+    expect(card().style.maxHeight).toBe(`${QUIET_CARD_H}px`);
     const summaries = within(card()).getAllByTestId('quiet-summary');
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toHaveTextContent(/Quiet — last active \d+[smhd] ago/);
@@ -87,8 +89,17 @@ describe('the QUIET variant — calm is one line, not a wall of absence (F1)', (
     for (const s of BANNED) expect(card()).not.toHaveTextContent(s);
   });
 
+  it('an OLD empty project is debris, not a beginning — plain quiet line, no invitation (W2)', () => {
+    render(<ProjectCard item={item('abandoned')} navigate={() => {}} />);
+    const summaries = within(card()).getAllByTestId('quiet-summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toHaveTextContent(/Quiet — last active \d+[smhd] ago/);
+    expect(card()).not.toHaveTextContent('Start by describing what you want');
+    expect(within(card()).getByTestId('quick-actions')).not.toHaveAttribute('data-detail');
+  });
+
   it('a brand-new empty project gets the first-run invitation as its one line (§2.1.2)', () => {
-    render(<ProjectCard item={item('scratch')} navigate={() => {}} />);
+    render(<ProjectCard item={item('scratch', { project: project('scratch', Date.now()) })} navigate={() => {}} />);
     const summaries = within(card()).getAllByTestId('quiet-summary');
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toHaveTextContent('Start by describing what you want');
@@ -115,7 +126,7 @@ describe('the quick actions — the mode spine, differentiated (F2, §2.2)', () 
   });
 
   it('first-run shows each verb\'s sublabel; elsewhere it survives as hover title', () => {
-    render(<ProjectCard item={item('scratch')} navigate={() => {}} />);
+    render(<ProjectCard item={item('scratch', { project: project('scratch', Date.now()) })} navigate={() => {}} />);
     const sublabels = within(card()).getAllByTestId('quick-action-sublabel');
     expect(sublabels.map((s) => s.textContent)).toEqual(MODES.map((m) => MODE_SPECS[m].sublabel));
     cleanup();
@@ -146,7 +157,7 @@ describe('the ACTIVE variant — rich, but an empty region is OMITTED (§2.1.1)'
       />,
     );
     expect(card()).toHaveAttribute('data-variant', 'active');
-    expect(card().style.height).toBe(`${ACTIVE_CARD_H}px`);
+    expect(card().style.maxHeight).toBe(`${ACTIVE_CARD_H}px`);
     // Omitted, not narrated: no tile, no absence line, no quiet summary.
     expect(within(card()).queryByTestId('doc-tile')).toBeNull();
     expect(within(card()).queryByTestId('quiet-summary')).toBeNull();

--- a/tests/ProjectCard.variants.test.tsx
+++ b/tests/ProjectCard.variants.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { ProjectCard, ACTIVE_CARD_H, QUIET_CARD_H } from '../src/components/ProjectCard.js';
+import { MODE_SPECS } from '../src/components/ModeSwitcher.js';
+import { MODES } from '../src/hooks/useRoute.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { DocSummary } from '../src/api/interactive.js';
+import type { Project, SessionStatus } from '../src/api/types.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The slice-2 DOM ACs (DES-UXFIX-001 §4.3): ACTIVE/QUIET card variants, the
+ * empty-state budget (absence is at most ONE line, `quiet-summary`, and the
+ * banned "nothing" strings appear nowhere), and the four quick actions
+ * relabelled to the mode spine with distinct `data-mode`, the switcher's
+ * glyphs, and first-run sublabels from MODE_SPECS.
+ */
+
+const BANNED = ['No documents yet', 'Nothing running', 'No runs yet', 'Start here'];
+
+beforeEach(() => {
+  useGateStore.setState({ gates: {} });
+  useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {} });
+});
+afterEach(cleanup);
+
+function project(id: string): Project {
+  return {
+    id, name: id, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at: Date.now() - 3 * 86_400_000,
+  };
+}
+
+function doc(name: string): DocSummary {
+  return { name, kind: 'doc', head: 1, versions: 1, updated_at: null };
+}
+
+function item(id: string, over: Partial<BoardProject> = {}): BoardProject {
+  return {
+    project: project(id), repo: null, runs: [], docs: [],
+    attention: 'quiet', score: 0, band: 'quiet', signal: null,
+    ...over,
+  };
+}
+
+function run(id: string, status: SessionStatus) {
+  return makeView({ id, status, unit_ix: 0 }, [makeUnit({ id: `${id}:u0`, session_id: id, ord: 0, stage: 'build' })]);
+}
+
+const card = (): HTMLElement => screen.getByTestId('project-card');
+
+describe('the QUIET variant — calm is one line, not a wall of absence (F1)', () => {
+  it('renders exactly ONE absence line and none of the banned "nothing" strings', () => {
+    render(
+      <ProjectCard
+        item={item('smoke-tests', {
+          runs: [run('r-old', 'completed')],
+          attention: 'quiet',
+          signal: null,
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(card()).toHaveAttribute('data-variant', 'quiet');
+    expect(card().style.height).toBe(`${QUIET_CARD_H}px`);
+    const summaries = within(card()).getAllByTestId('quiet-summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toHaveTextContent(/Quiet — last active \d+[smhd] ago/);
+    for (const s of BANNED) expect(card()).not.toHaveTextContent(s);
+    // The budget: no region furniture at all — one line plus the action row.
+    expect(within(card()).queryByTestId('doc-tile')).toBeNull();
+    expect(within(card()).queryByTestId('live-line')).toBeNull();
+    expect(within(card()).queryByTestId('run-chip')).toBeNull();
+  });
+
+  it('a quiet project WITH docs still shows one line — tiles are ACTIVE-card furniture', () => {
+    render(
+      <ProjectCard
+        item={item('notes', { docs: [doc('ideas'), doc('todo')], attention: 'drafts' })}
+        navigate={() => {}}
+      />,
+    );
+    expect(within(card()).getAllByTestId('quiet-summary')).toHaveLength(1);
+    expect(within(card()).queryByTestId('doc-tile')).toBeNull();
+    for (const s of BANNED) expect(card()).not.toHaveTextContent(s);
+  });
+
+  it('a brand-new empty project gets the first-run invitation as its one line (§2.1.2)', () => {
+    render(<ProjectCard item={item('scratch')} navigate={() => {}} />);
+    const summaries = within(card()).getAllByTestId('quiet-summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toHaveTextContent('Start by describing what you want');
+    // The invitation IS the one obvious next action (EC1) — a link into Chat.
+    expect(summaries[0]).toHaveAttribute('href', '/p/scratch/chat');
+    // First-run is the sublabelled 2×2 layout; other quiet cards are compact.
+    expect(within(card()).getByTestId('quick-actions')).toHaveAttribute('data-detail', 'true');
+  });
+});
+
+describe('the quick actions — the mode spine, differentiated (F2, §2.2)', () => {
+  it('four actions with distinct data-mode, MODE_SPECS labels and glyphs', () => {
+    render(<ProjectCard item={item('any')} navigate={() => {}} />);
+    const actions = within(card()).getAllByTestId('quick-action');
+    expect(actions).toHaveLength(4);
+    expect(actions.map((a) => a.getAttribute('data-mode'))).toEqual([...MODES]);
+    for (const [i, m] of MODES.entries()) {
+      expect(actions[i]).toHaveTextContent(MODE_SPECS[m].label);
+      expect(actions[i]).toHaveTextContent(MODE_SPECS[m].glyph);
+    }
+    // V9/V10: the old near-synonyms are gone.
+    expect(card()).not.toHaveTextContent('Do work');
+    expect(card()).not.toHaveTextContent('New chat');
+  });
+
+  it('first-run shows each verb\'s sublabel; elsewhere it survives as hover title', () => {
+    render(<ProjectCard item={item('scratch')} navigate={() => {}} />);
+    const sublabels = within(card()).getAllByTestId('quick-action-sublabel');
+    expect(sublabels.map((s) => s.textContent)).toEqual(MODES.map((m) => MODE_SPECS[m].sublabel));
+    cleanup();
+
+    render(
+      <ProjectCard
+        item={item('busy', { runs: [run('r1', 'executing')], attention: 'running', band: 'needs-you', score: 40, signal: { kind: 'running', at: Date.now(), runId: 'r1' } })}
+        navigate={() => {}}
+      />,
+    );
+    expect(within(card()).queryByTestId('quick-action-sublabel')).toBeNull();
+    for (const a of within(card()).getAllByTestId('quick-action')) {
+      expect(a.getAttribute('title')).toContain('—');
+    }
+  });
+});
+
+describe('the ACTIVE variant — rich, but an empty region is OMITTED (§2.1.1)', () => {
+  it('no docs ⇒ no Documents region; the runs and live regions stand on their own', () => {
+    render(
+      <ProjectCard
+        item={item('auth-refactor', {
+          runs: [run('r-fail', 'failed')],
+          attention: 'failing', band: 'needs-you', score: 66,
+          signal: { kind: 'failing', at: Date.now() - 12 * 60_000, runId: 'r-fail' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(card()).toHaveAttribute('data-variant', 'active');
+    expect(card().style.height).toBe(`${ACTIVE_CARD_H}px`);
+    // Omitted, not narrated: no tile, no absence line, no quiet summary.
+    expect(within(card()).queryByTestId('doc-tile')).toBeNull();
+    expect(within(card()).queryByTestId('quiet-summary')).toBeNull();
+    for (const s of BANNED) expect(card()).not.toHaveTextContent(s);
+    // A failed run is terminal — the live region is omitted too, never "Nothing running".
+    expect(within(card()).queryByTestId('live-activity')).toBeNull();
+    expect(within(card()).getByTestId('run-chip')).toHaveAttribute('data-status', 'failed');
+  });
+
+  it('the header pill names the signal in user words — "working", never "distributing" (V3)', () => {
+    render(
+      <ProjectCard
+        item={item('upload-endpoint', {
+          runs: [run('r-live', 'executing')],
+          attention: 'running', band: 'needs-you', score: 40,
+          signal: { kind: 'running', at: Date.now(), runId: 'r-live' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    const pill = within(card()).getByTestId('attention-pill');
+    expect(pill).toHaveAttribute('data-kind', 'running');
+    expect(pill).toHaveTextContent('working');
+    expect(within(card()).getByTestId('live-line')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Slice 2: cards spend their space on what EXISTS. ACTIVE/QUIET variants by attention band; empty regions omitted (banned absence strings gone, quiet = one line); attention pill in user words (gate/failed/working); quick actions renamed to the mode spine sharing MODE_SPECS with the switcher, glyphs + first-run sublabels; genuine first-run projects (<24h) get the accent invitation while 3-day-old empties render as debris. 765/765 tests; both browser rigs green against the final build; EC1/EC2/EC6 judged from pixels by verifier and operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)