### PR TITLE
feat(chrome): logo slot, tokenized chrome, switcher slide (DES-VISION-001 slice 3)

### DIFF
--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -56,7 +56,20 @@ from uxfix_fixture import (
 W2_PORT = int(os.environ.get("W2_PORT", "4333"))
 ORIGIN = f"http://127.0.0.1:{W2_PORT}"
 CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
-ACCENT_RGB = "rgb(255, 218, 25)"
+# The switcher's fill was pinned to the pre-token accent literal here; vision
+# slice 3 moved the active segment onto `var(--accent)` (DES-VISION-001 §5.2),
+# so the assertion is re-pinned to the TOKEN by in-page probe — same
+# supersession the slice-1 rig went through when the card background moved onto
+# `--surface-card`. The design assertion is unchanged: the active segment is
+# FILLED and an inactive one is not (F8).
+ACCENT_PROBE_JS = """() => {
+  const el = document.createElement('div');
+  el.style.background = 'var(--accent)';
+  document.body.appendChild(el);
+  const v = getComputedStyle(el).backgroundColor;
+  el.remove();
+  return v;
+}"""
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
 
 report: dict = {"ok": False, "steps": {}}
@@ -124,7 +137,9 @@ with sync_playwright() as p:
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     # AC 1 — the switcher is the spine (F8): filled active segment, glyph+label
-    # segments, summary in the DOM. All read from computed style / live DOM.
+    # segments, summary in the DOM. All read from computed style / live DOM;
+    # the fill's value comes from the accent TOKEN by probe (see ACCENT_PROBE_JS).
+    accent_rgb = page.evaluate(ACCENT_PROBE_JS)
     switcher = page.evaluate(
         """accent => {
              const active = document.querySelector('[data-testid="mode-tab-chat"]');
@@ -143,7 +158,7 @@ with sync_playwright() as p:
                summaryVisible: summary !== null && summary.offsetParent !== null,
              };
            }""",
-        ACCENT_RGB,
+        accent_rgb,
     )
 
     # AC 2 — first-run teaches, nothing warms. The network tap has recorded every

--- a/e2e/vision_slice3_test.py
+++ b/e2e/vision_slice3_test.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+vision_slice3_test.py — the DES-VISION-001 slice-3 gate: the chrome + mode
+switcher (§3.1, §5.2, §6.3 slice 3), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py — §6.2), on the project shell route /p/q3-review-deck/build.
+
+The slice DOM ACs, verbatim from §6.3:
+
+  1. `[data-testid="logo-slot"]` has `background-image` resolving from the
+     `--logo-url` CSS var (even when empty/none): computed 'none' by default,
+     and setting the property on <html> resolves a real image URL — plus the
+     §3.1 slot contract (exactly 32×32; the default mark is an SVG path whose
+     computed stroke IS the accent token, by probe);
+  2. the active mode segment's computed `background` resolves from
+     `var(--accent)` and its `color` from `var(--accent-fg)` (EC15 — probe
+     technique, no hex copied into this rig);
+  3. the active fill `<div>` transition FIRES on mode change — asserted via
+     `page.wait_for_function` on the fill's computed `left` changing, with the
+     CDP Animation domain slowed (setPlaybackRate) so a mid-transition frame is
+     capturable (§6.3's "capture via CDP timeline");
+  4. the connection status dot carries `data-state` matching the websocket
+     state ('connected' here: the run list only renders once /ws is up).
+
+Plus the slice's checklist reads (§6.1): EC8 (the switcher looks like the
+spine — filled active segment, glyph+label segments, summary on screen), EC11
+(no ornament in the chrome), EC12 (the accent is none of the status colors;
+the dot speaks the status layer), EC15 (chrome computed styles resolve from
+tokens), and the §6.3 preservation list (UXFIX-001 §2.5: glyphs match the
+board quick actions, active summary always visible, unavailable modes stay
+rendered — never hidden). The §2.8 reconciliation is asserted too: the loaded
+sans is Inter (the token names it; the legacy Archivo load is gone).
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-3-chrome.png                the chrome closeup (logo slot + name + dot + gear)
+  vision-3-switcher-active.png       the switcher with Build active + summary line
+  vision-3-switcher-transition.png   a mid-slide frame (CDP-slowed timeline)
+
+Finally: `npm run lint` must exit 0 with ZERO findings in this slice's files
+(the no-raw-color rule is ERROR there now) while the warn baseline still fires
+elsewhere.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: VISION_PORT (default 4342),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4342"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# This slice's error-mode files (eslint.config.mjs TOKEN_CLEAN): lint findings
+# here are FAILURES now, and the gate greps for them by name.
+SLICE_FILES = ["AppChrome.tsx", "WickedLogo.tsx", "LeftSidebar.tsx",
+               "SettingsMenu.tsx", "ModeSwitcher.tsx", "ProjectShell.tsx"]
+
+# A minimal SVG data URL for the --logo-url resolution probe (AC 1) — the value
+# is throwaway; the assertion is that the SLOT's computed background-image
+# follows the custom property. Unquoted CSS url() with the quotes URL-encoded,
+# so the string survives both Python and the CSS parser verbatim.
+LOGO_PROBE_URL = "url(data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27/%3E)"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # Freeze Date.now at NOW0 + 5s BEFORE the app boots (timers keep running),
+    # so every rendered age in the captures is deterministic (§6.0).
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
+    page.locator('[data-testid="app-chrome"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # §2.8 reconciled: BOTH faces load — Inter (the --font-sans token's own
+    # name) and JetBrains Mono. Archivo is not requested at all.
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('13px "Inter"')
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    # AC 4 precondition: the run list renders only once /ws is connected, so
+    # the dot must read connected. Wait for the state, then read the DOM fact.
+    dot_connected = settled(
+        """() => document.querySelector('[data-testid="connection-dot"]')
+                   ?.dataset.state === 'connected'""",
+    )
+
+    # ── AC 1 + §3.1: the logo slot contract ────────────────────────────────────
+    logo = page.evaluate(
+        """probeUrl => {
+             const probeColor = name => { const el = document.createElement('div');
+               el.style.color = `var(${name})`;
+               document.body.appendChild(el);
+               const v = getComputedStyle(el).color;
+               el.remove(); return v; };
+             const slot = document.querySelector('[data-testid="logo-slot"]');
+             const rect = slot.getBoundingClientRect();
+             const before = getComputedStyle(slot).backgroundImage;
+             document.documentElement.style.setProperty('--logo-url', probeUrl);
+             const after = getComputedStyle(slot).backgroundImage;
+             document.documentElement.style.removeProperty('--logo-url');
+             const restored = getComputedStyle(slot).backgroundImage;
+             const mark = document.querySelector('[data-testid="logo-wicked-mark"]');
+             const path = mark ? mark.querySelector('path') : null;
+             return {
+               width: rect.width, height: rect.height,
+               bgDefault: before,
+               bgWithVar: after,
+               bgRestored: restored,
+               markPresent: !!mark && mark.tagName.toLowerCase() === 'svg',
+               markStroke: path ? getComputedStyle(path).stroke : null,
+               accent: probeColor('--accent'),
+               fit: getComputedStyle(slot).backgroundSize,
+             }; }""",
+        LOGO_PROBE_URL,
+    )
+    logo_ok = (
+        logo["width"] == 32 and logo["height"] == 32
+        and logo["bgDefault"] == "none"
+        and "data:image/svg" in logo["bgWithVar"]
+        and logo["bgRestored"] == "none"
+        and logo["markPresent"]
+        and logo["markStroke"] == logo["accent"]
+        and logo["fit"] == "contain")
+
+    # ── AC 2 + EC8/EC12/EC15: the switcher + chrome computed FROM the tokens ──
+    styles = page.evaluate(
+        """() => {
+             const probeBg = name => { const el = document.createElement('div');
+               el.style.background = `var(${name})`;
+               document.body.appendChild(el);
+               const v = getComputedStyle(el).backgroundColor;
+               el.remove(); return v; };
+             const probeColor = name => { const el = document.createElement('div');
+               el.style.color = `var(${name})`;
+               document.body.appendChild(el);
+               const v = getComputedStyle(el).color;
+               el.remove(); return v; };
+             const active = document.querySelector('[data-testid="mode-tab-build"]');
+             const inactive = document.querySelector('[data-testid="mode-tab-chat"]');
+             const summary = document.querySelector('[data-testid="mode-summary"]');
+             const switcher = document.querySelector('[data-testid="mode-switcher"]');
+             const rail = document.querySelector('[data-testid="left-rail"]');
+             const dot = document.querySelector('[data-testid="connection-dot"]');
+             const fill = document.querySelector('[data-testid="mode-fill"]');
+             const tabs = Array.from(document.querySelectorAll(
+               '[data-testid="mode-switcher"] [role="tab"]'));
+             return {
+               accent: probeBg('--accent'),
+               accentFg: probeColor('--accent-fg'),
+               inkDim: probeColor('--ink-dim'),
+               surfaceRail: probeBg('--surface-rail'),
+               statusGate: probeBg('--status-gate'),
+               statusFail: probeBg('--status-fail'),
+               statusRun: probeBg('--status-run'),
+               activeBg: getComputedStyle(active).backgroundColor,
+               activeColor: getComputedStyle(active).color,
+               inactiveBg: getComputedStyle(inactive).backgroundColor,
+               fillBg: fill ? getComputedStyle(fill).backgroundColor : null,
+               summaryColor: summary ? getComputedStyle(summary).color : null,
+               summaryText: summary ? summary.textContent : null,
+               summaryVisible: summary !== null && summary.offsetParent !== null,
+               switcherBg: getComputedStyle(switcher).backgroundColor,
+               railBg: getComputedStyle(rail).backgroundColor,
+               dotBg: dot ? getComputedStyle(dot).backgroundColor : null,
+               dotState: dot ? dot.dataset.state : null,
+               tabTexts: tabs.map(t => t.textContent),
+               glyphsPresent: ['💬','⚙','▤','▶'].every((g, i) => tabs[i].textContent.includes(g)),
+               noneHidden: tabs.every(t => t.offsetParent !== null && !t.disabled),
+               unavailableFlags: tabs.map(t => t.dataset.unavailable ?? null),
+               railActionGlyphs: (document.querySelector('[data-testid="rail-actions"]')
+                 ?.textContent ?? ''),
+             }; }""")
+    active_ok = (styles["activeBg"] == styles["accent"]
+                 and styles["activeColor"] == styles["accentFg"]
+                 and styles["inactiveBg"] != styles["accent"]
+                 and styles["fillBg"] == styles["accent"])
+    ec12_ok = styles["accent"] not in (
+        styles["statusGate"], styles["statusFail"], styles["statusRun"])
+    ec15_ok = (styles["switcherBg"] == styles["surfaceRail"]
+               and styles["railBg"] == styles["surfaceRail"]
+               and styles["summaryColor"] == styles["inkDim"]
+               and styles["dotBg"] == styles["statusRun"])
+    dot_ok = dot_connected and styles["dotState"] == "connected"
+    # UXFIX-001 §2.5 preserved: four glyph+label segments (the board's own four
+    # glyphs — the rail's creation verbs carry two of them on this same page),
+    # the active summary ON SCREEN, no mode hidden or inert.
+    preserved_ok = (
+        len(styles["tabTexts"]) == 4 and styles["glyphsPresent"]
+        and styles["summaryVisible"]
+        and (styles["summaryText"] or "").startswith("Governed code work")
+        and styles["noneHidden"]
+        and "⚙" in styles["railActionGlyphs"] and "💬" in styles["railActionGlyphs"])
+
+    # ── The named steady-state screenshots (§6.3) — before the transition ─────
+    page.locator('[data-testid="app-chrome"]').screenshot(
+        path=str(VSHOTS / "vision-3-chrome.png"))
+    page.locator('[data-testid="mode-switcher"]').screenshot(
+        path=str(VSHOTS / "vision-3-switcher-active.png"))
+
+    # ── AC 3: the fill transition fires — CDP-slowed so mid-flight is real ────
+    switcher_box = page.locator('[data-testid="mode-switcher"]').bounding_box()
+    cdp = ctx.new_cdp_session(page)
+    cdp.send("Animation.enable")
+    cdp.send("Animation.setPlaybackRate", {"playbackRate": 0.08})
+
+    geometry = page.evaluate(
+        """() => ({
+             from: document.querySelector('[data-testid="mode-tab-build"]').offsetLeft,
+             to: document.querySelector('[data-testid="mode-tab-chat"]').offsetLeft,
+             fillLeft: parseFloat(getComputedStyle(
+               document.querySelector('[data-testid="mode-fill"]')).left),
+           })""")
+    page.locator('[data-testid="mode-tab-chat"]').click()
+    # The AC verbatim: the computed left CHANGES (the transition is running)…
+    fill_moved = settled(
+        """start => { const f = document.querySelector('[data-testid="mode-fill"]');
+             return f && Math.abs(parseFloat(getComputedStyle(f).left) - start) > 0.5; }""",
+        geometry["fillLeft"], timeout=5000,
+    )
+    # …and is BETWEEN the segments when the mid-flight frame is captured.
+    fill_mid = settled(
+        """g => { const f = document.querySelector('[data-testid="mode-fill"]');
+             if (!f) return false;
+             const left = parseFloat(getComputedStyle(f).left);
+             return left > g.to + 2 && left < g.from - 2; }""",
+        geometry, timeout=5000,
+    )
+    page.screenshot(path=str(VSHOTS / "vision-3-switcher-transition.png"), clip=switcher_box)
+    fill_settled = settled(
+        """g => { const f = document.querySelector('[data-testid="mode-fill"]');
+             return f && Math.abs(parseFloat(getComputedStyle(f).left) - g.to) < 1; }""",
+        geometry, timeout=15000,
+    )
+    cdp.send("Animation.setPlaybackRate", {"playbackRate": 1})
+    # The switch LANDED (mode surface + summary follow — §2.5 rule 2 held through it).
+    chat_active = settled(
+        """() => document.querySelector('[data-testid="mode-surface"]')?.dataset.mode === 'chat'
+              && document.querySelector('[data-testid="mode-tab-chat"]')
+                   ?.getAttribute('aria-selected') === 'true'""")
+
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([fonts_ok, logo_ok, active_ok, ec12_ok, ec15_ok, dot_ok, preserved_ok,
+               fill_moved, fill_mid, fill_settled, chat_active,
+               len(console_errors) == 0]),
+    "web_fonts_inter_and_mono": fonts_ok,
+    "logo_slot": logo,
+    "logo_slot_ok": logo_ok,
+    "computed": styles,
+    "active_segment_from_accent_tokens": active_ok,
+    "ec12_accent_not_a_status_color": ec12_ok,
+    "ec15_chrome_from_tokens": ec15_ok,
+    "connection_dot_state_matches_ws": dot_ok,
+    "uxfix_2_5_preserved": preserved_ok,
+    "fill_transition_fired": fill_moved,
+    "fill_mid_flight_captured": fill_mid,
+    "fill_settled_on_target": fill_settled,
+    "mode_switch_landed": chat_active,
+    "transition_geometry": geometry,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("vision-3-chrome.png", "vision-3-switcher-active.png",
+                     "vision-3-switcher-transition.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-3 DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0; ZERO findings in the error-mode slice files ──────
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+slice_hits = [f for f in SLICE_FILES if f in out]
+baseline_warnings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "exit_code": r.returncode,
+    "slice_files_with_findings": slice_hits,
+    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with no findings in the slice-3 "
+         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,6 +53,13 @@ const TOKEN_CLEAN = [
   'src/components/ProjectCard.tsx',
   'src/components/GateChip.tsx',
   'src/hooks/useBoardHeadline.ts',
+  // Vision slice 3 — the chrome + mode switcher (§3.1, §5.2).
+  'src/components/AppChrome.tsx',
+  'src/components/WickedLogo.tsx',
+  'src/components/LeftSidebar.tsx',
+  'src/components/SettingsMenu.tsx',
+  'src/components/ModeSwitcher.tsx',
+  'src/components/ProjectShell.tsx',
 ];
 
 export default tseslint.config(

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>wicked-studio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@0,62..125,100..900;1,62..125,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet" />
+    <!-- The two faces of DES-VISION-001 §2.8: Inter (the --font-sans token names it;
+         the legacy Archivo load was reconciled away in slice 3) + JetBrains Mono. -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+import { useConnectionStore } from '../store/connection.js';
+import { prefersReducedMotion } from './LiveEdge.js';
+import { SettingsMenu } from './SettingsMenu.js';
+import { WickedLogo } from './WickedLogo.js';
+
+/**
+ * The app chrome (DES-VISION-001 §6.3 slice 3, §3.1, §5.2): the one place the
+ * product frames itself — the logo slot, the product name, the connection
+ * status, and the settings entry point. It renders as the rail's header region
+ * (the chrome the product already had, token-converted — §6.0: no IA change),
+ * at the §2.7 chrome height (`--space-12`).
+ *
+ * The logo slot contract (§3.1):
+ *   - exactly 32×32, with `--space-2` clearspace to the viewport edge and the
+ *     product name; nothing encroaches;
+ *   - `background-image` resolves from the `--logo-url` custom property (none
+ *     by default) with contain-fit, so a custom asset is letterboxed, never
+ *     stretched or cropped — slice 7's Settings surface sets the property;
+ *   - the default mark is an SVG path stroked in `var(--accent)` (WickedLogo);
+ *     the old `[W]` font-character fallback is gone.
+ *
+ * The connection dot carries `data-state` = the websocket state, and its color
+ * is the STATUS layer, not the accent (§2.6): live = run-emerald, connecting =
+ * gate-amber, lost = fail-red. The reconnecting pulse is the ONE loop the
+ * motion grammar allows (§1.6) — it is state communication, and it stops for
+ * `prefers-reduced-motion`. The health popover it opens is the same one the
+ * rail's old pill owned — moved, not removed.
+ */
+
+interface Props {
+  /** The rail's collapsed state: icon-only column instead of the header row. */
+  collapsed: boolean;
+  navigate: (path: string) => void;
+}
+
+const DOT_COLOR = {
+  connected: 'var(--status-run)',
+  connecting: 'var(--status-gate)',
+  disconnected: 'var(--status-fail)',
+} as const;
+
+const DOT_WORD = {
+  connected: 'live',
+  connecting: 'connecting…',
+  disconnected: 'offline',
+} as const;
+
+interface HealthInfo {
+  status: string;
+  version: string;
+  ping: string;
+}
+
+function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; detail: string }): React.ReactElement {
+  const icon = ok === null ? '·' : ok ? '✓' : '✗';
+  const color = ok === null ? 'var(--ink-dim)' : ok ? 'var(--status-run)' : 'var(--status-fail)';
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}>
+      <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{icon}</span>
+      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-mono)', flex: 1 }}>{label}</span>
+      <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>{detail}</span>
+    </div>
+  );
+}
+
+/** The connection status dot + the health popover (moved from the rail pill). */
+function ConnectionDot({ collapsed }: { collapsed: boolean }): React.ReactElement {
+  const wsStatus = useConnectionStore((s) => s.status);
+  const [open, setOpen] = useState(false);
+  const [health, setHealth] = useState<HealthInfo | null>(null);
+  const [healthError, setHealthError] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setHealth(null);
+    setHealthError(false);
+    api.getHealth()
+      .then((h) => setHealth(h))
+      .catch(() => setHealthError(true));
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onOutside(e: MouseEvent): void {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('click', onOutside);
+    return () => document.removeEventListener('click', onOutside);
+  }, [open]);
+
+  const pillLabel =
+    wsStatus === 'connected' ? 'Connected' :
+    wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
+
+  return (
+    <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={`Connection: ${pillLabel}`}
+        aria-label={`Connection: ${pillLabel}`}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '5px', background: 'transparent',
+          border: 'none', padding: 'var(--space-1)', cursor: 'pointer',
+        }}
+      >
+        <span
+          data-testid="connection-dot"
+          data-state={wsStatus}
+          style={{
+            width: '7px', height: '7px', borderRadius: 'var(--radius-full)',
+            background: DOT_COLOR[wsStatus], flexShrink: 0,
+            // §1.6's one allowed loop: reconnecting IS a state, and it reads as one.
+            animation: wsStatus === 'connecting' && !prefersReducedMotion()
+              ? 'wk-live-pulse 2s ease-in-out infinite' : undefined,
+          }}
+        />
+        {!collapsed && (
+          <span style={{ fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)', whiteSpace: 'nowrap' }}>
+            {DOT_WORD[wsStatus]}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div style={{
+          position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 100,
+          background: 'var(--surface-overlay)', border: '1px solid var(--surface-raised)',
+          borderRadius: 'var(--radius-md)', padding: 'var(--space-3) 14px', minWidth: '220px',
+          boxShadow: 'var(--shadow-overlay)',
+        }}>
+          <p style={{
+            fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', textTransform: 'uppercase',
+            letterSpacing: '0.1em', color: 'var(--ink-dim)', marginBottom: 'var(--space-2)',
+            fontFamily: 'var(--font-mono)',
+          }}>
+            Health checks
+          </p>
+          <CheckRow label="WebSocket" ok={wsStatus === 'connected'} detail={pillLabel} />
+          {healthError ? (
+            <CheckRow label="API server" ok={false} detail="unreachable" />
+          ) : health ? (
+            <>
+              <CheckRow label="API server" ok={health.status === 'ok'} detail={health.status} />
+              <CheckRow label="wicked-core" ok detail={health.version} />
+            </>
+          ) : (
+            <CheckRow label="API server" ok={null} detail="checking…" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  // The §3.1 slot: 32×32 exactly, clearspace by margin, contain-fit custom
+  // asset via the --logo-url custom property, the accent-stroked mark inside.
+  const logoSlot = (
+    <button
+      type="button"
+      data-testid="logo-slot"
+      onClick={() => navigate('/')}
+      aria-label="Home"
+      style={{
+        width: '32px', height: '32px', flexShrink: 0, padding: 0, border: 'none',
+        margin: 'var(--space-2)',
+        backgroundColor: 'transparent',
+        backgroundImage: 'var(--logo-url, none)',
+        backgroundSize: 'contain', backgroundPosition: 'center', backgroundRepeat: 'no-repeat',
+        cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+    >
+      <WickedLogo size={32} />
+    </button>
+  );
+
+  const settingsButton = (
+    <div style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        type="button"
+        data-testid="chrome-settings"
+        onClick={() => setSettingsOpen((v) => !v)}
+        onMouseDown={(e) => e.stopPropagation()}
+        aria-label="Settings"
+        title="Settings"
+        style={{
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: 'var(--ink-muted)', fontSize: 'var(--text-md)', padding: 'var(--space-1)',
+          borderRadius: 'var(--radius-sm)', lineHeight: 1,
+        }}
+        onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--ink-body)'; }}
+        onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--ink-muted)'; }}
+      >
+        ⚙
+      </button>
+      {settingsOpen && (
+        <SettingsMenu onNavigate={navigate} onClose={() => setSettingsOpen(false)} />
+      )}
+    </div>
+  );
+
+  if (collapsed) {
+    return (
+      <div
+        data-testid="app-chrome"
+        style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-1)' }}
+      >
+        {logoSlot}
+        <ConnectionDot collapsed />
+        {settingsButton}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="app-chrome"
+      style={{
+        display: 'flex', alignItems: 'center', flex: 1, minWidth: 0,
+        height: 'var(--space-12)',   /* the chrome height (§2.7) */
+      }}
+    >
+      {logoSlot}
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        className="truncate transition-opacity hover:opacity-70"
+        style={{
+          background: 'transparent', border: 'none', cursor: 'pointer', padding: 0,
+          textAlign: 'left', flex: 1, minWidth: 0,
+          fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)',
+          fontWeight: 'var(--weight-semi)', color: 'var(--ink-body)',
+        }}
+      >
+        wicked-studio
+      </button>
+      <ConnectionDot collapsed={false} />
+      {settingsButton}
+    </div>
+  );
+}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,14 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import { lastMode, modePath } from '../hooks/useRoute.js';
-import { useConnectionStore } from '../store/connection.js';
+import { AppChrome } from './AppChrome.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NotificationBell } from './NotificationBell.js';
 import { ATTENTION_DOT } from './ProjectCard.js';
-import { SettingsMenu } from './SettingsMenu.js';
-import { WickedLogo } from './WickedLogo.js';
 
 /**
  * The rail, consolidated to TWO taxonomies (DES-UXFIX-001 §2.3, slice 3 — F4):
@@ -35,17 +33,22 @@ interface Props {
   navigate: (path: string) => void;
 }
 
+// The rail is chrome (§5.1's token table: `--surface-rail → rail, chrome`), so
+// slice 3's chrome conversion moves the whole palette onto the semantic tokens
+// (§2.11) — the legacy teal shell retires with it. Links and the creation verbs
+// are the rail's interactive affordances: on-accent, the §5.3 "Add agents"
+// precedent (low-key but on-accent to signal interactivity).
 const S = {
-  bg:        '#1c4053',
-  border:    'rgba(0,0,0,0.25)',
-  ink:       '#e6edf3',
-  muted:     'rgba(230,237,243,0.55)',
-  faint:     'rgba(230,237,243,0.3)',
-  hover:     'rgba(0,0,0,0.2)',
-  active:    'rgba(0,0,0,0.35)',
-  accent:    '#ffda19',
-  accentInk: '#0d1117',
-  link:      '#79c0ff',
+  bg:        'var(--surface-rail)',
+  border:    'var(--surface-raised)',
+  ink:       'var(--ink-body)',
+  muted:     'var(--ink-muted)',
+  faint:     'var(--ink-dim)',
+  hover:     'var(--surface-card)',
+  active:    'var(--surface-raised)',
+  accent:    'var(--accent)',
+  accentInk: 'var(--accent-fg)',
+  link:      'var(--accent)',
 };
 
 const SECTION_MAX = 4;
@@ -166,109 +169,6 @@ function SectionLabel({
   );
 }
 
-// ── Connection status pill + health popover ───────────────────────────────────
-
-interface HealthInfo {
-  status: string;
-  version: string;
-  ping: string;
-}
-
-function ConnectionPill(): React.ReactElement {
-  const wsStatus = useConnectionStore((s) => s.status);
-  const [open, setOpen] = useState(false);
-  const [health, setHealth] = useState<HealthInfo | null>(null);
-  const [healthError, setHealthError] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    setHealth(null);
-    setHealthError(false);
-    api.getHealth()
-      .then((h) => setHealth(h))
-      .catch(() => setHealthError(true));
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onOutside(e: MouseEvent): void {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener('click', onOutside);
-    return () => document.removeEventListener('click', onOutside);
-  }, [open]);
-
-  const dotColor =
-    wsStatus === 'connected' ? '#3fb950' :
-    wsStatus === 'connecting' ? '#ffda19' : '#f85149';
-
-  const pillLabel =
-    wsStatus === 'connected' ? 'Connected' :
-    wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
-
-  return (
-    <div ref={ref} style={{ position: 'relative' }}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        title="Connection status"
-        style={{
-          display: 'flex', alignItems: 'center', gap: '5px',
-          background: 'rgba(0,0,0,0.25)', border: '1px solid rgba(230,237,243,0.1)',
-          borderRadius: '20px', padding: '2px 8px 2px 6px', cursor: 'pointer',
-        }}
-      >
-        <span style={{
-          width: '7px', height: '7px', borderRadius: '50%',
-          background: dotColor, flexShrink: 0,
-          boxShadow: wsStatus === 'connected' ? `0 0 5px ${dotColor}` : 'none',
-        }} />
-        <span style={{ fontSize: '10px', fontFamily: 'monospace', color: dotColor, whiteSpace: 'nowrap' }}>
-          {pillLabel}
-        </span>
-        <span style={{ fontSize: '9px', color: 'rgba(230,237,243,0.35)', marginLeft: '1px' }}>▾</span>
-      </button>
-
-      {open && (
-        <div style={{
-          position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 100,
-          background: '#1b222e', border: '1px solid rgba(230,237,243,0.12)',
-          borderRadius: '10px', padding: '12px 14px', minWidth: '220px',
-          boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
-        }}>
-          <p style={{ fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'rgba(230,237,243,0.4)', marginBottom: '8px', fontFamily: 'monospace' }}>
-            Health checks
-          </p>
-          <CheckRow label="WebSocket" ok={wsStatus === 'connected'} detail={pillLabel} />
-          {healthError ? (
-            <CheckRow label="API server" ok={false} detail="unreachable" />
-          ) : health ? (
-            <>
-              <CheckRow label="API server" ok={health.status === 'ok'} detail={health.status} />
-              <CheckRow label="wicked-core" ok detail={health.version} />
-            </>
-          ) : (
-            <CheckRow label="API server" ok={null} detail="checking…" />
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; detail: string }): React.ReactElement {
-  const icon = ok === null ? '·' : ok ? '✓' : '✗';
-  const color = ok === null ? 'rgba(230,237,243,0.3)' : ok ? '#3fb950' : '#f85149';
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '5px' }}>
-      <span style={{ width: '12px', fontSize: '11px', color, fontFamily: 'monospace', flexShrink: 0 }}>{icon}</span>
-      <span style={{ fontSize: '11px', color: '#e6edf3', fontFamily: 'monospace', flex: 1 }}>{label}</span>
-      <span style={{ fontSize: '10px', color: 'rgba(230,237,243,0.45)', fontFamily: 'monospace' }}>{detail}</span>
-    </div>
-  );
-}
-
 /** One rail project row: the board's attention dot + the name. The row is the
  *  board card's one-glance summary, never a second place that explains it. */
 function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }): React.ReactElement {
@@ -293,7 +193,7 @@ function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }
           className="w-2 h-2 rounded-full shrink-0"
           style={{ background: ATTENTION_DOT[attention] }}
         />
-        <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+        <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: S.muted }}>
           {project.name}
         </span>
       </div>
