### PR TITLE
feat(document): three-pane relationship + Themes (DES-UXFIX-001 slice 6)

### DIFF
--- a/.product/evidence/uxfix-slice6/checklist.md
+++ b/.product/evidence/uxfix-slice6/checklist.md
@@ -1,0 +1,105 @@
+# DES-UXFIX-001 — Slice 6 experience-checklist verdicts (§4.1)
+
+**Slice:** 6 — Document three-pane relationship + Themes
+**Date:** 2026-08-20
+**Build:** branch `uxfix/slice-6-document-panes` (on `main` at `772c112`, slices 1–4
+merged; production commit `2180b5b`)
+**Rig:** `e2e/uxfix_slice6_test.py` — the shared W2 fixture server (`uxfix_fixture.py`,
+extended with the interactive document surface: preflight, themes, doc registry,
+per-doc manifests, rendered version HTML, create/fork/events, frames relayed over the
+same `/ws`; the board dataset and switches untouched), captured per the §4.0 contract:
+1440×900, `device_scale_factor=1`, every capture waits on a `data-testid`, never a
+sleep. The journey is W3's, driven through the REAL composer on the empty `scratch`
+project: create a deck from a brief → v1 lands → continue → v2 lands.
+
+The DOM ACs backing each verdict all passed in the same run with a NETWORK TAP
+(JSON report printed by the rig): the strip's box measured extending under the thread
+(`stripSpansUnderThread: true` from `getBoundingClientRect`), `thread-version-tag`
+texts exactly `["▤ v1 landed", "▤ v2 landed"]`, strip-select at v1 focusing the
+message the manifest's `meta.sourceMessageId` names (`focusedMessageId: dmsg-1` — the
+id the client minted at submit, round-tripped through the fixture manifest; the
+slice-9 regression guard), tag-click navigating to `?v=2`, `themes-explain` equal to
+the V19 line verbatim, `theme library` appearing in ZERO testids and ZERO copy, and
+the wire tap showing create/fork each carrying its `source_message_id` and the steer
+riding `wicked.interactive.chat.posted`. The slice-1, slice-2, slice-3 AND slice-4
+rigs were re-run against this exact `dist-sameorigin` build — all green, no
+regression. Full vitest suite: 84 files / 792 tests green; lint and typecheck clean.
+
+**Screenshots judged** (uncommitted evidence, `e2e/shots/uxfix/`):
+
+| Scene | File |
+|---|---|
+| The three-pane surface, v1+v2 landed, spine spanning both | `uxfix-6-document.png` |
+| v1 selected on the strip: canvas at v1, its message in view | `uxfix-6-version-crosslink.png` |
+| The Themes panel open, explaining itself in one line | `uxfix-6-themes.png` |
+
+Judged from the pixels alone, per §4.1 ("if you cannot tell from the image, it fails").
+
+---
+
+## EC7 — the surface teaches itself · **PASS**
+
+Readable from the images alone:
+
+- **The mode says what it is for without a hover.** Under the switcher in every shot,
+  the active summary (slice 4's always-on line) reads: *"Document mode is where the
+  interactive canvas lands: an HTML doc, deck or report, its version strip, and
+  point-and-comment feedback — all against this project's one thread."* One line, the
+  whole surface named.
+- **The spine says what selecting does.** At the strip's thread-side end, beside
+  [Themes] [Export]: *"selecting a version scrolls the thread to the message that made
+  it ▸"* — §2.6 rule 1's "the connective tissue is labelled by what it does", pointing
+  the eye at the pane the selection scrolls.
+- **The composer teaches the continue rhythm.** Its placeholder in the terminal state
+  reads *"Ask for a change — it lands as a new version…"* — what typing DOES, stated
+  where typing happens.
+
+## EC9 — the relationship is visible · **PASS**
+
+This is the slice's reason to exist (F9, W3), and it is legible in `uxfix-6-document.png`
+without knowing the app:
+
+- **Thread messages are tagged with the version they produced.** Each user message
+  carries an accent pill in the wireframe's literal words — *"▤ v1 landed"* under
+  *"Make me a deck for the Q3 review"*, *"▤ v2 landed"* under *"Tighten this
+  headline"* — so the thread side of the link is drawn, not inferred.
+- **The version strip visibly connects canvas and thread.** It is ONE bar along the
+  bottom spanning the full surface — under the canvas AND under the thread (§2.6
+  rule 2's spine, and the rig measures the geometry) — with an accent rule on top,
+  v1 and v2 entries, and the selected entry (v2) in the same accent as the thread
+  tags. There is no dead middle column anywhere: canvas | thread above, one spine
+  below.
+- **The link works in both directions, and the pixels show the state agreeing.** In
+  `uxfix-6-version-crosslink.png`, after selecting v1 on the strip: the canvas shows
+  the VERSION 1 slide (the verbose headline *"Q3 was a quarter of significant and
+  wide-ranging positive developments"*), the v1 entry is the highlighted one, and the
+  thread's v1-tagged message sits in view — canvas ↔ strip ↔ thread reading as one
+  fact. Against `uxfix-6-document.png` (v2: *"Q3: revenue up 18%"*, VERSION 2
+  footer), the same document is visibly two versions, each traceable to its message.
+- **Narration lands in the thread, versions on the strip, the artifact on the canvas**
+  (§2.6 rule 3): the thread shows the agent's own lines (*"Planning the deck — outline
+  first, then the slides."*, *"Tightening the headline and rebalancing the slide."*),
+  the divider *"continues as v2"* marks the continuation, and the canvas holds the
+  rendered deck — three destinations, one conversation, left to right.
+- **Themes is explained where it acts** (V19, the other half of F9): in
+  `uxfix-6-themes.png` the control sits on the strip beside Export, reads **Themes**,
+  and its panel opens with *"Borrow a look from a site, PDF, or image."* above the
+  two themes. No "theme library" spelling appears anywhere in any shot.
+
+## EC10 — no banned state · **PASS**
+
+- **No bare spinner, no bare "Working…", no whimsy** in any of the three shots: every
+  working/finished state names its subject — the narration lines name the deck work,
+  the tags name their versions, the strip entries name their timestamps, the export
+  row names its version ("EXPORT V2").
+- **No error without a next action**: no error state appears in any shot (and the rig
+  recorded zero console errors across the whole journey).
+- **No dead control**: both strip entries' "In thread" affordances are enabled (the
+  rig asserts it — every version in this journey has its anchor), Fork/Export/Themes
+  all name what they act on.
+
+---
+
+**Verdict: slice 6 PASSES its mapped checklist items (EC7, EC9, EC10) from the pixels
+alone, with the DOM ACs green in the same rig run and no regression in slices 1–4's
+surfaces (rigs 1–4 re-run green against the same build; full unit suite green).**

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -33,6 +33,7 @@ import base64
 import hashlib
 import json
 import os
+import re
 import subprocess
 import threading
 import time
@@ -163,6 +164,67 @@ ROSTER = [
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 NARRATION = "Writing the token-bucket middleware for /upload"
 
+# ── The slice-6 document surface (DES-UXFIX-001 §2.6): one doc journey, W3-shaped ──
+#
+# The interactive bridge, reduced to what Document mode reads through crew's proxy:
+# preflight, themes, the doc registry, per-doc manifests, the rendered version HTML,
+# create/fork/events. State is mutable ON PURPOSE — the slice-6 rig drives the real
+# composer (create → generate → continue), and the manifest must grow exactly the way
+# the bridge's would: the version's `meta.sourceMessageId` is whatever id the CLIENT
+# minted and sent, which is what makes the §7.6 strip→thread scroll assertable.
+#
+# Bus frames the journey emits ride the same /ws as the board narration, in the relay
+# envelope the client folds (`{type:"interactiveEvent", event}`): each POST queues its
+# frames and the socket loop drains the queue on its next tick.
+
+THEMES = [{"name": "stripe-ish", "source": "url", "learned_at": iso(NOW0 - 2 * DAY)},
+          {"name": "corporate"}]
+
+# The headline the continue "tightens" — v1 verbose, v2+ tight — so the canvas change
+# between versions is legible in the screenshots, not just a version number swapping.
+HEADLINES = {1: "Q3 was a quarter of significant and wide-ranging positive developments"}
+TIGHT_HEADLINE = "Q3: revenue up 18%"
+
+docs_lock = threading.Lock()
+# pid -> docId -> [version entries, manifest-shaped]. Grown by create/fork below.
+docs_created: dict = {}
+
+ws_lock = threading.Lock()
+ws_queue: list = []
+
+
+def queue_interactive(event_type: str, payload: dict) -> None:
+    """Queue one relayed interactive frame for the /ws loop's next tick."""
+    with ws_lock:
+        ws_queue.append({"type": "interactiveEvent",
+                         "event": {"event_type": event_type, "payload": payload}})
+
+
+def slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "doc"
+
+
+def doc_versions(pid: str, doc: str) -> list:
+    with docs_lock:
+        return list(docs_created.get(pid, {}).get(doc, []))
+
+
+def doc_html(doc: str, version: int) -> str:
+    """The rendered document at one version — a light deck slide, so the canvas reads
+    as a document against the app chrome and the v1→v2 headline change is visible."""
+    headline = HEADLINES.get(version, TIGHT_HEADLINE)
+    return f"""<!doctype html><html><head><meta charset="utf-8"><title>{doc} v{version}</title>
+<style>body{{margin:0;font-family:Georgia,serif;background:#f4f1ea;color:#1b1b1b;
+display:flex;align-items:center;justify-content:center;height:100vh}}
+main{{max-width:720px;padding:48px;background:#fffdf7;border:1px solid #ddd6c4;
+box-shadow:0 2px 18px rgba(0,0,0,.12)}}h1{{font-size:34px;line-height:1.2;margin:0 0 18px}}
+p{{font-size:16px;color:#4a463c;margin:0 0 8px}}footer{{margin-top:26px;font-size:11px;
+color:#8a8471;letter-spacing:.08em;text-transform:uppercase}}</style></head><body>
+<main data-wid="slide-1"><h1 data-wid="headline">{headline}</h1>
+<p>Pipeline grew in every segment; churn held under 2%.</p>
+<p>Focus for Q4: enterprise onboarding and the pricing revamp.</p>
+<footer>Q3 review deck · version {version}</footer></main></body></html>"""
+
 
 def ws_frame(payload: dict) -> bytes:
     data = json.dumps(payload).encode()
@@ -210,6 +272,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                 }))
                 self.wfile.flush()
             while True:
