### PR TITLE
feat(surfaces): all four modes on the token system (DES-VISION-001 slices 4-5)

### DIFF
--- a/.product/evidence/vision-slice4/checklist.md
+++ b/.product/evidence/vision-slice4/checklist.md
@@ -1,0 +1,99 @@
+# DES-VISION-001 slice 4 — experience checklist verdicts
+
+**Slice:** the mode SURFACES on the token system — Chat + Build (§5.3, §5.4) and
+Document + Video (§5.5, §5.6), landed as two commits on one branch
+(`vision/slice-4-surfaces`): GroupChat/ChatPanel/CenterDashboard, then
+DocumentCanvas/DocumentThread/VersionStrip + the strip toolbar (ThemesMenu,
+ExportMenu), the shared SurfaceState constants, threadAnchor (the §5.5
+cross-link animation), and VideoStoryboard. The no-raw-color rule is **ERROR**
+for all 11 files the slice touched (§2.11).
+**Rubric:** DES-VISION-001 §6.1, items mapped to this slice's two §6.3 entries:
+**EC7, EC9, EC10, EC11, EC13, EC15** (plus EC12 re-read on Build).
+**Images:** `e2e/shots/vision/vision-4-chat-firstrun.png`,
+`vision-4-build-runs.png`, `vision-5-document.png`, `vision-5-video.png` — all
+1440×900, `device_scale_factor=1`, per §6.0, by `e2e/vision_slice4_test.py`
+against the frozen-`NOW0` W2 fixture (§6.2) with the browser clock frozen at
+`NOW0+5s`; the Document scene drives the real W3 create→continue journey, the
+Video scene runs on the fixture's new `demo` switch (a recorded 4-step
+`checkout-demo`, GIF + thumbnails drawn deterministically). The shots are
+gitignored evidence; the rig's JSON report records each path beside the verdicts.
+
+| Item | Verdict | Read from the evidence |
+|---|---|---|
+| **EC7 — the surface teaches itself** (carried from UXFIX) | **PASS** | Chat's first-run states what it is and what typing does (the §5.3 instruction, on screen); Build's purpose statement is the first block under the H1 (`build-purpose`, always visible); each mode's summary line rides the switcher. All asserted off the live DOM. |
+| **EC9 — the relationship is visible** (carried from UXFIX) | **PASS** | The Document shot shows canvas ↔ strip ↔ thread with the strip spanning beneath both panes; the rig re-proves BOTH cross-link directions and the §5.5 flash: selecting v1 scrolls the thread to the anchored message AND flashes it (`wk-anchor-flash` observed on, then retired on animationend). |
+| **EC10 — no banned state** (carried from UXFIX) | **PASS** | No "Working…", no bare spinner anywhere in the four shots; the Video recording status names its subject (pinned in `VideoStoryboard.tokens.test.tsx` and unchanged narration suites); zero console errors across all four scenes. |
+| **EC11 — information is the aesthetic** | **PASS** | All four shots: no gradients, no ornament. Every colored pixel is signal — run-row left borders, the gate pair, the accent on the ONE primary/selection — and every text block is data. |
+| **EC12 — accent is singular** | **PASS** | Probed: `--accent` (violet) ≠ `--status-gate`/`--status-run`/`--status-fail`. On Build the accent appears ONLY on `+ Build something`; gates/statuses speak the §2.6 layer. Seat identity in Chat moved OFF per-CLI hues onto one surface/ink pair — color stays reserved for signal (§1.5 rule 2). |
+| **EC13 — two typefaces, one rule** | **PASS** | Computed in all four scenes: intent labels/prose/purpose in Inter (the sans token); status words, phases, cost, narration, version numbers/stamps, chapter offsets in JetBrains Mono. Both faces visible in every shot — the contrast is the rhythm. |
+| **EC15 — token discipline** (passing for these surfaces — the slice target) | **PASS** | Probe-asserted, no hex duplicated into the rig: `build-purpose` color == `var(--ink-body)`; gate-row `border-left` 2px == `var(--status-gate)` (run/fail rows likewise); composer bg == `var(--surface-raised)` with the `--accent-dim` focus ring (never full accent); version-strip active dot bg == `var(--accent)`; version tags == `var(--status-done)` at `--radius-sm`; selected chapter border 2px == `var(--accent)`. Lint: the rule is ERROR for the 11 slice files and finds **nothing** in them. |
+
+**Slice DOM ACs** (from the rig's JSON report, all true):
+
+- `[data-testid="build-purpose"]` computed `color` resolves from `--ink-body` (AC 1).
+- The `awaiting_human` run rows' computed `border-left-color` == the probe of
+  `--status-gate`, width `2px`; executing == `--status-run`; failed == `--status-fail` (AC 2).
+- Chat first-run shows the instruction text; `data-testid="add-agents"` present and
+  on-accent; **zero** `POST /api/v1/chats` fired on mount — the request tap covered the
+  page's whole life (AC 3).
+- Version strip active dot computed `background` resolves from `var(--accent)`;
+  `data-testid="themes-explanation"` non-empty, sans/13px; selecting a storyboard chapter
+  applies `border-color` from `--accent` (read after the `--dur-base` recolor settles) (AC 4,
+  the §6.3 slice-5 items this branch carries).
+- Console: zero errors across all four scenes.
+
+**Repo gates:** `npm run lint` exit **0** — the 11 slice files under the ERROR-mode rule
+with zero findings, the warn baseline still firing on the not-yet-converted rest (**1166**
+warnings, down **316** from main's 1482 — slice 6 retires them). `npm run typecheck` exit 0.
+`npm test` **847/847** (91 files; new: `DocumentSurfaces.tokens.test.tsx`,
+`VideoStoryboard.tokens.test.tsx`, plus the Chat/Build commit's `GroupChat.tokens` and
+`CenterDashboard.tokens` suites; `threadAnchor.test.ts` extended for the smooth scroll +
+one-run flash).
+
+**All rigs green on the fresh build** (`dist-sameorigin` deleted and rebuilt from this
+branch first): `uxfix_slice1..6_test.py`, `vision_slice1..3_test.py`, and this slice's
+`vision_slice4_test.py` — ten for ten, exit 0. Two rig-set reconciliations, both
+behavior-preserving:
+- `uxfix_slice5_test.py`'s EC1 accent census probed the inherited amber literal; it now
+  probes `var(--accent)` — the contract (exactly ONE accent-filled primary) is unchanged,
+  the hue moved onto the token by design (§2.5, applied to Build by this slice).
+- `vision_slice1_test.py`'s pixel gate was re-baselined the strong way: baseline captured
+  from an `origin/main` (pre-slice-4) build, check from this branch — **pixel-identical
+  (0 diff pixels)**, proving the surface conversions changed nothing on the home board.
+- `uxfix_slice6_test.py` follows the `themes-explain` → `themes-explanation` testid rename
+  (the §6.3 AC names the latter); the assertion itself is unchanged.
+
+**UXFIX preserved (§6.3's lists), re-proven:** Build purpose statement always visible; no
+campaigns panel ("campaign" absent from the surface text); intent labels on run rows (never
+raw prompts — uxfix-5's truncation checks still green); Chat single-agent default with
+"Add agents" opt-in and no warmed roster on first run (uxfix-4 green); Document three-pane +
+version cross-link both directions + Themes explanation on open (uxfix-6 green); Video
+narration rules (recording status names its subject and step; ffmpeg actionable state
+untouched).
+
+**Fixture gotcha fixed (rig infrastructure, not product):** the shared `/ws` one-shot
+queues were drained by whichever handler thread ticked first — a rig that navigates
+between routes leaves the previous page's handler looping until its write fails, and its
+pre-write drain STOLE the interactive frames meant for the live page (the Document journey
+stalled on any multi-route rig). Each connection now takes a generation number and only
+the NEWEST drains (`ws_gen` in `uxfix_fixture.py`).
+
+**What shipped (~640 LOC production across the two commits):** `GroupChat.tsx`,
+`ChatPanel.tsx` (§5.3): token conversion, seat identity on one surface/ink pair, first-run
+instruction sans/`--ink-body`, composer `--surface-raised`/`--radius-xl` with the
+`wk-composer` `--accent-dim` focus ring, on-accent "Add agents", transparent user bubbles /
+card agent bubbles, roster disclosure at `--dur-base`; `CenterDashboard.tsx` (§5.4): token
+conversion, run-row `border-left: 2px solid var(--status-*)` with `--dur-base` recolor and
+`--dur-fast` mount fade, gate-inbox pill on the gate pair, cost footer mono/dim beside the
+accent `+ Build something`; `DocumentCanvas.tsx`/`VersionStrip.tsx`/`DocumentThread.tsx` +
+`ThemesMenu.tsx`/`ExportMenu.tsx`/`SurfaceState.tsx` (§5.5): token conversion, active
+version dot on `var(--accent)`, strip on `--surface-rail` under an `--accent-subtle` spine,
+`--status-done`/`--radius-sm` version tags, gate/actionable cards on the §2.6 amber pair,
+framed canvas, the composer on §5.3's contract; `threadAnchor.ts` + `global.css`: smooth
+scroll + the 1s `wk-anchor-flash` fade of `--accent-subtle` (one run, class retired on
+animationend, `prefers-reduced-motion` honored); `VideoStoryboard.tsx` (§5.6): token
+conversion, `border: 2px solid var(--accent)` on the selected chapter (2px in every state —
+no layout shift), thumbs on `--surface-raised`, captions `--text-2xs --ink-dim` mono,
+recording status mono/`--text-xs`/`--ink-body`; `eslint.config.mjs`: TOKEN_CLEAN grows by
+the 11 slice files; `e2e/uxfix_fixture.py`: the `demo` switch + surface and the `ws_gen`
+drain fix; `e2e/vision_slice4_test.py`: the gate (this file's evidence source).

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -30,6 +30,11 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     rig posts one mid-page to prove the live feed updates from the
                     shared store within the 2s AC — a NEW line, not the loop's
                     repeated one.
+  demo            — whether q3-review-deck's doc registry carries the recorded
+                    `checkout-demo` (kind "demo") plus its spec / recording /
+                    frames, so Video mode has a §5.6 surface to render (vision
+                    slice 4; default False — the board rigs' doc tiles must not
+                    grow a tile they never asserted).
 
 A rig that never flips them gets the default W2 board.
 """
@@ -68,7 +73,7 @@ def iso(ms: int) -> str:
 # Mutable fixture switches, flipped over POST /__fixture between page loads.
 state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
-         "extra_narration": []}
+         "extra_narration": [], "demo": False}
 state_lock = threading.Lock()
 
 
@@ -156,6 +161,84 @@ NOTES_DOCS = [
     {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
 ]
 
+# ── The vision-slice-4 Video surface (DES-VISION-001 §5.6): one recorded demo ──
+#
+# The interactive bridge, reduced to what Video mode reads through crew's proxy:
+# a `kind: "demo"` doc in q3-review-deck's registry, its spec (4 ordered steps —
+# the §5.6 wireframe's `1 2 3 4` storyboard), the latest recording (a GIF, so no
+# ffmpeg/mp4 machinery is faked), a 1-version manifest, and the frames
+# themselves. All behind the `demo` switch so the board rigs' doc tiles never
+# grow a tile they did not assert. Frames are drawn lazily with Pillow (already
+# a rig prerequisite since vision slice 1) and cached per process.
+
+DEMO_NAME = "checkout-demo"
+DEMO_DOC = {"name": DEMO_NAME, "kind": "demo", "head": 1, "versions": 1,
+            "updated_at": iso(NOW0 - 5 * MIN)}
+DEMO_STEPS = [
+    {"index": 0, "title": "Open the storefront", "timestamp": 0,
+     "thumbnail": f"/d/{DEMO_NAME}/demo/thumb-0.png"},
+    {"index": 1, "title": "Add a hoodie to the cart", "timestamp": 6,
+     "thumbnail": f"/d/{DEMO_NAME}/demo/thumb-1.png"},
+    {"index": 2, "title": "Enter the card details", "timestamp": 13,
+     "thumbnail": f"/d/{DEMO_NAME}/demo/thumb-2.png"},
+    {"index": 3, "title": "Confirm the order", "timestamp": 21,
+     "thumbnail": f"/d/{DEMO_NAME}/demo/thumb-3.png"},
+]
+DEMO_SPEC = {"steps": DEMO_STEPS, "target_url": "https://shop.example/"}
+DEMO_RECORDING = {"version": 1, "gif_url": f"/d/{DEMO_NAME}/demo/v1.gif"}
+DEMO_MANIFEST = {"head": 1, "kind": "demo", "versions": [
+    {"version": 1, "parent": None, "feedback_file": None, "html_file": "v1.html",
+     "created_at": iso(NOW0 - 5 * MIN), "meta": {}}]}
+
+_demo_frames: dict = {}
+
+
+def demo_frame(name: str) -> bytes:
+    """Draw one demo frame (the recording GIF or a chapter thumbnail) with
+    Pillow, lazily, cached. A browser-window pastiche of the recorded shop —
+    light, so the player reads as CONTENT against the app's dark chrome."""
+    cached = _demo_frames.get(name)
+    if cached is not None:
+        return cached
+    import io
+
+    from PIL import Image, ImageDraw
+
+    if name == "v1.gif":
+        w, h = 960, 540
+        img = Image.new("RGB", (w, h), (244, 241, 234))
+        d = ImageDraw.Draw(img)
+        d.rectangle([0, 0, w, 44], fill=(255, 253, 247), outline=(221, 214, 196))
+        for i in range(3):  # traffic lights
+            d.ellipse([14 + i * 20, 16, 26 + i * 20, 28], fill=(200, 196, 186))
+        d.rounded_rectangle([120, 10, w - 120, 34], radius=12, fill=(238, 234, 224))
+        d.text((136, 15), "shop.example / checkout", fill=(120, 116, 106))
+        d.text((64, 84), "The Hoodie Shop", fill=(27, 27, 27))
+        d.rectangle([64, 130, 448, 420], fill=(255, 253, 247), outline=(221, 214, 196))
+        d.rectangle([96, 160, 416, 330], fill=(230, 226, 214))
+        d.text((96, 350), "Heavyweight hoodie", fill=(27, 27, 27))
+        d.text((96, 372), "$68", fill=(74, 70, 60))
+        d.rounded_rectangle([512, 200, 800, 248], radius=8, fill=(27, 98, 74))
+        d.text((560, 216), "Add to cart", fill=(255, 255, 255))
+        d.text((512, 280), "Step 2 of 4 - adding the hoodie", fill=(120, 116, 106))
+        buf = io.BytesIO()
+        img.save(buf, format="GIF")
+        body = buf.getvalue()
+    else:  # thumb-<n>.png
+        n = int(name.split("-")[1].split(".")[0])
+        img = Image.new("RGB", (296, 168), (244, 241, 234))
+        d = ImageDraw.Draw(img)
+        d.rectangle([0, 0, 296, 22], fill=(255, 253, 247), outline=(221, 214, 196))
+        d.rectangle([24, 44, 272, 132], fill=(255, 253, 247), outline=(221, 214, 196))
+        d.rounded_rectangle([24 + n * 30, 140, 80 + n * 30, 158], radius=6, fill=(27, 98, 74))
+        d.text((36, 52), DEMO_STEPS[n]["title"], fill=(27, 27, 27))
+        d.text((36, 76), f"step {n + 1}", fill=(120, 116, 106))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        body = buf.getvalue()
+    _demo_frames[name] = body
+    return body
+
 # The chat surface (slice 4, §2.4): a four-seat roster and instant-warm chat
 # endpoints. Seats warm the moment they are asked — determinism over realism —
 # and the daemon's real semantics are kept where the client depends on them:
@@ -197,6 +280,12 @@ docs_created: dict = {}
 
 ws_lock = threading.Lock()
 ws_queue: list = []
+# The NEWEST /ws connection owns the one-shot queues. A rig that navigates
+# between routes leaves the previous page's handler thread looping until its
+# next write raises — and that zombie's drain would STEAL queued frames from
+# the live page's socket (it drains before it writes, so the frames die with
+# it). Each connection takes a generation number; only the newest drains.
+ws_gen = [0]
 
 
 def queue_interactive(event_type: str, payload: dict) -> None:
@@ -267,6 +356,9 @@ class W2Handler(SimpleHTTPRequestHandler):
         self.wfile.flush()
         with state_lock:
             push_usage = state["usage_ws"]
+        with ws_lock:
+            ws_gen[0] += 1
+            my_gen = ws_gen[0]
         try:
             # Slice-5 switch: the Build stats footer folds cliUsage events, so the
             # frame is pushed ONCE per connection (never in the loop — a repeated
@@ -278,16 +370,26 @@ class W2Handler(SimpleHTTPRequestHandler):
                 }))
                 self.wfile.flush()
             while True:
+                # Drain the one-shot queues ONLY as the newest connection (see
+                # ws_gen above) — a superseded handler keeps streaming the
+                # narration loop until its socket dies, but must not steal
+                # frames meant for the live page.
+                with ws_lock:
+                    newest = ws_gen[0] == my_gen
                 # Drain the interactive frames the document journey queued (slice 6) —
                 # the client folds them into the doc thread off this one subscription.
-                with ws_lock:
-                    pending, ws_queue[:] = list(ws_queue), []
+                pending: list = []
+                if newest:
+                    with ws_lock:
+                        pending, ws_queue[:] = list(ws_queue), []
                 for frame in pending:
                     self.wfile.write(ws_frame(frame))
                 # Drain any one-shot narration lines a rig posted mid-page (vision
                 # slice 2: prove a NEW delta reaches the live feed within 2s).
-                with state_lock:
-                    extra, state["extra_narration"] = list(state["extra_narration"]), []
+                extra: list = []
+                if newest:
+                    with state_lock:
+                        extra, state["extra_narration"] = list(state["extra_narration"]), []
                 for line in extra:
                     self.wfile.write(ws_frame({
                         "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
@@ -350,7 +452,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                      "versions": len(vs), "updated_at": vs[-1]["created_at"]}
                     for doc, vs in docs_created.get(pid, {}).items()
                 ]
-            self._json(200, (NOTES_DOCS if pid == "notes" else []) + created)
+            with state_lock:
+                demo_on = state["demo"]
+            seeds = NOTES_DOCS if pid == "notes" else []
+            if demo_on and pid == "q3-review-deck":
+                seeds = seeds + [DEMO_DOC]
+            self._json(200, seeds + created)
             return True
         # The rest of the interactive surface the Document journey reads (slice 6).
         if self._interactive_get(path):
@@ -398,12 +505,41 @@ class W2Handler(SimpleHTTPRequestHandler):
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/versions$", path)
         if m:
             pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            with state_lock:
+                demo_on = state["demo"]
+            if demo_on and doc == DEMO_NAME:
+                self._json(200, DEMO_MANIFEST)
+                return True
             versions = doc_versions(pid, doc)
             if not versions:
                 self._json(404, {"error": f"no versions for {doc}"})
                 return True
             self._json(200, {"head": max(e["version"] for e in versions),
                              "kind": "doc", "versions": versions})
+            return True
+        # The vision-slice-4 demo surface (§5.6), behind the `demo` switch:
+        # spec, latest recording, and the frames the recording/storyboard show.
+        m = re.match(
+            r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/demo/(spec|recordings)$", path)
+        if m:
+            with state_lock:
+                demo_on = state["demo"]
+            if not demo_on or urllib.parse.unquote(m.group(2)) != DEMO_NAME:
+                self._json(404, {"error": f"no demo at {path}"})
+                return True
+            self._json(200, DEMO_SPEC if m.group(3) == "spec" else DEMO_RECORDING)
+            return True
+        m = re.match(
+            r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/demo/(v1\.gif|thumb-[0-3]\.png)$",
+            path)
+        if m:
+            body = demo_frame(m.group(3))
+            self.send_response(200)
+            self.send_header(
+                "Content-Type", "image/gif" if m.group(3).endswith(".gif") else "image/png")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
             return True
         # /api/v1/projects/<pid>/interactive/d/<doc>/doc/<v> — the rendered document.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/doc/(\d+)$", path)

--- a/e2e/uxfix_slice5_test.py
+++ b/e2e/uxfix_slice5_test.py
@@ -52,7 +52,15 @@ from uxfix_fixture import (
 
 W2_PORT = int(os.environ.get("W2_PORT", "4334"))
 ORIGIN = f"http://127.0.0.1:{W2_PORT}"
-ACCENT_RGB = "rgb(255, 218, 25)"
+
+# EC1's contract is that exactly ONE element on the surface is filled with THE
+# accent — whatever hue the token system says the accent is. Originally this
+# was the inherited amber literal; DES-VISION-001 made the accent a token
+# (§2.5, applied to this surface by vision slice 4), so the rig PROBES
+# var(--accent) in the page rather than pinning a hex that theming may move.
+ACCENT_PROBE = """() => { const el = document.createElement('div');
+  el.style.background = 'var(--accent)'; document.body.appendChild(el);
+  const v = getComputedStyle(el).backgroundColor; el.remove(); return v; }"""
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -118,7 +126,7 @@ with sync_playwright() as p:
     page.locator('[data-testid="build-something"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
-    empty = page.evaluate(SURFACE_JS, ACCENT_RGB)
+    empty = page.evaluate(SURFACE_JS, page.evaluate(ACCENT_PROBE))
     page.screenshot(path=str(SHOTS / "uxfix-5-build-empty.png"))
     page.close()
 
@@ -161,7 +169,7 @@ with sync_playwright() as p:
     )
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
-    working = page2.evaluate(SURFACE_JS, ACCENT_RGB)
+    working = page2.evaluate(SURFACE_JS, page2.evaluate(ACCENT_PROBE))
     page2.screenshot(path=str(SHOTS / "uxfix-5-build-runs.png"))
     page2.close()
 

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -262,7 +262,7 @@ with sync_playwright() as p:
     page.locator('[data-testid="theme-row"]').first.wait_for(timeout=30000)
     themes = page.evaluate(
         """expected => {
-             const explain = document.querySelector('[data-testid="themes-explain"]');
+             const explain = document.querySelector('[data-testid="themes-explanation"]');
              const rows = Array.from(document.querySelectorAll('[data-testid="theme-row"]'));
              return {
                explainText: explain ? explain.textContent.trim() : null,

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""
+vision_slice4_test.py — the DES-VISION-001 slice-4 gate: the four mode
+SURFACES on the token system — Chat + Build (§5.3, §5.4) and Document + Video
+(§5.5, §5.6) — against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py,
+§6.2), on the project-shell routes.
+
+The slice DOM ACs, verbatim from §6.3 (slice 4, plus the §5.5/§5.6 items the
+same branch converts):
+
+  1. `[data-testid="build-purpose"]` text `color` resolves from `--ink-body`
+     (EC15 — probe technique, no hex copied into this rig);
+  2. a run row's computed `border-left-color` matches `--status-gate` when
+     that run is at `awaiting_human` (and, same mechanism: `--status-run`
+     while executing, `--status-fail` when failed);
+  3. the Chat mode first-run state shows the instruction text and
+     `data-testid="add-agents"` is present but NO openChat request
+     (`POST /api/v1/chats`) fires on mount;
+  4. the version strip's active dot computed `background` resolves from
+     `var(--accent)`; the Themes popover `data-testid="themes-explanation"`
+     is non-empty; selecting a storyboard chapter applies `border-color`
+     from `--accent`.
+
+Plus the slice's checklist reads (§6.1): EC7 (the mode surfaces keep their
+UXFIX composition), EC10, EC11 (no ornament), EC13 (two typefaces — intent
+labels sans, status words/narration/stamps mono), EC15 (computed styles
+resolve from the tokens), and the §6.3 preservation lists (Build purpose
+always visible, no campaigns panel, intent labels never raw prompts; Chat
+single-agent default with the Add-agents opt-in; Document three-pane +
+cross-link; Video narration naming its subject). The §5.5 cross-link flash
+(wk-anchor-flash, one run) is asserted live.
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-4-chat-firstrun.png   Chat mode, first-run state (§5.3)
+  vision-4-build-runs.png      Build mode: W2's running + gate runs, left-border
+                               status coloring, gate inbox, cost footer (§5.4)
+  vision-5-document.png        Document mode, three-pane, v2 selected, version
+                               tags in thread (§5.5)
+  vision-5-video.png           Video mode: player + storyboard chapters (§5.6)
+
+Finally: `npm run lint` must exit 0 with ZERO findings in this slice's files
+(the no-raw-color rule is ERROR there now) while the warn baseline still fires
+elsewhere.
+
+Prereqs: Python Playwright + Pillow (the fixture draws the demo frames).
+Builds dist-sameorigin/ itself unless SKIP_STUDIO_BUILD=1 — ensure_build
+CACHES: delete a stale dist-sameorigin/ when the source changed. Env knobs:
+VISION_PORT (default 4343), SKIP_STUDIO_BUILD. Prints a JSON report to
+stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4343"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# This slice's error-mode files (eslint.config.mjs TOKEN_CLEAN): lint findings
+# here are FAILURES now, and the gate greps for them by name.
+SLICE_FILES = ["GroupChat.tsx", "ChatPanel.tsx", "CenterDashboard.tsx",
+               "DocumentCanvas.tsx", "DocumentThread.tsx", "VersionStrip.tsx",
+               "ThemesMenu.tsx", "ExportMenu.tsx", "VideoStoryboard.tsx",
+               "SurfaceState.tsx", "threadAnchor.ts"]
+
+# The token probe, shared by every scene: computed color of `var(<name>)` on a
+# scratch element — the technique that keeps hex values OUT of this rig.
+PROBES = """() => {
+  const probe = (name, prop) => { const el = document.createElement('div');
+    el.style[prop] = `var(${name})`;
+    document.body.appendChild(el);
+    const v = getComputedStyle(el)[prop === 'background' ? 'backgroundColor' : prop];
+    el.remove(); return v; };
+  return {
+    accent:       probe('--accent', 'background'),
+    accentDim:    probe('--accent-dim', 'background'),
+    accentSubtle: probe('--accent-subtle', 'background'),
+    inkBody:      probe('--ink-body', 'color'),
+    inkDim:       probe('--ink-dim', 'color'),
+    inkHigh:      probe('--ink-high', 'color'),
+    statusGate:   probe('--status-gate', 'background'),
+    statusGateDim:probe('--status-gate-dim', 'background'),
+    statusRun:    probe('--status-run', 'background'),
+    statusFail:   probe('--status-fail', 'background'),
+    statusDone:   probe('--status-done', 'color'),
+    surfaceRail:  probe('--surface-rail', 'background'),
+    surfaceRaised:probe('--surface-raised', 'background'),
+    surfaceBase:  probe('--surface-base', 'background'),
+  }; }"""
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+chat_posts: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    # AC 3's wire half: every POST /api/v1/chats the page EVER fires is recorded.
+    page.on("request", lambda req: chat_posts.append(urlparse(req.url).path)
+            if req.method == "POST" and urlparse(req.url).path == "/api/v1/chats" else None)
+
+    # Freeze Date.now at NOW0 + 5s BEFORE the app boots (timers keep running),
+    # so every rendered age in the captures is deterministic (§6.0).
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ══ Scene 1 — Chat, first run (§5.3) ══════════════════════════════════════
+    page.goto(f"{ORIGIN}/p/q3-review-deck/chat", wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # §2.8 reconciled fonts: both faces load; the sans is Inter.
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('13px "Inter"')
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    chat = page.evaluate(
+        f"""() => {{
+             const probes = ({PROBES})();
+             const instruction = document.querySelector('[data-testid="chat-firstrun-instruction"]');
+             const add = document.querySelector('[data-testid="add-agents"]');
+             const composer = document.querySelector('textarea.wk-composer');
+             const cs = composer ? getComputedStyle(composer) : null;
+             return {{
+               probes,
+               instructionText: instruction ? instruction.textContent : null,
+               instructionColor: instruction ? getComputedStyle(instruction).color : null,
+               instructionFont: instruction ? getComputedStyle(instruction).fontFamily : null,
+               addAgentsPresent: !!add,
+               addAgentsColor: add ? getComputedStyle(add).color : null,
+               composerBg: cs ? cs.backgroundColor : null,
+               composerRadius: cs ? cs.borderRadius : null,
+             }}; }}""")
+    pr = chat["probes"]
+    # Focus the composer: the §5.3 ring is --accent-dim, never the full accent.
+    page.locator("textarea.wk-composer").focus()
+    ring = page.evaluate(
+        """() => getComputedStyle(document.querySelector('textarea.wk-composer')).boxShadow""")
+    chat_ok = all([
+        (chat["instructionText"] or "").strip() != "",
+        chat["instructionColor"] == pr["inkBody"],
+        "Inter" in (chat["instructionFont"] or ""),
+        chat["addAgentsPresent"],
+        chat["addAgentsColor"] == pr["accent"],
+        chat["composerBg"] == pr["surfaceRaised"],
+        chat["composerRadius"] == "16px",
+        pr["accentDim"] in ring and pr["accent"] not in ring,
+        len(chat_posts) == 0,  # AC 3: NO openChat fired on mount
+    ])
+    page.screenshot(path=str(VSHOTS / "vision-4-chat-firstrun.png"))
+    report["steps"]["chat_firstrun"] = {
+        "ok": chat_ok, "web_fonts": fonts_ok, **chat,
+        "focus_ring": ring, "openchat_posts_on_mount": list(chat_posts),
+    }
+
+    # ══ Scene 2 — Build (§5.4): left-border status, purpose, gate inbox, footer ═
+    set_fixture(ORIGIN, usage_ws=True)
+    page.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="build-run-row"][data-status="gate"]').first.wait_for(timeout=30000)
+    page.locator('[data-testid="build-stats-footer"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    build = page.evaluate(
+        f"""() => {{
+             const probes = ({PROBES})();
+             const purpose = document.querySelector('[data-testid="build-purpose"]');
+             const row = st => document.querySelector(
+               `[data-testid="build-run-row"][data-status="${{st}}"]`);
+             const edge = el => el ? {{
+               color: getComputedStyle(el).borderLeftColor,
+               width: getComputedStyle(el).borderLeftWidth }} : null;
+             const gateRow = row('gate');
+             const spans = gateRow ? gateRow.querySelectorAll('span') : [];
+             const pill = document.querySelector('[data-testid="gate-inbox-pill"]');
+             const footer = document.querySelector('[data-testid="build-stats-footer"]');
+             const action = document.querySelector('[data-testid="build-something"]');
+             return {{
+               probes,
+               purposeVisible: !!purpose && purpose.offsetParent !== null,
+               purposeColor: purpose ? getComputedStyle(purpose).color : null,
+               purposeFont: purpose ? getComputedStyle(purpose).fontFamily : null,
+               gateEdge: edge(row('gate')),
+               workingEdge: edge(row('working')),
+               failedEdge: edge(row('failed')),
+               intentFont: spans[1] ? getComputedStyle(spans[1]).fontFamily : null,
+               intentText: spans[1] ? spans[1].textContent : null,
+               statusFont: spans[2] ? getComputedStyle(spans[2]).fontFamily : null,
+               pillBg: pill ? getComputedStyle(pill).backgroundColor : null,
+               pillColor: pill ? getComputedStyle(pill).color : null,
+               footerFont: footer ? getComputedStyle(footer).fontFamily : null,
+               footerColor: footer ? getComputedStyle(footer).color : null,
+               footerText: footer ? footer.textContent : null,
+               actionBg: action ? getComputedStyle(action).backgroundColor : null,
+               campaignsAbsent: !document.body.innerText.toLowerCase().includes('campaign'),
+             }}; }}""")
+    pb = build["probes"]
+    build_ok = all([
+        build["purposeVisible"],
+        build["purposeColor"] == pb["inkBody"],                    # AC 1
+        "Inter" in (build["purposeFont"] or ""),
+        (build["gateEdge"] or {}).get("color") == pb["statusGate"],   # AC 2
+        (build["gateEdge"] or {}).get("width") == "2px",
+        (build["workingEdge"] or {}).get("color") == pb["statusRun"],
+        (build["failedEdge"] or {}).get("color") == pb["statusFail"],
+        "Inter" in (build["intentFont"] or ""),                    # EC13
+        "JetBrains Mono" in (build["statusFont"] or ""),
+        build["pillBg"] == pb["statusGateDim"],
+        build["pillColor"] == pb["statusGate"],
+        "JetBrains Mono" in (build["footerFont"] or ""),
+        build["footerColor"] == pb["inkDim"],
+        "$0.42" in (build["footerText"] or ""),
+        build["actionBg"] == pb["accent"],
+        build["campaignsAbsent"],
+        # EC12: the accent is none of the status colors.
+        pb["accent"] not in (pb["statusGate"], pb["statusRun"], pb["statusFail"]),
+    ])
+    page.screenshot(path=str(VSHOTS / "vision-4-build-runs.png"))
+    report["steps"]["build_runs"] = {"ok": build_ok, **build}
+
+    # ══ Scene 3 — Document (§5.5): drive the W3 journey, then read the tokens ══
+    page.goto(f"{ORIGIN}/p/scratch/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-version-tag"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+
+    doc = page.evaluate(
+        f"""() => {{
+             const probes = ({PROBES})();
+             const strip = document.querySelector('[data-testid="version-strip"]');
+             const dot = document.querySelector('[data-testid="version-active-dot"]');
+             const selected = document.querySelector('[data-testid="version-entry"][data-selected="true"]');
+             const tag = document.querySelector('[data-testid="thread-version-tag"][data-version="2"]');
+             const thread = document.querySelector('[data-testid="thread"]');
+             const stamp = document.querySelector('[data-testid="version-stamp"]');
+             return {{
+               probes,
+               stripBg: strip ? getComputedStyle(strip).backgroundColor : null,
+               stripSpine: strip ? getComputedStyle(strip).borderTopColor : null,
+               dotPresent: !!dot,
+               dotBg: dot ? getComputedStyle(dot).backgroundColor : null,
+               dotInSelected: !!dot && !!selected && selected.contains(dot),
+               dotCount: document.querySelectorAll('[data-testid="version-active-dot"]').length,
+               tagColor: tag ? getComputedStyle(tag).color : null,
+               tagRadius: tag ? getComputedStyle(tag).borderRadius : null,
+               tagFont: tag ? getComputedStyle(tag).fontFamily : null,
+               threadBg: thread ? getComputedStyle(thread).backgroundColor : null,
+               stampFont: stamp ? getComputedStyle(stamp).fontFamily : null,
+               entries: document.querySelectorAll('[data-testid="version-entry"]').length,
+             }}; }}""")
+    pd = doc["probes"]
+
+    # The §5.5 cross-link flash: selecting v1 scrolls the thread to the message
+    # that made it AND flashes wk-anchor-flash once (then the class retires).
+    v1_msg_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"][data-version="1"]')
+                  ?.getAttribute('data-message-id')""")
+    page.locator('[data-testid="version-entry"][data-version="1"] [data-testid="version-select"]').click()
+    flash_on = settled(
+        """id => { const el = document.querySelector(`[data-message-id="${id}"]`);
+             return !!el && el.classList.contains('wk-anchor-flash')
+                 && getComputedStyle(el).animationName === 'wk-anchor-flash'; }""",
+        v1_msg_id, timeout=3000,
+    )
+    flash_off = settled(
+        """id => { const el = document.querySelector(`[data-message-id="${id}"]`);
+             return !!el && !el.classList.contains('wk-anchor-flash'); }""",
+        v1_msg_id, timeout=5000,
+    )
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+
+    # Themes: the popover opens WITH its explanation (the §6.3 AC's testid).
+    page.locator('[data-testid="themes-open"]').click()
+    page.locator('[data-testid="themes-panel"]').wait_for(timeout=30000)
+    themes = page.evaluate(
+        """() => { const ex = document.querySelector('[data-testid="themes-explanation"]');
+             return {
+               text: ex ? ex.textContent.trim() : null,
+               font: ex ? getComputedStyle(ex).fontFamily : null,
+               size: ex ? getComputedStyle(ex).fontSize : null,
+             }; }""")
+    page.keyboard.press("Escape")
+    page.locator('[data-testid="themes-open"]').click()  # toggle shut for the capture
+
+    # Back to v2 for the named capture (the slice entry: v2 selected, tags visible).
+    page.locator('[data-testid="thread-version-tag"][data-version="2"]').click()
+    page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+
+    doc_ok = all([
+        doc["stripBg"] == pd["surfaceRail"],
+        doc["stripSpine"] == pd["accentSubtle"],
+        doc["dotPresent"], doc["dotInSelected"], doc["dotCount"] == 1,
+        doc["dotBg"] == pd["accent"],                              # AC 4 (dot)
+        doc["tagColor"] == pd["statusDone"],
+        doc["tagRadius"] == "4px",
+        "JetBrains Mono" in (doc["tagFont"] or ""),
+        doc["threadBg"] == pd["surfaceBase"],
+        "JetBrains Mono" in (doc["stampFont"] or ""),              # EC13
+        doc["entries"] == 2,
+        v1_msg_id is not None, flash_on, flash_off,                # §5.5 flash
+        (themes["text"] or "") != "",                              # AC 4 (themes)
+        "Inter" in (themes["font"] or ""),
+        themes["size"] == "13px",
+    ])
+    page.screenshot(path=str(VSHOTS / "vision-5-document.png"))
+    report["steps"]["document_surface"] = {
+        "ok": doc_ok, **doc, "v1_message_id": v1_msg_id,
+        "flash_on": flash_on, "flash_off": flash_off, "themes_explanation": themes,
+    }
+
+    # ══ Scene 4 — Video (§5.6): storyboard chapters + the accent selection ═════
+    set_fixture(ORIGIN, demo=True)
+    page.goto(f"{ORIGIN}/p/q3-review-deck/video/checkout-demo", wait_until="domcontentloaded")
+    page.locator('[data-testid="chapter-card"][data-index="3"]').wait_for(timeout=30000)
+    page.locator('[data-testid="demo-gif"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # Every drawn frame is actually decoded before the capture.
+    settled("""() => Array.from(document.images).every(i => i.complete && i.naturalWidth > 0)""")
+
+    video = page.evaluate(
+        f"""() => {{
+             const probes = ({PROBES})();
+             const board = document.querySelector('[data-testid="demo-storyboard"]');
+             const card = i => document.querySelector(`[data-testid="chapter-card"][data-index="${{i}}"]`);
+             const sel = card(0), other = card(2);
+             const caption = sel ? sel.querySelector('span:last-child') : null;
+             const title = sel ? sel.querySelector('span:not(:last-child)') : null;
+             return {{
+               probes,
+               boardBg: board ? getComputedStyle(board).backgroundColor : null,
+               cards: document.querySelectorAll('[data-testid="chapter-card"]').length,
+               selBorder: sel ? getComputedStyle(sel).borderTopColor : null,
+               selBorderWidth: sel ? getComputedStyle(sel).borderTopWidth : null,
+               selBg: sel ? getComputedStyle(sel).backgroundColor : null,
+               selSelected: sel ? sel.getAttribute('data-selected') : null,
+               otherBorder: other ? getComputedStyle(other).borderTopColor : null,
+               captionFont: caption ? getComputedStyle(caption).fontFamily : null,
+               captionColor: caption ? getComputedStyle(caption).color : null,
+               captionSize: caption ? getComputedStyle(caption).fontSize : null,
+               titleFont: title ? getComputedStyle(title).fontFamily : null,
+               playerKind: document.querySelector('[data-testid="demo-player"]')
+                 ?.getAttribute('data-player-kind'),
+               thumbsLoaded: Array.from(document.querySelectorAll('[data-testid="chapter-thumbnail"]'))
+                 .every(i => i.complete && i.naturalWidth > 0),
+             }}; }}""")
+    pv = video["probes"]
+    # The AC's verb: SELECTING a chapter applies border-color from --accent.
+    # The recolor is a --dur-base TRANSITION (§5.4's grammar carried to §5.6),
+    # so the computed value is read after it settles, not mid-interpolation.
+    page.locator('[data-testid="chapter-card"][data-index="2"]').click()
+    recolored = settled(
+        """accent => getComputedStyle(document.querySelector(
+             '[data-testid="chapter-card"][data-index="2"]')).borderTopColor === accent""",
+        pv["accent"], timeout=5000,
+    )
+    picked = page.evaluate(
+        """() => { const c = document.querySelector('[data-testid="chapter-card"][data-index="2"]');
+             const prev = document.querySelector('[data-testid="chapter-card"][data-index="0"]');
+             return {
+               selected: c.getAttribute('data-selected'),
+               border: getComputedStyle(c).borderTopColor,
+               prevSelected: prev.getAttribute('data-selected'),
+               prevBorder: getComputedStyle(prev).borderTopColor,
+             }; }""")
+    video_ok = all([
+        video["cards"] == 4,
+        video["boardBg"] == pv["surfaceRail"],
+        video["selSelected"] == "true",
+        video["selBorder"] == pv["accent"],
+        video["selBorderWidth"] == "2px",
+        video["selBg"] == pv["surfaceRaised"],
+        video["otherBorder"] != pv["accent"],
+        "JetBrains Mono" in (video["captionFont"] or ""),          # EC13
+        video["captionColor"] == pv["inkDim"],
+        video["captionSize"] == "10px",
+        "Inter" in (video["titleFont"] or ""),
+        video["playerKind"] == "gif",
+        video["thumbsLoaded"],
+        recolored,
+        picked["selected"] == "true",
+        picked["border"] == pv["accent"],                          # AC 4 (chapter)
+        picked["prevSelected"] == "false",
+        picked["prevBorder"] != pv["accent"],
+    ])
+    # Capture with chapter 3 selected — the click IS the state the shot shows.
+    page.screenshot(path=str(VSHOTS / "vision-5-video.png"))
+    report["steps"]["video_surface"] = {"ok": video_ok, **video, "picked": picked}
+
+    browser.close()
+
+report["steps"]["console"] = {"ok": len(console_errors) == 0, "errors": console_errors[:10]}
+report["screenshots"] = [str(VSHOTS / n) for n in (
+    "vision-4-chat-firstrun.png", "vision-4-build-runs.png",
+    "vision-5-document.png", "vision-5-video.png")]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("dom_acs_verdict", f"slice-4 assertions did not all hold — see {', '.join(bad)}")
+
+# ── 4. Lint posture: exit 0; ZERO findings in the error-mode slice files ──────
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+slice_hits = [f for f in SLICE_FILES if f in out]
+baseline_warnings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "exit_code": r.returncode,
+    "slice_files_with_findings": slice_hits,
+    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with no findings in the slice-4 "
+         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,16 @@ const TOKEN_CLEAN = [
   'src/components/GroupChat.tsx',
   'src/components/ChatPanel.tsx',
   'src/components/CenterDashboard.tsx',
+  // Vision slice 4 (cont.) — the Document + Video surfaces (§5.5, §5.6),
+  // including the strip toolbar and the shared surface-state constants.
+  'src/components/DocumentCanvas.tsx',
+  'src/components/DocumentThread.tsx',
+  'src/components/VersionStrip.tsx',
+  'src/components/ThemesMenu.tsx',
+  'src/components/ExportMenu.tsx',
+  'src/components/VideoStoryboard.tsx',
+  'src/components/SurfaceState.tsx',
+  'src/components/threadAnchor.ts',
 ];
 
 export default tseslint.config(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,10 @@ const TOKEN_CLEAN = [
   'src/components/SettingsMenu.tsx',
   'src/components/ModeSwitcher.tsx',
   'src/components/ProjectShell.tsx',
+  // Vision slice 4 — the Chat + Build surfaces (§5.3, §5.4).
+  'src/components/GroupChat.tsx',
+  'src/components/ChatPanel.tsx',
+  'src/components/CenterDashboard.tsx',
 ];
 
 export default tseslint.config(

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -68,23 +68,25 @@ const FEED_EVENTS_PER_SESSION = 30;
 /** Most rows the ONE runs list shows before deferring to "view all →" (/work). */
 const MAX_RUN_ROWS = 9;
 
-// ── Style tokens (matches Dashboard.tsx palette) ───────────────────────────────
+// ── Style constants (DES-VISION-001 §2.11: semantic tokens only — the two-face
+//    rule of §2.8 rides on these: `mono` marks narration/data, `sans` labels/prose) ──
 
-const mono = { fontFamily: 'monospace' } as const;
+const mono = { fontFamily: 'var(--font-mono)' } as const;
+const sans = { fontFamily: 'var(--font-sans)' } as const;
 
 const cardBase = {
-  background: '#1b222e',
-  border: '1px solid rgba(230,237,243,0.08)',
-  borderRadius: '12px',
+  background: 'var(--surface-card)',
+  border: '1px solid var(--surface-raised)',
+  borderRadius: 'var(--radius-lg)',
 } as const;
 
 const sectionLabel: React.CSSProperties = {
-  fontSize: '10px',
+  fontSize: 'var(--text-2xs)',
   fontWeight: 600,
   textTransform: 'uppercase',
   letterSpacing: '0.1em',
-  color: 'rgba(230,237,243,0.4)',
-  fontFamily: 'monospace',
+  color: 'var(--ink-dim)',
+  ...mono,
   margin: 0,
 };
 
@@ -135,21 +137,24 @@ export function runRowModel(view: SessionView, failReason?: string): RunRowModel
   const n = view.units.length;
   const done = view.units.filter((u) => u.status === 'done').length;
   const phase = n > 0 ? Math.min(done + 1, n) : 0;
+  // The colors are the §2.6 STATUS layer (never the accent): amber = a gate
+  // needs a human, emerald = working, red = failed, dim ink = history. The
+  // same token drives the row's status icon AND its 2px left border (§5.4).
   switch (view.session.status) {
     case 'awaiting_human':
-      return { glyph: '⏸', status: 'gate', detail: 'needs you', color: '#ffda19' };
+      return { glyph: '⏸', status: 'gate', detail: 'needs you', color: 'var(--status-gate)' };
     case 'planning':
-      return { glyph: '⚙', status: 'planning', detail: '', color: '#79c0ff' };
+      return { glyph: '⚙', status: 'planning', detail: '', color: 'var(--status-run)' };
     case 'distributing':
     case 'executing':
       return {
         glyph: '⚙',
         status: 'working',
         detail: n > 0 ? `phase ${phase}/${n}` : '',
-        color: '#79c0ff',
+        color: 'var(--status-run)',
       };
     case 'completed':
-      return { glyph: '✓', status: 'done', detail: '', color: '#3fb950' };
+      return { glyph: '✓', status: 'done', detail: '', color: 'var(--status-done)' };
     case 'failed':
       return {
         glyph: '✕',
@@ -157,10 +162,10 @@ export function runRowModel(view: SessionView, failReason?: string): RunRowModel
         detail: [n > 0 ? `at phase ${phase}` : '', failReason ? truncate(failReason, 48) : '']
           .filter(Boolean)
           .join(': '),
-        color: '#f85149',
+        color: 'var(--status-fail)',
       };
     default:
-      return { glyph: '⊘', status: view.session.status, detail: '', color: 'rgba(230,237,243,0.35)' };
+      return { glyph: '⊘', status: view.session.status, detail: '', color: 'var(--ink-dim)' };
   }
 }
 
@@ -184,71 +189,75 @@ interface FeedMeta {
   badgeColor: string;
 }
 
+// Every entry speaks the §2.6 status layer: full token for text, `-dim` for the
+// pill's border + background (the GateChip convention from vision slice 2).
+// Council/workflow provenance is the one exception — it speaks the accent
+// (deliberation is the product's own voice, not a run state).
 const FEED_META: Record<string, FeedMeta> = {
   awaitingHuman: {
     icon: '🔒',
     label: 'Gate decision required',
-    borderColor: 'rgba(255,218,25,0.35)',
-    textColor: '#ffda19',
-    badgeColor: 'rgba(255,218,25,0.12)',
+    borderColor: 'var(--status-gate-dim)',
+    textColor: 'var(--status-gate)',
+    badgeColor: 'var(--status-gate-dim)',
   },
   gateEscalated: {
     icon: '⬆',
     label: 'Gate escalated to human',
-    borderColor: 'rgba(121,192,255,0.3)',
-    textColor: '#79c0ff',
-    badgeColor: 'rgba(121,192,255,0.08)',
+    borderColor: 'var(--status-gate-dim)',
+    textColor: 'var(--status-gate)',
+    badgeColor: 'transparent',
   },
   stepFailed: {
     icon: '✕',
     label: 'Step failed',
-    borderColor: 'rgba(248,81,73,0.3)',
-    textColor: '#f85149',
-    badgeColor: 'rgba(248,81,73,0.08)',
+    borderColor: 'var(--status-fail-dim)',
+    textColor: 'var(--status-fail)',
+    badgeColor: 'var(--status-fail-dim)',
   },
   sessionFailed: {
     icon: '✕',
     label: 'Session failed',
-    borderColor: 'rgba(248,81,73,0.3)',
-    textColor: '#f85149',
-    badgeColor: 'rgba(248,81,73,0.08)',
+    borderColor: 'var(--status-fail-dim)',
+    textColor: 'var(--status-fail)',
+    badgeColor: 'var(--status-fail-dim)',
   },
   crashRecoveryRedrive: {
     icon: '↻',
     label: 'Crash recovery redrive',
-    borderColor: 'rgba(248,81,73,0.2)',
-    textColor: 'rgba(248,81,73,0.8)',
-    badgeColor: 'rgba(248,81,73,0.06)',
+    borderColor: 'var(--status-fail-dim)',
+    textColor: 'var(--status-fail)',
+    badgeColor: 'transparent',
   },
   unitDone: {
     icon: '✓',
     label: 'Unit complete',
-    borderColor: 'rgba(63,185,80,0.2)',
-    textColor: '#3fb950',
-    badgeColor: 'rgba(63,185,80,0.06)',
+    borderColor: 'var(--surface-raised)',
+    textColor: 'var(--status-done)',
+    badgeColor: 'var(--status-done-dim)',
   },
   workflowSelected: {
     icon: '◈',
     label: 'Workflow selected',
-    borderColor: 'rgba(167,139,250,0.25)',
-    textColor: '#a78bfa',
-    badgeColor: 'rgba(167,139,250,0.06)',
+    borderColor: 'var(--accent-subtle)',
+    textColor: 'var(--accent)',
+    badgeColor: 'transparent',
   },
   acpFallback: {
     icon: '⚠',
     label: 'ACP degraded — single-shot fallback',
-    borderColor: 'rgba(248,81,73,0.2)',
-    textColor: 'rgba(248,81,73,0.75)',
-    badgeColor: 'rgba(248,81,73,0.05)',
+    borderColor: 'var(--status-fail-dim)',
+    textColor: 'var(--status-fail)',
+    badgeColor: 'transparent',
   },
 };
 
 const DEFAULT_META: FeedMeta = {
   icon: '·',
   label: 'Event',
-  borderColor: 'rgba(230,237,243,0.08)',
-  textColor: '#e6edf3',
-  badgeColor: 'rgba(230,237,243,0.04)',
+  borderColor: 'var(--surface-raised)',
+  textColor: 'var(--ink-body)',
+  badgeColor: 'transparent',
 };
 
 // ── GateActionCard — inline approval for a single awaiting-human gate ─────────
@@ -293,9 +302,9 @@ function GateActionCard({
   return (
     <div
       style={{
-        background: '#161c26',
+        background: 'var(--surface-card)',
         border: `1px solid ${meta.borderColor}`,
-        borderRadius: '10px',
+        borderRadius: 'var(--radius-lg)',
         padding: '14px 16px',
       }}
     >
@@ -325,8 +334,8 @@ function GateActionCard({
         </div>
         <span
           style={{
-            fontSize: '10px',
-            color: 'rgba(230,237,243,0.4)',
+            fontSize: 'var(--text-2xs)',
+            color: 'var(--ink-dim)',
             ...mono,
             flexShrink: 0,
             marginLeft: '8px',
@@ -339,8 +348,8 @@ function GateActionCard({
       {/* Context line */}
       <p
         style={{
-          fontSize: '11px',
-          color: 'rgba(230,237,243,0.45)',
+          fontSize: 'var(--text-xs)',
+          color: 'var(--ink-dim)',
           ...mono,
           margin: '0 0 8px',
         }}
@@ -349,13 +358,13 @@ function GateActionCard({
         {typeof ord === 'number' ? ` · before unit #${ord}` : ''}
       </p>
 
-      {/* Prompt excerpt */}
+      {/* Prompt excerpt — the gate's question is prose, so it reads in the sans (§2.8) */}
       {prompt && (
         <p
           style={{
-            fontSize: '12px',
-            color: 'rgba(230,237,243,0.7)',
-            ...mono,
+            fontSize: 'var(--text-sm)',
+            color: 'var(--ink-body)',
+            ...sans,
             margin: '0 0 10px',
             lineHeight: 1.5,
             display: '-webkit-box',
@@ -373,11 +382,11 @@ function GateActionCard({
         <textarea
           style={{
             width: '100%',
-            background: '#0f1419',
-            border: '1px solid rgba(230,237,243,0.14)',
-            borderRadius: '6px',
-            color: '#e6edf3',
-            fontSize: '12px',
+            background: 'var(--surface-base)',
+            border: '1px solid var(--surface-raised)',
+            borderRadius: 'var(--radius-sm)',
+            color: 'var(--ink-high)',
+            fontSize: 'var(--text-xs)',
             ...mono,
             padding: '6px 8px',
             resize: 'vertical',
@@ -395,19 +404,22 @@ function GateActionCard({
 
       {/* Action buttons */}
       <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+        {/* The GateChip pairs (vision slice 2): approve speaks run-emerald,
+            steer speaks gate-amber, reject speaks fail-red — status semantics,
+            never the accent (§2.6). Labels are actions, so they read sans. */}
         <button
           type="button"
           disabled={loading}
           onClick={() => void run(() => onApprove(runId))}
           style={{
-            background: '#3fb950',
-            color: '#0d1117',
-            border: 'none',
-            borderRadius: '6px',
+            background: 'var(--status-run-dim)',
+            color: 'var(--status-run)',
+            border: '1px solid var(--status-run-dim)',
+            borderRadius: 'var(--radius-sm)',
             padding: '5px 12px',
-            fontSize: '11px',
+            fontSize: 'var(--text-xs)',
             fontWeight: 700,
-            ...mono,
+            ...sans,
             cursor: loading ? 'not-allowed' : 'pointer',
             opacity: loading ? 0.5 : 1,
           }}
@@ -425,14 +437,14 @@ function GateActionCard({
             }
           }}
           style={{
-            background: steerOpen && amend.trim() ? '#ffda19' : 'rgba(255,218,25,0.12)',
-            color: steerOpen && amend.trim() ? '#0d1117' : '#ffda19',
-            border: '1px solid rgba(255,218,25,0.3)',
-            borderRadius: '6px',
+            background: steerOpen && amend.trim() ? 'var(--status-gate)' : 'var(--status-gate-dim)',
+            color: steerOpen && amend.trim() ? 'var(--surface-base)' : 'var(--status-gate)',
+            border: '1px solid var(--status-gate-dim)',
+            borderRadius: 'var(--radius-sm)',
             padding: '5px 12px',
-            fontSize: '11px',
+            fontSize: 'var(--text-xs)',
             fontWeight: 600,
-            ...mono,
+            ...sans,
             cursor: loading ? 'not-allowed' : 'pointer',
             opacity: loading ? 0.5 : 1,
           }}
@@ -444,14 +456,14 @@ function GateActionCard({
           disabled={loading}
           onClick={() => void run(() => onReject(runId))}
           style={{
-            background: 'rgba(248,81,73,0.1)',
-            color: '#f85149',
-            border: '1px solid rgba(248,81,73,0.3)',
-            borderRadius: '6px',
+            background: 'var(--status-fail-dim)',
+            color: 'var(--status-fail)',
+            border: '1px solid var(--status-fail-dim)',
+            borderRadius: 'var(--radius-sm)',
             padding: '5px 12px',
-            fontSize: '11px',
+            fontSize: 'var(--text-xs)',
             fontWeight: 600,
-            ...mono,
+            ...sans,
             cursor: loading ? 'not-allowed' : 'pointer',
             opacity: loading ? 0.5 : 1,
           }}
@@ -487,7 +499,7 @@ function FeedEventRow({
       style={{
         background: meta.badgeColor,
         border: `1px solid ${meta.borderColor}`,
-        borderRadius: '8px',
+        borderRadius: 'var(--radius-md)',
         padding: '8px 12px',
         display: 'flex',
         alignItems: 'flex-start',
@@ -499,19 +511,19 @@ function FeedEventRow({
       </span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px' }}>
-          <span style={{ fontSize: '11px', fontWeight: 600, color: meta.textColor, ...mono }}>
+          <span style={{ fontSize: 'var(--text-xs)', fontWeight: 600, color: meta.textColor, ...mono }}>
             {meta.label}
             {typeof ord === 'number' ? ` · unit #${ord}` : ''}
           </span>
-          <span style={{ fontSize: '10px', color: 'rgba(230,237,243,0.3)', ...mono, flexShrink: 0 }}>
+          <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', ...mono, flexShrink: 0 }}>
             {sessionId.slice(0, 6)}
           </span>
         </div>
         {detail && (
           <p
             style={{
-              fontSize: '11px',
-              color: 'rgba(230,237,243,0.55)',
+              fontSize: 'var(--text-xs)',
+              color: 'var(--ink-muted)',
               ...mono,
               margin: '2px 0 0',
               overflow: 'hidden',
@@ -524,7 +536,7 @@ function FeedEventRow({
           </p>
         )}
         {!detail && (
-          <p style={{ fontSize: '10px', color: 'rgba(230,237,243,0.3)', ...mono, margin: '2px 0 0' }}>
+          <p style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', ...mono, margin: '2px 0 0' }}>
             {sessionLbl}
           </p>
         )}
@@ -549,36 +561,46 @@ function RunRow({ view, failReason, onSelect }: RunRowProps): React.ReactElement
     <button
       type="button"
       data-testid="build-run-row"
+      data-status={m.status}
       title={view.session.problem || view.session.id}
       onClick={() => onSelect(view.session.id)}
+      // §5.4: the thin left border encodes run state at the list edge — the eye
+      // scans the margin for color without reading labels. The same status token
+      // drives the icon; a state change recolors both with a --dur-base
+      // transition, and a new row fades in once (wk-fade-in, §1.6: no loops).
+      className="wk-fade-in"
       style={{
         display: 'flex',
         alignItems: 'center',
         gap: '10px',
         padding: '9px 12px',
-        background: '#1b222e',
-        border: '1px solid rgba(230,237,243,0.07)',
-        borderRadius: '10px',
+        background: 'var(--surface-card)',
+        border: '1px solid var(--surface-raised)',
+        borderLeft: `2px solid ${m.color}`,
+        borderRadius: 'var(--radius-md)',
         cursor: 'pointer',
-        transition: 'border-color 0.15s',
+        transition: 'color var(--dur-base), border-color var(--dur-base), background var(--dur-instant)',
         width: '100%',
         textAlign: 'left',
       }}
       onMouseEnter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.borderColor = 'rgba(230,237,243,0.18)';
+        // Hover brightens the surface, never the border — the left border is
+        // status signal and must not be overwritten by an affordance.
+        (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-raised)';
       }}
       onMouseLeave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.borderColor = 'rgba(230,237,243,0.07)';
+        (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-card)';
       }}
     >
-      <span style={{ color: m.color, fontSize: '12px', flexShrink: 0, width: '14px' }}>
+      <span style={{ color: m.color, fontSize: 'var(--text-xs)', flexShrink: 0, width: '14px', transition: 'color var(--dur-base)' }}>
         {m.glyph}
       </span>
+      {/* Intent label: prose, so sans + high ink (§5.4 token usage). */}
       <span
         style={{
-          fontSize: '12px',
-          color: '#e6edf3',
-          ...mono,
+          fontSize: 'var(--text-sm)',
+          color: 'var(--ink-high)',
+          ...sans,
           flex: 1,
           minWidth: 0,
           overflow: 'hidden',
@@ -588,10 +610,11 @@ function RunRow({ view, failReason, onSelect }: RunRowProps): React.ReactElement
       >
         {intent}
       </span>
-      <span style={{ fontSize: '11px', color: m.color, ...mono, flexShrink: 0 }}>
+      {/* Status word + phase detail: data, so mono; the detail dims (§5.4). */}
+      <span style={{ fontSize: 'var(--text-xs)', color: m.color, ...mono, flexShrink: 0, transition: 'color var(--dur-base)' }}>
         {m.status}
         {m.detail ? (
-          <span style={{ color: 'rgba(230,237,243,0.45)' }}>{` · ${m.detail}`}</span>
+          <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)' }}>{` · ${m.detail}`}</span>
         ) : null}
       </span>
     </button>
@@ -649,11 +672,11 @@ function SendPanel({ activeRuns }: SendPanelProps): React.ReactElement {
                 onChange={(e) => setTarget(e.target.value)}
                 disabled={sending}
                 style={{
-                  background: '#0f1419',
-                  border: '1px solid rgba(230,237,243,0.14)',
-                  borderRadius: '6px',
-                  color: '#e6edf3',
-                  fontSize: '11px',
+                  background: 'var(--surface-base)',
+                  border: '1px solid var(--surface-raised)',
+                  borderRadius: 'var(--radius-sm)',
+                  color: 'var(--ink-high)',
+                  fontSize: 'var(--text-xs)',
                   ...mono,
                   padding: '4px 8px',
                   cursor: 'pointer',
@@ -683,11 +706,11 @@ function SendPanel({ activeRuns }: SendPanelProps): React.ReactElement {
               rows={3}
               style={{
                 width: '100%',
-                background: '#0f1419',
-                border: '1px solid rgba(230,237,243,0.14)',
-                borderRadius: '6px',
-                color: '#e6edf3',
-                fontSize: '12px',
+                background: 'var(--surface-base)',
+                border: '1px solid var(--surface-raised)',
+                borderRadius: 'var(--radius-sm)',
+                color: 'var(--ink-high)',
+                fontSize: 'var(--text-xs)',
                 ...mono,
                 padding: '8px 10px',
                 resize: 'vertical',
@@ -702,26 +725,28 @@ function SendPanel({ activeRuns }: SendPanelProps): React.ReactElement {
                 disabled={sending || !message.trim()}
                 onClick={() => void handleSend()}
                 style={{
-                  background: message.trim() ? '#79c0ff' : 'rgba(121,192,255,0.15)',
-                  color: message.trim() ? '#0d1117' : 'rgba(121,192,255,0.45)',
+                  // Send is an action → the accent, dimmed while it has nothing
+                  // to send (§2.5: the accent marks primary actions, sparingly).
+                  background: message.trim() ? 'var(--accent)' : 'var(--accent-subtle)',
+                  color: message.trim() ? 'var(--accent-fg)' : 'var(--ink-muted)',
                   border: 'none',
-                  borderRadius: '6px',
+                  borderRadius: 'var(--radius-sm)',
                   padding: '6px 14px',
-                  fontSize: '11px',
+                  fontSize: 'var(--text-xs)',
                   fontWeight: 700,
-                  ...mono,
+                  ...sans,
                   cursor: sending || !message.trim() ? 'not-allowed' : 'pointer',
-                  transition: 'all 0.15s',
+                  transition: 'background var(--dur-instant), color var(--dur-instant)',
                 }}
               >
                 {sending ? 'Sending…' : 'Send'}
               </button>
               {sent && (
-                <span style={{ fontSize: '11px', color: '#3fb950', ...mono }}>
+                <span style={{ fontSize: 'var(--text-xs)', color: 'var(--status-run)', ...mono }}>
                   ✓ Sent
                 </span>
               )}
-              <span style={{ fontSize: '10px', color: 'rgba(230,237,243,0.25)', ...mono }}>
+              <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', ...mono }}>
                 Ctrl+Enter
               </span>
             </div>
@@ -917,20 +942,23 @@ export function CenterDashboard({
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div data-testid="build-dashboard" style={{ color: '#e6edf3', ...mono }}>
+    // Two faces, one rule (§2.8): the surface defaults to the sans (labels and
+    // prose); data — status words, phases, ids, the cost — opts into the mono.
+    <div data-testid="build-dashboard" style={{ color: 'var(--ink-body)', ...sans }}>
       <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '28px 32px' }}>
 
         {/* ── 1. Header + purpose statement (the F7 fix; also the empty state) ── */}
-        <h1 style={{ fontSize: '20px', fontWeight: 600, color: '#e6edf3', margin: 0, ...mono }}>
+        <h1 style={{ fontSize: 'var(--text-xl)', fontWeight: 600, color: 'var(--ink-high)', margin: 0, ...sans }}>
           Build
         </h1>
+        {/* Purpose: prose — `--ink-body --text-sm` in the sans (§5.4 token usage). */}
         <p
           data-testid="build-purpose"
           style={{
-            fontSize: '13px',
+            fontSize: 'var(--text-sm)',
             lineHeight: 1.6,
-            color: 'rgba(230,237,243,0.65)',
-            ...mono,
+            color: 'var(--ink-body)',
+            ...sans,
             margin: '8px 0 24px',
             maxWidth: '640px',
           }}
@@ -941,13 +969,20 @@ export function CenterDashboard({
         {/* ── 2. Gate inbox — only when gates are pending (§2.7 rule 5, W4) ───── */}
         {openGates.length > 0 && (
           <div data-testid="gate-inbox" style={{ marginBottom: '24px' }}>
-            {/* Sentence case (the wireframe's "⏸ 1 gate needs you"), not the
-                uppercased section-label treatment: this line is a headline. */}
+            {/* The §5.4 gate-inbox pill: `--status-gate-dim` background,
+                `--status-gate` text. Sentence case — this line is a headline. */}
             <p
+              data-testid="gate-inbox-pill"
               style={{
-                fontSize: '12px',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '6px',
+                background: 'var(--status-gate-dim)',
+                borderRadius: 'var(--radius-full)',
+                padding: '4px 12px',
+                fontSize: 'var(--text-xs)',
                 fontWeight: 600,
-                color: '#ffda19',
+                color: 'var(--status-gate)',
                 ...mono,
                 margin: '0 0 10px',
               }}
@@ -1005,9 +1040,9 @@ export function CenterDashboard({
                 type="button"
                 onClick={() => navigate('/work')}
                 style={{
-                  fontSize: '11px',
-                  color: '#79c0ff',
-                  ...mono,
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--accent)',
+                  ...sans,
                   background: 'none',
                   border: 'none',
                   cursor: 'pointer',
@@ -1018,44 +1053,56 @@ export function CenterDashboard({
                 view all →
               </button>
             )}
-            {/* Stats footer — a summary of runs, shown only when there IS data
-                (§2.7 rule 2). Absent entirely otherwise; never `—`. */}
-            {footerParts.length > 0 && (
-              <p
-                data-testid="build-stats-footer"
-                style={{
-                  fontSize: '11px',
-                  color: 'rgba(230,237,243,0.4)',
-                  ...mono,
-                  margin: '10px 2px 0',
-                }}
-              >
-                {footerParts.join(' · ')}
-              </p>
-            )}
           </div>
         )}
 
-        {/* ── 4. The one primary action, in the mode's own words (§2.7 rule 6) ── */}
-        <button
-          type="button"
-          data-testid="build-something"
-          onClick={() => navigate('/runs/new')}
+        {/* ── 4. The one primary action + the cost footer, one row (§5.4's
+               wireframe: `[ + Build something ]` left, `cost: $0.24` right).
+               The action speaks the accent (§2.5); the footer is a data point,
+               not a hero — mono because it's a number, dim because it's ambient
+               (§5.4 token usage), and shown only when there IS data (§2.7
+               rule 2, never `—`). ─────────────────────────────────────────── */}
+        <div
           style={{
-            background: '#ffda19',
-            color: '#0d1117',
-            border: 'none',
-            borderRadius: '8px',
-            padding: '9px 18px',
-            fontSize: '12px',
-            fontWeight: 700,
-            ...mono,
-            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '16px',
             marginBottom: '28px',
           }}
         >
-          + Build something
-        </button>
+          <button
+            type="button"
+            data-testid="build-something"
+            onClick={() => navigate('/runs/new')}
+            style={{
+              background: 'var(--accent)',
+              color: 'var(--accent-fg)',
+              border: 'none',
+              borderRadius: 'var(--radius-md)',
+              padding: '9px 18px',
+              fontSize: 'var(--text-xs)',
+              fontWeight: 700,
+              ...sans,
+              cursor: 'pointer',
+            }}
+          >
+            + Build something
+          </button>
+          {runRows.length > 0 && footerParts.length > 0 && (
+            <p
+              data-testid="build-stats-footer"
+              style={{
+                fontSize: 'var(--text-xs)',
+                color: 'var(--ink-dim)',
+                ...mono,
+                margin: 0,
+              }}
+            >
+              {footerParts.join(' · ')}
+            </p>
+          )}
+        </div>
 
         {/* ── 5. Agent activity — compact feed, only when active sessions carry
                events and no gate is pending. An event-less feed is OMITTED

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -28,14 +28,10 @@ interface Props {
   navigate?: (path: string) => void;
 }
 
-// Per-CLI identity: consistent avatar colours across multi-agent runs
-const CLI_COLORS: Record<string, { bg: string; fg: string }> = {
-  claude:      { bg: 'rgba(139,92,246,0.25)',  fg: '#c4b5fd' },
-  codex:       { bg: 'rgba(59,130,246,0.25)',  fg: '#93c5fd' },
-  antigravity: { bg: 'rgba(34,197,94,0.2)',   fg: '#86efac' },
-  cursor:      { bg: 'rgba(20,184,166,0.2)',   fg: '#5eead4' },
-};
-const CLI_FALLBACK = { bg: 'rgba(230,237,243,0.1)', fg: 'rgba(230,237,243,0.55)' };
+// Agent identity under the token contract (DES-VISION-001 §2.11): one
+// surface/ink pair for every avatar — identity rides the monogram + name, and
+// color stays reserved for signal (§1.5 rule 2: status ≠ identity ≠ accent).
+const CLI_AVATAR = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
 
 function cliInitials(key: string): string {
   const parts = key.split(/[-_]/);
@@ -91,16 +87,17 @@ function routingSummary(unit: WorkUnit): string | null {
 type StepState = 'done' | 'rejected' | 'active' | 'queued';
 
 /**
- * `active` is link-blue, not accent-yellow: yellow is the colour of a gate — the state
- * that needs a human — and spending it on "a phase is running" left the two ranked the
- * same. Executing now carries the same blue live edge it carries on the board, and the
- * attention colour is free to mean only one thing.
+ * The stepper speaks the §2.6 status layer (DES-VISION-001): active = the
+ * run-emerald (the same signal the board's live edge carries — running, NOT the
+ * gate's amber, so "a phase is running" and "a gate needs you" stay ranked
+ * apart, the original intent of the pre-token link-blue); rejected = fail-red;
+ * done and queued are history/future — ink, not signal.
  */
 const STEP_STYLE: Record<StepState, { color: string; background: string; border: string }> = {
-  done:     { color: '#3fb950',               background: 'rgba(63,185,80,0.1)',    border: '1px solid rgba(63,185,80,0.25)' },
-  rejected: { color: '#f85149',               background: 'rgba(248,81,73,0.1)',    border: '1px solid rgba(248,81,73,0.3)' },
-  active:   { color: '#79c0ff',               background: 'rgba(121,192,255,0.12)', border: '1px solid rgba(121,192,255,0.35)' },
-  queued:   { color: 'rgba(230,237,243,0.3)', background: 'transparent',            border: '1px solid rgba(230,237,243,0.08)' },
+  done:     { color: 'var(--status-done)', background: 'var(--status-done-dim)', border: '1px solid var(--surface-raised)' },
+  rejected: { color: 'var(--status-fail)', background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)' },
+  active:   { color: 'var(--status-run)',  background: 'var(--status-run-dim)',  border: '1px solid var(--status-run-dim)' },
+  queued:   { color: 'var(--ink-dim)',     background: 'transparent',            border: '1px solid var(--surface-raised)' },
 };
 
 /**
@@ -128,7 +125,7 @@ function ProcessStepper({
       data-testid="process-stepper"
       aria-label="Workflow phases"
       className="flex items-center gap-1.5 flex-wrap px-6 py-2.5 shrink-0 font-mono text-[11px]"
-      style={{ borderBottom: '1px solid rgba(230,237,243,0.05)', background: '#161c26' }}
+      style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
     >
       {units.map((unit, i) => {
         const state: StepState =
@@ -153,7 +150,7 @@ function ProcessStepper({
         return (
           <Fragment key={unit.id}>
             {i > 0 && (
-              <span aria-hidden="true" style={{ color: 'rgba(230,237,243,0.15)' }}>
+              <span aria-hidden="true" style={{ color: 'var(--ink-dim)' }}>
                 ›
               </span>
             )}
@@ -170,7 +167,7 @@ function ProcessStepper({
                   continuity with the run's status, so it no longer pulses too. */}
               {state === 'active' && <LiveEdge state="executing" pill />}
               {state === 'active' && (
-                <span className="inline-block w-1.5 h-1.5 rounded-full shrink-0" style={{ background: '#79c0ff' }} />
+                <span className="inline-block w-1.5 h-1.5 rounded-full shrink-0" style={{ background: 'var(--status-run)' }} />
               )}
               {phaseName(runId, unit)}
             </span>
@@ -210,10 +207,10 @@ function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phas
 
   return (
     <div data-testid={`live-narration-${ord}`}>
-      <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
-        <span className="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: '#79c0ff' }} />
+      <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
+        <span className="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-run)' }} />
         {/* Phase label leads the entry (operator UX directive) — mirrors the done-unit header. */}
-        <span className="font-medium" style={{ color: '#79c0ff' }}>{phase}</span>
+        <span className="font-medium" style={{ color: 'var(--status-run)' }}>{phase}</span>
         <span>{hasText ? 'Working — live output' : 'Working…'}</span>
         {hasText && (
           <button
@@ -221,7 +218,7 @@ function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phas
             data-testid={`live-narration-toggle-${ord}`}
             onClick={() => setVisible((v) => !v)}
             className="ml-auto text-xs font-medium font-mono hover:underline"
-            style={{ color: '#79c0ff' }}
+            style={{ color: 'var(--accent)' }}
           >
             {visible ? '▾ Hide live output' : '▸ Show live output'}
           </button>
@@ -232,7 +229,7 @@ function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phas
           ref={scrollRef}
           data-testid={`live-narration-text-${ord}`}
           className="mt-2 max-h-64 overflow-auto rounded-lg p-2.5 text-[11px] leading-snug whitespace-pre-wrap break-words font-mono"
-          style={{ background: 'rgba(13,17,23,0.6)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.06)' }}
+          style={{ background: 'var(--surface-base)', color: 'var(--ink-body)', border: '1px solid var(--surface-raised)' }}
         >
           {tail}
         </pre>
@@ -249,7 +246,7 @@ function DegradedRoutingBanner({ reason }: { reason: string }): React.ReactEleme
   return (
     <div
       className="self-start max-w-[85%] rounded-xl px-4 py-2.5 text-xs font-mono flex flex-col gap-1.5"
-      style={{ background: 'rgba(255,218,25,0.08)', border: '1px solid rgba(255,218,25,0.2)', color: '#ffda19' }}
+      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)', color: 'var(--status-gate)' }}
     >
       <div className="flex items-center gap-2">
         <span className="shrink-0" aria-hidden="true">⚠</span>
@@ -258,7 +255,7 @@ function DegradedRoutingBanner({ reason }: { reason: string }): React.ReactEleme
           type="button"
           onClick={() => setExpanded(v => !v)}
           className="shrink-0 text-[10px] transition-opacity hover:opacity-70"
-          style={{ color: 'rgba(255,218,25,0.6)' }}
+          style={{ color: 'var(--status-gate)', opacity: 0.7 }}
           aria-expanded={expanded}
           aria-controls={detailId}
           aria-label={expanded ? 'Hide explanation' : 'Show explanation'}
@@ -269,14 +266,14 @@ function DegradedRoutingBanner({ reason }: { reason: string }): React.ReactEleme
           type="button"
           onClick={() => setDismissed(true)}
           className="shrink-0 transition-opacity hover:opacity-70"
-          style={{ color: 'rgba(255,218,25,0.5)' }}
+          style={{ color: 'var(--status-gate)', opacity: 0.6 }}
           aria-label="Dismiss degraded routing warning"
         >
           <span aria-hidden="true">✕</span>
         </button>
       </div>
       {expanded && (
-        <p id={detailId} className="text-[10px] leading-relaxed pl-5" style={{ color: 'rgba(255,218,25,0.6)' }}>
+        <p id={detailId} className="text-[10px] leading-relaxed pl-5" style={{ color: 'var(--status-gate)', opacity: 0.7 }}>
           The multi-model council could not reach a quorum vote. The unit proceeded using a
           fallback routing strategy. Open the <strong>Decisions</strong> section in the Insights
           panel on the right to see each reviewer's verdict.
@@ -287,24 +284,25 @@ function DegradedRoutingBanner({ reason }: { reason: string }): React.ReactEleme
 }
 
 function CliAvatar({ cli }: { cli: string }): React.ReactElement {
-  const { bg, fg } = CLI_COLORS[cli.toLowerCase()] ?? CLI_FALLBACK;
   return (
     <span
       aria-hidden="true"
       className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold font-mono select-none"
-      style={{ background: bg, color: fg }}
+      style={{ background: CLI_AVATAR.bg, color: CLI_AVATAR.fg }}
     >
       {cliInitials(cli)}
     </span>
   );
 }
 
-// Stage pill — wicked dark palette
+// Stage pill — the methodology stage is process vocabulary, not run state, so
+// it reads as quiet ink on a raised surface (§1.5 rule 2: color is signal;
+// four always-on badge hues would out-shout the actual status layer).
 const STAGE_BADGE: Record<StageKind, { bg: string; color: string }> = {
-  recon:   { bg: 'rgba(139,92,246,0.15)', color: '#a78bfa' },
-  build:   { bg: 'rgba(63,185,80,0.12)',  color: '#3fb950' },
-  review:  { bg: 'rgba(121,192,255,0.12)',color: '#79c0ff' },
-  test:    { bg: 'rgba(255,218,25,0.12)', color: '#ffda19' },
+  recon:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  build:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  review:  { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  test:    { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
 };
 
 const UNIT_STATUS_TEXT: Record<UnitStatus, string> = {
@@ -352,13 +350,15 @@ function systemEventLabel(type: string, detail: string): string {
   }
 }
 
+// The header dot speaks the §2.6 status layer: emerald while anything is
+// moving, amber at a gate, red on failure, dim ink once it's history.
 function statusDotColor(status: string): string {
   switch (status) {
-    case 'completed':      return '#3fb950';
-    case 'failed':        return '#f85149';
-    case 'cancelled':     return 'rgba(230,237,243,0.25)';
-    case 'awaiting_human': return '#ffda19';
-    default:              return '#79c0ff';
+    case 'completed':      return 'var(--status-done)';
+    case 'failed':        return 'var(--status-fail)';
+    case 'cancelled':     return 'var(--ink-dim)';
+    case 'awaiting_human': return 'var(--status-gate)';
+    default:              return 'var(--status-run)';
   }
 }
 
@@ -412,7 +412,7 @@ function ExportEvidenceButton({ runId, disabled }: { runId: string; disabled: bo
         <span
           role="alert"
           className="text-[11px] font-mono shrink-0 max-w-[14rem] truncate"
-          style={{ color: '#f85149' }}
+          style={{ color: 'var(--status-fail)' }}
         >
           Export failed: {error}
         </span>
@@ -425,7 +425,7 @@ function ExportEvidenceButton({ runId, disabled }: { runId: string; disabled: bo
         aria-label="Export evidence"
         aria-busy={busy}
         className="flex items-center justify-center w-6 h-6 rounded shrink-0 transition-opacity disabled:cursor-not-allowed"
-        style={{ color: error ? '#f85149' : '#79c0ff', opacity: inert ? 0.3 : 0.65 }}
+        style={{ color: error ? 'var(--status-fail)' : 'var(--accent)', opacity: inert ? 0.3 : 0.65 }}
         onMouseEnter={(e) => { if (!inert) e.currentTarget.style.opacity = '1'; }}
         onMouseLeave={(e) => { if (!inert) e.currentTarget.style.opacity = '0.65'; }}
       >
@@ -447,14 +447,14 @@ function StepFailedCard({
   return (
     <div
       className="self-start max-w-[85%] rounded-xl px-4 py-3 flex flex-col gap-2 font-mono text-xs"
-      style={{ background: 'rgba(248,81,73,0.07)', border: '1px solid rgba(248,81,73,0.25)', color: '#f85149' }}
+      style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)', color: 'var(--status-fail)' }}
     >
       <div className="flex items-center gap-2 font-semibold text-[11px] uppercase tracking-wide">
         <span>⚠</span>
         <span>Step failure</span>
       </div>
       {detail && (
-        <pre className="text-[11px] leading-relaxed whitespace-pre-wrap break-words m-0 overflow-hidden" style={{ color: 'rgba(230,237,243,0.6)', fontFamily: 'inherit' }}>
+        <pre className="text-[11px] leading-relaxed whitespace-pre-wrap break-words m-0 overflow-hidden" style={{ color: 'var(--ink-muted)', fontFamily: 'inherit' }}>
           {detail.length > 200 ? `${detail.slice(0, 200)}…` : detail}
         </pre>
       )}
@@ -464,7 +464,7 @@ function StepFailedCard({
           title="Reassign not yet available"
           disabled
           className="rounded px-3 py-1 text-[11px] font-semibold opacity-30 cursor-not-allowed"
-          style={{ background: 'rgba(230,237,243,0.08)', color: '#e6edf3' }}
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
         >
           Reassign
         </button>
@@ -473,7 +473,7 @@ function StepFailedCard({
           onClick={canStop ? onStop : undefined}
           disabled={!canStop}
           className="rounded px-3 py-1 text-[11px] font-semibold transition-opacity hover:opacity-100 opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
-          style={{ background: 'rgba(248,81,73,0.15)', color: '#f85149', border: '1px solid rgba(248,81,73,0.3)' }}
+          style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
         >
           Stop run
         </button>
@@ -486,13 +486,13 @@ function CrashRedriveCard({ attempt }: { attempt: number }): React.ReactElement 
   return (
     <div
       className="self-start max-w-[85%] rounded-xl px-4 py-3 flex flex-col gap-1 font-mono text-xs"
-      style={{ background: 'rgba(255,218,25,0.06)', border: '1px solid rgba(255,218,25,0.2)', color: '#ffda19' }}
+      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)', color: 'var(--status-gate)' }}
     >
       <div className="flex items-center gap-2 font-semibold text-[11px] uppercase tracking-wide">
         <span>↺</span>
         <span>Crash recovery — attempt {attempt}</span>
       </div>
-      <p className="text-[11px]" style={{ color: 'rgba(230,237,243,0.5)' }}>
+      <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
         The engine restarted and is re-dispatching this unit automatically.
       </p>
     </div>
@@ -533,8 +533,8 @@ function ModePill({
       title={readOnly ? 'Run mode (read-only — run is complete)' : undefined}
       className="flex items-center rounded-lg overflow-hidden shrink-0"
       style={{
-        background: 'rgba(230,237,243,0.06)',
-        border: '1px solid rgba(230,237,243,0.1)',
+        background: 'var(--surface-raised)',
+        border: '1px solid var(--surface-overlay)',
         opacity: readOnly ? 0.6 : 1,
       }}
     >
@@ -550,10 +550,13 @@ function ModePill({
           onKeyDown={readOnly ? undefined : (e) => handleKey(e, idx)}
           disabled={readOnly}
           className="px-3 py-1 text-[11px] font-mono font-medium transition-colors disabled:cursor-default"
+          // The selected segment is an interactive selection → the accent
+          // (mirrors the mode switcher's active fill, §5.2/§2.5); never amber —
+          // that's the gate's color.
           style={
             mode === m
-              ? { background: 'rgba(255,218,25,0.15)', color: readOnly ? 'rgba(255,218,25,0.7)' : '#ffda19' }
-              : { background: 'transparent', color: 'rgba(230,237,243,0.35)' }
+              ? { background: 'var(--accent)', color: 'var(--accent-fg)' }
+              : { background: 'transparent', color: 'var(--ink-dim)' }
           }
         >
           {MODE_LABELS[m]}
@@ -609,30 +612,32 @@ function LegacyChatHistory({
     <div className="flex flex-col h-full">
       <div
         className="flex items-center gap-3 px-6 py-4 shrink-0"
-        style={{ borderBottom: '1px solid rgba(230,237,243,0.07)', background: '#1b222e' }}
+        style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
       >
         <button
           type="button"
           onClick={onNavigateBack}
           aria-label="Back"
           className="w-8 h-8 flex items-center justify-center rounded-lg transition-colors shrink-0"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(230,237,243,0.06)'; e.currentTarget.style.color = '#e6edf3'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'rgba(230,237,243,0.4)'; }}
+          style={{ color: 'var(--ink-dim)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; e.currentTarget.style.color = 'var(--ink-high)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--ink-dim)'; }}
         >
           ←
         </button>
-        <p className="flex-1 text-base font-semibold truncate" style={{ color: '#e6edf3' }} title={session.problem}>
+        <p className="flex-1 text-base font-semibold truncate" style={{ color: 'var(--ink-high)' }} title={session.problem}>
           {session.problem}
         </p>
-        <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>legacy chat</span>
+        <span className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>legacy chat</span>
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 py-6 flex flex-col gap-6 max-w-3xl w-full mx-auto">
         <div className="flex justify-end">
           <div
+            // §5.3 token usage: the user's message is transparent — a hairline
+            // keeps the bubble shape without claiming a surface of its own.
             className="max-w-[72%] rounded-2xl text-base px-5 py-3.5 leading-relaxed"
-            style={{ background: '#224a5e', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.12)' }}
+            style={{ background: 'transparent', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
           >
             {session.problem}
           </div>
@@ -646,20 +651,20 @@ function LegacyChatHistory({
                 {unit.assigned_cli ? (
                   <>
                     <CliAvatar cli={unit.assigned_cli} />
-                    <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.55)' }}>
+                    <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
                       {unit.assigned_cli}
                     </span>
                   </>
                 ) : (
-                  <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.55)' }}>agent</span>
+                  <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>agent</span>
                 )}
               </div>
               <div
                 className="rounded-2xl px-5 py-4"
-                style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.08)' }}
+                style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
               >
                 {tc?.loading && (
-                  <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>Loading…</span>
+                  <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>Loading…</span>
                 )}
                 {!tc?.loading && tc?.text && (
                   <div>
@@ -667,19 +672,19 @@ function LegacyChatHistory({
                       type="button"
                       onClick={() => setTranscripts((prev) => ({ ...prev, [unit.ord]: { ...prev[unit.ord]!, visible: !tc.visible } }))}
                       className="text-xs font-medium font-mono hover:underline"
-                      style={{ color: '#79c0ff' }}
+                      style={{ color: 'var(--accent)' }}
                     >
                       {tc.visible ? '▾ Hide response' : '▸ View response'}
                     </button>
                     {tc.visible && (
-                      <div className="mt-2.5 max-h-96 overflow-auto rounded-xl p-4" style={{ background: '#0d1117' }}>
+                      <div className="mt-2.5 max-h-96 overflow-auto rounded-xl p-4" style={{ background: 'var(--surface-base)' }}>
                         <Markdown className="whitespace-pre-wrap">{tc.text}</Markdown>
                       </div>
                     )}
                   </div>
                 )}
                 {!tc?.loading && !tc?.text && (
-                  <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                  <span className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
                     Response not available — this session predates durable transcripts.
                   </span>
                 )}
@@ -788,7 +793,7 @@ function RunChat({
     });
   }
 
-  const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'rgba(230,237,243,0.5)' };
+  const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'var(--ink-muted)' };
   const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
   // Keep action + system events interleaved in arrival order (log is seq-ordered).
   const eventLog = log.filter((e) => SYSTEM_EVENT_TYPES.has(e.type) || ACTION_EVENT_TYPES.has(e.type));
@@ -804,16 +809,16 @@ function RunChat({
       {/* Run header */}
       <div
         className="flex items-center gap-3 px-6 py-4 shrink-0"
-        style={{ borderBottom: '1px solid rgba(230,237,243,0.07)', background: '#1b222e' }}
+        style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
       >
         <button
           type="button"
           onClick={onNavigateBack}
           aria-label="Back to run list"
           className="w-8 h-8 flex items-center justify-center rounded-lg transition-colors shrink-0"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(230,237,243,0.06)'; e.currentTarget.style.color = '#e6edf3'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'rgba(230,237,243,0.4)'; }}
+          style={{ color: 'var(--ink-dim)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; e.currentTarget.style.color = 'var(--ink-high)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--ink-dim)'; }}
         >
           ←
         </button>
@@ -821,7 +826,7 @@ function RunChat({
           className={`w-2.5 h-2.5 rounded-full shrink-0 ${pulse ? 'animate-pulse' : ''}`}
           style={{ background: dotColor }}
         />
-        <p className="flex-1 text-base font-semibold truncate" style={{ color: '#e6edf3' }} title={session.problem}>
+        <p className="flex-1 text-base font-semibold truncate" style={{ color: 'var(--ink-high)' }} title={session.problem}>
           {session.problem}
         </p>
         <span className="text-xs font-medium shrink-0 font-mono" style={{ color: style.color }}>{style.label}</span>
@@ -834,7 +839,7 @@ function RunChat({
             title="Kill run (Ctrl+K)"
             aria-label="Kill run"
             className="flex items-center justify-center w-6 h-6 rounded shrink-0 transition-opacity disabled:opacity-30"
-            style={{ color: '#f85149', opacity: 0.65 }}
+            style={{ color: 'var(--status-fail)', opacity: 0.65 }}
             onMouseEnter={(e) => { e.currentTarget.style.opacity = '1'; }}
             onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.65'; }}
           >
@@ -866,8 +871,10 @@ function RunChat({
         {/* User prompt bubble */}
         <div className="flex justify-end">
           <div
+            // §5.3 token usage: the user's message is transparent — a hairline
+            // keeps the bubble shape without claiming a surface of its own.
             className="max-w-[72%] rounded-2xl text-base px-5 py-3.5 leading-relaxed"
-            style={{ background: '#224a5e', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.12)' }}
+            style={{ background: 'transparent', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
           >
             {session.problem}
           </div>
@@ -877,7 +884,7 @@ function RunChat({
             inline before the unit it blocks when that unit has already entered the thread */}
         {timeline.flatMap((unit) => {
           const tc = transcripts[unit.ord];
-          const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'rgba(230,237,243,0.08)', color: 'rgba(230,237,243,0.5)' };
+          const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' };
           const gateBeforeThis = session.status === 'awaiting_human' && gate?.ord === unit.ord;
           const unitEl = (
             <div key={unit.id} data-message-id={unit.id} className="flex flex-col gap-2">
@@ -885,15 +892,15 @@ function RunChat({
               {unit.routing !== null && unit.routing.method === 'council' && (
                 <div
                   className="self-start max-w-[85%] rounded-xl px-4 py-2 text-xs flex items-center gap-2 font-mono"
-                  style={{ background: 'rgba(139,92,246,0.1)', border: '1px solid rgba(139,92,246,0.2)', color: '#a78bfa' }}
+                  style={{ background: 'var(--accent-subtle)', border: '1px solid var(--accent-subtle)', color: 'var(--accent)' }}
                 >
                   <span className="shrink-0">⚖</span>
                   <span>
                     <span className="font-semibold">Council → {unit.assigned_cli ?? '?'}</span>
-                    <span className="ml-2" style={{ color: 'rgba(167,139,250,0.6)' }}>
+                    <span className="ml-2" style={{ color: 'var(--accent)', opacity: 0.7 }}>
                       {quorumLabel(unit.routing)} · {unit.routing.agreement_pct}% agree · {unit.routing.dissent} dissent
                       {lostQuorum(unit.routing) && (
-                        <span className="ml-2" style={{ color: '#ffda19' }}>· quorum lost</span>
+                        <span className="ml-2" style={{ color: 'var(--status-gate)' }}>· quorum lost</span>
                       )}
                     </span>
                   </span>
@@ -902,12 +909,12 @@ function RunChat({
               {unit.routing !== null && unit.routing.method === 'evaluator_distinct' && (
                 <div
                   className="self-start max-w-[85%] rounded-xl px-4 py-2 text-xs flex items-center gap-2 font-mono"
-                  style={{ background: 'rgba(139,92,246,0.1)', border: '1px solid rgba(139,92,246,0.2)', color: '#a78bfa' }}
+                  style={{ background: 'var(--accent-subtle)', border: '1px solid var(--accent-subtle)', color: 'var(--accent)' }}
                 >
                   <span className="shrink-0">⚖</span>
                   <span>
                     <span className="font-semibold">Evaluator-distinct → {unit.assigned_cli ?? '?'}</span>
-                    <span className="ml-2" style={{ color: 'rgba(167,139,250,0.6)' }}>(was: {unit.routing.was})</span>
+                    <span className="ml-2" style={{ color: 'var(--accent)', opacity: 0.7 }}>(was: {unit.routing.was})</span>
                   </span>
                 </div>
               )}
@@ -930,9 +937,9 @@ function RunChat({
                         style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
                       >
                         <CliAvatar cli={unit.assigned_cli} />
-                        <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.55)' }}>
+                        <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
                           {unit.assigned_cli}
-                          <span style={{ color: 'rgba(230,237,243,0.3)' }}> · unit {unit.ord}</span>
+                          <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
                         </span>
                       </button>
                       {terminalIds[`${session.id}:${unit.assigned_cli}`] && (
@@ -947,7 +954,7 @@ function RunChat({
                             setAgentTerminal(agentTerminal?.cliKey === cli ? null : { cliKey: cli, terminalId: tid! });
                           }}
                           className="text-xs rounded px-1 py-0.5 transition-opacity hover:opacity-80"
-                          style={{ background: 'rgba(230,237,243,0.06)', border: 'none', cursor: 'pointer', color: 'rgba(230,237,243,0.55)', fontFamily: 'monospace' }}
+                          style={{ background: 'var(--surface-raised)', border: 'none', cursor: 'pointer', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}
                         >
                           ⌨
                         </button>
@@ -955,10 +962,10 @@ function RunChat({
                     </div>
                   ) : (
                     <div className="flex items-center gap-2">
-                      <span className="w-7 h-7 rounded-full shrink-0" style={{ background: 'rgba(230,237,243,0.06)' }} />
-                      <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.55)' }}>
+                      <span className="w-7 h-7 rounded-full shrink-0" style={{ background: 'var(--surface-raised)' }} />
+                      <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
                         agent
-                        <span style={{ color: 'rgba(230,237,243,0.3)' }}> · unit {unit.ord}</span>
+                        <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
                       </span>
                     </div>
                   )}
@@ -969,9 +976,9 @@ function RunChat({
                     {unit.stage}
                   </span>
                   {unit.has_validator_pin && (
-                    <span role="img" aria-label="Governance floor armed" style={{ color: '#ffda19', fontSize: '12px' }}>🔒</span>
+                    <span role="img" aria-label="Governance floor armed" style={{ color: 'var(--status-gate)', fontSize: '12px' }}>🔒</span>
                   )}
-                  <span className="text-xs font-mono truncate max-w-xs" style={{ color: 'rgba(230,237,243,0.35)' }} title={unit.description}>
+                  <span className="text-xs font-mono truncate max-w-xs" style={{ color: 'var(--ink-dim)' }} title={unit.description}>
                     {unit.description}
                   </span>
                 </div>
@@ -979,7 +986,7 @@ function RunChat({
                 {/* Content card */}
                 <div
                   className="rounded-2xl px-5 py-4"
-                  style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.08)' }}
+                  style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
                 >
                   {/* A `distributed` unit is in the timeline ONLY as the cursor unit of an
                       executing run (FINDING-052: distributed = routed, not running — queued
@@ -991,15 +998,15 @@ function RunChat({
                     <div data-testid={`unit-output-${unit.ord}`}>
                       {/* Output header: phase name + status (crew#272) */}
                       <div className="flex items-center gap-2 text-sm font-mono">
-                        <span style={{ color: '#3fb950' }}>✓</span>
-                        <span className="font-medium" style={{ color: '#3fb950' }}>{phaseName(session.id, unit)}</span>
-                        <span className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>{UNIT_STATUS_TEXT[unit.status]}</span>
+                        <span style={{ color: 'var(--status-done)' }}>✓</span>
+                        <span className="font-medium" style={{ color: 'var(--status-done)' }}>{phaseName(session.id, unit)}</span>
+                        <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>{UNIT_STATUS_TEXT[unit.status]}</span>
                         <button
                           type="button"
                           data-testid={`unit-output-toggle-${unit.ord}`}
                           onClick={() => toggleTranscript(unit.ord)}
                           className="ml-auto text-xs font-medium font-mono hover:underline"
-                          style={{ color: '#79c0ff' }}
+                          style={{ color: 'var(--accent)' }}
                         >
                           {tc?.visible ? '▾ Hide output' : '▸ Show output'}
                         </button>
@@ -1010,7 +1017,7 @@ function RunChat({
                       {tc?.visible && (
                         <div className="mt-2.5 max-h-[28rem] overflow-y-auto">
                           {tc.loading
-                            ? <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>Loading output…</span>
+                            ? <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>Loading output…</span>
                             : <Markdown className="whitespace-pre-wrap">{tc.text ?? ''}</Markdown>
                           }
                         </div>
@@ -1018,7 +1025,7 @@ function RunChat({
                     </div>
                   )}
                   {unit.status === 'rejected' && (
-                    <div className="text-sm font-medium font-mono" style={{ color: '#f85149' }}>
+                    <div className="text-sm font-medium font-mono" style={{ color: 'var(--status-fail)' }}>
                       Rejected{unit.denial_reason ? `: ${unit.denial_reason}` : ''}
                     </div>
                   )}
@@ -1065,7 +1072,7 @@ function RunChat({
             <div key={entry.seq} className="flex justify-center">
               <span
                 className="text-xs rounded-full px-3 py-1 font-mono"
-                style={{ color: 'rgba(230,237,243,0.4)', background: '#161c26', border: '1px solid rgba(230,237,243,0.07)' }}
+                style={{ color: 'var(--ink-dim)', background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
               >
                 {systemEventLabel(entry.type, entry.detail)}
               </span>
@@ -1136,10 +1143,10 @@ function NewRunView({
     <div className="flex flex-col h-full items-center justify-center">
       <div className="w-full max-w-2xl px-8 flex flex-col gap-5">
         <div className="flex flex-col gap-2 text-center">
-          <h1 className="text-3xl font-bold tracking-tight" style={{ color: '#e6edf3' }}>
+          <h1 className="text-3xl font-bold tracking-tight" style={{ color: 'var(--ink-high)' }}>
             {heading}
           </h1>
-          <p className="text-base leading-relaxed" style={{ color: 'rgba(230,237,243,0.5)' }}>
+          <p className="text-base leading-relaxed" style={{ color: 'var(--ink-muted)' }}>
             {sub}
           </p>
         </div>

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -41,14 +41,16 @@ function DocPicker({ projectId, navigate }: { projectId: string; navigate: Navig
 
   // §1.4's rule, applied to a surface: an empty region renders an invitation, never a
   // blank. Creation itself is slice 10, so the invitation points at the thread.
+  // §2.8's two faces: the invitation and doc names are prose (sans); the
+  // kind · version pair on each row is data (mono).
   if (docs.length === 0) {
     return (
-      <div data-testid="doc-picker-empty" style={{ padding: '32px' }}>
+      <div data-testid="doc-picker-empty" style={{ padding: '32px', fontFamily: 'var(--font-sans)' }}>
         <div style={PANEL}>
-          <h2 style={{ fontSize: '15px', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
+          <h2 style={{ fontSize: 'var(--text-md)', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
             No documents in this project yet
           </h2>
-          <p style={{ fontSize: '13px', color: S.muted, margin: 0, lineHeight: 1.5 }}>
+          <p style={{ fontSize: 'var(--text-sm)', color: S.muted, margin: 0, lineHeight: 1.5 }}>
             Ask for one in the thread — “make me a deck for the Q3 review”, “write this up as a
             report” — and it appears here, with its versions, as soon as it exists.
           </p>
@@ -58,10 +60,10 @@ function DocPicker({ projectId, navigate }: { projectId: string; navigate: Navig
   }
 
   return (
-    <div style={{ padding: '32px', overflowY: 'auto' }}>
+    <div style={{ padding: '32px', overflowY: 'auto', fontFamily: 'var(--font-sans)' }}>
       <p style={{
-        fontSize: '11px', fontWeight: 600, color: S.label, margin: '0 0 10px',
-        textTransform: 'uppercase', letterSpacing: '0.06em',
+        fontSize: 'var(--text-xs)', fontWeight: 600, color: S.label, margin: '0 0 10px',
+        textTransform: 'uppercase', letterSpacing: '0.06em', fontFamily: 'var(--font-mono)',
       }}>
         Documents
       </p>
@@ -77,11 +79,12 @@ function DocPicker({ projectId, navigate }: { projectId: string; navigate: Navig
               display: 'flex', alignItems: 'center', gap: '12px', width: '100%', textAlign: 'left',
               background: 'transparent', border: 'none',
               borderBottom: i < sorted.length - 1 ? `1px solid ${S.border}` : 'none',
-              color: S.ink, cursor: 'pointer', fontSize: '13px', padding: '12px 16px',
+              color: S.ink, cursor: 'pointer', fontSize: 'var(--text-sm)',
+              fontFamily: 'var(--font-sans)', padding: '12px 16px',
             }}
           >
             <span style={{ flex: 1, fontWeight: 500 }}>{doc.name}</span>
-            <span style={{ color: S.muted, flexShrink: 0, fontSize: '12px' }}>
+            <span style={{ color: S.muted, flexShrink: 0, fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)' }}>
               {doc.kind} · v{doc.head}
             </span>
           </button>
@@ -166,7 +169,14 @@ function DocFrame({
   return (
     <>
       <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-      <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+      {/* §5.5 token usage: the canvas is framed cleanly — a subtle 1px stroke at
+          --radius-lg, breathing room on the open sides — rather than bleeding to
+          the pane edges. The thread beside it keeps its own left border. */}
+      <div style={{
+        flex: 1, position: 'relative', overflow: 'hidden',
+        border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-lg)',
+        margin: '10px 10px 10px 10px', background: 'var(--surface-base)',
+      }}>
       <iframe
         // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
         // src. Mutating it navigates the frame, and a frame navigation lands in the
@@ -189,7 +199,7 @@ function DocFrame({
       />
       {/* The frame is in the DOM while it loads, so the named status sits over it. */}
       {loaded ? null : (
-        <div style={{ background: '#0d1117', inset: 0, position: 'absolute' }}>
+        <div style={{ background: 'var(--surface-base)', inset: 0, position: 'absolute' }}>
           <Loading surface="doc" subject={subject} />
         </div>
       )}

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -27,18 +27,26 @@ import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } f
 // There is no dead composer state and no synthetic liveness: no whimsy filler (filtered in
 // the store, §3.2), no `status.requested` heartbeat (never emitted at all).
 
+// DES-VISION-001 §5.5 token usage: the thread sits on --surface-base; agent
+// bubbles on --surface-card, user messages transparent with a hairline (the
+// same pair Chat wears, §5.3 — one language across modes). Cross-links and
+// primary actions speak the brand accent; live/steering state speaks the §2.6
+// run-emerald; gates and actionables the gate-amber; failures the fail-red.
+// Version tags are history, so they read --status-done (§5.5, mirrored by
+// Video's "recording complete" tag).
 const S = {
-  panel:  '#161b22',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.35)',
-  accent: '#ffda19',
-  user:   '#224a5e',
-  card:   '#1b222e',
-  footer: '#161c26',
-  live:   '#79c0ff',
-  danger: '#f85149',
+  panel:  'var(--surface-base)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  body:   'var(--ink-body)',
+  muted:  'var(--ink-muted)',
+  faint:  'var(--ink-dim)',
+  accent: 'var(--accent)',
+  card:   'var(--surface-card)',
+  footer: 'var(--surface-rail)',
+  live:   'var(--status-run)',
+  danger: 'var(--status-fail)',
+  done:   'var(--status-done)',
 };
 
 /** What the composer says it will do — the affordance, in words (§2.2, §3.3). */
@@ -66,12 +74,16 @@ function Bubble({
           data-message-id={msg.id}
           data-version={msg.version === undefined ? undefined : String(msg.version)}
           data-items={msg.items === undefined ? undefined : String(msg.items.length)}
+          // §5.3's user-message rule, shared across modes: transparent, a
+          // hairline keeps the bubble shape without claiming a surface.
           className="max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap"
-          style={{ background: S.user, color: S.ink, border: `1px solid ${S.border}` }}
+          style={{ background: 'transparent', color: S.ink, border: `1px solid ${S.border}`,
+                   fontFamily: 'var(--font-sans)' }}
         >
           {msg.text}
           {/* §4.3: each batched item DEEP-LINKS back to its element — the frame scrolls
-              it into view over the same protocol that reported its rect. */}
+              it into view over the same protocol that reported its rect. On-accent:
+              a cross-link is an affordance, not a status (§2.5). */}
           {msg.items !== undefined && msg.items.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1.5">
               {msg.items.map((item, i) => (
@@ -83,8 +95,8 @@ function Bubble({
                   title={`Show “${item.wid}” in the document`}
                   onClick={() => scrollToWid(item.wid)}
                   className="rounded-full px-2 py-0.5 text-[10px] font-mono"
-                  style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
-                           border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+                  style={{ background: 'transparent', color: S.accent,
+                           border: '1px solid var(--accent-subtle)', cursor: 'pointer' }}
                 >
                   {i + 1}. {item.wid}
                 </button>
@@ -99,6 +111,8 @@ function Bubble({
             is TAGGED with it, and the tag cross-links to the strip — the same seam the
             strip's "In thread" crosses the other way. The eye can trace canvas ↔ strip ↔
             thread in both directions. */}
+        {/* §5.5: the version tag is HISTORY — --status-done ink on a
+            --radius-sm badge (Video's "recording complete" tag mirrors it). */}
         {msg.version !== undefined && (
           <button
             type="button"
@@ -106,9 +120,10 @@ function Bubble({
             data-version={String(msg.version)}
             onClick={() => { if (msg.version !== undefined) onShowVersion?.(msg.version); }}
             title={`This message made v${msg.version} — show it on the canvas and the strip`}
-            className="rounded-full px-2 py-0.5 text-[10px] font-mono"
-            style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
-                     border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+            className="px-2 py-0.5 text-[10px] font-mono"
+            style={{ background: 'transparent', color: S.done,
+                     border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+                     cursor: 'pointer' }}
           >
             ▤ v{msg.version} landed
           </button>
@@ -117,8 +132,9 @@ function Bubble({
     );
   }
   if (msg.kind === 'narration') {
+    // Narration is data: the mono, body ink (§2.8); the dot is the run-emerald.
     return (
-      <div className="flex items-start gap-2 text-xs font-mono" data-testid="doc-narration" style={{ color: S.faint }}>
+      <div className="flex items-start gap-2 text-xs font-mono" data-testid="doc-narration" style={{ color: S.body }}>
         <span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0" style={{ background: S.live }} />
         <span>{msg.text}</span>
       </div>
@@ -145,8 +161,10 @@ function Bubble({
         <span className="text-[10px] font-mono uppercase tracking-wide" style={{ color: S.faint }}>
           {msg.kind === 'verdict' ? `${msg.author} · review` : msg.author}
         </span>
+        {/* Agent prose on --surface-card in the sans — §5.3's bubble pair. */}
         <div className="rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap"
-             style={{ background: S.card, border: `1px solid ${S.border}`, color: S.ink }}>
+             style={{ background: S.card, border: `1px solid ${S.border}`, color: S.body,
+                      fontFamily: 'var(--font-sans)' }}>
           {msg.text}
           {msg.kind === 'agent' && msg.href !== undefined && (
             // Served THROUGH the proxy, on the page's own origin (§5.3) — there is no
@@ -184,14 +202,18 @@ function ActionableCard({
   const [busy, setBusy] = useState(false);
   const retry = msg.retry;
   return (
+    // Actionable = "this needs you": the §2.6 gate-amber pair, exactly the
+    // GateChip convention — dim for the block, full for the command text.
     <div
       data-testid="doc-actionable"
       className="rounded-xl px-3.5 py-3 flex flex-col gap-2"
-      style={{ background: 'rgba(255,218,25,0.06)', border: '1px solid rgba(255,218,25,0.2)' }}
+      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)' }}
     >
-      <p className="text-sm leading-relaxed" style={{ color: S.ink, margin: 0 }}>{msg.text}</p>
+      <p className="text-sm leading-relaxed" style={{ color: S.ink, margin: 0, fontFamily: 'var(--font-sans)' }}>
+        {msg.text}
+      </p>
       <code data-testid="doc-actionable-hint" className="text-[11px] font-mono whitespace-pre-wrap"
-            style={{ color: S.accent }}>
+            style={{ color: 'var(--status-gate)' }}>
         {msg.hint}
       </code>
       {retry !== undefined && docId !== null && (
@@ -205,7 +227,8 @@ function ActionableCard({
               .finally(() => setBusy(false));
           }}
           className="self-start rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
-          style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+          style={{ background: 'var(--status-gate)', color: 'var(--surface-base)',
+                   border: 'none', cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
         >
           {busy ? 'Exporting…' : `Export ${retry.format.toUpperCase()} again`}
         </button>
@@ -238,8 +261,8 @@ function NotRecordedChip({
           .finally(() => setBusy(false));
       }}
       className="mt-2 block rounded-full px-2 py-0.5 text-[10px] font-mono disabled:opacity-40"
-      style={{ background: 'rgba(248,81,73,0.1)', color: S.danger,
-               border: '1px solid rgba(248,81,73,0.3)', cursor: 'pointer' }}
+      style={{ background: 'var(--status-fail-dim)', color: S.danger,
+               border: '1px solid var(--status-fail-dim)', cursor: 'pointer' }}
     >
       {busy ? 'retrying…' : 'not recorded in the run — retry'}
     </button>
@@ -279,13 +302,17 @@ function GateCard({
   }
 
   return (
+    // A gate speaks the §2.6 gate-amber pair (the GateChip convention); the
+    // question itself is prose → sans.
     <div
       data-testid="doc-gate"
       data-request-id={msg.requestId}
       className="rounded-xl px-3.5 py-3 flex flex-col gap-2"
-      style={{ background: 'rgba(255,218,25,0.06)', border: '1px solid rgba(255,218,25,0.2)' }}
+      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)' }}
     >
-      <p className="text-sm" style={{ color: S.accent, margin: 0 }}>{msg.question}</p>
+      <p className="text-sm" style={{ color: 'var(--status-gate)', margin: 0, fontFamily: 'var(--font-sans)' }}>
+        {msg.question}
+      </p>
       {msg.options.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {msg.options.map((option) => (
@@ -296,7 +323,8 @@ function GateCard({
               disabled={busy}
               onClick={() => void answer(option)}
               className="rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
-              style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+              style={{ background: 'var(--status-gate)', color: 'var(--surface-base)',
+                       border: 'none', cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
             >
               {option}
             </button>
@@ -443,7 +471,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
       data-testid="thread"
       data-composer-state={state}
       className="flex flex-col shrink-0 relative"
-      style={{ width: '340px', background: S.panel, borderLeft: `1px solid ${S.border}` }}
+      // §5.5: the thread pane sits on --surface-base; prose defaults to the
+      // sans — only data (narration, tags, ids) opts into the mono (§2.8).
+      style={{ width: '340px', background: S.panel, borderLeft: `1px solid ${S.border}`,
+               fontFamily: 'var(--font-sans)' }}
     >
       {wizard !== null && (
         <DemoWizard
@@ -461,7 +492,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
       )}
       <div className="flex-1 overflow-y-auto px-3.5 py-4 flex flex-col gap-3">
         {messages.length === 0 && (
-          <p className="text-xs leading-relaxed" style={{ color: S.muted }}>
+          <p className="leading-relaxed" style={{ color: S.body, fontSize: 'var(--text-sm)' }}>
             {docId === null
               ? mode === 'video'
                 ? 'Describe the demo you want — “a walkthrough of the checkout flow” — and its steps are authored from there, in order.'
@@ -503,8 +534,8 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                 .finally(() => setBusy(false));
             }}
             className="self-start rounded-full px-2.5 py-0.5 text-[10px] font-mono disabled:opacity-40"
-            style={{ background: 'rgba(255,218,25,0.1)', color: S.accent,
-                     border: '1px solid rgba(255,218,25,0.25)', cursor: 'pointer' }}
+            style={{ background: 'transparent', color: S.accent,
+                     border: '1px solid var(--accent-subtle)', cursor: 'pointer' }}
           >
             record this demo
           </button>
@@ -517,18 +548,24 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
           <span
             data-testid="steering-chip"
             className="self-start flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
-            style={{ background: 'rgba(121,192,255,0.08)', color: S.live, border: '1px solid rgba(121,192,255,0.2)' }}
+            style={{ background: 'var(--status-run-dim)', color: S.live,
+                     border: '1px solid var(--status-run-dim)' }}
           >
             <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
             steering the live {mode === 'video' ? 'demo' : 'document'} run
           </span>
         )}
-        <div className="flex items-end gap-2 rounded-2xl px-3 py-2"
-             style={{ background: S.card, border: `1px solid ${S.border}` }}>
+        {/* §5.3's composer contract, worn by every mode: --surface-raised at
+            --radius-xl, the wk-composer focus ring (--accent-dim via
+            :focus-within — never the full accent), an accent-filled submit. */}
+        <div className="wk-composer flex items-end gap-2 px-3 py-2"
+             style={{ background: 'var(--surface-raised)',
+                      border: '1px solid var(--surface-overlay)',
+                      borderRadius: 'var(--radius-xl)' }}>
           <textarea
             data-testid="doc-composer"
             className="flex-1 resize-none text-sm outline-none border-0 bg-transparent leading-6"
-            style={{ color: S.ink, fontFamily: 'inherit', minHeight: '28px' }}
+            style={{ color: S.ink, fontFamily: 'var(--font-sans)', minHeight: '28px' }}
             placeholder={prompt}
             value={text}
             rows={1}
@@ -544,7 +581,8 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
             onClick={() => void submit()}
             disabled={busy || text.trim() === ''}
             className="shrink-0 rounded-xl px-3 py-1.5 text-xs font-semibold disabled:opacity-40"
-            style={{ background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer' }}
+            style={{ background: S.accent, color: 'var(--accent-fg)', border: 'none',
+                     cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
           >
             {busy ? '…' : label}
           </button>

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -13,22 +13,27 @@ import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
 // here is only what the pressed button owes the finger that pressed it — which format is
 // running, and, on the board where no thread is on screen, the reason it stopped.
 
+// DES-VISION-001 §2.11: semantic tokens only. The RUNNING format speaks the
+// brand accent (an affordance state); the hint below is an actionable install
+// command, so it speaks the §2.6 gate layer in the mono (data, §2.8).
 const S = {
-  border: 'rgba(230,237,243,0.1)',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.3)',
-  accent: '#ffda19',
+  border: 'var(--surface-raised)',
+  muted:  'var(--ink-muted)',
+  faint:  'var(--ink-dim)',
+  accent: 'var(--accent)',
+  hint:   'var(--status-gate)',
 };
 
 const BUTTON: React.CSSProperties = {
-  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '5px',
-  color: S.muted, cursor: 'pointer', fontSize: '10px', lineHeight: 1.6, padding: '1px 6px',
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+  color: S.muted, cursor: 'pointer', fontSize: 'var(--text-2xs)',
+  fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
 };
 
 /** The tile variant: bare text, because a card is scanned and a box is a claim on the eye. */
 const COMPACT: React.CSSProperties = {
   background: 'none', border: 'none', color: S.muted, cursor: 'pointer',
-  fontFamily: 'monospace', fontSize: '9px', padding: 0,
+  fontFamily: 'var(--font-mono)', fontSize: '9px', padding: 0,
 };
 
 export interface ExportMenuProps {
@@ -64,8 +69,8 @@ export function ExportMenu({ projectId, docId, version, compact = false }: Expor
     >
       <div style={{ alignItems: 'center', display: 'flex', gap: compact ? '7px' : '5px' }}>
         {!compact && (
-          <span style={{ color: S.faint, fontSize: '10px', letterSpacing: '0.06em',
-                         textTransform: 'uppercase' }}>
+          <span style={{ color: S.faint, fontSize: 'var(--text-2xs)', letterSpacing: '0.06em',
+                         fontFamily: 'var(--font-mono)', textTransform: 'uppercase' }}>
             Export v{version}
           </span>
         )}
@@ -92,7 +97,7 @@ export function ExportMenu({ projectId, docId, version, compact = false }: Expor
         <span
           data-testid="export-hint"
           title={hint}
-          style={{ color: S.accent, fontSize: '9px', fontFamily: 'monospace',
+          style={{ color: S.hint, fontSize: '9px', fontFamily: 'var(--font-mono)',
                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
           {hint}

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -20,15 +20,22 @@ import { Markdown } from './Markdown.js';
  * exactly as before, because warm seats someone paid for must not be orphaned.
  */
 
-const SEAT_COLORS: Record<string, { bg: string; fg: string }> = {
-  claude: { bg: 'rgba(139,92,246,0.25)', fg: '#c4b5fd' },
-  codex: { bg: 'rgba(59,130,246,0.25)', fg: '#93c5fd' },
-  agy: { bg: 'rgba(34,197,94,0.2)', fg: '#86efac' },
-  pi: { bg: 'rgba(234,179,8,0.2)', fg: '#fde68a' },
-};
-const SEAT_FALLBACK = { bg: 'rgba(230,237,243,0.1)', fg: 'rgba(230,237,243,0.55)' };
+/**
+ * Seat identity under the token contract (DES-VISION-001 §2.11): every chip and
+ * avatar wears the SAME surface/ink pair, and identity rides the monogram +
+ * name, not a per-CLI hue. Color is reserved for signal (§1.5 rule 2): the
+ * chip's dot speaks the §2.6 status layer — warming = amber, ready = emerald,
+ * failed = red — and nothing else on the seat is colored.
+ */
+const SEAT_CHIP = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
 
 type SeatState = 'warming' | 'ready' | 'failed';
+
+const SEAT_DOT: Record<SeatState, string> = {
+  warming: 'var(--status-gate)',
+  ready: 'var(--status-run)',
+  failed: 'var(--status-fail)',
+};
 
 /**
  * Where a repo's live chat id is parked between mounts (FINDING-027).
@@ -373,24 +380,23 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     onBack();
   }
 
-  const seatChip = (cliKey: string, st: SeatState): React.ReactElement => {
-    const c = SEAT_COLORS[cliKey] ?? SEAT_FALLBACK;
-    return (
+  const seatChip = (cliKey: string, st: SeatState): React.ReactElement => (
+    // wk-disclose: the roster disclosure animates in at --dur-base ease-out
+    // (§5.3 motion) — once per chip mount, never a loop (§1.6).
+    <span
+      key={cliKey}
+      title={st === 'failed' ? seatErrors[cliKey] : st}
+      className="wk-disclose inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-[11px] font-mono"
+      style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg, opacity: st === 'failed' ? 0.5 : 1 }}
+    >
       <span
-        key={cliKey}
-        title={st === 'failed' ? seatErrors[cliKey] : st}
-        className="inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-[11px] font-mono"
-        style={{ background: c.bg, color: c.fg, opacity: st === 'failed' ? 0.5 : 1 }}
-      >
-        <span
-          className={`inline-block w-1.5 h-1.5 rounded-full ${st === 'warming' ? 'animate-pulse' : ''}`}
-          style={{ background: st === 'failed' ? '#f85149' : st === 'warming' ? '#d29922' : '#3fb950' }}
-        />
-        {cliKey}
-        {st === 'failed' ? ' ✕' : ''}
-      </span>
-    );
-  };
+        className={`inline-block w-1.5 h-1.5 rounded-full ${st === 'warming' ? 'animate-pulse' : ''}`}
+        style={{ background: SEAT_DOT[st] }}
+      />
+      {cliKey}
+      {st === 'failed' ? ' ✕' : ''}
+    </span>
+  );
 
   const anyReady = Object.values(seats).some((st) => st === 'ready');
   // V8: a teardown control exists only once there is something armed to tear down —
@@ -405,11 +411,13 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     messages.length === 0 && Object.keys(seats).length === 0 && openError === null && !resolving;
 
   return (
-    <div className="flex flex-col h-full" style={{ color: '#e6edf3' }}>
+    // The surface's own ink (§2.4); labels read in the sans by inheritance —
+    // only data (seat keys, narration) opts into the mono below (§2.8).
+    <div className="flex flex-col h-full" style={{ color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
       {/* Header: seats + close */}
-      <div className="flex items-center gap-3 px-6 py-3 border-b shrink-0" style={{ borderColor: 'rgba(230,237,243,0.08)' }}>
+      <div className="flex items-center gap-3 px-6 py-3 border-b shrink-0" style={{ borderColor: 'var(--surface-raised)' }}>
         <button type="button" onClick={onBack} className="text-sm font-mono opacity-60 hover:opacity-100">←</button>
-        <span className="text-sm font-mono font-semibold">Chat</span>
+        <span className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Chat</span>
         <div className="flex items-center gap-1.5 flex-wrap">
           {Object.entries(seats).map(([k, st]) => seatChip(k, st))}
         </div>
@@ -420,8 +428,8 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
             data-testid="chat-close"
             title="Disconnect the agents and end this chat"
             onClick={() => void endChat()}
-            className="text-[11px] font-mono px-2.5 py-1 rounded-lg"
-            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.18)' }}
+            className="text-[11px] px-2.5 py-1 rounded-lg"
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-overlay)' }}
           >
             Close
           </button>
@@ -431,19 +439,20 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3">
         {openError !== null && (
-          <p className="text-[12px] font-mono" style={{ color: '#f85149' }}>Could not open chat: {openError}</p>
+          <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
         )}
         {firstRun && (
           // §2.4: the first-run state TEACHES — what Chat is, what typing does, and the
           // product's central trick (choose a mode by conversation). Never a warmed roster.
+          // §5.3: the instruction reads as prose — the sans, body ink.
           <div
             data-testid="chat-firstrun"
             className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-8"
           >
-            <p className="text-[14px] font-semibold" style={{ margin: 0 }}>
+            <p style={{ fontSize: 'var(--text-md)', fontWeight: 'var(--weight-semi)', color: 'var(--ink-high)', fontFamily: 'var(--font-sans)', margin: 0 }}>
               Chat with an agent about this project.
             </p>
-            <p className="text-[12px]" style={{ color: 'rgba(230,237,243,0.55)', margin: 0, maxWidth: '480px' }}>
+            <p data-testid="chat-firstrun-instruction" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)', margin: 0, maxWidth: '480px' }}>
               No run, no gates — just talk. Ask for a deck or some code and I’ll switch
               you to the right mode.
             </p>
@@ -451,22 +460,30 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
         )}
         {messages.map((m, i) =>
           m.kind === 'user' ? (
-            <div key={i} className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]" style={{ background: 'rgba(88,166,255,0.15)' }}>
+            // §5.3 token usage: user messages are transparent — the hairline
+            // keeps the bubble shape without claiming a surface of its own.
+            <div
+              key={i}
+              className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
+              style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+            >
               {m.text}
             </div>
           ) : (
             <div key={i} className="self-start max-w-[80%] flex gap-2">
               <span
                 className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-mono font-bold mt-0.5"
-                style={{ background: (SEAT_COLORS[m.cliKey] ?? SEAT_FALLBACK).bg, color: (SEAT_COLORS[m.cliKey] ?? SEAT_FALLBACK).fg }}
+                style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
               >
                 {m.cliKey.slice(0, 2).toUpperCase()}
               </span>
               <div
+                // §5.3 token usage: agent bubbles sit on --surface-card; the
+                // border speaks status while a reply is pending or failed.
                 className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
                 style={{
-                  background: 'rgba(230,237,243,0.05)',
-                  border: `1px solid ${m.pending ? 'rgba(210,153,34,0.35)' : m.ok ? 'rgba(230,237,243,0.08)' : 'rgba(248,81,73,0.35)'}`,
+                  background: 'var(--surface-card)',
+                  border: `1px solid ${m.pending ? 'var(--status-run-dim)' : m.ok ? 'var(--surface-raised)' : 'var(--status-fail-dim)'}`,
                 }}
               >
                 {m.pending && m.text === '' ? (
@@ -481,8 +498,10 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
         <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
-      <div className="px-6 py-3 border-t shrink-0" style={{ borderColor: 'rgba(230,237,243,0.08)' }}>
+      {/* Input — §5.3 token usage: the composer sits on --surface-raised at
+          --radius-xl; its focus ring is --accent-dim (wk-composer in
+          global.css), never the full accent (§5.3 motion: too dominant). */}
+      <div className="px-6 py-3 border-t shrink-0" style={{ borderColor: 'var(--surface-raised)' }}>
         <div className="flex gap-2">
           <textarea
             value={input}
@@ -496,8 +515,14 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
             rows={2}
             autoFocus
             placeholder="Describe what you want… (Enter to send, Shift+Enter for newline)"
-            className="flex-1 rounded-xl px-4 py-2 text-[13px] font-mono outline-none resize-none"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.12)' }}
+            className="wk-composer flex-1 px-4 py-2 text-[13px] outline-none resize-none"
+            style={{
+              background: 'var(--surface-raised)',
+              border: '1px solid var(--surface-overlay)',
+              borderRadius: 'var(--radius-xl)',
+              color: 'var(--ink-high)',
+              fontFamily: 'var(--font-sans)',
+            }}
           />
           <button
             type="button"
@@ -506,8 +531,8 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
             // enables Send. Once a chat exists, sending needs a ready seat, as before.
             // (`resolving`: the stored chat is still being checked — not first-run yet.)
             disabled={input.trim() === '' || arming || resolving || (chatId !== null && !anyReady)}
-            className="px-4 rounded-xl text-sm font-mono font-semibold disabled:opacity-40"
-            style={{ background: 'rgba(88,166,255,0.2)', color: '#79c0ff' }}
+            className="px-4 text-sm font-semibold disabled:opacity-40"
+            style={{ background: 'var(--accent)', color: 'var(--accent-fg)', borderRadius: 'var(--radius-xl)' }}
           >
             Send
           </button>
@@ -519,8 +544,9 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
             disabled={arming || resolving}
             title="Warm every agent on the roster into this chat — replies stream side by side"
             onClick={() => void armChat('all')}
-            className="mt-2 text-[11px] font-mono px-2.5 py-1 rounded-lg disabled:opacity-40"
-            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.65)', border: '1px solid rgba(230,237,243,0.18)' }}
+            // §5.3: low-key but ON-ACCENT — color alone signals it's interactive.
+            className="mt-2 text-[11px] px-1 py-1 disabled:opacity-40"
+            style={{ background: 'transparent', color: 'var(--accent)', border: 'none', cursor: 'pointer' }}
           >
             + Add agents
           </button>

--- a/src/components/SurfaceState.tsx
+++ b/src/components/SurfaceState.tsx
@@ -12,17 +12,22 @@ import { BridgeUnavailableError } from '../api/interactive.js';
 // `surface` prefixes every test id (`doc-canvas-error`, `video-canvas-error`), so the two
 // modes stay independently addressable from Playwright.
 
+// The shared style constants under the token contract (DES-VISION-001 §2.11,
+// vision slice 4): both mode surfaces read these, so converting them converts
+// every consumer at a stroke. `accent` deliberately maps to the GATE status
+// token, not the brand accent — everywhere these files use it, it marks an
+// actionable "this needs you" hint (§3.3), which is the §2.6 amber layer.
 export const S = {
-  card:   '#161b22',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  accent: '#ffda19',
-  label:  'rgba(230,237,243,0.3)',
+  card:   'var(--surface-card)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  muted:  'var(--ink-muted)',
+  accent: 'var(--status-gate)',
+  label:  'var(--ink-dim)',
 };
 
 export const PANEL: React.CSSProperties = {
-  background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+  background: S.card, border: `1px solid ${S.border}`, borderRadius: 'var(--radius-lg)',
   padding: '20px 22px', maxWidth: '640px',
 };
 
@@ -40,7 +45,7 @@ export function Loading({ surface, subject }: { surface: string; subject: string
   return (
     <div
       data-testid={`${surface}-canvas-loading`}
-      style={{ padding: '32px', color: S.muted, fontSize: '13px' }}
+      style={{ padding: '32px', color: S.muted, fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)' }}
     >
       Loading {subject}…
     </div>
@@ -58,13 +63,13 @@ export function Failed({
   surface: string; subject: string; failure: Failure; onRetry: () => void;
 }): React.ReactElement {
   return (
-    <div data-testid={`${surface}-canvas-error`} style={{ padding: '32px' }}>
+    <div data-testid={`${surface}-canvas-error`} style={{ padding: '32px', fontFamily: 'var(--font-sans)' }}>
       <div style={PANEL}>
-        <p style={{ fontSize: '13px', color: S.ink, margin: '0 0 10px' }}>Could not load {subject}.</p>
+        <p style={{ fontSize: 'var(--text-sm)', color: S.ink, margin: '0 0 10px' }}>Could not load {subject}.</p>
         <p
           data-testid={failure.hint ? `${surface}-bridge-hint` : `${surface}-error-detail`}
           style={{
-            fontSize: '13px', color: failure.hint ? S.ink : S.muted, margin: '0 0 14px',
+            fontSize: 'var(--text-sm)', color: failure.hint ? S.ink : S.muted, margin: '0 0 14px',
             lineHeight: 1.5, borderLeft: `2px solid ${S.accent}`, paddingLeft: '10px',
           }}
         >
@@ -75,8 +80,8 @@ export function Failed({
           data-testid={`${surface}-canvas-retry`}
           onClick={onRetry}
           style={{
-            background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
-            color: S.ink, cursor: 'pointer', fontSize: '12px', padding: '6px 12px',
+            background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+            color: S.ink, cursor: 'pointer', fontSize: 'var(--text-xs)', padding: '6px 12px',
           }}
         >
           Retry

--- a/src/components/ThemesMenu.tsx
+++ b/src/components/ThemesMenu.tsx
@@ -15,19 +15,26 @@ import { contextKey, useDocContextStore } from '../store/docContext.js';
 // the canvas already shows. Learning a new theme stays in the composer's "learn a theme"
 // action, because that submission is a thread message (§2.3).
 
+// DES-VISION-001 §5.5 token usage: the popover is a raised surface; a PICKED
+// theme speaks the brand accent (an affordance state, §2.5), failures speak the
+// §2.6 status layer. The explainer is prose → sans/--ink-body/--text-sm; theme
+// names are identifiers → the mono.
 const S = {
-  ink:    '#e6edf3',
-  faint:  'rgba(230,237,243,0.35)',
-  muted:  'rgba(230,237,243,0.55)',
-  accent: '#ffda19',
-  card:   '#1b222e',
-  border: 'rgba(230,237,243,0.1)',
-  danger: '#f85149',
+  ink:    'var(--ink-high)',
+  body:   'var(--ink-body)',
+  faint:  'var(--ink-dim)',
+  muted:  'var(--ink-muted)',
+  accent: 'var(--accent)',
+  picked: 'var(--accent-subtle)',
+  card:   'var(--surface-raised)',
+  border: 'var(--surface-raised)',
+  danger: 'var(--status-fail)',
 };
 
 const BUTTON: React.CSSProperties = {
-  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '5px',
-  color: S.muted, cursor: 'pointer', fontSize: '10px', lineHeight: 1.6, padding: '1px 6px',
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+  color: S.muted, cursor: 'pointer', fontSize: 'var(--text-2xs)',
+  fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
 };
 
 /** V19's one-line explanation, shown every time the menu opens — never tooltip-only. */
@@ -85,14 +92,20 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
           data-testid="themes-panel"
           className="flex flex-col gap-1 overflow-y-auto"
           style={{
-            background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px',
+            background: S.card, border: '1px solid var(--surface-overlay)',
+            borderRadius: 'var(--radius-lg)', boxShadow: 'var(--shadow-overlay)',
             bottom: 'calc(100% + 6px)', maxHeight: '200px', padding: '8px 10px',
             position: 'absolute', right: 0, width: '250px', zIndex: 30,
           }}
         >
+          {/* §5.5: the one-line explanation opens WITH the popover, in
+              --font-sans --ink-body --text-sm — prose, never tooltip-only. */}
           <p
-            data-testid="themes-explain"
-            style={{ color: S.muted, fontSize: '11px', lineHeight: 1.4, margin: 0 }}
+            data-testid="themes-explanation"
+            style={{
+              color: S.body, fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)',
+              lineHeight: 1.4, margin: 0,
+            }}
           >
             {THEMES_EXPLAINER}
           </p>
@@ -117,7 +130,7 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
                 setOpen(false);
               }}
               className="flex items-baseline justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11px] font-mono"
-              style={{ background: picked === t.name ? 'rgba(255,218,25,0.1)' : 'transparent',
+              style={{ background: picked === t.name ? S.picked : 'transparent',
                        color: S.ink, border: 'none', cursor: 'pointer' }}
             >
               <span className="truncate">{t.name}</span>

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -28,15 +28,20 @@ import { scrollThreadToMessage } from './threadAnchor.js';
 // labelled by what it does). The canvas toolbar it carries is [Themes] [Export] — the
 // two actions that act on the document at the addressed version (rule 4, V19).
 
+// DES-VISION-001 §5.5 token usage: the strip is --surface-rail; the SELECTION
+// speaks the brand accent (it is the product's own pointer at which version is
+// addressed — an affordance, never a run state), and failures speak the §2.6
+// status layer. Version numbers and stamps are data, so they read in the mono
+// (§2.8); the spine caption is prose, so it reads in the sans.
 const S = {
-  bar:      '#0f1419',
-  border:   'rgba(230,237,243,0.1)',
-  ink:      '#e6edf3',
-  muted:    'rgba(230,237,243,0.55)',
-  faint:    'rgba(230,237,243,0.3)',
-  accent:   '#ffda19',
-  selected: 'rgba(255,218,25,0.1)',
-  danger:   '#f85149',
+  bar:      'var(--surface-rail)',
+  border:   'var(--surface-raised)',
+  ink:      'var(--ink-high)',
+  muted:    'var(--ink-muted)',
+  faint:    'var(--ink-dim)',
+  accent:   'var(--accent)',
+  selected: 'var(--accent-subtle)',
+  danger:   'var(--status-fail)',
 };
 
 /** §7.6: no anchor recorded ⇒ nothing to scroll to, and the reason is the tooltip. */
@@ -71,8 +76,9 @@ function anchorOf(entry: VersionEntry): string | null {
 }
 
 const ACTION: React.CSSProperties = {
-  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '5px',
-  color: S.muted, cursor: 'pointer', fontSize: '10px', lineHeight: 1.6, padding: '1px 6px',
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+  color: S.muted, cursor: 'pointer', fontSize: 'var(--text-2xs)',
+  fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
 };
 
 export interface VersionStripProps {
@@ -117,9 +123,11 @@ export function VersionStrip({
   return (
     <div
       data-testid="version-strip"
+      // The spine's drawn connection (DES-UXFIX-001 §2.6) now speaks the brand
+      // accent's subtle tier — connective tissue, not a status signal (§2.5).
       style={{
         alignItems: 'stretch', background: S.bar,
-        borderTop: '2px solid rgba(255,218,25,0.35)',
+        borderTop: '2px solid var(--accent-subtle)',
         display: 'flex', flexShrink: 0, gap: '8px', padding: '10px 12px',
       }}
     >
@@ -128,7 +136,8 @@ export function VersionStrip({
       <div style={{ alignItems: 'stretch', display: 'flex', flex: 1, gap: '8px',
                     minWidth: 0, overflowX: 'auto' }}>
       <span style={{
-        alignSelf: 'center', color: S.faint, flexShrink: 0, fontSize: '10px', fontWeight: 600,
+        alignSelf: 'center', color: S.faint, flexShrink: 0, fontSize: 'var(--text-2xs)',
+        fontWeight: 600, fontFamily: 'var(--font-mono)',
         letterSpacing: '0.06em', paddingRight: '2px', textTransform: 'uppercase',
       }}>
         Versions
@@ -148,8 +157,8 @@ export function VersionStrip({
             style={{
               background: isSelected ? S.selected : 'transparent',
               border: `1px solid ${isSelected ? S.accent : S.border}`,
-              borderRadius: '7px', display: 'flex', flexDirection: 'column', flexShrink: 0,
-              gap: '4px', minWidth: '124px', padding: '6px 9px',
+              borderRadius: 'var(--radius-md)', display: 'flex', flexDirection: 'column',
+              flexShrink: 0, gap: '4px', minWidth: '124px', padding: '6px 9px',
             }}
           >
             <button
@@ -163,18 +172,36 @@ export function VersionStrip({
                 display: 'flex', flexDirection: 'column', gap: '2px', padding: 0, textAlign: 'left',
               }}
             >
+              {/* v-numbers and stamps are data → the mono (§2.8). The SELECTED
+                  entry carries the §5.5 "active version dot": background from
+                  var(--accent) — the one place the wireframe's ● lives. */}
               <span style={{
-                color: isSelected ? S.accent : S.ink, fontSize: '12px', fontWeight: 600,
+                alignItems: 'center', display: 'inline-flex', gap: '5px',
+                color: isSelected ? S.ink : S.muted, fontSize: 'var(--text-xs)',
+                fontWeight: 600, fontFamily: 'var(--font-mono)',
               }}>
+                {isSelected && (
+                  <span
+                    data-testid="version-active-dot"
+                    style={{
+                      background: S.accent, borderRadius: 'var(--radius-full)',
+                      display: 'inline-block', flexShrink: 0, height: '6px', width: '6px',
+                    }}
+                  />
+                )}
                 v{entry.version}
               </span>
-              <span data-testid="version-stamp" style={{ color: S.muted, fontSize: '10px' }}>
+              <span data-testid="version-stamp" style={{
+                color: S.muted, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+              }}>
                 {stamp(entry.created_at)}
               </span>
             </button>
 
             {branchOf !== null && (
-              <span data-testid="version-lineage" style={{ color: S.accent, fontSize: '10px' }}>
+              <span data-testid="version-lineage" style={{
+                color: S.muted, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+              }}>
                 continues from v{branchOf}
               </span>
             )}
@@ -211,7 +238,10 @@ export function VersionStrip({
       {error !== null && (
         <span
           data-testid="version-fork-error"
-          style={{ alignSelf: 'center', color: S.danger, fontSize: '11px', paddingLeft: '4px' }}
+          style={{
+            alignSelf: 'center', color: S.danger, fontSize: 'var(--text-xs)',
+            fontFamily: 'var(--font-mono)', paddingLeft: '4px',
+          }}
         >
           Fork failed: {error} — the document is unchanged; try again.
         </span>
@@ -223,8 +253,9 @@ export function VersionStrip({
       <span
         data-testid="version-spine-caption"
         style={{
-          alignSelf: 'center', color: S.faint, flexShrink: 1, fontSize: '10px',
-          lineHeight: 1.3, maxWidth: '210px', minWidth: 0, textAlign: 'right',
+          alignSelf: 'center', color: S.faint, flexShrink: 1, fontSize: 'var(--text-2xs)',
+          fontFamily: 'var(--font-sans)', lineHeight: 1.3, maxWidth: '210px',
+          minWidth: 0, textAlign: 'right',
         }}
       >
         selecting a version scrolls the thread to the message that made it ▸

--- a/src/components/VideoStoryboard.tsx
+++ b/src/components/VideoStoryboard.tsx
@@ -87,14 +87,19 @@ export function playerState(
 /** Stable identity for "this thread has said nothing", so the selector never re-renders. */
 const NO_MESSAGES: DocMsg[] = [];
 
+// DES-VISION-001 §5.6 token usage: rails carry the strip and action bar;
+// primary actions are the brand accent with --accent-fg ink; labels read in
+// the sans, recording narration and offsets in the mono (§2.8).
 const ACTION: React.CSSProperties = {
-  border: 'none', borderRadius: '6px', cursor: 'pointer', flexShrink: 0,
-  fontSize: '11px', fontWeight: 600, padding: '5px 11px',
+  border: 'none', borderRadius: 'var(--radius-sm)', cursor: 'pointer', flexShrink: 0,
+  fontSize: 'var(--text-xs)', fontWeight: 600, fontFamily: 'var(--font-sans)',
+  padding: '5px 11px',
 };
 
 const BAR: React.CSSProperties = {
-  alignItems: 'center', background: '#0f1419', borderTop: `1px solid ${S.border}`,
+  alignItems: 'center', background: 'var(--surface-rail)', borderTop: `1px solid ${S.border}`,
   display: 'flex', flexShrink: 0, gap: '8px', padding: '8px 12px',
+  fontFamily: 'var(--font-sans)',
 };
 
 // ── Demo picker — the mode with no `:demoId` in the route ────────────────────
@@ -114,12 +119,12 @@ function DemoPicker({ projectId, navigate }: { projectId: string; navigate: Navi
   // agent's job, so the invitation points at the thread — recording from it is slice 14.
   if (demos.length === 0) {
     return (
-      <div data-testid="demo-picker-empty" style={{ padding: '32px' }}>
+      <div data-testid="demo-picker-empty" style={{ padding: '32px', fontFamily: 'var(--font-sans)' }}>
         <div style={PANEL}>
-          <h2 style={{ fontSize: '15px', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
+          <h2 style={{ fontSize: 'var(--text-md)', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
             No demos in this project yet
           </h2>
-          <p style={{ fontSize: '13px', color: S.muted, margin: 0, lineHeight: 1.5 }}>
+          <p style={{ fontSize: 'var(--text-sm)', color: S.muted, margin: 0, lineHeight: 1.5 }}>
             A demo is a set of steps the agent authors and the service records. Ask for a
             walkthrough in the thread — “a demo of the checkout flow” — and it appears here as
             a storyboard with its player as soon as the spec exists.
@@ -130,10 +135,10 @@ function DemoPicker({ projectId, navigate }: { projectId: string; navigate: Navi
   }
 
   return (
-    <div style={{ padding: '32px', overflowY: 'auto' }}>
+    <div style={{ padding: '32px', overflowY: 'auto', fontFamily: 'var(--font-sans)' }}>
       <p style={{
-        fontSize: '11px', fontWeight: 600, color: S.label, margin: '0 0 10px',
-        textTransform: 'uppercase', letterSpacing: '0.06em',
+        fontSize: 'var(--text-xs)', fontWeight: 600, color: S.label, margin: '0 0 10px',
+        textTransform: 'uppercase', letterSpacing: '0.06em', fontFamily: 'var(--font-mono)',
       }}>
         Demos
       </p>
@@ -149,11 +154,14 @@ function DemoPicker({ projectId, navigate }: { projectId: string; navigate: Navi
               display: 'flex', alignItems: 'center', gap: '12px', width: '100%', textAlign: 'left',
               background: 'transparent', border: 'none',
               borderBottom: i < sorted.length - 1 ? `1px solid ${S.border}` : 'none',
-              color: S.ink, cursor: 'pointer', fontSize: '13px', padding: '12px 16px',
+              color: S.ink, cursor: 'pointer', fontSize: 'var(--text-sm)',
+              fontFamily: 'var(--font-sans)', padding: '12px 16px',
             }}
           >
             <span style={{ flex: 1, fontWeight: 500 }}>{demo.name}</span>
-            <span style={{ color: S.muted, flexShrink: 0, fontSize: '12px' }}>v{demo.head}</span>
+            <span style={{ color: S.muted, flexShrink: 0, fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)' }}>
+              v{demo.head}
+            </span>
           </button>
         ))}
       </div>
@@ -187,27 +195,29 @@ function MissingRecording({
   }
 
   return (
-    <div data-testid="demo-no-recording" data-ffmpeg-absent={String(state.ffmpeg)} style={{ padding: '32px' }}>
+    <div data-testid="demo-no-recording" data-ffmpeg-absent={String(state.ffmpeg)}
+         style={{ padding: '32px', fontFamily: 'var(--font-sans)' }}>
       <div style={PANEL}>
-        <h2 style={{ fontSize: '15px', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
+        <h2 style={{ fontSize: 'var(--text-md)', fontWeight: 700, color: S.ink, margin: '0 0 8px' }}>
           {state.ffmpeg
             ? `“${demoId}” recorded, but the video could not be converted`
             : `“${demoId}” has no recording yet`}
         </h2>
         {/* The hint is the SERVICE's command and is rendered verbatim — paraphrasing it
-            would be paraphrasing something the user has to type (§3.3). */}
+            would be paraphrasing something the user has to type (§3.3). Actionable ⇒
+            it wears the gate-amber rule (S.accent maps to --status-gate here). */}
         {state.hint ? (
           <p
             data-testid="demo-ffmpeg-hint"
             style={{
-              fontSize: '13px', color: S.ink, margin: '0 0 14px', lineHeight: 1.5,
+              fontSize: 'var(--text-sm)', color: S.ink, margin: '0 0 14px', lineHeight: 1.5,
               borderLeft: `2px solid ${S.accent}`, paddingLeft: '10px',
             }}
           >
             <strong>To fix:</strong> {state.hint}
           </p>
         ) : (
-          <p style={{ fontSize: '13px', color: S.muted, margin: '0 0 14px', lineHeight: 1.5 }}>
+          <p style={{ fontSize: 'var(--text-sm)', color: S.muted, margin: '0 0 14px', lineHeight: 1.5 }}>
             The steps below are the spec the agent authored. Recording runs them in a real
             browser and captures the result.
           </p>
@@ -218,20 +228,21 @@ function MissingRecording({
           disabled={busy || queued}
           onClick={() => void go()}
           style={{
-            background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
+            background: 'transparent', border: `1px solid ${S.border}`,
+            borderRadius: 'var(--radius-sm)',
             color: queued ? S.muted : S.ink, cursor: busy || queued ? 'default' : 'pointer',
-            fontSize: '12px', padding: '6px 12px',
+            fontSize: 'var(--text-xs)', padding: '6px 12px',
           }}
         >
           {queued ? 'Recording queued' : busy ? `Asking the recorder to run “${demoId}”…` : 'Record this demo'}
         </button>
         {queued ? (
-          <p data-testid="demo-record-queued" style={{ fontSize: '12px', color: S.muted, margin: '10px 0 0' }}>
+          <p data-testid="demo-record-queued" style={{ fontSize: 'var(--text-xs)', color: S.muted, margin: '10px 0 0' }}>
             The recorder is running “{demoId}” — the player appears here when the version lands.
           </p>
         ) : null}
         {error !== null ? (
-          <p data-testid="demo-record-error" style={{ fontSize: '12px', color: S.ink, margin: '10px 0 0' }}>
+          <p data-testid="demo-record-error" style={{ fontSize: 'var(--text-xs)', color: S.ink, margin: '10px 0 0' }}>
             Could not queue the recording: {error}. Try again, or ask in the thread.
           </p>
         ) : null}
@@ -336,7 +347,12 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
         data-chapter={String(chapter)}
         data-position={String(at)}
         data-player-kind={player.kind}
-        style={{ flex: 1, overflow: 'auto', background: '#0d1117' }}
+        // §5.6: the player container wears the same framing as Document's canvas.
+        style={{
+          flex: 1, overflow: 'auto', background: 'var(--surface-base)',
+          border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-lg)',
+          margin: '10px 10px 0',
+        }}
       >
         {player.kind === 'video' ? (
           <video
@@ -353,7 +369,9 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
           // pretending the playhead moved (§3.3: informative, with its subject).
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', padding: '16px' }}>
             <img data-testid="demo-gif" src={player.src} alt={`Recording of ${demoId}`} style={{ maxWidth: '100%' }} />
-            <p data-testid="demo-position" style={{ fontSize: '12px', color: S.muted, margin: 0 }}>
+            <p data-testid="demo-position" style={{
+              fontSize: 'var(--text-xs)', color: S.muted, margin: 0, fontFamily: 'var(--font-sans)',
+            }}>
               {steps.length > 0
                 ? `Chapter ${chapter + 1} of ${steps.length}, at ${mmss(at)} — this recording is a `
                   + 'looping GIF with no timeline, so the chapter is shown rather than played to.'
@@ -371,11 +389,12 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
         data-steps={String(steps.length)}
         style={{
           display: 'flex', flexShrink: 0, gap: '8px', overflowX: 'auto', padding: '10px 12px',
-          background: '#0f1419', borderTop: `1px solid ${S.border}`,
+          background: 'var(--surface-rail)', borderTop: `1px solid ${S.border}`,
+          fontFamily: 'var(--font-sans)',
         }}
       >
         {steps.length === 0 ? (
-          <p data-testid="demo-storyboard-empty" style={{ fontSize: '12px', color: S.muted, margin: 0 }}>
+          <p data-testid="demo-storyboard-empty" style={{ fontSize: 'var(--text-xs)', color: S.muted, margin: 0 }}>
             {subject} has no steps yet — the agent is still authoring the spec.
           </p>
         ) : steps.map((step) => (
@@ -389,11 +408,19 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
             data-comments={String(items.filter((i) => i.index === step.index).length)}
             title={`Chapter ${step.index + 1}: ${step.title} — ${player.kind === 'video' ? 'seeks to' : 'starts at'} ${mmss(step.timestamp)}`}
             onClick={(e) => onChapter(step, e.currentTarget)}
+            // §5.6: thumbs sit on --surface-raised; the SELECTED chapter carries
+            // border: 2px solid var(--accent) (the slice DOM AC). A chapter with
+            // queued comments shows the dimmer accent tier — pending input, not a
+            // status. The border is 2px in every state so selection never shifts
+            // the layout.
             style={{
-              background: step.index === chapter ? 'rgba(255,218,25,0.1)' : 'transparent',
-              border: `1px solid ${step.index === chapter || items.some((i) => i.index === step.index) ? S.accent : S.border}`,
-              borderRadius: '8px', color: S.ink, cursor: 'pointer', flexShrink: 0,
+              background: 'var(--surface-raised)',
+              border: `2px solid ${step.index === chapter
+                ? 'var(--accent)'
+                : items.some((i) => i.index === step.index) ? 'var(--accent-dim)' : 'transparent'}`,
+              borderRadius: 'var(--radius-md)', color: S.ink, cursor: 'pointer', flexShrink: 0,
               padding: '8px', textAlign: 'left', width: '160px',
+              transition: 'border-color var(--dur-base)',
             }}
           >
             {step.thumbnail ? (
@@ -401,13 +428,19 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
                 data-testid="chapter-thumbnail"
                 src={interactiveUrl(projectId, step.thumbnail)}
                 alt=""
-                style={{ display: 'block', borderRadius: '4px', marginBottom: '6px', width: '100%' }}
+                style={{ display: 'block', borderRadius: 'var(--radius-sm)', marginBottom: '6px', width: '100%' }}
               />
             ) : null}
-            <span style={{ display: 'block', fontSize: '12px', fontWeight: 600 }}>
+            <span style={{ display: 'block', fontSize: 'var(--text-xs)', fontWeight: 600 }}>
               {step.index + 1}. {step.title}
             </span>
-            <span style={{ display: 'block', color: S.muted, fontSize: '11px' }}>{mmss(step.timestamp)}</span>
+            {/* Chapter caption: --text-2xs --ink-dim (§5.6); the offset is data → mono. */}
+            <span style={{
+              display: 'block', color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)',
+              fontFamily: 'var(--font-mono)',
+            }}>
+              {mmss(step.timestamp)}
+            </span>
           </button>
         ))}
       </div>
@@ -426,10 +459,15 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
       {steps.length > 0 && (
         <div data-testid="demo-actions" style={BAR}>
           {recording ? (
-            <span data-testid="demo-record-status" style={{ color: S.ink, fontSize: '12px' }}>{status}</span>
+            // §5.6: recording status narration is DATA — mono, --text-xs, --ink-body.
+            <span data-testid="demo-record-status" style={{
+              color: 'var(--ink-body)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+            }}>
+              {status}
+            </span>
           ) : draft !== null ? (
             <>
-              <span style={{ color: S.muted, fontFamily: 'monospace', fontSize: '10px', flexShrink: 0 }}>
+              <span style={{ color: S.muted, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)', flexShrink: 0 }}>
                 step {draft.index + 1}
               </span>
               <textarea
@@ -443,14 +481,18 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
                   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); }
                   if (e.key === 'Escape') setDraft(null);
                 }}
+                className="wk-composer"
                 style={{
-                  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: '6px',
-                  color: S.ink, flex: 1, fontFamily: 'inherit', fontSize: '12px', padding: '5px 7px', resize: 'none',
+                  background: 'var(--surface-raised)', border: '1px solid var(--surface-overlay)',
+                  borderRadius: 'var(--radius-sm)', outline: 'none',
+                  color: S.ink, flex: 1, fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-xs)', padding: '5px 7px', resize: 'none',
                 }}
               />
+              {/* Primary actions speak the accent with --accent-fg ink (§2.5). */}
               <button type="button" data-testid="step-comment-add" onClick={commit}
                       disabled={draft.text.trim() === ''}
-                      style={{ ...ACTION, background: S.accent, color: '#0d1117' }}>
+                      style={{ ...ACTION, background: 'var(--accent)', color: 'var(--accent-fg)' }}>
                 Add to batch
               </button>
               <button type="button" data-testid="step-comment-cancel" onClick={() => setDraft(null)}
@@ -471,14 +513,14 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
               </button>
               {sent && (
                 <>
-                  <span style={{ color: S.ink, fontSize: '12px' }}>
+                  <span style={{ color: S.ink, fontSize: 'var(--text-xs)' }}>
                     “{demoId}” was re-authored from your comments — record it again to see the change.
                   </span>
                   <button
                     type="button"
                     data-testid="demo-rerecord"
                     onClick={() => void record(`Re-record “${demoId}” with the updated steps.`)}
-                    style={{ ...ACTION, background: S.accent, color: '#0d1117' }}
+                    style={{ ...ACTION, background: 'var(--accent)', color: 'var(--accent-fg)' }}
                   >
                     Re-record
                   </button>
@@ -492,7 +534,7 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
                   disabled={busy || version === null}
                   title={version === null ? 'This demo has no version to comment on yet.' : 'One message, one re-authoring'}
                   onClick={() => void send()}
-                  style={{ ...ACTION, background: S.accent, color: '#0d1117', marginLeft: 'auto' }}
+                  style={{ ...ACTION, background: 'var(--accent)', color: 'var(--accent-fg)', marginLeft: 'auto' }}
                 >
                   {busy ? 'Sending…' : `Send ${items.length} comment${items.length === 1 ? '' : 's'}`}
                 </button>
@@ -500,7 +542,9 @@ function DemoSurface({ projectId, demoId }: { projectId: string; demoId: string 
             </>
           )}
           {error !== null && (
-            <span data-testid="step-feedback-error" style={{ color: '#f85149', fontFamily: 'monospace', fontSize: '11px' }}>
+            <span data-testid="step-feedback-error" style={{
+              color: 'var(--status-fail)', fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)',
+            }}>
               {error} — nothing was sent; try again.
             </span>
           )}

--- a/src/components/threadAnchor.ts
+++ b/src/components/threadAnchor.ts
@@ -19,16 +19,27 @@ function messageSelector(messageId: string): string {
  * lands on it (the same posture as a board gate deep-link). Returns false when the
  * thread or the message is not on screen — the caller decides what that means; the
  * version selection itself never depends on it.
+ *
+ * DES-VISION-001 §5.5 (the cross-link animation): the scroll is SMOOTH, and the
+ * anchored message flashes once — a 1s fade of `--accent-subtle` (the
+ * `wk-anchor-flash` keyframes in global.css; one run, never a loop, §1.6). The
+ * class is removed when its animation ends so a later select of the same
+ * version flashes again.
  */
 export function scrollThreadToMessage(messageId: string): boolean {
   const thread = document.querySelector('[data-testid="thread"]');
   if (thread === null) return false;
   const el = thread.querySelector(messageSelector(messageId));
   if (!(el instanceof HTMLElement)) return false;
-  el.scrollIntoView({ block: 'center' });
+  el.scrollIntoView({ block: 'center', behavior: 'smooth' });
   // Programmatically focusable only: the cross-link target, never a new tab stop.
   if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
   el.focus({ preventScroll: true });
+  el.classList.remove('wk-anchor-flash');
+  // Force a reflow so re-adding the class restarts a still-running animation.
+  void el.offsetWidth;
+  el.classList.add('wk-anchor-flash');
+  el.addEventListener('animationend', () => el.classList.remove('wk-anchor-flash'), { once: true });
   return true;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -144,3 +144,23 @@ code, pre, .font-mono {
   .wk-feed-line,
   .wk-feed-block { animation: none; }
 }
+
+/* Slice-4 surface motion (DES-VISION-001 §5.3/§5.4, grammar per §1.6):
+   - wk-fade-in: one fade on mount — a new Build run row appears at --dur-fast
+     (§5.4 "run row appears on creation with a fade-in"); no loops.
+   - wk-disclose: the Chat multi-agent roster disclosure at --dur-base ease-out
+     (§5.3 motion) — the seat chips' entrance when the strip is disclosed.
+   - wk-composer: the Chat composer's focus ring is --accent-dim, deliberately
+     NOT the full accent (§5.3 motion: full opacity is too dominant). */
+.wk-fade-in  { animation: wk-feed-in var(--dur-fast) var(--ease-out); }
+.wk-disclose { animation: wk-feed-in var(--dur-base) var(--ease-out); }
+
+.wk-composer:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-fade-in,
+  .wk-disclose { animation: none; }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -155,12 +155,24 @@ code, pre, .font-mono {
 .wk-fade-in  { animation: wk-feed-in var(--dur-fast) var(--ease-out); }
 .wk-disclose { animation: wk-feed-in var(--dur-base) var(--ease-out); }
 
-.wk-composer:focus {
+.wk-composer:focus,
+.wk-composer:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
 
+/* The §5.5 cross-link animation: selecting a version scrolls the thread AND
+   flashes the message that produced it — a 1s fade of --accent-subtle. One run
+   (§1.6: motion is state change, never a loop); threadAnchor.ts removes the
+   class on animationend so the next select can flash again. */
+@keyframes wk-anchor-flash {
+  from { background-color: var(--accent-subtle); }
+  to   { background-color: transparent; }
+}
+.wk-anchor-flash { animation: wk-anchor-flash 1s var(--ease-out); }
+
 @media (prefers-reduced-motion: reduce) {
   .wk-fade-in,
-  .wk-disclose { animation: none; }
+  .wk-disclose,
+  .wk-anchor-flash { animation: none; }
 }

--- a/tests/CenterDashboard.tokens.test.tsx
+++ b/tests/CenterDashboard.tokens.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * CenterDashboard — the Build surface under the token contract
+ * (DES-VISION-001 §5.4, vision slice 4).
+ *
+ * Pins the slice-4 composition at unit level (the e2e rig re-proves the
+ * computed values in a real browser):
+ *   - run rows carry a 2px LEFT border whose color is the run's status token —
+ *     amber at a gate, emerald working, red failed, dim ink done (§5.4: "the
+ *     eye can scan the left margin for color without reading labels");
+ *   - the purpose statement reads as prose: `--ink-body`, the sans (§5.4 +
+ *     §2.8's two-face rule — this is the slice's own DOM AC);
+ *   - the gate inbox headline is the §5.4 pill: `--status-gate-dim` background,
+ *     `--status-gate` text;
+ *   - the cost footer is mono + dim (a data point, not a hero) and shares the
+ *     footer row with the one accent-colored primary action;
+ *   - status words stay mono while intent labels read sans (EC13).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CenterDashboard, runRowModel } from '../src/components/CenterDashboard.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeUnit, makeView } from './factories.js';
+import type { SessionView } from '../src/api/types.js';
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    confirmGate: vi.fn(async () => ({})),
+    injectMessage: vi.fn(async () => ({})),
+  },
+}));
+
+function dash(runs: SessionView[] = []): void {
+  render(
+    <CenterDashboard
+      runs={runs}
+      onSelectRun={vi.fn()}
+      onApproveGate={vi.fn()}
+      onRejectGate={vi.fn()}
+      navigate={vi.fn()}
+    />,
+  );
+}
+
+function units(done: number, total: number, sid = 'run-1') {
+  return Array.from({ length: total }, (_, i) =>
+    makeUnit({ id: `${sid}:u${i}`, ord: i, status: i < done ? 'done' : 'pending' }),
+  );
+}
+
+beforeEach(() => {
+  useGateStore.setState({ gates: {} });
+  useRunEventStore.setState({ byRun: {} });
+});
+
+describe('run rows encode status at the list edge (§5.4)', () => {
+  it('border-left is 2px of the status token, per state', () => {
+    dash([
+      makeView({ id: 'r-gate', problem: 'migrate the tables', status: 'awaiting_human' }, units(0, 2, 'r-gate')),
+      makeView({ id: 'r-work', problem: 'add rate limiting', status: 'executing' }, units(1, 4, 'r-work')),
+      makeView({ id: 'r-fail', problem: 'spike the importer', status: 'failed' }),
+      makeView({ id: 'r-done', problem: 'fix the flaky test', status: 'completed' }),
+    ]);
+    const rows = screen.getAllByTestId('build-run-row');
+    const byStatus = Object.fromEntries(rows.map((r) => [r.getAttribute('data-status'), r]));
+    expect(byStatus['gate']!.style.borderLeft).toBe('2px solid var(--status-gate)');
+    expect(byStatus['working']!.style.borderLeft).toBe('2px solid var(--status-run)');
+    expect(byStatus['failed']!.style.borderLeft).toBe('2px solid var(--status-fail)');
+    expect(byStatus['done']!.style.borderLeft).toBe('2px solid var(--status-done)');
+    // The recolor on a state transition animates (§5.4 motion), and a new row
+    // fades in once — no loops (§1.6).
+    for (const r of rows) {
+      expect(r.style.transition).toContain('border-color var(--dur-base)');
+      expect(r.className).toContain('wk-fade-in');
+      expect(r.style.background).toBe('var(--surface-card)');
+    }
+  });
+
+  it('EC13 on the row: intent label reads sans/high ink, the status word mono', () => {
+    dash([makeView({ id: 'r-work', problem: 'add rate limiting', status: 'executing' }, units(1, 4, 'r-work'))]);
+    const row = screen.getByTestId('build-run-row');
+    const spans = Array.from(row.querySelectorAll('span'));
+    const intent = spans.find((s) => s.textContent === 'add rate limiting') as HTMLElement;
+    const status = spans.find((s) => s.textContent?.startsWith('working')) as HTMLElement;
+    expect(intent.style.fontFamily).toBe('var(--font-sans)');
+    expect(intent.style.color).toBe('var(--ink-high)');
+    expect(intent.style.fontSize).toBe('var(--text-sm)');
+    expect(status.style.fontFamily).toBe('var(--font-mono)');
+  });
+});
+
+describe('the purpose statement (the slice DOM AC) and the surface faces', () => {
+  it('build-purpose is --ink-body --text-sm in the sans', () => {
+    dash([]);
+    const purpose = screen.getByTestId('build-purpose');
+    expect(purpose.style.color).toBe('var(--ink-body)');
+    expect(purpose.style.fontSize).toBe('var(--text-sm)');
+    expect(purpose.style.fontFamily).toBe('var(--font-sans)');
+  });
+
+  it('the surface root defaults to the sans (labels/prose); data opts into mono', () => {
+    dash([]);
+    expect(screen.getByTestId('build-dashboard').style.fontFamily).toBe('var(--font-sans)');
+  });
+});
+
+describe('the gate inbox pill (§5.4 token usage)', () => {
+  it('is --status-gate-dim background with --status-gate text', () => {
+    useGateStore.setState({
+      gates: {
+        'r-gate': {
+          runId: 'r-gate', ord: 0, prompt: 'Approve the plan?', lifecycle: 'open', receivedAt: 1,
+        },
+      },
+    });
+    dash([makeView({ id: 'r-gate', problem: 'migrate the tables', status: 'awaiting_human' })]);
+    const pill = screen.getByTestId('gate-inbox-pill');
+    expect(pill.textContent).toContain('1 gate needs you');
+    expect(pill.style.background).toBe('var(--status-gate-dim)');
+    expect(pill.style.color).toBe('var(--status-gate)');
+    expect(pill.style.borderRadius).toBe('var(--radius-full)');
+  });
+});
+
+describe('the footer row: one accent action + the mono/dim cost stat (§5.4)', () => {
+  it('cost footer is mono + --ink-dim and shares a row with + Build something', () => {
+    useRunEventStore.setState({
+      byRun: {
+        'r-1': [
+          { type: 'cliUsage', session: 'r-1', inputTokens: 84_000, outputTokens: 14_000, costUsd: 0.42 },
+        ],
+      },
+    });
+    dash([makeView({ id: 'r-1', problem: 'billed work', status: 'executing' }, units(0, 2, 'r-1'))]);
+    const footer = screen.getByTestId('build-stats-footer');
+    expect(footer.style.fontFamily).toBe('var(--font-mono)');
+    expect(footer.style.color).toBe('var(--ink-dim)');
+    expect(footer.style.fontSize).toBe('var(--text-xs)');
+    const action = screen.getByTestId('build-something');
+    expect(action.style.background).toBe('var(--accent)');
+    expect(action.style.color).toBe('var(--accent-fg)');
+    // One row: the action and the stat share a parent (the §5.4 wireframe's
+    // `[ + Build something ]            cost: $0.24` line).
+    expect(footer.parentElement).toBe(action.parentElement);
+  });
+
+  it('runRowModel speaks tokens, never raw colors (§2.11)', () => {
+    for (const status of ['awaiting_human', 'planning', 'executing', 'completed', 'failed', 'cancelled'] as const) {
+      const { color } = runRowModel(makeView({ status }));
+      expect(color).toMatch(/^var\(--(status|ink)-/);
+    }
+  });
+});

--- a/tests/DocumentSurfaces.tokens.test.tsx
+++ b/tests/DocumentSurfaces.tokens.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Document mode — the §5.5 visual language under the token contract
+ * (DES-VISION-001 vision slice 4; the e2e rig re-proves computed values in a
+ * real browser).
+ *
+ * Pins the slice's §5.5 composition at unit level:
+ *   - the version strip sits on `--surface-rail` with the accent-subtle spine
+ *     rule, and the SELECTED entry carries the active version dot whose
+ *     background resolves from `var(--accent)` (the slice DOM AC);
+ *   - the Themes popover opens with `data-testid="themes-explanation"` — the
+ *     one-liner in `--font-sans --ink-body --text-sm` (§5.5);
+ *   - thread version tags are HISTORY: `--status-done` ink on a `--radius-sm`
+ *     badge (§5.5 — Video's "recording complete" tag mirrors this);
+ *   - the thread sits on `--surface-base`; user messages are transparent with
+ *     a hairline; the composer wears §5.3's contract (`--surface-raised`,
+ *     `--radius-xl`, the wk-composer focus-ring hook) with an accent-filled
+ *     submit;
+ *   - the §5.5 cross-link flash: scrollThreadToMessage is smooth AND flashes
+ *     `wk-anchor-flash` once (pinned in threadAnchor.test.ts; referenced here
+ *     because VersionStrip.select is the caller).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VersionStrip } from '../src/components/VersionStrip.js';
+import { ThemesMenu, THEMES_EXPLAINER } from '../src/components/ThemesMenu.js';
+import { DocumentThread } from '../src/components/DocumentThread.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+import type { VersionEntry, VersionManifest } from '../src/api/interactive.js';
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+
+const listThemes = vi.hoisted(() => vi.fn());
+vi.mock('../src/api/interactive.js', async (orig) => ({
+  ...(await orig<typeof import('../src/api/interactive.js')>()),
+  listThemes,
+}));
+
+function entry(version: number, over: Partial<VersionEntry> = {}): VersionEntry {
+  return {
+    version,
+    parent: version - 1 || null,
+    feedback_file: null,
+    html_file: `v${version}.html`,
+    created_at: `2026-08-1${version}T09:00:00Z`,
+    ...over,
+  };
+}
+
+function manifest(versions: VersionEntry[]): VersionManifest {
+  return { head: versions[versions.length - 1]!.version, versions };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+});
+
+describe('VersionStrip — the §5.5 tokens', () => {
+  function mount(selected = 2): void {
+    render(
+      <VersionStrip
+        projectId={PROJECT}
+        docId={DOC}
+        manifest={manifest([entry(1), entry(2)])}
+        selected={selected}
+        navigate={vi.fn()}
+        onForked={vi.fn()}
+      />,
+    );
+  }
+
+  it('the strip is --surface-rail with the accent-subtle spine rule on top', () => {
+    mount();
+    const strip = screen.getByTestId('version-strip');
+    expect(strip.style.background).toBe('var(--surface-rail)');
+    expect(strip.style.borderTop).toContain('var(--accent-subtle)');
+  });
+
+  it('the SELECTED entry carries the active version dot, background from var(--accent)', () => {
+    mount(2);
+    const dot = screen.getByTestId('version-active-dot');
+    expect(dot.style.background).toBe('var(--accent)');
+    // The dot lives in the selected entry and ONLY there.
+    const selectedEntry = document.querySelector('[data-testid="version-entry"][data-selected="true"]');
+    expect(selectedEntry?.contains(dot)).toBe(true);
+    expect(document.querySelectorAll('[data-testid="version-active-dot"]')).toHaveLength(1);
+  });
+
+  it('version numbers and stamps read in the mono (§2.8: data)', () => {
+    mount();
+    for (const stamp of screen.getAllByTestId('version-stamp')) {
+      expect(stamp.style.fontFamily).toBe('var(--font-mono)');
+    }
+  });
+});
+
+describe('ThemesMenu — the §5.5 explanation', () => {
+  it('opens with data-testid="themes-explanation" in sans / --ink-body / --text-sm', async () => {
+    listThemes.mockResolvedValue([{ name: 'stripe-ish' }]);
+    const user = userEvent.setup();
+    render(<ThemesMenu projectId={PROJECT} docId={DOC} />);
+    await user.click(screen.getByTestId('themes-open'));
+
+    const explanation = screen.getByTestId('themes-explanation');
+    expect(explanation).toHaveTextContent(THEMES_EXPLAINER);
+    expect(explanation.style.fontFamily).toBe('var(--font-sans)');
+    expect(explanation.style.color).toBe('var(--ink-body)');
+    expect(explanation.style.fontSize).toBe('var(--text-sm)');
+  });
+});
+
+describe('DocumentThread — the §5.5 tokens', () => {
+  function mountWithVersionTag(): void {
+    const key = threadKey(PROJECT, DOC);
+    // One user message already tagged with the version it produced (§7.6's
+    // fold, pre-applied — the fold itself is pinned by the store's own tests).
+    useDocThreadStore.setState({
+      messages: { [key]: [{ kind: 'user', id: 'msg-1', text: 'make me a deck', version: 1 }] },
+    });
+    render(
+      <DocumentThread
+        projectId={PROJECT}
+        docId={DOC}
+        selectedVersion={1}
+        navigate={vi.fn()}
+      />,
+    );
+  }
+
+  it('the thread pane sits on --surface-base in the sans', () => {
+    render(<DocumentThread projectId={PROJECT} docId={null} selectedVersion={null} navigate={vi.fn()} />);
+    const thread = screen.getByTestId('thread');
+    expect(thread.style.background).toBe('var(--surface-base)');
+    expect(thread.style.fontFamily).toBe('var(--font-sans)');
+  });
+
+  it('the version tag is history: --status-done ink on a --radius-sm badge', () => {
+    mountWithVersionTag();
+    const tag = screen.getByTestId('thread-version-tag');
+    expect(tag).toHaveTextContent('▤ v1 landed');
+    expect(tag.style.color).toBe('var(--status-done)');
+    expect(tag.style.borderRadius).toBe('var(--radius-sm)');
+    expect(tag.style.background).toBe('transparent');
+  });
+
+  it('user messages are transparent with a hairline (§5.3 shared across modes)', () => {
+    mountWithVersionTag();
+    const msg = screen.getByTestId('doc-message');
+    expect(msg.style.background).toBe('transparent');
+    expect(msg.style.border).toContain('var(--surface-raised)');
+  });
+
+  it('the composer wears §5.3: --surface-raised at --radius-xl, wk-composer hook, accent submit', () => {
+    render(<DocumentThread projectId={PROJECT} docId={null} selectedVersion={null} navigate={vi.fn()} />);
+    const composer = screen.getByTestId('doc-composer');
+    const box = composer.parentElement as HTMLElement;
+    expect(box.className).toContain('wk-composer');
+    expect(box.style.background).toBe('var(--surface-raised)');
+    expect(box.style.borderRadius).toBe('var(--radius-xl)');
+    const submit = screen.getByTestId('doc-composer-submit');
+    expect(submit.style.background).toBe('var(--accent)');
+    expect(submit.style.color).toBe('var(--accent-fg)');
+  });
+});

--- a/tests/GroupChat.tokens.test.tsx
+++ b/tests/GroupChat.tokens.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * GroupChat — the Chat surface under the token contract
+ * (DES-VISION-001 §5.3, vision slice 4).
+ *
+ * Pins the slice-4 composition at unit level (the e2e rig re-proves computed
+ * values in a real browser):
+ *   - the first-run instruction reads as prose: the sans, `--ink-body` (the
+ *     slice entry's "instruction text in sans/ink-body");
+ *   - the composer sits on `--surface-raised` at `--radius-xl` and carries the
+ *     wk-composer class whose :focus ring is `--accent-dim` (global.css —
+ *     §5.3 motion: never the full accent);
+ *   - "Add agents" is low-key but ON-ACCENT (§5.3: color alone signals it's
+ *     interactive) and Send is the accent-filled primary action;
+ *   - user messages are transparent, agent bubbles sit on `--surface-card`
+ *     (§5.3 token usage);
+ *   - none of this disturbs the §2.4 behaviours — the firstrun/rejoin suites
+ *     keep those pinned; this file is the visual-language contract only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+];
+
+beforeEach(() => {
+  openChat.mockReset();
+  getRoster.mockReset();
+  sendChatMessage.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ROSTER.map((s) => s.key)).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+});
+
+describe('GroupChat — the §5.3 visual language', () => {
+  it('the first-run instruction reads sans / --ink-body', () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const instruction = screen.getByTestId('chat-firstrun-instruction');
+    expect(instruction.style.fontFamily).toBe('var(--font-sans)');
+    expect(instruction.style.color).toBe('var(--ink-body)');
+    expect(instruction.style.fontSize).toBe('var(--text-sm)');
+  });
+
+  it('the composer: --surface-raised, --radius-xl, and the wk-composer focus-ring hook', () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const composer = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(composer.className).toContain('wk-composer');
+    expect(composer.style.background).toBe('var(--surface-raised)');
+    expect(composer.style.borderRadius).toBe('var(--radius-xl)');
+    expect(composer.style.fontFamily).toBe('var(--font-sans)');
+  });
+
+  it('"Add agents" is on-accent text; Send is the accent-filled action', () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const add = screen.getByTestId('add-agents');
+    expect(add.style.color).toBe('var(--accent)');
+    expect(add.style.background).toBe('transparent');
+    const send = screen.getByRole('button', { name: 'Send' });
+    expect(send.style.background).toBe('var(--accent)');
+    expect(send.style.color).toBe('var(--accent-fg)');
+  });
+
+  it('user messages are transparent; agent bubbles sit on --surface-card; chips disclose with wk-disclose', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.type(screen.getByRole('textbox'), 'make me a deck');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalled());
+
+    const bubble = screen.getByText('make me a deck');
+    expect(bubble.style.background).toBe('transparent');
+    // The one warmed seat's pending reply bubble is a card surface.
+    const pending = screen.getByText('thinking…').closest('div') as HTMLElement;
+    expect(pending.style.background).toBe('var(--surface-card)');
+    // The seat chip animates in via wk-disclose (§5.3 motion, one run, no loop).
+    const chip = screen.getByTitle('ready');
+    expect(chip.className).toContain('wk-disclose');
+  });
+});

--- a/tests/ThemesMenu.test.tsx
+++ b/tests/ThemesMenu.test.tsx
@@ -48,11 +48,11 @@ describe('Themes — named, placed, and explained (V19)', () => {
     // Nothing fetched and nothing explained until the user asks (the pill's old sin
     // was the reverse: always on screen, never explained).
     expect(listThemes).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('themes-explain')).toBeNull();
+    expect(screen.queryByTestId('themes-explanation')).toBeNull();
 
     await user.click(open);
-    expect(screen.getByTestId('themes-explain')).toHaveTextContent(THEMES_EXPLAINER);
-    expect(screen.getByTestId('themes-explain')).toHaveTextContent(
+    expect(screen.getByTestId('themes-explanation')).toHaveTextContent(THEMES_EXPLAINER);
+    expect(screen.getByTestId('themes-explanation')).toHaveTextContent(
       'Borrow a look from a site, PDF, or image.',
     );
     expect(listThemes).toHaveBeenCalledWith(PROJECT);

--- a/tests/VideoStoryboard.tokens.test.tsx
+++ b/tests/VideoStoryboard.tokens.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Video mode — the §5.6 visual language under the token contract
+ * (DES-VISION-001 vision slice 4; the e2e rig re-proves computed values in a
+ * real browser).
+ *
+ * Pins the slice's §5.6 composition at unit level:
+ *   - chapter thumbs sit on `--surface-raised`; the SELECTED chapter carries
+ *     `border: 2px solid var(--accent)` (the slice DOM AC), 2px in every state
+ *     so selection never shifts the layout;
+ *   - the chapter caption (the mm:ss offset) is `--text-2xs --ink-dim` in the
+ *     mono — data, not prose (§2.8);
+ *   - the storyboard and action bar sit on `--surface-rail`; the player
+ *     container wears the same clean framing as Document's canvas;
+ *   - recording-status narration reads `--font-mono --text-xs --ink-body`
+ *     (§5.6: never bare "Working…" — the §3.4 words are pinned elsewhere;
+ *     this file pins the face).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VideoStoryboard } from '../src/components/VideoStoryboard.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+import type { DemoStep } from '../src/api/interactive.js';
+
+const PROJECT = 'proj-abc-123';
+const DEMO = 'checkout-walkthrough';
+
+function setLocation(url: string): void {
+  Object.defineProperty(window, 'location', { value: new URL(url), writable: true, configurable: true });
+}
+
+type Reply = { status?: number; body: unknown };
+
+function stubFetch(routes: Record<string, Reply>): void {
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    const hit = Object.entries(routes).find(([frag]) => url.includes(frag));
+    if (!hit) return Promise.reject(new Error(`unstubbed fetch: ${url}`));
+    const { status = 200, body } = hit[1];
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: String(status),
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    });
+  }));
+}
+
+const STEPS: DemoStep[] = [
+  { index: 0, title: 'Open the storefront', timestamp: 0 },
+  { index: 1, title: 'Add a hoodie to the cart', timestamp: 6.5 },
+];
+
+beforeEach(() => {
+  vi.stubEnv('VITE_API_HOST', '');
+  setLocation('http://127.0.0.1:7788/');
+  stubFetch({
+    '/api/demo/spec': { body: { steps: STEPS } },
+    '/api/demo/recordings': { body: { version: 1, gif_url: '/d/x/demo/v1.gif' } },
+    '/api/versions': { body: { head: 1, kind: 'demo', versions: [] } },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+});
+
+describe('VideoStoryboard — the §5.6 tokens', () => {
+  it('chapter thumbs: --surface-raised, the SELECTED one bordered 2px var(--accent)', async () => {
+    const user = userEvent.setup();
+    render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
+    const cards = await screen.findAllByTestId('chapter-card');
+
+    expect(cards[0]!.style.background).toBe('var(--surface-raised)');
+    expect(cards[0]!.style.border).toBe('2px solid var(--accent)');
+    // Unselected stays 2px (transparent) so selecting never shifts the layout.
+    expect(cards[1]!.style.border).toBe('2px solid transparent');
+
+    await user.click(cards[1]!);
+    expect(cards[1]!.getAttribute('data-selected')).toBe('true');
+    expect(cards[1]!.style.border).toBe('2px solid var(--accent)');
+    expect(cards[0]!.style.border).toBe('2px solid transparent');
+  });
+
+  it('the chapter caption is --text-2xs --ink-dim in the mono (§5.6)', async () => {
+    render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
+    const cards = await screen.findAllByTestId('chapter-card');
+    const caption = cards[1]!.querySelector('span:last-child') as HTMLElement;
+    expect(caption).toHaveTextContent('0:06');
+    expect(caption.style.fontSize).toBe('var(--text-2xs)');
+    expect(caption.style.color).toBe('var(--ink-dim)');
+    expect(caption.style.fontFamily).toBe('var(--font-mono)');
+  });
+
+  it('the storyboard rides --surface-rail; the player wears the canvas framing', async () => {
+    render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
+    await screen.findAllByTestId('chapter-card');
+    expect(screen.getByTestId('demo-storyboard').style.background).toBe('var(--surface-rail)');
+    const player = screen.getByTestId('demo-player');
+    expect(player.style.background).toBe('var(--surface-base)');
+    expect(player.style.border).toContain('var(--surface-raised)');
+    expect(player.style.borderRadius).toBe('var(--radius-lg)');
+  });
+
+  it('recording-status narration reads mono / --text-xs / --ink-body (§5.6)', async () => {
+    useDocThreadStore.setState({ genState: { [threadKey(PROJECT, DEMO)]: 'generating' } });
+    render(<VideoStoryboard projectId={PROJECT} demoId={DEMO} navigate={() => {}} />);
+    await screen.findAllByTestId('chapter-card');
+    const status = screen.getByTestId('demo-record-status');
+    expect(status.style.fontFamily).toBe('var(--font-mono)');
+    expect(status.style.fontSize).toBe('var(--text-xs)');
+    expect(status.style.color).toBe('var(--ink-body)');
+    // §3.4 rule 3 held through the conversion: the status names its subject.
+    expect(status.textContent).toContain(DEMO);
+  });
+});

--- a/tests/threadAnchor.test.ts
+++ b/tests/threadAnchor.test.ts
@@ -20,16 +20,28 @@ afterEach(() => {
 });
 
 describe('scrollThreadToMessage (§7.6)', () => {
-  it('puts the anchored message in view and focuses it', () => {
+  it('puts the anchored message in view (smoothly, §5.5) and focuses it', () => {
     mountThread('msg-1', 'msg-2');
     const spy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
 
     expect(scrollThreadToMessage('msg-2')).toBe(true);
-    expect(spy).toHaveBeenCalledWith({ block: 'center' });
+    expect(spy).toHaveBeenCalledWith({ block: 'center', behavior: 'smooth' });
     const focused = document.activeElement as HTMLElement;
     expect(focused.getAttribute('data-message-id')).toBe('msg-2');
     // Focusable programmatically only — the cross-link target is not a new tab stop.
     expect(focused).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('flashes the anchored message once — wk-anchor-flash on, removed on animationend (§5.5, §1.6)', () => {
+    mountThread('msg-1');
+    expect(scrollThreadToMessage('msg-1')).toBe(true);
+    const el = document.querySelector('[data-message-id="msg-1"]') as HTMLElement;
+    expect(el.classList.contains('wk-anchor-flash')).toBe(true);
+    // The class retires with its one animation run, so a later select flashes again.
+    el.dispatchEvent(new Event('animationend'));
+    expect(el.classList.contains('wk-anchor-flash')).toBe(false);
+    expect(scrollThreadToMessage('msg-1')).toBe(true);
+    expect(el.classList.contains('wk-anchor-flash')).toBe(true);
   });
 
   it('leaves an existing tabindex alone', () => {


### PR DESCRIPTION
Covers the spec's slice-4 AND slice-5 entries: Chat, Build, Document, and Video fully converted to tokens with their §5.3-5.6 composition adjustments (accent-ringed composer, status-bordered run rows, accent version dot, anchor-flash motion, tokenized storyboard). Eleven more files under the error-mode lint — warnings 1482→1166. Built across two agents after a connection-loss kill (first agent's Chat/Build commit audited, not trusted); also fixes a real shared-fixture bug (zombie /ws handlers stealing queued frames). 847/847 tests; all TEN rigs green on a fresh build; verifier proved the lint bites in all 11 files and re-derived the vision-1 zero-regression baseline from an independent main build (byte-identical). Operator pixel-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)