### PR TITLE
feat(appearance): logo, accent, theme, live preview (DES-VISION-001 slice 7)

### DIFF
--- a/.product/evidence/vision-slice7/checklist.md
+++ b/.product/evidence/vision-slice7/checklist.md
@@ -1,0 +1,83 @@
+# DES-VISION-001 slice 7 — experience checklist verdicts
+
+**Slice:** the customization UI (§6.3 slice 7) — §3 end to end. The `/system`
+Settings surface gains the §3.2 **Appearance section** (a section, not a new
+page): logo upload-or-URL into the chrome's 32×32 `--logo-url` slot with the
+§3.1 contain-fit/clearspace contract, a 240px canvas hue wheel plus
+saturation/lightness sliders driving the three §2.5 accent primitives, the
+light/dark theme-instance picker (§2.14), the §3.2 preview strip (accent mode
+segment + FIXED gate chip + primary action), and the two independent §3.5
+resets. Live preview IS the page (§3.4): every move lands as inline
+custom-property overrides on `<html>` — the cascade seam tokens.css declares.
+Persistence (§3.3) is a 400ms-debounced, optimistic, silently-retried
+`PUT /api/v1/settings` under the namespaced `studio.appearance` key;
+`App.tsx` reads the key once at startup and applies it (a daemon without a
+settings surface fails silently into the stylesheet defaults — the
+§3.3 ASSUMPTION[external-transform] adaptation: studio treats the store as a
+flat key-value object and never depends on a targeted sub-route).
+**Rubric:** DES-VISION-001 §6.1 → this slice's §6.3 entry: **EC12, EC15, EC16**.
+**Images:** `e2e/shots/vision/vision-7-appearance-settings.png` (Settings open,
+Appearance section with the wheel dragged to teal and the preview strip live)
+and `e2e/shots/vision/vision-7-custom-accent.png` (the W2 board + chrome
+wearing a STORED teal accent ≈180° from startup), both 1440×900,
+`device_scale_factor=1`, per §6.0, by `e2e/vision_slice7_test.py` against the
+frozen-`NOW0` W2 fixture with the browser clock frozen at `NOW0+5s`. The shots
+are gitignored evidence; the rig's JSON report records the paths beside the
+verdicts.
+
+| Item | Verdict | Read from the evidence |
+|---|---|---|
+| **EC12 — accent is singular** | **PASS** | With the accent dragged to teal (and again with a STORED teal on the board), the probe-computed `--accent` differs from every fixed status color (`--status-gate` amber, `--status-fail` red, `--status-run` emerald) — asserted computed-vs-computed in both scenes, and visible in both shots: the gate chips/cards stay amber, FAILED stays red, WORKING stays emerald while the logo mark, nav links, active mode segment, and primary button all turn teal. Status colors are deliberately NOT offered in the surface; the section says so in copy ("fixed semantic signals"). |
+| **EC15 — token discipline** | **PASS** | The preview strip's computed `background`/`color` values equal the scratch-element probes of their semantic tokens (`--accent`, `--accent-fg`, `--status-gate-dim`, `--status-gate`) — no hex in the rig. `npm run lint` exits 0 with zero §2.11 findings including the new `AppearanceSettings.tsx`/`appearance.ts` (the wheel's canvas hues and the slider gradient tracks interpolate variables/`var()` refs, never literal channel values). |
+| **EC16 — logo slot respected** | **PASS** | Applying a same-origin custom URL (a deliberately NON-SQUARE 2:1 SVG) sets `--logo-url` on `<html>`; the chrome slot's computed `background-image` resolves the asset, computed `background-size` is `contain` (letterboxed, never stretched or cropped), the slot stays exactly 32×32, and `[data-testid="logo-wicked-mark"]` count is **0** — the W mark is absent, the two never stack. Remove restores the mark and clears the property; the PUT that carried the logo left the accent untouched (independence, §3.5). |
+
+**Slice DOM ACs** (from `vision_slice7_test.py`'s JSON report, all true):
+
+- On settings load with a SEEDED stored appearance (h=200, s=60, l=55),
+  `document.documentElement.style.getPropertyValue('--_accent-h')` reads back
+  exactly `'200'` (with `'60%'`/`'55%'` beside it) — startup applies the store
+  (AC 1).
+- A pointer-drag on the hue wheel to the 180° point updates `--_accent-h`
+  within ONE `requestAnimationFrame` (read back `'180'` on the next frame)
+  (AC 2).
+- The `PUT /api/v1/settings` fires only after the 400ms debounce (measured
+  ~0.4s after pointer-up), carries the FULL `studio.appearance` object with
+  the dragged hue, and a slider ArrowRight×2 lands the next debounced PUT
+  with `accent_s: 62` (AC 3).
+- Reset restores `--_accent-h: 258` (+72%/62%) inline AND persists 258/72/62
+  (AC 4).
+- With a logo URL set, `[data-testid="logo-slot"]` has a non-none
+  `background-image` resolving the asset and `[data-testid="logo-wicked-mark"]`
+  is absent (AC 5 / EC16).
+- The theme picker: Light sets `data-theme="light"` on `<html>` and flips the
+  computed `--surface-base` (rgb(9,9,15) → rgb(244,244,248)); Dark removes the
+  attribute; both persist their PUT.
+- Zero console errors across both scenes.
+
+**Repo gates:** `npm run lint` exit **0 — zero errors, zero warnings** (the
+§2.11 rule stays ERROR repo-wide over the new files). `npm run typecheck`
+exit 0. `npm test` **867/867** (93 files — +20 new: the appearance store's
+load/apply/debounce/retry/sanitize contract, the AppearanceSettings DOM
+contract incl. upload size-cap and data-URL landing, and the AppChrome
+mark-absence case).
+
+**All rigs green on the fresh build** (`dist-sameorigin` deleted and rebuilt
+from this branch first): `uxfix_slice1..6_test.py`,
+`vision_slice1..4_test.py`, `vision_slice6_test.py`, and this slice's
+`vision_slice7_test.py` — **twelve for twelve, exit 0.** Every pre-slice-7
+rig's page now GETs `/api/v1/settings` at boot (the App startup read); the
+fixture's defaults are exactly tokens.css's values, so nothing moved.
+
+**The vision-1 pixel gate, run the strong way (§6.3: "no UXFIX surfaces
+touched"):** baseline captured from a build of the STACK BASE
+(`vision/slice-6-token-completion` @ `fcc4f01`, a detached worktree — the
+zero-regression reference for a stacked branch; origin/main is behind the
+base by slice 6's sanctioned recolors, already accounted in slice 6's
+evidence), check from this branch: **pixel-identical, 0 differing pixels,
+empty diff bbox** — the startup settings read applying default inline
+overrides changes nothing the eye or the diff can see.
+
+**UXFIX preserved:** no UXFIX surface touched — the Appearance section is
+additive inside `/system`; the board/chrome deltas are zero at defaults (the
+pixel gate above) and, under a custom accent, confined to the accent layer by
+construction (the §2.6 status layer reads from untouched tokens).

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -35,6 +35,11 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     frames, so Video mode has a §5.6 surface to render (vision
                     slice 4; default False — the board rigs' doc tiles must not
                     grow a tile they never asserted).
+  appearance      — replaces the settings store's `studio.appearance` wholesale
+                    (a dict; None restores the tokens.css defaults), so the
+                    vision-slice-7 rig can seed a STORED accent/logo/theme
+                    between page loads. GET/PUT /api/v1/settings serve the
+                    store itself (DES-VISION-001 §3.3).
 
 A rig that never flips them gets the default W2 board.
 """
@@ -75,6 +80,28 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
          "extra_narration": [], "demo": False}
 state_lock = threading.Lock()
+
+# ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
+#
+# The daemon's GET/PUT /api/v1/settings surface reduced to what studio speaks:
+# a flat JSON object; PUT merges its body's top-level keys. `studio.appearance`
+# is studio's namespaced key — the App startup reads it and applies it as inline
+# custom-property overrides on <html>, so EVERY rig's page now GETs this route
+# on boot; the defaults below are exactly tokens.css's values, which keeps every
+# pre-slice-7 board pixel-identical. The slice-7 rig overwrites the key between
+# page loads via POST /__fixture {"appearance": {...}} (None restores defaults)
+# and reads back what the page PUT.
+DEFAULT_APPEARANCE = {"accent_h": 258, "accent_s": 72, "accent_l": 62,
+                      "logo_url": None, "theme": "dark"}
+settings_store: dict = {"graphNodeLimit": 150,
+                        "studio.appearance": dict(DEFAULT_APPEARANCE)}
+
+# A custom logo asset for the slice-7 rig (§3.1 / EC16): deliberately NON-SQUARE
+# (2:1) so contain-fit letterboxing — never stretch, never crop — is provable.
+LOGO_TEST_SVG = (b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32">'
+                 b'<rect width="64" height="32" rx="6" fill="#0e7490"/>'
+                 b'<circle cx="16" cy="16" r="9" fill="#f8fafc"/>'
+                 b'<rect x="30" y="10" width="26" height="12" rx="3" fill="#f8fafc"/></svg>')
 
 
 def project(pid: str, name: str, updated_at: int, **extra) -> dict:
@@ -409,6 +436,20 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/health":
             self._json(200, {"status": "ok", "version": "w2-fixture", "ping": "pong"})
             return True
+        # The settings store (§3.3): every page boot GETs it for studio.appearance.
+        if path == "/api/v1/settings":
+            with state_lock:
+                snapshot = json.loads(json.dumps(settings_store))
+            self._json(200, {"settings": snapshot})
+            return True
+        # The slice-7 rig's custom-logo asset (served same-origin, §3.1).
+        if path == "/__assets/logo-test.svg":
+            self.send_response(200)
+            self.send_header("Content-Type", "image/svg+xml")
+            self.send_header("Content-Length", str(len(LOGO_TEST_SVG)))
+            self.end_headers()
+            self.wfile.write(LOGO_TEST_SVG)
+            return True
         if path == "/api/v1/runs":
             with state_lock:
                 if state["no_runs"]:
@@ -630,6 +671,13 @@ class W2Handler(SimpleHTTPRequestHandler):
         body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
         if path == "/__fixture":
             with state_lock:
+                # `appearance` rides the same control channel but lands in the
+                # settings store: a dict replaces studio.appearance wholesale,
+                # None restores the defaults (vision slice 7).
+                if "appearance" in body:
+                    settings_store["studio.appearance"] = (
+                        dict(DEFAULT_APPEARANCE) if body["appearance"] is None
+                        else body["appearance"])
                 state.update({k: v for k, v in body.items() if k in state})
                 snapshot = dict(state)
             return self._json(200, {"ok": True, "state": snapshot})
@@ -649,6 +697,19 @@ class W2Handler(SimpleHTTPRequestHandler):
         parts = path.split("/")
         if len(parts) == 6 and parts[3] == "chats" and parts[5] == "messages":
             return self._json(200, {"seats": []})
+        return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+
+    def do_PUT(self):  # noqa: N802 (stdlib naming)
+        path = urllib.parse.urlparse(self.path).path
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+        # PUT /api/v1/settings — merge the body's top-level keys, answer the
+        # merged store (the daemon's contract; studio.appearance replaces whole).
+        if path == "/api/v1/settings":
+            with state_lock:
+                if isinstance(body, dict):
+                    settings_store.update(body)
+                snapshot = json.loads(json.dumps(settings_store))
+            return self._json(200, {"settings": snapshot})
         return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
 
     def do_DELETE(self):  # noqa: N802 (stdlib naming)

--- a/e2e/vision_slice7_test.py
+++ b/e2e/vision_slice7_test.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+vision_slice7_test.py — the DES-VISION-001 slice-7 gate: the customization
+surface (§3) works end-to-end against the crew settings API shape (§6.3
+slice 7; EC12, EC15, EC16).
+
+What slice 7 ships and this rig proves, in one browser session against the
+shared frozen-NOW0 W2 fixture (whose settings store now serves GET/PUT
+/api/v1/settings with `studio.appearance`, §3.3):
+
+  1. STARTUP APPLIES THE STORE (§3.3): with a seeded stored accent (h=200,
+     s=60, l=55), loading /system lands those values as INLINE overrides on
+     <html> — `--_accent-h` reads back exactly "200" (the DOM AC);
+  2. THE WHEEL IS LIVE (§3.4): a pointer-drag on the 240px hue wheel to the
+     180° point updates `--_accent-h` within ONE animation frame — the whole
+     page is the preview, no apply step;
+  3. PERSISTENCE IS DEBOUNCED (§3.3): the PUT to /api/v1/settings fires only
+     after the 400ms debounce (elapsed measured), carries the full
+     `studio.appearance` object with the dragged hue, and a slider nudge
+     (ArrowRight ×2) lands the next debounced PUT;
+  4. THE PREVIEW STRIP SPEAKS TOKENS (EC15) and the accent stays DISTINCT
+     from the fixed status trio (EC12) — probed computed-vs-computed, no hex
+     in this rig;
+  5. RESET (§3.5): restores 258/72/62 inline AND persists it; the logo is
+     untouched by design (asserted in the unit suite; here reset runs while
+     no logo is set);
+  6. LOGO (§3.1/EC16): applying a same-origin CUSTOM URL (a deliberately
+     non-square 2:1 SVG) sets `--logo-url`, the chrome slot's computed
+     background-image resolves it with contain-fit (letterboxed, never
+     cropped), and the default wicked mark is ABSENT; Remove restores it;
+  7. THEME (§2.14): Light sets `data-theme="light"` on <html> and flips the
+     computed `--surface-base`; Dark removes the attribute; both persist;
+  8. THE BOARD WEARS IT (EC12): with a stored teal accent (h=180), the W2
+     board renders from the stored value with the status colors untouched.
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-7-appearance-settings.png  Settings open, Appearance section with the
+                                    hue wheel (dragged teal) + preview strip.
+  vision-7-custom-accent.png        The W2 board + chrome with the stored teal
+                                    accent (≈180°) applied from startup.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: VISION_PORT (default 4347),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4347"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+SHOT_SETTINGS = VSHOTS / "vision-7-appearance-settings.png"
+SHOT_ACCENT = VSHOTS / "vision-7-custom-accent.png"
+
+FREEZE_MOTION = (
+    "*, *::before, *::after { animation: none !important; transition: none !important; }"
+)
+
+# The token probe (the rig-set's technique): computed color of `var(<name>)` on
+# a scratch element — keeps every hex value OUT of this rig.
+PROBES = """() => {
+  const probe = (name, prop) => { const el = document.createElement('div');
+    el.style[prop] = `var(${name})`;
+    document.body.appendChild(el);
+    const v = getComputedStyle(el)[prop === 'background' ? 'backgroundColor' : prop];
+    el.remove(); return v; };
+  return {
+    accent:        probe('--accent', 'background'),
+    surfaceBase:   probe('--surface-base', 'background'),
+    statusGate:    probe('--status-gate', 'color'),
+    statusGateDim: probe('--status-gate-dim', 'background'),
+    statusFail:    probe('--status-fail', 'color'),
+    statusRun:     probe('--status-run', 'color'),
+  }; }"""
+
+INLINE = """() => ({
+  h: document.documentElement.style.getPropertyValue('--_accent-h'),
+  s: document.documentElement.style.getPropertyValue('--_accent-s'),
+  l: document.documentElement.style.getPropertyValue('--_accent-l'),
+  logo: document.documentElement.style.getPropertyValue('--logo-url'),
+  theme: document.documentElement.getAttribute('data-theme'),
+})"""
+
+# The stored appearance scene A seeds (a NON-default hue, so "load applies the
+# store" is distinguishable from the stylesheet default) and scene B's teal.
+STORED_A = {"accent_h": 200, "accent_s": 60, "accent_l": 55, "logo_url": None, "theme": "dark"}
+STORED_B = {"accent_h": 180, "accent_s": 70, "accent_l": 58, "logo_url": None, "theme": "dark"}
+LOGO_URL = "/__assets/logo-test.svg"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def is_settings_put(r) -> bool:
+    return r.method == "PUT" and r.url.endswith("/api/v1/settings")
+
+
+def put_appearance(req) -> dict:
+    body = json.loads(req.post_data or "{}")
+    return body.get("studio.appearance") or {}
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    # ══ Scene A: /system — load-applies, wheel, debounce, reset, logo, theme ══
+    set_fixture(ORIGIN, appearance=STORED_A)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/system", wait_until="domcontentloaded")
+    page.locator('[data-testid="appearance-settings"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+
+    # AC 1 — startup applied the STORED values as inline overrides on <html>.
+    try:
+        page.wait_for_function(
+            "() => document.documentElement.style.getPropertyValue('--_accent-h') === '200'",
+            timeout=15000)
+    except Exception:
+        fail("load_applies_store",
+             f"--_accent-h never became '200' from the stored appearance; inline now: "
+             f"{page.evaluate(INLINE)}")
+    inline0 = page.evaluate(INLINE)
+    report["steps"]["load_applies_store"] = {
+        "ok": inline0 == {"h": "200", "s": "60%", "l": "55%", "logo": "", "theme": None},
+        "stored": STORED_A, "inline": inline0,
+    }
+
+    # AC 2+3 — drag the wheel to 180°: one-frame application, debounced PUT.
+    wheel = page.locator('[data-testid="hue-wheel"]')
+    wheel.scroll_into_view_if_needed()
+    box = wheel.bounding_box()
+    cx, cy = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+    ring_r = box["width"] / 2 - 13  # mid-ring: WHEEL/2 - RING/2 - 1
+    with page.expect_request(is_settings_put, timeout=8000) as put1:
+        page.mouse.move(cx + ring_r * math.cos(math.pi), cy + ring_r * math.sin(math.pi))
+        page.mouse.down()
+        page.mouse.up()
+        t_up = time.time()
+        hue_next_frame = page.evaluate(
+            """() => new Promise(res => requestAnimationFrame(
+                 () => res(document.documentElement.style.getPropertyValue('--_accent-h'))))""")
+    debounce_s = time.time() - t_up
+    dragged = put_appearance(put1.value)
+    hue_val = int(hue_next_frame or -1)
+    report["steps"]["wheel_drag"] = {
+        "ok": (178 <= hue_val <= 182
+               and debounce_s >= 0.3
+               and dragged.get("accent_h") == hue_val
+               and dragged.get("accent_s") == 60 and dragged.get("accent_l") == 55),
+        "hue_applied_within_one_frame": hue_next_frame,
+        "put_after_debounce_seconds": round(debounce_s, 3),
+        "put_studio_appearance": dragged,
+    }
+
+    # A slider nudge fine-tunes saturation (§3.2) and lands the NEXT debounced PUT.
+    with page.expect_request(is_settings_put, timeout=8000) as put2:
+        sat = page.locator('[data-testid="accent-sat"]')
+        sat.focus()
+        sat.press("ArrowRight")
+        sat.press("ArrowRight")
+    nudged = put_appearance(put2.value)
+    inline_s = page.evaluate("() => document.documentElement.style.getPropertyValue('--_accent-s')")
+    report["steps"]["slider_nudge"] = {
+        "ok": inline_s == "62%" and nudged.get("accent_s") == 62,
+        "inline_s": inline_s, "put_studio_appearance": nudged,
+    }
+
+    # EC15 + EC12 on the preview strip: tokens end-to-end, accent ≠ status trio.
+    probes = page.evaluate(PROBES)
+    strip = page.evaluate(
+        """() => {
+      const cs = (sel, prop) => { const el = document.querySelector(sel);
+        return el ? getComputedStyle(el)[prop] : null; };
+      return {
+        modeActiveBg: cs('[data-testid="preview-mode-active"]', 'backgroundColor'),
+        primaryBg:    cs('[data-testid="preview-primary"]', 'backgroundColor'),
+        gateChipBg:   cs('[data-testid="preview-gate-chip"]', 'backgroundColor'),
+        gateChipInk:  cs('[data-testid="preview-gate-chip"]', 'color'),
+      }; }""")
+    strip_checks = {
+        "mode_active_bg_is_accent": strip["modeActiveBg"] == probes["accent"],
+        "primary_bg_is_accent": strip["primaryBg"] == probes["accent"],
+        "gate_chip_bg_is_status_gate_dim": strip["gateChipBg"] == probes["statusGateDim"],
+        "gate_chip_ink_is_status_gate": strip["gateChipInk"] == probes["statusGate"],
+        "accent_distinct_from_gate": probes["accent"] != probes["statusGate"],
+        "accent_distinct_from_fail": probes["accent"] != probes["statusFail"],
+        "accent_distinct_from_run": probes["accent"] != probes["statusRun"],
+    }
+    report["steps"]["preview_strip"] = {"ok": all(strip_checks.values()),
+                                        **strip_checks, "computed": strip, "probes": probes}
+
+    # The named screenshot: Appearance section, wheel dragged teal, strip live.
+    try:
+        page.wait_for_function("() => document.fonts.status === 'loaded'", timeout=20000)
+    except Exception:
+        pass
+    page.screenshot(path=str(SHOT_SETTINGS))
+
+    # AC 4 — reset restores 258/72/62 inline AND persists it (§3.5).
+    with page.expect_request(is_settings_put, timeout=8000) as put3:
+        page.locator('[data-testid="accent-reset"]').click()
+    reset_put = put_appearance(put3.value)
+    inline_r = page.evaluate(INLINE)
+    report["steps"]["reset"] = {
+        "ok": (inline_r["h"] == "258" and inline_r["s"] == "72%" and inline_r["l"] == "62%"
+               and reset_put.get("accent_h") == 258 and reset_put.get("accent_s") == 72
+               and reset_put.get("accent_l") == 62),
+        "inline": inline_r, "put_studio_appearance": reset_put,
+    }
+
+    # AC 5 — the custom logo (EC16): URL in, slot resolves it, the mark is gone.
+    page.locator('[data-testid="logo-url-input"]').fill(LOGO_URL)
+    with page.expect_request(is_settings_put, timeout=8000) as put4:
+        page.locator('[data-testid="logo-url-apply"]').click()
+    logo_put = put_appearance(put4.value)
+    logo_state = page.evaluate(
+        """() => { const slot = document.querySelector('[data-testid="logo-slot"]');
+      const s = slot ? getComputedStyle(slot) : null;
+      return {
+        inlineLogo: document.documentElement.style.getPropertyValue('--logo-url'),
+        slotBgImage: s ? s.backgroundImage : null,
+        slotBgSize: s ? s.backgroundSize : null,
+        slotW: s ? s.width : null, slotH: s ? s.height : null,
+        markCount: document.querySelectorAll('[data-testid="logo-wicked-mark"]').length,
+        removeShown: !!document.querySelector('[data-testid="logo-remove"]'),
+      }; }""")
+    logo_checks = {
+        "inline_logo_url_set": logo_state["inlineLogo"] == f'url("{LOGO_URL}")',
+        "slot_bg_image_resolves_asset": (logo_state["slotBgImage"] or "") != "none"
+                                        and "logo-test.svg" in (logo_state["slotBgImage"] or ""),
+        "slot_contain_fit": logo_state["slotBgSize"] == "contain",
+        "slot_is_32x32": logo_state["slotW"] == "32px" and logo_state["slotH"] == "32px",
+        "wicked_mark_absent": logo_state["markCount"] == 0,
+        "remove_offered": logo_state["removeShown"],
+        "put_carries_logo_url": logo_put.get("logo_url") == LOGO_URL,
+        "logo_independent_of_accent": logo_put.get("accent_h") == 258,
+    }
+    report["steps"]["logo"] = {"ok": all(logo_checks.values()), **logo_checks, "computed": logo_state}
+
+    # …and Remove restores the default mark (§3.5 reset 2, independent of accent).
+    with page.expect_request(is_settings_put, timeout=8000) as put5:
+        page.locator('[data-testid="logo-remove"]').click()
+    remove_put = put_appearance(put5.value)
+    after_remove = page.evaluate(
+        """() => ({
+      inlineLogo: document.documentElement.style.getPropertyValue('--logo-url'),
+      markCount: document.querySelectorAll('[data-testid="logo-wicked-mark"]').length,
+    })""")
+    report["steps"]["logo_remove"] = {
+        "ok": (after_remove["inlineLogo"] == "" and after_remove["markCount"] >= 1
+               and remove_put.get("logo_url") is None and remove_put.get("accent_h") == 258),
+        "computed": after_remove, "put_studio_appearance": remove_put,
+    }
+
+    # AC 6 — the theme instance picker (§2.14): light flips the surface ramp.
+    dark_surface = probes["surfaceBase"]
+    with page.expect_request(is_settings_put, timeout=8000) as put6:
+        page.locator('[data-testid="theme-light"]').click()
+    light_put = put_appearance(put6.value)
+    light_state = page.evaluate(INLINE)
+    light_surface = page.evaluate(PROBES)["surfaceBase"]
+    with page.expect_request(is_settings_put, timeout=8000) as put7:
+        page.locator('[data-testid="theme-dark"]').click()
+    dark_put = put_appearance(put7.value)
+    back_state = page.evaluate(INLINE)
+    report["steps"]["theme_picker"] = {
+        "ok": (light_state["theme"] == "light" and light_put.get("theme") == "light"
+               and light_surface != dark_surface
+               and back_state["theme"] is None and dark_put.get("theme") == "dark"),
+        "light_inline": light_state, "surface_base_dark": dark_surface,
+        "surface_base_light": light_surface,
+    }
+    page.close()
+
+    # ══ Scene B: the board wears a STORED teal accent from startup (EC12) ══════
+    set_fixture(ORIGIN, appearance=STORED_B)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+    accent_ok = settled(
+        "() => document.documentElement.style.getPropertyValue('--_accent-h') === '180'",
+        timeout=15000,
+    )
+    fonts_ok = settled("() => document.fonts.status === 'loaded'", timeout=20000)
+
+    probes_b = page.evaluate(PROBES)
+    board_state = page.evaluate(
+        """() => ({
+      inlineH: document.documentElement.style.getPropertyValue('--_accent-h'),
+      markCount: document.querySelectorAll('[data-testid="logo-wicked-mark"]').length,
+      markStroke: (() => { const p = document.querySelector(
+        '[data-testid="logo-wicked-mark"] path');
+        return p ? getComputedStyle(p).stroke : null; })(),
+    })""")
+    page.screenshot(path=str(SHOT_ACCENT))
+
+    board_checks = {
+        "board_settled_w2_order": order_ok,
+        "live_narration_streamed": narration_ok,
+        "web_fonts_loaded": fonts_ok,
+        "stored_teal_applied": accent_ok and board_state["inlineH"] == "180",
+        "default_mark_present_no_logo": board_state["markCount"] >= 1,
+        "mark_stroke_follows_accent": board_state["markStroke"] == probes_b["accent"],
+        "accent_distinct_from_gate": probes_b["accent"] != probes_b["statusGate"],
+        "accent_distinct_from_fail": probes_b["accent"] != probes_b["statusFail"],
+        "accent_distinct_from_run": probes_b["accent"] != probes_b["statusRun"],
+    }
+    report["steps"]["board_custom_accent"] = {
+        "ok": all(board_checks.values()), **board_checks,
+        "computed": board_state, "probes": probes_b, "screenshot": str(SHOT_ACCENT),
+    }
+
+    browser.close()
+
+report["steps"]["console"] = {"ok": len(console_errors) == 0, "errors": console_errors[:10]}
+report["screenshots"] = [str(SHOT_SETTINGS), str(SHOT_ACCENT)]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("dom_acs_verdict", f"slice-7 assertions did not all hold — see {', '.join(bad)}")
+
+# ── 4. Lint: exit 0, ZERO §2.11 findings (the slice adds no raw color) ─────────
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings": findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero §2.11 findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { useRunEventStore } from './store/events.js';
 import { useDocThreadStore } from './store/docThread.js';
 import type { CoreEvent, RepoEntry } from './api/types.js';
 import { api } from './api/client.js';
+import { useAppearanceStore } from './theming/appearance.js';
 
 /** Frames that change run-list / unit state → trigger a `GET /runs` reconcile. */
 const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
@@ -119,6 +120,13 @@ export function App(): React.ReactElement {
   );
 
   useEventStream(handleEvent);
+
+  // Per-install appearance (DES-VISION-001 §3.3): one startup read of crew's
+  // settings store; `studio.appearance` lands as inline custom-property
+  // overrides on <html> — the cascade seam tokens.css declares for this.
+  useEffect(() => {
+    void useAppearanceStore.getState().load();
+  }, []);
 
   // Pre-merge bookmarks (`/runs/:id`, `/projects/:id`) redirect into the shell (§1.5).
   useLegacyRedirect({ panel, runId, projectId, mode, showLaunch }, navigate);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -453,6 +453,22 @@ export const api = {
       body: JSON.stringify(patch),
     }),
 
+  /**
+   * The per-install studio appearance rides the SAME settings store under the
+   * namespaced key `studio.appearance` (DES-VISION-001 §3.3). GET reads the
+   * whole settings object untyped — the key is studio-owned, not part of the
+   * daemon's `SystemSettings` contract, and may be absent on a daemon that has
+   * never persisted one; PUT writes just that key, leaving every other setting
+   * untouched (the daemon merges partial PUTs).
+   */
+  getAppearanceSettings: () => apiFetch<{ settings: Record<string, unknown> }>('/settings'),
+
+  putAppearanceSettings: (appearance: import('../theming/appearance.js').StudioAppearance) =>
+    apiFetch<{ settings: Record<string, unknown> }>('/settings', {
+      method: 'PUT',
+      body: JSON.stringify({ 'studio.appearance': appearance }),
+    }),
+
   // ── Projects (DES-PROJECT-001) ───────────────────────────────────────────────
 
   /** All projects; `status=active` (default) or `archived` filters. Includes the synthesized "Unfiled" default. */

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { useConnectionStore } from '../store/connection.js';
+import { useAppearanceStore } from '../theming/appearance.js';
 import { prefersReducedMotion } from './LiveEdge.js';
 import { SettingsMenu } from './SettingsMenu.js';
 import { WickedLogo } from './WickedLogo.js';
@@ -158,9 +159,13 @@ function ConnectionDot({ collapsed }: { collapsed: boolean }): React.ReactElemen
 
 export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const logoUrl = useAppearanceStore((s) => s.appearance.logo_url);
 
   // The §3.1 slot: 32×32 exactly, clearspace by margin, contain-fit custom
-  // asset via the --logo-url custom property, the accent-stroked mark inside.
+  // asset via the --logo-url custom property. The accent-stroked default mark
+  // renders ONLY while no custom logo is set (§3.1: "when no custom logo is
+  // set, the default SVG mark renders" — the slice-7 AC asserts its absence
+  // when `--logo-url` carries an asset, so the two never stack).
   const logoSlot = (
     <button
       type="button"
@@ -176,7 +181,7 @@ export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
         cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
       }}
     >
-      <WickedLogo size={32} />
+      {logoUrl === null && <WickedLogo size={32} />}
     </button>
   );
 

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAppearanceStore } from '../theming/appearance.js';
+import { WickedLogo } from './WickedLogo.js';
+
+/**
+ * The Appearance section of Settings (DES-VISION-001 §3.2) — a SECTION within
+ * the existing `/system` surface, not a new page (single-surface philosophy).
+ *
+ * Logo (§3.1): upload or URL into the 32×32 chrome slot via `--logo-url`;
+ * contain-fit (letterboxed, never stretched or cropped), `--space-2`
+ * clearspace, monochrome recommended. Remove reverts to the default mark.
+ *
+ * Accent (§3.2): a canvas hue wheel (240px — §7 sanctions a canvas wheel
+ * within budget; no library taken) drives `--_accent-h`; the two sliders
+ * fine-tune `--_accent-s` / `--_accent-l`. Every move applies as an inline
+ * override on <html> — the WHOLE PAGE is the live preview (§3.4); the strip
+ * below is just a convenient nearby example showing accent beside a gate chip
+ * (EC12: accent vs status, side by side). Reset restores 258/72/62 (§3.5) and
+ * persists; the logo is independent of the accent reset.
+ *
+ * Theme (§2.14): dark is tokens.css itself; light is the one theme instance,
+ * applied as `data-theme="light"` on <html> and persisted with the rest.
+ *
+ * Status colors are FIXED semantic signals (§2.6) — deliberately absent here.
+ */
+
+const WHEEL = 240;   /* §3.2: 240px diameter */
+const RING = 24;     /* ring thickness */
+const HANDLE = 16;
+
+/** Angle → hue: canvas convention (0° at +x, clockwise), matching the wedges. */
+function hueAtPointer(e: { clientX: number; clientY: number }, el: HTMLElement): number {
+  const rect = el.getBoundingClientRect();
+  const x = e.clientX - rect.left - rect.width / 2;
+  const y = e.clientY - rect.top - rect.height / 2;
+  return Math.round(((Math.atan2(y, x) * 180) / Math.PI + 360) % 360) % 360;
+}
+
+function HueWheel({ hue, onHue }: { hue: number; onHue: (h: number) => void }): React.ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return; // jsdom has no 2d context; the wheel is e2e-proven
+    const c = WHEEL / 2;
+    const r = c - RING / 2 - 1;
+    ctx.clearRect(0, 0, WHEEL, WHEEL);
+    ctx.lineWidth = RING;
+    for (let d = 0; d < 360; d++) {
+      ctx.beginPath();
+      ctx.arc(c, c, r, ((d - 1) * Math.PI) / 180, ((d + 1.5) * Math.PI) / 180);
+      ctx.strokeStyle = `hsl(${d} 100% 50%)`;
+      ctx.stroke();
+    }
+  }, []);
+
+  const rad = (hue * Math.PI) / 180;
+  const hr = WHEEL / 2 - RING / 2 - 1;
+
+  return (
+    <div
+      data-testid="hue-wheel"
+      role="slider"
+      aria-label="Accent hue"
+      aria-valuemin={0}
+      aria-valuemax={359}
+      aria-valuenow={hue}
+      tabIndex={0}
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture(e.pointerId);
+        setDragging(true);
+        onHue(hueAtPointer(e, e.currentTarget));
+      }}
+      onPointerMove={(e) => { if (dragging) onHue(hueAtPointer(e, e.currentTarget)); }}
+      onPointerUp={() => setDragging(false)}
+      onPointerCancel={() => setDragging(false)}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowUp') onHue((hue + 1) % 360);
+        else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') onHue((hue + 359) % 360);
+      }}
+      style={{
+        position: 'relative', width: `${WHEEL}px`, height: `${WHEEL}px`,
+        flexShrink: 0, cursor: 'crosshair', touchAction: 'none',
+        borderRadius: 'var(--radius-full)',
+      }}
+    >
+      <canvas ref={canvasRef} width={WHEEL} height={WHEEL} style={{ display: 'block' }} />
+      <div
+        data-testid="hue-handle"
+        style={{
+          position: 'absolute', width: `${HANDLE}px`, height: `${HANDLE}px`,
+          left: `${WHEEL / 2 + hr * Math.cos(rad) - HANDLE / 2}px`,
+          top: `${WHEEL / 2 + hr * Math.sin(rad) - HANDLE / 2}px`,
+          borderRadius: 'var(--radius-full)', pointerEvents: 'none',
+          background: 'hsl(var(--_accent-h) 100% 50%)',
+          border: '2px solid var(--ink-high)', boxShadow: 'var(--shadow-card)',
+        }}
+      />
+    </div>
+  );
+}
+
+function SliderRow({ label, testId, value, track, onChange }: {
+  label: string; testId: string; value: number; track: string; onChange: (v: number) => void;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs w-20 shrink-0" style={{ color: 'var(--ink-muted)' }}>{label}</span>
+      <input
+        type="range" min={0} max={100} value={value}
+        aria-label={label} data-testid={testId}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 h-1.5 rounded-full appearance-none cursor-pointer"
+        style={{ background: track, accentColor: 'var(--accent)' }}
+      />
+      <span
+        className="text-xs w-10 text-right tabular-nums font-mono"
+        style={{ color: 'var(--ink-dim)' }}
+      >
+        {value}%
+      </span>
+    </div>
+  );
+}
+
+/** §3.2's preview band: accent-consuming elements beside a FIXED gate chip. */
+function PreviewStrip(): React.ReactElement {
+  return (
+    <div
+      data-testid="appearance-preview"
+      className="flex items-center gap-4 rounded-lg px-4 py-3 flex-wrap"
+      style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)' }}
+    >
+      <div
+        className="flex items-center gap-0.5 rounded-lg p-0.5"
+        style={{ background: 'var(--surface-rail)' }}
+      >
+        {(['Chat', 'Build', 'Document', 'Video'] as const).map((m) => (
+          <span
+            key={m}
+            data-testid={m === 'Build' ? 'preview-mode-active' : undefined}
+            className="text-xs px-2.5 py-1 rounded-md font-medium"
+            style={m === 'Build'
+              ? { background: 'var(--accent)', color: 'var(--accent-fg)' }
+              : { color: 'var(--ink-muted)' }}
+          >
+            {m}
+          </span>
+        ))}
+      </div>
+      <span
+        data-testid="preview-gate-chip"
+        className="text-xs px-2.5 py-1 rounded-full font-mono"
+        style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
+      >
+        waiting on you
+      </span>
+      <span
+        data-testid="preview-primary"
+        className="text-xs px-3 py-1.5 rounded-lg font-medium"
+        style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+      >
+        + Build
+      </span>
+    </div>
+  );
+}
+
+const MAX_UPLOAD_BYTES = 256 * 1024;
+
+export function AppearanceSettings(): React.ReactElement {
+  const appearance = useAppearanceStore((s) => s.appearance);
+  const update = useAppearanceStore((s) => s.update);
+  const resetAccent = useAppearanceStore((s) => s.resetAccent);
+  const removeLogo = useAppearanceStore((s) => s.removeLogo);
+  const [logoDraft, setLogoDraft] = useState('');
+  const [logoError, setLogoError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function applyLogoUrl(): void {
+    const url = logoDraft.trim();
+    if (url === '') return;
+    setLogoError(null);
+    update({ logo_url: url });
+    setLogoDraft('');
+  }
+
+  function onUpload(e: React.ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setLogoError('Logo file too large — keep it under 256 KB, or host it and enter a URL.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setLogoError(null);
+      update({ logo_url: String(reader.result) });
+    };
+    reader.readAsDataURL(file);
+  }
+
+  const themeButton = (theme: 'dark' | 'light', label: string): React.ReactElement => {
+    const active = appearance.theme === theme;
+    return (
+      <button
+        type="button"
+        data-testid={`theme-${theme}`}
+        aria-pressed={active}
+        onClick={() => update({ theme })}
+        className="px-3 py-1 rounded-md text-xs font-medium"
+        style={active
+          ? { background: 'var(--accent)', color: 'var(--accent-fg)', border: '1px solid var(--accent)' }
+          : { background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <section
+      data-testid="appearance-settings"
+      className="rounded-xl px-5 mb-6"
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    >
+      <h2
+        className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
+        style={{ color: 'var(--ink-dim)' }}
+      >
+        Appearance
+      </h2>
+
+      {/* ── Logo (§3.1): the 32×32 chrome slot, contain-fit, --space-2 clearspace ── */}
+      <div className="flex items-start gap-4 py-4 border-b" style={{ borderColor: 'var(--surface-raised)' }}>
+        <div
+          data-testid="logo-thumb"
+          className="flex items-center justify-center shrink-0 rounded-lg"
+          style={{
+            width: '48px', height: '48px',
+            backgroundColor: 'var(--surface-rail)', border: '1px solid var(--surface-raised)',
+            backgroundImage: 'var(--logo-url, none)',
+            backgroundSize: 'contain', backgroundPosition: 'center', backgroundRepeat: 'no-repeat',
+          }}
+        >
+          {appearance.logo_url === null && <WickedLogo size={32} />}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>Logo</p>
+          <p className="text-xs mt-0.5 mb-2" style={{ color: 'var(--ink-muted)' }}>
+            Shown in the 32×32 chrome slot — letterboxed to fit, never stretched or cropped.
+            Monochrome marks work best on any surface.
+          </p>
+          <div className="flex items-center gap-2 flex-wrap">
+            <input ref={fileRef} type="file" accept="image/*" onChange={onUpload} className="hidden" data-testid="logo-file-input" />
+            <button
+              type="button"
+              data-testid="logo-upload"
+              onClick={() => fileRef.current?.click()}
+              className="px-2.5 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)' }}
+            >
+              Upload…
+            </button>
+            <input
+              type="text"
+              data-testid="logo-url-input"
+              aria-label="Logo URL"
+              placeholder="https://…/logo.svg"
+              value={logoDraft}
+              onChange={(e) => setLogoDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyLogoUrl(); }}
+              className="w-52 rounded px-2 py-1 text-xs font-mono focus:outline-none"
+              style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+            />
+            <button
+              type="button"
+              data-testid="logo-url-apply"
+              onClick={applyLogoUrl}
+              className="px-2.5 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)' }}
+            >
+              Use URL
+            </button>
+            {appearance.logo_url !== null && (
+              <button
+                type="button"
+                data-testid="logo-remove"
+                onClick={() => { setLogoError(null); removeLogo(); }}
+                className="px-2.5 py-1 rounded-lg text-xs font-medium"
+                style={{ background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          {logoError !== null && (
+            <p className="text-xs mt-1" style={{ color: 'var(--status-fail)' }} data-testid="logo-error">{logoError}</p>
+          )}
+        </div>
+      </div>
+
+      {/* ── Theme (§2.14): dark is the default instance; light is the override ── */}
+      <div className="flex items-center justify-between gap-4 py-4 border-b" style={{ borderColor: 'var(--surface-raised)' }}>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>Theme</p>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--ink-muted)' }}>
+            The surface and ink ramps. Accent and status colors carry across both.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          {themeButton('dark', 'Dark')}
+          {themeButton('light', 'Light')}
+        </div>
+      </div>
+
+      {/* ── Accent (§3.2): the wheel + sliders ARE the live preview (§3.4) ── */}
+      <div className="py-4">
+        <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>Accent color</p>
+        <p className="text-xs mt-0.5 mb-3" style={{ color: 'var(--ink-muted)' }}>
+          Applies live to the whole page — what you see is the current state; it persists automatically.
+        </p>
+        <div className="flex items-start gap-6 flex-wrap">
+          <HueWheel hue={appearance.accent_h} onHue={(h) => update({ accent_h: h })} />
+          <div className="flex-1 min-w-64 flex flex-col gap-4">
+            <SliderRow
+              label="Saturation"
+              testId="accent-sat"
+              value={appearance.accent_s}
+              track="linear-gradient(to right, hsl(var(--_accent-h) 0% 50%), hsl(var(--_accent-h) 100% 50%))"
+              onChange={(v) => update({ accent_s: v })}
+            />
+            <SliderRow
+              label="Lightness"
+              testId="accent-lgt"
+              value={appearance.accent_l}
+              track="linear-gradient(to right, hsl(var(--_accent-h) var(--_accent-s) 0%), hsl(var(--_accent-h) var(--_accent-s) 50%), hsl(var(--_accent-h) var(--_accent-s) 100%))"
+              onChange={(v) => update({ accent_l: v })}
+            />
+            <PreviewStrip />
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                data-testid="accent-reset"
+                onClick={resetAccent}
+                className="px-2.5 py-1 rounded-lg text-xs font-medium"
+                style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)' }}
+              >
+                Reset to default
+              </button>
+              {/* §3.5: two independent resets — this one never touches the logo. */}
+              <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
+                Accent only — the logo is a separate choice.
+              </span>
+            </div>
+          </div>
+        </div>
+        <p className="text-xs mt-3 pb-1" style={{ color: 'var(--ink-dim)' }}>
+          Status colors — gate amber, failing red, running emerald — are fixed semantic signals
+          and are not customizable.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
+import { AppearanceSettings } from './AppearanceSettings.js';
 import { Modal } from './Modal.js';
 import { Terminal } from './Terminal.js';
 
@@ -156,6 +157,11 @@ export function SystemSettings(): React.ReactElement {
           {error}
         </div>
       )}
+
+      {/* Appearance (DES-VISION-001 §3.2): a SECTION here, not a new page — it
+          persists itself through the appearance store (debounced PUT), so it
+          rides outside this page's dirty/Save machinery on purpose (§3.4). */}
+      <AppearanceSettings />
 
       <section
         className="rounded-xl px-5 mb-6"

--- a/src/theming/appearance.ts
+++ b/src/theming/appearance.ts
@@ -1,0 +1,143 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+
+/**
+ * Per-install appearance (DES-VISION-001 §3.3): the three accent primitives,
+ * the custom logo URL, and the theme instance, persisted in crew's settings
+ * store under the namespaced key `studio.appearance` and applied as INLINE
+ * custom-property overrides on `<html>` — the cascade seam tokens.css declares
+ * for exactly this (§3.3: inline style beats the `:root {}` stylesheet block,
+ * no `!important`, no runtime stylesheet injection).
+ *
+ * Live preview IS this application (§3.4): every accent move writes the
+ * primitives straight onto the document, so the whole page — not a sandboxed
+ * swatch — is the preview. Persistence is the only deferred step: a 400ms
+ * debounce collapses a drag into one `PUT /api/v1/settings`, optimistic
+ * (the UI never waits), fire-and-forget with one silent retry (§3.3).
+ */
+
+/** The `studio.appearance` wire object (§3.3) — what crew persists verbatim. */
+export interface StudioAppearance {
+  accent_h: number;
+  accent_s: number;
+  accent_l: number;
+  logo_url: string | null;
+  theme: 'dark' | 'light';
+}
+
+export const APPEARANCE_KEY = 'studio.appearance';
+
+/** §2.5's defaults: violet-indigo accent, no custom logo, the dark theme (§2.13). */
+export const DEFAULT_APPEARANCE: StudioAppearance = {
+  accent_h: 258,
+  accent_s: 72,
+  accent_l: 62,
+  logo_url: null,
+  theme: 'dark',
+};
+
+const PERSIST_DEBOUNCE_MS = 400;
+const RETRY_MS = 2000;
+
+function clamp(raw: unknown, lo: number, hi: number, fallback: number): number {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.round(raw) : fallback;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Never trust the stored shape (§3.3 is an external store): clamp and default. */
+export function sanitizeAppearance(raw: unknown): StudioAppearance {
+  const o = (raw !== null && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    accent_h: clamp(o.accent_h, 0, 359, DEFAULT_APPEARANCE.accent_h),
+    accent_s: clamp(o.accent_s, 0, 100, DEFAULT_APPEARANCE.accent_s),
+    accent_l: clamp(o.accent_l, 0, 100, DEFAULT_APPEARANCE.accent_l),
+    logo_url: typeof o.logo_url === 'string' && o.logo_url !== '' ? o.logo_url : null,
+    theme: o.theme === 'light' ? 'light' : 'dark',
+  };
+}
+
+/**
+ * Write the appearance onto `<html>`: the three accent primitives as §3.3
+ * spells them, `--logo-url` as a quoted `url(...)` (removed when unset, so the
+ * slot's `var(--logo-url, none)` fallback renders the default mark), and the
+ * theme instance as the `data-theme` attribute (§2.14 — absent = dark, §2.13).
+ */
+export function applyAppearance(a: StudioAppearance): void {
+  const root = document.documentElement;
+  root.style.setProperty('--_accent-h', String(a.accent_h));
+  root.style.setProperty('--_accent-s', `${a.accent_s}%`);
+  root.style.setProperty('--_accent-l', `${a.accent_l}%`);
+  if (a.logo_url !== null) {
+    root.style.setProperty('--logo-url', `url(${JSON.stringify(a.logo_url)})`);
+  } else {
+    root.style.removeProperty('--logo-url');
+  }
+  if (a.theme === 'light') root.setAttribute('data-theme', 'light');
+  else root.removeAttribute('data-theme');
+}
+
+interface AppearanceStore {
+  appearance: StudioAppearance;
+  /** True once the startup GET settled (either way) — gates nothing visual;
+   *  the stylesheet defaults ARE the pre-load render. */
+  loaded: boolean;
+  /** Startup read (App.tsx): GET the settings store, apply `studio.appearance`.
+   *  A daemon without a settings surface fails silently — defaults stand. */
+  load: () => Promise<void>;
+  /** Optimistic partial update: apply NOW, persist after the debounce. */
+  update: (patch: Partial<StudioAppearance>) => void;
+  /** §3.5 reset 1: the three accent primitives only — the logo is independent. */
+  resetAccent: () => void;
+  /** §3.5 reset 2: back to the default wicked mark — the accent is independent. */
+  removeLogo: () => void;
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function persistSoon(read: () => StudioAppearance): void {
+  if (persistTimer !== null) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    // Fire-and-forget with ONE silent retry (§3.3); the retry re-reads the
+    // store so a newer edit is never clobbered by a stale snapshot.
+    api.putAppearanceSettings(read()).catch(() => {
+      setTimeout(() => {
+        api.putAppearanceSettings(read()).catch(() => { /* stay silent (§3.3) */ });
+      }, RETRY_MS);
+    });
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+export const useAppearanceStore = create<AppearanceStore>((set, get) => ({
+  appearance: DEFAULT_APPEARANCE,
+  loaded: false,
+
+  load: async () => {
+    try {
+      const { settings } = await api.getAppearanceSettings();
+      const stored = (settings as Record<string, unknown>)[APPEARANCE_KEY];
+      const appearance = sanitizeAppearance(stored);
+      applyAppearance(appearance);
+      set({ appearance, loaded: true });
+    } catch {
+      // No settings surface (or it errored): the tokens.css defaults stand.
+      set({ loaded: true });
+    }
+  },
+
+  update: (patch) => {
+    const appearance = { ...get().appearance, ...patch };
+    applyAppearance(appearance);
+    set({ appearance });
+    persistSoon(() => get().appearance);
+  },
+
+  resetAccent: () =>
+    get().update({
+      accent_h: DEFAULT_APPEARANCE.accent_h,
+      accent_s: DEFAULT_APPEARANCE.accent_s,
+      accent_l: DEFAULT_APPEARANCE.accent_l,
+    }),
+
+  removeLogo: () => get().update({ logo_url: null }),
+}));

--- a/tests/AppChrome.test.tsx
+++ b/tests/AppChrome.test.tsx
@@ -17,10 +17,12 @@ vi.mock('../src/api/client.js', () => ({
 }));
 
 const { AppChrome } = await import('../src/components/AppChrome.js');
+const { DEFAULT_APPEARANCE, useAppearanceStore } = await import('../src/theming/appearance.js');
 
 afterEach(() => {
   cleanup();
   useConnectionStore.setState({ status: 'connecting' });
+  useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: false });
 });
 
 describe('AppChrome (DES-VISION-001 §3.1, §5.2)', () => {
@@ -42,6 +44,18 @@ describe('AppChrome (DES-VISION-001 §3.1, §5.2)', () => {
     const path = mark.querySelector('path');
     expect(path?.style.stroke).toBe('var(--accent)');
     expect(mark.querySelector('rect')).toBeNull();
+  });
+
+  it('a custom logo replaces the default mark — the two never stack (§3.1, slice-7 AC)', () => {
+    useAppearanceStore.setState({
+      appearance: { ...DEFAULT_APPEARANCE, logo_url: 'https://example.test/logo.png' },
+      loaded: true,
+    });
+    render(<AppChrome collapsed={false} navigate={() => {}} />);
+    // The slot stays (its background-image resolves the custom asset via
+    // --logo-url); the accent-stroked default mark is ABSENT.
+    expect(screen.getByTestId('logo-slot')).toBeInTheDocument();
+    expect(screen.queryByTestId('logo-wicked-mark')).toBeNull();
   });
 
   it('names the product and navigates home from name and slot', () => {

--- a/tests/AppearanceSettings.test.tsx
+++ b/tests/AppearanceSettings.test.tsx
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * The Appearance section (DES-VISION-001 §3.2): hue wheel + sliders + preview
+ * strip + the two independent resets + the theme instance picker, all writing
+ * through the appearance store. jsdom resolves no custom properties and paints
+ * no canvas — the computed/pixel halves live in e2e/vision_slice7_test.py;
+ * these cases pin the DOM contract, the inline token references, and the
+ * store wiring.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+    putAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+  },
+}));
+
+const { DEFAULT_APPEARANCE, useAppearanceStore } = await import('../src/theming/appearance.js');
+const { AppearanceSettings } = await import('../src/components/AppearanceSettings.js');
+
+const root = () => document.documentElement;
+
+beforeEach(() => {
+  useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: true });
+  root().removeAttribute('style');
+  root().removeAttribute('data-theme');
+});
+
+afterEach(cleanup);
+
+describe('AppearanceSettings (DES-VISION-001 §3.2)', () => {
+  it('renders the section: wheel, sliders at stored values, preview strip, fixed-status note', () => {
+    useAppearanceStore.setState({
+      appearance: { ...DEFAULT_APPEARANCE, accent_s: 60, accent_l: 55 }, loaded: true,
+    });
+    render(<AppearanceSettings />);
+
+    const wheel = screen.getByTestId('hue-wheel');
+    expect(wheel).toHaveAttribute('role', 'slider');
+    expect(wheel).toHaveAttribute('aria-valuenow', '258');
+    expect(screen.getByTestId('hue-handle')).toBeInTheDocument();
+    expect(screen.getByTestId('accent-sat')).toHaveValue('60');
+    expect(screen.getByTestId('accent-lgt')).toHaveValue('55');
+    // §3.2: status colors are fixed semantic signals — said, not offered.
+    expect(screen.getByText(/fixed semantic signals/)).toBeInTheDocument();
+  });
+
+  it('the preview strip speaks tokens: accent on segment + primary, status on the gate chip (EC12/EC15)', () => {
+    render(<AppearanceSettings />);
+    expect(screen.getByTestId('preview-mode-active').style.background).toBe('var(--accent)');
+    expect(screen.getByTestId('preview-mode-active').style.color).toBe('var(--accent-fg)');
+    expect(screen.getByTestId('preview-primary').style.background).toBe('var(--accent)');
+    expect(screen.getByTestId('preview-gate-chip').style.background).toBe('var(--status-gate-dim)');
+    expect(screen.getByTestId('preview-gate-chip').style.color).toBe('var(--status-gate)');
+  });
+
+  it('a slider move applies to <html> immediately — the page is the preview (§3.4)', () => {
+    render(<AppearanceSettings />);
+    fireEvent.change(screen.getByTestId('accent-sat'), { target: { value: '80' } });
+    expect(useAppearanceStore.getState().appearance.accent_s).toBe(80);
+    expect(root().style.getPropertyValue('--_accent-s')).toBe('80%');
+
+    fireEvent.change(screen.getByTestId('accent-lgt'), { target: { value: '40' } });
+    expect(root().style.getPropertyValue('--_accent-l')).toBe('40%');
+  });
+
+  it('the wheel moves the hue from the keyboard too', () => {
+    render(<AppearanceSettings />);
+    fireEvent.keyDown(screen.getByTestId('hue-wheel'), { key: 'ArrowRight' });
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(259);
+    fireEvent.keyDown(screen.getByTestId('hue-wheel'), { key: 'ArrowLeft' });
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(258);
+  });
+
+  it('reset restores the accent primitives and leaves the logo alone (§3.5)', () => {
+    useAppearanceStore.setState({
+      appearance: { ...DEFAULT_APPEARANCE, accent_h: 10, accent_s: 20, accent_l: 30, logo_url: '/l.png' },
+      loaded: true,
+    });
+    render(<AppearanceSettings />);
+    fireEvent.click(screen.getByTestId('accent-reset'));
+    const a = useAppearanceStore.getState().appearance;
+    expect([a.accent_h, a.accent_s, a.accent_l]).toEqual([258, 72, 62]);
+    expect(a.logo_url).toBe('/l.png');
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('258');
+  });
+
+  it('logo by URL: apply sets --logo-url; Remove reverts to the default mark', () => {
+    render(<AppearanceSettings />);
+    // No custom logo: the thumb shows the default accent-stroked mark, no Remove.
+    expect(screen.getByTestId('logo-thumb').querySelector('[data-testid="logo-wicked-mark"]')).not.toBeNull();
+    expect(screen.queryByTestId('logo-remove')).toBeNull();
+
+    fireEvent.change(screen.getByTestId('logo-url-input'), { target: { value: ' /assets/mark.svg ' } });
+    fireEvent.click(screen.getByTestId('logo-url-apply'));
+    expect(useAppearanceStore.getState().appearance.logo_url).toBe('/assets/mark.svg');
+    expect(root().style.getPropertyValue('--logo-url')).toBe('url("/assets/mark.svg")');
+    // The custom asset replaces the mark in the thumb (§3.1: the two never stack).
+    expect(screen.getByTestId('logo-thumb').querySelector('[data-testid="logo-wicked-mark"]')).toBeNull();
+    expect(screen.getByTestId('logo-url-input')).toHaveValue('');
+
+    fireEvent.click(screen.getByTestId('logo-remove'));
+    expect(useAppearanceStore.getState().appearance.logo_url).toBeNull();
+    expect(root().style.getPropertyValue('--logo-url')).toBe('');
+  });
+
+  it('upload: a small file lands as a data URL; an oversized one is refused with a hint', async () => {
+    render(<AppearanceSettings />);
+    const input = screen.getByTestId('logo-file-input');
+
+    const big = new File([new Uint8Array(300 * 1024)], 'big.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [big] } });
+    expect(screen.getByTestId('logo-error')).toHaveTextContent('under 256 KB');
+    expect(useAppearanceStore.getState().appearance.logo_url).toBeNull();
+
+    const small = new File(['<svg xmlns="http://www.w3.org/2000/svg"/>'], 'mark.svg', { type: 'image/svg+xml' });
+    fireEvent.change(input, { target: { files: [small] } });
+    await waitFor(() =>
+      expect(useAppearanceStore.getState().appearance.logo_url).toMatch(/^data:image\/svg\+xml/));
+    expect(screen.queryByTestId('logo-error')).toBeNull();
+  });
+
+  it('theme picker: light sets data-theme, dark removes it; the active choice is pressed', () => {
+    render(<AppearanceSettings />);
+    expect(screen.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByTestId('theme-light'));
+    expect(root().getAttribute('data-theme')).toBe('light');
+    expect(screen.getByTestId('theme-light')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('theme-dark')).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByTestId('theme-dark'));
+    expect(root().hasAttribute('data-theme')).toBe(false);
+  });
+});

--- a/tests/appearance.store.test.ts
+++ b/tests/appearance.store.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The appearance store (DES-VISION-001 §3.3–§3.5): startup read applies the
+ * stored `studio.appearance` as inline overrides on <html>; every edit is
+ * optimistic (applied NOW) with a 400ms-debounced PUT, fire-and-forget with
+ * one silent retry; the two resets are independent (§3.5). jsdom resolves no
+ * custom properties, so these cases pin the INLINE style writes — the
+ * computed-cascade half lives in e2e/vision_slice7_test.py.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn(),
+    putAppearanceSettings: vi.fn(),
+  },
+}));
+
+const { api } = await import('../src/api/client.js');
+const {
+  APPEARANCE_KEY, DEFAULT_APPEARANCE, sanitizeAppearance, useAppearanceStore,
+} = await import('../src/theming/appearance.js');
+
+const getApp = vi.mocked(api.getAppearanceSettings);
+const putApp = vi.mocked(api.putAppearanceSettings);
+const root = () => document.documentElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getApp.mockReset().mockResolvedValue({ settings: {} });
+  putApp.mockReset().mockResolvedValue({ settings: {} });
+  useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: false });
+  root().removeAttribute('style');
+  root().removeAttribute('data-theme');
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('load (§3.3 startup)', () => {
+  it('applies the stored appearance as inline overrides on <html>', async () => {
+    getApp.mockResolvedValue({
+      settings: {
+        [APPEARANCE_KEY]: {
+          accent_h: 200, accent_s: 60, accent_l: 55,
+          logo_url: 'https://example.test/logo.svg', theme: 'light',
+        },
+      },
+    });
+    await useAppearanceStore.getState().load();
+
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('200');
+    expect(root().style.getPropertyValue('--_accent-s')).toBe('60%');
+    expect(root().style.getPropertyValue('--_accent-l')).toBe('55%');
+    expect(root().style.getPropertyValue('--logo-url')).toBe('url("https://example.test/logo.svg")');
+    expect(root().getAttribute('data-theme')).toBe('light');
+    expect(useAppearanceStore.getState().loaded).toBe(true);
+    // Reading never writes: startup applies, it does not persist (§3.3).
+    vi.advanceTimersByTime(5000);
+    expect(putApp).not.toHaveBeenCalled();
+  });
+
+  it('a store without the key applies the defaults (dark, no logo, 258/72/62)', async () => {
+    await useAppearanceStore.getState().load();
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('258');
+    expect(root().style.getPropertyValue('--logo-url')).toBe('');
+    expect(root().hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('a failed GET leaves the stylesheet defaults standing — silently', async () => {
+    getApp.mockRejectedValue(new Error('API 404: no settings surface'));
+    await useAppearanceStore.getState().load();
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('');
+    expect(useAppearanceStore.getState().loaded).toBe(true);
+  });
+});
+
+describe('sanitizeAppearance (external store — never trusted)', () => {
+  it('clamps channels, defaults junk, and empties logo/theme correctly', () => {
+    expect(sanitizeAppearance({ accent_h: 999, accent_s: -4, accent_l: 'x', logo_url: '', theme: 'sepia' }))
+      .toEqual({ accent_h: 359, accent_s: 0, accent_l: 62, logo_url: null, theme: 'dark' });
+    expect(sanitizeAppearance(null)).toEqual(DEFAULT_APPEARANCE);
+    expect(sanitizeAppearance({ accent_h: 179.6 }).accent_h).toBe(180);
+  });
+});
+
+describe('update (§3.4 live preview + §3.3 debounced persistence)', () => {
+  it('applies immediately — the page IS the preview — and PUTs once after 400ms', () => {
+    useAppearanceStore.getState().update({ accent_h: 100 });
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('100');
+    expect(putApp).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(399);
+    expect(putApp).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(putApp).toHaveBeenCalledTimes(1);
+    expect(putApp).toHaveBeenCalledWith({ ...DEFAULT_APPEARANCE, accent_h: 100 });
+  });
+
+  it('collapses a drag into ONE PUT carrying the final value', () => {
+    for (const h of [90, 120, 150, 180]) useAppearanceStore.getState().update({ accent_h: h });
+    vi.advanceTimersByTime(400);
+    expect(putApp).toHaveBeenCalledTimes(1);
+    expect(putApp.mock.calls[0]![0].accent_h).toBe(180);
+  });
+
+  it('retries ONCE, silently, re-reading the store so a newer edit wins', async () => {
+    putApp.mockRejectedValueOnce(new Error('API 500'));
+    useAppearanceStore.getState().update({ accent_h: 45 });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putApp).toHaveBeenCalledTimes(1);
+
+    // The user keeps editing while the retry is pending.
+    useAppearanceStore.setState((s) => ({ appearance: { ...s.appearance, accent_h: 46 } }));
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(putApp).toHaveBeenCalledTimes(2);
+    expect(putApp.mock.calls[1]![0].accent_h).toBe(46);
+  });
+
+  it('sets and removes --logo-url as a quoted url()', () => {
+    useAppearanceStore.getState().update({ logo_url: '/assets/mark.png' });
+    expect(root().style.getPropertyValue('--logo-url')).toBe('url("/assets/mark.png")');
+    useAppearanceStore.getState().removeLogo();
+    expect(root().style.getPropertyValue('--logo-url')).toBe('');
+    expect(useAppearanceStore.getState().appearance.logo_url).toBeNull();
+  });
+
+  it('theme rides the data-theme attribute: light sets it, dark removes it (§2.14)', () => {
+    useAppearanceStore.getState().update({ theme: 'light' });
+    expect(root().getAttribute('data-theme')).toBe('light');
+    useAppearanceStore.getState().update({ theme: 'dark' });
+    expect(root().hasAttribute('data-theme')).toBe(false);
+  });
+});
+
+describe('resets (§3.5 — two, independent)', () => {
+  it('resetAccent restores 258/72/62, persists, and never touches the logo', () => {
+    useAppearanceStore.getState().update({ accent_h: 10, accent_s: 20, accent_l: 30, logo_url: '/l.png' });
+    vi.advanceTimersByTime(400);
+    putApp.mockClear();
+
+    useAppearanceStore.getState().resetAccent();
+    const a = useAppearanceStore.getState().appearance;
+    expect([a.accent_h, a.accent_s, a.accent_l]).toEqual([258, 72, 62]);
+    expect(a.logo_url).toBe('/l.png');
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('258');
+
+    vi.advanceTimersByTime(400);
+    expect(putApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeLogo never touches the accent', () => {
+    useAppearanceStore.getState().update({ accent_h: 33, logo_url: '/l.png' });
+    useAppearanceStore.getState().removeLogo();
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(33);
+    expect(useAppearanceStore.getState().appearance.logo_url).toBeNull();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -32,6 +32,7 @@ if (typeof window.HTMLCanvasElement.prototype.getContext !== 'function' ||
     measureText: (t: string) => ({ width: String(t).length * 7 }),
     fillText: () => {}, clearRect: () => {}, fillRect: () => {},
     beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
+    arc: () => {}, closePath: () => {},
     save: () => {}, restore: () => {}, scale: () => {}, translate: () => {},
   })) as unknown as typeof window.HTMLCanvasElement.prototype.getContext;
 }


### PR DESCRIPTION
The customization surface (§3): Settings → Appearance with the logo slot (URL/upload into --logo-url), accent hue/saturation on the slice-1 HSL channel, light/dark picker, live preview, reset-to-default — persisted via the crew settings API. Verified adversarially in the stacked worktree (approved, no must-fixes); re-landed by cherry-pick after slice 6's squash merge; gates re-run green on the re-landed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)