### PR TITLE
Slice C: chat agents added by default as removable chips (DES-FEEDBACK-001 §6)

### DIFF
--- a/e2e/feedback_sliceC_test.py
+++ b/e2e/feedback_sliceC_test.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+feedback_sliceC_test.py — the DES-FEEDBACK-001 slice-C gate: Chat default
+agent chips (§6, §8.3 slice C), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py).
+
+The slice DOM ACs, verbatim from §8.3:
+
+  1. `[data-testid="agent-chip"]` elements are present on first render without
+     any network request having fired;
+  2. the `data-count` attribute on `[data-testid="agent-chips-bar"]` equals 3;
+  3. clicking a chip's ✕ removes it (count decrements);
+  4. `[data-testid="add-agent"]` button opens the roster picker;
+  5. zero `openChat` requests fire on mount (verified by `page.on('request')`).
+
+"Without any network request" is measured as the slice-B rig measured it: the
+app-shell rail fires its own requests identically on main (projects, runs —
+they are not this slice's), so the tap records EVERY /api/v1/* request and the
+assertion is on the DELTA the chat surface could add — the chat-surface set
+(`/api/v1/chats*`, `/api/v1/roster`) must be EMPTY on mount (§6.1: chips render
+from the cache/fallback, the binding UXFIX §2.4 constraint). The rail's own
+requests are reported informationally, never asserted against.
+
+Plus the §8.3 preservation list this rig can see: the chat first-run teaching
+state (EC7 — the surface teaches itself; pinned in depth by uxfix_slice4) and
+EC13 (chip text reads in the SANS — asserted via computed style, with the
+token anatomy: --radius-full resolves to 9999px, --text-xs to 11px).
+
+Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback-C-chat-chips.png          Chat first-run, 3 default chips, no thread
+  feedback-C-chat-chips-removed.png  one chip removed, 2 remaining
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4353),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    REPO,
+    ensure_build,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4353"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# §6.2's hardcoded fallback trio — what renders here: nothing on this route
+# fetches a roster before Chat mounts, so the cache is cold by construction.
+FALLBACK = ["writer", "reviewer", "planner"]
+ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server (frozen NOW0, no crew daemon) ──────────────
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+
+def is_chat_surface(path: str) -> bool:
+    """The requests THIS slice could add — the §2.4 delta under assertion."""
+    return path.startswith("/api/v1/chats") or path == "/api/v1/roster"
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    # The tap: every API request since navigation, split into the chat-surface
+    # delta (asserted empty on mount) and the rail's own calls (reported only).
+    api_log: list[tuple[str, str, dict | None]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if not path.startswith("/api/"):
+            return
+        body = None
+        if req.post_data:
+            try:
+                body = json.loads(req.post_data)
+            except ValueError:
+                body = None
+        api_log.append((req.method, path, body))
+
+    page.on("request", on_request)
+
+    page.goto(CHAT_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.locator('[data-testid="agent-chips-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    fonts_ok = page.evaluate("() => document.fonts.status") is not None  # settle probe below
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+
+    # ── AC 1 + 2 (+ EC13 anatomy): chips on first render, count 3, token-built ──
+    first_render = page.evaluate(
+        """() => {
+             const bar = document.querySelector('[data-testid="agent-chips-bar"]');
+             const chips = Array.from(document.querySelectorAll('[data-testid="agent-chip"]'));
+             const c0 = chips[0] ? getComputedStyle(chips[0]) : null;
+             const x0 = chips[0]?.querySelector('button');
+             const xs = x0 ? getComputedStyle(x0) : null;
+             const add = document.querySelector('[data-testid="add-agent"]');
+             return {
+               barCount: bar ? bar.dataset.count : null,
+               chipKeys: chips.map(c => c.dataset.agent),
+               chipRadius: c0 ? c0.borderRadius : null,
+               chipFontSize: c0 ? c0.fontSize : null,
+               chipFontFamily: c0 ? c0.fontFamily : null,
+               chipPadding: c0 ? c0.padding : null,
+               xSize: xs ? `${xs.width} ${xs.height}` : null,
+               xBackground: xs ? xs.backgroundColor : null,
+               addPresent: !!add,
+               addDashed: add ? getComputedStyle(add).borderTopStyle === 'dashed' : false,
+               noThread: !document.querySelector('[title="ready"], [title="warming"]'),
+               teachPresent: !!document.querySelector('[data-testid="chat-firstrun"]'),
+               pickerClosed: !document.querySelector('[data-testid="agent-picker"]'),
+             };
+           }"""
+    )
+
+    # ── AC 5 (+ AC 1's "without any network request"): the mount delta is empty ─
+    mount_chat_surface = [(m, q) for (m, q, _b) in api_log if is_chat_surface(q)]
+    mount_rail = sorted({q for (_m, q, _b) in api_log if not is_chat_surface(q)})
+    open_posts_on_mount = [1 for (m, q, _b) in api_log if m == "POST" and q == "/api/v1/chats"]
+
+    # ── Capture 1: first-run, 3 default chips, no thread ───────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-C-chat-chips.png"))
+
+    # ── AC 3: ✕ removes — count decrements, chip gone ──────────────────────────
+    page.locator('[data-testid="agent-chip"][data-agent="writer"] button').click()
+    removed = page.evaluate(
+        """() => ({
+             barCount: document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null,
+             chipKeys: Array.from(document.querySelectorAll('[data-testid="agent-chip"]'))
+               .map(c => c.dataset.agent),
+           })"""
+    )
+
+    # ── Capture 2: one removed, 2 remaining ────────────────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-C-chat-chips-removed.png"))
+
+    # ── AC 4: [+ Add] opens the roster picker (its fetch rides the click) ──────
+    roster_gets_before = len([1 for (_m, q, _b) in api_log if q == "/api/v1/roster"])
+    page.locator('[data-testid="add-agent"]').click()
+    page.locator('[data-testid="agent-picker"]').wait_for(timeout=10000)
+    try:
+        page.wait_for_function(
+            """n => document.querySelectorAll('[data-testid="agent-picker-option"]').length === n""",
+            arg=len(ROSTER_KEYS), timeout=10000,
+        )
+        picker_options_ok = True
+    except Exception:
+        picker_options_ok = False
+    roster_gets_after = len([1 for (_m, q, _b) in api_log if q == "/api/v1/roster"])
+    picker = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="agent-picker-option"]'))
+                 .map(o => o.dataset.agentKey)"""
+    )
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["steps"]["chips_first_render"] = {
+    "ok": all([
+        fonts_ok,
+        first_render["barCount"] == "3",
+        first_render["chipKeys"] == FALLBACK,
+        # §6.3 anatomy in tokens: --radius-full → 9999px, --text-xs → 11px,
+        # EC13: the chip label reads in the SANS (Inter stack), 3px 8px 3px 6px.
+        first_render["chipRadius"] == "9999px",
+        first_render["chipFontSize"] == "11px",
+        "Inter" in (first_render["chipFontFamily"] or ""),
+        first_render["chipPadding"] == "3px 8px 3px 6px",
+        first_render["xSize"] == "12px 12px",
+        first_render["addPresent"], first_render["addDashed"],
+        first_render["noThread"], first_render["teachPresent"],
+        first_render["pickerClosed"],
+    ]),
+    **first_render,
+    "web_fonts_loaded": fonts_ok,
+    "screenshot": str(VSHOTS / "feedback-C-chat-chips.png"),
+}
+report["steps"]["mount_network_delta"] = {
+    "ok": len(mount_chat_surface) == 0 and len(open_posts_on_mount) == 0,
+    "chat_surface_requests_on_mount": mount_chat_surface,
+    "openChat_posts_on_mount": len(open_posts_on_mount),
+    "rail_owned_requests_ignored": mount_rail,
+}
+report["steps"]["chip_remove"] = {
+    "ok": removed["barCount"] == "2" and removed["chipKeys"] == ["reviewer", "planner"],
+    **removed,
+    "screenshot": str(VSHOTS / "feedback-C-chat-chips-removed.png"),
+}
+report["steps"]["add_agent_picker"] = {
+    "ok": all([
+        picker_options_ok,
+        picker == ROSTER_KEYS,
+        # The roster fetch rode the CLICK: zero before, exactly one after.
+        roster_gets_before == 0,
+        roster_gets_after == 1,
+    ]),
+    "picker_options": picker,
+    "roster_gets_before_click": roster_gets_before,
+    "roster_gets_after_click": roster_gets_after,
+}
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback-C-chat-chips.png"),
+    str(VSHOTS / "feedback-C-chat-chips-removed.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceC_verdict", f"slice-C assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -10,31 +10,48 @@ Same rig pattern as the slice-1/2/3 gates: the SHARED deterministic fixture
 server serves the `dist-sameorigin/` build plus every endpoint the routes read;
 no crew daemon is involved anywhere. This rig never flips the fixture switches.
 
-What it asserts (design §4.3, the slice-4 DOM AC):
+RE-SCOPED by DES-FEEDBACK-001 §6 (slice C): the "Add agents" disclosure this
+rig used to pin is retired — the operator asked for agents ADDED BY DEFAULT,
+and §6.2 reconciles that with the still-binding §2.4 (zero requests on mount)
+by rendering removable default chips from the roster CACHE (the hardcoded
+fallback trio on a cold cache — this route fetches no roster, so that is what
+renders here), never a fetch. The first send warms the chip selection; [+ Add]
+opens the roster picker, whose fetch rides that user action. The teaching
+state, the network tap, and the F8 switcher assertions carry over verbatim.
+
+What it asserts (design §4.3 as amended by DES-FEEDBACK-001 §6/§8.3):
   1. Switcher weight (F8): data-testid="mode-switcher" renders four segments,
      each glyph + label; the ACTIVE segment's computed background is FILLED
      (≠ transparent — asserted as the literal accent rgb), an inactive one is
      not; the active mode's summary is IN THE DOM (data-testid="mode-summary"),
      not just a title attribute.
-  2. Chat first-run (F6): entering /p/<id>/chat with nothing stored warms ZERO
-     seats — the rig taps the network and proves NO POST /api/v1/chats and NO
-     GET /api/v1/roster fires on mount — and shows the teaching state
-     (chat-firstrun), a focused composer, ONE disclosure (add-agents), no seat
-     chips, no Close, and no "Group chat"/"End chat" copy anywhere.
-  3. The disclosure: clicking add-agents fires exactly ONE POST /api/v1/chats
-     (with NO `clis` — the daemon warms its own roster), the four-seat chip
-     strip appears all-ready, Close appears, the disclosure retires.
-  4. Typing is the other opt-in: in a FRESH tab (own sessionStorage), typing a
+  2. Chat first-run (F6 + §6.2): entering /p/<id>/chat with nothing stored
+     warms ZERO seats — the rig taps the network and proves NO POST
+     /api/v1/chats and NO GET /api/v1/roster fires on mount — and shows the
+     teaching state (chat-firstrun), a focused composer, the default chips bar
+     (agent-chips-bar, data-count 3 — the §6.2 fallback trio, cache cold on
+     this route), no WARM seat chips, no Close, and no "Group chat"/"End chat"
+     copy anywhere.
+  3. [+ Add] is the roster opt-in now (§6.2): clicking add-agent fires exactly
+     ONE GET /api/v1/roster (a user action, not a mount), the picker lists the
+     roster, and an added agent joins the selection (data-count 4); the first
+     send then fires exactly ONE POST /api/v1/chats whose `clis` is the
+     selection (trio + addition), the four-seat chip strip appears all-ready,
+     Close appears, the chips bar retires.
+  4. Typing is the warm opt-in: in a FRESH tab (own sessionStorage), typing a
      message and pressing Enter fires exactly ONE POST /api/v1/chats whose
-     `clis` is ["claude"] — the single default agent, not the roster — then
-     POSTs the message to /chats/<id>/messages; the user bubble renders and the
-     disclosure is still available (one agent is not the multi-agent strip).
+     `clis` is the DEFAULT selection (the fallback trio — §6.2's "defaults +
+     additions − removals" with nothing touched) — then POSTs the message to
+     /chats/<id>/messages; the user bubble renders and the chips bar retires
+     (the header's warm seat chips are the truth now).
 
 Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
 data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
   uxfix-4-switcher.png        the weighted segmented control (element shot)
-  uxfix-4-chat-firstrun.png   the teaching first-run Chat surface (full page)
-  uxfix-4-chat-multiagent.png the disclosed multi-agent strip + Close (full page)
+  uxfix-4-chat-firstrun.png   the teaching first-run Chat surface with the
+                              §6.2 default chips (full page)
+  uxfix-4-chat-multiagent.png the warmed multi-agent strip + Close after a
+                              picker-add and first send (full page)
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
 SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4333), SKIP_STUDIO_BUILD.
@@ -71,6 +88,9 @@ ACCENT_PROBE_JS = """() => {
   return v;
 }"""
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
+# §6.2's hardcoded fallback trio — what the default chips render on this route
+# (nothing fetches the roster before Chat mounts, so the cache is cold).
+FALLBACK = ["writer", "reviewer", "planner"]
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -168,11 +188,15 @@ with sync_playwright() as p:
         """() => {
              const teach = document.querySelector('[data-testid="chat-firstrun"]');
              const body = document.body.innerText;
+             const bar = document.querySelector('[data-testid="agent-chips-bar"]');
              return {
                teachText: teach ? teach.innerText : null,
-               addAgents: !!document.querySelector('[data-testid="add-agents"]'),
+               chipsBarCount: bar ? bar.dataset.count : null,
+               chipKeys: Array.from(document.querySelectorAll('[data-testid="agent-chip"]'))
+                 .map(c => c.dataset.agent),
+               addAgent: !!document.querySelector('[data-testid="add-agent"]'),
                closeAbsent: !document.querySelector('[data-testid="chat-close"]'),
-               noChips: !document.querySelector('[title="ready"], [title="warming"]'),
+               noWarmChips: !document.querySelector('[title="ready"], [title="warming"]'),
                noGroupChatCopy: !body.includes('Group chat') && !body.includes('End chat'),
                composerFocused: document.activeElement?.tagName === 'TEXTAREA',
              };
@@ -186,12 +210,26 @@ with sync_playwright() as p:
         path=str(SHOTS / "uxfix-4-switcher.png"))
     page.screenshot(path=str(SHOTS / "uxfix-4-chat-firstrun.png"))
 
-    # AC 3 — the disclosure warms the roster and reveals the strip.
-    page.locator('[data-testid="add-agents"]').click()
+    # AC 3 — [+ Add] is the roster opt-in now (§6.2): the picker's fetch rides
+    # the click (ONE GET /roster), the addition joins the selection, and the
+    # first send warms the whole selection into the four-seat strip.
+    page.locator('[data-testid="add-agent"]').click()
+    page.locator('[data-testid="agent-picker"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        """n => document.querySelectorAll('[data-testid="agent-picker-option"]').length === n""",
+        arg=len(ROSTER_KEYS), timeout=10000,
+    )
+    picker_roster_gets = len([1 for (m, q, _b) in net if q == "/api/v1/roster"])
+    page.locator('[data-testid="agent-picker-option"][data-agent-key="claude"]').click()
+    added_count = page.evaluate(
+        """() => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null""")
+
+    page.locator("textarea").fill("warm the whole selection")
+    page.keyboard.press("Enter")
     page.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
     page.wait_for_function(
         """n => document.querySelectorAll('[title="ready"]').length === n""",
-        arg=len(ROSTER_KEYS), timeout=30000,
+        arg=len(FALLBACK) + 1, timeout=30000,
     )
     disclosed = page.evaluate(
         """keys => {
@@ -200,12 +238,12 @@ with sync_playwright() as p:
              return {
                chips,
                allSeats: keys.every(k => chips.includes(k)),
-               addAgentsRetired: !document.querySelector('[data-testid="add-agents"]'),
+               chipsBarRetired: !document.querySelector('[data-testid="agent-chips-bar"]'),
                closePresent: !!document.querySelector('[data-testid="chat-close"]'),
                firstrunGone: !document.querySelector('[data-testid="chat-firstrun"]'),
              };
            }""",
-        ROSTER_KEYS,
+        FALLBACK + ["claude"],
     )
     disclosed_opens = opens(net)
     page.screenshot(path=str(SHOTS / "uxfix-4-chat-multiagent.png"))
@@ -227,7 +265,7 @@ with sync_playwright() as p:
              userBubble: document.body.innerText.includes('make me a deck'),
              readyChips: Array.from(document.querySelectorAll('[title="ready"]'))
                .map(c => c.textContent.trim()),
-             addAgentsStillOffered: !!document.querySelector('[data-testid="add-agents"]'),
+             chipsBarRetired: !document.querySelector('[data-testid="agent-chips-bar"]'),
            })"""
     )
     typed_opens = opens(net2)
@@ -251,7 +289,11 @@ report["steps"]["slice4_chat_firstrun"] = {
         firstrun["teachText"] is not None,
         "Chat with an agent about this project." in (firstrun["teachText"] or ""),
         "just talk" in (firstrun["teachText"] or ""),
-        firstrun["addAgents"], firstrun["closeAbsent"], firstrun["noChips"],
+        # §6.2: the default chips render immediately — the fallback trio, no fetch.
+        firstrun["chipsBarCount"] == str(len(FALLBACK)),
+        firstrun["chipKeys"] == FALLBACK,
+        firstrun["addAgent"],
+        firstrun["closeAbsent"], firstrun["noWarmChips"],
         firstrun["noGroupChatCopy"], firstrun["composerFocused"],
         mount_opens == 0, mount_roster == 0,
     ]),
@@ -259,24 +301,29 @@ report["steps"]["slice4_chat_firstrun"] = {
     "openChat_requests_on_mount": mount_opens,
     "roster_requests_on_mount": mount_roster,
 }
-report["steps"]["slice4_add_agents"] = {
+report["steps"]["slice4_add_agent_picker"] = {
     "ok": all([
-        disclosed["allSeats"], disclosed["addAgentsRetired"], disclosed["closePresent"],
+        # The picker's roster fetch rode the CLICK — exactly one, none on mount.
+        picker_roster_gets == 1,
+        added_count == str(len(FALLBACK) + 1),
+        disclosed["allSeats"], disclosed["chipsBarRetired"], disclosed["closePresent"],
         disclosed["firstrunGone"],
         len(disclosed_opens) == 1,
-        (disclosed_opens[0] or {}).get("clis") is None,
+        (disclosed_opens[0] or {}).get("clis") == FALLBACK + ["claude"],
     ]),
     **disclosed,
+    "roster_gets_after_picker_open": picker_roster_gets,
+    "chip_count_after_add": added_count,
     "openChat_requests_total": len(disclosed_opens),
     "open_body_clis": (disclosed_opens[0] or {}).get("clis") if disclosed_opens else "none",
 }
 report["steps"]["slice4_first_send"] = {
     "ok": all([
         typed["userBubble"],
-        typed["readyChips"] == ["claude"],
-        typed["addAgentsStillOffered"],
+        typed["readyChips"] == FALLBACK,
+        typed["chipsBarRetired"],
         len(typed_opens) == 1,
-        (typed_opens[0] or {}).get("clis") == ["claude"],
+        (typed_opens[0] or {}).get("clis") == FALLBACK,
         len(sent) == 1,
         (sent[0][2] or {}).get("text") == "make me a deck",
     ]),

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
+import { setCachedRoster } from '../store/rosterCache.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
 import { NewProjectModal } from './NewProjectModal.js';
@@ -173,6 +174,8 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     api
       .getRoster()
       .then(({ roster: seats }) => {
+        // Deposit for Chat's default chips (§6.1: cached, never fetched on mount).
+        setCachedRoster(seats);
         setRoster(seats);
         try {
           const stored = localStorage.getItem('wicked_default_clis');

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { Project } from '../api/types.js';
+import type { Project, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
+import { getCachedRoster, setCachedRoster } from '../store/rosterCache.js';
 import { Markdown } from './Markdown.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
@@ -15,13 +16,38 @@ import { ProjectSwitcher } from './ProjectSwitcher.js';
  * live until "Close" (or daemon shutdown) — leaving the page keeps them warm.
  *
  * NOTHING warms on mount (DES-UXFIX-001 §2.4, F6). First-run is a calm teaching
- * state: one line on what Chat is, a focused composer, and ONE disclosure —
- * "Add agents". The first send warms the one default agent; "Add agents" warms
- * the whole roster and turns the header into the multi-agent chip strip. The
- * warm-and-rejoin machinery (FINDING-027) is preserved verbatim — it just runs
- * on opt-in, not on mount: a stored chat the daemon still holds is rejoined
- * exactly as before, because warm seats someone paid for must not be orphaned.
+ * state: one line on what Chat is, a focused composer, and the DEFAULT agent
+ * chips (DES-FEEDBACK-001 §6.2): the agents that WILL join, rendered
+ * synchronously from the cached roster (never fetched on mount — §6.1's
+ * reconciliation of "agents by default" with zero-requests-on-mount), each
+ * removable for this run via its ✕, extendable via [+ Add] (the roster
+ * picker — its fetch rides that user action). The first send warms exactly
+ * the selected set. The warm-and-rejoin machinery (FINDING-027) is preserved
+ * verbatim — it still runs on opt-in, not on mount: a stored chat the daemon
+ * still holds is rejoined exactly as before, because warm seats someone paid
+ * for must not be orphaned.
  */
+
+/**
+ * The hardcoded fallback default set (§6.2) — used ONLY when the roster cache
+ * is empty (nothing has fetched the roster yet this session). These are the
+ * ONLY hardcoded agent names in the agent layer; everything else comes from
+ * the roster cache or user action.
+ */
+export const DEFAULT_CHAT_AGENTS = ['writer', 'reviewer', 'planner'];
+
+/**
+ * The default chip selection for a chat being created (§6.2): the cached
+ * roster when the app has one (fetched at startup by the launch form, or by
+ * any other roster consumer), else the hardcoded fallback trio. Synchronous
+ * by construction — reading it can never fire a request.
+ */
+function defaultSelection(): string[] {
+  const cached = getCachedRoster();
+  return cached !== null && cached.length > 0
+    ? cached.map((s) => s.key)
+    : [...DEFAULT_CHAT_AGENTS];
+}
 
 /**
  * Seat identity under the token contract (DES-VISION-001 §2.11): every chip and
@@ -130,6 +156,19 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
 
+  // ── Default agent chips (DES-FEEDBACK-001 §6, slice C) ─────────────────────
+  // The agents that will join on the first send: defaults (cached roster or
+  // the fallback trio) + picker additions − ✕ removals. Per-run only, never
+  // persisted (§6.2). Initialized synchronously — zero requests (§6.1).
+  const [selectedAgents, setSelectedAgents] = useState<string[]>(defaultSelection);
+  const selectedAgentsRef = useRef<string[]>(selectedAgents);
+  selectedAgentsRef.current = selectedAgents;
+  // [+ Add] opens the roster picker; ITS roster read is allowed to fetch —
+  // opening the picker is a user action, not a mount (§2.4).
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerRoster, setPickerRoster] = useState<RosterSeat[]>(() => getCachedRoster() ?? []);
+  const pickerAnchorRef = useRef<HTMLDivElement>(null);
+
   // ── Project binding (DES-FEEDBACK-001 §5, slice B) ─────────────────────────
   // `null` = Unfiled: no `projectId` key in the open body, the backend default.
   // The list loads on the dropdown's first OPEN (§2.4: zero requests on mount).
@@ -151,6 +190,38 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         projectsRequested.current = false; // transient — retry on the next open
       });
   }
+
+  /** Toggle the roster picker; on first open with a cold cache, fetch (a user action — §2.4-safe). */
+  function togglePicker(): void {
+    const opening = !pickerOpen;
+    setPickerOpen(opening);
+    if (!opening) return;
+    const cached = getCachedRoster();
+    if (cached !== null) {
+      setPickerRoster(cached);
+      return;
+    }
+    api
+      .getRoster()
+      .then(({ roster }) => {
+        setCachedRoster(roster);
+        setPickerRoster(roster);
+      })
+      .catch(() => {
+        /* transient — the picker shows its empty state; the next open retries */
+      });
+  }
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function onOutside(e: MouseEvent): void {
+      if (pickerAnchorRef.current && !pickerAnchorRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, [pickerOpen]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -181,6 +252,10 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // The project selection belongs to the chat being CREATED — a repo switch
     // starts a new create flow, so the binding resets to Unfiled (§5.1).
     setSelectedProjectId(null);
+    // So does the chip selection (§6.2: per-run, never persisted): the new
+    // repo's create flow starts from the defaults again.
+    setSelectedAgents(defaultSelection());
+    setPickerOpen(false);
     // The id goes too, and it is the one reset that is not cosmetic. Resolving the new repo's chat
     // is ASYNC — a stored id costs a probe round-trip — and until it lands, a `chatId` still holding
     // the PREVIOUS repo's chat is actively wrong in three places: the event-stream guard below would
@@ -303,14 +378,15 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
 
   /**
    * Warm seats — the §2.4 opt-in, and the ONLY place a chat is minted or opened.
-   * `'one'` is the first send's path (the single default agent — the first
-   * council-enabled roster seat); `'all'` is the "Add agents" disclosure (the
-   * whole roster, exactly what the pre-slice-4 mount warmed). Reuses the live
+   * `agents` is the chip selection (DES-FEEDBACK-001 §6.2: defaults + picker
+   * additions − ✕ removals) and goes into the open body's `clis` array exactly
+   * as the pre-slice-C opt-in sent it — the wire shape is unchanged. No roster
+   * fetch here any more: the selection IS the answer (§6.1). Reuses the live
    * chat id when there is one: `chat_open` ensures per seat, so warming MORE
    * seats into an existing chat reuses the warm ones and adds only the missing.
    * Returns the seat keys that came up ready.
    */
-  async function armChat(scope: 'one' | 'all'): Promise<string[]> {
+  async function armChat(agents: string[]): Promise<string[]> {
     setArming(true);
     try {
       // The chat id is minted CLIENT-side and set before the open call: seats warm
@@ -323,22 +399,12 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         chatIdRef.current = id;
         writeStoredChatId(repoId, id);
       }
-      const roster = await api
-        .getRoster()
-        .then(({ roster: r }) => r)
-        .catch(() => []);
-      // A repo switch mid-arm resets `chatIdRef` (the mount effect) — every await
-      // below re-checks it so nothing is attributed to a repo we already left.
-      if (chatIdRef.current !== id) return [];
-      const keys = roster.flatMap((s) => (typeof s.key === 'string' ? [s.key] : []));
-      const one = roster.find((s) => s.enabled_for_council)?.key ?? keys[0];
-      const chosen = scope === 'one' ? (one !== undefined ? [one] : []) : keys;
       // Optimistic chips: each seat being warmed shows as warming while the open is in
       // flight; ready/failed events (and the open response) correct them as truth arrives.
       setSeats((prev) => ({
         ...prev,
         ...Object.fromEntries(
-          chosen.filter((k) => prev[k] !== 'ready').map((k) => [k, 'warming' as SeatState]),
+          agents.filter((k) => prev[k] !== 'ready').map((k) => [k, 'warming' as SeatState]),
         ),
       }));
       try {
@@ -348,11 +414,12 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         // switcher's selection; Unfiled omits the key (the backend default).
         const boundProject = projectId ?? selectedProjectRef.current;
         if (boundProject) body.projectId = boundProject;
-        // 'all' omits `clis` on purpose — the daemon warms its own full roster, exactly
-        // as the pre-slice-4 mount did. 'one' names the single default agent; with no
-        // roster answer it also omits, and the daemon's roster decides.
-        if (scope === 'one' && chosen.length > 0) body.clis = chosen;
+        // An empty selection omits `clis` — the daemon warms its own default
+        // roster (the pre-existing wire semantics for an absent array).
+        if (agents.length > 0) body.clis = agents;
         const { seats: opened } = await api.openChat(body);
+        // A repo switch mid-arm resets `chatIdRef` (the mount effect) — re-check
+        // after the await so nothing is attributed to a repo we already left.
         if (chatIdRef.current !== id) return [];
         const st: Record<string, SeatState> = {};
         const errs: Record<string, string> = {};
@@ -362,7 +429,20 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         }
         setSeats((prev) => ({ ...prev, ...st }));
         setSeatErrors((prev) => ({ ...prev, ...errs }));
-        return opened.filter((s) => s.ok).map((s) => s.cliKey);
+        const ready = opened.filter((s) => s.ok).map((s) => s.cliKey);
+        // §6.2 recoverable error: a default chip may name an agent the daemon no
+        // longer has (stale cache or a fallback name with no seat behind it).
+        // When NOTHING came up, say WHICH names were rejected — the chips bar is
+        // back on screen (no seat is ready), so the user can remove the stale
+        // chip and send again; the retry re-arms into the same chat id.
+        if (ready.length === 0 && opened.length > 0) {
+          const rejected = opened.map((s) => `"${s.cliKey}"`).join(', ');
+          setOpenError(
+            `The daemon rejected agent${opened.length > 1 ? 's' : ''} ${rejected} — ` +
+              `remove the stale chip${opened.length > 1 ? 's' : ''} (✕) and send again.`,
+          );
+        }
+        return ready;
       } catch (e: unknown) {
         // The id stays stored on purpose: an open that failed at the HTTP layer may still have
         // warmed seats server-side, and dropping the id here would orphan exactly what
@@ -380,16 +460,20 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // `resolving` waits out the rejoin probe: until it answers, "no chat id" does NOT
     // mean first-run, and treating it as one would mint over the stored id (FINDING-027).
     if (text === '' || ended || arming || resolving) return;
-    const firstSend = chatIdRef.current === null;
     let warm = Object.entries(seats)
       .filter(([, st]) => st === 'ready')
       .map(([k]) => k);
-    if (!firstSend && warm.length === 0) return;
+    // Nothing ready with nothing selected: nobody would receive this (§6.2's
+    // selection is the send's audience) — the disabled Send already says so.
+    if (warm.length === 0 && chatIdRef.current === null && selectedAgentsRef.current.length === 0) return;
     setInput('');
     setMessages((prev) => [...prev, { kind: 'user', text }]);
-    if (firstSend) {
-      // Typing IS the opt-in (§2.4): the first send warms the one default agent.
-      warm = await armChat('one');
+    if (warm.length === 0) {
+      // Typing IS the opt-in (§2.4): the first send warms the SELECTED agents —
+      // the §6.2 chips (defaults + additions − removals). Also the retry path
+      // after a rejected open (stale default chip): the re-arm reuses the same
+      // chat id with the corrected selection, so recovery is just "send again".
+      warm = await armChat(selectedAgentsRef.current);
       if (warm.length === 0) return; // armChat surfaced why (openError / failed chip)
     }
     const id = chatIdRef.current;
@@ -446,9 +530,12 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   // V8: a teardown control exists only once there is something armed to tear down —
   // warm agents, or a kept-on-error chat id the operator may want to disconnect.
   const closable = chatId !== null && (anyReady || openError !== null);
-  // The ONE disclosure (§2.4): shown until the roster is warmed in (0 seats =
-  // first-run, 1 seat = the single default agent the first send warmed).
-  const showAddAgents = !ended && Object.keys(seats).length <= 1;
+  // The §6.2 default chips: shown while the send's audience is still the chip
+  // SELECTION — before anything is warm (and not mid-arm, when the header's
+  // warming seat chips take over, nor mid-probe, when this may not be first-run
+  // at all). After a fully rejected open the bar returns: no seat is ready, and
+  // removing the stale chip + sending again is the §6.2 recovery path.
+  const showChipsBar = !ended && !resolving && !arming && !anyReady;
   // Not first-run while the rejoin probe is unresolved — teaching "nothing here yet"
   // over a chat that may be about to pop back in would be a lie held for milliseconds.
   const firstRun =
@@ -576,6 +663,122 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
             onClose={() => setShowNewProject(false)}
           />
         )}
+        {/* §6.2/§6.3: the default agent chips — the agents that WILL join the
+            first send. Rendered from the cached roster / fallback constant,
+            never a fetch (§6.1). Each chip is an agent that IS included; the
+            ✕ removes it for THIS run only. [+ Add] is the separate affordance
+            (dashed vs solid, --ink-dim vs --ink-body) opening the roster
+            picker. Chip text reads in the SANS (EC13: labels in sans — these
+            are selection labels, not narration data). */}
+        {showChipsBar && (
+          <div
+            data-testid="agent-chips-bar"
+            data-count={selectedAgents.length}
+            className="flex items-center gap-1.5 flex-wrap pb-2"
+          >
+            {selectedAgents.map((key) => (
+              <span
+                key={key}
+                data-testid="agent-chip"
+                data-agent={key}
+                className="wk-disclose inline-flex items-center gap-1"
+                style={{
+                  background: 'var(--surface-raised)',
+                  // §6.2 writes `border: 1px solid rgba(255,255,255,0.08)` literally;
+                  // that raw color would fail the §2.11 no-raw-color lint (ERROR), so
+                  // the hairline rides the token that carries that role one step above
+                  // a raised surface — --surface-overlay — exactly as the composer and
+                  // the Close pill already draw theirs.
+                  border: '1px solid var(--surface-overlay)',
+                  borderRadius: 'var(--radius-full)',
+                  color: 'var(--ink-body)',
+                  fontSize: 'var(--text-xs)',
+                  fontFamily: 'var(--font-sans)',
+                  padding: '3px 8px 3px 6px',
+                }}
+              >
+                <button
+                  type="button"
+                  aria-label={`Remove ${key}`}
+                  title={`Remove ${key} from this chat`}
+                  onClick={() => setSelectedAgents((prev) => prev.filter((a) => a !== key))}
+                  // §6.3: 12×12, transparent, --ink-dim → --ink-high on hover
+                  // (the wk-chip-x pair in global.css — hover needs CSS).
+                  className="wk-chip-x inline-flex items-center justify-center leading-none"
+                  style={{ width: '12px', height: '12px', background: 'transparent', border: 'none', padding: 0, fontSize: 'var(--text-2xs)', cursor: 'pointer' }}
+                >
+                  ✕
+                </button>
+                {key}
+              </span>
+            ))}
+            <div ref={pickerAnchorRef} className="relative inline-block">
+              <button
+                type="button"
+                data-testid="add-agent"
+                aria-haspopup="listbox"
+                aria-expanded={pickerOpen}
+                title="Add an agent from the roster to this chat"
+                onClick={togglePicker}
+                className="inline-flex items-center"
+                style={{
+                  background: 'transparent',
+                  border: '1px dashed var(--surface-overlay)',
+                  borderRadius: 'var(--radius-full)',
+                  color: 'var(--ink-dim)',
+                  fontSize: 'var(--text-xs)',
+                  fontFamily: 'var(--font-sans)',
+                  padding: '3px 8px',
+                  cursor: 'pointer',
+                }}
+              >
+                + Add
+              </button>
+              {pickerOpen && (
+                <div
+                  role="listbox"
+                  data-testid="agent-picker"
+                  className="absolute left-0 bottom-full mb-1 w-48 rounded-lg py-1 z-50 max-h-64 overflow-y-auto"
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--surface-overlay)',
+                    boxShadow: 'var(--shadow-raised)',
+                  }}
+                >
+                  {pickerRoster.length === 0 ? (
+                    <p className="px-3 py-1.5 text-xs font-mono italic m-0" style={{ color: 'var(--ink-dim)' }}>
+                      No roster loaded
+                    </p>
+                  ) : (
+                    pickerRoster.map((seat) => {
+                      const included = selectedAgents.includes(seat.key);
+                      return (
+                        <button
+                          key={seat.key}
+                          type="button"
+                          role="option"
+                          aria-selected={included}
+                          disabled={included}
+                          data-testid="agent-picker-option"
+                          data-agent-key={seat.key}
+                          onClick={() => {
+                            setSelectedAgents((prev) => (prev.includes(seat.key) ? prev : [...prev, seat.key]));
+                            setPickerOpen(false);
+                          }}
+                          className="w-full text-left px-3 py-1.5 text-xs font-mono truncate transition-colors hover:bg-surface-card disabled:opacity-40"
+                          style={{ color: included ? 'var(--ink-dim)' : 'var(--ink-body)' }}
+                        >
+                          {seat.key}
+                          {included ? ' ✓' : ''}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
         <div className="flex gap-2">
           <textarea
             value={input}
@@ -601,30 +804,18 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
           <button
             type="button"
             onClick={() => void send()}
-            // Before any chat exists, typing is how the first agent warms — so text alone
-            // enables Send. Once a chat exists, sending needs a ready seat, as before.
-            // (`resolving`: the stored chat is still being checked — not first-run yet.)
-            disabled={input.trim() === '' || arming || resolving || (chatId !== null && !anyReady)}
+            // Typing is how the selected agents warm — so text alone enables Send,
+            // including the §6.2 retry after a rejected open (send re-arms). The
+            // holds: `resolving` (the stored chat is still being probed — not
+            // first-run yet), `arming` (an open is in flight), and an EMPTY chip
+            // selection with nothing warm (nobody would receive the message).
+            disabled={input.trim() === '' || arming || resolving || (showChipsBar && selectedAgents.length === 0)}
             className="px-4 text-sm font-semibold disabled:opacity-40"
             style={{ background: 'var(--accent)', color: 'var(--accent-fg)', borderRadius: 'var(--radius-xl)' }}
           >
             Send
           </button>
         </div>
-        {showAddAgents && (
-          <button
-            type="button"
-            data-testid="add-agents"
-            disabled={arming || resolving}
-            title="Warm every agent on the roster into this chat — replies stream side by side"
-            onClick={() => void armChat('all')}
-            // §5.3: low-key but ON-ACCENT — color alone signals it's interactive.
-            className="mt-2 text-[11px] px-1 py-1 disabled:opacity-40"
-            style={{ background: 'transparent', color: 'var(--accent)', border: 'none', cursor: 'pointer' }}
-          >
-            + Add agents
-          </button>
-        )}
       </div>
     </div>
   );

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
+import { setCachedRoster } from '../store/rosterCache.js';
 import { Modal } from './Modal.js';
 import { Terminal } from './Terminal.js';
 
@@ -71,6 +72,8 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
       .catch((e: unknown) => setError(String(e)));
     api.getRoster()
       .then(({ roster: seats }) => {
+        // Deposit for Chat's default chips (DES-FEEDBACK-001 §6.1).
+        setCachedRoster(seats);
         setRoster(seats);
         setDefaultClis(loadDefaultClis(seats));
       })

--- a/src/store/rosterCache.ts
+++ b/src/store/rosterCache.ts
@@ -1,0 +1,35 @@
+import type { RosterSeat } from '../api/types.js';
+
+/**
+ * The agent-roster cache (DES-FEEDBACK-001 §6.1/§6.2, slice C).
+ *
+ * Chat's default agent chips must render on FIRST paint with zero network
+ * requests (DES-UXFIX-001 §2.4 — the binding constraint). The roster they
+ * render from is therefore never fetched on Chat's mount: this module holds
+ * the list the app has ALREADY fetched — every `api.getRoster()` call site
+ * (the Build launch form on startup, Settings, Chat's [+ Add] picker — a
+ * user action) deposits its answer here — and Chat reads it synchronously.
+ * When nothing has been deposited yet, Chat falls back to the hardcoded
+ * `DEFAULT_CHAT_AGENTS` constant (§6.2) rather than fetching.
+ *
+ * Plain module state, not a zustand store: no component re-renders when the
+ * cache fills — it is read at decision points (chip initialization, picker
+ * open), never subscribed to.
+ */
+
+let cached: RosterSeat[] | null = null;
+
+/** The last roster any surface fetched, or `null` when none has yet. */
+export function getCachedRoster(): RosterSeat[] | null {
+  return cached;
+}
+
+/** Deposit a freshly fetched roster for later synchronous reads. */
+export function setCachedRoster(roster: RosterSeat[]): void {
+  cached = roster;
+}
+
+/** Test hook: return to the cold-start state. */
+export function clearCachedRoster(): void {
+  cached = null;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -126,6 +126,12 @@ code, pre, .font-mono {
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
 
+/* Slice-C chip anatomy (DES-FEEDBACK-001 §6.3): the ✕ remove button reads
+   --ink-dim at rest and --ink-high on hover — a hover state needs CSS, so the
+   pair lives here rather than in an inline style. */
+.wk-chip-x        { color: var(--ink-dim); }
+.wk-chip-x:hover  { color: var(--ink-high); }
+
 /* The §5.5 cross-link animation: selecting a version scrolls the thread AND
    flashes the message that produced it — a 1s fade of --accent-subtle. One run
    (§1.6: motion is state change, never a loop); threadAnchor.ts removes the

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat, DEFAULT_CHAT_AGENTS } from '../src/components/GroupChat.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+/**
+ * DES-FEEDBACK-001 §6 (slice C) — Chat's default agent chips.
+ *
+ * Operator: "Agents should be added by default and those chips should be
+ * clickable to remove/add." Reconciled with the BINDING zero-requests-on-mount
+ * constraint (DES-UXFIX-001 §2.4) by §6.1's one rule: chips render from the
+ * CACHED roster (or the hardcoded fallback trio), never a fetch. These pin:
+ *   - chips render on first paint with ZERO api calls (spy across the client);
+ *   - a warm cache supplies the chip set; a cold cache falls back to
+ *     DEFAULT_CHAT_AGENTS — the only hardcoded names in the agent layer;
+ *   - ✕ removes for THIS run only: the count decrements and the send's clis
+ *     excludes the removal;
+ *   - [+ Add] opens the roster picker (its fetch rides the user action) and an
+ *     added agent joins the send;
+ *   - a stale default the daemon rejects surfaces a recoverable error NAMING
+ *     it, and removing the chip + sending again recovers into the SAME chat id.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const listProjects = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+  { key: 'agy', enabled_for_council: false },
+  { key: 'pi', enabled_for_council: false },
+] as unknown as RosterSeat[];
+
+const ALL_SPIES = { openChat, getChat, closeChat, getRoster, sendChatMessage, listProjects };
+
+beforeEach(() => {
+  for (const spy of Object.values(ALL_SPIES)) spy.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ROSTER.map((s) => s.key)).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+  clearCachedRoster();
+});
+
+function chipKeys(): (string | undefined)[] {
+  return screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent']);
+}
+
+describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
+  it('renders chips on first paint with ZERO api calls — the §6.1 constraint, spy-proven', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute(
+      'data-count',
+      String(DEFAULT_CHAT_AGENTS.length),
+    );
+    expect(screen.getAllByTestId('agent-chip')).toHaveLength(3);
+
+    // Flush microtasks, then hold the line: not one call on ANY api surface.
+    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    for (const [name, spy] of Object.entries(ALL_SPIES)) {
+      expect(spy, `${name} must not fire on mount (§2.4/§6.1)`).not.toHaveBeenCalled();
+    }
+  });
+
+  it('a warm cache supplies the chip set — still zero calls', async () => {
+    setCachedRoster(ROSTER);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    expect(chipKeys()).toEqual(['claude', 'codex', 'agy', 'pi']);
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '4');
+    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    expect(getRoster).not.toHaveBeenCalled();
+  });
+
+  it('a cold cache falls back to DEFAULT_CHAT_AGENTS — the only hardcoded names', () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    expect(chipKeys()).toEqual([...DEFAULT_CHAT_AGENTS]);
+  });
+
+  it('✕ removes for this run only: the count decrements and the send excludes the removal', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
+    expect(chipKeys()).toEqual(['reviewer', 'planner']);
+
+    await user.type(screen.getByRole('textbox'), 'no writer please');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner']);
+  });
+
+  it('[+ Add] opens the picker (fetch on the user action, cached after) and the addition joins the send', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.click(screen.getByTestId('add-agent'));
+    await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
+    const options = await screen.findAllByTestId('agent-picker-option');
+    expect(options.map((o) => o.dataset['agentKey'])).toEqual(['claude', 'codex', 'agy', 'pi']);
+
+    await user.click(options[1]!); // codex
+    expect(chipKeys()).toEqual([...DEFAULT_CHAT_AGENTS, 'codex']);
+
+    // Re-opening reads the now-warm cache — no second fetch.
+    await user.click(screen.getByTestId('add-agent'));
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    // An already-included agent is offered disabled, not duplicated.
+    const codexRow = screen
+      .getAllByTestId('agent-picker-option')
+      .find((o) => o.dataset['agentKey'] === 'codex')!;
+    expect(codexRow).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox'), 'bring codex too');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([
+      ...DEFAULT_CHAT_AGENTS,
+      'codex',
+    ]);
+  });
+
+  it('a stale default the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
+    const user = userEvent.setup();
+    // First open: every requested seat is rejected (stale fallback names).
+    openChat.mockImplementationOnce((body: { chatId: string; clis?: string[] }) =>
+      Promise.resolve({
+        chatId: body.chatId,
+        seats: (body.clis ?? []).map((cliKey) => ({ cliKey, ok: false, error: 'unknown agent' })),
+      }),
+    );
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.type(screen.getByRole('textbox'), 'hello?');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+
+    // The error NAMES the rejected agents (§6.2) …
+    await waitFor(() =>
+      expect(screen.getByText(/rejected agents "writer", "reviewer", "planner"/)).toBeInTheDocument(),
+    );
+    // … and the message did NOT go out.
+    expect(sendChatMessage).not.toHaveBeenCalled();
+    // Recoverable: the chips bar is back (nothing warmed), removals still work.
+    const bar = await screen.findByTestId('agent-chips-bar');
+    expect(bar).toHaveAttribute('data-count', '3');
+    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
+    await user.click(screen.getByRole('button', { name: 'Remove reviewer' }));
+
+    // The retry re-arms the SAME chat id with the corrected selection, then sends.
+    await user.type(screen.getByRole('textbox'), 'try again');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
+    const first = openChat.mock.calls[0]?.[0] as { chatId: string };
+    const second = openChat.mock.calls[1]?.[0] as { chatId: string; clis?: string[] };
+    expect(second.chatId, 'recovery must not mint a second chat (FINDING-027)').toBe(first.chatId);
+    expect(second.clis).toEqual(['planner']);
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(second.chatId, 'try again'));
+  });
+});

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -2,17 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
+import { clearCachedRoster } from '../src/store/rosterCache.js';
 
 /**
- * DES-UXFIX-001 slice 4 (§2.4, F6) — Chat's first-run moment teaches.
+ * DES-UXFIX-001 slice 4 (§2.4, F6) — Chat's first-run moment teaches — as
+ * re-scoped by DES-FEEDBACK-001 §6 (slice C).
  *
  * The audit finding, verbatim: entering a project dropped the user into a pre-armed
  * "Group chat" with six agent chips and an End-chat button before they'd typed anything.
- * The redesign: NOTHING warms on mount; the empty state says what Chat is and what typing
- * does; the first send warms the ONE default agent; the roster is a disclosed opt-in
- * ("Add agents"); the teardown control is "Close" and exists only once agents are warm.
- * These are the slice-4 DOM ACs (§4.3) at unit level — the e2e rig re-proves them
- * against a real build with a network tap.
+ * The §2.4 redesign: NOTHING warms on mount; the empty state says what Chat is and what
+ * typing does; the first send is the warm opt-in. Slice C's §6 compromise keeps every
+ * bit of that and replaces the "Add agents" disclosure with DEFAULT chips: the agents
+ * that WILL join render immediately from the roster CACHE (fallback trio when cold),
+ * still zero requests on mount — the chips are selection UI, not warm seats. The e2e
+ * rig re-proves these against a real build with a network tap.
  */
 
 const openChat = vi.fn();
@@ -42,6 +45,9 @@ const ROSTER = [
   { key: 'agy', enabled_for_council: false },
 ];
 
+/** §6.2's hardcoded fallback — what the chips show when the cache is cold. */
+const FALLBACK = ['writer', 'reviewer', 'planner'];
+
 beforeEach(() => {
   openChat.mockReset();
   getChat.mockReset();
@@ -57,30 +63,35 @@ beforeEach(() => {
   );
   sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
+  clearCachedRoster(); // cold cache — the §6.2 fallback path unless a test seeds it
 });
 
-describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4)', () => {
-  it('mounts cold: zero requests, zero seats, no Close — the AC verbatim', async () => {
+describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + DES-FEEDBACK-001 §6)', () => {
+  it('mounts cold: zero requests, default chips from the fallback, no Close — the AC verbatim', async () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     // The teaching state is on screen…
     const teach = screen.getByTestId('chat-firstrun');
     expect(teach).toHaveTextContent('Chat with an agent about this project.');
     expect(teach).toHaveTextContent(/No run, no gates — just talk/);
-    // …the one disclosure is offered…
-    expect(screen.getByTestId('add-agents')).toBeInTheDocument();
-    // …and the pre-armed ambush is gone: no chips, no teardown, no "Group chat".
+    // …the §6.2 default chips render IMMEDIATELY (cold cache → the fallback trio)…
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '3');
+    expect(screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent'])).toEqual(FALLBACK);
+    expect(screen.getByTestId('add-agent')).toBeInTheDocument();
+    // …and the pre-armed ambush is still gone: no warm seats, no teardown, no "Group chat".
     expect(screen.queryByTestId('chat-close')).toBeNull();
+    expect(screen.queryByTitle('ready')).toBeNull();
     expect(screen.queryByText('Group chat')).toBeNull();
 
-    // Flush pending microtasks, then hold the line: nothing fired on mount.
+    // Flush pending microtasks, then hold the line: nothing fired on mount —
+    // the chips came from the cache/fallback, never a fetch (§6.1).
     await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
     expect(openChat, 'no chat may open on mount').not.toHaveBeenCalled();
-    expect(getRoster, 'no roster fetch before the opt-in').not.toHaveBeenCalled();
+    expect(getRoster, 'no roster fetch on mount — chips read the cache').not.toHaveBeenCalled();
     expect(getChat, 'nothing stored, so nothing to probe').not.toHaveBeenCalled();
   });
 
-  it('the first send warms the ONE default agent, then sends', async () => {
+  it('the first send warms the SELECTED agents — the default chips — then sends', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
@@ -89,33 +100,40 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4)',
 
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
-    // The single default agent — the first council-enabled roster seat — not the roster.
-    expect(body.clis).toEqual(['claude']);
+    // §6.2: defaults + additions − removals ride the open's clis array (wire unchanged).
+    expect(body.clis).toEqual(FALLBACK);
+    // No roster fetch on the send either: the selection IS the answer (§6.1).
+    expect(getRoster).not.toHaveBeenCalled();
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, 'make me a deck'));
 
-    // The message and the one agent's pending bubble are on screen; the teaching state is done.
+    // The message and the warm seats are on screen; the teaching state and the
+    // selection chips are done — the header seat chips are the truth now.
     expect(screen.getByText('make me a deck')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-firstrun')).toBeNull();
-    // One warm agent is not the multi-agent strip: the disclosure stays available.
-    expect(screen.getByTestId('add-agents')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByTitle('ready')).toHaveLength(FALLBACK.length));
+    expect(screen.queryByTestId('agent-chips-bar')).toBeNull();
     // Agents are warm now, so the teardown control may exist (V8).
     await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
   });
 
-  it('"Add agents" is the roster opt-in: warms every seat, reveals the strip, then Close', async () => {
+  it('[+ Add] opens the roster picker (fetch rides the user action) and the addition joins the send', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
-    await user.click(screen.getByTestId('add-agents'));
+    expect(getRoster).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId('add-agent'));
+    // Opening the picker is a USER action — the one place the roster may be fetched here.
+    await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
+    const options = await screen.findAllByTestId('agent-picker-option');
+    expect(options.map((o) => o.dataset['agentKey'])).toEqual(ROSTER.map((s) => s.key));
 
-    // The daemon owns the full-roster warm: no `clis` on the open (pre-slice-4 mount behaviour).
+    await user.click(options[0]!); // add claude
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '4');
+
+    await user.type(screen.getByRole('textbox'), 'all hands');
+    await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toBeUndefined();
-
-    // The chip strip is now real — every roster seat, and the disclosure has done its job.
-    await waitFor(() => expect(screen.getAllByTitle('ready')).toHaveLength(ROSTER.length));
-    expect(screen.queryByTestId('add-agents')).toBeNull();
-    expect(screen.getByTestId('chat-close')).toBeInTheDocument();
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([...FALLBACK, 'claude']);
   });
 
   it('Send is enabled by text alone on first-run — typing is the opt-in', async () => {

--- a/tests/GroupChat.rejoin.test.tsx
+++ b/tests/GroupChat.rejoin.test.tsx
@@ -16,9 +16,11 @@ import { GroupChat } from '../src/components/GroupChat.js';
  * the exact remount trigger in production was never pinned down, and a fix keyed to one trigger
  * would leak on the next one.
  *
- * Slice 4 (DES-UXFIX-001 §2.4) moved warming behind the opt-ins (first send / "Add agents"), so a
- * bare mount no longer opens anything — each case below arms explicitly before it can leak. The
- * rejoin machinery these tests pin is otherwise verbatim.
+ * Slice 4 (DES-UXFIX-001 §2.4) moved warming behind the opt-ins, so a bare mount no longer opens
+ * anything — each case below arms explicitly before it can leak. Slice C (DES-FEEDBACK-001 §6)
+ * retired the "Add agents" disclosure in favour of default chips, leaving the FIRST SEND as the
+ * one warm opt-in — the arm helper types a message. The rejoin machinery these tests pin is
+ * otherwise verbatim.
  */
 
 const openChat = vi.fn();
@@ -63,9 +65,10 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-/** Arm the chat the way an operator does — the "Add agents" disclosure (§2.4). */
-async function armViaAddAgents(user: ReturnType<typeof userEvent.setup>): Promise<void> {
-  await user.click(await screen.findByTestId('add-agents'));
+/** Arm the chat the way an operator does — the first send warms the chip selection (§2.4/§6.2). */
+async function armViaFirstSend(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.type(screen.getByRole('textbox'), 'warm us up');
+  await user.keyboard('{Enter}');
 }
 
 describe('GroupChat — chat reuse (FINDING-027)', () => {
@@ -73,7 +76,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     const user = userEvent.setup();
     // Mount 1: nothing stored and nothing warmed — the operator opts in, which mints and opens.
     const first = render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const openedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
     expect(openedId).toBeTruthy();
@@ -105,7 +108,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument();
 
     // The next opt-in mints FRESH — never the reclaimed id.
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const openedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
     expect(openedId).not.toBe('reclaimed-id');
@@ -118,14 +121,14 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     // would not catch state that fails to reset across the switch.
     const user = userEvent.setup();
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const idA = sessionStorage.getItem('wicked.chat.r1');
 
     // A different repo is a different conversation — switching lands on ITS first-run state
     // (nothing stored for r2), and arming there opens its own chat rather than reusing r1's.
     rerender(<GroupChat repoId="r2" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
     const idB = sessionStorage.getItem('wicked.chat.r2');
 
@@ -143,7 +146,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     const user = userEvent.setup();
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
 
-    // The first send is the other opt-in (§2.4): it warms the one default agent, then sends.
+    // The first send is the warm opt-in (§2.4): it warms the chip selection, then sends.
     await user.type(screen.getByRole('textbox'), 'a message about repo one');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
@@ -198,9 +201,10 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
 
     expect(openChat, 'a send mid-probe must not mint a chat').not.toHaveBeenCalled();
     expect(sessionStorage.getItem('wicked.chat.r1'), 'the stored id must survive').toBe('probing-id');
-    // Both opt-ins are parked, visibly: Send and the disclosure wait for the probe.
+    // The opt-in is parked, visibly: Send waits for the probe, and the §6.2
+    // default chips do not show — mid-probe this may not be first-run at all.
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
-    expect(screen.getByTestId('add-agents')).toBeDisabled();
+    expect(screen.queryByTestId('agent-chips-bar')).toBeNull();
 
     // The probe answers: the chat rejoins, and the held-back text sends into IT — no mint.
     releaseProbe();
@@ -241,7 +245,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     sessionStorage.setItem('wicked.chat.r2', 'stored-b');
 
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const idA = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
 
@@ -274,7 +278,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     sessionStorage.setItem('wicked.chat.r2', 'stored-b');
 
     const { rerender } = render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const idA = sessionStorage.getItem('wicked.chat.r1');
 
@@ -291,7 +295,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
   it('Close forgets the id, so the next mount starts clean instead of rejoining a closed chat', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     expect(sessionStorage.getItem('wicked.chat.r1')).toBeTruthy();
 
@@ -306,7 +310,7 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     const user = userEvent.setup();
     closeChat.mockRejectedValue(new Error('daemon unreachable'));
     render(<GroupChat repoId="r1" onBack={() => undefined} />);
-    await armViaAddAgents(user);
+    await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
 
     await user.click(await screen.findByTestId('chat-close'));

--- a/tests/GroupChat.tokens.test.tsx
+++ b/tests/GroupChat.tokens.test.tsx
@@ -9,8 +9,11 @@
  *   - the composer sits on `--surface-raised` at `--radius-xl` and carries the
  *     wk-composer class whose :focus ring is `--accent-dim` (global.css —
  *     §5.3 motion: never the full accent);
- *   - "Add agents" is low-key but ON-ACCENT (§5.3: color alone signals it's
- *     interactive) and Send is the accent-filled primary action;
+ *   - the §6.2 default chips (DES-FEEDBACK-001, slice C) are token-built pills:
+ *     --surface-raised on --radius-full, --text-xs SANS --ink-body (EC13), a
+ *     --surface-overlay hairline standing in for §6.2's literal rgba (the
+ *     no-raw-color lint), the ✕ transparent at 12×12; [+ Add] is the separate
+ *     dashed --ink-dim affordance; Send is the accent-filled primary action;
  *   - user messages are transparent, agent bubbles sit on `--surface-card`
  *     (§5.3 token usage);
  *   - none of this disturbs the §2.4 behaviours — the firstrun/rejoin suites
@@ -20,6 +23,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
+import { clearCachedRoster } from '../src/store/rosterCache.js';
 
 const openChat = vi.fn();
 const getChat = vi.fn();
@@ -60,6 +64,7 @@ beforeEach(() => {
   );
   sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
+  clearCachedRoster(); // chips render the §6.2 fallback trio
 });
 
 describe('GroupChat — the §5.3 visual language', () => {
@@ -80,10 +85,29 @@ describe('GroupChat — the §5.3 visual language', () => {
     expect(composer.style.fontFamily).toBe('var(--font-sans)');
   });
 
-  it('"Add agents" is on-accent text; Send is the accent-filled action', () => {
+  it('the default chips wear §6.3 anatomy in tokens; [+ Add] is dashed --ink-dim; Send is accent-filled', () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
-    const add = screen.getByTestId('add-agents');
-    expect(add.style.color).toBe('var(--accent)');
+    const chip = screen.getAllByTestId('agent-chip')[0]!;
+    expect(chip.style.background).toBe('var(--surface-raised)');
+    expect(chip.style.borderRadius).toBe('var(--radius-full)');
+    expect(chip.style.fontSize).toBe('var(--text-xs)');
+    // EC13: chip text is a selection LABEL — the sans, --ink-body (§6.3).
+    expect(chip.style.fontFamily).toBe('var(--font-sans)');
+    expect(chip.style.color).toBe('var(--ink-body)');
+    expect(chip.style.padding).toBe('3px 8px 3px 6px');
+    // §6.2's literal `rgba(255,255,255,0.08)` hairline is substituted with the
+    // token carrying that role (no-raw-color lint) — see GroupChat.tsx comment.
+    expect(chip.style.border).toBe('1px solid var(--surface-overlay)');
+    // The ✕: 12×12, transparent, --ink-dim → --ink-high on hover (wk-chip-x).
+    const x = chip.querySelector('button')!;
+    expect(x.className).toContain('wk-chip-x');
+    expect(x.style.width).toBe('12px');
+    expect(x.style.height).toBe('12px');
+    expect(x.style.background).toBe('transparent');
+    // [+ Add] is the SEPARATE affordance (§6.3): dashed vs solid, dim vs body.
+    const add = screen.getByTestId('add-agent');
+    expect(add.style.border).toBe('1px dashed var(--surface-overlay)');
+    expect(add.style.color).toBe('var(--ink-dim)');
     expect(add.style.background).toBe('transparent');
     const send = screen.getByRole('button', { name: 'Send' });
     expect(send.style.background).toBe('var(--accent)');
@@ -100,11 +124,12 @@ describe('GroupChat — the §5.3 visual language', () => {
 
     const bubble = screen.getByText('make me a deck');
     expect(bubble.style.background).toBe('transparent');
-    // The one warmed seat's pending reply bubble is a card surface.
-    const pending = screen.getByText('thinking…').closest('div') as HTMLElement;
+    // Each warmed seat's pending reply bubble is a card surface (§6.2 warms the
+    // chip selection — the fallback trio here — not a single default agent).
+    const pending = screen.getAllByText('thinking…')[0]!.closest('div') as HTMLElement;
     expect(pending.style.background).toBe('var(--surface-card)');
-    // The seat chip animates in via wk-disclose (§5.3 motion, one run, no loop).
-    const chip = screen.getByTitle('ready');
+    // The seat chips animate in via wk-disclose (§5.3 motion, one run, no loop).
+    const chip = screen.getAllByTitle('ready')[0]!;
     expect(chip.className).toContain('wk-disclose');
   });
 });


### PR DESCRIPTION
Round-2 operator feedback, item 6: *"Not sure what the 'add agents' does, but they should be added by default and those chips should be clickable to remove/add."*

## What changed (design: `.product/DES-FEEDBACK-001.md` §6, §8.3 slice C)

- **Default chips on first paint**: the "Add agents" opt-in is gone. Chips render synchronously from the cached agent roster (a new module-level `rosterCache` seeded by the fetch sites that already exist) or, on a cold cache, the hardcoded `DEFAULT_CHAT_AGENTS = ['writer','reviewer','planner']` fallback — the only hardcoded names in the agent layer.
- **Zero requests on mount stays binding** (UXFIX §2.4): chips come from cache only; the roster GET rides the `[+ Add]` click, never the mount. Proven twice — spy-based unit tests and full request-tap rigs.
- **Chips are the operator's ask**: each pill has a leading ✕ that removes the agent for this run (count decrements, nothing persisted); `[+ Add]` (dashed) opens the existing roster picker; the selection rides the send in the existing `clis` wire field (§6.2 says "agents array", but the published `ChatOpenSchema` field is `clis` — the contract wins).
- **Recoverable stale-agent rejection** (§6.2): a fully rejected open surfaces an error naming the stale agents, and re-sending re-arms the same chat id (no double-mint, FINDING-027 pinned).
- The spec's own `rgba(255,255,255,0.08)` hairline would fail the no-raw-color lint; the chip border uses `var(--surface-overlay)` (noted in a code comment, pinned in the tokens test).

## Verification highlights

Adversarial verifier re-ran every gate; injected the spec's own rgba literal to prove lint bites; proved the rig fails on origin/main (no chips bar); and with independent Playwright: fresh chat mount → chat-surface request delta EMPTY with chips visible at `data-count=3`; ✕ → 2 with zero new requests; Send → exactly one `POST /api/v1/chats` carrying `{chatId, projectId, clis:["reviewer","planner"]}` verified against crew's strict `ChatOpenSchema`; `[+ Add]` roster GET fires 0-before/1-after the click and the added agent lands in the send.

## Gates

eslint `--max-warnings 0` clean · `tsc --noEmit` clean · vitest **940/940** · new rig `feedback_sliceC_test.py` PASS · `feedback_sliceB` PASS · `uxfix_slice4` re-scoped to §6 in a dedicated commit with all §2.4 zero-mount-request assertions preserved verbatim.

Named 1440×900 shots: `feedback-C-chat-chips.png`, `feedback-C-chat-chips-removed.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)