### PR TITLE
Slice E: home metrics bar + repo profile visuals (DES-FEEDBACK-001 §2–§3)

### DIFF
--- a/e2e/feedback_sliceE_test.py
+++ b/e2e/feedback_sliceE_test.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""
+feedback_sliceE_test.py — the DES-FEEDBACK-001 slice-E gate: home metrics bar
+(§2) + repo profile visuals (§3), against the shared W2 fixture
+(uxfix_fixture.py) with the `metrics_ws` + `repo` switches on.
+
+The slice DOM ACs, verbatim from §8.3:
+
+  1. `[data-testid="metrics-bar"]` is present on the home board;
+  2. it contains `[data-testid="run-outcome-bar"]`,
+     `[data-testid="gate-latency-chart"]`, `[data-testid="token-burn-sparkline"]`
+     — each with a `data-question` attribute matching its §2.1 named question;
+  3. no `<script>` tags for chart libraries are in the page HTML;
+  4. every `fill`/`stroke` on chart elements resolves from `var()` references
+     (EC15) — EXCEPT the sanctioned linguist hexes on the repo page (§3.3, the
+     ONLY raw-color exemption in the codebase);
+  5. `[data-testid="language-bar"]` is present on the repo profile page.
+
+Plus what the slice means beyond its testids:
+
+  - WIRE HONESTY: the outcome bar buckets on the membership attach clock (the
+    one per-run timestamp the wire carries), the burn tile folds REAL cliUsage
+    frames (`costUsd: null` never becomes $0.00), the cadence chart lives at
+    the git-history wire's own resolution (20 commits, %ar relative dates);
+  - the wall + live feed are UNCHANGED beneath the bar (the slice-2 NEEDS YOU
+    order and the live feed still hold — §8.3 preservation);
+  - the quiet-band rows carry the 7-day ProjectSparkline (--ink-dim bars);
+  - under 900px the gate-latency tile hides (§2.2).
+
+DELIBERATELY NOT frozen-clock: the burn + latency tiles fold ARRIVAL clocks
+(Date.now at ingest); freezing the page clock would collapse every arrival to
+one instant and the cumulative fold to a point. Ages in these two captures are
+therefore approximate ("35s" not "30s") — every assertion is on structure, not
+rendered ages.
+
+Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback-E-home-metrics.png   the W2 board with the metrics bar populated
+  feedback-E-repo-profile.png   the repo profile: language bar, cadence, hotspots
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 (delete a stale dist-sameorigin/ when the source changed).
+Env knobs: FEEDBACK_PORT (default 4355), SKIP_STUDIO_BUILD. Prints a JSON
+report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4355"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# §2.1's named operator questions, verbatim (EC19).
+QUESTIONS = {
+    "run-outcome-bar": "Is the system healthy right now?",
+    "gate-latency-chart": "Am I answering gates quickly or letting things stall?",
+    "token-burn-sparkline": "What am I spending, is it accelerating?",
+}
+
+# The sanctioned linguist hexes (§3.3) as jsdom/Chromium-normalized rgb() —
+# the ONLY raw colors allowed anywhere, and only on the repo profile.
+LINGUIST_RGB = {
+    "typescript": "rgb(49, 120, 198)",   # #3178c6
+    "javascript": "rgb(247, 223, 30)",   # #f7df1e
+    "css":        "rgb(86, 61, 124)",    # #563d7c
+    "python":     "rgb(53, 114, 165)",   # #3572a5
+    "rust":       "rgb(222, 165, 132)",  # #dea584
+    "go":         "rgb(0, 173, 216)",    # #00add8
+}
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build ────────────────────────────────────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture, slice-E switches on ──────────────────────────────
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, metrics_ws=True, repo=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0,
+                                     "metrics_ws": True, "repo": True}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ══ Scene 1 — home board with the metrics bar (§2) ═════════════════════════
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="metrics-bar"]').wait_for(timeout=30000)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('13px "Inter"')
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    # Settle: outcome bar bucketed off the members read (4 in-window W2 runs),
+    # both open gates reconciled into latency dots, and the burn drip drained
+    # (4 costed frames — the costUsd:null one must NOT count).
+    outcome_ok = settled(
+        """() => document.querySelector('[data-testid="run-outcome-bar"]')
+                   ?.getAttribute('data-total') === '4'""")
+    gates_ok = settled(
+        """() => document.querySelector('[data-testid="gate-latency-chart"]')
+                   ?.getAttribute('data-open') === '2'""")
+    burn_ok = settled(
+        """() => document.querySelector('[data-testid="token-burn-sparkline"]')
+                   ?.getAttribute('data-points') === '4'""")
+
+    # §8.3 preservation: the slice-2 NEEDS YOU order + the live feed, unchanged.
+    order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+
+    home = page.evaluate(
+        """() => {
+             const bar = document.querySelector('[data-testid="metrics-bar"]');
+             const tile = (id) => bar ? bar.querySelector(`[data-testid="${id}"]`) : null;
+             const shapes = bar ? Array.from(bar.querySelectorAll(
+               'rect, circle, line, polyline, polygon, stop')) : [];
+             const paints = shapes.map((el) => ({
+               tag: el.tagName.toLowerCase(),
+               fill: el.getAttribute('fill'),
+               stroke: el.getAttribute('stroke'),
+               stop: el.getAttribute('stop-color'),
+             }));
+             // EC15: every painted attribute is a var() reference (the burn
+             // area's url(#gradient) is a reference INTO var()-colored stops).
+             const raw = paints.filter((p) => [p.fill, p.stroke, p.stop].some((v) =>
+               v !== null && v !== 'none' && !v.startsWith('var(--') && !v.startsWith('url(#')));
+             // And each var() resolves to a real computed color on screen.
+             const resolved = shapes.every((el) => {
+               const cs = getComputedStyle(el);
+               return (cs.fill === 'none' || cs.fill.startsWith('rgb') || cs.fill.startsWith('url'))
+                   && (cs.stroke === 'none' || cs.stroke.startsWith('rgb'));
+             });
+             const scripts = Array.from(document.querySelectorAll('script'))
+               .map((s) => s.getAttribute('src') || '')
+               .filter((src) => /chart|d3|recharts|echarts|plotly|highcharts/i.test(src));
+             const barCs = bar ? getComputedStyle(bar) : null;
+             return {
+               barPresent: !!bar,
+               barHeight: bar ? bar.getBoundingClientRect().height : null,
+               barAboveWall: (() => {
+                 const wall = document.querySelector('[data-testid="project-board"]');
+                 return !!bar && !!wall
+                   && bar.getBoundingClientRect().bottom <= wall.getBoundingClientRect().top + 1;
+               })(),
+               barBg: barCs ? barCs.backgroundColor : null,
+               railBg: (() => {
+                 const probe = document.createElement('div');
+                 probe.style.background = 'var(--surface-rail)';
+                 document.body.appendChild(probe);
+                 const c = getComputedStyle(probe).backgroundColor;
+                 probe.remove();
+                 return c;
+               })(),
+               questions: Object.fromEntries(
+                 ['run-outcome-bar', 'gate-latency-chart', 'token-burn-sparkline']
+                   .map((id) => [id, tile(id)?.getAttribute('data-question') ?? null])),
+               outcomeRects: tile('run-outcome-bar')?.querySelectorAll('rect').length ?? 0,
+               outcomeUnplaced: tile('run-outcome-bar')?.getAttribute('data-unplaced') ?? null,
+               gateDots: tile('gate-latency-chart')?.querySelectorAll('circle').length ?? 0,
+               thresholdDashed: tile('gate-latency-chart')
+                 ?.querySelector('line')?.getAttribute('stroke-dasharray') ?? null,
+               burnTotal: tile('token-burn-sparkline')?.getAttribute('data-total') ?? null,
+               burnText: tile('token-burn-sparkline')?.textContent ?? '',
+               rawPaints: raw,
+               computedResolved: resolved,
+               chartLibScripts: scripts,
+               liveFeedPresent: !!document.querySelector('[data-testid="live-feed"]'),
+             };
+           }"""
+    )
+
+    # ── Capture 1: the home board with the metrics bar populated ───────────────
+    page.screenshot(path=str(VSHOTS / "feedback-E-home-metrics.png"))
+
+    # ── The quiet-band 7-day sparkline (§2.1): expand QUIET, find smoke-tests —
+    #    its two runs attached 6d ago sit inside the window. --ink-dim bars. ──
+    page.locator('[data-testid="band-quiet-toggle"]').click()
+    # The quiet grid is WINDOWED against the board scroller — smoke-tests sorts
+    # near the tail, so scroll until its card mounts.
+    for _ in range(40):
+        if page.evaluate(
+            """() => !!document.querySelector(
+                 '[data-testid="project-card"][data-project-id="smoke-tests"]')"""
+        ):
+            break
+        at_bottom = page.evaluate(
+            """() => { const s = document.querySelector('[data-testid="project-board"]');
+                       if (!s) return true;
+                       s.scrollTop += Math.max(200, s.clientHeight / 2);
+                       return s.scrollTop + s.clientHeight >= s.scrollHeight - 2; }"""
+        )
+        page.wait_for_timeout(150)
+        if at_bottom:
+            break
+    page.locator('[data-testid="project-card"][data-project-id="smoke-tests"]').wait_for(timeout=10000)
+    quiet_spark = page.evaluate(
+        """() => {
+             const card = document.querySelector(
+               '[data-testid="project-card"][data-project-id="smoke-tests"]');
+             const spark = card ? card.querySelector('[data-testid="project-sparkline"]') : null;
+             const rects = spark ? Array.from(spark.querySelectorAll('rect')) : [];
+             return {
+               present: !!spark,
+               total: spark?.getAttribute('data-total') ?? null,
+               question: spark?.getAttribute('data-question') ?? null,
+               fills: rects.map((r) => r.getAttribute('fill')),
+             };
+           }"""
+    )
+    page.locator('[data-testid="band-quiet-toggle"]').click()  # collapse back
+    page.evaluate(
+        """() => { const s = document.querySelector('[data-testid="project-board"]');
+                   if (s) s.scrollTop = 0; }""")
+
+    # ── §2.2: under 900px the gate-latency tile hides ──────────────────────────
+    page.set_viewport_size({"width": 860, "height": 900})
+    narrow = page.evaluate(
+        """() => {
+             const mid = document.querySelector('.wk-metrics-mid');
+             return {
+               midHidden: mid ? getComputedStyle(mid).display === 'none' : false,
+               barPresent: !!document.querySelector('[data-testid="metrics-bar"]'),
+             };
+           }"""
+    )
+    page.set_viewport_size({"width": 1440, "height": 900})
+
+    # ══ Scene 2 — the repo profile (§3) ════════════════════════════════════════
+    page.goto(f"{ORIGIN}/repo-detail/studio-api", wait_until="domcontentloaded")
+    page.locator('[data-testid="language-bar"][data-state="ready"]').wait_for(timeout=30000)
+    page.locator('[data-testid="commit-cadence"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    repo = page.evaluate(
+        """(linguist) => {
+             const bar = document.querySelector('[data-testid="language-bar"]');
+             const segs = Array.from(document.querySelectorAll('[data-testid="language-segment"]'));
+             const cadence = document.querySelector('[data-testid="commit-cadence"]');
+             const cadenceRects = cadence
+               ? Array.from(cadence.querySelectorAll('rect')).map((r) => r.getAttribute('fill'))
+               : [];
+             const excerpt = document.querySelector('[data-testid="hotspots-excerpt"]');
+             const buttons = Array.from(document.querySelectorAll('button')).map((b) => b.textContent || '');
+             return {
+               barPresent: !!bar,
+               barState: bar?.getAttribute('data-state') ?? null,
+               segLangs: segs.map((s) => s.getAttribute('data-lang')),
+               // §3.3: the segments carry EXACTLY the sanctioned linguist colors
+               // (raw hex is legal here and nowhere else).
+               segColors: segs.map((s) => getComputedStyle(s).backgroundColor),
+               segSanctioned: segs.every((s) => {
+                 const lang = s.getAttribute('data-lang');
+                 const c = getComputedStyle(s).backgroundColor;
+                 return c === linguist[lang] || (!(lang in linguist) && c !== '');
+               }),
+               labelText: Array.from(document.querySelectorAll('[data-testid="language-label"]'))
+                 .map((l) => (l.textContent || '').trim()),
+               unitNamed: (bar?.textContent || '').includes('by files indexed'),
+               cadenceState: cadence?.getAttribute('data-state') ?? null,
+               cadenceTotal: cadence?.getAttribute('data-total') ?? null,
+               cadenceQuestion: cadence?.getAttribute('data-question') ?? null,
+               cadenceFillsVar: cadenceRects.length > 0
+                 && cadenceRects.every((f) => f && f.startsWith('var(--')),
+               cadenceCaption: (cadence?.textContent || ''),
+               excerptPresent: !!excerpt,
+               excerptCount: excerpt?.getAttribute('data-count') ?? null,
+               viewAllPresent: !!document.querySelector('[data-testid="hotspots-view-all"]'),
+               graphButtonPresent: buttons.some((t) => t.includes('Open Graph')),
+             };
+           }""",
+        LINGUIST_RGB,
+    )
+
+    # ── Capture 2: the repo profile with its visuals ────────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback-E-repo-profile.png"))
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["steps"]["metrics_bar"] = {
+    "ok": all([
+        fonts_ok, outcome_ok, gates_ok, burn_ok,
+        home["barPresent"],
+        home["barHeight"] == 64,
+        home["barAboveWall"],
+        home["barBg"] == home["railBg"],  # --surface-rail band (§2.2)
+        home["questions"] == QUESTIONS,   # EC19, verbatim
+        home["outcomeRects"] >= 3,        # run/gate/fail stacks over the 4 in-window runs
+        home["outcomeUnplaced"] == "4",   # legacy(8d) + smokes(6d) + clockless orphan: excluded, counted
+        home["gateDots"] == 2,
+        home["thresholdDashed"] == "3 3",
+        home["burnTotal"] == "0.4200",    # 0.04+0.11+0.09+0.18 — the null-cost frame did NOT fold
+        "$0.42" in home["burnText"],
+    ]),
+    "web_fonts": fonts_ok,
+    "outcome_settled": outcome_ok, "gates_settled": gates_ok, "burn_settled": burn_ok,
+    **{k: home[k] for k in ("barPresent", "barHeight", "barAboveWall", "barBg", "railBg",
+                            "questions", "outcomeRects", "outcomeUnplaced", "gateDots",
+                            "thresholdDashed", "burnTotal")},
+    "screenshot": str(VSHOTS / "feedback-E-home-metrics.png"),
+}
+report["steps"]["no_chart_library_and_ec15"] = {
+    "ok": all([
+        home["chartLibScripts"] == [],
+        home["rawPaints"] == [],
+        home["computedResolved"],
+    ]),
+    "chart_lib_scripts": home["chartLibScripts"],
+    "raw_paints": home["rawPaints"],
+    "computed_resolved": home["computedResolved"],
+}
+report["steps"]["board_preserved"] = {
+    "ok": all([order_ok, home["liveFeedPresent"]]),
+    "needs_you_order": order_ok,
+    "live_feed_present": home["liveFeedPresent"],
+}
+report["steps"]["quiet_sparkline"] = {
+    "ok": all([
+        quiet_spark["present"],
+        quiet_spark["total"] == "2",
+        quiet_spark["question"] == "Which of my quiet projects is quietly doing work?",
+        len(quiet_spark["fills"]) >= 1,
+        all(f == "var(--ink-dim)" for f in quiet_spark["fills"]),
+    ]),
+    **quiet_spark,
+}
+report["steps"]["narrow_hides_gate_tile"] = {
+    "ok": narrow["midHidden"] and narrow["barPresent"],
+    **narrow,
+}
+report["steps"]["repo_profile"] = {
+    "ok": all([
+        repo["barPresent"],
+        repo["barState"] == "ready",
+        # files per lang off the graph: ts 8, rust 3, python 2, js 1 — sorted.
+        repo["segLangs"] == ["typescript", "rust", "python", "javascript"],
+        repo["segSanctioned"],
+        repo["segColors"][0] == LINGUIST_RGB["typescript"],
+        any(l.startswith("TypeScript") for l in repo["labelText"]),
+        repo["unitNamed"],
+        repo["cadenceState"] == "ready",
+        repo["cadenceTotal"] == "14",     # 15 commits on the wire, 1 older than 30d
+        repo["cadenceQuestion"] == "Is this repo active or stagnant?",
+        repo["cadenceFillsVar"],
+        "last 15 commits" in repo["cadenceCaption"],
+        "1 older than 30d" in repo["cadenceCaption"],
+        repo["excerptPresent"],
+        repo["excerptCount"] == "5",
+        repo["viewAllPresent"],
+        repo["graphButtonPresent"],
+    ]),
+    **repo,
+    "screenshot": str(VSHOTS / "feedback-E-repo-profile.png"),
+}
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback-E-home-metrics.png"),
+    str(VSHOTS / "feedback-E-repo-profile.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceE_verdict", f"slice-E assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -45,6 +45,18 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     step 4; default 4.0s — long enough for the rig to shoot
                     the in-progress state, short enough for one 3s poll).
   reset_learn     — True clears every learned theme, so scenes start clean.