@@ -306,7 +206,6 @@ function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }
 export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const [hovered, setHovered] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [repos, setRepos] = useState<RepoEntry[]>([]);
@@ -349,38 +248,20 @@ export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
       onMouseEnter={() => { if (collapsed) setHovered(true); }}
       onMouseLeave={() => setHovered(false)}
     >
-      {/* Header */}
-      <div className="flex items-center gap-2 px-4 pt-5 pb-3 shrink-0">
-        <button type="button" onClick={() => navigate('/')} className="shrink-0" aria-label="Home">
-          <WickedLogo size={26} />
-        </button>
-        {isExpanded && (
-          <button
-            type="button"
-            onClick={() => navigate('/')}
-            className="flex-1 text-left text-sm font-semibold font-mono truncate transition-opacity hover:opacity-70"
-            style={{ color: S.ink, background: 'transparent' }}
-          >
-            wicked-studio
-          </button>
-        )}
+      {/* The app chrome (DES-VISION-001 §6.3 slice 3): logo slot + product name
+          + connection dot + settings — the rail's header region, token-built. */}
+      <div className={`flex shrink-0 ${isExpanded ? 'items-center pr-2' : 'flex-col items-center pt-2 gap-1'}`}>
+        <AppChrome collapsed={!isExpanded} navigate={navigate} />
         <button
           type="button"
           onClick={() => setCollapsed(v => !v)}
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          className={`text-xs font-mono shrink-0 leading-none ${isExpanded ? 'ml-auto' : ''}`}
+          className="text-xs font-mono shrink-0 leading-none"
           style={{ color: S.faint }}
         >
           {collapsed ? '»' : '«'}
         </button>
       </div>
