### PR TITLE
feat(home): the orchestrator reimagined — status wall + live feed (DES-VISION-001 slice 2)

### DIFF
--- a/.product/evidence/vision-slice2/checklist.md
+++ b/.product/evidence/vision-slice2/checklist.md
@@ -1,0 +1,75 @@
+# DES-VISION-001 slice 2 — experience checklist verdicts
+
+**Slice:** the orchestrator home reimagined (§5.1 — the §1.3 composition: status wall +
+live-feed sidebar). HomeBoard/ProjectCard/GateChip token-converted wholesale; the 2px
+status bar on ACTIVE card tops (the leading signal kind AS color, §1.4); narration in
+`--font-mono` (§1.5 rule 3); NEW `LiveFeed.tsx` subscribed to the SAME runtime store as
+the cards (zero new sockets); the no-raw-color rule flipped to **ERROR** for every file
+this slice touched (§2.11).
+**Rubric:** DES-VISION-001 §6.1, items mapped to this slice: **EC3, EC4, EC11, EC12,
+EC13, EC14, EC15.**
+**Images:** `e2e/shots/vision/vision-2-home-live-feed.png` (the settled W2 board + live
+feed) and `e2e/shots/vision/vision-2-active-card.png` (the q3 ACTIVE-card closeup) —
+both at 1440×900, `device_scale_factor=1`, per §6.0, by `e2e/vision_slice2_test.py`
+against the frozen-`NOW0` W2 fixture (§6.2) with the browser clock frozen at `NOW0+5s`.
+The shots are gitignored evidence; the rig's JSON report records each path beside the
+verdicts.
+
+| Item | Verdict | Read from the evidence |
+|---|---|---|
+| **EC3 — bands** (carried from UXFIX) | **PASS** | NEEDS YOU settles to the exact W2 order `q3-review-deck, api-migration, auth-refactor, upload-endpoint`; QUIET (24) collapsed to the chip strip; "Not in a project (1)" last. `boardAttention.ts` untouched (`git diff` — zero hunks). |
+| **EC4 — decay** (carried from UXFIX) | **PASS** | The decay pair holds: `legacy-spike` (8-day failure, project touched an hour ago) is NOT in `band-needs-you` while fresh-failed `auth-refactor` leads with the red bar — asserted off the live DOM (`legacyDemoted: true`). |
+| **EC11 — information is the aesthetic** | **PASS** | Both shots: no gradients, no imagery, no ornament. Every colored pixel is a signal (status bars, dots, gate chips), every text block is data (names, narration, ages). The feed column is narration and nothing else — no header, no scrollbar (§1.3). |
+| **EC12 — accent is singular** | **PASS** | Computed probe: `--accent` = `rgb(130, 88, 228)` (violet) ≠ `--status-gate` `rgb(247, 210, 100)` ≠ `--status-fail` `rgb(243, 84, 73)`. On this surface the accent appears ONLY on the first-run invitation (an affordance); amber/red/emerald appear only as status. |
+| **EC13 — two typefaces, one rule** | **PASS** | Computed: card narration and feed lines render `"JetBrains Mono", "Fira Code", ui-monospace` (the `--font-mono` token); the project name renders the sans (`Archivo, ui-sans-serif`). Both faces visible in both shots — the contrast IS the rhythm. |
+| **EC14 — the live feed is live** | **PASS** | A NEW `unitOutputDelta` (`extra_narration` fixture switch, same `/ws`) landed in `live-feed-block-upload-endpoint` **within 2s** with no navigation (`feed_updated_within_2s: true`) — through the same store fold the cards read. |
+| **EC15 — token discipline** (passing for these components — the slice-2 target) | **PASS** | Probe-asserted, no hex duplicated into the rig: card computed `background` `rgb(26, 26, 38)` == the probe of `var(--surface-card)`; the q3 bar `border-top: 2px` == the probe of `var(--status-gate)`; auth's == `var(--status-fail)`. Lint: the rule is ERROR for the five slice files and finds **nothing** in them. |
+
+**Slice DOM ACs** (from the rig's JSON report, all true):
+
+- `data-testid="live-feed"` present and non-empty with runs active; blocks:
+  `upload-endpoint` narrating (headline + the fresh line), `auth-refactor` as the fail
+  block `failed 12m ago [open run]`; NO block for the decayed `legacy-spike` or the
+  gate-waiting `q3-review-deck` (the gate is answerable on the card — §1.3's wireframe).
+- `unitOutputDelta` → `live-feed-block-upload-endpoint` updated within 2s (EC14 above).
+- `getComputedStyle(project-card).background` resolves from `var(--surface-card)` (EC15).
+- The 2px bar's `border-top-color` matches `--status-gate` on the gate card and
+  `--status-fail` on the failure; `border-top-width: 2px`.
+- Console: zero errors across the run.
+
+**Repo gates:** `npm run lint` exit **0** — the five slice files under the ERROR-mode
+rule with zero findings, the warn baseline still firing on the not-yet-converted rest
+(1530 warnings, down 32 from slice 1's 1562). `npm run typecheck` exit 0. `npm test`
+**815/815** (86 files; +7 new: `LiveFeed.test.tsx`, and the slice-2 card-language
+asserts in `ProjectCard.variants.test.tsx`).
+
+**UXFIX preserved (§6.3's list), re-proven:** `boardAttention.ts` untouched; band
+structure + windowing intact (the grid tightened to §1.3's `minmax(280px)`/8px — the
+mount ceiling in `HomeBoard.test.tsx` re-derived for the extra column); the quiet-card
+budget still exactly ONE `quiet-summary` line per card (asserted expanded, in the rig
+and in unit tests); answerable gate chips (`gate-approve-r-q3`/`gate-reject-r-q3` live
+on the card); the attention pill kept with its V3 user words ("working", never
+"distributing") — §5.1 sketches the bar as the pill's replacement, but the UXFIX
+checklist this slice must preserve asserts the pill's words, so the bar lands BESIDE the
+pill and the pill's retirement is deferred to the checklist's own revision. All six
+uxfix rigs (`uxfix_slice1..6_test.py`) green on the fresh slice-2 build
+(`dist-sameorigin` deleted and rebuilt first). `vision_slice1_test.py` is a
+point-in-time gate whose pixel-baseline and hardcoded-`#161b22` baseline assertions are
+superseded by this slice BY DESIGN (its own docstring: "the baseline the next slice
+moves from") — its successor is this rig's probe assertions.
+
+**What shipped (~340 LOC production):** `src/components/LiveFeed.tsx` (new, ~160 lines
+with §-comments): per-project blocks — dot + dim name, then the newest distinct
+narration lines in mono, newest first, ≤3 per block, fail blocks with `[open run]`,
+`§1.6` motion (`wk-feed-in`, fade-in once, no loops, `prefers-reduced-motion` honored);
+`HomeBoard.tsx`: wall+feed row, token conversion, §1.3 grid, ResizeObserver re-measure
+(the feed mounts without a window resize — the rig caught the column math spending the
+feed's width); `ProjectCard.tsx`: token conversion, `SIGNAL_BAR` + the 2px status bar,
+mono narration, slot heights +6px for `--space-4` padding and the border-box bar;
+`GateChip.tsx`: token conversion (gate=amber status pair, approve=run pair,
+reject=fail pair); `useBoardHeadline.ts`: `lastMeaningfulLines(text, max)` (the feed's
+window; `lastMeaningfulLine` re-derived from it); `global.css`: the `wk-feed-in`
+keyframes; `eslint.config.mjs`: one shared selector list, WARN for `src/**`, **ERROR**
+for the five converted files (`TOKEN_CLEAN` — grows per slice until slice 6 flips
+`src/**`); `e2e/uxfix_fixture.py`: the one-shot `extra_narration` switch;
+`e2e/vision_slice2_test.py`: the gate (this file's evidence source).

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -25,6 +25,11 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     Build stats footer has real data to gate on (default False)
   long_prompt     — one extra run with a very long problem rides the run list, to
                     prove intent-phrase truncation in pixels (default False)
+  extra_narration — a list of strings; each is drained ONCE by the /ws loop as a
+                    `unitOutputDelta` for r-upload (default []). The vision-slice-2
+                    rig posts one mid-page to prove the live feed updates from the
+                    shared store within the 2s AC — a NEW line, not the loop's
+                    repeated one.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -62,7 +67,8 @@ def iso(ms: int) -> str:
 
 # Mutable fixture switches, flipped over POST /__fixture between page loads.
 state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
-         "no_runs": False, "usage_ws": False, "long_prompt": False}
+         "no_runs": False, "usage_ws": False, "long_prompt": False,
+         "extra_narration": []}
 state_lock = threading.Lock()
 
 
@@ -278,6 +284,15 @@ class W2Handler(SimpleHTTPRequestHandler):
                     pending, ws_queue[:] = list(ws_queue), []
                 for frame in pending:
                     self.wfile.write(ws_frame(frame))
+                # Drain any one-shot narration lines a rig posted mid-page (vision
+                # slice 2: prove a NEW delta reaches the live feed within 2s).
+                with state_lock:
+                    extra, state["extra_narration"] = list(state["extra_narration"]), []
+                for line in extra:
+                    self.wfile.write(ws_frame({
+                        "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                        "text": str(line) + "\n",
+                    }))
                 self.wfile.write(ws_frame({
                     "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
                     "text": NARRATION + "\n",

--- a/e2e/vision_slice1_test.py
+++ b/e2e/vision_slice1_test.py
@@ -65,9 +65,11 @@ BASELINE_MODE = os.environ.get("VISION_BASELINE") == "1"
 BASELINE_SHOT = SHOTS / "vision-1-baseline.png"
 CHECK_SHOT = SHOTS / "vision-1-token-check.png"
 
-# The pre-token card background (ProjectCard.tsx's hardcoded #161b22) — the EC15
-# baseline this slice records and slice 2 moves.
-CARD_BG_RGB = "rgb(22, 27, 34)"
+# The card background AFTER slice 2 moved it onto the token system: --surface-card
+# (#1a1a26). Slice 1 recorded the pre-token rgb(22,27,34) baseline; slice 2 superseded
+# it exactly as this rig's docstring declared it would, so the assertion now pins the
+# token-resolved value — the rig set stays all-green at every landed slice.
+CARD_BG_RGB = "rgb(26, 26, 38)"
 
 # One name per §2 table, so a hole in any section is caught, not just §2.3.
 SAMPLED_TOKENS = [

--- a/e2e/vision_slice2_test.py
+++ b/e2e/vision_slice2_test.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+vision_slice2_test.py — the DES-VISION-001 slice-2 gate: the orchestrator home
+reimagined (§5.1, §6.3 slice 2), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py — §6.2).
+
+The slice DOM ACs, verbatim from §6.3:
+
+  1. `data-testid="live-feed"` is present and non-empty when at least one
+     project has an active run;
+  2. a `unitOutputDelta` for a project updates its `live-feed-block-<id>`
+     within 2s without navigation (the fixture's `extra_narration` switch
+     pushes ONE new line mid-page over the same /ws);
+  3. `getComputedStyle([data-testid="project-card"])` resolves `background`
+     from `var(--surface-card)` — EC15 passing for these components. Asserted
+     by PROBE, not by a hex copied into this file: a probe element is given
+     `background: var(--surface-card)` and the card must computed-match it;
+  4. the 2px status bar's `border-top-color` matches `--status-gate` for the
+     gate-waiting card (q3-review-deck) — same probe technique — and
+     `--status-fail` for the fresh failure (auth-refactor).
+
+Plus the slice's checklist reads (§6.1): EC3/EC4 (bands + decay preserved from
+UXFIX — the W2 order and the 8-day failure demoted), EC12 (the accent is NOT
+any status color), EC13 (narration computed mono, name computed sans), EC14
+(the feed reflects the delta), EC15 (probe assertions above), and the §6.3
+preservation list (quiet-summary budget, answerable gate chips).
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-2-home-live-feed.png   the full W2 board + live feed
+  vision-2-active-card.png      ACTIVE card closeup: status bar + mono narration
+                                + answerable gate chip, all token-built
+
+Finally: `npm run lint` must exit 0 with ZERO findings in this slice's files
+(the no-raw-color rule is ERROR there now) while the warn-mode baseline still
+fires elsewhere.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: VISION_PORT (default 4341),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4341"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# The one-shot narration line posted mid-page (AC 2): distinct from the loop's
+# repeated NARRATION so "the feed updated" is a NEW string appearing, not the
+# old one persisting.
+FRESH_LINE = "Applying the token bucket to PUT /upload"
+
+# This slice's error-mode files (eslint.config.mjs TOKEN_CLEAN): lint findings
+# here are FAILURES now, and the gate greps for them by name.
+SLICE_FILES = ["HomeBoard.tsx", "LiveFeed.tsx", "ProjectCard.tsx",
+               "GateChip.tsx", "useBoardHeadline.ts"]
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # Freeze Date.now at NOW0 + 5s BEFORE the app boots (timers keep running —
+    # the /ws narration and the attention sorts still happen), so every rendered
+    # age ("30s", "12m", "8d") is deterministic in the captures.
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # The SAME settled state every board rig waits on: the W2 NEEDS YOU order
+    # (EC3/EC4 — bands + decay preserved: the 8-day failure is NOT here) and the
+    # live narration having streamed at least once.
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    # ── AC 1: the feed exists and is non-empty while runs are active ──────────
+    feed_ok = settled(
+        """() => { const f = document.querySelector('[data-testid="live-feed"]');
+                   return !!f && f.querySelectorAll('[data-testid^="live-feed-block-"]').length > 0
+                       && (f.textContent ?? '').trim() !== ''; }""",
+    )
+    # The executing project narrates in its block; the fresh failure gets its
+    # fail block with [open run]; the DECAYED failure (legacy-spike, 8d) and the
+    # gate-waiting q3 (answerable on the card, §1.3) get no block.
+    blocks = page.evaluate(
+        """() => ({
+             upload: document.querySelector('[data-testid="live-feed-block-upload-endpoint"]')?.textContent ?? null,
+             auth: document.querySelector('[data-testid="live-feed-block-auth-refactor"]')?.textContent ?? null,
+             authOpenRun: !!document.querySelector(
+               '[data-testid="live-feed-block-auth-refactor"] [data-testid="feed-open-run"]'),
+             legacy: !!document.querySelector('[data-testid="live-feed-block-legacy-spike"]'),
+             q3: !!document.querySelector('[data-testid="live-feed-block-q3-review-deck"]'),
+           })""")
+    membership_ok = (
+        blocks["upload"] is not None and NARRATION in blocks["upload"]
+        and blocks["auth"] is not None and "failed" in blocks["auth"] and blocks["authOpenRun"]
+        and not blocks["legacy"] and not blocks["q3"])
+
+    # ── AC 2 / EC14: a NEW delta lands in the block within 2s, no navigation ──
+    set_fixture(ORIGIN, extra_narration=[FRESH_LINE])
+    feed_updated = settled(
+        """text => (document.querySelector('[data-testid="live-feed-block-upload-endpoint"]')
+             ?.textContent ?? '').includes(text)""",
+        FRESH_LINE,
+        timeout=2000,
+    )
+
+    # ── AC 3/4 + EC12/EC13/EC15: computed styles resolve FROM the tokens ──────
+    styles = page.evaluate(
+        """() => {
+             // Probe: what each token computes to on this page — the assertion
+             // target, so no hex is duplicated into the rig.
+             const probe = name => { const el = document.createElement('div');
+               el.style.background = `var(${name})`;
+               document.body.appendChild(el);
+               const v = getComputedStyle(el).backgroundColor;
+               el.remove(); return v; };
+             const card = document.querySelector(
+               '[data-testid="project-card"][data-project-id="q3-review-deck"]');
+             const authCard = document.querySelector(
+               '[data-testid="project-card"][data-project-id="auth-refactor"]');
+             const cardCs = getComputedStyle(card);
+             const line = document.querySelector(
+               '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]');
+             const feedLine = document.querySelector(
+               '[data-testid="live-feed"] [data-testid="feed-line"]');
+             const name = card.querySelector('a');
+             return {
+               surfaceCard: probe('--surface-card'),
+               statusGate: probe('--status-gate'),
+               statusFail: probe('--status-fail'),
+               accent: probe('--accent'),
+               cardBackground: cardCs.backgroundColor,
+               gateBarColor: cardCs.borderTopColor,
+               gateBarWidth: cardCs.borderTopWidth,
+               failBarColor: getComputedStyle(authCard).borderTopColor,
+               narrationFont: line ? getComputedStyle(line).fontFamily : null,
+               feedLineFont: feedLine ? getComputedStyle(feedLine).fontFamily : null,
+               nameFont: name ? getComputedStyle(name).fontFamily : null,
+             }; }""")
+    ec15_card_bg = styles["cardBackground"] == styles["surfaceCard"]
+    bar_gate_ok = styles["gateBarColor"] == styles["statusGate"] and styles["gateBarWidth"] == "2px"
+    bar_fail_ok = styles["failBarColor"] == styles["statusFail"]
+    # EC12: the accent is singular — it is none of the status colors.
+    ec12_ok = styles["accent"] not in (styles["statusGate"], styles["statusFail"])
+    # EC13: narration (card + feed) computed MONO; the project name is NOT mono.
+    ec13_ok = (
+        styles["narrationFont"] is not None and "JetBrains Mono" in styles["narrationFont"]
+        and styles["feedLineFont"] is not None and "JetBrains Mono" in styles["feedLineFont"]
+        and styles["nameFont"] is not None and "JetBrains Mono" not in styles["nameFont"])
+
+    # ── The §6.3 preservation list, read off the live DOM ─────────────────────
+    preserved = page.evaluate(
+        """() => { const q3 = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="q3-review-deck"]');
+                   return {
+                     bands: !!document.querySelector('[data-testid="band-needs-you"]')
+                         && !!document.querySelector('[data-testid="band-quiet"]'),
+                     gateAnswerable: !!q3?.querySelector('[data-testid="gate-approve-r-q3"]')
+                         && !!q3?.querySelector('[data-testid="gate-reject-r-q3"]'),
+                     // EC4's decay pair: the 8-day failure is DEMOTED out of the
+                     // live band while the fresh one leads (boardAttention untouched).
+                     legacyDemoted: !document.querySelector(
+                       '[data-testid="band-needs-you"] [data-project-id="legacy-spike"]'),
+                   }; }""")
+
+    # ── The named screenshots (§6.3) — before any state-mutating interaction ──
+    page.screenshot(path=str(VSHOTS / "vision-2-home-live-feed.png"))
+    page.locator('[data-testid="project-card"][data-project-id="q3-review-deck"]') \
+        .screenshot(path=str(VSHOTS / "vision-2-active-card.png"))
+
+    # Expand QUIET and read the empty-state budget off the mounted quiet cards:
+    # absence is still exactly ONE `quiet-summary` line per card (§6.3 preserved).
+    page.locator('[data-testid="band-quiet-toggle"]').click()
+    budget_ok = settled(
+        """() => { const cards = Array.from(document.querySelectorAll(
+                     '[data-testid="project-card"][data-variant="quiet"]'));
+                   return cards.length > 0 && cards.every(c =>
+                     c.querySelectorAll('[data-testid="quiet-summary"]').length === 1); }""")
+    preserved["quietBudgetOneLine"] = budget_ok
+    preserved_ok = all(preserved.values())
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([order_ok, narration_ok, fonts_ok, feed_ok, membership_ok, feed_updated,
+               ec15_card_bg, bar_gate_ok, bar_fail_ok, ec12_ok, ec13_ok, preserved_ok]),
+    "board_settled_w2_order": order_ok,
+    "live_narration_streamed": narration_ok,
+    "web_fonts_loaded": fonts_ok,
+    "live_feed_present_nonempty": feed_ok,
+    "feed_blocks": blocks,
+    "feed_membership_ok": membership_ok,
+    "feed_updated_within_2s": feed_updated,
+    "computed": styles,
+    "ec15_card_bg_from_surface_card_token": ec15_card_bg,
+    "status_bar_2px_gate_token": bar_gate_ok,
+    "status_bar_fail_token": bar_fail_ok,
+    "ec12_accent_not_a_status_color": ec12_ok,
+    "ec13_mono_narration_sans_labels": ec13_ok,
+    "uxfix_preserved": preserved,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("vision-2-home-live-feed.png", "vision-2-active-card.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-2 DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0; ZERO findings in the error-mode slice files ──────
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+slice_hits = [f for f in SLICE_FILES if f in out]
+baseline_warnings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "exit_code": r.returncode,
+    "slice_files_with_findings": slice_hits,
+    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with no findings in the slice-2 "
+         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,52 @@
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 
+// DES-VISION-001 §2.11 — the no-raw-color contract's selectors. No file in
+// src/ ships a literal color: hex, or rgb()/hsl() with literal channel values.
+// Colors come from the semantic tokens in src/styles/tokens.css (a .css file —
+// outside ESLint's reach; its build-time twin, the PostCSS check, lands with
+// the global error-mode flip). One list, two postures below: WARN as the
+// migration baseline (§2.11 — the inherited hardcoded colors are converted
+// slice by slice), ERROR for every file a landed slice has converted.
+const NO_RAW_COLOR = [
+  {
+    selector: 'Literal[value=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]',
+    message: 'Raw hex color — use a semantic token from src/styles/tokens.css, e.g. var(--surface-card) (DES-VISION-001 §2.11).',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]',
+    message: 'Raw hex color — use a semantic token from src/styles/tokens.css, e.g. var(--surface-card) (DES-VISION-001 §2.11).',
+  },
+  {
+    selector: 'Literal[value=/\\brgba?\\(\\s*[0-9]/]',
+    message: 'rgb()/rgba() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/\\brgba?\\(\\s*[0-9]/]',
+    message: 'rgb()/rgba() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
+  },
+  {
+    selector: 'Literal[value=/\\bhsla?\\(\\s*[0-9.]/]',
+    message: 'hsl()/hsla() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/\\bhsla?\\(\\s*[0-9.]/]',
+    message: 'hsl()/hsla() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
+  },
+];
+
+// Files a landed slice has fully converted — the rule is ERROR here, and a raw
+// color is a build failure, not a review finding (§6.0). Grows slice by slice
+// until slice 6 flips src/** wholesale and this list retires.
+const TOKEN_CLEAN = [
+  // Vision slice 2 — the orchestrator home (§5.1).
+  'src/components/HomeBoard.tsx',
+  'src/components/LiveFeed.tsx',
+  'src/components/ProjectCard.tsx',
+  'src/components/GateChip.tsx',
+  'src/hooks/useBoardHeadline.ts',
+];
+
 export default tseslint.config(
   {
     ignores: [
@@ -29,42 +75,15 @@ export default tseslint.config(
     },
   },
   {
-    // DES-VISION-001 §2.11 — the no-raw-color contract. No file in src/ ships
-    // a literal color: hex, or rgb()/hsl() with literal channel values. Colors
-    // come from the semantic tokens in src/styles/tokens.css (a .css file —
-    // outside ESLint's reach; its build-time twin, the PostCSS check, lands
-    // with the error-mode flip). Slice-1 posture is WARN (§2.11 migration):
-    // the ~40 inherited hardcoded colors are converted slice by slice, and the
-    // rule moves to error per-surface as each slice lands, global by slice 6.
     files: ['src/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': [
-        'warn',
-        {
-          selector: 'Literal[value=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]',
-          message: 'Raw hex color — use a semantic token from src/styles/tokens.css, e.g. var(--surface-card) (DES-VISION-001 §2.11).',
-        },
-        {
-          selector: 'TemplateElement[value.raw=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]',
-          message: 'Raw hex color — use a semantic token from src/styles/tokens.css, e.g. var(--surface-card) (DES-VISION-001 §2.11).',
-        },
-        {
-          selector: 'Literal[value=/\\brgba?\\(\\s*[0-9]/]',
-          message: 'rgb()/rgba() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
-        },
-        {
-          selector: 'TemplateElement[value.raw=/\\brgba?\\(\\s*[0-9]/]',
-          message: 'rgb()/rgba() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
-        },
-        {
-          selector: 'Literal[value=/\\bhsla?\\(\\s*[0-9.]/]',
-          message: 'hsl()/hsla() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
-        },
-        {
-          selector: 'TemplateElement[value.raw=/\\bhsla?\\(\\s*[0-9.]/]',
-          message: 'hsl()/hsla() with literal values — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).',
-        },
-      ],
+      'no-restricted-syntax': ['warn', ...NO_RAW_COLOR],
+    },
+  },
+  {
+    files: TOKEN_CLEAN,
+    rules: {
+      'no-restricted-syntax': ['error', ...NO_RAW_COLOR],
     },
   },
 );

--- a/src/components/GateChip.tsx
+++ b/src/components/GateChip.tsx
@@ -26,29 +26,35 @@ import { isSimpleGate, useGateStore, type OpenGate } from '../store/gates.js';
 /** One-shot focus intent for the thread's gate card, read by `SteeringGate`. */
 export const GATE_HASH = '#gate';
 
-const S = {
-  accent: '#ffda19',
-  green:  '#3fb950',
-  red:    '#f85149',
-  muted:  'rgba(230,237,243,0.55)',
-};
-
+// DES-VISION-001 §5.1: the gate chip is STATUS furniture, not accent — amber
+// `--status-gate` on `--status-gate-dim`, with the answer buttons in the run
+// (emerald) and fail (red) status pairs. Every color is a semantic token (§2.11).
 const BTN: React.CSSProperties = {
-  fontSize: '10px', fontFamily: 'monospace', borderRadius: '4px', padding: '2px 6px',
-  border: '1px solid transparent', cursor: 'pointer', flexShrink: 0,
+  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', borderRadius: 'var(--radius-sm)',
+  padding: '2px 6px', border: '1px solid transparent', cursor: 'pointer', flexShrink: 0,
 };
 
 const CSS = {
   wrap: { display: 'flex', alignItems: 'center', gap: '4px', flexShrink: 0, flexWrap: 'nowrap' },
-  label: { fontSize: '10px', fontFamily: 'monospace', color: S.accent, fontWeight: 700 },
-  approve: { ...BTN, background: 'rgba(63,185,80,0.15)', borderColor: 'rgba(63,185,80,0.35)', color: S.green },
-  reject:  { ...BTN, background: 'rgba(248,81,73,0.12)', borderColor: 'rgba(248,81,73,0.3)', color: S.red },
+  label: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--status-gate)', fontWeight: 'var(--weight-bold)',
+  },
+  approve: {
+    ...BTN, background: 'var(--status-run-dim)',
+    borderColor: 'var(--status-run-dim)', color: 'var(--status-run)',
+  },
+  reject: {
+    ...BTN, background: 'var(--status-fail-dim)',
+    borderColor: 'var(--status-fail-dim)', color: 'var(--status-fail)',
+  },
   open: {
-    ...BTN, textDecoration: 'none', background: 'rgba(255,218,25,0.12)',
-    borderColor: 'rgba(255,218,25,0.35)', color: S.accent,
+    ...BTN, textDecoration: 'none', background: 'var(--status-gate-dim)',
+    borderColor: 'var(--status-gate-dim)', color: 'var(--status-gate)',
   },
   error: {
-    fontSize: '10px', fontFamily: 'monospace', color: S.red, maxWidth: '92px', flexShrink: 1,
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--status-fail)',
+    maxWidth: '92px', flexShrink: 1,
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
 } as const satisfies Record<string, React.CSSProperties>;
@@ -110,7 +116,7 @@ export function GateChip({ runId, projectId, gate, navigate }: Props): React.Rea
   if (answered !== null) {
     return (
       <span style={CSS.wrap} data-testid={`gate-answered-${runId}`}>
-        <span style={{ ...CSS.label, color: S.muted, fontWeight: 400 }}>{answered} · advancing…</span>
+        <span style={{ ...CSS.label, color: 'var(--ink-muted)', fontWeight: 'var(--weight-normal)' }}>{answered} · advancing…</span>
       </span>
     );
   }

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -111,6 +111,14 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     if (el === null) return;
     const measure = (): void => setBox({ w: el.clientWidth, h: el.clientHeight });
     measure();
+    // The wall's width changes WITHOUT a window resize — the live feed mounts
+    // beside it when the first run starts (§1.3) — so observe the element
+    // itself; the window listener is the jsdom fallback.
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(measure);
+      ro.observe(el);
+      return () => ro.disconnect();
+    }
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
   }, []);

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -4,6 +4,7 @@ import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { modePath } from '../hooks/useRoute.js';
+import { LiveFeed } from './LiveFeed.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 
 /**
@@ -22,11 +23,18 @@ import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js'
  * WINDOWED against the ONE shared scroller (`boardWindow.ts`): cards are a
  * fixed height, only the rows the viewport can show (plus overscan) are
  * mounted, and the container never grows past the viewport.
+ *
+ * Vision slice 2 (DES-VISION-001 §1.3/§5.1): the route is now the status wall
+ * (left, ~68%) beside the LIVE FEED (right, ~32%) — the one place cross-project
+ * narration aggregates — and every color on the surface resolves from a semantic
+ * token (§2.11, lint-enforced at ERROR for this file).
  */
 
-const GAP = 14;
-/** Below this the grid drops a column rather than squeezing a card unreadable. */
-const MIN_COL = 320;
+/** Card gap — §1.3's composition (blocks and cards sit 8px apart, `--space-2`). */
+const GAP = 8;
+/** Below this the grid drops a column rather than squeezing a card unreadable —
+ *  §1.3's `minmax(280px, 1fr)`: 3 ACTIVE cards up on the ~980px wall at 1440. */
+const MIN_COL = 280;
 /** Used when the container has not been measured yet (first paint, jsdom). */
 const FALLBACK_W = 1200;
 const FALLBACK_H = 900;
@@ -36,27 +44,23 @@ const BAND_H = 34;
 /** Collapsed QUIET shows at most this many one-line chips (D5). */
 const QUIET_PREVIEW = 6;
 
-const S = {
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.3)',
-  red:    '#f85149',
-  accent: '#ffda19',
-  border: 'rgba(230,237,243,0.1)',
-};
-
+// DES-VISION-001 §5.1's token map for this surface: page = `--surface-base`,
+// cards = `--surface-card` (in ProjectCard), feed = `--surface-rail`, all text
+// off the ink ramp, status colors only where they mean status.
 const CSS = {
   bandLabel: {
-    fontSize: '10px', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase',
+    fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-bold)',
+    letterSpacing: '0.08em', textTransform: 'uppercase',
     margin: '0 0 10px',
   },
   toggle: {
     background: 'none', border: 'none', cursor: 'pointer', padding: 0,
-    fontSize: '11px', fontFamily: 'monospace', color: S.muted,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
   },
   chip: {
     display: 'inline-flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
-    fontSize: '11px', color: S.muted, border: `1px solid ${S.border}`, borderRadius: '6px',
+    fontSize: 'var(--text-xs)', color: 'var(--ink-muted)',
+    border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)',
     padding: '4px 10px', whiteSpace: 'nowrap',
   },
 } as const satisfies Record<string, React.CSSProperties>;