+  repo            — whether GET /repos carries the `studio-api` repo plus its
+                    graph / git-history / contributors routes (slice E's repo
+                    profile visuals; default False). Every field served is on
+                    the REAL crew wire: `RepoEntry` verbatim, graph nodes with
+                    estate's per-node `lang`, git-history commits dated with
+                    git `%ar` RELATIVE strings capped at 20 (routes.ts) —
+                    never an absolute date or a language field the daemon
+                    does not serve.
+  metrics_ws      — /ws drips ONE cliUsage frame per loop tick until the
+                    5-frame burn drains (slice E's token-burn tile; default
+                    False). Same real frame shape as usage_ws; drip-fed so
+                    the cumulative fold has more than one arrival instant.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -83,7 +95,8 @@ def iso(ms: int) -> str:
 # Mutable fixture switches, flipped over POST /__fixture between page loads.
 state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
-         "extra_narration": [], "demo": False, "learn_delay_s": 4.0}
+         "extra_narration": [], "demo": False, "learn_delay_s": 4.0,
+         "repo": False, "metrics_ws": False}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -313,6 +326,83 @@ def demo_frame(name: str) -> bytes:
     _demo_frames[name] = body
     return body
 
+# ── The slice-E repo profile surface (DES-FEEDBACK-001 §3): one indexed repo ──
+#
+# Behind the `repo` switch. Everything below is the REAL crew wire and nothing
+# more: `RepoEntry` verbatim (routes.ts RepoSchema — no language field, because
+# the daemon serves none); the code graph with estate's per-node `lang` (the
+# ONE language signal on the wire — the language bar derives from it); commits
+# from `git log --pretty=…%ar -n 20` — RELATIVE date strings, 20 max (the
+# cadence chart must live at that resolution, not a fabricated daily history).
+
+REPO_ID = "studio-api"
+REPO_ENTRY = {
+    "id": REPO_ID, "name": "studio-api", "root_path": "/tmp/w2/studio-api",
+    "default_branch": "main", "registered_at": NOW0 - 40 * DAY,
+    "git_url": "https://github.com/example/studio-api.git",
+    "code_graph_db": "/tmp/w2/studio-api/.wicked-estate/code_graph.db",
+}
+
+
+def _graph_node(i: int, name: str, kind: str, file: str, lang: str,
+                in_deg: int, out_deg: int) -> dict:
+    # The estate graph-view node shape crew relays verbatim (routes.ts):
+    # id/name/kind/file/lang/score/inDeg/outDeg.
+    return {"id": f"sym-{i}-{name}", "name": name, "kind": kind, "file": file,
+            "lang": lang, "score": round(0.9 - i * 0.04, 2),
+            "inDeg": in_deg, "outDeg": out_deg}
+
+
+REPO_GRAPH_NODES = [
+    _graph_node(0, "registerRoutes", "function", "src/api/routes.ts", "typescript", 31, 12),
+    _graph_node(1, "SessionStore", "class", "src/store/sessions.ts", "typescript", 24, 6),
+    _graph_node(2, "dispatchUnit", "function", "src/engine/dispatch.ts", "typescript", 19, 9),
+    _graph_node(3, "GateCache", "class", "src/engine/gates.ts", "typescript", 14, 4),
+    _graph_node(4, "wireContract", "interface", "src/api/contract.ts", "typescript", 11, 2),
+    _graph_node(5, "renderBoard", "function", "src/ui/board.ts", "typescript", 8, 7),
+    _graph_node(6, "useRuns", "function", "src/ui/hooks.ts", "typescript", 7, 3),
+    _graph_node(7, "parseArgs", "function", "src/cli/args.ts", "typescript", 5, 1),
+    _graph_node(8, "run_actor", "function", "core/src/actor.rs", "rust", 22, 8),
+    _graph_node(9, "EventLog", "struct", "core/src/event_log.rs", "rust", 16, 3),
+    _graph_node(10, "open_store", "function", "core/src/store.rs", "rust", 9, 5),
+    _graph_node(11, "evidence_check", "function", "scripts/evidence_check.py", "python", 4, 2),
+    _graph_node(12, "bundle_report", "function", "scripts/report.py", "python", 3, 1),
+    _graph_node(13, "legacyShim", "function", "shim/legacy.js", "javascript", 2, 1),
+]
+REPO_GRAPH = {
+    "nodes": REPO_GRAPH_NODES,
+    "edges": [{"src": REPO_GRAPH_NODES[i]["id"], "tgt": REPO_GRAPH_NODES[0]["id"]}
+              for i in range(1, 8)],
+    "stats": {"nodeCount": len(REPO_GRAPH_NODES), "edgeCount": 7,
+              "fileCount": len({n["file"] for n in REPO_GRAPH_NODES})},
+}
+
+# git %ar labels exactly as `git log --pretty=…%ar` prints them — day-or-finer
+# up to 13 days, then git's own week rounding, then months (out of the 30d
+# window on purpose: the cadence caption must count it, not paint it).
+REPO_COMMITS = [
+    ("2 hours ago", "tighten gate cache reconcile"),
+    ("5 hours ago", "fix: unit ordinal drift on redrive"),
+    ("26 hours ago", "routes: repo graph relay"),
+    ("2 days ago", "actor: single-writer store seam"),
+    ("2 days ago", "board: quiet band decay"),
+    ("3 days ago", "cli: args parser hardening"),
+    ("5 days ago", "evidence bundle v2"),
+    ("6 days ago", "event log: seq per envelope"),
+    ("9 days ago", "hooks: debounce runs refresh"),
+    ("11 days ago", "contract: additive frame fields"),
+    ("13 days ago", "dispatch: rework attempts"),
+    ("2 weeks ago", "store: WAL checkpoint tuning"),
+    ("3 weeks ago", "report script: markdown out"),
+    ("4 weeks ago", "shim: legacy import path"),
+    ("2 months ago", "initial carve-out"),
+]
+REPO_CONTRIBUTORS = [
+    {"commits": 42, "name": "Mika Ellis", "email": "mika@example.com"},
+    {"commits": 17, "name": "Ravi Chandra", "email": "ravi@example.com"},
+    {"commits": 6, "name": "Jo Beck", "email": "jo@example.com"},
+]
+
 # The chat surface (slice 4, §2.4): a four-seat roster and instant-warm chat
 # endpoints. Seats warm the moment they are asked — determinism over realism —
 # and the daemon's real semantics are kept where the client depends on them:
@@ -480,9 +570,26 @@ class W2Handler(SimpleHTTPRequestHandler):
         self.wfile.flush()
         with state_lock:
             push_usage = state["usage_ws"]
