### PR TITLE
Slice D: project dashboard landing + persistent project-context header (DES-FEEDBACK-001 §4)

### DIFF
--- a/e2e/feedback_sliceD_test.py
+++ b/e2e/feedback_sliceD_test.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+feedback_sliceD_test.py — the DES-FEEDBACK-001 slice-D gate: project dashboard
+landing + persistent project-context header (§4.1, §4.2, §8.3 slice D), against
+the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the `demo` switch on
+(so q3-review-deck's registry carries the recorded demo doc — the docs tile has
+something true to list).
+
+The slice DOM ACs, verbatim from §8.3:
+
+  1. `[data-testid="project-dashboard"]` is present when navigating to
+     `/p/:projectId` with no mode segment;
+  2. it contains `[data-testid="dashboard-runs"]`, `[data-testid="dashboard-docs"]`,
+     `[data-testid="dashboard-gates"]`, `[data-testid="dashboard-activity"]`;
+  3. inside Build mode at `/p/:projectId/build`,
+     `[data-testid="project-context-header"]` shows the project name and "Build";
+  4. clicking the project name navigates to `/p/:projectId`.
+
+Plus what the slice means beyond its testids:
+
+  - the LAST-USED-MODE REDIRECT IS GONE: entering Chat first, then navigating to
+    the bare project route, still lands on the dashboard (never a remembered mode);
+  - the dashboard is NOT a fifth mode — no mode switcher, no Dashboard tab;
+  - the runs tile is project-scoped (r-q3 only, never the other fixture runs)
+    and each row is a real link into the run's own mode view;
+  - the gate tile reuses the board's answerable chip: inline Approve for the
+    simple r-q3 gate fires the SAME `POST /runs/:id/gate` the board chip fires;
+  - the §4.2 header anatomy: 32px band, project name in --ink-muted linking to
+    the dashboard, mode name in --ink-high, both --text-sm(13px)/--weight-medium(500)
+    sans — and it is present in ALL FOUR mode surfaces (EC17);
+  - §8.3 preservation: the Build purpose statement still renders below the header.
+
+Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback-D-project-dashboard.png   the q3 dashboard, all four tiles populated
+  feedback-D-build-with-header.png   Build mode with the project-context header
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4354),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4354"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+PROJECT = "q3-review-deck"
+DASH_URL = f"{ORIGIN}/p/{PROJECT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server, demo switch ON (q3's registry carries the
+#      recorded checkout-demo, so the docs tile lists a real wire shape) ────────
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, demo=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0, "demo": True}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+# What the §4.2 anatomy probe resolves the ink tokens through: two zero-size
+# probes whose color IS the token, compared against the crumb's computed color.
+TOKEN_PROBE = """() => {
+  const resolve = (token) => {
+    const el = document.createElement('span');
+    el.style.color = `var(${token})`;
+    document.body.appendChild(el);
+    const c = getComputedStyle(el).color;
+    el.remove();
+    return c;
+  };
+  return { muted: resolve('--ink-muted'), high: resolve('--ink-high') };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    # The tap: every gate answer the page sends — the reuse proof (§4.1 tile 3:
+    # the dashboard's chip must fire the SAME POST /runs/:id/gate the board's does).
+    gate_posts: list[tuple[str, dict | None]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and path.startswith("/api/v1/runs/") and path.endswith("/gate"):
+            body = None
+            if req.post_data:
+                try:
+                    body = json.loads(req.post_data)
+                except ValueError:
+                    body = None
+            gate_posts.append((path, body))
+
+    page.on("request", on_request)
+
+    # ── Scene 0 (redirect-gone setup): enter CHAT first, so any surviving
+    #    "last-used mode" memory would have something to remember. ──────────────
+    page.goto(f"{ORIGIN}/p/{PROJECT}/chat", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # ── AC 1 + redirect gone: the bare project route lands on the DASHBOARD ────
+    page.goto(DASH_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # The gate tile settles once useRuns' reconcile pulls r-q3's cached gate.
+    page.locator('[data-testid="gate-approve-r-q3"]').wait_for(timeout=30000)
+
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+
+    landing = page.evaluate(
+        """() => {
+             const dash = document.querySelector('[data-testid="project-dashboard"]');
+             const q = (sel) => dash ? dash.querySelector(sel) : null;
+             const runs = Array.from(document.querySelectorAll('[data-testid="dashboard-run"]'));
+             const docs = Array.from(document.querySelectorAll('[data-testid="dashboard-doc"]'));
+             return {
+               pathname: window.location.pathname,
+               dashPresent: !!dash,
+               // AC 2: all four tiles INSIDE the dashboard.
+               runsTile: !!q('[data-testid="dashboard-runs"]'),
+               docsTile: !!q('[data-testid="dashboard-docs"]'),
+               gatesTile: !!q('[data-testid="dashboard-gates"]'),
+               activityTile: !!q('[data-testid="dashboard-activity"]'),
+               // NOT a fifth mode: no switcher, no Dashboard tab, no mode surface.
+               noSwitcher: !document.querySelector('[data-testid="mode-switcher"]'),
+               noModeSurface: !document.querySelector('[data-testid="mode-surface"]'),
+               noDashboardTab: !document.querySelector('[data-testid="mode-tab-dashboard"]'),
+               // Tile 1: project-scoped (r-q3 ONLY), a real link into the run's mode view.
+               runsCount: q('[data-testid="dashboard-runs"]')?.dataset.count ?? null,
+               runIds: runs.map(r => r.dataset.runId),
+               runStatuses: runs.map(r => r.dataset.status),
+               runHref: runs[0]?.getAttribute('href') ?? null,
+               // Tile 2: the demo doc from listDocs(q3), linking into ITS mode (Video).
+               docIds: docs.map(d => d.dataset.docId),
+               docHref: docs[0]?.getAttribute('href') ?? null,
+               // Tile 3: the board's answerable chip, inline for the simple r-q3 gate.
+               gatesCount: q('[data-testid="dashboard-gates"]')?.dataset.count ?? null,
+               approvePresent: !!document.querySelector('[data-testid="gate-approve-r-q3"]'),
+               rejectPresent: !!document.querySelector('[data-testid="gate-reject-r-q3"]'),
+               // Tile 4: the 7-day sparkline is a real inline SVG with content.
+               sparkTotal: q('[data-testid="dashboard-activity"]')?.dataset.total ?? null,
+               sparkSvg: !!document.querySelector('svg[data-testid="activity-sparkline"]'),
+               // §2.3 bar sparkline: one <rect> per counted bucket, token-filled.
+               sparkRects: Array.from(document.querySelectorAll(
+                 '[data-testid="activity-sparkline"] rect')).map(r => r.getAttribute('fill')),
+               // Header: name + the four mode doors + the meta line (no invented cost).
+               metaText: document.querySelector('[data-testid="dashboard-meta"]')?.textContent ?? '',
+               modeDoors: ['chat','build','document','video'].map(m =>
+                 document.querySelector(`[data-testid="dashboard-mode-${m}"]`)?.getAttribute('href')),
+             };
+           }"""
+    )
+
+    # ── Capture 1: the dashboard, all four tiles populated ─────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-D-project-dashboard.png"))
+
+    # ── Tile 1 navigation: a run row opens the run's mode view ─────────────────
+    page.locator('[data-testid="dashboard-run"][data-run-id="r-q3"]').click()
+    page.locator('[data-testid="mode-surface"][data-mode="build"]').wait_for(timeout=30000)
+    run_nav = page.evaluate("() => window.location.pathname")
+
+    # ── AC 3 + EC17 anatomy: the Build surface wears the context header ────────
+    page.goto(f"{ORIGIN}/p/{PROJECT}/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+    page.locator('[data-testid="build-purpose"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    tokens = page.evaluate(TOKEN_PROBE)
+    header = page.evaluate(
+        """() => {
+             const h = document.querySelector('[data-testid="project-context-header"]');
+             const name = document.querySelector('[data-testid="project-name"]');
+             const mode = document.querySelector('[data-testid="context-mode"]');
+             const purpose = document.querySelector('[data-testid="build-purpose"]');
+             const ncs = name ? getComputedStyle(name) : null;
+             const mcs = mode ? getComputedStyle(mode) : null;
+             return {
+               height: h ? h.getBoundingClientRect().height : null,
+               nameText: name?.textContent ?? null,
+               nameHref: name?.getAttribute('href') ?? null,
+               nameColor: ncs?.color ?? null,
+               modeText: mode?.textContent ?? null,
+               modeColor: mcs?.color ?? null,
+               fontSize: mcs?.fontSize ?? null,
+               fontWeight: mcs?.fontWeight ?? null,
+               fontFamily: mcs?.fontFamily ?? null,
+               // §8.3 preservation: the purpose statement sits BELOW the header.
+               purposeBelowHeader: !!h && !!purpose
+                 && purpose.getBoundingClientRect().top > h.getBoundingClientRect().bottom - 1,
+             };
+           }"""
+    )
+
+    # ── Capture 2: Build mode with the context header ───────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-D-build-with-header.png"))
+
+    # ── AC 4: clicking the project name lands back on the dashboard ────────────
+    page.locator('[data-testid="project-name"]').click()
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=30000)
+    back_path = page.evaluate("() => window.location.pathname")
+
+    # ── EC17 sweep: the header is in ALL FOUR mode surfaces, correctly worded ──
+    ec17: dict = {}
+    for mode, label in [("chat", "Chat"), ("build", "Build"),
+                        ("document", "Document"), ("video", "Video")]:
+        page.goto(f"{ORIGIN}/p/{PROJECT}/{mode}", wait_until="domcontentloaded")
+        page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        got = page.evaluate(
+            """() => ({
+                 name: document.querySelector('[data-testid="project-name"]')?.textContent ?? null,
+                 mode: document.querySelector('[data-testid="context-mode"]')?.textContent ?? null,
+                 visible: (() => {
+                   const h = document.querySelector('[data-testid="project-context-header"]');
+                   if (!h) return false;
+                   const r = h.getBoundingClientRect();
+                   return r.height > 0 && r.width > 0;
+                 })(),
+               })"""
+        )
+        ec17[mode] = {"ok": got["name"] == PROJECT and got["mode"] == label and got["visible"], **got}
+
+    # ── Tile 3 reuse proof: inline Approve fires the board chip's POST ──────────
+    page.goto(DASH_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="gate-approve-r-q3"]').wait_for(timeout=30000)
+    posts_before = len(gate_posts)
+    page.locator('[data-testid="gate-approve-r-q3"]').click()
+    # The POST is fired synchronously on click; give the tap one settle tick.
+    page.wait_for_timeout(500)
+    approve_posts = gate_posts[posts_before:]
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["steps"]["dashboard_landing"] = {
+    "ok": all([
+        fonts_ok,
+        landing["pathname"] == f"/p/{PROJECT}",
+        landing["dashPresent"],
+        landing["runsTile"], landing["docsTile"],
+        landing["gatesTile"], landing["activityTile"],
+        landing["noSwitcher"], landing["noModeSurface"], landing["noDashboardTab"],
+    ]),
+    **{k: landing[k] for k in ("pathname", "dashPresent", "runsTile", "docsTile",
+                               "gatesTile", "activityTile", "noSwitcher",
+                               "noModeSurface", "noDashboardTab")},
+    "web_fonts_loaded": fonts_ok,
+    "screenshot": str(VSHOTS / "feedback-D-project-dashboard.png"),
+}
+report["steps"]["tiles_populated"] = {
+    "ok": all([
+        # Runs: r-q3 ONLY (project-scoped — none of the fixture's 6 other runs).
+        landing["runsCount"] == "1",
+        landing["runIds"] == ["r-q3"],
+        landing["runStatuses"] == ["awaiting_human"],
+        landing["runHref"] == f"/p/{PROJECT}/build/r-q3",
+        # Docs: the demo registry entry, linking into Video (its own mode view).
+        landing["docIds"] == ["checkout-demo"],
+        landing["docHref"] == f"/p/{PROJECT}/video/checkout-demo",
+        # Gates: the one open q3 gate, answerable INLINE (simple shape).
+        landing["gatesCount"] == "1",
+        landing["approvePresent"], landing["rejectPresent"],
+        # Activity: 1 run attached inside the 7-day window, drawn as real SVG.
+        landing["sparkTotal"] == "1",
+        landing["sparkSvg"],
+        len(landing["sparkRects"]) == 1,
+        all(f.startswith("var(--") for f in landing["sparkRects"]),
+        # Meta: honest fields only — open-run count present, no invented cost.
+        "1 open run" in landing["metaText"],
+        "cost" not in landing["metaText"].lower(),
+        landing["modeDoors"] == [f"/p/{PROJECT}/chat", f"/p/{PROJECT}/build",
+                                 f"/p/{PROJECT}/document", f"/p/{PROJECT}/video"],
+    ]),
+    **{k: landing[k] for k in ("runsCount", "runIds", "runStatuses", "runHref",
+                               "docIds", "docHref", "gatesCount", "approvePresent",
+                               "rejectPresent", "sparkTotal", "sparkSvg",
+                               "sparkRects", "metaText", "modeDoors")},
+}
+report["steps"]["run_row_navigates"] = {
+    "ok": run_nav == f"/p/{PROJECT}/build/r-q3",
+    "landed": run_nav,
+}
+report["steps"]["context_header_build"] = {
+    "ok": all([
+        header["height"] == 32,
+        header["nameText"] == PROJECT,
+        header["nameHref"] == f"/p/{PROJECT}",
+        header["modeText"] == "Build",
+        # §4.2 anatomy: muted project name, high-ink mode, 13px/500 sans.
+        header["nameColor"] == tokens["muted"],
+        header["modeColor"] == tokens["high"],
+        header["fontSize"] == "13px",
+        header["fontWeight"] == "500",
+        "Inter" in (header["fontFamily"] or ""),
+        header["purposeBelowHeader"],
+    ]),
+    **header,
+    "resolved_tokens": tokens,
+    "screenshot": str(VSHOTS / "feedback-D-build-with-header.png"),
+}
+report["steps"]["name_click_lands_on_dashboard"] = {
+    "ok": back_path == f"/p/{PROJECT}",
+    "landed": back_path,
+}
+report["steps"]["ec17_all_modes"] = {
+    "ok": all(v["ok"] for v in ec17.values()),
+    **ec17,
+}
+report["steps"]["gate_chip_reuse"] = {
+    # The dashboard chip speaks the board chip's wire: POST /runs/r-q3/gate {approve:true}.
+    "ok": approve_posts == [("/api/v1/runs/r-q3/gate", {"approve": True})],
+    "gate_posts": approve_posts,
+}
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback-D-project-dashboard.png"),
+    str(VSHOTS / "feedback-D-build-with-header.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceD_verdict", f"slice-D assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -123,7 +123,10 @@ PROJECTS = [
     project("default", "Unfiled", NOW0),  # synthesized — must never render (F5)
     project("legacy-spike", "legacy-spike", NOW0 - HOUR),
     project("upload-endpoint", "upload-endpoint", NOW0),
-    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC),
+    # q3 carries an interactive root so the slice-D project dashboard's docs
+    # tile (root-guarded, exactly like the board's §7.12 guard) lists its
+    # registry — which holds the recorded demo when the `demo` switch is on.
+    project("q3-review-deck", "q3-review-deck", NOW0 - 30 * SEC, interactiveRoot="/tmp/wi-q3"),
     project("api-migration", "api-migration", NOW0 - 2 * MIN),
     project("auth-refactor", "auth-refactor", NOW0 - 12 * MIN),
     project("smoke-tests", "smoke-tests", NOW0 - 6 * DAY),
@@ -138,6 +141,21 @@ MEMBERS = {
     "api-migration": ["r-api"],
     "auth-refactor": ["r-auth"],
     "smoke-tests": ["r-smoke1", "r-smoke2"],
+}
+
+# When each run ENTERED its project — `attached_at` on the members wire, the one
+# honest per-run clock that route carries (`AgentSession` has no timestamps).
+# Real epoch-ms so the slice-D dashboard's 7-day activity window has something
+# true to bucket: r-legacy sits OUTSIDE the window (8 days — proves windowing),
+# the rest inside it. Everything not named keeps the old inert `1`.
+ATTACHED_AT = {
+    "r-q3": NOW0 - 30 * SEC,
+    "r-api": NOW0 - 2 * MIN,
+    "r-upload": NOW0 - HOUR,
+    "r-auth": NOW0 - 13 * MIN,
+    "r-legacy": NOW0 - 8 * DAY,
+    "r-smoke1": NOW0 - 6 * DAY,
+    "r-smoke2": NOW0 - 6 * DAY,
 }
 
 
@@ -558,7 +576,8 @@ class W2Handler(SimpleHTTPRequestHandler):
             pid = urllib.parse.unquote(parts[4])
             self._json(200, {"members": [
                 {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
-                 "member_ref": ref, "meta": None, "attached_at": 1, "attached_by": "studio"}
+                 "member_ref": ref, "meta": None,
+                 "attached_at": ATTACHED_AT.get(ref, 1), "attached_by": "studio"}
                 for ref in MEMBERS.get(pid, [])
             ]})
             return True

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -28,8 +28,9 @@ What it asserts (design §4.3, the slice-3 DOM AC):
   4. /runs remains reachable via data-testid="rail-all-runs": a real <a
      href="/runs"> whose click lands the SPA on /runs (the flat-list escape
      hatch), with the board unmounted.
-  5. A rail project row enters the project shell, Chat mode default (§1.5):
-     clicking q3-review-deck lands on /p/q3-review-deck/chat.
+  5. A rail project row enters the project — re-scoped by DES-FEEDBACK-001
+     §4.1 (slice D): clicking q3-review-deck lands on the PROJECT DASHBOARD at
+     /p/q3-review-deck (context before actions), not a remembered mode.
 
 Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
 data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
@@ -175,11 +176,15 @@ with sync_playwright() as p:
         """() => window.location.pathname === '/runs'
               && !document.querySelector('[data-testid="project-board"]')""")
 
-    # ── AC 5: a rail project row enters the shell, Chat mode default (§1.5) ────
+    # ── AC 5 (re-scoped by DES-FEEDBACK-001 §4.1, slice D): a rail project row
+    #    enters the project — which now means the PROJECT DASHBOARD, not the
+    #    last-used mode. Context before actions; the mode is chosen there. ──────
     page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
     page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').wait_for(timeout=30000)
     page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').click()
-    shell_ok = settled("""() => window.location.pathname === '/p/q3-review-deck/chat'""")
+    shell_ok = settled(
+        """() => window.location.pathname === '/p/q3-review-deck'
+              && !!document.querySelector('[data-testid="project-dashboard"]')""")
 
     ctx.close()
     browser.close()

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -383,6 +383,13 @@ with sync_playwright() as p:
     # canvas-first geometry (EC18) holds on this 1440px viewport.
     set_fixture(ORIGIN, demo=True)
     page.goto(f"{ORIGIN}/p/q3-review-deck/video/checkout-demo", wait_until="domcontentloaded")
+    # Park the pointer mid-canvas before measuring EC18: the rail is
+    # hover-to-peek (§7.3), so a stationary cursor left over the rail band by
+    # the PREVIOUS scene's last click keeps it expanded and shrinks the canvas
+    # below the 0.8 ratio — a cursor artifact, not a layout regression. (Became
+    # visible when slice D's 32px context header shifted the document scene's
+    # click targets; the geometry itself is unchanged on a fresh navigation.)
+    page.mouse.move(720, 450)
     player_el = page.locator('[data-testid="demo-player"]')
     player_el.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)

--- a/e2e/vision_slice8_test.py
+++ b/e2e/vision_slice8_test.py
@@ -173,6 +173,11 @@ with sync_playwright() as p:
 
     page.goto(f"{ORIGIN}/theme", wait_until="domcontentloaded")
     page.locator('[data-testid="brand-learn"]').wait_for(timeout=30000)
+    # Pin the proxy project this rig asserts against: the form DEFAULTS to the
+    # first root-bound project, and the W2 fixture now has more than one
+    # (q3-review-deck gained a root for the slice-D dashboard tiles), so the
+    # rig picks `notes` explicitly — same journey, deterministic wire.
+    page.locator('[data-testid="learn-project"]').select_option("notes")
     page.add_style_tag(content=HIDE_GATE_TOASTS + "\n" + FREEZE_MOTION)
     try:
         page.wait_for_function("() => document.fonts.status === 'loaded'", timeout=20000)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { DocumentCanvas } from './components/DocumentCanvas.js';
 import { DocumentThread } from './components/DocumentThread.js';
 import { VideoStoryboard } from './components/VideoStoryboard.js';
 import { PolicyManager } from './components/PolicyManager.js';
+import { ProjectDashboard } from './components/ProjectDashboard.js';
 import { ProjectShell } from './components/ProjectShell.js';
 import { ProjectDetailPage } from './components/ProjectDetailPage.js';
 import { ProjectsPage } from './components/ProjectsPage.js';
@@ -337,6 +338,18 @@ export function App(): React.ReactElement {
         <ProjectShell projectId={projectId} mode={mode} artifactId={artifactId} navigate={navigate}>
           {renderModeSurface(mode, projectId)}
         </ProjectShell>
+      );
+    }
+    // `/p/:projectId` with NO mode segment is the PROJECT DASHBOARD (DES-FEEDBACK-001
+    // §4.1, slice D) — context before actions, replacing the last-used-mode redirect.
+    // Not a fifth mode: no shell, no switcher tab; the mode verbs live in its header.
+    // (`panel === 'project-detail'` is the legacy `/projects/:id` page, which keeps
+    // its own branch below while `useLegacyRedirect` replaces it with this route.)
+    if (projectId !== null && panel !== 'project-detail') {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <ProjectDashboard projectId={projectId} runs={runs} navigate={navigate} />
+        </div>
       );
     }
     // `/` is the orchestrator board (§1.4, slice 5); the flat run list it replaced is

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
-import { lastMode, modePath } from '../hooks/useRoute.js';
+import { projectPath } from '../hooks/useRoute.js';
 import { AppChrome } from './AppChrome.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NewProjectModal } from './NewProjectModal.js';
@@ -252,9 +252,9 @@ export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive =
   const q = searchQuery.trim().toLowerCase();
   const filteredRepos = q ? repos.filter(r => r.name.toLowerCase().includes(q)) : repos;
 
-  /** Enter a project's shell: last-used mode, Chat default (§1.5, §2.3). */
+  /** Enter a project: its DASHBOARD (DES-FEEDBACK-001 §4.1) — context before actions. */
   const openProject = (projectId: string): void => {
-    navigate(modePath(projectId, lastMode(projectId)));
+    navigate(projectPath(projectId));
   };
 
   return (

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,7 +1,7 @@
 import type { SessionView } from '../api/types.js';
 import type { SignalKind } from '../board/boardAttention.js';
 import { isLive, useRunHeadline } from '../hooks/useBoardHeadline.js';
-import { modePath, MODES, type Navigate } from '../hooks/useRoute.js';
+import { modePath, MODES, projectPath, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
@@ -311,7 +311,9 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
       }}
     />
   );
-  const name = <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>;
+  // The name leads to the project DASHBOARD (DES-FEEDBACK-001 §4.1, W6): context
+  // before actions. The quick actions beside it are still the direct mode doors.
+  const name = <a {...link(projectPath(project.id))} style={CSS.name}>{project.name}</a>;
   const repoTag = repo != null
     ? <span data-testid="project-repo" style={CSS.repo}>{repo}</span>
     : null;

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,0 +1,354 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import { listDocs, type DocSummary } from '../api/interactive.js';
+import type { SessionView } from '../api/types.js';
+import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
+import { interactiveRootOf } from '../hooks/useBoardModel.js';
+import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { useGateStore } from '../store/gates.js';
+import { useProjectsStore } from '../store/projects.js';
+import { GateChip } from './GateChip.js';
+import { MODE_LABEL } from './ProjectShell.js';
+import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { RunSparkline } from './RunSparkline.js';
+import { STATUS_STYLE } from './RunCard.js';
+
+/**
+ * The project dashboard (DES-FEEDBACK-001 §4.1, slice D): what `/p/:projectId`
+ * with NO mode segment renders — context before actions. It is NOT a fifth
+ * mode (no Dashboard tab in the switcher); it is what you see before you
+ * choose one, and where the context header's project name leads back to.
+ *
+ * Everything here derives from data the app already fetches: the shared `runs`
+ * list (passed down from App's one `useRuns()`), one membership read (the same
+ * call the board makes per project), one `listDocs(projectId)` (the same call
+ * Document mode makes — only when the project has an interactive root), and
+ * the gate store `useRuns` already reconciles. No polling loops.
+ */
+
+/** Statuses that mean the run is moving under its own power (board's set). */
+const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+/** Membership kinds that make a run/thread a member of a project. */
+const RUN_KINDS: ReadonlySet<string> = new Set(['crew.run', 'crew.chat']);
+
+const DAY = 24 * 3_600_000;
+/** The activity tile's window (§4.1 tile 4): 7 daily run-count buckets. */
+const SPARK_DAYS = 7;
+
+/** Rows a tile shows before it reports a count instead of growing. */
+const MAX_ROWS = 6;
+
+const CSS = {
+  page: { padding: 'var(--space-5) var(--space-6)', maxWidth: '1080px' },
+  name: {
+    fontSize: 'var(--text-lg)', fontWeight: 'var(--weight-bold)',
+    fontFamily: 'var(--font-sans)', color: 'var(--ink-high)', margin: 0,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  modeBtn: {
+    display: 'inline-flex', alignItems: 'center', gap: '5px', textDecoration: 'none',
+    background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-md)', color: 'var(--ink-high)', cursor: 'pointer',
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', padding: '5px 12px',
+    whiteSpace: 'nowrap',
+  },
+  meta: {
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-muted)', margin: '6px 0 0',
+  },
+  grid: {
+    display: 'grid', gap: 'var(--space-3)', marginTop: 'var(--space-4)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+  },
+  tile: {
+    background: 'var(--surface-card)', boxShadow: 'var(--shadow-card)',
+    borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', minWidth: 0,
+  },
+  tileHead: {
+    fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-bold)',
+    letterSpacing: '0.08em', textTransform: 'uppercase',
+    color: 'var(--ink-muted)', margin: '0 0 10px',
+  },
+  row: {
+    display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+    border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)',
+    padding: '5px 8px', textDecoration: 'none',
+  },
+  rowText: {
+    flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  empty: { fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', margin: 0 },
+  overflow: { fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '6px 0 0' },
+} as const satisfies Record<string, React.CSSProperties>;
+
+/** The per-run attention signal — the home board's model (§2.1.3) scoped to one run. */
+function runSignal(v: SessionView, gateAt: number | undefined, fallback: number): Signal | null {
+  const status = v.session.status;
+  const kind: SignalKind | null =
+    status === 'awaiting_human' ? 'gate'
+    : status === 'failed' ? 'failing'
+    : ACTIVE.has(status) ? 'running'
+    : null;
+  return kind === null ? null : { kind, at: gateAt ?? fallback, runId: v.session.id };
+}
+
+interface Props {
+  projectId: string;
+  /** The one cross-project run list App already holds (`useRuns()`). */
+  runs: SessionView[];
+  navigate: Navigate;
+}
+
+export function ProjectDashboard({ projectId, runs, navigate }: Props): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const loadProjects = useProjectsStore((s) => s.load);
+  const gates = useGateStore((s) => s.gates);
+
+  useEffect(() => {
+    if (projects.length === 0) void loadProjects();
+  }, [projects.length, loadProjects]);
+
+  const project = projects.find((p) => p.id === projectId) ?? null;
+  const name = project?.name ?? projectId;
+
+  // One membership read on mount — the same call the board makes per project.
+  // ref → kind (a `crew.chat` member opens in Chat), ref → attached_at (the
+  // honest per-run clock this wire carries; `AgentSession` has no timestamps).
+  const [memberKinds, setMemberKinds] = useState<Record<string, string>>({});
+  const [attachedAt, setAttachedAt] = useState<Record<string, number>>({});
+  useEffect(() => {
+    let cancelled = false;
+    api.listProjectMembers(projectId)
+      .then(({ members }) => {
+        if (cancelled) return;
+        const kinds: Record<string, string> = {};
+        const at: Record<string, number> = {};
+        for (const m of members) {
+          if (!RUN_KINDS.has(m.member_kind)) continue;
+          kinds[m.member_ref] = m.member_kind;
+          at[m.member_ref] = m.attached_at;
+        }
+        setMemberKinds(kinds);
+        setAttachedAt(at);
+      })
+      .catch(() => { /* members unreadable — the tiles simply stay empty */ });
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  // One listDocs on mount — the same call Document mode makes — and only when
+  // the project HAS an interactive root (the board's §7.12 guard: no root, no
+  // bridge to cold-start).
+  const [docs, setDocs] = useState<DocSummary[]>([]);
+  useEffect(() => {
+    if (project === null || interactiveRootOf(project) === null) return;
+    let cancelled = false;
+    listDocs(projectId)
+      .then((d) => { if (!cancelled) setDocs(d); })
+      .catch(() => { /* bridge cold/unreachable — no doc tiles, never an error wall */ });
+    return () => { cancelled = true; };
+  }, [projectId, project]);
+
+  // ── The project's runs, attention-ordered (the board's model, §4.1 tile 1) ──
+  const fallbackAt = project?.updated_at ?? 0;
+  const myRuns = useMemo(() => {
+    const now = Date.now();
+    return runs
+      .filter((v) => v.session.id in memberKinds && v.session.archived_at == null)
+      .map((v) => {
+        const signal = runSignal(v, gates[v.session.id]?.receivedAt, attachedAt[v.session.id] ?? fallbackAt);
+        return {
+          view: v,
+          signal,
+          score: signal === null ? 0 : scoreOf(signal, now),
+          at: signal?.at ?? attachedAt[v.session.id] ?? fallbackAt,
+        };
+      })
+      .sort((a, b) => compareScored(
+        { score: a.score, at: a.at, name: a.view.session.problem },
+        { score: b.score, at: b.at, name: b.view.session.problem },
+      ));
+  }, [runs, memberKinds, attachedAt, gates, fallbackAt]);
+
+  const openRuns = myRuns.filter(({ view }) => !['completed', 'cancelled', 'failed'].includes(view.session.status));
+  const waiting = myRuns.filter(({ view }) => view.session.status === 'awaiting_human');
+
+  // ── The 7-day run-count sparkline (§4.1 tile 4): one bucket per day, oldest
+  // first, counted off the membership attach clock — when each run entered the
+  // project, the one per-run timestamp this wire carries. ──
+  const now = Date.now();
+  const sparkCounts = useMemo(() => {
+    const counts = new Array<number>(SPARK_DAYS).fill(0);
+    for (const id of Object.keys(attachedAt)) {
+      const age = now - (attachedAt[id] ?? 0);
+      if (age < 0 || age >= SPARK_DAYS * DAY) continue;
+      const bucket = SPARK_DAYS - 1 - Math.floor(age / DAY);
+      counts[bucket] = (counts[bucket] ?? 0) + 1;
+    }
+    return counts;
+    // `now` deliberately not a dep: the tile re-derives when the data moves, not on a timer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attachedAt]);
+  const sparkTotal = sparkCounts.reduce((a, c) => a + c, 0);
+
+  // Meta line (§4.1): last activity + open runs. Cost is NOT here on purpose —
+  // the `/runs` wire carries no cost field, and the dashboard never invents one.
+  const lastActivity = Math.max(
+    fallbackAt,
+    ...Object.values(attachedAt),
+    ...waiting.map(({ view }) => gates[view.session.id]?.receivedAt ?? 0),
+  );
+
+  /** Every affordance is a real link — deep-linkable, middle-clickable. */
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
+
+  /** Where a run row opens: its OWN mode view — Chat for a chat thread, Build otherwise. */
+  const runModeOf = (id: string): Mode => (memberKinds[id] === 'crew.chat' ? 'chat' : 'build');
+
+  return (
+    <div data-testid="project-dashboard" data-project-id={projectId} style={CSS.page}>
+      {/* ── Project header: name, the four mode verbs, the meta line (§4.1) ── */}
+      <header>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <h1 style={CSS.name}>{name}</h1>
+          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+            {(Object.keys(MODE_LABEL) as Mode[]).map((m) => (
+              <a
+                key={m}
+                {...link(modePath(projectId, m))}
+                data-testid={`dashboard-mode-${m}`}
+                style={CSS.modeBtn}
+              >
+                {MODE_LABEL[m]}
+              </a>
+            ))}
+          </div>
+        </div>
+        <p style={CSS.meta} data-testid="dashboard-meta">
+          last activity {ago(lastActivity)} ago · {openRuns.length} open {openRuns.length === 1 ? 'run' : 'runs'}
+        </p>
+      </header>
+
+      <div style={CSS.grid}>
+        {/* ── Tile 1: runs, attention-ordered, each a link into its mode view ── */}
+        <section data-testid="dashboard-runs" data-count={myRuns.length} style={CSS.tile}>
+          <p style={CSS.tileHead}>Active runs ({openRuns.length})</p>
+          {myRuns.length === 0 ? (
+            <p style={CSS.empty}>No runs yet — Build starts one.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {myRuns.slice(0, MAX_ROWS).map(({ view, signal }) => {
+                const { session } = view;
+                const style = STATUS_STYLE[session.status];
+                return (
+                  <a
+                    key={session.id}
+                    {...link(modePath(projectId, runModeOf(session.id), session.id))}
+                    data-testid="dashboard-run"
+                    data-run-id={session.id}
+                    data-status={session.status}
+                    style={CSS.row}
+                  >
+                    <span
+                      aria-hidden
+                      style={{
+                        width: '6px', height: '6px', borderRadius: 'var(--radius-full)', flexShrink: 0,
+                        // SignalKind is a subset of Attention, so the board's dot map reads directly.
+                        background: signal !== null ? ATTENTION_DOT[signal.kind] : 'var(--ink-dim)',
+                      }}
+                    />
+                    <span style={CSS.rowText}>{session.problem}</span>
+                    <span style={{ flexShrink: 0, color: style?.color ?? 'var(--ink-dim)' }}>
+                      {style?.label ?? session.status}
+                    </span>
+                  </a>
+                );
+              })}
+              {myRuns.length > MAX_ROWS && (
+                <p style={CSS.overflow}>{myRuns.length - MAX_ROWS} more</p>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* ── Tile 2: documents, from the one listDocs the Document mode makes ── */}
+        <section data-testid="dashboard-docs" data-count={docs.length} style={CSS.tile}>
+          <p style={CSS.tileHead}>Documents ({docs.length})</p>
+          {docs.length === 0 ? (
+            <p style={CSS.empty}>No documents yet — Document drafts one.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {docs.slice(0, MAX_ROWS).map((d) => (
+                <a
+                  key={d.name}
+                  {...link(modePath(projectId, d.kind === 'demo' ? 'video' : 'document', d.name))}
+                  data-testid="dashboard-doc"
+                  data-doc-id={d.name}
+                  style={CSS.row}
+                >
+                  <span aria-hidden style={{ flexShrink: 0, color: 'var(--ink-dim)' }}>
+                    {d.kind === 'demo' ? '▶' : '▤'}
+                  </span>
+                  <span style={CSS.rowText}>{d.name}</span>
+                  <span style={{ flexShrink: 0, color: 'var(--ink-dim)' }}>v{d.head}</span>
+                </a>
+              ))}
+              {docs.length > MAX_ROWS && (
+                <p style={CSS.overflow}>{docs.length - MAX_ROWS} more</p>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* ── Tile 3: the gate inbox — the SAME answerable chip as the board (§4.1) ── */}
+        <section data-testid="dashboard-gates" data-count={waiting.length} style={CSS.tile}>
+          <p style={CSS.tileHead}>Gate inbox ({waiting.length})</p>
+          {waiting.length === 0 ? (
+            <p style={CSS.empty}>Nothing is waiting on you.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              {waiting.slice(0, MAX_ROWS).map(({ view }) => {
+                const id = view.session.id;
+                const gate = gates[id];
+                return (
+                  <div key={id} data-testid="dashboard-gate" data-run-id={id} style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                    <span
+                      title={gate?.prompt}
+                      style={{
+                        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                        fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+                      }}
+                    >
+                      {gate?.prompt ?? view.session.problem}
+                    </span>
+                    <GateChip runId={id} projectId={projectId} gate={gate} navigate={navigate} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        {/* ── Tile 4: 7-day activity sparkline (§2.3's SVG approach, own component) ── */}
+        <section data-testid="dashboard-activity" data-total={sparkTotal} style={CSS.tile}>
+          <p style={CSS.tileHead}>Activity (7d)</p>
+          {sparkTotal === 0 ? (
+            <p style={CSS.empty}>No runs in the last 7 days.</p>
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'flex-end', gap: '12px' }}>
+              <RunSparkline counts={sparkCounts} width={168} height={40} color="var(--accent)" testId="activity-sparkline" />
+              <span style={{ fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)' }}>
+                {sparkTotal} {sparkTotal === 1 ? 'run' : 'runs'} this week
+              </span>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -59,7 +59,9 @@ const CSS = {
   },
   grid: {
     display: 'grid', gap: 'var(--space-3)', marginTop: 'var(--space-4)',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    // §4.1's 2x2: two columns at the page's 1080px max (auto-fit's only job is
+    // the 1-column fallback below ~430px tiles — never a 3+1 row).
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 420px), 1fr))',
   },
   tile: {
     background: 'var(--surface-card)', boxShadow: 'var(--shadow-card)',

--- a/src/components/ProjectShell.tsx
+++ b/src/components/ProjectShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { usePreflight } from '../hooks/usePreflight.js';
-import { MODES, modePath, rememberMode, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { MODES, modePath, projectPath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import { useConnectionStore } from '../store/connection.js';
 import { useProjectsStore } from '../store/projects.js';
 import {
@@ -16,6 +16,22 @@ const S = {
   border: 'var(--surface-raised)',
   ink:    'var(--ink-high)',
   muted:  'var(--ink-muted)',
+  dim:    'var(--ink-dim)',
+};
+
+/** The context header's word for each mode (§4.2) — the switcher's capitalization. */
+export const MODE_LABEL: Record<Mode, string> = {
+  chat: 'Chat',
+  build: 'Build',
+  document: 'Document',
+  video: 'Video',
+};
+
+/** §4.2's type spec, shared by both breadcrumb segments: sans, sm, medium. */
+const CRUMB: React.CSSProperties = {
+  fontSize: 'var(--text-sm)',
+  fontWeight: 'var(--weight-medium)',
+  fontFamily: 'var(--font-sans)',
 };
 
 interface Props {
@@ -54,8 +70,6 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
   const lastArtifact = useRef<Partial<Record<Mode, string>>>({});
   if (artifactId) lastArtifact.current[mode] = artifactId;
 
-  useEffect(() => { rememberMode(projectId, mode); }, [projectId, mode]);
-
   const onSelectMode = useCallback(
     (next: Mode) => navigate(modePath(projectId, next, lastArtifact.current[next] ?? null)),
     [navigate, projectId],
@@ -79,10 +93,17 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden" data-testid="project-shell" data-project-id={projectId}>
+      {/* The project-context header (DES-FEEDBACK-001 §4.2, slice D): one slim
+          32px band — "project › mode" — above the switcher in EVERY mode surface.
+          It absorbed the shell's old breadcrumb rather than stacking beneath it;
+          always visible, never collapses. It answers: "where am I, and how do I
+          get back?" — the project name links back to the dashboard (§4.1). */}
       <header
+        data-testid="project-context-header"
         style={{
           display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0,
-          padding: '10px 14px 8px', background: S.bar, borderBottom: `1px solid ${S.border}`,
+          height: '32px', boxSizing: 'border-box', padding: '0 14px',
+          background: S.bar, borderBottom: `1px solid ${S.border}`,
         }}
       >
         <button
@@ -90,21 +111,27 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
           onClick={() => navigate('/')}
           title="All projects"
           style={{
-            background: 'transparent', border: 'none', color: S.muted, cursor: 'pointer',
+            background: 'transparent', border: 'none', color: S.dim, cursor: 'pointer',
             fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', padding: 0,
           }}
         >
           ‹ Projects
         </button>
-        <h1
+        {/* The project name is CONTEXT, not the current focus (§4.2): muted ink,
+            and a real link — deep-linkable, middle-clickable — to the dashboard. */}
+        <a
           data-testid="project-name"
-          style={{
-            fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-semi)',
-            fontFamily: 'var(--font-sans)', color: S.ink, margin: 0,
-          }}
+          href={projectPath(projectId)}
+          onClick={(e) => { e.preventDefault(); navigate(projectPath(projectId)); }}
+          title={`${name} — project dashboard`}
+          style={{ ...CRUMB, color: S.muted, textDecoration: 'none', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
           {name}
-        </h1>
+        </a>
+        <span aria-hidden style={{ ...CRUMB, color: S.dim }}>›</span>
+        <span data-testid="context-mode" style={{ ...CRUMB, color: S.ink }}>
+          {MODE_LABEL[mode]}
+        </span>
       </header>
 
       <ModeSwitcher mode={mode} onSelect={onSelectMode} unavailable={unavailable} />

--- a/src/components/RunSparkline.tsx
+++ b/src/components/RunSparkline.tsx
@@ -1,0 +1,66 @@
+/**
+ * RunSparkline — the §2.3 bar sparkline, SVG-first, no chart library.
+ *
+ * One `<rect>` per bucket, height proportional to that bucket's count within
+ * the series max; buckets with no count render nothing (transparent per §2.3,
+ * never a zero-height sliver pretending to be data). Colors are semantic
+ * tokens only — the DEFAULT is `--ink-dim` (the quiet-band spelling); a caller
+ * that means status passes a status token.
+ *
+ * Deliberately its own tiny component (DES-FEEDBACK-001 §8.3 slice D): the
+ * project dashboard's 7-day activity tile uses it now, and slice E's home
+ * metrics bar + quiet-band project rows reuse it rather than re-deriving the
+ * `<rect>` math.
+ */
+
+interface Props {
+  /** Bucket counts, oldest first (e.g. 7 daily run counts). */
+  counts: number[];
+  width?: number;
+  height?: number;
+  /** Fill token for buckets with a count. Semantic tokens only (EC15). */
+  color?: string;
+  testId?: string;
+}
+
+const BAR_GAP = 2;
+
+export function RunSparkline({
+  counts,
+  width = 56,
+  height = 16,
+  color = 'var(--ink-dim)',
+  testId,
+}: Props): React.ReactElement {
+  const n = Math.max(1, counts.length);
+  const max = counts.reduce((a, c) => Math.max(a, c), 0);
+  const colW = (width - BAR_GAP * (n - 1)) / n;
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`activity: ${counts.join(', ')}`}
+      {...(testId !== undefined ? { 'data-testid': testId } : {})}
+      style={{ display: 'block', overflow: 'visible' }}
+    >
+      {max > 0 && counts.map((c, i) => {
+        if (c <= 0) return null;
+        // Full height for the max; at least 2px so a 1-in-a-big-week day is visible.
+        const h = Math.max(2, (c / max) * height);
+        return (
+          <rect
+            key={i}
+            x={i * (colW + BAR_GAP)}
+            y={height - h}
+            width={colW}
+            height={h}
+            rx={1}
+            fill={color}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { api } from '../api/client.js';
-import { lastMode, modePath, type Mode, type Navigate } from './useRoute.js';
+import { modePath, projectPath, type Mode, type Navigate } from './useRoute.js';
 
 /** The synthesized "unfiled" project — a run that appears only there has no project. */
 const DEFAULT_PROJECT_ID = 'default';
@@ -47,8 +47,11 @@ interface LegacyRoute {
  * Every redirect REPLACES its history entry, so Back leaves the shell instead of
  * bouncing through the redirect again.
  *
- *   /projects/:id  →  /p/:id/<last-used mode>
+ *   /projects/:id  →  /p/:id                    (the project dashboard, §4.1)
  *   /runs/:id      →  /p/<project>/build/:id   (when the run is filed under one)
+ *
+ * A bare `/p/:id` is NOT redirected any more — it IS the project dashboard
+ * (DES-FEEDBACK-001 §4.1, slice D). The last-used-mode redirect is gone.
  *
  * A run with no project keeps the existing run view: no bookmark breaks, and no
  * guessed project binding.
@@ -60,8 +63,11 @@ export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void 
     if (mode !== null) return; // already in the shell
 
     if (projectId !== null) {
-      // Both `/projects/:id` (legacy panel) and a bare `/p/:id` land on the last-used mode.
-      navigate(modePath(projectId, lastMode(projectId)), { replace: true });
+      // Only the LEGACY `/projects/:id` panel redirects — onto the dashboard
+      // route. `/p/:id` renders the dashboard directly and must stay put.
+      if (panel === 'project-detail') {
+        navigate(projectPath(projectId), { replace: true });
+      }
       return;
     }
 

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -58,26 +58,19 @@ function safeDecode(s: string): string {
   try { return decodeURIComponent(s); } catch { return s; }
 }
 
-/** Where `/p/:projectId` (no mode) lands, per project. §1.5: last-used mode, default `chat`. */
-const LAST_MODE_KEY = 'wk.studio.lastMode';
-
-export function lastMode(projectId: string): Mode {
-  try {
-    return asMode(window.localStorage.getItem(`${LAST_MODE_KEY}.${projectId}`) ?? '') ?? 'chat';
-  } catch {
-    return 'chat'; // storage denied (private mode) — the default is still correct
-  }
-}
-
-export function rememberMode(projectId: string, mode: Mode): void {
-  try {
-    window.localStorage.setItem(`${LAST_MODE_KEY}.${projectId}`, mode);
-  } catch { /* storage denied — the default mode simply stays 'chat' */ }
+/**
+ * Where `/p/:projectId` (no mode) lands: the PROJECT DASHBOARD (DES-FEEDBACK-001
+ * §4.1) — context before actions. This replaced the last-used-mode redirect
+ * (slice D): entering a project no longer jumps into whatever mode was open
+ * last; the operator sees the project's state and CHOOSES a mode.
+ */
+export function projectPath(projectId: string): string {
+  return `/p/${encodeURIComponent(projectId)}`;
 }
 
 /** Build a project-shell path. The single spelling of `/p/:projectId/:mode[/:artifactId]`. */
 export function modePath(projectId: string, mode: Mode, artifactId?: string | null): string {
-  const base = `/p/${encodeURIComponent(projectId)}/${mode}`;
+  const base = `${projectPath(projectId)}/${mode}`;
   return artifactId ? `${base}/${encodeURIComponent(artifactId)}` : base;
 }
 

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -91,7 +91,7 @@ describe('the rail: two taxonomies (§2.3)', () => {
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     fireEvent.click(screen.getAllByTestId('rail-project')[0]!);
-    expect(navigate).toHaveBeenCalledWith('/p/q3-review-deck/chat');
+    expect(navigate).toHaveBeenCalledWith('/p/q3-review-deck');
   });
 
   it('keeps /runs reachable through the ONE escape hatch — at the runs section bottom (§1.4)', async () => {

--- a/tests/ProjectDashboard.test.tsx
+++ b/tests/ProjectDashboard.test.tsx
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useProjectsStore } from '../src/store/projects.js';
+import type { Project, ProjectMember, SessionStatus } from '../src/api/types.js';
+import type { DocSummary } from '../src/api/interactive.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The project dashboard (DES-FEEDBACK-001 §4.1, slice D): the `/p/:projectId`
+ * no-mode landing — four tiles, all derived from data the app already holds.
+ */
+
+const listProjectMembers = vi.fn();
+const confirmGate = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects: [] }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+    confirmGate: (...a: unknown[]) => confirmGate(...a),
+  },
+}));
+
+const listDocs = vi.fn();
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (...a: unknown[]) => listDocs(...a),
+}));
+
+const NOW = Date.now();
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+function project(id: string, extra: Partial<Project> = {}): Project {
+  return {
+    id, name: `The ${id} project`, description: null, status: 'active',
+    scope: `project:${id}`, created_at: NOW - 10 * DAY, updated_at: NOW - HOUR, ...extra,
+  };
+}
+
+function member(ref: string, kind = 'crew.run', attachedAt = NOW - 2 * HOUR): ProjectMember {
+  return {
+    id: `proj-1:${kind}:${ref}`, project_id: 'proj-1', member_kind: kind,
+    member_ref: ref, meta: null, attached_at: attachedAt, attached_by: 'studio',
+  };
+}
+
+function run(id: string, status: SessionStatus, problem = `problem of ${id}`) {
+  return makeView(
+    { id, status, problem, unit_ix: 0 },
+    [makeUnit({ id: `${id}:u0`, session_id: id, ord: 0 })],
+  );
+}
+
+function doc(name: string, kind: 'doc' | 'demo' = 'doc'): DocSummary {
+  return { name, kind, head: 3, versions: 3, updated_at: null };
+}
+
+beforeEach(() => {
+  listProjectMembers.mockReset();
+  listDocs.mockReset();
+  confirmGate.mockReset();
+  listProjectMembers.mockResolvedValue({ members: [] });
+  listDocs.mockResolvedValue([]);
+  useGateStore.setState({ gates: {} });
+  useProjectsStore.setState({ projects: [project('proj-1')], loading: false, error: null });
+});
+afterEach(cleanup);
+
+describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
+  it('renders the dashboard with all four tiles, the mode verbs, and the meta line', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    expect(screen.getByTestId('project-dashboard')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-runs')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-docs')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-gates')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-activity')).toBeInTheDocument();
+
+    // NOT a fifth mode: no switcher on this surface — the four verbs are header links.
+    expect(screen.queryByTestId('mode-switcher')).toBeNull();
+    for (const m of ['chat', 'build', 'document', 'video']) {
+      expect(screen.getByTestId(`dashboard-mode-${m}`)).toHaveAttribute('href', `/p/proj-1/${m}`);
+    }
+
+    // The meta line: last activity + open runs. NO cost — the wire carries none.
+    expect(screen.getByTestId('dashboard-meta')).toHaveTextContent(/last activity .* · 0 open runs/);
+    expect(screen.getByTestId('dashboard-meta').textContent).not.toMatch(/\$/);
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('proj-1'));
+  });
+
+  it('runs tile: scoped to the project and attention-ordered — gate first, then failing, then working, then done', async () => {
+    listProjectMembers.mockResolvedValue({
+      members: [member('r-done'), member('r-work'), member('r-gate'), member('r-fail')],
+    });
+    useGateStore.setState({
+      gates: { 'r-gate': { runId: 'r-gate', ord: 0, prompt: 'ok?', lifecycle: 'open', receivedAt: NOW - HOUR } },
+    });
+    const runs = [
+      run('r-done', 'completed'),
+      run('r-work', 'executing'),
+      run('r-gate', 'awaiting_human'),
+      run('r-fail', 'failed'),
+      run('r-other', 'executing', 'someone else’s run'), // NOT a member — must not render
+    ];
+    render(<ProjectDashboard projectId="proj-1" runs={runs} navigate={() => {}} />);
+
+    await waitFor(() => expect(screen.getAllByTestId('dashboard-run')).toHaveLength(4));
+    const ids = screen.getAllByTestId('dashboard-run').map((el) => el.getAttribute('data-run-id'));
+    expect(ids).toEqual(['r-gate', 'r-fail', 'r-work', 'r-done']);
+    expect(ids).not.toContain('r-other');
+    // Open count excludes terminal states.
+    expect(screen.getByTestId('dashboard-meta')).toHaveTextContent('2 open runs');
+  });
+
+  it('a run row links into the run’s mode view — Build for a run, Chat for a chat thread', async () => {
+    listProjectMembers.mockResolvedValue({
+      members: [member('r-1', 'crew.run'), member('t-1', 'crew.chat')],
+    });
+    const navigate = vi.fn();
+    render(
+      <ProjectDashboard
+        projectId="proj-1"
+        runs={[run('r-1', 'executing'), run('t-1', 'executing')]}
+        navigate={navigate}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('dashboard-run')).toHaveLength(2));
+
+    const rows = screen.getAllByTestId('dashboard-run');
+    const byId = (id: string) => rows.find((r) => r.getAttribute('data-run-id') === id)!;
+    expect(byId('r-1')).toHaveAttribute('href', '/p/proj-1/build/r-1');
+    expect(byId('t-1')).toHaveAttribute('href', '/p/proj-1/chat/t-1');
+    fireEvent.click(byId('r-1'));
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/build/r-1');
+  });
+
+  it('docs tile: lists listDocs(projectId) results (root present) and navigates into Document mode', async () => {
+    useProjectsStore.setState({
+      projects: [project('proj-1', { interactiveRoot: '/tmp/wi-proj-1' })],
+      loading: false, error: null,
+    });
+    listDocs.mockResolvedValue([doc('spec'), doc('pitch'), doc('walkthrough', 'demo')]);
+    const navigate = vi.fn();
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={navigate} />);
+
+    await waitFor(() => expect(screen.getAllByTestId('dashboard-doc')).toHaveLength(3));
+    expect(listDocs).toHaveBeenCalledWith('proj-1');
+    expect(screen.getByTestId('dashboard-docs')).toHaveAttribute('data-count', '3');
+
+    const rows = screen.getAllByTestId('dashboard-doc');
+    expect(rows[0]).toHaveAttribute('href', '/p/proj-1/document/spec');
+    // A demo doc opens in Video mode — a demo is a doc whose manifest says so (§7.4).
+    expect(rows[2]).toHaveAttribute('href', '/p/proj-1/video/walkthrough');
+    fireEvent.click(rows[0]!);
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/document/spec');
+  });
+
+  it('docs tile: no interactive root ⇒ no listDocs call, and the tile states its empty case', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
+    expect(listDocs).not.toHaveBeenCalled();
+    expect(screen.getByTestId('dashboard-docs')).toHaveTextContent('No documents yet');
+  });
+
+  it('gate tile: approve fires the SAME action as the board chip — POST confirmGate {approve:true}', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-gate')] });
+    useGateStore.setState({
+      gates: { 'r-gate': { runId: 'r-gate', ord: 0, prompt: 'Approve the outline?', lifecycle: 'open', receivedAt: NOW - HOUR } },
+    });
+    confirmGate.mockResolvedValue({ status: 'ok' });
+    render(
+      <ProjectDashboard projectId="proj-1" runs={[run('r-gate', 'awaiting_human')]} navigate={() => {}} />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-gate')).toBeInTheDocument());
+    const tile = screen.getByTestId('dashboard-gates');
+    expect(tile).toHaveTextContent('Approve the outline?');
+
+    fireEvent.click(within(tile).getByTestId('gate-approve-r-gate'));
+    await waitFor(() => expect(confirmGate).toHaveBeenCalledWith('r-gate', { approve: true }));
+    // The chip clears its gate from the shared store exactly as it does on the board.
+    expect(useGateStore.getState().gates['r-gate']).toBeUndefined();
+  });
+
+  it('activity tile: 7-day sparkline reads the membership attach clock, one bucket per day', async () => {
+    listProjectMembers.mockResolvedValue({
+      members: [
+        member('r-a', 'crew.run', NOW - 1 * HOUR),      // today
+        member('r-b', 'crew.run', NOW - 1 * HOUR - 1),  // today
+        member('r-c', 'crew.run', NOW - 3 * DAY),       // 3 days back
+        member('r-old', 'crew.run', NOW - 20 * DAY),    // outside the window
+      ],
+    });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-activity')).toHaveAttribute('data-total', '3'));
+    const svg = screen.getByTestId('activity-sparkline');
+    // Two buckets with counts ⇒ two bars; the max bucket (2) renders full height.
+    expect(svg.querySelectorAll('rect')).toHaveLength(2);
+    expect(screen.getByTestId('dashboard-activity')).toHaveTextContent('3 runs this week');
+  });
+});

--- a/tests/ProjectShell.test.tsx
+++ b/tests/ProjectShell.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ProjectShell } from '../src/components/ProjectShell.js';
 import { useProjectsStore } from '../src/store/projects.js';
-import { lastMode } from '../src/hooks/useRoute.js';
+import { MODES, type Mode } from '../src/hooks/useRoute.js';
 
 vi.mock('../src/api/client.js', () => ({
   api: { listProjects: () => Promise.resolve({ projects: [] }) },
@@ -83,12 +83,46 @@ describe('ProjectShell (DES-MERGE-001 §1.2)', () => {
     expect(navigate).toHaveBeenLastCalledWith('/p/proj-1/build/run-9');
   });
 
-  it('records the last-used mode, which is where a bare /p/:projectId lands', () => {
+  // ── The project-context header (DES-FEEDBACK-001 §4.2, slice D) ────────────
+
+  const MODE_WORD: Record<Mode, string> = {
+    chat: 'Chat', build: 'Build', document: 'Document', video: 'Video',
+  };
+
+  it.each(MODES.map((m) => [m] as const))(
+    'shows the project-context header in %s mode — project name › mode word (EC17)',
+    (m) => {
+      render(
+        <ProjectShell projectId="proj-1" mode={m} artifactId={null} navigate={() => {}}>
+          <p>surface</p>
+        </ProjectShell>,
+      );
+      const header = screen.getByTestId('project-context-header');
+      expect(header).toBeInTheDocument();
+      expect(screen.getByTestId('project-name')).toHaveTextContent('Merge the skins');
+      expect(screen.getByTestId('context-mode')).toHaveTextContent(MODE_WORD[m]);
+    },
+  );
+
+  it('the header project name links back to the project dashboard (§4.2)', () => {
+    const navigate = vi.fn();
+    render(
+      <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    const crumb = screen.getByTestId('project-name');
+    expect(crumb).toHaveAttribute('href', '/p/proj-1');
+    fireEvent.click(crumb);
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1');
+  });
+
+  it('no longer writes a last-used-mode memory — the dashboard replaced the redirect (slice D)', () => {
     render(
       <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={() => {}}>
         <p>surface</p>
       </ProjectShell>,
     );
-    expect(lastMode('proj-1')).toBe('build');
+    expect(window.localStorage.getItem('wk.studio.lastMode.proj-1')).toBeNull();
   });
 });

--- a/tests/legacyRedirect.test.ts
+++ b/tests/legacyRedirect.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { Project, ProjectMember } from '../src/api/types.js';
 import { resolveRunProject, useLegacyRedirect } from '../src/hooks/useLegacyRedirect.js';
-import { rememberMode } from '../src/hooks/useRoute.js';
 
 const listProjects = vi.fn();
 const listProjectMembers = vi.fn();
@@ -102,21 +101,21 @@ describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () =>
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it('/projects/:id → /p/:id on the last-used mode, with no membership lookup', () => {
+  it('/projects/:id → /p/:id (the project dashboard), with no membership lookup', () => {
     const navigate = vi.fn();
-    rememberMode('proj-1', 'document');
 
     renderHook(() => useLegacyRedirect(legacy.projects('proj-1'), navigate));
 
-    expect(navigate).toHaveBeenCalledWith('/p/proj-1/document', { replace: true });
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1', { replace: true });
     expect(listProjects).not.toHaveBeenCalled();
   });
 
-  it('a bare /p/:projectId lands on chat by default', () => {
+  it('a bare /p/:projectId is NOT redirected — it IS the dashboard (DES-FEEDBACK-001 §4.1)', () => {
     const navigate = vi.fn();
     renderHook(() => useLegacyRedirect(
       { panel: 'runs', runId: null, projectId: 'proj-1', mode: null, showLaunch: false }, navigate));
-    expect(navigate).toHaveBeenCalledWith('/p/proj-1/chat', { replace: true });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(listProjects).not.toHaveBeenCalled();
   });
 
   it('never redirects a route that is already in the shell, or the launch form', () => {

--- a/tests/useRoute.modes.test.ts
+++ b/tests/useRoute.modes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
-import { MODES, lastMode, modePath, rememberMode, useRoute } from '../src/hooks/useRoute.js';
+import { MODES, modePath, projectPath, useRoute } from '../src/hooks/useRoute.js';
 
 /** Render the hook against a given path — the parse reads `window.location` at mount. */
 function routeAt(path: string) {
@@ -107,22 +107,15 @@ describe('navigate', () => {
   });
 });
 
-describe('modePath / last-used mode', () => {
+describe('modePath / projectPath', () => {
   it('builds the single spelling of the shell path', () => {
     expect(modePath('proj-1', 'build')).toBe('/p/proj-1/build');
     expect(modePath('proj-1', 'build', 'run-9')).toBe('/p/proj-1/build/run-9');
     expect(modePath('proj one', 'chat', 'run/9')).toBe('/p/proj%20one/chat/run%2F9');
   });
 
-  it('defaults to chat and remembers per project', () => {
-    expect(lastMode('proj-1')).toBe('chat');
-    rememberMode('proj-1', 'build');
-    expect(lastMode('proj-1')).toBe('build');
-    expect(lastMode('proj-2')).toBe('chat');
-  });
-
-  it('ignores a junk stored value rather than routing to a mode that does not exist', () => {
-    window.localStorage.setItem('wk.studio.lastMode.proj-1', 'sideways');
-    expect(lastMode('proj-1')).toBe('chat');
+  it('builds the dashboard path — the no-mode project landing (DES-FEEDBACK-001 §4.1)', () => {
+    expect(projectPath('proj-1')).toBe('/p/proj-1');
+    expect(projectPath('proj one')).toBe('/p/proj%20one');
   });
 });


### PR DESCRIPTION
Round-2 operator feedback, item 5: *"should have a dashboard and context, right now just defaults to action view but with no context of project. Build just takes to new build page but no context of current project you kicked off from."*

## What changed (design: `.product/DES-FEEDBACK-001.md` §4.1–§4.2, §8.3 slice D)

- **Dashboard landing**: `/p/:projectId` with no mode segment now renders a project dashboard instead of jumping to the last-used mode (the `lastMode`/`rememberMode` machinery is deleted). Not a fifth mode — no Dashboard tab. Header: project name, the four mode buttons, and a meta line (last activity · open runs; cost deliberately omitted — the `/runs` wire carries no cost field, asserted in the rig).
- **Four tiles** (2×2): active runs scoped to the project and attention-ordered on the board's model; documents from one `listDocs(projectId)`; gate inbox reusing the board's `GateChip` (inline Approve fires the board chip's exact `POST /runs/:id/gate {approve:true}`, intercepted and proven); a 7-day run-count SVG sparkline in its own component for slice E to reuse.
- **Project-context header (§4.2)**: the shell's breadcrumb became a slim 32px `project › mode` band across all four mode surfaces — muted project name linking back to the dashboard, bright mode name. Board cards and rail rows now lead to the dashboard.
- §8.3 named `ProjectDetailPage.tsx`, but the last-mode behavior lived in `useRoute`/App routing — implemented there; `/projects/:id` redirects to the dashboard route.

## Verification highlights

Adversarial verifier re-ran every gate, proved lint bites, proved the rig fails on origin/main, and independently drove: redirect-gone (fresh load of `/p/:id` after using Build stays on the dashboard; no localStorage keys), the gate-POST capture, tile navigation, and the header in all four modes. It also **caught a real layout deviation** — tiles rendered 3+1 instead of the design's 2×2 at 1440px — and fixed it (grid `minmax` cap) before regenerating the shots. Immersive canvas fractions re-measured at 0.81 (>0.8, EC18 preserved).

Pre-existing (not this branch): `vision_slice4`'s chat_firstrun step fails identically on origin/main — it pins the pre-slice-C "add agents" element; re-scope will ride slice E. `vision_slice1` needs a local pixel re-baseline (environmental).

## Gates

eslint `--max-warnings 0` clean · `tsc --noEmit` clean · vitest **951/951** · rigs: `feedback_sliceD` (new) + `feedback A/B/C`, `uxfix_slice3` (AC5 re-scoped to the dashboard in a dedicated commit), `uxfix 1/2/5/6`, `vision 2/3/6/7/8` all PASS on fresh builds.

Named 1440×900 shots: `feedback-D-project-dashboard.png`, `feedback-D-build-with-header.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)