@@ -151,15 +155,24 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   });
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    // §1.3's composition: the status wall (left) beside the live feed (right).
+    <div className="flex flex-1 overflow-hidden" style={{ background: 'var(--surface-base)' }}>
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
       <header
         style={{
           display: 'flex', alignItems: 'baseline', gap: '12px', flexShrink: 0,
-          padding: '20px 24px 12px',
+          padding: 'var(--space-5) var(--space-6) var(--space-3)',
         }}
       >
-        <h1 style={{ fontSize: '16px', fontWeight: 700, color: S.ink, margin: 0 }}>Projects</h1>
-        <p style={{ fontSize: '12px', color: S.muted, margin: 0 }}>
+        <h1
+          style={{
+            fontSize: 'var(--text-md)', fontWeight: 'var(--weight-bold)',
+            color: 'var(--ink-high)', margin: 0,
+          }}
+        >
+          Projects
+        </h1>
+        <p style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: 0 }}>
           Sorted by what needs you first.
         </p>
         {/* The flat run list this board replaced stays reachable (§1.5 escape hatch). */}
@@ -167,7 +180,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
           href="/runs"
           onClick={(e) => { e.preventDefault(); navigate('/runs'); }}
           data-testid="all-runs-link"
-          style={{ marginLeft: 'auto', fontSize: '12px', color: S.muted }}
+          style={{ marginLeft: 'auto', fontSize: 'var(--text-xs)', color: 'var(--ink-muted)' }}
         >
           All runs ›
         </a>
