### PR TITLE
feat(theming): brand-learn — the mapper, the flow, the garden skill (DES-VISION-001 slice 8)

### DIFF
--- a/.garden/skills/studio-learn-brand.yaml
+++ b/.garden/skills/studio-learn-brand.yaml
@@ -1,0 +1,48 @@
+# .garden/skills/studio-learn-brand.yaml
+name: wicked-studio:theming:learn-brand
+description: >
+  Extract a brand's visual identity from a URL, PDF, or image using
+  wicked-interactive's theme-learn machinery, map it to studio's
+  design-token set, and apply it as the per-install appearance.
+
+inputs:
+  source:
+    type: string
+    description: >
+      The brand source. One of:
+        • A live URL (https://…) — captured headlessly by the interactive bridge.
+          The SSRF guard (loopback/private/link-local rejection) applies server-side;
+          the skill sends the URL to the proxy, never fetches it directly.
+        • An absolute local path to a PDF — read server-side, nothing uploads.
+        • An absolute local path to an image (PNG/JPG/SVG) — read server-side.
+    required: true
+  project_id:
+    type: string
+    description: >
+      The crew project whose interactive root is used. The brand theme
+      is learned within this project's scope and applied per-install.
+    required: true
+  apply:
+    type: boolean
+    default: false
+    description: >
+      If true, the skill applies the theme immediately after preview
+      without waiting for explicit confirmation. Use for automation;
+      interactive use should leave this false (the Settings UI handles confirm).
+
+outputs:
+  theme_id:
+    type: string
+    description: The interactive bridge's identifier for the learned theme.
+  token_overrides:
+    type: object
+    description: >
+      The studio token overrides derived by the mapper. Keys: accent_h, accent_s,
+      accent_l, logo_url (null when no logo asset was found).
+  applied:
+    type: boolean
+  mapper_adjustments:
+    type: array
+    description: >
+      Any adjustments the mapper made to satisfy contrast or distinctness constraints.
+      Each entry: { constraint, original, adjusted, reason }.

--- a/.product/evidence/vision-slice8/checklist.md
+++ b/.product/evidence/vision-slice8/checklist.md
@@ -68,12 +68,16 @@ verdicts.
   resource line excepted, filtered by exact shape).
 
 **The §4.5 mapper guarantees, unit-proven** (`tests/brandMapper.test.ts`,
-26 cases): contrast floor raised-and-capped (90%), the low-saturation rescue
+27 cases): contrast floor raised-and-capped (90%), the low-saturation rescue
 (s→40 minimum), hue search in ±5° steps with the nearest-side win pinned
 (`#22c55e` h142 → 117, down at 5 steps beats up at 8) and the dead-center
 tie-break to max total status distance (h148 → 178), all four clamps,
 CIE76-deltaE distinctness with the g1-beats-g4 ordering (a perceptual nudge
-never breaks the contrast floor), a **whole-gamut property sweep** (h×s×l
+never breaks the contrast floor) AND the g3-beats-g4 ordering (a nudge that
+can satisfy the deltaE floor inside the l≤78 clamp never leaves it — pinned
+on `hsl(96 60% 70%)`, where the in-clamp down-nudge beats a marginally-farther
+out-of-clamp up-nudge; the up-nudge may exceed the clamp, disclosed, only
+when no in-clamp ±10 move meets the floor), a **whole-gamut property sweep** (h×s×l
 grid: every input either satisfies all four guarantees or discloses
 `unsatisfiable`), degenerate palettes (`{}`, unparseable strings, grey, black,
 white, secondary-only — §4.4 tolerant reading, every fallback disclosed), logo
@@ -81,7 +85,7 @@ passthrough, and purity (frozen input, deep-equal reruns).
 
 **Repo gates:** `npm run lint` exit **0 — zero errors, zero warnings** (the
 §2.11 rule stays ERROR repo-wide over the new files). `npm run typecheck`
-exit 0. `npm test` **906/906** (95 files — +39 new: the mapper's 26, the
+exit 0. `npm test` **907/907** (95 files — +40 new: the mapper's 27, the
 BrandLearn flow's 10 incl. verbatim-error and poll-past-a-flake cases, and
 `getTheme` in the wrapper suite's resolver/happy-path tables).
 

--- a/.product/evidence/vision-slice8/checklist.md
+++ b/.product/evidence/vision-slice8/checklist.md
@@ -1,0 +1,112 @@
+# DES-VISION-001 slice 8 — experience checklist verdicts
+
+**Slice:** brand-learn (§6.3 slice 8) — §4 end to end. The garden skill
+definition lands verbatim at `.garden/skills/studio-learn-brand.yaml` (§4.2);
+`src/theming/brandMapper.ts` is the §4.5 mapper — a PURE `ThemeDetail →
+{accent_h, accent_s, accent_l, logo_url, adjustments[]}` function carrying the
+four guarantees (WCAG AA ≥4.5:1 contrast vs `--surface-card`, ≥30° circular
+hue separation from the status trio, `s∈[20,88]`/`l∈[42,78]` clamps, ≥25
+deltaE perceptual distinctness), every move disclosed, `unsatisfiable` never
+silent; `src/api/interactive.ts` gains §4.4's ONE new wrapper (`ThemeDetail` +
+`getTheme`, through the existing proxy — the SPA never fetches a brand
+source); and the Appearance section gains the §4.3 **Learn from brand source**
+row (`BrandLearn.tsx`): source-kind radios + input → `learnTheme` → the
+bridge's queue `message` VERBATIM (§3.3) → `listThemes` polled every 3s until
+`learned_at` → `getTheme` → mapper → **preview via the slice-7 live-preview
+machinery** (`applyAppearance` writes the mapped primitives inline on `<html>`
+— the page IS the preview, §3.4, nothing persisted) → Apply persists through
+the appearance store's debounced PUT with the **fully resolved** logo URL
+(§4.5: the logo must survive the bridge); Discard restores the stored
+appearance. Adjustments are disclosed under the preview (§4.3 step 7).
+**Rubric:** DES-VISION-001 §6.1 → this slice's §6.3 entry: **EC12, EC15,
+EC16** (logo from brand — extracted here).
+**Images:** `e2e/shots/vision/vision-8-brand-learn-running.png` (Settings
+mid-learn: source row filled, the bridge's queued message on screen verbatim)
+and `e2e/shots/vision/vision-8-brand-learn-applied.png` (the W2 board + chrome
+wearing the learned brand: navy accent ≈217°, the 2:1 brand logo contained in
+the 32×32 slot, status colors untouched), both 1440×900,
+`device_scale_factor=1`, per §6.0, by `e2e/vision_slice8_test.py` against the
+frozen-`NOW0` W2 fixture (browser clock frozen at `NOW0+5s`). The shots are
+gitignored evidence; the rig's JSON report records the paths beside the
+verdicts.
+
+| Item | Verdict | Read from the evidence |
+|---|---|---|
+| **EC12 — accent is singular** | **PASS** | The fixture's brand primary is a deep navy (`#0a2a5e` → hue 217°, ≥30° from gate 45° / fail 4° / run 148°); after mapping, the probe-computed `--accent` differs from every fixed status color in BOTH scenes (Settings preview and the applied board) — asserted computed-vs-computed, no hex in the rig. The applied shot shows it: chrome links, quick actions, and the logo turn navy while GATE stays amber, FAILED stays red, WORKING stays emerald. The §4.5 guarantees are the mechanism, not luck: the unit suite's whole-gamut property sweep (`tests/brandMapper.test.ts`) proves ANY extracted color lands ≥30° hue-separated and ≥25 deltaE from the trio (or is disclosed `unsatisfiable` and Apply is disabled — never silent). |
+| **EC15 — token discipline** | **PASS** | With the mapped accent previewing, the §3.2 preview strip's computed `background` equals the scratch-element probe of `--accent` — the mapped values flow through the token cascade, not through any component restyle. `npm run lint` exits 0 with zero §2.11 findings including the new `brandMapper.ts`/`BrandLearn.tsx` (the mapper's fixed reference points — the card surface and status trio — are NUMERIC mirrors of tokens.css, pinned to `#1a1a26` by a unit test, because §2.11 bans raw color strings outside the token files). |
+| **EC16 — logo slot respected** | **PASS** | The learned theme names a bridge-relative, deliberately NON-SQUARE (2:1) logo; the mapper passes it through untransformed, the Settings UI resolves it via `interactiveUrl`, and the PUT stores the FULLY RESOLVED URL (§4.5). On the applied board: the chrome slot's computed `background-image` resolves the brand asset, `background-size` is `contain` (letterboxed, never stretched or cropped), the slot stays exactly 32×32, and `[data-testid="logo-wicked-mark"]` count is **0**. |
+
+**Slice DOM ACs** (from `vision_slice8_test.py`'s JSON report, all true):
+
+- Clicking Learn with a valid URL fires **exactly one** request to
+  `/api/v1/projects/notes/interactive/api/theme/learn` and **zero** requests
+  to the brand host itself (`page.on('request')` filter over every request the
+  session made; a final sweep confirms no host other than the fixture origin
+  and Google Fonts was ever contacted).
+- `data-testid="learn-status"` shows the bridge's `message` verbatim:
+  `Queued — reading the brand at https://acme.example/brand (theme-learn agent)`
+  (the rig waits on exact string equality with the response body's field).
+- Learning `http://169.254.169.254/` is rejected by the bridge (**400**), the
+  status shows the refusal verbatim (`refusing to fetch 169.254.169.254:
+  loopback, private and link-local addresses are blocked (SSRF guard)`), and
+  **no outbound request** touches the metadata address.
+- After the 3s `listThemes` poll finds `learned_at`, `getTheme` fires ONCE and
+  the preview updates: inline `--_accent-h/s/l` read back exactly
+  `217/81%/59%` (the §4.5 mapping of `#0a2a5e`, pinned independently in the
+  unit suite) and the preview strip's computed background equals the `--accent`
+  probe — with **zero** settings PUTs before Apply (§3.4: preview ≠ persist).
+- The mapper's two adjustments are disclosed in
+  `data-testid="mapper-adjustments"`: `lightness-clamp` (l=20%→42%) and
+  `contrast-floor` (l=42%→59%, "was 2.60:1 — raised for WCAG AA (4.5:1)").
+- Apply fires ONE `PUT /api/v1/settings` carrying
+  `studio.appearance = {accent_h: 217, accent_s: 81, accent_l: 59, logo_url:
+  <origin>/api/v1/projects/notes/interactive/api/brand/logo.svg, theme: "dark"}`.
+- A fresh page load renders the W2 board FROM the stored brand appearance
+  (startup applies `--_accent-h: 217`), with the brand logo in the slot and
+  the W2 order + live narration intact.
+- Zero console errors across both scenes (the SSRF probe's by-design 400
+  resource line excepted, filtered by exact shape).
+
+**The §4.5 mapper guarantees, unit-proven** (`tests/brandMapper.test.ts`,
+26 cases): contrast floor raised-and-capped (90%), the low-saturation rescue
+(s→40 minimum), hue search in ±5° steps with the nearest-side win pinned
+(`#22c55e` h142 → 117, down at 5 steps beats up at 8) and the dead-center
+tie-break to max total status distance (h148 → 178), all four clamps,
+CIE76-deltaE distinctness with the g1-beats-g4 ordering (a perceptual nudge
+never breaks the contrast floor), a **whole-gamut property sweep** (h×s×l
+grid: every input either satisfies all four guarantees or discloses
+`unsatisfiable`), degenerate palettes (`{}`, unparseable strings, grey, black,
+white, secondary-only — §4.4 tolerant reading, every fallback disclosed), logo
+passthrough, and purity (frozen input, deep-equal reruns).
+
+**Repo gates:** `npm run lint` exit **0 — zero errors, zero warnings** (the
+§2.11 rule stays ERROR repo-wide over the new files). `npm run typecheck`
+exit 0. `npm test` **906/906** (95 files — +39 new: the mapper's 26, the
+BrandLearn flow's 10 incl. verbatim-error and poll-past-a-flake cases, and
+`getTheme` in the wrapper suite's resolver/happy-path tables).
+
+**All rigs green on the fresh build** (`dist-sameorigin` deleted and rebuilt
+from this branch first): `uxfix_slice1..6_test.py`,
+`vision_slice1..4_test.py`, `vision_slice6..7_test.py`, and this slice's
+`vision_slice8_test.py` — **thirteen for thirteen, exit 0.**
+
+**The vision-1 pixel gate:** the baseline was regenerated per its
+`VISION_BASELINE=1` flow and the check passes **pixel-identical (0 differing
+pixels)**. Disclosure, because the slice claims "no UXFIX surfaces touched":
+a base-commit (`04f8f7c`) baseline first differed from the branch build by 27
+pixels (±1/255 on one channel) confined to quiet-chip border-corner
+antialiasing. Investigated before regenerating: the built CSS bundle is
+**byte-identical** between base and branch (same content hash,
+`index-DkF-X_o3.css`), and a live two-build probe found the quiet chips'
+DOM geometry, computed border colors, radii, and fonts **identical to the
+fraction of a pixel**; the same ±1 corner wobble also appears between
+captures of identical content under different capture conditions. It is
+rasterization noise on fractional-width rounded borders, not a rendered
+change — the board is visually and structurally unchanged at default
+appearance.
+
+**UXFIX preserved:** no UXFIX surface touched — brand-learn is a new §4.3 row
+inside the slice-7 Appearance section; the board/chrome change only when the
+operator APPLIES a learned brand, and then only through the same §3.3
+appearance path slice 7 shipped (the §2.6 status layer reads from untouched
+tokens by construction).

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -40,6 +40,11 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     vision-slice-7 rig can seed a STORED accent/logo/theme
                     between page loads. GET/PUT /api/v1/settings serve the
                     store itself (DES-VISION-001 §3.3).
+  learn_delay_s   — how long a queued theme-learn "runs" before listThemes
+                    reports it with `learned_at` set (vision slice 8, §4.3
+                    step 4; default 4.0s — long enough for the rig to shoot
+                    the in-progress state, short enough for one 3s poll).
+  reset_learn     — True clears every learned theme, so scenes start clean.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -78,7 +83,7 @@ def iso(ms: int) -> str:
 # Mutable fixture switches, flipped over POST /__fixture between page loads.
 state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
-         "extra_narration": [], "demo": False}
+         "extra_narration": [], "demo": False, "learn_delay_s": 4.0}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -295,6 +300,56 @@ NARRATION = "Writing the token-bucket middleware for /upload"
 
 THEMES = [{"name": "stripe-ish", "source": "url", "learned_at": iso(NOW0 - 2 * DAY)},
           {"name": "corporate"}]
+
+# ── The vision-slice-8 brand-learn surface (DES-VISION-001 §4) ─────────────────
+#
+# The bridge's theme-learn loop, reduced to what the §4.1 flow reads through
+# crew's proxy: POST /api/theme/learn queues (with the bridge-side SSRF guard —
+# loopback/private/link-local URLs are a 400, §4.6 of DES-MERGE-001), the theme
+# then rides GET /api/themes WITHOUT `learned_at` until `learn_delay_s` elapses
+# (so the rig can shoot the in-progress state and prove the 3s poll), and
+# GET /api/themes/<id> serves the ThemeDetail the mapper consumes (§4.4).
+#
+# The learned palette's primary is a DEEP NAVY (#0a2a5e → hsl(217 81% 20%)) on
+# purpose: it forces the mapper's lightness-clamp (20→42) and contrast-floor
+# (42→59) adjustments — pinned in tests/brandMapper.test.ts — so the §4.3
+# step-7 disclosure has something real to disclose, while hue 217° stays ≥30°
+# clear of the whole status trio (EC12). The logo is bridge-relative and
+# non-square (2:1), matching the §3.1 contain-fit contract end to end.
+
+BRAND_LOGO_SVG = (b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 32">'
+                  b'<rect width="64" height="32" rx="8" fill="#0a2a5e"/>'
+                  b'<path d="M10 22 L18 10 L26 22" fill="none" stroke="#f8fafc" '
+                  b'stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>'
+                  b'<rect x="34" y="13" width="22" height="6" rx="3" fill="#f8fafc"/></svg>')
+
+
+def brand_detail(theme_id: str) -> dict:
+    return {"name": theme_id, "primary": "#0a2a5e", "secondary": "#22c55e",
+            "background": "#f4f4f8", "logo_url": "/api/brand/logo.svg"}
+
+
+# theme_id -> {"ready_at": float epoch, "source": kind}; guarded by state_lock.
+learned_themes: dict = {}
+
+PRIVATE_HOST = re.compile(
+    r"^(localhost$|127\.|0\.0\.0\.0$|10\.|192\.168\."
+    r"|172\.(1[6-9]|2[0-9]|3[01])\.|169\.254\.|::1$|fe80:|fd)")
+
+
+def ssrf_reject_reason(url: str) -> str | None:
+    """The bridge-side guard (DES-MERGE-001 §4.6): why this URL is refused, or None."""
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        return f"unparseable URL: {url}"
+    if parts.scheme not in ("http", "https"):
+        return f"unsupported scheme {parts.scheme or '(none)'} — only http(s) brand sources are captured"
+    host = (parts.hostname or "").lower()
+    if host == "" or PRIVATE_HOST.match(host):
+        return (f"refusing to fetch {host or url}: loopback, private and link-local "
+                "addresses are blocked (SSRF guard)")
+    return None
 
 # The headline the continue "tightens" — v1 verbose, v2+ tight — so the canvas change
 # between versions is legible in the screenshots, not just a version number swapping.
@@ -537,10 +592,41 @@ class W2Handler(SimpleHTTPRequestHandler):
         if m:
             self._json(200, {"deps": []})
             return True
-        # /api/v1/projects/<pid>/interactive/api/themes — the library (§4.6).
+        # /api/v1/projects/<pid>/interactive/api/themes — the library (§4.6):
+        # built-ins + everything learned; a queued learn rides WITHOUT
+        # `learned_at` until its delay elapses (vision slice 8, §4.3 step 4).
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/themes$", path)
         if m:
-            self._json(200, {"themes": THEMES})
+            now = time.time()
+            with state_lock:
+                learned = [
+                    {"name": tid, "source": t["source"],
+                     **({"learned_at": iso(NOW0)} if now >= t["ready_at"] else {})}
+                    for tid, t in learned_themes.items()
+                ]
+            self._json(200, {"themes": THEMES + learned})
+            return True
+        # /api/v1/projects/<pid>/interactive/api/themes/<id> — the ThemeDetail
+        # the §4.5 mapper consumes (DES-VISION-001 §4.4). 404 until learned.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/themes/([^/]+)$", path)
+        if m:
+            tid = urllib.parse.unquote(m.group(2))
+            now = time.time()
+            with state_lock:
+                ready = tid in learned_themes and now >= learned_themes[tid]["ready_at"]
+            if not ready:
+                self._json(404, {"error": f"no such theme {tid}"})
+                return True
+            self._json(200, brand_detail(tid))
+            return True
+        # The brand logo asset the learned theme names, bridge-relative (§4.5).
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/brand/logo\.svg$", path)
+        if m:
+            self.send_response(200)
+            self.send_header("Content-Type", "image/svg+xml")
+            self.send_header("Content-Length", str(len(BRAND_LOGO_SVG)))
+            self.end_headers()
+            self.wfile.write(BRAND_LOGO_SVG)
             return True
         # /api/v1/projects/<pid>/interactive/d/<doc>/api/versions — the manifest.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/versions$", path)
@@ -635,6 +721,39 @@ class W2Handler(SimpleHTTPRequestHandler):
                      "meta": {"sourceMessageId": body.get("source_message_id")}})
             self._json(200, {"version": v, "parent": frm})
             return True
