### PR TITLE
Brand-learn restored on the real learned-theme wire (closes the #73 retraction)

### DIFF
--- a/e2e/brand_learn_test.py
+++ b/e2e/brand_learn_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+brand_learn_test.py — the /theme "Learn from a brand" flow, end to end against
+the shared W2 fixture (the restored capability studio#73 retracted; back on the
+real wires now that interactive#181 gave the doc-scoped learn a readback).
+
+What this rig proves in a real browser:
+
+  1. INERT AT REST: /theme renders the brand-learn section beside the manual
+     appearance surface, and fires ZERO learn-related requests until the user
+     acts — no /api/theme read, no write under the bridge proxy. (The board
+     rail's ordinary GET …/interactive/api/docs is page chrome on every route
+     and predates this flow.)
+  2. THE FLOW IS THE REAL WIRE CHAIN: submit → the scratch doc is ensured via
+     the real registry route (POST …/interactive/api/docs), the learn rides
+     POST …/api/events (theme.requested), and the readback poll walks
+     GET …/d/brand-learn/api/theme/learned through the 404→200 ripening.
+  3. THE PREVIEW IS REAL: the mapped accent (fixture navy #0a2a5e → hue 217)
+     lands inline on <html> — getComputedStyle proves the var changed — with
+     the mapper's adjustments disclosed, and NOTHING persisted yet.
+  4. APPLY PERSISTS THROUGH THE EXISTING STORE: the debounced settings PUT
+     lands and the fixture's settings store holds the mapped accent.
+  5. NO LOOP OUTLIVES THE FLOW: once the tokens landed, the readback route is
+     never polled again.
+
+Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  brand-learn-form.png     the section, source filled, before submit.
+  brand-learn-applied.png  mapped accent applied — page wearing the brand.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: BRAND_LEARN_PORT (default 4352).
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+PORT = int(os.environ.get("BRAND_LEARN_PORT", "4352"))
+ORIGIN = f"http://127.0.0.1:{PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+SHOT_FORM = VSHOTS / "brand-learn-form.png"
+SHOT_APPLIED = VSHOTS / "brand-learn-applied.png"
+
+# The project the learn rides: the fixture's one interactive-rooted project —
+# the component's default pick (first project bound to a root).
+PROJECT = "q3-review-deck"
+READBACK = f"/api/v1/projects/{PROJECT}/interactive/d/brand-learn/api/theme/learned"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture server ────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+start_server(PORT, dist)
+# A generous ripening delay so the poll PROVABLY witnesses the 404 before the 200.
+set_fixture(ORIGIN, learn_delay_s=1.5, reset_learn=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+# ── 2. The browser flow ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+console_errors: list[str] = []
+request_log: list[tuple[str, str]] = []  # every (method, path), in order
+readback_statuses: list[int] = []        # every response status of the readback route
+
+
+def learn_related(method: str, path: str) -> bool:
+    """The LEARN flow's own wires: any theme read, any write under the bridge
+    proxy (the scratch-doc create, the events emit). The board rail's ordinary
+    GET …/interactive/api/docs (LeftSidebar's doc tiles, on every route since
+    long before this flow) is page chrome, not the learn."""
+    return "/api/theme" in path or (method == "POST" and "/interactive/" in path)
+
+
+def accent_h(page) -> str:
+    return page.evaluate(
+        "() => getComputedStyle(document.documentElement).getPropertyValue('--_accent-h').trim()")
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda req: request_log.append((req.method, urlparse(req.url).path)))
+    page.on("response", lambda res: readback_statuses.append(res.status)
+            if urlparse(res.url).path == READBACK else None)
+
+    page.goto(f"{ORIGIN}/theme", wait_until="domcontentloaded")
+    page.locator('[data-testid="brand-learn"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1200)  # give any eager wire time to (wrongly) fire
+
+    # AC 1 — both sections render; the learn section is INERT until the user acts.
+    surface = page.evaluate(
+        """() => ({
+             appearance: !!document.querySelector('[data-testid="appearance-settings"]'),
+             brandLearn: !!document.querySelector('[data-testid="brand-learn"]'),
+             sourceUrl: !!document.querySelector('[data-testid="learn-source-url"]'),
+             sourcePdf: !!document.querySelector('[data-testid="learn-source-pdf"]'),
+             sourceImage: !!document.querySelector('[data-testid="learn-source-image"]'),
+             projectPick: !!document.querySelector('[data-testid="learn-project"]'),
+             logoHonesty: (document.body.innerText || '').includes('the logo stays your manual choice'),
+           })"""
+    )
+    eager = [f"{m} {q}" for m, q in request_log if learn_related(m, q)]
+    report["steps"]["inert_at_rest"] = {
+        "ok": all(surface.values()) and eager == [],
+        **surface,
+        "eager_learn_requests": eager,
+        "requests_seen": len(request_log),
+    }
+
+    accent_before = accent_h(page)
+
+    # AC 2 — the flow: url source in, the interactive-rooted project preselected.
+    page.locator('[data-testid="learn-input"]').fill("https://acme.example.com")
+    picked = page.locator('[data-testid="learn-project"]').input_value()
+    page.locator('[data-testid="brand-learn"]').scroll_into_view_if_needed()
+    page.screenshot(path=str(SHOT_FORM))
+    page.locator('[data-testid="learn-submit"]').click()
+
+    page.locator('[data-testid="learn-preview-chip"]').wait_for(timeout=30000)
+
+    ensured_doc = any(
+        m == "POST" and q == f"/api/v1/projects/{PROJECT}/interactive/api/docs"
+        for m, q in request_log)
+    fired_event = any(
+        m == "POST" and q == f"/api/v1/projects/{PROJECT}/interactive/api/events"
+        for m, q in request_log)
+    report["steps"]["real_wire_chain"] = {
+        "ok": (picked == PROJECT and ensured_doc and fired_event
+               and 404 in readback_statuses and 200 in readback_statuses),
+        "project_preselected": picked,
+        "scratch_doc_route_hit": ensured_doc,
+        "events_route_hit": fired_event,
+        "readback_statuses": readback_statuses[:10],
+    }
+
+    # AC 3 — the preview is real: the accent var CHANGED to the mapped hue,
+    # the adjustments are disclosed, and nothing has persisted yet.
+    accent_preview = accent_h(page)
+    adjustments = page.locator('[data-testid="mapper-adjustments"]').inner_text()
+    report["steps"]["preview_is_real"] = {
+        "ok": (accent_before == "258" and accent_preview == "217"
+               and "contrast-floor" in adjustments and "lightness-clamp" in adjustments),
+        "accent_before": accent_before,
+        "accent_preview": accent_preview,
+        "adjustments_excerpt": adjustments[:300],
+    }
+
+    # Nothing persisted before Apply: the fixture settings store still holds 258.
+    with urllib.request.urlopen(f"{ORIGIN}/api/v1/settings", timeout=10) as res:
+        stored = json.loads(res.read())["settings"]["studio.appearance"]
+    report["steps"]["nothing_persisted_before_apply"] = {
+        "ok": stored["accent_h"] == 258, "stored": stored,
+    }
+
+    # AC 4 — Apply persists through the EXISTING appearance store (debounced PUT).
+    page.locator('[data-testid="learn-apply"]').click()
+    page.wait_for_timeout(1500)  # the store's 400ms debounce + slack
+    with urllib.request.urlopen(f"{ORIGIN}/api/v1/settings", timeout=10) as res:
+        stored = json.loads(res.read())["settings"]["studio.appearance"]
+    accent_applied = accent_h(page)
+    report["steps"]["apply_persists"] = {
+        "ok": (stored["accent_h"] == 217 and stored["accent_s"] == 81
+               and stored["accent_l"] == 59 and stored["logo_url"] is None
+               and accent_applied == "217"),
+        "stored": stored,
+        "accent_applied": accent_applied,
+    }
+
+    page.screenshot(path=str(SHOT_APPLIED))
+
+    # AC 5 — no poll outlives the flow: the readback count freezes.
+    polls_at_done = len(readback_statuses)
+    page.wait_for_timeout(3000)
+    report["steps"]["no_poll_outlives_the_flow"] = {
+        "ok": len(readback_statuses) == polls_at_done,
+        "polls_at_done": polls_at_done,
+        "polls_after_3s": len(readback_statuses),
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [str(SHOT_FORM), str(SHOT_APPLIED)]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("brand_learn_verdict", f"brand-learn assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/interactive_wire_contract_test.py
+++ b/e2e/interactive_wire_contract_test.py
@@ -29,8 +29,12 @@ tests ROUTE EXISTENCE, not recording success (§9 names this out of scope).
 The theme wires are FATAL steps since issue #65 (they were slice F's advisory
 finding): the corrected client speaks `wicked.interactive.theme.requested` over
 POST /api/events, and the invented `GET /api/themes` / `POST /api/theme/learn`
-must stay 404. The remaining known-invented wire OUTSIDE scope (sources attach:
-slice 19) is still probed as ADVISORY — reported, not fatal.
+must stay 404. The learned-theme READBACK (interactive#181) is FATAL too:
+`GET /d/:docId/api/theme/learned` must answer its own JSON 404 on a fresh doc,
+the tokens VERBATIM after a written learn, and the JSON 404 again on a corrupt
+file — the wire studio's restored brand-learn flow polls. The remaining
+known-invented wire OUTSIDE scope (sources attach: slice 19) is still probed as
+ADVISORY — reported, not fatal.
 
 Env knobs:
   WICKED_INTERACTIVE_DIR  the bridge checkout (default: ../wicked-interactive
@@ -98,12 +102,14 @@ def http(method: str, url: str, body: dict | None = None) -> tuple[int, str, str
 # A client that cannot build the URL cannot regress onto it.
 import re  # noqa: E402 (grouped with its one use, harness style)
 
-# Issue #65 adds the invented theme spellings: the path literals /api/themes and
-# /api/theme/learn, and the wrappers that built them. (`learnTheme\b` does not match
-# `learnThemeFromThread` — that helper now speaks the corrected event wire.)
+# Issue #65 adds the invented theme spellings: the path literal /api/themes and the
+# wrappers that built them. (`learnTheme\b` does not match `learnThemeFromThread` —
+# that helper now speaks the corrected event wire; `api/theme/learn\b` does not match
+# `api/theme/learned` — the REAL interactive#181 readback route getLearnedTheme
+# builds, whose existence is asserted as a FATAL positive step below.)
 BANNED_SPELLINGS = re.compile(
     r"getDemoSpec|getLatestRecording|api/demo/(spec|recordings|record)\b"
-    r"|api/themes|api/theme/learn|listThemes|getTheme\b|learnTheme\b")
+    r"|api/themes|api/theme/learn\b|listThemes|getTheme\b|learnTheme\b")
 spelled: list[str] = []
 for f in sorted((REPO / "src").rglob("*")):
     if f.suffix not in (".ts", ".tsx"):
@@ -259,6 +265,72 @@ try:
         "ok": gif_ok and rec_ok,
         "gif_export": {"status": gif_status, "body": gif_text[:200]},
         "recording_file_missing": {"status": rec_status, "body": rec_text[:200]},
+    }
+
+    # ── 6. The learned-theme READBACK exists (interactive#181) — FATAL ──────────
+    # `getLearnedTheme` builds GET /d/:docId/api/theme/learned. Four probes:
+    #   a. FRESH doc → the route's OWN 404 {"error":"no learned theme"} — the JSON
+    #      body IS the route-exists proof (an express-default 404 is HTML
+    #      "Cannot GET …", which is what an absent route would answer).
+    #   b. a WRITTEN learn: drop learned.theme.json into the doc workspace (the
+    #      exact file the assist agent writes) → 200 {document_id, learned_at,
+    #      tokens} with the tokens VERBATIM.
+    #   c. CORRUPT file → back to the route's own 404 (the apply seam degrades
+    #      past it identically — resolveLearnedTheme returns null).
+    #   d. UNKNOWN doc → status 404 asserted, and STATUS ONLY (the body there is
+    #      express's, not the route's — never pin it).
+    def learned_get(doc: str) -> tuple[int, str, str]:
+        return http("GET", f"{base}/d/{doc}/api/theme/learned")
+
+    fresh_status, fresh_text, _ = learned_get(DEMO)
+    try:
+        fresh_body = json.loads(fresh_text)
+    except ValueError:
+        fresh_body = None
+    fresh_ok = (fresh_status == 404 and isinstance(fresh_body, dict)
+                and fresh_body.get("error") == "no learned theme")
+
+    theme_dir = tmp / "docs" / DEMO / "theme"
+    theme_dir.mkdir(parents=True, exist_ok=True)
+    LEARNED_TOKENS = {
+        "name": "contract-check-brand",
+        "colors": {"background": "#f8fafc", "surface": "#ffffff", "primary": "#0a2a5e",
+                   "secondary": "#0e7490", "accent": "#0a2a5e", "text_primary": "#1e293b"},
+        "fonts": {"heading": "Georgia", "body": "Georgia", "mono": "Menlo"},
+    }
+    (theme_dir / "learned.theme.json").write_text(json.dumps(LEARNED_TOKENS), encoding="utf-8")
+    learned_status, learned_text, learned_ctype = learned_get(DEMO)
+    try:
+        learned_body = json.loads(learned_text)
+    except ValueError:
+        learned_body = {}
+    learned_ok = (learned_status == 200
+                  and learned_body.get("document_id") == DEMO
+                  and learned_body.get("tokens") == LEARNED_TOKENS  # the file VERBATIM
+                  and ("learned_at" in learned_body))
+
+    (theme_dir / "learned.theme.json").write_text("{not json", encoding="utf-8")
+    corrupt_status, corrupt_text, _ = learned_get(DEMO)
+    try:
+        corrupt_body = json.loads(corrupt_text)
+    except ValueError:
+        corrupt_body = None
+    corrupt_ok = (corrupt_status == 404 and isinstance(corrupt_body, dict)
+                  and corrupt_body.get("error") == "no learned theme")
+
+    unknown_status, _, _ = learned_get("absent-doc-that-never-existed")
+    unknown_ok = unknown_status == 404  # status ONLY — the body is express's, not ours
+
+    report["steps"]["learned_theme_readback"] = {
+        "ok": fresh_ok and learned_ok and corrupt_ok and unknown_ok,
+        "fresh_doc_404_with_route_body": {"ok": fresh_ok, "status": fresh_status,
+                                          "body": fresh_text[:200]},
+        "written_learn_200_verbatim": {"ok": learned_ok, "status": learned_status,
+                                       "content_type": learned_ctype,
+                                       **({} if learned_ok else {"body": learned_text[:400]})},
+        "corrupt_file_404": {"ok": corrupt_ok, "status": corrupt_status,
+                             "body": corrupt_text[:200]},
+        "unknown_doc_404_status_only": {"ok": unknown_ok, "status": unknown_status},
     }
 
     # ── Advisory: invented wires OUTSIDE this scope (on the record, not fatal) ──

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -52,6 +52,12 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     5-frame burn drains (slice E's token-burn tile; default
                     False). Same real frame shape as usage_ws; drip-fed so
                     the cumulative fold has more than one arrival instant.
+  learn_delay_s   — how long after a successful theme.requested the learned
+                    tokens ripen into GET /d/<doc>/api/theme/learned
+                    (interactive#181; default 0.75 — long enough for the
+                    brand-learn rig to witness the 404→200 transition).
+  reset_learn     — POST {"reset_learn": true} clears all learned-theme
+                    readback state (back to the 404).
 
 A rig that never flips them gets the default W2 board.
 """
@@ -91,7 +97,11 @@ def iso(ms: int) -> str:
 state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
          "extra_narration": [], "demo": False,
-         "repo": False, "metrics_ws": False}
+         "repo": False, "metrics_ws": False,
+         # theme-learn readback (interactive#181): how long after a successful
+         # theme.requested the learned tokens become readable (the 404→200
+         # ripening the studio poll rides). reset_learn clears learned state.
+         "learn_delay_s": 0.75}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -440,6 +450,32 @@ PRIVATE_HOST = re.compile(
     r"^(localhost$|127\.|0\.0\.0\.0$|10\.|192\.168\."
     r"|172\.(1[6-9]|2[0-9]|3[01])\.|169\.254\.|::1$|fe80:|fd)")
 
+# ── The learned-theme READBACK (interactive#181) ───────────────────────────────
+#
+# The real bridge serves GET /d/<doc>/api/theme/learned: 404 {"error":"no
+# learned theme"} until a learn lands, then 200 {document_id, learned_at,
+# tokens} with tokens = the doc's learned.theme.json VERBATIM. This fixture
+# materializes the same ripening: a successful theme.requested records the
+# learned tokens for (pid, doc) with a small delay (`learn_delay_s`, default
+# 0.75s — enough for the rig to witness the 404→200 transition the studio poll
+# rides); the SSRF-refused path records NOTHING, exactly as the real
+# materializer leaves no learned file behind a refusal.
+#
+# The token object is the bridge's own theme vocabulary — nested colors/fonts,
+# partials legal. The deep-navy #0a2a5e primary forces the studio mapper's two
+# disclosed adjustments (lightness-clamp + contrast-floor), same as the old
+# slice-8 fixture brand did.
+LEARNED_TOKENS = {
+    "name": "acme-brand",
+    "colors": {"background": "#f8fafc", "surface": "#ffffff", "primary": "#0a2a5e",
+               "secondary": "#0e7490", "accent": "#0a2a5e", "text_primary": "#1e293b"},
+    "fonts": {"heading": "Georgia", "body": "Georgia", "mono": "Menlo"},
+}
+
+learned_lock = threading.Lock()
+# (pid, doc) -> ready_at_ms. Readable (200) once NOW >= ready_at_ms.
+learned_themes: dict = {}
+
 
 def ssrf_reject_reason(url: str) -> str | None:
     """The bridge-side guard (DES-MERGE-001 §4.6): why this URL is refused, or None."""
@@ -747,6 +783,21 @@ class W2Handler(SimpleHTTPRequestHandler):
         if m:
             self._json(404, {"error": f"no such route on the bridge: {path}"})
             return True
+        # The REAL learned-theme readback (interactive#181): 404 with the route's
+        # OWN JSON body until the doc's learn has ripened, then the tokens
+        # verbatim — exactly the shapes the contract check pins on the bridge.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/theme/learned$", path)
+        if m:
+            pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            with learned_lock:
+                ready_at = learned_themes.get((pid, doc))
+            now = int(time.time() * 1000)
+            if ready_at is None or now < ready_at:
+                self._json(404, {"error": "no learned theme"})
+            else:
+                self._json(200, {"document_id": doc, "learned_at": iso(ready_at),
+                                 "tokens": LEARNED_TOKENS})
+            return True
         # /api/v1/projects/<pid>/interactive/d/<doc>/api/versions — the manifest.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/versions$", path)
         if m:
@@ -878,6 +929,14 @@ class W2Handler(SimpleHTTPRequestHandler):
                         **({"url": url} if url else {"path": file_path}),
                         "render_path": file_path or f"/docs/{doc}/theme/learned_1.pdf",
                         "format": "pdf"})
+                    # …and the tokens ripen into the READBACK route (#181) after
+                    # learn_delay_s — the 404→200 transition the studio poll rides.
+                    # The refused branch above records nothing, exactly as the real
+                    # materializer leaves no learned.theme.json behind a refusal.
+                    with state_lock:
+                        delay_ms = int(float(state["learn_delay_s"]) * 1000)
+                    with learned_lock:
+                        learned_themes[(pid, doc)] = int(time.time() * 1000) + delay_ms
                 self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
                 return True
             if body.get("event_type") == "wicked.interactive.chat.posted" and doc:
@@ -908,6 +967,11 @@ class W2Handler(SimpleHTTPRequestHandler):
         path = urllib.parse.urlparse(self.path).path
         body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
         if path == "/__fixture":
+            # `reset_learn` clears the learned-theme readback state between page
+            # loads (the brand-learn rig re-runs the flow from a clean 404).
+            if body.get("reset_learn"):
+                with learned_lock:
+                    learned_themes.clear()
             with state_lock:
                 # `appearance` rides the same control channel but lands in the
                 # settings store: a dict replaces studio.appearance wholesale,

--- a/e2e/vision_slice8_test.py
+++ b/e2e/vision_slice8_test.py
@@ -1,36 +1,32 @@
 #!/usr/bin/env python3
 """
-vision_slice8_test.py — the /theme page, after the theme-wire correction
-(issue #65; formerly the DES-VISION-001 slice-8 brand-learn gate).
+vision_slice8_test.py — the /theme page honesty gate, re-scoped again.
 
-Slice 8's subject — the brand-learn extraction loop (learn a source, poll a
-theme list, read a palette back, map it onto the studio accent) — was built
-entirely on INVENTED wires: `POST /api/theme/learn`, a polled `GET /api/themes`
-and `GET /api/themes/:id` were never served by the real wicked-interactive
-bridge (verified in interactive_wire_contract_test.py, which now pins all
-three as must-stay-404). On the real bridge a theme is learned FOR ONE
-DOCUMENT via the `wicked.interactive.theme.requested` bus command, and its
-result is never readable back over HTTP — so a studio-accent extraction leg
-has no wire to ride, and the honest fix removed the affordance (BrandLearn)
-rather than keeping a dead one.
+The history this gate carries: slice 8 built the brand-learn extraction loop
+on INVENTED wires (POST /api/theme/learn, a polled GET /api/themes,
+GET /api/themes/:id — never served by the real bridge), so issue #65 removed
+the affordance and this gate pinned its ABSENCE. wicked-interactive#181 then
+gave the doc-scoped learn the readback it was missing
+(GET /d/:docId/api/theme/learned), and the affordance is BACK — on real wires
+this time (theme.requested over POST /api/events + the readback poll; see
+brand_learn_test.py for the full flow rig). So the honesty this gate now pins
+is three-sided:
 
-What this rig proves instead, in a real browser against the shared W2 fixture:
-
-  1. THE PAGE IS HONEST: /theme renders the appearance surface
-     (data-testid="appearance-settings" — accent wheel, logo, theme mode; all
-     real, crew-persisted wires) and NO brand-learn affordance survives — no
-     [data-testid="brand-learn"], no learn-submit, no "Learn from brand
-     source" copy.
-  2. NO INVENTED WIRE IS EVEN ATTEMPTED: across the whole visit not one
-     request path contains /api/themes or /api/theme/learn — the browser-side
-     twin of the contract check's grep AC.
-  3. THE REAL SURFACE STILL WORKS: the appearance settings PUT (the slice-7
-     machinery this page hosts) still answers, so removing the dead leg did
-     not take the live one with it.
+  1. THE PAGE IS WHOLE: /theme renders BOTH surfaces — the manual appearance
+     section (accent wheel, logo, theme mode; untouched) AND the restored
+     "Learn from a brand" section (data-testid="brand-learn", its submit, its
+     logo-stays-manual copy).
+  2. THE DEAD WIRES STAY DEAD, AND THE LIVE ONE STAYS LAZY: across the whole
+     visit not one request path contains /api/themes (the registry that never
+     existed), and the REAL readback route (/api/theme/learned) is not touched
+     either — the section renders with zero learn-related requests until the
+     user acts. (The browser-side twin of the contract check's grep AC.)
+  3. THE MANUAL SURFACE STILL WORKS: the appearance settings PUT (the slice-7
+     machinery) still answers — restoring the learn leg did not disturb the
+     live one.
 
 Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
-  theme-wire-fix-theme-page.png  the /theme page — appearance surface present,
-                                 brand-learn affordance honestly absent.
+  theme-page-restored-learn.png  the /theme page — both surfaces present.
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
 SKIP_STUDIO_BUILD=1. Env knobs: VISION_PORT (default 4348), SKIP_STUDIO_BUILD.
@@ -52,7 +48,7 @@ from uxfix_fixture import (
 VISION_PORT = int(os.environ.get("VISION_PORT", "4348"))
 ORIGIN = f"http://127.0.0.1:{VISION_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
-SHOT_PAGE = VSHOTS / "theme-wire-fix-theme-page.png"
+SHOT_PAGE = VSHOTS / "theme-page-restored-learn.png"
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -88,9 +84,11 @@ with sync_playwright() as p:
 
     page.goto(f"{ORIGIN}/theme", wait_until="domcontentloaded")
     page.locator('[data-testid="appearance-settings"]').wait_for(timeout=30000)
+    page.locator('[data-testid="brand-learn"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
-    # AC 1 — the appearance surface is present; the brand-learn affordance is not.
+    # AC 1 — both surfaces present: the manual appearance section AND the
+    # restored brand-learn section (real wires — see brand_learn_test.py).
     surface = page.evaluate(
         """() => ({
              appearance: !!document.querySelector('[data-testid="appearance-settings"]'),
@@ -98,19 +96,19 @@ with sync_playwright() as p:
              preview: !!document.querySelector('[data-testid="appearance-preview"]'),
              brandLearn: !!document.querySelector('[data-testid="brand-learn"]'),
              learnSubmit: !!document.querySelector('[data-testid="learn-submit"]'),
-             learnCopy: (document.body.innerText || '').includes('Learn from brand source'),
+             learnCopy: (document.body.innerText || '').toLowerCase()
+               .includes('learn from a brand'),  // the heading is CSS-uppercased
+             logoHonesty: (document.body.innerText || '')
+               .includes('the logo stays your manual choice'),
            })"""
     )
-    report["steps"]["theme_page_honest"] = {
-        "ok": all([
-            surface["appearance"], surface["hueWheel"], surface["preview"],
-            not surface["brandLearn"], not surface["learnSubmit"], not surface["learnCopy"],
-        ]),
+    report["steps"]["theme_page_whole"] = {
+        "ok": all(surface.values()),
         **surface,
     }
 
-    # AC 3 — the REAL wire this page hosts still answers: move the accent lightness
-    # and wait for the debounced settings PUT to land (the slice-7 machinery).
+    # AC 3 — the REAL manual wire this page hosts still answers: move the accent
+    # lightness and wait for the debounced settings PUT to land (slice-7 machinery).
     page.locator('[data-testid="accent-lgt"]').wait_for(timeout=30000)
     put_before = sum(1 for q in request_paths if q == "/api/v1/settings")
     page.locator('[data-testid="accent-lgt"]').fill("55")
@@ -123,11 +121,15 @@ with sync_playwright() as p:
 
     page.screenshot(path=str(SHOT_PAGE))
 
-    # AC 2 — no invented theme wire was even attempted, page-wide.
-    invented = [q for q in request_paths if "/api/themes" in q or "/api/theme/learn" in q]
-    report["steps"]["no_invented_wire_attempted"] = {
-        "ok": invented == [],
+    # AC 2 — the invented wires stay dead, and the real readback stays LAZY:
+    # nothing touched /api/themes (the never-existed registry) or
+    # /api/theme/learn(ed) — the user never acted on the learn section.
+    invented = [q for q in request_paths if "/api/themes" in q]
+    learn_touched = [q for q in request_paths if "/api/theme/learn" in q]
+    report["steps"]["dead_wires_dead_live_wire_lazy"] = {
+        "ok": invented == [] and learn_touched == [],
         "invented_requests": invented,
+        "learn_requests_before_user_acts": learn_touched,
         "requests_seen": len(request_paths),
     }
 

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -341,7 +341,9 @@ export interface LearnThemeBody {
  * Consequences the caller must design to:
  *   - the learn is DOC-SCOPED: the learned tokens land at `<doc>/theme/learned.theme.json`
  *     and every subsequent version of THAT document wears them (theme-source.js). There
- *     is no cross-doc theme registry, no theme id, and no route that reads a theme back.
+ *     is no cross-doc theme registry and no theme id; what a learn produced for THIS doc
+ *     is readable back at `GET /d/:docId/api/theme/learned` (interactive#181 —
+ *     `getLearnedTheme` below), which is what the /theme page's brand-learn flow polls.
  *   - the ack is an EventAck, not a result: progress and refusals (including the SSRF
  *     guard's) arrive async as the bridge's own `status.posted` messages in the thread.
  */
@@ -357,6 +359,46 @@ export function requestThemeLearn(
       ...(body.kind === 'url' ? { url: body.url } : { path: body.path }),
     },
   });
+}
+
+/**
+ * `GET /d/:docId/api/theme/learned` — the learned-theme READBACK
+ * (wicked-interactive#181, the wire studio#73 was waiting for).
+ *
+ * What the doc's learn produced, served through the bridge's own apply-seam
+ * resolver (`resolveLearnedTheme`), so this body is exactly what every new
+ * version of the doc will wear: `{document_id, learned_at, tokens}` where
+ * `tokens` is `<doc>/theme/learned.theme.json` VERBATIM — nested
+ * `{name, colors:{background,surface,primary,secondary,accent,text_primary,…},
+ * fonts:{heading,body,mono}, …}`, partials legal. `learned_at` is the file's
+ * mtime (advisory; null when unstattable).
+ *
+ * Resolves `null` on the route's own `404 {"error":"no learned theme"}` —
+ * the doc exists but no learn has landed (or the file is corrupt, which the
+ * apply seam degrades past identically). Every OTHER failure still throws:
+ * an unknown doc is an express-default 404 with no JSON error to match, a
+ * dead bridge is the usual typed 503.
+ */
+export function getLearnedTheme(
+  projectId: string,
+  docId: string,
+): Promise<LearnedTheme | null> {
+  return iFetch<LearnedTheme>(`${docBase(projectId, docId)}/api/theme/learned`)
+    .catch((e: unknown) => {
+      if (e instanceof Error && e.message === 'API 404: no learned theme') return null;
+      throw e;
+    });
+}
+
+/** `GET /d/:docId/api/theme/learned`'s 200 body (interactive#181). */
+export interface LearnedTheme {
+  document_id: string;
+  /** ISO mtime of the learned file — advisory, null when unstattable. */
+  learned_at: string | null;
+  /** The learned.theme.json object verbatim. The bridge owns this vocabulary
+   *  (it is the same object `themed()` applies), so studio reads it TOLERANTLY
+   *  — `adaptLearnedTokens` narrows it — rather than pinning a shape here. */
+  tokens: Record<string, unknown>;
 }
 
 /**

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -363,15 +363,13 @@ export function AppearanceSettings(): React.ReactElement {
         </p>
       </div>
 
-      {/* NOTE (issue #65): the "Learn from brand source" leg (BrandLearn, vision
-          slice 8) is GONE. Its whole loop — a learn POST, a polled theme list,
-          a theme-detail read — was an invented wire: the real
-          wicked-interactive bridge has never served a theme route (verified
-          against src/service/server.js and its history). Theme learning on the
-          real bridge is DOC-scoped (wicked.interactive.theme.requested) and its
-          result is never readable back over HTTP, so a studio-accent extraction
-          leg has no wire to ride. The manual accent/logo/theme controls above
-          are the appearance surface's real, crew-persisted capability.
+      {/* NOTE: the "Learn from a brand" extraction leg lives in its OWN section
+          (BrandLearn.tsx, rendered beside this one on /theme). Issue #65 removed
+          it from here because its old loop rode invented routes; it returned on
+          real wires once wicked-interactive#181 gave the doc-scoped learn a
+          readback (GET /d/:docId/api/theme/learned). This section stays the
+          MANUAL surface only — accent/logo/theme, crew-persisted — and the
+          brand-learn Apply funnels into the same appearance store it uses.
       */}
     </section>
   );

--- a/src/components/BrandLearn.tsx
+++ b/src/components/BrandLearn.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useRef, useState } from 'react';
+import { getLearnedTheme, requestThemeLearn } from '../api/interactive.js';
+import { interactiveRootOf } from '../hooks/useBoardModel.js';
+import { learnBody, learnReady, LEARN_KINDS, LEARN_LABEL } from '../interactive/themeWire.js';
+import { threadKey, useDocThreadStore } from '../store/docThread.js';
+import { useProjectsStore } from '../store/projects.js';
+import { applyAppearance, useAppearanceStore } from '../theming/appearance.js';
+import { isUnsatisfiable, mapBrandTheme, type BrandTokenOverrides } from '../theming/brandMapper.js';
+import { adaptLearnedTokens } from '../theming/learnedTheme.js';
+import { pollLearnedTheme } from '../theming/learnPoll.js';
+import { ensureScratchDoc } from '../theming/scratchDoc.js';
+import type { LearnKind } from '../api/interactive.js';
+
+/**
+ * "Learn from a brand" on the /theme page — the operator-directed accent
+ * extraction studio#73 retracted (its old loop rode invented routes), back on
+ * REAL wires now that interactive#181 gave the learn a readback:
+ *
+ *   pick a source (the same url | pdf | image trio the bridge's materializer
+ *   accepts) and a target project → ensure that project's studio-owned
+ *   scratch doc exists (`ensureScratchDoc`, the real registry route) → fire
+ *   `theme.requested` over POST /api/events (`requestThemeLearn`, the #73
+ *   wire) → poll `GET /d/:docId/api/theme/learned` (bounded, cancellable —
+ *   learnPoll.ts) until the 404 turns 200 or the bridge's own status error
+ *   surfaces → adapt the nested tokens (learnedTheme.ts) → the resurrected
+ *   §4.5 mapper → preview inline on <html> (the whole page IS the preview,
+ *   §3.4; nothing persists) → Apply through the EXISTING appearance store,
+ *   the same persistence as the manual wheel above. No new surface.
+ *
+ * Honesty notes carried into the copy:
+ *   - the learned shape has NO logo — the logo slot above stays manual;
+ *   - refusals (the server-side SSRF guard's included) are shown VERBATIM;
+ *   - an unsatisfiable mapping discloses its adjustments and offers no Apply;
+ *   - this section fires ZERO requests until the user acts, and the poll
+ *     cannot outlive the flow (hard cap + abort on cancel/unmount).
+ */
+
+type Phase = 'idle' | 'preparing' | 'queued' | 'ready' | 'applied' | 'error';
+
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function BrandLearn(): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const [kind, setKind] = useState<LearnKind>('url');
+  const [source, setSource] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [status, setStatus] = useState<string | null>(null);
+  const [mapping, setMapping] = useState<BrandTokenOverrides | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // The project list is the page's ordinary context (same load the switcher
+  // does); the LEARN wires — docs, events, readback — fire only on submit.
+  useEffect(() => {
+    if (useProjectsStore.getState().projects.length === 0) void useProjectsStore.getState().load();
+  }, []);
+  useEffect(() => () => { abortRef.current?.abort(); }, []); // unmount ends any poll
+
+  // The learn rides one project's bridge (the proxy path encodes it). Default
+  // to the first project already bound to an interactive root, else the first
+  // real project; 'default' (Unfiled) is synthesized and never offered.
+  const selectable = projects.filter((p) => p.id !== 'default');
+  const effectiveProject = projectId !== '' ? projectId
+    : (selectable.find((p) => interactiveRootOf(p) !== null) ?? selectable[0])?.id ?? '';
+
+  const busy = phase === 'preparing' || phase === 'queued';
+
+  async function onLearn(): Promise<void> {
+    const value = source.trim();
+    if (!learnReady(kind, value) || effectiveProject === '' || busy) return;
+    abortRef.current?.abort();
+    const ctl = new AbortController();
+    abortRef.current = ctl;
+    setMapping(null);
+    setPhase('preparing');
+    setStatus(`Preparing the scratch document in “${effectiveProject}”…`);
+    try {
+      const docId = await ensureScratchDoc(effectiveProject);
+      if (ctl.signal.aborted) return;
+      // The bridge reports refusals ASYNC as status.posted errors on the
+      // scratch doc's thread; snapshot the newest one so only a NEW arrival
+      // ends this learn (identity comparison — see ThreadError).
+      const key = threadKey(effectiveProject, docId);
+      const baseline = useDocThreadStore.getState().lastError[key];
+      await requestThemeLearn(effectiveProject, docId, learnBody(kind, value));
+      if (ctl.signal.aborted) return;
+      setPhase('queued');
+      setStatus('Queued — the bridge is reading the source. Watching for the learned '
+        + 'tokens; this stops by itself in about a minute, or cancel below.');
+      const outcome = await pollLearnedTheme({
+        fetchLearned: () => getLearnedTheme(effectiveProject, docId),
+        bridgeError: () => {
+          const current = useDocThreadStore.getState().lastError[key];
+          return current !== undefined && current !== baseline ? current.text : null;
+        },
+        signal: ctl.signal,
+      });
+      if (ctl.signal.aborted) return; // cancel already reset the surface
+      if (outcome.kind === 'cancelled') { setPhase('idle'); setStatus(null); return; }
+      if (outcome.kind === 'bridge-error') { setPhase('error'); setStatus(outcome.reason); return; }
+      if (outcome.kind === 'timeout') {
+        setPhase('error');
+        setStatus(`No learned theme appeared after ${outcome.attempts} checks — the learn `
+          + 'may still be running on the bridge. Try again in a moment.'
+          + (outcome.lastFetchError !== null ? ` (last read error: ${outcome.lastFetchError})` : ''));
+        return;
+      }
+      const adapted = adaptLearnedTokens(outcome.result.tokens);
+      if (!adapted.ok) { setPhase('error'); setStatus(adapted.reason); return; }
+      const mapped = mapBrandTheme(adapted.palette);
+      setMapping(mapped);
+      if (isUnsatisfiable(mapped)) {
+        // §4.5: never applied silently — disclose, and offer no Apply.
+        setPhase('error');
+        setStatus('The extracted palette cannot satisfy the contrast and distinctness '
+          + 'guarantees — see the adjustments below.');
+        return;
+      }
+      // Preview IS the page (§3.4): the mapped primitives land inline on
+      // <html>, NOT through the store — nothing persists until Apply. The
+      // learned shape carries no logo, so the logo override is never touched.
+      const current = useAppearanceStore.getState().appearance;
+      applyAppearance({
+        ...current,
+        accent_h: mapped.accent_h,
+        accent_s: mapped.accent_s,
+        accent_l: mapped.accent_l,
+      });
+      setPhase('ready');
+      setStatus(`Learned “${adapted.palette.name}” — the whole page is previewing it; `
+        + 'nothing is saved until you apply.');
+    } catch (e: unknown) {
+      if (ctl.signal.aborted) return;
+      setPhase('error');
+      setStatus(errorText(e)); // sync refusals (unknown doc, 403, the typed 503) verbatim
+    }
+  }
+
+  function onApply(): void {
+    if (mapping === null || isUnsatisfiable(mapping) || phase !== 'ready') return;
+    // Persistence is the appearance store's job — the SAME optimistic inline
+    // apply + debounced PUT the manual wheel above uses. No new surface.
+    useAppearanceStore.getState().update({
+      accent_h: mapping.accent_h,
+      accent_s: mapping.accent_s,
+      accent_l: mapping.accent_l,
+    });
+    setPhase('applied');
+    setStatus('Applied — persisted as the per-install appearance, exactly like the wheel above.');
+  }
+
+  function onDiscard(): void {
+    abortRef.current?.abort();
+    // Revert the un-persisted preview: the stored appearance is the truth.
+    applyAppearance(useAppearanceStore.getState().appearance);
+    setMapping(null);
+    setPhase('idle');
+    setStatus(null);
+  }
+
+  const applicable = mapping !== null && !isUnsatisfiable(mapping) && phase === 'ready';
+
+  return (
+    <section
+      data-testid="brand-learn"
+      className="rounded-xl px-5 py-4 mb-6"
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    >
+      <h2
+        className="text-xs font-semibold uppercase tracking-wide pb-2 font-mono"
+        style={{ color: 'var(--ink-dim)' }}
+      >
+        Learn from a brand
+      </h2>
+      <p className="text-xs mt-0.5 mb-3" style={{ color: 'var(--ink-muted)' }}>
+        Point at a brand — a live website, a local PDF, or an image — and the interactive
+        bridge learns its look for a scratch document in the chosen project; the learned
+        palette is read back and mapped onto the studio accent, kept readable and distinct
+        from the fixed status colors. Nothing applies until you confirm. A learned theme
+        carries colors and fonts only — no logo, so the logo stays your manual choice above.
+      </p>
+
+      <div className="flex items-center gap-4 flex-wrap mb-2">
+        {LEARN_KINDS.map((k) => (
+          <label key={k} className="flex items-center gap-1.5 text-xs cursor-pointer"
+            style={{ color: kind === k ? 'var(--ink-body)' : 'var(--ink-muted)' }}>
+            <input
+              type="radio"
+              name="brand-learn-kind"
+              data-testid={`learn-source-${k}`}
+              checked={kind === k}
+              onChange={() => setKind(k)}
+              style={{ accentColor: 'var(--accent)' }}
+            />
+            {LEARN_LABEL[k].noun}
+          </label>
+        ))}
+        {selectable.length > 1 && (
+          <select
+            data-testid="learn-project"
+            aria-label="Project"
+            value={effectiveProject}
+            onChange={(e) => setProjectId(e.target.value)}
+            className="text-xs rounded px-1.5 py-1 ml-auto"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {selectable.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          data-testid="learn-input"
+          aria-label="Brand source"
+          placeholder={LEARN_LABEL[kind].placeholder}
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void onLearn(); }}
+          className="flex-1 min-w-0 rounded px-2 py-1 text-xs font-mono focus:outline-none"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+        />
+        <button
+          type="button"
+          data-testid="learn-submit"
+          disabled={busy}
+          onClick={() => void onLearn()}
+          className="px-3 py-1 rounded-lg text-xs font-medium disabled:opacity-50"
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+        >
+          Learn
+        </button>
+      </div>
+
+      {status !== null && (
+        <p
+          data-testid="learn-status"
+          className="text-xs mt-2 font-mono"
+          style={{ color: phase === 'error' ? 'var(--status-fail)' : 'var(--ink-body)' }}
+        >
+          {status}
+        </p>
+      )}
+
+      {busy && (
+        <div className="mt-2">
+          <button
+            type="button"
+            data-testid="learn-cancel"
+            onClick={onDiscard}
+            className="px-2.5 py-1 rounded-lg text-xs font-medium"
+            style={{ background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {mapping !== null && (
+        <div className="mt-3">
+          {applicable && (
+            <div className="flex items-center gap-3 flex-wrap">
+              <span
+                data-testid="learn-preview-chip"
+                className="text-xs px-2.5 py-1 rounded-full font-medium"
+                style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+              >
+                learned accent {mapping.accent_h}° {mapping.accent_s}% {mapping.accent_l}%
+              </span>
+              <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
+                The whole page is wearing it now — this chip included.
+              </span>
+            </div>
+          )}
+          {mapping.adjustments.length > 0 && (
+            <ul data-testid="mapper-adjustments" className="mt-2 flex flex-col gap-1">
+              {mapping.adjustments.map((a, i) => (
+                <li key={i} className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+                  <span style={{ color: a.constraint === 'unsatisfiable' ? 'var(--status-fail)' : 'var(--ink-dim)' }}>
+                    {a.constraint}
+                  </span>{' '}
+                  {a.original} → {a.adjusted} — <span style={{ color: 'var(--ink-body)' }}>{a.reason}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              type="button"
+              data-testid="learn-apply"
+              disabled={!applicable}
+              onClick={onApply}
+              className="px-3 py-1 rounded-lg text-xs font-medium disabled:opacity-50"
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+            >
+              Apply
+            </button>
+            <button
+              type="button"
+              data-testid="learn-discard"
+              onClick={onDiscard}
+              className="px-3 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'transparent', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ThemePage.tsx
+++ b/src/components/ThemePage.tsx
@@ -1,11 +1,19 @@
 import { AppearanceSettings } from './AppearanceSettings.js';
+import { BrandLearn } from './BrandLearn.js';
 
 /**
  * The dedicated Theme page (/theme) — a first-class home for the appearance
  * customization surface (DES-VISION-001 §3), moved off the system/settings
- * page so theming gets the room it deserves. The brand-learn flow that used
- * to live here was removed by issue #65: its wires were invented (see the
- * note in AppearanceSettings).
+ * page so theming gets the room it deserves.
+ *
+ * Two sections, two authorities:
+ *   - AppearanceSettings: the manual accent/logo/theme controls (untouched —
+ *     crew-persisted, the appearance store's wires).
+ *   - BrandLearn: "Learn from a brand" — retracted by studio#73 because its
+ *     old loop rode invented routes, back now on the REAL wires
+ *     (theme.requested over POST /api/events + the interactive#181 readback
+ *     GET /d/:docId/api/theme/learned). It renders inert: no learn-related
+ *     request leaves the page until the user acts.
  */
 export function ThemePage(): React.ReactElement {
   return (
@@ -17,6 +25,7 @@ export function ThemePage(): React.ReactElement {
         </p>
       </div>
       <AppearanceSettings />
+      <BrandLearn />
     </div>
   );
 }

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -97,10 +97,21 @@ export function threadKey(projectId: string, docId: string): string {
 
 // ── Store ────────────────────────────────────────────────────────────────────
 
+/** One bridge-reported failure line (`status.posted {state:"error"}`), per thread.
+ *  Consumers compare entry IDENTITY (a new object per error), so "did a NEW error
+ *  arrive since I started?" needs no clock — snapshot the entry, watch it change. */
+export interface ThreadError { text: string }
+
 interface DocThreadStore {
   messages: Record<string, DocMsg[]>;
   /** What the stream last said the generation is doing, per thread. */
   genState: Record<string, GenState>;
+  /** The newest `status.posted {state:"error"}` line, per thread — what the
+   *  brand-learn poll (learnPoll.ts) reads to surface the bridge's ASYNC
+   *  refusals (the SSRF guard's, a failed grab) while it waits on the
+   *  readback route. The transcript keeps carrying the same line as a
+   *  narration message; this is an index into it, not a second author. */
+  lastError: Record<string, ThreadError>;
   /** The user message a landing version will be tagged with (§7.6, client half). */
   anchor: Record<string, string>;
   /**
@@ -145,6 +156,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   genState: {},
   anchor: {},
   landed: {},
+  lastError: {},
 
   ingest: (event) => {
     const frame = frameOf(event);
@@ -174,14 +186,20 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         }
         const done = state === 'complete' || state === 'error';
         const next: GenState = done ? 'terminal' : was === 'gated' ? 'gated' : 'generating';
+        // An error line is ALSO indexed as the thread's newest failure (a fresh
+        // object each time — see ThreadError), so waiters can spot its arrival.
+        const failed = state === 'error' && text !== null
+          ? { lastError: { ...s.lastError, [key]: { text } } }
+          : {};
         // §3.2/§3.3: filler never reaches the transcript — rotating flavour text and a
         // subject-less `Working…` are both dropped AT THE SEAM, so an upstream bridge that
         // still speaks either cannot put it on screen. A filtered frame still carries the
         // state transition it rode in on: dropping the LINE is not dropping the fact.
-        if (text === null || isFiller(text)) return { genState: { ...s.genState, [key]: next } };
+        if (text === null || isFiller(text)) return { genState: { ...s.genState, [key]: next }, ...failed };
         return {
           messages: append(messages, key, { kind: 'narration', id: nextMsgId(), text }),
           genState: { ...s.genState, [key]: next },
+          ...failed,
         };
       }
 
@@ -306,6 +324,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       const genState = { ...s.genState }; delete genState[key];
       const anchor = { ...s.anchor }; delete anchor[key];
       const landed = { ...s.landed }; delete landed[key];
-      return { messages, genState, anchor, landed };
+      const lastError = { ...s.lastError }; delete lastError[key];
+      return { messages, genState, anchor, landed, lastError };
     }),
 }));

--- a/src/theming/brandMapper.ts
+++ b/src/theming/brandMapper.ts
@@ -1,0 +1,475 @@
+/**
+ * The palette the mapper consumes — flat CSS color strings, all optional but
+ * the name. Resurrected from the retracted slice-8 `ThemeDetail` (studio#73
+ * removed that wire-side type with the invented route it rode); the mapper's
+ * input shape survives unchanged, and `adaptLearnedTokens` (learnedTheme.ts)
+ * is the seam that folds the REAL readback shape — the bridge's nested
+ * `tokens.colors.*` from `GET /d/:docId/api/theme/learned` (interactive#181)
+ * — down to this.
+ */
+export interface BrandPalette {
+  name: string;
+  primary?: string;    /* CSS color string — dominant brand color */
+  secondary?: string;  /* CSS color string — secondary brand color, if extracted */
+  background?: string; /* CSS color string — brand background, if extracted */
+  logo_url?: string;   /* URL within the bridge to a logo asset, if found.
+                          NOT part of the learned-theme readback shape — kept for
+                          the mapper's purity contract and its historical tests. */
+}
+
+/**
+ * The brand mapper (DES-VISION-001 §4.5): `BrandPalette` → studio token
+ * overrides. A PURE function with no side effects — both invocation paths
+ * (the Settings UI and the garden skill `wicked-studio:theming:learn-brand`)
+ * run exactly this logic, so there is one spelling of "brand → accent".
+ *
+ * Four guarantees, in priority order (§4.5 — priority means which wins on
+ * conflict, not execution order):
+ *
+ *   1. WCAG AA contrast floor — `contrast(--accent, --surface-card) ≥ 4.5:1`
+ *      against the dark card surface default (`--_surface-2`, tokens.css §2.3).
+ *      Below the floor, lightness rises until it is met (cap 90%); if lightness
+ *      alone cannot meet it, saturation rises to 40% minimum. The floor may
+ *      push lightness past guarantee 3's 78% clamp — priority 1 beats 3.
+ *   2. Status-color distinctness — the accent hue stays ≥30° (circular) from
+ *      each status hue (gate 45°, failing 4°, running 148°; tokens.css §2.6).
+ *      A conflicting hue is walked outward in ±5° increments to the nearest
+ *      clear position; when both directions clear at the same distance, the
+ *      one maximizing total distance from all three status hues wins.
+ *   3. Saturation and lightness clamps — `accent_s ∈ [20, 88]`,
+ *      `accent_l ∈ [42, 78]` (dark theme): no near-greys, no neon, nothing
+ *      that disappears into the dark surfaces or washes out as white.
+ *   4. Perceptual distinctness — the full computed accent keeps a deltaE
+ *      (CIE76 Lab distance — §4.5 sanctions a simplified approximation) of
+ *      ≥25 from each full status color; a too-close accent has its lightness
+ *      moved ±10 to push them apart, never below the contrast floor. Because
+ *      guarantee 3 outranks 4, a nudge that satisfies the floor WITHIN the
+ *      lightness clamp always beats one that leaves it; the up-nudge may
+ *      exceed the 78% ceiling (disclosed) only when no in-clamp move meets
+ *      the floor — the §4.5 remedy is literally ±10, clamp or no clamp.
+ *
+ * Every move is logged as a `MapperAdjustment` (§4.5: no silent truncation —
+ * an unsatisfiable combination returns a `constraint: 'unsatisfiable'` entry
+ * and the UI shows it rather than applying silently).
+ *
+ * Tolerant reading (§4.4's ASSUMPTION[external-transform]): absent fields are
+ * null; only `primary` is required to derive an accent, `secondary` fills in
+ * when `primary` is missing, and a theme with no usable color at all maps to
+ * the §2.5 defaults with the fallback disclosed. `logo_url` passes through
+ * untransformed — resolving it to a same-origin URL is the caller's job
+ * (`interactiveUrl`), because the mapper is pure and knows no project.
+ */
+
+export interface MapperAdjustment {
+  constraint:
+    | 'contrast-floor'       /* §4.5 guarantee 1 */
+    | 'hue-separation'       /* §4.5 guarantee 2 */
+    | 'saturation-clamp'     /* §4.5 guarantee 3 */
+    | 'lightness-clamp'      /* §4.5 guarantee 3 */
+    | 'perceptual-distance'  /* §4.5 guarantee 4 */
+    | 'source-fallback'      /* §4.4 tolerant reading */
+    | 'unsatisfiable';       /* §4.5 no-silent-truncation */
+  original: string;
+  adjusted: string;
+  reason: string;
+}
+
+/** What the mapper hands back — the §4.2 skill's `token_overrides` + the log. */
+export interface BrandTokenOverrides {
+  accent_h: number;
+  accent_s: number;
+  accent_l: number;
+  logo_url: string | null;
+  adjustments: MapperAdjustment[];
+}
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// ── The fixed surfaces the guarantees measure against ────────────────────────
+// Numeric mirrors of tokens.css (§2.3, §2.6) — numbers, not color literals,
+// because §2.11 bans raw color strings outside the token files. If tokens.css
+// moves these, move them here (the unit suite pins the pairing).
+
+/** `--_surface-2` — the dark card surface (#1a1a26 in tokens.css §2.3). */
+export const SURFACE_CARD_RGB: Rgb = { r: 26, g: 26, b: 38 };
+
+/** §2.6's status trio: full (not -dim) variants, as HSL numbers. */
+export const STATUS_COLORS = [
+  { name: 'gate (amber)', h: 45, s: 90, l: 68 },
+  { name: 'failing (red)', h: 4, s: 88, l: 62 },
+  { name: 'running (emerald)', h: 148, s: 58, l: 58 },
+] as const;
+
+const CONTRAST_FLOOR = 4.5;   /* §4.5 g1: WCAG AA */
+const LIGHTNESS_CAP = 90;     /* §4.5 g1: the raise stops here */
+const MIN_SAT_FOR_CONTRAST = 40; /* §4.5 g1: the low-saturation rescue */
+const HUE_SEPARATION = 30;    /* §4.5 g2: degrees from each status hue */
+const HUE_STEP = 5;           /* §4.5 g2: search increment */
+const SAT_MIN = 20;           /* §4.5 g3 */
+const SAT_MAX = 88;           /* §4.5 g3 */
+const LGT_MIN = 42;           /* §4.5 g3 (dark theme) */
+const LGT_MAX = 78;           /* §4.5 g3 (dark theme) */
+const DELTA_E_FLOOR = 25;     /* §4.5 g4 */
+const PERCEPTUAL_NUDGE = 10;  /* §4.5 g4: lightness is adjusted by ±10 */
+
+// ── Color math ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a CSS color string tolerantly: hex (#rgb/#rgba/#rrggbb/#rrggbbaa),
+ * rgb()/rgba() (0–255 or %), hsl()/hsla(). Anything else — including a
+ * non-string — is null, which the pipeline treats as "absent" (§4.4).
+ */
+export function parseCssColor(input: unknown): Rgb | null {
+  if (typeof input !== 'string') return null;
+  const str = input.trim().toLowerCase();
+  if (str.startsWith('#')) {
+    const hex = str.slice(1);
+    if (!/^[0-9a-f]+$/.test(hex)) return null;
+    if (hex.length === 3 || hex.length === 4) {
+      return {
+        r: parseInt(hex.charAt(0) + hex.charAt(0), 16),
+        g: parseInt(hex.charAt(1) + hex.charAt(1), 16),
+        b: parseInt(hex.charAt(2) + hex.charAt(2), 16),
+      };
+    }
+    if (hex.length === 6 || hex.length === 8) {
+      return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16),
+      };
+    }
+    return null;
+  }
+  const fn = /^(rgba?|hsla?)\s*\(([^)]*)\)$/.exec(str);
+  if (fn === null) return null;
+  const parts = (fn[2] ?? '').split(/[,\s/]+/).filter((p) => p !== '');
+  const [c0, c1, c2] = [parts[0] ?? '', parts[1] ?? '', parts[2] ?? ''];
+  if (parts.length < 3) return null;
+  if ((fn[1] ?? '').startsWith('rgb')) {
+    const chan = (raw: string): number | null => {
+      const pct = raw.endsWith('%');
+      const n = Number.parseFloat(raw);
+      if (!Number.isFinite(n)) return null;
+      const v = pct ? (n / 100) * 255 : n;
+      return Math.min(255, Math.max(0, Math.round(v)));
+    };
+    const r = chan(c0);
+    const g = chan(c1);
+    const b = chan(c2);
+    return r === null || g === null || b === null ? null : { r, g, b };
+  }
+  const h = Number.parseFloat(c0);
+  const s = Number.parseFloat(c1);
+  const l = Number.parseFloat(c2);
+  if (!Number.isFinite(h) || !Number.isFinite(s) || !Number.isFinite(l)) return null;
+  return hslToRgb(((h % 360) + 360) % 360, Math.min(100, Math.max(0, s)), Math.min(100, Math.max(0, l)));
+}
+
+export function hslToRgb(h: number, s: number, l: number): Rgb {
+  const sn = s / 100;
+  const ln = l / 100;
+  const chroma = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = chroma * (1 - Math.abs((hp % 2) - 1));
+  let rp = 0;
+  let gp = 0;
+  let bp = 0;
+  if (hp < 1) [rp, gp, bp] = [chroma, x, 0];
+  else if (hp < 2) [rp, gp, bp] = [x, chroma, 0];
+  else if (hp < 3) [rp, gp, bp] = [0, chroma, x];
+  else if (hp < 4) [rp, gp, bp] = [0, x, chroma];
+  else if (hp < 5) [rp, gp, bp] = [x, 0, chroma];
+  else [rp, gp, bp] = [chroma, 0, x];
+  const m = ln - chroma / 2;
+  return {
+    r: Math.round((rp + m) * 255),
+    g: Math.round((gp + m) * 255),
+    b: Math.round((bp + m) * 255),
+  };
+}
+
+export function rgbToHsl({ r, g, b }: Rgb): { h: number; s: number; l: number } {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0;
+  let s = 0;
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1));
+    if (max === rn) h = 60 * (((gn - bn) / d) % 6);
+    else if (max === gn) h = 60 * ((bn - rn) / d + 2);
+    else h = 60 * ((rn - gn) / d + 4);
+  }
+  return {
+    h: Math.round(((h % 360) + 360) % 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+function channelLuminance(c255: number): number {
+  const c = c255 / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+/** WCAG contrast ratio, 1:1 → 21:1. */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function toLab({ r, g, b }: Rgb): { L: number; a: number; b: number } {
+  // sRGB → XYZ (D65) → CIELAB.
+  const lin = (c255: number): number => {
+    const c = c255 / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const rl = lin(r);
+  const gl = lin(g);
+  const bl = lin(b);
+  const x = (0.4124 * rl + 0.3576 * gl + 0.1805 * bl) / 0.95047;
+  const y = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+  const z = (0.0193 * rl + 0.1192 * gl + 0.9505 * bl) / 1.08883;
+  const f = (t: number): number => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  const fx = f(x);
+  const fy = f(y);
+  const fz = f(z);
+  return { L: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
+}
+
+/** CIE76 deltaE — the §4.5-sanctioned simplified perceptual distance. */
+export function deltaE(a: Rgb, b: Rgb): number {
+  const la = toLab(a);
+  const lb = toLab(b);
+  return Math.sqrt((la.L - lb.L) ** 2 + (la.a - lb.a) ** 2 + (la.b - lb.b) ** 2);
+}
+
+/** Circular hue distance in degrees, 0–180. */
+export function hueDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return Math.min(d, 360 - d);
+}
+
+// ── The pipeline ──────────────────────────────────────────────────────────────
+
+function minStatusHueSeparation(h: number): number {
+  return Math.min(...STATUS_COLORS.map((st) => hueDistance(h, st.h)));
+}
+
+function totalStatusHueDistance(h: number): number {
+  return STATUS_COLORS.reduce((sum, st) => sum + hueDistance(h, st.h), 0);
+}
+
+/**
+ * §4.5 g2's search: walk outward in ±5° increments to the nearest hue that
+ * clears every status hue by ≥30°; a same-distance tie goes to the candidate
+ * with the greater total distance from all three status hues.
+ */
+function nearestClearHue(h: number): number {
+  for (let k = 1; k <= Math.ceil(360 / HUE_STEP); k++) {
+    const up = (h + k * HUE_STEP) % 360;
+    const down = (((h - k * HUE_STEP) % 360) + 360) % 360;
+    const upOk = minStatusHueSeparation(up) >= HUE_SEPARATION;
+    const downOk = minStatusHueSeparation(down) >= HUE_SEPARATION;
+    if (upOk && downOk) return totalStatusHueDistance(up) >= totalStatusHueDistance(down) ? up : down;
+    if (upOk) return up;
+    if (downOk) return down;
+  }
+  return h; // structurally unreachable while clear arcs exist; caller logs it
+}
+
+/** Raise lightness until the floor is met or the cap is hit; returns final l. */
+function raiseLightnessToFloor(h: number, s: number, l: number): number {
+  let cur = l;
+  while (cur < LIGHTNESS_CAP && contrastRatio(hslToRgb(h, s, cur), SURFACE_CARD_RGB) < CONTRAST_FLOOR) {
+    cur += 1;
+  }
+  return cur;
+}
+
+/** The §4.5 mapper: pure, tolerant, every move disclosed. */
+export function mapBrandTheme(theme: BrandPalette): BrandTokenOverrides {
+  const adjustments: MapperAdjustment[] = [];
+  const logoRaw = typeof theme.logo_url === 'string' && theme.logo_url.trim() !== ''
+    ? theme.logo_url.trim()
+    : null;
+
+  // ── Source color (§4.4 tolerant reading): primary, else secondary, else defaults ──
+  let src = parseCssColor(theme.primary);
+  if (src === null) {
+    src = parseCssColor(theme.secondary);
+    if (src !== null) {
+      adjustments.push({
+        constraint: 'source-fallback',
+        original: `primary=${String(theme.primary ?? null)}`,
+        adjusted: `secondary=${String(theme.secondary)}`,
+        reason: 'No usable primary color was extracted — the accent derives from the secondary brand color.',
+      });
+    }
+  }
+  if (src === null) {
+    adjustments.push({
+      constraint: 'source-fallback',
+      original: `primary=${String(theme.primary ?? null)}, secondary=${String(theme.secondary ?? null)}`,
+      adjusted: 'accent 258 72% 62% (default)',
+      reason: 'No usable brand color was extracted from the source — the default accent stands.',
+    });
+    return { accent_h: 258, accent_s: 72, accent_l: 62, logo_url: logoRaw, adjustments };
+  }
+
+  let { h, s, l } = rgbToHsl(src);
+
+  // ── Guarantee 3: saturation and lightness clamps ──
+  if (s < SAT_MIN || s > SAT_MAX) {
+    const clamped = Math.min(SAT_MAX, Math.max(SAT_MIN, s));
+    adjustments.push({
+      constraint: 'saturation-clamp',
+      original: `s=${s}%`,
+      adjusted: `s=${clamped}%`,
+      reason: s < SAT_MIN
+        ? `Saturation ${s}% is a near-grey — raised to the ${SAT_MIN}% floor so the accent reads as a color.`
+        : `Saturation ${s}% is neon on dark surfaces — lowered to the ${SAT_MAX}% ceiling.`,
+    });
+    s = clamped;
+  }
+  if (l < LGT_MIN || l > LGT_MAX) {
+    const clamped = Math.min(LGT_MAX, Math.max(LGT_MIN, l));
+    adjustments.push({
+      constraint: 'lightness-clamp',
+      original: `l=${l}%`,
+      adjusted: `l=${clamped}%`,
+      reason: l < LGT_MIN
+        ? `Lightness ${l}% disappears into the dark background — raised to the ${LGT_MIN}% floor.`
+        : `Lightness ${l}% washes out as white — lowered to the ${LGT_MAX}% ceiling.`,
+    });
+    l = clamped;
+  }
+
+  // ── Guarantee 2: ≥30° circular separation from every status hue ──
+  if (minStatusHueSeparation(h) < HUE_SEPARATION) {
+    const moved = nearestClearHue(h);
+    if (minStatusHueSeparation(moved) < HUE_SEPARATION) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `h=${h}°`,
+        adjusted: `h=${h}°`,
+        reason: 'Every hue position conflicts with a status hue — no ≥30° separation exists.',
+      });
+    } else {
+      const nearest = STATUS_COLORS.reduce((a, b) => (hueDistance(h, a.h) <= hueDistance(h, b.h) ? a : b));
+      adjustments.push({
+        constraint: 'hue-separation',
+        original: `h=${h}°`,
+        adjusted: `h=${moved}°`,
+        reason: `Hue ${h}° sits within 30° of the ${nearest.name} status hue — moved to the nearest clear position.`,
+      });
+      h = moved;
+    }
+  }
+
+  // ── Guarantee 1: WCAG AA contrast floor against the card surface ──
+  let contrast = contrastRatio(hslToRgb(h, s, l), SURFACE_CARD_RGB);
+  if (contrast < CONTRAST_FLOOR) {
+    const startL = l;
+    let raised = raiseLightnessToFloor(h, s, startL);
+    let finalS = s;
+    if (contrastRatio(hslToRgb(h, finalS, raised), SURFACE_CARD_RGB) < CONTRAST_FLOOR
+        && finalS < MIN_SAT_FOR_CONTRAST) {
+      adjustments.push({
+        constraint: 'contrast-floor',
+        original: `s=${finalS}%`,
+        adjusted: `s=${MIN_SAT_FOR_CONTRAST}%`,
+        reason: `The ${CONTRAST_FLOOR}:1 floor could not be met by lightness alone — saturation raised to the ${MIN_SAT_FOR_CONTRAST}% minimum.`,
+      });
+      finalS = MIN_SAT_FOR_CONTRAST;
+      raised = raiseLightnessToFloor(h, finalS, startL);
+    }
+    if (raised !== startL) {
+      adjustments.push({
+        constraint: 'contrast-floor',
+        original: `l=${startL}%`,
+        adjusted: `l=${raised}%`,
+        reason: `Contrast against the card surface was ${contrast.toFixed(2)}:1 — lightness raised for WCAG AA (${CONTRAST_FLOOR}:1) on dark surfaces.`,
+      });
+    }
+    s = finalS;
+    l = raised;
+    contrast = contrastRatio(hslToRgb(h, s, l), SURFACE_CARD_RGB);
+    if (contrast < CONTRAST_FLOOR) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `l=${startL}%`,
+        adjusted: `l=${l}%, s=${s}%`,
+        reason: `The ${CONTRAST_FLOOR}:1 contrast floor cannot be met: ${contrast.toFixed(2)}:1 at the ${LIGHTNESS_CAP}% lightness cap.`,
+      });
+    }
+  }
+
+  // ── Guarantee 4: perceptual distance ≥25 from every full status color ──
+  const tooClose = (lgt: number): { name: string; d: number } | null => {
+    const accent = hslToRgb(h, s, lgt);
+    let worst: { name: string; d: number } | null = null;
+    for (const st of STATUS_COLORS) {
+      const d = deltaE(accent, hslToRgb(st.h, st.s, st.l));
+      if (d < DELTA_E_FLOOR && (worst === null || d < worst.d)) worst = { name: st.name, d };
+    }
+    return worst;
+  };
+  const near = tooClose(l);
+  if (near !== null) {
+    const minDeltaAt = (lgt: number): number =>
+      Math.min(...STATUS_COLORS.map((st) => deltaE(hslToRgb(h, s, lgt), hslToRgb(st.h, st.s, st.l))));
+    const meetsContrast = (lgt: number): boolean =>
+      contrastRatio(hslToRgb(h, s, lgt), SURFACE_CARD_RGB) >= CONTRAST_FLOOR;
+    const candidates = [
+      Math.min(LIGHTNESS_CAP, l + PERCEPTUAL_NUDGE),
+      Math.max(LGT_MIN, l - PERCEPTUAL_NUDGE),
+    ].filter((c) => c !== l && meetsContrast(c)); // g1 outranks g4: never break the floor
+    // g3 outranks g4: when a candidate satisfies the deltaE floor WITHOUT
+    // leaving the [42,78] clamp, it wins — the up-nudge may exceed the clamp
+    // (disclosed) only when no in-clamp candidate meets the floor.
+    const inClamp = candidates.filter((c) => c <= LGT_MAX && minDeltaAt(c) >= DELTA_E_FLOOR);
+    const pool = inClamp.length > 0 ? inClamp : candidates;
+    if (pool.length > 0) {
+      const best = pool.reduce((a, b) => (minDeltaAt(a) >= minDeltaAt(b) ? a : b));
+      adjustments.push({
+        constraint: 'perceptual-distance',
+        original: `l=${l}%`,
+        adjusted: `l=${best}%`,
+        reason: `The accent sat only ${near.d.toFixed(1)} deltaE from the ${near.name} status color — lightness moved to push them ≥${DELTA_E_FLOOR} apart.`,
+      });
+      l = best;
+    }
+    const still = tooClose(l);
+    if (still !== null) {
+      adjustments.push({
+        constraint: 'unsatisfiable',
+        original: `deltaE=${near.d.toFixed(1)}`,
+        adjusted: `deltaE=${still.d.toFixed(1)}`,
+        reason: `The accent remains within ${DELTA_E_FLOOR} deltaE of the ${still.name} status color after the ±${PERCEPTUAL_NUDGE}% lightness adjustment.`,
+      });
+    }
+  }
+
+  return { accent_h: h, accent_s: s, accent_l: l, logo_url: logoRaw, adjustments };
+}
+
+/** True when the mapping must NOT be applied silently (§4.5 no-silent-truncation). */
+export function isUnsatisfiable(m: BrandTokenOverrides): boolean {
+  return m.adjustments.some((a) => a.constraint === 'unsatisfiable');
+}

--- a/src/theming/learnPoll.ts
+++ b/src/theming/learnPoll.ts
@@ -1,0 +1,83 @@
+import { BridgeUnavailableError, type LearnedTheme } from '../api/interactive.js';
+
+/**
+ * The bounded readback poll behind the /theme brand-learn flow.
+ *
+ * A learn is fire-and-forget on the wire (`theme.requested` acks with an
+ * EventAck; the work happens on the bridge), so the ONLY way to know the
+ * tokens landed is to poll `GET /d/:docId/api/theme/learned` (interactive#181)
+ * until its 404 turns 200. The hard constraints this module owns:
+ *
+ *   - BOUNDED: the schedule below is the whole lifetime — a gentle backoff
+ *     to a 5s cadence, hard-capped at ~66s of waiting. No interval survives
+ *     the outcome; there is nothing to leak.
+ *   - CANCELLABLE: the caller's AbortSignal ends the loop at the next seam
+ *     (including mid-sleep). Unmount aborts; navigation aborts.
+ *   - HONEST about refusals: the bridge reports failures ASYNC as
+ *     `status.posted {state:"error"}` frames (the SSRF guard's refusal, a
+ *     failed grab). `bridgeError` is read every tick so a refusal ends the
+ *     wait with the bridge's OWN sentence instead of a timeout shrug.
+ *   - a FLAKY poll is not a failed learn: a thrown fetch keeps the loop
+ *     alive (remembered for the timeout report) — except the typed 503,
+ *     which means the bridge itself is gone and waiting cannot help.
+ */
+
+/** ~66s total: 1s → 5s backoff, then a 5s cadence. */
+export const LEARN_POLL_DELAYS_MS: readonly number[] = [
+  1_000, 1_500, 2_500, 4_000, 5_000, 5_000, 5_000, 5_000, 5_000, 5_000, 5_000,
+  5_000, 5_000, 5_000, 5_000,
+];
+
+export type LearnPollOutcome =
+  | { kind: 'learned'; result: LearnedTheme }
+  | { kind: 'bridge-error'; reason: string }
+  | { kind: 'cancelled' }
+  | { kind: 'timeout'; attempts: number; lastFetchError: string | null };
+
+export interface LearnPollDeps {
+  /** One readback attempt — `getLearnedTheme`: the result, or null while 404. */
+  fetchLearned: () => Promise<LearnedTheme | null>;
+  /** The bridge's async refusal, if one has arrived since the learn was fired
+   *  (the docThread store's `lastError` behind an identity snapshot). */
+  bridgeError?: () => string | null;
+  signal: AbortSignal;
+  /** Test seam: the backoff schedule (defaults to LEARN_POLL_DELAYS_MS). */
+  delays?: readonly number[];
+  /** Test seam: the sleeper (defaults to an abort-aware setTimeout). */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+/** setTimeout that resolves EARLY on abort — the loop re-checks at the top. */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) { resolve(); return; }
+    const timer = setTimeout(() => { signal.removeEventListener('abort', onAbort); resolve(); }, ms);
+    function onAbort(): void { clearTimeout(timer); resolve(); }
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export async function pollLearnedTheme(deps: LearnPollDeps): Promise<LearnPollOutcome> {
+  const { fetchLearned, bridgeError, signal } = deps;
+  const delays = deps.delays ?? LEARN_POLL_DELAYS_MS;
+  const sleep = deps.sleep ?? abortableSleep;
+  let lastFetchError: string | null = null;
+
+  // delays.length sleeps ⇒ delays.length + 1 attempts, then the hard cap.
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    if (signal.aborted) return { kind: 'cancelled' };
+    const refusal = bridgeError?.() ?? null;
+    if (refusal !== null) return { kind: 'bridge-error', reason: refusal };
+    try {
+      const result = await fetchLearned();
+      if (result !== null) return { kind: 'learned', result };
+    } catch (e: unknown) {
+      // The bridge itself is gone — waiting cannot land tokens.
+      if (e instanceof BridgeUnavailableError) return { kind: 'bridge-error', reason: e.message };
+      lastFetchError = e instanceof Error ? e.message : String(e);
+    }
+    if (signal.aborted) return { kind: 'cancelled' };
+    if (attempt < delays.length) await sleep(delays[attempt] as number, signal);
+  }
+  return { kind: 'timeout', attempts: delays.length + 1, lastFetchError };
+}

--- a/src/theming/learnedTheme.ts
+++ b/src/theming/learnedTheme.ts
@@ -1,0 +1,79 @@
+import { parseCssColor, type BrandPalette } from './brandMapper.js';
+
+/**
+ * The seam between the REAL learned-theme shape and the resurrected mapper.
+ *
+ * `GET /d/:docId/api/theme/learned` (interactive#181) serves the doc's
+ * `learned.theme.json` VERBATIM — the bridge's own theme-token vocabulary,
+ * NESTED: `{name, colors:{background,surface,primary,secondary,accent,
+ * text_primary,…}, fonts:{heading,body,mono}, …}`, with any field free to be
+ * absent (partials are legal — the bridge's `themed()` applies whatever is
+ * there). The §4.5 mapper (brandMapper.ts, resurrected from history) consumes
+ * the FLAT `BrandPalette` it always consumed. This adapter folds one onto the
+ * other and nothing more — no §4.5 logic lives here.
+ *
+ * Honesty rules:
+ *   - `colors.primary` is the dominant brand color; `colors.secondary`, then
+ *     `colors.accent`, fill the mapper's `secondary` channel (its own §4.4
+ *     fallback discloses when it derives the accent from there).
+ *   - a tokens object with NO usable brand color is an ERROR outcome, not a
+ *     silent default: mapping "nothing" onto the stock accent and calling it
+ *     a learned brand would be the dishonesty studio#73 existed to remove.
+ *   - the learned shape carries NO logo. The logo slot stays the manual
+ *     choice it already is on /theme, and the UI says so.
+ */
+
+export type AdaptOutcome =
+  | { ok: true; palette: BrandPalette }
+  | { ok: false; reason: string };
+
+/** First member of `bag` under `keys` that parses as a CSS color, else null. */
+function firstColor(bag: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = bag[key];
+    if (typeof value === 'string' && parseCssColor(value) !== null) return value;
+  }
+  return null;
+}
+
+/** Narrow an unknown to a plain object, else `{}` (tolerant reading). */
+function asObject(raw: unknown): Record<string, unknown> {
+  return typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {};
+}
+
+/**
+ * Fold the readback's `tokens` down to the mapper's input.
+ *
+ * `ok: false` when no usable brand color exists anywhere in `colors.primary`
+ * / `colors.secondary` / `colors.accent` — the caller shows the reason
+ * instead of applying anything.
+ */
+export function adaptLearnedTokens(tokens: unknown): AdaptOutcome {
+  const bag = asObject(tokens);
+  const colors = asObject(bag.colors);
+  const primary = firstColor(colors, 'primary');
+  // The mapper's own secondary-fallback (§4.4, disclosed) does the rest —
+  // this just decides WHICH extracted color rides each channel.
+  const secondary = firstColor(colors, 'secondary', 'accent');
+  if (primary === null && secondary === null) {
+    return {
+      ok: false,
+      reason: 'The learned theme carries no usable brand color — '
+        + 'colors.primary, colors.secondary and colors.accent are all absent or '
+        + 'unparseable — so the accent was left as it is.',
+    };
+  }
+  const name = typeof bag.name === 'string' && bag.name.trim() !== ''
+    ? bag.name.trim()
+    : 'learned-theme';
+  return {
+    ok: true,
+    palette: {
+      name,
+      ...(primary !== null ? { primary } : {}),
+      ...(secondary !== null ? { secondary } : {}),
+      // No logo_url: the learned shape has none (see the header) — the mapper
+      // sees an absent logo and the manual /theme logo choice stands.
+    },
+  };
+}

--- a/src/theming/scratchDoc.ts
+++ b/src/theming/scratchDoc.ts
@@ -1,0 +1,51 @@
+import { createDoc, listDocs, type CreateDocResult, type DocSummary } from '../api/interactive.js';
+
+/**
+ * The studio-owned scratch document a brand learn rides (one per project).
+ *
+ * A theme learn is DOC-SCOPED on the real bridge (`theme.requested` needs a
+ * `document_id`; the tokens land in that doc's workspace), but the /theme
+ * page's subject is the STUDIO accent, not any particular document — so the
+ * flow keeps a named scratch doc per project and reuses it forever:
+ *
+ *   - already listed → reused verbatim, nothing created (idempotent);
+ *   - absent → created through the REAL registry route (`POST /api/docs` with
+ *     the same `kind:'source' + brief + project` shape the slice-F composer
+ *     launch uses — the one create that needs no `html` body);
+ *   - a concurrent create's 409 ("doc already exists") → the doc exists,
+ *     which is the goal — reused.
+ */
+
+export const SCRATCH_DOC_NAME = 'brand-learn';
+
+export const SCRATCH_DOC_BRIEF =
+  'Scratch document wicked-studio uses to learn brand themes. Each "learn from '
+  + 'a brand" run on the /theme page points the bridge at a source and reads '
+  + 'the learned tokens back from this document’s workspace.';
+
+export interface ScratchDocDeps {
+  listDocs: (projectId: string) => Promise<DocSummary[]>;
+  createDoc: (
+    projectId: string,
+    body: { name: string; kind: 'source'; brief: string; project: string },
+  ) => Promise<CreateDocResult>;
+}
+
+/** Ensure the project's scratch doc exists; resolve its doc id. */
+export async function ensureScratchDoc(
+  projectId: string,
+  deps: ScratchDocDeps = { listDocs, createDoc },
+): Promise<string> {
+  const docs = await deps.listDocs(projectId);
+  if (docs.some((d) => d.name === SCRATCH_DOC_NAME)) return SCRATCH_DOC_NAME;
+  try {
+    const created = await deps.createDoc(projectId, {
+      name: SCRATCH_DOC_NAME, kind: 'source', brief: SCRATCH_DOC_BRIEF, project: projectId,
+    });
+    return created.name;
+  } catch (e: unknown) {
+    // Raced another creator: the bridge's 409 means the doc now exists — use it.
+    if (e instanceof Error && /^API 409: /.test(e.message)) return SCRATCH_DOC_NAME;
+    throw e;
+  }
+}

--- a/tests/BrandLearn.test.tsx
+++ b/tests/BrandLearn.test.tsx
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Project } from '../src/api/types.js';
+
+/**
+ * "Learn from a brand" (/theme) on the REAL wires — the flow studio#73
+ * retracted, restored over interactive#181's readback:
+ *
+ *   ensure the project's scratch doc (real registry route, idempotent) →
+ *   theme.requested over POST /api/events → bounded poll of
+ *   GET /d/:docId/api/theme/learned → adapter → the resurrected §4.5 mapper →
+ *   inline preview (nothing persisted) → Apply through the EXISTING
+ *   appearance store. Every wrapper is mocked here, so ANY network the
+ *   component did itself would be a jsdom failure — and the inert-at-rest
+ *   constraint (zero learn-related calls before the user acts) is assertable.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+    putAppearanceSettings: vi.fn().mockResolvedValue({ settings: {} }),
+    listProjects: vi.fn().mockResolvedValue({ projects: [] }),
+  },
+}));
+
+const listDocs = vi.fn();
+const createDoc = vi.fn();
+const requestThemeLearn = vi.fn();
+const getLearnedTheme = vi.fn();
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: (...a: unknown[]) => listDocs(...a) as unknown,
+  createDoc: (...a: unknown[]) => createDoc(...a) as unknown,
+  requestThemeLearn: (...a: unknown[]) => requestThemeLearn(...a) as unknown,
+  getLearnedTheme: (...a: unknown[]) => getLearnedTheme(...a) as unknown,
+  attachSource: vi.fn(),
+  interactiveUrl: (pid: string, p: string) =>
+    `/api/v1/projects/${pid}/interactive${p.startsWith('/') ? p : `/${p}`}`,
+  BridgeUnavailableError: class BridgeUnavailableError extends Error {},
+  ServiceHintError: class ServiceHintError extends Error {
+    readonly hint: string;
+    constructor(message: string, hint: string) { super(message); this.hint = hint; }
+  },
+}));
+
+const { api } = await import('../src/api/client.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { threadKey, useDocThreadStore } = await import('../src/store/docThread.js');
+const { DEFAULT_APPEARANCE, useAppearanceStore } = await import('../src/theming/appearance.js');
+const { SCRATCH_DOC_NAME } = await import('../src/theming/scratchDoc.js');
+const { BrandLearn } = await import('../src/components/BrandLearn.js');
+
+const root = () => document.documentElement;
+
+function project(id: string, extra: Record<string, unknown> = {}): Project {
+  return {
+    id, name: id, description: null, status: 'active',
+    scope: `project:${id}`, created_at: 1, updated_at: 1, ...extra,
+  };
+}
+
+function scratchSummary() {
+  return { name: SCRATCH_DOC_NAME, kind: 'doc', head: 1, versions: 1, updated_at: null };
+}
+
+// The fixture navy: #0a2a5e → the mapper lands (217, 81%, 59%) with a
+// lightness-clamp + a contrast-floor adjustment (pinned in brandMapper.test.ts).
+const LEARNED = {
+  document_id: SCRATCH_DOC_NAME,
+  learned_at: '2026-08-21T12:00:00.000Z',
+  tokens: {
+    name: 'acme-brand',
+    colors: { background: '#f8fafc', primary: '#0a2a5e', secondary: '#0e7490' },
+    fonts: { heading: 'Georgia', body: 'Georgia', mono: 'Menlo' },
+  },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  listDocs.mockReset().mockResolvedValue([scratchSummary()]); // scratch doc exists by default
+  createDoc.mockReset().mockResolvedValue({ name: SCRATCH_DOC_NAME, head: 0 });
+  requestThemeLearn.mockReset().mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  getLearnedTheme.mockReset().mockResolvedValue(LEARNED);
+  vi.mocked(api.putAppearanceSettings).mockClear();
+  useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: true });
+  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {}, lastError: {} });
+  useProjectsStore.setState({
+    projects: [
+      project('default'),
+      project('scratch'),
+      project('notes', { interactiveRoot: '/tmp/wi-notes' }),
+    ],
+    loading: false,
+    error: null,
+  });
+  root().removeAttribute('style');
+  root().removeAttribute('data-theme');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+async function learnFrom(value = 'https://acme.example'): Promise<void> {
+  fireEvent.change(screen.getByTestId('learn-input'), { target: { value } });
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('learn-submit'));
+    await vi.advanceTimersByTimeAsync(0); // ensure-doc + learn + the first poll settle
+  });
+}
+
+describe('BrandLearn — the restored /theme extraction flow', () => {
+  it('renders inert: the form is there, and NOT ONE learn wire has been touched', () => {
+    render(<BrandLearn />);
+    expect(screen.getByTestId('learn-source-url')).toBeChecked();
+    expect(screen.getByTestId('learn-source-pdf')).toBeInTheDocument();
+    expect(screen.getByTestId('learn-source-image')).toBeInTheDocument();
+    expect(screen.getByTestId('learn-project')).toBeInTheDocument();
+    expect(screen.getByTestId('learn-submit')).toBeInTheDocument();
+    expect(screen.queryByTestId('learn-status')).toBeNull();
+    expect(listDocs).not.toHaveBeenCalled();
+    expect(createDoc).not.toHaveBeenCalled();
+    expect(requestThemeLearn).not.toHaveBeenCalled();
+    expect(getLearnedTheme).not.toHaveBeenCalled();
+  });
+
+  it('mentions the logo honesty in its copy — the learned shape carries none', () => {
+    render(<BrandLearn />);
+    expect(screen.getByTestId('brand-learn').textContent)
+      .toMatch(/no logo, so the logo stays your manual choice/);
+  });
+
+  it('Learn reuses the existing scratch doc and fires theme.requested at it', async () => {
+    render(<BrandLearn />);
+    await learnFrom();
+    // The default project is the one already bound to an interactive root.
+    expect(listDocs).toHaveBeenCalledExactlyOnceWith('notes');
+    expect(createDoc).not.toHaveBeenCalled(); // idempotent: listed → reused
+    expect(requestThemeLearn).toHaveBeenCalledExactlyOnceWith(
+      'notes', SCRATCH_DOC_NAME, { kind: 'url', url: 'https://acme.example' });
+  });
+
+  it('creates the scratch doc (slice-F shape) when the registry lacks it', async () => {
+    listDocs.mockResolvedValue([]);
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(createDoc).toHaveBeenCalledTimes(1);
+    const [pid, body] = createDoc.mock.calls[0] as [string, Record<string, unknown>];
+    expect(pid).toBe('notes');
+    expect(body).toMatchObject({ name: SCRATCH_DOC_NAME, kind: 'source', project: 'notes' });
+    expect(requestThemeLearn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a local path kind sends {kind, path} — nothing uploads from the browser', async () => {
+    render(<BrandLearn />);
+    fireEvent.click(screen.getByTestId('learn-source-pdf'));
+    await learnFrom('/Users/op/brand.pdf');
+    expect(requestThemeLearn).toHaveBeenCalledExactlyOnceWith(
+      'notes', SCRATCH_DOC_NAME, { kind: 'pdf', path: '/Users/op/brand.pdf' });
+  });
+
+  it('rides the 404→200 readback, then previews inline WITHOUT persisting', async () => {
+    getLearnedTheme
+      .mockResolvedValueOnce(null)  // still 404: no learned theme
+      .mockResolvedValueOnce(LEARNED);
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(getLearnedTheme).toHaveBeenCalledExactlyOnceWith('notes', SCRATCH_DOC_NAME);
+    expect(screen.queryByTestId('learn-preview-chip')).toBeNull(); // still waiting
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); }); // first backoff step
+    expect(getLearnedTheme).toHaveBeenCalledTimes(2);
+
+    // Preview via the slice-7 machinery: inline overrides on <html>…
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('217');
+    expect(root().style.getPropertyValue('--_accent-s')).toBe('81%');
+    expect(root().style.getPropertyValue('--_accent-l')).toBe('59%');
+    expect(root().style.getPropertyValue('--logo-url')).toBe(''); // logo NEVER touched
+    // …but NOTHING persisted: the store still holds the defaults, no PUT fired.
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(258);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(api.putAppearanceSettings).not.toHaveBeenCalled();
+    expect(screen.getByTestId('learn-preview-chip').textContent).toContain('217');
+    // The mapper's moves are disclosed under the preview.
+    const list = screen.getByTestId('mapper-adjustments');
+    expect(list.textContent).toContain('lightness-clamp');
+    expect(list.textContent).toContain('contrast-floor');
+  });
+
+  it('polling stops the moment the tokens land — no loop outlives the flow', async () => {
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1); // learned on the first read
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1); // and never again
+  });
+
+  it('Apply persists the mapped accent through the EXISTING appearance store, logo untouched', async () => {
+    render(<BrandLearn />);
+    await learnFrom();
+    fireEvent.click(screen.getByTestId('learn-apply'));
+    const a = useAppearanceStore.getState().appearance;
+    expect(a.accent_h).toBe(217);
+    expect(a.accent_s).toBe(81);
+    expect(a.accent_l).toBe(59);
+    expect(a.logo_url).toBeNull(); // the manual choice stands — no logo in the learned shape
+    await act(async () => { await vi.advanceTimersByTimeAsync(400); }); // the store's debounce
+    expect(api.putAppearanceSettings).toHaveBeenCalledExactlyOnceWith(a);
+    expect(screen.getByTestId('learn-status').textContent).toMatch(/Applied/);
+  });
+
+  it('Discard reverts the un-persisted preview to the stored appearance', async () => {
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('217');
+    fireEvent.click(screen.getByTestId('learn-discard'));
+    expect(root().style.getPropertyValue('--_accent-h')).toBe('258');
+    expect(useAppearanceStore.getState().appearance.accent_h).toBe(258);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+    expect(api.putAppearanceSettings).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+  });
+
+  it('Cancel while queued aborts the poll — no further readback requests', async () => {
+    getLearnedTheme.mockResolvedValue(null); // never learns
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1);
+    await act(async () => { fireEvent.click(screen.getByTestId('learn-cancel')); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1); // the abort ended the loop
+    expect(screen.queryByTestId('learn-status')).toBeNull(); // back to idle
+  });
+
+  it('unmount aborts the poll', async () => {
+    getLearnedTheme.mockResolvedValue(null);
+    const { unmount } = render(<BrandLearn />);
+    await learnFrom();
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1);
+    unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    expect(getLearnedTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the bridge's ASYNC refusal (status.posted error) VERBATIM and stops polling", async () => {
+    getLearnedTheme.mockResolvedValue(null);
+    const refusal = "Couldn't grab that URL: refusing to fetch 169.254.169.254: "
+      + 'loopback, private and link-local addresses are blocked (SSRF guard)';
+    render(<BrandLearn />);
+    await learnFrom('http://169.254.169.254/');
+    // The bridge's own error line arrives on the scratch doc's thread over /ws.
+    act(() => {
+      useDocThreadStore.getState().ingest({
+        type: 'interactiveEvent',
+        event: {
+          event_type: 'wicked.interactive.status.posted',
+          payload: {
+            project_id: 'notes', document_id: SCRATCH_DOC_NAME,
+            state: 'error', message: refusal,
+          },
+        },
+      } as never);
+    });
+    const polls = getLearnedTheme.mock.calls.length;
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000); }); // next tick reads it
+    expect(screen.getByTestId('learn-status').textContent).toBe(refusal);
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+    expect(root().style.getPropertyValue('--_accent-h')).toBe(''); // no preview
+    const after = getLearnedTheme.mock.calls.length;
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    expect(getLearnedTheme.mock.calls.length).toBe(after); // refusal ended the loop
+    expect(after - polls).toBeLessThanOrEqual(1);
+  });
+
+  it('a STALE thread error (from before this learn) does not end the wait', async () => {
+    const key = threadKey('notes', SCRATCH_DOC_NAME);
+    useDocThreadStore.setState({ lastError: { [key]: { text: 'old failure from last week' } } });
+    render(<BrandLearn />);
+    await learnFrom();
+    // The learn resolves on the first read — the stale error never surfaced.
+    expect(screen.getByTestId('learn-status').textContent).not.toContain('old failure');
+    expect(screen.getByTestId('learn-preview-chip')).toBeInTheDocument();
+  });
+
+  it('learned tokens with no usable brand color are an honest error, not a default accent', async () => {
+    getLearnedTheme.mockResolvedValue({
+      ...LEARNED, tokens: { name: 'fonts-only', fonts: { body: 'Georgia' } },
+    });
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(screen.getByTestId('learn-status').textContent).toMatch(/no usable brand color/);
+    expect(root().style.getPropertyValue('--_accent-h')).toBe(''); // nothing applied
+    expect(screen.queryByTestId('learn-apply')).toBeNull();
+  });
+
+  it('a SYNC refusal from the emit (unknown doc, 403, 503) shows verbatim and never polls', async () => {
+    requestThemeLearn.mockRejectedValue(new Error('API 403: event type not emittable'));
+    render(<BrandLearn />);
+    await learnFrom();
+    expect(screen.getByTestId('learn-status').textContent).toBe('API 403: event type not emittable');
+    expect(getLearnedTheme).not.toHaveBeenCalled();
+  });
+});

--- a/tests/brandMapper.test.ts
+++ b/tests/brandMapper.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+import {
+  contrastRatio,
+  deltaE,
+  hslToRgb,
+  hueDistance,
+  isUnsatisfiable,
+  mapBrandTheme,
+  parseCssColor,
+  rgbToHsl,
+  SURFACE_CARD_RGB,
+  STATUS_COLORS,
+  type BrandTokenOverrides,
+} from '../src/theming/brandMapper.js';
+
+/**
+ * The §4.5 mapper contract (DES-VISION-001): a PURE BrandPalette → token-override
+ * function with four guarantees — WCAG AA contrast floor against the card
+ * surface, ≥30° hue separation from the status trio, saturation/lightness
+ * clamps, and ≥25 deltaE perceptual distinctness — every move disclosed as an
+ * adjustment, nothing silently truncated, degenerate palettes tolerated (§4.4).
+ */
+
+const CONTRAST_FLOOR = 4.5;
+const HUE_SEP = 30;
+const DELTA_FLOOR = 25;
+
+function accentRgb(m: BrandTokenOverrides) {
+  return hslToRgb(m.accent_h, m.accent_s, m.accent_l);
+}
+
+function minStatusHueSep(h: number): number {
+  return Math.min(...STATUS_COLORS.map((st) => hueDistance(h, st.h)));
+}
+
+function minStatusDeltaE(m: BrandTokenOverrides): number {
+  return Math.min(...STATUS_COLORS.map((st) => deltaE(accentRgb(m), hslToRgb(st.h, st.s, st.l))));
+}
+
+describe('color math', () => {
+  it('parses hex, rgb(), rgb(%), hsl() and rejects garbage', () => {
+    expect(parseCssColor('#0a2a5e')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseCssColor('#FFF8')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseCssColor('#0a2a5eff')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgb(10, 42, 94)')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgba(10 42 94 / 0.5)')).toEqual({ r: 10, g: 42, b: 94 });
+    expect(parseCssColor('rgb(100%, 0%, 0%)')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(parseCssColor('hsl(0, 100%, 50%)')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(parseCssColor('hsl(217 81% 20%)')).toEqual(hslToRgb(217, 81, 20));
+    expect(parseCssColor('cornflowerblue')).toBeNull(); // named colors: tolerated as absent
+    expect(parseCssColor('#12345')).toBeNull();
+    expect(parseCssColor('#zzz')).toBeNull();
+    expect(parseCssColor('rgb(a, b, c)')).toBeNull();
+    expect(parseCssColor('')).toBeNull();
+    expect(parseCssColor(undefined)).toBeNull();
+    expect(parseCssColor(42)).toBeNull();
+  });
+
+  it('round-trips hsl → rgb → hsl within rounding', () => {
+    const { h, s, l } = rgbToHsl(hslToRgb(258, 72, 62));
+    expect(Math.abs(h - 258)).toBeLessThanOrEqual(1);
+    expect(Math.abs(s - 72)).toBeLessThanOrEqual(1);
+    expect(Math.abs(l - 62)).toBeLessThanOrEqual(1);
+  });
+
+  it('contrastRatio: white vs black is 21:1, self vs self is 1:1', () => {
+    expect(contrastRatio({ r: 255, g: 255, b: 255 }, { r: 0, g: 0, b: 0 })).toBeCloseTo(21, 0);
+    expect(contrastRatio(SURFACE_CARD_RGB, SURFACE_CARD_RGB)).toBeCloseTo(1, 5);
+  });
+
+  it('hueDistance is circular', () => {
+    expect(hueDistance(350, 10)).toBe(20);
+    expect(hueDistance(10, 350)).toBe(20);
+    expect(hueDistance(0, 180)).toBe(180);
+    expect(hueDistance(45, 45)).toBe(0);
+  });
+
+  it('SURFACE_CARD_RGB mirrors tokens.css --_surface-2 (#1a1a26)', () => {
+    // The mapper measures guarantee 1 against the REAL card surface; if
+    // tokens.css moves, this pairing must move with it (§4.5 g1).
+    expect(SURFACE_CARD_RGB).toEqual(parseCssColor('#1a1a26'));
+  });
+});
+
+describe('mapBrandTheme — guarantee 1: WCAG AA contrast floor (§4.5)', () => {
+  it('raises lightness for a deep navy until accent vs card ≥ 4.5:1, and discloses it', () => {
+    const m = mapBrandTheme({ name: 'navy', primary: '#0a2a5e' });
+    expect(m.accent_h).toBe(217); // hue preserved — no status conflict at 217°
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+    expect(m.adjustments.some((a) => a.constraint === 'lightness-clamp')).toBe(true);
+    expect(m.adjustments.some((a) => a.constraint === 'contrast-floor')).toBe(true);
+    expect(isUnsatisfiable(m)).toBe(false);
+  });
+
+  it('every adjustment carries {constraint, original, adjusted, reason}', () => {
+    const m = mapBrandTheme({ name: 'navy', primary: '#0a2a5e' });
+    expect(m.adjustments.length).toBeGreaterThan(0);
+    for (const a of m.adjustments) {
+      expect(a.constraint).toBeTruthy();
+      expect(a.original).toBeTruthy();
+      expect(a.adjusted).toBeTruthy();
+      expect(a.reason).toBeTruthy();
+    }
+  });
+
+  it('the lightness raise caps at 90%', () => {
+    const m = mapBrandTheme({ name: 'near-black', primary: '#050508' });
+    expect(m.accent_l).toBeLessThanOrEqual(90);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
+});
+
+describe('mapBrandTheme — guarantee 2: ≥30° hue separation from the status trio (§4.5)', () => {
+  it('moves an emerald-adjacent hue off the running hue via ±5° search (nearest side wins)', () => {
+    // #22c55e ≈ hue 142° — inside the running (148°) exclusion band.
+    // Down clears at 5 steps (117°), up only at 8 (182°) — nearest wins.
+    const m = mapBrandTheme({ name: 'green', primary: '#22c55e' });
+    expect(m.accent_h).toBe(117);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    expect(m.adjustments.some((a) => a.constraint === 'hue-separation')).toBe(true);
+  });
+
+  it('a dead-center conflict tie-breaks to the direction maximizing total status distance', () => {
+    // Hue exactly 148 (the running hue): both directions clear at 6 steps
+    // (118° and 178°); 178° has the greater total distance from all three.
+    const m = mapBrandTheme({ name: 'emerald', primary: 'hsl(148, 58%, 58%)' });
+    expect(m.accent_h).toBe(178);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+  });
+
+  it('an amber-adjacent hue is pushed out of the gate band', () => {
+    const m = mapBrandTheme({ name: 'amber', primary: 'hsl(50, 90%, 60%)' });
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    expect(m.adjustments.some((a) => a.constraint === 'hue-separation')).toBe(true);
+  });
+});
+
+describe('mapBrandTheme — guarantee 3: saturation and lightness clamps (§4.5)', () => {
+  it('clamps a neon: s > 88 → 88', () => {
+    const m = mapBrandTheme({ name: 'neon', primary: 'hsl(217, 100%, 60%)' });
+    expect(m.accent_s).toBe(88);
+    expect(m.adjustments.some((a) => a.constraint === 'saturation-clamp')).toBe(true);
+  });
+
+  it('clamps a near-grey: s < 20 → 20 (and the hue then clears the fail band)', () => {
+    const m = mapBrandTheme({ name: 'grey', primary: '#808080' }); // s=0, h=0 (≈ fail hue 4°)
+    expect(m.accent_s).toBeGreaterThanOrEqual(20);
+    expect(m.adjustments.some((a) => a.constraint === 'saturation-clamp')).toBe(true);
+    expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+  });
+
+  it('clamps a wash-out: l > 78 → 78 (contrast floor already satisfied there)', () => {
+    const m = mapBrandTheme({ name: 'pale', primary: 'hsl(217, 60%, 92%)' });
+    expect(m.accent_l).toBe(78);
+    expect(m.adjustments.some((a) => a.constraint === 'lightness-clamp')).toBe(true);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
+
+  it('black and white both land inside every guarantee', () => {
+    for (const hex of ['#000000', '#ffffff']) {
+      const m = mapBrandTheme({ name: 'edge', primary: hex });
+      expect(m.accent_s).toBeGreaterThanOrEqual(20);
+      expect(m.accent_s).toBeLessThanOrEqual(88);
+      expect(m.accent_l).toBeGreaterThanOrEqual(42);
+      expect(m.accent_l).toBeLessThanOrEqual(90);
+      expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+      expect(minStatusHueSep(m.accent_h)).toBeGreaterThanOrEqual(HUE_SEP);
+    }
+  });
+});
+
+describe('mapBrandTheme — guarantee 4: perceptual distinctness (§4.5)', () => {
+  it('a satisfiable mapping never sits within 25 deltaE of a status color', () => {
+    // Colors chosen to hug each status color after the hue push.
+    for (const primary of ['hsl(75, 90%, 68%)', 'hsl(34, 88%, 62%)', 'hsl(178, 58%, 58%)']) {
+      const m = mapBrandTheme({ name: 'close', primary });
+      if (!isUnsatisfiable(m)) {
+        expect(minStatusDeltaE(m)).toBeGreaterThanOrEqual(DELTA_FLOOR);
+      } else {
+        // Never silent: the residual proximity is disclosed.
+        expect(m.adjustments.some((a) => a.constraint === 'unsatisfiable')).toBe(true);
+      }
+    }
+  });
+
+  it('a perceptual nudge never breaks the contrast floor (priority 1 beats 4)', () => {
+    for (const primary of ['hsl(75, 90%, 55%)', 'hsl(178, 58% ,48%)']) {
+      const m = mapBrandTheme({ name: 'nudge', primary });
+      expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+    }
+  });
+
+  it('a nudge that can satisfy the floor IN-clamp never leaves it (priority 3 beats 4)', () => {
+    // hsl(96 60% 70%): both ±10 candidates clear 25 deltaE (up 80 ≈ 30.2,
+    // down 60 ≈ 29.6) — the in-clamp 60 must win over the marginally-farther
+    // out-of-clamp 80, because guarantee 3's l ≤ 78 outranks maximizing g4.
+    const m = mapBrandTheme({ name: 'in-clamp', primary: 'hsl(96, 60%, 70%)' });
+    expect(m.adjustments.some((a) => a.constraint === 'perceptual-distance')).toBe(true);
+    expect(m.accent_l).toBeLessThanOrEqual(78);
+    expect(minStatusDeltaE(m)).toBeGreaterThanOrEqual(DELTA_FLOOR);
+    expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB)).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+  });
+});
+
+describe('mapBrandTheme — the whole-gamut property (§4.5: all four at once)', () => {
+  it('any input either satisfies every guarantee or discloses unsatisfiability', () => {
+    for (let h = 0; h < 360; h += 15) {
+      for (const s of [0, 35, 70, 100]) {
+        for (const l of [5, 35, 65, 95]) {
+          const rgb = hslToRgb(h, s, l);
+          const hex = `#${[rgb.r, rgb.g, rgb.b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+          const m = mapBrandTheme({ name: 'sweep', primary: hex });
+          const label = `input hsl(${h} ${s}% ${l}%) → hsl(${m.accent_h} ${m.accent_s}% ${m.accent_l}%)`;
+          if (isUnsatisfiable(m)) continue; // disclosed, never silent — allowed
+          expect(contrastRatio(accentRgb(m), SURFACE_CARD_RGB), `${label}: contrast`)
+            .toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+          expect(minStatusHueSep(m.accent_h), `${label}: hue separation`)
+            .toBeGreaterThanOrEqual(HUE_SEP);
+          expect(minStatusDeltaE(m), `${label}: deltaE`).toBeGreaterThanOrEqual(DELTA_FLOOR);
+          expect(m.accent_s, `${label}: sat range`).toBeGreaterThanOrEqual(20);
+          expect(m.accent_s, `${label}: sat range`).toBeLessThanOrEqual(88);
+          expect(m.accent_l, `${label}: lgt range`).toBeGreaterThanOrEqual(42);
+          expect(m.accent_l, `${label}: lgt range`).toBeLessThanOrEqual(90);
+        }
+      }
+    }
+  });
+});
+
+describe('mapBrandTheme — degenerate palettes (§4.4 tolerant reading)', () => {
+  it('no colors at all → the default accent stands, disclosed as a source fallback', () => {
+    const m = mapBrandTheme({ name: 'empty' });
+    expect(m).toMatchObject({ accent_h: 258, accent_s: 72, accent_l: 62, logo_url: null });
+    expect(m.adjustments).toHaveLength(1);
+    expect(m.adjustments[0]?.constraint).toBe('source-fallback');
+  });
+
+  it('an unparseable primary is treated as absent', () => {
+    const m = mapBrandTheme({ name: 'junk', primary: 'linear-gradient(red, blue)' });
+    expect(m.accent_h).toBe(258);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(true);
+  });
+
+  it('secondary fills in when primary is missing, and says so', () => {
+    const m = mapBrandTheme({ name: 'sec', secondary: '#0a2a5e' });
+    expect(m.accent_h).toBe(217);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(true);
+  });
+
+  it('primary wins over secondary when both parse', () => {
+    const m = mapBrandTheme({ name: 'both', primary: '#0a2a5e', secondary: '#22c55e' });
+    expect(m.accent_h).toBe(217);
+    expect(m.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(false);
+  });
+});
+
+describe('mapBrandTheme — logo passthrough and purity (§4.5)', () => {
+  it('passes a bridge-relative logo_url through untransformed', () => {
+    const m = mapBrandTheme({ name: 'logo', primary: '#0a2a5e', logo_url: '/api/brand/logo.svg' });
+    expect(m.logo_url).toBe('/api/brand/logo.svg');
+  });
+
+  it('a blank or absent logo_url is null', () => {
+    expect(mapBrandTheme({ name: 'x', primary: '#0a2a5e', logo_url: '   ' }).logo_url).toBeNull();
+    expect(mapBrandTheme({ name: 'x', primary: '#0a2a5e' }).logo_url).toBeNull();
+  });
+
+  it('the logo survives a palette with no usable color', () => {
+    const m = mapBrandTheme({ name: 'logo-only', logo_url: '/api/brand/logo.svg' });
+    expect(m.logo_url).toBe('/api/brand/logo.svg');
+    expect(m.accent_h).toBe(258);
+  });
+
+  it('is pure: same input → deep-equal output, input never mutated', () => {
+    const input = Object.freeze({ name: 'pure', primary: '#22c55e', logo_url: '/l.svg' });
+    const a = mapBrandTheme(input);
+    const b = mapBrandTheme(input);
+    expect(a).toEqual(b);
+    expect(input).toEqual({ name: 'pure', primary: '#22c55e', logo_url: '/l.svg' });
+  });
+});

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -12,6 +12,7 @@ import {
   BridgeUnavailableError,
   ServiceHintError,
   createDoc,
+  getLearnedTheme,
   getSources,
   listDemos,
   getVersions,
@@ -358,9 +359,10 @@ describe('happy-path shapes', () => {
   });
 
   it('requestThemeLearn speaks the CORRECTED wire: theme.requested over POST /api/events (issue #65)', async () => {
-    // The bridge has no theme route at all — no learn endpoint, no registry. The real
-    // learn trigger is the UI-emittable `wicked.interactive.theme.requested` bus command
-    // (materializeThemeRequested), doc-scoped exactly like demo.requested.
+    // The bridge has no learn endpoint and no theme registry. The real learn trigger is
+    // the UI-emittable `wicked.interactive.theme.requested` bus command
+    // (materializeThemeRequested), doc-scoped exactly like demo.requested; what it
+    // produced is read back per-doc via getLearnedTheme (interactive#181, below).
     const calls = stubFetch({ ok: true, event_id: 'e1', correlation_id: 'c1' });
     await requestThemeLearn(PROJECT, DOC, { kind: 'url', url: 'https://acme.example' });
     expect(calls[0]!.init?.method).toBe('POST');
@@ -379,5 +381,42 @@ describe('happy-path shapes', () => {
     const body = JSON.parse(calls[0]!.init?.body as string);
     expect(body.payload).toEqual({ document_id: DOC, path: '/brand/guide.pdf' });
     expect(body.payload).not.toHaveProperty('url');
+  });
+
+  // ── getLearnedTheme — the interactive#181 readback ──────────────────────────
+
+  it('getLearnedTheme GETs the per-doc readback route and returns the body verbatim', async () => {
+    const learned = {
+      document_id: DOC,
+      learned_at: '2026-08-21T12:00:00.000Z',
+      tokens: {
+        name: 'acme-brand',
+        colors: { background: '#f8fafc', primary: '#0a2a5e' },
+        fonts: { heading: 'Georgia', body: 'Georgia', mono: 'Menlo' },
+      },
+    };
+    const calls = stubFetch(learned);
+    const result = await getLearnedTheme(PROJECT, DOC);
+    expect(calls[0]!.init?.method ?? 'GET').toBe('GET');
+    expect(calls[0]!.url).toBe(
+      `${apiBase()}/projects/${PROJECT}/interactive/d/${DOC}/api/theme/learned`,
+    );
+    expect(result).toEqual(learned); // tokens are the learned.theme.json VERBATIM
+  });
+
+  it("getLearnedTheme resolves null on the route's own 404 {error:'no learned theme'}", async () => {
+    // The 404-with-JSON body is the not-learned-yet signal (also the corrupt-file
+    // degradation) — the poll's "keep waiting", never an exception.
+    stubFetch({ error: 'no learned theme' }, 404);
+    await expect(getLearnedTheme(PROJECT, DOC)).resolves.toBeNull();
+  });
+
+  it('getLearnedTheme still throws on any OTHER failure — unknown doc, dead bridge', async () => {
+    // An unknown doc is an express-default 404 (no JSON error to match) — a real error.
+    stubFetch('Cannot GET /d/absent/api/theme/learned', 404);
+    await expect(getLearnedTheme(PROJECT, 'absent')).rejects.toThrow(/404/);
+    // A dead bridge stays the typed 503, exactly as every other wrapper.
+    stubFetch({ code: 'bridge_unavailable', hint: 'npm i -g wicked-interactive' }, 503);
+    await expect(getLearnedTheme(PROJECT, DOC)).rejects.toBeInstanceOf(BridgeUnavailableError);
   });
 });

--- a/tests/learnPoll.test.ts
+++ b/tests/learnPoll.test.ts
@@ -40,7 +40,7 @@ describe('pollLearnedTheme', () => {
     const ctl = new AbortController();
     const fetchLearned = vi.fn().mockResolvedValue(null);
     // A sleeper that aborts DURING the wait, as the real abortableSleep resolves early.
-    const sleep = (_ms: number): Promise<void> => { ctl.abort(); return Promise.resolve(); };
+    const sleep = (): Promise<void> => { ctl.abort(); return Promise.resolve(); };
     const out = await pollLearnedTheme({ fetchLearned, signal: ctl.signal, sleep });
     expect(out).toEqual({ kind: 'cancelled' });
     expect(fetchLearned).toHaveBeenCalledTimes(1); // nothing after the abort

--- a/tests/learnPoll.test.ts
+++ b/tests/learnPoll.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BridgeUnavailableError, type LearnedTheme } from '../src/api/interactive.js';
+import { LEARN_POLL_DELAYS_MS, pollLearnedTheme } from '../src/theming/learnPoll.js';
+
+/**
+ * The bounded readback poll: 404→200 transition, cancellation at every seam,
+ * async bridge refusals surfacing, and the hard cap — no loop outlives the
+ * learn flow, by construction.
+ */
+
+const LEARNED: LearnedTheme = {
+  document_id: 'brand-learn',
+  learned_at: '2026-08-21T12:00:00.000Z',
+  tokens: { name: 'acme', colors: { primary: '#0a2a5e' } },
+};
+
+/** An instant sleeper that logs the schedule it was asked for. */
+function instantSleep(): { sleep: (ms: number) => Promise<void>; slept: number[] } {
+  const slept: number[] = [];
+  return { sleep: (ms: number) => { slept.push(ms); return Promise.resolve(); }, slept };
+}
+
+describe('pollLearnedTheme', () => {
+  it('rides the 404 (null) → 200 transition and returns the learned result', async () => {
+    const { sleep, slept } = instantSleep();
+    const fetchLearned = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(LEARNED);
+    const out = await pollLearnedTheme({
+      fetchLearned, signal: new AbortController().signal, sleep,
+    });
+    expect(out).toEqual({ kind: 'learned', result: LEARNED });
+    expect(fetchLearned).toHaveBeenCalledTimes(3);
+    // Backoff honored: the two waits are the schedule's first two entries.
+    expect(slept).toEqual([LEARN_POLL_DELAYS_MS[0], LEARN_POLL_DELAYS_MS[1]]);
+  });
+
+  it('cancel mid-sleep ends the loop with no further fetch', async () => {
+    const ctl = new AbortController();
+    const fetchLearned = vi.fn().mockResolvedValue(null);
+    // A sleeper that aborts DURING the wait, as the real abortableSleep resolves early.
+    const sleep = (_ms: number): Promise<void> => { ctl.abort(); return Promise.resolve(); };
+    const out = await pollLearnedTheme({ fetchLearned, signal: ctl.signal, sleep });
+    expect(out).toEqual({ kind: 'cancelled' });
+    expect(fetchLearned).toHaveBeenCalledTimes(1); // nothing after the abort
+  });
+
+  it('an already-aborted signal never fetches at all', async () => {
+    const ctl = new AbortController();
+    ctl.abort();
+    const fetchLearned = vi.fn();
+    const out = await pollLearnedTheme({
+      fetchLearned, signal: ctl.signal, sleep: () => Promise.resolve(),
+    });
+    expect(out).toEqual({ kind: 'cancelled' });
+    expect(fetchLearned).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the bridge's async refusal (status.posted error) with its OWN sentence", async () => {
+    const { sleep } = instantSleep();
+    const refusal = "Couldn't grab that URL: refusing to fetch 169.254.169.254: "
+      + 'loopback, private and link-local addresses are blocked (SSRF guard)';
+    let ticks = 0;
+    const out = await pollLearnedTheme({
+      fetchLearned: vi.fn().mockResolvedValue(null),
+      bridgeError: () => (++ticks >= 2 ? refusal : null),
+      signal: new AbortController().signal,
+      sleep,
+    });
+    expect(out).toEqual({ kind: 'bridge-error', reason: refusal });
+  });
+
+  it('a flaky poll is not a failed learn — a thrown fetch keeps the loop alive', async () => {
+    const { sleep } = instantSleep();
+    const fetchLearned = vi.fn()
+      .mockRejectedValueOnce(new Error('API 500: hiccup'))
+      .mockResolvedValueOnce(LEARNED);
+    const out = await pollLearnedTheme({
+      fetchLearned, signal: new AbortController().signal, sleep,
+    });
+    expect(out).toEqual({ kind: 'learned', result: LEARNED });
+  });
+
+  it('the typed 503 ends the wait immediately — the bridge itself is gone', async () => {
+    const out = await pollLearnedTheme({
+      fetchLearned: vi.fn().mockRejectedValue(
+        new BridgeUnavailableError('npm i -g wicked-interactive')),
+      signal: new AbortController().signal,
+      sleep: instantSleep().sleep,
+    });
+    expect(out.kind).toBe('bridge-error');
+    if (out.kind === 'bridge-error') expect(out.reason).toMatch(/npm i -g wicked-interactive/);
+  });
+
+  it('hard cap: the schedule exhausts into a timeout carrying the attempt count', async () => {
+    const { sleep, slept } = instantSleep();
+    const fetchLearned = vi.fn().mockResolvedValue(null);
+    const delays = [10, 20, 30];
+    const out = await pollLearnedTheme({
+      fetchLearned, signal: new AbortController().signal, sleep, delays,
+    });
+    expect(out).toEqual({ kind: 'timeout', attempts: 4, lastFetchError: null });
+    expect(fetchLearned).toHaveBeenCalledTimes(4); // delays.length + 1, no more
+    expect(slept).toEqual(delays);                 // every wait from the schedule, once
+  });
+
+  it('a timeout remembers the last non-fatal fetch error for the report', async () => {
+    const out = await pollLearnedTheme({
+      fetchLearned: vi.fn().mockRejectedValue(new Error('API 502: proxy blip')),
+      signal: new AbortController().signal,
+      sleep: instantSleep().sleep,
+      delays: [1],
+    });
+    expect(out).toEqual({ kind: 'timeout', attempts: 2, lastFetchError: 'API 502: proxy blip' });
+  });
+
+  it('the default schedule is bounded (~66s) — the constraint, pinned', () => {
+    const total = LEARN_POLL_DELAYS_MS.reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(70_000);
+    expect(LEARN_POLL_DELAYS_MS.every((d) => d >= 1_000 && d <= 5_000)).toBe(true);
+  });
+});

--- a/tests/learnedTheme.test.ts
+++ b/tests/learnedTheme.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { adaptLearnedTokens } from '../src/theming/learnedTheme.js';
+import { mapBrandTheme } from '../src/theming/brandMapper.js';
+
+/**
+ * The adapter between the interactive#181 readback shape (nested
+ * `tokens.colors.*`, partials legal) and the resurrected mapper's flat
+ * BrandPalette. Pure shape-folding — no §4.5 logic — plus the one honesty
+ * rule: no usable brand color is an ERROR, never a silent default accent.
+ */
+
+const FULL_TOKENS = {
+  name: 'acme-brand',
+  colors: {
+    background: '#f8fafc', surface: '#ffffff', primary: '#0a2a5e',
+    secondary: '#0e7490', accent: '#22c55e', text_primary: '#1e293b',
+  },
+  fonts: { heading: 'Georgia', body: 'Georgia', mono: 'Menlo' },
+};
+
+describe('adaptLearnedTokens — nested readback → mapper input', () => {
+  it('folds colors.primary/secondary onto the flat palette, name carried', () => {
+    const out = adaptLearnedTokens(FULL_TOKENS);
+    expect(out).toEqual({
+      ok: true,
+      palette: { name: 'acme-brand', primary: '#0a2a5e', secondary: '#0e7490' },
+    });
+  });
+
+  it('the adapted palette feeds the mapper exactly like the historical flat shape', () => {
+    const out = adaptLearnedTokens(FULL_TOKENS);
+    if (!out.ok) throw new Error('expected ok');
+    // #0a2a5e is the fixture navy the old suite pinned: hue 217 preserved,
+    // lightness clamped + raised for the contrast floor — both disclosed.
+    const mapped = mapBrandTheme(out.palette);
+    expect(mapped.accent_h).toBe(217);
+    expect(mapped.adjustments.some((a) => a.constraint === 'lightness-clamp')).toBe(true);
+    expect(mapped.adjustments.some((a) => a.constraint === 'contrast-floor')).toBe(true);
+    expect(mapped.logo_url).toBeNull(); // the learned shape carries no logo
+  });
+
+  it('partial tokens are legal: primary alone is enough', () => {
+    const out = adaptLearnedTokens({ name: 'p', colors: { primary: '#22c55e' } });
+    expect(out).toEqual({ ok: true, palette: { name: 'p', primary: '#22c55e' } });
+  });
+
+  it('missing primary falls to secondary, then accent, on the secondary channel', () => {
+    expect(adaptLearnedTokens({ colors: { secondary: '#0e7490' } })).toEqual({
+      ok: true, palette: { name: 'learned-theme', secondary: '#0e7490' },
+    });
+    expect(adaptLearnedTokens({ colors: { accent: '#0e7490' } })).toEqual({
+      ok: true, palette: { name: 'learned-theme', secondary: '#0e7490' },
+    });
+    // …and the mapper DISCLOSES that the accent derives from the fallback (§4.4).
+    const out = adaptLearnedTokens({ colors: { accent: '#0a2a5e' } });
+    if (!out.ok) throw new Error('expected ok');
+    const mapped = mapBrandTheme(out.palette);
+    expect(mapped.adjustments.some((a) => a.constraint === 'source-fallback')).toBe(true);
+    expect(mapped.accent_h).toBe(217);
+  });
+
+  it('an unparseable primary is skipped, not passed through', () => {
+    const out = adaptLearnedTokens({
+      colors: { primary: 'linear-gradient(red, blue)', secondary: '#0e7490' },
+    });
+    expect(out).toEqual({ ok: true, palette: { name: 'learned-theme', secondary: '#0e7490' } });
+  });
+
+  it('no usable brand color at all → an honest error, never a silent default', () => {
+    for (const tokens of [
+      {},                                              // nothing at all
+      { name: 'x', fonts: { body: 'Georgia' } },       // fonts only
+      { colors: {} },                                  // empty palette
+      { colors: { primary: 'cornflowerblue' } },       // named colors are absent (parser contract)
+      { colors: { background: '#ffffff', text_primary: '#111111' } }, // no BRAND channel
+      null, 42, 'tokens',                              // not even an object
+    ]) {
+      const out = adaptLearnedTokens(tokens);
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.reason).toMatch(/no usable brand color/);
+    }
+  });
+
+  it('background/surface/text colors never masquerade as the brand color', () => {
+    // Only primary/secondary/accent are BRAND channels; a theme that extracted
+    // only surfaces must not paint the studio accent white.
+    const out = adaptLearnedTokens({ colors: { background: '#ffffff', surface: '#f8fafc' } });
+    expect(out.ok).toBe(false);
+  });
+
+  it('a blank name defaults without inventing meaning', () => {
+    expect(adaptLearnedTokens({ name: '   ', colors: { primary: '#0a2a5e' } })).toEqual({
+      ok: true, palette: { name: 'learned-theme', primary: '#0a2a5e' },
+    });
+  });
+});

--- a/tests/scratchDoc.test.ts
+++ b/tests/scratchDoc.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureScratchDoc, SCRATCH_DOC_NAME } from '../src/theming/scratchDoc.js';
+import type { DocSummary } from '../src/api/interactive.js';
+
+/**
+ * The per-project scratch doc a brand learn rides: created once through the
+ * REAL registry route, reused forever — including across the 409 race.
+ */
+
+function summary(name: string): DocSummary {
+  return { name, kind: 'doc', head: 1, versions: 1, updated_at: null };
+}
+
+describe('ensureScratchDoc', () => {
+  it('reuses an existing scratch doc — nothing is created', async () => {
+    const listDocs = vi.fn().mockResolvedValue([summary('q3-deck'), summary(SCRATCH_DOC_NAME)]);
+    const createDoc = vi.fn();
+    await expect(ensureScratchDoc('proj-1', { listDocs, createDoc }))
+      .resolves.toBe(SCRATCH_DOC_NAME);
+    expect(listDocs).toHaveBeenCalledExactlyOnceWith('proj-1');
+    expect(createDoc).not.toHaveBeenCalled();
+  });
+
+  it('creates the doc through the slice-F shape when absent: kind source + brief + project', async () => {
+    const listDocs = vi.fn().mockResolvedValue([summary('q3-deck')]);
+    const createDoc = vi.fn().mockResolvedValue({ name: SCRATCH_DOC_NAME, head: 0 });
+    await expect(ensureScratchDoc('proj-1', { listDocs, createDoc }))
+      .resolves.toBe(SCRATCH_DOC_NAME);
+    expect(createDoc).toHaveBeenCalledTimes(1);
+    const [pid, body] = createDoc.mock.calls[0] as [string, Record<string, unknown>];
+    expect(pid).toBe('proj-1');
+    expect(body.name).toBe(SCRATCH_DOC_NAME);
+    expect(body.kind).toBe('source');       // the one html-less create the bridge accepts
+    expect(body.project).toBe('proj-1');    // registration is the authority (§2.3)
+    expect(typeof body.brief).toBe('string');
+    expect(body.brief).toMatch(/learn brand themes/);
+  });
+
+  it('idempotent across calls: the second call lists the doc and never re-creates', async () => {
+    const docs: DocSummary[] = [];
+    const listDocs = vi.fn().mockImplementation(() => Promise.resolve([...docs]));
+    const createDoc = vi.fn().mockImplementation(() => {
+      docs.push(summary(SCRATCH_DOC_NAME));
+      return Promise.resolve({ name: SCRATCH_DOC_NAME, head: 0 });
+    });
+    await ensureScratchDoc('proj-1', { listDocs, createDoc });
+    await ensureScratchDoc('proj-1', { listDocs, createDoc });
+    expect(createDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('a concurrent 409 ("doc already exists") resolves to the doc, not an error', async () => {
+    const listDocs = vi.fn().mockResolvedValue([]);
+    const createDoc = vi.fn().mockRejectedValue(new Error('API 409: doc already exists'));
+    await expect(ensureScratchDoc('proj-1', { listDocs, createDoc }))
+      .resolves.toBe(SCRATCH_DOC_NAME);
+  });
+
+  it('every other create failure propagates — a doc that cannot be filed is loud', async () => {
+    const listDocs = vi.fn().mockResolvedValue([]);
+    const createDoc = vi.fn().mockRejectedValue(
+      new Error('API 502: project unknown-project not attachable'));
+    await expect(ensureScratchDoc('unknown-project', { listDocs, createDoc }))
+      .rejects.toThrow(/502/);
+  });
+});


### PR DESCRIPTION
Restores the operator-directed brand-learn accent extraction that #73 retracted for riding invented wires — now on the real surface end to end, using interactive#181's readback route.

## The flow (all real wires)

/theme gains **Learn from a brand**: source trio (website / PDF / image) + project picker → an idempotent per-project scratch doc (the one html-less create the bridge accepts: `kind:'source'` — the task spec's `kind:'doc'` body would 400 "html required", verified in server source) → `theme.requested` over `POST /api/events` → bounded (~66s cap), abort-cancellable poll of `GET /d/:docId/api/theme/learned` → adapter folds `tokens.colors.*` onto the mapper input → **§4.5 mapper returns VERBATIM from retracted commit a6d6bff** (27-case suite included; input type renamed, contrast floors untouched) → inline preview with disclosed adjustments in plain language → Apply through the existing appearance store. The bridge's async SSRF refusal surfaces verbatim via a small additive `lastError` index on docThread. Logo honestly stays the manual choice (the learned shape carries none). Zero learn requests until the user acts.

## Verification highlights

The adversarial verifier ran the flow **end-to-end against the real bridge** with an adversarial dark-red palette and — decisively — **reimplemented the §4.5 pipeline independently in Python from the spec**: the TypeScript mapper's output matched exactly (hsl(330, 59%, 58%) with the same three disclosed adjustments, final contrast 4.51 ≥ 4.5), as did the fixture-navy case the rig proves in the browser (accent 258→217, hsl(217, 81%, 59%), contrast 4.66) and both near-white/near-black floor spot-checks. `brandMapper.ts` is byte-identical to history except the input rename. Negative check: the rig fails on origin/main (no affordance). Contract check: readback promoted to FATAL (fresh-doc JSON 404 as route-exists proof, written-learn 200 verbatim, corrupt→404, unknown-doc status-only) — green against the real bridge.

## Gates

eslint clean · tsc clean · vitest **996/996** · new rig `brand_learn_test.py` PASS · contract check vs real bridge PASS · `vision_slice8` re-scoped in a dedicated commit (the affordance is back, dead wires stay dead, live wire stays lazy) · `feedback_sliceA` PASS.

Shots: `brand-learn-form.png`, `brand-learn-applied.png`, `theme-page-restored-learn.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)