@@ -181,22 +194,22 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
         data-needs-you={needsYou.length}
         data-quiet={quiet.length}
         data-rendered={mounted}
-        style={{ flex: 1, overflowY: 'auto', padding: '0 24px 24px' }}
+        style={{ flex: 1, overflowY: 'auto', padding: '0 var(--space-6) var(--space-6)' }}
       >
         {loading && (
-          <p style={{ fontSize: '13px', color: S.faint, fontFamily: 'monospace' }}>Loading projects…</p>
+          <p style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>Loading projects…</p>
         )}
         {!loading && error !== null && (
-          <p style={{ fontSize: '13px', color: S.red }}>Could not load projects: {error}</p>
+          <p style={{ fontSize: 'var(--text-sm)', color: 'var(--status-fail)' }}>Could not load projects: {error}</p>
         )}
         {!loading && error === null && items.length === 0 && (
-          <div style={{ padding: '40px 0' }}>
-            <p style={{ fontSize: '14px', color: S.muted, margin: '0 0 4px' }}>No projects yet</p>
+          <div style={{ padding: 'var(--space-10) 0' }}>
+            <p style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-muted)', margin: '0 0 4px' }}>No projects yet</p>
             <a
               href="/projects"
               onClick={(e) => { e.preventDefault(); navigate('/projects'); }}
               data-testid="create-first-project"
-              style={{ fontSize: '12px', color: S.ink }}
+              style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-high)' }}
             >
               Create your first project ›
             </a>
