### PR TITLE
feat(theme): token conversion complete — no raw color ships again (DES-VISION-001 slice 6)

### DIFF
--- a/.product/evidence/vision-slice6/checklist.md
+++ b/.product/evidence/vision-slice6/checklist.md
@@ -102,6 +102,22 @@ not the nearest hex; §2.6 status/accent separation):
   (Terminal/AgentTerminal) and cytoscape stylesheets (CytoGraph) resolve tokens
   through the cascade at mount/build time via the new
   `src/styles/resolveToken.ts` — customization (§3.3) still reaches them.
+  **Found-and-fixed in adversarial verification:** the first cut read
+  `getPropertyValue(name)` off `:root`, which returns an unregistered custom
+  property's RAW token stream — `hsl(258 72% 62%)` (space-separated) and even
+  `hsl(258 72% calc(62% - 18%))` (calc unevaluated). Cytoscape's color regexes
+  require comma-separated channels and no calc: verified in a real Chromium
+  against the bundled cytoscape, it logged "style property … is invalid" and
+  fell back to its gray/black defaults for every hsl-family token — the graph's
+  categorical colors, selected border, and highlight edges were silently lost
+  (xterm was unaffected: its canvas-parser fallback handles both forms; SVG
+  presentation attributes take `var()` directly, so ForceGraph was fine).
+  `resolveToken` now applies `var(--token)` to a probe element's `color` and
+  reads the COMPUTED color — canonical `rgb()`/`rgba()`, which every sink
+  parses (re-verified: the same in-browser cytoscape run accepts every token
+  with zero warnings). jsdom's passthrough (`"var(--x)"`) is guarded, keeping
+  the documented `''`-in-unit-tests contract; all gates and all eleven rigs
+  re-ran green on a rebuilt dist after the fix.
 
 **UXFIX preserved:** this slice is color replacement only — all ten prior rigs
 (every UXFIX behavior contract among them) pass unchanged on this build; the

--- a/.product/evidence/vision-slice6/checklist.md
+++ b/.product/evidence/vision-slice6/checklist.md
@@ -1,0 +1,108 @@
+# DES-VISION-001 slice 6 — experience checklist verdicts
+
+**Slice:** the remaining component token conversion (§6.3 slice 6) — finishes
+§2.11. The ~1166-warning lint baseline slices 1–5 left (50 files still speaking
+the inherited GitHub-dark shell palette) is converted to the semantic tokens;
+the legacy `--wk-*` palette in global.css, its Tailwind `wk` aliases, and the
+unconsumed `.wk-crew-bg` raw-color background are retired; the no-raw-color
+rule moves to **ERROR for all of `src/**`** and the per-file `TOKEN_CLEAN`
+allowlist machinery is deleted; `postcss.config.js` gains the §2.11 build-time
+twin (`no-raw-colors`) guarding the stylesheets. Mechanical color replacement
+only — no behavioral change, no new features.
+**Rubric:** DES-VISION-001 §6.1 → this slice's §6.3 entry: **EC15 (globally
+passing for the first time)**, with EC11/EC12 re-read after the bulk recolor.
+**Images:** `e2e/shots/vision/vision-6-token-complete.png` (the settled W2
+board, 1440×900, `device_scale_factor=1`, per §6.0, by `e2e/vision_slice6_test.py`
+against the frozen-`NOW0` W2 fixture with the browser clock frozen at
+`NOW0+5s`). The shots are gitignored evidence; the rig's JSON report records
+the path beside the verdicts.
+
+| Item | Verdict | Read from the evidence |
+|---|---|---|
+| **EC15 — token discipline (GLOBAL)** | **PASS** | `npm run lint` exits **0 with zero §2.11 findings** across all of `src/` under the ERROR-mode rule (1166 → 0). The rig's EC15 sweep probes TEN `data-testid` elements across two scenes and matches every computed `background`/`color`/`border-color` against the scratch-element probe of its semantic token — no hex duplicated into the rig: left-rail bg == `--surface-rail`; project-card bg == `--surface-card`; awaiting run-chip border+bg == `--status-gate-dim` and its phase label == `--status-gate`; executing phase label == `--status-run`; live-line == `--ink-body` in JetBrains Mono; gate-approve == `--status-run` on `--status-run-dim`; and on `/work` the RunLink status dots == `--status-gate` / `--status-run` / `--status-fail` / `--status-done`. |
+| **EC12 — accent is singular** (re-read) | **PASS** | The conversion **strengthened** the separation §2.6 demands: the legacy amber `--wk-accent` was split by ROLE — primary CTAs / selection / links / checkbox accents onto `var(--accent)` (+`--accent-fg` ink), while gates, awaiting-human states, warnings, conditional verdicts, and "needs attention" markers went to the `--status-gate` layer. Legacy blue `#79c0ff` likewise: links/selection → accent; executing/active → `--status-run`. No hue family other than the violet accent reads as interactive in the shot. |
+| **EC11 — information is the aesthetic** (re-read) | **PASS** | The shot is the same board slices 1–3 shipped — no gradients, no ornament introduced by the recolor; the only visible deltas are status-layer signals (below). The unconsumed `.wk-crew-bg` decorative background (gradients + watermark) was deleted, not converted. |
+| **EC10 — no banned state** (preserved) | **PASS** | Zero console errors across both rig scenes; all ten prior rigs re-prove their narration/copy contracts on this build. |
+
+**Slice DOM ACs** (from `vision_slice6_test.py`'s JSON report, all true):
+
+- `npm run lint` exits 0 with NO findings on raw colors across all of `src/` (AC 1).
+- The Playwright `getComputedStyle` sweep across 10 `data-testid` elements confirms
+  every probed `background`/`color`/`border-color` resolves through the token
+  (probe-equality, EC15 passing globally) (AC 2).
+- Enforcement posture, statically read: `'no-restricted-syntax': ['error', ...]`
+  for `src/**/*.{ts,tsx}`; no `const TOKEN_CLEAN` declaration and no
+  `files: TOKEN_CLEAN` block; warn-mode gone; `no-raw-colors` PostCSS twin
+  present; no `--wk-*`/`.wk-crew-bg` in global.css (AC 3).
+
+**Repo gates:** `npm run lint` exit **0 — zero errors, zero warnings** (the §2.11
+rule at ERROR repo-wide; the react-hooks advisories that ride the config also
+report nothing). `npm run typecheck` exit 0. `npm test` **847/847** (91 files —
+unchanged suite; the conversion needed no test rewrites). `npm run build` green
+with the PostCSS twin in the pipeline; the twin was negative-tested: a probe
+`color: #ff0000` appended to global.css fails the build with the §2.11 message
+naming the file/line, and the token sources stay exempt (per-declaration source
+check, pre-Tailwind, so generated utilities/preflight are not misattributed).
+
+**All rigs green on the fresh build** (`dist-sameorigin` deleted and rebuilt from
+this branch first): `uxfix_slice1..6_test.py`, `vision_slice1..4_test.py`, and
+this slice's `vision_slice6_test.py` — **eleven for eleven, exit 0.**
+
+**The vision-1 pixel gate, run the strong way (§6.3: "zero visual regression"):**
+baseline captured from an **origin/main** build (a detached worktree at
+`0bfebd2`), check from this branch — the diff was **911 pixels in four row
+bands**, every one a sanctioned slice-6 recolor on the home board, verified by
+color-pair census and eye-check of the diff crop:
+- run-chip gate phase labels: `#ffda19` → `--status-gate` (hsl 45 90% 68%);
+- gate pill fills: translucent amber → `--status-gate-dim`;
+- the Notifications label: legacy gray-blue → `--ink-dim`.
+No layout shifts, no other surfaces moved. Per the rig's VISION_BASELINE flow
+the baseline was then regenerated on this branch and the check re-run:
+**pixel-identical, 0 diff pixels** — determinism intact, the delta exactly the
+declared §2.6 vocabulary change and nothing else.
+
+**Rig-set reconciliations** (contract advanced; behavior-preserving):
+- `vision_slice1..4_test.py` each asserted the WARN baseline was still firing
+  elsewhere ("raw_color_warnings > 0") — the §2.11 migration those assertions
+  staged is complete, so they now pin the end state: exit 0 AND zero findings
+  repo-wide. Their own error-mode-files-clean assertions are unchanged.
+
+**Role decisions of record** (semantic fidelity — the token matching the ROLE,
+not the nearest hex; §2.6 status/accent separation):
+- **Status vocabulary** (`RunCard.STATUS_STYLE`, `RunLink.statusColor`, shared by
+  the converted board): distributing/executing → `--status-run` (emerald =
+  running, was legacy blue), awaiting_human → `--status-gate`, completed →
+  `--status-done` (was legacy green — §2.6: emerald means *running*), failed →
+  `--status-fail`. The dead `className: 'text-wk-*'` field was deleted with its
+  aliases.
+- **Primary CTAs** (legacy amber bg + dark ink): `var(--accent)` +
+  `var(--accent-fg)` — Build/launch/save/register/steer-approve buttons.
+- **Gate/attention layer**: gate toasts, steering gate, sign-in-needed chips,
+  "risk flagged", conditional verdicts, quorum-lost/degraded notes, ungoverned
+  terminal marker, proposed domain entities → `--status-gate`(-dim).
+- **Selection/identity**: chosen elicitation option, active time-range/sort
+  column, selected workflow chip, attached-context chips, evaluator/creator
+  identity, member-kind pills → the accent family (`--accent`, `--accent-dim`,
+  `--accent-subtle`).
+- **Graph categorical palettes** (CytoGraph/ForceGraph/HotspotsView/
+  RepoGraphModal, one shared mapping): callables → `--status-run`, data shapes
+  (class/struct, rust) → `--status-gate`, interface-likes (interface/trait/
+  type_alias, python) → `--accent`, enum/macro/go → `--accent-dim`, fallback
+  `--ink-muted`; graph selection/highlight → `--accent` (was `#fbbf24`).
+- **Surfaces**: legacy shell hexes onto the ramp by elevation (canvas →
+  `--surface-base`, canvas-2/wells → `--surface-rail`, cards → `--surface-card`,
+  hovers/hairlines/input fills → `--surface-raised`, the "blue modal" →
+  `--surface-overlay`/`--surface-raised`); whole legacy shadow strings onto
+  `--shadow-card/-raised/-overlay`.
+- **New semantic token, one**: `--scrim` (rgba 0,0,0,.6 in tokens.css) for the
+  modal/backdrop fills that must stay translucent; the FeedbackOverlay's
+  selection fill uses `color-mix(in srgb, var(--accent) 10%, transparent)` for
+  the same reason (a token-derived translucency, no literal channels).
+- **The var()-blind sinks** (§2.11 escape hatch): xterm themes
+  (Terminal/AgentTerminal) and cytoscape stylesheets (CytoGraph) resolve tokens
+  through the cascade at mount/build time via the new
+  `src/styles/resolveToken.ts` — customization (§3.3) still reaches them.
+
+**UXFIX preserved:** this slice is color replacement only — all ten prior rigs
+(every UXFIX behavior contract among them) pass unchanged on this build; the
+unit suite needed zero edits.

--- a/e2e/vision_slice1_test.py
+++ b/e2e/vision_slice1_test.py
@@ -220,22 +220,26 @@ if not BASELINE_MODE:
         fail("pixel_compare_verdict", "vision-1-token-check.png is not pixel-identical "
              "to the pre-slice baseline — see pixel_compare")
 
-# ── 5. Lint posture: exit 0, and the new rule WARNS on the existing raw colors ─
+# ── 5. Lint posture: exit 0 with ZERO §2.11 findings. Slice 1 established the
+#      rule in warn mode and this step originally asserted the warn baseline
+#      was firing; slice 6 finished the migration (§2.11: error repo-wide, the
+#      TOKEN_CLEAN staging retired), exactly as slice 1's docstring declared the
+#      arc would — so the posture this rig pins is the end state: clean.
 if not BASELINE_MODE:
     r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
                        capture_output=True, text=True, timeout=600)
     out = r.stdout + r.stderr
-    raw_color_warnings = out.count("(DES-VISION-001 §2.11)")
+    raw_color_findings = out.count("(DES-VISION-001 §2.11)")
     report["steps"]["lint"] = {
-        "ok": r.returncode == 0 and raw_color_warnings > 0,
+        "ok": r.returncode == 0 and raw_color_findings == 0,
         "exit_code": r.returncode,
         "exits_zero_no_errors": r.returncode == 0,
-        "raw_color_warnings": raw_color_warnings,
+        "raw_color_findings": raw_color_findings,
         "tail": out[-600:],
     }
     if not report["steps"]["lint"]["ok"]:
-        fail("lint_verdict", "lint must exit 0 (warnings only) AND warn on the "
-             "existing raw colors — see lint")
+        fail("lint_verdict", "lint must exit 0 with zero raw-color findings "
+             "(§2.11 complete since slice 6) — see lint")
 
 report["ok"] = True
 print(json.dumps(report, indent=2))

--- a/e2e/vision_slice2_test.py
+++ b/e2e/vision_slice2_test.py
@@ -277,17 +277,19 @@ r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
                    capture_output=True, text=True, timeout=600)
 out = r.stdout + r.stderr
 slice_hits = [f for f in SLICE_FILES if f in out]
+# Slice 6 completed the §2.11 migration: the rule is ERROR repo-wide and the
+# warn baseline this step once expected is retired — zero findings, full stop.
 baseline_warnings = out.count("(DES-VISION-001 §2.11)")
 report["steps"]["lint"] = {
-    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings == 0,
     "exit_code": r.returncode,
     "slice_files_with_findings": slice_hits,
-    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "raw_color_findings_repo_wide": baseline_warnings,
     "tail": out[-400:],
 }
 if not report["steps"]["lint"]["ok"]:
     fail("lint_verdict", "lint must exit 0 with no findings in the slice-2 "
-         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+         "files (nor anywhere: the rule is error repo-wide since slice 6) — see lint")
 
 report["ok"] = True
 print(json.dumps(report, indent=2))

--- a/e2e/vision_slice3_test.py
+++ b/e2e/vision_slice3_test.py
@@ -323,17 +323,19 @@ r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
                    capture_output=True, text=True, timeout=600)
 out = r.stdout + r.stderr
 slice_hits = [f for f in SLICE_FILES if f in out]
+# Slice 6 completed the §2.11 migration: the rule is ERROR repo-wide and the
+# warn baseline this step once expected is retired — zero findings, full stop.
 baseline_warnings = out.count("(DES-VISION-001 §2.11)")
 report["steps"]["lint"] = {
-    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings == 0,
     "exit_code": r.returncode,
     "slice_files_with_findings": slice_hits,
-    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "raw_color_findings_repo_wide": baseline_warnings,
     "tail": out[-400:],
 }
 if not report["steps"]["lint"]["ok"]:
     fail("lint_verdict", "lint must exit 0 with no findings in the slice-3 "
-         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+         "files (nor anywhere: the rule is error repo-wide since slice 6) — see lint")
 
 report["ok"] = True
 print(json.dumps(report, indent=2))

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -457,17 +457,19 @@ r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
                    capture_output=True, text=True, timeout=600)
 out = r.stdout + r.stderr
 slice_hits = [f for f in SLICE_FILES if f in out]
+# Slice 6 completed the §2.11 migration: the rule is ERROR repo-wide and the
+# warn baseline this step once expected is retired — zero findings, full stop.
 baseline_warnings = out.count("(DES-VISION-001 §2.11)")
 report["steps"]["lint"] = {
-    "ok": r.returncode == 0 and not slice_hits and baseline_warnings > 0,
+    "ok": r.returncode == 0 and not slice_hits and baseline_warnings == 0,
     "exit_code": r.returncode,
     "slice_files_with_findings": slice_hits,
-    "warn_baseline_still_firing_elsewhere": baseline_warnings,
+    "raw_color_findings_repo_wide": baseline_warnings,
     "tail": out[-400:],
 }
 if not report["steps"]["lint"]["ok"]:
     fail("lint_verdict", "lint must exit 0 with no findings in the slice-4 "
-         "error-mode files (and the warn baseline still firing elsewhere) — see lint")
+         "files (nor anywhere: the rule is error repo-wide since slice 6) — see lint")
 
 report["ok"] = True
 print(json.dumps(report, indent=2))

--- a/e2e/vision_slice6_test.py
+++ b/e2e/vision_slice6_test.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+vision_slice6_test.py — the DES-VISION-001 slice-6 gate: the remaining
+component token conversion is COMPLETE and §2.11 holds globally (§6.3 slice 6,
+EC15 passing for the first time).
+
+Slice 6 is the bulk conversion: every component that still spoke the inherited
+GitHub-dark shell palette (the ~1166-warning lint baseline slices 1–5 left)
+now consumes the semantic tokens; the legacy --wk-* palette and its Tailwind
+aliases are retired; the no-raw-color rule is ERROR repo-wide (the TOKEN_CLEAN
+per-file staging deleted) with a PostCSS twin guarding the stylesheets. No
+behavioral change, no new features — so the gate is:
+
+  1. EC15 sweep — a getComputedStyle sweep across TEN data-testid elements,
+     spanning both long-converted surfaces (rail, card, gate chip) and
+     slice-6-converted code (the RunCard STATUS_STYLE phase labels on the home
+     board's run chips, RunLink status dots on the Work page): every probed
+     background / color / border-color equals the computed value of its
+     semantic token, probed via a scratch element so no hex is copied into
+     this rig (EC15 globally — the §6.3 DOM AC);
+  2. `npm run lint` exits 0 with ZERO §2.11 findings anywhere in src/;
+  3. the enforcement posture is the end state: eslint.config.mjs carries the
+     rule as ERROR for src/** and no TOKEN_CLEAN allowlist; postcss.config.js
+     carries the `no-raw-colors` twin; global.css carries no --wk-* block.
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-6-token-complete.png   the settled W2 board — the §6.3 screenshot,
+                                confirming zero visual regression from slices
+                                1–5 after the bulk conversion (the vision-1
+                                pixel gate re-proves this against its baseline;
+                                the ONLY home-board deltas slice 6 makes are
+                                the §2.6 status recolors of the run-chip phase
+                                labels, re-baselined per that rig's flow).
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: VISION_PORT (default 4346),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4346"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+SHOT = VSHOTS / "vision-6-token-complete.png"
+
+FREEZE_MOTION = (
+    "*, *::before, *::after { animation: none !important; transition: none !important; }"
+)
+
+# The token probe (slice-4's technique): computed color of `var(<name>)` on a
+# scratch element — keeps every hex value OUT of this rig.
+PROBES = """() => {
+  const probe = (name, prop) => { const el = document.createElement('div');
+    el.style[prop] = `var(${name})`;
+    document.body.appendChild(el);
+    const v = getComputedStyle(el)[prop === 'background' ? 'backgroundColor' : prop];
+    el.remove(); return v; };
+  return {
+    surfaceRail:   probe('--surface-rail', 'background'),
+    surfaceCard:   probe('--surface-card', 'background'),
+    inkBody:       probe('--ink-body', 'color'),
+    statusGate:    probe('--status-gate', 'color'),
+    statusGateDim: probe('--status-gate-dim', 'background'),
+    statusRun:     probe('--status-run', 'color'),
+    statusRunDim:  probe('--status-run-dim', 'background'),
+    statusFail:    probe('--status-fail', 'background'),
+    statusDone:    probe('--status-done', 'background'),
+  }; }"""
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # Frozen browser clock (slice-1's determinism recipe) — every rendered age
+    # is stable so the shot is comparable across runs.
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    # ── Scene A: the settled W2 board (the §6.3 screenshot + home sweep) ──────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'""",
+        timeout=20000,
+    )
+
+    probes = page.evaluate(PROBES)
+
+    # EC15 home sweep — element, property, expected token (probed, not hexed).
+    home_sweep = page.evaluate(
+        """() => {
+      const cs = (sel, prop) => { const el = document.querySelector(sel);
+        return el ? getComputedStyle(el)[prop] : null; };
+      const chipSpan = (status, prop) => { const el = document.querySelector(
+        `[data-testid="run-chip"][data-status="${status}"] span:not([data-testid="live-edge"])`);
+        return el ? getComputedStyle(el)[prop] : null; };
+      return {
+        leftRailBg:        cs('[data-testid="left-rail"]', 'backgroundColor'),
+        projectCardBg:     cs('[data-testid="project-card"]', 'backgroundColor'),
+        gateChipBorder:    cs('[data-testid="run-chip"][data-status="awaiting_human"]', 'borderTopColor'),
+        gateChipBg:        cs('[data-testid="run-chip"][data-status="awaiting_human"]', 'backgroundColor'),
+        gatePhaseColor:    chipSpan('awaiting_human', 'color'),
+        execPhaseColor:    chipSpan('executing', 'color'),
+        liveLineColor:     cs('[data-testid="live-line"]', 'color'),
+        liveLineFont:      cs('[data-testid="live-line"]', 'fontFamily'),
+        approveBg:         cs('[data-testid^="gate-approve-"]', 'backgroundColor'),
+        approveColor:      cs('[data-testid^="gate-approve-"]', 'color'),
+      }; }"""
+    )
+
+    page.screenshot(path=str(SHOT))
+
+    home_checks = {
+        "left_rail_bg_is_surface_rail": home_sweep["leftRailBg"] == probes["surfaceRail"],
+        "project_card_bg_is_surface_card": home_sweep["projectCardBg"] == probes["surfaceCard"],
+        "awaiting_chip_border_is_status_gate_dim": home_sweep["gateChipBorder"] == probes["statusGateDim"],
+        "awaiting_chip_bg_is_status_gate_dim": home_sweep["gateChipBg"] == probes["statusGateDim"],
+        "awaiting_phase_label_is_status_gate": home_sweep["gatePhaseColor"] == probes["statusGate"],
+        "executing_phase_label_is_status_run": home_sweep["execPhaseColor"] == probes["statusRun"],
+        "live_line_color_is_ink_body": home_sweep["liveLineColor"] == probes["inkBody"],
+        "live_line_is_mono": "JetBrains Mono" in (home_sweep["liveLineFont"] or ""),
+        "gate_approve_bg_is_status_run_dim": home_sweep["approveBg"] == probes["statusRunDim"],
+        "gate_approve_color_is_status_run": home_sweep["approveColor"] == probes["statusRun"],
+    }
+    report["steps"]["home_sweep"] = {
+        "ok": order_ok and narration_ok and fonts_ok and all(home_checks.values()),
+        "board_settled_w2_order": order_ok,
+        "live_narration_streamed": narration_ok,
+        "web_fonts_loaded": fonts_ok,
+        **home_checks,
+        "computed": home_sweep,
+        "screenshot": str(SHOT),
+    }
+
+    # ── Scene B: the Work page — slice-6 RunLink status dots (§2.6 vocabulary) ─
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+    page.locator('[data-testid="run-link"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+
+    work_sweep = page.evaluate(
+        """() => {
+      const dot = (status) => { const el = document.querySelector(
+        `[data-testid="run-link"][data-status="${status}"] .rounded-full`);
+        return el ? getComputedStyle(el).backgroundColor : null; };
+      return {
+        awaitingDot:  dot('awaiting_human'),
+        executingDot: dot('executing'),
+        failedDot:    dot('failed'),
+        completedDot: dot('completed'),
+      }; }"""
+    )
+    # Re-probe on this document (same stylesheet — belt and braces).
+    probes_b = page.evaluate(PROBES)
+    work_checks = {
+        "awaiting_dot_is_status_gate": work_sweep["awaitingDot"] == probes_b["statusGate"],
+        "executing_dot_is_status_run": work_sweep["executingDot"] == probes_b["statusRun"],
+        "failed_dot_is_status_fail": work_sweep["failedDot"] == probes_b["statusFail"],
+        "completed_dot_is_status_done": work_sweep["completedDot"] == probes_b["statusDone"],
+    }
+    report["steps"]["work_sweep"] = {
+        "ok": all(work_checks.values()),
+        **work_checks,
+        "computed": work_sweep,
+    }
+
+    browser.close()
+
+report["steps"]["console"] = {"ok": len(console_errors) == 0, "errors": console_errors[:10]}
+report["screenshots"] = [str(SHOT)]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("dom_acs_verdict", f"slice-6 assertions did not all hold — see {', '.join(bad)}")
+
+# ── 4. Lint: exit 0, ZERO §2.11 findings anywhere (the migration is complete) ──
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings": findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero §2.11 findings — see lint")
+
+# ── 5. Enforcement posture: the end state, statically read ─────────────────────
+eslint_cfg = (REPO / "eslint.config.mjs").read_text()
+postcss_cfg = (REPO / "postcss.config.js").read_text()
+global_css = (REPO / "src" / "styles" / "global.css").read_text()
+posture = {
+    "rule_is_error_for_src": "'no-restricted-syntax': ['error', ...NO_RAW_COLOR]" in eslint_cfg
+                             and "src/**/*.{ts,tsx}" in eslint_cfg,
+    # The machinery, not its mention: the config may NAME the retired allowlist
+    # in prose; what must be gone is the declaration and any files: use of it.
+    "token_clean_allowlist_deleted": "const TOKEN_CLEAN" not in eslint_cfg
+                                     and "files: TOKEN_CLEAN" not in eslint_cfg,
+    "warn_mode_gone": "['warn', ...NO_RAW_COLOR]" not in eslint_cfg,
+    "postcss_twin_present": "no-raw-colors" in postcss_cfg,
+    "wk_palette_retired": "--wk-canvas" not in global_css and ".wk-crew-bg" not in global_css,
+}
+report["steps"]["posture"] = {"ok": all(posture.values()), **posture}
+if not report["steps"]["posture"]["ok"]:
+    fail("posture_verdict", "the slice-6 enforcement end state is not in place — see posture")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,10 +12,11 @@ import reactHooks from 'eslint-plugin-react-hooks';
 // DES-VISION-001 §2.11 — the no-raw-color contract's selectors. No file in
 // src/ ships a literal color: hex, or rgb()/hsl() with literal channel values.
 // Colors come from the semantic tokens in src/styles/tokens.css (a .css file —
