### PR TITLE
feat(rail): two taxonomies, attention-ordered (DES-UXFIX-001 slice 3)

### DIFF
--- a/.product/evidence/uxfix-slice3/checklist.md
+++ b/.product/evidence/uxfix-slice3/checklist.md
@@ -1,0 +1,93 @@
+# DES-UXFIX-001 — Slice 3 experience-checklist verdicts (§4.1)
+
+**Slice:** 3 — rail to two taxonomies
+**Date:** 2026-08-20
+**Build:** branch `uxfix/slice-3-rail` (on top of slice 2, `49b7697`)
+**Rig:** `e2e/uxfix_slice3_test.py` — the W2 messy-reality fixture (§4.2) served by
+the SHARED deterministic fixture server (`e2e/uxfix_fixture.py`, extracted from
+the slice-1/2 rigs per the slice-2 verifier's recommendation; both older rigs now
+import it and stay green), captured per the §4.0 contract: 1440×900,
+`device_scale_factor=1`, every capture waits on a `data-testid`, never a sleep.
+The DOM ACs backing each verdict all passed in the same run (JSON report printed
+by the rig; `rail_banned_strings_found: []`, `page_banned_strings_found: []`,
+`rail_matches_board_needs_you: true`), and the slice-1 AND slice-2 rigs were
+re-run against this exact build — both green, no regression.
+
+**Screenshots judged** (uncommitted evidence, `e2e/shots/uxfix/`):
+
+| Scene | File |
+|---|---|
+| The consolidated rail beside the settled W2 board | `uxfix-3-rail.png` |
+
+Judged from the pixels alone, per §4.1 ("if you cannot tell from the image, it
+fails").
+
+---
+
+## EC1 — one obvious next action · **PASS**
+
+The BEFORE rail opened with three stacked, equal-weight, full-width creation
+links — "Do Work" / "New Chat" / "New Repository" — three near-synonym primaries
+competing before any content (F2's second occurrence). In `uxfix-3-rail.png`
+that stack is gone: the creation verbs are ONE compact subordinate row
+(`+ ⚙ Build  + 💬 Chat` / `+ Repository`), and the visually dominant element of
+the rail is the PROJECTS list itself — whose top row, by decayed attention
+order, is the gate-carrying `q3-review-deck` with the accent-yellow dot. The
+rail now points at the same single next action the board leads with (enter the
+project that needs you), instead of manufacturing three primary verbs of its
+own. Secondary affordances ("view all", the search glyph, "All runs ›") are
+visibly demoted: small, link-coloured, single-line. The one absence on the
+surface ("No repositories yet") is one italic line — the empty-state budget
+holds here too.
+
+## EC7 — the surface teaches itself · **PASS**
+
+Readable from the image alone:
+
+- The two section labels name exactly what they hold — **PROJECTS ›** (a real
+  list, colour-dotted by the same attention palette the board cards use, in the
+  same order as the board's NEEDS YOU band: gate, gate, failed, working) and
+  **REPOSITORIES** (with its search). Nothing else claims to be a taxonomy.
+- The creation verbs are the mode spine's own words with the switcher's glyphs
+  (⚙ Build, 💬 Chat) — the same four symbols meaning the same things everywhere
+  (§1, §2.5 rule 4) — so the rail teaches by vocabulary the switcher already
+  established, not by a second dialect ("Do Work" vs "New Chat" is gone; the
+  rig asserts the strings appear nowhere on the page).
+- **All runs ›** says precisely what the escape hatch is: the one flat list,
+  behind one link, not two rail sections of visually identical truncated run
+  items (F4). The Chats/Work sections — and their "No chats yet"/"No work yet"
+  absence lines — appear nowhere (asserted against the rail's full text).
+- The rail teaches the board's order by AGREEING with it: same axis, same
+  colours, same top-four (the rig asserts rail order === board NEEDS YOU order
+  from the same DOM, including the R3 trap — `legacy-spike`'s 8-day failure is
+  in neither).
+
+---
+
+## Notes / caveats (honest, not blocking)
+
+1. **The rail row's signal is colour + order only.** The board card pairs the
+   dot with a pill word ("gate"/"failed"/"working"); the rail row carries just
+   the dot and its position. A colour-blind operator still gets the ordering,
+   and the board (one glance right) names the signal — but a later pass could
+   add the pill word to the row's `title`.
+2. **`useBoardModel` now mounts twice on `/`** (rail + board), so a home-route
+   visit duplicates the projects/members/docs fetch set once. Deliberate for
+   this slice — the rail needs the model on EVERY route, and hoisting one
+   instance into `App` would churn `HomeBoard`'s contract; that hoist is the
+   named cleanup if the duplication ever grates.
+3. **Three loose selectors in the merged rigs were card-scoped**
+   (`[data-project-id=…]` → `[data-testid="project-card"][data-project-id=…]`):
+   the rail now legitimately carries `data-project-id` rows (it is the same
+   axis — the point of the slice), which made the bare attribute ambiguous and
+   had slice-2's gate-chip check matching the rail row. The assertions'
+   subjects (the board cards) and semantics are unchanged; both rigs pass.
+4. **The collapsed rail changed axis too**: it shows attention dots for the top
+   projects (same order, same colours) instead of one dot per run — consistent
+   with Chats/Work leaving the rail, but a behaviour change for anyone who used
+   the collapsed strip as a run list. The runs remain one click away at
+   `/runs`.
+5. **Work items got their distinguishable labels in `RunLink`** (spine word +
+   glyph, `data-kind`), which renders on `/work` and `/repo-detail` — the flat
+   escape-hatch lists — not in the rail (the rail no longer lists runs at
+   all, which is the design's stronger fix for F4).

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+uxfix_fixture.py — the ONE deterministic W2 messy-reality fixture server
+(DES-UXFIX-001 §4.2) shared by every uxfix slice rig.
+
+Extracted from uxfix_slice1_test.py / uxfix_slice2_test.py (which previously
+each carried a verbatim copy, as the slice-2 verifier flagged): a
+ThreadingHTTPServer that serves the `dist-sameorigin/` build (the no-
+VITE_API_HOST build — `apiBase()` derives from window.location, so the page,
+the API and the `/ws` handshake share ONE origin, no rebuild) plus every
+endpoint the home route reads, with all timestamps computed from a single NOW0
+captured at import. No crew daemon is involved anywhere.
+
+The dataset is §4.2's rows verbatim, including the two adjacencies the rigs
+must not lose:
+  - `legacy-spike`: run failed 8 DAYS ago but its project was touched an HOUR
+    ago — the R3 trap the `runEvents` backfill exists to defuse;
+  - `upload-endpoint`: live, narrating over the rig's own /ws.
+
+Mutable switches (flipped over POST /__fixture between page loads):
+  orphan          — whether the orphan run rides the run list (default True)
+  q3_gate_age_ms  — the r-q3 gate's receivedAt age (default 30s)
+
+A rig that never flips them gets the default W2 board.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import threading
+import time
+import urllib.parse
+import urllib.request
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SHOTS = REPO / "e2e" / "shots" / "uxfix"
+NPM = "npm.cmd" if os.name == "nt" else "npm"
+
+# Same rule as the main harness: gate toasts are not these surfaces (and the
+# home route does not render them), but the suppression is cheap and display-only.
+HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
+
+# ── The frozen clock (§4.0 determinism): every age derives from this one NOW0 ──
+NOW0 = int(time.time() * 1000)
+SEC, MIN, HOUR, DAY = 1_000, 60_000, 3_600_000, 86_400_000
+
+
+def iso(ms: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ms / 1000)) + f".{ms % 1000:03d}Z"
+
+
+# Mutable fixture switches, flipped over POST /__fixture between page loads.
+state = {"orphan": True, "q3_gate_age_ms": 30 * SEC}
+state_lock = threading.Lock()
+
+
+def project(pid: str, name: str, updated_at: int, **extra) -> dict:
+    return {"id": pid, "name": name, "description": None, "status": "active",
+            "scope": f"project:{pid}" if pid != "default" else "",
+            "created_at": updated_at, "updated_at": updated_at, **extra}
+
+
+# §4.2's rows. `legacy-spike`'s project was touched an HOUR ago while its run
+# failed 8 DAYS ago — the exact R3 trap the runEvents backfill exists to defuse.
+QUIET_CLONES = [project(f"quiet-{i:02d}", f"quiet-clone-{i:02d}", NOW0 - 3 * DAY - i * 7 * HOUR)
+                for i in range(20)]
+PROJECTS = [
+    project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
+    project("legacy-spike", "legacy-spike", NOW0 - HOUR),
+    project("upload-endpoint", "upload-endpoint", NOW0),
+    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
+    project("api-migration", "api-migration", NOW0 - 2 * MIN),
+    project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
+    project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
+    project("notes", "notes", NOW0 - 2 * DAY, interactiveRoot="/tmp/wi-notes"),
+    project("scratch", "scratch", NOW0),
+] + QUIET_CLONES
+
+MEMBERS = {
+    "legacy-spike": ["r-legacy"],
+    "upload-endpoint": ["r-upload"],
+    "q3-review-deck": ["r-q3"],
+    "api-migration": ["r-api"],
+    "auth-refactor": ["r-auth"],
+    "smoke-tests": ["r-smoke1", "r-smoke2"],
+}
+
+
+def session(rid: str, status: str, problem: str, unit_desc: str) -> dict:
+    return {"session": {
+        "id": rid, "workflow_id": "wf-w2", "problem": problem, "entity_mode": "shared",
+        "collection_scope": None, "clis": ["claude"], "status": status,
+        "human_confirm": "all" if status == "awaiting_human" else "none",
+        "unit_ix": 0, "attempt": 0, "workdir": None, "repo_ref": None,
+        "extra_write_roots": [], "archived_at": None, "archive_note": None,
+    }, "units": [{
+        "id": f"{rid}:u0", "session_id": rid, "ord": 0, "description": unit_desc,
+        "stage": "build", "assigned_cli": None, "assigned_invocation": None,
+        "council_task_ref": None, "routing": None, "denial_reason": None,
+        "phase_ref": None, "conformance_ref": None, "phase_status": None,
+        "collection_scope": None, "status": "pending",
+    }]}
+
+
+RUNS = [
+    session("r-q3", "awaiting_human", "make the Q3 review deck", "author the deck outline"),
+    session("r-api", "awaiting_human", "migrate the auth tables", "plan the migration"),
+    session("r-upload", "executing", "add rate-limiting to the upload endpoint",
+            "add rate-limiting to the upload endpoint"),
+    session("r-auth", "failed", "refactor the auth middleware", "refactor the auth middleware"),
+    session("r-legacy", "failed", "spike the legacy importer", "spike the legacy importer"),
+    session("r-smoke1", "completed", "smoke: login flow", "smoke the login flow"),
+    session("r-smoke2", "completed", "smoke: checkout flow", "smoke the checkout flow"),
+]
+ORPHAN = session("r-orphan", "executing", "stranded work from another client",
+                 "stranded work from another client")
+
+# The durable-log tails (D3 step 2): the ONE honest clock for a failure's age.
+RUN_EVENTS = {
+    "r-legacy": [{"type": "sessionStarted", "session": "r-legacy", "ts": NOW0 - 8 * DAY - MIN},
+                 {"type": "sessionFailed", "session": "r-legacy", "ts": NOW0 - 8 * DAY}],
+    "r-auth": [{"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 13 * MIN},
+               {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 12 * MIN}],
+}
+
+NOTES_DOCS = [
+    {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
+    {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
+]
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+NARRATION = "Writing the token-bucket middleware for /upload"
+
+
+def ws_frame(payload: dict) -> bytes:
+    data = json.dumps(payload).encode()
+    if len(data) < 126:
+        head = bytes([0x81, len(data)])
+    else:
+        head = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
+    return head + data
+
+
+class W2Handler(SimpleHTTPRequestHandler):
+    """SPA + the whole /api/v1 surface the home route reads + /ws, one origin."""
+
+    def log_message(self, *_args):  # keep stdout JSON-clean
+        pass
+
+    def _json(self, status: int, payload) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _ws(self) -> None:
+        """Accept the upgrade, then stream `unitOutputDelta` frames for the live
+        run — `useRuns` gates its first fetch on a connected socket, so the
+        handshake is mandatory, and the narration keeps the headline honest."""
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+        self.wfile.write(
+            ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+             f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
+        self.wfile.flush()
+        try:
+            while True:
+                self.wfile.write(ws_frame({
+                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                    "text": NARRATION + "\n",
+                }))
+                self.wfile.flush()
+                time.sleep(1.0)
+        except OSError:
+            pass
+        self.close_connection = True
+
+    def _api(self, path: str) -> bool:
+        if path == "/api/v1/health":
+            self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
+            return True
+        if path == "/api/v1/runs":
+            with state_lock:
+                runs = RUNS + ([ORPHAN] if state["orphan"] else [])
+            self._json(200, {"runs": runs})
+            return True
+        if path == "/api/v1/projects":
+            self._json(200, {"projects": PROJECTS})
+            return True
+        if path == "/api/v1/repos":
+            self._json(200, {"repos": []})
+            return True
+        parts = path.split("/")
+        # /api/v1/projects/<id>/members
+        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
+            pid = urllib.parse.unquote(parts[4])
+            self._json(200, {"members": [
+                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
+                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
+                for ref in MEMBERS.get(pid, [])
+            ]})
+            return True
+        # /api/v1/projects/<id>/interactive/api/docs — the notes project's registry
+        if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
+            pid = urllib.parse.unquote(path.split("/")[4])
+            self._json(200, NOTES_DOCS if pid == "notes" else [])
+            return True
+        # /api/v1/runs/<id>/gate
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
+            rid = urllib.parse.unquote(parts[4])
+            if rid == "r-q3":
+                with state_lock:
+                    age = state["q3_gate_age_ms"]
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "Approve the deck outline?",
+                                 "receivedAt": iso(NOW0 - age)})
+            elif rid == "r-api":
+                # `options: null` = free text ⇒ the COMPLEX gate shape (§7.11).
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": "How should the tables move?",
+                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
+            else:
+                self._json(404, {"error": f"no gate cached for {rid}"})
+            return True
+        # /api/v1/runs/<id>/events
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
+            rid = urllib.parse.unquote(parts[4])
+            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
+            return True
+        if path.startswith("/api/v1/"):
+            self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+            return True
+        return False
+
+    def do_GET(self):  # noqa: N802 (stdlib naming)
+        if self.headers.get("Upgrade", "").lower() == "websocket":
+            return self._ws()
+        path = urllib.parse.urlparse(self.path).path
+        if self._api(path):
+            return None
+        if not Path(self.translate_path(self.path)).is_file():
+            self.path = "/index.html"  # client-side routes resolve to the shell
+        return super().do_GET()
+
+    def do_POST(self):  # noqa: N802 (stdlib naming)
+        path = urllib.parse.urlparse(self.path).path
+        if path == "/__fixture":
+            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+            with state_lock:
+                state.update({k: v for k, v in body.items() if k in state})
+                snapshot = dict(state)
+            return self._json(200, {"ok": True, "state": snapshot})
+        return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+
+
+def ensure_build(fail) -> Path:
+    """The same-origin build (shared across the rigs — same dist dir).
+    `fail(step, why)` is the calling rig's reporter; SKIP_STUDIO_BUILD=1 skips."""
+    dist = REPO / "dist-sameorigin"
+    if os.environ.get("SKIP_STUDIO_BUILD") == "1":
+        if not (dist / "index.html").is_file():
+            fail("build", f"SKIP_STUDIO_BUILD=1 but {dist}/index.html is missing — "
+                 "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
+    elif not (dist / "index.html").is_file():
+        env = dict(os.environ, VITE_API_HOST="")
+        r = subprocess.run(
+            [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
+            cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
+        )
+        if r.returncode != 0:
+            fail("build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+    return dist
+
+
+def start_server(port: int, dist: Path) -> str:
+    """Serve `dist` + the fixture API on 127.0.0.1:`port` (daemon thread); returns the origin."""
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), partial(W2Handler, directory=str(dist)))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{port}"
+
+
+def set_fixture(origin: str, **kwargs) -> None:
+    """Flip the mutable switches over POST /__fixture between page loads."""
+    req = urllib.request.Request(f"{origin}/__fixture", method="POST",
+                                 data=json.dumps(kwargs).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        res.read()

--- a/e2e/uxfix_slice1_test.py
+++ b/e2e/uxfix_slice1_test.py
@@ -187,10 +187,15 @@ with sync_playwright() as p:
                      '[data-testid="project-card"][data-project-id="legacy-spike"]');
                    return !!c && c.dataset.band === 'quiet' && c.dataset.signal === 'failing'
                        && Number(c.dataset.score) < 1; }""")
-    # …and upload-endpoint precedes it in document order (EC4, read from the DOM).
+    # …and upload-endpoint's CARD precedes legacy-spike's in document order (EC4,
+    # read from the DOM). Card-scoped: since slice 3 the RAIL also carries
+    # data-project-id rows (the same axis as the board), so the bare attribute
+    # is ambiguous — the assertion's subject was always the board card.
     precedes_ok = page.evaluate(
-        """() => { const up = document.querySelector('[data-project-id="upload-endpoint"]');
-                   const legacy = document.querySelector('[data-project-id="legacy-spike"]');
+        """() => { const up = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="upload-endpoint"]');
+                   const legacy = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="legacy-spike"]');
                    return !!up && !!legacy &&
                      !!(up.compareDocumentPosition(legacy) & Node.DOCUMENT_POSITION_FOLLOWING); }""")
 
@@ -206,7 +211,8 @@ with sync_playwright() as p:
                    return ids.includes('q3-review-deck')
                        && ids.indexOf('q3-review-deck') < ids.indexOf('auth-refactor'); }""")
     ancient_gate_score = page.evaluate(
-        """() => document.querySelector('[data-project-id="q3-review-deck"]')?.dataset.score ?? null""")
+        """() => document.querySelector(
+             '[data-testid="project-card"][data-project-id="q3-review-deck"]')?.dataset.score ?? null""")
 
     # ── Assertion 5's second half: no orphan ⇒ no shelf in the DOM at all ──────
     set_fixture(orphan=False)

--- a/e2e/uxfix_slice1_test.py
+++ b/e2e/uxfix_slice1_test.py
@@ -4,13 +4,14 @@ uxfix_slice1_test.py — the DES-UXFIX-001 slice-1 gate: attention decay + board
 bands, proven in a real browser against the W2 messy-reality fixture (§4.2).
 
 The daemon cannot produce an 8-day-old failure — its durable log is stamped at
-emit and `POST /runs` starts now — so the fixture is served by a DETERMINISTIC
-FIXTURE SERVER, the same pattern the doc rig in studio_standalone_test.py §12
-uses: a ThreadingHTTPServer that serves the `dist-sameorigin/` build (the
+emit and `POST /runs` starts now — so the fixture is served by the SHARED
+DETERMINISTIC FIXTURE SERVER in `uxfix_fixture.py` (extracted from this rig;
+same pattern the doc rig in studio_standalone_test.py §12 uses): a
+ThreadingHTTPServer that serves the `dist-sameorigin/` build (the
 no-VITE_API_HOST build — `apiBase()` derives from window.location, so the page,
 the API and the `/ws` handshake share ONE origin, no rebuild) plus every
 endpoint the home route reads, with all timestamps computed from a single NOW0
-captured at start.  No crew daemon is involved anywhere.
+captured at import.  No crew daemon is involved anywhere.
 
 What it asserts (design §5.5, the slice-1 DOM AC):
   1. `legacy-spike` (failed 8 DAYS ago, but its project touched an hour ago —
@@ -41,29 +42,23 @@ Env knobs: W2_PORT (default 4330), SKIP_STUDIO_BUILD.
 Prints a JSON report to stdout; exit 0/1.
 """
 
-import base64
-import hashlib
 import json
 import os
-import subprocess
 import sys
-import threading
-import time
-import urllib.parse
-import urllib.request
-from functools import partial
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-SHOTS = REPO / "e2e" / "shots" / "uxfix"
+from uxfix_fixture import (
+    DAY,
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    SHOTS,
+    ensure_build,
+    set_fixture as fixture_post,
+    start_server,
+)
+
 W2_PORT = int(os.environ.get("W2_PORT", "4330"))
 ORIGIN = f"http://127.0.0.1:{W2_PORT}"
-NPM = "npm.cmd" if os.name == "nt" else "npm"
-
-# Same rule as the main harness: gate toasts are not this surface (and the home
-# route does not render them), but the suppression is cheap and display-only.
-HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -75,247 +70,16 @@ def fail(step: str, why: str) -> None:
 
 
 # ── 1. The same-origin build (shared with the doc rig — no third studio build) ─
-dist = REPO / "dist-sameorigin"
-if os.environ.get("SKIP_STUDIO_BUILD") == "1":
-    if not (dist / "index.html").is_file():
-        fail("build", f"SKIP_STUDIO_BUILD=1 but {dist}/index.html is missing — "
-             "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
-elif not (dist / "index.html").is_file():
-    env = dict(os.environ, VITE_API_HOST="")
-    r = subprocess.run(
-        [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
-        cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
-    )
-    if r.returncode != 0:
-        fail("build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+dist = ensure_build(fail)
 report["steps"]["build"] = {"ok": True, "dist": str(dist)}
 
-# ── 2. The W2 fixture (§4.2), every age from ONE frozen NOW0 ───────────────────
-NOW0 = int(time.time() * 1000)
-SEC, MIN, HOUR, DAY = 1_000, 60_000, 3_600_000, 86_400_000
-
-
-def iso(ms: int) -> str:
-    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ms / 1000)) + f".{ms % 1000:03d}Z"
-
-
-# Mutable fixture switches, flipped over POST /__fixture between page loads.
-state = {"orphan": True, "q3_gate_age_ms": 30 * SEC}
-state_lock = threading.Lock()
-
-
-def project(pid: str, name: str, updated_at: int, **extra) -> dict:
-    return {"id": pid, "name": name, "description": None, "status": "active",
-            "scope": f"project:{pid}" if pid != "default" else "",
-            "created_at": updated_at, "updated_at": updated_at, **extra}
-
-
-# §4.2's rows. `legacy-spike`'s project was touched an HOUR ago while its run
-# failed 8 DAYS ago — the exact R3 trap the runEvents backfill exists to defuse.
-QUIET_CLONES = [project(f"quiet-{i:02d}", f"quiet-clone-{i:02d}", NOW0 - 3 * DAY - i * 7 * HOUR)
-                for i in range(20)]
-PROJECTS = [
-    project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
-    project("legacy-spike", "legacy-spike", NOW0 - HOUR),
-    project("upload-endpoint", "upload-endpoint", NOW0),
-    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
-    project("api-migration", "api-migration", NOW0 - 2 * MIN),
-    project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
-    project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
-    project("notes", "notes", NOW0 - 2 * DAY, interactiveRoot="/tmp/wi-notes"),
-    project("scratch", "scratch", NOW0),
-] + QUIET_CLONES
-
-MEMBERS = {
-    "legacy-spike": ["r-legacy"],
-    "upload-endpoint": ["r-upload"],
-    "q3-review-deck": ["r-q3"],
-    "api-migration": ["r-api"],
-    "auth-refactor": ["r-auth"],
-    "smoke-tests": ["r-smoke1", "r-smoke2"],
-}
-
-
-def session(rid: str, status: str, problem: str, unit_desc: str) -> dict:
-    return {"session": {
-        "id": rid, "workflow_id": "wf-w2", "problem": problem, "entity_mode": "shared",
-        "collection_scope": None, "clis": ["claude"], "status": status,
-        "human_confirm": "all" if status == "awaiting_human" else "none",
-        "unit_ix": 0, "attempt": 0, "workdir": None, "repo_ref": None,
-        "extra_write_roots": [], "archived_at": None, "archive_note": None,
-    }, "units": [{
-        "id": f"{rid}:u0", "session_id": rid, "ord": 0, "description": unit_desc,
-        "stage": "build", "assigned_cli": None, "assigned_invocation": None,
-        "council_task_ref": None, "routing": None, "denial_reason": None,
-        "phase_ref": None, "conformance_ref": None, "phase_status": None,
-        "collection_scope": None, "status": "pending",
-    }]}
-
-
-RUNS = [
-    session("r-q3", "awaiting_human", "make the Q3 review deck", "author the deck outline"),
-    session("r-api", "awaiting_human", "migrate the auth tables", "plan the migration"),
-    session("r-upload", "executing", "add rate-limiting to the upload endpoint",
-            "add rate-limiting to the upload endpoint"),
-    session("r-auth", "failed", "refactor the auth middleware", "refactor the auth middleware"),
-    session("r-legacy", "failed", "spike the legacy importer", "spike the legacy importer"),
-    session("r-smoke1", "completed", "smoke: login flow", "smoke the login flow"),
-    session("r-smoke2", "completed", "smoke: checkout flow", "smoke the checkout flow"),
-]
-ORPHAN = session("r-orphan", "executing", "stranded work from another client",
-                 "stranded work from another client")
-
-# The durable-log tails (D3 step 2): the ONE honest clock for a failure's age.
-RUN_EVENTS = {
-    "r-legacy": [{"type": "sessionStarted", "session": "r-legacy", "ts": NOW0 - 8 * DAY - MIN},
-                 {"type": "sessionFailed", "session": "r-legacy", "ts": NOW0 - 8 * DAY}],
-    "r-auth": [{"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 13 * MIN},
-               {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 12 * MIN}],
-}
-
-NOTES_DOCS = [
-    {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
-    {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
-]
-
-WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-NARRATION = "Writing the token-bucket middleware for /upload"
-
-
-def ws_frame(payload: dict) -> bytes:
-    data = json.dumps(payload).encode()
-    if len(data) < 126:
-        head = bytes([0x81, len(data)])
-    else:
-        head = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
-    return head + data
-
-
-class W2Handler(SimpleHTTPRequestHandler):
-    """SPA + the whole /api/v1 surface the home route reads + /ws, one origin."""
-
-    def log_message(self, *_args):  # keep stdout JSON-clean
-        pass
-
-    def _json(self, status: int, payload) -> None:
-        body = json.dumps(payload).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _ws(self) -> None:
-        """Accept the upgrade, then stream `unitOutputDelta` frames for the live
-        run — `useRuns` gates its first fetch on a connected socket, so the
-        handshake is mandatory, and the narration keeps the headline honest."""
-        key = self.headers.get("Sec-WebSocket-Key", "")
-        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
-        self.wfile.write(
-            ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
-             f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
-        self.wfile.flush()
-        try:
-            while True:
-                self.wfile.write(ws_frame({
-                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
-                    "text": NARRATION + "\n",
-                }))
-                self.wfile.flush()
-                time.sleep(1.0)
-        except OSError:
-            pass
-        self.close_connection = True
-
-    def _api(self, path: str) -> bool:
-        if path == "/api/v1/health":
-            self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
-            return True
-        if path == "/api/v1/runs":
-            with state_lock:
-                runs = RUNS + ([ORPHAN] if state["orphan"] else [])
-            self._json(200, {"runs": runs})
-            return True
-        if path == "/api/v1/projects":
-            self._json(200, {"projects": PROJECTS})
-            return True
-        if path == "/api/v1/repos":
-            self._json(200, {"repos": []})
-            return True
-        parts = path.split("/")
-        # /api/v1/projects/<id>/members
-        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
-            pid = urllib.parse.unquote(parts[4])
-            self._json(200, {"members": [
-                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
-                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
-                for ref in MEMBERS.get(pid, [])
-            ]})
-            return True
-        # /api/v1/projects/<id>/interactive/api/docs — the notes project's registry
-        if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
-            pid = urllib.parse.unquote(path.split("/")[4])
-            self._json(200, NOTES_DOCS if pid == "notes" else [])
-            return True
-        # /api/v1/runs/<id>/gate
-        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
-            rid = urllib.parse.unquote(parts[4])
-            if rid == "r-q3":
-                with state_lock:
-                    age = state["q3_gate_age_ms"]
-                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
-                                 "prompt": "Approve the deck outline?",
-                                 "receivedAt": iso(NOW0 - age)})
-            elif rid == "r-api":
-                # `options: null` = free text ⇒ the COMPLEX gate shape (§7.11).
-                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
-                                 "prompt": "How should the tables move?",
-                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
-            else:
-                self._json(404, {"error": f"no gate cached for {rid}"})
-            return True
-        # /api/v1/runs/<id>/events
-        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
-            rid = urllib.parse.unquote(parts[4])
-            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
-            return True
-        if path.startswith("/api/v1/"):
-            self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
-            return True
-        return False
-
-    def do_GET(self):  # noqa: N802 (stdlib naming)
-        if self.headers.get("Upgrade", "").lower() == "websocket":
-            return self._ws()
-        path = urllib.parse.urlparse(self.path).path
-        if self._api(path):
-            return None
-        if not Path(self.translate_path(self.path)).is_file():
-            self.path = "/index.html"  # client-side routes resolve to the shell
-        return super().do_GET()
-
-    def do_POST(self):  # noqa: N802 (stdlib naming)
-        path = urllib.parse.urlparse(self.path).path
-        if path == "/__fixture":
-            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
-            with state_lock:
-                state.update({k: v for k, v in body.items() if k in state})
-                snapshot = dict(state)
-            return self._json(200, {"ok": True, "state": snapshot})
-        return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
-
-
-httpd = ThreadingHTTPServer(("127.0.0.1", W2_PORT), partial(W2Handler, directory=str(dist)))
-threading.Thread(target=httpd.serve_forever, daemon=True).start()
+# ── 2. The shared W2 fixture server (§4.2 — `uxfix_fixture.py`, one frozen NOW0) ─
+start_server(W2_PORT, dist)
 report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
 
 
 def set_fixture(**kwargs) -> None:
-    req = urllib.request.Request(f"{ORIGIN}/__fixture", method="POST",
-                                 data=json.dumps(kwargs).encode())
-    req.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(req, timeout=10) as res:
-        res.read()
+    fixture_post(ORIGIN, **kwargs)
 
 
 # ── 3. The browser gate ───────────────────────────────────────────────────────

--- a/e2e/uxfix_slice2_test.py
+++ b/e2e/uxfix_slice2_test.py
@@ -4,10 +4,12 @@ uxfix_slice2_test.py — the DES-UXFIX-001 slice-2 gate: card variants, the
 empty-state budget, and the mode-spine quick actions, proven in a real browser
 against the W2 messy-reality fixture (§4.2).
 
-Same rig pattern as uxfix_slice1_test.py (which stays the slice-1 gate): a
-deterministic ThreadingHTTPServer serves the `dist-sameorigin/` build plus every
-endpoint the home route reads, all timestamps computed from one frozen NOW0, the
-live run narrating over the rig's own /ws. No crew daemon is involved anywhere.
+Same rig pattern as uxfix_slice1_test.py (which stays the slice-1 gate): the
+SHARED deterministic fixture server in `uxfix_fixture.py` serves the
+`dist-sameorigin/` build plus every endpoint the home route reads, all
+timestamps computed from one frozen NOW0, the live run narrating over the rig's
+own /ws. No crew daemon is involved anywhere. This rig never flips the fixture
+switches, so it sees the default W2 board (orphan present, 30s q3 gate).
 
 What it asserts (design §4.3, the slice-2 DOM AC):
   1. Every mounted card in band-needs-you carries data-variant="active"; an
@@ -37,26 +39,21 @@ SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4331), SKIP_STUDIO_BUILD.
 Prints a JSON report to stdout; exit 0/1.
 """
 
-import base64
-import hashlib
 import json
 import os
-import subprocess
 import sys
-import threading
-import time
-import urllib.parse
-from functools import partial
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-SHOTS = REPO / "e2e" / "shots" / "uxfix"
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    SHOTS,
+    ensure_build,
+    start_server,
+)
+
 W2_PORT = int(os.environ.get("W2_PORT", "4331"))
 ORIGIN = f"http://127.0.0.1:{W2_PORT}"
-NPM = "npm.cmd" if os.name == "nt" else "npm"
-
-HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -68,208 +65,11 @@ def fail(step: str, why: str) -> None:
 
 
 # ── 1. The same-origin build (shared with the slice-1 rig — same dist dir) ─────
-dist = REPO / "dist-sameorigin"
-if os.environ.get("SKIP_STUDIO_BUILD") == "1":
-    if not (dist / "index.html").is_file():
-        fail("build", f"SKIP_STUDIO_BUILD=1 but {dist}/index.html is missing — "
-             "build it with `npx vite build --outDir dist-sameorigin` (no VITE_API_HOST)")
-elif not (dist / "index.html").is_file():
-    env = dict(os.environ, VITE_API_HOST="")
-    r = subprocess.run(
-        [NPM, "exec", "--", "vite", "build", "--outDir", "dist-sameorigin", "--emptyOutDir"],
-        cwd=REPO, env=env, capture_output=True, text=True, timeout=600,
-    )
-    if r.returncode != 0:
-        fail("build", f"same-origin vite build failed:\n{r.stdout[-2000:]}\n{r.stderr[-2000:]}")
+dist = ensure_build(fail)
 report["steps"]["build"] = {"ok": True, "dist": str(dist)}
 
-# ── 2. The W2 fixture (§4.2), every age from ONE frozen NOW0 ───────────────────
-NOW0 = int(time.time() * 1000)
-SEC, MIN, HOUR, DAY = 1_000, 60_000, 3_600_000, 86_400_000
-
-
-def iso(ms: int) -> str:
-    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ms / 1000)) + f".{ms % 1000:03d}Z"
-
-
-def project(pid: str, name: str, updated_at: int, **extra) -> dict:
-    return {"id": pid, "name": name, "description": None, "status": "active",
-            "scope": f"project:{pid}" if pid != "default" else "",
-            "created_at": updated_at, "updated_at": updated_at, **extra}
-
-
-QUIET_CLONES = [project(f"quiet-{i:02d}", f"quiet-clone-{i:02d}", NOW0 - 3 * DAY - i * 7 * HOUR)
-                for i in range(20)]
-PROJECTS = [
-    project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
-    project("legacy-spike", "legacy-spike", NOW0 - HOUR),
-    project("upload-endpoint", "upload-endpoint", NOW0),
-    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
-    project("api-migration", "api-migration", NOW0 - 2 * MIN),
-    project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
-    project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
-    project("notes", "notes", NOW0 - 2 * DAY, interactiveRoot="/tmp/wi-notes"),
-    project("scratch", "scratch", NOW0),
-] + QUIET_CLONES
-
-MEMBERS = {
-    "legacy-spike": ["r-legacy"],
-    "upload-endpoint": ["r-upload"],
-    "q3-review-deck": ["r-q3"],
-    "api-migration": ["r-api"],
-    "auth-refactor": ["r-auth"],
-    "smoke-tests": ["r-smoke1", "r-smoke2"],
-}
-
-
-def session(rid: str, status: str, problem: str, unit_desc: str) -> dict:
-    return {"session": {
-        "id": rid, "workflow_id": "wf-w2", "problem": problem, "entity_mode": "shared",
-        "collection_scope": None, "clis": ["claude"], "status": status,
-        "human_confirm": "all" if status == "awaiting_human" else "none",
-        "unit_ix": 0, "attempt": 0, "workdir": None, "repo_ref": None,
-        "extra_write_roots": [], "archived_at": None, "archive_note": None,
-    }, "units": [{
-        "id": f"{rid}:u0", "session_id": rid, "ord": 0, "description": unit_desc,
-        "stage": "build", "assigned_cli": None, "assigned_invocation": None,
-        "council_task_ref": None, "routing": None, "denial_reason": None,
-        "phase_ref": None, "conformance_ref": None, "phase_status": None,
-        "collection_scope": None, "status": "pending",
-    }]}
-
-
-RUNS = [
-    session("r-q3", "awaiting_human", "make the Q3 review deck", "author the deck outline"),
-    session("r-api", "awaiting_human", "migrate the auth tables", "plan the migration"),
-    session("r-upload", "executing", "add rate-limiting to the upload endpoint",
-            "add rate-limiting to the upload endpoint"),
-    session("r-auth", "failed", "refactor the auth middleware", "refactor the auth middleware"),
-    session("r-legacy", "failed", "spike the legacy importer", "spike the legacy importer"),
-    session("r-smoke1", "completed", "smoke: login flow", "smoke the login flow"),
-    session("r-smoke2", "completed", "smoke: checkout flow", "smoke the checkout flow"),
-    session("r-orphan", "executing", "stranded work from another client",
-            "stranded work from another client"),
-]
-
-RUN_EVENTS = {
-    "r-legacy": [{"type": "sessionStarted", "session": "r-legacy", "ts": NOW0 - 8 * DAY - MIN},
-                 {"type": "sessionFailed", "session": "r-legacy", "ts": NOW0 - 8 * DAY}],
-    "r-auth": [{"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 13 * MIN},
-               {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 12 * MIN}],
-}
-
-NOTES_DOCS = [
-    {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
-    {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
-]
-
-WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-NARRATION = "Writing the token-bucket middleware for /upload"
-
-
-def ws_frame(payload: dict) -> bytes:
-    data = json.dumps(payload).encode()
-    if len(data) < 126:
-        head = bytes([0x81, len(data)])
-    else:
-        head = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
-    return head + data
-
-
-class W2Handler(SimpleHTTPRequestHandler):
-    """SPA + the whole /api/v1 surface the home route reads + /ws, one origin."""
-
-    def log_message(self, *_args):  # keep stdout JSON-clean
-        pass
-
-    def _json(self, status: int, payload) -> None:
-        body = json.dumps(payload).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _ws(self) -> None:
-        key = self.headers.get("Sec-WebSocket-Key", "")
-        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
-        self.wfile.write(
-            ("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
-             f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n").encode())
-        self.wfile.flush()
-        try:
-            while True:
-                self.wfile.write(ws_frame({
-                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
-                    "text": NARRATION + "\n",
-                }))
-                self.wfile.flush()
-                time.sleep(1.0)
-        except OSError:
-            pass
-        self.close_connection = True
-
-    def _api(self, path: str) -> bool:
-        if path == "/api/v1/health":
-            self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
-            return True
-        if path == "/api/v1/runs":
-            self._json(200, {"runs": RUNS})
-            return True
-        if path == "/api/v1/projects":
-            self._json(200, {"projects": PROJECTS})
-            return True
-        if path == "/api/v1/repos":
-            self._json(200, {"repos": []})
-            return True
-        parts = path.split("/")
-        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
-            pid = urllib.parse.unquote(parts[4])
-            self._json(200, {"members": [
-                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
-                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
-                for ref in MEMBERS.get(pid, [])
-            ]})
-            return True
-        if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
-            pid = urllib.parse.unquote(path.split("/")[4])
-            self._json(200, NOTES_DOCS if pid == "notes" else [])
-            return True
-        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
-            rid = urllib.parse.unquote(parts[4])
-            if rid == "r-q3":
-                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
-                                 "prompt": "Approve the deck outline?",
-                                 "receivedAt": iso(NOW0 - 30 * SEC)})
-            elif rid == "r-api":
-                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
-                                 "prompt": "How should the tables move?",
-                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
-            else:
-                self._json(404, {"error": f"no gate cached for {rid}"})
-            return True
-        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
-            rid = urllib.parse.unquote(parts[4])
-            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
-            return True
-        if path.startswith("/api/v1/"):
-            self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
-            return True
-        return False
-
-    def do_GET(self):  # noqa: N802 (stdlib naming)
-        if self.headers.get("Upgrade", "").lower() == "websocket":
-            return self._ws()
-        path = urllib.parse.urlparse(self.path).path
-        if self._api(path):
-            return None
-        if not Path(self.translate_path(self.path)).is_file():
-            self.path = "/index.html"  # client-side routes resolve to the shell
-        return super().do_GET()
-
-
-httpd = ThreadingHTTPServer(("127.0.0.1", W2_PORT), partial(W2Handler, directory=str(dist)))
-threading.Thread(target=httpd.serve_forever, daemon=True).start()
+# ── 2. The shared W2 fixture server (§4.2 — `uxfix_fixture.py`, one frozen NOW0) ─
+start_server(W2_PORT, dist)
 report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
 
 # ── 3. The browser gate ───────────────────────────────────────────────────────

--- a/e2e/uxfix_slice2_test.py
+++ b/e2e/uxfix_slice2_test.py
@@ -142,9 +142,12 @@ with sync_playwright() as p:
         """() => ['auth-refactor', 'q3-review-deck'].every(id => {
                const c = document.querySelector(`[data-testid="project-card"][data-project-id="${id}"]`);
                return !!c && c.querySelectorAll('[data-testid="doc-tile"]').length === 0; })""")
-    # The gate chip is live on the q3 card (§2.1.5 weight — it is why the card leads).
+    # The gate chip is live on the q3 card (§2.1.5 weight — it is why the card
+    # leads). Card-scoped: since slice 3 the RAIL also carries data-project-id
+    # rows (the same axis as the board), so the bare attribute is ambiguous.
     gate_chip_ok = page.evaluate(
-        """() => { const c = document.querySelector('[data-project-id="q3-review-deck"]');
+        """() => { const c = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="q3-review-deck"]');
                    return !!c && !!c.querySelector('[data-testid="gate-approve-r-q3"]')
                        && !!c.querySelector('[data-testid="gate-reject-r-q3"]'); }""")
     # The header pill names the signal in user words (V3: 'working', not 'distributing').

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+uxfix_slice3_test.py — the DES-UXFIX-001 slice-3 gate: the rail consolidated to
+TWO taxonomies (§2.3, F4), proven in a real browser against the W2
+messy-reality fixture (§4.2).
+
+Same rig pattern as the slice-1/2 gates: the SHARED deterministic fixture
+server in `uxfix_fixture.py` serves the `dist-sameorigin/` build plus every
+endpoint the home route reads, all timestamps computed from one frozen NOW0,
+the live run narrating over the rig's own /ws. No crew daemon is involved
+anywhere. This rig never flips the fixture switches, so it sees the default W2
+board (orphan present, 30s q3 gate).
+
+What it asserts (design §4.3, the slice-3 DOM AC):
+  1. The rail contains data-testid="rail-section-projects" AND
+     "rail-section-repos", and NO rail-section-chats / rail-section-work; the
+     retired section labels and their empty strings ("Chats", "Work",
+     "No chats yet", "No work yet") appear nowhere in the rail's text, and the
+     old near-synonym verbs ("Do Work", "New Chat") appear nowhere on the page.
+  2. Projects lists ATTENTION-ORDERED: the rail's rows settle to the same
+     decayed-score order as the board's NEEDS YOU band — q3-review-deck (gate
+     30s) → api-migration (gate 2m) → auth-refactor (failed 12m) →
+     upload-endpoint (live) — capped at SECTION_MAX (4 of the fixture's 28)
+     with a "view all". legacy-spike (8-day failure, the R3 trap) is NOT among
+     them: the rail agrees with the board, read from the same DOM.
+  3. The creation verbs speak the mode spine (V9/V10): Build / Chat /
+     Repository inside data-testid="rail-actions".
+  4. /runs remains reachable via data-testid="rail-all-runs": a real <a
+     href="/runs"> whose click lands the SPA on /runs (the flat-list escape
+     hatch), with the board unmounted.
+  5. A rail project row enters the project shell, Chat mode default (§1.5):
+     clicking q3-review-deck lands on /p/q3-review-deck/chat.
+
+Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
+data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
+  uxfix-3-rail.png   the consolidated rail beside the settled W2 board
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4332), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    SHOTS,
+    ensure_build,
+    start_server,
+)
+
+W2_PORT = int(os.environ.get("W2_PORT", "4332"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared with the slice-1/2 rigs — same dist dir) ──
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (§4.2 — `uxfix_fixture.py`, one frozen NOW0) ─
+start_server(W2_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ───────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+RAIL_ROWS = """() => Array.from(document.querySelectorAll(
+    '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
+    .map(r => r.dataset.projectId)"""
+# Retired vocabulary that must not survive inside the rail (AC 1). "Chats" and
+# "Work" are checked against the RAIL's text only — the board legitimately
+# renders run problems containing the word "work" in prose.
+RAIL_BANNED = ["Chats", "Work", "No chats yet", "No work yet"]
+PAGE_BANNED = ["Do Work", "New Chat", "New Repository"]
+
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    # §4.0's capture contract, verbatim: 1440x900, device_scale_factor=1.
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="left-rail"]').wait_for(timeout=30000)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── AC 2: settle on the DECAYED verdict — the rail's rows reach the same
+    # order as the board's NEEDS YOU band (legacy-spike demoted by its 8-day
+    # durable-log tail, the gate leading regardless). Wait on BOTH surfaces.
+    rail_order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
+               .map(r => r.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    board_order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    rail_rows = page.evaluate(RAIL_ROWS)
+    # The rail and the board AGREE (§2.3: "the same axis as the board").
+    rail_matches_board = page.evaluate(
+        """() => { const rail = Array.from(document.querySelectorAll(
+                     '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
+                     .map(r => r.dataset.projectId);
+                   const board = Array.from(document.querySelectorAll(
+                     '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+                     .map(c => c.dataset.projectId);
+                   return JSON.stringify(rail) === JSON.stringify(board); }""")
+    capped_ok = len(rail_rows) == 4 and "legacy-spike" not in rail_rows
+    view_all_ok = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+              '[data-testid="rail-section-projects"] button'))
+              .some(b => (b.textContent ?? '').trim() === 'view all')""")
+
+    # ── AC 1: two taxonomies, and only two ─────────────────────────────────────
+    sections_ok = page.evaluate(
+        """() => !!document.querySelector('[data-testid="rail-section-projects"]')
+              && !!document.querySelector('[data-testid="rail-section-repos"]')
+              && !document.querySelector('[data-testid="rail-section-chats"]')
+              && !document.querySelector('[data-testid="rail-section-work"]')""")
+    rail_text = page.evaluate(
+        """() => document.querySelector('[data-testid="left-rail"]').innerText""")
+    rail_banned_hits = [s for s in RAIL_BANNED if s in rail_text]
+    body_text = page.evaluate("() => document.body.innerText")
+    page_banned_hits = [s for s in PAGE_BANNED if s in body_text]
+
+    # ── AC 3: the creation verbs are the mode spine's words ────────────────────
+    verbs_ok = page.evaluate(
+        """() => { const labels = Array.from(document.querySelectorAll(
+                     '[data-testid="rail-actions"] button'))
+                     .map(b => b.getAttribute('aria-label'));
+                   return JSON.stringify(labels)
+                       === JSON.stringify(['Build', 'Chat', 'Repository']); }""")
+
+    # ── Capture: the consolidated rail beside the settled W2 board (§4.0) ──────
+    page.locator('[data-testid="rail-all-runs"]').wait_for(timeout=10000)
+    page.locator('[data-testid="left-rail"]').screenshot(path=str(SHOTS / "uxfix-3-rail.png"))
+
+    # ── AC 4: the ONE escape hatch — a real link that lands on /runs ───────────
+    hatch_href = page.evaluate(
+        """() => document.querySelector('[data-testid="rail-all-runs"]')?.getAttribute('href')""")
+    page.locator('[data-testid="rail-all-runs"]').click()
+    hatch_ok = settled(
+        """() => window.location.pathname === '/runs'
+              && !document.querySelector('[data-testid="project-board"]')""")
+
+    # ── AC 5: a rail project row enters the shell, Chat mode default (§1.5) ────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').wait_for(timeout=30000)
+    page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').click()
+    shell_ok = settled("""() => window.location.pathname === '/p/q3-review-deck/chat'""")
+
+    ctx.close()
+    browser.close()
+
+report["steps"]["slice3_rail"] = {
+    "ok": all([
+        rail_order_ok, board_order_ok, rail_matches_board, capped_ok, view_all_ok,
+        sections_ok, not rail_banned_hits, not page_banned_hits, verbs_ok,
+        hatch_href == "/runs", hatch_ok, shell_ok,
+    ]),
+    "rail_projects_order": rail_rows,
+    "expected_order": EXPECTED_ORDER,
+    "rail_order_ok": rail_order_ok,
+    "board_order_ok": board_order_ok,
+    "rail_matches_board_needs_you": rail_matches_board,
+    "capped_at_section_max_no_stale": capped_ok,
+    "view_all_present": view_all_ok,
+    "two_taxonomies_no_chats_no_work": sections_ok,
+    "rail_banned_strings_found": rail_banned_hits,
+    "page_banned_strings_found": page_banned_hits,
+    "creation_verbs_mode_spine": verbs_ok,
+    "all_runs_href": hatch_href,
+    "all_runs_lands_on_flat_list": hatch_ok,
+    "project_row_enters_shell_chat_default": shell_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(SHOTS / "uxfix-3-rail.png")],
+}
+if not report["steps"]["slice3_rail"]["ok"]:
+    fail("slice3_verdict", "slice-3 rail assertions did not all hold — see slice3_rail")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -426,12 +426,7 @@ export function App(): React.ReactElement {
 
   return (
     <div className="flex h-screen overflow-hidden bg-wk-canvas">
-      <LeftSidebar
-        runs={runs}
-        selectedRunId={runId}
-        onSelectRun={selectRun}
-        navigate={navigate}
-      />
+      <LeftSidebar runs={runs} navigate={navigate} />
 
       <div className="flex flex-1 overflow-hidden">
         {renderCenter()}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -73,12 +73,14 @@ function IconSearch(): React.ReactElement {
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
-/** One creation verb: a faint "+" (create), the spine glyph, the mode's own word.
- *  `hint` (the MODE_SPECS sublabel) teaches what the verb produces, on hover. */
+/** One creation verb: a faint "+" (create, unless the glyph already is one),
+ *  the spine glyph, the mode's own word. `hint` (the MODE_SPECS sublabel)
+ *  teaches what the verb produces, on hover. */
 function ActionLink({
   glyph,
   label,
   hint,
+  plus,
   testId,
   onClick,
   collapsed,
@@ -86,6 +88,7 @@ function ActionLink({
   glyph: React.ReactNode;
   label: string;
   hint?: string;
+  plus?: boolean;
   testId?: string;
   onClick: () => void;
   collapsed: boolean;
@@ -102,7 +105,7 @@ function ActionLink({
       }`}
       style={{ color: S.accent, background: 'transparent' }}
     >
-      {!collapsed && <span aria-hidden style={{ color: S.faint, fontWeight: 400 }}>+</span>}
+      {plus === true && !collapsed && <span aria-hidden style={{ color: S.faint, fontWeight: 400 }}>+</span>}
       <span aria-hidden>{glyph}</span>
       {!collapsed && <span>{label}</span>}
     </button>
@@ -340,6 +343,7 @@ export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
 
   return (
     <div
+      data-testid="left-rail"
       className={`flex flex-col shrink-0 transition-all duration-200 ${isExpanded ? 'w-[280px]' : 'w-14'}`}
       style={{ background: S.bg, borderRight: `1px solid ${S.border}` }}
       onMouseEnter={() => { if (collapsed) setHovered(true); }}
@@ -390,8 +394,8 @@ export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
         data-testid="rail-actions"
         className={`flex ${!isExpanded ? 'flex-col px-2 items-center gap-2 mt-1' : 'flex-wrap items-center px-4 pt-1 pb-1 gap-x-3 gap-y-0.5'}`}
       >
-        <ActionLink glyph={MODE_SPECS.build.glyph} label="Build" hint={MODE_SPECS.build.sublabel} testId="new-run" onClick={() => navigate('/runs/new')} collapsed={!isExpanded} />
-        <ActionLink glyph={MODE_SPECS.chat.glyph} label="Chat" hint={MODE_SPECS.chat.sublabel} onClick={() => navigate('/chat/new')} collapsed={!isExpanded} />
+        <ActionLink glyph={MODE_SPECS.build.glyph} label="Build" hint={MODE_SPECS.build.sublabel} plus testId="new-run" onClick={() => navigate('/runs/new')} collapsed={!isExpanded} />
+        <ActionLink glyph={MODE_SPECS.chat.glyph} label="Chat" hint={MODE_SPECS.chat.sublabel} plus onClick={() => navigate('/chat/new')} collapsed={!isExpanded} />
         <ActionLink glyph={<IconPlus />} label="Repository" onClick={() => navigate('/repos/new')} collapsed={!isExpanded} />
       </div>
 

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,16 +1,37 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
+import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
+import { lastMode, modePath } from '../hooks/useRoute.js';
 import { useConnectionStore } from '../store/connection.js';
+import { MODE_SPECS } from './ModeSwitcher.js';
 import { NotificationBell } from './NotificationBell.js';
-import { RunLink } from './RunLink.js';
+import { ATTENTION_DOT } from './ProjectCard.js';
 import { SettingsMenu } from './SettingsMenu.js';
 import { WickedLogo } from './WickedLogo.js';
 
+/**
+ * The rail, consolidated to TWO taxonomies (DES-UXFIX-001 §2.3, slice 3 — F4):
+ *
+ *   1. PROJECTS — the same axis as the board, attention-ordered (§2.1.3) off the
+ *      SAME model the board reads (`useBoardModel`), so the rail and the board
+ *      agree on which project needs you first. Clicking one enters its shell
+ *      (last-used mode, Chat default — §1.5).
+ *   2. REPOSITORIES — the one cross-project axis a coder genuinely browses by.
+ *      Unchanged in behaviour; keeps its search.
+ *
+ * Chats and Work are GONE as rail sections: they were one object (a run) sliced
+ * by an internal field (`workflow_id`, V5) into two visually identical truncated
+ * lists. A run lives under its project now; the flat cross-project lists survive
+ * only behind the single "All runs ›" escape hatch (§1.5).
+ *
+ * The creation verbs compress to one compact row in the mode spine's own words
+ * (V9/V10: Build / Chat — the switcher's glyphs, not "Do Work" vs "New Chat")
+ * plus Repository.
+ */
+
 interface Props {
   runs: SessionView[];
-  selectedRunId: string | null;
-  onSelectRun: (id: string) => void;
   navigate: (path: string) => void;
 }
 
@@ -28,24 +49,10 @@ const S = {
 };
 
 const SECTION_MAX = 4;
+/** Collapsed rail: at most this many project dots — a glance strip, not a list. */
+const COLLAPSED_MAX = 12;
 
 // ── Inline SVG icons ──────────────────────────────────────────────────────────
-
-function IconDoWork(): React.ReactElement {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-      <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
-    </svg>
-  );
-}
-
-function IconChat(): React.ReactElement {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-      <path d="M20 2H4C2.9 2 2 2.9 2 4v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z" />
-    </svg>
-  );
-}
 
 function IconPlus(): React.ReactElement {
   return (
@@ -66,15 +73,19 @@ function IconSearch(): React.ReactElement {
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
+/** One creation verb: a faint "+" (create), the spine glyph, the mode's own word.
+ *  `hint` (the MODE_SPECS sublabel) teaches what the verb produces, on hover. */
 function ActionLink({
-  icon,
+  glyph,
   label,
+  hint,
   testId,
   onClick,
   collapsed,
 }: {
-  icon: React.ReactElement;
+  glyph: React.ReactNode;
   label: string;
+  hint?: string;
   testId?: string;
   onClick: () => void;
   collapsed: boolean;
@@ -85,13 +96,14 @@ function ActionLink({
       data-testid={testId}
       onClick={onClick}
       aria-label={label}
-      title={label}
-      className={`flex items-center gap-2 rounded text-sm font-semibold transition-opacity hover:opacity-70 ${
-        collapsed ? 'w-9 h-9 justify-center mx-auto' : 'w-full px-2 py-1.5'
+      title={hint !== undefined ? `${label} — ${hint}` : label}
+      className={`flex items-center gap-1.5 rounded text-sm font-semibold transition-opacity hover:opacity-70 ${
+        collapsed ? 'w-9 h-9 justify-center mx-auto' : 'px-1 py-1'
       }`}
       style={{ color: S.accent, background: 'transparent' }}
     >
-      {icon}
+      {!collapsed && <span aria-hidden style={{ color: S.faint, fontWeight: 400 }}>+</span>}
+      <span aria-hidden>{glyph}</span>
       {!collapsed && <span>{label}</span>}
     </button>
   );
@@ -254,15 +266,50 @@ function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; de
   );
 }
 
+/** One rail project row: the board's attention dot + the name. The row is the
+ *  board card's one-glance summary, never a second place that explains it. */
+function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }): React.ReactElement {
+  const { project, attention, score, band } = item;
+  return (
+    <button
+      type="button"
+      data-testid="rail-project"
+      data-project-id={project.id}
+      data-band={band}
+      data-score={score.toFixed(2)}
+      onClick={onOpen}
+      title={project.name}
+      className="w-full text-left px-3 py-1.5 rounded-md transition-colors"
+      style={{ background: 'transparent' }}
+      onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: ATTENTION_DOT[attention] }}
+        />
+        <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+          {project.name}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Props): React.ReactElement {
+export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [repos, setRepos] = useState<RepoEntry[]>([]);
+  // The board's own model, attention-ordered (§2.1.3) — the rail's Projects list
+  // is the board's first column, not a fourth taxonomy of its own.
+  const { items, loading, error } = useBoardModel(runs);
 
   const isExpanded = !collapsed || hovered;
 
@@ -283,20 +330,13 @@ export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Prop
     return () => { disposed = true; clearInterval(id); };
   }, []);
 
-  const chats: SessionView[] = [];
-  const work: SessionView[] = [];
-  for (const v of runs) {
-    if (!v.session.workflow_id || v.session.workflow_id === 'chat') {
-      chats.push(v);
-    } else {
-      work.push(v);
-    }
-  }
-
   const q = searchQuery.trim().toLowerCase();
-  const filteredRepos  = q ? repos.filter(r => r.name.toLowerCase().includes(q)) : repos;
-  const filteredChats  = q ? chats.filter(v => v.session.problem.toLowerCase().includes(q)) : chats;
-  const filteredWork   = q ? work.filter(v  => v.session.problem.toLowerCase().includes(q)) : work;
+  const filteredRepos = q ? repos.filter(r => r.name.toLowerCase().includes(q)) : repos;
+
+  /** Enter a project's shell: last-used mode, Chat default (§1.5, §2.3). */
+  const openProject = (projectId: string): void => {
+    navigate(modePath(projectId, lastMode(projectId)));
+  };
 
   return (
     <div
@@ -343,25 +383,30 @@ export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Prop
         <NotificationBell navigate={navigate} collapsed={!isExpanded} />
       </div>
 
-      {/* Action links */}
-      <div className={`flex flex-col ${!isExpanded ? 'px-2 items-center gap-2 mt-1' : 'px-5 pt-1 pb-1 gap-1'}`}>
-        <ActionLink icon={<IconDoWork />} label="Do Work"        testId="new-run" onClick={() => navigate('/runs/new')}  collapsed={!isExpanded} />
-        <ActionLink icon={<IconChat />}   label="New Chat"                         onClick={() => navigate('/chat/new')} collapsed={!isExpanded} />
-        <ActionLink icon={<IconPlus />}   label="New Repository"                   onClick={() => navigate('/repos/new')} collapsed={!isExpanded} />
+      {/* Creation verbs — ONE compact row in the mode spine's words (§2.3, V9/V10):
+          Build and Chat are the switcher's verbs with the switcher's glyphs, so
+          they are differentiable (F2); Repository keeps its plus. */}
+      <div
+        data-testid="rail-actions"
+        className={`flex ${!isExpanded ? 'flex-col px-2 items-center gap-2 mt-1' : 'flex-wrap items-center px-4 pt-1 pb-1 gap-x-3 gap-y-0.5'}`}
+      >
+        <ActionLink glyph={MODE_SPECS.build.glyph} label="Build" hint={MODE_SPECS.build.sublabel} testId="new-run" onClick={() => navigate('/runs/new')} collapsed={!isExpanded} />
+        <ActionLink glyph={MODE_SPECS.chat.glyph} label="Chat" hint={MODE_SPECS.chat.sublabel} onClick={() => navigate('/chat/new')} collapsed={!isExpanded} />
+        <ActionLink glyph={<IconPlus />} label="Repository" onClick={() => navigate('/repos/new')} collapsed={!isExpanded} />
       </div>
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto flex flex-col min-h-0 mt-2">
         {isExpanded ? (
           <>
-            {/* Search input (shared across all sections) */}
+            {/* Search input (repositories) */}
             {searchOpen && (
               <div className="px-4 pb-2">
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={e => setSearchQuery(e.target.value)}
-                  placeholder="Search…"
+                  placeholder="Search repositories…"
                   autoFocus
                   className="w-full bg-transparent text-xs font-mono outline-none border-b"
                   style={{ color: S.ink, borderColor: S.faint, caretColor: S.accent }}
@@ -369,89 +414,102 @@ export function LeftSidebar({ runs, selectedRunId, onSelectRun, navigate }: Prop
               </div>
             )}
 
-            {/* ── Projects section ── */}
-            <SectionLabel
-              label="Projects"
-              asLink
-              onClick={() => navigate('/projects')}
-            />
+            {/* ── Taxonomy 1: Projects — the board's axis, attention-ordered ── */}
+            <div data-testid="rail-section-projects">
+              <SectionLabel
+                label="Projects"
+                asLink
+                onClick={() => navigate('/projects')}
+              />
+              {/* Loading/error render nothing here — the board owns those states
+                  (§3.1); the rail never narrates absence it cannot yet know. */}
+              {!loading && error === null && (
+                <SectionList empty="No projects yet" viewAllPath="/projects" navigate={navigate}>
+                  {items.slice(0, SECTION_MAX).map(item => (
+                    <ProjectRow key={item.project.id} item={item} onOpen={() => openProject(item.project.id)} />
+                  ))}
+                </SectionList>
+              )}
+              {items.length > SECTION_MAX && (
+                <ViewAll onClick={() => navigate('/projects')} />
+              )}
+            </div>
 
-            {/* ── Repositories section ── */}
-            <SectionLabel
-              label="Repositories"
-              withSearch
-              searchActive={searchOpen}
-              onToggleSearch={() => { setSearchOpen(v => !v); if (searchOpen) setSearchQuery(''); }}
-            />
-            <SectionList
-              empty="No repositories yet"
-              viewAllPath="/repos"
-              navigate={navigate}
-            >
-              {filteredRepos.slice(0, SECTION_MAX).map(repo => (
-                <button
-                  key={repo.id}
-                  type="button"
-                  onClick={() => navigate(`/repo-detail/${encodeURIComponent(repo.id)}`)}
-                  title={repo.root_path}
-                  className="w-full text-left px-3 py-2 rounded-md transition-colors"
-                  style={{ background: 'transparent' }}
-                  onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
-                  onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
-                      {repo.name}
-                    </span>
-                  </div>
-                  <p className="text-[10px] mt-0.5 font-mono truncate" style={{ color: 'rgba(230,237,243,0.3)' }}>
-                    {repo.root_path}
-                  </p>
-                </button>
-              ))}
-            </SectionList>
-            {filteredRepos.length > SECTION_MAX && (
-              <ViewAll onClick={() => navigate('/repos')} />
-            )}
+            {/* ── Taxonomy 2: Repositories — the cross-project axis, with search ── */}
+            <div data-testid="rail-section-repos">
+              <SectionLabel
+                label="Repositories"
+                withSearch
+                searchActive={searchOpen}
+                onToggleSearch={() => { setSearchOpen(v => !v); if (searchOpen) setSearchQuery(''); }}
+              />
+              <SectionList
+                empty="No repositories yet"
+                viewAllPath="/repos"
+                navigate={navigate}
+              >
+                {filteredRepos.slice(0, SECTION_MAX).map(repo => (
+                  <button
+                    key={repo.id}
+                    type="button"
+                    onClick={() => navigate(`/repo-detail/${encodeURIComponent(repo.id)}`)}
+                    title={repo.root_path}
+                    className="w-full text-left px-3 py-2 rounded-md transition-colors"
+                    style={{ background: 'transparent' }}
+                    onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+                        {repo.name}
+                      </span>
+                    </div>
+                    <p className="text-[10px] mt-0.5 font-mono truncate" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                      {repo.root_path}
+                    </p>
+                  </button>
+                ))}
+              </SectionList>
+              {filteredRepos.length > SECTION_MAX && (
+                <ViewAll onClick={() => navigate('/repos')} />
+              )}
+            </div>
 
-            {/* ── Chats section ── */}
-            <SectionLabel label="Chats" />
-            <SectionList empty="No chats yet" viewAllPath="/chats" navigate={navigate}>
-              {filteredChats.slice(0, SECTION_MAX).map(v => (
-                <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelectRun} />
-              ))}
-            </SectionList>
-            {filteredChats.length > SECTION_MAX && (
-              <ViewAll onClick={() => navigate('/chats')} />
-            )}
-
-            {/* ── Work section ── */}
-            <SectionLabel label="Work" />
-            <SectionList empty="No work yet" viewAllPath="/work" navigate={navigate}>
-              {filteredWork.slice(0, SECTION_MAX).map(v => (
-                <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelectRun} />
-              ))}
-            </SectionList>
-            {filteredWork.length > SECTION_MAX && (
-              <ViewAll onClick={() => navigate('/work')} />
-            )}
+            {/* ── The ONE escape hatch to the flat cross-project run lists (§2.3):
+                   Chats and Work are not rail taxonomies any more — a run lives
+                   under its project, and the power-user lists live behind this. ── */}
+            <div className="px-3 pt-3 pb-1">
+              <a
+                href="/runs"
+                data-testid="rail-all-runs"
+                onClick={(e) => { e.preventDefault(); navigate('/runs'); }}
+                className="text-[11px] font-mono transition-opacity hover:opacity-80"
+                style={{ color: S.link, textDecoration: 'none' }}
+              >
+                All runs ›
+              </a>
+            </div>
           </>
         ) : (
-          /* Not expanded: dots for all runs */
+          /* Not expanded: attention dots for the top projects — same axis, same
+             order, same colours as the expanded list and the board. */
           <div className="px-2 flex flex-col gap-0.5 mt-1">
-            {runs.map(v => (
+            {items.slice(0, COLLAPSED_MAX).map(item => (
               <button
-                key={v.session.id}
+                key={item.project.id}
                 type="button"
-                onClick={() => onSelectRun(v.session.id)}
-                aria-label={v.session.problem}
-                title={v.session.problem}
+                onClick={() => openProject(item.project.id)}
+                aria-label={item.project.name}
+                title={item.project.name}
                 className="w-9 h-9 mx-auto flex items-center justify-center rounded-md transition-colors"
-                style={{ background: selectedRunId === v.session.id ? S.active : 'transparent' }}
-                onMouseEnter={e => { if (selectedRunId !== v.session.id) e.currentTarget.style.background = S.hover; }}
-                onMouseLeave={e => { if (selectedRunId !== v.session.id) e.currentTarget.style.background = 'transparent'; }}
+                style={{ background: 'transparent' }}
+                onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
               >
-                <CollapsedDot status={v.session.status} />
+                <span
+                  className={`w-2.5 h-2.5 rounded-full ${item.attention === 'gate' || item.attention === 'running' ? 'animate-pulse' : ''}`}
+                  style={{ background: ATTENTION_DOT[item.attention] }}
+                />
               </button>
             ))}
           </div>
@@ -530,25 +588,5 @@ function ViewAll({ onClick }: { onClick: () => void }): React.ReactElement {
     >
       view all
     </button>
-  );
-}
-
-function CollapsedDot({ status }: { status: string }): React.ReactElement {
-  const color =
-    status === 'completed'      ? '#3fb950' :
-    status === 'failed'         ? '#f85149' :
-    status === 'cancelled'      ? 'rgba(230,237,243,0.25)' :
-    status === 'awaiting_human' ? '#ffda19' :
-    '#79c0ff';
-  const pulse =
-    status === 'awaiting_human' ||
-    status === 'executing' ||
-    status === 'distributing' ||
-    status === 'planning';
-  return (
-    <span
-      className={`w-2.5 h-2.5 rounded-full ${pulse ? 'animate-pulse' : ''}`}
-      style={{ background: color }}
-    />
   );
 }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -64,7 +64,9 @@ const S = {
   accent: '#ffda19',
 };
 
-const DOT: Record<Attention, string> = {
+/** Attention → dot colour — shared with the rail (slice 3), so the same signal
+ *  reads as the same colour on the board card and the sidebar's project list. */
+export const ATTENTION_DOT: Record<Attention, string> = {
   gate:    '#ffda19',
   failing: '#f85149',
   running: '#79c0ff',
@@ -274,7 +276,7 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
     <span
       data-testid="project-status-dot"
       aria-hidden
-      style={{ width: '8px', height: '8px', borderRadius: '50%', background: DOT[attention], flexShrink: 0 }}
+      style={{ width: '8px', height: '8px', borderRadius: '50%', background: ATTENTION_DOT[attention], flexShrink: 0 }}
     />
   );
   const name = <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>;
@@ -339,7 +341,7 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             data-kind={signal.kind}
             style={{
               marginLeft: 'auto', flexShrink: 0, fontSize: '10px', fontWeight: 700,
-              letterSpacing: '0.06em', textTransform: 'uppercase', color: DOT[attention],
+              letterSpacing: '0.06em', textTransform: 'uppercase', color: ATTENTION_DOT[attention],
               border: `1px solid ${S.border}`, borderRadius: '999px', padding: '1px 8px',
             }}
           >

--- a/src/components/RunLink.tsx
+++ b/src/components/RunLink.tsx
@@ -1,4 +1,5 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
+import { MODE_SPECS } from './ModeSwitcher.js';
 
 interface Props {
   view: SessionView;
@@ -27,6 +28,11 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
   const unitCount = units.length;
   const pulse = session.status === 'awaiting_human' || session.status === 'executing'
     || session.status === 'distributing' || session.status === 'planning';
+  // A run item names its MODE (DES-UXFIX-001 §1 spine, slice 3 — the F4 fix for
+  // "visually identical truncated work items"): `workflow_id` stays internal
+  // (V5) — what the user reads is the spine word + glyph, Chat or Build.
+  const kind = !session.workflow_id || session.workflow_id === 'chat' ? 'chat' : 'build';
+  const spec = MODE_SPECS[kind];
 
   return (
     <button
@@ -34,12 +40,16 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
       data-testid="run-link"
       data-run-id={session.id}
       data-status={session.status}
+      data-kind={kind}
       onClick={() => onSelect(session.id)}
       className={`w-full text-left px-3 py-2 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 ${
         isActive ? 'bg-black/35' : 'bg-transparent hover:bg-black/20 focus-visible:bg-black/20'
       }`}
     >
       <div className="flex items-center gap-2">
+        <span aria-hidden className="shrink-0 text-[11px]" title={spec.label}>
+          {spec.glyph}
+        </span>
         <span
           className="flex-1 truncate text-xs leading-tight font-mono"
           style={{ color: isActive ? '#e6edf3' : 'rgba(230,237,243,0.7)' }}
@@ -53,7 +63,7 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
         />
       </div>
       <p className="text-[10px] mt-0.5 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
-        {unitCount} task{unitCount === 1 ? '' : 's'} · {session.id.slice(0, 8)}
+        {spec.label} · {unitCount} task{unitCount === 1 ? '' : 's'} · {session.id.slice(0, 8)}
       </p>
     </button>
   );

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import { makeView } from './factories.js';
+
+/**
+ * The rail consolidated to TWO taxonomies (DES-UXFIX-001 §2.3, slice-3 DOM AC):
+ * Projects (attention-ordered, the board's own axis) and Repositories. The
+ * Chats/Work sections are gone; the flat lists survive behind ONE "All runs ›"
+ * escape hatch; the creation verbs speak the mode spine (Build / Chat), not
+ * "Do Work" / "New Chat" (F2's second occurrence, V9/V10).
+ *
+ * The board model is mocked: the rail's contract is "render what the model
+ * ordered, verbatim" — the ordering arithmetic itself is pinned in
+ * boardAttention.test.ts / boardModel.test.ts.
+ */
+
+let boardItems: BoardProject[] = [];
+
+vi.mock('../src/hooks/useBoardModel.js', () => ({
+  useBoardModel: () => ({ items: boardItems, unfiled: [], loading: false, error: null }),
+}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ status: 'ok', version: '0.2.0', ping: 'pong' }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+}));
+
+const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+const { RunLink } = await import('../src/components/RunLink.js');
+
+function bp(id: string, attention: BoardProject['attention'], score: number): BoardProject {
+  return {
+    project: {
+      id, name: id, description: null, status: 'active',
+      scope: `project:${id}`, created_at: 1, updated_at: 1,
+    },
+    repo: null, runs: [], docs: [], attention, score,
+    band: score >= 20 ? 'needs-you' : 'quiet', signal: null,
+  };
+}
+
+/** The W2 top of the board, already model-ordered, plus quiet tail. */
+const W2_ORDERED = [
+  bp('q3-review-deck', 'gate', 100),
+  bp('api-migration', 'gate', 100),
+  bp('auth-refactor', 'failing', 67),
+  bp('upload-endpoint', 'running', 40),
+  bp('notes', 'drafts', 12),
+  bp('smoke-tests', 'quiet', 0),
+];
+
+beforeEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  boardItems = W2_ORDERED;
+});
+
+describe('the rail: two taxonomies (§2.3)', () => {
+  it('carries Projects and Repositories — and NO Chats/Work sections', async () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    expect(screen.getByTestId('rail-section-projects')).toBeInTheDocument();
+    expect(screen.getByTestId('rail-section-repos')).toBeInTheDocument();
+    expect(screen.queryByTestId('rail-section-chats')).toBeNull();
+    expect(screen.queryByTestId('rail-section-work')).toBeNull();
+    // The old section labels are gone from the surface entirely.
+    expect(screen.queryByText('Chats')).toBeNull();
+    expect(screen.queryByText('Work')).toBeNull();
+    expect(screen.queryByText('No chats yet')).toBeNull();
+    expect(screen.queryByText('No work yet')).toBeNull();
+  });
+
+  it('lists projects in the model\'s attention order, capped with "view all"', async () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const rows = within(screen.getByTestId('rail-section-projects')).getAllByTestId('rail-project');
+    expect(rows.map((r) => r.dataset.projectId)).toEqual([
+      'q3-review-deck', 'api-migration', 'auth-refactor', 'upload-endpoint',
+    ]);
+    expect(screen.getByText('view all')).toBeInTheDocument();
+  });
+
+  it('a project row enters the shell — Chat mode default (§1.5)', async () => {
+    const navigate = vi.fn();
+    render(<LeftSidebar runs={[]} navigate={navigate} />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    fireEvent.click(screen.getAllByTestId('rail-project')[0]!);
+    expect(navigate).toHaveBeenCalledWith('/p/q3-review-deck/chat');
+  });
+
+  it('keeps /runs reachable through the ONE escape hatch', async () => {
+    const navigate = vi.fn();
+    render(<LeftSidebar runs={[]} navigate={navigate} />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const hatch = screen.getByTestId('rail-all-runs');
+    expect(hatch).toHaveAttribute('href', '/runs');
+    fireEvent.click(hatch);
+    expect(navigate).toHaveBeenCalledWith('/runs');
+  });
+
+  it('speaks the mode spine for creation: Build / Chat / Repository, never the old synonyms', async () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const actions = within(screen.getByTestId('rail-actions'));
+    expect(actions.getByRole('button', { name: 'Build' })).toBeInTheDocument();
+    expect(actions.getByRole('button', { name: 'Chat' })).toBeInTheDocument();
+    expect(actions.getByRole('button', { name: 'Repository' })).toBeInTheDocument();
+    expect(screen.queryByText('Do Work')).toBeNull();
+    expect(screen.queryByText('New Chat')).toBeNull();
+    expect(screen.queryByText('New Repository')).toBeNull();
+  });
+});
+
+describe('run items name their mode (F4: no more identical truncated items)', () => {
+  it('a chat run and a work run are distinguishable by spine word + glyph', () => {
+    const chat = makeView({ id: 'r-chat', problem: 'talk about the thing', workflow_id: 'chat' });
+    const work = makeView({ id: 'r-work', problem: 'work on the thing', workflow_id: 'wf-1' });
+    render(
+      <>
+        <RunLink view={chat} selectedRunId={null} onSelect={() => {}} />
+        <RunLink view={work} selectedRunId={null} onSelect={() => {}} />
+      </>,
+    );
+
+    const links = screen.getAllByTestId('run-link');
+    expect(links.map((l) => l.dataset.kind)).toEqual(['chat', 'build']);
+    expect(links[0]!.textContent).toContain('Chat ·');
+    expect(links[1]!.textContent).toContain('Build ·');
+    expect(links[0]!.textContent).toContain('💬');
+    expect(links[1]!.textContent).toContain('⚙');
+  });
+});

--- a/tests/productName.test.tsx
+++ b/tests/productName.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../src/api/client.js', () => ({
   api: {
     getHealth: () => Promise.resolve({ ok: true, version: '0.2.0' }),
     listRepos: () => Promise.resolve({ repos: [] }),
+    listProjects: () => Promise.resolve({ projects: [] }),
   },
 }));
 
@@ -20,9 +21,7 @@ const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
 
 describe('visible product name', () => {
   it('the sidebar wordmark reads wicked-studio', async () => {
-    render(
-      <LeftSidebar runs={[]} selectedRunId={null} onSelectRun={() => {}} navigate={() => {}} />,
-    );
+    render(<LeftSidebar runs={[]} navigate={() => {}} />);
 
     // The wordmark is the home button next to the logo. `findByRole` also settles the
     // health/repos fetches the sidebar kicks off on mount. Matched exactly, so the old


### PR DESCRIPTION
Slice 3: the rail stops competing with the board. PROJECTS (attention-ordered off the same model as the board, matching dots, cap + view-all, rows enter at last-used mode) + REPOSITORIES; Chats/Work retired behind the single 'All runs ›' escape hatch; creation verbs on the mode spine; run rows distinguishable by glyph + spine word. Shared W2 fixture server extracted (slice-2 verifier's recommendation) — all three rigs green against one fresh build; 771/771 tests; EC1/EC7 judged from pixels by verifier and operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)