@@ -205,10 +218,12 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
 
         {items.length > 0 && (
           <section data-testid="band-needs-you" data-count={needsYou.length}>
-            <p style={{ ...CSS.bandLabel, color: S.accent }}>Needs you</p>
+            {/* Amber names the band because amber MEANS "you are the blocker"
+                (§2.6) — a status color, not the accent (§1.5 rule 2). */}
+            <p style={{ ...CSS.bandLabel, color: 'var(--status-gate)' }}>Needs you</p>
             {needsYou.length === 0 ? (
               // The all-quiet state (§3.1): calm is one line, not a wall of absence.
-              <p data-testid="board-all-quiet" style={{ fontSize: '12px', color: S.muted, margin: '0 0 6px' }}>
+              <p data-testid="board-all-quiet" style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '0 0 6px' }}>
                 Nothing needs you right now.
               </p>
             ) : (
@@ -232,7 +247,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
             style={{ marginTop: '18px' }}
           >
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
-              <p style={{ ...CSS.bandLabel, color: S.faint, margin: 0 }}>Quiet ({quiet.length})</p>
+              <p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }}>Quiet ({quiet.length})</p>
               <button
                 type="button"
                 data-testid="band-quiet-toggle"
@@ -266,9 +281,9 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                     data-score={i.score.toFixed(2)}
                     style={CSS.chip}
                   >