-// outside ESLint's reach; its build-time twin, the PostCSS check, lands with
-// the global error-mode flip). One list, two postures below: WARN as the
-// migration baseline (§2.11 — the inherited hardcoded colors are converted
-// slice by slice), ERROR for every file a landed slice has converted.
+// outside ESLint's reach; its build-time twin, the PostCSS check in
+// postcss.config.js, covers the stylesheets). Slice 6 finished the migration:
+// the rule is ERROR for all of src/ — a raw color anywhere is a build failure,
+// not a review finding. The per-file TOKEN_CLEAN allowlist that staged the
+// slice-by-slice conversion is retired.
 const NO_RAW_COLOR = [
   {
     selector: 'Literal[value=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]',
@@ -43,39 +44,6 @@ const NO_RAW_COLOR = [
   },
 ];
 
-// Files a landed slice has fully converted — the rule is ERROR here, and a raw
-// color is a build failure, not a review finding (§6.0). Grows slice by slice
-// until slice 6 flips src/** wholesale and this list retires.
-const TOKEN_CLEAN = [
-  // Vision slice 2 — the orchestrator home (§5.1).
-  'src/components/HomeBoard.tsx',
-  'src/components/LiveFeed.tsx',
-  'src/components/ProjectCard.tsx',
-  'src/components/GateChip.tsx',
-  'src/hooks/useBoardHeadline.ts',
-  // Vision slice 3 — the chrome + mode switcher (§3.1, §5.2).
-  'src/components/AppChrome.tsx',
-  'src/components/WickedLogo.tsx',
-  'src/components/LeftSidebar.tsx',
-  'src/components/SettingsMenu.tsx',
-  'src/components/ModeSwitcher.tsx',
-  'src/components/ProjectShell.tsx',
-  // Vision slice 4 — the Chat + Build surfaces (§5.3, §5.4).
-  'src/components/GroupChat.tsx',
-  'src/components/ChatPanel.tsx',
-  'src/components/CenterDashboard.tsx',
-  // Vision slice 4 (cont.) — the Document + Video surfaces (§5.5, §5.6),
-  // including the strip toolbar and the shared surface-state constants.
-  'src/components/DocumentCanvas.tsx',
-  'src/components/DocumentThread.tsx',
-  'src/components/VersionStrip.tsx',
-  'src/components/ThemesMenu.tsx',
-  'src/components/ExportMenu.tsx',
-  'src/components/VideoStoryboard.tsx',
-  'src/components/SurfaceState.tsx',
-  'src/components/threadAnchor.ts',
-];
-
 export default tseslint.config(
   {
     ignores: [
@@ -97,12 +65,6 @@ export default tseslint.config(
   },
   {
     files: ['src/**/*.{ts,tsx}'],
-    rules: {
-      'no-restricted-syntax': ['warn', ...NO_RAW_COLOR],
-    },
-  },
-  {
-    files: TOKEN_CLEAN,
     rules: {
       'no-restricted-syntax': ['error', ...NO_RAW_COLOR],
     },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,42 @@
+// PostCSS pipeline — Tailwind + autoprefixer, guarded by the §2.11 twin.
+//
+// DES-VISION-001 §2.11: no .css file outside the token sources ships a raw
+// color. ESLint enforces the contract for .ts/.tsx (eslint.config.mjs); this
+// inline plugin is the build-time twin for the stylesheets — it fails the
+// build on a literal hex / rgb() / hsl() in any src/ stylesheet EXCEPT
+// src/styles/tokens.css and src/styles/themes/*.css (the only files allowed
+// to hold raw values). It checks in `Once`, BEFORE Tailwind expands its
+// directives, so it judges exactly what the repo's stylesheets say — not the
+// generated utilities or preflight (not ours to police). Files outside src/
+// (e.g. xterm's CSS from node_modules) are skipped for the same reason.
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+
+const RAW_COLOR = /#[0-9a-fA-F]{3,8}\b|\brgba?\(\s*\d|\bhsla?\(\s*[\d.]/;
+const TOKEN_SOURCES = /src\/styles\/(tokens\.css|themes\/[^/]+\.css)$/;
+
+function noRawColors() {
+  return {
+    postcssPlugin: 'no-raw-colors',
+    Once(root) {
+      // Judge each declaration by ITS OWN source file (an @import-inlined node
+      // keeps the imported file as its source), so the token sources stay exempt
+      // no matter whether the import was inlined before or after this pass.
+      root.walkDecls((decl) => {
+        const file = (decl.source?.input?.file ?? '').replace(/\\/g, '/');
+        if (!file.includes('/src/') || file.includes('/node_modules/')) return;
+        if (TOKEN_SOURCES.test(file)) return;
+        if (RAW_COLOR.test(decl.value)) {
+          throw decl.error(
+            `Raw color in "${decl.prop}: ${decl.value}" — use a semantic token from src/styles/tokens.css (DES-VISION-001 §2.11).`,
+          );
+        }
+      });
+    },
+  };
+}
+noRawColors.postcss = true;
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [noRawColors, tailwindcss, autoprefixer],
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,7 +425,7 @@ export function App(): React.ReactElement {
   }
 
   return (
-    <div className="flex h-screen overflow-hidden bg-wk-canvas">
+    <div className="flex h-screen overflow-hidden bg-surface-base">
       <LeftSidebar runs={runs} navigate={navigate} />
 
       <div className="flex flex-1 overflow-hidden">

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { terminalWsUrl } from '../api/client.js';
+import { resolveToken } from '../styles/resolveToken.js';
 
 interface Props {
   /** The terminalId from a workerSessionStarted event — connects to this existing PTY. */
@@ -40,7 +41,14 @@ export function AgentTerminal({ terminalId, cliKey, onClose }: Props): React.Rea
       disableStdin: true,
       fontSize: 12,
       fontFamily: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-      theme: { background: '#0d1117', foreground: '#e6edf3', cursor: '#ffda19', cursorAccent: '#0d1117' },
+      // xterm parses concrete colors (no var() support) — resolve the tokens
+      // through the cascade at mount time (§2.11's escape hatch).
+      theme: {
+        background: resolveToken('--surface-base'),
+        foreground: resolveToken('--ink-body'),
+        cursor: resolveToken('--accent'),
+        cursorAccent: resolveToken('--surface-base'),
+      },
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -91,21 +99,21 @@ export function AgentTerminal({ terminalId, cliKey, onClose }: Props): React.Rea
   return (
     <div
       className="flex flex-col rounded-xl overflow-hidden"
-      style={{ background: '#0d1117', border: '1px solid rgba(230,237,243,0.08)' }}
+      style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)' }}
     >
       <div
         className="flex items-center justify-between px-3 py-1.5 shrink-0"
-        style={{ background: '#161c26', borderBottom: '1px solid rgba(230,237,243,0.06)' }}
+        style={{ background: 'var(--surface-rail)', borderBottom: '1px solid var(--surface-raised)' }}
       >
-        <span className="text-[11px] font-mono font-semibold" style={{ color: 'rgba(230,237,243,0.5)' }}>
-          {cliKey} <span style={{ color: 'rgba(230,237,243,0.3)', fontWeight: 400 }}>· observer</span>
+        <span className="text-[11px] font-mono font-semibold" style={{ color: 'var(--ink-muted)' }}>
+          {cliKey} <span style={{ color: 'var(--ink-dim)', fontWeight: 400 }}>· observer</span>
         </span>
         <button
           type="button"
           onClick={onClose}
           aria-label={`Close ${cliKey} terminal`}
           className="text-[13px] leading-none opacity-50 hover:opacity-100 transition-opacity"
-          style={{ background: 'transparent', border: 'none', color: '#e6edf3', cursor: 'pointer' }}
+          style={{ background: 'transparent', border: 'none', color: 'var(--ink-high)', cursor: 'pointer' }}
         >
           ×
         </button>

--- a/src/components/AssumptionsPanel.tsx
+++ b/src/components/AssumptionsPanel.tsx
@@ -31,7 +31,7 @@ export function AssumptionsPanel({ model }: Props): React.ReactElement {
     <div data-testid="assumptions" className="flex flex-col gap-2 text-[11px]">
       {recorded.length > 0 && (
         <div className="flex flex-col gap-1">
-          <p className="font-mono font-semibold" style={{ color: 'rgba(230,237,243,0.6)' }}>
+          <p className="font-mono font-semibold" style={{ color: 'var(--ink-muted)' }}>
             external transformations
           </p>
           <ul className="flex flex-col gap-1">
@@ -41,34 +41,34 @@ export function AssumptionsPanel({ model }: Props): React.ReactElement {
                 data-testid="assumption-transform"
                 className="rounded p-1.5 font-mono"
                 style={{
-                  background: a.known ? 'rgba(63,185,80,0.06)' : 'rgba(255,218,25,0.08)',
+                  background: a.known ? 'var(--status-run-dim)' : 'var(--status-gate-dim)',
                   border: a.known
-                    ? '1px solid rgba(63,185,80,0.2)'
-                    : '1px dashed rgba(255,218,25,0.45)',
+                    ? '1px solid var(--status-run-dim)'
+                    : '1px dashed var(--status-gate)',
                 }}
               >
                 <div className="flex items-center gap-1.5">
-                  <span style={{ color: '#e6edf3' }}>unit #{a.ord}</span>
-                  <span style={{ color: '#79c0ff' }}>{a.library}</span>
+                  <span style={{ color: 'var(--ink-high)' }}>unit #{a.ord}</span>
+                  <span style={{ color: 'var(--accent)' }}>{a.library}</span>
                   {!a.known && (
                     <span
                       data-testid="needs-review-badge"
                       className="rounded px-1 text-[9px] font-semibold uppercase"
-                      style={{ background: 'rgba(255,218,25,0.2)', color: '#ffda19' }}
+                      style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
                     >
                       needs review
                     </span>
                   )}
                 </div>
-                <p style={{ color: 'rgba(230,237,243,0.7)' }}>{a.transform}</p>
-                <p style={{ color: 'rgba(230,237,243,0.45)' }}>{a.detail}</p>
+                <p style={{ color: 'var(--ink-muted)' }}>{a.transform}</p>
+                <p style={{ color: 'var(--ink-muted)' }}>{a.detail}</p>
               </li>
             ))}
           </ul>
         </div>
       )}
       {routed.length === 0 ? (
-        <p style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p style={{ color: 'var(--ink-dim)' }}>
           No routing decisions recorded yet.
         </p>
       ) : (
@@ -77,11 +77,11 @@ export function AssumptionsPanel({ model }: Props): React.ReactElement {
             <li
               key={u.ord}
               className="rounded p-1.5 font-mono"
-              style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.07)', color: 'rgba(230,237,243,0.6)' }}
+              style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
             >
-              <span className="font-medium" style={{ color: '#e6edf3' }}>unit #{u.ord}</span>
+              <span className="font-medium" style={{ color: 'var(--ink-high)' }}>unit #{u.ord}</span>
               {u.description.includes(' — ') && (
-                <span className="ml-1" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                <span className="ml-1" style={{ color: 'var(--ink-dim)' }}>
                   {u.description.split(' — ')[0]}
                 </span>
               )}{' '}

--- a/src/components/Burn.tsx
+++ b/src/components/Burn.tsx
@@ -24,8 +24,8 @@ export function Burn({ model }: Props): React.ReactElement {
   const partialTotals = nonTerminal || b.noAdapterClis.length > 0 || b.pendingUsageClis.length > 0;
 
   const cardStyle = {
-    background: '#161c26',
-    border: '1px solid rgba(230,237,243,0.07)',
+    background: 'var(--surface-rail)',
+    border: '1px solid var(--surface-raised)',
     borderRadius: '6px',
     padding: '8px',
   };
@@ -33,7 +33,7 @@ export function Burn({ model }: Props): React.ReactElement {
   return (
     <div data-testid="burn" className="flex flex-col gap-2 text-[11px]">
       {!b.hasUsage ? (
-        <p style={{ color: 'rgba(230,237,243,0.4)' }} data-testid="burn-empty">
+        <p style={{ color: 'var(--ink-dim)' }} data-testid="burn-empty">
           Awaiting usage — token/cost burn lights up when a CLI emits <code>cliUsage</code>{' '}
           (claude reports tokens + cost directly).
         </p>
@@ -41,42 +41,42 @@ export function Burn({ model }: Props): React.ReactElement {
         <>
           <div className="grid grid-cols-3 gap-2">
             <div style={cardStyle}>
-              <p style={{ color: 'rgba(230,237,243,0.4)' }}>tokens{partialTotals ? ' (partial)' : ''}</p>
-              <p className="font-mono text-sm" style={{ color: '#e6edf3' }}>{tokens(b.totalTokens)}</p>
-              <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p style={{ color: 'var(--ink-dim)' }}>tokens{partialTotals ? ' (partial)' : ''}</p>
+              <p className="font-mono text-sm" style={{ color: 'var(--ink-high)' }}>{tokens(b.totalTokens)}</p>
+              <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
                 {tokens(b.totalInput)} in / {tokens(b.totalOutput)} out
               </p>
               {(b.totalCacheRead > 0 || b.totalCacheCreation > 0) && (
-                <p className="text-[10px]" style={{ color: 'rgba(96,165,250,0.55)' }}>
+                <p className="text-[10px]" style={{ color: 'var(--ink-muted)' }}>
                   {tokens(b.totalCacheRead)} cached · {tokens(b.totalCacheCreation)} written
                 </p>
               )}
             </div>
             <div style={cardStyle}>
-              <p style={{ color: 'rgba(230,237,243,0.4)' }}>cost{b.costComplete && !partialTotals ? '' : ' (partial)'}</p>
-              <p className="font-mono text-sm" style={{ color: '#e6edf3' }}>{cost(b.totalCost)}</p>
-              {b.totalCost === null && <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>no cost reported</p>}
+              <p style={{ color: 'var(--ink-dim)' }}>cost{b.costComplete && !partialTotals ? '' : ' (partial)'}</p>
+              <p className="font-mono text-sm" style={{ color: 'var(--ink-high)' }}>{cost(b.totalCost)}</p>
+              {b.totalCost === null && <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>no cost reported</p>}
             </div>
             <div style={cardStyle} data-testid="burn-rework">
-              <p style={{ color: 'rgba(230,237,243,0.4)' }}>rework{partialTotals ? ' (prov.)' : ''}</p>
-              <p className="font-mono text-sm" style={{ color: '#e6edf3' }}>
+              <p style={{ color: 'var(--ink-dim)' }}>rework{partialTotals ? ' (prov.)' : ''}</p>
+              <p className="font-mono text-sm" style={{ color: 'var(--ink-high)' }}>
                 {partialTotals ? '~' : ''}{b.reworkPct.toFixed(0)}%
               </p>
-              <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>{tokens(b.reworkTokens)} tok</p>
+              <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>{tokens(b.reworkTokens)} tok</p>
             </div>
           </div>
 
           {partialTotals && (
-            <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }} data-testid="burn-partial">
+            <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }} data-testid="burn-partial">
               Token totals and rework% are from connect onward; earlier usage may be missing.
             </p>
           )}
 
           <div>
-            <p className="mb-1" style={{ color: 'rgba(230,237,243,0.4)' }}>per CLI</p>
+            <p className="mb-1" style={{ color: 'var(--ink-dim)' }}>per CLI</p>
             <ul className="flex flex-col gap-0.5">
               {b.perCli.map((c) => (
-                <li key={c.cli} className="flex justify-between font-mono" style={{ color: 'rgba(230,237,243,0.6)' }}>
+                <li key={c.cli} className="flex justify-between font-mono" style={{ color: 'var(--ink-muted)' }}>
                   <span>{c.cli}</span>
                   <span>{tokens(c.input + c.output)} tok · {cost(c.cost)}</span>
                 </li>
@@ -87,13 +87,13 @@ export function Burn({ model }: Props): React.ReactElement {
       )}
 
       {b.noAdapterClis.length > 0 && (
-        <p style={{ color: '#ffda19' }} data-testid="burn-unavailable">
+        <p style={{ color: 'var(--status-gate)' }} data-testid="burn-unavailable">
           usage unavailable for {b.noAdapterClis.join(', ')} — no usage adapter
         </p>
       )}
 
       {b.pendingUsageClis.length > 0 && (
-        <p style={{ color: 'rgba(230,237,243,0.4)' }} data-testid="burn-pending">
+        <p style={{ color: 'var(--ink-dim)' }} data-testid="burn-pending">
           usage not yet reported for {b.pendingUsageClis.join(', ')}
         </p>
       )}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -65,9 +65,9 @@ function ActivePill({
     <span
       className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-mono"
       style={{
-        background: 'rgba(230,237,243,0.07)',
-        color: 'rgba(230,237,243,0.6)',
-        border: '1px solid rgba(230,237,243,0.1)',
+        background: 'var(--surface-raised)',
+        color: 'var(--ink-muted)',
+        border: '1px solid var(--surface-raised)',
       }}
     >
       {label}
@@ -325,21 +325,21 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       return (
         <div
           className="px-5 py-4 flex flex-col gap-2 shrink-0"
-          style={{ borderTop: '1px solid rgba(230,237,243,0.07)', background: '#161c26' }}
+          style={{ borderTop: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
         >
           {steerError && (
-            <p className="text-[11px] font-mono" style={{ color: '#f85149' }}>
+            <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
               {steerError}
             </p>
           )}
           <div
             className="flex items-end gap-3 rounded-2xl px-4 py-3"
-            style={{ background: '#1b222e', border: '1px solid rgba(255,218,25,0.25)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--status-gate-dim)' }}
           >
             <textarea
               ref={steerRef}
               className="flex-1 resize-none text-base outline-none border-0 bg-transparent leading-6"
-              style={{ minHeight: '28px', color: '#e6edf3', fontFamily: 'inherit' }}
+              style={{ minHeight: '28px', color: 'var(--ink-high)', fontFamily: 'inherit' }}
               placeholder="Send steering guidance… (approves gate)"
               value={steerText}
               onChange={(e) => setSteerText(e.target.value)}
@@ -357,14 +357,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               onClick={() => void submitSteer()}
               disabled={!canSteer}
               className="shrink-0 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity disabled:opacity-40"
-              style={{ background: '#ffda19', color: '#0d1117' }}
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
             >
               {steering ? '…' : 'Steer →'}
             </button>
           </div>
           <p
             className="text-[10px] font-mono text-center"
-            style={{ color: 'rgba(230,237,243,0.3)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >
             Approve + steer · Cmd+Enter · Use the gate panel above to approve/reject without steering
           </p>
@@ -381,20 +381,20 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       return (
         <div
           className="px-5 py-4 flex flex-col gap-2 shrink-0"
-          style={{ borderTop: '1px solid rgba(230,237,243,0.07)', background: '#161c26' }}
+          style={{ borderTop: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
         >
           {injectError && (
-            <p className="text-[11px] font-mono" style={{ color: '#f85149' }}>
+            <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
               {injectError}
             </p>
           )}
           <div
             className="flex items-end gap-3 rounded-2xl px-4 py-3"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.12)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <textarea
               className="flex-1 resize-none text-base outline-none border-0 bg-transparent leading-6"
-              style={{ minHeight: '28px', color: '#e6edf3', fontFamily: 'inherit' }}
+              style={{ minHeight: '28px', color: 'var(--ink-high)', fontFamily: 'inherit' }}
               placeholder={`Send message to ${targetLabel}…`}
               value={injectText}
               onChange={(e) => setInjectText(e.target.value)}
@@ -412,7 +412,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               onClick={() => void submitInject()}
               disabled={!canInject}
               className="shrink-0 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity disabled:opacity-40"
-              style={{ background: '#ffda19', color: '#0d1117' }}
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
             >
               {injecting ? '…' : 'Send →'}
             </button>
@@ -423,21 +423,21 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             <span
               data-testid="steering-live-chip"
               className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-mono shrink-0"
-              style={{ background: 'rgba(121,192,255,0.08)', color: '#79c0ff', border: '1px solid rgba(121,192,255,0.2)' }}
+              style={{ background: 'var(--status-run-dim)', color: 'var(--status-run)', border: '1px solid var(--status-run-dim)' }}
             >
-              <span className="inline-block w-1 h-1 rounded-full animate-pulse" style={{ background: '#79c0ff' }} />
+              <span className="inline-block w-1 h-1 rounded-full animate-pulse" style={{ background: 'var(--status-run)' }} />
               steering live run
             </span>
             <p
               className="text-[10px] font-mono flex-1"
-              style={{ color: 'rgba(230,237,243,0.3)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               Cmd+Enter · Click an agent to target it
             </p>
             {isTargeted && (
               <span
                 className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
-                style={{ background: 'rgba(139,92,246,0.15)', color: '#c4b5fd', border: '1px solid rgba(139,92,246,0.25)' }}
+                style={{ background: 'var(--accent-subtle)', color: 'var(--accent)', border: '1px solid var(--accent-subtle)' }}
               >
                 → {normalizedTarget}
                 {onClearInjectTarget && (
@@ -461,13 +461,13 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     return (
       <div
         className="px-5 py-4 shrink-0"
-        style={{ borderTop: '1px solid rgba(230,237,243,0.07)', background: '#161c26' }}
+        style={{ borderTop: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
       >
         <div
           className="rounded-2xl px-5 py-4"
-          style={{ border: '1px solid rgba(230,237,243,0.1)', background: '#1b222e' }}
+          style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
         >
-          <p className="text-sm italic font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+          <p className="text-sm italic font-mono" style={{ color: 'var(--ink-dim)' }}>
             Steer at the next gate.
           </p>
         </div>
@@ -548,8 +548,8 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         embedded
           ? {}
           : {
-              borderTop: '1px solid rgba(230,237,243,0.07)',
-              background: '#161c26',
+              borderTop: '1px solid var(--surface-raised)',
+              background: 'var(--surface-rail)',
             }
       }
     >
@@ -558,13 +558,13 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         <div
           className="flex items-center gap-2 text-xs rounded-xl px-4 py-2 font-mono"
           style={{
-            background: '#161c26',
-            border: '1px solid rgba(230,237,243,0.1)',
-            color: 'rgba(230,237,243,0.7)',
+            background: 'var(--surface-rail)',
+            border: '1px solid var(--surface-raised)',
+            color: 'var(--ink-muted)',
           }}
         >
           <span>
-            Detected: <strong style={{ color: '#ffda19' }}>{detectedWorkflow}</strong> workflow
+            Detected: <strong style={{ color: 'var(--accent)' }}>{detectedWorkflow}</strong> workflow
           </span>
           <button
             type="button"
@@ -573,7 +573,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               setWorkflowDismissed(true);
             }}
             className="rounded-lg px-3 py-1 font-semibold text-xs"
-            style={{ background: '#ffda19', color: '#0d1117' }}
+            style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
           >
             Apply
           </button>
@@ -581,7 +581,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             type="button"
             onClick={() => setWorkflowDismissed(true)}
             className="ml-auto"
-            style={{ color: 'rgba(230,237,243,0.35)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >
             ✕
           </button>
@@ -594,9 +594,9 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           data-testid="signin-warning"
           className="flex items-center gap-2 text-xs rounded-xl px-4 py-2 font-mono"
           style={{
-            background: 'rgba(248,81,73,0.08)',
-            border: '1px solid rgba(248,81,73,0.3)',
-            color: '#f85149',
+            background: 'var(--status-fail-dim)',
+            border: '1px solid var(--status-fail-dim)',
+            color: 'var(--status-fail)',
           }}
         >
           <span className="flex-1">
@@ -608,7 +608,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             type="button"
             onClick={() => navigate?.('/system')}
             className="rounded-lg px-3 py-1 font-semibold text-xs shrink-0"
-            style={{ background: 'rgba(248,81,73,0.15)', color: '#f85149', border: '1px solid rgba(248,81,73,0.35)' }}
+            style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
           >
             Open Settings
           </button>
@@ -618,7 +618,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       {/* ── Main input bubble ────────────────────────────────────────────── */}
       <div
         className="flex items-end gap-2 rounded-2xl px-4 py-3 transition-all"
-        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.14)' }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       >
         {/* + button with floating popover — both share the anchor ref */}
         <div className="relative shrink-0" ref={popoverAnchorRef}>
@@ -668,14 +668,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             style={
               popoverOpen
                 ? {
-                    background: 'rgba(255,218,25,0.15)',
-                    color: '#ffda19',
-                    border: '1px solid rgba(255,218,25,0.3)',
+                    background: 'var(--accent-subtle)',
+                    color: 'var(--accent)',
+                    border: '1px solid var(--accent-dim)',
                   }
                 : {
-                    background: 'rgba(230,237,243,0.06)',
-                    color: 'rgba(230,237,243,0.4)',
-                    border: '1px solid rgba(230,237,243,0.08)',
+                    background: 'var(--surface-raised)',
+                    color: 'var(--ink-dim)',
+                    border: '1px solid var(--surface-raised)',
                   }
             }
           >
@@ -688,7 +688,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           ref={textareaRef}
           data-testid="launch-problem"
           className="flex-1 resize-none text-base outline-none border-0 bg-transparent leading-6"
-          style={{ minHeight: '28px', color: '#e6edf3', fontFamily: 'inherit' }}
+          style={{ minHeight: '28px', color: 'var(--ink-high)', fontFamily: 'inherit' }}
           placeholder="What do you need built?"
           value={problem}
           onChange={(e) => {
@@ -713,7 +713,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           disabled={!canSubmit}
           aria-label="Send"
           className="shrink-0 rounded-xl px-5 py-2.5 text-sm font-semibold font-mono disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
-          style={{ background: '#ffda19', color: '#0d1117' }}
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
           {submitting ? `${elapsedSecs}s` : 'Send'}
         </button>
@@ -732,7 +732,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       {error && (
         <p
           className="text-xs px-1 font-mono"
-          style={{ color: '#f85149' }}
+          style={{ color: 'var(--status-fail)' }}
           data-testid="launch-error"
         >
           {error}
@@ -741,7 +741,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
 
       {/* Planning latency hint */}
       {submitting && elapsedSecs >= 5 && (
-        <p className="text-xs text-center font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+        <p className="text-xs text-center font-mono" style={{ color: 'var(--ink-dim)' }}>
           Creating run… council distribution happens off-thread once launched.
         </p>
       )}

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -42,7 +42,7 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
   );
 
   return (
-    <div className="flex flex-col gap-6" style={{ color: '#e6edf3' }}>
+    <div className="flex flex-col gap-6" style={{ color: 'var(--ink-high)' }}>
 
       {/* ── Header ── */}
       <div className="px-8 pt-8 pb-4 flex items-center justify-between gap-4">
@@ -56,9 +56,9 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
             onChange={e => setQuery(e.target.value)}
             className="rounded-xl px-4 py-2 text-sm font-mono outline-none"
             style={{
-              background: '#1b222e',
-              border: '1px solid rgba(230,237,243,0.12)',
-              color: '#e6edf3',
+              background: 'var(--surface-card)',
+              border: '1px solid var(--surface-raised)',
+              color: 'var(--ink-high)',
               width: '220px',
             }}
           />
@@ -66,7 +66,7 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
             type="button"
             onClick={() => navigate('/chat/new')}
             className="rounded-lg px-4 py-2 text-sm font-semibold font-mono shrink-0"
-            style={{ background: '#ffda19', color: '#0d1117' }}
+            style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
           >
             New Chat
           </button>
@@ -77,23 +77,23 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
       <div className="px-8 grid grid-cols-3 gap-4">
         {([
           { label: 'Total Chats', value: String(chats.length),  accent: undefined   },
-          { label: 'Active',      value: String(active.length), accent: '#79c0ff'   },
-          { label: 'Avg Units',   value: avgUnits,              accent: '#a78bfa'   },
+          { label: 'Active',      value: String(active.length), accent: 'var(--status-run)'   },
+          { label: 'Avg Units',   value: avgUnits,              accent: 'var(--accent)'   },
         ] as const).map(s => (
           <div
             key={s.label}
             className="rounded-2xl px-6 py-4"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <p
               className="text-xs font-mono uppercase tracking-widest"
-              style={{ color: 'rgba(230,237,243,0.4)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               {s.label}
             </p>
             <p
               className="text-3xl font-semibold mt-1"
-              style={{ color: s.accent ?? '#e6edf3' }}
+              style={{ color: s.accent ?? 'var(--ink-high)' }}
             >
               {s.value}
             </p>
@@ -106,12 +106,12 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
         {filtered.length === 0 ? (
           <div
             className="rounded-2xl p-10 text-center"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <p className="text-base font-mono font-semibold mb-3">No chat sessions yet</p>
             <p
               className="text-sm font-mono"
-              style={{ color: 'rgba(230,237,243,0.45)' }}
+              style={{ color: 'var(--ink-muted)' }}
             >
               Chat sessions let you explore your repos, ask questions, and get answers
               without kicking off a full build workflow.
@@ -121,7 +121,7 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
                 type="button"
                 onClick={() => navigate('/chat/new')}
                 className="text-sm font-mono hover:underline"
-                style={{ color: '#79c0ff', background: 'none', border: 'none', cursor: 'pointer' }}
+                style={{ color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer' }}
               >
                 Click New Chat to start
               </button>
@@ -134,10 +134,10 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
               type="button"
               onClick={() => onSelect(v.session.id)}
               className="w-full text-left rounded-2xl px-5 py-4 transition-colors"
-              style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
             >
               <p className="text-sm font-mono truncate">{v.session.problem}</p>
-              <p className="text-xs mt-1 font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="text-xs mt-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
                 {v.session.id.slice(0, 8)} · {v.session.status}
               </p>
             </button>

--- a/src/components/ComposerContext.tsx
+++ b/src/components/ComposerContext.tsx
@@ -27,17 +27,17 @@ import { contextKey, useDocContextStore } from '../store/docContext.js';
 // Record button does: they render as messages, and a message needs a thread to land in.
 
 const S = {
-  ink:    '#e6edf3',
-  faint:  'rgba(230,237,243,0.35)',
-  muted:  'rgba(230,237,243,0.55)',
-  accent: '#ffda19',
-  card:   '#1b222e',
-  border: 'rgba(230,237,243,0.1)',
-  danger: '#f85149',
+  ink:    'var(--ink-high)',
+  faint:  'var(--ink-dim)',
+  muted:  'var(--ink-muted)',
+  accent: 'var(--accent)',
+  card:   'var(--surface-card)',
+  border: 'var(--surface-raised)',
+  danger: 'var(--status-fail)',
 };
 
 const CHIP: React.CSSProperties = {
-  background: 'rgba(255,218,25,0.1)', color: S.accent, border: '1px solid rgba(255,218,25,0.25)',
+  background: 'var(--accent-subtle)', color: S.accent, border: '1px solid var(--accent-subtle)',
 };
 const ACTION: React.CSSProperties = {
   background: 'transparent', color: S.muted, border: `1px solid ${S.border}`, cursor: 'pointer',
@@ -47,7 +47,7 @@ const FIELD: React.CSSProperties = {
   borderRadius: '8px', outline: 'none',
 };
 const SUBMIT: React.CSSProperties = {
-  background: S.accent, color: '#0d1117', border: 'none', cursor: 'pointer',
+  background: S.accent, color: 'var(--accent-fg)', border: 'none', cursor: 'pointer',
 };
 const BOX: React.CSSProperties = { background: S.card, border: `1px solid ${S.border}` };
 const PANEL = 'flex flex-col gap-1.5 rounded-xl px-2.5 py-2';

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,9 +1,9 @@
 import { useConnectionStore } from '../store/connection.js';
 
 const statusConfig = {
-  connecting:   { label: 'Connecting…', color: '#ffda19' },
-  connected:    { label: 'Connected',   color: '#3fb950' },
-  disconnected: { label: 'Disconnected',color: '#f85149' },
+  connecting:   { label: 'Connecting…', color: 'var(--status-gate)' },
+  connected:    { label: 'Connected',   color: 'var(--status-run)' },
+  disconnected: { label: 'Disconnected',color: 'var(--status-fail)' },
 } as const;
 
 export function ConnectionStatus(): React.ReactElement {

--- a/src/components/ContextPopover.tsx
+++ b/src/components/ContextPopover.tsx
@@ -41,7 +41,7 @@ function SectionHead({ children }: { children: React.ReactNode }): React.ReactEl
   return (
     <p
       className="text-[10px] uppercase tracking-widest font-semibold mb-2"
-      style={{ color: 'rgba(230,237,243,0.35)' }}
+      style={{ color: 'var(--ink-dim)' }}
     >
       {children}
     </p>
@@ -49,7 +49,7 @@ function SectionHead({ children }: { children: React.ReactNode }): React.ReactEl
 }
 
 function Divider(): React.ReactElement {
-  return <div style={{ height: '1px', background: 'rgba(230,237,243,0.07)' }} />;
+  return <div style={{ height: '1px', background: 'var(--surface-raised)' }} />;
 }
 
 /**
@@ -94,9 +94,9 @@ export function ContextPopover({
       aria-label="Launch options"
       className="flex flex-col text-xs font-mono overflow-y-auto rounded-2xl"
       style={{
-        background: '#1b222e',
-        border: '1px solid rgba(230,237,243,0.15)',
-        boxShadow: '0 16px 48px rgba(0,0,0,0.55)',
+        background: 'var(--surface-card)',
+        border: '1px solid var(--surface-raised)',
+        boxShadow: 'var(--shadow-overlay)',
         width: '300px',
         maxHeight: '460px',
       }}
@@ -109,9 +109,9 @@ export function ContextPopover({
           onClick={() => fileInputRef.current?.click()}
           className="rounded-lg px-3 py-1.5 font-semibold transition-opacity hover:opacity-80"
           style={{
-            background: 'rgba(230,237,243,0.07)',
-            color: '#e6edf3',
-            border: '1px solid rgba(230,237,243,0.1)',
+            background: 'var(--surface-raised)',
+            color: 'var(--ink-high)',
+            border: '1px solid var(--surface-raised)',
           }}
         >
           Choose file(s)…
@@ -132,9 +132,9 @@ export function ContextPopover({
                 key={i}
                 className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px]"
                 style={{
-                  background: 'rgba(121,192,255,0.1)',
-                  color: '#79c0ff',
-                  border: '1px solid rgba(121,192,255,0.2)',
+                  background: 'var(--accent-subtle)',
+                  color: 'var(--accent)',
+                  border: '1px solid var(--accent-subtle)',
                 }}
               >
                 {f.name}
@@ -158,14 +158,14 @@ export function ContextPopover({
       <div className="px-4 py-3">
         <SectionHead>CLIs on/off</SectionHead>
         {roster.length === 0 ? (
-          <span style={{ color: 'rgba(230,237,243,0.3)' }}>No roster loaded</span>
+          <span style={{ color: 'var(--ink-dim)' }}>No roster loaded</span>
         ) : (
           <div className="flex flex-wrap gap-x-4 gap-y-1.5">
             {roster.map((seat) => (
               <label
                 key={seat.key}
                 className="flex items-center gap-1.5 cursor-pointer"
-                style={{ color: 'rgba(230,237,243,0.65)' }}
+                style={{ color: 'var(--ink-muted)' }}
               >
                 <input
                   type="checkbox"
@@ -177,7 +177,7 @@ export function ContextPopover({
                 {seat.health?.status === 'inactive' && (
                   <span
                     className="rounded-full border px-1.5 text-[10px] font-mono"
-                    style={{ color: '#f85149', borderColor: 'rgba(248,81,73,0.5)' }}
+                    style={{ color: 'var(--status-fail)', borderColor: 'var(--status-fail-dim)' }}
                     title={seat.health.message ?? 'marked inactive by the platform'}
                     data-testid={`seat-health-${seat.key}`}
                   >
@@ -187,7 +187,7 @@ export function ContextPopover({
                 {seat.signed_in === false && (
                   <span
                     className="rounded-full border px-1.5 text-[10px] font-mono"
-                    style={{ color: '#f85149', borderColor: 'rgba(248,81,73,0.5)' }}
+                    style={{ color: 'var(--status-fail)', borderColor: 'var(--status-fail-dim)' }}
                     title={`${seat.key} isn't signed in — runs routed there will fall back or fail. Sign in in Settings.`}
                     data-testid={`seat-signin-${seat.key}`}
                   >
@@ -210,9 +210,9 @@ export function ContextPopover({
             data-testid="launch-confirm"
             className="rounded-lg px-2 py-1"
             style={{
-              background: '#0d1117',
-              border: '1px solid rgba(230,237,243,0.14)',
-              color: '#e6edf3',
+              background: 'var(--surface-base)',
+              border: '1px solid var(--surface-raised)',
+              color: 'var(--ink-high)',
             }}
             value={confirmMode}
             onChange={(e) => onConfirmModeChange(e.target.value as ConfirmMode)}
@@ -229,9 +229,9 @@ export function ContextPopover({
               onChange={(e) => onBeforeOrdChange(Math.max(1, Number(e.target.value) || 1))}
               className="w-14 rounded-lg px-2 py-1"
               style={{
-                background: '#0d1117',
-                border: '1px solid rgba(230,237,243,0.14)',
-                color: '#e6edf3',
+                background: 'var(--surface-base)',
+                border: '1px solid var(--surface-raised)',
+                color: 'var(--ink-high)',
               }}
             />
           )}
@@ -253,8 +253,8 @@ export function ContextPopover({
               className="rounded-lg px-3 py-1 capitalize font-medium transition-colors"
               style={
                 entityMode === m
-                  ? { background: 'rgba(230,237,243,0.12)', color: '#e6edf3' }
-                  : { color: 'rgba(230,237,243,0.4)' }
+                  ? { background: 'var(--surface-raised)', color: 'var(--ink-high)' }
+                  : { color: 'var(--ink-dim)' }
               }
             >
               {m}
@@ -272,9 +272,9 @@ export function ContextPopover({
           data-testid="launch-workflow"
           className="rounded-lg px-2 py-1 w-full"
           style={{
-            background: '#0d1117',
-            border: '1px solid rgba(230,237,243,0.14)',
-            color: '#e6edf3',
+            background: 'var(--surface-base)',
+            border: '1px solid var(--surface-raised)',
+            color: 'var(--ink-high)',
           }}
           value={workflow}
           onChange={(e) => onWorkflowChange(e.target.value)}
@@ -297,7 +297,7 @@ export function ContextPopover({
       <div className="px-4 py-3">
         <SectionHead>Add repos</SectionHead>
         {repos.length === 0 ? (
-          <p className="text-[11px] font-mono italic" style={{ color: 'rgba(230,237,243,0.3)' }}>No repos registered.</p>
+          <p className="text-[11px] font-mono italic" style={{ color: 'var(--ink-dim)' }}>No repos registered.</p>
         ) : (
           <div className="flex flex-col gap-1.5 max-h-36 overflow-y-auto pr-1">
             {repos.map((r) => {
@@ -305,7 +305,7 @@ export function ContextPopover({
               return (
                 <label
                   key={r.id}
-                  className="flex items-center gap-2 cursor-pointer rounded px-1 py-0.5 hover:bg-[rgba(230,237,243,0.04)]"
+                  className="flex items-center gap-2 cursor-pointer rounded px-1 py-0.5 hover:bg-[var(--surface-raised)]"
                 >
                   <input
                     type="checkbox"
@@ -315,9 +315,9 @@ export function ContextPopover({
                       if (checked) onRepoRefsChange(repoRefs.filter((id) => id !== r.id));
                       else onRepoRefsChange([...repoRefs, r.id]);
                     }}
-                    className="accent-[#ffda19] w-3.5 h-3.5 shrink-0"
+                    className="w-3.5 h-3.5 shrink-0" style={{ accentColor: 'var(--accent)' }}
                   />
-                  <span className="text-[11px] font-mono truncate" style={{ color: '#e6edf3' }}>
+                  <span className="text-[11px] font-mono truncate" style={{ color: 'var(--ink-high)' }}>
                     {r.name}
                   </span>
                 </label>

--- a/src/components/CoverageView.tsx
+++ b/src/components/CoverageView.tsx
@@ -70,12 +70,12 @@ function GateStatus({ report }: { report: CoverageReport }): React.ReactElement 
   // yet" and "extraction left holes" are different problems with different next actions, and
   // collapsing them is the defect this file already carries a note about.
   const style = {
-    pass: { bg: 'rgba(63,185,80,0.12)', fg: '#3fb950', bd: 'rgba(63,185,80,0.3)', label: 'GATE PASS' },
-    deny: { bg: 'rgba(248,81,73,0.12)', fg: '#f85149', bd: 'rgba(248,81,73,0.3)', label: 'GATE FAIL' },
+    pass: { bg: 'var(--status-run-dim)', fg: 'var(--status-run)', bd: 'var(--status-run-dim)', label: 'GATE PASS' },
+    deny: { bg: 'var(--status-fail-dim)', fg: 'var(--status-fail)', bd: 'var(--status-fail-dim)', label: 'GATE FAIL' },
     'no-data': {
-      bg: 'rgba(230,237,243,0.08)',
-      fg: 'rgba(230,237,243,0.6)',
-      bd: 'rgba(230,237,243,0.2)',
+      bg: 'var(--surface-raised)',
+      fg: 'var(--ink-muted)',
+      bd: 'var(--surface-raised)',
       label: 'NOT EXTRACTED',
     },
   }[verdict];
@@ -112,10 +112,10 @@ function Ledger({ report }: { report: CoverageReport }): React.ReactElement {
         <div
           key={label}
           className="rounded p-2 text-center"
-          style={{ border: '1px solid rgba(230,237,243,0.07)', background: '#1b222e' }}
+          style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
         >
-          <p className="text-[11px]" style={{ color: 'rgba(230,237,243,0.4)' }}>{label}</p>
-          <p className="text-sm font-semibold" style={{ color: '#e6edf3' }}>{value}</p>
+          <p className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>{label}</p>
+          <p className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>{value}</p>
         </div>
       ))}
     </div>
@@ -123,11 +123,11 @@ function Ledger({ report }: { report: CoverageReport }): React.ReactElement {
 }
 
 function PerAppTable({ apps }: { apps: CoveragePerApp[] }): React.ReactElement {
-  if (apps.length === 0) return <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>No per-app data.</p>;
+  if (apps.length === 0) return <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>No per-app data.</p>;
   return (
     <table className="w-full text-[11px]">
       <thead>
-        <tr className="border-b text-left" style={{ borderColor: 'rgba(230,237,243,0.08)', color: 'rgba(230,237,243,0.4)' }}>
+        <tr className="border-b text-left" style={{ borderColor: 'var(--surface-raised)', color: 'var(--ink-dim)' }}>
           <th className="py-1 pr-3 font-medium">App</th>
           <th className="py-1 pr-3 font-medium text-right">Behavior-bearing</th>
           <th className="py-1 pr-3 font-medium text-right">Resolved</th>
@@ -138,13 +138,13 @@ function PerAppTable({ apps }: { apps: CoveragePerApp[] }): React.ReactElement {
       </thead>
       <tbody>
         {apps.map((a) => (
-          <tr key={a.app} className="border-b" style={{ borderColor: 'rgba(230,237,243,0.06)' }}>
-            <td className="py-1 pr-3 font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>{a.app}</td>
-            <td className="py-1 pr-3 text-right" style={{ color: 'rgba(230,237,243,0.6)' }}>{a.behavior_bearing}</td>
-            <td className="py-1 pr-3 text-right" style={{ color: '#3fb950' }}>{a.resolved}</td>
-            <td className="py-1 pr-3 text-right" style={{ color: '#ffda19' }}>{a.risk_flagged}</td>
-            <td className="py-1 pr-3 text-right" style={{ color: '#f85149' }}>{a.unaccounted}</td>
-            <td className="py-1 text-right font-semibold" style={{ color: '#e6edf3' }}>{coveragePct(a)}</td>
+          <tr key={a.app} className="border-b" style={{ borderColor: 'var(--surface-raised)' }}>
+            <td className="py-1 pr-3 font-mono" style={{ color: 'var(--ink-muted)' }}>{a.app}</td>
+            <td className="py-1 pr-3 text-right" style={{ color: 'var(--ink-muted)' }}>{a.behavior_bearing}</td>
+            <td className="py-1 pr-3 text-right" style={{ color: 'var(--status-run)' }}>{a.resolved}</td>
+            <td className="py-1 pr-3 text-right" style={{ color: 'var(--status-gate)' }}>{a.risk_flagged}</td>
+            <td className="py-1 pr-3 text-right" style={{ color: 'var(--status-fail)' }}>{a.unaccounted}</td>
+            <td className="py-1 text-right font-semibold" style={{ color: 'var(--ink-high)' }}>{coveragePct(a)}</td>
           </tr>
         ))}
       </tbody>
@@ -170,7 +170,7 @@ function NodeSortBtn({
       type="button"
       onClick={() => onSort(col)}
       className="font-medium transition-colors"
-      style={{ color: active === col ? '#79c0ff' : 'rgba(230,237,243,0.4)' }}
+      style={{ color: active === col ? 'var(--accent)' : 'var(--ink-dim)' }}
     >
       {children}
       {active === col ? (dir === 'asc' ? ' ▲' : ' ▼') : ''}
@@ -216,10 +216,10 @@ function UnaccountedList({ nodes }: { nodes: UnaccountedNode[] }): React.ReactEl
     });
   }, [nodes, query, kindFilter, appFilter, sortKey, sortDir]);
 
-  const inputStyle = { background: '#161c26', border: '1px solid rgba(230,237,243,0.1)', color: '#e6edf3' };
+  const inputStyle = { background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' };
 
   if (nodes.length === 0) {
-    return <p className="text-xs" style={{ color: '#3fb950' }}>No unaccounted nodes — gate is satisfied.</p>;
+    return <p className="text-xs" style={{ color: 'var(--status-run)' }}>No unaccounted nodes — gate is satisfied.</p>;
   }
 
   return (
@@ -254,14 +254,14 @@ function UnaccountedList({ nodes }: { nodes: UnaccountedNode[] }): React.ReactEl
           <option value="">All apps</option>
           {apps.map((a) => <option key={a} value={a}>{a}</option>)}
         </select>
-        <span className="ml-auto text-[11px]" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <span className="ml-auto text-[11px]" style={{ color: 'var(--ink-dim)' }}>
           {filtered.length} / {nodes.length} hole{nodes.length !== 1 ? 's' : ''}
         </span>
       </div>
 
       <table className="w-full text-[11px]">
         <thead>
-          <tr className="border-b" style={{ borderColor: 'rgba(230,237,243,0.08)' }}>
+          <tr className="border-b" style={{ borderColor: 'var(--surface-raised)' }}>
             <th className="py-1 pr-3">
               <NodeSortBtn col="name" active={sortKey} dir={sortDir} onSort={handleSort}>Name</NodeSortBtn>
             </th>
@@ -281,12 +281,12 @@ function UnaccountedList({ nodes }: { nodes: UnaccountedNode[] }): React.ReactEl
             <tr
               key={n.symbol_id}
               className="border-b"
-              style={{ borderColor: 'rgba(230,237,243,0.06)' }}
+              style={{ borderColor: 'var(--surface-raised)' }}
             >
-              <td className="py-1 pr-3 font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>{n.name ?? n.symbol_id}</td>
-              <td className="py-1 pr-3" style={{ color: 'rgba(230,237,243,0.45)' }}>{n.kind ?? '—'}</td>
-              <td className="py-1 pr-3" style={{ color: 'rgba(230,237,243,0.45)' }}>{n.app ?? '—'}</td>
-              <td className="py-1" style={{ color: 'rgba(230,237,243,0.35)' }} title={n.file}>
+              <td className="py-1 pr-3 font-mono" style={{ color: 'var(--ink-muted)' }}>{n.name ?? n.symbol_id}</td>
+              <td className="py-1 pr-3" style={{ color: 'var(--ink-muted)' }}>{n.kind ?? '—'}</td>
+              <td className="py-1 pr-3" style={{ color: 'var(--ink-muted)' }}>{n.app ?? '—'}</td>
+              <td className="py-1" style={{ color: 'var(--ink-dim)' }} title={n.file}>
                 <div className="truncate max-w-xs">{n.file ?? '—'}</div>
               </td>
             </tr>
@@ -347,7 +347,7 @@ export function CoverageView(): React.ReactElement {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold" style={{ color: '#e6edf3' }}>Coverage gate</h2>
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Coverage gate</h2>
         <div className="flex items-center gap-2">
           {/* FINDING-009: pick the repo to measure; `All` is the legacy daemon-wide (vacuous) view. */}
           <select
@@ -356,7 +356,7 @@ export function CoverageView(): React.ReactElement {
             onChange={(e) => setRepoRef(e.target.value)}
             disabled={loading}
             className="rounded px-2 py-1 text-[11px] disabled:opacity-50"
-            style={{ border: '1px solid rgba(230,237,243,0.1)', color: 'rgba(230,237,243,0.6)', background: 'transparent' }}
+            style={{ border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)', background: 'transparent' }}
           >
             <option value="">All (daemon)</option>
             {repos.map((r) => (
@@ -368,7 +368,7 @@ export function CoverageView(): React.ReactElement {
             onClick={() => void load()}
             disabled={loading}
             className="rounded px-2 py-1 text-[11px] disabled:opacity-50"
-            style={{ border: '1px solid rgba(230,237,243,0.1)', color: 'rgba(230,237,243,0.6)' }}
+            style={{ border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
           >
             {loading ? 'Loading…' : 'Refresh'}
           </button>
@@ -376,15 +376,15 @@ export function CoverageView(): React.ReactElement {
       </div>
 
       {error && (
-        <p className="rounded px-3 py-2 text-xs" style={{ background: 'rgba(248,81,73,0.08)', color: '#f85149' }}>
+        <p className="rounded px-3 py-2 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
           {error}
         </p>
       )}
 
       {!loading && !error && report === null && (
-        <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>
           No coverage data — run{' '}
-          <code className="font-mono" style={{ color: 'rgba(230,237,243,0.6)' }}>wicked-core rules ingest</code>{' '}
+          <code className="font-mono" style={{ color: 'var(--ink-muted)' }}>wicked-core rules ingest</code>{' '}
           to populate.
         </p>
       )}
@@ -393,15 +393,15 @@ export function CoverageView(): React.ReactElement {
           repo (the daemon has no repo code graph). */}
       {graphKinds && (
         <section className="flex flex-col gap-1" aria-label="Code graph summary">
-          <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+          <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
             Code graph ({graphKinds.reduce((n, k) => n + k.count, 0)} nodes)
           </p>
           {graphKinds.length === 0 ? (
-            <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>
+            <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>
               This repo’s graph holds no nodes yet — onboard the repo to populate it.
             </p>
           ) : (
-            <table className="text-xs" style={{ color: 'rgba(230,237,243,0.7)' }}>
+            <table className="text-xs" style={{ color: 'var(--ink-muted)' }}>
               <tbody>
                 {graphKinds.map((k) => (
                   <tr key={k.kind}>
@@ -418,7 +418,7 @@ export function CoverageView(): React.ReactElement {
       {report && (
         <>
           <div className="flex items-center gap-3">
-            <span className="text-2xl font-bold" style={{ color: '#e6edf3' }}>{coveragePct(report)}</span>
+            <span className="text-2xl font-bold" style={{ color: 'var(--ink-high)' }}>{coveragePct(report)}</span>
             <GateStatus report={report} />
           </div>
 
@@ -426,7 +426,7 @@ export function CoverageView(): React.ReactElement {
 
           {report.per_app.length > 0 && (
             <section className="flex flex-col gap-1">
-              <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+              <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
                 Per-app
               </p>
               <PerAppTable apps={report.per_app} />
@@ -434,7 +434,7 @@ export function CoverageView(): React.ReactElement {
           )}
 
           <section className="flex flex-col gap-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+            <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
               Coverage holes ({report.unaccounted})
             </p>
             <UnaccountedList nodes={report.unaccounted_nodes} />

--- a/src/components/CytoGraph.tsx
+++ b/src/components/CytoGraph.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
 import type { CodeGraphNode, CodeGraphEdge } from '../api/types.js';
+import { resolveToken } from '../styles/resolveToken.js';
 
 cytoscape.use(fcose as Parameters<typeof cytoscape.use>[0]);
 
@@ -13,28 +14,36 @@ interface Props {
   onNodeSelect?: (node: CodeGraphNode | null) => void;
 }
 
-const KIND_COLORS: Record<string, string> = {
-  function:    '#10b981',
-  method:      '#10b981',
-  constructor: '#10b981',
-  class:       '#f97316',
-  struct:      '#f97316',
-  interface:   '#3b82f6',
-  type_alias:  '#3b82f6',
-  trait:       '#3b82f6',
-  enum:        '#8b5cf6',
-  macro:       '#a855f7',
+// Cytoscape parses concrete colors (no var() support), so these maps carry
+// token NAMES and nodeColor resolves them through the cascade at graph-build
+// time (§2.11's escape hatch). Same palette as ForceGraph/HotspotsView/
+// RepoGraphModal: the legacy categorical hues collapsed onto the sanctioned
+// families (§2.5/§2.6) — callables run-emerald, data shapes gate-amber,
+// interface-likes the accent, the rest accent-dim.
+const KIND_TOKENS: Record<string, string> = {
+  function:    '--status-run',
+  method:      '--status-run',
+  constructor: '--status-run',
+  class:       '--status-gate',
+  struct:      '--status-gate',
+  interface:   '--accent',
+  type_alias:  '--accent',
+  trait:       '--accent',
+  enum:        '--accent-dim',
+  macro:       '--accent-dim',
 };
-const LANG_COLORS: Record<string, string> = {
-  typescript: '#10b981',
-  javascript: '#10b981',
-  rust:       '#f97316',
-  python:     '#3b82f6',
-  go:         '#06b6d4',
+const LANG_TOKENS: Record<string, string> = {
+  typescript: '--status-run',
+  javascript: '--status-run',
+  rust:       '--status-gate',
+  python:     '--accent',
+  go:         '--accent-dim',
 };
 
 function nodeColor(n: CodeGraphNode): string {
-  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? '#9ca3af';
+  return resolveToken(
+    KIND_TOKENS[n.kind?.toLowerCase()] ?? LANG_TOKENS[n.lang?.toLowerCase()] ?? '--ink-muted',
+  );
 }
 
 function nodeSize(inDeg: number): number {
@@ -105,7 +114,7 @@ export function CytoGraph({ nodes, edges, externalSelectedId, onNodeClick, onNod
             label: 'data(label)',
             'font-size': 10,
             'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-            color: '#ffffff',
+            color: resolveToken('--ink-high'),
             'text-valign': 'center',
             'text-halign': 'center',
             'text-outline-color': 'data(color)',
@@ -122,7 +131,7 @@ export function CytoGraph({ nodes, edges, externalSelectedId, onNodeClick, onNod
           selector: 'node:selected',
           style: {
             'border-width': 3,
-            'border-color': '#fbbf24',
+            'border-color': resolveToken('--accent'),
             'border-opacity': 1,
           },
         },
@@ -138,8 +147,8 @@ export function CytoGraph({ nodes, edges, externalSelectedId, onNodeClick, onNod
           selector: 'edge',
           style: {
             width: 1,
-            'line-color': '#cbd5e1',
-            'target-arrow-color': '#94a3b8',
+            'line-color': resolveToken('--ink-body'),
+            'target-arrow-color': resolveToken('--ink-muted'),
             'target-arrow-shape': 'triangle',
             'arrow-scale': 0.7,
             'curve-style': 'bezier',
@@ -148,7 +157,7 @@ export function CytoGraph({ nodes, edges, externalSelectedId, onNodeClick, onNod
         },
         {
           selector: 'edge.highlighted',
-          style: { 'line-color': '#fbbf24', 'target-arrow-color': '#fbbf24', opacity: 0.9, width: 2 },
+          style: { 'line-color': resolveToken('--accent'), 'target-arrow-color': resolveToken('--accent'), opacity: 0.9, width: 2 },
         },
         {
           selector: 'edge.dimmed',

--- a/src/components/DataUsed.tsx
+++ b/src/components/DataUsed.tsx
@@ -10,7 +10,7 @@ export function DataUsed({ model }: Props): React.ReactElement {
   return (
     <div data-testid="data-used" className="flex flex-col gap-2 text-[11px]">
       {withFiles.length === 0 ? (
-        <p style={{ color: 'rgba(230,237,243,0.4)' }} data-testid="data-used-empty">
+        <p style={{ color: 'var(--ink-dim)' }} data-testid="data-used-empty">
           No files-read captured yet — populated from claude <code>tool_use</code> blocks via{' '}
           <code>dataUsed</code>.
         </p>
@@ -18,13 +18,13 @@ export function DataUsed({ model }: Props): React.ReactElement {
         <ul className="flex flex-col gap-2">
           {withFiles.map((u) => (
             <li key={u.ord} data-testid="data-used-unit" data-ord={u.ord}>
-              <p className="font-semibold font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+              <p className="font-semibold font-mono" style={{ color: 'var(--ink-muted)' }}>
                 unit #{u.ord}
                 {u.assignedCli ? ` · ${u.assignedCli}` : ''}
               </p>
               <ul className="mt-0.5 flex flex-col gap-0.5">
                 {u.filesRead.map((f) => (
-                  <li key={f} className="truncate font-mono" style={{ color: 'rgba(230,237,243,0.45)' }} title={f}>
+                  <li key={f} className="truncate font-mono" style={{ color: 'var(--ink-muted)' }} title={f}>
                     {f}
                   </li>
                 ))}
@@ -37,7 +37,7 @@ export function DataUsed({ model }: Props): React.ReactElement {
       <p
         data-testid="data-used-recall-disabled"
         className="rounded p-1.5 font-mono"
-        style={{ border: '1px dashed rgba(230,237,243,0.12)', color: 'rgba(230,237,243,0.35)' }}
+        style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
       >
         memory / knowledge recall: disabled (pending core-ts binding)
       </p>

--- a/src/components/DecisionsLedger.tsx
+++ b/src/components/DecisionsLedger.tsx
@@ -51,8 +51,8 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
   })();
 
   const rowStyle = {
-    background: '#161c26',
-    border: '1px solid rgba(230,237,243,0.07)',
+    background: 'var(--surface-rail)',
+    border: '1px solid var(--surface-raised)',
     borderRadius: '6px',
     padding: '8px',
   };
@@ -60,7 +60,7 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
   return (
     <div data-testid="decisions-ledger" className="flex flex-col gap-2">
       {decidedUnits.length === 0 && pendingGate === null ? (
-        <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
           No governed decisions recorded yet.
         </p>
       ) : (
@@ -69,14 +69,14 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
             <li key={u.ord} data-testid="ledger-row" data-ord={u.ord} style={rowStyle}>
               <div className="flex items-center justify-between mb-1">
                 <div className="flex items-center gap-1">
-                  <span className="font-semibold text-[11px] font-mono" style={{ color: '#e6edf3' }}>unit #{u.ord}</span>
+                  <span className="font-semibold text-[11px] font-mono" style={{ color: 'var(--ink-high)' }}>unit #{u.ord}</span>
                   {(u.role === 'creator' || u.role === 'evaluator') && (
                     <span
                       data-testid="role-badge"
                       className="text-[10px] font-mono px-1 rounded"
                       style={{
-                        background: u.role === 'evaluator' ? 'rgba(56,139,253,0.15)' : 'rgba(63,185,80,0.12)',
-                        color: u.role === 'evaluator' ? '#58a6ff' : '#3fb950',
+                        background: u.role === 'evaluator' ? 'var(--accent-subtle)' : 'var(--status-run-dim)',
+                        color: u.role === 'evaluator' ? 'var(--accent)' : 'var(--status-run)',
                       }}
                     >
                       {u.role === 'creator' ? 'Creator' : 'Evaluator'}
@@ -86,7 +86,7 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                     <span
                       data-testid="gate-badge"
                       className="text-[10px] font-mono px-1 rounded"
-                      style={{ background: 'rgba(255,218,25,0.1)', color: '#ffda19' }}
+                      style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
                     >
                       {typeof u.gate === 'string' && u.gate === 'human_confirm'
                         ? 'HUMAN-CONFIRM'
@@ -99,21 +99,21 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                     <span
                       data-testid="rework-badge"
                       className="text-[10px] font-mono px-1 rounded"
-                      style={{ background: 'rgba(248,81,73,0.12)', color: '#f85149' }}
+                      style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}
                     >
                       ×{u.attempts.length}
                     </span>
                   )}
                 </div>
-                <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                   {u.resolved ? u.stage : 'resolving…'}
                 </span>
               </div>
 
               <RoutingProvenance routing={u.routing} />
               {u.skillRef && (
-                <p className="text-[11px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
-                  skill: <span style={{ color: 'rgba(230,237,243,0.6)' }}>{u.skillRef}</span>
+                <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+                  skill: <span style={{ color: 'var(--ink-muted)' }}>{u.skillRef}</span>
                 </p>
               )}
 
@@ -121,33 +121,33 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                 <div
                   key={i}
                   className="mt-1 rounded p-1.5"
-                  style={{ background: '#0f1419', border: '1px solid rgba(230,237,243,0.05)' }}
+                  style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
                 >
                   <p className="text-[11px] font-mono">
                     <span
                       className="font-semibold"
-                      style={{ color: g.combined ? '#3fb950' : '#f85149' }}
+                      style={{ color: g.combined ? 'var(--status-run)' : 'var(--status-fail)' }}
                     >
                       {g.combined ? 'ALLOW' : 'DENY'}
                     </span>
-                    <span style={{ color: 'rgba(230,237,243,0.45)' }}>
+                    <span style={{ color: 'var(--ink-muted)' }}>
                       {' · '}{gateDecider(g)}
                       {g.criterion ? ` · ${g.criterion}` : ' · (ungated)'}
                     </span>
                   </p>
                   {g.hasDeterministicFloor && (
-                    <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                    <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                       deterministic: {g.deterministicPass ? 'pass' : 'fail'}
                     </p>
                   )}
                   {g.agentVerdict !== null && (
-                    <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                    <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                       agent: {g.agentVerdict}
                       {g.agentReasoning ? ` — ${g.agentReasoning}` : ''}
                     </p>
                   )}
                   {g.evaluatorPass !== null && (
-                    <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                    <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                       evaluator: {g.evaluatorPass ? 'pass' : 'fail'}
                       {/* Name the policies that ran, or say plainly that none did — "pass" on its
                           own reads as an enforced approval when it is a default-allow. */}
@@ -159,7 +159,7 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                     </p>
                   )}
                   {g.denialReason && (
-                    <p className="text-[10px] font-mono" style={{ color: '#f85149' }}>
+                    <p className="text-[10px] font-mono" style={{ color: 'var(--status-fail)' }}>
                       reason: {g.denialReason}
                     </p>
                   )}
@@ -167,7 +167,7 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
               ))}
 
               {u.denialReason && u.gateEvals.length === 0 && (
-                <p className="mt-1 text-[11px] font-mono" style={{ color: '#f85149' }} data-testid="ledger-denial">
+                <p className="mt-1 text-[11px] font-mono" style={{ color: 'var(--status-fail)' }} data-testid="ledger-denial">
                   denied: {u.denialReason}
                 </p>
               )}
@@ -179,9 +179,9 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
               data-testid="ledger-pending"
               className="rounded p-2 text-[11px] font-mono"
               style={{
-                background: 'rgba(255,218,25,0.06)',
-                border: '1px dashed rgba(255,218,25,0.35)',
-                color: '#ffda19',
+                background: 'var(--status-gate-dim)',
+                border: '1px dashed var(--status-gate)',
+                color: 'var(--status-gate)',
               }}
             >
               <span className="font-semibold">PENDING</span> · awaiting human · before unit #
@@ -194,8 +194,8 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
               data-testid="ledger-next"
               className="rounded p-2 text-[11px] font-mono"
               style={{
-                border: '1px dashed rgba(230,237,243,0.12)',
-                color: 'rgba(230,237,243,0.35)',
+                border: '1px dashed var(--surface-raised)',
+                color: 'var(--ink-dim)',
               }}
             >
               {nextIsGated ? 'next decision point · unit #' : 'next unit · unit #'}

--- a/src/components/DemoWizard.tsx
+++ b/src/components/DemoWizard.tsx
@@ -16,7 +16,7 @@ import { S } from './SurfaceState.js';
 // without the other is not authored, for the same reason a status line is never bare.
 
 const FIELD: React.CSSProperties = {
-  background: 'rgba(13,17,23,0.6)', border: `1px solid ${S.border}`, borderRadius: '6px',
+  background: 'var(--surface-rail)', border: `1px solid ${S.border}`, borderRadius: '6px',
   color: S.ink, fontFamily: 'inherit', fontSize: '12px', padding: '6px 8px', width: '100%',
 };
 
@@ -93,7 +93,7 @@ export function DemoWizard({ projectId, seed, msgId, onCancel, onCreated }: Demo
             {draft.steps.map((s, i) => (
               <li key={`${s.subject}-${i}`} data-testid="wizard-step" data-index={String(i)}
                   className="flex items-center gap-2 rounded-md px-2 py-1 text-[11px]"
-                  style={{ background: 'rgba(13,17,23,0.6)', border: `1px solid ${S.border}`, color: S.ink }}>
+                  style={{ background: 'var(--surface-rail)', border: `1px solid ${S.border}`, color: S.ink }}>
                 <span className="font-mono" style={{ color: S.accent }}>{i + 1}</span>
                 <span className="flex-1">{stepTitle(s)}</span>
                 <button type="button" data-testid="wizard-step-remove"
@@ -124,7 +124,7 @@ export function DemoWizard({ projectId, seed, msgId, onCancel, onCreated }: Demo
       <div className="mt-auto flex items-center gap-2 pt-2">
         <button type="button" data-testid="wizard-create" disabled={!draftReady(draft) || busy}
                 onClick={() => void create()} className="disabled:opacity-40"
-                style={{ ...BTN, background: S.accent, color: '#0d1117' }}>
+                style={{ ...BTN, background: S.accent, color: 'var(--surface-base)' }}>
           {busy ? 'Authoring…' : `Create demo (${draft.steps.length} steps)`}
         </button>
         <button type="button" data-testid="wizard-cancel" onClick={onCancel}
@@ -133,7 +133,7 @@ export function DemoWizard({ projectId, seed, msgId, onCancel, onCreated }: Demo
         </button>
       </div>
       {error !== null && (
-        <p data-testid="wizard-error" className="text-[11px] font-mono" style={{ color: '#f85149', margin: 0 }}>
+        <p data-testid="wizard-error" className="text-[11px] font-mono" style={{ color: 'var(--status-fail)', margin: 0 }}>
           {error} — nothing was created; fix it and submit again.
         </p>
       )}

--- a/src/components/DomainModelBrowser.tsx
+++ b/src/components/DomainModelBrowser.tsx
@@ -5,15 +5,15 @@ import type { DomainGraph, DomainGraphDomain, DomainGraphRequirement } from '../
 function statusBadge(status: string | undefined): React.ReactElement | null {
   if (!status) return null;
   const colors: Record<string, string> = {
-    active: '#3fb950',
-    proposed: '#ffda19',
-    deprecated: '#f85149',
+    active: 'var(--status-run)',
+    proposed: 'var(--status-gate)',
+    deprecated: 'var(--status-fail)',
   };
-  const color = colors[status] ?? 'rgba(230,237,243,0.5)';
+  const color = colors[status] ?? 'var(--ink-muted)';
   return (
     <span
       className="inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
-      style={{ background: 'rgba(230,237,243,0.06)', color }}
+      style={{ background: 'var(--surface-raised)', color }}
     >
       {status}
     </span>
@@ -23,47 +23,47 @@ function statusBadge(status: string | undefined): React.ReactElement | null {
 function RequirementRow({ id, req }: { id: string; req: DomainGraphRequirement }): React.ReactElement {
   const [open, setOpen] = useState(false);
   return (
-    <div className="rounded" style={{ border: '1px solid rgba(230,237,243,0.07)' }}>
+    <div className="rounded" style={{ border: '1px solid var(--surface-raised)' }}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="w-full flex items-start gap-2 px-3 py-2 text-left transition-colors"
         style={{ background: 'transparent' }}
-        onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(230,237,243,0.03)'; }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; }}
         onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
       >
-        <span className="mt-0.5 shrink-0 text-[10px]" style={{ color: 'rgba(230,237,243,0.25)' }}>{open ? '▾' : '▸'}</span>
+        <span className="mt-0.5 shrink-0 text-[10px]" style={{ color: 'var(--ink-dim)' }}>{open ? '▾' : '▸'}</span>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap">
-            <span className="font-mono text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>{id}</span>
-            <span className="text-[11px] font-medium truncate" style={{ color: '#e6edf3' }}>{req.title}</span>
+            <span className="font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>{id}</span>
+            <span className="text-[11px] font-medium truncate" style={{ color: 'var(--ink-high)' }}>{req.title}</span>
             {statusBadge(req.status)}
             {req.disposition && (
-              <span className="text-[10px] italic" style={{ color: 'rgba(230,237,243,0.4)' }}>{req.disposition}</span>
+              <span className="text-[10px] italic" style={{ color: 'var(--ink-dim)' }}>{req.disposition}</span>
             )}
           </div>
           {!open && req.description && (
-            <p className="text-[10px] truncate mt-0.5" style={{ color: 'rgba(230,237,243,0.4)' }}>{req.description}</p>
+            <p className="text-[10px] truncate mt-0.5" style={{ color: 'var(--ink-dim)' }}>{req.description}</p>
           )}
         </div>
-        <span className="shrink-0 text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.25)' }}>
+        <span className="shrink-0 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           {req.business_rules?.length ?? 0}br · {req.validations?.length ?? 0}val
         </span>
       </button>
 
       {open && (
-        <div className="px-4 pb-3 flex flex-col gap-2 text-[10px]" style={{ background: '#0f1419' }}>
-          {req.description && <p style={{ color: 'rgba(230,237,243,0.55)' }}>{req.description}</p>}
+        <div className="px-4 pb-3 flex flex-col gap-2 text-[10px]" style={{ background: 'var(--surface-rail)' }}>
+          {req.description && <p style={{ color: 'var(--ink-muted)' }}>{req.description}</p>}
 
           {(req.business_rules?.length ?? 0) > 0 && (
             <div>
-              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>Business rules</p>
+              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'var(--ink-dim)' }}>Business rules</p>
               <ul className="flex flex-col gap-0.5">
                 {(req.business_rules ?? []).map((br) => (
                   <li key={br.id} className="flex items-start gap-1.5">
-                    <span className="font-mono shrink-0" style={{ color: 'rgba(230,237,243,0.25)' }}>{br.id}</span>
-                    <span style={{ color: 'rgba(230,237,243,0.65)' }}>{br.statement}</span>
-                    <span className="ml-auto shrink-0 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>{(br.confidence * 100).toFixed(0)}%</span>
+                    <span className="font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>{br.id}</span>
+                    <span style={{ color: 'var(--ink-muted)' }}>{br.statement}</span>
+                    <span className="ml-auto shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>{(br.confidence * 100).toFixed(0)}%</span>
                   </li>
                 ))}
               </ul>
@@ -72,12 +72,12 @@ function RequirementRow({ id, req }: { id: string; req: DomainGraphRequirement }
 
           {(req.validations?.length ?? 0) > 0 && (
             <div>
-              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>Validations</p>
+              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'var(--ink-dim)' }}>Validations</p>
               <ul className="flex flex-col gap-0.5">
                 {(req.validations ?? []).map((v) => (
                   <li key={v.id} className="flex items-start gap-1.5">
-                    <span className="font-mono shrink-0" style={{ color: 'rgba(230,237,243,0.25)' }}>{v.id}</span>
-                    <span style={{ color: 'rgba(230,237,243,0.65)' }}>{v.statement}</span>
+                    <span className="font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>{v.id}</span>
+                    <span style={{ color: 'var(--ink-muted)' }}>{v.statement}</span>
                   </li>
                 ))}
               </ul>
@@ -86,12 +86,12 @@ function RequirementRow({ id, req }: { id: string; req: DomainGraphRequirement }
 
           {(req.error_paths?.length ?? 0) > 0 && (
             <div>
-              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'rgba(248,81,73,0.6)' }}>Error paths</p>
+              <p className="font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'var(--status-fail-dim)' }}>Error paths</p>
               <ul className="flex flex-col gap-0.5">
                 {(req.error_paths ?? []).map((ep) => (
                   <li key={ep.id} className="flex items-start gap-1.5">
-                    <span className="font-mono shrink-0" style={{ color: 'rgba(230,237,243,0.25)' }}>{ep.id}</span>
-                    <span style={{ color: '#f85149' }}>{ep.statement}</span>
+                    <span className="font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>{ep.id}</span>
+                    <span style={{ color: 'var(--status-fail)' }}>{ep.statement}</span>
                   </li>
                 ))}
               </ul>
@@ -108,29 +108,29 @@ function DomainSection({ name, domain }: { name: string; domain: DomainGraphDoma
   const reqIds = Object.keys(domain.requirements ?? {});
   const entityIds = Object.keys(domain.entities ?? {});
   return (
-    <div className="rounded-lg overflow-hidden" style={{ border: '1px solid rgba(230,237,243,0.08)' }}>
+    <div className="rounded-lg overflow-hidden" style={{ border: '1px solid var(--surface-raised)' }}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="w-full flex items-center gap-2 px-4 py-2.5 text-left transition-colors"
-        style={{ background: '#1b222e', borderBottom: '1px solid rgba(230,237,243,0.07)' }}
-        onMouseEnter={(e) => { e.currentTarget.style.background = '#1f2937'; }}
-        onMouseLeave={(e) => { e.currentTarget.style.background = '#1b222e'; }}
+        style={{ background: 'var(--surface-card)', borderBottom: '1px solid var(--surface-raised)' }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; }}
+        onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--surface-card)'; }}
       >
-        <span className="text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>{open ? '▾' : '▸'}</span>
-        <span className="font-semibold text-[12px]" style={{ color: '#e6edf3' }}>{name}</span>
-        <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+        <span className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>{open ? '▾' : '▸'}</span>
+        <span className="font-semibold text-[12px]" style={{ color: 'var(--ink-high)' }}>{name}</span>
+        <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           {reqIds.length} req · {entityIds.length} entity
         </span>
         {domain.cluster_id !== undefined && (
-          <span className="ml-auto text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.25)' }}>cluster {domain.cluster_id}</span>
+          <span className="ml-auto text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>cluster {domain.cluster_id}</span>
         )}
       </button>
 
       {open && (
-        <div className="p-3 flex flex-col gap-2" style={{ background: '#161c26' }}>
+        <div className="p-3 flex flex-col gap-2" style={{ background: 'var(--surface-rail)' }}>
           {domain.description && (
-            <p className="text-[10px] italic" style={{ color: 'rgba(230,237,243,0.4)' }}>{domain.description}</p>
+            <p className="text-[10px] italic" style={{ color: 'var(--ink-dim)' }}>{domain.description}</p>
           )}
 
           {reqIds.length > 0 && (
@@ -143,14 +143,14 @@ function DomainSection({ name, domain }: { name: string; domain: DomainGraphDoma
 
           {entityIds.length > 0 && (
             <div>
-              <p className="text-[10px] font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>Entities</p>
+              <p className="text-[10px] font-semibold uppercase tracking-wider mb-1 font-mono" style={{ color: 'var(--ink-dim)' }}>Entities</p>
               <div className="flex flex-wrap gap-1">
                 {entityIds.map((e) => (
                   <span
                     key={e}
                     title={domain.entities[e]?.description}
                     className="rounded px-2 py-0.5 text-[10px] font-mono"
-                    style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.6)' }}
+                    style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
                   >
                     {e}
                   </span>
@@ -185,26 +185,26 @@ export function DomainModelBrowser(): React.ReactElement {
 
   useEffect(() => { void load(); }, [load]);
 
-  if (loading) return <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading domain model…</p>;
+  if (loading) return <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading domain model…</p>;
   if (error) return (
-    <p className="rounded px-2 py-1 text-xs" style={{ background: 'rgba(248,81,73,0.08)', color: '#f85149' }}>
+    <p className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
       {error}
     </p>
   );
   if (!graph) {
     return (
       <div className="flex flex-col gap-2">
-        <p className="text-sm" style={{ color: 'rgba(230,237,243,0.5)' }}>No domain model found.</p>
-        <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-sm" style={{ color: 'var(--ink-muted)' }}>No domain model found.</p>
+        <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
           Run{' '}
           <span
             className="font-mono rounded px-1"
-            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.6)' }}
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
           >
             wicked-core domain-graph
           </span>{' '}
           to generate{' '}
-          <span className="font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
+          <span className="font-mono" style={{ color: 'var(--ink-muted)' }}>
             .wicked-estate/requirements/requirements_graph.json
           </span>.
         </p>
@@ -229,8 +229,8 @@ export function DomainModelBrowser(): React.ReactElement {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
-        <h2 className="text-sm font-semibold" style={{ color: '#e6edf3' }}>Domain Model</h2>
-        <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Domain Model</h2>
+        <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           schema {graph.metadata.schema_version} · {Object.keys(graph.domains).length} domains
         </span>
         <input
@@ -240,20 +240,20 @@ export function DomainModelBrowser(): React.ReactElement {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="ml-auto rounded px-2 py-0.5 text-[11px] w-40 focus:outline-none"
-          style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.1)', color: '#e6edf3' }}
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
         />
         <button
           type="button"
           onClick={() => void load()}
           className="text-[10px] hover:underline"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Refresh
         </button>
       </div>
 
       {domainNames.length === 0 ? (
-        <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>No domains match your search.</p>
+        <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>No domains match your search.</p>
       ) : (
         <div className="flex flex-col gap-3">
           {domainNames.map((name) => (
@@ -263,7 +263,7 @@ export function DomainModelBrowser(): React.ReactElement {
       )}
 
       {graph.metadata.source && (
-        <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.25)' }}>
+        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           Source: <span>{graph.metadata.source}</span>
         </p>
       )}

--- a/src/components/ElicitationPrompt.tsx
+++ b/src/components/ElicitationPrompt.tsx
@@ -83,14 +83,14 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
   return (
     <div
       className="flex flex-col gap-2 rounded p-3"
-      style={{ border: '1px solid rgba(230,237,243,0.12)', background: '#1b222e' }}
+      style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
       data-testid="elicitation-prompt"
     >
       <p className="text-[11px] font-semibold uppercase tracking-wider font-mono"
-         style={{ color: 'rgba(230,237,243,0.4)' }}>
+         style={{ color: 'var(--ink-dim)' }}>
         Input requested
       </p>
-      <p className="text-sm" style={{ color: '#e6edf3' }}>{e.message}</p>
+      <p className="text-sm" style={{ color: 'var(--ink-high)' }}>{e.message}</p>
 
       {e.options === null ? (
         <input
@@ -101,7 +101,7 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
           placeholder="Your answer"
           aria-label="Your answer"
           className="rounded px-2 py-1 text-sm"
-          style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.1)', color: '#e6edf3' }}
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
         />
       ) : (
         <div className="flex flex-wrap gap-1">
@@ -113,9 +113,9 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
               onClick={() => setChoice(opt)}
               className="rounded px-2 py-0.5 text-xs font-mono"
               style={{
-                background: choice === opt ? 'rgba(121,192,255,0.15)' : '#161c26',
-                border: `1px solid ${choice === opt ? '#79c0ff' : 'rgba(230,237,243,0.1)'}`,
-                color: '#e6edf3',
+                background: choice === opt ? 'var(--accent-subtle)' : 'var(--surface-rail)',
+                border: `1px solid ${choice === opt ? 'var(--accent)' : 'var(--surface-raised)'}`,
+                color: 'var(--ink-high)',
               }}
             >
               {opt}
@@ -125,7 +125,7 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
       )}
 
       {error !== null && (
-        <p className="text-xs" style={{ color: '#f85149' }}>{error}</p>
+        <p className="text-xs" style={{ color: 'var(--status-fail)' }}>{error}</p>
       )}
 
       <div className="flex gap-2">
@@ -135,9 +135,9 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
           onClick={() => void send('accept')}
           className="rounded px-2 py-0.5 text-xs font-semibold"
           style={{
-            background: canAccept ? 'rgba(63,185,80,0.12)' : 'rgba(230,237,243,0.05)',
-            border: `1px solid ${canAccept ? 'rgba(63,185,80,0.3)' : 'rgba(230,237,243,0.1)'}`,
-            color: canAccept ? '#3fb950' : 'rgba(230,237,243,0.3)',
+            background: canAccept ? 'var(--status-run-dim)' : 'var(--surface-raised)',
+            border: `1px solid ${canAccept ? 'var(--status-run-dim)' : 'var(--surface-raised)'}`,
+            color: canAccept ? 'var(--status-run)' : 'var(--ink-dim)',
           }}
         >
           Send
@@ -147,7 +147,7 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
           disabled={busy}
           onClick={() => void send('decline')}
           className="rounded px-2 py-0.5 text-xs"
-          style={{ border: '1px solid rgba(230,237,243,0.15)', color: 'rgba(230,237,243,0.7)' }}
+          style={{ border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
         >
           Decline
         </button>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -28,14 +28,14 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div
           className="flex flex-col items-center justify-center h-full gap-4 p-8 font-mono"
-          style={{ color: 'rgba(230,237,243,0.5)' }}
+          style={{ color: 'var(--ink-muted)' }}
         >
-          <p className="text-sm font-semibold" style={{ color: '#f85149' }}>
+          <p className="text-sm font-semibold" style={{ color: 'var(--status-fail)' }}>
             Something went wrong
           </p>
           <p
             className="text-xs text-center max-w-sm"
-            style={{ color: 'rgba(230,237,243,0.4)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >
             {this.state.error.message || 'An unexpected error occurred.'}
           </p>
@@ -43,7 +43,7 @@ export class ErrorBoundary extends Component<Props, State> {
             type="button"
             onClick={() => window.location.reload()}
             className="text-xs px-4 py-1.5 rounded-lg transition-opacity hover:opacity-80"
-            style={{ background: 'rgba(230,237,243,0.08)', color: '#e6edf3' }}
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
           >
             Reload
           </button>

--- a/src/components/FailureBanner.tsx
+++ b/src/components/FailureBanner.tsx
@@ -20,9 +20,9 @@ export function FailureBanner({ view, log }: Props): React.ReactElement | null {
         data-kind="cancelled"
         className="rounded-lg p-3 text-xs font-mono"
         style={{
-          background: 'rgba(230,237,243,0.04)',
-          border: '1px solid rgba(230,237,243,0.1)',
-          color: 'rgba(230,237,243,0.5)',
+          background: 'var(--surface-raised)',
+          border: '1px solid var(--surface-raised)',
+          color: 'var(--ink-muted)',
         }}
       >
         Run cancelled.
@@ -36,15 +36,15 @@ export function FailureBanner({ view, log }: Props): React.ReactElement | null {
       data-kind="failed"
       className="rounded-lg p-3 text-xs font-mono"
       style={{
-        background: 'rgba(248,81,73,0.08)',
-        border: '1px solid rgba(248,81,73,0.25)',
-        color: '#f85149',
+        background: 'var(--status-fail-dim)',
+        border: '1px solid var(--status-fail-dim)',
+        color: 'var(--status-fail)',
       }}
     >
       <p className="font-semibold">Run halted.</p>
-      {lastError && <p className="mt-1" style={{ color: 'rgba(230,237,243,0.65)' }}>{lastError.detail}</p>}
+      {lastError && <p className="mt-1" style={{ color: 'var(--ink-muted)' }}>{lastError.detail}</p>}
       {denied.length > 0 && (
-        <ul className="mt-1 list-disc pl-4" style={{ color: 'rgba(230,237,243,0.55)' }}>
+        <ul className="mt-1 list-disc pl-4" style={{ color: 'var(--ink-muted)' }}>
           {denied.map((u) => (
             <li key={u.id}>
               Unit #{u.ord}: {u.denial_reason ?? 'rejected'}

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -23,13 +23,13 @@ import type { FeedbackItem } from '../store/docThread.js';
 //     because documents are interactive HTML and clicking them must click them.
 
 const S = {
-  card:   '#161b22',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  accent: '#ffda19',
-  live:   '#79c0ff',
-  danger: '#f85149',
+  card:   'var(--surface-card)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  muted:  'var(--ink-muted)',
+  accent: 'var(--accent)',
+  live:   'var(--accent)',
+  danger: 'var(--status-fail)',
 };
 
 /** The bridge script runs on the frame's load; ask a few times before giving up. */
@@ -178,7 +178,7 @@ export function FeedbackOverlay({
           style={{
             ...px(hoverBox), position: 'absolute', pointerEvents: 'none',
             border: `2px solid ${S.accent}`, borderRadius: '3px',
-            background: 'rgba(255,218,25,0.08)',
+            background: 'color-mix(in srgb, var(--accent) 10%, transparent)',
           }}
         />
       )}
@@ -195,7 +195,7 @@ export function FeedbackOverlay({
               // Just OUTSIDE the element's left edge where there is room, so the pin
               // marks the target without sitting on top of the text being commented on.
               position: 'absolute', left: `${Math.max(0, box.left - 18)}px`, top: `${box.top}px`,
-              background: S.accent, borderRadius: '9px', color: '#0d1117',
+              background: S.accent, borderRadius: '9px', color: 'var(--accent-fg)',
               fontSize: '10px', fontWeight: 700, padding: '1px 6px', pointerEvents: 'none',
             }}
           >
@@ -238,7 +238,7 @@ export function FeedbackOverlay({
             <button
               type="button" data-testid="feedback-comment-add" onClick={commit}
               disabled={draft.text.trim() === ''}
-              style={{ ...btn, background: S.accent, color: '#0d1117' }}
+              style={{ ...btn, background: S.accent, color: 'var(--accent-fg)' }}
             >
               Add to batch
             </button>
@@ -268,7 +268,7 @@ export function FeedbackOverlay({
           <button
             type="button" data-testid="feedback-submit" onClick={() => void submit()} disabled={busy}
             title={`Send all ${items.length} comments as one message`}
-            style={{ ...btn, background: S.accent, color: '#0d1117' }}
+            style={{ ...btn, background: S.accent, color: 'var(--accent-fg)' }}
           >
             {busy ? '…' : `Send ${items.length} comment${items.length === 1 ? '' : 's'}`}
           </button>
@@ -284,9 +284,9 @@ export function FeedbackOverlay({
           onClick={() => { setActive((a) => !a); setDraft(null); setHover(null); }}
           style={{
             ...btn,
-            background: active ? S.live : 'rgba(13,17,23,0.75)',
+            background: active ? S.live : 'var(--scrim)',
             border: `1px solid ${active ? S.live : S.border}`,
-            color: active ? '#0d1117' : ready ? S.ink : S.muted,
+            color: active ? 'var(--surface-base)' : ready ? S.ink : S.muted,
             cursor: ready ? 'pointer' : 'not-allowed',
             opacity: ready ? 1 : 0.5,
           }}

--- a/src/components/ForceGraph.tsx
+++ b/src/components/ForceGraph.tsx
@@ -12,28 +12,28 @@ interface Props {
 }
 
 const KIND_COLORS: Record<string, string> = {
-  function:    '#10b981',
-  method:      '#10b981',
-  constructor: '#10b981',
-  class:       '#f97316',
-  struct:      '#f97316',
-  interface:   '#3b82f6',
-  type_alias:  '#3b82f6',
-  trait:       '#3b82f6',
-  enum:        '#8b5cf6',
-  macro:       '#a855f7',
+  function:    'var(--status-run)',
+  method:      'var(--status-run)',
+  constructor: 'var(--status-run)',
+  class:       'var(--status-gate)',
+  struct:      'var(--status-gate)',
+  interface:   'var(--accent)',
+  type_alias:  'var(--accent)',
+  trait:       'var(--accent)',
+  enum:        'var(--accent-dim)',
+  macro:       'var(--accent-dim)',
 };
 
 const LANG_COLORS: Record<string, string> = {
-  typescript: '#10b981',
-  javascript: '#10b981',
-  rust:       '#f97316',
-  python:     '#3b82f6',
-  go:         '#06b6d4',
+  typescript: 'var(--status-run)',
+  javascript: 'var(--status-run)',
+  rust:       'var(--status-gate)',
+  python:     'var(--accent)',
+  go:         'var(--accent-dim)',
 };
 
 function nodeColor(n: CodeGraphNode): string {
-  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? '#9ca3af';
+  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? 'var(--ink-muted)';
 }
 
 function nodeRadius(inDeg: number): number {
@@ -311,7 +311,7 @@ export function ForceGraph({
               y1={s.y}
               x2={t.x}
               y2={t.y}
-              stroke="#6b7280"
+              stroke="var(--ink-dim)"
               strokeOpacity={highlighted ? 0.8 : 0.3}
               strokeWidth={highlighted ? 1.5 : 1}
             />
@@ -366,14 +366,14 @@ export function ForceGraph({
                 width={labelW}
                 height={subLabel ? 30 : 18}
                 rx={3}
-                fill="#1f2937"
+                fill="var(--surface-raised)"
                 opacity={0.92}
               />
               <text x={hoverPos.x + rad + 11} y={hoverPos.y - 3} fontSize={11} fontWeight="600" fill="white">
                 {label}
               </text>
               {subLabel && (
-                <text x={hoverPos.x + rad + 11} y={hoverPos.y + 11} fontSize={9} fill="#9ca3af">
+                <text x={hoverPos.x + rad + 11} y={hoverPos.y + 11} fontSize={9} fill="var(--ink-muted)">
                   {subLabel}
                 </text>
               )}

--- a/src/components/GateNotifications.tsx
+++ b/src/components/GateNotifications.tsx
@@ -28,25 +28,25 @@ export function GateNotifications({ onSelect, runId }: Props): React.ReactElemen
           data-run-id={gate.runId}
           className="w-72 rounded-xl p-3 text-left transition-all"
           style={{
-            background: '#1b222e',
-            border: '1px solid rgba(255,218,25,0.35)',
-            boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            background: 'var(--surface-card)',
+            border: '1px solid var(--status-gate-dim)',
+            boxShadow: 'var(--shadow-overlay)',
             pointerEvents: 'auto',
           }}
-          onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.55)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'rgba(255,218,25,0.35)'; }}
+          onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--status-gate)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--status-gate-dim)'; }}
         >
           <div className="flex items-center gap-2 mb-1">
-            <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: '#ffda19' }} />
-            <p className="text-xs font-semibold" style={{ color: '#ffda19' }}>Run awaiting human</p>
+            <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-gate)' }} />
+            <p className="text-xs font-semibold" style={{ color: 'var(--status-gate)' }}>Run awaiting human</p>
           </div>
-          <p className="text-[11px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+          <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>
             {gate.runId.slice(0, 8)} · before unit #{gate.ord}
           </p>
           {gate.prompt && (
-            <p className="mt-1 text-xs line-clamp-2" style={{ color: 'rgba(230,237,243,0.6)' }}>{gate.prompt}</p>
+            <p className="mt-1 text-xs line-clamp-2" style={{ color: 'var(--ink-muted)' }}>{gate.prompt}</p>
           )}
-          <p className="mt-1.5 text-[11px] font-mono" style={{ color: '#79c0ff' }}>Review →</p>
+          <p className="mt-1.5 text-[11px] font-mono" style={{ color: 'var(--accent)' }}>Review →</p>
         </button>
       ))}
     </div>

--- a/src/components/GovernanceAudit.tsx
+++ b/src/components/GovernanceAudit.tsx
@@ -9,9 +9,9 @@ interface Props {
 
 function DecisionBadge({ decision }: { decision: GovernanceClaim['decision'] }): React.ReactElement {
   const styles: Record<GovernanceClaim['decision'], { bg: string; color: string }> = {
-    allow:                { bg: 'rgba(63,185,80,0.12)',   color: '#3fb950' },
-    deny:                 { bg: 'rgba(248,81,73,0.12)',   color: '#f85149' },
-    allow_with_conditions:{ bg: 'rgba(255,218,25,0.12)',  color: '#ffda19' },
+    allow:                { bg: 'var(--status-run-dim)',   color: 'var(--status-run)' },
+    deny:                 { bg: 'var(--status-fail-dim)',   color: 'var(--status-fail)' },
+    allow_with_conditions:{ bg: 'var(--status-gate-dim)', color: 'var(--status-gate)' },
   };
   const labels: Record<GovernanceClaim['decision'], string> = {
     allow: 'ALLOW',
@@ -36,21 +36,21 @@ function ClaimRow({ claim }: { claim: GovernanceClaim }): React.ReactElement {
   return (
     <li
       className="rounded p-2 text-[11px]"
-      style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.07)' }}
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
     >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <DecisionBadge decision={claim.decision} />
-          <span className="font-mono truncate" style={{ color: 'rgba(230,237,243,0.6)' }}>{claim.phase}</span>
+          <span className="font-mono truncate" style={{ color: 'var(--ink-muted)' }}>{claim.phase}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <span className="font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>{ts}</span>
+          <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>{ts}</span>
           {(claim.criteria || claim.obligations.length > 0 || claim.policy_ids.length > 0) && (
             <button
               type="button"
               onClick={() => setOpen((v) => !v)}
               className="text-xs"
-              style={{ color: 'rgba(230,237,243,0.35)' }}
+              style={{ color: 'var(--ink-dim)' }}
               aria-label={open ? 'Collapse' : 'Expand'}
             >
               {open ? '▲' : '▼'}
@@ -60,17 +60,17 @@ function ClaimRow({ claim }: { claim: GovernanceClaim }): React.ReactElement {
       </div>
 
       {open && (
-        <div className="mt-2 flex flex-col gap-1.5 text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
+        <div className="mt-2 flex flex-col gap-1.5 text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>
           {claim.criteria && (
             <p>
-              <span className="font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>criteria: </span>
+              <span className="font-semibold" style={{ color: 'var(--ink-muted)' }}>criteria: </span>
               {claim.criteria}
             </p>
           )}
 
           {claim.policy_ids.length > 0 && (
             <div>
-              <p className="font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>policies matched:</p>
+              <p className="font-semibold" style={{ color: 'var(--ink-muted)' }}>policies matched:</p>
               <ul className="list-inside list-disc pl-1">
                 {claim.policy_ids.map((pid) => <li key={pid}>{pid}</li>)}
               </ul>
@@ -79,7 +79,7 @@ function ClaimRow({ claim }: { claim: GovernanceClaim }): React.ReactElement {
 
           {claim.obligations.length > 0 && (
             <div>
-              <p className="font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>obligations:</p>
+              <p className="font-semibold" style={{ color: 'var(--ink-muted)' }}>obligations:</p>
               <ul className="list-inside list-disc pl-1">
                 {claim.obligations.map((ob, i) => <li key={i}>{ob}</li>)}
               </ul>
@@ -121,19 +121,19 @@ export function GovernanceAudit({ model }: Props): React.ReactElement {
       type="button"
       onClick={() => void load()}
       className="self-start text-[10px] font-mono hover:underline"
-      style={{ color: 'rgba(230,237,243,0.4)' }}
+      style={{ color: 'var(--ink-dim)' }}
     >
       Refresh
     </button>
   );
 
-  if (loading) return <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading governance claims…</p>;
+  if (loading) return <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>Loading governance claims…</p>;
   if (error) {
     return (
       <div className="flex flex-col gap-1">
         <p
           className="rounded px-2 py-1 text-xs font-mono"
-          style={{ background: 'rgba(248,81,73,0.1)', color: '#f85149', border: '1px solid rgba(248,81,73,0.2)' }}
+          style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
         >
           {error}
         </p>
@@ -145,10 +145,10 @@ export function GovernanceAudit({ model }: Props): React.ReactElement {
   if (claims.length === 0) {
     return (
       <div className="flex flex-col gap-1">
-        <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
           No governance claims recorded for this run.
         </p>
-        <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           Claims appear when wicked-core runs governance decisions (core#24/#26).
         </p>
         {refreshBtn}
@@ -162,10 +162,10 @@ export function GovernanceAudit({ model }: Props): React.ReactElement {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
           {claims.length} decision{claims.length !== 1 ? 's' : ''}
-          {denies > 0 && <span className="ml-1 font-semibold" style={{ color: '#f85149' }}>· {denies} denied</span>}
-          {conditioned > 0 && <span className="ml-1" style={{ color: '#ffda19' }}>· {conditioned} with obligations</span>}
+          {denies > 0 && <span className="ml-1 font-semibold" style={{ color: 'var(--status-fail)' }}>· {denies} denied</span>}
+          {conditioned > 0 && <span className="ml-1" style={{ color: 'var(--status-gate)' }}>· {conditioned} with obligations</span>}
         </p>
         {refreshBtn}
       </div>

--- a/src/components/HotspotsView.tsx
+++ b/src/components/HotspotsView.tsx
@@ -7,26 +7,26 @@ interface Props {
 }
 
 const KIND_COLORS: Record<string, string> = {
-  function:    '#10b981',
-  method:      '#10b981',
-  constructor: '#10b981',
-  class:       '#f97316',
-  struct:      '#f97316',
-  interface:   '#3b82f6',
-  type_alias:  '#3b82f6',
-  trait:       '#3b82f6',
-  enum:        '#8b5cf6',
-  macro:       '#a855f7',
+  function:    'var(--status-run)',
+  method:      'var(--status-run)',
+  constructor: 'var(--status-run)',
+  class:       'var(--status-gate)',
+  struct:      'var(--status-gate)',
+  interface:   'var(--accent)',
+  type_alias:  'var(--accent)',
+  trait:       'var(--accent)',
+  enum:        'var(--accent-dim)',
+  macro:       'var(--accent-dim)',
 };
 const LANG_COLORS: Record<string, string> = {
-  typescript: '#10b981',
-  javascript: '#10b981',
-  rust:       '#f97316',
-  python:     '#3b82f6',
-  go:         '#06b6d4',
+  typescript: 'var(--status-run)',
+  javascript: 'var(--status-run)',
+  rust:       'var(--status-gate)',
+  python:     'var(--accent)',
+  go:         'var(--accent-dim)',
 };
 function nodeColor(n: CodeGraphNode): string {
-  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? '#9ca3af';
+  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? 'var(--ink-muted)';
 }
 
 export function HotspotsView({ nodes, selectedId, onSelect }: Props): React.ReactElement {
@@ -34,7 +34,7 @@ export function HotspotsView({ nodes, selectedId, onSelect }: Props): React.Reac
   const maxInDeg = top40[0]?.inDeg ?? 1;
 
   return (
-    <div className="h-full flex flex-col overflow-hidden" style={{ background: '#0f1419' }}>
+    <div className="h-full flex flex-col overflow-hidden" style={{ background: 'var(--surface-rail)' }}>
       <div className="flex-1 overflow-y-auto">
         {top40.map((n, i) => {
           const barPct = maxInDeg > 0 ? (n.inDeg / maxInDeg) * 100 : 0;
@@ -50,10 +50,10 @@ export function HotspotsView({ nodes, selectedId, onSelect }: Props): React.Reac
               onClick={() => onSelect?.(n)}
               className="w-full text-left px-4 py-2.5 relative transition-colors border-b"
               style={{
-                borderColor: 'rgba(230,237,243,0.06)',
-                background: isSelected ? 'rgba(63,185,80,0.08)' : 'transparent',
+                borderColor: 'var(--surface-raised)',
+                background: isSelected ? 'var(--status-run-dim)' : 'transparent',
               }}
-              onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = 'rgba(230,237,243,0.04)'; }}
+              onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = 'var(--surface-raised)'; }}
               onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = 'transparent'; }}
             >
               <div
@@ -64,7 +64,7 @@ export function HotspotsView({ nodes, selectedId, onSelect }: Props): React.Reac
               <div className="relative flex items-center gap-2">
                 <span
                   className="text-[10px] tabular-nums w-5 text-right shrink-0 font-mono"
-                  style={{ color: 'rgba(230,237,243,0.25)' }}
+                  style={{ color: 'var(--ink-dim)' }}
                 >
                   {i + 1}
                 </span>
@@ -72,21 +72,21 @@ export function HotspotsView({ nodes, selectedId, onSelect }: Props): React.Reac
                 <span className="flex-1 min-w-0 flex flex-col">
                   <span
                     className="font-mono text-[11px] truncate font-medium"
-                    style={{ color: '#e6edf3' }}
+                    style={{ color: 'var(--ink-high)' }}
                     title={n.name || n.id}
                   >
                     {displayName}
                   </span>
                   {filePart && (
-                    <span className="text-[9px] truncate font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
-                      {n.kind && <span style={{ color: 'rgba(230,237,243,0.45)', marginRight: '4px' }}>{n.kind}</span>}
+                    <span className="text-[9px] truncate font-mono" style={{ color: 'var(--ink-dim)' }}>
+                      {n.kind && <span style={{ color: 'var(--ink-muted)', marginRight: '4px' }}>{n.kind}</span>}
                       {filePart}
                     </span>
                   )}
                 </span>
                 <span
                   className="shrink-0 text-[11px] font-semibold tabular-nums ml-2 font-mono"
-                  style={{ color: isSelected ? '#3fb950' : 'rgba(230,237,243,0.6)' }}
+                  style={{ color: isSelected ? 'var(--status-run)' : 'var(--ink-muted)' }}
                 >
                   {n.inDeg}
                 </span>

--- a/src/components/InstallGate.tsx
+++ b/src/components/InstallGate.tsx
@@ -15,7 +15,7 @@ import type { Mode } from '../hooks/useRoute.js';
 // document.
 
 const CODE: React.CSSProperties = {
-  background: '#0d1117', border: `1px solid ${S.border}`, borderRadius: '6px',
+  background: 'var(--surface-base)', border: `1px solid ${S.border}`, borderRadius: '6px',
   color: S.ink, display: 'block', fontFamily: 'ui-monospace, monospace', fontSize: '12px',
   margin: '6px 0 0', padding: '8px 10px', userSelect: 'all', whiteSpace: 'pre-wrap',
 };

--- a/src/components/LiveOutput.tsx
+++ b/src/components/LiveOutput.tsx
@@ -31,23 +31,23 @@ export function LiveOutput({ runId }: Props): React.ReactElement {
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-3" data-testid="live-output">
       <section>
         <p className="text-[11px] font-semibold uppercase tracking-wider mb-1 font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}>
+          style={{ color: 'var(--ink-dim)' }}>
           Live output
         </p>
         <div
           ref={outputRef}
           data-testid="live-output-pane"
           className="max-h-64 overflow-auto rounded p-2 text-[10px] leading-tight font-mono"
-          style={{ background: '#0d1117', color: '#e6edf3' }}
+          style={{ background: 'var(--surface-base)', color: 'var(--ink-high)' }}
         >
           {unitOutputs.length === 0 ? (
-            <span style={{ color: 'rgba(230,237,243,0.3)' }}>
+            <span style={{ color: 'var(--ink-dim)' }}>
               No streaming output — the engine emits output via transcript after each unit completes.
             </span>
           ) : (
             unitOutputs.map(({ ord, text }) => (
               <div key={ord} className="mb-2">
-                <p style={{ color: 'rgba(230,237,243,0.3)' }}>— unit #{ord} —</p>
+                <p style={{ color: 'var(--ink-dim)' }}>— unit #{ord} —</p>
                 <pre className="whitespace-pre-wrap">{text}</pre>
               </div>
             ))
@@ -57,28 +57,28 @@ export function LiveOutput({ runId }: Props): React.ReactElement {
 
       <section>
         <p className="text-[11px] font-semibold uppercase tracking-wider mb-1 font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}>
+          style={{ color: 'var(--ink-dim)' }}>
           Event log
         </p>
         <ol
           data-testid="event-log"
           className="max-h-64 overflow-auto rounded p-2 text-[11px] font-mono"
-          style={{ background: '#0f1419', border: '1px solid rgba(230,237,243,0.07)' }}
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
         >
           {log.length === 0 ? (
-            <li style={{ color: 'rgba(230,237,243,0.3)' }}>No events yet.</li>
+            <li style={{ color: 'var(--ink-dim)' }}>No events yet.</li>
           ) : (
             log.map((e) => (
               <li
                 key={e.seq}
                 className="flex gap-2 py-0.5 last:border-0"
-                style={{ borderBottom: '1px solid rgba(230,237,243,0.04)' }}
+                style={{ borderBottom: '1px solid var(--surface-raised)' }}
               >
-                <span className="shrink-0" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                <span className="shrink-0" style={{ color: 'var(--ink-dim)' }}>
                   {typeof e.ord === 'number' ? `#${e.ord}` : '·'}
                 </span>
-                <span className="font-medium shrink-0" style={{ color: '#79c0ff' }}>{e.type}</span>
-                <span className="truncate" style={{ color: 'rgba(230,237,243,0.5)' }}>{e.detail}</span>
+                <span className="font-medium shrink-0" style={{ color: 'var(--accent)' }}>{e.type}</span>
+                <span className="truncate" style={{ color: 'var(--ink-muted)' }}>{e.detail}</span>
               </li>
             ))
           )}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -3,17 +3,17 @@ import remarkGfm from 'remark-gfm';
 import type { Components } from 'react-markdown';
 
 const components: Components = {
-  h1: ({ children }) => <h1 className="text-lg font-bold mt-4 mb-2" style={{ color: '#e6edf3' }}>{children}</h1>,
-  h2: ({ children }) => <h2 className="text-base font-bold mt-3 mb-1.5" style={{ color: '#e6edf3' }}>{children}</h2>,
-  h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1" style={{ color: '#e6edf3' }}>{children}</h3>,
+  h1: ({ children }) => <h1 className="text-lg font-bold mt-4 mb-2" style={{ color: 'var(--ink-high)' }}>{children}</h1>,
+  h2: ({ children }) => <h2 className="text-base font-bold mt-3 mb-1.5" style={{ color: 'var(--ink-high)' }}>{children}</h2>,
+  h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1" style={{ color: 'var(--ink-high)' }}>{children}</h3>,
   p: ({ children }) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
   a: ({ href, children }) => (
-    <a href={href} target="_blank" rel="noopener noreferrer" className="underline" style={{ color: '#79c0ff' }}>
+    <a href={href} target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--accent)' }}>
       {children}
     </a>
   ),
   img: ({ alt }) => (
-    <span className="text-xs font-mono rounded px-1" style={{ background: 'rgba(230,237,243,0.08)', color: 'rgba(230,237,243,0.4)' }}>
+    <span className="text-xs font-mono rounded px-1" style={{ background: 'var(--surface-raised)', color: 'var(--ink-dim)' }}>
       [image{alt ? `: ${alt}` : ''}]
     </span>
   ),
@@ -24,7 +24,7 @@ const components: Components = {
       return (
         <code
           className={`block overflow-auto rounded-lg px-4 py-3 text-xs leading-5 font-mono my-2 ${className ?? ''}`}
-          style={{ background: '#0d1117', color: '#e6edf3' }}
+          style={{ background: 'var(--surface-base)', color: 'var(--ink-high)' }}
         >
           {children}
         </code>
@@ -33,7 +33,7 @@ const components: Components = {
     return (
       <code
         className="rounded px-1.5 py-0.5 text-xs font-mono"
-        style={{ background: 'rgba(230,237,243,0.1)', color: '#e6edf3' }}
+        style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
       >
         {children}
       </code>
@@ -43,7 +43,7 @@ const components: Components = {
   blockquote: ({ children }) => (
     <blockquote
       className="pl-3 my-2 italic text-sm"
-      style={{ borderLeft: '3px solid rgba(230,237,243,0.2)', color: 'rgba(230,237,243,0.6)' }}
+      style={{ borderLeft: '3px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
     >
       {children}
     </blockquote>
@@ -56,22 +56,22 @@ const components: Components = {
       <table className="text-xs w-full border-collapse font-mono">{children}</table>
     </div>
   ),
-  thead: ({ children }) => <thead style={{ borderBottom: '1px solid rgba(230,237,243,0.12)' }}>{children}</thead>,
+  thead: ({ children }) => <thead style={{ borderBottom: '1px solid var(--surface-raised)' }}>{children}</thead>,
   tbody: ({ children }) => <tbody>{children}</tbody>,
-  tr: ({ children }) => <tr style={{ borderBottom: '1px solid rgba(230,237,243,0.06)' }}>{children}</tr>,
+  tr: ({ children }) => <tr style={{ borderBottom: '1px solid var(--surface-raised)' }}>{children}</tr>,
   th: ({ children }) => (
-    <th className="text-left px-3 py-1.5 font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>
+    <th className="text-left px-3 py-1.5 font-semibold" style={{ color: 'var(--ink-muted)' }}>
       {children}
     </th>
   ),
   td: ({ children }) => (
-    <td className="px-3 py-1.5" style={{ color: '#e6edf3' }}>
+    <td className="px-3 py-1.5" style={{ color: 'var(--ink-high)' }}>
       {children}
     </td>
   ),
-  hr: () => <hr className="my-3" style={{ borderColor: 'rgba(230,237,243,0.1)' }} />,
-  strong: ({ children }) => <strong className="font-semibold" style={{ color: '#e6edf3' }}>{children}</strong>,
-  em: ({ children }) => <em style={{ color: 'rgba(230,237,243,0.8)' }}>{children}</em>,
+  hr: () => <hr className="my-3" style={{ borderColor: 'var(--surface-raised)' }} />,
+  strong: ({ children }) => <strong className="font-semibold" style={{ color: 'var(--ink-high)' }}>{children}</strong>,
+  em: ({ children }) => <em style={{ color: 'var(--ink-body)' }}>{children}</em>,
 };
 
 interface Props {
@@ -83,7 +83,7 @@ export function Markdown({ children, className }: Props): React.ReactElement {
   return (
     <div
       className={`text-sm leading-relaxed ${className ?? ''}`}
-      style={{ color: '#e6edf3' }}
+      style={{ color: 'var(--ink-high)' }}
     >
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -19,26 +19,26 @@ export function Modal({ title, onClose, children, disableEscapeKey }: Props): Re
     return () => document.removeEventListener('keydown', handler);
   }, [onClose, disableEscapeKey]);
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.6)' }}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
       <div
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
         className="relative w-[90vw] h-[80vh] rounded-xl flex flex-col shadow-2xl"
-        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.1)' }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       >
         <div
           className="flex items-center justify-between px-4 py-3 shrink-0"
-          style={{ borderBottom: '1px solid rgba(230,237,243,0.07)' }}
+          style={{ borderBottom: '1px solid var(--surface-raised)' }}
         >
-          <h2 id={titleId} className="text-sm font-semibold font-mono" style={{ color: '#e6edf3' }}>{title}</h2>
+          <h2 id={titleId} className="text-sm font-semibold font-mono" style={{ color: 'var(--ink-high)' }}>{title}</h2>
           <button
             type="button"
             onClick={onClose}
             className="text-lg leading-none transition-colors"
-            style={{ color: 'rgba(230,237,243,0.35)' }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = '#e6edf3'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = 'rgba(230,237,243,0.35)'; }}
+            style={{ color: 'var(--ink-dim)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--ink-high)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--ink-dim)'; }}
             aria-label="Close"
           >
             ✕

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -11,15 +11,15 @@ interface Props {
 // ── Design tokens (matching LeftSidebar's `S` palette) ──────────────────────
 
 const S = {
-  bg:        '#1c4053',
-  ink:       '#e6edf3',
-  muted:     'rgba(230,237,243,0.55)',
-  faint:     'rgba(230,237,243,0.3)',
-  hover:     'rgba(0,0,0,0.2)',
-  accent:    '#ffda19',
-  accentInk: '#0d1117',
-  link:      '#79c0ff',
-  danger:    '#f85149',
+  bg:        'var(--surface-overlay)',
+  ink:       'var(--ink-high)',
+  muted:     'var(--ink-muted)',
+  faint:     'var(--ink-dim)',
+  hover:     'var(--surface-raised)',
+  accent:    'var(--status-gate)',
+  accentInk: 'var(--surface-base)',
+  link:      'var(--accent)',
+  danger:    'var(--status-fail)',
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -145,12 +145,12 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
             top: 'calc(100% + 6px)',
             left: 0,
             zIndex: 200,
-            background: '#1b222e',
-            border: '1px solid rgba(230,237,243,0.12)',
+            background: 'var(--surface-card)',
+            border: '1px solid var(--surface-raised)',
             borderRadius: '10px',
             minWidth: '280px',
             maxWidth: '320px',
-            boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+            boxShadow: 'var(--shadow-overlay)',
             overflow: 'hidden',
           }}
         >
@@ -161,7 +161,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
               alignItems: 'center',
               justifyContent: 'space-between',
               padding: '10px 14px 8px',
-              borderBottom: '1px solid rgba(230,237,243,0.08)',
+              borderBottom: '1px solid var(--surface-raised)',
             }}
           >
             <span
@@ -170,7 +170,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                 fontWeight: 600,
                 textTransform: 'uppercase',
                 letterSpacing: '0.1em',
-                color: 'rgba(230,237,243,0.4)',
+                color: 'var(--ink-dim)',
                 fontFamily: 'monospace',
               }}
             >
@@ -216,13 +216,13 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                     type="button"
                     role="menuitem"
                     onClick={() => handleNotifClick(n.id, n.runId)}
-                    className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#79c0ff]"
+                    className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
                     style={{
                       width: '100%',
                       textAlign: 'left',
-                      background: n.read ? 'transparent' : 'rgba(255,218,25,0.04)',
+                      background: n.read ? 'transparent' : 'var(--status-gate-dim)',
                       border: 'none',
-                      borderBottom: '1px solid rgba(230,237,243,0.06)',
+                      borderBottom: '1px solid var(--surface-raised)',
                       padding: '10px 14px',
                       cursor: 'pointer',
                       display: 'block',
@@ -233,7 +233,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                     onMouseLeave={(e) => {
                       (e.currentTarget as HTMLButtonElement).style.background = n.read
                         ? 'transparent'
-                        : 'rgba(255,218,25,0.04)';
+                        : 'var(--status-gate-dim)';
                     }}
                   >
                     {/* Kind label + timestamp */}
@@ -274,7 +274,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                         style={{
                           fontSize: '9px',
                           fontFamily: 'monospace',
-                          color: 'rgba(230,237,243,0.3)',
+                          color: 'var(--ink-dim)',
                           whiteSpace: 'nowrap',
                           marginLeft: '8px',
                         }}
@@ -286,7 +286,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                     <p
                       style={{
                         fontSize: '11px',
-                        color: 'rgba(230,237,243,0.65)',
+                        color: 'var(--ink-muted)',
                         margin: '0 0 3px',
                         overflow: 'hidden',
                         display: '-webkit-box',

--- a/src/components/PhaseLadder.tsx
+++ b/src/components/PhaseLadder.tsx
@@ -5,17 +5,17 @@ interface Props {
 }
 
 const STATUS_DOT: Record<UnitModel['status'], { bg: string; border: string; color: string; label: string }> = {
-  pending:     { bg: 'rgba(230,237,243,0.04)', border: 'rgba(230,237,243,0.15)', color: 'rgba(230,237,243,0.3)', label: 'pending' },
-  distributed: { bg: 'rgba(121,192,255,0.08)', border: '#79c0ff',               color: '#79c0ff',               label: 'dispatched' },
-  done:        { bg: 'rgba(63,185,80,0.08)',   border: '#3fb950',                color: '#3fb950',               label: 'done' },
-  rejected:    { bg: 'rgba(248,81,73,0.08)',   border: '#f85149',                color: '#f85149',               label: 'rejected' },
+  pending:     { bg: 'var(--surface-raised)', border: 'var(--surface-raised)', color: 'var(--ink-dim)', label: 'pending' },
+  distributed: { bg: 'var(--accent-subtle)', border: 'var(--accent)',      color: 'var(--accent)',      label: 'dispatched' },
+  done:        { bg: 'var(--status-run-dim)',   border: 'var(--status-run)',                color: 'var(--status-run)',               label: 'done' },
+  rejected:    { bg: 'var(--status-fail-dim)',   border: 'var(--status-fail)',                color: 'var(--status-fail)',               label: 'rejected' },
 };
 
 const STAGE_COLOR: Record<UnitModel['stage'], string> = {
-  recon:  '#79c0ff',
-  build:  '#3fb950',
-  review: '#a78bfa',
-  test:   '#ffda19',
+  recon:  'var(--accent)',
+  build:  'var(--status-run)',
+  review: 'var(--accent-dim)',
+  test:   'var(--status-gate)',
 };
 
 export function PhaseLadder({ model }: Props): React.ReactElement {
@@ -30,7 +30,7 @@ export function PhaseLadder({ model }: Props): React.ReactElement {
 
   if (units.length === 0) {
     return (
-      <div data-testid="phase-ladder" className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+      <div data-testid="phase-ladder" className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
         No units planned yet.
       </div>
     );
@@ -38,7 +38,7 @@ export function PhaseLadder({ model }: Props): React.ReactElement {
 
   return (
     <div data-testid="phase-ladder" className="flex flex-col gap-2">
-      <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+      <p className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
         Phase ladder
       </p>
       <ol className="flex flex-wrap items-stretch gap-1">
@@ -52,13 +52,13 @@ export function PhaseLadder({ model }: Props): React.ReactElement {
                 data-ord={u.ord}
                 data-resolving="true"
               >
-                {i > 0 && <span className="h-px w-3" style={{ background: 'rgba(230,237,243,0.08)' }} aria-hidden />}
+                {i > 0 && <span className="h-px w-3" style={{ background: 'var(--surface-raised)' }} aria-hidden />}
                 <div
                   className="flex min-w-[3.5rem] flex-col items-center rounded px-2 py-1 font-mono"
                   style={{
-                    background: 'rgba(230,237,243,0.03)',
-                    border: '1px dashed rgba(230,237,243,0.15)',
-                    color: 'rgba(230,237,243,0.3)',
+                    background: 'var(--surface-raised)',
+                    border: '1px dashed var(--surface-raised)',
+                    color: 'var(--ink-dim)',
                   }}
                   title={`unit #${u.ord} — resolving (awaiting snapshot)`}
                 >
@@ -73,21 +73,21 @@ export function PhaseLadder({ model }: Props): React.ReactElement {
           const gate = u.gateEvals.length > 0;
           const gateDenied = u.gateEvals.some((g) => !g.combined) || u.status === 'rejected';
           const human = humanGateAt(u.ord);
-          const stageColor = STAGE_COLOR[u.stage] ?? 'rgba(230,237,243,0.4)';
+          const stageColor = STAGE_COLOR[u.stage] ?? 'var(--ink-dim)';
           return (
             <li key={u.ord} className="flex items-center gap-1" data-testid="ladder-unit" data-ord={u.ord}>
-              {i > 0 && <span className="h-px w-3" style={{ background: 'rgba(230,237,243,0.08)' }} aria-hidden />}
+              {i > 0 && <span className="h-px w-3" style={{ background: 'var(--surface-raised)' }} aria-hidden />}
               <div
                 className="flex min-w-[3.5rem] flex-col items-center rounded px-2 py-1 font-mono"
                 style={{
                   background: dot.bg,
-                  border: `1px solid ${isCurrent ? '#79c0ff' : dot.border}`,
-                  boxShadow: isCurrent ? '0 0 0 2px rgba(121,192,255,0.2)' : 'none',
+                  border: `1px solid ${isCurrent ? 'var(--accent)' : dot.border}`,
+                  boxShadow: isCurrent ? '0 0 0 2px var(--accent-subtle)' : 'none',
                   color: dot.color,
                 }}
                 title={`unit #${u.ord} — ${u.stage} — ${dot.label}`}
               >
-                <span className="text-[10px] font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>#{u.ord}</span>
+                <span className="text-[10px] font-semibold" style={{ color: 'var(--ink-muted)' }}>#{u.ord}</span>
                 <span className="text-[9px] font-medium uppercase" style={{ color: stageColor }}>{u.stage}</span>
                 <span className="text-[9px]">{dot.label}</span>
               </div>
@@ -95,7 +95,7 @@ export function PhaseLadder({ model }: Props): React.ReactElement {
                 <span
                   data-testid="ladder-gate"
                   className="text-xs"
-                  style={{ color: gateDenied ? '#f85149' : gate ? '#3fb950' : 'rgba(230,237,243,0.3)' }}
+                  style={{ color: gateDenied ? 'var(--status-fail)' : gate ? 'var(--status-run)' : 'var(--ink-dim)' }}
                   title={
                     gate
                       ? `gate evaluated (${gateDenied ? 'denied' : 'allowed'})`

--- a/src/components/PolicyManager.tsx
+++ b/src/components/PolicyManager.tsx
@@ -3,15 +3,15 @@ import { api } from '../api/client.js';
 import type { GovernancePolicy } from '../api/types.js';
 
 const EFFECT_COLOR: Record<string, string> = {
-  deny: '#f85149',
-  allow_with_conditions: '#ffda19',
-  allow: '#3fb950',
+  deny: 'var(--status-fail)',
+  allow_with_conditions: 'var(--status-gate)',
+  allow: 'var(--status-run)',
 };
 
 const SEVERITY_COLOR: Record<string, string> = {
-  high: '#f85149',
-  medium: '#ffda19',
-  low: 'rgba(230,237,243,0.4)',
+  high: 'var(--status-fail)',
+  medium: 'var(--status-gate)',
+  low: 'var(--ink-dim)',
 };
 
 const POLICY_TEMPLATE: GovernancePolicy = {
@@ -46,41 +46,41 @@ function PolicyRow({
     <tr
       className="text-[11px]"
       style={{
-        borderBottom: '1px solid rgba(230,237,243,0.06)',
+        borderBottom: '1px solid var(--surface-raised)',
         opacity: retired ? 0.45 : 1,
       }}
     >
-      <td className="px-3 py-2 font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>
+      <td className="px-3 py-2 font-mono" style={{ color: 'var(--ink-muted)' }}>
         {policy.id}
         {retired && (
           <span
             className="ml-2 inline-flex rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider"
-            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.45)' }}
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
           >
             retired
           </span>
         )}
       </td>
-      <td className="px-3 py-2" style={{ color: 'rgba(230,237,243,0.45)' }}>{policy.kind}</td>
+      <td className="px-3 py-2" style={{ color: 'var(--ink-muted)' }}>{policy.kind}</td>
       <td className="px-3 py-2">
         <span
           className="inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
-          style={{ background: 'rgba(230,237,243,0.06)', color: EFFECT_COLOR[policy.effect] ?? 'rgba(230,237,243,0.5)' }}
+          style={{ background: 'var(--surface-raised)', color: EFFECT_COLOR[policy.effect] ?? 'var(--ink-muted)' }}
         >
           {policy.effect}
         </span>
       </td>
-      <td className="px-3 py-2 text-[11px] font-semibold" style={{ color: SEVERITY_COLOR[policy.severity] ?? 'rgba(230,237,243,0.5)' }}>
+      <td className="px-3 py-2 text-[11px] font-semibold" style={{ color: SEVERITY_COLOR[policy.severity] ?? 'var(--ink-muted)' }}>
         {policy.severity}
       </td>
-      <td className="px-3 py-2 truncate max-w-xs" style={{ color: 'rgba(230,237,243,0.5)' }}>{policy.rule}</td>
+      <td className="px-3 py-2 truncate max-w-xs" style={{ color: 'var(--ink-muted)' }}>{policy.rule}</td>
       <td className="px-3 py-2">
         <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={() => onEdit(policy)}
             className="text-[10px] hover:underline"
-            style={{ color: '#79c0ff' }}
+            style={{ color: 'var(--accent)' }}
           >
             Edit
           </button>
@@ -100,7 +100,7 @@ function PolicyRow({
                 });
               }}
               className="text-[10px] hover:underline disabled:opacity-50"
-              style={{ color: armed ? '#f85149' : 'rgba(230,237,243,0.4)' }}
+              style={{ color: armed ? 'var(--status-fail)' : 'var(--ink-dim)' }}
             >
               {busy ? 'Retiring…' : armed ? 'Confirm retire' : 'Retire'}
             </button>
@@ -187,12 +187,12 @@ export function PolicyManager(): React.ReactElement {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
-        <h2 className="text-sm font-semibold" style={{ color: '#e6edf3' }}>Policies</h2>
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Policies</h2>
         <button
           type="button"
           onClick={() => void load()}
           className="text-[10px] hover:underline"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Refresh
         </button>
@@ -200,7 +200,7 @@ export function PolicyManager(): React.ReactElement {
           type="button"
           onClick={() => openEditor()}
           className="ml-auto rounded px-2 py-1 text-[11px] font-semibold"
-          style={{ background: '#ffda19', color: '#0d1117' }}
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
           + New policy
         </button>
@@ -209,21 +209,21 @@ export function PolicyManager(): React.ReactElement {
       {error && (
         <p
           className="rounded px-2 py-1 text-xs"
-          style={{ background: 'rgba(248,81,73,0.08)', color: '#f85149' }}
+          style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}
         >
           {error}
         </p>
       )}
 
       {loading ? (
-        <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading policies…</p>
+        <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading policies…</p>
       ) : (
-        <div className="overflow-x-auto rounded" style={{ border: '1px solid rgba(230,237,243,0.08)' }}>
+        <div className="overflow-x-auto rounded" style={{ border: '1px solid var(--surface-raised)' }}>
           <table className="w-full text-[11px]">
             <thead>
               <tr
                 className="text-[10px] uppercase tracking-wider"
-                style={{ borderBottom: '1px solid rgba(230,237,243,0.08)', background: '#0f1419', color: 'rgba(230,237,243,0.4)' }}
+                style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-rail)', color: 'var(--ink-dim)' }}
               >
                 <th className="px-3 py-2 text-left">ID</th>
                 <th className="px-3 py-2 text-left">Kind</th>
@@ -236,7 +236,7 @@ export function PolicyManager(): React.ReactElement {
             <tbody>
               {policies.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-3 py-4 text-center text-xs" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                  <td colSpan={6} className="px-3 py-4 text-center text-xs" style={{ color: 'var(--ink-dim)' }}>
                     No policies registered.
                   </td>
                 </tr>
@@ -253,15 +253,15 @@ export function PolicyManager(): React.ReactElement {
       {editorJson !== '' && (
         <div
           className="flex flex-col gap-2 rounded p-3"
-          style={{ border: '1px solid rgba(255,218,25,0.25)', background: 'rgba(255,218,25,0.04)' }}
+          style={{ border: '1px solid var(--status-gate-dim)', background: 'var(--surface-rail)' }}
         >
           <div className="flex items-center gap-2">
-            <span className="text-[11px] font-semibold" style={{ color: '#ffda19' }}>Policy JSON</span>
+            <span className="text-[11px] font-semibold" style={{ color: 'var(--status-gate)' }}>Policy JSON</span>
             <button
               type="button"
               onClick={() => { setEditorJson(''); setSaveStatus('idle'); }}
               className="ml-auto text-[10px] hover:underline"
-              style={{ color: 'rgba(230,237,243,0.4)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               Cancel
             </button>
@@ -272,10 +272,10 @@ export function PolicyManager(): React.ReactElement {
             onChange={(e) => handleEditorChange(e.target.value)}
             spellCheck={false}
             className="rounded p-2 font-mono text-[10px] focus:outline-none min-h-[200px] resize-y"
-            style={{ background: '#0d1117', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.1)' }}
+            style={{ background: 'var(--surface-base)', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
           />
           {parseError && (
-            <p className="text-[10px]" style={{ color: '#f85149' }}>{parseError}</p>
+            <p className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{parseError}</p>
           )}
           <div className="flex items-center gap-2">
             <button
@@ -283,13 +283,13 @@ export function PolicyManager(): React.ReactElement {
               onClick={() => void handleSave()}
               disabled={!!parseError || saveStatus === 'saving'}
               className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-50"
-              style={{ background: '#3fb950', color: '#0d1117' }}
+              style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
             >
               {saveStatus === 'saving' ? 'Saving…' : 'Save policy'}
             </button>
-            {saveStatus === 'ok' && <span className="text-[10px]" style={{ color: '#3fb950' }}>Saved.</span>}
+            {saveStatus === 'ok' && <span className="text-[10px]" style={{ color: 'var(--status-run)' }}>Saved.</span>}
             {saveStatus === 'error' && (
-              <span className="text-[10px]" style={{ color: '#f85149' }}>{saveError}</span>
+              <span className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{saveError}</span>
             )}
           </div>
         </div>

--- a/src/components/ProjectDetailPage.tsx
+++ b/src/components/ProjectDetailPage.tsx
@@ -4,15 +4,15 @@ import type { ActivityEntry, ProjectDetail, ProjectMember } from '../api/types.j
 import { useProjectsStore } from '../store/projects.js';
 
 const S = {
-  card:   '#161b22',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.3)',
-  accent: '#ffda19',
-  green:  '#3fb950',
-  red:    '#f85149',
-  hover:  'rgba(230,237,243,0.04)',
+  card:   'var(--surface-card)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  muted:  'var(--ink-muted)',
+  faint:  'var(--ink-dim)',
+  accent: 'var(--accent)',
+  green:  'var(--status-run)',
+  red:    'var(--status-fail)',
+  hover:  'var(--surface-raised)',
 };
 
 function IconBack(): React.ReactElement {
@@ -36,11 +36,11 @@ function Pill({ label, color }: { label: string; color: string }): React.ReactEl
 
 function MemberKindLabel({ kind }: { kind: string }): React.ReactElement {
   const colors: Record<string, string> = {
-    'crew.run': '#79c0ff',
-    'crew.chat': '#a5d6ff',
-    'crew.repo': '#7ee787',
-    'crew.workflow': '#ffa657',
-    'interactive.doc': '#d2a8ff',
+    'crew.run': 'var(--accent)',
+    'crew.chat': 'var(--accent)',
+    'crew.repo': 'var(--accent)',
+    'crew.workflow': 'var(--accent)',
+    'interactive.doc': 'var(--accent-dim)',
   };
   const color = colors[kind] ?? S.faint;
   return <Pill label={kind} color={color} />;
@@ -66,7 +66,7 @@ function ActivityRow({ entry }: { entry: ActivityEntry }): React.ReactElement {
       </div>
       <span style={{
         fontSize: '10px', fontFamily: 'monospace', flexShrink: 0,
-        color: entry.source === 'crew' ? '#79c0ff' : '#d2a8ff',
+        color: entry.source === 'crew' ? 'var(--accent)' : 'var(--accent-dim)',
       }}>
         {entry.source}
       </span>
@@ -265,7 +265,7 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
             onChange={(e) => setEditName(e.target.value)}
             autoFocus
             style={{
-              width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+              width: '100%', background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
               borderRadius: '6px', padding: '8px 10px', fontSize: '18px', fontWeight: 700,
               color: S.ink, outline: 'none', marginBottom: '8px', boxSizing: 'border-box',
             }}
@@ -276,7 +276,7 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
             rows={2}
             placeholder="Description (optional)"
             style={{
-              width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+              width: '100%', background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
               borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
               outline: 'none', resize: 'vertical', marginBottom: '10px', boxSizing: 'border-box',
               fontFamily: 'inherit',
@@ -289,7 +289,7 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
               onClick={() => void saveEdit()}
               disabled={editBusy || !editName.trim()}
               style={{
-                background: S.accent, color: '#0d1117', border: 'none', borderRadius: '6px',
+                background: S.accent, color: 'var(--accent-fg)', border: 'none', borderRadius: '6px',
                 padding: '6px 14px', fontSize: '12px', fontWeight: 700, cursor: 'pointer',
                 opacity: editBusy ? 0.5 : 1,
               }}

--- a/src/components/ProjectsPage.tsx
+++ b/src/components/ProjectsPage.tsx
@@ -4,16 +4,16 @@ import type { Project } from '../api/types.js';
 import { useProjectsStore } from '../store/projects.js';
 
 const S = {
-  bg:     '#0d1117',
-  card:   '#161b22',
-  border: 'rgba(230,237,243,0.1)',
-  ink:    '#e6edf3',
-  muted:  'rgba(230,237,243,0.55)',
-  faint:  'rgba(230,237,243,0.3)',
-  accent: '#ffda19',
-  hover:  'rgba(230,237,243,0.05)',
-  green:  '#3fb950',
-  red:    '#f85149',
+  bg:     'var(--surface-base)',
+  card:   'var(--surface-card)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  muted:  'var(--ink-muted)',
+  faint:  'var(--ink-dim)',
+  accent: 'var(--accent)',
+  hover:  'var(--surface-raised)',
+  green:  'var(--status-run)',
+  red:    'var(--status-fail)',
 };
 
 function IconFolder(): React.ReactElement {
@@ -86,7 +86,7 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
         onChange={(e) => setName(e.target.value)}
         onKeyDown={(e) => { if (e.key === 'Enter') void submit(); if (e.key === 'Escape') onCancel(); }}
         style={{
-          width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+          width: '100%', background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
           borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
           outline: 'none', marginBottom: '8px', boxSizing: 'border-box',
         }}
@@ -97,7 +97,7 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
         onChange={(e) => setDescription(e.target.value)}
         rows={2}
         style={{
-          width: '100%', background: 'rgba(255,255,255,0.05)', border: `1px solid ${S.border}`,
+          width: '100%', background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
           borderRadius: '6px', padding: '8px 10px', fontSize: '13px', color: S.ink,
           outline: 'none', resize: 'vertical', marginBottom: '12px', boxSizing: 'border-box',
           fontFamily: 'inherit',
@@ -110,7 +110,7 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
           onClick={() => void submit()}
           disabled={busy || !name.trim()}
           style={{
-            background: S.accent, color: '#0d1117', border: 'none', borderRadius: '6px',
+            background: S.accent, color: 'var(--accent-fg)', border: 'none', borderRadius: '6px',
             padding: '7px 16px', fontSize: '12px', fontWeight: 700, cursor: busy ? 'default' : 'pointer',
             opacity: busy || !name.trim() ? 0.5 : 1,
           }}
@@ -145,7 +145,7 @@ function ProjectCard({ project, onClick }: { project: Project; onClick: () => vo
       onMouseLeave={() => setHovered(false)}
       style={{
         display: 'block', width: '100%', textAlign: 'left',
-        background: hovered ? 'rgba(230,237,243,0.04)' : S.card,
+        background: hovered ? 'var(--surface-raised)' : S.card,
         border: `1px solid ${S.border}`,
         borderRadius: '10px', padding: '16px', cursor: 'pointer',
         transition: 'background 0.1s',
@@ -235,7 +235,7 @@ export function ProjectsPage({ navigate }: Props): React.ReactElement {
           onClick={() => setShowCreate(true)}
           style={{
             display: 'flex', alignItems: 'center', gap: '6px',
-            background: S.accent, color: '#0d1117', border: 'none', borderRadius: '7px',
+            background: S.accent, color: 'var(--accent-fg)', border: 'none', borderRadius: '7px',
             padding: '8px 14px', fontSize: '12px', fontWeight: 700, cursor: 'pointer',
             flexShrink: 0,
           }}

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -57,19 +57,19 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
 
   if (loading) {
     return (
-      <div className="p-8 font-mono text-sm" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading…</div>
+      <div className="p-8 font-mono text-sm" style={{ color: 'var(--ink-dim)' }}>Loading…</div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-8 font-mono text-sm" style={{ color: '#f85149' }}>{error}</div>
+      <div className="p-8 font-mono text-sm" style={{ color: 'var(--status-fail)' }}>{error}</div>
     );
   }
 
   if (!repo) {
     return (
-      <div className="p-8 font-mono text-sm" style={{ color: '#f85149' }}>Repo not found.</div>
+      <div className="p-8 font-mono text-sm" style={{ color: 'var(--status-fail)' }}>Repo not found.</div>
     );
   }
 
@@ -104,14 +104,14 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
   }
 
   return (
-    <div className="flex flex-col gap-6 p-8" style={{ color: '#e6edf3' }}>
+    <div className="flex flex-col gap-6 p-8" style={{ color: 'var(--ink-high)' }}>
       {/* Header */}
       <div className="flex flex-col gap-3">
         <button
           type="button"
           onClick={() => navigate('/repos')}
           className="text-xs font-mono self-start transition-opacity hover:opacity-70"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           ← Repositories
         </button>
@@ -124,7 +124,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                 onClick={() => void startOnboarding()}
                 disabled={onboarding}
                 className="px-3 py-1 rounded-lg text-xs font-semibold font-mono transition-opacity disabled:opacity-50"
-                style={{ background: '#ffda19', color: '#0d1117' }}
+                style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
               >
                 {onboarding ? 'Starting…' : '↺ Run Onboarding'}
               </button>
@@ -132,7 +132,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                 type="button"
                 onClick={() => onOpenGraph()}
                 className="px-3 py-1 rounded-lg text-xs font-semibold font-mono transition-opacity hover:opacity-80"
-                style={{ background: 'rgba(121,192,255,0.12)', color: '#79c0ff', border: '1px solid rgba(121,192,255,0.2)' }}
+                style={{ background: 'var(--accent-subtle)', color: 'var(--accent)', border: '1px solid var(--accent-subtle)' }}
               >
                 Open Graph →
               </button>
@@ -140,15 +140,15 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                 type="button"
                 onClick={() => setRequirementsOpen(true)}
                 className="px-3 py-1 rounded-lg text-xs font-semibold font-mono transition-opacity hover:opacity-80"
-                style={{ background: 'rgba(63,185,80,0.12)', color: '#3fb950', border: '1px solid rgba(63,185,80,0.2)' }}
+                style={{ background: 'var(--status-run-dim)', color: 'var(--status-run)', border: '1px solid var(--status-run-dim)' }}
               >
                 Open Requirements →
               </button>
             </div>
             {onboardError && (
-              <p className="text-[11px] font-mono mt-1" style={{ color: '#f85149' }}>{onboardError}</p>
+              <p className="text-[11px] font-mono mt-1" style={{ color: 'var(--status-fail)' }}>{onboardError}</p>
             )}
-            <p className="text-xs font-mono mt-1 break-all" style={{ color: 'rgba(230,237,243,0.4)' }}>
+            <p className="text-xs font-mono mt-1 break-all" style={{ color: 'var(--ink-dim)' }}>
               {repo.root_path}
             </p>
             {repo.git_url && (
@@ -158,7 +158,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-[11px] font-mono mt-0.5 block truncate hover:underline"
-                  style={{ color: '#79c0ff' }}
+                  style={{ color: 'var(--accent)' }}
                   title={repo.git_url}
                 >
                   {repo.git_url}
@@ -166,7 +166,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
               ) : (
                 <span
                   className="text-[11px] font-mono mt-0.5 block truncate"
-                  style={{ color: '#79c0ff' }}
+                  style={{ color: 'var(--accent)' }}
                   title={repo.git_url}
                 >
                   {repo.git_url}
@@ -177,9 +177,9 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
           <span
             className="shrink-0 mt-1 rounded px-2 py-0.5 text-[11px] font-mono"
             style={{
-              background: 'rgba(121,192,255,0.12)',
-              color: '#79c0ff',
-              border: '1px solid rgba(121,192,255,0.2)',
+              background: 'var(--accent-subtle)',
+              color: 'var(--accent)',
+              border: '1px solid var(--accent-subtle)',
             }}
           >
             {repo.default_branch}
@@ -191,22 +191,22 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
       <div className="grid grid-cols-4 gap-4">
         {[
           { label: 'Total Runs', value: runs.length,      accent: undefined },
-          { label: 'Active',     value: active.length,    accent: active.length > 0 ? '#79c0ff' : undefined },
-          { label: 'Completed',  value: completed.length, accent: completed.length > 0 ? '#3fb950' : undefined },
-          { label: 'Failed',     value: failed.length,    accent: failed.length > 0 ? '#f85149' : undefined },
+          { label: 'Active',     value: active.length,    accent: active.length > 0 ? 'var(--status-run)' : undefined },
+          { label: 'Completed',  value: completed.length, accent: completed.length > 0 ? 'var(--status-run)' : undefined },
+          { label: 'Failed',     value: failed.length,    accent: failed.length > 0 ? 'var(--status-fail)' : undefined },
         ].map(s => (
           <div
             key={s.label}
             className="rounded-2xl px-6 py-4"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <p
               className="text-[10px] font-semibold uppercase tracking-widest font-mono"
-              style={{ color: 'rgba(230,237,243,0.4)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               {s.label}
             </p>
-            <p className="text-3xl font-semibold mt-1" style={{ color: s.accent ?? '#e6edf3' }}>
+            <p className="text-3xl font-semibold mt-1" style={{ color: s.accent ?? 'var(--ink-high)' }}>
               {s.value}
             </p>
           </div>
@@ -241,7 +241,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                   type="button"
                   onClick={() => setExpanded(e => !e)}
                   className="mt-3 text-xs font-mono hover:underline"
-                  style={{ color: 'rgba(230,237,243,0.4)' }}
+                  style={{ color: 'var(--ink-dim)' }}
                 >
                   {expanded ? '↑ show less' : `↓ show all ${runs.length} runs`}
                 </button>
@@ -252,7 +252,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
           {/* Code Hotspots */}
           <Section title="Code Hotspots">
             {hotspots.length === 0 ? (
-              <p className="text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 Graph not yet indexed — run onboarding to build it.
               </p>
             ) : (
@@ -261,24 +261,24 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                   <div
                     key={node.id}
                     className="flex items-center gap-3 px-3 py-2 rounded-lg"
-                    style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.05)' }}
+                    style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
                   >
                     <span
                       className="text-[10px] font-mono w-4 text-right shrink-0"
-                      style={{ color: 'rgba(230,237,243,0.3)' }}
+                      style={{ color: 'var(--ink-dim)' }}
                     >
                       {i + 1}
                     </span>
                     <span
                       className="flex-1 text-xs font-mono truncate"
-                      style={{ color: 'rgba(230,237,243,0.75)' }}
+                      style={{ color: 'var(--ink-body)' }}
                       title={node.file}
                     >
                       {node.file}
                     </span>
                     <span
                       className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
-                      style={{ background: 'rgba(121,192,255,0.12)', color: '#79c0ff' }}
+                      style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
                     >
                       {node.inDeg} edges
                     </span>
@@ -286,7 +286,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                       type="button"
                       onClick={() => onOpenGraph()}
                       className="shrink-0 text-[10px] font-mono hover:underline"
-                      style={{ color: 'rgba(230,237,243,0.4)' }}
+                      style={{ color: 'var(--ink-dim)' }}
                     >
                       → Graph
                     </button>
@@ -296,7 +296,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                   type="button"
                   onClick={() => onOpenGraph()}
                   className="mt-2 self-start text-xs font-mono hover:underline"
-                  style={{ color: '#79c0ff' }}
+                  style={{ color: 'var(--accent)' }}
                 >
                   Open full graph →
                 </button>
@@ -317,21 +317,21 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                   { label: 'Files indexed', value: graphStats.fileCount },
                 ].map(s => (
                   <div key={s.label} className="flex items-center justify-between">
-                    <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>{s.label}</span>
-                    <span className="text-sm font-semibold font-mono" style={{ color: '#e6edf3' }}>{s.value.toLocaleString()}</span>
+                    <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>{s.label}</span>
+                    <span className="text-sm font-semibold font-mono" style={{ color: 'var(--ink-high)' }}>{s.value.toLocaleString()}</span>
                   </div>
                 ))}
                 <button
                   type="button"
                   onClick={() => onOpenGraph()}
                   className="mt-2 self-start text-xs font-mono hover:underline"
-                  style={{ color: '#79c0ff' }}
+                  style={{ color: 'var(--accent)' }}
                 >
                   Browse full graph →
                 </button>
               </div>
             ) : (
-              <p className="text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 No graph yet — run onboarding to index this repo.
               </p>
             )}
@@ -342,7 +342,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
             {commits === null ? (
               <SkeletonRows count={6} widths={['w-14', 'w-16', 'flex-1', 'w-12']} />
             ) : commits.length === 0 ? (
-              <p className="text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 No commits yet.
               </p>
             ) : (
@@ -355,22 +355,22 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                         target="_blank"
                         rel="noopener noreferrer"
                         className="shrink-0 text-[10px] font-mono hover:underline"
-                        style={{ color: '#79c0ff', marginTop: '1px' }}
+                        style={{ color: 'var(--accent)', marginTop: '1px' }}
                       >
                         {c.shortSha}
                       </a>
                     ) : (
-                      <span className="shrink-0 text-[10px] font-mono" style={{ color: '#79c0ff', marginTop: '1px' }}>
+                      <span className="shrink-0 text-[10px] font-mono" style={{ color: 'var(--accent)', marginTop: '1px' }}>
                         {c.shortSha}
                       </span>
                     )}
-                    <span className="shrink-0 text-[9px] font-mono truncate max-w-[80px]" style={{ color: 'rgba(230,237,243,0.45)' }} title={c.author}>
+                    <span className="shrink-0 text-[9px] font-mono truncate max-w-[80px]" style={{ color: 'var(--ink-muted)' }} title={c.author}>
                       {c.author}
                     </span>
-                    <span className="flex-1 text-[10px] font-mono truncate" style={{ color: 'rgba(230,237,243,0.8)' }} title={c.message}>
+                    <span className="flex-1 text-[10px] font-mono truncate" style={{ color: 'var(--ink-body)' }} title={c.message}>
                       {c.message.length > 72 ? `${c.message.slice(0, 72)}…` : c.message}
                     </span>
-                    <span className="shrink-0 text-[9px] font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                    <span className="shrink-0 text-[9px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                       {c.date}
                     </span>
                   </div>
@@ -384,7 +384,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
             {contributors === null ? (
               <SkeletonContributors count={4} />
             ) : contributors.length === 0 ? (
-              <p className="text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 No contributors found.
               </p>
             ) : (
@@ -395,12 +395,12 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                     <div key={`${c.email}-${c.name}-${i}`} className="flex items-center gap-2">
                       <span
                         className="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-bold font-mono"
-                        style={{ background: 'rgba(121,192,255,0.15)', color: '#79c0ff' }}
+                        style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
                       >
                         {initials}
                       </span>
-                      <span className="flex-1 text-xs font-mono truncate" style={{ color: 'rgba(230,237,243,0.8)' }}>{c.name}</span>
-                      <span className="shrink-0 text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                      <span className="flex-1 text-xs font-mono truncate" style={{ color: 'var(--ink-body)' }}>{c.name}</span>
+                      <span className="shrink-0 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                         {c.commits} commit{c.commits !== 1 ? 's' : ''}
                       </span>
                     </div>
@@ -426,7 +426,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
   );
 }
 
-const SKELETON_BG = 'rgba(230,237,243,0.06)';
+const SKELETON_BG = 'var(--surface-raised)';
 
 function SkeletonBlock({ className }: { className: string }): React.ReactElement {
   return (
@@ -472,10 +472,10 @@ function SkeletonContributors({ count }: { count: number }): React.ReactElement 
 
 function Section({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
   return (
-    <div className="rounded-2xl p-6" style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}>
+    <div className="rounded-2xl p-6" style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}>
       <h2
         className="text-[10px] font-semibold uppercase tracking-widest mb-4 font-mono"
-        style={{ color: 'rgba(230,237,243,0.4)' }}
+        style={{ color: 'var(--ink-dim)' }}
       >
         {title}
       </h2>

--- a/src/components/RepoGraphModal.tsx
+++ b/src/components/RepoGraphModal.tsx
@@ -17,48 +17,46 @@ type GraphType = 'code' | 'domain';
 
 // Wicked design tokens (matches tokens.css)
 const T = {
-  canvas:       '#0d1117',
-  canvas2:      '#161c26',
-  surface:      '#1b222e',
-  surface2:     '#0f1419',
-  ink:          '#e6edf3',
-  muted:        'rgba(230,237,243,0.55)',
-  faint:        'rgba(230,237,243,0.24)',
-  hairline:     'rgba(230,237,243,0.07)',
-  hairlineS:    'rgba(230,237,243,0.14)',
-  accent:       '#ffda19',
-  accentInk:    '#0d1117',
-  link:         '#79c0ff',
-  ok:           '#3fb950',
-  deny:         '#f85149',
-  // Blue modal
-  blue:         '#1c4053',
-  blue2:        '#182f3c',
-  blueS:        '#224a5e',
-  blueS2:       '#1a3b4e',
+  canvas:       'var(--surface-base)',
+  canvas2:      'var(--surface-rail)',
+  surface:      'var(--surface-card)',
+  surface2:     'var(--surface-rail)',
+  ink:          'var(--ink-high)',
+  muted:        'var(--ink-muted)',
+  faint:        'var(--ink-dim)',
+  hairline:     'var(--surface-raised)',
+  hairlineS:    'var(--surface-raised)',
+  accent:       'var(--accent)',
+  accentInk:    'var(--accent-fg)',
+  link:         'var(--accent)',
+  ok:           'var(--status-run)',
+  deny:         'var(--status-fail)',
+  // The former "blue modal" surfaces, now on the surface ramp.
+  blue:         'var(--surface-overlay)',
+  blue2:        'var(--surface-raised)',
 };
 
 const KIND_COLORS: Record<string, string> = {
-  function:    '#10b981',
-  method:      '#10b981',
-  constructor: '#10b981',
-  class:       '#f97316',
-  struct:      '#f97316',
-  interface:   '#3b82f6',
-  type_alias:  '#3b82f6',
-  trait:       '#3b82f6',
-  enum:        '#8b5cf6',
-  macro:       '#a855f7',
+  function:    'var(--status-run)',
+  method:      'var(--status-run)',
+  constructor: 'var(--status-run)',
+  class:       'var(--status-gate)',
+  struct:      'var(--status-gate)',
+  interface:   'var(--accent)',
+  type_alias:  'var(--accent)',
+  trait:       'var(--accent)',
+  enum:        'var(--accent-dim)',
+  macro:       'var(--accent-dim)',
 };
 const LANG_COLORS: Record<string, string> = {
-  typescript: '#10b981',
-  javascript: '#10b981',
-  rust:       '#f97316',
-  python:     '#3b82f6',
-  go:         '#06b6d4',
+  typescript: 'var(--status-run)',
+  javascript: 'var(--status-run)',
+  rust:       'var(--status-gate)',
+  python:     'var(--accent)',
+  go:         'var(--accent-dim)',
 };
 function symbolColor(n: CodeGraphNode): string {
-  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? '#9ca3af';
+  return KIND_COLORS[n.kind?.toLowerCase()] ?? LANG_COLORS[n.lang?.toLowerCase()] ?? 'var(--ink-muted)';
 }
 
 function NodeDetailPanel({
@@ -127,7 +125,7 @@ function NodeDetailPanel({
                 onClick={() => onBlast(node)}
                 disabled={blastBusy}
                 className="flex-1 px-2 py-1 rounded-lg text-[10px] font-mono font-semibold disabled:opacity-50"
-                style={{ background: 'rgba(248,81,73,0.12)', color: T.deny, border: `1px solid ${T.hairline}` }}
+                style={{ background: 'var(--status-fail-dim)', color: T.deny, border: `1px solid ${T.hairline}` }}
               >
                 {blastBusy ? 'Computing…' : '⚡ Blast radius'}
               </button>
@@ -138,7 +136,7 @@ function NodeDetailPanel({
                 onClick={() => onExpand(node)}
                 disabled={expandBusy}
                 className="flex-1 px-2 py-1 rounded-lg text-[10px] font-mono font-semibold disabled:opacity-50"
-                style={{ background: 'rgba(121,192,255,0.12)', color: T.link, border: `1px solid ${T.hairline}` }}
+                style={{ background: 'var(--accent-subtle)', color: T.link, border: `1px solid ${T.hairline}` }}
               >
                 {expandBusy ? 'Expanding…' : '⤢ Expand neighbors'}
               </button>
@@ -404,7 +402,7 @@ function DomainDetailPanel({
                     <span
                       className="text-[9px] uppercase font-semibold px-1.5 py-0.5 rounded font-mono"
                       style={{
-                        background: req.status === 'active' ? 'rgba(63,185,80,0.15)' : req.status === 'deprecated' ? 'rgba(248,81,73,0.15)' : T.surface,
+                        background: req.status === 'active' ? 'var(--status-run-dim)' : req.status === 'deprecated' ? 'var(--status-fail-dim)' : T.surface,
                         color: req.status === 'active' ? T.ok : req.status === 'deprecated' ? T.deny : T.muted,
                       }}
                     >
@@ -435,7 +433,7 @@ function PanelDots(): React.ReactElement {
   return (
     <div className="flex items-center gap-1.5">
       <span className="w-3 h-3 rounded-full" style={{ background: T.deny }} />
-      <span className="w-3 h-3 rounded-full" style={{ background: T.accent }} />
+      <span className="w-3 h-3 rounded-full" style={{ background: 'var(--status-gate)' }} />
       <span className="w-3 h-3 rounded-full" style={{ background: T.ok }} />
     </div>
   );
@@ -610,7 +608,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
         style={{
           background: active ? T.surface : 'transparent',
           color: active ? T.ink : T.muted,
-          boxShadow: active ? '0 1px 4px rgba(0,0,0,0.4)' : 'none',
+          boxShadow: active ? 'var(--shadow-card)' : 'none',
         }}
       >
         {label}
@@ -621,7 +619,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'rgba(0,0,0,0.75)' }}
+      style={{ background: 'var(--scrim)' }}
       onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       {/* Modal card — wicked teal-blue */}
@@ -630,7 +628,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
         style={{
           background: T.blue,
           border: `1px solid ${T.hairlineS}`,
-          boxShadow: '0 40px 80px -20px rgba(0,0,0,0.8)',
+          boxShadow: 'var(--shadow-overlay)',
         }}
       >
         {/* ── Header ─────────────────────────────────────────────────────── */}
@@ -646,7 +644,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
           {/* Graph-type pills */}
           <div
             className="flex gap-0.5 rounded p-0.5"
-            style={{ background: 'rgba(0,0,0,0.25)' }}
+            style={{ background: 'var(--surface-rail)' }}
           >
             {(['code', 'domain'] as GraphType[]).map((t) => (
               <TabPill key={t} value={t} current={graphType} label={t === 'code' ? 'Code' : 'Domain'} onChange={setGraphType} />
@@ -657,7 +655,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
           {graphType === 'code' && (
             <div
               className="flex gap-0.5 rounded p-0.5"
-              style={{ background: 'rgba(0,0,0,0.25)' }}
+              style={{ background: 'var(--surface-rail)' }}
             >
               {(['graph', 'hotspots'] as TabId[]).map((t) => (
                 <TabPill key={t} value={t} current={tab} label={t === 'graph' ? 'Graph' : 'Hotspots'} onChange={setTab} />
@@ -672,8 +670,8 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
               onClick={() => setHideTests((h) => !h)}
               className="flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-mono font-medium transition-colors border"
               style={{
-                borderColor: hideTests ? T.hairline : 'rgba(255,218,25,0.4)',
-                background:  hideTests ? 'rgba(0,0,0,0.2)' : 'rgba(255,218,25,0.08)',
+                borderColor: hideTests ? T.hairline : 'var(--accent-dim)',
+                background:  hideTests ? 'var(--surface-rail)' : 'var(--accent-subtle)',
                 color:       hideTests ? T.faint : T.accent,
               }}
             >
@@ -685,7 +683,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
           {codeData && graphType === 'code' && (
             <span
               className="text-[10px] font-mono px-2 py-0.5 rounded"
-              style={{ background: 'rgba(0,0,0,0.2)', color: T.muted }}
+              style={{ background: 'var(--surface-rail)', color: T.muted }}
             >
               {localNodes.length} nodes · {codeData.stats.edgeCount} edges
             </span>
@@ -802,7 +800,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
                     flex: 1,
                     border: `1px solid ${T.hairlineS}`,
                     background: T.canvas2,
-                    boxShadow: '0 20px 50px -20px rgba(0,0,0,0.6)',
+                    boxShadow: 'var(--shadow-overlay)',
                   }}
                 >
                   {/* Panel header — traffic lights + title */}
@@ -840,7 +838,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
                     flex: 1,
                     border: `1px solid ${T.hairlineS}`,
                     background: T.canvas2,
-                    boxShadow: '0 20px 50px -20px rgba(0,0,0,0.6)',
+                    boxShadow: 'var(--shadow-overlay)',
                   }}
                 >
                   <div

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -22,9 +22,9 @@ function relativeTime(tsSeconds: number): string {
 }
 
 const inputCss: React.CSSProperties = {
-  background: '#0f1419',
-  border: '1px solid rgba(230,237,243,0.14)',
-  color: '#e6edf3',
+  background: 'var(--surface-rail)',
+  border: '1px solid var(--surface-raised)',
+  color: 'var(--ink-high)',
   borderRadius: '6px',
   padding: '6px 10px',
   fontSize: '12px',
@@ -37,14 +37,14 @@ function StatCard({ label, value, hint }: { label: string; value: number; hint?:
   return (
     <div
       className="rounded-2xl p-5 flex flex-col gap-1"
-      style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
     >
-      <p className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'rgba(230,237,243,0.4)' }}>
+      <p className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'var(--ink-dim)' }}>
         {label}
       </p>
-      <p className="text-3xl font-mono font-bold" style={{ color: '#e6edf3' }}>{value}</p>
+      <p className="text-3xl font-mono font-bold" style={{ color: 'var(--ink-high)' }}>{value}</p>
       {hint && (
-        <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>{hint}</p>
+        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{hint}</p>
       )}
     </div>
   );
@@ -163,15 +163,15 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
         <div className="flex items-center gap-3 mb-5">
           <h1
             className="text-base font-bold font-mono flex-1"
-            style={{ color: '#e6edf3', letterSpacing: '-0.01em' }}
+            style={{ color: 'var(--ink-high)', letterSpacing: '-0.01em' }}
           >
             Repositories
           </h1>
           <input
             style={{
-              background: '#1b222e',
-              border: '1px solid rgba(230,237,243,0.12)',
-              color: '#e6edf3',
+              background: 'var(--surface-card)',
+              border: '1px solid var(--surface-raised)',
+              color: 'var(--ink-high)',
               borderRadius: '6px',
               padding: '6px 12px',
               fontSize: '12px',
@@ -190,7 +190,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
               else { setShowRegister(true); navigate('/repos/new'); }
             }}
             className="shrink-0 rounded-lg px-4 py-1.5 text-xs font-semibold font-mono"
-            style={{ background: showRegister ? 'rgba(230,237,243,0.1)' : '#ffda19', color: showRegister ? '#e6edf3' : '#0d1117' }}
+            style={{ background: showRegister ? 'var(--surface-raised)' : 'var(--accent)', color: showRegister ? 'var(--ink-high)' : 'var(--accent-fg)' }}
           >
             {showRegister ? 'Cancel' : '+ Add Repository'}
           </button>
@@ -200,7 +200,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
         {showRegister && (
           <div
             className="flex flex-col gap-3 rounded-2xl p-5 mb-5"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.08)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             {/* Source mode toggle — two mutually exclusive options; aria-pressed is correct for a binary toggle */}
             <div role="group" aria-label="Repository source" className="flex gap-1">
@@ -213,8 +213,8 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                   className="rounded-md px-3 py-1 text-[11px] font-mono font-medium transition-colors"
                   style={
                     sourceMode === m
-                      ? { background: 'rgba(230,237,243,0.12)', color: '#e6edf3' }
-                      : { color: 'rgba(230,237,243,0.4)' }
+                      ? { background: 'var(--surface-raised)', color: 'var(--ink-high)' }
+                      : { color: 'var(--ink-dim)' }
                   }
                 >
                   {m === 'local' ? 'Local path' : 'Remote URL'}
@@ -254,7 +254,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                   }}
                 />
                 <div className="flex flex-col gap-1">
-                  <label className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                  <label className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                     Clone to (optional)
                   </label>
                   <input
@@ -267,14 +267,14 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
               </>
             )}
 
-            <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+            <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
               {sourceMode === 'remote'
                 ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run.`
                 : 'Runs the onboarding workflow (index → annotate → domain) as a governed run.'}
             </p>
 
             {registerError && (
-              <p className="text-[11px] font-mono" style={{ color: '#f85149' }}>
+              <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
                 {registerError}
               </p>
             )}
@@ -284,7 +284,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
               onClick={() => void registerRepo()}
               disabled={registering || !canSubmit}
               className="self-start rounded-lg px-4 py-1.5 text-[11px] font-semibold font-mono disabled:opacity-50"
-              style={{ background: '#ffda19', color: '#0d1117' }}
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
             >
               {registering
                 ? sourceMode === 'remote'
@@ -318,22 +318,22 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
 
         {/* ── Content area ── */}
         {loading ? (
-          <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+          <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
             Loading repositories…
           </p>
         ) : error ? (
-          <p className="text-xs font-mono" style={{ color: '#f85149' }}>{error}</p>
+          <p className="text-xs font-mono" style={{ color: 'var(--status-fail)' }}>{error}</p>
         ) : repos.length === 0 ? (
           /* Empty state */
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <div
               className="rounded-2xl p-10 flex flex-col items-center gap-4"
-              style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)', maxWidth: 420 }}
+              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)', maxWidth: 420 }}
             >
-              <p className="text-2xl font-mono font-bold" style={{ color: 'rgba(230,237,243,0.15)' }}>
+              <p className="text-2xl font-mono font-bold" style={{ color: 'var(--ink-dim)' }}>
                 No repositories
               </p>
-              <p className="text-sm font-mono" style={{ color: 'rgba(230,237,243,0.45)' }}>
+              <p className="text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
                 Register a local git repo or clone a remote one. wicked-crew will index it,
                 annotate the domain model, and keep the knowledge graph up to date.
               </p>
@@ -341,14 +341,14 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                 type="button"
                 onClick={() => setShowRegister(true)}
                 className="rounded-lg px-5 py-2 text-xs font-semibold font-mono mt-2"
-                style={{ background: '#ffda19', color: '#0d1117' }}
+                style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
               >
                 + Add Repository
               </button>
             </div>
           </div>
         ) : filteredRepos.length === 0 ? (
-          <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+          <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
             No repos match &ldquo;{search}&rdquo;.
           </p>
         ) : (
@@ -362,7 +362,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                 <div
                   key={repo.id}
                   className="rounded-2xl p-5 flex flex-col gap-3 cursor-pointer transition-colors"
-                  style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.08)' }}
+                  style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
                   onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}
                   role="button"
                   tabIndex={0}
@@ -377,13 +377,13 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                     <div className="flex-1 min-w-0">
                       <p
                         className="text-sm font-bold font-mono truncate"
-                        style={{ color: '#e6edf3' }}
+                        style={{ color: 'var(--ink-high)' }}
                       >
                         {repo.name}
                       </p>
                       <p
                         className="text-[11px] font-mono mt-0.5 truncate"
-                        style={{ color: 'rgba(230,237,243,0.4)' }}
+                        style={{ color: 'var(--ink-dim)' }}
                         title={repo.root_path}
                       >
                         {repo.root_path}
@@ -393,14 +393,14 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                       {activeCount > 0 && (
                         <span
                           className="rounded-full px-2 py-0.5 text-[10px] font-mono font-semibold"
-                          style={{ background: 'rgba(63,185,80,0.15)', color: '#3fb950' }}
+                          style={{ background: 'var(--status-run-dim)', color: 'var(--status-run)' }}
                         >
                           {activeCount} active
                         </span>
                       )}
                       <span
                         className="rounded-full px-2 py-0.5 text-[10px] font-mono"
-                        style={{ background: 'rgba(121,192,255,0.12)', color: '#79c0ff' }}
+                        style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
                       >
                         {repo.default_branch}
                       </span>
@@ -408,13 +408,13 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                   </div>
 
                   {/* Timestamp */}
-                  <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                  <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                     {relativeTime(repo.registered_at)}
                   </p>
 
                   {/* Error (if onboard failed) */}
                   {runErr && (
-                    <p className="text-[11px] font-mono" style={{ color: '#f85149' }}>
+                    <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
                       {runErr}
                     </p>
                   )}
@@ -430,7 +430,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                       type="button"
                       onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}
                       className="text-xs font-mono hover:underline"
-                      style={{ color: '#79c0ff' }}
+                      style={{ color: 'var(--accent)' }}
                     >
                       View →
                     </button>
@@ -440,9 +440,9 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                       onClick={() => void rerunOnboarding(repo.id)}
                       className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
                       style={{
-                        background: 'rgba(230,237,243,0.07)',
-                        color: 'rgba(230,237,243,0.6)',
-                        border: '1px solid rgba(230,237,243,0.08)',
+                        background: 'var(--surface-raised)',
+                        color: 'var(--ink-muted)',
+                        border: '1px solid var(--surface-raised)',
                       }}
                     >
                       {isRerunning ? 'Starting…' : 'Onboard'}

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -13,19 +13,19 @@ import { api } from '../api/client.js';
 import type { RequirementSummary, RequirementDetail, RequirementsPage, RequirementPatch } from '../api/types.js';
 
 const T = {
-  canvas: '#0d1117',
-  canvas2: '#121826',
-  surface: '#151b2c',
-  surface2: '#161d2f',
-  ink: '#e6edf3',
-  muted: 'rgba(230,237,243,0.6)',
-  faint: 'rgba(230,237,243,0.35)',
-  hairline: 'rgba(230,237,243,0.08)',
-  hairlineS: 'rgba(230,237,243,0.14)',
-  ok: '#3fb950',
-  deny: '#f85149',
-  link: '#79c0ff',
-  accent: '#ffda19',
+  canvas: 'var(--surface-base)',
+  canvas2: 'var(--surface-rail)',
+  surface: 'var(--surface-card)',
+  surface2: 'var(--surface-raised)',
+  ink: 'var(--ink-high)',
+  muted: 'var(--ink-muted)',
+  faint: 'var(--ink-dim)',
+  hairline: 'var(--surface-raised)',
+  hairlineS: 'var(--surface-raised)',
+  ok: 'var(--status-run)',
+  deny: 'var(--status-fail)',
+  link: 'var(--accent)',
+  accent: 'var(--accent)',
 };
 
 const PAGE_SIZE = 50;
@@ -102,7 +102,7 @@ export function RequirementsModal({ repoId, repoName, onClose, onNavigateCompone
   const pageNo = Math.floor(offset / PAGE_SIZE) + 1;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.6)' }}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
       <div
         className="w-[92vw] h-[92vh] rounded-2xl flex flex-col overflow-hidden border"
         style={{ background: T.surface, border: `1px solid ${T.hairlineS}` }}
@@ -172,7 +172,7 @@ export function RequirementsModal({ repoId, repoName, onClose, onNavigateCompone
                 aria-pressed={risk === r}
                 className="px-2.5 py-1 rounded-lg text-[11px] font-mono font-semibold"
                 style={{
-                  background: risk === r ? (r === 'risk' ? 'rgba(248,81,73,0.18)' : T.surface2) : 'transparent',
+                  background: risk === r ? (r === 'risk' ? 'var(--status-fail-dim)' : T.surface2) : 'transparent',
                   color: risk === r ? (r === 'risk' ? T.deny : T.ink) : T.faint,
                   border: `1px solid ${risk === r ? T.hairlineS : 'transparent'}`,
                 }}
@@ -307,7 +307,7 @@ function RequirementRow({
       {req.risk && (
         <span
           className="text-[9px] uppercase font-semibold font-mono px-1.5 py-0.5 rounded shrink-0"
-          style={{ background: 'rgba(248,81,73,0.15)', color: T.deny }}
+          style={{ background: 'var(--status-fail-dim)', color: T.deny }}
           title={req.riskSource === 'operator' ? 'Marked risk by operator' : 'Risk derived from business rules'}
         >
           risk{req.riskSource === 'operator' ? ' ●' : ''}
@@ -316,7 +316,7 @@ function RequirementRow({
       <span
         className="text-[9px] uppercase font-mono px-1.5 py-0.5 rounded shrink-0"
         style={{
-          background: req.status === 'active' ? 'rgba(63,185,80,0.12)' : req.status === 'deprecated' ? 'rgba(248,81,73,0.12)' : T.surface2,
+          background: req.status === 'active' ? 'var(--status-run-dim)' : req.status === 'deprecated' ? 'var(--status-fail-dim)' : T.surface2,
           color: req.status === 'active' ? T.ok : req.status === 'deprecated' ? T.deny : T.muted,
         }}
       >
@@ -470,7 +470,7 @@ function RequirementEditRail({
               disabled={saving}
               className="text-[11px] font-mono font-semibold px-3 py-1 rounded-lg disabled:opacity-50"
               style={{
-                background: detail.risk ? 'rgba(248,81,73,0.18)' : T.canvas2,
+                background: detail.risk ? 'var(--status-fail-dim)' : T.canvas2,
                 color: detail.risk ? T.deny : T.muted,
                 border: `1px solid ${T.hairlineS}`,
               }}
@@ -545,7 +545,7 @@ function RequirementEditRail({
               onClick={() => save()}
               disabled={saving}
               className="px-4 py-1.5 rounded-lg text-[12px] font-mono font-semibold disabled:opacity-50"
-              style={{ background: T.accent, color: '#0d1117' }}
+              style={{ background: T.accent, color: 'var(--surface-base)' }}
             >
               {saving ? 'Saving…' : 'Save'}
             </button>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -63,16 +63,16 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
   const glyph = opKind === 'delete' ? '−' : opKind === 'write' ? '±' : '~';
   const glyphColor =
     opKind === 'delete'
-      ? '#f85149'
+      ? 'var(--status-fail)'
       : opKind === 'write'
-        ? '#ffda19'
-        : 'rgba(230,237,243,0.25)';
+        ? 'var(--status-gate)'
+        : 'var(--ink-dim)';
   const nameColor =
     opKind === 'delete'
-      ? '#f85149'
+      ? 'var(--status-fail)'
       : opKind === 'write'
-        ? '#e6edf3'
-        : '#e6edf3';
+        ? 'var(--ink-high)'
+        : 'var(--ink-high)';
 
   function flash(state: FileFeedback): void {
     setFeedback(state);
@@ -113,16 +113,16 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
         title={`Open with system default app: ${path}`}
         style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
       >
-        {dir && <span style={{ color: 'rgba(230,237,243,0.3)' }}>{dir}</span>}
+        {dir && <span style={{ color: 'var(--ink-dim)' }}>{dir}</span>}
         <span style={{ color: nameColor }}>{name}</span>
         {feedback === 'opened' && (
-          <span className="ml-1 text-[9px]" style={{ color: '#3fb950' }}>✓ opened</span>
+          <span className="ml-1 text-[9px]" style={{ color: 'var(--status-run)' }}>✓ opened</span>
         )}
         {feedback === 'copied' && (
-          <span className="ml-1 text-[9px]" style={{ color: '#3fb950' }}>✓ copied</span>
+          <span className="ml-1 text-[9px]" style={{ color: 'var(--status-run)' }}>✓ copied</span>
         )}
         {feedback === 'open-failed' && (
-          <span className="ml-1 text-[9px]" style={{ color: '#ffda19' }}>
+          <span className="ml-1 text-[9px]" style={{ color: 'var(--status-gate)' }}>
             open unavailable — path copied
           </span>
         )}
@@ -133,7 +133,7 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
         aria-label={`Copy path ${path}`}
         title="Copy path"
         className="shrink-0 mt-0.5 text-[9px] font-mono leading-5 transition-opacity hover:opacity-70"
-        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'rgba(230,237,243,0.35)' }}
+        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--ink-dim)' }}
       >
         ⧉
       </button>
@@ -184,7 +184,7 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
 
   if (!hasAny) {
     return (
-      <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+      <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
         {isActive ? 'No files changed yet.' : 'No files changed.'}
       </p>
     );
@@ -199,11 +199,11 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
       {/* Modified / Created section */}
       {(hasModified || isActive) && (
         <div>
-          <p className="text-[10px] font-mono mb-2 uppercase tracking-wider" style={{ color: 'rgba(230,237,243,0.3)' }}>
+          <p className="text-[10px] font-mono mb-2 uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>
             Modified / Created
           </p>
           {!hasModified ? (
-            <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+            <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
               No files changed yet.
             </p>
           ) : (
@@ -222,7 +222,7 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
       {/* Referenced section */}
       {sortedReferenced.length > 0 && (
         <div>
-          <p className="text-[10px] font-mono mb-2 uppercase tracking-wider" style={{ color: 'rgba(230,237,243,0.3)' }}>
+          <p className="text-[10px] font-mono mb-2 uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>
             Referenced
           </p>
           <ul className="flex flex-col gap-1">
@@ -233,7 +233,7 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
         </div>
       )}
 
-      <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.2)' }}>
+      <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
         {allFiles.size} file{allFiles.size !== 1 ? 's' : ''} total
       </p>
     </div>
@@ -265,13 +265,13 @@ export function RightPanel({ view }: Props): React.ReactElement {
     return (
       <div
         className="flex flex-col items-center w-10 shrink-0 py-3 gap-2"
-        style={{ background: '#0c1015', borderLeft: '1px solid rgba(230,237,243,0.07)' }}
+        style={{ background: 'var(--surface-base)', borderLeft: '1px solid var(--surface-raised)' }}
       >
         <button
           type="button"
           onClick={() => setCollapsed(false)}
           className="text-sm leading-none"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
           aria-label="Expand insights panel"
         >
           ‹
@@ -282,7 +282,7 @@ export function RightPanel({ view }: Props): React.ReactElement {
           title="Terminal"
           aria-label="Open terminal"
           className="w-7 h-7 flex items-center justify-center rounded text-sm"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           ⬛
         </button>
@@ -292,7 +292,7 @@ export function RightPanel({ view }: Props): React.ReactElement {
           title="Coverage"
           aria-label="Open coverage"
           className="w-7 h-7 flex items-center justify-center rounded text-sm font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           %
         </button>
@@ -303,12 +303,12 @@ export function RightPanel({ view }: Props): React.ReactElement {
   return (
     <div
       className="flex flex-col w-72 shrink-0 overflow-hidden"
-      style={{ background: '#0c1015', borderLeft: '1px solid rgba(230,237,243,0.07)' }}
+      style={{ background: 'var(--surface-base)', borderLeft: '1px solid var(--surface-raised)' }}
     >
       {/* Header */}
       <div
         className="flex items-center gap-1 px-3 py-2 border-b shrink-0"
-        style={{ background: '#090d12', borderColor: 'rgba(230,237,243,0.07)' }}
+        style={{ background: 'var(--surface-base)', borderColor: 'var(--surface-raised)' }}
       >
         <button
           type="button"
@@ -316,8 +316,8 @@ export function RightPanel({ view }: Props): React.ReactElement {
           className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
           aria-label="Collapse insights panel"
         >
-          <span className="text-sm leading-none shrink-0" style={{ color: 'rgba(230,237,243,0.35)' }}>›</span>
-          <span className="text-[10px] font-semibold uppercase tracking-widest font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+          <span className="text-sm leading-none shrink-0" style={{ color: 'var(--ink-dim)' }}>›</span>
+          <span className="text-[10px] font-semibold uppercase tracking-widest font-mono" style={{ color: 'var(--ink-dim)' }}>
             Insights
           </span>
         </button>
@@ -327,7 +327,7 @@ export function RightPanel({ view }: Props): React.ReactElement {
           title="Terminal"
           aria-label="Open terminal"
           className="rounded px-2 py-0.5 text-[11px] font-mono"
-          style={{ color: 'rgba(230,237,243,0.45)' }}
+          style={{ color: 'var(--ink-muted)' }}
         >
           Term
         </button>
@@ -337,7 +337,7 @@ export function RightPanel({ view }: Props): React.ReactElement {
           title="Coverage"
           aria-label="Open coverage report"
           className="rounded px-2 py-0.5 text-[11px] font-mono"
-          style={{ color: 'rgba(230,237,243,0.45)' }}
+          style={{ color: 'var(--ink-muted)' }}
         >
           Cov
         </button>
@@ -346,13 +346,13 @@ export function RightPanel({ view }: Props): React.ReactElement {
       {/* Accordion sections */}
       <div className="flex-1 overflow-y-auto">
         {ACCORDIONS.map(({ id, label }) => (
-          <div key={id} style={{ borderBottom: '1px solid rgba(230,237,243,0.06)' }}>
+          <div key={id} style={{ borderBottom: '1px solid var(--surface-raised)' }}>
             <button
               type="button"
               onClick={() => toggleAccordion(id)}
               className="w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors"
-              style={{ color: openAccordion === id ? '#e6edf3' : 'rgba(230,237,243,0.55)' }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(230,237,243,0.04)'; }}
+              style={{ color: openAccordion === id ? 'var(--ink-high)' : 'var(--ink-muted)' }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; }}
               onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
               aria-expanded={openAccordion === id}
             >
@@ -361,18 +361,18 @@ export function RightPanel({ view }: Props): React.ReactElement {
                 {id === 'files' && fileCount !== null && fileCount > 0 && (
                   <span
                     className="text-[9px] font-mono px-1 py-0.5 rounded"
-                    style={{ background: 'rgba(121,192,255,0.12)', color: '#79c0ff' }}
+                    style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
                   >
                     {fileCount}
                   </span>
                 )}
               </div>
-              <span className="text-xs" style={{ color: 'rgba(230,237,243,0.3)' }}>
+              <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
                 {openAccordion === id ? '▲' : '▼'}
               </span>
             </button>
             {openAccordion === id && model && (
-              <div className="px-4 py-3" style={{ background: '#0a0d12' }}>
+              <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
                 {id === 'decisions' && <DecisionsLedger model={model} />}
                 {id === 'governance' && <GovernanceAudit model={model} />}
                 {id === 'burn' && <Burn model={model} />}
@@ -385,7 +385,7 @@ export function RightPanel({ view }: Props): React.ReactElement {
             )}
             {openAccordion === id && !model && (
               <div className="px-4 py-3">
-                <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>Loading…</p>
+                <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>Loading…</p>
               </div>
             )}
           </div>

--- a/src/components/RoutingProvenance.tsx
+++ b/src/components/RoutingProvenance.tsx
@@ -10,17 +10,17 @@ export function RoutingProvenance({ routing }: Props): React.ReactElement | null
 
   if (routing.method === 'council') {
     return (
-      <p className="text-[11px] font-mono" style={{ color: 'rgba(230,237,243,0.45)' }} data-testid="routing-provenance">
-        <span className="font-medium" style={{ color: 'rgba(230,237,243,0.6)' }}>Council:</span>{' '}
+      <p className="text-[11px] font-mono" style={{ color: 'var(--ink-muted)' }} data-testid="routing-provenance">
+        <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>Council:</span>{' '}
         {routing.winner} won · {routing.agreement_pct}% agreement · {quorumLabel(routing)} · {routing.dissent} dissent
-        {lostQuorum(routing) && <span style={{ color: '#ffda19' }}> · quorum lost</span>}
+        {lostQuorum(routing) && <span style={{ color: 'var(--status-gate)' }}> · quorum lost</span>}
       </p>
     );
   }
 
   if (routing.method === 'degraded') {
     return (
-      <p className="text-[11px] font-mono" style={{ color: '#ffda19' }} data-testid="routing-provenance">
+      <p className="text-[11px] font-mono" style={{ color: 'var(--status-gate)' }} data-testid="routing-provenance">
         <span className="font-medium">Degraded:</span> {routing.reason}
       </p>
     );
@@ -28,14 +28,14 @@ export function RoutingProvenance({ routing }: Props): React.ReactElement | null
 
   if (routing.method === 'tool') {
     return (
-      <p className="text-[11px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }} data-testid="routing-provenance">
+      <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }} data-testid="routing-provenance">
         <span className="font-medium">Tool:</span> direct command — no council
       </p>
     );
   }
 
   return (
-    <p className="text-[11px] font-mono" style={{ color: '#a78bfa' }} data-testid="routing-provenance">
+    <p className="text-[11px] font-mono" style={{ color: 'var(--accent)' }} data-testid="routing-provenance">
       <span className="font-medium">Evaluator-distinct:</span> {routing.winner} (was {routing.was})
     </p>
   );

--- a/src/components/RuleManager.tsx
+++ b/src/components/RuleManager.tsx
@@ -3,10 +3,10 @@ import { api } from '../api/client.js';
 import type { ConformanceRule, RulePreviewQuery } from '../api/types.js';
 
 const SEVERITY_COLOR: Record<string, string> = {
-  critical: '#f85149',
-  error: '#f97316',
-  warn: '#ffda19',
-  info: 'rgba(230,237,243,0.5)',
+  critical: 'var(--status-fail)',
+  error: 'var(--status-fail)',
+  warn: 'var(--status-gate)',
+  info: 'var(--ink-muted)',
 };
 
 const RULE_TEMPLATE: ConformanceRule = {
@@ -27,19 +27,19 @@ function RuleRow({
   onEdit: (r: ConformanceRule) => void;
 }): React.ReactElement {
   return (
-    <tr className="text-[11px]" style={{ borderBottom: '1px solid rgba(230,237,243,0.06)' }}>
-      <td className="px-3 py-2 font-mono" style={{ color: 'rgba(230,237,243,0.7)' }}>{rule.id}</td>
-      <td className="px-3 py-2" style={{ color: 'rgba(230,237,243,0.45)' }}>{rule.rule_type}</td>
+    <tr className="text-[11px]" style={{ borderBottom: '1px solid var(--surface-raised)' }}>
+      <td className="px-3 py-2 font-mono" style={{ color: 'var(--ink-muted)' }}>{rule.id}</td>
+      <td className="px-3 py-2" style={{ color: 'var(--ink-muted)' }}>{rule.rule_type}</td>
       <td className="px-3 py-2">
         <span
           className="inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
-          style={{ background: 'rgba(230,237,243,0.06)', color: SEVERITY_COLOR[rule.severity] ?? 'rgba(230,237,243,0.5)' }}
+          style={{ background: 'var(--surface-raised)', color: SEVERITY_COLOR[rule.severity] ?? 'var(--ink-muted)' }}
         >
           {rule.severity}
         </span>
       </td>
-      <td className="px-3 py-2 truncate max-w-xs" style={{ color: 'rgba(230,237,243,0.6)' }}>{rule.statement}</td>
-      <td className="px-3 py-2 text-[10px]" style={{ color: 'rgba(230,237,243,0.35)' }}>
+      <td className="px-3 py-2 truncate max-w-xs" style={{ color: 'var(--ink-muted)' }}>{rule.statement}</td>
+      <td className="px-3 py-2 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
         {[rule.targets?.language, rule.targets?.layer, rule.targets?.framework]
           .filter(Boolean)
           .join(' / ') || '—'}
@@ -49,7 +49,7 @@ function RuleRow({
           type="button"
           onClick={() => onEdit(rule)}
           className="text-[10px] hover:underline"
-          style={{ color: '#79c0ff' }}
+          style={{ color: 'var(--accent)' }}
         >
           Edit
         </button>
@@ -148,19 +148,19 @@ export function RuleManager(): React.ReactElement {
       value={previewQuery[key] ?? ''}
       onChange={(e) => setPreviewQuery((q) => ({ ...q, [key]: e.target.value || undefined }))}
       className="rounded px-2 py-0.5 text-[10px] focus:outline-none w-24"
-      style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.1)', color: '#e6edf3' }}
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
     />
   );
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
-        <h2 className="text-sm font-semibold" style={{ color: '#e6edf3' }}>Conformance rules</h2>
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Conformance rules</h2>
         <button
           type="button"
           onClick={() => void load()}
           className="text-[10px] hover:underline"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Refresh
         </button>
@@ -168,27 +168,27 @@ export function RuleManager(): React.ReactElement {
           type="button"
           onClick={() => openEditor()}
           className="ml-auto rounded px-2 py-1 text-[11px] font-semibold"
-          style={{ background: '#ffda19', color: '#0d1117' }}
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
           + New rule
         </button>
       </div>
 
       {error && (
-        <p className="rounded px-2 py-1 text-xs" style={{ background: 'rgba(248,81,73,0.08)', color: '#f85149' }}>
+        <p className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
           {error}
         </p>
       )}
 
       {loading ? (
-        <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading rules…</p>
+        <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading rules…</p>
       ) : (
-        <div className="overflow-x-auto rounded" style={{ border: '1px solid rgba(230,237,243,0.08)' }}>
+        <div className="overflow-x-auto rounded" style={{ border: '1px solid var(--surface-raised)' }}>
           <table className="w-full text-[11px]">
             <thead>
               <tr
                 className="text-[10px] uppercase tracking-wider"
-                style={{ borderBottom: '1px solid rgba(230,237,243,0.08)', background: '#0f1419', color: 'rgba(230,237,243,0.4)' }}
+                style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-rail)', color: 'var(--ink-dim)' }}
               >
                 <th className="px-3 py-2 text-left">ID</th>
                 <th className="px-3 py-2 text-left">Type</th>
@@ -201,7 +201,7 @@ export function RuleManager(): React.ReactElement {
             <tbody>
               {rules.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-3 py-4 text-center text-xs" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                  <td colSpan={6} className="px-3 py-4 text-center text-xs" style={{ color: 'var(--ink-dim)' }}>
                     No conformance rules registered.
                   </td>
                 </tr>
@@ -218,15 +218,15 @@ export function RuleManager(): React.ReactElement {
       {editorJson !== '' && (
         <div
           className="flex flex-col gap-2 rounded p-3"
-          style={{ border: '1px solid rgba(255,218,25,0.25)', background: 'rgba(255,218,25,0.04)' }}
+          style={{ border: '1px solid var(--status-gate-dim)', background: 'var(--surface-rail)' }}
         >
           <div className="flex items-center gap-2">
-            <span className="text-[11px] font-semibold" style={{ color: '#ffda19' }}>Rule JSON</span>
+            <span className="text-[11px] font-semibold" style={{ color: 'var(--status-gate)' }}>Rule JSON</span>
             <button
               type="button"
               onClick={() => { setEditorJson(''); setSaveStatus('idle'); }}
               className="ml-auto text-[10px] hover:underline"
-              style={{ color: 'rgba(230,237,243,0.4)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               Cancel
             </button>
@@ -237,22 +237,22 @@ export function RuleManager(): React.ReactElement {
             onChange={(e) => handleEditorChange(e.target.value)}
             spellCheck={false}
             className="rounded p-2 font-mono text-[10px] focus:outline-none min-h-[200px] resize-y"
-            style={{ background: '#0d1117', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.1)' }}
+            style={{ background: 'var(--surface-base)', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
           />
-          {parseError && <p className="text-[10px]" style={{ color: '#f85149' }}>{parseError}</p>}
+          {parseError && <p className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{parseError}</p>}
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={() => void handleSave()}
               disabled={!!parseError || saveStatus === 'saving'}
               className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-50"
-              style={{ background: '#3fb950', color: '#0d1117' }}
+              style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
             >
               {saveStatus === 'saving' ? 'Saving…' : 'Save rule'}
             </button>
-            {saveStatus === 'ok' && <span className="text-[10px]" style={{ color: '#3fb950' }}>Saved.</span>}
+            {saveStatus === 'ok' && <span className="text-[10px]" style={{ color: 'var(--status-run)' }}>Saved.</span>}
             {saveStatus === 'error' && (
-              <span className="text-[10px]" style={{ color: '#f85149' }}>{saveError}</span>
+              <span className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{saveError}</span>
             )}
           </div>
         </div>
@@ -261,9 +261,9 @@ export function RuleManager(): React.ReactElement {
       {/* Preview panel */}
       <div
         className="flex flex-col gap-2 rounded p-3"
-        style={{ border: '1px solid rgba(230,237,243,0.08)', background: '#0f1419' }}
+        style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
       >
-        <p className="text-[11px] font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>Preview — which rules apply?</p>
+        <p className="text-[11px] font-semibold" style={{ color: 'var(--ink-muted)' }}>Preview — which rules apply?</p>
         <div className="flex flex-wrap gap-2 items-center">
           {pqField('language', 'language')}
           {pqField('layer', 'layer')}
@@ -275,27 +275,27 @@ export function RuleManager(): React.ReactElement {
             onClick={() => void runPreview()}
             disabled={previewLoading}
             className="rounded px-2 py-0.5 text-[10px] font-semibold disabled:opacity-50"
-            style={{ background: '#1b222e', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.1)' }}
+            style={{ background: 'var(--surface-card)', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
           >
             {previewLoading ? 'Loading…' : 'Preview'}
           </button>
         </div>
-        {previewError && <p className="text-[10px]" style={{ color: '#f85149' }}>{previewError}</p>}
+        {previewError && <p className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{previewError}</p>}
         {previewRules !== null && (
           previewRules.length === 0 ? (
-            <p className="text-[10px]" style={{ color: 'rgba(230,237,243,0.4)' }}>No rules match this query.</p>
+            <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>No rules match this query.</p>
           ) : (
             <ul className="flex flex-col gap-0.5">
               {previewRules.map((r) => (
                 <li key={r.id} className="flex items-center gap-2 text-[10px]">
                   <span
                     className="inline-flex rounded px-1 text-[9px] font-semibold font-mono"
-                    style={{ background: 'rgba(230,237,243,0.06)', color: SEVERITY_COLOR[r.severity] ?? 'rgba(230,237,243,0.5)' }}
+                    style={{ background: 'var(--surface-raised)', color: SEVERITY_COLOR[r.severity] ?? 'var(--ink-muted)' }}
                   >
                     {r.severity}
                   </span>
-                  <span className="font-mono" style={{ color: 'rgba(230,237,243,0.6)' }}>{r.id}</span>
-                  <span className="truncate" style={{ color: 'rgba(230,237,243,0.45)' }}>{r.statement}</span>
+                  <span className="font-mono" style={{ color: 'var(--ink-muted)' }}>{r.id}</span>
+                  <span className="truncate" style={{ color: 'var(--ink-muted)' }}>{r.statement}</span>
                 </li>
               ))}
             </ul>

--- a/src/components/RunCard.tsx
+++ b/src/components/RunCard.tsx
@@ -1,15 +1,15 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 
-// Status metadata — className uses wicked semantic colors
-export const STATUS_STYLE: Record<SessionStatus, { label: string; className: string; color: string }> = {
-  planning:       { label: 'Planning',        className: 'text-wk-muted',   color: 'rgba(230,237,243,0.55)' },
-  distributing:   { label: 'Distributing',    className: 'text-wk-link',    color: '#79c0ff' },
-  executing:      { label: 'Executing',        className: 'text-wk-link',    color: '#79c0ff' },
-  awaiting_human: { label: 'Awaiting human',  className: 'text-wk-accent',  color: '#ffda19' },
-  completed:      { label: 'Completed',        className: 'text-wk-ok',      color: '#3fb950' },
-  cancelled:      { label: 'Cancelled',        className: 'text-wk-muted',   color: 'rgba(230,237,243,0.4)' },
-  failed:         { label: 'Failed',           className: 'text-wk-deny',    color: '#f85149' },
+// Status metadata — colors speak the §2.6 status layer
+export const STATUS_STYLE: Record<SessionStatus, { label: string; color: string }> = {
+  planning:       { label: 'Planning',        color: 'var(--ink-muted)' },
+  distributing:   { label: 'Distributing',    color: 'var(--status-run)' },
+  executing:      { label: 'Executing',        color: 'var(--status-run)' },
+  awaiting_human: { label: 'Awaiting human',  color: 'var(--status-gate)' },
+  completed:      { label: 'Completed',        color: 'var(--status-done)' },
+  cancelled:      { label: 'Cancelled',        color: 'var(--ink-dim)' },
+  failed:         { label: 'Failed',           color: 'var(--status-fail)' },
 };
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 
 export function RunCard({ view, selected, onSelect }: Props): React.ReactElement {
   const { session, units } = view;
-  const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'rgba(230,237,243,0.4)' };
+  const style = STATUS_STYLE[session.status] ?? { label: session.status, color: 'var(--ink-dim)' };
   const awaiting = session.status === 'awaiting_human';
 
   return (
@@ -33,34 +33,34 @@ export function RunCard({ view, selected, onSelect }: Props): React.ReactElement
       aria-pressed={selected}
       className="w-full text-left rounded-lg p-4 transition relative overflow-hidden"
       style={{
-        background: selected ? '#1b222e' : '#161c26',
+        background: selected ? 'var(--surface-card)' : 'var(--surface-rail)',
         border: selected
-          ? '1px solid rgba(121,192,255,0.25)'
-          : '1px solid rgba(230,237,243,0.08)',
-        boxShadow: selected ? '0 0 0 1px rgba(121,192,255,0.1)' : 'none',
+          ? '1px solid var(--accent-dim)'
+          : '1px solid var(--surface-raised)',
+        boxShadow: selected ? '0 0 0 1px var(--accent-subtle)' : 'none',
       }}
     >
       {/* Same treatment as the board card, so a run reads identically on both surfaces. */}
       <LiveEdge state={edgeStateOf([session.status])} />
       <div className="flex justify-between items-start gap-2 mb-1">
-        <p className="font-semibold text-sm line-clamp-2 flex-1 font-mono" style={{ color: '#e6edf3' }}>
+        <p className="font-semibold text-sm line-clamp-2 flex-1 font-mono" style={{ color: 'var(--ink-high)' }}>
           {session.problem}
         </p>
         {awaiting && (
           <span
             data-testid="run-card-gate-flag"
             className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold font-mono animate-pulse"
-            style={{ background: 'rgba(255,218,25,0.15)', color: '#ffda19', border: '1px solid rgba(255,218,25,0.3)' }}
+            style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)', border: '1px solid var(--status-gate-dim)' }}
           >
             gate
           </span>
         )}
       </div>
       <div className="flex justify-between items-center">
-        <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>{session.id.slice(0, 8)}</p>
+        <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>{session.id.slice(0, 8)}</p>
         <span className="text-xs font-medium font-mono" style={{ color: style.color }}>{style.label}</span>
       </div>
-      <p className="text-[11px] mt-1 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+      <p className="text-[11px] mt-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
         {units.length} unit{units.length === 1 ? '' : 's'}
       </p>
     </button>

--- a/src/components/RunLink.tsx
+++ b/src/components/RunLink.tsx
@@ -42,8 +42,8 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
       data-status={session.status}
       data-kind={kind}
       onClick={() => onSelect(session.id)}
-      className={`w-full text-left px-3 py-2 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 ${
-        isActive ? 'bg-black/35' : 'bg-transparent hover:bg-black/20 focus-visible:bg-black/20'
+      className={`w-full text-left px-3 py-2 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-dim ${
+        isActive ? 'bg-surface-raised' : 'bg-transparent hover:bg-surface-card focus-visible:bg-surface-card'
       }`}
     >
       <div className="flex items-center gap-2">

--- a/src/components/RunLink.tsx
+++ b/src/components/RunLink.tsx
@@ -9,11 +9,11 @@ interface Props {
 
 function statusColor(status: SessionStatus): string {
   switch (status) {
-    case 'completed':      return '#3fb950';
-    case 'failed':         return '#f85149';
-    case 'cancelled':      return 'rgba(230,237,243,0.25)';
-    case 'awaiting_human': return '#ffda19';
-    default:               return '#79c0ff';
+    case 'completed':      return 'var(--status-done)';
+    case 'failed':         return 'var(--status-fail)';
+    case 'cancelled':      return 'var(--ink-dim)';
+    case 'awaiting_human': return 'var(--status-gate)';
+    default:               return 'var(--status-run)';
   }
 }
 
@@ -52,7 +52,7 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
         </span>
         <span
           className="flex-1 truncate text-xs leading-tight font-mono"
-          style={{ color: isActive ? '#e6edf3' : 'rgba(230,237,243,0.7)' }}
+          style={{ color: isActive ? 'var(--ink-high)' : 'var(--ink-muted)' }}
           title={session.problem}
         >
           {title}
@@ -62,7 +62,7 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
           style={{ background: statusColor(session.status) }}
         />
       </div>
-      <p className="text-[10px] mt-0.5 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+      <p className="text-[10px] mt-0.5 font-mono" style={{ color: 'var(--ink-dim)' }}>
         {spec.label} · {unitCount} task{unitCount === 1 ? '' : 's'} · {session.id.slice(0, 8)}
       </p>
     </button>

--- a/src/components/RunList.tsx
+++ b/src/components/RunList.tsx
@@ -16,7 +16,7 @@ export function RunList({ runs, selectedRunId, onSelect }: Props): React.ReactEl
   // actions), so we surface the disconnect explicitly and let reconnect refill.
   if (status === 'disconnected') {
     return (
-      <div data-testid="run-list" className="p-4 text-sm text-gray-400 text-center">
+      <div data-testid="run-list" className="p-4 text-sm text-ink-muted text-center">
         Daemon not reachable — reconnecting…
       </div>
     );
@@ -24,7 +24,7 @@ export function RunList({ runs, selectedRunId, onSelect }: Props): React.ReactEl
 
   if (runs.length === 0) {
     return (
-      <div data-testid="run-list" className="p-4 text-sm text-gray-400 text-center">
+      <div data-testid="run-list" className="p-4 text-sm text-ink-muted text-center">
         No runs yet
       </div>
     );

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -111,20 +111,20 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
     <div
       className="rounded-xl p-4"
       style={{
-        background: '#161c26',
-        border: '1px solid rgba(255,218,25,0.3)',
-        boxShadow: '0 0 0 1px rgba(255,218,25,0.08)',
+        background: 'var(--surface-rail)',
+        border: '1px solid var(--status-gate-dim)',
+        boxShadow: '0 0 0 1px var(--status-gate-dim)',
       }}
       data-testid="steering-gate"
       data-run-id={runId}
     >
       <div className="flex items-center gap-2 mb-2">
-        <span className="w-2 h-2 rounded-full animate-pulse" style={{ background: '#ffda19' }} />
-        <p className="font-semibold text-sm font-mono" style={{ color: '#ffda19' }}>
+        <span className="w-2 h-2 rounded-full animate-pulse" style={{ background: 'var(--status-gate)' }} />
+        <p className="font-semibold text-sm font-mono" style={{ color: 'var(--status-gate)' }}>
           Awaiting human decision
         </p>
       </div>
-      <p className="text-xs font-mono mb-3" style={{ color: 'rgba(230,237,243,0.4)' }}>
+      <p className="text-xs font-mono mb-3" style={{ color: 'var(--ink-dim)' }}>
         run {runId.slice(0, 8)}
         {typeof ord === 'number' ? ` · before unit #${ord}` : ''}
       </p>
@@ -135,7 +135,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
         // Focusable only programmatically: the deep-link target, never a tab stop.
         tabIndex={-1}
         className="text-xs mb-1 leading-relaxed font-mono"
-        style={{ color: 'rgba(230,237,243,0.85)', outline: 'none' }}
+        style={{ color: 'var(--ink-body)', outline: 'none' }}
         data-testid="steering-prompt"
       >
         {headline}
@@ -143,7 +143,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
 
       {/* Coverage stats — shown when evaluator gate fails and we have repo coverage data */}
       {isCoverageFail && coverage && (
-        <p className="text-xs mb-2 font-mono" style={{ color: 'rgba(96,165,250,0.85)' }}>
+        <p className="text-xs mb-2 font-mono" style={{ color: 'var(--ink-body)' }}>
           {coverageLabel(coverage)}
         </p>
       )}
@@ -153,11 +153,11 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
         <details className="mb-3">
           <summary
             className="text-[10px] font-mono cursor-pointer select-none"
-            style={{ color: 'rgba(230,237,243,0.3)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >
             why this gate fired
           </summary>
-          <p className="text-[10px] font-mono mt-1 leading-relaxed" style={{ color: 'rgba(230,237,243,0.35)' }}>
+          <p className="text-[10px] font-mono mt-1 leading-relaxed" style={{ color: 'var(--ink-dim)' }}>
             {footnote}
           </p>
         </details>
@@ -168,9 +168,9 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
         data-testid="steering-amend"
         className="w-full rounded-lg p-2 text-xs mb-3 resize-none font-mono"
         style={{
-          background: '#0f1419',
-          border: '1px solid rgba(230,237,243,0.14)',
-          color: '#e6edf3',
+          background: 'var(--surface-rail)',
+          border: '1px solid var(--surface-raised)',
+          color: 'var(--ink-high)',
           outline: 'none',
         }}
         rows={2}
@@ -185,7 +185,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
       />
 
       {error && (
-        <p className="text-xs mb-3 font-mono" style={{ color: '#f85149' }} data-testid="steering-error">
+        <p className="text-xs mb-3 font-mono" style={{ color: 'var(--status-fail)' }} data-testid="steering-error">
           {error}
         </p>
       )}
@@ -197,7 +197,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
           onClick={() => void approve()}
           disabled={loading}
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
-          style={{ background: '#3fb950', color: '#0d1117' }}
+          style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
         >
           Approve
         </button>
@@ -206,7 +206,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
           onClick={() => void approveWithSteer()}
           disabled={loading || !amend.trim()}
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
-          style={{ background: '#ffda19', color: '#0d1117' }}
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
           Approve + steer
         </button>
@@ -215,7 +215,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
           onClick={() => void reject()}
           disabled={loading}
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
-          style={{ background: 'rgba(248,81,73,0.15)', border: '1px solid rgba(248,81,73,0.3)', color: '#f85149' }}
+          style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)', color: 'var(--status-fail)' }}
         >
           Reject
         </button>
@@ -224,14 +224,14 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
           onClick={() => void cancel()}
           disabled={loading}
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
-          style={{ background: 'rgba(139,148,158,0.12)', border: '1px solid rgba(139,148,158,0.25)', color: 'rgba(139,148,158,0.9)' }}
+          style={{ background: 'var(--surface-raised)', border: '1px solid var(--ink-dim)', color: 'var(--ink-muted)' }}
         >
           Cancel run
         </button>
       </div>
 
       {/* Mode-selector note: workflow gates are always HITL regardless of run-level human_confirm */}
-      <p className="text-[10px] font-mono mt-2" style={{ color: 'rgba(230,237,243,0.25)' }}>
+      <p className="text-[10px] font-mono mt-2" style={{ color: 'var(--ink-dim)' }}>
         Workflow-declared gate — run-level human_confirm setting does not apply here.
       </p>
     </div>

--- a/src/components/SteeringTimeline.tsx
+++ b/src/components/SteeringTimeline.tsx
@@ -5,10 +5,10 @@ interface Props {
 }
 
 const ACTION_STYLE: Record<SteeringAction, { label: string; color: string }> = {
-  approve:            { label: 'Approved',          color: '#3fb950' },
-  'approve-with-steer':{ label: 'Approved + steered',color: '#ffda19' },
-  reject:             { label: 'Rejected',           color: '#f85149' },
-  cancel:             { label: 'Cancelled run',      color: 'rgba(230,237,243,0.5)' },
+  approve:            { label: 'Approved',          color: 'var(--status-run)' },
+  'approve-with-steer':{ label: 'Approved + steered',color: 'var(--status-gate)' },
+  reject:             { label: 'Rejected',           color: 'var(--status-fail)' },
+  cancel:             { label: 'Cancelled run',      color: 'var(--ink-muted)' },
 };
 
 export function SteeringTimeline({ runId }: Props): React.ReactElement {
@@ -16,7 +16,7 @@ export function SteeringTimeline({ runId }: Props): React.ReactElement {
 
   if (entries.length === 0) {
     return (
-      <p data-testid="steering-timeline" className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+      <p data-testid="steering-timeline" className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
         No interventions recorded this session. Operator gate actions (approve / reject /
         amend) appear here as they happen.
       </p>
@@ -25,7 +25,7 @@ export function SteeringTimeline({ runId }: Props): React.ReactElement {
 
   return (
     <div className="flex flex-col gap-2">
-      <p data-testid="steering-scope-note" className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+      <p data-testid="steering-scope-note" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
         Client-recorded, this session only — daemon keeps no per-action history, cleared on reload.
       </p>
       <ol data-testid="steering-timeline" className="flex flex-col gap-2">
@@ -36,23 +36,23 @@ export function SteeringTimeline({ runId }: Props): React.ReactElement {
               key={e.seq}
               data-testid="steering-entry"
               className="rounded p-2 text-[11px]"
-              style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.07)' }}
+              style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
             >
               <div className="flex items-center justify-between">
                 <span className="font-semibold font-mono" style={{ color: s.color }}>{s.label}</span>
-                <span className="font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>
                   {typeof e.ord === 'number' ? `before unit #${e.ord}` : '—'}
                 </span>
               </div>
               {e.amend && (
                 <p
                   className="mt-1 whitespace-pre-wrap rounded p-1.5 font-mono"
-                  style={{ background: '#0f1419', color: 'rgba(230,237,243,0.6)' }}
+                  style={{ background: 'var(--surface-rail)', color: 'var(--ink-muted)' }}
                 >
-                  <span className="font-medium" style={{ color: '#e6edf3' }}>amended instruction:</span> {e.amend}
+                  <span className="font-medium" style={{ color: 'var(--ink-high)' }}>amended instruction:</span> {e.amend}
                 </p>
               )}
-              <p className="mt-1 text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="mt-1 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                 effect: {e.action === 'approve-with-steer'
                   ? 'steers the next unit'
                   : e.action === 'approve'

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -24,11 +24,11 @@ function SettingRow({ label, description, children }: SettingRowProps): React.Re
   return (
     <div
       className="flex items-start justify-between gap-6 py-4 border-b last:border-b-0"
-      style={{ borderColor: 'rgba(230,237,243,0.07)' }}
+      style={{ borderColor: 'var(--surface-raised)' }}
     >
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium" style={{ color: '#e6edf3' }}>{label}</p>
-        <p className="text-xs mt-0.5" style={{ color: 'rgba(230,237,243,0.45)' }}>{description}</p>
+        <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>{label}</p>
+        <p className="text-xs mt-0.5" style={{ color: 'var(--ink-muted)' }}>{description}</p>
       </div>
       <div className="shrink-0">{children}</div>
     </div>
@@ -136,12 +136,12 @@ export function SystemSettings(): React.ReactElement {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6">
-        <h1 className="text-lg font-semibold" style={{ color: '#e6edf3' }}>System</h1>
-        <p className="text-sm mt-1" style={{ color: 'rgba(230,237,243,0.45)' }}>
+        <h1 className="text-lg font-semibold" style={{ color: 'var(--ink-high)' }}>System</h1>
+        <p className="text-sm mt-1" style={{ color: 'var(--ink-muted)' }}>
           Runtime tunables persisted to{' '}
           <code
             className="font-mono text-xs rounded px-1 py-0.5"
-            style={{ background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.7)' }}
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
           >
             ~/.config/wicked-core/settings.json
           </code>.
@@ -151,7 +151,7 @@ export function SystemSettings(): React.ReactElement {
       {error && (
         <div
           className="mb-4 px-3 py-2 rounded text-xs"
-          style={{ background: 'rgba(248,81,73,0.08)', border: '1px solid rgba(248,81,73,0.3)', color: '#f85149' }}
+          style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)', color: 'var(--status-fail)' }}
         >
           {error}
         </div>
@@ -159,11 +159,11 @@ export function SystemSettings(): React.ReactElement {
 
       <section
         className="rounded-xl px-5 mb-6"
-        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       >
         <h2
           className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Code Graph
         </h2>
@@ -183,18 +183,18 @@ export function SystemSettings(): React.ReactElement {
               if (!Number.isNaN(n)) patch('graphNodeLimit', Math.max(20, Math.min(500, n)));
             }}
             className="w-24 rounded px-2 py-1 text-sm text-right tabular-nums focus:outline-none"
-            style={{ background: '#161c26', border: '1px solid rgba(230,237,243,0.12)', color: '#e6edf3' }}
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
           />
         </SettingRow>
       </section>
 
       <section
         className="rounded-xl px-5 mb-6"
-        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       >
         <h2
           className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Workers
         </h2>
@@ -215,18 +215,18 @@ export function SystemSettings(): React.ReactElement {
               }}
               className="w-56 rounded px-2 py-1 text-sm font-mono focus:outline-none"
               style={{
-                background: '#161c26',
-                border: `1px solid ${workerRootInvalid || workerRootError ? 'rgba(248,81,73,0.5)' : 'rgba(230,237,243,0.12)'}`,
-                color: '#e6edf3',
+                background: 'var(--surface-rail)',
+                border: `1px solid ${workerRootInvalid || workerRootError ? 'var(--status-fail-dim)' : 'var(--surface-raised)'}`,
+                color: 'var(--ink-high)',
               }}
             />
             {workerRootInvalid && (
-              <p className="text-xs" style={{ color: '#f85149' }} data-testid="worker-root-invalid">
+              <p className="text-xs" style={{ color: 'var(--status-fail)' }} data-testid="worker-root-invalid">
                 Must be empty or an absolute path.
               </p>
             )}
             {workerRootError && (
-              <p className="text-xs" style={{ color: '#f85149' }} data-testid="worker-root-error">
+              <p className="text-xs" style={{ color: 'var(--status-fail)' }} data-testid="worker-root-error">
                 {workerRootError}
               </p>
             )}
@@ -241,33 +241,33 @@ export function SystemSettings(): React.ReactElement {
           disabled={!hasDirty || saving}
           className="px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-40"
           style={hasDirty && !saving
-            ? { background: '#3fb950', color: '#0d1117' }
-            : { background: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.35)', cursor: 'not-allowed' }
+            ? { background: 'var(--status-run)', color: 'var(--surface-base)' }
+            : { background: 'var(--surface-raised)', color: 'var(--ink-dim)', cursor: 'not-allowed' }
           }
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
-        {saved && <span className="text-xs font-medium" style={{ color: '#3fb950' }}>Saved</span>}
+        {saved && <span className="text-xs font-medium" style={{ color: 'var(--status-run)' }}>Saved</span>}
       </div>
 
       {/* ── CLI seats & sign-in ───────────────────────────────────────────── */}
       <section
         className="rounded-xl px-5 mb-6"
-        style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       >
         <h2
           className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           CLI seats &amp; sign-in
         </h2>
-        <p className="text-xs mb-4" style={{ color: 'rgba(230,237,243,0.4)' }}>
+        <p className="text-xs mb-4" style={{ color: 'var(--ink-dim)' }}>
           Checked CLIs are pre-selected when you open the launch form (takes effect on the next new
           session). The status shows whether each seat looks signed in; Sign in opens that CLI&apos;s
           own login flow in a terminal.
         </p>
         {roster.length === 0 ? (
-          <p className="text-xs italic pb-4 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>Loading roster…</p>
+          <p className="text-xs italic pb-4 font-mono" style={{ color: 'var(--ink-dim)' }}>Loading roster…</p>
         ) : (
           <div className="flex flex-col gap-2 pb-4">
             {roster.map((seat) => (
@@ -279,19 +279,19 @@ export function SystemSettings(): React.ReactElement {
                     type="checkbox"
                     checked={defaultClis.has(seat.key)}
                     onChange={() => toggleDefaultCli(seat.key)}
-                    className="accent-[#ffda19] w-3.5 h-3.5 shrink-0"
+                    className="w-3.5 h-3.5 shrink-0" style={{ accentColor: 'var(--accent)' }}
                   />
-                  <span className="text-sm font-mono truncate" style={{ color: '#e6edf3' }}>
+                  <span className="text-sm font-mono truncate" style={{ color: 'var(--ink-high)' }}>
                     {seat.display_name}
                   </span>
                 </label>
-                <span className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+                <span className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
                   {seat.key}
                 </span>
                 {seat.signed_in === true && (
                   <span
                     className="text-xs font-mono"
-                    style={{ color: '#3fb950' }}
+                    style={{ color: 'var(--status-run)' }}
                     data-testid={`seat-signin-${seat.key}`}
                   >
                     ✓ signed in
@@ -300,7 +300,7 @@ export function SystemSettings(): React.ReactElement {
                 {seat.signed_in === false && (
                   <span
                     className="text-xs font-mono"
-                    style={{ color: '#f85149' }}
+                    style={{ color: 'var(--status-fail)' }}
                     data-testid={`seat-signin-${seat.key}`}
                   >
                     sign in needed
@@ -312,7 +312,7 @@ export function SystemSettings(): React.ReactElement {
                     onClick={() => setSignInSeat(seat)}
                     aria-label={`Sign in ${seat.display_name}`}
                     className="px-2.5 py-1 rounded-lg text-xs font-medium shrink-0"
-                    style={{ background: 'rgba(255,218,25,0.15)', color: '#ffda19', border: '1px solid rgba(255,218,25,0.3)' }}
+                    style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)', border: '1px solid var(--status-gate-dim)' }}
                   >
                     Sign in
                   </button>
@@ -324,17 +324,17 @@ export function SystemSettings(): React.ReactElement {
         {roster.length > 0 && (
           <div
             className="flex items-center gap-3 pb-4 pt-2 border-t"
-            style={{ borderColor: 'rgba(230,237,243,0.07)' }}
+            style={{ borderColor: 'var(--surface-raised)' }}
           >
             <button
               type="button"
               onClick={saveDefaultClis}
               className="px-4 py-2 rounded-lg text-sm font-medium"
-              style={{ background: '#ffda19', color: '#0d1117' }}
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
             >
               Save CLI defaults
             </button>
-            {clisSaved && <span className="text-xs font-medium" style={{ color: '#3fb950' }}>Saved</span>}
+            {clisSaved && <span className="text-xs font-medium" style={{ color: 'var(--status-run)' }}>Saved</span>}
           </div>
         )}
       </section>
@@ -351,11 +351,11 @@ export function SystemSettings(): React.ReactElement {
           disableEscapeKey
         >
           <div className="flex flex-col gap-3">
-            <p className="text-xs font-mono" style={{ color: 'rgba(230,237,243,0.5)' }}>
+            <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
               Running{' '}
               <code
                 className="rounded px-1 py-0.5"
-                style={{ background: 'rgba(230,237,243,0.06)', color: '#e6edf3' }}
+                style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
               >
                 {signInSeat.login_invocation}
               </code>{' '}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { api, terminalWsUrl } from '../api/client.js';
+import { resolveToken } from '../styles/resolveToken.js';
 
 interface Props {
   /** Working directory the PTY opens in. */
@@ -56,7 +57,14 @@ export function Terminal({ cwd, cmd, governed = true, initialInput }: Props): Re
       cursorBlink: true,
       fontSize: 12,
       fontFamily: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-      theme: { background: '#0d1117', foreground: '#e6edf3', cursor: '#ffda19', cursorAccent: '#0d1117' },
+      // xterm parses concrete colors (no var() support) — resolve the tokens
+      // through the cascade at mount time (§2.11's escape hatch).
+      theme: {
+        background: resolveToken('--surface-base'),
+        foreground: resolveToken('--ink-body'),
+        cursor: resolveToken('--accent'),
+        cursorAccent: resolveToken('--surface-base'),
+      },
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -156,10 +164,10 @@ export function Terminal({ cwd, cmd, governed = true, initialInput }: Props): Re
   return (
     <div data-testid="terminal" className="flex flex-col gap-1">
       <div className="flex items-center justify-between text-[11px]">
-        <span className="font-semibold font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Terminal</span>
+        <span className="font-semibold font-mono" style={{ color: 'var(--ink-dim)' }}>Terminal</span>
         <span
           data-testid="terminal-governed"
-          style={{ color: governed ? 'rgba(230,237,243,0.35)' : '#ffda19', fontWeight: governed ? undefined : 600 }}
+          style={{ color: governed ? 'var(--ink-dim)' : 'var(--status-gate)', fontWeight: governed ? undefined : 600 }}
         >
           {governed ? 'governed' : 'ungoverned operator shell'}
         </span>
@@ -168,7 +176,7 @@ export function Terminal({ cwd, cmd, governed = true, initialInput }: Props): Re
         ref={hostRef}
         data-testid="terminal-host"
         className="h-64 w-full overflow-hidden rounded p-1"
-        style={{ background: '#0d1117' }}
+        style={{ background: 'var(--surface-base)' }}
       />
     </div>
   );

--- a/src/components/TimeRangeSelector.tsx
+++ b/src/components/TimeRangeSelector.tsx
@@ -29,9 +29,9 @@ export function TimeRangeSelector({ value, onChange }: Props): React.ReactElemen
             ...mono,
             cursor: 'pointer',
             border: '1px solid',
-            borderColor: value === r ? 'rgba(121,192,255,0.5)' : 'rgba(230,237,243,0.1)',
-            background: value === r ? 'rgba(121,192,255,0.12)' : 'transparent',
-            color: value === r ? '#79c0ff' : 'rgba(230,237,243,0.4)',
+            borderColor: value === r ? 'var(--accent)' : 'var(--surface-raised)',
+            background: value === r ? 'var(--accent-subtle)' : 'transparent',
+            color: value === r ? 'var(--accent)' : 'var(--ink-dim)',
             transition: 'all 0.15s',
           }}
         >

--- a/src/components/UnitList.tsx
+++ b/src/components/UnitList.tsx
@@ -17,7 +17,7 @@ interface Props {
 export function UnitList({ runId, units, gateOrd, onResolved }: Props): React.ReactElement {
   if (units.length === 0) {
     return (
-      <p data-testid="unit-list" className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>
+      <p data-testid="unit-list" className="text-xs" style={{ color: 'var(--ink-dim)' }}>
         No units planned yet.
       </p>
     );

--- a/src/components/WhatWhere.tsx
+++ b/src/components/WhatWhere.tsx
@@ -7,10 +7,10 @@ interface Props {
 function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): React.ReactElement {
   return (
     <div className="flex gap-2 text-[11px]">
-      <span className="w-20 shrink-0 font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>{label}</span>
+      <span className="w-20 shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>{label}</span>
       <span
         className={mono ? 'font-mono break-all' : ''}
-        style={{ color: 'rgba(230,237,243,0.7)' }}
+        style={{ color: 'var(--ink-muted)' }}
       >
         {value}
       </span>
@@ -30,7 +30,7 @@ export function WhatWhere({ model }: Props): React.ReactElement {
       <Row label="entity" value={session.entity_mode} />
       <div
         className="mt-1 rounded p-1.5 text-[10px] font-mono"
-        style={{ border: '1px dashed rgba(230,237,243,0.12)', color: 'rgba(230,237,243,0.35)' }}
+        style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
       >
         diff: not exposed on the run DTO (<code>work_output</code> pending daemon surface)
       </div>

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -123,7 +123,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
     : failedGroup;
 
   return (
-    <div className="flex flex-col h-full" style={{ color: '#e6edf3' }}>
+    <div className="flex flex-col h-full" style={{ color: 'var(--ink-high)' }}>
       {/* Header */}
       <div className="px-8 pt-8 pb-4 flex items-center gap-4">
         <h1 className="text-xl font-semibold font-mono">Work</h1>
@@ -136,9 +136,9 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
           onChange={e => setQuery(e.target.value)}
           className="rounded-xl px-4 py-2 text-sm font-mono outline-none"
           style={{
-            background: '#1b222e',
-            border: '1px solid rgba(230,237,243,0.12)',
-            color: '#e6edf3',
+            background: 'var(--surface-card)',
+            border: '1px solid var(--surface-raised)',
+            color: 'var(--ink-high)',
             width: '240px',
           }}
         />
@@ -146,7 +146,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
           type="button"
           onClick={() => navigate('/runs/new')}
           className="rounded-lg px-4 py-2 text-sm font-semibold font-mono shrink-0"
-          style={{ background: '#ffda19', color: '#0d1117' }}
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
           Do Work
         </button>
@@ -156,24 +156,24 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
       <div className="px-8 pb-4 grid gap-3" style={{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
         {([
           { label: 'Total Runs',    value: String(metrics.total),       accent: undefined },
-          { label: 'Active',        value: String(metrics.active),       accent: '#79c0ff' },
-          { label: 'Success Rate',  value: metrics.successRate,          accent: '#3fb950' },
+          { label: 'Active',        value: String(metrics.active),       accent: 'var(--status-run)' },
+          { label: 'Success Rate',  value: metrics.successRate,          accent: 'var(--status-run)' },
           { label: 'Top Workflow',  value: metrics.topWorkflow,          accent: undefined },
         ] as const).map(s => (
           <div
             key={s.label}
             className="rounded-xl px-4 py-3"
-            style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <p
               className="text-[10px] font-mono uppercase tracking-widest"
-              style={{ color: 'rgba(230,237,243,0.4)', margin: 0 }}
+              style={{ color: 'var(--ink-dim)', margin: 0 }}
             >
               {s.label}
             </p>
             <p
               className="text-xl font-semibold font-mono mt-1 truncate"
-              style={{ color: s.accent ?? '#e6edf3', margin: '4px 0 0' }}
+              style={{ color: s.accent ?? 'var(--ink-high)', margin: '4px 0 0' }}
             >
               {s.value}
             </p>
@@ -217,8 +217,8 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
             className="rounded-full px-3 py-1 text-xs font-mono"
             style={
               tab === t.id
-                ? { background: 'rgba(230,237,243,0.1)', color: '#e6edf3' }
-                : { color: 'rgba(230,237,243,0.4)' }
+                ? { background: 'var(--surface-raised)', color: 'var(--ink-high)' }
+                : { color: 'var(--ink-dim)' }
             }
           >
             {t.label} {counts[t.id]}
@@ -233,8 +233,8 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
           className="rounded-full px-3 py-1 text-xs font-mono"
           style={
             showArchived
-              ? { background: 'rgba(230,237,243,0.1)', color: '#e6edf3', border: '1px dashed rgba(230,237,243,0.3)' }
-              : { color: 'rgba(230,237,243,0.4)', border: '1px dashed rgba(230,237,243,0.15)' }
+              ? { background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px dashed var(--ink-dim)' }
+              : { color: 'var(--ink-dim)', border: '1px dashed var(--surface-raised)' }
           }
         >
           Archived{archivedRuns !== null ? ` ${archivedRuns.length}` : ''}
@@ -291,7 +291,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
           <>
             <GroupLabel>Archived</GroupLabel>
             {archivedRuns.length === 0 ? (
-              <p className="px-3 py-3 text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+              <p className="px-3 py-3 text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 Nothing archived.
               </p>
             ) : (
@@ -304,7 +304,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
                     type="button"
                     onClick={() => void unarchive(v.session.id)}
                     className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
-                    style={{ color: 'rgba(230,237,243,0.55)', border: '1px solid rgba(230,237,243,0.15)' }}
+                    style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
                   >
                     Unarchive
                   </button>
@@ -322,12 +322,12 @@ function GroupLabel({ children, pulse }: { children: React.ReactNode; pulse?: bo
   return (
     <div
       className="flex items-center gap-2 px-3 py-2 text-[10px] uppercase tracking-widest font-semibold font-mono"
-      style={{ color: 'rgba(230,237,243,0.4)' }}
+      style={{ color: 'var(--ink-dim)' }}
     >
       {pulse && (
         <span
           className="w-1.5 h-1.5 rounded-full animate-pulse shrink-0"
-          style={{ background: '#79c0ff' }}
+          style={{ background: 'var(--status-run)' }}
         />
       )}
       {children}
@@ -342,7 +342,7 @@ function EmptyState({ query, tab }: { query: string; tab?: StatusTab }): React.R
     ? `No ${tab} runs yet.`
     : 'No work sessions yet.';
   return (
-    <p className="px-3 py-6 text-sm font-mono italic" style={{ color: 'rgba(230,237,243,0.35)' }}>
+    <p className="px-3 py-6 text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
       {msg}
     </p>
   );

--- a/src/components/WorkUnitDetail.tsx
+++ b/src/components/WorkUnitDetail.tsx
@@ -6,17 +6,17 @@ import { useRuntimeStore, outputKey } from '../store/runtime.js';
 import { RoutingProvenance } from './RoutingProvenance.js';
 
 const STAGE_STYLE: Record<StageKind, { bg: string; color: string }> = {
-  recon:   { bg: 'rgba(121,192,255,0.12)', color: '#79c0ff' },
-  build:   { bg: 'rgba(63,185,80,0.12)',   color: '#3fb950' },
-  review:  { bg: 'rgba(167,139,250,0.12)', color: '#a78bfa' },
-  test:    { bg: 'rgba(255,218,25,0.12)',  color: '#ffda19' },
+  recon:   { bg: 'var(--accent-subtle)', color: 'var(--accent)' },
+  build:   { bg: 'var(--status-run-dim)',   color: 'var(--status-run)' },
+  review:  { bg: 'var(--accent-subtle)', color: 'var(--accent)' },
+  test:    { bg: 'var(--status-gate-dim)', color: 'var(--status-gate)' },
 };
 
 const UNIT_STATUS_COLOR: Record<UnitStatus, string> = {
-  pending:     'rgba(230,237,243,0.3)',
-  distributed: '#79c0ff',
-  done:        '#3fb950',
-  rejected:    '#f85149',
+  pending:     'var(--ink-dim)',
+  distributed: 'var(--accent)',
+  done:        'var(--status-run)',
+  rejected:    'var(--status-fail)',
 };
 
 interface Props {
@@ -88,18 +88,18 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
     }
   }
 
-  const stageBadge = STAGE_STYLE[unit.stage] ?? { bg: 'rgba(230,237,243,0.06)', color: 'rgba(230,237,243,0.5)' };
-  const statusColor = UNIT_STATUS_COLOR[unit.status] ?? 'rgba(230,237,243,0.4)';
+  const stageBadge = STAGE_STYLE[unit.stage] ?? { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' };
+  const statusColor = UNIT_STATUS_COLOR[unit.status] ?? 'var(--ink-dim)';
 
   return (
     <li
       className="rounded-lg p-3"
-      style={{ background: '#1b222e', border: '1px solid rgba(230,237,243,0.07)' }}
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
       data-testid="work-unit"
       data-ord={unit.ord}
     >
       <div className="flex items-center gap-2 text-sm">
-        <span className="w-6 text-center text-xs shrink-0 font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+        <span className="w-6 text-center text-xs shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>
           #{unit.ord}
         </span>
         <span
@@ -111,13 +111,13 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
         {(() => {
           const sep = unit.description.indexOf(' — ');
           return sep === -1 ? (
-            <span className="flex-1 truncate text-xs" style={{ color: 'rgba(230,237,243,0.7)' }}>{unit.description}</span>
+            <span className="flex-1 truncate text-xs" style={{ color: 'var(--ink-muted)' }}>{unit.description}</span>
           ) : (
             <span className="flex-1 min-w-0 flex items-baseline gap-1">
-              <span className="text-xs font-medium shrink-0" style={{ color: '#e6edf3' }}>
+              <span className="text-xs font-medium shrink-0" style={{ color: 'var(--ink-high)' }}>
                 {unit.description.slice(0, sep)}
               </span>
-              <span className="truncate text-[10px]" style={{ color: 'rgba(230,237,243,0.4)' }}>
+              <span className="truncate text-[10px]" style={{ color: 'var(--ink-dim)' }}>
                 {unit.description.slice(sep + 3)}
               </span>
             </span>
@@ -130,13 +130,13 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
 
       <div className="mt-1.5 pl-8 flex flex-col gap-0.5">
         {unit.assigned_cli && (
-          <p className="text-[11px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
-            cli: <span style={{ color: 'rgba(230,237,243,0.65)' }}>{unit.assigned_cli}</span>
+          <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+            cli: <span style={{ color: 'var(--ink-muted)' }}>{unit.assigned_cli}</span>
           </p>
         )}
         <RoutingProvenance routing={unit.routing} />
         {unit.denial_reason && (
-          <p className="text-[11px] font-mono" style={{ color: '#f85149' }} data-testid="unit-denial-reason">
+          <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }} data-testid="unit-denial-reason">
             denied: {unit.denial_reason}
           </p>
         )}
@@ -147,7 +147,7 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
             data-testid="unit-transcript-toggle"
             onClick={() => void toggleTranscript()}
             className="text-[11px] hover:underline font-mono"
-            style={{ color: '#79c0ff' }}
+            style={{ color: 'var(--accent)' }}
           >
             {showTranscript ? 'Hide transcript' : 'View transcript'}
           </button>
@@ -158,7 +158,7 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
               onClick={() => void approve()}
               disabled={approving}
               className="rounded px-2 py-0.5 text-[11px] font-semibold disabled:opacity-50"
-              style={{ background: '#3fb950', color: '#0d1117' }}
+              style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
             >
               Approve this unit
             </button>
@@ -169,7 +169,7 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
           <pre
             data-testid="unit-transcript"
             className="mt-1 max-h-96 overflow-auto rounded-lg p-2 text-[10px] leading-tight whitespace-pre-wrap font-mono"
-            style={{ background: '#0d1117', color: '#e6edf3' }}
+            style={{ background: 'var(--surface-base)', color: 'var(--ink-high)' }}
           >
             {loadingTranscript ? 'Loading…' : transcript}
           </pre>

--- a/src/components/WorkflowViewer.tsx
+++ b/src/components/WorkflowViewer.tsx
@@ -13,14 +13,14 @@ function gateLabel(gate: GateSpec): string {
 }
 
 const KIND_DOT_COLOR: Record<string, string> = {
-  recon: '#79c0ff',
-  build: '#3fb950',
-  review: '#a78bfa',
-  test: '#ffda19',
+  recon: 'var(--accent)',
+  build: 'var(--status-run)',
+  review: 'var(--accent-dim)',
+  test: 'var(--status-gate)',
 };
 
 function kindDotColor(kind: PhaseDef['kind']): string {
-  return KIND_DOT_COLOR[kind] ?? 'rgba(230,237,243,0.3)';
+  return KIND_DOT_COLOR[kind] ?? 'var(--ink-dim)';
 }
 
 // ── Viewer-only phase card ─────────────────────────────────────────────────────
@@ -31,18 +31,18 @@ function PhaseCard({ phase }: { phase: PhaseDef }): React.ReactElement {
   return (
     <div
       className="rounded px-3 py-2 text-[11px] flex flex-col gap-1"
-      style={{ border: '1px solid rgba(230,237,243,0.08)', background: '#1b222e' }}
+      style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
     >
       <div className="flex items-center gap-2 flex-wrap">
         <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: dotColor }} title={phase.kind} />
-        <span className="font-semibold" style={{ color: '#e6edf3' }}>{phase.id}</span>
-        <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>{phase.kind}</span>
+        <span className="font-semibold" style={{ color: 'var(--ink-high)' }}>{phase.id}</span>
+        <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{phase.kind}</span>
         {phase.role !== 'neutral' && (
           <span
             className="rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
             style={{
-              background: phase.role === 'creator' ? 'rgba(121,192,255,0.1)' : 'rgba(167,139,250,0.1)',
-              color: phase.role === 'creator' ? '#79c0ff' : '#a78bfa',
+              background: 'var(--accent-subtle)',
+              color: phase.role === 'creator' ? 'var(--accent)' : 'var(--accent-dim)',
             }}
           >
             {phase.role}
@@ -51,26 +51,26 @@ function PhaseCard({ phase }: { phase: PhaseDef }): React.ReactElement {
         {ex && ex.type === 'tool' && (
           <span
             className="rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
-            style={{ background: 'rgba(255,218,25,0.08)', color: '#ffda19' }}
+            style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
           >
             tool: {ex.cmd.join(' ')}
           </span>
         )}
       </div>
-      <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[10px]" style={{ color: 'rgba(230,237,243,0.45)' }}>
+      <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[10px]" style={{ color: 'var(--ink-muted)' }}>
         <span>
-          <span className="font-medium" style={{ color: 'rgba(230,237,243,0.6)' }}>gate:</span>{' '}
+          <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>gate:</span>{' '}
           {phase.gate_type ? `${phase.gate_type} / ` : ''}{gateLabel(phase.gate)}
         </span>
         {phase.depends_on.length > 0 && (
           <span>
-            <span className="font-medium" style={{ color: 'rgba(230,237,243,0.6)' }}>after:</span>{' '}
+            <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>after:</span>{' '}
             {phase.depends_on.join(', ')}
           </span>
         )}
         {phase.skill_ref && (
           <span>
-            <span className="font-medium" style={{ color: 'rgba(230,237,243,0.6)' }}>skill:</span>{' '}
+            <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>skill:</span>{' '}
             <span className="font-mono">{phase.skill_ref}</span>
           </span>
         )}
@@ -160,7 +160,7 @@ async function buildDef(id: string, phases: BuilderPhase[]): Promise<WorkflowDef
 
 // ── Phase editor ───────────────────────────────────────────────────────────────
 
-const inputStyle = { background: '#0f1419', border: '1px solid rgba(230,237,243,0.1)', color: '#e6edf3' };
+const inputStyle = { background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' };
 
 function ToggleBtn({
   active,
@@ -177,8 +177,8 @@ function ToggleBtn({
       onClick={onClick}
       className="rounded px-2.5 py-1 text-[11px] font-medium capitalize transition-colors"
       style={active
-        ? { background: '#1b222e', color: '#e6edf3', border: '1px solid rgba(230,237,243,0.2)' }
-        : { background: 'transparent', color: 'rgba(230,237,243,0.4)', border: '1px solid transparent' }
+        ? { background: 'var(--surface-card)', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }
+        : { background: 'transparent', color: 'var(--ink-dim)', border: '1px solid transparent' }
       }
     >
       {children}
@@ -211,32 +211,32 @@ function PhaseEditor({
   return (
     <div
       className="rounded p-3 flex flex-col gap-2"
-      style={{ border: '1px solid rgba(230,237,243,0.08)', background: '#1b222e' }}
+      style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
     >
       {/* header */}
       <div className="flex items-center gap-2">
         <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: kindDotColor(phase.kind) }} />
-        <span className="text-[11px] font-semibold" style={{ color: 'rgba(230,237,243,0.7)' }}>Phase {index + 1}</span>
+        <span className="text-[11px] font-semibold" style={{ color: 'var(--ink-muted)' }}>Phase {index + 1}</span>
         <div className="ml-auto flex items-center gap-1">
           <button
             type="button"
             onClick={onMoveUp}
             disabled={index === 0}
             className="px-1 text-[10px] disabled:opacity-30"
-            style={{ color: 'rgba(230,237,243,0.4)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >▲</button>
           <button
             type="button"
             onClick={onMoveDown}
             disabled={index === total - 1}
             className="px-1 text-[10px] disabled:opacity-30"
-            style={{ color: 'rgba(230,237,243,0.4)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >▼</button>
           <button
             type="button"
             onClick={onRemove}
             className="px-1 text-[10px]"
-            style={{ color: '#f85149' }}
+            style={{ color: 'var(--status-fail)' }}
           >✕</button>
         </div>
       </div>
@@ -285,7 +285,7 @@ function PhaseEditor({
         {phase.execMode === 'script' && (
           <div className="flex flex-col gap-1">
             <div className="flex gap-1 items-center">
-              <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Language:</span>
+              <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>Language:</span>
               {(['bash', 'sh', 'python'] as ScriptLang[]).map((l) => (
                 <ToggleBtn key={l} active={phase.scriptLang === l} onClick={() => up('scriptLang', l)}>
                   {l}
@@ -298,11 +298,11 @@ function PhaseEditor({
               placeholder={phase.scriptLang === 'python' ? '# python script\nprint("hello")' : '# bash script\necho "hello"'}
               value={phase.script}
               onChange={(e) => up('script', e.target.value)}
-              style={{ ...inputStyle, background: '#0d1117' }}
+              style={{ ...inputStyle, background: 'var(--surface-base)' }}
             />
-            <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.3)' }}>
+            <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
               Saved to{' '}
-              <span style={{ color: 'rgba(230,237,243,0.5)' }}>
+              <span style={{ color: 'var(--ink-muted)' }}>
                 ~/.wicked/scripts/{phase.id || 'script'}.{phase.scriptLang === 'python' ? 'py' : 'sh'}
               </span>
             </p>
@@ -313,7 +313,7 @@ function PhaseEditor({
       {/* gate + role */}
       <div className="flex gap-2 flex-wrap">
         <div className="flex flex-col gap-0.5">
-          <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Gate</span>
+          <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>Gate</span>
           <div className="flex gap-1">
             {([['auto', 'Auto'], ['human', 'Human'], ['human_if', 'Human if fails']] as [GateMode, string][]).map(([v, label]) => (
               <ToggleBtn key={v} active={phase.gate === v} onClick={() => up('gate', v)}>
@@ -323,7 +323,7 @@ function PhaseEditor({
           </div>
         </div>
         <div className="flex flex-col gap-0.5">
-          <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Role</span>
+          <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>Role</span>
           <div className="flex gap-1">
             {(['neutral', 'creator', 'evaluator'] as const).map((r) => (
               <ToggleBtn key={r} active={phase.role === r} onClick={() => up('role', r)}>
@@ -337,10 +337,10 @@ function PhaseEditor({
       {/* depends on */}
       {prior.length > 0 && (
         <div className="flex flex-col gap-0.5">
-          <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>Depends on</span>
+          <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>Depends on</span>
           <div className="flex flex-wrap gap-1.5">
             {prior.map((pid) => (
-              <label key={pid} className="flex items-center gap-1 text-[10px] cursor-pointer" style={{ color: 'rgba(230,237,243,0.55)' }}>
+              <label key={pid} className="flex items-center gap-1 text-[10px] cursor-pointer" style={{ color: 'var(--ink-muted)' }}>
                 <input
                   type="checkbox"
                   checked={phase.dependsOn.includes(pid)}
@@ -358,7 +358,7 @@ function PhaseEditor({
       )}
 
       {/* flags */}
-      <div className="flex gap-3 text-[10px]" style={{ color: 'rgba(230,237,243,0.45)' }}>
+      <div className="flex gap-3 text-[10px]" style={{ color: 'var(--ink-muted)' }}>
         <label className="flex items-center gap-1 cursor-pointer">
           <input type="checkbox" checked={phase.executesCode} onChange={(e) => up('executesCode', e.target.checked)} />
           executes code
@@ -496,7 +496,7 @@ function WorkflowBuilder({
           type="button"
           onClick={() => fileRef.current?.click()}
           className="rounded px-2 py-1 text-[11px]"
-          style={{ border: '1px solid rgba(230,237,243,0.1)', color: 'rgba(230,237,243,0.6)' }}
+          style={{ border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
         >
           Upload JSON
         </button>
@@ -504,7 +504,7 @@ function WorkflowBuilder({
           type="button"
           onClick={() => void handlePreview()}
           className="rounded px-2 py-1 text-[11px]"
-          style={{ border: '1px solid rgba(230,237,243,0.1)', color: 'rgba(230,237,243,0.6)' }}
+          style={{ border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
         >
           Preview JSON
         </button>
@@ -512,7 +512,7 @@ function WorkflowBuilder({
           type="button"
           onClick={onCancel}
           className="text-[11px] px-1 hover:underline"
-          style={{ color: 'rgba(230,237,243,0.4)' }}
+          style={{ color: 'var(--ink-dim)' }}
         >
           Cancel
         </button>
@@ -523,7 +523,7 @@ function WorkflowBuilder({
         <div className="relative">
           <pre
             className="rounded text-[10px] p-3 overflow-auto max-h-48 font-mono"
-            style={{ background: '#0d1117', color: '#3fb950' }}
+            style={{ background: 'var(--surface-base)', color: 'var(--status-run)' }}
           >
             {previewJson}
           </pre>
@@ -531,7 +531,7 @@ function WorkflowBuilder({
             type="button"
             onClick={() => setShowJson(false)}
             className="absolute top-1 right-1 text-[10px]"
-            style={{ color: 'rgba(230,237,243,0.4)' }}
+            style={{ color: 'var(--ink-dim)' }}
           >✕</button>
         </div>
       )}
@@ -557,19 +557,19 @@ function WorkflowBuilder({
         type="button"
         onClick={addPhase}
         className="self-start rounded px-3 py-1 text-[11px] transition-colors"
-        style={{ border: '1px dashed rgba(230,237,243,0.15)', color: 'rgba(230,237,243,0.45)' }}
+        style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-muted)' }}
       >
         + Add phase
       </button>
 
-      {error && <p className="text-[11px]" style={{ color: '#f85149' }}>{error}</p>}
+      {error && <p className="text-[11px]" style={{ color: 'var(--status-fail)' }}>{error}</p>}
 
       <button
         type="button"
         onClick={() => void handleSave()}
         disabled={saving}
         className="self-start rounded px-4 py-1.5 text-[11px] font-semibold disabled:opacity-50"
-        style={{ background: '#3fb950', color: '#0d1117' }}
+        style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
       >
         {saving ? 'Saving…' : 'Save workflow'}
       </button>
@@ -624,14 +624,14 @@ export function WorkflowViewer(): React.ReactElement {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-2 flex-wrap">
-        <h2 className="text-sm font-semibold flex-1" style={{ color: '#e6edf3' }}>Workflows</h2>
+        <h2 className="text-sm font-semibold flex-1" style={{ color: 'var(--ink-high)' }}>Workflows</h2>
         {!building && (
           <>
             <button
               type="button"
               onClick={() => openBuilder()}
               className="rounded px-3 py-1 text-[11px] font-semibold"
-              style={{ background: '#3fb950', color: '#0d1117' }}
+              style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
             >
               New workflow
             </button>
@@ -639,7 +639,7 @@ export function WorkflowViewer(): React.ReactElement {
               type="button"
               onClick={() => void load()}
               className="text-[10px] hover:underline"
-              style={{ color: 'rgba(230,237,243,0.4)' }}
+              style={{ color: 'var(--ink-dim)' }}
             >
               Refresh
             </button>
@@ -647,9 +647,9 @@ export function WorkflowViewer(): React.ReactElement {
         )}
       </div>
 
-      {loading && <p className="text-xs" style={{ color: 'rgba(230,237,243,0.4)' }}>Loading workflows…</p>}
+      {loading && <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading workflows…</p>}
       {error && (
-        <p className="rounded px-2 py-1 text-xs" style={{ background: 'rgba(248,81,73,0.08)', color: '#f85149' }}>
+        <p className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
           {error}
         </p>
       )}
@@ -665,12 +665,12 @@ export function WorkflowViewer(): React.ReactElement {
                 onClick={() => setSelected(w.id)}
                 className="w-full text-left rounded px-3 py-2 text-[11px] transition-colors"
                 style={w.id === selected
-                  ? { border: '1px solid rgba(121,192,255,0.4)', background: 'rgba(121,192,255,0.08)', color: '#79c0ff' }
-                  : { border: '1px solid rgba(230,237,243,0.08)', background: '#1b222e', color: 'rgba(230,237,243,0.7)' }
+                  ? { border: '1px solid var(--accent-dim)', background: 'var(--accent-subtle)', color: 'var(--accent)' }
+                  : { border: '1px solid var(--surface-raised)', background: 'var(--surface-card)', color: 'var(--ink-muted)' }
                 }
               >
                 <div className="font-semibold">{w.id}</div>
-                <div className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>{w.phases.length} phases</div>
+                <div className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{w.phases.length} phases</div>
               </button>
             ))}
           </div>
@@ -687,17 +687,17 @@ export function WorkflowViewer(): React.ReactElement {
           ) : current ? (
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
-                <span className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'rgba(230,237,243,0.4)' }}>
+                <span className="text-[11px] font-semibold uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
                   {current.id}
                 </span>
-                <span className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.35)' }}>
+                <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                   — {current.phases.length} phases
                 </span>
                 <button
                   type="button"
                   onClick={() => openBuilder(current)}
                   className="ml-auto text-[10px] hover:underline"
-                  style={{ color: '#79c0ff' }}
+                  style={{ color: 'var(--accent)' }}
                 >
                   Edit
                 </button>
@@ -705,7 +705,7 @@ export function WorkflowViewer(): React.ReactElement {
                   type="button"
                   onClick={() => openBuilder({ ...current, id: `${current.id}-copy` })}
                   className="text-[10px] hover:underline"
-                  style={{ color: 'rgba(230,237,243,0.4)' }}
+                  style={{ color: 'var(--ink-dim)' }}
                 >
                   Duplicate
                 </button>
@@ -717,9 +717,9 @@ export function WorkflowViewer(): React.ReactElement {
       </div>
 
       {!building && (
-        <p className="text-[10px] font-mono" style={{ color: 'rgba(230,237,243,0.25)' }}>
-          Workflows saved to <span style={{ color: 'rgba(230,237,243,0.4)' }}>~/.wicked/workflows/</span> and registered immediately.
-          Scripts saved to <span style={{ color: 'rgba(230,237,243,0.4)' }}>~/.wicked/scripts/</span>.
+        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+          Workflows saved to <span style={{ color: 'var(--ink-dim)' }}>~/.wicked/workflows/</span> and registered immediately.
+          Scripts saved to <span style={{ color: 'var(--ink-dim)' }}>~/.wicked/scripts/</span>.
         </p>
       )}
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,9 +5,9 @@
  * so cascade position vs Tailwind's preflight is irrelevant), then Tailwind,
  * then the app-global rules that must override preflight by source order.
  * Everything below the Tailwind directives moved VERBATIM from src/index.css
- * (slice 1 is the enabler: zero visual change is the gate). The --wk-* block
- * is the INHERITED palette — slices 2–6 migrate its consumers onto the
- * semantic tokens and it retires with the last one. */
+ * (slice 1 is the enabler: zero visual change is the gate). The inherited
+ * --wk-* palette lived here until slice 6 converted its last consumer onto
+ * the semantic tokens; it is retired — tokens.css is the only color source. */
 @import './tokens.css';
 @import './themes/dark.css';
 @import './themes/light.css';
@@ -17,8 +17,8 @@
 @tailwind utilities;
 
 html, body, #root {
-  background: var(--wk-canvas);
-  color: var(--wk-ink);
+  background: var(--surface-base);
+  color: var(--ink-body);
   height: 100%;
   /* §2.8's one sans, resolved from the token: Inter (loaded in index.html —
      slice 3 reconciled the legacy Archivo load against the token contract;
@@ -27,49 +27,14 @@ html, body, #root {
   -webkit-font-smoothing: antialiased;
 }
 
-/* Wicked design tokens — mirrors wicked-web/src/styles/tokens.css
-   Dark theme (default) + the light-theme teal-blue canvas ("the blue of wicked-agile"). */
-:root {
-  --wk-canvas:          #0d1117;
-  --wk-canvas-2:        #161c26;
-  --wk-surface:         #1b222e;
-  --wk-surface-2:       #0f1419;
-  --wk-ink:             #e6edf3;
-  --wk-muted:           rgba(230, 237, 243, 0.55);
-  --wk-faint:           rgba(230, 237, 243, 0.24);
-  --wk-hairline:        rgba(230, 237, 243, 0.07);
-  --wk-hairline-strong: rgba(230, 237, 243, 0.14);
-  --wk-accent:          #ffda19;
-  --wk-accent-ink:      #0d1117;
-  --wk-link:            #79c0ff;
-  --wk-ok:              #3fb950;
-  --wk-deny:            #f85149;
-  /* Light-theme teal-blue canvas — "the blue of wicked-agile" */
-  --wk-blue:            #1c4053;
-  --wk-blue-2:          #182f3c;
-  --wk-blue-surface:    #224a5e;
-  --wk-blue-surface-2:  #1a3b4e;
-  --wk-font-display:    var(--font-sans);
-  --wk-font-mono:       "JetBrains Mono", ui-monospace, monospace;
-}
+/* The legacy --wk-* palette block was retired by DES-VISION-001 slice 6 —
+   every color now resolves from src/styles/tokens.css. */
 
 code, pre, .font-mono {
-  font-family: var(--wk-font-mono);
+  font-family: var(--font-mono);
 }
 
-/* Crew-site ambient background — matches wc.wickedagile.com lighter sections.
-   Three layers: amber glow (top-left) + deny glow (bottom-right) + schematic
-   SVG watermark at 8% ink opacity (same art as crew site body::before). */
-.wk-crew-bg {
-  background-color: #0d1117;
-  background-image:
-    radial-gradient(ellipse 50% 42% at 3% 5%, rgba(255,218,25,0.15), transparent 60%),
-    radial-gradient(ellipse 46% 46% at 97% 95%, rgba(248,81,73,0.11), transparent 62%),
-    url("data:image/svg+xml,%3Csvg%20width='1600'%20height='900'%20viewBox='0%200%201600%20900'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cg%20fill='none'%20stroke='rgb(230,237,243)'%20stroke-opacity='0.08'%20stroke-width='1.4'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M312%20168%20H586'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M736%20166%20H998'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M1156%20166%20H1356'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M578%20162%20l8%206%20l-8%206'/%3E%3Cpath%20d='M990%20160%20l8%206%20l-8%206'/%3E%3Cpath%20d='M1348%20160%20l8%206%20l-8%206'/%3E%3Cpath%20d='M338%20453%20H584'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M768%20472%20H1054'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M1182%20472%20H1392'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M576%20447%20l8%206%20l-8%206'/%3E%3Cpath%20d='M1046%20466%20l8%206%20l-8%206'/%3E%3Cpath%20d='M1384%20466%20l8%206%20l-8%206'/%3E%3Cpath%20d='M250%20792%20H424'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M556%20782%20H754'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M924%20792%20H1064'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M1226%20792%20H1354'%20stroke-dasharray='5%209'/%3E%3Cpath%20d='M416%20786%20l8%206%20l-8%206'/%3E%3Cpath%20d='M746%20776%20l8%206%20l-8%206'/%3E%3Cpath%20d='M1056%20786%20l8%206%20l-8%206'/%3E%3Cpath%20d='M1346%20786%20l8%206%20l-8%206'/%3E%3Cpath%20d='M230%20224%20V430'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M675%20226%20V420'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M1118%20220%20V420'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M205%20548%20V716'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M820%20548%20V700'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M1180%20552%20V690'%20stroke-dasharray='6%2010'/%3E%3Cpath%20d='M470%20590%20l9%2010%20l16%20-22'/%3E%3Cpath%20d='M900%20300%20l9%2010%20l16%20-22'/%3E%3Cpath%20d='M1250%20580%20l9%2010%20l16%20-22'/%3E%3Cpath%20d='M520%20250%20l8%209%20l15%20-20'/%3E%3Ccircle%20cx='360'%20cy='300'%20r='6'/%3E%3Ccircle%20cx='1000'%20cy='560'%20r='6'/%3E%3Ccircle%20cx='700'%20cy='860'%20r='6'/%3E%3Ccircle%20cx='1440'%20cy='300'%20r='6'/%3E%3Ccircle%20cx='230'%20cy='430'%20r='5'/%3E%3Ccircle%20cx='675'%20cy='420'%20r='5'/%3E%3Ccircle%20cx='1118'%20cy='420'%20r='5'/%3E%3Cg%20transform='translate(150%20120)'%3E%3Crect%20width='158'%20height='96'%20rx='13'%20stroke-width='1.8'/%3E%3Cpath%20d='M0%2025%20H158'/%3E%3Ccircle%20cx='18'%20cy='13'%20r='3'/%3E%3Ccircle%20cx='31'%20cy='13'%20r='3'/%3E%3Ccircle%20cx='44'%20cy='13'%20r='3'/%3E%3Cpath%20d='M22%2046%20l18%2014%20l-18%2014'/%3E%3Cpath%20d='M48%2074%20H98'/%3E%3Crect%20x='108'%20y='62'%20width='13'%20height='18'%20rx='2'/%3E%3C/g%3E%3Cg%20transform='translate(600%20120)'%3E%3Crect%20width='128'%20height='100'%20rx='18'%20stroke-width='1.8'/%3E%3Cpath%20d='M64%200%20V-16'/%3E%3Ccircle%20cx='64'%20cy='-21'%20r='4.5'/%3E%3Cpath%20d='M0%2046%20H-11'/%3E%3Cpath%20d='M128%2046%20H139'/%3E%3Ccircle%20cx='42'%20cy='44'%20r='8'/%3E%3Ccircle%20cx='86'%20cy='44'%20r='8'/%3E%3Cpath%20d='M40%2076%20H88'/%3E%3Cpath%20d='M52%2072%20V80%20M64%2072%20V80%20M76%2072%20V80'/%3E%3C/g%3E%3Cg%20transform='translate(1000%20110)'%3E%3Cpath%20d='M14%20112%20V24'/%3E%3Ccircle%20cx='14'%20cy='20'%20r='6'/%3E%3Cpath%20d='M14%2020%20H150'/%3E%3Cpath%20d='M44%2014%20l-16%2012%20M72%2014%20l-16%2012%20M100%2014%20l-16%2012%20M128%2014%20l-16%2012'/%3E%3Cpath%20d='M0%20112%20H60'/%3E%3Cpath%20d='M92%2082%20l14%2015%20l26%20-34'/%3E%3C/g%3E%3Cg%20transform='translate(1360%20150)'%3E%3Ccircle%20cx='56'%20cy='56'%20r='30'/%3E%3Ccircle%20cx='56'%20cy='56'%20r='11'/%3E%3Cpath%20d='M86%2056%20H98%20M14%2056%20H26%20M56%2086%20V98%20M56%2014%20V26'/%3E%3Cpath%20d='M77%2077%20L86%2086%20M35%2077%20L26%2086%20M35%2035%20L26%2026%20M77%2035%20L86%2026'/%3E%3C/g%3E%3Cg%20transform='translate(230%20430)'%3E%3Crect%20width='100'%20height='46'%20rx='23'%20stroke-width='1.8'/%3E%3Ccircle%20cx='72'%20cy='23'%20r='15'/%3E%3C/g%3E%3Cg%20transform='translate(590%20420)'%3E%3Crect%20width='170'%20height='104'%20rx='12'%20stroke-width='1.6'%20stroke-dasharray='7%207'/%3E%3Ccircle%20cx='40'%20cy='58'%20r='7'/%3E%3Cpath%20d='M40%2058%20H96'/%3E%3Cpath%20d='M96%2058%20C116%2058%20116%2034%20116%2034'/%3E%3Ccircle%20cx='116'%20cy='28'%20r='7'/%3E%3Cpath%20d='M96%2058%20C116%2058%20116%2082%20116%2082'/%3E%3Ccircle%20cx='116'%20cy='88'%20r='7'/%3E%3Crect%20x='128'%20y='18'%20width='30'%20height='15'%20rx='4'/%3E%3C/g%3E%3Cg%20transform='translate(1060%20420)'%3E%3Cpath%20d='M60%200%20L114%2020%20V52%20C114%2092%2090%20114%2060%20128%20C30%20114%206%2092%206%2052%20V20%20Z'%20stroke-width='1.8'/%3E%3Cpath%20d='M34%2060%20l18%2020%20l32%20-42'/%3E%3C/g%3E%3Cg%20transform='translate(1400%20490)'%3E%3Ccircle%20cx='0'%20cy='0'%20r='8'/%3E%3Cpath%20d='M12%200%20H52'/%3E%3Cpath%20d='M44%20-6%20l8%206%20l-8%206'/%3E%3Ccircle%20cx='66'%20cy='0'%20r='8'/%3E%3Cpath%20d='M78%200%20H118'/%3E%3Cpath%20d='M110%20-6%20l8%206%20l-8%206'/%3E%3Ccircle%20cx='132'%20cy='0'%20r='8'/%3E%3C/g%3E%3Cg%20transform='translate(150%20720)'%3E%3Ccircle%20cx='56'%20cy='56'%20r='30'/%3E%3Ccircle%20cx='56'%20cy='56'%20r='11'/%3E%3Cpath%20d='M86%2056%20H98%20M14%2056%20H26%20M56%2086%20V98%20M56%2014%20V26'/%3E%3Cpath%20d='M77%2077%20L86%2086%20M35%2077%20L26%2086%20M35%2035%20L26%2026%20M77%2035%20L86%2026'/%3E%3C/g%3E%3Cg%20transform='translate(430%20690)'%3E%3Cpath%20d='M0%2012%20C0%205%205%200%2012%200%20H92%20L120%2028%20V138%20C120%20145%20115%20150%20108%20150%20H12%20C5%20150%200%20145%200%20138%20Z'%20stroke-width='1.8'/%3E%3Cpath%20d='M92%200%20V28%20H120'/%3E%3Cpath%20d='M44%2062%20C33%2062%2038%2076%2027%2080%20C38%2084%2033%2098%2044%2098'/%3E%3Cpath%20d='M78%2062%20C89%2062%2084%2076%2095%2080%20C84%2084%2089%2098%2078%2098'/%3E%3Cpath%20d='M30%20120%20H92%20M30%20133%20H72'/%3E%3C/g%3E%3Cg%20transform='translate(760%20700)'%3E%3Crect%20width='158'%20height='96'%20rx='13'%20stroke-width='1.8'/%3E%3Cpath%20d='M0%2025%20H158'/%3E%3Ccircle%20cx='18'%20cy='13'%20r='3'/%3E%3Ccircle%20cx='31'%20cy='13'%20r='3'/%3E%3Ccircle%20cx='44'%20cy='13'%20r='3'/%3E%3Cpath%20d='M22%2046%20l18%2014%20l-18%2014'/%3E%3Cpath%20d='M48%2074%20H98'/%3E%3Crect%20x='108'%20y='62'%20width='13'%20height='18'%20rx='2'/%3E%3C/g%3E%3Cg%20transform='translate(1070%20700)'%3E%3Cpath%20d='M14%20112%20V24'/%3E%3Ccircle%20cx='14'%20cy='20'%20r='6'/%3E%3Cpath%20d='M14%2020%20H150'/%3E%3Cpath%20d='M44%2014%20l-16%2012%20M72%2014%20l-16%2012%20M100%2014%20l-16%2012%20M128%2014%20l-16%2012'/%3E%3Cpath%20d='M0%20112%20H60'/%3E%3Cpath%20d='M92%2082%20l14%2015%20l26%20-34'/%3E%3C/g%3E%3Cg%20transform='translate(1360%20690)'%3E%3Cpath%20d='M60%200%20L114%2020%20V52%20C114%2092%2090%20114%2060%20128%20C30%20114%206%2092%206%2052%20V20%20Z'%20stroke-width='1.8'/%3E%3Cpath%20d='M34%2060%20l18%2020%20l32%20-42'/%3E%3C/g%3E%3C/g%3E%3Cg%20fill='rgb(230,237,243)'%20fill-opacity='0.08'%3E%3Ccircle%20cx='150'%20cy='620'%20r='2.5'/%3E%3Ccircle%20cx='163'%20cy='620'%20r='2.5'/%3E%3Ccircle%20cx='176'%20cy='620'%20r='2.5'/%3E%3Ccircle%20cx='980'%20cy='860'%20r='2.5'/%3E%3Ccircle%20cx='993'%20cy='860'%20r='2.5'/%3E%3Ccircle%20cx='1006'%20cy='860'%20r='2.5'/%3E%3Ccircle%20cx='1300'%20cy='450'%20r='2.5'/%3E%3Ccircle%20cx='1313'%20cy='450'%20r='2.5'/%3E%3Ccircle%20cx='1326'%20cy='450'%20r='2.5'/%3E%3C/g%3E%3C/svg%3E");
-  background-size: cover, cover, cover;
-  background-position: 0 0, 0 0, center;
-  background-repeat: no-repeat, no-repeat, no-repeat;
-}
+
 
 /* Live edge — the leading-edge strip that marks the element doing work, and the one
    waiting on a human (see components/LiveEdge.tsx for the ranking rationale). Rendered

--- a/src/styles/resolveToken.ts
+++ b/src/styles/resolveToken.ts
@@ -1,5 +1,5 @@
 /**
- * resolveToken — read a semantic design token's computed value at call time.
+ * resolveToken — read a semantic design token as a CONCRETE computed color.
  *
  * The §2.11 contract (DES-VISION-001): components never ship a raw color; they
  * consume the semantic tokens from src/styles/tokens.css. DOM styles do that
@@ -10,6 +10,16 @@
  * tokens.css, so theme overrides and accent customization (§3.3) reach these
  * consumers too, as long as they resolve at (re)build time.
  *
+ * WHY A PROBE ELEMENT, not getPropertyValue on :root: an unregistered custom
+ * property's computed value is its raw token stream after var() substitution —
+ * the §2.5/§2.6 tokens come back as `hsl(258 72% 62%)` (space-separated) or
+ * even `hsl(258 72% calc(62% - 18%))` (calc unevaluated). The var()-blind
+ * sinks this function exists for parse NEITHER: cytoscape's color regexes
+ * require comma-separated channels and no calc (it discards the declaration
+ * and falls back to its gray default). Applying `var(--token)` to a probe's
+ * `color` and reading the COMPUTED color instead makes the browser do the full
+ * math and hands back canonical `rgb()`/`rgba()` — which every sink parses.
+ *
  * In non-browser environments (jsdom tests) custom properties declared in
  * stylesheets are not computed; this returns '' and the consumer falls back
  * to its library default — the components involved mock those libraries in
@@ -17,5 +27,12 @@
  */
 export function resolveToken(name: string): string {
   if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') return '';
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  const probe = document.createElement('div');
+  probe.style.color = `var(${name})`;
+  document.body.appendChild(probe);
+  const computed = getComputedStyle(probe).color.trim();
+  probe.remove();
+  // A real resolution computes to a concrete color function or hex. Anything
+  // else (jsdom's unset '' / uncomputed passthrough) keeps the '' contract.
+  return /^(rgb|hsl|color|#)/i.test(computed) && !computed.includes('var(') ? computed : '';
 }

--- a/src/styles/resolveToken.ts
+++ b/src/styles/resolveToken.ts
@@ -1,0 +1,21 @@
+/**
+ * resolveToken — read a semantic design token's computed value at call time.
+ *
+ * The §2.11 contract (DES-VISION-001): components never ship a raw color; they
+ * consume the semantic tokens from src/styles/tokens.css. DOM styles do that
+ * with `var(--token)` directly. A few sinks cannot take a var() reference —
+ * xterm.js themes and cytoscape stylesheets parse concrete color strings —
+ * so they resolve the token through the cascade instead. This is the
+ * §2.11-clean escape hatch, not a bypass: the value still originates in
+ * tokens.css, so theme overrides and accent customization (§3.3) reach these
+ * consumers too, as long as they resolve at (re)build time.
+ *
+ * In non-browser environments (jsdom tests) custom properties declared in
+ * stylesheets are not computed; this returns '' and the consumer falls back
+ * to its library default — the components involved mock those libraries in
+ * unit tests and are probed for real in the Playwright rigs.
+ */
+export function resolveToken(name: string): string {
+  if (typeof document === 'undefined' || typeof getComputedStyle !== 'function') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -106,6 +106,11 @@
   --shadow-raised:  0 4px 12px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.08);
   --shadow-overlay: 0 8px 24px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.10);
 
+  /* Modal/backdrop scrim — the one translucent fill that must stay translucent
+     (content behind a backdrop is context, not noise). Semantic, theme-owned:
+     a light theme may soften it without touching any consumer. */
+  --scrim: rgba(0, 0, 0, 0.6);
+
   /* ── Motion tokens (§2.10) — motion is state change, never decoration (§1.5) ── */
   --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);     /* smooth deceleration — most transitions */
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* slight overshoot — gate pulse, board reorder */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,25 +39,8 @@ export default {
           done: 'var(--status-done)',
           'done-dim': 'var(--status-done-dim)',
         },
-        // The INHERITED shell palette — consumed by today's components; slices
-        // 2–6 migrate them onto the semantic aliases above, then this retires.
-        wk: {
-          canvas:       '#0d1117',
-          'canvas-2':   '#161c26',
-          surface:      '#1b222e',
-          'surface-2':  '#0f1419',
-          ink:          '#e6edf3',
-          accent:       '#ffda19',
-          'accent-ink': '#0d1117',
-          link:         '#79c0ff',
-          ok:           '#3fb950',
-          deny:         '#f85149',
-          muted:        'rgba(230,237,243,0.55)',
-          blue:         '#1c4053',
-          'blue-2':     '#182f3c',
-          'blue-s':     '#224a5e',
-          'blue-s2':    '#1a3b4e',
-        },
+        // The inherited `wk` shell palette retired with DES-VISION-001 slice 6 —
+        // its last consumers moved onto the semantic aliases above.
       },
     },
   },


### PR DESCRIPTION
§2.11 finished: all 50 remaining components converted with role fidelity (legacy amber split CTA-vs-gate, legacy blue split link-vs-running), the --wk-* palette retired, the no-raw-color rule now ERROR across src/** with the allowlist machinery deleted, plus the PostCSS twin (an injected hex fails the BUILD). 1,166 warnings → zero. The verifier caught and fixed a real regression no rig covered: resolveToken fed cytoscape unparseable token streams, silently graying the repo graph — now resolved via computed-color probe. 847/847 tests; all eleven rigs green; the 911 changed pixels vs main are exactly the sanctioned §2.6 status recolors (census-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)