+            push_metrics = state["metrics_ws"]
         with ws_lock:
             ws_gen[0] += 1
             my_gen = ws_gen[0]
+        # Slice-E burn drip: the REAL cliUsage frame shape (costUsd dollars when
+        # the CLI reports them, null when unknown — the null one must never fold
+        # to $0), one frame per loop tick so the cumulative curve has more than
+        # one arrival instant. Per-connection, never re-armed in the loop.
+        burn_drip = [
+            {"type": "cliUsage", "session": "r-upload", "ord": 0, "attempt": 0,
+             "inputTokens": 21000, "outputTokens": 3000, "costUsd": 0.04},
+            {"type": "cliUsage", "session": "r-smoke1", "ord": 0, "attempt": 0,
+             "inputTokens": 40000, "outputTokens": 9000, "costUsd": 0.11},
+            {"type": "cliUsage", "session": "r-upload", "ord": 0, "attempt": 1,
+             "inputTokens": 18000, "outputTokens": 2500, "costUsd": None},
+            {"type": "cliUsage", "session": "r-smoke2", "ord": 0, "attempt": 0,
+             "inputTokens": 33000, "outputTokens": 7000, "costUsd": 0.09},
+            {"type": "cliUsage", "session": "r-upload", "ord": 0, "attempt": 2,
+             "inputTokens": 52000, "outputTokens": 12000, "costUsd": 0.18},
+        ] if push_metrics else []
         try:
             # Slice-5 switch: the Build stats footer folds cliUsage events, so the
             # frame is pushed ONCE per connection (never in the loop — a repeated
@@ -519,6 +626,9 @@ class W2Handler(SimpleHTTPRequestHandler):
                         "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
                         "text": str(line) + "\n",
                     }))
+                # One burn frame per tick until the slice-E drip drains.
+                if newest and burn_drip:
+                    self.wfile.write(ws_frame(burn_drip.pop(0)))
                 self.wfile.write(ws_frame({
                     "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
                     "text": NARRATION + "\n",
@@ -560,7 +670,29 @@ class W2Handler(SimpleHTTPRequestHandler):
             self._json(200, {"projects": PROJECTS})
             return True
         if path == "/api/v1/repos":
-            self._json(200, {"repos": []})
+            with state_lock:
+                repo_on = state["repo"]
+            self._json(200, {"repos": [REPO_ENTRY] if repo_on else []})
+            return True
+        # The slice-E repo profile reads (all real crew routes, switch-gated).
+        m = re.match(r"^/api/v1/repos/([^/]+)/(graph|git-history|contributors)$", path)
+        if m:
+            rid, leaf = urllib.parse.unquote(m.group(1)), m.group(2)
+            with state_lock:
+                repo_on = state["repo"]
+            if not repo_on or rid != REPO_ID:
+                self._json(404, {"error": f"Repo {rid} not found"})
+                return True
+            if leaf == "graph":
+                self._json(200, {"graph": REPO_GRAPH})
+            elif leaf == "git-history":
+                self._json(200, {"commits": [
+                    {"sha": f"{i:07x}{'0' * 33}", "shortSha": f"{i:07x}",
+                     "message": msg, "author": "Mika Ellis", "date": date}
+                    for i, (date, msg) in enumerate(REPO_COMMITS)
+                ]})
+            else:
+                self._json(200, {"contributors": REPO_CONTRIBUTORS})
             return True
         if path == "/api/v1/roster":
             self._json(200, {"roster": ROSTER})

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -13,9 +13,14 @@ same branch converts):
   2. a run row's computed `border-left-color` matches `--status-gate` when
      that run is at `awaiting_human` (and, same mechanism: `--status-run`
      while executing, `--status-fail` when failed);
-  3. the Chat mode first-run state shows the instruction text and
-     `data-testid="add-agents"` is present but NO openChat request
-     (`POST /api/v1/chats`) fires on mount;
+  3. the Chat mode first-run state shows the instruction text and NO openChat
+     request (`POST /api/v1/chats`) fires on mount. (RE-SCOPED to the
+     DES-FEEDBACK-001 §6 chips reality, which slice C shipped: the pre-slice-C
+     `add-agents` opt-in this AC originally pinned no longer exists — the
+     default agent chips render from `DEFAULT_CHAT_AGENTS` with a `✕` each,
+     and the `[+ Add]` affordance (`data-testid="add-agent"`, dashed border,
+     --ink-dim) opens the roster picker. Zero-requests-on-mount is UNCHANGED —
+     the chips render from the cached roster / fallback constant, §6.1.);
   4. the version strip's active dot computed `background` resolves from
      `var(--accent)`; the Themes popover `data-testid="themes-explanation"`
      is non-empty. (The storyboard-chapter accent AC retired with the
@@ -31,7 +36,7 @@ UXFIX composition), EC10, EC11 (no ornament), EC13 (two typefaces — intent
 labels sans, status words/narration/stamps mono), EC15 (computed styles
 resolve from the tokens), and the §6.3 preservation lists (Build purpose
 always visible, no campaigns panel, intent labels never raw prompts; Chat
-single-agent default with the Add-agents opt-in; Document three-pane +
+zero-requests-on-mount with the §6 default chips; Document three-pane +
 cross-link; Video narration naming its subject). The §5.5 cross-link flash
 (wk-anchor-flash, one run) is asserted live.
 
@@ -169,7 +174,13 @@ with sync_playwright() as p:
         f"""() => {{
              const probes = ({PROBES})();
              const instruction = document.querySelector('[data-testid="chat-firstrun-instruction"]');
-             const add = document.querySelector('[data-testid="add-agents"]');
+             // The §6 chips reality (DES-FEEDBACK-001, slice C): default agent
+             // chips + the separate [+ Add] affordance — the pre-slice-C
+             // "add-agents" opt-in this scene originally pinned is gone.
+             const chipsBar = document.querySelector('[data-testid="agent-chips-bar"]');
+             const chips = Array.from(document.querySelectorAll('[data-testid="agent-chip"]'));
+             const add = document.querySelector('[data-testid="add-agent"]');
+             const addCs = add ? getComputedStyle(add) : null;
              const composer = document.querySelector('textarea.wk-composer');
              const cs = composer ? getComputedStyle(composer) : null;
              return {{
@@ -177,8 +188,13 @@ with sync_playwright() as p:
                instructionText: instruction ? instruction.textContent : null,
                instructionColor: instruction ? getComputedStyle(instruction).color : null,
                instructionFont: instruction ? getComputedStyle(instruction).fontFamily : null,
-               addAgentsPresent: !!add,
-               addAgentsColor: add ? getComputedStyle(add).color : null,
+               chipsBarCount: chipsBar ? chipsBar.getAttribute('data-count') : null,
+               chipAgents: chips.map(c => c.getAttribute('data-agent')),
+               chipFont: chips[0] ? getComputedStyle(chips[0]).fontFamily : null,
+               chipColor: chips[0] ? getComputedStyle(chips[0]).color : null,
+               addAgentPresent: !!add,
+               addAgentColor: addCs ? addCs.color : null,
+               addAgentBorderStyle: addCs ? addCs.borderTopStyle : null,
                composerBg: cs ? cs.backgroundColor : null,
                composerRadius: cs ? cs.borderRadius : null,
              }}; }}""")
@@ -191,12 +207,19 @@ with sync_playwright() as p:
         (chat["instructionText"] or "").strip() != "",
         chat["instructionColor"] == pr["inkBody"],
         "Inter" in (chat["instructionFont"] or ""),
-        chat["addAgentsPresent"],
-        chat["addAgentsColor"] == pr["accent"],
+        # §6.2: three default chips render immediately from the cache/fallback.
+        chat["chipsBarCount"] == "3",
+        chat["chipAgents"] == ["writer", "reviewer", "planner"],
+        # EC13: chip text in the sans; §6.3 anatomy — [+ Add] dashed, --ink-dim.
+        "Inter" in (chat["chipFont"] or ""),
+        chat["chipColor"] == pr["inkBody"],
+        chat["addAgentPresent"],
+        chat["addAgentColor"] == pr["inkDim"],
+        chat["addAgentBorderStyle"] == "dashed",
         chat["composerBg"] == pr["surfaceRaised"],
         chat["composerRadius"] == "16px",
         pr["accentDim"] in ring and pr["accent"] not in ring,
-        len(chat_posts) == 0,  # AC 3: NO openChat fired on mount
+        len(chat_posts) == 0,  # AC 3 (unchanged): NO openChat fired on mount
     ])
     page.screenshot(path=str(VSHOTS / "vision-4-chat-firstrun.png"))
     report["steps"]["chat_firstrun"] = {

--- a/src/components/CommitCadence.tsx
+++ b/src/components/CommitCadence.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from 'react';
+import type { GitCommit } from '../api/types.js';
+import { RunSparkline } from './RunSparkline.js';
+
+/**
+ * Commit cadence sparkline (DES-FEEDBACK-001 §3.1, slice E): "Is this repo
+ * active or stagnant?" — daily commit bars over the last 30 days, SVG-first
+ * via the shared RunSparkline.
+ *
+ * WIRE HONESTY — the resolution. The crew wire (`GET /repos/:id/git-history`)
+ * returns AT MOST 20 commits, dated with git's `%ar` RELATIVE strings
+ * ("3 hours ago", "2 days ago", "3 weeks ago") — there is no absolute commit
+ * date on this wire. So:
+ *   - each commit is placed at the day its own label names (git's rounding,
+ *     rendered verbatim: "2 weeks ago" lands at day 14) — never at an
+ *     invented finer time;
+ *   - labels coarser than the window ("2 months ago", "1 year ago") are NOT
+ *     painted into a day — they count into the "older" tally the caption
+ *     reports;
+ *   - the caption says "last N commits", because 20 recent commits is what
+ *     the wire carries, not a complete 30-day history;
+ *   - an unparseable date drops the commit from the chart (counted as older),
+ *     never lands it at a made-up day.
+ */
+
+const DAYS = 30;
+
+/**
+ * Days-ago for one git `%ar` label (defensively also accepts an absolute date,
+ * should the wire ever gain one), or `null` when the label is coarser than a
+ * day-in-window placement allows (months/years) or unparseable.
+ */
+export function daysAgoOf(date: string, now: number = Date.now()): number | null {
+  const m = /^(\d+)\s+(second|minute|hour|day|week)s?\s+ago$/.exec(date.trim());
+  if (m !== null) {
+    const n = Number(m[1]);
+    const unit = m[2];
+    if (unit === 'second' || unit === 'minute') return 0;
+    if (unit === 'hour') return n >= 24 ? Math.floor(n / 24) : 0;
+    if (unit === 'day') return n;
+    return n * 7; // weeks — git's own rounding, placed at the day it names
+  }
+  const parsed = Date.parse(date);
+  if (!Number.isNaN(parsed)) {
+    const days = Math.floor((now - parsed) / 86_400_000);
+    return days >= 0 ? days : null;
+  }
+  return null;
+}
+
+interface Props {
+  /** `null` = still loading (the page's decoupled git fetch). */
+  commits: GitCommit[] | null;
+  now?: number;
+}
+
+export function CommitCadence({ commits, now }: Props): React.ReactElement {
+  const at = now ?? Date.now();
+  const { counts, inWindow, older } = useMemo(() => {
+    const buckets = new Array<number>(DAYS).fill(0);
+    let painted = 0;
+    let outside = 0;
+    for (const c of commits ?? []) {
+      const days = daysAgoOf(c.date, at);
+      if (days === null || days >= DAYS) {
+        outside += 1;
+        continue;
+      }
+      const bucket = DAYS - 1 - days;
+      buckets[bucket] = (buckets[bucket] ?? 0) + 1;
+      painted += 1;
+    }
+    return { counts: buckets, inWindow: painted, older: outside };
+  }, [commits, at]);
+
+  if (commits === null) {
+    return (
+      <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)', margin: 0 }}>
+        Loading commit history…
+      </p>
+    );
+  }
+
+  if (commits.length === 0) {
+    return (
+      <div data-testid="commit-cadence" data-state="empty">
+        <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)', margin: 0 }}>
+          No commits yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="commit-cadence"
+      data-state={inWindow > 0 ? 'ready' : 'older-only'}
+      data-total={inWindow}
+      data-question="Is this repo active or stagnant?"
+    >
+      {inWindow > 0 ? (
+        <RunSparkline counts={counts} width={280} height={36} color="var(--accent)" testId="commit-cadence-svg" />
+      ) : (
+        <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)', margin: 0 }}>
+          Nothing in the last 30 days.
+        </p>
+      )}
+      <p
+        className="text-[10px] font-mono"
+        style={{ color: 'var(--ink-dim)', margin: '6px 0 0' }}
+      >
+        last {commits.length} {commits.length === 1 ? 'commit' : 'commits'}
+        {older > 0 ? ` · ${older} older than 30d` : ''} · day precision from git relative dates
+      </p>
+    </div>
+  );
+}