+        # POST /api/v1/projects/<pid>/interactive/api/theme/learn — the §4.1 loop's
+        # entry (vision slice 8): SSRF-guard URLs server-side (a 400 with the
+        # refusal VERBATIM — the client shows it, never paraphrases), then queue.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/theme/learn$", path)
+        if m:
+            kind = body.get("kind")
+            if kind == "url":
+                url = str(body.get("url") or "")
+                reason = ssrf_reject_reason(url)
+                if reason is not None:
+                    self._json(400, {"error": reason})
+                    return True
+                parts = urllib.parse.urlsplit(url)
+                theme_id = slug(f"{parts.hostname or 'brand'} {parts.path}")
+                source_label = url
+            elif kind in ("pdf", "image"):
+                p = str(body.get("path") or "")
+                if not (p.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", p)):
+                    self._json(400, {"error": f"the source path must be absolute: {p or '(empty)'}"})
+                    return True
+                theme_id = slug(Path(p).stem)
+                source_label = p
+            else:
+                self._json(400, {"error": f"unknown learn kind: {kind}"})
+                return True
+            with state_lock:
+                learned_themes[theme_id] = {
+                    "ready_at": time.time() + float(state["learn_delay_s"]),
+                    "source": kind,
+                }
+            self._json(202, {"theme_id": theme_id, "status": "queued",
+                             "message": f"Queued — reading the brand at {source_label} (theme-learn agent)"})
+            return True
         # POST /api/v1/projects/<pid>/interactive/api/events — the inject wire (§5.4).
         # A chat.posted steer regenerates the doc's head version: narrate, then land it.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/events$", path)
@@ -678,6 +797,9 @@ class W2Handler(SimpleHTTPRequestHandler):
                     settings_store["studio.appearance"] = (
                         dict(DEFAULT_APPEARANCE) if body["appearance"] is None
                         else body["appearance"])
+                # `reset_learn` clears the learned-theme registry (vision slice 8).
+                if body.get("reset_learn"):
+                    learned_themes.clear()
                 state.update({k: v for k, v in body.items() if k in state})
                 snapshot = dict(state)
             return self._json(200, {"ok": True, "state": snapshot})

--- a/e2e/vision_slice8_test.py
+++ b/e2e/vision_slice8_test.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+vision_slice8_test.py — the DES-VISION-001 slice-8 gate: brand learning (§4)
+works end-to-end through the EXISTING interactive proxy (§6.3 slice 8;
+EC12, EC15, EC16).
+
+What slice 8 ships and this rig proves, in one browser session against the
+shared frozen-NOW0 W2 fixture (whose bridge surface now speaks the theme-learn
+loop — POST /api/theme/learn with the server-side SSRF guard, GET /api/themes
+ripening `learned_at`, GET /api/themes/<id> serving the ThemeDetail):
+
+  1. THE PROXY IS THE ONLY WIRE (§4.4 / the slice DOM AC): clicking Learn with
+     a valid URL fires EXACTLY ONE request to
+     /api/v1/projects/:id/interactive/api/theme/learn and ZERO requests to the
+     brand host itself (page.on('request') filter — the SPA never fetches the
+     source);
+  2. THE SSRF GUARD REFUSES THE METADATA ADDRESS server-side: learning
+     http://169.254.169.254/ is a bridge 400, the status shows the refusal
+     VERBATIM, and no outbound request touches 169.254.169.254;
+  3. THE BRIDGE MESSAGE IS VERBATIM (§4.3 step 3): the queued status is the
+     bridge's own `message`, never a paraphrase;
+  4. THE POLL FINDS THE THEME (§4.3 step 4): listThemes every 3s until
+     `learned_at` is set, then getTheme → the §4.5 mapper. The deep-navy brand
+     (#0a2a5e) forces TWO disclosed adjustments (lightness-clamp 20→42, then
+     contrast-floor 42→59 — pinned in tests/brandMapper.test.ts), landing the
+     accent at (217°, 81%, 59%);
+  5. PREVIEW IS THE PAGE, NOT A PERSIST (§3.4): the mapped primitives land as
+     inline overrides on <html> (the slice-7 machinery), the §3.2 preview
+     strip wears them (EC15, computed-vs-probe), the adjustments are disclosed
+     in [data-testid="mapper-adjustments"], and NO settings PUT fires until
+     Apply;
+  6. APPLY PERSISTS (§4.5): one debounced PUT carrying the mapped accent AND
+     the RESOLVED same-origin logo URL (bridge-relative no more — the logo
+     must survive the bridge);
+  7. THE BOARD WEARS THE BRAND (EC12/EC16): a fresh page load applies the
+     stored brand accent from startup, the chrome slot shows the brand logo
+     (contain-fit, the default mark absent), and the accent stays distinct
+     from the fixed status trio — probed computed-vs-computed, no hex here.
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  vision-8-brand-learn-running.png  Settings mid-learn: source row filled, the
+                                    bridge's queued message visible verbatim.
+  vision-8-brand-learn-applied.png  The W2 board + chrome wearing the learned
+                                    brand: navy accent, brand logo in the slot,
+                                    status colors untouched.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: VISION_PORT (default 4348),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NARRATION,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+VISION_PORT = int(os.environ.get("VISION_PORT", "4348"))
+ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+SHOT_RUNNING = VSHOTS / "vision-8-brand-learn-running.png"
+SHOT_APPLIED = VSHOTS / "vision-8-brand-learn-applied.png"
+
+BRAND_URL = "https://acme.example/brand"
+SSRF_URL = "http://169.254.169.254/"
+# The §4.5 mapping of the fixture's #0a2a5e brand — pinned by the unit suite.
+MAPPED = {"h": "217", "s": "81%", "l": "59%"}
+# §4.5: the FULLY RESOLVED URL is what persists (apiBase() is origin-absolute
+# in the same-origin build, so the stored logo survives the bridge going away).
+RESOLVED_LOGO = f"{ORIGIN}/api/v1/projects/notes/interactive/api/brand/logo.svg"
+
+FREEZE_MOTION = (
+    "*, *::before, *::after { animation: none !important; transition: none !important; }"
+)
+
+# The token probe (the rig-set's technique): computed color of `var(<name>)` on
+# a scratch element — keeps every hex value OUT of this rig.
+PROBES = """() => {
+  const probe = (name, prop) => { const el = document.createElement('div');
+    el.style[prop] = `var(${name})`;
+    document.body.appendChild(el);
+    const v = getComputedStyle(el)[prop === 'background' ? 'backgroundColor' : prop];
+    el.remove(); return v; };
+  return {
+    accent:        probe('--accent', 'background'),
+    statusGate:    probe('--status-gate', 'color'),
+    statusFail:    probe('--status-fail', 'color'),
+    statusRun:     probe('--status-run', 'color'),
+  }; }"""
+
+INLINE = """() => ({
+  h: document.documentElement.style.getPropertyValue('--_accent-h'),
+  s: document.documentElement.style.getPropertyValue('--_accent-s'),
+  l: document.documentElement.style.getPropertyValue('--_accent-l'),
+  logo: document.documentElement.style.getPropertyValue('--logo-url'),
+})"""
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def host_of(url: str) -> str:
+    try:
+        return (urllib.parse.urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(VISION_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+console_errors: list[str] = []
+requests_log: list[str] = []  # every URL the page requested, in order
+
+
+def on_console(m) -> None:
+    if m.type != "error":
+        return
+    # The SSRF probe's 400 is BY DESIGN (scene A step 2) — the refusal itself
+    # is the assertion. Everything else stays a failure.
+    if "400" in m.text and "Failed to load resource" in m.text:
+        return
+    console_errors.append(m.text)
+
+
+def is_learn_response(res) -> bool:
+    return "/interactive/api/theme/learn" in res.url and res.request.method == "POST"
+
+
+def is_settings_put(r) -> bool:
+    return r.method == "PUT" and r.url.endswith("/api/v1/settings")
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    # ══ Scene A: /system — SSRF refusal, then the full §4.1 loop to Apply ══════
+    set_fixture(ORIGIN, appearance=None, reset_learn=True, learn_delay_s=4.0)
+    page = ctx.new_page()
+    page.on("console", on_console)
+    page.on("request", lambda r: requests_log.append(f"{r.method} {r.url}"))
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/system", wait_until="domcontentloaded")
+    page.locator('[data-testid="brand-learn"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+    try:
+        page.wait_for_function("() => document.fonts.status === 'loaded'", timeout=20000)
+    except Exception:
+        pass
+
+    # AC 2 — the SSRF guard: the metadata address is refused SERVER-SIDE.
+    page.locator('[data-testid="learn-input"]').fill(SSRF_URL)
+    mark = len(requests_log)
+    with page.expect_response(is_learn_response, timeout=8000) as ssrf_res:
+        page.locator('[data-testid="learn-submit"]').click()
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="learn-status"]')?.textContent ?? '')
+                 .includes('SSRF guard')""", timeout=8000)
+    ssrf_status = page.locator('[data-testid="learn-status"]').text_content() or ""
+    ssrf_window = requests_log[mark:]
+    ssrf_checks = {
+        "bridge_refused_400": ssrf_res.value.status == 400,
+        "status_carries_refusal_verbatim":
+            "refusing to fetch 169.254.169.254: loopback, private and link-local "
+            "addresses are blocked (SSRF guard)" in ssrf_status,
+        "no_outbound_to_metadata_address":
+            all(host_of(u.split(" ", 1)[1]) != "169.254.169.254" for u in ssrf_window),
+        "exactly_one_learn_post": sum(1 for u in ssrf_window if "/api/theme/learn" in u) == 1,
+        "no_apply_offered": page.locator('[data-testid="learn-apply"]').count() == 0,
+    }
+    report["steps"]["ssrf_guard"] = {"ok": all(ssrf_checks.values()), **ssrf_checks,
+                                     "status_text": ssrf_status}
+
+    # AC 1+3 — the real learn: one proxy POST, zero to the brand host, message verbatim.
+    page.locator('[data-testid="learn-input"]').fill(BRAND_URL)
+    mark = len(requests_log)
+    with page.expect_response(is_learn_response, timeout=8000) as learn_res:
+        page.locator('[data-testid="learn-submit"]').click()
+    learn_body = learn_res.value.json()
+    page.wait_for_function(
+        """msg => (document.querySelector('[data-testid="learn-status"]')?.textContent ?? '') === msg""",
+        arg=learn_body.get("message"), timeout=8000)
+    learn_window = requests_log[mark:]
+    learn_checks = {
+        "learn_posted_through_notes_proxy":
+            any("/api/v1/projects/notes/interactive/api/theme/learn" in u for u in learn_window),
+        "exactly_one_learn_post": sum(1 for u in learn_window if "/api/theme/learn" in u) == 1,
+        "zero_requests_to_brand_host":
+            all(host_of(u.split(" ", 1)[1]) != "acme.example" for u in requests_log),
+        "status_is_bridge_message_verbatim": True,  # the wait above IS the assertion
+        "queued_shape": learn_body.get("status") == "queued" and bool(learn_body.get("theme_id")),
+    }
+    report["steps"]["learn_submit"] = {"ok": all(learn_checks.values()), **learn_checks,
+                                       "bridge_message": learn_body.get("message")}
+
+    # The named screenshot: the learn in progress, status verbatim on screen.
+    page.screenshot(path=str(SHOT_RUNNING))
+
+    # AC 4+5 — the poll lands the theme; the mapper previews WITHOUT persisting.
+    puts_before_apply = sum(1 for u in requests_log if u.startswith("PUT ") and u.endswith("/api/v1/settings"))
+    try:
+        page.wait_for_function(
+            """() => (document.querySelector('[data-testid="learn-status"]')?.textContent ?? '')
+                     === 'Ready — preview below'""", timeout=25000)
+    except Exception:
+        fail("poll_to_ready",
+             f"learn never became ready; status now: "
+             f"{page.locator('[data-testid=\"learn-status\"]').text_content()}")
+    inline_preview = page.evaluate(INLINE)
+    probes_a = page.evaluate(PROBES)
+    strip_bg = page.evaluate(
+        """() => getComputedStyle(document.querySelector(
+             '[data-testid="preview-mode-active"]')).backgroundColor""")
+    adjustments = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+             '[data-testid="mapper-adjustments"] li')).map(li => li.textContent)""")
+    theme_gets = [u for u in requests_log if "/interactive/api/themes/" in u]
+    puts_at_ready = sum(1 for u in requests_log if u.startswith("PUT ") and u.endswith("/api/v1/settings"))
+    ready_checks = {
+        "mapped_accent_inline": (inline_preview["h"] == MAPPED["h"]
+                                 and inline_preview["s"] == MAPPED["s"]
+                                 and inline_preview["l"] == MAPPED["l"]),
+        "resolved_logo_previewed": inline_preview["logo"] == f'url("{RESOLVED_LOGO}")',
+        "preview_strip_wears_mapped_accent": strip_bg == probes_a["accent"],
+        "adjustments_disclosed": len(adjustments) == 2
+            and any("lightness-clamp" in a for a in adjustments)
+            and any("contrast-floor" in a for a in adjustments),
+        "theme_detail_fetched_once": len(theme_gets) == 1
+            and "/projects/notes/interactive/api/themes/" in theme_gets[0],
+        "no_put_before_apply": puts_at_ready == puts_before_apply,
+        "accent_distinct_from_gate": probes_a["accent"] != probes_a["statusGate"],
+        "accent_distinct_from_fail": probes_a["accent"] != probes_a["statusFail"],
+        "accent_distinct_from_run": probes_a["accent"] != probes_a["statusRun"],
+    }
+    report["steps"]["preview_ready"] = {"ok": all(ready_checks.values()), **ready_checks,
+                                        "inline": inline_preview, "adjustments": adjustments}
+
+    # AC 6 — Apply persists the mapped overrides + the RESOLVED logo URL.
+    with page.expect_request(is_settings_put, timeout=8000) as put_req:
+        page.locator('[data-testid="learn-apply"]').click()
+    applied = (json.loads(put_req.value.post_data or "{}")).get("studio.appearance") or {}
+    apply_checks = {
+        "put_carries_mapped_accent": (applied.get("accent_h") == 217
+                                      and applied.get("accent_s") == 81
+                                      and applied.get("accent_l") == 59),
+        "put_carries_resolved_logo": applied.get("logo_url") == RESOLVED_LOGO,
+        "theme_untouched": applied.get("theme") == "dark",
+    }
+    report["steps"]["apply_persists"] = {"ok": all(apply_checks.values()), **apply_checks,
+                                         "put_studio_appearance": applied}
+    page.close()
+
+    # ══ Scene B: a fresh load — the board wears the learned brand (EC12/EC16) ══
+    page = ctx.new_page()
+    page.on("console", on_console)
+    page.on("request", lambda r: requests_log.append(f"{r.method} {r.url}"))
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    narration_ok = settled(
+        """text => (document.querySelector(
+             '[data-testid="project-card"][data-project-id="upload-endpoint"] [data-testid="live-line"]')
+             ?.textContent ?? '').includes(text)""",
+        NARRATION,
+    )
+    accent_ok = settled(
+        f"""() => document.documentElement.style.getPropertyValue('--_accent-h') === '{MAPPED["h"]}'""",
+        timeout=15000,
+    )
+    fonts_ok = settled("() => document.fonts.status === 'loaded'", timeout=20000)
+
+    probes_b = page.evaluate(PROBES)
+    board_state = page.evaluate(
+        """() => { const slot = document.querySelector('[data-testid="logo-slot"]');
+      const s = slot ? getComputedStyle(slot) : null;
+      return {
+        inline: {
+          h: document.documentElement.style.getPropertyValue('--_accent-h'),
+          logo: document.documentElement.style.getPropertyValue('--logo-url'),
+        },
+        slotBgImage: s ? s.backgroundImage : null,
+        slotBgSize: s ? s.backgroundSize : null,
+        slotW: s ? s.width : null, slotH: s ? s.height : null,
+        markCount: document.querySelectorAll('[data-testid="logo-wicked-mark"]').length,
+      }; }""")
+    page.screenshot(path=str(SHOT_APPLIED))
+
+    board_checks = {
+        "board_settled_w2_order": order_ok,
+        "live_narration_streamed": narration_ok,
+        "web_fonts_loaded": fonts_ok,
+        "stored_brand_accent_applied": accent_ok and board_state["inline"]["h"] == MAPPED["h"],
+        "brand_logo_in_slot": "brand/logo.svg" in (board_state["slotBgImage"] or ""),
+        "slot_contain_fit": board_state["slotBgSize"] == "contain",
+        "slot_is_32x32": board_state["slotW"] == "32px" and board_state["slotH"] == "32px",
+        "wicked_mark_absent": board_state["markCount"] == 0,
+        "accent_distinct_from_gate": probes_b["accent"] != probes_b["statusGate"],
+        "accent_distinct_from_fail": probes_b["accent"] != probes_b["statusFail"],
+        "accent_distinct_from_run": probes_b["accent"] != probes_b["statusRun"],
+    }
+    report["steps"]["board_wears_brand"] = {
+        "ok": all(board_checks.values()), **board_checks,
+        "computed": board_state, "probes": probes_b, "screenshot": str(SHOT_APPLIED),
+    }
+
+    browser.close()
+
+# The whole session never spoke to a non-fixture origin (the §4.4 posture:
+# the proxy is the ONLY wire — brand host and metadata address asserted above;
+# this closes the door on every other host too, web fonts excepted).
+FONT_HOSTS = {"fonts.googleapis.com", "fonts.gstatic.com"}
+foreign = sorted({host_of(u.split(" ", 1)[1]) for u in requests_log}
+                 - {"127.0.0.1", ""} - FONT_HOSTS)
+report["steps"]["no_foreign_hosts"] = {"ok": foreign == [], "foreign_hosts": foreign}
+
+report["steps"]["console"] = {"ok": len(console_errors) == 0, "errors": console_errors[:10]}
+report["screenshots"] = [str(SHOT_RUNNING), str(SHOT_APPLIED)]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("dom_acs_verdict", f"slice-8 assertions did not all hold — see {', '.join(bad)}")
+
+# ── 4. Lint: exit 0, ZERO §2.11 findings (the slice adds no raw color) ─────────
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings": findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero §2.11 findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -347,6 +347,29 @@ export function learnTheme(projectId: string, body: LearnThemeBody): Promise<Lea
 }
 
 /**
+ * Full theme data for one learned theme — the palette the mapper consumes.
+ * `GET /api/themes/:themeId` — bridge-root-relative, per (§4.6 of DES-MERGE-001).
+ *
+ * The shape is the interactive service's own theme JSON format (src/themes/*.json),
+ * which the bridge already reads for `core/theme.js`. The fields here are the
+ * minimum the mapper needs; additional fields are tolerated (tolerant reading —
+ * DES-VISION-001 §4.4's ASSUMPTION[external-transform]: absent fields are null,
+ * and the mapper derives what it can from what is present).
+ */
+export interface ThemeDetail {
+  name: string;
+  primary?: string;    /* CSS color string — dominant brand color */
+  secondary?: string;  /* CSS color string — secondary brand color, if extracted */
+  background?: string; /* CSS color string — brand background, if extracted */
+  logo_url?: string;   /* URL within the bridge to a logo asset, if found */
+}
+
+/** `GET /api/themes/:themeId` — one learned theme's palette (DES-VISION-001 §4.4). */
+export function getTheme(projectId: string, themeId: string): Promise<ThemeDetail> {
+  return iFetch<ThemeDetail>(`${interactiveBase(projectId)}/api/themes/${encodeURIComponent(themeId)}`);
+}
+
+/**
  * `POST /d/:docId/api/sources { path }` — attach a local reference path (§4.9).
  *
  * The body is `application/json` carrying only the path string — the service reads the files

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAppearanceStore } from '../theming/appearance.js';
+import { BrandLearn } from './BrandLearn.js';
 import { WickedLogo } from './WickedLogo.js';
 
 /**
@@ -362,6 +363,9 @@ export function AppearanceSettings(): React.ReactElement {
           and are not customizable.
         </p>
       </div>
+
+      {/* ── Learn from brand source (§4.3): the brand-learn loop, in-section ── */}
+      <BrandLearn />
     </section>
   );
 }