-
-      {/* Connection pill — below logo, matching the gap between action links and section headers */}
-      {isExpanded && (
-        <div className="px-4 pt-1 pb-3">
-          <ConnectionPill />
-        </div>
-      )}
 
       {/* Notification bell — always visible (collapsed: icon-only with badge; expanded: label too) */}
       <div className={isExpanded ? 'px-4 pb-2' : 'flex justify-center pb-2'}>
@@ -464,11 +345,11 @@ export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
                     onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                   >
                     <div className="flex items-center gap-2">
-                      <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+                      <span className="flex-1 truncate text-xs leading-tight font-mono" style={{ color: S.muted }}>
                         {repo.name}
                       </span>
                     </div>
-                    <p className="text-[10px] mt-0.5 font-mono truncate" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                    <p className="text-[10px] mt-0.5 font-mono truncate" style={{ color: S.faint }}>
                       {repo.root_path}
                     </p>
                   </button>
@@ -520,36 +401,6 @@ export function LeftSidebar({ runs, navigate }: Props): React.ReactElement {
         )}
       </div>
 
-      {/* Footer */}
-      <div className={`px-2 pb-3 shrink-0 ${!isExpanded ? 'flex flex-col items-center gap-1' : ''}`}>
-        <div className="relative">
-          <button
-            type="button"
-            onClick={() => setSettingsOpen(v => !v)}
-            onMouseDown={e => e.stopPropagation()}
-            aria-label="Settings"
-            className={`rounded transition-colors ${
-              !isExpanded
-                ? 'w-9 h-9 flex items-center justify-center text-base'
-                : 'w-full flex items-center gap-2 px-2 py-1.5 text-xs'
-            }`}
-            style={{ color: S.faint }}
-            onMouseEnter={e => { e.currentTarget.style.background = S.hover; e.currentTarget.style.color = S.ink; }}
-            onMouseLeave={e => { e.currentTarget.style.background = ''; e.currentTarget.style.color = S.faint; }}
-          >
-            <span>⚙</span>
-            {isExpanded && (
-              <>
-                <span>Settings</span>
-                <span className="ml-auto text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.25)' }}>v0.3.2</span>
-              </>
-            )}
-          </button>
-          {settingsOpen && (
-            <SettingsMenu onNavigate={navigate} onClose={() => setSettingsOpen(false)} />
-          )}
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -1,16 +1,19 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import { MODES, type Mode } from '../hooks/useRoute.js';
+import { prefersReducedMotion } from './LiveEdge.js';
 