--- a/src/components/GateLatencyChart.tsx
+++ b/src/components/GateLatencyChart.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import { useGateStore } from '../store/gates.js';
+import { useRuntimeStore } from '../store/runtime.js';
+import { MetricTile } from './MetricTile.js';
+
+/**
+ * Gate latency scatter (DES-FEEDBACK-001 §2.1/§2.3, slice E): the home
+ * metrics-bar tile answering "Am I answering gates quickly or letting things
+ * stall?". SVG-first, no chart library: one `<circle>` per gate (x = when it
+ * opened, y = minutes until it was answered), with the dashed 30-minute
+ * threshold rule in `--status-gate-dim`.
+ *
+ * WIRE HONESTY — the clocks. The `awaitingHuman` / `gateDecided` event types
+ * exist exactly as §2.4 named them, but a live `/ws` frame carries NO `ts`
+ * (arrival IS the time), so the raw event store cannot time them. Two stores
+ * the app already fills carry honest clocks instead:
+ *
+ *   - ANSWERED gates: the runtime store's per-run log stamps every structured
+ *     frame with an arrival `ts` — pairing each `awaitingHuman` entry with the
+ *     next `gateDecided`/`resumed` in the same run's log gives a real observed
+ *     latency (scoped to what this page has watched — no polling backfill).
+ *   - OPEN gates: the gate store's `receivedAt` (the daemon-cached server ISO
+ *     on reconcile, arrival time live) — elapsed-so-far is the stall signal
+ *     the question is really about.
+ *
+ * Zero new requests: both stores are fed by the app's one `/ws` subscription
+ * plus the `useRuns` reconcile that already runs.
+ */
+
+const DAY_MS = 24 * 3_600_000;
+/** The §2.2 threshold: gates answered slower than this are stalling. */
+const THRESHOLD_MIN = 30;
+/** y-axis ceiling in minutes — slower gates clamp to the top. */
+const MAX_MIN = 60;
+const W = 168;
+const H = 26;
+const R = 2.5;
+
+export interface GatePoint {
+  /** When the gate opened (epoch ms). */
+  openedAt: number;
+  /** Minutes open → answered (answered) or open → now (still open). */
+  minutes: number;
+  open: boolean;
+}
+
+interface Props {
+  now?: number;
+}
+
+export function GateLatencyChart({ now }: Props): React.ReactElement {
+  const logs = useRuntimeStore((s) => s.logs);
+  const gates = useGateStore((s) => s.gates);
+  const at = now ?? Date.now();
+
+  const points = useMemo(() => {
+    const pts: GatePoint[] = [];
+    // Answered pairs, from the arrival-stamped per-run logs.
+    for (const log of Object.values(logs)) {
+      let pending: number | null = null;
+      for (const entry of log) {
+        if (entry.type === 'awaitingHuman') {
+          pending = entry.ts;
+        } else if (pending !== null && (entry.type === 'gateDecided' || entry.type === 'resumed')) {
+          pts.push({ openedAt: pending, minutes: (entry.ts - pending) / 60_000, open: false });
+          pending = null;
+        }
+      }
+    }
+    // Still-open gates: elapsed so far, off the gate store's receivedAt.
+    for (const gate of Object.values(gates)) {
+      pts.push({ openedAt: gate.receivedAt, minutes: (at - gate.receivedAt) / 60_000, open: true });
+    }
+    return pts.filter((p) => at - p.openedAt <= DAY_MS && p.minutes >= 0);
+  }, [logs, gates, at]);
+
+  const answered = points.filter((p) => !p.open);
+  const open = points.filter((p) => p.open);
+  const avg = answered.length > 0
+    ? answered.reduce((a, p) => a + p.minutes, 0) / answered.length
+    : null;
+
+  const value =
+    points.length === 0
+      ? 'no gates'
+      : [
+          avg !== null ? `avg ${avg < 1 ? '<1' : Math.round(avg)}m` : null,
+          open.length > 0 ? `${open.length} open` : null,
+        ].filter((s) => s !== null).join(' · ');
+
+  const x = (openedAt: number): number => ((openedAt - (at - DAY_MS)) / DAY_MS) * W;
+  const y = (minutes: number): number => H - (Math.min(minutes, MAX_MIN) / MAX_MIN) * (H - R) - R / 2;
+  const thresholdY = y(THRESHOLD_MIN);
+
+  return (
+    <MetricTile
+      testId="gate-latency-chart"
+      question="Am I answering gates quickly or letting things stall?"
+      title="Gate latency"
+      value={value}
+      data={{ 'data-count': points.length, 'data-open': open.length }}
+    >
+      {points.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No gates in the last 24h.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={H}
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`gate response times: ${value}`}
+          style={{ display: 'block', overflow: 'visible' }}
+        >
+          {/* The 30-minute stall threshold (§2.3). */}
+          <line
+            x1={0}
+            y1={thresholdY}
+            x2={W}
+            y2={thresholdY}
+            stroke="var(--status-gate-dim)"
+            strokeWidth={1}
+            strokeDasharray="3 3"
+          />
+          {points.map((p, i) => (
+            <circle
+              key={i}
+              cx={Math.max(R, Math.min(W - R, x(p.openedAt)))}
+              cy={y(p.minutes)}
+              r={R}
+              fill="var(--status-gate)"
+              data-open={p.open}
+            />
+          ))}
+        </svg>
+      )}
+    </MetricTile>
+  );
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SessionView } from '../api/types.js';
 import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { modePath } from '../hooks/useRoute.js';
+import { GateLatencyChart } from './GateLatencyChart.js';
 import { LiveFeed } from './LiveFeed.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
+import { ProjectSparkline } from './ProjectSparkline.js';
+import { RunOutcomeBar } from './RunOutcomeBar.js';
+import { TokenBurnSparkline } from './TokenBurnSparkline.js';
 
 /**
  * The orchestrator home board (DES-MERGE-001 §1.2/§1.4; bands per DES-UXFIX-001
@@ -28,6 +32,13 @@ import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js'
  * (left, ~68%) beside the LIVE FEED (right, ~32%) — the one place cross-project
  * narration aggregates — and every color on the surface resolves from a semantic
  * token (§2.11, lint-enforced at ERROR for this file).
+ *
+ * Feedback slice E (DES-FEEDBACK-001 §2): a 64px METRICS BAR sits between the
+ * chrome and the wall — three SVG-first tiles, each answering a §2.1 named
+ * operator question (EC19), all derived from stores the page already holds
+ * (zero new requests). The bar AUGMENTS the wall and the live feed; neither
+ * changes beneath it. The gate-latency tile hides under 900px (§2.2 — the
+ * least critical at a glance; `.wk-metrics-mid` in global.css).
  */
 
 /** Card gap — §1.3's composition (blocks and cards sit 8px apart, `--space-2`). */
@@ -162,9 +173,33 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     onClick: (e) => { e.preventDefault(); navigate(path); },
   });
 