-                    <span aria-hidden style={{ color: S.faint }}>○</span>
+                    <span aria-hidden style={{ color: 'var(--ink-dim)' }}>○</span>
                     {i.project.name}
-                    <span style={{ color: S.faint }}>
+                    <span style={{ color: 'var(--ink-dim)' }}>
                       · {ago(i.signal?.at ?? i.project.updated_at)}
                     </span>
                   </a>
@@ -289,7 +304,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
             style={{ marginTop: '18px' }}
           >
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
-              <p style={{ ...CSS.bandLabel, color: S.faint, margin: 0 }}>
+              <p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }}>
                 Not in a project ({unfiled.length})
               </p>
               <button
@@ -312,7 +327,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                     style={{ ...CSS.chip, alignSelf: 'flex-start', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
                   >
                     {v.session.problem}
-                    <span style={{ color: S.faint }}>· {v.session.status}</span>
+                    <span style={{ color: 'var(--ink-dim)' }}>· {v.session.status}</span>
                   </a>
                 ))}
               </div>
@@ -320,6 +335,11 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
           </section>
         )}
       </div>
+      </div>
+
+      {/* The live feed (§1.3 right column): all projects with moving runs,
+          narrating off the SAME runtime store the cards read — zero new sockets. */}
+      <LiveFeed items={items} navigate={navigate} />
     </div>
   );
 }

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,0 +1,159 @@
+import type { SessionView } from '../api/types.js';
+import { activeUnit, lastMeaningfulLines, useRunHeadline } from '../hooks/useBoardHeadline.js';
+import type { BoardProject } from '../hooks/useBoardModel.js';
+import { modePath, type Navigate } from '../hooks/useRoute.js';
+import { outputKey, useRuntimeStore } from '../store/runtime.js';
+import { ago, SIGNAL_BAR } from './ProjectCard.js';
+
+/**
+ * The live feed — the orchestrator home's right sidebar (DES-VISION-001 §1.3,
+ * §1.4, §5.1): the ONE place where cross-project narration aggregates. The wall's
+ * cards are per-project; this column is the system's heartbeat.
+ *
+ * A narrow column, no header, no scrollbar. Each project with a MOVING run gets
+ * a block — dot + name (dim, small, sans), then the newest narration lines in
+ * `--font-mono`, newest first — including a project whose attention score sits
+ * below the triage threshold: it is doing work, and the operator deserves
+ * peripheral awareness of it (§1.4). A project whose LEADING signal is a failure
+ * still in NEEDS YOU gets a fail block with the one action worth taking from the
+ * periphery: open the run. A decayed failure does not haunt the feed.
+ *
+ * Zero new sockets (§5.1): the narration subscribes to the SAME runtime store the
+ * cards read, fed by the app's one `/ws` subscription — a `unitOutputDelta` lands
+ * here and on the owning card from the same fold. Motion is §1.6's grammar: a new
+ * line fades in at the top of its block (`--dur-fast`), a new block fades in
+ * (`--dur-base`), nothing loops (see `.wk-feed-*` in global.css).
+ */
+
+/** Statuses in which a run is moving under its own power — what earns a block. */
+const MOVING: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+/** Runs narrating per block, and lines for the lead run — the block never exceeds
+ *  3 lines (§1.3): 2 from the newest run, 1 from the next; extras are silence. */
+const MAX_RUNS = 2;
+const MAX_LINES = 2;
+
+const CSS = {
+  feed: {
+    width: '32%', minWidth: '260px', maxWidth: '460px', flexShrink: 0,
+    // No scrollbar (§1.3): the feed is peripheral vision, not a log to trawl —
+    // the thread inside the project is where a user goes to watch (§1.4).
+    overflow: 'hidden',
+    background: 'var(--surface-rail)', padding: 'var(--space-4)',
+    display: 'flex', flexDirection: 'column', gap: 'var(--space-2)',
+  },
+  head: { display: 'flex', alignItems: 'center', gap: '6px', margin: '0 0 2px', minWidth: 0 },
+  dot: { width: '6px', height: '6px', borderRadius: 'var(--radius-full)', flexShrink: 0 },
+  name: {
+    fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', textDecoration: 'none',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  line: {
+    fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)', color: 'var(--ink-body)',
+    margin: '0 0 2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+type Link = (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+
+/**
+ * One moving run's narration window: the newest distinct lines of its active
+ * unit's delta buffer, newest first; before any output has streamed, the run's
+ * headline (§3.4(b)) — a truthful subject, never a blank block.
+ */
+function RunLines({ view, max }: { view: SessionView; max: number }): React.ReactElement {
+  const runId = view.session.id;
+  const ord = activeUnit(view)?.ord ?? 0;
+  const text = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
+  const headline = useRunHeadline(view);
+  const lines = lastMeaningfulLines(text, max);
+  const shown = lines.length > 0 ? lines : [headline];
+  return (
+    <>
+      {shown.map((line) => (
+        // Keyed by content: a NEW line remounts and plays the §1.6 fade-in once;
+        // a repeated frame carrying the same status is the same element, no motion.
+        <p
+          key={line}
+          data-testid="feed-line"
+          data-run-id={runId}
+          title={line}
+          className="wk-feed-line"
+          style={CSS.line}
+        >
+          {line}
+        </p>
+      ))}
+    </>
+  );
+}
+
+function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate }): React.ReactElement {
+  const { project, runs, signal } = item;
+  const moving = runs.filter((v) => MOVING.has(v.session.status));
+  const failing = signal !== null && signal.kind === 'failing'
+    ? runs.find((v) => v.session.status === 'failed')
+    : undefined;
+  const link: Link = (path) => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
+  return (
+    <section
+      data-testid={`live-feed-block-${project.id}`}
+      data-project-id={project.id}
+      className="wk-feed-block"
+    >
+      <p style={CSS.head}>
+        <span
+          aria-hidden
+          style={{ ...CSS.dot, background: signal !== null ? SIGNAL_BAR[signal.kind] : 'var(--ink-dim)' }}
+        />
+        <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
+      </p>
+      {moving.slice(0, MAX_RUNS).map((v, i) => (
+        <RunLines key={v.session.id} view={v} max={i === 0 ? MAX_LINES : 1} />
+      ))}
+      {failing !== undefined && signal !== null && (
+        <p
+          data-testid="feed-line"
+          data-run-id={failing.session.id}
+          style={{ ...CSS.line, color: 'var(--status-fail)' }}
+        >
+          failed {ago(signal.at)} ago
+          <a
+            {...link(modePath(project.id, 'build', failing.session.id))}
+            data-testid="feed-open-run"
+            style={{ marginLeft: '6px', color: 'var(--status-fail)', textDecoration: 'underline' }}
+          >
+            [open run]
+          </a>
+        </p>
+      )}
+    </section>
+  );
+}
+
+interface Props {
+  /** The board's own score-ordered items — the feed adds no second data model. */
+  items: BoardProject[];
+  navigate: Navigate;
+}
+
+export function LiveFeed({ items, navigate }: Props): React.ReactElement | null {
+  const blocks = items.filter(
+    (i) =>
+      i.runs.some((v) => MOVING.has(v.session.status)) ||
+      (i.band === 'needs-you' && i.signal?.kind === 'failing'),
+  );
+  // Nothing is running anywhere: the column is ABSENT, not an empty frame —
+  // the empty-state budget (DES-UXFIX-001 §2.1.2) applies to regions too.
+  if (blocks.length === 0) return null;
+  return (
+    <aside data-testid="live-feed" data-blocks={blocks.length} style={CSS.feed}>
+      {blocks.map((item) => (
+        <FeedBlock key={item.project.id} item={item} navigate={navigate} />
+      ))}
+    </aside>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -30,6 +30,12 @@ import { STATUS_STYLE } from './RunCard.js';
  * (slice 6) — the same stores the run view reads, fed by the app's ONE `/ws`
  * subscription (§3.5). A card therefore updates in place while the user is looking
  * at a different card, with no second socket and no polling anywhere on this route.
+ *
+ * Visual language is DES-VISION-001 §5.1 (vision slice 2): every color resolves
+ * from a semantic token (§2.11 — lint-enforced at ERROR for this file), the card
+ * is `--surface-card` under `--shadow-card`, the ACTIVE card carries a 2px
+ * status bar along its top whose color IS the leading signal kind (§1.4), and
+ * narration reads in `--font-mono` against the sans labels (§1.5 rule 3).
  */
 
 /** ACTIVE-card slot height in px — the NEEDS YOU band's windowing depends on it.
@@ -37,13 +43,15 @@ import { STATUS_STYLE } from './RunCard.js';
  *  chips + a tile row + the action row), so the bottom-anchored actions inside
  *  `overflow: hidden` are never clipped. The card itself sizes to content and
  *  treats this as a `maxHeight`, so a light card is short, not hollow — the
- *  SLOT stays fixed for the windowing math, the pixels do not. */
-export const ACTIVE_CARD_H = 330;
+ *  SLOT stays fixed for the windowing math, the pixels do not. (Vision slice 2:
+ *  +6px over the pre-token slot — `--space-4` padding is 16px, was 14px, and the
+ *  2px status bar rides inside the border-box.) */
+export const ACTIVE_CARD_H = 336;
 
 /** QUIET-card slot height in px — one summary line plus the action row, with
  *  room for the first-run 2×2 sublabelled grid (§2.2) in the same slot. Also a
  *  `maxHeight`: a compact quiet card renders at its natural ~one-line height. */
-export const QUIET_CARD_H = 112;
+export const QUIET_CARD_H = 118;
 
 /** How recently a project must have been created for its empty card to read as
  *  "a genuinely brand-new project a user just created" (§2.1.2) and show the
@@ -56,22 +64,26 @@ const MAX_CHIPS = 2;
 /** Live lines per card. Fixed height, so extra runs report as a count, not a list. */
 const MAX_LINES = 2;
 
-const S = {
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.3)',
-  accent: '#ffda19',
+/** Attention → dot colour — shared with the rail (slice 3), so the same signal
+ *  reads as the same colour on the board card and the sidebar's project list.
+ *  Values are semantic tokens (DES-VISION-001 §2.6): status colors are a
+ *  separate layer from the accent, and they are NOT customizable. */
+export const ATTENTION_DOT: Record<Attention, string> = {
+  gate:    'var(--status-gate)',
+  failing: 'var(--status-fail)',
+  running: 'var(--status-run)',
+  drafts:  'var(--ink-muted)',
+  quiet:   'var(--ink-dim)',
 };
 
-/** Attention → dot colour — shared with the rail (slice 3), so the same signal
- *  reads as the same colour on the board card and the sidebar's project list. */
-export const ATTENTION_DOT: Record<Attention, string> = {
-  gate:    '#ffda19',
-  failing: '#f85149',
-  running: '#79c0ff',
-  drafts:  'rgba(230,237,243,0.45)',
-  quiet:   'rgba(230,237,243,0.2)',
+/** Signal kind → the 2px status-bar color on an ACTIVE card's top (§1.4): the
+ *  bar IS the color of the leading signal. Shared with the live feed's block
+ *  dots, so the same signal reads identically on the wall and in the feed. */
+export const SIGNAL_BAR: Record<SignalKind, string> = {
+  gate:    'var(--status-gate)',
+  failing: 'var(--status-fail)',
+  running: 'var(--status-run)',
+  drafts:  'var(--status-done)',
 };
 
 /** The pill's word for the signal that put the card in NEEDS YOU — user words
@@ -85,40 +97,49 @@ const PILL: Record<SignalKind, string> = {
 
 const CSS = {
   card: {
-    boxSizing: 'border-box', overflow: 'hidden', background: '#161b22',
-    border: `1px solid ${S.border}`, borderRadius: '10px', padding: '14px',
+    boxSizing: 'border-box', overflow: 'hidden', background: 'var(--surface-card)',
+    boxShadow: 'var(--shadow-card)', borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)',
     display: 'flex', flexDirection: 'column',
     // Anchors the live edge, and the radius above clips its ends (see LiveEdge).
     position: 'relative',
   },
-  header: { display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 },
+  header: { display: 'flex', alignItems: 'center', gap: '6px', minWidth: 0 },
   name: {
-    fontSize: '13px', fontWeight: 700, color: S.ink, textDecoration: 'none',
+    fontSize: 'var(--text-md)', fontWeight: 'var(--weight-semi)', color: 'var(--ink-high)',
+    textDecoration: 'none', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  repo: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-dim)', flexShrink: 0,
+  },
+  tile: {
+    flex: 1, minWidth: 0, background: 'transparent',
+    border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)', padding: '5px 7px',
+  },
+  tileName: {
+    fontSize: 'var(--text-xs)', color: 'var(--ink-body)', margin: 0,
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
-  repo: { fontSize: '10px', fontFamily: 'monospace', color: S.faint, flexShrink: 0 },
-  tile: {
-    flex: 1, minWidth: 0, background: 'rgba(230,237,243,0.04)',
-    border: `1px solid ${S.border}`, borderRadius: '6px', padding: '5px 7px',
-  },
-  tileName: { fontSize: '11px', color: S.ink, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   chip: {
     display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none',
-    fontSize: '11px', fontFamily: 'monospace', color: S.muted, borderRadius: '5px', padding: '3px 7px',
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+    borderRadius: 'var(--radius-sm)', padding: '3px 7px',
   },
   quick: {
     display: 'flex', alignItems: 'center', gap: '5px', textDecoration: 'none',
-    background: 'rgba(230,237,243,0.05)', border: `1px solid ${S.border}`,
-    borderRadius: '6px', color: S.ink, fontSize: '11px',
+    background: 'var(--surface-raised)', border: 'none',
+    borderRadius: 'var(--radius-md)', color: 'var(--ink-high)', fontSize: 'var(--text-xs)',
     overflow: 'hidden', whiteSpace: 'nowrap', minWidth: 0,
   },
+  // Narration is DATA: it reads in the mono face at body ink (§1.5 rule 3, §1.4).
   line: {
     display: 'flex', alignItems: 'center', gap: '6px', margin: '0 0 2px',
-    fontSize: '11px', color: S.muted,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
   pulse: {
-    width: '5px', height: '5px', borderRadius: '50%', background: '#79c0ff', flexShrink: 0,
+    width: '5px', height: '5px', borderRadius: 'var(--radius-full)',
+    background: 'var(--status-run)', flexShrink: 0,
   },
 } as const satisfies Record<string, React.CSSProperties>;
 
@@ -170,11 +191,14 @@ function QuickActions({ projectId, link, detail }: {
             }}
           >
             <span aria-hidden style={{ flexShrink: 0 }}>{spec.glyph}</span>
-            <span style={{ fontWeight: 600, flexShrink: 0 }}>{spec.label}</span>
+            <span style={{ fontWeight: 'var(--weight-semi)', flexShrink: 0 }}>{spec.label}</span>
             {detail && (
               <span
                 data-testid="quick-action-sublabel"
-                style={{ color: S.faint, fontSize: '10px', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                style={{
+                  color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)',
+                  overflow: 'hidden', textOverflow: 'ellipsis',
+                }}
               >
                 {spec.sublabel}
               </span>
@@ -206,7 +230,12 @@ function DocTile({ projectId, name, kind, head, when }: {
         <span aria-hidden style={{ marginRight: '4px' }}>{kind === 'demo' ? '▶' : '▤'}</span>
         {name}
       </p>
-      <p style={{ fontSize: '10px', color: S.faint, margin: '2px 0 0', fontFamily: 'monospace' }}>
+      <p
+        style={{
+          fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', margin: '2px 0 0',
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
         {Number.isNaN(when) ? 'not yet edited' : `${ago(when)} ago`}
       </p>
       {/* The card exports the HEAD — the only version a surface that shows none can mean. */}
@@ -276,7 +305,10 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
     <span
       data-testid="project-status-dot"
       aria-hidden
-      style={{ width: '8px', height: '8px', borderRadius: '50%', background: ATTENTION_DOT[attention], flexShrink: 0 }}
+      style={{
+        width: '8px', height: '8px', borderRadius: 'var(--radius-full)',
+        background: ATTENTION_DOT[attention], flexShrink: 0,
+      }}
     />
   );
   const name = <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>;
@@ -302,14 +334,21 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
               data-testid="quiet-summary"
               data-invitation="true"
               // EC1: the ONE obvious next action — the brightest thing on the card.
-              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', fontWeight: 600, color: S.accent, textDecoration: 'none' }}
+              // The ACCENT, not a status color: an invitation is an affordance (§2.5).
+              style={{
+                marginLeft: 'auto', flexShrink: 0, fontSize: 'var(--text-xs)',
+                fontWeight: 'var(--weight-semi)', color: 'var(--accent)', textDecoration: 'none',
+              }}
             >
               Start by describing what you want →
             </a>
           ) : (
             <p
               data-testid="quiet-summary"
-              style={{ marginLeft: 'auto', flexShrink: 0, fontSize: '11px', color: S.faint, margin: 0 }}
+              style={{
+                marginLeft: 'auto', flexShrink: 0, fontSize: 'var(--text-xs)',
+                color: 'var(--ink-dim)', margin: 0,
+              }}
             >
               Quiet — last active {ago(signal?.at ?? project.updated_at)} ago
             </p>
@@ -324,7 +363,17 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
 
   // ── ACTIVE (§2.1.1): rich, but a region with no content is OMITTED (F1) ──
   return (
-    <section {...cardData} style={{ ...CSS.card, maxHeight: `${ACTIVE_CARD_H}px` }}>
+    <section
+      {...cardData}
+      style={{
+        ...CSS.card,
+        maxHeight: `${ACTIVE_CARD_H}px`,
+        // The 2px status bar (DES-VISION-001 §1.4/§5.1): the card's leading
+        // signal kind, as color, along the whole top edge — glanceable from
+        // across the wall, where the pill's word needs focus to read.
+        borderTop: `2px solid ${signal !== null ? SIGNAL_BAR[signal.kind] : 'var(--status-done)'}`,
+      }}
+    >
       {/* The card's own state signal, read from the RUNS rather than from `attention`:
           a project bucketed as `failing` can still have something executing on it, and
           the edge answers "is work moving here", not "which bucket did this sort into". */}
@@ -340,9 +389,11 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             data-testid="attention-pill"
             data-kind={signal.kind}
             style={{
-              marginLeft: 'auto', flexShrink: 0, fontSize: '10px', fontWeight: 700,
-              letterSpacing: '0.06em', textTransform: 'uppercase', color: ATTENTION_DOT[attention],
-              border: `1px solid ${S.border}`, borderRadius: '999px', padding: '1px 8px',
+              marginLeft: 'auto', flexShrink: 0, fontSize: 'var(--text-2xs)',
+              fontWeight: 'var(--weight-bold)', letterSpacing: '0.06em',
+              textTransform: 'uppercase', color: ATTENTION_DOT[attention],
+              border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-full)',
+              padding: '1px 8px',
             }}
           >
             {PILL[signal.kind]}
@@ -364,7 +415,10 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             </p>
           )}
           {live.length > MAX_LINES && (
-            <span data-testid="live-overflow" style={{ fontSize: '11px', color: S.muted }}>
+            <span
+              data-testid="live-overflow"
+              style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)' }}
+            >
               {live.length - MAX_LINES} more running
             </span>
           )}