+                # Drain the interactive frames the document journey queued (slice 6) —
+                # the client folds them into the doc thread off this one subscription.
+                with ws_lock:
+                    pending, ws_queue[:] = list(ws_queue), []
+                for frame in pending:
+                    self.wfile.write(ws_frame(frame))
                 self.wfile.write(ws_frame({
                     "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
                     "text": NARRATION + "\n",
@@ -257,10 +325,20 @@ class W2Handler(SimpleHTTPRequestHandler):
                 for ref in MEMBERS.get(pid, [])
             ]})
             return True
-        # /api/v1/projects/<id>/interactive/api/docs — the notes project's registry
+        # /api/v1/projects/<id>/interactive/api/docs — the registry: the notes seeds
+        # plus whatever the slice-6 journey has created in this server's lifetime.
         if path.startswith("/api/v1/projects/") and path.endswith("/interactive/api/docs"):
             pid = urllib.parse.unquote(path.split("/")[4])
-            self._json(200, NOTES_DOCS if pid == "notes" else [])
+            with docs_lock:
+                created = [
+                    {"name": doc, "kind": "doc", "head": max(e["version"] for e in vs),
+                     "versions": len(vs), "updated_at": vs[-1]["created_at"]}
+                    for doc, vs in docs_created.get(pid, {}).items()
+                ]
+            self._json(200, (NOTES_DOCS if pid == "notes" else []) + created)
+            return True
+        # The rest of the interactive surface the Document journey reads (slice 6).
+        if self._interactive_get(path):
             return True
         # /api/v1/runs/<id>/gate
         if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
@@ -289,6 +367,103 @@ class W2Handler(SimpleHTTPRequestHandler):
             return True
         return False
 
+    def _interactive_get(self, path: str) -> bool:
+        """GET half of the slice-6 bridge surface (DES-UXFIX-001 §2.6)."""
+        # /api/v1/projects/<pid>/interactive/api/preflight — all deps present.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/preflight$", path)
+        if m:
+            self._json(200, {"deps": []})
+            return True
+        # /api/v1/projects/<pid>/interactive/api/themes — the library (§4.6).
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/themes$", path)
+        if m:
+            self._json(200, {"themes": THEMES})
+            return True
+        # /api/v1/projects/<pid>/interactive/d/<doc>/api/versions — the manifest.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/versions$", path)
+        if m:
+            pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            versions = doc_versions(pid, doc)
+            if not versions:
+                self._json(404, {"error": f"no versions for {doc}"})
+                return True
+            self._json(200, {"head": max(e["version"] for e in versions),
+                             "kind": "doc", "versions": versions})
+            return True
+        # /api/v1/projects/<pid>/interactive/d/<doc>/doc/<v> — the rendered document.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/doc/(\d+)$", path)
+        if m:
+            doc = urllib.parse.unquote(m.group(2))
+            body = doc_html(doc, int(m.group(3))).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return True
+        return False
+
+    def _interactive_post(self, path: str, body: dict) -> bool:
+        """POST half: create / fork / the UI-originated bus emit. Each one commits the
+        manifest move FIRST and then queues the frames the bridge would emit, so the
+        client's next read is never behind the event that announced it."""
+        # POST /api/v1/projects/<pid>/interactive/api/docs — create (§2.2 case 1).
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/docs$", path)
+        if m:
+            pid = urllib.parse.unquote(m.group(1))
+            doc = slug(str(body.get("name") or "doc"))
+            anchor = body.get("source_message_id")
+            with docs_lock:
+                docs_created.setdefault(pid, {})[doc] = [
+                    {"version": 1, "parent": None, "feedback_file": None,
+                     "html_file": "v1.html", "created_at": iso(NOW0),
+                     "meta": {"sourceMessageId": anchor}}]
+            queue_interactive("wicked.interactive.status.posted", {
+                "project_id": pid, "document_id": doc, "state": "working",
+                "message": "Planning the deck — outline first, then the slides."})
+            queue_interactive("wicked.interactive.version.created", {
+                "project_id": pid, "document_id": doc,
+                "version": 1, "parent": None, "kind": "generated"})
+            self._json(201, {"name": doc, "head": 1, "generating": True, "project_id": pid})
+            return True
+        # POST /api/v1/projects/<pid>/interactive/d/<doc>/api/fork — branch (§7.10).
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/fork$", path)
+        if m:
+            pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            frm = int(body.get("from") or 0)
+            with docs_lock:
+                versions = docs_created.get(pid, {}).get(doc)
+                if versions is None:
+                    self._json(404, {"error": f"no such doc {doc}"})
+                    return True
+                v = max(e["version"] for e in versions) + 1
+                versions.append(
+                    {"version": v, "parent": frm, "feedback_file": None,
+                     "html_file": f"v{v}.html", "created_at": iso(NOW0 + v * SEC),
+                     "meta": {"sourceMessageId": body.get("source_message_id")}})
+            self._json(200, {"version": v, "parent": frm})
+            return True
+        # POST /api/v1/projects/<pid>/interactive/api/events — the inject wire (§5.4).
+        # A chat.posted steer regenerates the doc's head version: narrate, then land it.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/events$", path)
+        if m:
+            pid = urllib.parse.unquote(m.group(1))
+            payload = body.get("payload") or {}
+            doc = payload.get("document_id")
+            if body.get("event_type") == "wicked.interactive.chat.posted" and doc:
+                versions = doc_versions(pid, doc)
+                head = max((e["version"] for e in versions), default=1)
+                queue_interactive("wicked.interactive.status.posted", {
+                    "project_id": pid, "document_id": doc, "state": "working",
+                    "message": "Tightening the headline and rebalancing the slide."})
+                queue_interactive("wicked.interactive.version.created", {
+                    "project_id": pid, "document_id": doc,
+                    "version": head, "parent": head - 1 if head > 1 else None,
+                    "kind": "generated"})
+            self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
+            return True
+        return False
+
     def do_GET(self):  # noqa: N802 (stdlib naming)
         if self.headers.get("Upgrade", "").lower() == "websocket":
             return self._ws()
@@ -307,6 +482,9 @@ class W2Handler(SimpleHTTPRequestHandler):
                 state.update({k: v for k, v in body.items() if k in state})
                 snapshot = dict(state)
             return self._json(200, {"ok": True, "state": snapshot})