+  // The run-outcome tile buckets on the one honest per-run clock the board
+  // already fetched — the membership attach times, merged across projects.
+  const attachedAt = useMemo(() => {
+    const merged: Record<string, number> = {};
+    for (const item of items) Object.assign(merged, item.attachedAt);
+    return merged;
+  }, [items]);
+
   return (
-    // §1.3's composition: the status wall (left) beside the live feed (right).
-    <div className="flex flex-1 overflow-hidden" style={{ background: 'var(--surface-base)' }}>
+    // §1.3's composition — with slice E's metrics bar (§2.2) banded above it.
+    <div className="flex flex-1 flex-col overflow-hidden" style={{ background: 'var(--surface-base)' }}>
+      <div
+        data-testid="metrics-bar"
+        style={{
+          height: '64px', flexShrink: 0, display: 'flex', alignItems: 'stretch',
+          background: 'var(--surface-rail)', padding: '0 var(--space-3)',
+        }}
+      >
+        <RunOutcomeBar runs={runs} attachedAt={attachedAt} />
+        {/* Hidden under 900px (§2.2) — the media query lives in global.css. */}
+        <div className="wk-metrics-mid" style={{ display: 'flex', flex: 1, minWidth: 0 }}>
+          <GateLatencyChart />
+        </div>
+        <TokenBurnSparkline />
+      </div>
+
+      <div className="flex min-w-0 flex-1 overflow-hidden">
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
       <header
         style={{
@@ -291,6 +326,9 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                   >
                     <span aria-hidden style={{ color: 'var(--ink-dim)' }}>○</span>
                     {i.project.name}
+                    {/* Slice E (§2.1): which quiet project is quietly doing work —
+                        7-day activity inline, off the honest attach clock. */}
+                    <ProjectSparkline runs={i.runs} attachedAt={i.attachedAt} />
                     <span style={{ color: 'var(--ink-dim)' }}>
                       · {ago(i.signal?.at ?? i.project.updated_at)}
                     </span>
@@ -348,6 +386,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
       {/* The live feed (§1.3 right column): all projects with moving runs,
           narrating off the SAME runtime store the cards read — zero new sockets. */}
       <LiveFeed items={items} navigate={navigate} />
+      </div>
     </div>
   );
 }

--- a/src/components/LanguageBar.tsx
+++ b/src/components/LanguageBar.tsx
@@ -1,0 +1,109 @@
+/**
+ * Language composition bar (DES-FEEDBACK-001 §3.1/§3.3, slice E): "What is
+ * this repo actually built of?" — a proportional segmented bar + labels.
+ *
+ * WIRE HONESTY — where the breakdown comes from. `RepoEntry` carries NO
+ * language field; the real language signal on this wire is the `lang` each
+ * `CodeGraphNode` carries (`GET /repos/:id/graph`, estate indexing). The page
+ * derives files-per-language from the graph it already fetched and passes it
+ * here; no graph yet ⇒ the honest not-indexed state, never an invented mix.
+ * The unit is FILES INDEXED (not linguist's bytes) and the label says so.
+ *
+ * COLOR EXEMPTION (§3.3): language colors are a universal developer convention
+ * (GitHub's linguist palette); overriding them with the token accent would
+ * make TypeScript look indigo-violet, destroying recognition. This is the ONLY
+ * sanctioned raw-color exemption in the codebase — each literal carries the
+ * design's lint comment. Unlisted languages fall back to `var(--ink-dim)`.
+ */
+
+/** linguist display names + hex, keyed by estate's lowercase `lang` values. */
+const LANG_META: Record<string, { label: string; color: string }> = {
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  typescript: { label: 'TypeScript', color: '#3178c6' },
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  javascript: { label: 'JavaScript', color: '#f7df1e' },
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  css: { label: 'CSS', color: '#563d7c' },
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  python: { label: 'Python', color: '#3572a5' },
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  rust: { label: 'Rust', color: '#dea584' },
+  // eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token
+  go: { label: 'Go', color: '#00add8' },
+};
+const FALLBACK = 'var(--ink-dim)';
+
+const MAX_LABELS = 4;
+
+export function langMeta(lang: string): { label: string; color: string } {
+  return LANG_META[lang.toLowerCase()] ?? {
+    label: lang.charAt(0).toUpperCase() + lang.slice(1) || 'Other',
+    color: FALLBACK,
+  };
+}
+
+interface Props {
+  /** lowercase `lang` → files indexed, or `null` when the graph is not built. */
+  breakdown: Record<string, number> | null;
+}
+
+export function LanguageBar({ breakdown }: Props): React.ReactElement {
+  const entries = breakdown === null ? [] : Object.entries(breakdown).filter(([, n]) => n > 0);
+  const total = entries.reduce((a, [, n]) => a + n, 0);
+
+  if (breakdown === null || total === 0) {
+    return (
+      <div data-testid="language-bar" data-state="empty">
+        <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)', margin: 0 }}>
+          Language mix not indexed yet — run onboarding to build the code graph.
+        </p>
+      </div>
+    );
+  }
+
+  const sorted = entries.sort(([, a], [, b]) => b - a);
+
+  return (
+    <div data-testid="language-bar" data-state="ready" data-langs={sorted.length}>
+      <div
+        style={{
+          display: 'flex',
+          height: '8px',
+          borderRadius: 'var(--radius-full)',
+          overflow: 'hidden',
+        }}
+      >
+        {sorted.map(([lang, files]) => (
+          <div
+            key={lang}
+            data-testid="language-segment"
+            data-lang={lang}
+            title={`${langMeta(lang).label} — ${files} ${files === 1 ? 'file' : 'files'}`}
+            style={{ flexBasis: `${(files / total) * 100}%`, background: langMeta(lang).color }}
+          />
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: '16px', marginTop: '6px', flexWrap: 'wrap', alignItems: 'baseline' }}>
+        {sorted.slice(0, MAX_LABELS).map(([lang, files]) => (
+          <span
+            key={lang}
+            data-testid="language-label"
+            style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-sans)' }}
+          >
+            <span
+              aria-hidden
+              style={{
+                display: 'inline-block', width: '8px', height: '8px', borderRadius: '2px',
+                background: langMeta(lang).color, marginRight: '4px',
+              }}
+            />
+            {langMeta(lang).label} {Math.round((files / total) * 100)}%
+          </span>
+        ))}
+        <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          by files indexed
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MetricTile.tsx
+++ b/src/components/MetricTile.tsx
@@ -1,0 +1,70 @@
+/**
+ * The shared shell of one home metrics-bar tile (DES-FEEDBACK-001 §2.2, slice E):
+ * a 2xs uppercase title on the left, the current value in mono on the right,
+ * and the SVG chart beneath — compact enough to live inside the 64px band.
+ *
+ * Every tile carries a `data-question` attribute naming the operator question
+ * it answers, verbatim from §2.1 (EC19): a chart without a question is
+ * decoration and is rejected.
+ */
+
+interface Props {
+  testId: string;
+  /** The §2.1 named operator question, verbatim (EC19). */
+  question: string;
+  title: string;
+  /** The current-value caption (mono, right-aligned). */
+  value: string;
+  /** Extra data-* attributes for the rigs. */
+  data?: Record<string, string | number>;
+  children: React.ReactNode;
+}
+
+export function MetricTile({ testId, question, title, value, data, children }: Props): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      data-question={question}
+      {...data}
+      style={{
+        flex: 1,
+        minWidth: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        gap: '4px',
+        padding: '0 var(--space-3)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0 }}>
+        <span
+          style={{
+            fontSize: 'var(--text-2xs)',
+            fontWeight: 'var(--weight-bold)',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'var(--ink-dim)',
+            fontFamily: 'var(--font-sans)',
+            flexShrink: 0,
+          }}
+        >
+          {title}
+        </span>
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontSize: 'var(--text-2xs)',
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--ink-muted)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {value}
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -7,6 +7,7 @@ import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
 import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
+import { ProjectSparkline } from './ProjectSparkline.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { STATUS_STYLE } from './RunCard.js';
@@ -345,15 +346,20 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
               Start by describing what you want →
             </a>
           ) : (
-            <p
-              data-testid="quiet-summary"
-              style={{
-                marginLeft: 'auto', flexShrink: 0, fontSize: 'var(--text-xs)',
-                color: 'var(--ink-dim)', margin: 0,
-              }}
-            >
-              Quiet — last active {ago(signal?.at ?? project.updated_at)} ago
-            </p>
+            <>
+              <p
+                data-testid="quiet-summary"
+                style={{
+                  marginLeft: 'auto', flexShrink: 0, fontSize: 'var(--text-xs)',
+                  color: 'var(--ink-dim)', margin: 0,
+                }}
+              >
+                Quiet — last active {ago(signal?.at ?? project.updated_at)} ago
+              </p>
+              {/* Slice E (DES-FEEDBACK-001 §2.1): the 7-day activity sparkline in the
+                  quiet row — renders nothing when the window is empty (§2.3). */}
+              <ProjectSparkline runs={runs} attachedAt={item.attachedAt} />
+            </>
           )}
         </div>
         {/* Compact on a quiet card — a calm board is scanned, not operated (W2);

--- a/src/components/ProjectSparkline.tsx
+++ b/src/components/ProjectSparkline.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import type { SessionView } from '../api/types.js';
+import { RunSparkline } from './RunSparkline.js';
+
+/**
+ * The quiet-row 7-day activity sparkline (DES-FEEDBACK-001 §2.1/§2.3, slice E):
+ * 16×56, `--ink-dim` bars, one bucket per day — answering "Which of my quiet
+ * projects is quietly doing work?" inline in the quiet-band project row.
+ *
+ * Counted off the membership `attached_at` clock — when each run entered the
+ * project, the one per-run timestamp the wire carries (`AgentSession` has no
+ * timestamps) — exactly as the slice-D dashboard's activity tile counts. A
+ * project with zero in-window runs renders NOTHING: absence stays absent
+ * (§2.3 — transparent, never zero-height slivers).
+ */
+
+const DAY = 24 * 3_600_000;
+const DAYS = 7;
+
+interface Props {
+  runs: SessionView[];
+  /** Run id → membership `attached_at` (epoch ms) for THIS project. */
+  attachedAt: Record<string, number>;
+  now?: number;
+}
+
+export function ProjectSparkline({ runs, attachedAt, now }: Props): React.ReactElement | null {
+  const at = now ?? Date.now();
+  const counts = useMemo(() => {
+    const buckets = new Array<number>(DAYS).fill(0);
+    for (const v of runs) {
+      const clock = attachedAt[v.session.id];
+      if (clock === undefined) continue;
+      const age = at - clock;
+      if (age < 0 || age >= DAYS * DAY) continue;
+      const bucket = DAYS - 1 - Math.floor(age / DAY);
+      buckets[bucket] = (buckets[bucket] ?? 0) + 1;
+    }
+    return buckets;
+  }, [runs, attachedAt, at]);
+
+  if (counts.every((c) => c === 0)) return null;
+
+  return (
+    <span
+      data-testid="project-sparkline"
+      data-question="Which of my quiet projects is quietly doing work?"
+      data-total={counts.reduce((a, c) => a + c, 0)}
+      title={`runs entering this project, last ${DAYS} days`}
+      style={{ display: 'inline-flex', flexShrink: 0 }}
+    >
+      <RunSparkline counts={counts} width={56} height={16} color="var(--ink-dim)" />
+    </span>
+  );
+}

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api/client.js';
+import { CommitCadence } from './CommitCadence.js';
+import { HotspotsView } from './HotspotsView.js';
+import { LanguageBar } from './LanguageBar.js';
 import { RequirementsModal } from './RequirementsModal.js';
 import type { CodeGraphData, GitCommit, GitContributor, RepoEntry, SessionView } from '../api/types.js';
 import { RunLink } from './RunLink.js';
@@ -85,6 +88,26 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
         .sort((a, b) => b.inDeg - a.inDeg)
         .slice(0, 5)
     : [];
+
+  // Language mix (DES-FEEDBACK-001 §3.3): files indexed per language, derived
+  // from the code graph's per-node `lang` — the one language signal this wire
+  // carries (`RepoEntry` has none). No graph ⇒ `null` ⇒ the honest empty state.
+  const langBreakdown: Record<string, number> | null = (() => {
+    if (!graph) return null;
+    const filesByLang = new Map<string, Set<string>>();
+    for (const n of graph.nodes) {
+      if (!n.file || n.file.startsWith('node_modules/')) continue;
+      const lang = (n.lang || 'other').toLowerCase();
+      let files = filesByLang.get(lang);
+      if (files === undefined) {
+        files = new Set<string>();
+        filesByLang.set(lang, files);
+      }
+      files.add(n.file);
+    }
+    if (filesByLang.size === 0) return null;
+    return Object.fromEntries([...filesByLang].map(([lang, files]) => [lang, files.size]));
+  })();
 
   const displayedRuns = expanded ? runs : runs.slice(0, 10);
 
@@ -213,6 +236,11 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
         ))}
       </div>
 
+      {/* Language composition (§3.3) — what this repo is actually built of. */}
+      <Section title="Languages">
+        <LanguageBar breakdown={langBreakdown} />
+      </Section>
+
       {/* Active Now */}
       {active.length > 0 && (
         <Section title="Active Now">
@@ -249,56 +277,33 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
             </Section>
           )}
 
-          {/* Code Hotspots */}
+          {/* Code Hotspots — the inline excerpt (§3.4): the REAL HotspotsView,
+              top 5, surfaced here rather than only behind the modal. The full
+              view (and the CytoGraph) stay behind [Graph ›] / "View all →". */}
           <Section title="Code Hotspots">
             {hotspots.length === 0 ? (
               <p className="text-sm font-mono italic" style={{ color: 'var(--ink-dim)' }}>
                 Graph not yet indexed — run onboarding to build it.
               </p>
             ) : (
-              <div className="flex flex-col gap-2">
-                {hotspots.map((node, i) => (
-                  <div
-                    key={node.id}
-                    className="flex items-center gap-3 px-3 py-2 rounded-lg"
-                    style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
-                  >
-                    <span
-                      className="text-[10px] font-mono w-4 text-right shrink-0"
-                      style={{ color: 'var(--ink-dim)' }}
-                    >
-                      {i + 1}
-                    </span>
-                    <span
-                      className="flex-1 text-xs font-mono truncate"
-                      style={{ color: 'var(--ink-body)' }}
-                      title={node.file}
-                    >
-                      {node.file}
-                    </span>
-                    <span
-                      className="shrink-0 text-[10px] font-mono px-2 py-0.5 rounded"
-                      style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
-                    >
-                      {node.inDeg} edges
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => onOpenGraph()}
-                      className="shrink-0 text-[10px] font-mono hover:underline"
-                      style={{ color: 'var(--ink-dim)' }}
-                    >
-                      → Graph
-                    </button>
-                  </div>
-                ))}
+              <div data-testid="hotspots-excerpt" data-count={hotspots.length}>
+                <div
+                  className="rounded-lg overflow-hidden"
+                  style={{ border: '1px solid var(--surface-raised)' }}
+                >
+                  <HotspotsView
+                    nodes={hotspots}
+                    onSelect={(node) => onOpenGraph(node.name || node.id)}
+                  />
+                </div>
                 <button
                   type="button"
+                  data-testid="hotspots-view-all"
                   onClick={() => onOpenGraph()}
                   className="mt-2 self-start text-xs font-mono hover:underline"
                   style={{ color: 'var(--accent)' }}
                 >
-                  Open full graph →
+                  View all →
                 </button>
               </div>
             )}
@@ -335,6 +340,12 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                 No graph yet — run onboarding to index this repo.
               </p>
             )}