+// DES-VISION-001 §5.2: the switcher's visual language is the token contract's
+// (§2.11 — no raw colors). Active segment: accent fill + accent-fg ink; inactive:
+// transparent + ink-muted; hover: surface-raised + ink-body.
 const S = {
-  bar:      '#161c26',
-  border:   'rgba(230,237,243,0.1)',
-  ink:      '#e6edf3',
-  muted:    'rgba(230,237,243,0.55)',
-  faint:    'rgba(230,237,243,0.3)',
-  accent:   '#ffda19',
-  /** Text on a filled accent segment — the house pairing for accent-filled controls. */
-  accentInk: '#0d1117',
-  /** An unfilled segment's resting surface — present enough to read as a control. */
-  segment:  'rgba(230,237,243,0.04)',
+  bar:    'var(--surface-rail)',
+  border: 'var(--surface-raised)',
+  muted:  'var(--ink-muted)',
+  dim:    'var(--ink-dim)',
+  hover:  'var(--surface-raised)',
+  hoverInk: 'var(--ink-body)',
+  accent: 'var(--accent)',
+  accentInk: 'var(--accent-fg)',
 };
 
 export interface ModeSpec {
@@ -97,16 +100,65 @@ interface Props {
  * title still names the one enabling action (§1.3 rule 3).
  */
 export function ModeSwitcher({ mode, onSelect, unavailable }: Props): React.ReactElement {
+  const listRef = useRef<HTMLDivElement>(null);
+  // The active fill's rect, measured off the active segment. Null until the
+  // first layout pass; the active button paints its own accent from frame one,
+  // so the control is never fill-less.
+  const [fill, setFill] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
+  const reduced = prefersReducedMotion();
+
+  // §5.2: "the active fill slides between segments via a positioned <div> that
+  // transitions its left and width" — measured, not derived, so font loading
+  // and container resizes re-place it (the ResizeObserver below).
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const measure = (): void => {
+      const btn = list.querySelector<HTMLElement>(`[data-mode="${mode}"]`);
+      if (btn) {
+        setFill({ left: btn.offsetLeft, top: btn.offsetTop, width: btn.offsetWidth, height: btn.offsetHeight });
+      }
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(list);
+    return () => ro.disconnect();
+  }, [mode]);
+
   return (
     <div
       data-testid="mode-switcher"
       style={{ flexShrink: 0, background: S.bar, borderBottom: `1px solid ${S.border}` }}
     >
       <div
+        ref={listRef}
         role="tablist"
         aria-label="Project mode"
-        style={{ display: 'flex', gap: '6px', padding: '10px 12px 0' }}
+        style={{ position: 'relative', display: 'flex', gap: 'var(--space-2)', padding: 'var(--space-2) var(--space-3) 0' }}
       >
+        {/* The active fill underlayer (§1.6: mode segment click → the fill slides,
+            220ms, --ease-in-out; the labels do not move). One div, transitioned on
+            left/width; prefers-reduced-motion snaps it. */}
+        {fill !== null && (
+          <div
+            aria-hidden
+            data-testid="mode-fill"
+            style={{
+              position: 'absolute',
+              left: `${fill.left}px`,
+              top: `${fill.top}px`,
+              width: `${fill.width}px`,
+              height: `${fill.height}px`,
+              background: S.accent,
+              borderRadius: 'var(--radius-md)',
+              transition: reduced
+                ? 'none'
+                : 'left var(--dur-base) var(--ease-in-out), width var(--dur-base) var(--ease-in-out)',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
         {MODES.map((m) => {
           const spec = MODE_SPECS[m];
           const active = m === mode;
@@ -125,20 +177,34 @@ export function ModeSwitcher({ mode, onSelect, unavailable }: Props): React.Reac
               // "how do I turn this on" to a user who is still asking "what is this".
               title={action !== null ? `${spec.summary}\n${spec.label} ${action}` : spec.summary}
               onClick={() => onSelect(m)}
+              onMouseEnter={(e) => {
+                if (!active) { e.currentTarget.style.background = S.hover; e.currentTarget.style.color = S.hoverInk; }
+              }}
+              onMouseLeave={(e) => {
+                if (!active) { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = S.muted; }
+              }}
               style={{
+                position: 'relative',
+                zIndex: 1,
                 display: 'inline-flex',
                 alignItems: 'center',
                 gap: '7px',
-                // The F8 fix in one property: the active segment is FILLED, not underlined.
-                background: active ? S.accent : S.segment,
-                border: `1px solid ${active ? S.accent : S.border}`,
-                borderRadius: '8px',
+                // The segment itself resolves the accent (EC15's computed-style AC);
+                // its paint is DELAYED one slide so the traveling fill, not the
+                // endpoint, carries the motion — accent lands on accent, seamlessly.
+                background: active ? S.accent : 'transparent',
+                border: 'none',
+                borderRadius: 'var(--radius-md)',
                 color: active ? S.accentInk : S.muted,
                 cursor: 'pointer',
-                fontSize: '13px',
-                fontWeight: active ? 700 : 500,
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 'var(--weight-medium)',
                 opacity: action !== null && !active ? 0.45 : 1,
                 padding: '7px 14px',
+                transition: active && !reduced
+                  ? 'background-color var(--dur-fast) var(--ease-in-out) var(--dur-base), color var(--dur-fast) var(--ease-in-out)'
+                  : 'none',
               }}
             >
               {/* The SAME four glyphs as the board quick actions and doc tiles (§2.5 rule 4). */}
@@ -148,10 +214,14 @@ export function ModeSwitcher({ mode, onSelect, unavailable }: Props): React.Reac
           );
         })}
       </div>
-      {/* §2.5 rule 2: the active mode's summary is ON SCREEN, not tooltip-only. */}
+      {/* §2.5 rule 2: the active mode's summary is ON SCREEN, not tooltip-only.
+          §5.2: normal weight, --text-xs, sans, --ink-dim. */}
       <p
         data-testid="mode-summary"
-        style={{ color: S.muted, fontSize: '11px', margin: 0, padding: '7px 14px 9px' }}
+        style={{
+          color: S.dim, fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)',
+          fontWeight: 'var(--weight-normal)', margin: 0, padding: '7px 14px 9px',
+        }}
       >
         {MODE_SPECS[mode].summary}
       </p>

--- a/src/components/ProjectShell.tsx
+++ b/src/components/ProjectShell.tsx
@@ -9,11 +9,13 @@ import {
 import { InstallGate } from './InstallGate.js';
 import { ModeSwitcher } from './ModeSwitcher.js';
 
+// The shell's breadcrumb bar is chrome (DES-VISION-001 §5.2: breadcrumb, mode
+// switcher, mode surface, connection status) — token-resolved per §2.11.
 const S = {
-  bar:    '#161c26',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
+  bar:    'var(--surface-rail)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  muted:  'var(--ink-muted)',
 };
 
 interface Props {
@@ -87,11 +89,20 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
           type="button"
           onClick={() => navigate('/')}
           title="All projects"
-          style={{ background: 'transparent', border: 'none', color: S.muted, cursor: 'pointer', fontSize: '12px', padding: 0 }}
+          style={{
+            background: 'transparent', border: 'none', color: S.muted, cursor: 'pointer',
+            fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', padding: 0,
+          }}
         >
           ‹ Projects
         </button>
-        <h1 data-testid="project-name" style={{ fontSize: '13px', fontWeight: 700, color: S.ink, margin: 0 }}>
+        <h1
+          data-testid="project-name"
+          style={{
+            fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-semi)',
+            fontFamily: 'var(--font-sans)', color: S.ink, margin: 0,
+          }}
+        >
           {name}
         </h1>
       </header>

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -14,6 +14,13 @@ const ITEMS: { label: string; path: string }[] = [
   { label: 'System', path: '/system' },
 ];
 
+/**
+ * The settings popover, anchored to the chrome's gear (DES-VISION-001 §6.3
+ * slice 3). It opens DOWNWARD now — the gear moved from the rail footer into
+ * the app chrome — and its colors are the token contract's (§2.11): a raised
+ * overlay surface, ink-ramp text, no raw values. The version tag the old rail
+ * footer carried rides along as the menu's quiet last row.
+ */
 export function SettingsMenu({ onNavigate, onClose }: Props): React.ReactElement {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -30,11 +37,11 @@ export function SettingsMenu({ onNavigate, onClose }: Props): React.ReactElement
   return (
     <div
       ref={ref}
-      className="absolute bottom-full left-0 mb-1 w-44 rounded-lg py-1 z-50"
+      className="absolute top-full left-0 mt-1 w-44 rounded-lg py-1 z-50"
       style={{
-        background: '#1b222e',
-        border: '1px solid rgba(230,237,243,0.1)',
-        boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+        background: 'var(--surface-overlay)',
+        border: '1px solid var(--surface-raised)',
+        boxShadow: 'var(--shadow-overlay)',
       }}
       role="menu"
     >
@@ -44,12 +51,18 @@ export function SettingsMenu({ onNavigate, onClose }: Props): React.ReactElement
           type="button"
           role="menuitem"
           onClick={() => { onNavigate(item.path); onClose(); }}
-          className="w-full text-left px-3 py-2 text-xs font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 hover:bg-white/[0.06] hover:text-[#e6edf3] focus-visible:bg-white/[0.06] focus-visible:text-[#e6edf3]"
-          style={{ color: 'rgba(230,237,243,0.6)' }}
+          className="w-full text-left px-3 py-2 text-xs font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ink-dim hover:bg-surface-raised hover:text-ink-body focus-visible:bg-surface-raised focus-visible:text-ink-body"
+          style={{ color: 'var(--ink-muted)' }}
         >
           {item.label}
         </button>
       ))}
+      <p
+        className="px-3 pt-1.5 pb-0.5 text-[10px] font-mono select-none"
+        style={{ color: 'var(--ink-dim)', margin: 0 }}
+      >
+        v0.3.2
+      </p>
     </div>
   );
 }

--- a/src/components/WickedLogo.tsx
+++ b/src/components/WickedLogo.tsx
@@ -1,17 +1,31 @@
-export function WickedLogo({ size = 28, className = '' }: { size?: number; className?: string }) {
+/**
+ * The default wicked mark (DES-VISION-001 §3.1): an SVG PATH, not a font
+ * character — so it scales cleanly at 32×32 — stroked in `var(--accent)` so it
+ * follows accent customization (§3) with zero component changes. The old
+ * filled-square + dark-stroke rendering carried its own raw palette; the mark
+ * is now monochrome accent, the token contract's own recommendation for marks
+ * ("monochrome logos work on any surface ramp", §3.1).
+ *
+ * Rendered by the chrome's logo slot (`AppChrome.tsx`) when no custom
+ * `--logo-url` is set; slice 7's customization surface swaps it for the
+ * operator's asset. `data-testid="logo-wicked-mark"` is the §6.3 slice-7 AC's
+ * name for it — pinned here so the swap is assertable.
+ */
+export function WickedLogo({ size = 32, className = '' }: { size?: number; className?: string }) {
   return (
     <svg
+      data-testid="logo-wicked-mark"
       width={size}
       height={size}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
+      aria-hidden
     >
-      <rect width="32" height="32" rx="7" fill="#ffda19" />
       <path
         d="M6 10L10.5 24L16 13L21.5 24L26 10"
-        stroke="#0d1117"
+        style={{ stroke: 'var(--accent)' }}
         strokeWidth="3"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,7 +20,10 @@ html, body, #root {
   background: var(--wk-canvas);
   color: var(--wk-ink);
   height: 100%;
-  font-family: "Archivo", ui-sans-serif, sans-serif;
+  /* §2.8's one sans, resolved from the token: Inter (loaded in index.html —
+     slice 3 reconciled the legacy Archivo load against the token contract;
+     the doc names Inter in §1.5 rule 3 and §2.8, so Inter is what loads). */
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -46,7 +49,7 @@ html, body, #root {
   --wk-blue-2:          #182f3c;
   --wk-blue-surface:    #224a5e;
   --wk-blue-surface-2:  #1a3b4e;
-  --wk-font-display:    "Archivo", ui-sans-serif, sans-serif;
+  --wk-font-display:    var(--font-sans);
   --wk-font-mono:       "JetBrains Mono", ui-monospace, monospace;
 }
 
@@ -81,15 +84,18 @@ code, pre, .font-mono {
   50%      { opacity: 1;   }
 }
 
-/* EXECUTING: 2px, breathing, faint matching glow. Slow and low-contrast on purpose. */
+/* EXECUTING: 2px, breathing, faint matching glow. Slow and low-contrast on
+   purpose. Colors are the STATUS layer (DES-VISION-001 §2.6 — slice 3 retired
+   the legacy --wk-link/--wk-accent pair here): executing = run-emerald with the
+   §5.1 `--status-run-dim` glow, gate = the amber the gate chip already speaks. */
 .wk-live-edge {
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
   width: 2px;
-  background: var(--wk-link);
-  box-shadow: 0 0 8px rgba(121, 192, 255, 0.2);
+  background: var(--status-run);
+  box-shadow: 0 0 8px var(--status-run-dim);
   animation: wk-live-pulse 2s ease-in-out infinite;
   pointer-events: none;
 }
@@ -104,11 +110,11 @@ code, pre, .font-mono {
   .wk-live-edge { animation: none; opacity: 1; width: 3px; }
 }
 
-/* GATE-WAITING: out-ranks executing — wider, accent-yellow, solid, never breathing. */
+/* GATE-WAITING: out-ranks executing — wider, gate-amber, solid, never breathing. */
 .wk-live-edge--gate {
   width: 3px;
-  background: var(--wk-accent);
-  box-shadow: 0 0 10px rgba(255, 218, 25, 0.3);
+  background: var(--status-gate);
+  box-shadow: 0 0 10px var(--status-gate-dim);
   animation: none;
   opacity: 1;
 }

--- a/tests/AppChrome.test.tsx
+++ b/tests/AppChrome.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useConnectionStore } from '../src/store/connection.js';
+
+/**
+ * The app chrome (DES-VISION-001 §6.3 slice 3): the logo slot's §3.1 contract,
+ * the product name, the connection dot's `data-state`, and the settings entry —
+ * all token-resolved (§2.11). The computed-style halves of the slice ACs live
+ * in e2e/vision_slice3_test.py (jsdom does not resolve custom properties);
+ * these cases pin the DOM contract and the inline token references.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ status: 'ok', version: '0.2.0', ping: 'pong' }),
+  },
+}));
+
+const { AppChrome } = await import('../src/components/AppChrome.js');
+
+afterEach(() => {
+  cleanup();
+  useConnectionStore.setState({ status: 'connecting' });
+});
+
+describe('AppChrome (DES-VISION-001 §3.1, §5.2)', () => {
+  it('renders the 32×32 logo slot with --logo-url background and the accent-stroked default mark', () => {
+    render(<AppChrome collapsed={false} navigate={() => {}} />);
+    const slot = screen.getByTestId('logo-slot');
+    // §3.1: the slot is exactly 32×32, its background-image resolves from the
+    // --logo-url custom property (none until slice 7 sets it), contain-fit so a
+    // custom asset is never stretched or cropped, --space-2 clearspace.
+    expect(slot.style.width).toBe('32px');
+    expect(slot.style.height).toBe('32px');
+    expect(slot.style.backgroundImage).toBe('var(--logo-url, none)');
+    expect(slot.style.backgroundSize).toBe('contain');
+    expect(slot.style.margin).toBe('var(--space-2)');
+    // The default mark: an SVG PATH stroked in the accent token — the old [W]
+    // font character and its raw palette are gone (§3.1).
+    const mark = screen.getByTestId('logo-wicked-mark');
+    expect(mark.tagName.toLowerCase()).toBe('svg');
+    const path = mark.querySelector('path');
+    expect(path?.style.stroke).toBe('var(--accent)');
+    expect(mark.querySelector('rect')).toBeNull();
+  });
+
+  it('names the product and navigates home from name and slot', () => {
+    const navigate = vi.fn();
+    render(<AppChrome collapsed={false} navigate={navigate} />);
+    fireEvent.click(screen.getByRole('button', { name: 'wicked-studio' }));
+    expect(navigate).toHaveBeenCalledWith('/');
+    fireEvent.click(screen.getByTestId('logo-slot'));
+    expect(navigate).toHaveBeenCalledTimes(2);
+  });
+
+  it('the connection dot carries data-state matching the websocket state', () => {
+    for (const status of ['connecting', 'connected', 'disconnected'] as const) {
+      useConnectionStore.setState({ status });
+      const { unmount } = render(<AppChrome collapsed={false} navigate={() => {}} />);
+      expect(screen.getByTestId('connection-dot')).toHaveAttribute('data-state', status);
+      unmount();
+    }
+  });
+
+  it('the dot speaks the status layer, never the accent (EC12)', () => {
+    const expected = {
+      connected: 'var(--status-run)',
+      disconnected: 'var(--status-fail)',
+      connecting: 'var(--status-gate)',
+    } as const;
+    for (const [status, token] of Object.entries(expected)) {
+      useConnectionStore.setState({ status: status as keyof typeof expected });
+      const { unmount } = render(<AppChrome collapsed={false} navigate={() => {}} />);
+      expect(screen.getByTestId('connection-dot').style.background).toBe(token);
+      unmount();
+    }
+  });
+
+  it('opens the settings menu from the chrome gear', () => {
+    render(<AppChrome collapsed={false} navigate={() => {}} />);
+    expect(screen.queryByRole('menu')).toBeNull();
+    fireEvent.click(screen.getByTestId('chrome-settings'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'System' })).toBeInTheDocument();
+  });
+
+  it('collapsed: keeps the slot, the dot, and settings reachable — no product name', () => {
+    render(<AppChrome collapsed navigate={() => {}} />);
+    expect(screen.getByTestId('logo-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-dot')).toBeInTheDocument();
+    expect(screen.getByTestId('chrome-settings')).toBeInTheDocument();
+    expect(screen.queryByText('wicked-studio')).toBeNull();
+  });
+});

--- a/tests/ModeSwitcher.test.tsx
+++ b/tests/ModeSwitcher.test.tsx
@@ -24,16 +24,41 @@ describe('ModeSwitcher (DES-MERGE-001 §1.3)', () => {
     expect(screen.getByTestId('mode-tab-chat')).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('fills the active segment and greys none of the rest — F8, the weight fix (§2.5)', () => {
+  it('fills the active segment from the accent token — F8 weight, §5.2 language (EC15)', () => {
     render(<ModeSwitcher mode="document" onSelect={() => {}} />);
-    // The slice-4 DOM AC verbatim: the active segment's background is FILLED,
-    // not transparent — the switcher reads as a control, not as text links.
-    const ACCENT = /#ffda19|rgb\(255,\s*218,\s*25\)/;
+    // DES-VISION-001 §5.2: active = accent fill + accent-fg ink; inactive =
+    // transparent + ink-muted. The fill is a TOKEN now (the uxfix slice-4 AC's
+    // literal yellow was that token's pre-vision value) — the switcher still
+    // reads as a control because the active segment is FILLED, not underlined.
     const active = screen.getByTestId('mode-tab-document');
-    expect(active.style.background).toMatch(ACCENT);
+    expect(active.style.background).toBe('var(--accent)');
+    expect(active.style.color).toBe('var(--accent-fg)');
     const inactive = screen.getByTestId('mode-tab-chat');
-    expect(inactive.style.background).not.toMatch(ACCENT);
-    expect(inactive.style.background).not.toBe('transparent');
+    expect(inactive.style.background).toBe('transparent');
+    expect(inactive.style.color).toBe('var(--ink-muted)');
+  });
+
+  it('slides an accent fill underlayer sized to the active segment (§5.2, §1.6)', () => {
+    render(<ModeSwitcher mode="build" onSelect={() => {}} />);
+    // The positioned <div> §5.2 names: accent-filled, transitioned on left/width
+    // at --dur-base / --ease-in-out. jsdom has no layout, so the RECT is 0 here —
+    // the rig (e2e/vision_slice3_test.py) asserts the real slide; this pins the
+    // contract's shape: the div exists, is aria-hidden, and transitions the two
+    // properties the design says move (left, width — never the labels).
+    const fill = screen.getByTestId('mode-fill');
+    expect(fill).toHaveAttribute('aria-hidden');
+    expect(fill.style.background).toBe('var(--accent)');
+    expect(fill.style.transition).toContain('left var(--dur-base) var(--ease-in-out)');
+    expect(fill.style.transition).toContain('width var(--dur-base) var(--ease-in-out)');
+    expect(fill.style.pointerEvents).toBe('none');
+  });
+
+  it('keeps the summary in the §5.2 voice: --text-xs sans in --ink-dim', () => {
+    render(<ModeSwitcher mode="chat" onSelect={() => {}} />);
+    const summary = screen.getByTestId('mode-summary');
+    expect(summary.style.color).toBe('var(--ink-dim)');
+    expect(summary.style.fontSize).toBe('var(--text-xs)');
+    expect(summary.style.fontFamily).toBe('var(--font-sans)');
   });
 
   it('keeps the active mode’s summary ON SCREEN, not tooltip-only (§2.5 rule 2)', () => {


### PR DESCRIPTION
Vision slice 3: the chrome becomes the brand's canvas. Logo slot (32×32, `--logo-url` var with the default accent-stroked mark — the yellow W block retired), Inter/JetBrains Mono loaded per §2.8 (Archivo out), connection dot with the one sanctioned motion loop, ModeSwitcher's active-fill slide (220ms, reduced-motion snaps), six more files under the error-mode lint (warnings 1530→1482).

Build agent was killed by a machine sleep AFTER committing both commits — the verifier reconstructed the claims from the diff and verified adversarially (hex-injection per file, nine rigs on a fresh build, negative-check on main, CDP mid-slide capture). Operator pixel-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)