@@ -393,12 +447,13 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
                     ...CSS.chip, flex: 1, minWidth: 0, overflow: 'hidden', position: 'relative',
                     // Clears the strip so a phase label never sits on top of it.
                     paddingLeft: '10px',
-                    border: `1px solid ${waiting ? 'rgba(255,218,25,0.3)' : S.border}`,
-                    background: waiting ? 'rgba(255,218,25,0.1)' : 'transparent',
+                    // A waiting gate is amber-status furniture (§5.1): dim fill, full-token text.
+                    border: `1px solid ${waiting ? 'var(--status-gate-dim)' : 'var(--surface-raised)'}`,
+                    background: waiting ? 'var(--status-gate-dim)' : 'transparent',
                   }}
                 >
                   <LiveEdge state={edgeStateOf([session.status])} />
-                  <span style={{ color: style?.color ?? S.faint }}>{phase}</span>
+                  <span style={{ color: style?.color ?? 'var(--ink-dim)' }}>{phase}</span>
                   {/* Elapsed exists only where the wire carries a timestamp: `AgentSession`
                       has no `started_at`, so a gate's daemon-cached `receivedAt` is the one
                       honest clock on this surface. */}
@@ -413,7 +468,10 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             );
           })}
           {runs.length > MAX_CHIPS && (
-            <span data-testid="run-overflow" style={{ fontSize: '11px', color: S.muted }}>
+            <span
+              data-testid="run-overflow"
+              style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)' }}
+            >
               {runs.length - MAX_CHIPS} more
             </span>
           )}
