### PR TITLE
Slice B: create flows default to Unfiled with an inline project switcher (DES-FEEDBACK-001 §5, §4.3)

### DIFF
--- a/e2e/feedback_sliceB_test.py
+++ b/e2e/feedback_sliceB_test.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+feedback_sliceB_test.py — the DES-FEEDBACK-001 slice-B gate: create-flow
+project defaults (§5, §8.3 slice B), against the shared frozen-NOW0 W2
+fixture (uxfix_fixture.py).
+
+The slice DOM ACs, verbatim from §8.3:
+
+  1. In the Build new-run form, `[data-testid="project-field"]` default value
+     is "Unfiled";
+  2. clicking it opens a dropdown containing project names;
+  3. when navigated from `/p/:projectId/build`, the field shows the project
+     name and has `data-locked="true"` (locked = not clickable/changeable);
+  4. `[data-testid="project-switcher-add"]` option renders in the dropdown.
+
+Plus the §8.3 preservation list this rig can see: the Build purpose statement
+(`[data-testid="build-purpose"]`, DES-UXFIX-001 §2.7/EC7 — the surface teaches
+itself) and the intent input (`[data-testid="launch-problem"]`, "What do you
+need built?"). Chat's single-agent default and §6.2 chips are untouched by
+this slice (chips are slice C) and covered at unit level. EC17's
+project-context header is slice D's build; here the §4.3 LOCKED project field
+is what carries the project context inside the create surface.
+
+Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback-B-build-unfiled.png   the Build create form (/runs/new), Unfiled default
+  feedback-B-build-prebound.png  the Build form entered from project context
+                                 (/p/q3-review-deck/build → + Build something),
+                                 project pre-filled and locked
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4352),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    REPO,
+    ensure_build,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4352"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# The fixture's real (non-synthesized, non-quiet-clone) project names the
+# dropdown must list — presence, not exhaustiveness.
+EXPECTED_NAMES = {"q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"}
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    def new_page():
+        page = ctx.new_page()
+        page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+        # Freeze Date.now at NOW0 + 5s BEFORE the app boots so every rendered
+        # age is deterministic in the captures.
+        page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+        return page
+
+    def settled(page, expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── Scene 1: the flat Build create form (/runs/new) — Unfiled default ─────
+    page = new_page()
+    page.goto(f"{ORIGIN}/runs/new", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-field"]').wait_for(timeout=30000)
+    page.locator('[data-testid="launch-problem"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    fonts_ok = settled(
+        page,
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    closed = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const field = q('[data-testid="project-field"]');
+             return {
+               fieldText: field?.textContent ?? null,
+               locked: field?.dataset.locked ?? null,
+               listOpen: !!q('[data-testid="project-switcher-list"]'),
+               // §5.2: the field sits ABOVE the intent input in the form.
+               rowFirst: !!q('[data-testid="launch-project-row"]'),
+               intentPlaceholder: q('[data-testid="launch-problem"]')?.placeholder ?? null,
+               // EC7 preserved: the surface says what it is for, in one line.
+               teachesItself: (document.body.innerText || '').includes(
+                 'Describe your goal. The council elects a CLI'),
+             }; }""")
+
+    ac1_unfiled = (closed["fieldText"] or "").strip().startswith("Unfiled") \
+        and closed["locked"] == "false" and not closed["listOpen"]
+    intent_ok = closed["intentPlaceholder"] == "What do you need built?" and closed["rowFirst"]
+
+    # ── Capture 1: the Unfiled default, BEFORE any interaction ────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-B-build-unfiled.png"))
+
+    # ── ACs 2 + 4: the dropdown — project names + "+ New project" ─────────────
+    page.locator('[data-testid="project-field"]').click()
+    list_opens = settled(
+        page,
+        """() => document.querySelectorAll('[data-testid="project-switcher-option"]').length > 3""",
+        timeout=10000,
+    )
+    dropdown = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const names = Array.from(document.querySelectorAll(
+               '[data-testid="project-switcher-option"]')).map(r => r.textContent);
+             const ids = Array.from(document.querySelectorAll(
+               '[data-testid="project-switcher-option"]')).map(r => r.dataset.projectId);
+             return {
+               names, ids,
+               addRow: !!q('[data-testid="project-switcher-add"]'),
+               addText: q('[data-testid="project-switcher-add"]')?.textContent ?? null,
+               unfiledRow: !!q('[data-testid="project-switcher-unfiled"]'),
+               filterInput: !!q('input[placeholder="filter projects…"]'),
+             }; }""")
+
+    ac2_names = EXPECTED_NAMES.issubset(set(dropdown["names"]))
+    # The synthesized `default` project must never list as a row (F5).
+    default_hidden = "default" not in dropdown["ids"]
+    ac4_add = dropdown["addRow"] and dropdown["addText"] == "+ New project"
+    anatomy_ok = dropdown["unfiledRow"] and dropdown["filterInput"]
+
+    # Selecting a project updates the field; re-selecting Unfiled restores it —
+    # the §5.2 "opportunity to change" is one click away in both directions.
+    page.locator('[data-testid="project-switcher-option"][data-project-id="q3-review-deck"]').click()
+    select_ok = settled(
+        page,
+        """() => (document.querySelector('[data-testid="project-field"]')?.textContent ?? '')
+                   .includes('q3-review-deck')""",
+        timeout=5000,
+    )
+    page.locator('[data-testid="project-field"]').click()
+    page.locator('[data-testid="project-switcher-unfiled"]').click()
+    unfiled_back = settled(
+        page,
+        """() => (document.querySelector('[data-testid="project-field"]')?.textContent ?? '')
+                   .includes('Unfiled')""",
+        timeout=5000,
+    )
+    page.close()
+
+    report["steps"]["build_unfiled"] = {
+        "ok": all([fonts_ok, ac1_unfiled, intent_ok, list_opens, ac2_names,
+                   default_hidden, ac4_add, anatomy_ok, select_ok, unfiled_back,
+                   closed["teachesItself"]]),
+        "web_fonts_loaded": fonts_ok,
+        "ac1_field_defaults_unfiled": ac1_unfiled,
+        "field_text": closed["fieldText"],
+        "intent_input_preserved": intent_ok,
+        "ec7_surface_teaches_itself": closed["teachesItself"],
+        "ac2_dropdown_lists_projects": ac2_names,
+        "dropdown_names_head": dropdown["names"][:8],
+        "synthesized_default_hidden": default_hidden,
+        "ac4_new_project_row": ac4_add,
+        "dropdown_anatomy_filter_and_unfiled": anatomy_ok,
+        "select_then_unfiled_roundtrip": select_ok and unfiled_back,
+        "screenshot": str(VSHOTS / "feedback-B-build-unfiled.png"),
+    }
+    if not report["steps"]["build_unfiled"]["ok"]:
+        fail("build_unfiled_verdict", "scene-1 DOM assertions did not all hold — see build_unfiled")
+
+    # ── Scene 2: entered from project context — pre-filled and LOCKED (§4.3) ──
+    page2 = new_page()
+    page2.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page2.locator('[data-testid="build-purpose"]').wait_for(timeout=30000)   # preserved (EC7)
+    page2.locator('[data-testid="build-something"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+    purpose_ok = page2.evaluate(
+        """() => (document.querySelector('[data-testid="build-purpose"]')?.textContent ?? '')
+                   .startsWith('Build runs governed code work')""")
+
+    # The journey the AC names: FROM /p/:projectId/build into the create form.
+    page2.locator('[data-testid="build-something"]').click()
+    route_ok = settled(
+        page2,
+        """() => location.pathname === '/p/q3-review-deck/build/new'""",
+        timeout=10000,
+    )
+    page2.locator('[data-testid="project-field"]').wait_for(timeout=30000)
+    # AC 3: the field shows the project NAME (resolved from /projects) and locks.
+    prebound_settled = settled(
+        page2,
+        """() => { const f = document.querySelector('[data-testid="project-field"]');
+                   return !!f && f.dataset.locked === 'true'
+                       && (f.textContent ?? '').includes('q3-review-deck'); }""",
+        timeout=15000,
+    )
+    # Locked = not clickable/changeable: a click must NOT open the dropdown.
+    page2.locator('[data-testid="project-field"]').click()
+    page2.wait_for_timeout(300)
+    locked_state = page2.evaluate(
+        """() => ({
+             listOpen: !!document.querySelector('[data-testid="project-switcher-list"]'),
+             caret: (document.querySelector('[data-testid="project-field"]')?.textContent ?? '')
+               .includes('▾'),
+             intentPresent: !!document.querySelector('[data-testid="launch-problem"]'),
+           })""")
+    lock_holds = not locked_state["listOpen"] and not locked_state["caret"]
+
+    # ── Capture 2: the pre-bound, locked form ──────────────────────────────────
+    page2.screenshot(path=str(VSHOTS / "feedback-B-build-prebound.png"))
+    page2.close()
+    browser.close()
+
+report["steps"]["build_prebound"] = {
+    "ok": all([purpose_ok, route_ok, prebound_settled, lock_holds,
+               locked_state["intentPresent"]]),
+    "purpose_statement_preserved": purpose_ok,
+    "route_is_project_scoped_new": route_ok,
+    "ac3_prefilled_and_locked": prebound_settled,
+    "lock_refuses_to_open": lock_holds,
+    "intent_input_present": locked_state["intentPresent"],
+    "console_errors": console_errors[:10],
+    "screenshot": str(VSHOTS / "feedback-B-build-prebound.png"),
+}
+if not report["steps"]["build_prebound"]["ok"]:
+    fail("build_prebound_verdict", "scene-2 DOM assertions did not all hold — see build_prebound")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,15 +235,23 @@ export function App(): React.ReactElement {
         onApproveGate={onDashboardApproveGate}
         onRejectGate={onDashboardRejectGate}
         navigate={navigate}
+        projectId={projectId}
       />
     </div>
   );
 
-  const groupChatSurface = (repo: string | null): React.ReactElement => (
+  // In the project shell the new chat is FILED into the project at open time
+  // (DES-FEEDBACK-001 §5.1 — `projectId` on the POST body, never a silent unfiled
+  // thread); outside it, GroupChat renders its own ProjectSwitcher (§5.2).
+  const groupChatSurface = (repo: string | null, pid: string | null = null): React.ReactElement => (
     <div className="flex-1 overflow-hidden">
-      <GroupChat repoId={repo} onBack={onNavigateBack} />
+      <GroupChat repoId={repo} onBack={onNavigateBack} projectId={pid} navigate={navigate} />
     </div>
   );
+
+  // §4.3 pre-bind: `/p/:projectId/build/new` is the launch form LOCKED to the
+  // project; the flat `/runs/new` stays unbound (Unfiled default, §5.1).
+  const launchProjectId = projectId !== null && mode === 'build' && showLaunch ? projectId : null;
 
   const runSurface = (): React.ReactElement => (
     <div className="flex-1 overflow-hidden">
@@ -255,6 +263,7 @@ export function App(): React.ReactElement {
         onRefresh={refresh}
         onKill={onKill}
         navigate={navigate}
+        launchProjectId={launchProjectId}
       />
     </div>
   );
@@ -314,8 +323,9 @@ export function App(): React.ReactElement {
         </VideoStoryboard>
       );
     }
-    if (m === 'chat' && !artifactId) return groupChatSurface(null);
-    return artifactId ? runSurface() : dashboardSurface();
+    if (m === 'chat' && !artifactId) return groupChatSurface(null, pid);
+    // `showLaunch` here is `/p/:pid/build/new` — the §4.3 pre-bound launch form.
+    return artifactId || showLaunch ? runSurface() : dashboardSurface();
   }
 
   // Center panel content based on route

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -168,7 +168,9 @@ export const api = {
 
   /** A unit's captured transcript (string, or `null`). Pass the unit key (the suffix after `<run>:`). */
   // ── Chat sessions (crew#165): warm seats + group fan-out ─────────────────
-  openChat: (body: { chatId?: string; clis?: string[]; repoRef?: string }) =>
+  /** `projectId` files the chat into a project at open time (`crew.chat`
+   *  membership, DES-PROJECT-001) — omitted = unfiled, the backend default. */
+  openChat: (body: { chatId?: string; clis?: string[]; repoRef?: string; projectId?: string }) =>
     apiFetch<{ chatId: string; seats: { cliKey: string; ok: boolean; error?: string }[] }>(`/chats`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -20,6 +20,7 @@ import { useGateStore } from '../store/gates.js';
 import { useRunEventStore } from '../store/events.js';
 import { useSteeringStore } from '../store/steering.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
+import { modePath } from '../hooks/useRoute.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -30,6 +31,13 @@ interface Props {
   onApproveGate: (runId: string, amend?: string) => void;
   onRejectGate: (runId: string) => void;
   navigate: (path: string) => void;
+  /**
+   * The project shell's context (DES-FEEDBACK-001 §4.3, slice B): when Build is
+   * entered via `/p/:projectId/build`, "+ Build something" opens the launch form
+   * PRE-BOUND to this project (`/p/:projectId/build/new`) instead of the flat
+   * unbound `/runs/new`.
+   */
+  projectId?: string | null;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -765,6 +773,7 @@ export function CenterDashboard({
   onApproveGate,
   onRejectGate,
   navigate,
+  projectId = null,
 }: Props): React.ReactElement {
   const byRun = useRunEventStore((s) => s.byRun);
   const gates = useGateStore((s) => s.gates);
@@ -1074,7 +1083,8 @@ export function CenterDashboard({
           <button
             type="button"
             data-testid="build-something"
-            onClick={() => navigate('/runs/new')}
+            // §4.3: from project context the launch form opens pre-bound and locked.
+            onClick={() => navigate(projectId ? modePath(projectId, 'build', 'new') : '/runs/new')}
             style={{
               background: 'var(--accent)',
               color: 'var(--accent-fg)',

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { EntityMode, LaunchRunBody, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
+import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
+import { NewProjectModal } from './NewProjectModal.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
 import type { RunMode } from './runMode.js';
 
 interface Props {
@@ -37,6 +39,13 @@ interface Props {
    * it just render the warning with no working link.
    */
   navigate?: (path: string) => void;
+  /**
+   * §4.3 pre-bind (DES-FEEDBACK-001, slice B): when set, the launch form's
+   * ProjectSwitcher pre-fills with this project and LOCKS, and every launch
+   * carries `projectId` in the POST body. When absent the field defaults to
+   * Unfiled (§5.1) — NO `projectId` key on the body, the backend default.
+   */
+  lockedProjectId?: string | null;
 }
 
 const INJECT_STATUSES = new Set(['executing', 'distributing', 'planning']);
@@ -88,7 +97,7 @@ function ActivePill({
 // Defense-in-depth denylist: catches system workflows that predate the is_system flag.
 const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
 
-export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget, navigate }: Props): React.ReactElement {
+export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget, navigate, lockedProjectId = null }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
 
   // ── Steer mode state ───────────────────────────────────────────────────────
@@ -121,6 +130,29 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const [confirmMode, setConfirmMode] = useState<ConfirmMode>('none');
   const [beforeOrd, setBeforeOrd] = useState(1);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
+
+  // ── Project binding (DES-FEEDBACK-001 §5, slice B) ─────────────────────────
+  // `null` = Unfiled (§5.1): no `projectId` key in the POST body, the backend
+  // default — byte-identical to the pre-slice request. The list loads lazily on
+  // the dropdown's first open (or on mount when pre-bound, to resolve the name).
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [showNewProject, setShowNewProject] = useState(false);
+  const projectsRequested = useRef(false);
+
+  function loadProjects(): void {
+    if (projectsRequested.current) return;
+    projectsRequested.current = true;
+    api
+      .listProjects()
+      .then(({ projects: ps }) =>
+        // Recency-ordered (updated_at desc) — the attention axis's cheap proxy;
+        // the synthesized `default` row is filtered by the switcher itself.
+        setProjects([...ps].sort((a, b) => b.updated_at - a.updated_at)))
+      .catch(() => {
+        projectsRequested.current = false; // transient failure — retry on next open
+      });
+  }
 
   const [submitting, setSubmitting] = useState(false);
   const [elapsedSecs, setElapsedSecs] = useState(0);
@@ -163,6 +195,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       .then(({ workflows: wfs }) => setWorkflows(wfs))
       .catch(() => {});
   }, []);
+
+  // §4.3 pre-bound: resolve the locked project's NAME up front — the field must
+  // show the name, not the id. Unbound forms load nothing until the first open.
+  useEffect(() => {
+    if (lockedProjectId != null) loadProjects();
+    // loadProjects is stable in behaviour (ref-guarded, single-shot).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockedProjectId]);
 
   // ── Elapsed-time ticker ────────────────────────────────────────────────────
   useEffect(() => {
@@ -267,6 +307,10 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     if (firstRepo) body.repoRef = firstRepo;
     const wf = workflowOverride?.trim() || workflow;
     if (wf) body.workflow = wf;
+    // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
+    // or pre-bound project files the run atomically with the launch.
+    const boundProject = lockedProjectId ?? selectedProjectId;
+    if (boundProject) body.projectId = boundProject;
 
     try {
       const { runId: newRunId } = await api.launchRun(body);
@@ -482,6 +526,18 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const canSubmit = problem.trim().length > 0 && selectedClis.size > 0 && !submitting;
   const showDetection = detectedWorkflow !== null && !workflowDismissed && !workflow && !workflowOverride;
 
+  // The switcher's current binding (§5.2). Pre-bound (§4.3): the project rides
+  // the route, so it shows even before the name resolves — id first, name once
+  // the list lands (fixture/daemon ids are stable slugs, so this never flashes
+  // an unrelated string).
+  const boundProjectId = lockedProjectId ?? selectedProjectId;
+  const currentProject: Project | null =
+    projects.find((p) => p.id === boundProjectId)
+    ?? (lockedProjectId != null
+      ? { id: lockedProjectId, name: lockedProjectId, description: null,
+          status: 'active', scope: `project:${lockedProjectId}`, created_at: 0, updated_at: 0 }
+      : null);
+
   // Seats routed to by this launch that the daemon observed as NOT signed in.
   // Strictly `=== false` — `null`/absent means "unknowable cheaply", not a problem.
   // A warning only: fallbacks exist, so the launch is never blocked on it.
@@ -553,6 +609,34 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             }
       }
     >
+      {/* ── Project binding — the FIRST field of every create flow (§5.2) ──
+          Unfiled by default; pre-bound-and-locked from project context (§4.3). */}
+      <div className="flex items-center gap-2 px-1" data-testid="launch-project-row">
+        <span
+          className="text-[11px] font-mono uppercase tracking-widest"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Project
+        </span>
+        <ProjectSwitcher
+          current={currentProject}
+          projects={projects}
+          onSelect={setSelectedProjectId}
+          onNewProject={() => setShowNewProject(true)}
+          onOpen={loadProjects}
+          locked={lockedProjectId != null}
+          // Docked (non-embedded) forms sit at the pane's bottom edge — open up.
+          dropUp={!embedded}
+        />
+      </div>
+
+      {showNewProject && (
+        <NewProjectModal
+          navigate={navigate ?? ((): void => undefined)}
+          onClose={() => setShowNewProject(false)}
+        />
+      )}
+
       {/* Workflow detection hint */}
       {showDetection && (
         <div

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -200,8 +200,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // show the name, not the id. Unbound forms load nothing until the first open.
   useEffect(() => {
     if (lockedProjectId != null) loadProjects();
-    // loadProjects is stable in behaviour (ref-guarded, single-shot).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // (loadProjects is ref-guarded and single-shot, so listing only the lock is safe.)
   }, [lockedProjectId]);
 
   // ── Elapsed-time ticker ────────────────────────────────────────────────────

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -26,6 +26,12 @@ interface Props {
   onKill?: (runId: string) => void | Promise<void>;
   /** App-level route navigation — threaded to ChatInput's seat sign-in warning (→ /system). */
   navigate?: (path: string) => void;
+  /**
+   * §4.3 pre-bind (DES-FEEDBACK-001, slice B): non-null when the launch form was
+   * entered from project context (`/p/:projectId/build/new`) — the ProjectSwitcher
+   * field pre-fills with this project and LOCKS.
+   */
+  launchProjectId?: string | null;
 }
 
 // Agent identity under the token contract (DES-VISION-001 §2.11): one
@@ -1125,12 +1131,14 @@ function NewRunView({
   onModeChange,
   onLaunched,
   navigate,
+  launchProjectId = null,
 }: {
   chatMode: boolean;
   mode: RunMode;
   onModeChange: (m: RunMode) => void;
   onLaunched: (id: string) => void;
   navigate?: (path: string) => void;
+  launchProjectId?: string | null;
 }): React.ReactElement {
   const heading = chatMode
     ? 'What do you want to explore?'
@@ -1157,6 +1165,7 @@ function NewRunView({
           embedded
           mode={mode}
           onLaunched={onLaunched}
+          lockedProjectId={launchProjectId}
           {...(chatMode ? { workflowOverride: 'chat' } : {})}
           {...(navigate !== undefined ? { navigate } : {})}
         />
@@ -1165,7 +1174,7 @@ function NewRunView({
   );
 }
 
-export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill, navigate }: Props): React.ReactElement {
+export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill, navigate, launchProjectId = null }: Props): React.ReactElement {
   const [mode, setMode] = useState<RunMode>('balanced');
 
   if (view) {
@@ -1204,6 +1213,7 @@ export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefres
       mode={mode}
       onModeChange={setMode}
       onLaunched={onLaunched}
+      launchProjectId={launchProjectId}
       {...(navigate !== undefined ? { navigate } : {})}
     />
   );

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
+import type { Project } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
 import { Markdown } from './Markdown.js';
+import { NewProjectModal } from './NewProjectModal.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
 
 /**
  * CHAT (crew#165 / core#134): warm persistent CLI sessions + fan-out.
@@ -89,9 +92,21 @@ type Msg = UserMsg | SeatMsg;
 interface Props {
   repoId?: string | null;
   onBack: () => void;
+  /**
+   * The project shell's context (DES-FEEDBACK-001 §4.3/§5.1, slice B): when set,
+   * the chat is FILED into this project at open time (`projectId` on the POST
+   * body) with no switcher UI — the shell already IS the project context, and
+   * resolving its display name would cost a mount request Chat must not make
+   * (DES-UXFIX-001 §2.4). When absent, the create flow renders a ProjectSwitcher
+   * defaulting to Unfiled (§5.2); its project list loads on the dropdown's first
+   * OPEN — a user action — never on mount.
+   */
+  projectId?: string | null;
+  /** App-level route navigation — needed only by the "+ New project" hand-off. */
+  navigate?: (path: string) => void;
 }
 
-export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
+export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props): React.ReactElement {
   const [chatId, setChatId] = useState<string | null>(null);
   const [seats, setSeats] = useState<Record<string, SeatState>>({});
   const [seatErrors, setSeatErrors] = useState<Record<string, string>>({});
@@ -114,6 +129,28 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
+
+  // ── Project binding (DES-FEEDBACK-001 §5, slice B) ─────────────────────────
+  // `null` = Unfiled: no `projectId` key in the open body, the backend default.
+  // The list loads on the dropdown's first OPEN (§2.4: zero requests on mount).
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [showNewProject, setShowNewProject] = useState(false);
+  const projectsRequested = useRef(false);
+  const selectedProjectRef = useRef<string | null>(null);
+  selectedProjectRef.current = selectedProjectId;
+
+  function loadProjects(): void {
+    if (projectsRequested.current) return;
+    projectsRequested.current = true;
+    api
+      .listProjects()
+      .then(({ projects: ps }) =>
+        setProjects([...ps].sort((a, b) => b.updated_at - a.updated_at)))
+      .catch(() => {
+        projectsRequested.current = false; // transient — retry on the next open
+      });
+  }
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -141,6 +178,9 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
     setSeatErrors({});
     setOpenError(null);
     setEnded(false);
+    // The project selection belongs to the chat being CREATED — a repo switch
+    // starts a new create flow, so the binding resets to Unfiled (§5.1).
+    setSelectedProjectId(null);
     // The id goes too, and it is the one reset that is not cosmetic. Resolving the new repo's chat
     // is ASYNC — a stored id costs a probe round-trip — and until it lands, a `chatId` still holding
     // the PREVIOUS repo's chat is actively wrong in three places: the event-stream guard below would
@@ -302,8 +342,12 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
         ),
       }));
       try {
-        const body: { chatId: string; repoRef?: string; clis?: string[] } = { chatId: id };
+        const body: { chatId: string; repoRef?: string; clis?: string[]; projectId?: string } = { chatId: id };
         if (repoId) body.repoRef = repoId;
+        // §5.1/§4.3: the binding rides the OPEN — shell context wins, then the
+        // switcher's selection; Unfiled omits the key (the backend default).
+        const boundProject = projectId ?? selectedProjectRef.current;
+        if (boundProject) body.projectId = boundProject;
         // 'all' omits `clis` on purpose — the daemon warms its own full roster, exactly
         // as the pre-slice-4 mount did. 'one' names the single default agent; with no
         // roster answer it also omits, and the daemon's roster decides.
@@ -409,6 +453,11 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
   // over a chat that may be about to pop back in would be a lie held for milliseconds.
   const firstRun =
     messages.length === 0 && Object.keys(seats).length === 0 && openError === null && !resolving;
+  // The create-flow project field (§5.2) shows only while the chat is still being
+  // CREATED (binding happens at open time) and only outside the project shell —
+  // in the shell the context IS the project (§4.3) and rides `projectId` silently.
+  const showProjectField = projectId == null && chatId === null && !resolving && !ended;
+  const currentProject = projects.find((p) => p.id === selectedProjectId) ?? null;
 
   return (
     // The surface's own ink (§2.4); labels read in the sans by inheritance —
@@ -502,6 +551,31 @@ export function GroupChat({ repoId, onBack }: Props): React.ReactElement {
           --radius-xl; its focus ring is --accent-dim (wk-composer in
           global.css), never the full accent (§5.3 motion: too dominant). */}
       <div className="px-6 py-3 border-t shrink-0" style={{ borderColor: 'var(--surface-raised)' }}>
+        {/* §5.2: the project field sits ABOVE the intent input, Unfiled default. */}
+        {showProjectField && (
+          <div className="flex items-center gap-2 pb-2" data-testid="chat-project-row">
+            <span
+              className="text-[10px] font-mono uppercase tracking-widest"
+              style={{ color: 'var(--ink-dim)' }}
+            >
+              Project
+            </span>
+            <ProjectSwitcher
+              current={currentProject}
+              projects={projects}
+              onSelect={setSelectedProjectId}
+              onNewProject={() => setShowNewProject(true)}
+              onOpen={loadProjects}
+              dropUp
+            />
+          </div>
+        )}
+        {showNewProject && (
+          <NewProjectModal
+            navigate={navigate ?? ((): void => undefined)}
+            onClose={() => setShowNewProject(false)}
+          />
+        )}
         <div className="flex gap-2">
           <textarea
             value={input}

--- a/src/components/ProjectSwitcher.tsx
+++ b/src/components/ProjectSwitcher.tsx
@@ -22,9 +22,18 @@ interface Props {
   onNewProject?: () => void;
   /** §4.3 pre-bound surfaces: render the value, refuse to open. */
   locked?: boolean;
+  /**
+   * Fired when the dropdown OPENS — the lazy-load hook for callers with a
+   * request budget (Chat's zero-requests-on-mount, DES-UXFIX-001 §2.4): the
+   * project list is fetched on this first user action, never on mount.
+   */
+  onOpen?: () => void;
+  /** Open the list ABOVE the field — for fields docked at the viewport bottom
+   *  (Chat's composer), where a downward list would fall below the fold. */
+  dropUp?: boolean;
 }
 
-export function ProjectSwitcher({ current, projects, onSelect, onNewProject, locked = false }: Props): React.ReactElement {
+export function ProjectSwitcher({ current, projects, onSelect, onNewProject, locked = false, onOpen, dropUp = false }: Props): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
   const ref = useRef<HTMLDivElement>(null);
@@ -52,7 +61,11 @@ export function ProjectSwitcher({ current, projects, onSelect, onNewProject, loc
         data-locked={locked ? 'true' : 'false'}
         aria-haspopup="listbox"
         aria-expanded={open}
-        onClick={() => { if (!locked) setOpen((v) => !v); }}
+        onClick={() => {
+          if (locked) return;
+          if (!open) onOpen?.();
+          setOpen(!open);
+        }}
         className="flex items-center gap-1 px-2 py-1 rounded text-xs transition-opacity hover:opacity-80"
         style={{
           background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)',
@@ -68,7 +81,7 @@ export function ProjectSwitcher({ current, projects, onSelect, onNewProject, loc
         <div
           role="listbox"
           data-testid="project-switcher-list"
-          className="absolute top-full left-0 mt-1 w-56 rounded-lg py-1 z-50 max-h-64 overflow-y-auto"
+          className={`absolute left-0 w-56 rounded-lg py-1 z-50 max-h-64 overflow-y-auto ${dropUp ? 'bottom-full mb-1' : 'top-full mt-1'}`}
           style={{
             background: 'var(--surface-raised)',
             border: '1px solid var(--surface-raised)',

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { RepoEntry, SessionView } from '../api/types.js';
+import type { Project, RepoEntry, SessionView } from '../api/types.js';
+import { NewProjectModal } from './NewProjectModal.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
 
 type SourceMode = 'local' | 'remote';
 
@@ -70,6 +72,27 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
   const [registering, setRegistering] = useState(false);
   const nameEditedRef = useRef(false);
 
+  // ── Project binding (DES-FEEDBACK-001 §5, slice B) ──────────────────────────
+  // POST /repos takes no projectId (its schema is strict), so a selected project
+  // binds via POST /projects/:id/members (`crew.repo`) right after registration.
+  // `null` = Unfiled: register exactly as before, attach nothing.
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [showNewProject, setShowNewProject] = useState(false);
+  const projectsRequested = useRef(false);
+
+  function loadProjects(): void {
+    if (projectsRequested.current) return;
+    projectsRequested.current = true;
+    api
+      .listProjects()
+      .then(({ projects: ps }) =>
+        setProjects([...ps].sort((a, b) => b.updated_at - a.updated_at)))
+      .catch(() => {
+        projectsRequested.current = false; // transient — retry on the next open
+      });
+  }
+
   useEffect(() => {
     setLoading(true);
     Promise.all([api.listRepos(), api.listRuns()])
@@ -124,6 +147,18 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
         ? await api.cloneAndRegisterRepo(name, target, checkoutPath.trim() || undefined)
         : await api.registerRepo(name, target);
 
+      // §5.1/§5.2: a selected project binds the repo AT CREATION — the register
+      // route's strict schema carries no projectId, so the binding is the
+      // membership attach. A failed attach surfaces (never a silent unfiled
+      // repo); the registration itself has already succeeded.
+      if (selectedProjectId !== null) {
+        await api.attachProjectMember(selectedProjectId, {
+          kind: 'crew.repo',
+          ref: repo.id,
+          attachedBy: 'studio',
+        });
+      }
+
       setRepos((prev) => [...prev, repo]);
       setShowRegister(false);
       setNewName('');
@@ -131,6 +166,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
       setNewGitUrl('');
       setCheckoutPath('');
       setSourceMode('local');
+      setSelectedProjectId(null);
       nameEditedRef.current = false;
 
       navigate('/repo-detail/' + encodeURIComponent(repo.id));
@@ -202,6 +238,24 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
             className="flex flex-col gap-3 rounded-2xl p-5 mb-5"
             style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
+            {/* §5.2: the project field is the FIRST field — Unfiled by default;
+                a selected project binds the repo at creation via membership. */}
+            <div className="flex items-center gap-2" data-testid="repo-project-row">
+              <span
+                className="text-[10px] font-mono uppercase tracking-widest"
+                style={{ color: 'var(--ink-dim)' }}
+              >
+                Project
+              </span>
+              <ProjectSwitcher
+                current={projects.find((p) => p.id === selectedProjectId) ?? null}
+                projects={projects}
+                onSelect={setSelectedProjectId}
+                onNewProject={() => setShowNewProject(true)}
+                onOpen={loadProjects}
+              />
+            </div>
+
             {/* Source mode toggle — two mutually exclusive options; aria-pressed is correct for a binary toggle */}
             <div role="group" aria-label="Repository source" className="flex gap-1">
               {(['local', 'remote'] as SourceMode[]).map((m) => (
@@ -295,6 +349,10 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                   : 'Register & onboard'}
             </button>
           </div>
+        )}
+
+        {showNewProject && (
+          <NewProjectModal navigate={navigate} onClose={() => setShowNewProject(false)} />
         )}
       </div>
 

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -121,11 +121,18 @@ function parse(pathname: string): Route {
   // `Panel` union below is untouched and still owns every side panel.
   if (first === 'p' && second) {
     const mode = asMode(third);
-    const artifactId = mode !== null && fourth ? safeDecode(fourth) : null;
+    const raw = mode !== null && fourth ? safeDecode(fourth) : null;
+    // `/p/:projectId/:mode/new` is the project-scoped CREATE route (DES-FEEDBACK-001
+    // §4.3, slice B): the launch form pre-bound to the project — never an artifact
+    // named "new", so `artifactId` stays null and no run-selected machinery
+    // (event backfill, kill shortcut) fires against a non-id.
+    const isNew = raw === 'new';
+    const artifactId = isNew ? null : raw;
     return route({
       projectId: safeDecode(second),
       mode,
       artifactId,
+      showLaunch: isNew,
       // Build and Chat wire straight into the existing run surfaces, so the artifact IS
       // the run: every run-selected behaviour (event backfill, Ctrl+K kill, RightPanel,
       // gate toasts) keeps working unchanged inside the shell.

--- a/tests/ChatInput.project.test.tsx
+++ b/tests/ChatInput.project.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import * as client from '../src/api/client.js';
+import type { LaunchRunBody, Project } from '../src/api/types.js';
+
+/**
+ * DES-FEEDBACK-001 slice B (§5.1/§5.2/§4.3) — the Build launch form's project
+ * binding:
+ *   - default is Unfiled: the launch POST body carries NO `projectId` key at
+ *     all (the backend default, byte-identical to the pre-slice request);
+ *   - selecting a project in the switcher puts `projectId` on the body;
+ *   - `lockedProjectId` (entered via /p/:projectId/build/new) pre-fills the
+ *     field with the project, marks it data-locked, refuses to open, and
+ *     forces `projectId` onto every launch;
+ *   - the project list is fetched lazily on the dropdown's first open (or on
+ *     mount when locked, to resolve the name) — never on an unbound mount.
+ */
+
+function proj(id: string, name: string, updated = 1): Project {
+  return {
+    id, name, description: null, status: 'active',
+    scope: `project:${id}`, created_at: 1, updated_at: updated,
+  };
+}
+
+const PROJECTS = [
+  proj('api-migration', 'api-migration', 5),
+  proj('q3-review-deck', 'q3-review-deck', 9),
+  proj('default', 'Unfiled', 99),
+];
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: PROJECTS });
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  localStorage.clear();
+});
+
+async function typeAndLaunch(user: ReturnType<typeof userEvent.setup>): Promise<LaunchRunBody> {
+  await user.type(screen.getByTestId('launch-problem'), 'build the thing');
+  // The Send button enables once the roster load has landed a selected CLI.
+  await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+  await user.click(screen.getByTestId('launch-submit'));
+  await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+  return vi.mocked(client.api.launchRun).mock.calls[0]![0];
+}
+
+describe('ChatInput launch form — project binding (slice B)', () => {
+  it('defaults to Unfiled and launches WITHOUT a projectId key', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    const field = screen.getByTestId('project-field');
+    expect(field.textContent).toContain('Unfiled');
+    expect(field.dataset.locked).toBe('false');
+    // §5.1: the unbound form fetches no project list on mount.
+    expect(client.api.listProjects).not.toHaveBeenCalled();
+
+    const body = await typeAndLaunch(user);
+    expect('projectId' in body, 'Unfiled = no projectId key at all').toBe(false);
+  });
+
+  it('lazy-loads projects on open, and a selected project rides the POST body', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    await user.click(screen.getByTestId('project-field'));
+    expect(client.api.listProjects).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBe(2));
+    // Recency order (updated_at desc), and the synthesized default never lists.
+    const rows = screen.getAllByTestId('project-switcher-option');
+    expect(rows.map((r) => r.dataset.projectId)).toEqual(['q3-review-deck', 'api-migration']);
+    // §5.2: the "+ New project" hand-off is in the dropdown.
+    expect(screen.getByTestId('project-switcher-add')).toBeInTheDocument();
+
+    await user.click(rows[0]!);
+    expect(screen.getByTestId('project-field').textContent).toContain('q3-review-deck');
+
+    const body = await typeAndLaunch(user);
+    expect(body.projectId).toBe('q3-review-deck');
+  });
+
+  it('locked pre-bind (§4.3): shows the project name, data-locked, refuses to open, launches bound', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} lockedProjectId="q3-review-deck" />,
+    );
+
+    const field = screen.getByTestId('project-field');
+    expect(field.dataset.locked).toBe('true');
+    // The name resolves from the mount fetch the LOCK (and only the lock) triggers.
+    await waitFor(() => expect(client.api.listProjects).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(field.textContent).toContain('q3-review-deck'));
+
+    await user.click(field);
+    expect(screen.queryByTestId('project-switcher-list'), 'locked field must not open').toBeNull();
+
+    const body = await typeAndLaunch(user);
+    expect(body.projectId).toBe('q3-review-deck');
+  });
+});

--- a/tests/GroupChat.project.test.tsx
+++ b/tests/GroupChat.project.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+
+/**
+ * DES-FEEDBACK-001 slice B (§5.1/§5.2/§4.3) — the Chat create flow's project
+ * binding, under the standing §2.4 constraint (zero requests on mount):
+ *   - the standalone new-thread flow renders a ProjectSwitcher defaulting to
+ *     Unfiled; the OPEN body carries no `projectId` key;
+ *   - the project list loads on the dropdown's first OPEN (a user action),
+ *     never on mount;
+ *   - a selected project rides `projectId` on the open body;
+ *   - inside the project shell (`projectId` prop) there is no switcher — the
+ *     context IS the project — and the open body is bound silently.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const listProjects = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+];
+
+const PROJECTS = [
+  { id: 'q3-review-deck', name: 'q3-review-deck', description: null, status: 'active', scope: 'project:q3-review-deck', created_at: 1, updated_at: 9 },
+  { id: 'api-migration', name: 'api-migration', description: null, status: 'active', scope: 'project:api-migration', created_at: 1, updated_at: 5 },
+  { id: 'default', name: 'Unfiled', description: null, status: 'active', scope: '', created_at: 1, updated_at: 99 },
+];
+
+beforeEach(() => {
+  openChat.mockReset();
+  getChat.mockReset();
+  closeChat.mockReset();
+  getRoster.mockReset();
+  sendChatMessage.mockReset();
+  listProjects.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  listProjects.mockResolvedValue({ projects: PROJECTS });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ROSTER.map((s) => s.key)).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+});
+
+describe('GroupChat — create-flow project binding (slice B)', () => {
+  it('renders the Unfiled field, fetches nothing on mount, and opens the chat WITHOUT projectId', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    const field = screen.getByTestId('project-field');
+    expect(field.textContent).toContain('Unfiled');
+    // §2.4 preserved: the field's list is NOT fetched on mount.
+    expect(listProjects).not.toHaveBeenCalled();
+    expect(openChat).not.toHaveBeenCalled();
+    expect(getRoster).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole('textbox'), 'hello there');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const body = openChat.mock.calls[0]![0] as Record<string, unknown>;
+    expect('projectId' in body, 'Unfiled = no projectId key at all').toBe(false);
+  });
+
+  it('loads projects on first open, and the selection binds the chat at creation', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.click(screen.getByTestId('project-field'));
+    expect(listProjects).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBe(2));
+    // §5.2: "+ New project" rides the dropdown here too.
+    expect(screen.getByTestId('project-switcher-add')).toBeInTheDocument();
+    await user.click(screen.getAllByTestId('project-switcher-option')[0]!);
+    expect(screen.getByTestId('project-field').textContent).toContain('q3-review-deck');
+
+    await user.type(screen.getByRole('textbox'), 'file me properly');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]![0] as { projectId?: string }).projectId).toBe('q3-review-deck');
+
+    // Once the chat exists the create-flow field is gone — binding is at creation.
+    await waitFor(() => expect(screen.queryByTestId('chat-project-row')).toBeNull());
+  });
+
+  it('project shell (§4.3): no switcher UI, the open body is bound silently, still zero mount requests', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+
+    expect(screen.queryByTestId('project-field')).toBeNull();
+    expect(listProjects).not.toHaveBeenCalled();
+    expect(openChat).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole('textbox'), 'shell-bound thread');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]![0] as { projectId?: string }).projectId).toBe('api-migration');
+  });
+});

--- a/tests/ProjectSwitcher.test.tsx
+++ b/tests/ProjectSwitcher.test.tsx
@@ -80,4 +80,33 @@ describe('ProjectSwitcher', () => {
     fireEvent.click(field);
     expect(screen.queryByTestId('project-switcher-list')).toBeNull();
   });
+
+  it('onOpen fires when the dropdown OPENS — never on mount, never on close (slice B lazy-load)', () => {
+    const onOpen = vi.fn();
+    render(<ProjectSwitcher current={null} projects={PROJECTS} onSelect={() => {}} onOpen={onOpen} />);
+    expect(onOpen, 'mount must not open').not.toHaveBeenCalled();
+
+    const field = screen.getByTestId('project-field');
+    fireEvent.click(field); // open
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    fireEvent.click(field); // close
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    fireEvent.click(field); // re-open
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it('locked never fires onOpen (slice B: a pre-bound field costs no fetch)', () => {
+    const onOpen = vi.fn();
+    render(<ProjectSwitcher current={PROJECTS[0]!} projects={PROJECTS} onSelect={() => {}} locked onOpen={onOpen} />);
+    fireEvent.click(screen.getByTestId('project-field'));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('dropUp opens the list above the field (bottom-docked composers)', () => {
+    render(<ProjectSwitcher current={null} projects={PROJECTS} onSelect={() => {}} dropUp />);
+    fireEvent.click(screen.getByTestId('project-field'));
+    const list = screen.getByTestId('project-switcher-list');
+    expect(list.className).toContain('bottom-full');
+    expect(list.className).not.toContain('top-full');
+  });
 });

--- a/tests/RepositoriesPanel.project.test.tsx
+++ b/tests/RepositoriesPanel.project.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RepositoriesPanel } from '../src/components/RepositoriesPanel.js';
+import * as client from '../src/api/client.js';
+import type { Project, RepoEntry } from '../src/api/types.js';
+
+/**
+ * DES-FEEDBACK-001 slice B (§5.1/§5.2) — the repo register flow's project
+ * binding. POST /repos has a strict schema with no projectId, so:
+ *   - Unfiled (the default) registers exactly as before — register body
+ *     unchanged, NO membership attach;
+ *   - a selected project binds the repo at creation via
+ *     POST /projects/:id/members with kind `crew.repo`.
+ */
+
+function proj(id: string, updated = 1): Project {
+  return {
+    id, name: id, description: null, status: 'active',
+    scope: `project:${id}`, created_at: 1, updated_at: updated,
+  };
+}
+
+const REPO: RepoEntry = {
+  id: 'repo-1', name: 'my-repo', root_path: '/tmp/my-repo',
+  default_branch: 'main', registered_at: 1_700_000_000,
+} as unknown as RepoEntry;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listRuns').mockResolvedValue({ runs: [] });
+  vi.spyOn(client.api, 'getRepoGraph').mockResolvedValue({ graph: null } as never);
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({
+    projects: [proj('q3-review-deck', 9), proj('api-migration', 5), proj('default', 99)],
+  });
+  vi.spyOn(client.api, 'registerRepo').mockResolvedValue({ repo: REPO, onboardRunId: 'r-onboard' });
+  vi.spyOn(client.api, 'attachProjectMember').mockResolvedValue({
+    member: {
+      id: 'm1', project_id: 'q3-review-deck', member_kind: 'crew.repo', member_ref: 'repo-1',
+      meta: null, attached_at: 1, attached_by: 'studio',
+    },
+  });
+});
+
+async function fillAndRegister(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.type(screen.getByPlaceholderText('Repo name'), 'my-repo');
+  await user.type(screen.getByPlaceholderText('Absolute path to git repo'), '/tmp/my-repo');
+  await user.click(screen.getByRole('button', { name: 'Register & onboard' }));
+  await waitFor(() => expect(client.api.registerRepo).toHaveBeenCalledTimes(1));
+}
+
+describe('RepositoriesPanel register flow — project binding (slice B)', () => {
+  it('the project field is the first form field, Unfiled by default; register attaches nothing', async () => {
+    const user = userEvent.setup();
+    render(<RepositoriesPanel navigate={vi.fn()} autoShowRegister />);
+
+    const row = screen.getByTestId('repo-project-row');
+    expect(row).toBeInTheDocument();
+    expect(screen.getByTestId('project-field').textContent).toContain('Unfiled');
+    // Lazy: no project list fetch until the dropdown opens.
+    expect(client.api.listProjects).not.toHaveBeenCalled();
+
+    await fillAndRegister(user);
+    // §5.1: unfiled = the register request is byte-identical to before, and no attach.
+    expect(client.api.registerRepo).toHaveBeenCalledWith('my-repo', '/tmp/my-repo');
+    expect(client.api.attachProjectMember).not.toHaveBeenCalled();
+  });
+
+  it('a selected project binds the repo at creation via crew.repo membership', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    render(<RepositoriesPanel navigate={navigate} autoShowRegister />);
+
+    await user.click(screen.getByTestId('project-field'));
+    expect(client.api.listProjects).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBe(2));
+    expect(screen.getByTestId('project-switcher-add')).toBeInTheDocument();
+    await user.click(screen.getAllByTestId('project-switcher-option')[0]!);
+    expect(screen.getByTestId('project-field').textContent).toContain('q3-review-deck');
+
+    await fillAndRegister(user);
+    await waitFor(() =>
+      expect(client.api.attachProjectMember).toHaveBeenCalledWith('q3-review-deck', {
+        kind: 'crew.repo',
+        ref: 'repo-1',
+        attachedBy: 'studio',
+      }),
+    );
+    // The flow still lands on the repo detail page after the bind.
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/repo-detail/repo-1'));
+  });
+});


### PR DESCRIPTION
Round-2 operator feedback, item 3: *"All of these (the links from sidebar) should default to unfiled but give the user the opportunity to change."*

## What changed (design: `.product/DES-FEEDBACK-001.md` §5 + §4.3 pre-bind)

- **All three create flows** get slice A's `ProjectSwitcher` as the first field, defaulting to **Unfiled** — which means the POST body carries **no project key at all** (byte-identical to today's requests, proven by intercepting the actual bodies).
- **Build** (`/runs/new` — the form lives in ChatPanel's NewRunView/ChatInput; §8.3's CenterDashboard naming was the dashboard, noted in code): Project row above the intent input; `launchRun` gains `projectId` only when bound.
- **Chat** (`/chat/new`): switcher above the composer (drop-up), visible only until the chat is minted; zero-requests-on-mount preserved (UXFIX §2.4) — the project list loads lazily on the dropdown's first open via a new `onOpen` prop.
- **Repository register**: crew's `RegisterRepoSchema` is `.strict()` with no `projectId`, so a selected project binds via the real `POST /projects/:id/members {kind:'crew.repo', attachedBy:'studio'}` after registration; Unfiled registers byte-identically with zero members calls.
- **Pre-bind (§4.3)**: new route `/p/:projectId/build/new` — "+ Build something" from a project navigates there; the field shows the project name with `data-locked="true"` and refuses to open; launch carries that `projectId`.

## Verification highlights

Adversarial verifier re-ran every gate, proved both lint guards bite, proved the rig **fails on origin/main** (missing `project-field`), regenerated the shots from the branch build, and — the heart of the slice — intercepted the real POST bodies for all seven paths (Build/Chat/Repo × Unfiled/bound, plus locked pre-bind): Unfiled bodies contain no `projectId` substring at all; bound bodies match the field names in crew's actual `LaunchSchema`/`ChatOpenSchema`/`AttachMemberSchema`. Slice C's agent-chip territory untouched (zero chip hunks in the diff).

## Gates

eslint `--max-warnings 0` clean · `tsc --noEmit` clean · vitest **934/934** · new rig `feedback_sliceB_test.py` PASS · `feedback_sliceA`, `uxfix_slice5` (Build purpose statement), `vision_slice2` all PASS on a fresh build.

Named 1440×900 shots: `feedback-B-build-unfiled.png`, `feedback-B-build-prebound.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)