+          </Section>
+
+          {/* Commit cadence (§3.1) — active or stagnant, at the wire's honest
+              resolution (last 20 commits, git relative dates). */}
+          <Section title="Commits (30d)">
+            <CommitCadence commits={commits} />
           </Section>
 
           {/* Git History */}

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import type { SessionView } from '../api/types.js';
+import { MetricTile } from './MetricTile.js';
+
+/**
+ * Run outcome bar (DES-FEEDBACK-001 §2.1/§2.3, slice E): the home metrics-bar
+ * tile answering the named operator question "Is the system healthy right now?".
+ *
+ * SVG-first, no chart library (§2.3): 12 stacked bars, one per 2-hour window
+ * over the last 24h, segments filled with the status tokens (`--status-run`
+ * working / `--status-gate` waiting / `--status-fail` failed-or-cancelled /
+ * `--status-done` completed).
+ *
+ * WIRE HONESTY — the clock. §2.4 assumed a `created_at` on the session;
+ * `AgentSession` carries NO timestamps (the board model documents this). The
+ * one honest per-run clock the app already fetches is the membership
+ * `attached_at` (when the run entered its project) — the same clock the
+ * slice-D project dashboard buckets its 7-day activity on — so the windows
+ * bucket on THAT, and runs with no attach clock inside the window (unfiled /
+ * orphaned, or simply older than 24h) are excluded from the bars and reported
+ * in the label rather than painted at an invented time.
+ */
+
+const WINDOWS = 12;
+const WINDOW_MS = 2 * 3_600_000; // 2h × 12 = the 24h span
+/** ViewBox geometry — stretched to the tile via preserveAspectRatio="none". */
+const W = 168;
+const H = 26;
+const COL_GAP = 2;
+
+type Outcome = 'run' | 'gate' | 'fail' | 'done';
+
+/** Stack order bottom→top, with the fill token each segment means. */
+const SEGMENTS: ReadonlyArray<{ key: Outcome; fill: string }> = [
+  { key: 'run', fill: 'var(--status-run)' },
+  { key: 'gate', fill: 'var(--status-gate)' },
+  { key: 'fail', fill: 'var(--status-fail)' },
+  { key: 'done', fill: 'var(--status-done)' },
+];
+
+export function outcomeOf(status: string): Outcome {
+  if (status === 'awaiting_human') return 'gate';
+  if (status === 'failed' || status === 'cancelled') return 'fail';
+  if (status === 'completed') return 'done';
+  return 'run';
+}
+
+interface Props {
+  runs: SessionView[];
+  /** Run id → membership `attached_at` (epoch ms) — from `useBoardModel`. */
+  attachedAt: Record<string, number>;
+  /** Injectable clock for tests; defaults to the real one. */
+  now?: number;
+}
+
+export function RunOutcomeBar({ runs, attachedAt, now }: Props): React.ReactElement {
+  const at = now ?? Date.now();
+  const { windows, counts, unplaced } = useMemo(() => {
+    const buckets = Array.from({ length: WINDOWS }, () => ({ run: 0, gate: 0, fail: 0, done: 0 }));
+    const totals = { run: 0, gate: 0, fail: 0, done: 0 };
+    let outside = 0;
+    const start = at - WINDOWS * WINDOW_MS;
+    for (const v of runs) {
+      if (v.session.archived_at != null) continue;
+      const clock = attachedAt[v.session.id];
+      if (clock === undefined || clock < start || clock > at) {
+        outside += 1;
+        continue;
+      }
+      const ix = Math.min(WINDOWS - 1, Math.floor((clock - start) / WINDOW_MS));
+      const outcome = outcomeOf(v.session.status);
+      const bucket = buckets[ix];
+      if (bucket !== undefined) bucket[outcome] += 1;
+      totals[outcome] += 1;
+    }
+    return { windows: buckets, counts: totals, unplaced: outside };
+  }, [runs, attachedAt, at]);
+
+  const inWindow = counts.run + counts.gate + counts.fail + counts.done;
+  const colMax = windows.reduce((m, w) => Math.max(m, w.run + w.gate + w.fail + w.done), 0);
+  const colW = (W - COL_GAP * (WINDOWS - 1)) / WINDOWS;
+
+  const value =
+    inWindow === 0
+      ? 'no runs in 24h'
+      : [
+          counts.run > 0 ? `${counts.run} working` : null,
+          counts.gate > 0 ? `${counts.gate} gate` : null,
+          counts.fail > 0 ? `${counts.fail} failed` : null,
+          counts.done > 0 ? `${counts.done} done` : null,
+        ].filter((s) => s !== null).join(' · ');
+
+  return (
+    <MetricTile
+      testId="run-outcome-bar"
+      question="Is the system healthy right now?"
+      title="Runs (24h)"
+      value={value}
+      data={{ 'data-total': inWindow, 'data-unplaced': unplaced }}
+    >
+      {inWindow === 0 ? (
+        // Honest emptiness: no bars, one quiet line — never a wall of zero-height
+        // rects pretending to be data (§2.3).
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No runs attached in the last 24h.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={H}
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`run outcomes over the last 24h: ${value}`}
+          style={{ display: 'block' }}
+        >
+          {windows.map((w, i) => {
+            const total = w.run + w.gate + w.fail + w.done;
+            if (total === 0) return null;
+            let y = H;
+            return SEGMENTS.map(({ key, fill }) => {
+              if (w[key] === 0) return null;
+              const h = Math.max(2, (w[key] / colMax) * H);
+              y -= h;
+              return (
+                <rect
+                  key={`${i}-${key}`}
+                  x={i * (colW + COL_GAP)}
+                  y={y}
+                  width={colW}
+                  height={h}
+                  fill={fill}
+                />
+              );
+            });
+          })}
+        </svg>
+      )}
+    </MetricTile>
+  );
+}

--- a/src/components/TokenBurnSparkline.tsx
+++ b/src/components/TokenBurnSparkline.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { useRuntimeStore } from '../store/runtime.js';
+import { MetricTile } from './MetricTile.js';
+
+/**
+ * Token burn area sparkline (DES-FEEDBACK-001 §2.1/§2.3, slice E): the home
+ * metrics-bar tile answering "What am I spending, is it accelerating?".
+ * SVG-first: a cumulative `--accent`-gradient area with the running total in
+ * mono.
+ *
+ * WIRE HONESTY — where the dollars come from. §2.1 assumed a `cost` field on
+ * `SessionView`; the wire carries NONE (slice D's verifier proved it, and the
+ * project dashboard already refuses to invent one). The REAL cost signal is
+ * the `cliUsage` CoreEvent (`costUsd: number | null` — dollars when the CLI
+ * reports them), which the app's one `/ws` subscription already ingests. The
+ * runtime store's per-run log preserves each frame's `costUsd` beside its
+ * arrival `ts`, so the fold here is (time, dollars) pairs of REAL reported
+ * cost — scoped to what this page has observed, which the title says out
+ * loud. Frames with `costUsd: null` (cost unknown) are never counted as $0;
+ * they simply do not enter the fold. Zero new requests.
+ */
+
+const W = 168;
+const H = 26;
+const GRAD_ID = 'wk-burn-grad';
+
+interface Props {
+  now?: number;
+}
+
+export function TokenBurnSparkline({ now }: Props): React.ReactElement {
+  const logs = useRuntimeStore((s) => s.logs);
+  const at = now ?? Date.now();
+
+  const { steps, total } = useMemo(() => {
+    const usages: Array<{ ts: number; cost: number }> = [];
+    for (const log of Object.values(logs)) {
+      for (const entry of log) {
+        if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
+          usages.push({ ts: entry.ts, cost: entry.costUsd });
+        }
+      }
+    }
+    usages.sort((a, b) => a.ts - b.ts);
+    let sum = 0;
+    const cumulative = usages.map((u) => {
+      sum += u.cost;
+      return { ts: u.ts, total: sum };
+    });
+    return { steps: cumulative, total: sum };
+  }, [logs]);
+
+  // x spans first-observed → now, so the newest edge of the area is "now" and a
+  // flattening slope reads as spending slowing down.
+  const first = steps[0]?.ts ?? at;
+  const span = Math.max(1, at - first);
+  const x = (ts: number): number => ((ts - first) / span) * W;
+  const y = (v: number): number => (total > 0 ? H - (v / total) * (H - 2) : H);
+
+  const linePoints = steps.map((s) => `${x(s.ts).toFixed(1)},${y(s.total).toFixed(1)}`);
+  // Hold the last observed total out to "now".
+  const last = steps[steps.length - 1];
+  if (last !== undefined && x(last.ts) < W) linePoints.push(`${W},${y(last.total).toFixed(1)}`);
+  const areaPoints = [`0,${H}`, ...linePoints, `${W},${H}`].join(' ');
+
+  return (
+    <MetricTile
+      testId="token-burn-sparkline"
+      question="What am I spending, is it accelerating?"
+      title="Token burn (observed)"
+      value={steps.length === 0 ? 'no usage yet' : `$${total.toFixed(2)}`}
+      data={{ 'data-total': total.toFixed(4), 'data-points': steps.length }}
+    >
+      {steps.length === 0 ? (
+        // Honest emptiness: the wire reports cost per cliUsage frame and none
+        // has arrived — never a fabricated $0.00 curve.
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No usage reported yet.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={H}
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`cumulative token burn observed: $${total.toFixed(2)}`}
+          style={{ display: 'block' }}
+        >
+          <defs>
+            <linearGradient id={GRAD_ID} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.05" />
+            </linearGradient>
+          </defs>
+          <polygon points={areaPoints} fill={`url(#${GRAD_ID})`} />
+          <polyline
+            points={linePoints.join(' ')}
+            stroke="var(--accent)"
+            strokeWidth="1.5"
+            fill="none"
+          />
+        </svg>
+      )}
+    </MetricTile>
+  );
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -57,6 +57,14 @@ export interface BoardProject {
   repo: string | null;
   runs: SessionView[];
   docs: DocSummary[];
+  /**
+   * When each member run ENTERED this project (`attached_at` off the members
+   * wire, run id → epoch ms) — the one honest per-run clock this surface can
+   * reach, since `AgentSession` carries no timestamps. Slice E's charts bucket
+   * on it (run outcome windows, the 7-day quiet-row sparklines), exactly as the
+   * slice-D project dashboard already does.
+   */
+  attachedAt: Record<string, number>;
   attention: Attention;
   /** Decayed attention (§2.1.3): the max over the project's signals at the last tick. */
   score: number;
@@ -137,9 +145,11 @@ interface Bindings {
   runIds: ReadonlySet<string>;
   repo: string | null;
   docs: DocSummary[];
+  /** Run id → `attached_at` (epoch ms) off the same members read. */
+  attachedAt: Record<string, number>;
 }
 
-const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [] };
+const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {} };
 
 async function loadBindings(p: Project, repoNames: Map<string, string>): Promise<Bindings> {
   const [members, docs] = await Promise.all([
@@ -149,10 +159,14 @@ async function loadBindings(p: Project, repoNames: Map<string, string>): Promise
     interactiveRootOf(p) ? listDocs(p.id).catch((): DocSummary[] => []) : Promise.resolve([]),
   ]);
   const repoRef = members.find((m) => m.member_kind === 'crew.repo')?.member_ref ?? null;
+  const runMembers = members.filter((m) => RUN_KINDS.has(m.member_kind));
+  const attachedAt: Record<string, number> = {};
+  for (const m of runMembers) attachedAt[m.member_ref] = m.attached_at;
   return {
-    runIds: new Set(members.filter((m) => RUN_KINDS.has(m.member_kind)).map((m) => m.member_ref)),
+    runIds: new Set(runMembers.map((m) => m.member_ref)),
     repo: repoRef === null ? null : repoNames.get(repoRef) ?? repoRef,
     docs,
+    attachedAt,
   };
 }
 
@@ -296,7 +310,7 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
             now,
           );
           return {
-            project, repo: b.repo, runs: mine, docs: b.docs,
+            project, repo: b.repo, runs: mine, docs: b.docs, attachedAt: b.attachedAt,
             attention: deriveAttention(mine, b.docs),
             score, band: bandOf(score), signal,
           };