@@ -439,7 +497,13 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             />
           ))}
           {docs.length > MAX_TILES && (
-            <span data-testid="doc-overflow" style={{ alignSelf: 'center', fontSize: '11px', color: S.muted, flexShrink: 0 }}>
+            <span
+              data-testid="doc-overflow"
+              style={{
+                alignSelf: 'center', fontSize: 'var(--text-xs)',
+                color: 'var(--ink-muted)', flexShrink: 0,
+              }}
+            >
               {docs.length - MAX_TILES} more
             </span>
           )}

--- a/src/hooks/useBoardHeadline.ts
+++ b/src/hooks/useBoardHeadline.ts
@@ -49,21 +49,33 @@ function clamp(line: string): string {
 }
 
 /**
- * The newest line of a delta buffer worth showing, or `null` when the buffer holds
- * only noise. ANSI is stripped; `\r` counts as a line break because a progress bar
+ * The newest `max` DISTINCT lines of a delta buffer worth showing, newest first —
+ * the live feed's per-block window (DES-VISION-001 §1.3: "the last 2 narration
+ * lines"). ANSI is stripped; `\r` counts as a line break because a progress bar
  * redraws in place — the segment after the last `\r` is that line's newest state,
- * not a continuation of it.
+ * not a continuation of it. Duplicates are folded because a worker that re-emits
+ * the same status every second is saying ONE thing, not two.
  */