+        # The slice-6 document journey's writes (create / fork / bus emit).
+        if self._interactive_post(path, body if isinstance(body, dict) else {}):
+            return None
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
         if path == "/api/v1/chats":

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+uxfix_slice6_test.py — the DES-UXFIX-001 slice-6 gate: Document mode's three-pane
+doc→canvas→thread relationship made visible (§2.6, F9) and the "theme library"
+pill become an explained **Themes** control (V19), proven in a real browser
+against the shared W2 fixture (`uxfix_fixture.py`) extended with the interactive
+document surface (preflight/themes/manifest/rendered HTML/create/fork/events,
+frames relayed over the same /ws).
+
+Same rig pattern as the slice-1/2/3/4 gates: the shared deterministic fixture
+server serves the `dist-sameorigin/` build plus every endpoint the routes read;
+no crew daemon is involved anywhere. This rig never flips the fixture switches.
+
+The journey is W3's, driven through the REAL composer on the empty `scratch`
+project: create a deck from a brief, watch v1 land, continue with a change,
+watch v2 land — then walk the relationship in both directions.
+
+What it asserts (design §4.3, the slice-6 DOM AC):
+  1. The spine (§2.6 rules 1+2): the version strip renders BELOW the row
+     holding canvas AND thread — its box extends under the thread (measured
+     from getBoundingClientRect, not inferred) — with the caption naming what
+     selecting does, and no dead middle column between the panes.
+  2. Thread tags: each message that produced a version carries
+     data-testid="thread-version-tag" with its data-version, reading
+     "▤ v<N> landed"; a tag click navigates to that version (?v=N) and the
+     strip entry highlights — the thread→strip direction.
+  3. The slice-9 regression guard (§7.6): selecting a strip entry swaps the
+     canvas to that version AND scrolls/focuses the thread message whose id
+     the manifest's meta.sourceMessageId names — the id the CLIENT minted at
+     submit, echoed back through the fixture's manifest.
+  4. Themes (V19): data-testid="themes-open" reads "Themes", sits on the strip
+     beside Export, and opening it reveals the one-line explanation ("Borrow a
+     look from a site, PDF, or image."); picking one lands the composer chip.
+     NO data-testid and NO copy reading "theme library" anywhere.
+
+Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
+data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
+  uxfix-6-document.png           the three-pane surface, v1+v2 landed (full page)
+  uxfix-6-version-crosslink.png  v1 selected: canvas at v1, its message focused
+  uxfix-6-themes.png             the Themes panel open, explaining itself
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4334), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    SHOTS,
+    ensure_build,
+    start_server,
+)
+
+W2_PORT = int(os.environ.get("W2_PORT", "4334"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+DOC_URL = f"{ORIGIN}/p/scratch/document"
+EXPLAINER = "Borrow a look from a site, PDF, or image."
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared with the other uxfix rigs — same dist dir) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (§4.2 + the slice-6 document surface) ──────
+start_server(W2_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+console_errors: list[str] = []
+
+
+def tap(page):
+    """Record the document journey's writes: (method, path, json-body-or-None)."""
+    log: list[tuple[str, str, dict | None]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and "/interactive/" in path:
+            body = None
+            if req.post_data:
+                try:
+                    body = json.loads(req.post_data)
+                except ValueError:
+                    body = None
+            log.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return log
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    # §4.0's capture contract, verbatim: 1440x900, device_scale_factor=1.
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net = tap(page)
+
+    # ── Scene 0: the doc-less mode — empty state points at the thread (§2.6 rule 5) ─
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-picker-empty"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    empty = page.evaluate(
+        """() => ({
+             invitesThread: (document.querySelector('[data-testid="doc-picker-empty"]')?.innerText || '')
+               .toLowerCase().includes('thread'),
+             noStrip: !document.querySelector('[data-testid="version-strip"]'),
+             threadUp: !!document.querySelector('[data-testid="doc-composer"]'),
+           })"""
+    )
+    report["steps"]["slice6_empty_state"] = {"ok": all(empty.values()), **empty}
+
+    # ── Scene A: W3 — create from the brief, watch v1 land ────────────────────────
+    page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-entry"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
+
+    # ── Scene B: continue — one composer action, v2 lands, everything advances ────
+    page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="version-divider"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread-version-tag"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    # The canvas is LOADED (its named loading state has retired) before any capture.
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+
+    # AC 1 — the spine: strip below the row holding canvas AND thread, spanning both.
+    spine = page.evaluate(
+        """() => {
+             const strip = document.querySelector('[data-testid="version-strip"]');
+             const row = strip?.previousElementSibling;
+             const canvas = document.querySelector('[data-testid="doc-canvas"]');
+             const thread = document.querySelector('[data-testid="thread"]');
+             const caption = document.querySelector('[data-testid="version-spine-caption"]');
+             const themes = document.querySelector('[data-testid="version-strip"] [data-testid="themes-open"]');
+             const exportMenu = document.querySelector('[data-testid="version-strip"] [data-testid="export-menu"]');
+             const sr = strip?.getBoundingClientRect(), tr = thread?.getBoundingClientRect();
+             return {
+               rowHoldsCanvasAndThread: !!row && row.contains(canvas) && row.contains(thread),
+               stripBelowRow: !!row && row.nextElementSibling === strip,
+               stripSpansUnderThread: !!sr && !!tr && sr.right > tr.left + 100 && sr.top >= tr.bottom - 2,
+               captionText: caption ? caption.textContent : null,
+               themesOnStrip: !!themes, exportOnStrip: !!exportMenu,
+               entries: document.querySelectorAll('[data-testid="version-entry"]').length,
+             };
+           }"""
+    )
+    report["steps"]["slice6_spine"] = {
+        "ok": all([
+            spine["rowHoldsCanvasAndThread"], spine["stripBelowRow"],
+            spine["stripSpansUnderThread"], spine["themesOnStrip"], spine["exportOnStrip"],
+            "scrolls the thread" in (spine["captionText"] or ""),
+            spine["entries"] == 2,
+        ]),
+        **spine,
+    }
+
+    # AC 2 — the tags: both landed versions are tagged, legibly, on their messages.
+    tags = page.evaluate(
+        """() => {
+             const tags = Array.from(document.querySelectorAll('[data-testid="thread-version-tag"]'));
+             const msgs = Array.from(document.querySelectorAll('[data-testid="doc-message"]'));
+             return {
+               tagTexts: tags.map(t => t.textContent.trim()),
+               tagVersions: tags.map(t => t.getAttribute('data-version')),
+               taggedMessageIds: msgs.filter(m => m.hasAttribute('data-version'))
+                 .map(m => [m.getAttribute('data-version'), m.getAttribute('data-message-id')]),
+             };
+           }"""
+    )
+    report["steps"]["slice6_thread_tags"] = {
+        "ok": tags["tagVersions"] == ["1", "2"]
+              and tags["tagTexts"] == ["▤ v1 landed", "▤ v2 landed"]
+              and len(tags["taggedMessageIds"]) == 2,
+        **tags,
+    }
+
+    # AC 4 (half) — no spelling of "theme library" anywhere on the surface.
+    v19 = page.evaluate(
+        """() => ({
+             libraryTestids: document.querySelectorAll('[data-testid*="theme-library"]').length,
+             libraryCopy: document.body.innerText.toLowerCase().includes('theme library'),
+             themesLabel: document.querySelector('[data-testid="themes-open"]')?.textContent.trim(),
+           })"""
+    )
+    report["steps"]["slice6_v19_rename"] = {
+        "ok": v19["libraryTestids"] == 0 and not v19["libraryCopy"] and v19["themesLabel"] == "Themes",
+        **v19,
+    }
+
+    page.screenshot(path=str(SHOTS / "uxfix-6-document.png"))
+
+    # ── Scene C: the cross-link, BOTH directions ──────────────────────────────────
+    # strip → thread (the slice-9 regression guard): selecting v1 swaps the canvas
+    # AND focuses the message whose id the manifest's meta.sourceMessageId names.
+    v1_msg_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"][data-version="1"]')
+                  ?.getAttribute('data-message-id')"""
+    )
+    page.locator('[data-testid="version-entry"][data-version="1"] [data-testid="version-select"]').click()
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+    strip_to_thread = page.evaluate(
+        """() => ({
+             url: location.pathname + location.search,
+             canvasVersion: document.querySelector('[data-testid="doc-canvas"]')?.getAttribute('data-version'),
+             v1Selected: document.querySelector('[data-testid="version-entry"][data-version="1"]')
+               ?.getAttribute('data-selected'),
+             focusedMessageId: document.activeElement?.getAttribute('data-message-id') || null,
+             inThreadEnabled: Array.from(document.querySelectorAll('[data-testid="version-scroll"]'))
+               .every(b => !b.disabled),
+           })"""
+    )
+    report["steps"]["slice6_strip_to_thread"] = {
+        "ok": all([
+            strip_to_thread["url"].endswith("?v=1"),
+            strip_to_thread["canvasVersion"] == "1",
+            strip_to_thread["v1Selected"] == "true",
+            v1_msg_id is not None and strip_to_thread["focusedMessageId"] == v1_msg_id,
+            strip_to_thread["inThreadEnabled"],
+        ]),
+        "v1_message_id": v1_msg_id,
+        **strip_to_thread,
+    }
+    page.screenshot(path=str(SHOTS / "uxfix-6-version-crosslink.png"))
+
+    # thread → strip: clicking a tag navigates to ITS version; the strip follows.
+    page.locator('[data-testid="thread-version-tag"][data-version="2"]').click()
+    page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    thread_to_strip = page.evaluate("() => location.pathname + location.search")
+    report["steps"]["slice6_thread_to_strip"] = {
+        "ok": thread_to_strip.endswith("?v=2"),
+        "url": thread_to_strip,
+    }
+
+    # ── Scene D: Themes explains itself, and a pick becomes the composer chip ─────
+    page.locator('[data-testid="themes-open"]').click()
+    page.locator('[data-testid="themes-panel"]').wait_for(timeout=30000)
+    page.locator('[data-testid="theme-row"]').first.wait_for(timeout=30000)
+    themes = page.evaluate(
+        """expected => {
+             const explain = document.querySelector('[data-testid="themes-explain"]');
+             const rows = Array.from(document.querySelectorAll('[data-testid="theme-row"]'));
+             return {
+               explainText: explain ? explain.textContent.trim() : null,
+               explainMatches: !!explain && explain.textContent.trim() === expected,
+               rowNames: rows.map(r => r.getAttribute('data-theme')),
+             };
+           }""",
+        EXPLAINER,
+    )
+    page.screenshot(path=str(SHOTS / "uxfix-6-themes.png"))
+
+    page.locator('[data-testid="theme-row"][data-theme="stripe-ish"]').click()
+    page.locator('[data-testid="context-chip"][data-chip-value="stripe-ish"]').wait_for(timeout=30000)
+    picked = page.evaluate(
+        """() => ({
+             chipKind: document.querySelector('[data-testid="context-chip"]')?.getAttribute('data-chip-kind'),
+             buttonNamesPick: (document.querySelector('[data-testid="themes-open"]')?.textContent || '')
+               .includes('stripe-ish'),
+           })"""
+    )
+    report["steps"]["slice6_themes"] = {
+        "ok": all([
+            themes["explainMatches"],
+            themes["rowNames"] == ["stripe-ish", "corporate"],
+            picked["chipKind"] == "theme",
+            picked["buttonNamesPick"],
+        ]),
+        **themes, **picked,
+    }
+
+    # ── The wire, as the tap saw it: create carried the anchor; fork carried the
+    # second anchor and branched from v1; the steer rode the inject event. ────────
+    creates = [b for (_m, q, b) in net if q.endswith("/interactive/api/docs")]
+    forks = [b for (_m, q, b) in net if q.endswith("/api/fork")]
+    events = [b for (_m, q, b) in net if q.endswith("/api/events")]
+    report["steps"]["slice6_wire"] = {
+        "ok": all([
+            len(creates) == 1, bool((creates[0] or {}).get("source_message_id")),
+            len(forks) == 1, (forks[0] or {}).get("from") == 1,
+            bool((forks[0] or {}).get("source_message_id")),
+            any((e or {}).get("event_type") == "wicked.interactive.chat.posted" for e in events),
+        ]),
+        "create_bodies": creates, "fork_bodies": forks, "event_types":
+            [(e or {}).get("event_type") for e in events],
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(SHOTS / "uxfix-6-document.png"),
+    str(SHOTS / "uxfix-6-version-crosslink.png"),
+    str(SHOTS / "uxfix-6-themes.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("slice6_verdict", f"slice-6 assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,24 +263,24 @@ export function App(): React.ReactElement {
     // The document's VERSION rides in the query (`?v=N`, slice 9) — the artifact is the
     // doc, the version is a lens on it — so the strip's selection is a real navigation.
     if (m === 'document') {
-      // Canvas and thread are SIBLINGS, never nested: §1.2's "mode surface + the one
-      // conversation thread, always present" (slice 10). The thread is fixed-width and
-      // dismissible-by-navigation — never force-opened over the canvas (§2.5).
+      // Canvas and thread stay VISUAL siblings — the thread is fixed-width and never
+      // force-opened over the canvas (§1.2, §2.5) — but the thread passes through
+      // `DocumentCanvas` as its children so the version strip renders BELOW BOTH: the
+      // spine spanning canvas and thread, DES-UXFIX-001 §2.6 rule 2 (the F9 fix).
       return (
-        <>
-          <DocumentCanvas
-            projectId={pid}
-            docId={artifactId}
-            version={routedVersion(search)}
-            navigate={navigate}
-          />
+        <DocumentCanvas
+          projectId={pid}
+          docId={artifactId}
+          version={routedVersion(search)}
+          navigate={navigate}
+        >
           <DocumentThread
             projectId={pid}
             docId={artifactId}
             selectedVersion={routedVersion(search)}
             navigate={navigate}
           />
-        </>
+        </DocumentCanvas>
       );
     }
     // Video is the same two-sibling shape (§6.4 slice 13): the storyboard + player pair

--- a/src/components/ComposerContext.tsx
+++ b/src/components/ComposerContext.tsx
@@ -1,26 +1,30 @@
 import { useState } from 'react';
-import { listThemes, type LearnKind, type ThemeSummary } from '../api/interactive.js';
+import { type LearnKind } from '../api/interactive.js';
 import {
   attachSourceFromThread, learnReady, learnThemeFromThread, LEARN_KINDS, LEARN_LABEL,
 } from '../interactive/themeWire.js';
 import { contextKey, useDocContextStore } from '../store/docContext.js';
 
-// The composer's context row (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16).
+// The composer's context row (DES-MERGE-001 §4.6, §4.9, §6.4 slice 16; narrowed by
+// DES-UXFIX-001 §2.6 rule 4 / V19, slice 6).
 //
-// Three actions and the chips they produce, in the footer beside the composer, because
+// Two actions and the chips they produce, in the footer beside the composer, because
 // what they change is what the NEXT message generates:
 //
-//   Style   — teach the agent a theme from a website, a PDF or an image (§4.6). The
+//   Learn   — teach the agent a theme from a website, a PDF or an image (§4.6). The
 //             submission is a message (§2.3) and the learning narrates in the thread.
-//   Theme   — the library (built-ins + everything learned). Picking one is a chip, and
-//             the chip rides with the next generation as `theme_id`.
 //   Sources — attach a folder or file the service reads IN PLACE (§4.9). The chip is a
 //             path, never a payload: this component has no file input and builds no
 //             FormData, so attaching context uploads nothing.
 //
-// The two thread actions require an open document, for the same reason the storyboard's
+// PICKING a theme is no longer here: the audit's unexplained "theme library" pill (F9,
+// V19) is now the **Themes** control on the version strip beside Export (`ThemesMenu`),
+// where it acts on the document and explains itself on open. The pick still lands in the
+// same docContext store, so the chip below still shows it and it still rides with the
+// next generation as `theme_id` — only the control moved.
+//
+// Both remaining actions require an open document, for the same reason the storyboard's
 // Record button does: they render as messages, and a message needs a thread to land in.
-// Picking a theme does not — it is context for a generation that has not started yet.
 
 const S = {
   ink:    '#e6edf3',
@@ -52,15 +56,13 @@ const INPUT = 'px-2 py-1 text-[11px] font-mono';
 const GO = 'self-start rounded-lg px-2.5 py-1 text-[11px] font-semibold disabled:opacity-40';
 const NOTE = 'text-[10px] font-mono';
 
-type Panel = 'learn' | 'library' | 'sources';
+type Panel = 'learn' | 'sources';
 
-/** The three actions, in §4.6/§4.9's order. `needsDoc` marks the ones that render as
- *  MESSAGES: a message needs a transcript, so they wait for a document to exist. */
+/** The two actions, in §4.6/§4.9's order. Both render as MESSAGES: a message needs a
+ *  transcript, so they wait for a document to exist. */
 const ACTIONS: ReadonlyArray<{ panel: Panel; testId: string; label: string; title: string; needsDoc: boolean }> = [
   { panel: 'learn', testId: 'context-learn', label: 'learn a theme', needsDoc: true,
     title: 'Teach the agent a theme from a website, a PDF or an image' },
-  { panel: 'library', testId: 'context-library', label: 'theme library', needsDoc: false,
-    title: 'Pick a theme for the next generation' },
   { panel: 'sources', testId: 'context-sources', label: 'attach sources', needsDoc: true,
     title: 'Point at a folder or file the service reads in place — nothing uploads' },
 ];
@@ -99,17 +101,9 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
   const [value, setValue] = useState('');
   const [path, setPath] = useState('');
   const [busy, setBusy] = useState(false);
-  const [themes, setThemes] = useState<ThemeSummary[] | null>(null);
-  const [libraryError, setLibraryError] = useState<string | null>(null);
 
   function toggle(next: Panel): void {
-    const opening = panel !== next;
-    setPanel(opening ? next : null);
-    if (!opening || next !== 'library') return;
-    setLibraryError(null);
-    listThemes(projectId)
-      .then(setThemes)
-      .catch((e: unknown) => setLibraryError(e instanceof Error ? e.message : String(e)));
+    setPanel(panel !== next ? next : null);
   }
 
   async function submitLearn(): Promise<void> {
@@ -119,7 +113,7 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
     // service's own reason) — the panel's job is only to stop offering the same submit.
     const outcome = await learnThemeFromThread({ projectId, docId, kind, value });
     setBusy(false);
-    if (outcome.ok) { setValue(''); setPanel(null); setThemes(null); }
+    if (outcome.ok) { setValue(''); setPanel(null); }
   }
 
   async function submitSource(): Promise<void> {
@@ -131,18 +125,6 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
     useDocContextStore.getState().addSource(key, outcome.entry.path);
     setPath(''); setPanel(null);
   }
-
-  // §3.3: the library says what it is doing or why it cannot, and a library that failed
-  // to load picks nothing rather than silently offering the default as if it were chosen.
-  const status = libraryError !== null
-    ? { testId: 'theme-library-error', danger: true,
-        text: `${libraryError} — no theme was picked; the next generation uses the default.` }
-    : themes === null
-      ? { testId: 'theme-library-loading', danger: false, text: 'Loading the theme library…' }
-      : themes.length === 0
-        ? { testId: 'theme-library-empty', danger: false,
-            text: 'No themes yet — learn one from a website, a PDF or an image.' }
-        : null;
 
   return (
     <div data-testid="thread-context" className="flex flex-col gap-1.5">
@@ -159,15 +141,20 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
         </div>
       )}
 
-      <div className="flex flex-wrap gap-1.5">
-        {ACTIONS.filter((a) => docId !== null || !a.needsDoc).map((a) => (
-          <button key={a.panel} type="button" data-testid={a.testId} title={a.title}
-                  aria-expanded={panel === a.panel} onClick={() => toggle(a.panel)}
-                  className={PILL} style={ACTION}>
-            {a.label}
-          </button>
-        ))}
-      </div>
+      {/* Both actions render as messages, so a doc-less composer offers neither — an
+          empty action row is omitted, not rendered blank (DES-UXFIX-001 §2.1.2's rule,
+          applied at this altitude). */}
+      {docId !== null && (
+        <div className="flex flex-wrap gap-1.5">
+          {ACTIONS.filter((a) => !a.needsDoc || docId !== null).map((a) => (
+            <button key={a.panel} type="button" data-testid={a.testId} title={a.title}
+                    aria-expanded={panel === a.panel} onClick={() => toggle(a.panel)}
+                    className={PILL} style={ACTION}>
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {panel === 'learn' && docId !== null && (
         <div data-testid="learn-panel" className={PANEL} style={BOX}>
@@ -199,30 +186,6 @@ export function ComposerContext({ projectId, docId }: ComposerContextProps): Rea
                   disabled={busy || !learnReady(kind, value)} onClick={() => void submitLearn()}>
             {busy ? 'Submitting…' : `Learn from this ${LEARN_LABEL[kind].noun}`}
           </button>
-        </div>
-      )}
-
-      {panel === 'library' && (
-        <div data-testid="theme-library" className={`${PANEL} gap-1 max-h-40 overflow-y-auto`} style={BOX}>
-          {status !== null && (
-            <p data-testid={status.testId} className={NOTE}
-               style={{ color: status.danger ? S.danger : S.faint, margin: 0 }}>
-              {status.text}
-            </p>
-          )}
-          {(themes ?? []).map((t) => (
-            <button
-              key={t.name} type="button" data-testid="theme-row" data-theme={t.name}
-              aria-pressed={theme === t.name}
-              onClick={() => { useDocContextStore.getState().pickTheme(key, t.name); setPanel(null); }}
-              className="flex items-baseline justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11px] font-mono"
-              style={{ background: theme === t.name ? 'rgba(255,218,25,0.1)' : 'transparent',
-                       color: S.ink, border: 'none', cursor: 'pointer' }}
-            >
-              <span className="truncate">{t.name}</span>
-              <span className="shrink-0 text-[10px]" style={{ color: S.faint }}>{t.source ?? 'built-in'}</span>
-            </button>
-          ))}
         </div>
       )}
 

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getVersions, interactiveUrl, listDocs } from '../api/interactive.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
+import { threadKey, useDocThreadStore } from '../store/docThread.js';
 import { FeedbackOverlay } from './FeedbackOverlay.js';
 import { Failed, Loading, PANEL, S, useLoad } from './SurfaceState.js';
 import { VersionStrip } from './VersionStrip.js';
@@ -18,6 +19,12 @@ import { VersionStrip } from './VersionStrip.js';
 // cannot read `localStorage`, cannot call `/api/v1` with the user's ambient authority,
 // and the parent cannot read `contentDocument` back. Everything the overlay needs comes
 // over the instrument bridge instead (§7.3: the overlay never shipped without it).
+//
+// DES-UXFIX-001 §2.6 (slice 6): the component owns the THREE-PANE relationship. The
+// caller passes the thread as `children`; canvas and thread stay visual siblings in the
+// top row, and the version strip renders BELOW BOTH as the spine spanning canvas and
+// thread (§2.6 rule 2) — there is no dead middle column, and the strip is the one piece
+// of connective tissue between the panes, labelled by what it does (rule 1).
 
 // ── Doc picker — the mode with no `:docId` in the route ──────────────────────
 
@@ -96,13 +103,26 @@ function resolveVersion(manifest: VersionManifest, routed: number | null): numbe
 }
 
 function DocFrame({
-  projectId, docId, version, navigate,
+  projectId, docId, version, navigate, children,
 }: {
   projectId: string; docId: string; version: number | null; navigate: Navigate;
+  children?: React.ReactNode;
 }): React.ReactElement {
-  const [manifest, failure, retry] = useLoad(
-    () => getVersions(projectId, docId), [projectId, docId],
+  // §2.6 rule 3: a landing version re-reads the manifest, so the strip advances and the
+  // canvas swaps the moment the stream lands one — the newcomer watches a message produce
+  // a version produce a canvas change, left to right, without a reload. (VideoStoryboard
+  // already keys its own re-read to the same `landed` fact.)
+  const landed = useDocThreadStore((s) => s.landed[threadKey(projectId, docId)]);
+  const [fresh, failure, retry] = useLoad(
+    () => getVersions(projectId, docId), [projectId, docId, landed],
   );
+  // The last good manifest carries the surface through a re-read: `useLoad` nulls its
+  // value per run, and a strip that unmounted on every landed version would visibly
+  // blink. A doc change REMOUNTS DocFrame (it is keyed on `projectId/docId`), so the
+  // ref can never leak one document's lineage into another's.
+  const lastManifest = useRef<VersionManifest | null>(null);
+  if (fresh !== null) lastManifest.current = fresh;
+  const manifest = fresh ?? lastManifest.current;
   const [loaded, setLoaded] = useState(false);
   // The overlay's instrumentation handshake is keyed to LOADS, not to renders: every
   // swapped version is a different document with a different inventory (§4.3 / INV-1
@@ -112,8 +132,21 @@ function DocFrame({
   useEffect(() => { setLoaded(false); }, [projectId, docId, version]);
 
   const subject = `“${docId}”`;
-  if (failure) return <Failed surface="doc" subject={subject} failure={failure} onRetry={retry} />;
-  if (manifest === null) return <Loading surface="doc" subject={subject} />;
+  // Failure / loading occupy the CANVAS pane only — the thread beside them stays up
+  // (§1.2: the one conversation is always present), and with no manifest there is no
+  // strip, because a spine with nothing to connect would be decoration.
+  if (manifest === null) {
+    return (
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
+          {failure
+            ? <Failed surface="doc" subject={subject} failure={failure} onRetry={retry} />
+            : <Loading surface="doc" subject={subject} />}
+        </div>
+        {children}
+      </div>
+    );
+  }
 
   const shown = resolveVersion(manifest, version);
   // Version-addressed: the VersionStrip swaps this number through the route, nothing else.
@@ -132,6 +165,7 @@ function DocFrame({
 
   return (
     <>
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
       <iframe
         // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
@@ -169,6 +203,10 @@ function DocFrame({
         version={shown}
       />
       </div>
+      {/* The thread pane — a visual sibling of the canvas in this row, so the strip
+          below spans BENEATH BOTH: §2.6 rule 2's spine, drawn rather than implied. */}
+      {children}
+      </div>
       <VersionStrip
         projectId={projectId}
         docId={docId}
@@ -188,15 +226,28 @@ export interface DocumentCanvasProps {
   /** The routed `?v=N` (slice 9); `null` addresses the manifest head. */
   version?: number | null;
   navigate: Navigate;
+  /** The thread pane (DES-UXFIX-001 §2.6): rendered in the top row beside the canvas so
+   *  the version strip spans beneath both. Canvas and thread stay visual siblings — this
+   *  slot exists only so ONE component owns where the spine sits relative to the panes. */
+  children?: React.ReactNode;
 }
 
 export function DocumentCanvas({
-  projectId, docId, version = null, navigate,
+  projectId, docId, version = null, navigate, children,
 }: DocumentCanvasProps): React.ReactElement {
   return (
     <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
       {docId === null
-        ? <DocPicker projectId={projectId} navigate={navigate} />
+        ? (
+          // No doc means no versions, so there is no spine row — the picker's empty
+          // state points at the thread instead (§2.6 rule 5, W3 step 2).
+          <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+            <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
+              <DocPicker projectId={projectId} navigate={navigate} />
+            </div>
+            {children}
+          </div>
+        )
         : (
           <DocFrame
             key={`${projectId}/${docId}`}
@@ -204,7 +255,9 @@ export function DocumentCanvas({
             docId={docId}
             version={version}
             navigate={navigate}
-          />
+          >
+            {children}
+          </DocFrame>
         )}
     </div>
   );

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -6,6 +6,7 @@ import { recordFromThread } from '../interactive/demoWire.js';
 import { runExport } from '../interactive/exportWire.js';
 import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
+import { scrollStripToVersion } from './threadAnchor.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { contextKey, useDocContextStore } from '../store/docContext.js';
 import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
@@ -50,10 +51,16 @@ const COMPOSER: Record<GenState, { placeholder: string; submit: string }> = {
 
 // ── Message renderers ────────────────────────────────────────────────────────
 
-function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; docId: string | null }): React.ReactElement | null {
+function Bubble({
+  msg, projectId, docId, onShowVersion,
+}: {
+  msg: DocMsg; projectId: string; docId: string | null;
+  /** The tag's cross-link (DES-UXFIX-001 §2.6 rule 2): show this version on the strip. */
+  onShowVersion?: (version: number) => void;
+}): React.ReactElement | null {
   if (msg.kind === 'user') {
     return (
-      <div className="flex justify-end">
+      <div className="flex flex-col items-end gap-1">
         <div
           data-testid="doc-message"
           data-message-id={msg.id}
@@ -88,6 +95,24 @@ function Bubble({ msg, projectId, docId }: { msg: DocMsg; projectId: string; doc
             <NotRecordedChip projectId={projectId} docId={docId} msgId={msg.id} text={msg.text} />
           )}
         </div>
+        {/* §2.6 rule 2 (DES-UXFIX-001, the F9 fix): the message that produced a version
+            is TAGGED with it, and the tag cross-links to the strip — the same seam the
+            strip's "In thread" crosses the other way. The eye can trace canvas ↔ strip ↔
+            thread in both directions. */}
+        {msg.version !== undefined && (
+          <button
+            type="button"
+            data-testid="thread-version-tag"
+            data-version={String(msg.version)}
+            onClick={() => { if (msg.version !== undefined) onShowVersion?.(msg.version); }}
+            title={`This message made v${msg.version} — show it on the canvas and the strip`}
+            className="rounded-full px-2 py-0.5 text-[10px] font-mono"
+            style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
+                     border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+          >
+            ▤ v{msg.version} landed
+          </button>
+        )}
       </div>
     );
   }
@@ -398,6 +423,15 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     }
   }
 
+  // The tag's cross-link (§2.6 rule 2): selecting the version IS a navigation — the
+  // same `?v=N` the strip selects by — plus putting its strip entry in view. The strip
+  // owns the reverse direction (its select scrolls the thread to the message, §7.6).
+  function showVersion(version: number): void {
+    if (docId === null) return;
+    navigate(versionPath(projectId, docId, version));
+    scrollStripToVersion(version);
+  }
+
   const { placeholder, submit: label } = COMPOSER[state];
   // Case 1 is the only state whose words differ by artifact — what the composer DOES is
   // the same function of run state either way (§2.2), it just says what it will make.
@@ -446,7 +480,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                   onAnswered={() => useDocThreadStore.getState().setGenState(key, 'generating')}
                 />
               )) || null
-            : <Bubble key={m.id} msg={m} projectId={projectId} docId={docId} />,
+            : <Bubble key={m.id} msg={m} projectId={projectId} docId={docId} onShowVersion={showVersion} />,
         )}
         <div ref={bottom} />
       </div>

--- a/src/components/ThemesMenu.tsx
+++ b/src/components/ThemesMenu.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { listThemes, type ThemeSummary } from '../api/interactive.js';
+import { contextKey, useDocContextStore } from '../store/docContext.js';
+
+// The Themes control (DES-UXFIX-001 §2.6 rule 4, V19; the library itself is DES-MERGE-001
+// §4.6). The audit's "theme library" pill floated unexplained in the composer context
+// (F9): a newcomer could not say what a theme was or what picking one did. The redesign
+// renames it to the one word "Themes", moves it into the canvas toolbar beside Export —
+// where it acts on the document — and opens with ONE line saying what it is:
+// "Borrow a look from a site, PDF, or image."
+//
+// Picking is unchanged underneath: the choice lands in the docContext store keyed to this
+// composer, renders as the composer's context chip, and rides with the NEXT generation as
+// `theme_id` — a theme is context for what the conversation makes, not an edit of what
+// the canvas already shows. Learning a new theme stays in the composer's "learn a theme"
+// action, because that submission is a thread message (§2.3).
+
+const S = {
+  ink:    '#e6edf3',
+  faint:  'rgba(230,237,243,0.35)',
+  muted:  'rgba(230,237,243,0.55)',
+  accent: '#ffda19',
+  card:   '#1b222e',
+  border: 'rgba(230,237,243,0.1)',
+  danger: '#f85149',
+};
+
+const BUTTON: React.CSSProperties = {
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '5px',
+  color: S.muted, cursor: 'pointer', fontSize: '10px', lineHeight: 1.6, padding: '1px 6px',
+};
+
+/** V19's one-line explanation, shown every time the menu opens — never tooltip-only. */
+export const THEMES_EXPLAINER = 'Borrow a look from a site, PDF, or image.';
+
+export interface ThemesMenuProps {
+  projectId: string;
+  docId: string;
+}
+
+export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactElement {
+  const key = contextKey(projectId, docId);
+  const picked = useDocContextStore((s) => s.theme[key]);
+  const [open, setOpen] = useState(false);
+  const [themes, setThemes] = useState<ThemeSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function toggle(): void {
+    const opening = !open;
+    setOpen(opening);
+    if (!opening) return;
+    setError(null);
+    listThemes(projectId)
+      .then(setThemes)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+  }
+
+  // §3.3: the menu says what it is doing or why it cannot, and a list that failed to
+  // load picks nothing rather than silently offering the default as if it were chosen.
+  const status = error !== null
+    ? { testId: 'themes-error', danger: true,
+        text: `${error} — no theme was picked; the next generation uses the default.` }
+    : themes === null
+      ? { testId: 'themes-loading', danger: false, text: 'Loading the themes…' }
+      : themes.length === 0
+        ? { testId: 'themes-empty', danger: false,
+            text: 'No themes yet — learn one from a website, a PDF or an image.' }
+        : null;
+
+  return (
+    <div style={{ alignSelf: 'center', flexShrink: 0, position: 'relative' }}>
+      <button
+        type="button"
+        data-testid="themes-open"
+        aria-expanded={open}
+        onClick={toggle}
+        title={`${THEMES_EXPLAINER} The pick rides with the next generation.`}
+        style={{ ...BUTTON, ...(picked !== undefined ? { color: S.accent } : {}) }}
+      >
+        Themes{picked !== undefined ? `: ${picked}` : ''}
+      </button>
+
+      {open && (
+        <div
+          data-testid="themes-panel"
+          className="flex flex-col gap-1 overflow-y-auto"
+          style={{
+            background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+            bottom: 'calc(100% + 6px)', maxHeight: '200px', padding: '8px 10px',
+            position: 'absolute', right: 0, width: '250px', zIndex: 30,
+          }}
+        >
+          <p
+            data-testid="themes-explain"
+            style={{ color: S.muted, fontSize: '11px', lineHeight: 1.4, margin: 0 }}
+          >
+            {THEMES_EXPLAINER}
+          </p>
+          {status !== null && (
+            <p
+              data-testid={status.testId}
+              className="text-[10px] font-mono"
+              style={{ color: status.danger ? S.danger : S.faint, margin: 0 }}
+            >
+              {status.text}
+            </p>
+          )}
+          {(themes ?? []).map((t) => (
+            <button
+              key={t.name}
+              type="button"
+              data-testid="theme-row"
+              data-theme={t.name}
+              aria-pressed={picked === t.name}
+              onClick={() => {
+                useDocContextStore.getState().pickTheme(key, t.name);
+                setOpen(false);
+              }}
+              className="flex items-baseline justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11px] font-mono"
+              style={{ background: picked === t.name ? 'rgba(255,218,25,0.1)' : 'transparent',
+                       color: S.ink, border: 'none', cursor: 'pointer' }}
+            >
+              <span className="truncate">{t.name}</span>
+              <span className="shrink-0 text-[10px]" style={{ color: S.faint }}>
+                {t.source ?? 'built-in'}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -3,6 +3,7 @@ import { postFork } from '../api/interactive.js';
 import type { ForkResult, VersionEntry, VersionManifest } from '../api/interactive.js';
 import { versionPath, type Navigate } from '../hooks/useRoute.js';
 import { ExportMenu } from './ExportMenu.js';
+import { ThemesMenu } from './ThemesMenu.js';
 import { scrollThreadToMessage } from './threadAnchor.js';
 
 // The rewind / compare / fork surface (DES-MERGE-001 §4.2, §6.3 slice 9). The version
@@ -20,6 +21,12 @@ import { scrollThreadToMessage } from './threadAnchor.js';
 //   3. A fork is the service's decision: `POST /d/:docId/api/fork` returns the new
 //      version and its parent, and the strip re-reads the manifest rather than
 //      predicting what the branch produced.
+//
+// DES-UXFIX-001 §2.6 (slice 6): the strip is drawn as the SPINE — its owner mounts it
+// spanning canvas and thread, the accent rule along its top is the drawn connection, and
+// it says in one line what selecting a version does (rule 1: the connective tissue is
+// labelled by what it does). The canvas toolbar it carries is [Themes] [Export] — the
+// two actions that act on the document at the addressed version (rule 4, V19).
 
 const S = {
   bar:      '#0f1419',
@@ -111,7 +118,8 @@ export function VersionStrip({
     <div
       data-testid="version-strip"
       style={{
-        alignItems: 'stretch', background: S.bar, borderTop: `1px solid ${S.border}`,
+        alignItems: 'stretch', background: S.bar,
+        borderTop: '2px solid rgba(255,218,25,0.35)',
         display: 'flex', flexShrink: 0, gap: '8px', padding: '10px 12px',
       }}
     >
@@ -209,6 +217,21 @@ export function VersionStrip({
         </span>
       )}
       </div>
+
+      {/* §2.6 rule 1: the spine is labelled by what it does. This caption sits at the
+          strip's thread-side end, pointing the eye at the pane the selection scrolls. */}
+      <span
+        data-testid="version-spine-caption"
+        style={{
+          alignSelf: 'center', color: S.faint, flexShrink: 1, fontSize: '10px',
+          lineHeight: 1.3, maxWidth: '210px', minWidth: 0, textAlign: 'right',
+        }}
+      >
+        selecting a version scrolls the thread to the message that made it ▸
+      </span>
+
+      {/* The canvas toolbar (§2.6 rule 4): [Themes] [Export], acting on the document. */}
+      <ThemesMenu projectId={projectId} docId={docId} />
 
       {/* §4.4: export is PER-VERSION, so it belongs to the surface that owns which version
           is addressed. The selection is the subject — exporting "the document" would be

--- a/src/components/threadAnchor.ts
+++ b/src/components/threadAnchor.ts
@@ -31,3 +31,20 @@ export function scrollThreadToMessage(messageId: string): boolean {
   el.focus({ preventScroll: true });
   return true;
 }
+
+/**
+ * The same seam, pointed the other way (DES-UXFIX-001 §2.6 rule 2): a thread message's
+ * `▤ v<N> landed` tag puts ITS version entry in view on the strip, so the eye can trace
+ * thread → strip → canvas as well as canvas → strip → thread. The strip scrolls
+ * horizontally, so the entry is centred on the inline axis; a strip that is not on
+ * screen (a doc-less thread) is a reported miss, never a throw — the tag's navigation
+ * (the `?v=N` route) never depends on it.
+ */
+export function scrollStripToVersion(version: number): boolean {
+  const el = document.querySelector(
+    `[data-testid="version-strip"] [data-testid="version-entry"][data-version="${version}"]`,
+  );
+  if (!(el instanceof HTMLElement)) return false;
+  el.scrollIntoView({ block: 'nearest', inline: 'center' });
+  return true;
+}

--- a/tests/ComposerContext.test.tsx
+++ b/tests/ComposerContext.test.tsx
@@ -90,67 +90,38 @@ beforeEach(() => {
 });
 afterEach(cleanup);
 
-// ── AC: theme pick → chip ────────────────────────────────────────────────────
+// ── AC (DES-UXFIX-001 V19, slice 6): the library pill LEFT this row ──────────
 
-describe('the theme library', () => {
-  it('lists the learned themes and picking one renders the context chip', async () => {
+describe('the theme pick moved to the strip (V19) — the chip stayed here', () => {
+  it('offers NO library pill and no "theme library" spelling — that control is ThemesMenu, on the strip', () => {
+    const { container } = mountContext();
+    expect(screen.queryByTestId('context-library')).toBeNull();
+    expect(container.querySelectorAll('[data-testid*="theme-library"]')).toHaveLength(0);
+    expect(container.textContent ?? '').not.toMatch(/theme library/i);
+    // Never fetched from here either: the row no longer has a reason to list themes.
+    expect(listThemes).not.toHaveBeenCalled();
+  });
+
+  it('a theme picked on the strip still renders as THIS row’s chip, and the chip clears the pick', async () => {
     const user = userEvent.setup();
+    useDocContextStore.getState().pickTheme(contextKey(PROJECT, DOC), 'stripe-ish');
     mountContext();
-    expect(chips()).toHaveLength(0);
 
-    await user.click(screen.getByTestId('context-library'));
-    const rows = await screen.findAllByTestId('theme-row');
-    expect(rows.map((r) => r.getAttribute('data-theme'))).toEqual(['stripe-ish', 'corporate']);
-    expect(listThemes).toHaveBeenCalledWith(PROJECT);
-
-    await user.click(rows[0]!);
     await waitFor(() => expect(chips()).toHaveLength(1));
     expect(chips()[0]).toHaveAttribute('data-chip-kind', 'theme');
     expect(chips()[0]).toHaveAttribute('data-chip-value', 'stripe-ish');
     expect(chips()[0]).toHaveTextContent('stripe-ish');
-  });
-
-  it('picking a second theme REPLACES the first — one theme at a time (§4.6)', async () => {
-    const user = userEvent.setup();
-    mountContext();
-    await user.click(screen.getByTestId('context-library'));
-    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
-    await user.click(screen.getByTestId('context-library'));
-    await user.click((await screen.findAllByTestId('theme-row'))[1]!);
-    await waitFor(() => expect(chips()).toHaveLength(1));
-    expect(chips()[0]).toHaveAttribute('data-chip-value', 'corporate');
-  });
-
-  it('the chip is removable, and removing it clears the pick', async () => {
-    const user = userEvent.setup();
-    mountContext();
-    await user.click(screen.getByTestId('context-library'));
-    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
-    await waitFor(() => expect(chips()).toHaveLength(1));
 
     await user.click(screen.getByTestId('context-chip-remove'));
     await waitFor(() => expect(chips()).toHaveLength(0));
     expect(useDocContextStore.getState().theme[contextKey(PROJECT, DOC)]).toBeUndefined();
   });
 
-  it('is pickable with NO document open — it is context for a generation not yet started', async () => {
-    const user = userEvent.setup();
+  it('with NO document open the row offers nothing — both remaining actions are messages', () => {
     mountContext(null);
-    // The two THREAD actions need a transcript for their message; the pick does not.
     expect(screen.queryByTestId('context-learn')).toBeNull();
     expect(screen.queryByTestId('context-sources')).toBeNull();
-    await user.click(screen.getByTestId('context-library'));
-    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
-    await waitFor(() => expect(chips()).toHaveLength(1));
-  });
-
-  it('a library that cannot be read says so and picks nothing (§3.3)', async () => {
-    listThemes.mockRejectedValue(new Error('API 503: bridge down'));
-    const user = userEvent.setup();
-    mountContext();
-    await user.click(screen.getByTestId('context-library'));
-    expect(await screen.findByTestId('theme-library-error')).toHaveTextContent('bridge down');
-    expect(chips()).toHaveLength(0);
+    expect(screen.queryByTestId('context-library')).toBeNull();
   });
 });
 

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -8,9 +8,10 @@
 //   3. The picker orders most-recent first and navigates into /p/<id>/document/<docId>;
 //      empty invites creation rather than rendering blank.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DocumentCanvas } from '../src/components/DocumentCanvas.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
 import type { DocSummary, VersionManifest } from '../src/api/interactive.js';
 
 const PROJECT = 'proj-abc-123';
@@ -309,5 +310,96 @@ describe('DocumentCanvas — the picker (§6.3: no :docId in the route)', () => 
 
     await waitFor(() => expect(seen.length).toBe(1));
     expect(seen[0]).toBe(`http://127.0.0.1:7788/api/v1/projects/${PROJECT}/interactive/api/docs`);
+  });
+});
+
+// ── DES-UXFIX-001 §2.6 (slice 6): the three-pane spine ───────────────────────
+
+describe('DocumentCanvas — the strip is the spine spanning canvas and thread (§2.6)', () => {
+  const thread = <aside data-testid="fake-thread">the thread pane</aside>;
+
+  beforeEach(() => {
+    useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  });
+
+  it('AC: the thread rides IN the top row and the strip renders BELOW both — no dead middle column', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(
+      <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
+        {thread}
+      </DocumentCanvas>,
+    );
+
+    await screen.findByTestId('doc-canvas');
+    const row = screen.getByTestId('fake-thread').parentElement!;
+    const strip = screen.getByTestId('version-strip');
+    // Canvas and thread are visual siblings in one row; the strip is that row's OWN
+    // next sibling — beneath canvas AND thread, the drawn doc↔canvas↔thread spine.
+    expect(row.contains(screen.getByTestId('doc-canvas'))).toBe(true);
+    expect(row.contains(strip)).toBe(false);
+    expect(row.nextElementSibling).toBe(strip);
+  });
+
+  it('the spine says what selecting does, and carries [Themes] [Export] (§2.6 rules 1+4)', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    await screen.findByTestId('doc-canvas');
+    const strip = screen.getByTestId('version-strip');
+    expect(strip.querySelector('[data-testid="version-spine-caption"]'))
+      .toHaveTextContent(/selecting a version scrolls the thread/i);
+    expect(strip.querySelector('[data-testid="themes-open"]')).toHaveTextContent('Themes');
+    expect(strip.querySelector('[data-testid="export-menu"]')).not.toBeNull();
+  });
+
+  it('the thread stays up while the canvas loads AND when it fails (§1.2: always present)', async () => {
+    stubFetch({ '/api/versions': { status: 500, body: { error: 'versions.json is corrupt' } } });
+    render(
+      <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
+        {thread}
+      </DocumentCanvas>,
+    );
+
+    expect(screen.getByTestId('fake-thread')).toBeInTheDocument();     // while loading
+    await screen.findByTestId('doc-canvas-error');
+    expect(screen.getByTestId('fake-thread')).toBeInTheDocument();     // on failure
+    expect(screen.queryByTestId('version-strip')).toBeNull();          // no manifest, no spine
+  });
+
+  it('the doc-less picker keeps the thread beside it, with no spine row', async () => {
+    stubFetch({ '/api/docs': { body: [] } });
+    render(
+      <DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}}>
+        {thread}
+      </DocumentCanvas>,
+    );
+
+    await screen.findByTestId('doc-picker-empty');
+    expect(screen.getByTestId('fake-thread')).toBeInTheDocument();
+    expect(screen.queryByTestId('version-strip')).toBeNull();
+  });
+
+  it('AC (§2.6 rule 3): a LANDED version re-reads the manifest — the strip advances, no reload', async () => {
+    const grown: VersionManifest = {
+      head: 4,
+      versions: [...MANIFEST.versions, {
+        version: 4, parent: 3, feedback_file: null, html_file: 'v4.html',
+        created_at: '2026-08-18T11:00:00Z', meta: { sourceMessageId: 'dmsg-4' },
+      }],
+    };
+    let reads = 0;
+    stubFetch({ '/api/versions': { get body() { reads += 1; return reads === 1 ? MANIFEST : grown; } } });
+    render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
+
+    await screen.findByTestId('doc-canvas');
+    expect(screen.getAllByTestId('version-entry')).toHaveLength(3);
+
+    // The stream lands v4 (the docThread store's `landed` fact — same trigger
+    // VideoStoryboard re-reads on). The strip must advance without a remount.
+    act(() => { useDocThreadStore.setState({ landed: { [threadKey(PROJECT, DOC)]: 4 } }); });
+
+    await waitFor(() => expect(screen.getAllByTestId('version-entry')).toHaveLength(4));
+    // …and the strip never blinked: the canvas stayed mounted through the re-read.
+    expect(screen.getByTestId('doc-canvas')).toBeInTheDocument();
   });
 });

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -258,3 +258,47 @@ describe('the transcript is the record (§2.3, §2.5)', () => {
     expect(screen.getByTestId('thread').querySelector('[data-message-id="dmsg-anchor"]')).toBe(message);
   });
 });
+
+// ── DES-UXFIX-001 §2.6 rule 2 (slice 6): the visible half of the F9 fix ──────
+
+describe('the ▤ v<N> landed tag — the thread half of the doc↔canvas↔thread link', () => {
+  function landVersion(version: number): void {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dmsg-anchor', 'make the intro punchier');
+    store.ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.version.created',
+        payload: { project_id: PROJECT, document_id: DOC, version, parent: version - 1, kind: 'generated' },
+      },
+    } as never);
+  }
+
+  it('AC: the message that produced a version is TAGGED with it, visibly', () => {
+    landVersion(7);
+    mount(DOC);
+
+    const tag = screen.getByTestId('thread-version-tag');
+    expect(tag).toHaveAttribute('data-version', '7');
+    // The tag is the wireframe's literal words — legible, not attribute-only (EC9).
+    expect(tag).toHaveTextContent('▤ v7 landed');
+  });
+
+  it('AC: the tag CROSS-LINKS to the strip — clicking navigates to that version', async () => {
+    landVersion(7);
+    mount(DOC);
+
+    await userEvent.click(screen.getByTestId('thread-version-tag'));
+    // The same `?v=N` route the strip selects by: the canvas swaps, the strip entry
+    // highlights, and Back rewinds the move — a navigation, never local state.
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=7`);
+  });
+
+  it('a message that produced NO version carries no tag', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'dmsg-1', 'still thinking about this');
+    mount(DOC);
+
+    expect(screen.getByTestId('doc-message')).not.toHaveAttribute('data-version');
+    expect(screen.queryByTestId('thread-version-tag')).toBeNull();
+  });
+});

--- a/tests/ThemesMenu.test.tsx
+++ b/tests/ThemesMenu.test.tsx
@@ -1,0 +1,137 @@
+// The Themes control on the version strip — DES-UXFIX-001 §2.6 rule 4 / V19 (slice 6).
+//
+// The audit's finding (F9): a "theme library" pill floating unexplained in the composer
+// context. What is asserted here is the redesign's contract: the control is named
+// "Themes", it EXPLAINS itself in one line the moment it opens, picking still lands in
+// the docContext store (so the chip and the `theme_id` wire of slice 16 are untouched),
+// and no spelling of "theme library" survives anywhere on the surface.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposerContext } from '../src/components/ComposerContext.js';
+import { ThemesMenu, THEMES_EXPLAINER } from '../src/components/ThemesMenu.js';
+import { contextKey, useDocContextStore } from '../src/store/docContext.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'q3-report';
+const KEY = contextKey(PROJECT, DOC);
+
+const listThemes = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  listThemes: (...a: unknown[]) => listThemes(...a),
+}));
+
+const THEMES = [
+  { name: 'stripe-ish', source: 'url' as const, learned_at: '2026-08-18T10:00:00Z' },
+  { name: 'corporate', learned_at: undefined },
+];
+
+function mount(): ReturnType<typeof render> {
+  return render(<ThemesMenu projectId={PROJECT} docId={DOC} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocContextStore.setState({ theme: {}, sources: {} });
+  listThemes.mockResolvedValue(THEMES);
+});
+afterEach(cleanup);
+
+describe('Themes — named, placed, and explained (V19)', () => {
+  it('AC: the control reads "Themes" and opening it reveals the ONE-LINE explanation', async () => {
+    const user = userEvent.setup();
+    mount();
+
+    const open = screen.getByTestId('themes-open');
+    expect(open).toHaveTextContent('Themes');
+    // Nothing fetched and nothing explained until the user asks (the pill's old sin
+    // was the reverse: always on screen, never explained).
+    expect(listThemes).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('themes-explain')).toBeNull();
+
+    await user.click(open);
+    expect(screen.getByTestId('themes-explain')).toHaveTextContent(THEMES_EXPLAINER);
+    expect(screen.getByTestId('themes-explain')).toHaveTextContent(
+      'Borrow a look from a site, PDF, or image.',
+    );
+    expect(listThemes).toHaveBeenCalledWith(PROJECT);
+  });
+
+  it('AC: NO spelling of "theme library" survives — testid or copy', async () => {
+    const user = userEvent.setup();
+    const { container } = mount();
+    await user.click(screen.getByTestId('themes-open'));
+    await screen.findAllByTestId('theme-row');
+
+    expect(container.querySelectorAll('[data-testid*="theme-library"]')).toHaveLength(0);
+    expect(container.textContent ?? '').not.toMatch(/theme library/i);
+  });
+
+  it('lists the themes and picking one lands in the docContext store (the slice-16 wire)', async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.click(screen.getByTestId('themes-open'));
+
+    const rows = await screen.findAllByTestId('theme-row');
+    expect(rows.map((r) => r.getAttribute('data-theme'))).toEqual(['stripe-ish', 'corporate']);
+
+    await user.click(rows[0]!);
+    // The pick is context for the NEXT generation — same store, same key, same chip.
+    expect(useDocContextStore.getState().theme[KEY]).toBe('stripe-ish');
+    // The menu closes and the control now NAMES what is in effect.
+    expect(screen.queryByTestId('themes-panel')).toBeNull();
+    expect(screen.getByTestId('themes-open')).toHaveTextContent('Themes: stripe-ish');
+  });
+
+  it('picking a second theme REPLACES the first — one theme at a time (§4.6)', async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.click(screen.getByTestId('themes-open'));
+    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
+    await user.click(screen.getByTestId('themes-open'));
+    await user.click((await screen.findAllByTestId('theme-row'))[1]!);
+
+    expect(useDocContextStore.getState().theme[KEY]).toBe('corporate');
+  });
+
+  it('the pick still renders as the composer chip, and removing the chip clears it', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <ThemesMenu projectId={PROJECT} docId={DOC} />
+        <ComposerContext projectId={PROJECT} docId={DOC} />
+      </>,
+    );
+    await user.click(screen.getByTestId('themes-open'));
+    await user.click((await screen.findAllByTestId('theme-row'))[0]!);
+
+    const chip = await screen.findByTestId('context-chip');
+    expect(chip).toHaveAttribute('data-chip-kind', 'theme');
+    expect(chip).toHaveAttribute('data-chip-value', 'stripe-ish');
+
+    await user.click(screen.getByTestId('context-chip-remove'));
+    await waitFor(() => expect(screen.queryByTestId('context-chip')).toBeNull());
+    expect(useDocContextStore.getState().theme[KEY]).toBeUndefined();
+  });
+
+  it('a list that cannot be read says so and picks NOTHING (§3.3)', async () => {
+    listThemes.mockRejectedValue(new Error('API 503: bridge down'));
+    const user = userEvent.setup();
+    mount();
+    await user.click(screen.getByTestId('themes-open'));
+
+    expect(await screen.findByTestId('themes-error')).toHaveTextContent('bridge down');
+    expect(screen.getByTestId('themes-error')).toHaveTextContent('no theme was picked');
+    expect(useDocContextStore.getState().theme[KEY]).toBeUndefined();
+  });
+
+  it('an empty list points at where themes come from, in one line', async () => {
+    listThemes.mockResolvedValue([]);
+    const user = userEvent.setup();
+    mount();
+    await user.click(screen.getByTestId('themes-open'));
+
+    expect(await screen.findByTestId('themes-empty')).toHaveTextContent(/learn one/i);
+  });
+});


### PR DESCRIPTION
Slice 6 closes the UXFIX arc: the doc→canvas→thread relationship made visible. Version strip spans below canvas AND thread with the rule caption; thread messages that produced a version carry 'v<N> landed' tags cross-linking both ways; the canvas re-reads the manifest as versions land (the strip advances live); the unexplained 'theme library' pill becomes a Themes menu on the strip ('Borrow a look from a site, PDF, or image.'). Rebased over slice 5; all six rigs green on a fresh build (an earlier local failure was a stale dist cache, not a semantic conflict); EC-judged from pixels by verifier and operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)