--- a/src/components/BrandLearn.tsx
+++ b/src/components/BrandLearn.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  BridgeUnavailableError,
+  getTheme,
+  interactiveUrl,
+  learnTheme,
+  listThemes,
+  type LearnKind,
+} from '../api/interactive.js';
+import { interactiveRootOf } from '../hooks/useBoardModel.js';
+import { useProjectsStore } from '../store/projects.js';
+import { applyAppearance, useAppearanceStore } from '../theming/appearance.js';
+import { isUnsatisfiable, mapBrandTheme, type BrandTokenOverrides } from '../theming/brandMapper.js';
+
+/**
+ * The "Learn from brand source" row of the Appearance section
+ * (DES-VISION-001 §4.3) — the studio-direct invocation path of the
+ * `wicked-studio:theming:learn-brand` garden skill (§4.2): the UI calls the
+ * API itself and runs the §4.5 mapper in the client; no agent is spawned.
+ *
+ * The §4.1 loop, end to end: source in → `learnTheme` THROUGH THE EXISTING
+ * PROXY (§4.4 — the SSRF guard is server-side; the SPA never fetches the
+ * brand source itself) → the bridge's queue `message` shown VERBATIM (§3.3:
+ * show it, never paraphrase) → `listThemes` polled every 3s until the theme
+ * lands with `learned_at` set → `getTheme` → `mapBrandTheme` (§4.5's four
+ * guarantees) → preview via the slice-7 live-preview machinery
+ * (`applyAppearance` writes the mapped primitives inline on `<html>`, no
+ * persist — the whole page is the preview, §3.4) → Apply persists through the
+ * appearance store's debounced PUT; Discard restores the stored appearance.
+ *
+ * Mapper adjustments are DISCLOSED under the preview (§4.3 step 7), and an
+ * `unsatisfiable` mapping disables Apply entirely (§4.5: never silent).
+ *
+ * Logo (§4.5): a bridge-relative `logo_url` is resolved through
+ * `interactiveUrl` and the RESOLVED URL is what persists — the logo must
+ * survive the bridge being unavailable.
+ */
+
+const POLL_MS = 3000; /* §4.3 step 4: poll listThemes every 3s */
+
+type Phase = 'idle' | 'queued' | 'ready' | 'applied' | 'error';
+
+const KINDS: { kind: LearnKind; label: string; placeholder: string }[] = [
+  { kind: 'url', label: 'URL', placeholder: 'https://brand.example.com…' },
+  { kind: 'pdf', label: 'Local PDF', placeholder: '/absolute/path/to/brand.pdf' },
+  { kind: 'image', label: 'Image file', placeholder: '/absolute/path/to/logo.png' },
+];
+
+function errorText(e: unknown): string {
+  if (e instanceof BridgeUnavailableError) return e.message;
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function BrandLearn(): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const [kind, setKind] = useState<LearnKind>('url');
+  const [source, setSource] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [status, setStatus] = useState<string | null>(null);
+  const [mapping, setMapping] = useState<BrandTokenOverrides | null>(null);
+  const [resolvedLogo, setResolvedLogo] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // The proxy path encodes the project (§4.4); brand-learn for non-crew
+  // projects is out of scope (§7). Default to the first project already bound
+  // to an interactive root, else the first real project.
+  useEffect(() => {
+    if (useProjectsStore.getState().projects.length === 0) void useProjectsStore.getState().load();
+  }, []);
+  const selectable = projects.filter((p) => p.id !== 'default');
+  const effectiveProject = projectId !== '' ? projectId
+    : (selectable.find((p) => interactiveRootOf(p) !== null) ?? selectable[0])?.id ?? '';
+
+  const stopPolling = useCallback((): void => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+  useEffect(() => stopPolling, [stopPolling]);
+
+  /** One poll tick (§4.3 step 4): learned when the id is listed WITH learned_at. */
+  const pollOnce = useCallback(async (pid: string, themeId: string): Promise<void> => {
+    let learned = false;
+    try {
+      const themes = await listThemes(pid);
+      learned = themes.some((t) => t.name === themeId
+        && typeof t.learned_at === 'string' && t.learned_at !== '');
+    } catch {
+      return; // a flaky poll is not a failed learn — keep polling
+    }
+    if (!learned) return;
+    stopPolling();
+    try {
+      const detail = await getTheme(pid, themeId); // §4.4's one new wrapper
+      const mapped = mapBrandTheme(detail);        // §4.5, pure, client-side
+      const logo = mapped.logo_url !== null ? interactiveUrl(pid, mapped.logo_url) : null;
+      setMapping(mapped);
+      setResolvedLogo(logo);
+      if (isUnsatisfiable(mapped)) {
+        // §4.5: never applied silently — disclose, and offer no Apply.
+        setPhase('error');
+        setStatus('The extracted palette cannot satisfy the contrast and distinctness guarantees — see the adjustments below.');
+      } else {
+        // Preview IS the page (§3.4): mapped primitives land inline on <html>,
+        // NOT through the store — nothing persists until Apply.
+        const current = useAppearanceStore.getState().appearance;
+        applyAppearance({
+          ...current,
+          accent_h: mapped.accent_h,
+          accent_s: mapped.accent_s,
+          accent_l: mapped.accent_l,
+          logo_url: logo ?? current.logo_url,
+        });
+        setPhase('ready');
+        setStatus('Ready — preview below');
+      }
+    } catch (e: unknown) {
+      setPhase('error');
+      setStatus(errorText(e));
+    }
+  }, [stopPolling]);
+
+  async function onLearn(): Promise<void> {
+    const src = source.trim();
+    if (src === '' || effectiveProject === '' || phase === 'queued') return;
+    setMapping(null);
+    setResolvedLogo(null);
+    setPhase('queued');
+    setStatus(null);
+    try {
+      const body = kind === 'url' ? { kind, url: src } : { kind, path: src };
+      const res = await learnTheme(effectiveProject, body);
+      // §4.3 step 3: the bridge's message VERBATIM — shown, never paraphrased.
+      setStatus(res.message ?? 'Queued');
+      const themeId = res.theme_id;
+      stopPolling();
+      pollRef.current = setInterval(() => { void pollOnce(effectiveProject, themeId); }, POLL_MS);
+      void pollOnce(effectiveProject, themeId);
+    } catch (e: unknown) {
+      stopPolling();
+      setPhase('error');
+      setStatus(errorText(e)); // the bridge's refusal (SSRF guard 400/503) verbatim
+    }
+  }
+
+  function onApply(): void {
+    if (mapping === null || isUnsatisfiable(mapping)) return;
+    // Persistence is the appearance store's job (§3.3): optimistic inline
+    // apply + the debounced PUT. The RESOLVED logo URL is what persists (§4.5).
+    useAppearanceStore.getState().update({
+      accent_h: mapping.accent_h,
+      accent_s: mapping.accent_s,
+      accent_l: mapping.accent_l,
+      ...(resolvedLogo !== null ? { logo_url: resolvedLogo } : {}),
+    });
+    setPhase('applied');
+    setStatus('Applied — persisted as the per-install appearance.');
+  }
+
+  function onDiscard(): void {
+    stopPolling();
+    // Revert the un-persisted preview: the stored appearance is the truth.
+    applyAppearance(useAppearanceStore.getState().appearance);
+    setMapping(null);
+    setResolvedLogo(null);
+    setPhase('idle');
+    setStatus(null);
+  }
+
+  const placeholder = KINDS.find((k) => k.kind === kind)?.placeholder ?? '';
+  const applicable = mapping !== null && !isUnsatisfiable(mapping) && phase === 'ready';
+
+  return (
+    <div
+      data-testid="brand-learn"
+      className="py-4 border-t"
+      style={{ borderColor: 'var(--surface-raised)' }}
+    >
+      <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>
+        Learn from brand source
+      </p>
+      <p className="text-xs mt-0.5 mb-2" style={{ color: 'var(--ink-muted)' }}>
+        Point at a brand — a live URL, a local PDF, or an image — and the interactive
+        bridge extracts its identity. The mapper keeps the accent readable and distinct
+        from the fixed status colors; nothing applies until you confirm.
+      </p>
+
+      <div className="flex items-center gap-4 flex-wrap mb-2">
+        {KINDS.map((k) => (
+          <label key={k.kind} className="flex items-center gap-1.5 text-xs cursor-pointer"
+            style={{ color: kind === k.kind ? 'var(--ink-body)' : 'var(--ink-muted)' }}>
+            <input
+              type="radio"
+              name="brand-learn-kind"
+              data-testid={`learn-source-${k.kind}`}
+              checked={kind === k.kind}
+              onChange={() => setKind(k.kind)}
+              style={{ accentColor: 'var(--accent)' }}
+            />
+            {k.label}
+          </label>
+        ))}
+        {selectable.length > 1 && (
+          <select
+            data-testid="learn-project"
+            aria-label="Project"
+            value={effectiveProject}
+            onChange={(e) => setProjectId(e.target.value)}
+            className="text-xs rounded px-1.5 py-1 ml-auto"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {selectable.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          data-testid="learn-input"
+          aria-label="Brand source"
+          placeholder={placeholder}
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void onLearn(); }}
+          className="flex-1 min-w-0 rounded px-2 py-1 text-xs font-mono focus:outline-none"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+        />
+        <button
+          type="button"
+          data-testid="learn-submit"
+          disabled={phase === 'queued'}
+          onClick={() => void onLearn()}
+          className="px-3 py-1 rounded-lg text-xs font-medium disabled:opacity-50"
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+        >
+          Learn
+        </button>
+      </div>
+
+      {status !== null && (
+        <p
+          data-testid="learn-status"
+          className="text-xs mt-2 font-mono"
+          style={{ color: phase === 'error' ? 'var(--status-fail)' : 'var(--ink-body)' }}
+        >
+          {status}
+        </p>
+      )}
+
+      {mapping !== null && (
+        <div className="mt-3">
+          {applicable && (
+            <div className="flex items-center gap-3 flex-wrap">
+              <span
+                data-testid="learn-preview-chip"
+                className="text-xs px-2.5 py-1 rounded-full font-medium"
+                style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+              >
+                learned accent {mapping.accent_h}° {mapping.accent_s}% {mapping.accent_l}%
+              </span>
+              <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
+                The whole page — and the preview strip above — is wearing it now.
+              </span>
+            </div>
+          )}
+          {mapping.adjustments.length > 0 && (
+            <ul data-testid="mapper-adjustments" className="mt-2 flex flex-col gap-1">
+              {mapping.adjustments.map((a, i) => (
+                <li key={i} className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+                  <span style={{ color: a.constraint === 'unsatisfiable' ? 'var(--status-fail)' : 'var(--ink-dim)' }}>
+                    {a.constraint}
+                  </span>{' '}
+                  {a.original} → {a.adjusted} — <span style={{ color: 'var(--ink-body)' }}>{a.reason}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              type="button"
+              data-testid="learn-apply"
+              disabled={!applicable}
+              onClick={onApply}
+              className="px-3 py-1 rounded-lg text-xs font-medium disabled:opacity-50"
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+            >
+              Apply
+            </button>
+            <button
+              type="button"
+              data-testid="learn-discard"
+              onClick={onDiscard}
+              className="px-3 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      )}
+      {(phase === 'queued') && mapping === null && (
+        <div className="mt-2">
+          <button
+            type="button"
+            data-testid="learn-discard"
+            onClick={onDiscard}
+            className="px-2.5 py-1 rounded-lg text-xs font-medium"
+            style={{ background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/theming/brandMapper.ts
+++ b/src/theming/brandMapper.ts
@@ -1,0 +1,449 @@
+import type { ThemeDetail } from '../api/interactive.js';
+
+/**
+ * The brand mapper (DES-VISION-001 §4.5): `ThemeDetail` → studio token
+ * overrides. A PURE function with no side effects — both invocation paths
+ * (the Settings UI and the garden skill `wicked-studio:theming:learn-brand`)
+ * run exactly this logic, so there is one spelling of "brand → accent".
+ *
+ * Four guarantees, in priority order (§4.5 — priority means which wins on
+ * conflict, not execution order):
+ *
+ *   1. WCAG AA contrast floor — `contrast(--accent, --surface-card) ≥ 4.5:1`
+ *      against the dark card surface default (`--_surface-2`, tokens.css §2.3).
+ *      Below the floor, lightness rises until it is met (cap 90%); if lightness
+ *      alone cannot meet it, saturation rises to 40% minimum. The floor may
+ *      push lightness past guarantee 3's 78% clamp — priority 1 beats 3.
+ *   2. Status-color distinctness — the accent hue stays ≥30° (circular) from
+ *      each status hue (gate 45°, failing 4°, running 148°; tokens.css §2.6).
+ *      A conflicting hue is walked outward in ±5° increments to the nearest
+ *      clear position; when both directions clear at the same distance, the
+ *      one maximizing total distance from all three status hues wins.
+ *   3. Saturation and lightness clamps — `accent_s ∈ [20, 88]`,
+ *      `accent_l ∈ [42, 78]` (dark theme): no near-greys, no neon, nothing
+ *      that disappears into the dark surfaces or washes out as white.
+ *   4. Perceptual distinctness — the full computed accent keeps a deltaE
+ *      (CIE76 Lab distance — §4.5 sanctions a simplified approximation) of
+ *      ≥25 from each full status color; a too-close accent has its lightness
+ *      moved ±10 to push them apart, never below the contrast floor.
+ *
+ * Every move is logged as a `MapperAdjustment` (§4.5: no silent truncation —
+ * an unsatisfiable combination returns a `constraint: 'unsatisfiable'` entry
+ * and the UI shows it rather than applying silently).
+ *
+ * Tolerant reading (§4.4's ASSUMPTION[external-transform]): absent fields are
+ * null; only `primary` is required to derive an accent, `secondary` fills in
+ * when `primary` is missing, and a theme with no usable color at all maps to
+ * the §2.5 defaults with the fallback disclosed. `logo_url` passes through
+ * untransformed — resolving it to a same-origin URL is the caller's job
+ * (`interactiveUrl`), because the mapper is pure and knows no project.
+ */
+
+export interface MapperAdjustment {
+  constraint:
+    | 'contrast-floor'       /* §4.5 guarantee 1 */
+    | 'hue-separation'       /* §4.5 guarantee 2 */
+    | 'saturation-clamp'     /* §4.5 guarantee 3 */
+    | 'lightness-clamp'      /* §4.5 guarantee 3 */
+    | 'perceptual-distance'  /* §4.5 guarantee 4 */
+    | 'source-fallback'      /* §4.4 tolerant reading */
+    | 'unsatisfiable';       /* §4.5 no-silent-truncation */
+  original: string;
+  adjusted: string;
+  reason: string;
+}
+
+/** What the mapper hands back — the §4.2 skill's `token_overrides` + the log. */
+export interface BrandTokenOverrides {
+  accent_h: number;
+  accent_s: number;
+  accent_l: number;
+  logo_url: string | null;
+  adjustments: MapperAdjustment[];
+}
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// ── The fixed surfaces the guarantees measure against ────────────────────────
+// Numeric mirrors of tokens.css (§2.3, §2.6) — numbers, not color literals,
+// because §2.11 bans raw color strings outside the token files. If tokens.css
+// moves these, move them here (the unit suite pins the pairing).
+
+/** `--_surface-2` — the dark card surface (#1a1a26 in tokens.css §2.3). */
+export const SURFACE_CARD_RGB: Rgb = { r: 26, g: 26, b: 38 };
+
+/** §2.6's status trio: full (not -dim) variants, as HSL numbers. */
+export const STATUS_COLORS = [
+  { name: 'gate (amber)', h: 45, s: 90, l: 68 },
+  { name: 'failing (red)', h: 4, s: 88, l: 62 },
+  { name: 'running (emerald)', h: 148, s: 58, l: 58 },
+] as const;
+
+const CONTRAST_FLOOR = 4.5;   /* §4.5 g1: WCAG AA */
+const LIGHTNESS_CAP = 90;     /* §4.5 g1: the raise stops here */
+const MIN_SAT_FOR_CONTRAST = 40; /* §4.5 g1: the low-saturation rescue */
+const HUE_SEPARATION = 30;    /* §4.5 g2: degrees from each status hue */
+const HUE_STEP = 5;           /* §4.5 g2: search increment */
+const SAT_MIN = 20;           /* §4.5 g3 */
+const SAT_MAX = 88;           /* §4.5 g3 */
+const LGT_MIN = 42;           /* §4.5 g3 (dark theme) */
+const LGT_MAX = 78;           /* §4.5 g3 (dark theme) */
+const DELTA_E_FLOOR = 25;     /* §4.5 g4 */
+const PERCEPTUAL_NUDGE = 10;  /* §4.5 g4: lightness is adjusted by ±10 */
+
+// ── Color math ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a CSS color string tolerantly: hex (#rgb/#rgba/#rrggbb/#rrggbbaa),
+ * rgb()/rgba() (0–255 or %), hsl()/hsla(). Anything else — including a
+ * non-string — is null, which the pipeline treats as "absent" (§4.4).
+ */
+export function parseCssColor(input: unknown): Rgb | null {
+  if (typeof input !== 'string') return null;
+  const str = input.trim().toLowerCase();
+  if (str.startsWith('#')) {
+    const hex = str.slice(1);
+    if (!/^[0-9a-f]+$/.test(hex)) return null;
+    if (hex.length === 3 || hex.length === 4) {
+      return {
+        r: parseInt(hex.charAt(0) + hex.charAt(0), 16),
+        g: parseInt(hex.charAt(1) + hex.charAt(1), 16),
+        b: parseInt(hex.charAt(2) + hex.charAt(2), 16),
+      };
+    }
+    if (hex.length === 6 || hex.length === 8) {
+      return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16),
+      };
+    }
+    return null;
+  }
+  const fn = /^(rgba?|hsla?)\s*\(([^)]*)\)$/.exec(str);
+  if (fn === null) return null;
+  const parts = (fn[2] ?? '').split(/[,\s/]+/).filter((p) => p !== '');
+  const [c0, c1, c2] = [parts[0] ?? '', parts[1] ?? '', parts[2] ?? ''];
+  if (parts.length < 3) return null;
+  if ((fn[1] ?? '').startsWith('rgb')) {
+    const chan = (raw: string): number | null => {
+      const pct = raw.endsWith('%');
+      const n = Number.parseFloat(raw);
+      if (!Number.isFinite(n)) return null;
+      const v = pct ? (n / 100) * 255 : n;
+      return Math.min(255, Math.max(0, Math.round(v)));
+    };
+    const r = chan(c0);
+    const g = chan(c1);
+    const b = chan(c2);
+    return r === null || g === null || b === null ? null : { r, g, b };
+  }
+  const h = Number.parseFloat(c0);
+  const s = Number.parseFloat(c1);
+  const l = Number.parseFloat(c2);
+  if (!Number.isFinite(h) || !Number.isFinite(s) || !Number.isFinite(l)) return null;
+  return hslToRgb(((h % 360) + 360) % 360, Math.min(100, Math.max(0, s)), Math.min(100, Math.max(0, l)));
+}
+
+export function hslToRgb(h: number, s: number, l: number): Rgb {
+  const sn = s / 100;
+  const ln = l / 100;
+  const chroma = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = chroma * (1 - Math.abs((hp % 2) - 1));
+  let rp = 0;
+  let gp = 0;
+  let bp = 0;
+  if (hp < 1) [rp, gp, bp] = [chroma, x, 0];
+  else if (hp < 2) [rp, gp, bp] = [x, chroma, 0];
+  else if (hp < 3) [rp, gp, bp] = [0, chroma, x];
+  else if (hp < 4) [rp, gp, bp] = [0, x, chroma];
+  else if (hp < 5) [rp, gp, bp] = [x, 0, chroma];
+  else [rp, gp, bp] = [chroma, 0, x];
+  const m = ln - chroma / 2;
+  return {
+    r: Math.round((rp + m) * 255),
+    g: Math.round((gp + m) * 255),
+    b: Math.round((bp + m) * 255),
+  };
+}
+
+export function rgbToHsl({ r, g, b }: Rgb): { h: number; s: number; l: number } {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0;
+  let s = 0;
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1));
+    if (max === rn) h = 60 * (((gn - bn) / d) % 6);
+    else if (max === gn) h = 60 * ((bn - rn) / d + 2);
+    else h = 60 * ((rn - gn) / d + 4);
+  }
+  return {
+    h: Math.round(((h % 360) + 360) % 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+function channelLuminance(c255: number): number {
+  const c = c255 / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+/** WCAG contrast ratio, 1:1 → 21:1. */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function toLab({ r, g, b }: Rgb): { L: number; a: number; b: number } {
+  // sRGB → XYZ (D65) → CIELAB.
+  const lin = (c255: number): number => {
+    const c = c255 / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const rl = lin(r);
+  const gl = lin(g);
+  const bl = lin(b);
+  const x = (0.4124 * rl + 0.3576 * gl + 0.1805 * bl) / 0.95047;
+  const y = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+  const z = (0.0193 * rl + 0.1192 * gl + 0.9505 * bl) / 1.08883;
+  const f = (t: number): number => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  const fx = f(x);
+  const fy = f(y);
+  const fz = f(z);
+  return { L: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
+}
+
+/** CIE76 deltaE — the §4.5-sanctioned simplified perceptual distance. */
+export function deltaE(a: Rgb, b: Rgb): number {
+  const la = toLab(a);
+  const lb = toLab(b);
+  return Math.sqrt((la.L - lb.L) ** 2 + (la.a - lb.a) ** 2 + (la.b - lb.b) ** 2);
+}
+
+/** Circular hue distance in degrees, 0–180. */
+export function hueDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return Math.min(d, 360 - d);
+}
+
+// ── The pipeline ──────────────────────────────────────────────────────────────
+
+function minStatusHueSeparation(h: number): number {
+  return Math.min(...STATUS_COLORS.map((st) => hueDistance(h, st.h)));
+}
+
+function totalStatusHueDistance(h: number): number {
+  return STATUS_COLORS.reduce((sum, st) => sum + hueDistance(h, st.h), 0);
+}
+
+/**
+ * §4.5 g2's search: walk outward in ±5° increments to the nearest hue that
+ * clears every status hue by ≥30°; a same-distance tie goes to the candidate
+ * with the greater total distance from all three status hues.
+ */
+function nearestClearHue(h: number): number {
+  for (let k = 1; k <= Math.ceil(360 / HUE_STEP); k++) {
+    const up = (h + k * HUE_STEP) % 360;
+    const down = (((h - k * HUE_STEP) % 360) + 360) % 360;
+    const upOk = minStatusHueSeparation(up) >= HUE_SEPARATION;
+    const downOk = minStatusHueSeparation(down) >= HUE_SEPARATION;
+    if (upOk && downOk) return totalStatusHueDistance(up) >= totalStatusHueDistance(down) ? up : down;
+    if (upOk) return up;
+    if (downOk) return down;
+  }
+  return h; // structurally unreachable while clear arcs exist; caller logs it
+}
+
+/** Raise lightness until the floor is met or the cap is hit; returns final l. */
+function raiseLightnessToFloor(h: number, s: number, l: number): number {
+  let cur = l;
+  while (cur < LIGHTNESS_CAP && contrastRatio(hslToRgb(h, s, cur), SURFACE_CARD_RGB) < CONTRAST_FLOOR) {
+    cur += 1;
+  }
+  return cur;
+}
+
+/** The §4.5 mapper: pure, tolerant, every move disclosed. */
+export function mapBrandTheme(theme: ThemeDetail): BrandTokenOverrides {
+  const adjustments: MapperAdjustment[] = [];
+  const logoRaw = typeof theme.logo_url === 'string' && theme.logo_url.trim() !== ''
+    ? theme.logo_url.trim()
+    : null;
+
+  // ── Source color (§4.4 tolerant reading): primary, else secondary, else defaults ──
+  let src = parseCssColor(theme.primary);
+  if (src === null) {
+    src = parseCssColor(theme.secondary);
+    if (src !== null) {
+      adjustments.push({
+        constraint: 'source-fallback',
+        original: `primary=${String(theme.primary ?? null)}`,
+        adjusted: `secondary=${String(theme.secondary)}`,
+        reason: 'No usable primary color was extracted — the accent derives from the secondary brand color.',
+      });
+    }
+  }
+  if (src === null) {
+    adjustments.push({
+      constraint: 'source-fallback',
+      original: `primary=${String(theme.primary ?? null)}, secondary=${String(theme.secondary ?? null)}`,
+      adjusted: 'accent 258 72% 62% (default)',
+      reason: 'No usable brand color was extracted from the source — the default accent stands.',
+    });
+    return { accent_h: 258, accent_s: 72, accent_l: 62, logo_url: logoRaw, adjustments };
+  }
+
+  let { h, s, l } = rgbToHsl(src);
+
+  // ── Guarantee 3: saturation and lightness clamps ──
+  if (s < SAT_MIN || s > SAT_MAX) {
+    const clamped = Math.min(SAT_MAX, Math.max(SAT_MIN, s));
+    adjustments.push({
+      constraint: 'saturation-clamp',
+      original: `s=${s}%`,
+      adjusted: `s=${clamped}%`,
+      reason: s < SAT_MIN
+        ? `Saturation ${s}% is a near-grey — raised to the ${SAT_MIN}% floor so the accent reads as a color.`
+        : `Saturation ${s}% is neon on dark surfaces — lowered to the ${SAT_MAX}% ceiling.`,
+    });
+    s = clamped;
+  }
+  if (l < LGT_MIN || l > LGT_MAX) {
+    const clamped = Math.min(LGT_MAX, Math.max(LGT_MIN, l));
+    adjustments.push({
+      constraint: 'lightness-clamp',
+      original: `l=${l}%`,
+      adjusted: `l=${clamped}%`,
+      reason: l < LGT_MIN
+        ? `Lightness ${l}% disappears into the dark background — raised to the ${LGT_MIN}% floor.`
+        : `Lightness ${l}% washes out as white — lowered to the ${LGT_MAX}% ceiling.`,
+    });
+    l = clamped;
+  }
+
+  // ── Guarantee 2: ≥30° circular separation from every status hue ──
+  if (minStatusHueSeparation(h) < HUE_SEPARATION) {
+    const moved = nearestClearHue(h);
+    if (minStatusHueSeparation(moved) < HUE_SEPARATION) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `h=${h}°`,
+        adjusted: `h=${h}°`,
+        reason: 'Every hue position conflicts with a status hue — no ≥30° separation exists.',
+      });
+    } else {
+      const nearest = STATUS_COLORS.reduce((a, b) => (hueDistance(h, a.h) <= hueDistance(h, b.h) ? a : b));
+      adjustments.push({
+        constraint: 'hue-separation',
+        original: `h=${h}°`,
+        adjusted: `h=${moved}°`,
+        reason: `Hue ${h}° sits within 30° of the ${nearest.name} status hue — moved to the nearest clear position.`,
+      });
+      h = moved;
+    }
+  }
+
+  // ── Guarantee 1: WCAG AA contrast floor against the card surface ──
+  let contrast = contrastRatio(hslToRgb(h, s, l), SURFACE_CARD_RGB);
+  if (contrast < CONTRAST_FLOOR) {
+    const startL = l;
+    let raised = raiseLightnessToFloor(h, s, startL);
+    let finalS = s;
+    if (contrastRatio(hslToRgb(h, finalS, raised), SURFACE_CARD_RGB) < CONTRAST_FLOOR
+        && finalS < MIN_SAT_FOR_CONTRAST) {
+      adjustments.push({
+        constraint: 'contrast-floor',
+        original: `s=${finalS}%`,
+        adjusted: `s=${MIN_SAT_FOR_CONTRAST}%`,
+        reason: `The ${CONTRAST_FLOOR}:1 floor could not be met by lightness alone — saturation raised to the ${MIN_SAT_FOR_CONTRAST}% minimum.`,
+      });
+      finalS = MIN_SAT_FOR_CONTRAST;
+      raised = raiseLightnessToFloor(h, finalS, startL);
+    }
+    if (raised !== startL) {
+      adjustments.push({
+        constraint: 'contrast-floor',
+        original: `l=${startL}%`,
+        adjusted: `l=${raised}%`,
+        reason: `Contrast against the card surface was ${contrast.toFixed(2)}:1 — lightness raised for WCAG AA (${CONTRAST_FLOOR}:1) on dark surfaces.`,
+      });
+    }
+    s = finalS;
+    l = raised;
+    contrast = contrastRatio(hslToRgb(h, s, l), SURFACE_CARD_RGB);
+    if (contrast < CONTRAST_FLOOR) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `l=${startL}%`,
+        adjusted: `l=${l}%, s=${s}%`,
+        reason: `The ${CONTRAST_FLOOR}:1 contrast floor cannot be met: ${contrast.toFixed(2)}:1 at the ${LIGHTNESS_CAP}% lightness cap.`,
+      });
+    }
+  }
+
+  // ── Guarantee 4: perceptual distance ≥25 from every full status color ──
+  const tooClose = (lgt: number): { name: string; d: number } | null => {
+    const accent = hslToRgb(h, s, lgt);
+    let worst: { name: string; d: number } | null = null;
+    for (const st of STATUS_COLORS) {
+      const d = deltaE(accent, hslToRgb(st.h, st.s, st.l));
+      if (d < DELTA_E_FLOOR && (worst === null || d < worst.d)) worst = { name: st.name, d };
+    }
+    return worst;
+  };
+  const near = tooClose(l);
+  if (near !== null) {
+    const minDeltaAt = (lgt: number): number =>
+      Math.min(...STATUS_COLORS.map((st) => deltaE(hslToRgb(h, s, lgt), hslToRgb(st.h, st.s, st.l))));
+    const meetsContrast = (lgt: number): boolean =>
+      contrastRatio(hslToRgb(h, s, lgt), SURFACE_CARD_RGB) >= CONTRAST_FLOOR;
+    const candidates = [
+      Math.min(LIGHTNESS_CAP, l + PERCEPTUAL_NUDGE),
+      Math.max(LGT_MIN, l - PERCEPTUAL_NUDGE),
+    ].filter((c) => c !== l && meetsContrast(c)); // g1 outranks g4: never break the floor
+    if (candidates.length > 0) {
+      const best = candidates.reduce((a, b) => (minDeltaAt(a) >= minDeltaAt(b) ? a : b));
+      adjustments.push({
+        constraint: 'perceptual-distance',
+        original: `l=${l}%`,
+        adjusted: `l=${best}%`,
+        reason: `The accent sat only ${near.d.toFixed(1)} deltaE from the ${near.name} status color — lightness moved to push them ≥${DELTA_E_FLOOR} apart.`,
+      });
+      l = best;
+    }
+    const still = tooClose(l);
+    if (still !== null) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `deltaE=${near.d.toFixed(1)}`,
+        adjusted: `deltaE=${still.d.toFixed(1)}`,
+        reason: `The accent remains within ${DELTA_E_FLOOR} deltaE of the ${still.name} status color after the ±${PERCEPTUAL_NUDGE}% lightness adjustment.`,
+      });
+    }
+  }
+
+  return { accent_h: h, accent_s: s, accent_l: l, logo_url: logoRaw, adjustments };
+}
+
+/** True when the mapping must NOT be applied silently (§4.5 no-silent-truncation). */
+export function isUnsatisfiable(m: BrandTokenOverrides): boolean {
+  return m.adjustments.some((a) => a.constraint === 'unsatisfiable');
+}

--- a/src/theming/brandMapper.ts
+++ b/src/theming/brandMapper.ts
@@ -25,7 +25,11 @@ import type { ThemeDetail } from '../api/interactive.js';
  *   4. Perceptual distinctness — the full computed accent keeps a deltaE
  *      (CIE76 Lab distance — §4.5 sanctions a simplified approximation) of
  *      ≥25 from each full status color; a too-close accent has its lightness
- *      moved ±10 to push them apart, never below the contrast floor.
+ *      moved ±10 to push them apart, never below the contrast floor. Because
+ *      guarantee 3 outranks 4, a nudge that satisfies the floor WITHIN the
+ *      lightness clamp always beats one that leaves it; the up-nudge may
+ *      exceed the 78% ceiling (disclosed) only when no in-clamp move meets
+ *      the floor — the §4.5 remedy is literally ±10, clamp or no clamp.
  *
  * Every move is logged as a `MapperAdjustment` (§4.5: no silent truncation —
  * an unsatisfiable combination returns a `constraint: 'unsatisfiable'` entry
@@ -419,8 +423,13 @@ export function mapBrandTheme(theme: ThemeDetail): BrandTokenOverrides {
       Math.min(LIGHTNESS_CAP, l + PERCEPTUAL_NUDGE),
       Math.max(LGT_MIN, l - PERCEPTUAL_NUDGE),
     ].filter((c) => c !== l && meetsContrast(c)); // g1 outranks g4: never break the floor
-    if (candidates.length > 0) {
-      const best = candidates.reduce((a, b) => (minDeltaAt(a) >= minDeltaAt(b) ? a : b));
+    // g3 outranks g4: when a candidate satisfies the deltaE floor WITHOUT
+    // leaving the [42,78] clamp, it wins — the up-nudge may exceed the clamp
+    // (disclosed) only when no in-clamp candidate meets the floor.
+    const inClamp = candidates.filter((c) => c <= LGT_MAX && minDeltaAt(c) >= DELTA_E_FLOOR);
+    const pool = inClamp.length > 0 ? inClamp : candidates;
+    if (pool.length > 0) {
+      const best = pool.reduce((a, b) => (minDeltaAt(a) >= minDeltaAt(b) ? a : b));
       adjustments.push({
         constraint: 'perceptual-distance',
         original: `l=${l}%`,

--- a/tests/BrandLearn.test.tsx
+++ b/tests/BrandLearn.test.tsx
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Project } from '../src/api/types.js';
+
+/**
+ * The "Learn from brand source" row (DES-VISION-001 §4.3) — the §4.1 loop as
+ * the Settings UI drives it: learnTheme through the proxy wrappers (never a
+ * direct fetch — the wrappers are mocked here, so ANY network the component
+ * did itself would be a jsdom failure), the bridge message verbatim, the 3s
+ * listThemes poll, getTheme → the §4.5 mapper, preview via the slice-7
+ * applyAppearance machinery WITHOUT persisting, Apply persisting through the
+ * appearance store, Discard restoring the stored appearance.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+    putAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+    listProjects: vi.fn().mockResolvedValue({ projects: [] }),
+  },
+}));
+
+const learnTheme = vi.fn();
+const listThemes = vi.fn();
+const getTheme = vi.fn();
+vi.mock('../src/api/interactive.js', () => ({
+  learnTheme: (...a: unknown[]) => learnTheme(...a) as unknown,
+  listThemes: (...a: unknown[]) => listThemes(...a) as unknown,
+  getTheme: (...a: unknown[]) => getTheme(...a) as unknown,
+  interactiveUrl: (pid: string, p: string) =>
+    `/api/v1/projects/${pid}/interactive${p.startsWith('/') ? p : `/${p}`}`,
+  BridgeUnavailableError: class BridgeUnavailableError extends Error {},
+}));
+
+const { api } = await import('../src/api/client.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { DEFAULT_APPEARANCE, useAppearanceStore } = await import('../src/theming/appearance.js');
+const { BrandLearn } = await import('../src/components/BrandLearn.js');
+
+const root = () => document.documentElement;
+
+function project(id: string, extra: Record<string, unknown> = {}): Project {
+  return {
+    id, name: id, description: null, status: 'active',
+    scope: `project:${id}`, created_at: 1, updated_at: 1, ...extra,
+  };
+}
+
+// The W2-fixture brand: #0a2a5e → the mapper lands (217, 81%, 59%) with a
+// lightness-clamp + a contrast-floor adjustment (pinned in brandMapper.test.ts).
+const BRAND_DETAIL = { name: 'acme-brand', primary: '#0a2a5e', logo_url: '/api/brand/logo.svg' };
+const QUEUED_MSG = 'Queued — the agent is reading the brand at https://acme.example…';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  learnTheme.mockReset().mockResolvedValue({ theme_id: 'acme-brand', status: 'queued', message: QUEUED_MSG });
+  listThemes.mockReset().mockResolvedValue([{ name: 'acme-brand' }]);
+  getTheme.mockReset().mockResolvedValue(BRAND_DETAIL);
+  vi.mocked(api.putAppearanceSettings).mockClear();
+  useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: true });
+  useProjectsStore.setState({
+    projects: [
+      project('default'),
+      project('scratch'),
+      project('notes', { interactiveRoot: '/tmp/wi-notes' }),
+    ],
+    loading: false,
+    error: null,
+  });
+  root().removeAttribute('style');
+  root().removeAttribute('data-theme');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+async function learnFromUrl(url = 'https://acme.example'): Promise<void> {
+  fireEvent.change(screen.getByTestId('learn-input'), { target: { value: url } });
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('learn-submit'));
+    await vi.advanceTimersByTimeAsync(0); // let learnTheme + the first poll settle
+  });
+}
+
+async function completeLearn(): Promise<void> {
+  listThemes.mockResolvedValue([{ name: 'acme-brand', source: 'url', learned_at: '2026-08-21T00:00:00Z' }]);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(3000); // §4.3 step 4: the 3s poll finds it
+  });
+}
+
+describe('BrandLearn (DES-VISION-001 §4.3)', () => {
+  it('renders the source row: three kinds, input, Learn — idle status is silent', () => {
+    render(<BrandLearn />);
+    expect(screen.getByTestId('learn-source-url')).toBeChecked();
+    expect(screen.getByTestId('learn-source-pdf')).toBeInTheDocument();
+    expect(screen.getByTestId('learn-source-image')).toBeInTheDocument();
+    expect(screen.getByTestId('learn-submit')).toBeInTheDocument();
+    expect(screen.queryByTestId('learn-status')).toBeNull();
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+  });
+
+  it('Learn calls the proxy wrapper with the interactive-root project and shows the bridge message VERBATIM', async () => {
+    render(<BrandLearn />);
+    await learnFromUrl();
+    // The default project is the one already bound to an interactive root (§4.4).
+    expect(learnTheme).toHaveBeenCalledExactlyOnceWith('notes', { kind: 'url', url: 'https://acme.example' });
+    expect(screen.getByTestId('learn-status').textContent).toBe(QUEUED_MSG);
+  });
+
+  it('a local path kind sends {kind, path} — nothing uploads from the browser', async () => {
+    render(<BrandLearn />);
+    fireEvent.click(screen.getByTestId('learn-source-pdf'));
+    await learnFromUrl('/Users/op/brand.pdf');
+    expect(learnTheme).toHaveBeenCalledExactlyOnceWith('notes', { kind: 'pdf', path: '/Users/op/brand.pdf' });
+  });
+
+  it('polls listThemes every 3s until learned_at is set, then previews WITHOUT persisting (§3.4)', async () => {
+    render(<BrandLearn />);
+    await learnFromUrl();
+    expect(listThemes).toHaveBeenCalledTimes(1); // the immediate first poll
+    expect(getTheme).not.toHaveBeenCalled();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    expect(listThemes).toHaveBeenCalledTimes(2); // still unlearned — keeps polling
+
+    await completeLearn();
+    expect(getTheme).toHaveBeenCalledExactlyOnceWith('notes', 'acme-brand');
+
+    // Preview via the slice-7 machinery: inline overrides on <html>…
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('217');
+    expect(root().style.getPropertyValue('--_accent-s')).toBe('81%');
+    expect(root().style.getPropertyValue('--_accent-l')).toBe('59%');
+    expect(root().style.getPropertyValue('--logo-url'))
+      .toBe('url("/api/v1/projects/notes/interactive/api/brand/logo.svg")');
+    // …but NOTHING persisted: the store still holds the defaults, no PUT fired.
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(258);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(api.putAppearanceSettings).not.toHaveBeenCalled();
+    expect(screen.getByTestId('learn-status').textContent).toBe('Ready — preview below');
+  });
+
+  it('discloses the mapper adjustments (§4.3 step 7) under the preview', async () => {
+    render(<BrandLearn />);
+    await learnFromUrl();
+    await completeLearn();
+    const list = screen.getByTestId('mapper-adjustments');
+    expect(list.children).toHaveLength(2);
+    expect(list.textContent).toContain('lightness-clamp');
+    expect(list.textContent).toContain('contrast-floor');
+    expect(list.textContent).toContain('WCAG AA');
+  });
+
+  it('Apply persists the mapped overrides + the RESOLVED logo URL through the appearance store (§4.5)', async () => {
+    render(<BrandLearn />);
+    await learnFromUrl();
+    await completeLearn();
+    fireEvent.click(screen.getByTestId('learn-apply'));
+    const a = useAppearanceStore.getState().appearance;
+    expect(a.accent_h).toBe(217);
+    expect(a.accent_s).toBe(81);
+    expect(a.accent_l).toBe(59);
+    expect(a.logo_url).toBe('/api/v1/projects/notes/interactive/api/brand/logo.svg');
+    await act(async () => { await vi.advanceTimersByTimeAsync(400); }); // the §3.3 debounce
+    expect(api.putAppearanceSettings).toHaveBeenCalledExactlyOnceWith(a);
+    expect(screen.getByTestId('learn-status').textContent).toMatch(/Applied/);
+  });
+
+  it('Discard reverts the preview to the STORED appearance and persists nothing', async () => {
+    render(<BrandLearn />);
+    await learnFromUrl();
+    await completeLearn();
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('217');
+    fireEvent.click(screen.getByTestId('learn-discard'));
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('258');
+    expect(root().style.getPropertyValue('--logo-url')).toBe('');
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(258);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(api.putAppearanceSettings).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+  });
+
+  it('a bridge refusal (the server-side SSRF guard) shows the error VERBATIM and never previews', async () => {
+    learnTheme.mockRejectedValue(
+      new Error('API 400: refusing to fetch link-local address 169.254.169.254 (SSRF guard)'));
+    render(<BrandLearn />);
+    await learnFromUrl('http://169.254.169.254/');
+    expect(screen.getByTestId('learn-status').textContent)
+      .toBe('API 400: refusing to fetch link-local address 169.254.169.254 (SSRF guard)');
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('');
+    expect(listThemes).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+  });
+
+  it('a flaky poll is not a failed learn — polling continues past a rejection', async () => {
+    render(<BrandLearn />);
+    listThemes.mockRejectedValueOnce(new Error('boom'));
+    await learnFromUrl();
+    await completeLearn();
+    expect(screen.getByTestId('learn-status').textContent).toBe('Ready — preview below');
+  });
+
+  it('unmount stops the poll loop', async () => {
+    const { unmount } = render(<BrandLearn />);
+    await learnFromUrl();
+    expect(listThemes).toHaveBeenCalledTimes(1);
+    unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(9000); });
+    expect(listThemes).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/brandMapper.test.ts
+++ b/tests/brandMapper.test.ts
@@ -190,6 +190,17 @@ describe('mapBrandTheme — guarantee 4: perceptual distinctness (§4.5)', () =>
       expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
     }
   });
+
+  it('a nudge that can satisfy the floor IN-clamp never leaves it (priority 3 beats 4)', () => {
+    // hsl(96 60% 70%): both ±10 candidates clear 25 deltaE (up 80 ≈ 30.2,
+    // down 60 ≈ 29.6) — the in-clamp 60 must win over the marginally-farther
+    // out-of-clamp 80, because guarantee 3's l ≤ 78 outranks maximizing g4.
+    const m = mapBrandTheme({ name: 'in-clamp', primary: 'hsl(96, 60%, 70%)' });
+    expect(m.adjustments.some((a) => a.constraint === 'perceptual-distance')).toBe(true);
+    expect(m.accent_l).toBeLessThanOrEqual(78);
+    expect(minStatusDeltaE(m)).toBeGreaterThanOrEqual(DELTA_FLOOR);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
 });
 
 describe('mapBrandTheme — the whole-gamut property (§4.5: all four at once)', () => {

--- a/tests/brandMapper.test.ts
+++ b/tests/brandMapper.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+import {
+  contrastRatio,
+  deltaE,
+  hslToRgb,
+  hueDistance,
+  isUnsatisfiable,
+  mapBrandTheme,
+  parseCssColor,
+  rgbToHsl,
+  SURFACE_CARD_RGB,
+  STATUS_COLORS,
+  type BrandTokenOverrides,
+} from '../src/theming/brandMapper.js';
+
+/**
+ * The §4.5 mapper contract (DES-VISION-001): a PURE ThemeDetail → token-override
+ * function with four guarantees — WCAG AA contrast floor against the card
+ * surface, ≥30° hue separation from the status trio, saturation/lightness
+ * clamps, and ≥25 deltaE perceptual distinctness — every move disclosed as an
+ * adjustment, nothing silently truncated, degenerate palettes tolerated (§4.4).
+ */
+
+const CONTRAST_FLOOR = 4.5;
+const HUE_SEP = 30;
+const DELTA_FLOOR = 25;
+
+function accentRgb(m: BrandTokenOverrides) {
+  return hslToRgb(m.accent_h, m.accent_s, m.accent_l);
+}
+
+function minStatusHueSep(h: number): number {
+  return Math.min(...STATUS_COLORS.map((st) => hueDistance(h, st.h)));
+}
+
+function minStatusDeltaE(m: BrandTokenOverrides): number {
+  return Math.min(...STATUS_COLORS.map((st) => deltaE(accentRgb(m), hslToRgb(st.h, st.s, st.l))));
+}
+
+describe('color math', () => {
+  it('parses hex, rgb(), rgb(%), hsl() and rejects garbage', () => {
+    expect(parseCssColor('#0a2a5e')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseCssColor('#FFF8')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseCssColor('#0a2a5eff')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgb(10, 42, 94)')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgba(10 42 94 / 0.5)')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgb(100%, 0%, 0%)')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(parseCssColor('hsl(0, 100%, 50%)')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(parseCssColor('hsl(217 81% 20%)')).toEqual(hslToRgb(217, 81, 20));
+    expect(parseCssColor('cornflowerblue')).toBeNull(); // named colors: tolerated as absent
+    expect(parseCssColor('#12345')).toBeNull();
+    expect(parseCssColor('#zzz')).toBeNull();
+    expect(parseCssColor('rgb(a, b, c)')).toBeNull();
+    expect(parseCssColor('')).toBeNull();
+    expect(parseCssColor(undefined)).toBeNull();
+    expect(parseCssColor(42)).toBeNull();
+  });
+
+  it('round-trips hsl → rgb → hsl within rounding', () => {
+    const { h, s, l } = rgbToHsl(hslToRgb(258, 72, 62));
+    expect(Math.abs(h - 258)).toBeLessThanOrEqual(1);
+    expect(Math.abs(s - 72)).toBeLessThanOrEqual(1);
+    expect(Math.abs(l - 62)).toBeLessThanOrEqual(1);
+  });
+
+  it('contrastRatio: white vs black is 21:1, self vs self is 1:1', () => {
+    expect(contrastRatio({ r: 255, g: 255, b: 255 }, { r: 0, g: 0, b: 0 })).toBeCloseTo(21, 0);
+    expect(contrastRatio(SURFACE_CARD_RGB, SURFACE_CARD_RGB)).toBeCloseTo(1, 5);
+  });
+
+  it('hueDistance is circular', () => {
+    expect(hueDistance(350, 10)).toBe(20);
+    expect(hueDistance(10, 350)).toBe(20);
+    expect(hueDistance(0, 180)).toBe(180);
+    expect(hueDistance(45, 45)).toBe(0);
+  });
+
+  it('SURFACE_CARD_RGB mirrors tokens.css --_surface-2 (#1a1a26)', () => {
+    // The mapper measures guarantee 1 against the REAL card surface; if
+    // tokens.css moves, this pairing must move with it (§4.5 g1).
+    expect(SURFACE_CARD_RGB).toEqual(parseCssColor('#1a1a26'));
+  });
+});
+
+describe('mapBrandTheme — guarantee 1: WCAG AA contrast floor (§4.5)', () => {
+  it('raises lightness for a deep navy until accent vs card ≥ 4.5:1, and discloses it', () => {
+    const m = mapBrandTheme({ name: 'navy', primary: '#0a2a5e' });
+    expect(m.accent_h).toBe(217); // hue preserved — no status conflict at 217°
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+    expect(m.adjustments.some((a) => a.constraint === 'lightness-clamp')).toBe(true);
+    expect(m.adjustments.some((a) => a.constraint === 'contrast-floor')).toBe(true);
+    expect(isUnsatisfiable(m)).toBe(false);
+  });
+
+  it('every adjustment carries {constraint, original, adjusted, reason}', () => {
+    const m = mapBrandTheme({ name: 'navy', primary: '#0a2a5e' });
+    expect(m.adjustments.length).toBeGreaterThan(0);
+    for (const a of m.adjustments) {
+      expect(a.constraint).toBeTruthy();
+      expect(a.original).toBeTruthy();
+      expect(a.adjusted).toBeTruthy();
+      expect(a.reason).toBeTruthy();
+    }
+  });
+
+  it('the lightness raise caps at 90%', () => {
+    const m = mapBrandTheme({ name: 'near-black', primary: '#050508' });
+    expect(m.accent_l).toBeLessThanOrEqual(90);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
+});
+
+describe('mapBrandTheme — guarantee 2: ≥30° hue separation from the status trio (§4.5)', () => {
+  it('moves an emerald-adjacent hue off the running hue via ±5° search (nearest side wins)', () => {
+    // #22c55e ≈ hue 142° — inside the running (148°) exclusion band.
+    // Down clears at 5 steps (117°), up only at 8 (182°) — nearest wins.
+    const m = mapBrandTheme({ name: 'green', primary: '#22c55e' });
+    expect(m.accent_h).toBe(117);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    expect(m.adjustments.some((a) => a.constraint === 'hue-separation')).toBe(true);
+  });
+
+  it('a dead-center conflict tie-breaks to the direction maximizing total status distance', () => {
+    // Hue exactly 148 (the running hue): both directions clear at 6 steps
+    // (118° and 178°); 178° has the greater total distance from all three.
+    const m = mapBrandTheme({ name: 'emerald', primary: 'hsl(148, 58%, 58%)' });
+    expect(m.accent_h).toBe(178);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+  });
+
+  it('an amber-adjacent hue is pushed out of the gate band', () => {
+    const m = mapBrandTheme({ name: 'amber', primary: 'hsl(50, 90%, 60%)' });
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    expect(m.adjustments.some((a) => a.constraint === 'hue-separation')).toBe(true);
+  });
+});
+
+describe('mapBrandTheme — guarantee 3: saturation and lightness clamps (§4.5)', () => {
+  it('clamps a neon: s > 88 → 88', () => {
+    const m = mapBrandTheme({ name: 'neon', primary: 'hsl(217, 100%, 60%)' });
+    expect(m.accent_s).toBe(88);
+    expect(m.adjustments.some((a) => a.constraint === 'saturation-clamp')).toBe(true);
+  });
+
+  it('clamps a near-grey: s < 20 → 20 (and the hue then clears the fail band)', () => {
+    const m = mapBrandTheme({ name: 'grey', primary: '#808080' }); // s=0, h=0 (≈ fail hue 4°)
+    expect(m.accent_s).toBeGreaterThanOrEqual(20);
+    expect(m.adjustments.some((a) => a.constraint === 'saturation-clamp')).toBe(true);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+  });
+
+  it('clamps a wash-out: l > 78 → 78 (contrast floor already satisfied there)', () => {
+    const m = mapBrandTheme({ name: 'pale', primary: 'hsl(217, 60%, 92%)' });
+    expect(m.accent_l).toBe(78);
+    expect(m.adjustments.some((a) => a.constraint === 'lightness-clamp')).toBe(true);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
+
+  it('black and white both land inside every guarantee', () => {
+    for (const hex of ['#000000', '#ffffff']) {
+      const m = mapBrandTheme({ name: 'edge', primary: hex });
+      expect(m.accent_s).toBeGreaterThanOrEqual(20);
+      expect(m.accent_s).toBeLessThanOrEqual(88);
+      expect(m.accent_l).toBeGreaterThanOrEqual(42);
+      expect(m.accent_l).toBeLessThanOrEqual(90);
+      expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+      expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    }
+  });
+});
+
+describe('mapBrandTheme — guarantee 4: perceptual distinctness (§4.5)', () => {
+  it('a satisfiable mapping never sits within 25 deltaE of a status color', () => {
+    // Colors chosen to hug each status color after the hue push.
+    for (const primary of ['hsl(75, 90%, 68%)', 'hsl(34, 88%, 62%)', 'hsl(178, 58%, 58%)']) {
+      const m = mapBrandTheme({ name: 'close', primary });
+      if (!isUnsatisfiable(m)) {
+        expect(minStatusDeltaE(m)).toBeGreaterThanOrEqual(DELTA_FLOOR);
+      } else {
+        // Never silent: the residual proximity is disclosed.
+        expect(m.adjustments.some((a) => a.constraint === 'unsatisfiable')).toBe(true);
+      }
+    }
+  });
+
+  it('a perceptual nudge never breaks the contrast floor (priority 1 beats 4)', () => {
+    for (const primary of ['hsl(75, 90%, 55%)', 'hsl(178, 58% ,48%)']) {
+      const m = mapBrandTheme({ name: 'nudge', primary });
+      expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+    }
+  });
+});
+
+describe('mapBrandTheme — the whole-gamut property (§4.5: all four at once)', () => {
+  it('any input either satisfies every guarantee or discloses unsatisfiability', () => {
+    for (let h = 0; h < 360; h += 15) {
+      for (const s of [0, 35, 70, 100]) {
+        for (const l of [5, 35, 65, 95]) {
+          const rgb = hslToRgb(h, s, l);
+          const hex = `#${[rgb.r, rgb.g, rgb.b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+          const m = mapBrandTheme({ name: 'sweep', primary: hex });
+          const label = `input hsl(${h} ${s}% ${l}%) → hsl(${m.accent_h} ${m.accent_s}% ${m.accent_l}%)`;
+          if (isUnsatisfiable(m)) continue; // disclosed, never silent — allowed
+          expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB), `${label}: contrast`)
+            .toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+          expect(minStatusHueSep(m.accent_h), `${label}: hue separation`)
+            .toBeGreaterThanOrEqual(HUE_SEP);
+          expect(minStatusDeltaE(m), `${label}: deltaE`).toBeGreaterThanOrEqual(DELTA_FLOOR);
+          expect(m.accent_s, `${label}: sat range`).toBeGreaterThanOrEqual(20);
+          expect(m.accent_s, `${label}: sat range`).toBeLessThanOrEqual(88);
+          expect(m.accent_l, `${label}: lgt range`).toBeGreaterThanOrEqual(42);
+          expect(m.accent_l, `${label}: lgt range`).toBeLessThanOrEqual(90);
+        }
+      }
+    }
+  });
+});
+
+describe('mapBrandTheme — degenerate palettes (§4.4 tolerant reading)', () => {
+  it('no colors at all → the default accent stands, disclosed as a source fallback', () => {
+    const m = mapBrandTheme({ name: 'empty' });
+    expect(m).toMatchObject({ accent_h: 258, accent_s: 72, accent_l: 62, logo_url: null });
+    expect(m.adjustments).toHaveLength(1);
+    expect(m.adjustments[0]?.constraint).toBe('source-fallback');
+  });
+
+  it('an unparseable primary is treated as absent', () => {
+    const m = mapBrandTheme({ name: 'junk', primary: 'linear-gradient(red, blue)' });
+    expect(m.accent_h).toBe(258);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(true);
+  });
+
+  it('secondary fills in when primary is missing, and says so', () => {
+    const m = mapBrandTheme({ name: 'sec', secondary: '#0a2a5e' });
+    expect(m.accent_h).toBe(217);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(true);
+  });
+
+  it('primary wins over secondary when both parse', () => {
+    const m = mapBrandTheme({ name: 'both', primary: '#0a2a5e', secondary: '#22c55e' });
+    expect(m.accent_h).toBe(217);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(false);
+  });
+});
+
+describe('mapBrandTheme — logo passthrough and purity (§4.5)', () => {
+  it('passes a bridge-relative logo_url through untransformed', () => {
+    const m = mapBrandTheme({ name: 'logo', primary: '#0a2a5e', logo_url: '/api/brand/logo.svg' });
+    expect(m.logo_url).toBe('/api/brand/logo.svg');
+  });
+
+  it('a blank or absent logo_url is null', () => {
+    expect(mapBrandTheme({ name: 'x', primary: '#0a2a5e', logo_url: '   ' }).logo_url).toBeNull();
+    expect(mapBrandTheme({ name: 'x', primary: '#0a2a5e' }).logo_url).toBeNull();
+  });
+
+  it('the logo survives a palette with no usable color', () => {
+    const m = mapBrandTheme({ name: 'logo-only', logo_url: '/api/brand/logo.svg' });
+    expect(m.logo_url).toBe('/api/brand/logo.svg');
+    expect(m.accent_h).toBe(258);
+  });
+
+  it('is pure: same input → deep-equal output, input never mutated', () => {
+    const input = Object.freeze({ name: 'pure', primary: '#22c55e', logo_url: '/l.svg' });
+    const a = mapBrandTheme(input);
+    const b = mapBrandTheme(input);
+    expect(a).toEqual(b);
+    expect(input).toEqual({ name: 'pure', primary: '#22c55e', logo_url: '/l.svg' });
+  });
+});

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -15,6 +15,7 @@ import {
   getDemoSpec,
   getLatestRecording,
   getSources,
+  getTheme,
   listDemos,
   getVersions,
   interactiveUrl,
@@ -87,6 +88,8 @@ describe('interactive URL resolver', () => {
     ['getDemoSpec', { steps: [] },                     () => getDemoSpec(PROJECT, DEMO)],
     ['getLatestRecording', { version: 1 },             () => getLatestRecording(PROJECT, DEMO)],
     ['requestRecord', { queued: true },                () => requestRecord(PROJECT, DEMO)],
+    // DES-VISION-001 §4.4's one new wrapper — the palette the brand mapper consumes.
+    ['getTheme',   { name: 'acme' },                   () => getTheme(PROJECT, 'acme')],
   ];
 
   describe('prod (same-origin)', () => {
@@ -354,6 +357,18 @@ describe('happy-path shapes', () => {
     expect(calls[0]!.init?.method).toBe('POST');
     expect(calls[0]!.url).toBe(
       `${apiBase()}/projects/${PROJECT}/interactive/d/${DEMO}/api/demo/record`,
+    );
+  });
+
+  it('getTheme GETs /api/themes/:themeId and tolerates extra fields (DES-VISION-001 §4.4)', async () => {
+    // Tolerant reading: the bridge's theme JSON may carry more than the mapper's
+    // minimum — the wrapper passes the body through untouched.
+    const detail = { name: 'acme', primary: '#0a2a5e', logo_url: '/api/brand/logo.svg', fonts: ['Inter'] };
+    const calls = stubFetch(detail);
+    await expect(getTheme(PROJECT, 'acme')).resolves.toEqual(detail);
+    expect(calls[0]!.init?.method).toBeUndefined(); // a bare GET
+    expect(calls[0]!.url).toBe(
+      `${apiBase()}/projects/${PROJECT}/interactive/api/themes/acme`,
     );
   });
 });


### PR DESCRIPTION
The vision arc's finale (§4): Settings → 'Learn from your brand' — a URL/PDF/image goes to wicked-interactive's theme extraction through the existing proxy (SSRF stays server-side), the §4.5 mapper converts the extracted palette to studio's token instance with contrast floors and accent-vs-status separation guaranteed (pure module, unit-tested incl. degenerate palettes; the verifier caught and fixed a priority inversion in the perceptual-nudge clamp), preview rides slice 7's live-preview machinery, apply persists. The `learn-brand` garden skill file lands at the §4.2 path. Verified adversarially in the stacked worktree; re-landed by cherry-pick; gates re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)