### PR TITLE
feat(shell): switcher as segmented spine + Chat teaches on first run (DES-UXFIX-001 slice 4)

### DIFF
--- a/.product/evidence/uxfix-slice4/checklist.md
+++ b/.product/evidence/uxfix-slice4/checklist.md
@@ -1,0 +1,114 @@
+# DES-UXFIX-001 — Slice 4 experience-checklist verdicts (§4.1)
+
+**Slice:** 4 — mode switcher weight + Chat first-run
+**Date:** 2026-08-20
+**Build:** branch `uxfix/slice-4-switcher-chat` (on top of slice 3, `7dda8b8`; production
+commit `29e5cf5`)
+**Rig:** `e2e/uxfix_slice4_test.py` — the shared W2 fixture server (`uxfix_fixture.py`,
+extended with a four-seat roster + instant-warm chat endpoints; dataset and switches
+untouched), captured per the §4.0 contract: 1440×900, `device_scale_factor=1`, every
+capture waits on a `data-testid`, never a sleep. The DOM ACs backing each verdict all
+passed in the same run with a NETWORK TAP (JSON report printed by the rig:
+`openChat_requests_on_mount: 0`, `roster_requests_on_mount: 0`,
+`open_body_clis: null` on Add agents, `open_body_clis: ["claude"]` on the first typed
+send), and the slice-1, slice-2 AND slice-3 rigs were re-run against this exact
+`dist-sameorigin` build — all green, no regression. Full vitest suite: 83 files /
+778 tests green; lint and typecheck clean.
+
+**Screenshots judged** (uncommitted evidence, `e2e/shots/uxfix/`):
+
+| Scene | File |
+|---|---|
+| The weighted segmented switcher (element shot) | `uxfix-4-switcher.png` |
+| Chat first-run: the teaching state, nothing armed | `uxfix-4-chat-firstrun.png` |
+| The disclosed multi-agent strip + Close | `uxfix-4-chat-multiagent.png` |
+
+Judged from the pixels alone, per §4.1 ("if you cannot tell from the image, it fails").
+
+---
+
+## EC7 — the surface teaches itself · **PASS**
+
+Readable from the images alone:
+
+- **The switcher teaches the current mode without a hover.** Below the segmented
+  control, the active mode's one-line summary is always on screen — in
+  `uxfix-4-switcher.png`: *"Talk to an agent with no artifact committed yet — and choose
+  a mode by conversation."* Before this slice that sentence lived in a tooltip; a
+  newcomer had to know to hover a low-contrast link to learn what a mode was.
+- **Chat's first-run state says what Chat IS and what typing does.** The centre of
+  `uxfix-4-chat-firstrun.png` is two lines — *"Chat with an agent about this project."*
+  and *"No run, no gates — just talk. Ask for a deck or some code and I'll switch you to
+  the right mode."* — which teach the surface, its cost model (no run, no gates), and
+  the product's central trick (choose a mode by conversation, §2.4 rule 3), which this
+  empty state is the ONE place to teach. The composer below is focused and its
+  placeholder is the action ("Describe what you want…"); the sole disclosure
+  (`+ Add agents`) sits under it, visibly subordinate.
+- **The BEFORE is legible as the finding.** F6's ambush — "Group chat" header, six
+  pre-armed agent chips, an "End chat" button before a word is typed — appears nowhere
+  in the first-run shot: the header says **Chat**, carries zero chips, and has no
+  teardown button. The rig asserts the strings "Group chat" and "End chat" appear
+  nowhere in the page text.
+
+## EC8 — the switcher looks like the spine · **PASS**
+
+- In both full-page shots the switcher is the highest-contrast control on screen: the
+  active **Chat** segment is a filled accent-yellow pill with dark ink and its glyph —
+  the ONE fill of that colour in the chrome — while Build / Document / Video are real
+  bordered segments (glyph + label, resting surface), not bare text. This is §2.5
+  rule 1 verbatim: segmented, active FILLED, not underlined. The rig pins it below the
+  pixels too: computed `backgroundColor` of the active segment is the literal accent
+  (`rgb(255, 218, 25)`) and of an inactive segment is not.
+- The four glyphs are the same four the board quick actions, rail verbs and doc tiles
+  use (💬 ⚙ ▤ ▶ — §2.5 rule 4); the rail's `+ ⚙ Build + 💬 Chat` in the same shot
+  demonstrates the one-vocabulary spine directly.
+- Readiness behaviour is untouched (greyed-never-hidden with the enabling action in the
+  title, §1.3 rule 3) — no unavailable mode occurs in the fixture, so that state is
+  covered by the unit suite (`ProjectShell.gate.test.tsx`), not by these pixels.
+
+## EC10 — no banned state · **PASS**
+
+- **No ambush, no warmed seats on first run** — the slice's own banned state. The
+  first-run shot shows zero chips and no Close, and the network tap proves the absence
+  is real, not cosmetic: zero `POST /chats`, zero roster fetches on mount. Warm chips
+  exist only in `uxfix-4-chat-multiagent.png`, i.e. only AFTER the one disclosure was
+  clicked — where all four seats render green/ready with Close now present (V8).
+- No bare spinner, no bare "Working…", no whimsy, no error-without-next-action anywhere
+  in the three shots. The old pre-arm path's "Warming seats…" floater (a subject-less
+  progress line on a surface the user never asked to warm) is gone entirely; seat
+  progress now lives on the named per-agent chips (warming/ready/failed), which is
+  §3.3's contract for the disclosed state.
+
+---
+
+## Notes / caveats (honest, not blocking)
+
+1. **The multi-agent shot has an empty transcript.** The scene is the disclosed strip
+   (chips + Close), not a conversation; replies stream over `/ws` in production and the
+   fixture's socket only narrates the board's live run. The typed-send AC (user bubble +
+   single-agent open + message POST) is asserted in the same rig run on a fresh tab,
+   without a capture.
+2. **"Add agents" stays offered after a single-agent first send** (one warm seat ≤ 1).
+   Deliberate: one default agent is not the multi-agent strip, and the disclosure is
+   how the roster arrives. It retires only once the roster is warmed in.
+3. **The single default agent is the first council-enabled roster seat.** The
+   `wicked_default_clis` localStorage set (SystemSettings) is not consulted; unifying
+   the two "default agent" notions is a later pass. With no roster answer, the open
+   omits `clis` and the daemon's roster decides.
+4. **Warming more seats into an existing chat reuses the warm ones** — verified against
+   the engine (`acp_runner.rs::chat_open` → `chat_ensure` reuses a live session per
+   seat), so clicking Add agents after a single-agent send adds seats without dropping
+   the first agent's conversation memory.
+5. **The mid-switch "End chat" race is now structurally closed, and its test re-keyed.**
+   The teardown control no longer exists before anything is armed, so the
+   close-the-wrong-repo's-chat window the old always-visible button opened cannot be
+   reached from the UI; the rejoin suite now pins exactly that (no Close mid-switch,
+   both repos' stored ids intact).
+6. **The kept-on-error chat shows Close with zero visible chips** (V8's one exception):
+   when the daemon can't be reached to probe a stored id, the chat is real but
+   unobservable, and Close is the operator's named way to disconnect it — the error
+   copy points at it.
+7. **FINDING-027 unchanged:** a stored chat the daemon still holds is rejoined on
+   mount exactly as before (warm seats must not be orphaned); only the reclaimed case
+   changed destination — it now lands on the first-run state instead of auto-minting a
+   fresh warm-all chat, which was itself a miniature of F6.

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -133,6 +133,17 @@ NOTES_DOCS = [
     {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
 ]
 
+# The chat surface (slice 4, §2.4): a four-seat roster and instant-warm chat
+# endpoints. Seats warm the moment they are asked — determinism over realism —
+# and the daemon's real semantics are kept where the client depends on them:
+# GET /chats/<id> answers an EMPTY seat list (a 200, not a 404) for a chat this
+# fixture has never been told about, which is the "reclaimed" signal the rejoin
+# probe distinguishes from an error.
+ROSTER = [
+    {"key": k, "display_name": k, "binary": k, "enabled_for_council": True}
+    for k in ("claude", "codex", "agy", "pi")
+]
+
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 NARRATION = "Writing the token-bucket middleware for /upload"
 
@@ -197,6 +208,14 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/repos":
             self._json(200, {"repos": []})
             return True
+        if path == "/api/v1/roster":
+            self._json(200, {"roster": ROSTER})
+            return True
+        # /api/v1/chats/<id> — seats of a chat. Empty for a chat we never opened
+        # (the daemon does not 404 an unknown id; empty means reclaimed/none).
+        if path.startswith("/api/v1/chats/") and len(path.split("/")) == 5:
+            self._json(200, {"chatId": urllib.parse.unquote(path.split("/")[4]), "seats": []})
+            return True
         parts = path.split("/")
         # /api/v1/projects/<id>/members
         if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
@@ -251,12 +270,31 @@ class W2Handler(SimpleHTTPRequestHandler):
 
     def do_POST(self):  # noqa: N802 (stdlib naming)
         path = urllib.parse.urlparse(self.path).path
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
         if path == "/__fixture":
-            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
             with state_lock:
                 state.update({k: v for k, v in body.items() if k in state})
                 snapshot = dict(state)
             return self._json(200, {"ok": True, "state": snapshot})
+        # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
+        # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
+        if path == "/api/v1/chats":
+            clis = body.get("clis") or [s["key"] for s in ROSTER]
+            return self._json(201, {
+                "chatId": body.get("chatId") or "fixture-chat",
+                "seats": [{"cliKey": k, "ok": True} for k in clis],
+            })
+        # POST /api/v1/chats/<id>/messages — accept the fan-out; replies would
+        # stream over /ws, which this fixture leaves to the narration loop.
+        parts = path.split("/")
+        if len(parts) == 6 and parts[3] == "chats" and parts[5] == "messages":
+            return self._json(200, {"seats": []})
+        return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+
+    def do_DELETE(self):  # noqa: N802 (stdlib naming)
+        path = urllib.parse.urlparse(self.path).path
+        if path.startswith("/api/v1/chats/"):
+            return self._json(200, {"ok": True})
         return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
 
 

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+uxfix_slice4_test.py — the DES-UXFIX-001 slice-4 gate: the mode switcher given
+real visual weight (§2.5, F8) and Chat's first-run moment made to teach
+(§2.4, F6), proven in a real browser against the W2 messy-reality fixture
+(§4.2) extended with the chat surface (roster + instant-warm chat endpoints in
+`uxfix_fixture.py`).
+
+Same rig pattern as the slice-1/2/3 gates: the SHARED deterministic fixture
+server serves the `dist-sameorigin/` build plus every endpoint the routes read;
+no crew daemon is involved anywhere. This rig never flips the fixture switches.
+
+What it asserts (design §4.3, the slice-4 DOM AC):
+  1. Switcher weight (F8): data-testid="mode-switcher" renders four segments,
+     each glyph + label; the ACTIVE segment's computed background is FILLED
+     (≠ transparent — asserted as the literal accent rgb), an inactive one is
+     not; the active mode's summary is IN THE DOM (data-testid="mode-summary"),
+     not just a title attribute.
+  2. Chat first-run (F6): entering /p/<id>/chat with nothing stored warms ZERO
+     seats — the rig taps the network and proves NO POST /api/v1/chats and NO
+     GET /api/v1/roster fires on mount — and shows the teaching state
+     (chat-firstrun), a focused composer, ONE disclosure (add-agents), no seat
+     chips, no Close, and no "Group chat"/"End chat" copy anywhere.
+  3. The disclosure: clicking add-agents fires exactly ONE POST /api/v1/chats
+     (with NO `clis` — the daemon warms its own roster), the four-seat chip
+     strip appears all-ready, Close appears, the disclosure retires.
+  4. Typing is the other opt-in: in a FRESH tab (own sessionStorage), typing a
+     message and pressing Enter fires exactly ONE POST /api/v1/chats whose
+     `clis` is ["claude"] — the single default agent, not the roster — then
+     POSTs the message to /chats/<id>/messages; the user bubble renders and the
+     disclosure is still available (one agent is not the multi-agent strip).
+
+Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
+data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
+  uxfix-4-switcher.png        the weighted segmented control (element shot)
+  uxfix-4-chat-firstrun.png   the teaching first-run Chat surface (full page)
+  uxfix-4-chat-multiagent.png the disclosed multi-agent strip + Close (full page)
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4333), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    SHOTS,
+    ensure_build,
+    start_server,
+)
+
+W2_PORT = int(os.environ.get("W2_PORT", "4333"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
+ACCENT_RGB = "rgb(255, 218, 25)"
+ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared with the slice-1/2/3 rigs — same dist dir) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (§4.2 + the slice-4 chat surface) ─────────
+start_server(W2_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ───────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+console_errors: list[str] = []
+
+
+def tap(page):
+    """Record the chat-surface requests: (method, path, json-body-or-None)."""
+    log: list[tuple[str, str, dict | None]] = []
+
+    def on_request(req):
+        from urllib.parse import urlparse
+        path = urlparse(req.url).path
+        if path.startswith("/api/v1/chats") or path == "/api/v1/roster":
+            body = None
+            if req.post_data:
+                try:
+                    body = json.loads(req.post_data)
+                except ValueError:
+                    body = None
+            log.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return log
+
+
+def opens(log) -> list[dict | None]:
+    return [b for (m, p, b) in log if m == "POST" and p == "/api/v1/chats"]
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    # §4.0's capture contract, verbatim: 1440x900, device_scale_factor=1.
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    # ── Scene A: first-run + the disclosure, on one tab ────────────────────────
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net = tap(page)
+
+    page.goto(CHAT_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # AC 1 — the switcher is the spine (F8): filled active segment, glyph+label
+    # segments, summary in the DOM. All read from computed style / live DOM.
+    switcher = page.evaluate(
+        """accent => {
+             const active = document.querySelector('[data-testid="mode-tab-chat"]');
+             const inactive = document.querySelector('[data-testid="mode-tab-build"]');
+             const summary = document.querySelector('[data-testid="mode-summary"]');
+             const tabs = Array.from(document.querySelectorAll(
+               '[data-testid="mode-switcher"] [role="tab"]'));
+             return {
+               activeBg: getComputedStyle(active).backgroundColor,
+               inactiveBg: getComputedStyle(inactive).backgroundColor,
+               activeFilled: getComputedStyle(active).backgroundColor === accent,
+               inactiveNotFilled: getComputedStyle(inactive).backgroundColor !== accent,
+               tabTexts: tabs.map(t => t.textContent),
+               glyphsPresent: ['💬','⚙','▤','▶'].every((g, i) => tabs[i].textContent.includes(g)),
+               summaryText: summary ? summary.textContent : null,
+               summaryVisible: summary !== null && summary.offsetParent !== null,
+             };
+           }""",
+        ACCENT_RGB,
+    )
+
+    # AC 2 — first-run teaches, nothing warms. The network tap has recorded every
+    # chat/roster request since navigation; by now the page settled through several
+    # DOM waits, so an eager mount-warm would already be in the log.
+    firstrun = page.evaluate(
+        """() => {
+             const teach = document.querySelector('[data-testid="chat-firstrun"]');
+             const body = document.body.innerText;
+             return {
+               teachText: teach ? teach.innerText : null,
+               addAgents: !!document.querySelector('[data-testid="add-agents"]'),
+               closeAbsent: !document.querySelector('[data-testid="chat-close"]'),
+               noChips: !document.querySelector('[title="ready"], [title="warming"]'),
+               noGroupChatCopy: !body.includes('Group chat') && !body.includes('End chat'),
+               composerFocused: document.activeElement?.tagName === 'TEXTAREA',
+             };
+           }"""
+    )
+    mount_opens = len(opens(net))
+    mount_roster = len([1 for (m, q, _b) in net if q == "/api/v1/roster"])
+
+    # Captures: the weighted switcher (element) + the teaching surface (full page).
+    page.locator('[data-testid="mode-switcher"]').screenshot(
+        path=str(SHOTS / "uxfix-4-switcher.png"))
+    page.screenshot(path=str(SHOTS / "uxfix-4-chat-firstrun.png"))
+
+    # AC 3 — the disclosure warms the roster and reveals the strip.
+    page.locator('[data-testid="add-agents"]').click()
+    page.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
+    page.wait_for_function(
+        """n => document.querySelectorAll('[title="ready"]').length === n""",
+        arg=len(ROSTER_KEYS), timeout=30000,
+    )
+    disclosed = page.evaluate(
+        """keys => {
+             const chips = Array.from(document.querySelectorAll('[title="ready"]'))
+               .map(c => c.textContent.trim());
+             return {
+               chips,
+               allSeats: keys.every(k => chips.includes(k)),
+               addAgentsRetired: !document.querySelector('[data-testid="add-agents"]'),
+               closePresent: !!document.querySelector('[data-testid="chat-close"]'),
+               firstrunGone: !document.querySelector('[data-testid="chat-firstrun"]'),
+             };
+           }""",
+        ROSTER_KEYS,
+    )
+    disclosed_opens = opens(net)
+    page.screenshot(path=str(SHOTS / "uxfix-4-chat-multiagent.png"))
+    page.close()
+
+    # ── Scene B: typing is the opt-in — a FRESH tab (own sessionStorage) ───────
+    page2 = ctx.new_page()
+    page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net2 = tap(page2)
+    page2.goto(CHAT_URL, wait_until="domcontentloaded")
+    page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    page2.locator("textarea").fill("make me a deck")
+    page2.keyboard.press("Enter")
+    page2.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
+    typed = page2.evaluate(
+        """() => ({
+             userBubble: document.body.innerText.includes('make me a deck'),
+             readyChips: Array.from(document.querySelectorAll('[title="ready"]'))
+               .map(c => c.textContent.trim()),
+             addAgentsStillOffered: !!document.querySelector('[data-testid="add-agents"]'),
+           })"""
+    )
+    typed_opens = opens(net2)
+    sent = [(m, q, b) for (m, q, b) in net2 if m == "POST" and q.endswith("/messages")]
+    page2.close()
+
+    ctx.close()
+    browser.close()
+
+report["steps"]["slice4_switcher"] = {
+    "ok": all([
+        switcher["activeFilled"], switcher["inactiveNotFilled"], switcher["glyphsPresent"],
+        switcher["summaryVisible"],
+        (switcher["summaryText"] or "").startswith("Talk to an agent"),
+        len(switcher["tabTexts"]) == 4,
+    ]),
+    **switcher,
+}
+report["steps"]["slice4_chat_firstrun"] = {
+    "ok": all([
+        firstrun["teachText"] is not None,
+        "Chat with an agent about this project." in (firstrun["teachText"] or ""),
+        "just talk" in (firstrun["teachText"] or ""),
+        firstrun["addAgents"], firstrun["closeAbsent"], firstrun["noChips"],
+        firstrun["noGroupChatCopy"], firstrun["composerFocused"],
+        mount_opens == 0, mount_roster == 0,
+    ]),
+    **firstrun,
+    "openChat_requests_on_mount": mount_opens,
+    "roster_requests_on_mount": mount_roster,
+}
+report["steps"]["slice4_add_agents"] = {
+    "ok": all([
+        disclosed["allSeats"], disclosed["addAgentsRetired"], disclosed["closePresent"],
+        disclosed["firstrunGone"],
+        len(disclosed_opens) == 1,
+        (disclosed_opens[0] or {}).get("clis") is None,
+    ]),
+    **disclosed,
+    "openChat_requests_total": len(disclosed_opens),
+    "open_body_clis": (disclosed_opens[0] or {}).get("clis") if disclosed_opens else "none",
+}
+report["steps"]["slice4_first_send"] = {
+    "ok": all([
+        typed["userBubble"],
+        typed["readyChips"] == ["claude"],
+        typed["addAgentsStillOffered"],
+        len(typed_opens) == 1,
+        (typed_opens[0] or {}).get("clis") == ["claude"],
+        len(sent) == 1,
+        (sent[0][2] or {}).get("text") == "make me a deck",
+    ]),
+    **typed,
+    "openChat_requests_total": len(typed_opens),
+    "open_body_clis": (typed_opens[0] or {}).get("clis") if typed_opens else "none",
+    "message_posts": len(sent),
+}
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(SHOTS / "uxfix-4-switcher.png"),
+    str(SHOTS / "uxfix-4-chat-firstrun.png"),
+    str(SHOTS / "uxfix-4-chat-multiagent.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("slice4_verdict", f"slice-4 assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -94,6 +94,16 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
   const [ended, setEnded] = useState(false);
   /** An arm (warm) in flight — guards the two opt-in paths against double fire. */
   const [arming, setArming] = useState(false);
+  /**
+   * The rejoin probe is in flight — a stored id is being checked against the daemon.
+   * While it is, this repo is NOT first-run and the opt-ins must wait: `chatId` is
+   * still null, so a send in this window would read as a first send, mint a fresh id
+   * and write it OVER the stored one — orphaning the warm chat the probe was about
+   * to rejoin (the FINDING-027 leak, reintroduced by a fast finger on the focused
+   * composer). Never true when nothing is stored, so first-run still fires zero
+   * requests and gates nothing.
+   */
+  const [resolving, setResolving] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
@@ -135,11 +145,14 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     setChatId(null);
     chatIdRef.current = null;
 
+    // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
+    // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
+    // stored, this is first-run: NO probe, NO roster fetch, NO warming — zero requests (§2.4).
+    // Read SYNCHRONOUSLY, and park the opt-ins while the probe runs (see `resolving`).
+    const stored = readStoredChatId(repoId);
+    setResolving(stored !== null);
+
     void (async () => {
-      // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
-      // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
-      // stored, this is first-run: NO probe, NO roster fetch, NO warming — zero requests (§2.4).
-      const stored = readStoredChatId(repoId);
       if (stored === null) return;
       // Three distinct answers, and collapsing them is how the leak comes back. `chat_seats`
       // returns an empty list (a 200, not an error) for a chat the daemon no longer holds, so
@@ -159,6 +172,7 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
           `Could not reach the daemon to check the previous chat (${probe.error}). Keeping it — ` +
             `reload to retry, or Close to disconnect the agents.`,
         );
+        setResolving(false);
         return;
       }
       if (probe.seats.length > 0) {
@@ -168,11 +182,15 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
         // starts with an empty log. The SESSIONS carry the conversation memory, which is the
         // expensive part; re-minting would have thrown that away as well as leaking it.
         setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        setResolving(false);
         return;
       }
       // Reclaimed → back to the calm first-run state, not a re-mint: warming is the
       // user's call now, and the next opt-in mints fresh.
       clearStoredChatId(repoId);
+      setResolving(false);
+      // (On the cancelled path `resolving` is deliberately left alone: the next effect
+      // run has already set its own value for the new repo.)
     })();
 
     return () => {
@@ -308,7 +326,9 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
 
   async function send(): Promise<void> {
     const text = input.trim();
-    if (text === '' || ended || arming) return;
+    // `resolving` waits out the rejoin probe: until it answers, "no chat id" does NOT
+    // mean first-run, and treating it as one would mint over the stored id (FINDING-027).
+    if (text === '' || ended || arming || resolving) return;
     const firstSend = chatIdRef.current === null;
     let warm = Object.entries(seats)
       .filter(([, st]) => st === 'ready')
@@ -379,7 +399,10 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
   // The ONE disclosure (§2.4): shown until the roster is warmed in (0 seats =
   // first-run, 1 seat = the single default agent the first send warmed).
   const showAddAgents = !ended && Object.keys(seats).length <= 1;
-  const firstRun = messages.length === 0 && Object.keys(seats).length === 0 && openError === null;
+  // Not first-run while the rejoin probe is unresolved — teaching "nothing here yet"
+  // over a chat that may be about to pop back in would be a lie held for milliseconds.
+  const firstRun =
+    messages.length === 0 && Object.keys(seats).length === 0 && openError === null && !resolving;
 
   return (
     <div className="flex flex-col h-full" style={{ color: '#e6edf3' }}>
@@ -481,7 +504,8 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
             onClick={() => void send()}
             // Before any chat exists, typing is how the first agent warms — so text alone
             // enables Send. Once a chat exists, sending needs a ready seat, as before.
-            disabled={input.trim() === '' || arming || (chatId !== null && !anyReady)}
+            // (`resolving`: the stored chat is still being checked — not first-run yet.)
+            disabled={input.trim() === '' || arming || resolving || (chatId !== null && !anyReady)}
             className="px-4 rounded-xl text-sm font-mono font-semibold disabled:opacity-40"
             style={{ background: 'rgba(88,166,255,0.2)', color: '#79c0ff' }}
           >
@@ -492,7 +516,7 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
           <button
             type="button"
             data-testid="add-agents"
-            disabled={arming}
+            disabled={arming || resolving}
             title="Warm every agent on the roster into this chat — replies stream side by side"
             onClick={() => void armChat('all')}
             className="mt-2 text-[11px] font-mono px-2.5 py-1 rounded-lg disabled:opacity-40"

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -4,13 +4,20 @@ import { useEventStream } from '../hooks/useEventStream.js';
 import { Markdown } from './Markdown.js';
 
 /**
- * GROUP CHAT (crew#165 / core#134): warm persistent CLI sessions + fan-out.
+ * CHAT (crew#165 / core#134): warm persistent CLI sessions + fan-out.
  *
- * NOT a run — no council, no gates, no units. On mount the daemon warms one ACP
- * session per roster seat; each user message fans out to every warm seat and the
- * replies stream back side by side (`chatDelta` tokens, `chatReply` terminal).
- * Sessions hold conversation memory across turns; they live until "End chat"
- * (or daemon shutdown) — leaving the page keeps them warm.
+ * NOT a run — no council, no gates, no units. Each user message fans out to
+ * every warm seat and the replies stream back side by side (`chatDelta` tokens,
+ * `chatReply` terminal). Sessions hold conversation memory across turns; they
+ * live until "Close" (or daemon shutdown) — leaving the page keeps them warm.
+ *
+ * NOTHING warms on mount (DES-UXFIX-001 §2.4, F6). First-run is a calm teaching
+ * state: one line on what Chat is, a focused composer, and ONE disclosure —
+ * "Add agents". The first send warms the one default agent; "Add agents" warms
+ * the whole roster and turns the header into the multi-agent chip strip. The
+ * warm-and-rejoin machinery (FINDING-027) is preserved verbatim — it just runs
+ * on opt-in, not on mount: a stored chat the daemon still holds is rejoined
+ * exactly as before, because warm seats someone paid for must not be orphaned.
  */
 
 const SEAT_COLORS: Record<string, { bg: string; fg: string }> = {
@@ -85,6 +92,8 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
   const [input, setInput] = useState('');
   const [openError, setOpenError] = useState<string | null>(null);
   const [ended, setEnded] = useState(false);
+  /** An arm (warm) in flight — guards the two opt-in paths against double fire. */
+  const [arming, setArming] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
@@ -93,12 +102,10 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  // Open once on mount; sessions OUTLIVE the page (explicit End chat closes them).
-  // The chat id is minted CLIENT-side and set before the open call: seats warm
-  // serially (~2-3s each), and their chatSessionReady events arrive BEFORE the
-  // POST resolves — a server-minted id would drop every one of them.
+  // The mount effect REJOINS — it never warms (§2.4 rule 1). Warming moved to
+  // `armChat` below, which runs only on the two opt-ins (first send / Add agents).
   //
-  // REJOIN, don't re-mint (FINDING-027). This effect used to call crypto.randomUUID() on every
+  // REJOIN, don't re-mint (FINDING-027). The pre-fix component called crypto.randomUUID() on every
   // fire, so each remount or repo switch abandoned a warm chat that nothing would ever close:
   // measured at ~520 MB of pinned CLI processes per orphan, one leaked deterministically per mount,
   // 19 seats warmed against 2 chats ever closed across a campaign. Closing on unmount would have
@@ -128,87 +135,44 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     setChatId(null);
     chatIdRef.current = null;
 
-    // Started now so the network round-trip overlaps the probe below, but APPLIED only on the mint
-    // path. Optimistic chips are a stand-in for an open that is in flight; after a rejoin there is
-    // no open and no incoming seat events, so a roster seat that is not warm in the rejoined chat
-    // would sit at `warming` forever with nothing left to correct it.
-    const rosterP = api
-      .getRoster()
-      .then(({ roster }) => roster)
-      .catch(() => []);
-
     void (async () => {
       // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
-      // so it may have reclaimed this one underneath us. Ask before trusting it.
+      // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
+      // stored, this is first-run: NO probe, NO roster fetch, NO warming — zero requests (§2.4).
       const stored = readStoredChatId(repoId);
-      if (stored !== null) {
-        // Three distinct answers, and collapsing them is how the leak comes back. `chat_seats`
-        // returns an empty list (a 200, not an error) for a chat the daemon no longer holds, so
-        // ONLY that means reclaimed. A thrown error means we do not know — and "do not know" must
-        // not mint, because minting on a transient 5xx orphans a chat that is still warm and burns
-        // the one id that could have reached it.
-        const probe = await api
-          .getChat(stored)
-          .then(({ seats }) => ({ seats }))
-          .catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
-        if (cancelled) return;
-
-        if ('error' in probe) {
-          setChatId(stored);
-          chatIdRef.current = stored;
-          setOpenError(
-            `Could not reach the daemon to check the previous chat (${probe.error}). Keeping it — ` +
-              `reload to retry, or End chat to disconnect the agents.`,
-          );
-          return;
-        }
-        if (probe.seats.length > 0) {
-          setChatId(stored);
-          chatIdRef.current = stored;
-          // Warm seats only — the transcript is not persisted server-side, so a rejoined chat
-          // starts with an empty log. The SESSIONS carry the conversation memory, which is the
-          // expensive part; re-minting would have thrown that away as well as leaking it.
-          setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
-          return;
-        }
-        clearStoredChatId(repoId);
-      }
-
-      const id = crypto.randomUUID();
+      if (stored === null) return;
+      // Three distinct answers, and collapsing them is how the leak comes back. `chat_seats`
+      // returns an empty list (a 200, not an error) for a chat the daemon no longer holds, so
+      // ONLY that means reclaimed. A thrown error means we do not know — and "do not know" must
+      // not forget the id, because forgetting on a transient 5xx orphans a chat that is still
+      // warm and burns the one id that could have reached it.
+      const probe = await api
+        .getChat(stored)
+        .then(({ seats }) => ({ seats }))
+        .catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
       if (cancelled) return;
-      setChatId(id);
-      chatIdRef.current = id;
-      writeStoredChatId(repoId, id);
 
-      // Optimistic chips: every enabled roster seat shows as warming while the open is in flight;
-      // ready/failed events (and the open response) correct them as truth arrives.
-      const roster = await rosterP;
-      if (cancelled) return;
-      setSeats(
-        Object.fromEntries(
-          roster.flatMap((seat) =>
-            typeof seat.key === 'string' ? [[seat.key, 'warming' as SeatState]] : [],
-          ),
-        ),
-      );
-
-      try {
-        const { seats } = await api.openChat(repoId ? { chatId: id, repoRef: repoId } : { chatId: id });
-        if (cancelled) return;
-        const st: Record<string, SeatState> = {};
-        const errs: Record<string, string> = {};
-        for (const s of seats) {
-          st[s.cliKey] = s.ok ? 'ready' : 'failed';
-          if (!s.ok && s.error) errs[s.cliKey] = s.error;
-        }
-        setSeats(st);
-        setSeatErrors(errs);
-      } catch (e: unknown) {
-        // The id stays stored on purpose: an open that failed at the HTTP layer may still have
-        // warmed seats server-side, and dropping the id here would orphan exactly what this
-        // change exists to stop orphaning. The next mount re-checks it and clears it if dead.
-        if (!cancelled) setOpenError(e instanceof Error ? e.message : String(e));
+      if ('error' in probe) {
+        setChatId(stored);
+        chatIdRef.current = stored;
+        setOpenError(
+          `Could not reach the daemon to check the previous chat (${probe.error}). Keeping it — ` +
+            `reload to retry, or Close to disconnect the agents.`,
+        );
+        return;
       }
+      if (probe.seats.length > 0) {
+        setChatId(stored);
+        chatIdRef.current = stored;
+        // Warm seats only — the transcript is not persisted server-side, so a rejoined chat
+        // starts with an empty log. The SESSIONS carry the conversation memory, which is the
+        // expensive part; re-minting would have thrown that away as well as leaking it.
+        setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        return;
+      }
+      // Reclaimed → back to the calm first-run state, not a re-mint: warming is the
+      // user's call now, and the next opt-in mints fresh.
+      clearStoredChatId(repoId);
     })();
 
     return () => {
@@ -272,21 +236,99 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     });
   }
 
+  /**
+   * Warm seats — the §2.4 opt-in, and the ONLY place a chat is minted or opened.
+   * `'one'` is the first send's path (the single default agent — the first
+   * council-enabled roster seat); `'all'` is the "Add agents" disclosure (the
+   * whole roster, exactly what the pre-slice-4 mount warmed). Reuses the live
+   * chat id when there is one: `chat_open` ensures per seat, so warming MORE
+   * seats into an existing chat reuses the warm ones and adds only the missing.
+   * Returns the seat keys that came up ready.
+   */
+  async function armChat(scope: 'one' | 'all'): Promise<string[]> {
+    setArming(true);
+    try {
+      // The chat id is minted CLIENT-side and set before the open call: seats warm
+      // serially (~2-3s each), and their chatSessionReady events arrive BEFORE the
+      // POST resolves — a server-minted id would drop every one of them.
+      let id = chatIdRef.current;
+      if (id === null) {
+        id = crypto.randomUUID();
+        setChatId(id);
+        chatIdRef.current = id;
+        writeStoredChatId(repoId, id);
+      }
+      const roster = await api
+        .getRoster()
+        .then(({ roster: r }) => r)
+        .catch(() => []);
+      // A repo switch mid-arm resets `chatIdRef` (the mount effect) — every await
+      // below re-checks it so nothing is attributed to a repo we already left.
+      if (chatIdRef.current !== id) return [];
+      const keys = roster.flatMap((s) => (typeof s.key === 'string' ? [s.key] : []));
+      const one = roster.find((s) => s.enabled_for_council)?.key ?? keys[0];
+      const chosen = scope === 'one' ? (one !== undefined ? [one] : []) : keys;
+      // Optimistic chips: each seat being warmed shows as warming while the open is in
+      // flight; ready/failed events (and the open response) correct them as truth arrives.
+      setSeats((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          chosen.filter((k) => prev[k] !== 'ready').map((k) => [k, 'warming' as SeatState]),
+        ),
+      }));
+      try {
+        const body: { chatId: string; repoRef?: string; clis?: string[] } = { chatId: id };
+        if (repoId) body.repoRef = repoId;
+        // 'all' omits `clis` on purpose — the daemon warms its own full roster, exactly
+        // as the pre-slice-4 mount did. 'one' names the single default agent; with no
+        // roster answer it also omits, and the daemon's roster decides.
+        if (scope === 'one' && chosen.length > 0) body.clis = chosen;
+        const { seats: opened } = await api.openChat(body);
+        if (chatIdRef.current !== id) return [];
+        const st: Record<string, SeatState> = {};
+        const errs: Record<string, string> = {};
+        for (const s of opened) {
+          st[s.cliKey] = s.ok ? 'ready' : 'failed';
+          if (!s.ok && s.error) errs[s.cliKey] = s.error;
+        }
+        setSeats((prev) => ({ ...prev, ...st }));
+        setSeatErrors((prev) => ({ ...prev, ...errs }));
+        return opened.filter((s) => s.ok).map((s) => s.cliKey);
+      } catch (e: unknown) {
+        // The id stays stored on purpose: an open that failed at the HTTP layer may still have
+        // warmed seats server-side, and dropping the id here would orphan exactly what
+        // FINDING-027 exists to stop orphaning. The next mount re-checks it and clears it if dead.
+        if (chatIdRef.current === id) setOpenError(e instanceof Error ? e.message : String(e));
+        return [];
+      }
+    } finally {
+      setArming(false);
+    }
+  }
+
   async function send(): Promise<void> {
     const text = input.trim();
-    const anyReady = Object.values(seats).some((st) => st === 'ready');
-    if (text === '' || chatId === null || ended || !anyReady) return;
-    setInput('');
-    const warm = Object.entries(seats)
+    if (text === '' || ended || arming) return;
+    const firstSend = chatIdRef.current === null;
+    let warm = Object.entries(seats)
       .filter(([, st]) => st === 'ready')
       .map(([k]) => k);
+    if (!firstSend && warm.length === 0) return;
+    setInput('');
+    setMessages((prev) => [...prev, { kind: 'user', text }]);
+    if (firstSend) {
+      // Typing IS the opt-in (§2.4): the first send warms the one default agent.
+      warm = await armChat('one');
+      if (warm.length === 0) return; // armChat surfaced why (openError / failed chip)
+    }
+    const id = chatIdRef.current;
+    if (id === null) return; // repo switched under the send
     setMessages((prev) => [
       ...prev,
-      { kind: 'user', text },
       ...warm.map((cliKey): SeatMsg => ({ kind: 'seat', cliKey, text: '', pending: true, ok: false })),
     ]);
     try {
-      await api.sendChatMessage(chatId, text);
+      await api.sendChatMessage(id, text);
     } catch (e: unknown) {
       const err = e instanceof Error ? e.message : String(e);
       setMessages((prev) =>
@@ -330,24 +372,37 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     );
   };
 
+  const anyReady = Object.values(seats).some((st) => st === 'ready');
+  // V8: a teardown control exists only once there is something armed to tear down —
+  // warm agents, or a kept-on-error chat id the operator may want to disconnect.
+  const closable = chatId !== null && (anyReady || openError !== null);
+  // The ONE disclosure (§2.4): shown until the roster is warmed in (0 seats =
+  // first-run, 1 seat = the single default agent the first send warmed).
+  const showAddAgents = !ended && Object.keys(seats).length <= 1;
+  const firstRun = messages.length === 0 && Object.keys(seats).length === 0 && openError === null;
+
   return (
     <div className="flex flex-col h-full" style={{ color: '#e6edf3' }}>
-      {/* Header: seats + end */}
+      {/* Header: seats + close */}
       <div className="flex items-center gap-3 px-6 py-3 border-b shrink-0" style={{ borderColor: 'rgba(230,237,243,0.08)' }}>
         <button type="button" onClick={onBack} className="text-sm font-mono opacity-60 hover:opacity-100">←</button>
-        <span className="text-sm font-mono font-semibold">Group chat</span>
+        <span className="text-sm font-mono font-semibold">Chat</span>
         <div className="flex items-center gap-1.5 flex-wrap">
           {Object.entries(seats).map(([k, st]) => seatChip(k, st))}
         </div>
         <div className="flex-1" />
-        <button
-          type="button"
-          onClick={() => void endChat()}
-          className="text-[11px] font-mono px-2.5 py-1 rounded-lg"
-          style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.18)' }}
-        >
-          End chat
-        </button>
+        {closable && (
+          <button
+            type="button"
+            data-testid="chat-close"
+            title="Disconnect the agents and end this chat"
+            onClick={() => void endChat()}
+            className="text-[11px] font-mono px-2.5 py-1 rounded-lg"
+            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.18)' }}
+          >
+            Close
+          </button>
+        )}
       </div>
 
       {/* Messages */}
@@ -355,8 +410,21 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
         {openError !== null && (
           <p className="text-[12px] font-mono" style={{ color: '#f85149' }}>Could not open chat: {openError}</p>
         )}
-        {Object.keys(seats).length === 0 && openError === null && (
-          <p className="text-[12px] font-mono opacity-60">Warming seats…</p>
+        {firstRun && (
+          // §2.4: the first-run state TEACHES — what Chat is, what typing does, and the
+          // product's central trick (choose a mode by conversation). Never a warmed roster.
+          <div
+            data-testid="chat-firstrun"
+            className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-8"
+          >
+            <p className="text-[14px] font-semibold" style={{ margin: 0 }}>
+              Chat with an agent about this project.
+            </p>
+            <p className="text-[12px]" style={{ color: 'rgba(230,237,243,0.55)', margin: 0, maxWidth: '480px' }}>
+              No run, no gates — just talk. Ask for a deck or some code and I’ll switch
+              you to the right mode.
+            </p>
+          </div>
         )}
         {messages.map((m, i) =>
           m.kind === 'user' ? (
@@ -403,20 +471,36 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
               }
             }}
             rows={2}
-            placeholder="Message the agents… (Enter to send, Shift+Enter for newline)"
+            autoFocus
+            placeholder="Describe what you want… (Enter to send, Shift+Enter for newline)"
             className="flex-1 rounded-xl px-4 py-2 text-[13px] font-mono outline-none resize-none"
             style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.12)' }}
           />
           <button
             type="button"
             onClick={() => void send()}
-            disabled={!Object.values(seats).some((st) => st === 'ready') || input.trim() === ''}
+            // Before any chat exists, typing is how the first agent warms — so text alone
+            // enables Send. Once a chat exists, sending needs a ready seat, as before.
+            disabled={input.trim() === '' || arming || (chatId !== null && !anyReady)}
             className="px-4 rounded-xl text-sm font-mono font-semibold disabled:opacity-40"
             style={{ background: 'rgba(88,166,255,0.2)', color: '#79c0ff' }}
           >
             Send
           </button>
         </div>
+        {showAddAgents && (
+          <button
+            type="button"
+            data-testid="add-agents"
+            disabled={arming}
+            title="Warm every agent on the roster into this chat — replies stream side by side"
+            onClick={() => void armChat('all')}
+            className="mt-2 text-[11px] font-mono px-2.5 py-1 rounded-lg disabled:opacity-40"
+            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.18)' }}
+          >
+            + Add agents
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -7,6 +7,10 @@ const S = {
   muted:    'rgba(230,237,243,0.55)',
   faint:    'rgba(230,237,243,0.3)',
   accent:   '#ffda19',
+  /** Text on a filled accent segment — the house pairing for accent-filled controls. */
+  accentInk: '#0d1117',
+  /** An unfilled segment's resting surface — present enough to read as a control. */
+  segment:  'rgba(230,237,243,0.04)',
 };
 
 export interface ModeSpec {
@@ -83,52 +87,74 @@ interface Props {
  *
  * Each mode is a verb on the current project, not a document type, and each is
  * peer-level: Document is deliberately NOT a tab under Build (§1.3 rule 4).
+ *
+ * Slice 4 (DES-UXFIX-001 §2.5, F8) gives it the weight of the spine it is: a
+ * SEGMENTED control — glyph + label per segment, the active segment FILLED
+ * (accent background, dark ink), not a row of low-contrast text links — and the
+ * active mode's one-line summary always on screen below the control, so a
+ * newcomer reads what the current mode IS without hovering (W1). The readiness
+ * model is untouched: an unavailable segment is greyed, never hidden, and its
+ * title still names the one enabling action (§1.3 rule 3).
  */
 export function ModeSwitcher({ mode, onSelect, unavailable }: Props): React.ReactElement {
   return (
     <div
-      role="tablist"
-      aria-label="Project mode"
       data-testid="mode-switcher"
-      style={{
-        display: 'flex', gap: '2px', padding: '0 12px', flexShrink: 0,
-        background: S.bar, borderBottom: `1px solid ${S.border}`,
-      }}
+      style={{ flexShrink: 0, background: S.bar, borderBottom: `1px solid ${S.border}` }}
     >
-      {MODES.map((m) => {
-        const spec = MODE_SPECS[m];
-        const active = m === mode;
-        const action = unavailable?.[m] ?? null;
-        return (
-          <button
-            key={m}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            data-testid={`mode-tab-${m}`}
-            data-mode={m}
-            data-unavailable={action !== null ? 'true' : undefined}
-            // §1.3 rule 3: a mode that cannot open states the one action that enables it —
-            // on its own line, under what the mode IS. Replacing the summary would answer
-            // "how do I turn this on" to a user who is still asking "what is this".
-            title={action !== null ? `${spec.summary}\n${spec.label} ${action}` : spec.summary}
-            onClick={() => onSelect(m)}
-            style={{
-              background: 'transparent',
-              border: 'none',
-              borderBottom: `2px solid ${active ? S.accent : 'transparent'}`,
-              color: active ? S.ink : S.muted,
-              cursor: 'pointer',
-              fontSize: '13px',
-              fontWeight: active ? 700 : 500,
-              opacity: action !== null && !active ? 0.45 : 1,
-              padding: '10px 14px',
-            }}
-          >
-            {spec.label}
-          </button>
-        );
-      })}
+      <div
+        role="tablist"
+        aria-label="Project mode"
+        style={{ display: 'flex', gap: '6px', padding: '10px 12px 0' }}
+      >
+        {MODES.map((m) => {
+          const spec = MODE_SPECS[m];
+          const active = m === mode;
+          const action = unavailable?.[m] ?? null;
+          return (
+            <button
+              key={m}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              data-testid={`mode-tab-${m}`}
+              data-mode={m}
+              data-unavailable={action !== null ? 'true' : undefined}
+              // §1.3 rule 3: a mode that cannot open states the one action that enables it —
+              // on its own line, under what the mode IS. Replacing the summary would answer
+              // "how do I turn this on" to a user who is still asking "what is this".
+              title={action !== null ? `${spec.summary}\n${spec.label} ${action}` : spec.summary}
+              onClick={() => onSelect(m)}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '7px',
+                // The F8 fix in one property: the active segment is FILLED, not underlined.
+                background: active ? S.accent : S.segment,
+                border: `1px solid ${active ? S.accent : S.border}`,
+                borderRadius: '8px',
+                color: active ? S.accentInk : S.muted,
+                cursor: 'pointer',
+                fontSize: '13px',
+                fontWeight: active ? 700 : 500,
+                opacity: action !== null && !active ? 0.45 : 1,
+                padding: '7px 14px',
+              }}
+            >
+              {/* The SAME four glyphs as the board quick actions and doc tiles (§2.5 rule 4). */}
+              <span aria-hidden style={{ flexShrink: 0 }}>{spec.glyph}</span>
+              {spec.label}
+            </button>
+          );
+        })}
+      </div>
+      {/* §2.5 rule 2: the active mode's summary is ON SCREEN, not tooltip-only. */}
+      <p
+        data-testid="mode-summary"
+        style={{ color: S.muted, fontSize: '11px', margin: 0, padding: '7px 14px 9px' }}
+      >
+        {MODE_SPECS[mode].summary}
+      </p>
     </div>
   );
 }

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+
+/**
+ * DES-UXFIX-001 slice 4 (§2.4, F6) — Chat's first-run moment teaches.
+ *
+ * The audit finding, verbatim: entering a project dropped the user into a pre-armed
+ * "Group chat" with six agent chips and an End-chat button before they'd typed anything.
+ * The redesign: NOTHING warms on mount; the empty state says what Chat is and what typing
+ * does; the first send warms the ONE default agent; the roster is a disclosed opt-in
+ * ("Add agents"); the teardown control is "Close" and exists only once agents are warm.
+ * These are the slice-4 DOM ACs (§4.3) at unit level — the e2e rig re-proves them
+ * against a real build with a network tap.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+  { key: 'agy', enabled_for_council: false },
+];
+
+beforeEach(() => {
+  openChat.mockReset();
+  getChat.mockReset();
+  closeChat.mockReset();
+  getRoster.mockReset();
+  sendChatMessage.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ROSTER.map((s) => s.key)).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+});
+
+describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4)', () => {
+  it('mounts cold: zero requests, zero seats, no Close — the AC verbatim', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    // The teaching state is on screen…
+    const teach = screen.getByTestId('chat-firstrun');
+    expect(teach).toHaveTextContent('Chat with an agent about this project.');
+    expect(teach).toHaveTextContent(/No run, no gates — just talk/);
+    // …the one disclosure is offered…
+    expect(screen.getByTestId('add-agents')).toBeInTheDocument();
+    // …and the pre-armed ambush is gone: no chips, no teardown, no "Group chat".
+    expect(screen.queryByTestId('chat-close')).toBeNull();
+    expect(screen.queryByText('Group chat')).toBeNull();
+
+    // Flush pending microtasks, then hold the line: nothing fired on mount.
+    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    expect(openChat, 'no chat may open on mount').not.toHaveBeenCalled();
+    expect(getRoster, 'no roster fetch before the opt-in').not.toHaveBeenCalled();
+    expect(getChat, 'nothing stored, so nothing to probe').not.toHaveBeenCalled();
+  });
+
+  it('the first send warms the ONE default agent, then sends', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.type(screen.getByRole('textbox'), 'make me a deck');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
+    // The single default agent — the first council-enabled roster seat — not the roster.
+    expect(body.clis).toEqual(['claude']);
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, 'make me a deck'));
+
+    // The message and the one agent's pending bubble are on screen; the teaching state is done.
+    expect(screen.getByText('make me a deck')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-firstrun')).toBeNull();
+    // One warm agent is not the multi-agent strip: the disclosure stays available.
+    expect(screen.getByTestId('add-agents')).toBeInTheDocument();
+    // Agents are warm now, so the teardown control may exist (V8).
+    await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
+  });
+
+  it('"Add agents" is the roster opt-in: warms every seat, reveals the strip, then Close', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.click(screen.getByTestId('add-agents'));
+
+    // The daemon owns the full-roster warm: no `clis` on the open (pre-slice-4 mount behaviour).
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toBeUndefined();
+
+    // The chip strip is now real — every roster seat, and the disclosure has done its job.
+    await waitFor(() => expect(screen.getAllByTitle('ready')).toHaveLength(ROSTER.length));
+    expect(screen.queryByTestId('add-agents')).toBeNull();
+    expect(screen.getByTestId('chat-close')).toBeInTheDocument();
+  });
+
+  it('Send is enabled by text alone on first-run — typing is the opt-in', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    const send = screen.getByRole('button', { name: 'Send' });
+    expect(send).toBeDisabled();
+    await user.type(screen.getByRole('textbox'), 'hello');
+    expect(send).toBeEnabled();
+  });
+});

--- a/tests/GroupChat.rejoin.test.tsx
+++ b/tests/GroupChat.rejoin.test.tsx
@@ -25,6 +25,7 @@ const openChat = vi.fn();
 const getChat = vi.fn();
 const closeChat = vi.fn();
 const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
 
 vi.mock('../src/api/client.js', () => ({
   api: {
@@ -32,7 +33,7 @@ vi.mock('../src/api/client.js', () => ({
     getChat: (...a: unknown[]) => getChat(...a),
     closeChat: (...a: unknown[]) => closeChat(...a),
     getRoster: (...a: unknown[]) => getRoster(...a),
-    sendChatMessage: vi.fn(),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
   },
   wsBase: () => 'ws://localhost',
 }));
@@ -57,6 +58,8 @@ beforeEach(() => {
   getRoster.mockResolvedValue({ roster: [{ key: 'claude' }] });
   openChat.mockResolvedValue({ chatId: 'x', seats: [{ cliKey: 'claude', ok: true }] });
   closeChat.mockResolvedValue({ ok: true });
+  sendChatMessage.mockReset();
+  sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
 });
 
@@ -172,6 +175,41 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     // The kept-on-error chat is disconnectable: Close renders for it (V8's one exception —
     // there IS something armed here, we just cannot see it).
     expect(screen.getByTestId('chat-close')).toBeInTheDocument();
+  });
+
+  it('a send during the rejoin probe cannot mint over the stored chat', async () => {
+    // Slice 4 made typing the first-send opt-in AND autofocused the composer, which opened a
+    // window the old always-disabled Send never had: while the stored id's probe is in flight,
+    // `chatId` is still null, so a fast finger's send would read as first-run, mint a fresh id
+    // and write it OVER the stored one — orphaning the warm chat the probe was about to rejoin
+    // (the FINDING-027 leak, back through the front door). The opt-ins must wait the probe out.
+    const user = userEvent.setup();
+    sessionStorage.setItem('wicked.chat.r1', 'probing-id');
+    let releaseProbe = (): void => undefined;
+    getChat.mockReturnValue(
+      new Promise((resolve) => {
+        releaseProbe = () => resolve({ chatId: 'probing-id', seats: ['claude'] });
+      }),
+    );
+
+    render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await user.type(screen.getByRole('textbox'), 'typed before the probe answered');
+    await user.keyboard('{Enter}');
+
+    expect(openChat, 'a send mid-probe must not mint a chat').not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('wicked.chat.r1'), 'the stored id must survive').toBe('probing-id');
+    // Both opt-ins are parked, visibly: Send and the disclosure wait for the probe.
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    expect(screen.getByTestId('add-agents')).toBeDisabled();
+
+    // The probe answers: the chat rejoins, and the held-back text sends into IT — no mint.
+    releaseProbe();
+    await waitFor(() => expect(screen.getByTitle('ready')).toHaveTextContent('claude'));
+    await user.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(sendChatMessage).toHaveBeenCalledWith('probing-id', 'typed before the probe answered'),
+    );
+    expect(openChat, 'the rejoined chat needs no open').not.toHaveBeenCalled();
   });
 
   it('a rejoin shows the seats the chat actually has, and never consults the roster', async () => {

--- a/tests/GroupChat.rejoin.test.tsx
+++ b/tests/GroupChat.rejoin.test.tsx
@@ -15,6 +15,10 @@ import { GroupChat } from '../src/components/GroupChat.js';
  * These tests pin the CONSEQUENCE (a second mount does not open a second chat), not the mechanism —
  * the exact remount trigger in production was never pinned down, and a fix keyed to one trigger
  * would leak on the next one.
+ *
+ * Slice 4 (DES-UXFIX-001 §2.4) moved warming behind the opt-ins (first send / "Add agents"), so a
+ * bare mount no longer opens anything — each case below arms explicitly before it can leak. The
+ * rejoin machinery these tests pin is otherwise verbatim.
  */
 
 const openChat = vi.fn();
@@ -56,10 +60,17 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
+/** Arm the chat the way an operator does — the "Add agents" disclosure (§2.4). */
+async function armViaAddAgents(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.click(await screen.findByTestId('add-agents'));
+}
+
 describe('GroupChat — chat reuse (FINDING-027)', () => {
   it('a remount rejoins the live chat instead of opening a second one', async () => {
-    // Mount 1: nothing stored, so it mints and opens.
+    const user = userEvent.setup();
+    // Mount 1: nothing stored and nothing warmed — the operator opts in, which mints and opens.
     const first = render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const openedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
     expect(openedId).toBeTruthy();
@@ -68,7 +79,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     getChat.mockResolvedValue({ chatId: openedId, seats: ['claude'] });
     first.unmount();
 
-    // Mount 2: the leak. Before the fix this called openChat a second time and the first chat's
+    // Mount 2: the leak. Before the fix this opened a second chat and the first chat's
     // seats stayed warm forever, referenced by nobody.
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
     await waitFor(() => expect(getChat).toHaveBeenCalledWith(openedId));
@@ -76,14 +87,22 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     expect(openChat, 'a rejoin must not open a second chat').toHaveBeenCalledTimes(1);
   });
 
-  it('a stored id the daemon has already reclaimed is discarded, not rejoined', async () => {
+  it('a stored id the daemon has already reclaimed is discarded — back to first-run, not a re-mint', async () => {
     // The daemon reaps idle chats and enforces a pool cap, so a stored id is a claim and not a
     // fact. `chat_seats` answers an empty list for an unknown chat rather than erroring — which is
-    // exactly the shape that would silently produce a dead-looking chat if trusted.
+    // exactly the shape that would silently produce a dead-looking chat if trusted. Post-slice-4
+    // the discard lands on the calm first-run state (§2.4): nothing re-warms until the user opts in.
+    const user = userEvent.setup();
     sessionStorage.setItem('wicked.chat.r1', 'reclaimed-id');
     getChat.mockResolvedValue({ chatId: 'reclaimed-id', seats: [] });
 
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await waitFor(() => expect(sessionStorage.getItem('wicked.chat.r1')).toBeNull());
+    expect(openChat, 'a reclaimed id must not auto-mint a replacement').not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument();
+
+    // The next opt-in mints FRESH — never the reclaimed id.
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const openedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
     expect(openedId).not.toBe('reclaimed-id');
@@ -94,12 +113,16 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     // A prop change on ONE mounted component, not two renders: `repoId` is an effect dep, so a
     // switch re-runs the effect in place. Two separate mounts would exercise a different path and
     // would not catch state that fails to reset across the switch.
+    const user = userEvent.setup();
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const idA = sessionStorage.getItem('wicked.chat.r1');
 
-    // A different repo is a different conversation — it opens its own rather than reusing r1's.
+    // A different repo is a different conversation — switching lands on ITS first-run state
+    // (nothing stored for r2), and arming there opens its own chat rather than reusing r1's.
     rerender(<GroupChat repoId="r2" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
     const idB = sessionStorage.getItem('wicked.chat.r2');
 
@@ -116,18 +139,20 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     // repo's chat, which is a wrong answer rendered confidently.
     const user = userEvent.setup();
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
 
+    // The first send is the other opt-in (§2.4): it warms the one default agent, then sends.
     await user.type(screen.getByRole('textbox'), 'a message about repo one');
     await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByText('a message about repo one')).toBeTruthy());
 
     rerender(<GroupChat repoId="r2" onBack={() => undefined} />);
-    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
     expect(
       screen.queryByText('a message about repo one'),
       "r1's transcript must not appear under r2's chat",
     ).toBeNull();
+    expect(openChat, "switching repos must not open r2's chat uninvited").toHaveBeenCalledTimes(1);
   });
 
   it('a daemon we cannot reach is not the same as a chat that is gone', async () => {
@@ -144,32 +169,26 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
 
     expect(openChat, 'an unreachable daemon must not mint a second chat').not.toHaveBeenCalled();
     expect(sessionStorage.getItem('wicked.chat.r1')).toBe('maybe-alive');
+    // The kept-on-error chat is disconnectable: Close renders for it (V8's one exception —
+    // there IS something armed here, we just cannot see it).
+    expect(screen.getByTestId('chat-close')).toBeInTheDocument();
   });
 
-  it('a rejoin shows the seats the chat actually has, not the ones the roster lists', async () => {
-    // Optimistic `warming` chips stand in for an open that is in flight. After a rejoin there is no
-    // open and no seat events are coming, so a roster seat absent from the rejoined chat would sit
+  it('a rejoin shows the seats the chat actually has, and never consults the roster', async () => {
+    // Optimistic `warming` chips stand in for an open that is in flight. A rejoin has no open in
+    // flight and no seat events coming, so a roster seat absent from the rejoined chat would sit
     // at `warming` forever with nothing left to correct it — a chip that lies indefinitely.
-    //
-    // The roster is resolved LAST, deliberately. Both requests are in flight at once and the bug
-    // only bites when the roster lands after the rejoin has already written the seat map; letting
-    // the mocks race would make this test pass or fail on microtask ordering rather than on
-    // behaviour.
-    let releaseRoster = (): void => undefined;
-    getRoster.mockReturnValue(
-      new Promise((resolve) => {
-        releaseRoster = () => resolve({ roster: [{ key: 'claude' }, { key: 'codex' }] });
-      }),
-    );
+    // Post-slice-4 the roster is only fetched by the opt-in warm path, so a rejoin must not
+    // touch it at all.
+    getRoster.mockResolvedValue({ roster: [{ key: 'claude' }, { key: 'codex' }] });
     sessionStorage.setItem('wicked.chat.r1', 'live-id');
     getChat.mockResolvedValue({ chatId: 'live-id', seats: ['claude'] });
 
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
     await waitFor(() => expect(screen.getByTitle('ready')).toHaveTextContent('claude'));
-    releaseRoster();
-    await waitFor(() => expect(getRoster).toHaveBeenCalled());
 
     expect(openChat).not.toHaveBeenCalled();
+    expect(getRoster, 'a rejoin warms nothing, so it needs no roster').not.toHaveBeenCalled();
     expect(screen.queryByTitle('warming'), 'no seat may be left warming after a rejoin').toBeNull();
   });
 
@@ -180,13 +199,15 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
    * unresolved on purpose — that is the state under test, not a race to be waited out.
    */
   it('a frame from the previous repo cannot render under the new one', async () => {
+    const user = userEvent.setup();
     sessionStorage.setItem('wicked.chat.r2', 'stored-b');
-    getChat.mockReturnValue(new Promise(() => undefined)); // the probe never answers
 
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const idA = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
 
+    getChat.mockReturnValue(new Promise(() => undefined)); // the probe never answers
     rerender(<GroupChat repoId="r2" onBack={() => undefined} />);
     await waitFor(() => expect(getChat).toHaveBeenCalledWith('stored-b'));
 
@@ -206,36 +227,37 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     ).toBeNull();
   });
 
-  it('ending a chat mid-switch does not close the previous repo’s chat', async () => {
-    // The sharpest form of the misattribution: `closeChat` took the stale id while
-    // `clearStoredChatId` took the CURRENT repo — so it closed r1's chat, dropped r2's key, and left
-    // r1's stored key pointing at a chat that is now dead. Both repos end up wrong at once, and r1's
-    // seats are orphaned behind an id nothing references: the leak, reintroduced by a repo switch.
+  it('mid-switch there is nothing to close — and the previous repo’s chat survives', async () => {
+    // The sharpest form of the misattribution used to be reachable here: an always-visible
+    // "End chat" mid-switch could close r1's chat while clearing r2's key. Post-slice-4 the
+    // teardown control only exists once something is armed (V8), so the window closes
+    // structurally: no Close renders while r2's probe is unresolved, and r1's id survives.
     const user = userEvent.setup();
     sessionStorage.setItem('wicked.chat.r2', 'stored-b');
-    getChat.mockReturnValue(new Promise(() => undefined));
 
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    const idA = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    const idA = sessionStorage.getItem('wicked.chat.r1');
 
+    getChat.mockReturnValue(new Promise(() => undefined));
     rerender(<GroupChat repoId="r2" onBack={() => undefined} />);
     await waitFor(() => expect(getChat).toHaveBeenCalledWith('stored-b'));
 
-    await user.click(screen.getByRole('button', { name: 'End chat' }));
-
-    expect(closeChat, "r1's chat must not be closed by ending r2").not.toHaveBeenCalled();
+    expect(screen.queryByTestId('chat-close'), 'no teardown for an unresolved chat').toBeNull();
+    expect(closeChat).not.toHaveBeenCalled();
     expect(sessionStorage.getItem('wicked.chat.r1')).toBe(idA);
-    expect(sessionStorage.getItem('wicked.chat.r2')).toBeNull();
+    expect(sessionStorage.getItem('wicked.chat.r2')).toBe('stored-b');
   });
 
-  it('End chat forgets the id, so the next mount starts clean instead of rejoining a closed chat', async () => {
+  it('Close forgets the id, so the next mount starts clean instead of rejoining a closed chat', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     expect(sessionStorage.getItem('wicked.chat.r1')).toBeTruthy();
 
-    await user.click(screen.getByRole('button', { name: 'End chat' }));
+    await user.click(await screen.findByTestId('chat-close'));
     await waitFor(() => expect(closeChat).toHaveBeenCalledTimes(1));
     expect(sessionStorage.getItem('wicked.chat.r1')).toBeNull();
   });
@@ -246,9 +268,10 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     const user = userEvent.setup();
     closeChat.mockRejectedValue(new Error('daemon unreachable'));
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
+    await armViaAddAgents(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
 
-    await user.click(screen.getByRole('button', { name: 'End chat' }));
+    await user.click(await screen.findByTestId('chat-close'));
     await waitFor(() => expect(closeChat).toHaveBeenCalledTimes(1));
     expect(sessionStorage.getItem('wicked.chat.r1')).toBeNull();
   });

--- a/tests/ModeSwitcher.test.tsx
+++ b/tests/ModeSwitcher.test.tsx
@@ -6,18 +6,46 @@ import { MODE_SPECS, ModeSwitcher } from '../src/components/ModeSwitcher.js';
 afterEach(cleanup);
 
 describe('ModeSwitcher (DES-MERGE-001 §1.3)', () => {
-  it('shows exactly four tabs, in mode order', () => {
+  it('shows exactly four segments, in mode order, each glyph + label (§2.5 rule 4)', () => {
     render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
     const tabs = screen.getByTestId('mode-switcher').querySelectorAll('[role="tab"]');
     expect(tabs).toHaveLength(4);
     expect([...tabs].map((t) => t.getAttribute('data-mode'))).toEqual(['chat', 'build', 'document', 'video']);
-    expect([...tabs].map((t) => t.textContent)).toEqual(['Chat', 'Build', 'Document', 'Video']);
+    // Each segment carries the mode's glyph AND its label — the same four symbols
+    // the board quick actions and doc tiles use (the spine, DES-UXFIX-001 §2.5).
+    expect([...tabs].map((t) => t.textContent)).toEqual(
+      MODES.map((m) => `${MODE_SPECS[m].glyph}${MODE_SPECS[m].label}`),
+    );
   });
 
   it('marks the active mode selected', () => {
     render(<ModeSwitcher mode="build" onSelect={() => {}} />);
     expect(screen.getByTestId('mode-tab-build')).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByTestId('mode-tab-chat')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('fills the active segment and greys none of the rest — F8, the weight fix (§2.5)', () => {
+    render(<ModeSwitcher mode="document" onSelect={() => {}} />);
+    // The slice-4 DOM AC verbatim: the active segment's background is FILLED,
+    // not transparent — the switcher reads as a control, not as text links.
+    const ACCENT = /#ffda19|rgb\(255,\s*218,\s*25\)/;
+    const active = screen.getByTestId('mode-tab-document');
+    expect(active.style.background).toMatch(ACCENT);
+    const inactive = screen.getByTestId('mode-tab-chat');
+    expect(inactive.style.background).not.toMatch(ACCENT);
+    expect(inactive.style.background).not.toBe('transparent');
+  });
+
+  it('keeps the active mode’s summary ON SCREEN, not tooltip-only (§2.5 rule 2)', () => {
+    render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
+    const summary = screen.getByTestId('mode-summary');
+    expect(summary).toHaveTextContent(MODE_SPECS.chat.summary);
+  });
+
+  it('the summary follows the active mode', () => {
+    const { rerender } = render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
+    rerender(<ModeSwitcher mode="video" onSelect={() => {}} />);
+    expect(screen.getByTestId('mode-summary')).toHaveTextContent(MODE_SPECS.video.summary);
   });
 
   it('selects a mode on click', () => {

--- a/tests/copyTriage.test.tsx
+++ b/tests/copyTriage.test.tsx
@@ -29,9 +29,13 @@ describe('copy triage — internal vocabulary stays internal', () => {
     for (const p of placeholders) expect(p).not.toMatch(/warm seat/i);
   });
 
-  it('the End chat button is not styled as a destructive action', async () => {
+  it('the Close button (né "End chat", V8) is not styled as a destructive action', async () => {
     const src = (await import('node:fs')).readFileSync('src/components/GroupChat.tsx', 'utf8');
-    const btn = src.slice(src.indexOf('End chat') - 600, src.indexOf('End chat'));
+    const anchor = src.indexOf('data-testid="chat-close"');
+    expect(anchor).toBeGreaterThan(-1);
+    const btn = src.slice(anchor, anchor + 600);
     expect(btn).not.toMatch(/f85149|248,\s*81,\s*73/);
+    // V8's rename holds: the old label must not resurface as user copy.
+    expect(src).not.toContain('End chat');
   });
 });


### PR DESCRIPTION
Slice 4: the two front-door findings. ModeSwitcher becomes a real segmented control (glyph+label, accent-filled active segment, always-visible mode summary); Chat mounts cold with zero requests, a teaching empty state, one 'Add agents' disclosure, first send warms a single default agent, 'End chat' → 'Close' and only when something is armed. The verifier caught and fixed a send-during-rejoin-probe race that could orphan a warm chat (FINDING-027 class), regression-pinned. 779/779 tests; all four uxfix rigs green on one fresh build; EC7/EC8/EC10 judged from pixels by verifier and operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)