-export function lastMeaningfulLine(text: string | undefined): string | null {
-  if (text === undefined || text === '') return null;
+export function lastMeaningfulLines(text: string | undefined, max: number): string[] {
+  if (text === undefined || text === '' || max < 1) return [];
   const lines = text.replace(ANSI, '').split(/[\r\n]+/);
-  for (let i = lines.length - 1; i >= 0; i--) {
+  const found: string[] = [];
+  for (let i = lines.length - 1; i >= 0 && found.length < max; i--) {
     const line = (lines[i] ?? '').trim();
     // Pure punctuation / box drawing / bars carry no subject, so they are not a status.
     if (line === '' || !/[\p{L}\p{N}]/u.test(line) || PROGRESS.test(line)) continue;
-    return clamp(line);
+    const clamped = clamp(line);
+    if (!found.includes(clamped)) found.push(clamped);
   }
-  return null;
+  return found;
+}
+
+/**
+ * The newest line of a delta buffer worth showing, or `null` when the buffer holds
+ * only noise — the card's one-line reduction of the same window.
+ */
+export function lastMeaningfulLine(text: string | undefined): string | null {
+  return lastMeaningfulLines(text, 1)[0] ?? null;
 }
 
 /** The unit the run is on — the one whose buffer and phase the card is about. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -122,3 +122,19 @@ code, pre, .font-mono {
   border-radius: 1px;
   box-shadow: none;
 }
+
+/* The live feed's motion grammar (DES-VISION-001 §1.6/§5.1): a NEW narration
+   line fades in at the top of its block (120ms), a NEW project block fades in
+   (220ms). One run each — content-keyed elements remount only on change, and
+   nothing here loops (§1.6's rule). */
+@keyframes wk-feed-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: none; }
+}
+.wk-feed-line  { animation: wk-feed-in var(--dur-fast) var(--ease-out); }
+.wk-feed-block { animation: wk-feed-in var(--dur-base) var(--ease-out); }
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-feed-line,
+  .wk-feed-block { animation: none; }
+}

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -217,7 +217,10 @@ describe('HomeBoard — the orchestrator board', () => {
     await expandQuiet();
     expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', '60');
     const at60 = screen.getAllByTestId('project-card').length;
-    expect(at60).toBeLessThan(30);
+    // The ceiling is viewport rows × columns: vision slice 2's denser grid
+    // (§1.3's minmax(280px) — 4 columns at the jsdom fallback width, was 3)
+    // mounts one more card per row, and still nowhere near the project count.
+    expect(at60).toBeLessThan(40);
   });
 
   it('states what is missing rather than showing a blank board', async () => {

--- a/tests/LiveFeed.test.tsx
+++ b/tests/LiveFeed.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import type { CoreEvent, Project, ProjectMember, SessionStatus, SessionView } from '../src/api/types.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The live feed (DES-VISION-001 §1.3/§1.4/§5.1, vision slice 2): the home
+ * route's right column, where cross-project narration aggregates. These pin
+ * the slice's DOM ACs that need no browser:
+ *
+ *  - the feed exists exactly when something is moving (or a fresh failure
+ *    leads a project) — absent otherwise, never an empty frame;
+ *  - a `unitOutputDelta` for project B lands in `live-feed-block-B` through
+ *    the SAME store fold the cards read — zero new sockets;
+ *  - a project below the triage threshold still narrates (peripheral
+ *    awareness, §1.4) while a DECAYED failure does not haunt the feed;
+ *  - narration reads in the mono face (EC13) and the block dot / card status
+ *    bar colors resolve from status tokens, never literals (EC15).
+ */
+
+let projects: Project[] = [];
+let members: Record<string, ProjectMember[]> = {};
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: members[id] ?? [] }),
+    getRunEvents: () => Promise.resolve({ events: [] }),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: () => Promise.resolve([]),
+}));
+
+const { HomeBoard } = await import('../src/components/HomeBoard.js');
+
+function project(id: string, over: Partial<Project> = {}): Project {
+  return {
+    id, name: id, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at: Date.now(), ...over,
+  };
+}
+
+function member(project_id: string, member_ref: string): ProjectMember {
+  return {
+    id: `${project_id}:crew.run:${member_ref}`, project_id, member_kind: 'crew.run',
+    member_ref, meta: null, attached_at: 1, attached_by: 'studio',
+  };
+}
+
+const running = (id: string, status: SessionStatus = 'executing'): SessionView =>
+  makeView({ id, status, unit_ix: 0 }, [makeUnit({ id: `${id}:u0`, session_id: id, ord: 0, stage: 'build', description: 'wire the board' })]);
+
+const push = (event: CoreEvent): void => {
+  act(() => { useRuntimeStore.getState().ingest(event); });
+};
+
+const block = (id: string): HTMLElement | null =>
+  screen.queryByTestId(`live-feed-block-${id}`);
+
+async function board(runs: SessionView[]): Promise<void> {
+  render(<HomeBoard runs={runs} navigate={() => {}} />);
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('project-board')).toHaveAttribute('data-total', String(projects.length));
+  });
+  // Bindings (memberships) land a beat after the projects — flush them, so a
+  // feed asserted ABSENT is absent with the runs placed, not merely unplaced.
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+}
+
+describe('LiveFeed — the home route heartbeat (vision slice 2)', () => {
+  beforeEach(() => {
+    projects = [];
+    members = {};
+    useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
+  });
+
+  it('every moving project gets a block; a delta for B updates live-feed-block-B in place', async () => {
+    projects = [project('p-a'), project('p-b')];
+    members = { 'p-a': [member('p-a', 'run-a')], 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-a'), running('run-b')]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('live-feed')).toHaveAttribute('data-blocks', '2');
+    });
+    // Before any output: the block narrates the run's truthful headline (rule 3).
+    expect(within(block('p-b') as HTMLElement).getByTestId('feed-line'))
+      .toHaveTextContent('build — wire the board');
+
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Writing AC-3 for the checkout flow\n' } as CoreEvent);
+
+    // The AC: the delta lands in B's block off the shared store — no navigation.
+    await vi.waitFor(() => {
+      expect(block('p-b') as HTMLElement).toHaveTextContent('Writing AC-3 for the checkout flow');
+    });
+    expect(block('p-a') as HTMLElement).not.toHaveTextContent('Writing AC-3');
+
+    // EC13: narration is DATA — the mono face, off the token.
+    const line = within(block('p-b') as HTMLElement).getAllByTestId('feed-line')[0] as HTMLElement;
+    expect(line.style.fontFamily).toBe('var(--font-mono)');
+    expect(line.className).toContain('wk-feed-line');
+  });
+
+  it('shows the newest lines newest-first, capped, duplicates folded', async () => {
+    projects = [project('p-b')];
+    members = { 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-b')]);
+
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'first step\n' } as CoreEvent);
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'second step\nsecond step\n' } as CoreEvent);
+
+    await vi.waitFor(() => {
+      const lines = within(block('p-b') as HTMLElement).getAllByTestId('feed-line');
+      expect(lines.map((l) => l.textContent)).toEqual(['second step', 'first step']);
+    });
+  });
+
+  it('no moving runs anywhere ⇒ the feed is ABSENT, not an empty frame', async () => {
+    projects = [project('p-done')];
+    members = { 'p-done': [member('p-done', 'run-done')] };
+    await board([running('run-done', 'completed')]);
+
+    expect(screen.queryByTestId('live-feed')).toBeNull();
+  });
+
+  it('a gated-only project does not narrate; an executing one below triage still does', async () => {
+    // The gate block belongs on the card, where it is answerable — the feed is
+    // for narration (§1.3's wireframe: the gate-waiting project has no block).
+    projects = [project('p-gate')];
+    members = { 'p-gate': [member('p-gate', 'run-gate')] };
+    await board([running('run-gate', 'awaiting_human')]);
+    // The gate did land (the card leads the board) — the feed still has no block.
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('project-card')).toHaveAttribute('data-attention', 'gate');
+    });
+    expect(screen.queryByTestId('live-feed')).toBeNull();
+  });
+
+  it('a FRESH failure that leads its project gets the fail block with [open run]; a decayed one does not', async () => {
+    projects = [
+      project('p-fresh'),
+      // 8 days stale: the failing score has decayed to ~0 — quiet band.
+      project('p-stale', { updated_at: Date.now() - 8 * 86_400_000 }),
+    ];
+    members = { 'p-fresh': [member('p-fresh', 'run-f')], 'p-stale': [member('p-stale', 'run-s')] };
+    await board([running('run-f', 'failed'), running('run-s', 'failed')]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('live-feed')).toHaveAttribute('data-blocks', '1');
+    });
+    const fresh = block('p-fresh') as HTMLElement;
+    expect(fresh).toHaveTextContent(/failed \d+[smhd] ago/);
+    expect(within(fresh).getByTestId('feed-open-run'))
+      .toHaveAttribute('href', '/p/p-fresh/build/run-f');
+    expect(block('p-stale')).toBeNull();
+  });
+});

--- a/tests/ProjectCard.variants.test.tsx
+++ b/tests/ProjectCard.variants.test.tsx
@@ -184,3 +184,56 @@ describe('the ACTIVE variant — rich, but an empty region is OMITTED (§2.1.1)'
     expect(within(card()).getByTestId('live-line')).toBeInTheDocument();
   });
 });
+
+describe('the vision-slice-2 card language (DES-VISION-001 §5.1)', () => {
+  it('the card is token-built: --surface-card ground, --shadow-card, mono narration (EC13/EC15)', () => {
+    render(
+      <ProjectCard
+        item={item('upload-endpoint', {
+          runs: [run('r-live', 'executing')],
+          attention: 'running', band: 'needs-you', score: 40,
+          signal: { kind: 'running', at: Date.now(), runId: 'r-live' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(card().style.background).toBe('var(--surface-card)');
+    expect(card().style.boxShadow).toBe('var(--shadow-card)');
+    // Narration is DATA — the mono face at body ink (§1.5 rule 3).
+    const line = within(card()).getByTestId('live-line');
+    expect(line.style.fontFamily).toBe('var(--font-mono)');
+    expect(line.style.color).toBe('var(--ink-body)');
+  });
+
+  it('the 2px status bar tops the ACTIVE card in the leading signal\'s color (§1.4)', () => {
+    render(
+      <ProjectCard
+        item={item('q3-review-deck', {
+          runs: [run('r-gate', 'awaiting_human')],
+          attention: 'gate', band: 'needs-you', score: 100,
+          signal: { kind: 'gate', at: Date.now(), runId: 'r-gate' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(card().style.borderTop).toBe('2px solid var(--status-gate)');
+    cleanup();
+
+    render(
+      <ProjectCard
+        item={item('auth-refactor', {
+          runs: [run('r-fail', 'failed')],
+          attention: 'failing', band: 'needs-you', score: 66,
+          signal: { kind: 'failing', at: Date.now(), runId: 'r-fail' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(card().style.borderTop).toBe('2px solid var(--status-fail)');
+    cleanup();
+
+    // A QUIET card carries no bar — the bar is the ACTIVE card's signal (§5.1).
+    render(<ProjectCard item={item('smoke-tests')} navigate={() => {}} />);
+    expect(card().style.borderTop).toBe('');
+  });
+});


### PR DESCRIPTION
The first visible piece of the re-envisioned interface (§1.3's decided composition): the status wall with 2px state bars on every active card, and the NEW LiveFeed sidebar — streaming narration across ALL active projects off the same runtime store, failure blocks with [open run], §1.6 motion grammar with reduced-motion honored. HomeBoard/ProjectCard/GateChip fully token-converted; the no-raw-color rule is now ERROR for every touched file (warnings 1562→1530 and only going down).

Verifier negative-checked the rig against main, proved the lint bites by injecting a hex, and pixel-judged EC3/4/11-15; operator pixel-reviewed. UXFIX preserved: boardAttention untouched, bands, quiet budget, gate chips (rig-enforced). Slice-1's rig re-pinned to the token value it declared it would supersede to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)