### PR TITLE
Slice G: universal command palette + global shortcut registry (DES-FEEDBACK-002 §1)

### DIFF
--- a/e2e/feedback2_sliceG_test.py
+++ b/e2e/feedback2_sliceG_test.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceG_test.py — the DES-FEEDBACK-002 slice-G gate: shortcut registry
++ universal command palette (§1, P0-1), against the shared frozen-NOW0 W2
+fixture (uxfix_fixture.py) with the `repo` switch on (so the REPOSITORIES group
+has the studio-api entry to list — the §1.4 GET /repos cache has something true
+to fetch).
+
+The slice DOM ACs, verbatim from §1.7:
+
+  1. `[data-testid="command-palette"]` is absent until Cmd+K/Ctrl+K or Ctrl+P
+     fires; present and focused (activeElement is its input) after;
+  2. palette CLOSED + non-terminal run selected: Ctrl+Shift+K cancels (assert
+     `POST /runs/:id/cancel`); plain Ctrl+K does NOT cancel — it opens the
+     palette (assert no cancel request);
+  3. with focus inside an input/textarea, Cmd+K does nothing (typing guard —
+     asserted by focusing the chat composer first);
+  4. `p:` filters rows to `[data-group="projects"]` only; `run:`, `repo:`, `>`
+     likewise; the `[data-testid="palette-row"]` count matches the fixture;
+  5. ArrowDown/ArrowUp move `[data-selected="true"]`; Enter on a row navigates
+     (assert URL); Escape closes and returns focus;
+  6. zero palette-attributable requests on mount; on first OPEN exactly one
+     `GET /repos`; a warm cache fetches nothing on reopen;
+  7. computed `background` of the overlay and the selected row resolve from
+     `var()` token references (EC15).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-G-palette-mixed.png   open palette, mixed groups, selection ring
+  feedback2-G-palette-verbs.png   `>` prefix, verb list with Cancel run present
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4359),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4359"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build ────────────────────────────────────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server, repo switch ON ─────────────────────────────
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, repo=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "repo": True}
+
+# The fixture's own run count — AC 4's "count matches the fixture" is measured
+# against the wire, never hardcoded.
+with urllib.request.urlopen(f"{ORIGIN}/api/v1/runs", timeout=10) as res:
+    FIXTURE_RUNS = len(json.load(res)["runs"])
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+TOKEN_PROBE = """() => {
+  const resolve = (token, prop) => {
+    const el = document.createElement('span');
+    el.style[prop || 'background'] = `var(${token})`;
+    document.body.appendChild(el);
+    const c = getComputedStyle(el).backgroundColor;
+    el.remove();
+    return c;
+  };
+  return { overlay: resolve('--surface-overlay'),
+           accentSubtle: resolve('--accent-subtle') };
+}"""
+
+PALETTE_STATE = """() => {
+  const pal = document.querySelector('[data-testid="command-palette"]');
+  const rows = Array.from(document.querySelectorAll('[data-testid="palette-row"]'));
+  const sel = rows.findIndex((r) => r.dataset.selected === 'true');
+  return {
+    present: !!pal,
+    inputFocused: document.activeElement?.dataset?.testid === 'palette-input',
+    groups: rows.map((r) => r.dataset.group),
+    labels: rows.map((r) => r.textContent ?? ''),
+    hrefs: rows.map((r) => r.getAttribute('href')),
+    selectedIx: sel,
+    paletteBg: pal ? getComputedStyle(pal).backgroundColor : null,
+    selectedBg: sel >= 0 ? getComputedStyle(rows[sel]).backgroundColor : null,
+    selectedOutline: sel >= 0 ? getComputedStyle(rows[sel]).outlineStyle : null,
+  };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # The tap: every request the page makes, by API path.
+    requests: list[tuple[str, str]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if path.startswith("/api/") or path == "/ws":
+            requests.append((req.method, path))
+
+    page.on("request", on_request)
+
+    def repos_gets() -> int:
+        return sum(1 for m, p_ in requests if m == "GET" and p_ == "/api/v1/repos")
+
+    def cancel_posts() -> list[str]:
+        return [p_ for m, p_ in requests if m == "POST" and p_.endswith("/cancel")]
+
+    # ── Scene 1: the home board — palette absent, corpus loading is the BOARD's ──
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1200)  # let the board's own fetch burst settle
+
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+
+    absent_before = page.evaluate(
+        "() => document.querySelector('[data-testid=\"command-palette\"]') === null"
+    )
+    repos_before_open = repos_gets()
+    requests_before_open = len(requests)
+
+    # ── AC 1 + 6: Ctrl+K opens; first open fires exactly one GET /repos ─────────
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_timeout(800)  # request-settle tick for the tap
+    opened = page.evaluate(PALETTE_STATE)
+    tokens = page.evaluate(TOKEN_PROBE)
+    new_reqs = requests[requests_before_open:]
+    # Attribution: App/board machinery (debounced GET /runs reconciles, gate
+    # cache reads, per-project member/doc trickle, /ws) keeps its own cadence —
+    # the palette has no code path to any of it; everything else new must be
+    # the ONE repo fetch the doc allows on first open.
+    palette_reqs = [
+        (m, p_) for m, p_ in new_reqs
+        if not p_.startswith("/api/v1/runs")
+        and not p_.startswith("/api/v1/projects")
+        and p_ != "/ws"
+    ]
+
+    report["steps"]["open_on_ctrl_k"] = {
+        "ok": all([
+            fonts_ok,
+            absent_before,
+            opened["present"],
+            opened["inputFocused"],
+            opened["selectedIx"] == 0,
+            # Mixed groups in §1.3 order, each contiguous.
+            [g for i, g in enumerate(opened["groups"]) if i == 0 or opened["groups"][i - 1] != g]
+            == ["runs", "projects", "repos", "verbs"],
+            # Gates lead the runs group (r-q3 / r-api are the awaiting_human pair).
+            "gate" in opened["labels"][0],
+            # EC15: overlay + selected row backgrounds ARE the resolved tokens.
+            opened["paletteBg"] == tokens["overlay"],
+            opened["selectedBg"] == tokens["accentSubtle"],
+            opened["selectedOutline"] == "solid",
+            # §1.4: exactly one GET /repos on first open, nothing else stolen.
+            palette_reqs == [("GET", "/api/v1/repos")],
+            repos_gets() == repos_before_open + 1,
+        ]),
+        "absent_before": absent_before,
+        "web_fonts_loaded": fonts_ok,
+        **{k: opened[k] for k in ("present", "inputFocused", "selectedIx",
+                                  "paletteBg", "selectedBg", "selectedOutline")},
+        "group_run": [g for i, g in enumerate(opened["groups"])
+                      if i == 0 or opened["groups"][i - 1] != g],
+        "first_label": opened["labels"][0] if opened["labels"] else None,
+        "resolved_tokens": tokens,
+        "palette_requests_on_open": palette_reqs,
+    }
+
+    # ── Capture 1: mixed groups, selection ring on row 0 ────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback2-G-palette-mixed.png"))
+
+    # ── AC 5: arrows move the selection ─────────────────────────────────────────
+    page.keyboard.press("ArrowDown")
+    down = page.evaluate(PALETTE_STATE)
+    page.keyboard.press("ArrowUp")
+    up = page.evaluate(PALETTE_STATE)
+    report["steps"]["arrows_move_selection"] = {
+        "ok": down["selectedIx"] == 1 and up["selectedIx"] == 0,
+        "after_down": down["selectedIx"],
+        "after_up": up["selectedIx"],
+    }
+
+    # ── AC 4 + navigation: "p: q3" → projects only, Enter → the q3 dashboard ────
+    page.keyboard.type("p: q3")
+    scoped = page.evaluate(PALETTE_STATE)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=10000)
+    landed = page.evaluate("() => window.location.pathname")
+    closed_after_enter = page.evaluate(
+        "() => document.querySelector('[data-testid=\"command-palette\"]') === null"
+    )
+    report["steps"]["p_prefix_and_navigate"] = {
+        "ok": all([
+            len(scoped["groups"]) > 0,
+            all(g == "projects" for g in scoped["groups"]),
+            "q3-review-deck" in scoped["labels"][0],
+            scoped["hrefs"][0] == "/p/q3-review-deck",
+            landed == "/p/q3-review-deck",
+            closed_after_enter,
+        ]),
+        "groups": scoped["groups"],
+        "first_label": scoped["labels"][0] if scoped["labels"] else None,
+        "landed": landed,
+        "closed_after_enter": closed_after_enter,
+    }
+
+    # ── AC 6 (warm cache) + AC 4 (run:/repo: counts match the fixture) ──────────
+    repos_before_reopen = repos_gets()
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    page.wait_for_timeout(500)
+    page.keyboard.type("run:")
+    run_scoped = page.evaluate(PALETTE_STATE)
+    for _ in range(4):
+        page.keyboard.press("Backspace")
+    page.keyboard.type("repo:")
+    repo_scoped = page.evaluate(PALETTE_STATE)
+    report["steps"]["run_repo_prefixes_warm_cache"] = {
+        "ok": all([
+            repos_gets() == repos_before_reopen,  # warm cache: nothing at all
+            all(g == "runs" for g in run_scoped["groups"]),
+            len(run_scoped["groups"]) == FIXTURE_RUNS,
+            all(g == "repos" for g in repo_scoped["groups"]),
+            len(repo_scoped["groups"]) == 1,
+            "studio-api" in repo_scoped["labels"][0],
+            repo_scoped["hrefs"][0] == "/repo-detail/studio-api",
+        ]),
+        "fixture_runs": FIXTURE_RUNS,
+        "run_rows": len(run_scoped["groups"]),
+        "repo_rows": repo_scoped["labels"],
+        "repos_gets_after_reopen": repos_gets(),
+    }
+
+    # ── Into a run view via the palette itself: "run: rate" → r-upload ──────────
+    for _ in range(5):
+        page.keyboard.press("Backspace")
+    page.keyboard.type("run: rate")
+    page.keyboard.press("Enter")
+    # The palette navigates to `/runs/r-upload`; the pre-merge legacy redirect
+    # (§1.5, untouched by this slice) immediately rewrites it into the shell.
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/upload-endpoint/build/r-upload'",
+        timeout=10000,
+    )
+
+    # ── AC 2: kill-run relocation on the selected non-terminal run ──────────────
+    pre_cancels = cancel_posts()
+    page.keyboard.press("Control+Shift+K")
+    page.wait_for_timeout(600)
+    after_shift = {
+        "cancels": cancel_posts()[len(pre_cancels):],
+        "palette_open": page.evaluate(
+            "() => document.querySelector('[data-testid=\"command-palette\"]') !== null"
+        ),
+    }
+    cancels_after_shift = len(cancel_posts())
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    page.wait_for_timeout(400)
+    plain_k_cancels = len(cancel_posts()) - cancels_after_shift
+    report["steps"]["kill_relocated_to_ctrl_shift_k"] = {
+        "ok": all([
+            after_shift["cancels"] == ["/api/v1/runs/r-upload/cancel"],
+            not after_shift["palette_open"],
+            plain_k_cancels == 0,
+        ]),
+        "shift_k_cancels": after_shift["cancels"],
+        "palette_open_after_shift_k": after_shift["palette_open"],
+        "plain_k_cancels": plain_k_cancels,
+    }
+
+    # ── The verb list on a run view: Cancel run present (non-terminal selected) ──
+    page.keyboard.type("> ")
+    verbs = page.evaluate(PALETTE_STATE)
+    verb_names = ["New Build", "New Chat", "New Project", "Toggle Theme",
+                  "Open Terminal", "Cancel run"]
+    report["steps"]["verb_list"] = {
+        "ok": all([
+            all(g == "verbs" for g in verbs["groups"]),
+            all(any(v in lbl for lbl in verbs["labels"]) for v in verb_names),
+        ]),
+        "labels": verbs["labels"],
+    }
+
+    # ── Capture 2: the `>` prefix with Cancel run present ───────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback2-G-palette-verbs.png"))
+
+    # ── AC 5: Escape closes and returns focus ───────────────────────────────────
+    page.keyboard.press("Escape")
+    escape_state = page.evaluate(
+        """() => ({
+             closed: document.querySelector('[data-testid="command-palette"]') === null,
+             focusReturned: document.activeElement !== null
+               && document.activeElement.dataset?.testid !== 'palette-input',
+           })"""
+    )
+    report["steps"]["escape_closes"] = {
+        "ok": escape_state["closed"] and escape_state["focusReturned"],
+        **escape_state,
+    }
+
+    # ── Verb execution E2E: "> New Chat" lands on the group-chat surface ────────
+    page.keyboard.press("Control+p")  # the OTHER chord the operator named
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    ctrl_p_opened = True
+    page.keyboard.type("> new chat")
+    page.keyboard.press("Enter")
+    # Inside the shell the verb is PROJECT-SCOPED (§1.3's table): the new chat
+    # files into the current project, never a silent unfiled thread.
+    try:
+        page.wait_for_function(
+            "() => window.location.pathname === '/p/upload-endpoint/chat/new'", timeout=10000
+        )
+    except Exception:
+        dump = page.evaluate(
+            """() => ({
+                 path: window.location.pathname,
+                 palette: !!document.querySelector('[data-testid="command-palette"]'),
+                 active: document.activeElement?.dataset?.testid
+                   ?? document.activeElement?.tagName,
+                 value: document.querySelector('[data-testid="palette-input"]')?.value ?? null,
+                 rows: Array.from(document.querySelectorAll('[data-testid="palette-row"]'))
+                   .map((r) => r.textContent?.slice(0, 40)),
+               })"""
+        )
+        fail("new_chat_verb", f"did not land on the project-scoped chat: {json.dumps(dump)}")
+    page.locator("textarea.wk-composer").wait_for(timeout=10000)
+
+    # ── AC 3: the typing guard — Cmd+K inside the chat composer does nothing ────
+    page.locator("textarea.wk-composer").click()
+    page.keyboard.type("k")
+    cancels_before_guard = len(cancel_posts())
+    page.keyboard.press("Meta+k")
+    page.keyboard.press("Control+k")
+    page.wait_for_timeout(400)
+    guard = page.evaluate(
+        """() => ({
+             paletteAbsent: document.querySelector('[data-testid="command-palette"]') === null,
+             composerFocused: document.activeElement?.classList?.contains('wk-composer') ?? false,
+             composerValue: document.querySelector('textarea.wk-composer')?.value ?? null,
+           })"""
+    )
+    report["steps"]["typing_guard"] = {
+        "ok": all([
+            ctrl_p_opened,
+            guard["paletteAbsent"],
+            guard["composerFocused"],
+            guard["composerValue"] == "k",
+            len(cancel_posts()) == cancels_before_guard,
+        ]),
+        "ctrl_p_opened": ctrl_p_opened,
+        **guard,
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-G-palette-mixed.png"),
+    str(VSHOTS / "feedback2-G-palette-verbs.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceG_verdict", f"slice-G assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CenterDashboard } from './components/CenterDashboard.js';
+import { CommandPalette, paletteShortcutEntries } from './components/CommandPalette.js';
 import { ChatsPage } from './components/ChatsPage.js';
 import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
@@ -26,6 +27,7 @@ import { WorkPage } from './components/WorkPage.js';
 import { SystemSettings } from './components/SystemSettings.js';
 import { ThemePage } from './components/ThemePage.js';
 import { useEventStream } from './hooks/useEventStream.js';
+import { setShortcutsPaletteOpen, useGlobalShortcuts } from './hooks/useGlobalShortcuts.js';
 import { useLegacyRedirect } from './hooks/useLegacyRedirect.js';
 import { modePath, routedVersion, useRoute, type Mode } from './hooks/useRoute.js';
 import { useRuns } from './hooks/useRuns.js';
@@ -55,35 +57,8 @@ const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
   'sessionCompleted',
 ]);
 
-/**
- * Ctrl+K keyboard shortcut — kill the selected run when it is not in a terminal state.
- * Wired here (global handler) so it works regardless of which panel has focus.
- */
-function useKillShortcut(
-  runId: string | null,
-  runs: { session: { id: string; status: string } }[],
-  onKill: (id: string) => Promise<void>,
-): void {
-  useEffect(() => {
-    if (!runId) return;
-    function handler(e: KeyboardEvent): void {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k' && runId) {
-        const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase() ?? '';
-        const editable = (e.target as HTMLElement | null)?.isContentEditable ?? false;
-        if (tag === 'input' || tag === 'textarea' || tag === 'select' || editable) return;
-        const run = runs.find((r) => r.session.id === runId);
-        if (!run) return;
-        const terminal = ['completed', 'cancelled', 'failed'].includes(run.session.status);
-        if (!terminal) {
-          e.preventDefault();
-          void onKill(runId);
-        }
-      }
-    }
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [runId, runs, onKill]);
-}
+/** Terminal run states — a run here can no longer be cancelled. */
+const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
   const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate, search } = useRoute();
@@ -206,9 +181,37 @@ export function App(): React.ReactElement {
     [refresh],
   );
 
-  useKillShortcut(runId, runs, onKill);
-
   const selected = runs.find((v) => v.session.id === runId) ?? null;
+
+  // ── DES-FEEDBACK-002 §1.2 (slice G): shortcut registry + command palette ────
+  // Cmd/Ctrl+K and Ctrl/Cmd+P open the palette (the unconditional, safe action
+  // gets the prime chord); kill-run relocates to Ctrl/Cmd+Shift+K with its
+  // guards and silent-fail contract intact, and also rides the palette as the
+  // `> Cancel run` verb. One listener, one guard — `useGlobalShortcuts`.
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const paletteOpenRef = useRef(paletteOpen);
+  useEffect(() => {
+    paletteOpenRef.current = paletteOpen;
+    setShortcutsPaletteOpen(paletteOpen);
+  }, [paletteOpen]);
+
+  const shortcutEntries = useMemo(
+    () =>
+      paletteShortcutEntries({
+        isOpen: () => paletteOpenRef.current,
+        setOpen: setPaletteOpen,
+        killEligible: () => {
+          if (!runId) return false;
+          const run = runs.find((r) => r.session.id === runId);
+          return run !== undefined && !TERMINAL_STATES.includes(run.session.status);
+        },
+        kill: () => {
+          if (runId) void onKill(runId);
+        },
+      }),
+    [runId, runs, onKill],
+  );
+  useGlobalShortcuts(shortcutEntries);
 
   // ── Repo graph modal — opened from RepoDetailPage via onOpenGraph ───────────
   const [graphModalRepo, setGraphModalRepo] = useState<RepoEntry | null>(null);
@@ -486,6 +489,19 @@ export function App(): React.ReactElement {
       {selected !== null && (
         <RightPanel view={selected} />
       )}
+
+      {/* The universal command palette (DES-FEEDBACK-002 §1, slice G) — corpus
+          from already-loaded stores + the runs prop; repos cached on first open. */}
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        runs={runs}
+        navigate={navigate}
+        runPath={runPath}
+        projectId={projectId}
+        selectedRun={selected}
+        onKill={(id) => void onKill(id)}
+      />
 
       {/* Gate toasts — renders above everything; scoped to the current run. NOT on the
           orchestrator board: there every waiting gate is already an answerable chip on

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,502 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Search } from 'lucide-react';
+import type { RepoEntry, SessionView } from '../api/types.js';
+import { api } from '../api/client.js';
+import { fuzzyMatch } from '../palette/fuzzy.js';
+import { modePath, projectPath, type Navigate } from '../hooks/useRoute.js';
+import type { ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
+import { useProjectsStore } from '../store/projects.js';
+import { useGateStore } from '../store/gates.js';
+import { useAppearanceStore } from '../theming/appearance.js';
+import { GATE_HASH } from './GateChip.js';
+import { NewProjectModal } from './NewProjectModal.js';
+import { Modal } from './Modal.js';
+import { Terminal } from './Terminal.js';
+
+/**
+ * The universal command palette (DES-FEEDBACK-002 §1, slice G): Cmd+K / Ctrl+K /
+ * Ctrl+P open it; fuzzy search over projects (`p:`), runs & open gates (`run:`),
+ * repositories (`repo:`) and quick verbs (`>`); selecting navigates (the board's
+ * real-link contract) or executes the verb.
+ *
+ * The corpus steals nothing (§1.4): projects and gates come from already-loaded
+ * stores, runs from App's one `useRuns()`; only the repo list is fetched — once,
+ * on the first OPEN (a user gesture, never a mount), then cached for the session.
+ */
+
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'cancelled', 'failed']);
+const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+type Group = 'runs' | 'projects' | 'repos' | 'verbs';
+
+const GROUP_LABEL: Record<Group, string> = {
+  runs: 'RUNS & GATES',
+  projects: 'PROJECTS',
+  repos: 'REPOSITORIES',
+  verbs: 'VERBS',
+};
+
+interface Entry {
+  id: string;
+  group: Group;
+  /** Fuzzy-matched text. Verbs match on the name after the `>`. */
+  label: string;
+  /** Mono dim context (project/status/branch). */
+  context: string;
+  /** Real-link target (href + onClick-preventDefault, deep-linkable). */
+  href?: string;
+  /** Verb execution — runs instead of navigation. */
+  action?: () => void;
+  /** Group-internal rank: lower first (gates before active before terminal). */
+  rank: number;
+}
+
+/** Session-scoped repo cache (§1.4): filled on first open, then warm. */
+let repoCache: RepoEntry[] | null = null;
+
+export function clearPaletteRepoCache(): void {
+  repoCache = null;
+}
+
+/**
+ * The two global chords App registers (§1.2) — exported so the wiring the app
+ * mounts is the wiring the unit tests exercise. Order matters: the palette
+ * toggle first (and it alone survives `paletteOpen`), the relocated kill-run
+ * (Ctrl+Shift+K, same guards + silent-fail contract as the old `useKillShortcut`)
+ * after it.
+ */
+export function paletteShortcutEntries(opts: {
+  isOpen: () => boolean;
+  setOpen: (open: boolean) => void;
+  killEligible: () => boolean;
+  kill: () => void;
+}): ShortcutEntry[] {
+  const toggle = (e: KeyboardEvent): void => {
+    e.preventDefault(); // Ctrl+P must suppress browser print
+    opts.setOpen(!opts.isOpen());
+  };
+  return [
+    {
+      id: 'palette-toggle-k',
+      chord: { key: 'k', ctrlOrMeta: true },
+      description: 'Open the command palette',
+      handler: toggle,
+      allowWhilePaletteOpen: true,
+    },
+    {
+      id: 'palette-toggle-p',
+      chord: { key: 'p', ctrlOrMeta: true },
+      description: 'Open the command palette',
+      handler: toggle,
+      allowWhilePaletteOpen: true,
+    },
+    {
+      id: 'kill-run',
+      chord: { key: 'k', ctrlOrMeta: true, shift: true },
+      description: 'Cancel the selected run',
+      guard: opts.killEligible,
+      handler: (e) => {
+        e.preventDefault();
+        opts.kill();
+      },
+    },
+  ];
+}
+
+/** Accent-highlight the fuzzy-matched characters (§1.5 — the row's only accent). */
+function highlight(label: string, positions: number[]): React.ReactNode {
+  if (positions.length === 0) return label;
+  const set = new Set(positions);
+  return label.split('').map((ch, i) =>
+    set.has(i) ? (
+      <span key={i} style={{ color: 'var(--accent)', fontWeight: 'var(--weight-semi)' }}>
+        {ch}
+      </span>
+    ) : (
+      ch
+    ),
+  );
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  runs: SessionView[];
+  navigate: Navigate;
+  runPath: (id: string) => string;
+  projectId: string | null;
+  selectedRun: SessionView | null;
+  onKill: (id: string) => void;
+}
+
+export function CommandPalette({
+  open, onClose, runs, navigate, runPath, projectId, selectedRun, onKill,
+}: Props): React.ReactElement | null {
+  const [query, setQuery] = useState('');
+  const [sel, setSel] = useState(0);
+  const [repos, setRepos] = useState<RepoEntry[]>(repoCache ?? []);
+  const [showNewProject, setShowNewProject] = useState(false);
+  const [showTerminal, setShowTerminal] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  const projects = useProjectsStore((s) => s.projects);
+  const gates = useGateStore((s) => s.gates);
+
+  // Open: remember focus, reset the query, focus the input; fetch the repo list
+  // only when the cache is cold (§1.4 — first open fires exactly one GET /repos;
+  // a warm cache fetches nothing at all).
+  useEffect(() => {
+    if (!open) return;
+    restoreRef.current = document.activeElement as HTMLElement | null;
+    setQuery('');
+    setSel(0);
+    inputRef.current?.focus();
+    if (repoCache === null) {
+      api
+        .listRepos()
+        .then(({ repos: r }) => {
+          repoCache = r;
+          setRepos(r);
+        })
+        .catch(() => {
+          /* no repo surface — the group just stays empty this session */
+        });
+    } else {
+      setRepos(repoCache);
+    }
+  }, [open]);
+
+  const close = (): void => {
+    onClose();
+    restoreRef.current?.focus?.();
+  };
+
+  // ── The corpus (§1.3/§1.4): stores + props only — zero fetching here ────────
+  const { scope, needle } = useMemo(() => {
+    const q = query.trimStart();
+    if (q.startsWith('>')) return { scope: 'verbs' as const, needle: q.slice(1).trim() };
+    if (q.startsWith('p:')) return { scope: 'projects' as const, needle: q.slice(2).trim() };
+    if (q.startsWith('run:')) return { scope: 'runs' as const, needle: q.slice(4).trim() };
+    if (q.startsWith('repo:')) return { scope: 'repos' as const, needle: q.slice(5).trim() };
+    return { scope: 'all' as const, needle: q.trim() };
+  }, [query]);
+
+  const rows = useMemo(() => {
+    const status = selectedRun?.session.status ?? '';
+    const entries: Entry[] = [];
+
+    // Runs & gates — a gated run IS its gate row (deep link to #gate); rank:
+    // gates first (attention order — the list is already daemon-sorted), then
+    // active runs, terminal runs after (§1.3 prefix table).
+    for (const v of runs) {
+      const id = v.session.id;
+      const gated = v.session.status === 'awaiting_human' || gates[id] !== undefined;
+      entries.push({
+        id: `run-${id}`,
+        group: 'runs',
+        label: v.session.problem,
+        context: gated ? 'gate' : v.session.status,
+        href: gated ? `${runPath(id)}${GATE_HASH}` : runPath(id),
+        rank: gated ? 0 : ACTIVE.has(v.session.status) ? 1 : 2,
+      });
+    }
+
+    // Projects — the store the board/shell already loaded; the synthesized
+    // Unfiled bucket never renders (F5). Recency-ordered (`updated_at`): the
+    // store-reachable order — the board's decayed attention needs membership
+    // joins the palette must not fetch.
+    const visible = projects.filter((p) => p.id !== 'default' && p.status === 'active');
+    const byRecency = [...visible].sort((a, b) => b.updated_at - a.updated_at);
+    byRecency.forEach((p, i) =>
+      entries.push({
+        id: `project-${p.id}`,
+        group: 'projects',
+        label: p.name,
+        context: 'project',
+        href: projectPath(p.id),
+        rank: i,
+      }),
+    );
+
+    for (const r of repos) {
+      entries.push({
+        id: `repo-${r.id}`,
+        group: 'repos',
+        label: r.name,
+        context: r.default_branch,
+        href: `/repo-detail/${encodeURIComponent(r.id)}`,
+        rank: 0,
+      });
+    }
+
+    // Verbs (§1.3's table — each names its existing mechanism, none invents one).
+    const verbs: Array<{ name: string; action: () => void; when?: boolean }> = [
+      {
+        name: 'New Build',
+        action: () => navigate(projectId !== null ? `${modePath(projectId, 'build')}/new` : '/runs/new'),
+      },
+      {
+        name: 'New Chat',
+        action: () => navigate(projectId !== null ? `${modePath(projectId, 'chat')}/new` : '/chat/new'),
+      },
+      { name: 'New Project', action: () => setShowNewProject(true) },
+      {
+        name: 'Toggle Theme',
+        action: () => {
+          const cur = useAppearanceStore.getState().appearance.theme;
+          useAppearanceStore.getState().update({ theme: cur === 'dark' ? 'light' : 'dark' });
+        },
+      },
+      { name: 'Open Terminal', action: () => setShowTerminal(true) },
+      {
+        name: 'Cancel run',
+        when: selectedRun !== null && !TERMINAL.has(status),
+        action: () => {
+          if (selectedRun !== null) onKill(selectedRun.session.id);
+        },
+      },
+      {
+        name: 'Approve gate',
+        when: status === 'awaiting_human',
+        action: () => {
+          if (selectedRun !== null) void api.confirmGate(selectedRun.session.id, { approve: true });
+        },
+      },
+      {
+        name: 'Reject gate',
+        when: status === 'awaiting_human',
+        action: () => {
+          if (selectedRun !== null) void api.confirmGate(selectedRun.session.id, { approve: false });
+        },
+      },
+    ];
+    verbs.forEach((v, i) => {
+      if (v.when === false) return;
+      entries.push({ id: `verb-${v.name}`, group: 'verbs', label: v.name, context: 'verb', action: v.action, rank: i });
+    });
+
+    // Scope, fuzzy-rank, group (§1.3's group order; §1.5's scorer).
+    const scoped = scope === 'all' ? entries : entries.filter((en) => en.group === scope);
+    const matched = scoped
+      .map((en) => ({ en, m: fuzzyMatch(needle, en.label) }))
+      .filter((x): x is { en: Entry; m: { score: number; positions: number[] } } => x.m !== null);
+    const order: Group[] = ['runs', 'projects', 'repos', 'verbs'];
+    matched.sort((a, b) => {
+      const g = order.indexOf(a.en.group) - order.indexOf(b.en.group);
+      if (g !== 0) return g;
+      if (b.m.score !== a.m.score) return b.m.score - a.m.score;
+      return a.en.rank - b.en.rank;
+    });
+    return matched;
+  }, [runs, projects, repos, gates, scope, needle, runPath, navigate, projectId, selectedRun, onKill]);
+
+  // Clamp the selection whenever the row set changes.
+  const selIx = Math.min(sel, Math.max(0, rows.length - 1));
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-selected="true"]')
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [selIx, rows]);
+
+  const activate = (row: (typeof rows)[number] | undefined): void => {
+    if (row === undefined) return;
+    close();
+    if (row.en.action !== undefined) row.en.action();
+    else if (row.en.href !== undefined) navigate(row.en.href);
+  };
+
+  // §1.2 precedence: list-navigation keys are handled by the palette's focused
+  // input — including the toggle chords, which the registry cannot see from
+  // inside a typing context.
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && (e.key === 'k' || e.key === 'p')) {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSel(Math.min(selIx + 1, rows.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSel(Math.max(selIx - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      activate(rows[selIx]);
+    } else if (e.key === 'Tab') {
+      // Cycle to the next group's first row (the hint row's "tab cycle groups").
+      e.preventDefault();
+      const cur = rows[selIx]?.en.group;
+      const next = rows.findIndex((r, i) => i > selIx && r.en.group !== cur);
+      setSel(next >= 0 ? next : 0);
+    }
+  };
+
+  return (
+    <>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex justify-center"
+          style={{ background: 'var(--scrim)', paddingTop: '15vh' }}
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <div
+            data-testid="command-palette"
+            className="wk-palette-in flex flex-col self-start overflow-hidden"
+            style={{
+              width: 560,
+              maxHeight: 420,
+              background: 'var(--surface-overlay)',
+              boxShadow: 'var(--shadow-overlay)',
+              borderRadius: 'var(--radius-xl)',
+            }}
+          >
+            {/* input row */}
+            <div
+              className="flex items-center gap-2 px-4 py-3 shrink-0"
+              style={{ background: 'var(--surface-raised)' }}
+            >
+              <Search size={14} style={{ color: 'var(--ink-dim)' }} aria-hidden />
+              <input
+                ref={inputRef}
+                data-testid="palette-input"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setSel(0);
+                }}
+                onKeyDown={onKeyDown}
+                placeholder="type to search…  p: run: repo: >"
+                aria-label="Command palette search"
+                className="flex-1 bg-transparent outline-none"
+                style={{
+                  fontSize: 'var(--text-md)',
+                  fontFamily: 'var(--font-sans)',
+                  color: 'var(--ink-high)',
+                }}
+              />
+              <span
+                className="font-mono"
+                style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}
+              >
+                esc
+              </span>
+            </div>
+
+            {/* grouped results */}
+            <div ref={listRef} role="listbox" aria-label="Palette results" className="flex-1 overflow-y-auto py-1">
+              {rows.length === 0 && (
+                <p
+                  className="px-4 py-3"
+                  style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-dim)' }}
+                >
+                  nothing matches
+                </p>
+              )}
+              {rows.map((row, i) => {
+                const first = i === 0 || rows[i - 1]?.en.group !== row.en.group;
+                const shared = {
+                  'data-testid': 'palette-row',
+                  'data-group': row.en.group,
+                  'data-selected': i === selIx ? 'true' : 'false',
+                  role: 'option',
+                  'aria-selected': i === selIx,
+                  onClick: (e: React.MouseEvent) => {
+                    e.preventDefault();
+                    activate(row);
+                  },
+                  onMouseEnter: () => setSel(i),
+                  className: 'flex w-full items-baseline gap-3 px-4 py-1.5 text-left',
+                  style: {
+                    background: i === selIx ? 'var(--accent-subtle)' : 'transparent',
+                    outline: i === selIx ? '2px solid var(--accent)' : 'none',
+                    outlineOffset: -2,
+                  } as React.CSSProperties,
+                } as const;
+                const body = (
+                  <>
+                    <span
+                      className="min-w-0 flex-1 truncate"
+                      style={{
+                        fontSize: 'var(--text-sm)',
+                        fontFamily: 'var(--font-sans)',
+                        color: 'var(--ink-high)',
+                      }}
+                    >
+                      {row.en.group === 'verbs' ? '> ' : ''}
+                      {highlight(row.en.label, row.m.positions)}
+                    </span>
+                    <span
+                      className="shrink-0 font-mono"
+                      style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}
+                    >
+                      {row.en.context}
+                    </span>
+                  </>
+                );
+                return (
+                  <div key={row.en.id}>
+                    {first && (
+                      <p
+                        className="px-4 pt-2 pb-1 uppercase"
+                        style={{
+                          fontSize: 'var(--text-2xs)',
+                          fontWeight: 'var(--weight-medium)',
+                          color: 'var(--ink-dim)',
+                          letterSpacing: '0.08em',
+                        }}
+                      >
+                        {GROUP_LABEL[row.en.group]}
+                      </p>
+                    )}
+                    {row.en.href !== undefined ? (
+                      <a {...shared} href={row.en.href}>
+                        {body}
+                      </a>
+                    ) : (
+                      <button {...shared} type="button">
+                        {body}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* hint row */}
+            <p
+              className="px-4 py-2 shrink-0 font-mono"
+              style={{
+                fontSize: 'var(--text-2xs)',
+                color: 'var(--ink-dim)',
+                borderTop: '1px solid var(--surface-raised)',
+              }}
+            >
+              ↑↓ navigate · ↵ open · tab cycle groups · esc close
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* `> New Project` — the slice-A modal, unchanged */}
+      {showNewProject && (
+        <NewProjectModal navigate={(p: string) => navigate(p)} onClose={() => setShowNewProject(false)} />
+      )}
+
+      {/* `> Open Terminal` — the RightPanel pair (Modal + governed Terminal) */}
+      {showTerminal && (
+        <Modal title="Operator shell" onClose={() => setShowTerminal(false)} disableEscapeKey>
+          <Terminal cwd={selectedRun?.session.workdir ?? '.'} governed />
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -144,14 +144,18 @@ export function CommandPalette({
   const projects = useProjectsStore((s) => s.projects);
   const gates = useGateStore((s) => s.gates);
 
-  // Open: remember focus, reset the query, focus the input; fetch the repo list
-  // only when the cache is cold (§1.4 — first open fires exactly one GET /repos;
-  // a warm cache fetches nothing at all).
+  // Open: remember focus and focus the input; fetch the repo list only when the
+  // cache is cold (§1.4 — first open fires exactly one GET /repos; a warm cache
+  // fetches nothing at all). The query resets on CLOSE, not open, so a reopen
+  // renders empty from its first frame — a keystroke racing the open can never
+  // append to the previous session's text.
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setQuery('');
+      setSel(0);
+      return;
+    }
     restoreRef.current = document.activeElement as HTMLElement | null;
-    setQuery('');
-    setSel(0);
     inputRef.current?.focus();
     if (repoCache === null) {
       api

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -10,6 +10,7 @@ import {
   type Signal,
 } from '../board/boardAttention.js';
 import { useGateStore, type OpenGate } from '../store/gates.js';
+import { useProjectsStore } from '../store/projects.js';
 import { useRuntimeStore } from '../store/runtime.js';
 
 /**
@@ -237,6 +238,10 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
       // Cards render as soon as the projects are known; tiles and chips fill in behind
       // them, so a slow bridge never holds the whole board on a spinner (§3.3).
       setProjects(active);
+      // Mirror into the shared projects store (a store WRITE of already-fetched
+      // data, no extra request) so the command palette's corpus (DES-FEEDBACK-002
+      // §1.4 — "already loaded by the board/shell") is true on the board too.
+      useProjectsStore.setState({ projects: active });
       setLoading(false);
       const entries = await Promise.all(
         active.map(async (p) => [p.id, await loadBindings(p, repoNames.current)] as const),

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,101 @@
+import { useEffect } from 'react';
+
+/**
+ * The global shortcut registry (DES-FEEDBACK-002 §1.2, slice G).
+ *
+ * ONE `window.addEventListener('keydown')` for the whole app — the EC21
+ * contract: every global chord (the palette toggle, the relocated kill-run,
+ * slice H's triage keys) registers an entry in the ordered table below, and the
+ * shared `isTypingContext` guard runs before ANY entry, so no shortcut — chorded
+ * or not — ever acts while something editable has focus. The modal family's
+ * document-level Escape-only listeners (§1.1) are local, preserved, and exempt.
+ */
+
+export interface ShortcutChord {
+  /** `KeyboardEvent.key`, lowercased (`'k'`, `'p'`, `'j'`, `'escape'`). */
+  key: string;
+  /** Chord requires Ctrl OR Meta (the cross-platform Cmd/Ctrl pairing). */
+  ctrlOrMeta?: boolean;
+  /** Chord requires Shift. Absent = Shift must be UP — this is what keeps
+   *  Ctrl+K (palette) and Ctrl+Shift+K (kill) two different chords. */
+  shift?: boolean;
+}
+
+export interface ShortcutEntry {
+  id: string;
+  chord: ShortcutChord;
+  /** Human-readable, for future discoverability surfaces. */
+  description: string;
+  /** Extra availability gate, evaluated after the typing guard. `false` means
+   *  the entry YIELDS silently — no preventDefault, no handler (the kill
+   *  shortcut's silent-fail contract). */
+  guard?: () => boolean;
+  handler: (e: KeyboardEvent) => void;
+  /** §1.2 precedence: while the palette is open the table yields everything
+   *  except the toggle chord itself. Only the palette toggle sets this. */
+  allowWhilePaletteOpen?: boolean;
+}
+
+/**
+ * The one typing-context predicate (the exact App.tsx:71–73 test, spelled once):
+ * keys pass through untouched while an input, textarea, select, or
+ * contentEditable element has focus.
+ */
+export function isTypingContext(e: KeyboardEvent): boolean {
+  const t = e.target as HTMLElement | null;
+  const tag = t?.tagName?.toLowerCase() ?? '';
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || (t?.isContentEditable ?? false);
+}
+
+/** Strict chord match — Alt always disqualifies; Shift and Ctrl/Meta must equal
+ *  the chord's declaration, so `Ctrl+K` never fires a `Ctrl+Shift+K` entry. */
+export function chordMatches(e: KeyboardEvent, chord: ShortcutChord): boolean {
+  if (e.altKey) return false;
+  if ((e.key ?? '').toLowerCase() !== chord.key) return false;
+  if ((e.ctrlKey || e.metaKey) !== (chord.ctrlOrMeta ?? false)) return false;
+  if (e.shiftKey !== (chord.shift ?? false)) return false;
+  return true;
+}
+
+/** The ordered handler table — registration order is precedence. */
+const table: ShortcutEntry[] = [];
+
+/** §1.2: while open, the palette owns the keyboard; the table yields. */
+let paletteOpen = false;
+
+export function setShortcutsPaletteOpen(open: boolean): void {
+  paletteOpen = open;
+}
+
+function dispatch(e: KeyboardEvent): void {
+  if (isTypingContext(e)) return;
+  for (const entry of table) {
+    if (paletteOpen && entry.allowWhilePaletteOpen !== true) continue;
+    if (!chordMatches(e, entry.chord)) continue;
+    if (entry.guard !== undefined && !entry.guard()) continue; // yield silently
+    entry.handler(e);
+    return; // one owner per chord — first matching entry wins
+  }
+}
+
+let listening = false;
+
+/** Register entries (in order); returns the unregister. Non-hook form for tests. */
+export function registerShortcuts(entries: ShortcutEntry[]): () => void {
+  if (!listening) {
+    listening = true;
+    window.addEventListener('keydown', dispatch);
+  }
+  table.push(...entries);
+  return () => {
+    for (const entry of entries) {
+      const i = table.indexOf(entry);
+      if (i >= 0) table.splice(i, 1);
+    }
+  };
+}
+
+/** Mount-scoped registration. Memoize `entries` — re-created arrays re-register. */
+export function useGlobalShortcuts(entries: ShortcutEntry[]): void {
+  useEffect(() => registerShortcuts(entries), [entries]);
+}

--- a/src/palette/fuzzy.ts
+++ b/src/palette/fuzzy.ts
@@ -1,0 +1,48 @@
+/**
+ * The palette's fuzzy matcher (DES-FEEDBACK-002 §1.5) — no library, per the
+ * §2.3 precedent: the corpus is a few hundred strings in memory, so a
+ * case-insensitive subsequence scorer is the whole job. Characters must appear
+ * in order; the score rewards word-boundary hits and consecutive matches and
+ * penalizes gaps. Ties are broken by the CALLER (recency for runs, attention
+ * for projects) — this module ranks text only.
+ */
+
+export interface FuzzyResult {
+  score: number;
+  /** Indices into the haystack of every matched character — the accent-render seam. */
+  positions: number[];
+}
+
+const BOUNDARY = /[\s\-_./:]/;
+
+function isBoundary(hay: string, i: number): boolean {
+  return i === 0 || BOUNDARY.test(hay[i - 1] ?? '');
+}
+
+/**
+ * Match `needle` as an in-order subsequence of `haystack` (case-insensitive).
+ * Empty needle matches everything at score 0. No subsequence ⇒ `null`.
+ */
+export function fuzzyMatch(needle: string, haystack: string): FuzzyResult | null {
+  if (needle === '') return { score: 0, positions: [] };
+  const n = needle.toLowerCase();
+  const h = haystack.toLowerCase();
+  const positions: number[] = [];
+  let score = 0;
+  let hi = 0;
+  let prev = -2;
+  for (let ni = 0; ni < n.length; ni++) {
+    const c = n[ni] as string;
+    const at = h.indexOf(c, hi);
+    if (at === -1) return null;
+    // Base hit +1; word-boundary hit +2; consecutive-run hit +1.5; gap −0.05/char.
+    score += 1;
+    if (isBoundary(h, at)) score += 2;
+    if (at === prev + 1) score += 1.5;
+    score -= Math.max(0, at - hi) * 0.05;
+    positions.push(at);
+    prev = at;
+    hi = at + 1;
+  }
+  return { score, positions };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -98,6 +98,18 @@ code, pre, .font-mono {
    line fades in at the top of its block (120ms), a NEW project block fades in
    (220ms). One run each — content-keyed elements remount only on change, and
    nothing here loops (§1.6's rule). */
+/* The command palette's entrance (DES-FEEDBACK-002 §1.6): fade + 4px rise at
+   --dur-fast --ease-out, one run, nothing loops (§1.6's grammar). */
+@keyframes wk-palette-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+.wk-palette-in { animation: wk-palette-in var(--dur-fast) var(--ease-out); }
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-palette-in { animation: none; }
+}
+
 @keyframes wk-feed-in {
   from { opacity: 0; transform: translateY(-4px); }
   to   { opacity: 1; transform: none; }

--- a/tests/CommandPalette.test.tsx
+++ b/tests/CommandPalette.test.tsx
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Project } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * The universal command palette (DES-FEEDBACK-002 §1, slice G): prefix grammar
+ * over an already-loaded corpus (zero store fetches on open — only the repo
+ * list, once, cached for the session), grouped keyboard-navigable rows, the
+ * §1.3 verb table, Escape/focus-restore behavior.
+ */
+
+const listRepos = vi.fn();
+const confirmGate = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: new Proxy(
+    {},
+    {
+      // EVERY api surface is a spy: the zero-fetch assertion below is "nothing
+      // but listRepos was called", not a hand-picked subset.
+      get: (_t, prop) => {
+        const name = String(prop);
+        if (name === 'listRepos') return listRepos;
+        if (name === 'confirmGate') return confirmGate;
+        return calls(name);
+      },
+    },
+  ),
+}));
+
+const otherCalls = new Map<string, ReturnType<typeof vi.fn>>();
+function calls(prop: string): ReturnType<typeof vi.fn> {
+  let fn = otherCalls.get(prop);
+  if (fn === undefined) {
+    fn = vi.fn(() => Promise.resolve({}));
+    otherCalls.set(prop, fn);
+  }
+  return fn;
+}
+
+const { CommandPalette, clearPaletteRepoCache } = await import('../src/components/CommandPalette.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useGateStore } = await import('../src/store/gates.js');
+const { useAppearanceStore } = await import('../src/theming/appearance.js');
+
+function proj(id: string, name: string, updated_at: number): Project {
+  return { id, name, description: null, status: 'active', scope: `project:${id}`, created_at: 1, updated_at };
+}
+
+const RUNS = [
+  makeView({ id: 'r-gate', problem: 'migrate the auth tables', status: 'awaiting_human' }),
+  makeView({ id: 'r-live', problem: 'add rate-limiting', status: 'executing' }),
+  makeView({ id: 'r-done', problem: 'smoke the login flow', status: 'completed' }),
+];
+
+function renderPalette(over: Partial<Parameters<typeof CommandPalette>[0]> = {}) {
+  const navigate = vi.fn();
+  const onKill = vi.fn();
+  const onClose = vi.fn();
+  const utils = render(
+    <CommandPalette
+      open
+      onClose={onClose}
+      runs={RUNS}
+      navigate={navigate}
+      runPath={(id) => `/runs/${id}`}
+      projectId={null}
+      selectedRun={null}
+      onKill={onKill}
+      {...over}
+    />,
+  );
+  return { navigate, onKill, onClose, ...utils };
+}
+
+beforeEach(() => {
+  clearPaletteRepoCache();
+  listRepos.mockReset();
+  confirmGate.mockReset();
+  otherCalls.clear();
+  listRepos.mockResolvedValue({
+    repos: [{ id: 'studio-api', name: 'studio-api', root_path: '/x', default_branch: 'main', registered_at: 1 }],
+  });
+  useProjectsStore.setState({
+    projects: [proj('default', 'Unfiled', 9), proj('q3-review-deck', 'q3-review-deck', 5), proj('api-migration', 'api-migration', 7)],
+  });
+  useGateStore.setState({ gates: {} });
+});
+afterEach(cleanup);
+
+function rows(): HTMLElement[] {
+  return screen.queryAllByTestId('palette-row');
+}
+function groupsOf(list: HTMLElement[]): string[] {
+  return list.map((r) => r.dataset.group ?? '');
+}
+
+describe('corpus & prefixes (§1.3/§1.4)', () => {
+  it('opens with mixed groups: gates first in runs, then projects (recency), repos, verbs — never Unfiled', async () => {
+    renderPalette();
+    await waitFor(() => expect(rows().some((r) => r.dataset.group === 'repos')).toBe(true));
+    const gs = groupsOf(rows());
+    // Grouped in §1.3 order, each group contiguous.
+    expect([...new Set(gs)]).toEqual(['runs', 'projects', 'repos', 'verbs']);
+    // Gates lead the runs group; terminal runs trail it.
+    const runRows = rows().filter((r) => r.dataset.group === 'runs');
+    expect(runRows[0]?.textContent).toContain('migrate the auth tables');
+    expect(runRows[0]?.textContent).toContain('gate');
+    expect(runRows[2]?.textContent).toContain('smoke the login flow');
+    // Projects are recency-ordered and the synthesized default never renders (F5).
+    const projRows = rows().filter((r) => r.dataset.group === 'projects');
+    expect(projRows.map((r) => r.textContent?.includes('Unfiled'))).toEqual([false, false]);
+    expect(projRows[0]?.textContent).toContain('api-migration');
+  });
+
+  it('the gated run row deep-links to #gate; a plain run links to its run path', () => {
+    renderPalette();
+    const runRows = rows().filter((r) => r.dataset.group === 'runs');
+    expect(runRows[0]?.getAttribute('href')).toBe('/runs/r-gate#gate');
+    expect(runRows[1]?.getAttribute('href')).toBe('/runs/r-live');
+  });
+
+  it('p: / run: / repo: / > scope to exactly one group', async () => {
+    renderPalette();
+    const input = screen.getByTestId('palette-input');
+    fireEvent.change(input, { target: { value: 'p:' } });
+    expect(new Set(groupsOf(rows()))).toEqual(new Set(['projects']));
+    expect(rows()).toHaveLength(2);
+
+    fireEvent.change(input, { target: { value: 'run:' } });
+    expect(new Set(groupsOf(rows()))).toEqual(new Set(['runs']));
+    expect(rows()).toHaveLength(3);
+
+    fireEvent.change(input, { target: { value: 'repo:' } });
+    await waitFor(() => expect(rows()).toHaveLength(1));
+    expect(new Set(groupsOf(rows()))).toEqual(new Set(['repos']));
+
+    fireEvent.change(input, { target: { value: '>' } });
+    expect(new Set(groupsOf(rows()))).toEqual(new Set(['verbs']));
+  });
+
+  it('fuzzy-filters within a scope: "p: q3" keeps only q3-review-deck', () => {
+    renderPalette();
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: 'p: q3' } });
+    const r = rows();
+    expect(r).toHaveLength(1);
+    expect(r[0]?.textContent).toContain('q3-review-deck');
+    expect(r[0]?.getAttribute('href')).toBe('/p/q3-review-deck');
+  });
+});
+
+describe('zero fetching on open (§1.4)', () => {
+  it('calls NOTHING but listRepos on first open — and not even that on reopen (session cache)', async () => {
+    const first = renderPalette();
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
+    expect([...otherCalls.entries()].filter(([, fn]) => fn.mock.calls.length > 0)).toEqual([]);
+    first.unmount();
+
+    renderPalette();
+    await waitFor(() => expect(rows().some((r) => r.dataset.group === 'repos')).toBe(true));
+    expect(listRepos).toHaveBeenCalledTimes(1); // warm cache: nothing at all
+    expect([...otherCalls.entries()].filter(([, fn]) => fn.mock.calls.length > 0)).toEqual([]);
+  });
+});
+
+describe('keyboard navigation & activation (§1.7)', () => {
+  it('ArrowDown/ArrowUp move data-selected; Enter navigates the selected row', () => {
+    const { navigate } = renderPalette();
+    const input = screen.getByTestId('palette-input');
+    expect(rows()[0]?.dataset.selected).toBe('true');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(rows()[0]?.dataset.selected).toBe('false');
+    expect(rows()[1]?.dataset.selected).toBe('true');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(rows()[0]?.dataset.selected).toBe('true');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(navigate).toHaveBeenCalledWith('/runs/r-gate#gate');
+  });
+
+  it('Escape closes and returns focus to the previously focused element', () => {
+    const before = document.createElement('button');
+    document.body.appendChild(before);
+    before.focus();
+    const { onClose } = renderPalette();
+    expect(document.activeElement).toBe(screen.getByTestId('palette-input'));
+    fireEvent.keyDown(screen.getByTestId('palette-input'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(before);
+    before.remove();
+  });
+
+  it('the toggle chords close from inside the input (the §1.2 typing-context seam)', () => {
+    const { onClose } = renderPalette();
+    fireEvent.keyDown(screen.getByTestId('palette-input'), { key: 'k', ctrlKey: true });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the verb table (§1.3)', () => {
+  it('"> " lists the always-verbs; Cancel run and gate verbs need an eligible selected run', () => {
+    renderPalette();
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> ' } });
+    const names = rows().map((r) => r.textContent ?? '');
+    for (const v of ['New Build', 'New Chat', 'New Project', 'Toggle Theme', 'Open Terminal']) {
+      expect(names.some((n) => n.includes(v))).toBe(true);
+    }
+    expect(names.some((n) => n.includes('Cancel run'))).toBe(false);
+    expect(names.some((n) => n.includes('Approve gate'))).toBe(false);
+  });
+
+  it('Cancel run shows for a non-terminal selected run and dispatches onKill; terminal hides it', () => {
+    const { onKill } = renderPalette({ selectedRun: RUNS[1] ?? null });
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> cancel' } });
+    const row = rows().find((r) => r.textContent?.includes('Cancel run'));
+    expect(row).toBeDefined();
+    fireEvent.click(row!);
+    expect(onKill).toHaveBeenCalledWith('r-live');
+
+    cleanup();
+    renderPalette({ selectedRun: RUNS[2] ?? null });
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> cancel' } });
+    expect(rows().find((r) => r.textContent?.includes('Cancel run'))).toBeUndefined();
+  });
+
+  it('Approve/Reject gate show only for awaiting_human and fire the chip wire (POST gate)', () => {
+    renderPalette({ selectedRun: RUNS[0] ?? null });
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> approve' } });
+    const row = rows().find((r) => r.textContent?.includes('Approve gate'));
+    expect(row).toBeDefined();
+    fireEvent.click(row!);
+    expect(confirmGate).toHaveBeenCalledWith('r-gate', { approve: true });
+  });
+
+  it('Toggle Theme flips the appearance store instance (the §2.14 mechanism)', () => {
+    renderPalette();
+    const before = useAppearanceStore.getState().appearance.theme;
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> toggle' } });
+    const row = rows().find((r) => r.textContent?.includes('Toggle Theme'));
+    fireEvent.click(row!);
+    expect(useAppearanceStore.getState().appearance.theme).not.toBe(before);
+  });
+
+  it('New Build navigates to the flat launch route when unscoped, the pre-bound one inside a project', () => {
+    const { navigate } = renderPalette();
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> new build' } });
+    fireEvent.click(rows().find((r) => r.textContent?.includes('New Build'))!);
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+
+    cleanup();
+    const scoped = renderPalette({ projectId: 'q3-review-deck' });
+    fireEvent.change(screen.getByTestId('palette-input'), { target: { value: '> new build' } });
+    fireEvent.click(rows().find((r) => r.textContent?.includes('New Build'))!);
+    expect(scoped.navigate).toHaveBeenCalledWith('/p/q3-review-deck/build/new');
+  });
+});

--- a/tests/fuzzy.test.ts
+++ b/tests/fuzzy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { fuzzyMatch } from '../src/palette/fuzzy.js';
+
+/** The palette's library-free subsequence scorer (DES-FEEDBACK-002 §1.5). */
+describe('fuzzyMatch', () => {
+  it('matches in-order subsequences, case-insensitively', () => {
+    expect(fuzzyMatch('q3', 'Q3-review-deck')).not.toBeNull();
+    expect(fuzzyMatch('qrd', 'q3-review-deck')).not.toBeNull();
+    expect(fuzzyMatch('deck q', 'q3-review-deck')).toBeNull(); // out of order
+    expect(fuzzyMatch('zz', 'q3-review-deck')).toBeNull();
+  });
+
+  it('empty needle matches everything at score 0 with no positions', () => {
+    expect(fuzzyMatch('', 'anything')).toEqual({ score: 0, positions: [] });
+  });
+
+  it('reports the matched character positions (the accent-render seam)', () => {
+    const m = fuzzyMatch('rd', 'review-deck');
+    expect(m?.positions).toEqual([0, 7]);
+  });
+
+  it('rewards word-boundary and consecutive hits over scattered ones', () => {
+    const boundary = fuzzyMatch('rate', 'add rate-limiting')!;
+    const scattered = fuzzyMatch('rate', 'refactor authentication middleware')!;
+    expect(boundary.score).toBeGreaterThan(scattered.score);
+
+    const consecutive = fuzzyMatch('mig', 'migrate the auth tables')!;
+    const gapped = fuzzyMatch('mig', 'make the Q3 review... going')!;
+    expect(consecutive.score).toBeGreaterThan(gapped.score);
+  });
+
+  it('penalizes gaps: a tighter match of the same letters scores higher', () => {
+    const tight = fuzzyMatch('auth', 'auth-refactor')!;
+    const loose = fuzzyMatch('auth', 'xaxxuxxtxxhx')!;
+    expect(tight.score).toBeGreaterThan(loose.score);
+  });
+});

--- a/tests/useGlobalShortcuts.test.ts
+++ b/tests/useGlobalShortcuts.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The global shortcut registry (DES-FEEDBACK-002 §1.2, slice G): ONE
+ * window-level keydown listener, an ordered entry table, the shared
+ * `isTypingContext` guard before EVERY entry (EC21), strict chord matching
+ * (Ctrl+K ≠ Ctrl+Shift+K), and the paletteOpen yield.
+ */
+
+import {
+  chordMatches,
+  isTypingContext,
+  registerShortcuts,
+  setShortcutsPaletteOpen,
+  type ShortcutEntry,
+} from '../src/hooks/useGlobalShortcuts.js';
+
+function key(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+}
+
+const cleanups: Array<() => void> = [];
+function register(entries: ShortcutEntry[]): void {
+  cleanups.push(registerShortcuts(entries));
+}
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+  setShortcutsPaletteOpen(false);
+  document.body.innerHTML = '';
+});
+
+describe('chordMatches — strict, shift-discriminating (§1.2)', () => {
+  const plainK = { key: 'k', ctrlOrMeta: true };
+  const shiftK = { key: 'k', ctrlOrMeta: true, shift: true };
+
+  it('Ctrl+K matches the plain chord, never the shift chord', () => {
+    const e = key({ key: 'k', ctrlKey: true });
+    expect(chordMatches(e, plainK)).toBe(true);
+    expect(chordMatches(e, shiftK)).toBe(false);
+  });
+
+  it('Ctrl+Shift+K matches the shift chord, never the plain chord', () => {
+    const e = key({ key: 'K', ctrlKey: true, shiftKey: true });
+    expect(chordMatches(e, shiftK)).toBe(true);
+    expect(chordMatches(e, plainK)).toBe(false);
+  });
+
+  it('Meta stands in for Ctrl (the Cmd pairing); bare K and Alt chords never match', () => {
+    expect(chordMatches(key({ key: 'k', metaKey: true }), plainK)).toBe(true);
+    expect(chordMatches(key({ key: 'k' }), plainK)).toBe(false);
+    expect(chordMatches(key({ key: 'k', ctrlKey: true, altKey: true }), plainK)).toBe(false);
+  });
+});
+
+describe('isTypingContext — the one shared guard (EC21)', () => {
+  for (const tag of ['input', 'textarea', 'select']) {
+    it(`${tag} focus is a typing context`, () => {
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      let seen: boolean | null = null;
+      el.addEventListener('keydown', (e) => {
+        seen = isTypingContext(e);
+      });
+      el.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+      expect(seen).toBe(true);
+    });
+  }
+
+  it('contentEditable focus is a typing context; a plain div is not', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    let seen: boolean | null = null;
+    div.addEventListener('keydown', (e) => {
+      seen = isTypingContext(e);
+    });
+    div.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(seen).toBe(true);
+
+    const plain = document.createElement('div');
+    document.body.appendChild(plain);
+    plain.addEventListener('keydown', (e) => {
+      seen = isTypingContext(e);
+    });
+    plain.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(seen).toBe(false);
+  });
+});
+
+describe('registerShortcuts — dispatch, order, unregistration', () => {
+  it('fires the handler on a matching chord; unregistration stops it', () => {
+    const handler = vi.fn();
+    const off = registerShortcuts([
+      { id: 't', chord: { key: 'k', ctrlOrMeta: true }, description: 't', handler },
+    ]);
+    window.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(handler).toHaveBeenCalledTimes(1);
+    off();
+    window.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('the typing guard runs before EVERY entry: keys from a textarea pass through', () => {
+    const handler = vi.fn();
+    register([{ id: 't', chord: { key: 'k', ctrlOrMeta: true }, description: 't', handler }]);
+    const ta = document.createElement('textarea');
+    document.body.appendChild(ta);
+    ta.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('shift discrimination end-to-end: Ctrl+Shift+K fires kill, plain Ctrl+K fires palette', () => {
+    const palette = vi.fn();
+    const kill = vi.fn();
+    register([
+      { id: 'palette', chord: { key: 'k', ctrlOrMeta: true }, description: 'p', handler: palette },
+      { id: 'kill', chord: { key: 'k', ctrlOrMeta: true, shift: true }, description: 'k', handler: kill },
+    ]);
+    window.dispatchEvent(key({ key: 'K', ctrlKey: true, shiftKey: true }));
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(palette).not.toHaveBeenCalled();
+    window.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(palette).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('a false guard yields silently — no handler, and later entries still run', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    register([
+      {
+        id: 'a',
+        chord: { key: 'j' },
+        description: 'a',
+        guard: () => false,
+        handler: first,
+      },
+      { id: 'b', chord: { key: 'j' }, description: 'b', handler: second },
+    ]);
+    window.dispatchEvent(key({ key: 'j' }));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('first matching entry wins — one owner per chord', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    register([
+      { id: 'a', chord: { key: 'j' }, description: 'a', handler: first },
+      { id: 'b', chord: { key: 'j' }, description: 'b', handler: second },
+    ]);
+    window.dispatchEvent(key({ key: 'j' }));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('while the palette is open the table yields everything except the toggle (§1.2)', () => {
+    const toggle = vi.fn();
+    const kill = vi.fn();
+    register([
+      {
+        id: 'toggle',
+        chord: { key: 'k', ctrlOrMeta: true },
+        description: 't',
+        handler: toggle,
+        allowWhilePaletteOpen: true,
+      },
+      { id: 'kill', chord: { key: 'k', ctrlOrMeta: true, shift: true }, description: 'k', handler: kill },
+    ]);
+    setShortcutsPaletteOpen(true);
+    window.dispatchEvent(key({ key: 'K', ctrlKey: true, shiftKey: true }));
+    expect(kill).not.toHaveBeenCalled();
+    window.dispatchEvent(key({ key: 'k', ctrlKey: true }));
+    expect(toggle).toHaveBeenCalledTimes(1);
+    setShortcutsPaletteOpen(false);
+    window.dispatchEvent(key({ key: 'K', ctrlKey: true, shiftKey: true }));
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Round-3 operator feedback, P0-1: a universal command & jump palette, with the binding story the design settled: **the palette takes Cmd+K/Ctrl+K (and Ctrl/Cmd+P); kill-run relocates to Ctrl/Cmd+Shift+K** and is also a `> Cancel run` palette verb.

## What changed (design: `.product/DES-FEEDBACK-002.md` §1)

- **`useGlobalShortcuts`** — the ONE window-level keydown registry (EC21: grep proves a single listener; the four modal document-level Escape handlers are the doc's named exemptions), shared `isTypingContext` guard before every entry, strict shift-discriminating chords. The old ad-hoc `useKillShortcut` is deleted; the relocation preserves its contract byte-for-byte (same guards, same terminal-state silence).
- **CommandPalette** per §1.3: prefix grammar (`p:` `run:` `repo:` `>`), gates-first grouped rows with `#gate` deep links, the full verb table, library-free subsequence fuzzy scorer (§1.5 — typo'd queries like `uplod`/`q3rd` rank correctly), keyboard navigation, tokens only.
- **Zero-fetch corpus**: results come from already-loaded stores (board projects mirrored into the store — a write, not a request); the only network the palette ever causes is exactly one `GET /repos` on first open, nothing when warm (rig-asserted).

## Verification highlights

Independent binding proofs in the verifier's own Playwright: plain Ctrl+K opens the palette with **zero cancel POSTs** and the run untouched; Ctrl+Shift+K fires exactly one cancel POST without opening the palette and stays silent on terminal runs; with the chat composer focused, j/k/a/r type as characters and every chord steals nothing; Escape still closes all three modal types. Corpus equality proven against the wire (8/8 runs, 28/28 projects, 1/1 repos). Negative check: the rig fails on origin/main. The rig also caught and fixed a real race (palette query reset moved to close so a keystroke can't leak into the next session).

Disclosed doc deviations (all argued in caveats/comments): repo rows use the real `/repo-detail/:id` route (the doc's `/repos/:id` has no route); warm cache fetches nothing on reopen (the §1.7 AC wins over §1.4's contradictory "stale-refreshed" sentence); project tie-break is recency, not decayed attention (computing attention would need fetches the palette is forbidden to make).

**Size note**: net production diff ~640 LOC vs the §12.0 ≤350 guidance — the registry and its first consumer are one cohesive feature (splitting yields a meaningless intermediate), and the excess is house-style comment density plus JSX anatomy; every functional/pixel gate passes.

## Gates

eslint `--max-warnings 0` clean · `tsc --noEmit` clean · vitest **1027/1027** (31 new) · new rig `feedback2_sliceG_test.py` (10 steps) + `feedback_sliceA`, `feedback_sliceC`, `brand_learn`, `uxfix_slice4` all PASS on fresh builds.

Shots: `feedback2-G-palette-mixed.png`, `feedback2-G-palette-verbs.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)