--- a/src/store/runtime.ts
+++ b/src/store/runtime.ts
@@ -15,6 +15,16 @@ export interface LoggedEvent {
   ord?: number;
   /** Attempt number — preserved from any event that carries an `attempt` field. */
   attempt?: number;
+  /**
+   * `cliUsage` only: the dollar cost the frame reported (DES-FEEDBACK-001 §2.1).
+   * Preserved here because this log is the ONE client store that stamps an
+   * arrival clock (`ts`) on live frames — `useRunEventStore` keeps the full
+   * frame but live `/ws` frames carry no `ts`, so a burn-over-time fold needs
+   * the (ts, cost) pair from HERE. Only ever a number: a `costUsd: null`
+   * ("cost unknown") frame is not preserved, so no consumer can turn an
+   * unknown cost into $0.00.
+   */
+  costUsd?: number;
   ts: number;
   /** A short human summary of the frame (cli won, description, prompt, message...). */
   detail: string;
@@ -101,6 +111,8 @@ function summarize(event: CoreEvent): string {
       return typeof event.message === 'string'
         ? `${String(event.target ?? 'all')}: "${event.message.length > 80 ? event.message.slice(0, 80) + '…' : event.message}"`
         : event.type;
+    case 'cliUsage':
+      return typeof event.costUsd === 'number' ? `usage $${event.costUsd.toFixed(2)}` : 'usage reported (no cost)';
     case 'error':
       return typeof event.message === 'string' ? `error: ${event.message}` : 'error';
     default:
@@ -468,6 +480,7 @@ export const useRuntimeStore = create<RuntimeStore>((set) => ({
       const entry: LoggedEvent = { seq, type: event.type, ts: Date.now(), detail: summarize(event) };
       if (typeof event.ord === 'number') entry.ord = event.ord;
       if (typeof event.attempt === 'number') entry.attempt = event.attempt;
+      if (event.type === 'cliUsage' && typeof event.costUsd === 'number') entry.costUsd = event.costUsd;
       const prevLog = s.logs[session] ?? [];
       const nextLog = [...prevLog, entry];
       if (nextLog.length > LOG_CAP) nextLog.splice(0, nextLog.length - LOG_CAP);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -147,3 +147,10 @@ code, pre, .font-mono {
   .wk-disclose,
   .wk-anchor-flash { animation: none; }
 }
+
+/* Slice-E metrics bar (DES-FEEDBACK-001 §2.2): under 900px the gate-latency
+   tile — the least critical at a glance — hides, and the two remaining tiles
+   share the band. A media query needs CSS, so the rule lives here. */
+@media (max-width: 899px) {
+  .wk-metrics-mid { display: none !important; }
+}

--- a/tests/GateChip.test.tsx
+++ b/tests/GateChip.test.tsx
@@ -30,6 +30,7 @@ function item(status: SessionStatus = 'awaiting_human'): BoardProject {
     repo: null,
     runs: [makeView({ id: RUN, status, unit_ix: 0 }, [makeUnit({ id: `${RUN}:u0`, session_id: RUN, ord: 0, stage: 'build' })])],
     docs: [],
+    attachedAt: {},
     attention: status === 'awaiting_human' ? 'gate' : 'running',
     // Slice-1 score fields: the chip is driven by run status + the gate store,
     // so a nominal score/band is enough to typecheck.

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -37,7 +37,7 @@ function bp(id: string, attention: BoardProject['attention'], score: number): Bo
       id, name: id, description: null, status: 'active',
       scope: `project:${id}`, created_at: 1, updated_at: 1,
     },
-    repo: null, runs: [], docs: [], attention, score,
+    repo: null, runs: [], docs: [], attachedAt: {}, attention, score,
     band: score >= 20 ? 'needs-you' : 'quiet', signal: null,
   };
 }

--- a/tests/ProjectCard.variants.test.tsx
+++ b/tests/ProjectCard.variants.test.tsx
@@ -41,7 +41,7 @@ function doc(name: string): DocSummary {
 
 function item(id: string, over: Partial<BoardProject> = {}): BoardProject {
   return {
-    project: project(id), repo: null, runs: [], docs: [],
+    project: project(id), repo: null, runs: [], docs: [], attachedAt: {},
     attention: 'quiet', score: 0, band: 'quiet', signal: null,
     ...over,
   };

--- a/tests/liveEdge.surfaces.test.tsx
+++ b/tests/liveEdge.surfaces.test.tsx
@@ -37,6 +37,7 @@ function card(id: string, statuses: SessionStatus[], attention: BoardProject['at
       makeView({ id: `${id}-run-${i}`, status }, [makeUnit({ id: `${id}-u${i}`, stage: 'build' })]),
     ),
     docs: [],
+    attachedAt: {},
     attention,
     score: attention === 'quiet' ? 0 : 100,
     band: attention === 'quiet' ? 'quiet' : 'needs-you',

--- a/tests/metricsBar.test.tsx
+++ b/tests/metricsBar.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { GateLatencyChart } from '../src/components/GateLatencyChart.js';
+import { RunOutcomeBar, outcomeOf } from '../src/components/RunOutcomeBar.js';
+import { TokenBurnSparkline } from '../src/components/TokenBurnSparkline.js';
+import { ProjectSparkline } from '../src/components/ProjectSparkline.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore, type LoggedEvent } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * The home metrics bar (DES-FEEDBACK-001 §2, slice E): three SVG-first tiles,
+ * each answering a §2.1 named operator question off data the page ALREADY
+ * holds — no chart library, no new polling, no invented wire fields.
+ */
+
+const NOW = 1_700_000_000_000;
+const MIN = 60_000;
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+/** Every network path the tiles could take is a spy — zero requests allowed. */
+const fetchSpy = vi.fn(() => Promise.reject(new Error('metrics tiles must not fetch')));
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchSpy);
+  useGateStore.setState({ gates: {} });
+  useRuntimeStore.setState({ logs: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  fetchSpy.mockClear();
+});
+
+function log(runId: string, entries: Array<Partial<LoggedEvent> & { type: string; ts: number }>): void {
+  const logs = { ...useRuntimeStore.getState().logs };
+  logs[runId] = entries.map((e, i) => ({ seq: i, detail: e.type, ...e }));
+  useRuntimeStore.setState({ logs });
+}
+
+describe('RunOutcomeBar (§2.1 — "Is the system healthy right now?")', () => {
+  const runs = [
+    makeView({ id: 'r-a', status: 'executing' }),
+    makeView({ id: 'r-b', status: 'awaiting_human' }),
+    makeView({ id: 'r-c', status: 'failed' }),
+    makeView({ id: 'r-d', status: 'completed' }),
+    makeView({ id: 'r-old', status: 'completed' }), // outside the 24h window
+    makeView({ id: 'r-orphan', status: 'executing' }), // no attach clock at all
+  ];
+  const attachedAt = {
+    'r-a': NOW - 30 * MIN,
+    'r-b': NOW - 3 * HOUR,
+    'r-c': NOW - 5 * HOUR,
+    'r-d': NOW - 23 * HOUR,
+    'r-old': NOW - 3 * DAY,
+  };
+
+  it('buckets by the attach clock into token-filled stacked rects — zero fetches', () => {
+    render(<RunOutcomeBar runs={runs} attachedAt={attachedAt} now={NOW} />);
+    const tile = screen.getByTestId('run-outcome-bar');
+    expect(tile.getAttribute('data-question')).toBe('Is the system healthy right now?');
+    // 4 in-window (one per outcome class); r-old and the clockless orphan excluded.
+    expect(tile.getAttribute('data-total')).toBe('4');
+    expect(tile.getAttribute('data-unplaced')).toBe('2');
+    const fills = [...tile.querySelectorAll('rect')].map((r) => r.getAttribute('fill'));
+    expect(fills).toHaveLength(4);
+    expect(new Set(fills)).toEqual(new Set([
+      'var(--status-run)', 'var(--status-gate)', 'var(--status-fail)', 'var(--status-done)',
+    ]));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders the honest empty line — never zero-height rects — when nothing is in-window', () => {
+    render(<RunOutcomeBar runs={[makeView({ id: 'r-x', status: 'executing' })]} attachedAt={{}} now={NOW} />);
+    const tile = screen.getByTestId('run-outcome-bar');
+    expect(tile.getAttribute('data-total')).toBe('0');
+    expect(tile.querySelectorAll('rect')).toHaveLength(0);
+    expect(tile.textContent).toContain('No runs attached in the last 24h');
+  });
+
+  it('maps statuses to outcome classes (cancelled counts as failed)', () => {
+    expect(outcomeOf('executing')).toBe('run');
+    expect(outcomeOf('awaiting_human')).toBe('gate');
+    expect(outcomeOf('failed')).toBe('fail');
+    expect(outcomeOf('cancelled')).toBe('fail');
+    expect(outcomeOf('completed')).toBe('done');
+  });
+});
+
+describe('GateLatencyChart (§2.1 — "Am I answering gates quickly or letting things stall?")', () => {
+  it('plots answered pairs from the arrival-stamped log and open gates from the gate store', () => {
+    log('r-1', [
+      { type: 'awaitingHuman', ts: NOW - 40 * MIN },
+      { type: 'gateDecided', ts: NOW - 32 * MIN }, // answered in 8m
+    ]);
+    useGateStore.setState({
+      gates: { 'r-2': { runId: 'r-2', ord: 0, prompt: 'ok?', lifecycle: 'open', receivedAt: NOW - 10 * MIN } },
+    });
+    render(<GateLatencyChart now={NOW} />);
+    const tile = screen.getByTestId('gate-latency-chart');
+    expect(tile.getAttribute('data-question')).toBe('Am I answering gates quickly or letting things stall?');
+    expect(tile.getAttribute('data-count')).toBe('2');
+    expect(tile.getAttribute('data-open')).toBe('1');
+    const dots = [...tile.querySelectorAll('circle')];
+    expect(dots).toHaveLength(2);
+    expect(dots.every((d) => d.getAttribute('fill') === 'var(--status-gate)')).toBe(true);
+    // The dashed 30-minute threshold rule.
+    const line = tile.querySelector('line');
+    expect(line?.getAttribute('stroke')).toBe('var(--status-gate-dim)');
+    expect(line?.getAttribute('stroke-dasharray')).toBe('3 3');
+    expect(tile.textContent).toContain('avg 8m');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('pairs an awaitingHuman with a resumed when no gateDecided was logged', () => {
+    log('r-1', [
+      { type: 'awaitingHuman', ts: NOW - 20 * MIN },
+      { type: 'resumed', ts: NOW - 15 * MIN },
+    ]);
+    render(<GateLatencyChart now={NOW} />);
+    expect(screen.getByTestId('gate-latency-chart').getAttribute('data-count')).toBe('1');
+    expect(screen.getByTestId('gate-latency-chart').getAttribute('data-open')).toBe('0');
+  });
+
+  it('renders the honest empty line when no gate has been observed', () => {
+    render(<GateLatencyChart now={NOW} />);
+    const tile = screen.getByTestId('gate-latency-chart');
+    expect(tile.querySelectorAll('circle')).toHaveLength(0);
+    expect(tile.textContent).toContain('No gates in the last 24h');
+  });
+});
+
+describe('TokenBurnSparkline (§2.1 — "What am I spending, is it accelerating?")', () => {
+  it('folds cliUsage costs into a cumulative accent area; null costs never become $0', () => {
+    log('r-1', [
+      { type: 'cliUsage', ts: NOW - 50 * MIN, costUsd: 0.1 },
+      { type: 'cliUsage', ts: NOW - 20 * MIN }, // costUsd null on the wire → NOT preserved, NOT counted
+      { type: 'cliUsage', ts: NOW - 5 * MIN, costUsd: 0.32 },
+    ]);
+    render(<TokenBurnSparkline now={NOW} />);
+    const tile = screen.getByTestId('token-burn-sparkline');
+    expect(tile.getAttribute('data-question')).toBe('What am I spending, is it accelerating?');
+    expect(tile.getAttribute('data-points')).toBe('2');
+    expect(tile.textContent).toContain('$0.42');
+    const line = tile.querySelector('polyline');
+    expect(line?.getAttribute('stroke')).toBe('var(--accent)');
+    const area = tile.querySelector('polygon');
+    expect(area?.getAttribute('fill')).toMatch(/^url\(#/);
+    const stops = [...tile.querySelectorAll('stop')].map((s) => s.getAttribute('stop-color'));
+    expect(stops).toEqual(['var(--accent)', 'var(--accent)']);
+    // No NaN anywhere in the geometry.
+    expect(line?.getAttribute('points')).not.toContain('NaN');
+    expect(area?.getAttribute('points')).not.toContain('NaN');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders the honest empty line — never a fabricated $0.00 curve — with no usage', () => {
+    render(<TokenBurnSparkline now={NOW} />);
+    const tile = screen.getByTestId('token-burn-sparkline');
+    expect(tile.querySelectorAll('polyline')).toHaveLength(0);
+    expect(tile.textContent).toContain('No usage reported yet');
+    expect(tile.textContent).not.toContain('$0.00');
+  });
+});
+
+describe('ProjectSparkline (§2.1 — quiet-row 7-day activity)', () => {
+  const runs = [makeView({ id: 'r-1' }), makeView({ id: 'r-2' }), makeView({ id: 'r-old' })];
+
+  it('buckets in-window runs per day off the attach clock, --ink-dim bars', () => {
+    const { container } = render(
+      <ProjectSparkline
+        runs={runs}
+        attachedAt={{ 'r-1': NOW - 2 * DAY, 'r-2': NOW - 2 * DAY, 'r-old': NOW - 10 * DAY }}
+        now={NOW}
+      />,
+    );
+    const spark = container.querySelector('[data-testid="project-sparkline"]');
+    expect(spark?.getAttribute('data-total')).toBe('2');
+    const rects = [...(spark?.querySelectorAll('rect') ?? [])];
+    expect(rects).toHaveLength(1); // both runs share one day bucket
+    expect(rects[0]?.getAttribute('fill')).toBe('var(--ink-dim)');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders NOTHING when the 7-day window is empty (absence stays absent)', () => {
+    const { container } = render(
+      <ProjectSparkline runs={runs} attachedAt={{ 'r-old': NOW - 10 * DAY }} now={NOW} />,
+    );
+    expect(container.querySelector('[data-testid="project-sparkline"]')).toBeNull();
+  });
+});

--- a/tests/repoVisuals.test.tsx
+++ b/tests/repoVisuals.test.tsx
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { CommitCadence, daysAgoOf } from '../src/components/CommitCadence.js';
+import { LanguageBar, langMeta } from '../src/components/LanguageBar.js';
+
+/**
+ * The repo-profile visuals (DES-FEEDBACK-001 §3, slice E): language bar off
+ * the code graph's per-node lang, commit cadence off the git-history wire's
+ * relative dates — honest empty states when the wire has nothing, and the
+ * linguist palette as the ONE sanctioned raw-color exemption.
+ */
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+afterEach(cleanup);
+
+describe('LanguageBar (§3.3)', () => {
+  it('renders proportional linguist-colored segments with a token fallback', () => {
+    render(<LanguageBar breakdown={{ typescript: 60, css: 20, javascript: 15, zig: 5 }} />);
+    const bar = screen.getByTestId('language-bar');
+    expect(bar.getAttribute('data-state')).toBe('ready');
+    const segments = [...bar.querySelectorAll('[data-testid="language-segment"]')];
+    expect(segments.map((s) => s.getAttribute('data-lang'))).toEqual(['typescript', 'css', 'javascript', 'zig']);
+    // linguist hexes for the convention languages (jsdom normalizes to rgb);
+    // token fallback for the rest.
+    expect(langMeta('typescript').color).toBe('#3178c6');
+    expect(segments[0]?.getAttribute('style')).toContain('rgb(49, 120, 198)');
+    expect(segments[3]?.getAttribute('style')).toContain('var(--ink-dim)');
+    expect(segments[0]?.getAttribute('style')).toContain('60%');
+    // Labels carry the display name + rounded percent, and name the unit.
+    expect(bar.textContent).toContain('TypeScript 60%');
+    expect(bar.textContent).toContain('by files indexed');
+  });
+
+  it('renders the honest not-indexed state when the graph is absent or empty', () => {
+    for (const breakdown of [null, {}]) {
+      const { unmount } = render(<LanguageBar breakdown={breakdown} />);
+      const bar = screen.getByTestId('language-bar');
+      expect(bar.getAttribute('data-state')).toBe('empty');
+      expect(bar.textContent).toContain('not indexed yet');
+      expect(bar.querySelectorAll('[data-testid="language-segment"]')).toHaveLength(0);
+      unmount();
+    }
+  });
+
+  it('pins the linguist exemption: every hex literal carries the sanctioned lint comment', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(join(here, '../src/components/LanguageBar.tsx'), 'utf8');
+    const lines = source.split('\n');
+    const DISABLE = '// eslint-disable-next-line no-restricted-syntax -- linguist palette, convention over token';
+    let hexLines = 0;
+    lines.forEach((line, i) => {
+      if (!/#[0-9a-fA-F]{6}\b/.test(line)) return;
+      hexLines += 1;
+      expect((lines[i - 1] ?? '').trim(), `hex on line ${i + 1} must carry the design's exact disable comment`).toBe(DISABLE);
+    });
+    expect(hexLines).toBe(6); // the six linguist entries — and nothing else raw
+    // This is the ONLY file in src/ sanctioned to carry the exemption comment.
+    expect(source).toContain('linguist palette');
+  });
+});
+
+describe('daysAgoOf — the git %ar relative-date placement (§3.1 wire honesty)', () => {
+  it('places day-or-finer labels at their literal day', () => {
+    expect(daysAgoOf('30 seconds ago')).toBe(0);
+    expect(daysAgoOf('5 minutes ago')).toBe(0);
+    expect(daysAgoOf('3 hours ago')).toBe(0);
+    expect(daysAgoOf('26 hours ago')).toBe(1);
+    expect(daysAgoOf('1 day ago')).toBe(1);
+    expect(daysAgoOf('13 days ago')).toBe(13);
+    expect(daysAgoOf('2 weeks ago')).toBe(14); // git's own rounding, verbatim
+    expect(daysAgoOf('4 weeks ago')).toBe(28);
+  });
+
+  it('refuses to invent a day for coarser or unparseable labels', () => {
+    expect(daysAgoOf('2 months ago')).toBeNull();
+    expect(daysAgoOf('1 year ago')).toBeNull();
+    expect(daysAgoOf('garbage')).toBeNull();
+  });
+
+  it('defensively accepts an absolute date, should the wire ever gain one', () => {
+    expect(daysAgoOf(new Date(NOW - 3 * DAY).toISOString(), NOW)).toBe(3);
+  });
+});
+
+describe('CommitCadence (§3.1)', () => {
+  const commit = (date: string, i: number) => ({
+    sha: `sha-${i}`, shortSha: `s${i}`, message: `m${i}`, author: 'a', date,
+  });
+
+  it('buckets in-window commits daily and reports the out-of-window tally', () => {
+    render(
+      <CommitCadence
+        now={NOW}
+        commits={['3 hours ago', '2 days ago', '2 days ago', '3 weeks ago', '2 months ago'].map(commit)}
+      />,
+    );
+    const el = screen.getByTestId('commit-cadence');
+    expect(el.getAttribute('data-state')).toBe('ready');
+    expect(el.getAttribute('data-total')).toBe('4');
+    expect(el.getAttribute('data-question')).toBe('Is this repo active or stagnant?');
+    const rects = [...el.querySelectorAll('rect')];
+    expect(rects).toHaveLength(3); // day 0, day 2 (×2), day 21
+    expect(rects.every((r) => r.getAttribute('fill') === 'var(--accent)')).toBe(true);
+    expect(el.textContent).toContain('last 5 commits');
+    expect(el.textContent).toContain('1 older than 30d');
+  });
+
+  it('renders honest states: loading, no commits, nothing in-window', () => {
+    const { unmount: u1, container } = render(<CommitCadence commits={null} now={NOW} />);
+    expect(container.textContent).toContain('Loading commit history');
+    u1();
+
+    const { unmount: u2 } = render(<CommitCadence commits={[]} now={NOW} />);
+    expect(screen.getByTestId('commit-cadence').getAttribute('data-state')).toBe('empty');
+    expect(screen.getByTestId('commit-cadence').textContent).toContain('No commits yet');
+    u2();
+
+    render(<CommitCadence commits={[commit('2 months ago', 0)]} now={NOW} />);
+    const el = screen.getByTestId('commit-cadence');
+    expect(el.getAttribute('data-state')).toBe('older-only');
+    expect(el.querySelectorAll('rect')).toHaveLength(0);
+    expect(el.textContent).toContain('Nothing in the last 30 days');
+  });
+});


### PR DESCRIPTION
Round-2 operator feedback, items 2 + 4 — the final slice of the arc: home *"needs visuals (charts/graphs) and needs to be a true view of all system happenings"*; repo profile *"still not visual, lots of lists of things — we said visually stunning"*.

## What changed (design: `.product/DES-FEEDBACK-001.md` §2, §3, §8.3 slice E)

- **Home metrics bar** (64px, between chrome and wall — the wall, live feed, and attention model are untouched): three SVG-first tiles, no chart library, every mark token-painted, each carrying its §2.1 operator question verbatim as `data-question` (EC19). Run outcome (12×2h stacked status bars), gate latency (dot scatter with dashed 30-min threshold), token burn (cumulative accent area). Middle tile hides under 900px per §2.2. Quiet-band project rows gain 7-day sparklines.
- **Repo profile visuals** (§3): linguist-palette LanguageBar (the design's one sanctioned raw-color exemption, each hex carrying the mandated eslint-disable justification, pinned by a source test), 30-day commit cadence, inline top-5 hotspot excerpt with "View all →" (CytoGraph stays behind the Graph button).

## Wire honesty — the arc's hard lesson, applied

Every chart's data source was verified against the real crew/core wire, not the fixture:
- **Token burn**: `SessionView` has no cost field — the tile folds real `cliUsage` frames' `costUsd` (a real CoreEvent, fanned verbatim to `/ws`), labeled **"Token burn (observed)"** because it is what this page session has watched; `costUsd: null` frames never fold to $0.00.
- **Gate latency**: `awaitingHuman`/`gateDecided`/`resumed` exist verbatim; frames carry no `ts`, so answered pairs use the arrival-stamped runtime log and open gates use the server-ISO `receivedAt`.
- **Repo**: the repo wire carries no language breakdown and git history arrives as `%ar` relative strings capped at 20 — the language bar derives from the estate graph's per-node `lang` ("by files indexed", honest "not indexed yet" state), and cadence renders at the wire's own resolution with the caption saying so. The fixture serves only real crew shapes.
- **Bonus finding**: §2.4 assumed `session.created_at` — `AgentSession` carries no timestamps at all; bars bucket on the membership `attached_at` clock (slice D's precedent), with out-of-window runs surfaced as `data-unplaced`, never painted at invented times.

Also carries the `vision_slice4` chat_firstrun re-scope (pre-existing staleness since slice C, failed on main; dedicated commit).

## Gates

eslint `--max-warnings 0` clean · `tsc --noEmit` clean · vitest **969/969** · rigs: `feedback_sliceE` (new) + `feedback A/B/C/D`, `vision_slice2`, `vision_slice4` (re-scoped), `uxfix_slice1` all green on fresh builds. Adversarial verifier re-ran everything, proved lint bites while the linguist exemption stays scoped to LanguageBar only, proved the rig fails on origin/main, verified each wire claim against crew/core sources (down to `event.rs` emit sites), and confirmed the $0.42 in the shot is exactly the fixture's non-null cost frames summed.

Named 1440×900 shots: `feedback-E-home-metrics.png`, `feedback-E-repo-profile.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)