### PR TITLE
feat(theme): theming gets its own page (operator change order)

### DIFF
--- a/e2e/vision_slice7_test.py
+++ b/e2e/vision_slice7_test.py
@@ -149,7 +149,7 @@ with sync_playwright() as p:
     page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
     page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
 
-    page.goto(f"{ORIGIN}/system", wait_until="domcontentloaded")
+    page.goto(f"{ORIGIN}/theme", wait_until="domcontentloaded")
     page.locator('[data-testid="appearance-settings"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
 

--- a/e2e/vision_slice8_test.py
+++ b/e2e/vision_slice8_test.py
@@ -171,7 +171,7 @@ with sync_playwright() as p:
     page.on("request", lambda r: requests_log.append(f"{r.method} {r.url}"))
     page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
 
-    page.goto(f"{ORIGIN}/system", wait_until="domcontentloaded")
+    page.goto(f"{ORIGIN}/theme", wait_until="domcontentloaded")
     page.locator('[data-testid="brand-learn"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
     try:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { GroupChat } from './components/GroupChat.js';
 import { WorkflowViewer } from './components/WorkflowViewer.js';
 import { WorkPage } from './components/WorkPage.js';
 import { SystemSettings } from './components/SystemSettings.js';
+import { ThemePage } from './components/ThemePage.js';
 import { useEventStream } from './hooks/useEventStream.js';
 import { useLegacyRedirect } from './hooks/useLegacyRedirect.js';
 import { modePath, routedVersion, useRoute, type Mode } from './hooks/useRoute.js';
@@ -416,7 +417,14 @@ export function App(): React.ReactElement {
     if (panel === 'system') {
       return (
         <div className="flex-1 overflow-y-auto p-6">
-          <SystemSettings />
+          <SystemSettings navigate={navigate} />
+        </div>
+      );
+    }
+    if (panel === 'theme') {
+      return (
+        <div className="flex-1 overflow-y-auto p-6">
+          <ThemePage />
         </div>
       );
     }

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -6,6 +6,7 @@ interface Props {
 }
 
 const ITEMS: { label: string; path: string }[] = [
+  { label: 'Theme', path: '/theme' },
   { label: 'Coverage', path: '/coverage' },
   { label: 'Domain', path: '/domain' },
   { label: 'Workflows', path: '/workflows' },

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
-import { AppearanceSettings } from './AppearanceSettings.js';
 import { Modal } from './Modal.js';
 import { Terminal } from './Terminal.js';
 
@@ -44,7 +43,11 @@ function loadDefaultClis(roster: RosterSeat[]): Set<string> {
   return new Set(roster.filter((s) => s.enabled_for_council).map((s) => s.key));
 }
 
-export function SystemSettings(): React.ReactElement {
+interface SystemSettingsProps {
+  navigate?: (path: string) => void;
+}
+
+export function SystemSettings({ navigate = (p) => { history.pushState(null, '', p); window.dispatchEvent(new PopStateEvent('popstate')); } }: SystemSettingsProps): React.ReactElement {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [dirty, setDirty] = useState<Partial<Settings>>({});
   const [saving, setSaving] = useState(false);
@@ -158,10 +161,27 @@ export function SystemSettings(): React.ReactElement {
         </div>
       )}
 
-      {/* Appearance (DES-VISION-001 §3.2): a SECTION here, not a new page — it
-          persists itself through the appearance store (debounced PUT), so it
-          rides outside this page's dirty/Save machinery on purpose (§3.4). */}
-      <AppearanceSettings />
+      {/* Theming lives at /theme — link, not a duplicate surface. */}
+      <div
+        className="rounded-xl px-5 mb-6 flex items-center justify-between py-4"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+      >
+        <div>
+          <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>Theme</p>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--ink-muted)' }}>
+            Appearance, accent, logo, and brand identity.
+          </p>
+        </div>
+        <a
+          href="/theme"
+          data-testid="theme-page-link"
+          onClick={(e) => { e.preventDefault(); navigate('/theme'); }}
+          className="text-xs font-mono transition-opacity hover:opacity-80"
+          style={{ color: 'var(--accent)', textDecoration: 'none' }}
+        >
+          Theme ›
+        </a>
+      </div>
 
       <section
         className="rounded-xl px-5 mb-6"

--- a/src/components/ThemePage.tsx
+++ b/src/components/ThemePage.tsx
@@ -1,0 +1,20 @@
+import { AppearanceSettings } from './AppearanceSettings.js';
+
+/**
+ * The dedicated Theme page (/theme) — a first-class home for the appearance
+ * customization surface and brand-learn flow (DES-VISION-001 §3–§4), moved off
+ * the system/settings page so theming gets the room it deserves.
+ */
+export function ThemePage(): React.ReactElement {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold" style={{ color: 'var(--ink-high)' }}>Theme</h1>
+        <p className="text-sm mt-1" style={{ color: 'var(--ink-muted)' }}>
+          Appearance, accent, and brand identity — persisted per-install.
+        </p>
+      </div>
+      <AppearanceSettings />
+    </div>
+  );
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not


### PR DESCRIPTION
Brand-learn and the appearance surface move off the system page onto a dedicated `/theme` page — preview prominent, controls grouped, brand-learn its own labeled section; the system page keeps a 'Theme →' link so nobody dead-ends; nav entry repointed; slice-7/8 rigs repointed with assertions unchanged. Authored and delivered by governed run `022c170f-b401-45aa-bb5c-a6a2d60c8a41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)