### PR TITLE
Slice H: keyboard gate triage — j/k select, a approve, r reject-with-note (DES-FEEDBACK-002 §2)

### DIFF
--- a/e2e/feedback2_sliceH_test.py
+++ b/e2e/feedback2_sliceH_test.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceH_test.py — the DES-FEEDBACK-002 slice-H gate: keyboard-first
+gate triage (§2, P0-2), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py). j/k walk the needs-you cards / the dashboard's gate-inbox
+rows, `a` approves through the ONE shared decideGate, `r` opens the inline
+reject note whose text rides the POST's `amend`, Enter opens, Escape clears —
+all through the slice-G registry, so the typing guard and the paletteOpen
+yield hold by construction.
+
+The slice DOM ACs, from §2.6:
+
+  1. pressing `j` sets `[data-kbd-selected="true"]` on the FIRST needs-you card
+     and moves DOM focus there; `j` again advances; `k` returns; the walk is
+     the band's own render order and CLAMPS at the ends; the ring's computed
+     `outline-color` resolves from `var(--accent)` (EC15/EC22);
+  2. with the cursor on a simple-gate card, `a` fires `POST /runs/:id/gate`
+     `{"approve":true}` exactly once (request tap); the card shows the
+     answered state without navigation; a second `a` is dropped;
+  3. `r` renders `[data-testid="gate-reject-note"]` focused inside the
+     selected card; typing a reason and Enter fires `{approve:false,
+     amend:"<reason>"}`; Escape instead restores the chip row, firing nothing;
+  4. while the note input is focused, `j`/`a`/`r` insert characters normally
+     and move no cursor (the §1.2 typing guard — EC21);
+  5. with the palette open, keys belong to the PALETTE (its focused input /
+     its arrow selection), and the board cursor does not move;
+  6. on a complex-gate card, `a` navigates to the run thread with `#gate` and
+     fires no gate POST;
+  7. the ProjectDashboard's gate-inbox rows carry the same cursor: `j` selects
+     the first row (focus + ring), `a` fires the same POST.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-H-triage-cursor.png  needs-you band, SECOND card ring-selected,
+                                 hint row visible
+  feedback2-H-reject-note.png    inline note open and focused on the selected card
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4360),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4360"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+SIMPLE_PROJECT = "q3-review-deck"   # r-q3 — the fixture's simple gate
+SIMPLE_RUN = "r-q3"
+COMPLEX_PROJECT = "api-migration"   # r-api — options:null ⇒ complex (§7.11)
+COMPLEX_RUN = "r-api"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build ────────────────────────────────────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server ─────────────────────────────────────────────
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN)  # defaults — the board scenes need no switches
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+TOKEN_PROBE = """() => {
+  const el = document.createElement('span');
+  el.style.color = 'var(--accent)';
+  document.body.appendChild(el);
+  const c = getComputedStyle(el).color;
+  el.remove();
+  return c;
+}"""
+
+# The board's cursor state, read straight off the DOM the ACs name.
+CURSOR_STATE = """() => {
+  const cards = Array.from(document.querySelectorAll(
+    '[data-testid="band-needs-you"] [data-testid="project-card"]'));
+  const sel = cards.find((c) => c.dataset.kbdSelected === 'true') ?? null;
+  return {
+    order: cards.map((c) => c.dataset.projectId),
+    selected: sel?.dataset?.projectId ?? null,
+    focusedItem: document.activeElement?.dataset?.kbdItem ?? null,
+    ringColor: sel ? getComputedStyle(sel).outlineColor : null,
+    ringStyle: sel ? getComputedStyle(sel).outlineStyle : null,
+    hint: !!document.querySelector('[data-testid="triage-hint"]'),
+    noteOpen: !!document.querySelector('[data-testid="gate-reject-note"]'),
+    noteFocused: document.activeElement?.dataset?.testid === 'gate-reject-note',
+  };
+}"""
+
+
+def select_project(page, pid: str, order: list) -> None:
+    """Walk the cursor onto `pid` with j presses from a CLEARED cursor."""
+    page.keyboard.press("Escape")
+    for _ in range(order.index(pid) + 1):
+        page.keyboard.press("j")
+    page.wait_for_function(
+        """(pid) => document.querySelector(
+             '[data-kbd-selected="true"]')?.dataset?.projectId === pid""",
+        arg=pid, timeout=5000,
+    )
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # The tap: every gate decision the page POSTs, path + parsed body.
+    gate_posts: list[tuple[str, dict | None]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and path.startswith("/api/v1/runs/") and path.endswith("/gate"):
+            try:
+                body = json.loads(req.post_data or "null")
+            except json.JSONDecodeError:
+                body = None
+            gate_posts.append((path, body))
+
+    page.on("request", on_request)
+
+    # ── Scene 1: the home board — the cursor walk (AC 1) ────────────────────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1200)  # let the board's own fetch burst settle
+
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+
+    accent = page.evaluate(TOKEN_PROBE)
+    before = page.evaluate(CURSOR_STATE)
+    order = before["order"]
+    if len(order) < 2 or SIMPLE_PROJECT not in order or COMPLEX_PROJECT not in order:
+        fail("fixture_shape", f"needs-you band lacks the two gated projects: {order}")
+
+    page.keyboard.press("j")
+    first = page.evaluate(CURSOR_STATE)
+    page.keyboard.press("j")
+    second = page.evaluate(CURSOR_STATE)
+
+    # ── Capture 1: second card ring-selected, hint row visible ──────────────────
+    page.screenshot(path=str(VSHOTS / "feedback2-H-triage-cursor.png"))
+
+    page.keyboard.press("k")
+    back = page.evaluate(CURSOR_STATE)
+
+    # The full walk follows the band's own render order and clamps at the end.
+    walked = [back["selected"]]
+    for _ in range(len(order) - 1):
+        page.keyboard.press("j")
+        walked.append(page.evaluate(CURSOR_STATE)["selected"])
+    page.keyboard.press("j")  # past the end — must clamp, never wrap
+    clamped = page.evaluate(CURSOR_STATE)["selected"]
+
+    page.keyboard.press("Escape")
+    cleared = page.evaluate(CURSOR_STATE)
+
+    report["steps"]["cursor_walk"] = {
+        "ok": all([
+            fonts_ok,
+            before["selected"] is None and not before["hint"],
+            first["selected"] == order[0],
+            first["focusedItem"] == order[0],       # EC22: the cursor is focus
+            first["ringColor"] == accent,           # EC15: the ring IS the token
+            first["ringStyle"] == "solid",
+            first["hint"],                          # §2.5: hint while active
+            second["selected"] == order[1],
+            second["focusedItem"] == order[1],
+            back["selected"] == order[0],
+            walked == order,
+            clamped == order[-1],
+            cleared["selected"] is None and not cleared["hint"],
+        ]),
+        "band_order": order,
+        "accent_resolved": accent,
+        "first": {k: first[k] for k in ("selected", "focusedItem", "ringColor", "ringStyle", "hint")},
+        "walked": walked,
+        "clamped_at": clamped,
+        "cleared": cleared["selected"],
+    }
+
+    # ── AC 3 (cancel half) + capture 2: r opens the note; Escape fires nothing ──
+    select_project(page, SIMPLE_PROJECT, order)
+    posts_before = len(gate_posts)
+    page.keyboard.press("r")
+    page.locator('[data-testid="gate-reject-note"]').wait_for(timeout=5000)
+    note_open = page.evaluate(CURSOR_STATE)
+    page.screenshot(path=str(VSHOTS / "feedback2-H-reject-note.png"))
+
+    # ── AC 4: the open note is a typing context — j/a/r are just characters ─────
+    page.keyboard.type("jar")
+    typed = page.evaluate(
+        """() => ({
+             value: document.querySelector('[data-testid="gate-reject-note"]')?.value ?? null,
+             selected: document.querySelector('[data-kbd-selected="true"]')?.dataset?.projectId ?? null,
+           })"""
+    )
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+    note_cancelled = page.evaluate(CURSOR_STATE)
+
+    report["steps"]["reject_note_cancel_and_typing_guard"] = {
+        "ok": all([
+            note_open["noteOpen"],
+            note_open["noteFocused"],                       # focused immediately
+            note_open["selected"] == SIMPLE_PROJECT,
+            typed["value"] == "jar",                        # the keys became TEXT
+            typed["selected"] == SIMPLE_PROJECT,            # …and moved no cursor
+            not note_cancelled["noteOpen"],                 # Escape restores the row
+            note_cancelled["selected"] == SIMPLE_PROJECT,   # selection survives
+            len(gate_posts) == posts_before,                # …and NOTHING fired
+        ]),
+        "note_open": {k: note_open[k] for k in ("noteOpen", "noteFocused", "selected")},
+        "typed": typed,
+        "posts_during": gate_posts[posts_before:],
+    }
+
+    # ── AC 5: with the palette open, the keyboard belongs to the palette ────────
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    PALETTE_SEL = """() => ({
+      paletteSel: Array.from(document.querySelectorAll('[data-testid="palette-row"]'))
+        .findIndex((r) => r.dataset.selected === 'true'),
+      query: document.querySelector('[data-testid="palette-input"]')?.value ?? null,
+      boardSel: document.querySelector('[data-kbd-selected="true"]')?.dataset?.projectId ?? null,
+    })"""
+    page.keyboard.press("ArrowDown")  # moves the PALETTE selection…
+    arrowed = page.evaluate(PALETTE_SEL)
+    page.keyboard.press("j")          # …and letters are QUERY text, never triage
+    typed_palette = page.evaluate(PALETTE_SEL)
+    page.keyboard.press("Escape")     # close the palette; focus returns
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"command-palette\"]') === null", timeout=5000
+    )
+    after_palette = page.evaluate(CURSOR_STATE)
+    report["steps"]["palette_owns_the_keyboard"] = {
+        "ok": all([
+            arrowed["paletteSel"] == 1,                     # arrows move the palette
+            arrowed["boardSel"] == SIMPLE_PROJECT,          # board cursor unmoved
+            typed_palette["query"] == "j",                  # j is query text
+            typed_palette["boardSel"] == SIMPLE_PROJECT,
+            after_palette["selected"] == SIMPLE_PROJECT,    # …and still there after
+            len(gate_posts) == posts_before,
+        ]),
+        "arrowed": arrowed,
+        "typed": typed_palette,
+    }
+
+    # ── AC 2: a approves the simple gate — one POST, no navigation ──────────────
+    page.keyboard.press("a")
+    page.locator(f'[data-testid="gate-answered-{SIMPLE_RUN}"]').wait_for(timeout=10000)
+    page.keyboard.press("a")  # answered — the shared guard drops the second
+    page.wait_for_timeout(400)
+    approve_posts = gate_posts[posts_before:]
+    approve_state = page.evaluate(
+        """(run) => ({
+             path: window.location.pathname,
+             answered: document.querySelector(`[data-testid="gate-answered-${run}"]`)?.textContent ?? null,
+           })""",
+        SIMPLE_RUN,
+    )
+    report["steps"]["a_approves_once"] = {
+        "ok": all([
+            approve_posts == [(f"/api/v1/runs/{SIMPLE_RUN}/gate", {"approve": True})],
+            approve_state["path"] == "/",                   # answering never navigates
+            approve_state["answered"] is not None
+            and "approved" in approve_state["answered"],
+        ]),
+        "gate_posts": approve_posts,
+        **approve_state,
+    }
+
+    # ── AC 6: a on the COMPLEX gate opens the thread at #gate, POSTs nothing ────
+    posts_before_complex = len(gate_posts)
+    select_project(page, COMPLEX_PROJECT, order)
+    # Tap the pushState itself: `navigate` pushes `…/build/r-api#gate`, then the
+    # thread's SteeringGate CONSUMES the one-shot hash — so the pushed URL, not
+    # the settled location.hash, is where the `#gate` intent is observable.
+    page.evaluate(
+        """() => {
+          window.__pushed = [];
+          const orig = history.pushState.bind(history);
+          history.pushState = (s, t, url) => { window.__pushed.push(String(url)); orig(s, t, url); };
+        }"""
+    )
+    page.keyboard.press("a")
+    page.wait_for_function(
+        """(args) => window.location.pathname === `/p/${args[0]}/build/${args[1]}`""",
+        arg=[COMPLEX_PROJECT, COMPLEX_RUN], timeout=10000,
+    )
+    pushed = page.evaluate("() => window.__pushed")
+    report["steps"]["complex_gate_opens_thread"] = {
+        "ok": all([
+            gate_posts[posts_before_complex:] == [],
+            f"/p/{COMPLEX_PROJECT}/build/{COMPLEX_RUN}#gate" in pushed,
+        ]),
+        "landed": page.evaluate("() => window.location.pathname + window.location.hash"),
+        "pushed": pushed,
+        "posts_during": gate_posts[posts_before_complex:],
+    }
+
+    # ── Scene 2 (fresh load — fresh stores): r + note + Enter sends the amend ───
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1200)
+    order2 = page.evaluate(CURSOR_STATE)["order"]
+    select_project(page, SIMPLE_PROJECT, order2)
+    posts_before_reject = len(gate_posts)
+    page.keyboard.press("r")
+    page.locator('[data-testid="gate-reject-note"]').wait_for(timeout=5000)
+    page.keyboard.type("needs the Q3 numbers first")
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"gate-reject-note\"]') === null", timeout=5000
+    )
+    page.wait_for_timeout(400)
+    reject_posts = gate_posts[posts_before_reject:]
+    report["steps"]["r_note_rides_amend"] = {
+        "ok": reject_posts == [(
+            f"/api/v1/runs/{SIMPLE_RUN}/gate",
+            {"approve": False, "amend": "needs the Q3 numbers first"},
+        )],
+        "gate_posts": reject_posts,
+    }
+
+    # Enter opens the selected card (the same target as clicking it).
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        f"() => window.location.pathname === '/p/{SIMPLE_PROJECT}'", timeout=10000
+    )
+    report["steps"]["enter_opens_card"] = {
+        "ok": True,
+        "landed": page.evaluate("() => window.location.pathname"),
+    }
+
+    # ── Scene 3 (fresh load): the ProjectDashboard's gate-inbox rows (AC 7) ─────
+    page.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}", wait_until="domcontentloaded")
+    page.locator('[data-testid="dashboard-gates"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator(f'[data-testid="gate-approve-{SIMPLE_RUN}"]').wait_for(timeout=30000)
+    posts_before_dash = len(gate_posts)
+    page.keyboard.press("j")
+    dash = page.evaluate(
+        """(run) => {
+          const row = document.querySelector(`[data-testid="dashboard-gate"][data-run-id="${run}"]`);
+          return {
+            selected: row?.dataset?.kbdSelected === 'true',
+            focusedItem: document.activeElement?.dataset?.kbdItem ?? null,
+            ringColor: row ? getComputedStyle(row).outlineColor : null,
+          };
+        }""",
+        SIMPLE_RUN,
+    )
+    page.keyboard.press("a")
+    page.locator(f'[data-testid="gate-answered-{SIMPLE_RUN}"]').wait_for(timeout=10000)
+    page.wait_for_timeout(400)
+    dash_posts = gate_posts[posts_before_dash:]
+    report["steps"]["dashboard_inbox_cursor"] = {
+        "ok": all([
+            dash["selected"],
+            dash["focusedItem"] == SIMPLE_RUN,
+            dash["ringColor"] == accent,
+            dash_posts == [(f"/api/v1/runs/{SIMPLE_RUN}/gate", {"approve": True})],
+            page.evaluate("() => window.location.pathname") == f"/p/{SIMPLE_PROJECT}",
+        ]),
+        **dash,
+        "gate_posts": dash_posts,
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-H-triage-cursor.png"),
+    str(VSHOTS / "feedback2-H-reject-note.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceH_verdict", f"slice-H assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -986,6 +986,13 @@ class W2Handler(SimpleHTTPRequestHandler):
         # The slice-6 document journey's writes (create / fork / bus emit).
         if self._interactive_post(path, body if isinstance(body, dict) else {}):
             return None
+        # POST /api/v1/runs/<id>/gate — the steering-gate decision (slice H,
+        # DES-FEEDBACK-002 §2.3). The fixture accepts it so the answered state
+        # ("approved · advancing…") renders truthfully after a triage key or a
+        # chip click; the rigs assert the request BODY off the browser tap.
+        parts = path.split("/")
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
+            return self._json(200, {"status": "resumed"})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
         if path == "/api/v1/chats":

--- a/src/board/gateActions.ts
+++ b/src/board/gateActions.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+import type { GateDecision } from '../api/types.js';
+import { modePath } from '../hooks/useRoute.js';
+import { useGateStore } from '../store/gates.js';
+
+/**
+ * The ONE gate-decision implementation (DES-FEEDBACK-002 §2.3, slice H): the
+ * GateChip's buttons, the palette's Approve/Reject verbs, and the triage keys
+ * (`a`/`r`) all answer a gate through `decideGate` — same POST, same
+ * double-submit guard, same §3.3 in-flight/error contract. Extracted from
+ * `GateChip.tsx` so a keyboard answer and a mouse answer are literally the same
+ * action, not two implementations that happen to agree today.
+ *
+ * State is keyed by run id and RESET whenever a new gate arrives for that run
+ * (the gate-store subscription below): a LATER gate on the same run is a fresh
+ * decision with fresh state — `answered` for the first gate must never block
+ * the second — while the answered line survives the immediate local prune of
+ * the gate it answered (`clearGate`) until the daemon's frame moves the run.
+ */
+
+/** One-shot focus intent for the thread's gate card, read by `SteeringGate`.
+ *  (Lives here so the chip, the palette, and the triage cursor share it without
+ *  a component-module cycle; `GateChip` re-exports it for its old importers.) */
+export const GATE_HASH = '#gate';
+
+export interface GateActionState {
+  /** A POST is in flight — the §3.3 "answering…" state. */
+  busy: boolean;
+  /** The decision landed; the run is advancing (the chip's terminal line). */
+  answered: 'approved' | 'rejected' | null;
+  /** The named failure, adjacent to the still-enabled controls (§3.3). */
+  error: string | null;
+}
+
+export const IDLE_GATE_ACTION: GateActionState = { busy: false, answered: null, error: null };
+
+interface GateActionsStore {
+  byGate: Record<string, GateActionState>;
+}
+
+export const useGateActionStore = create<GateActionsStore>(() => ({ byGate: {} }));
+
+function patch(runId: string, part: Partial<GateActionState>): void {
+  useGateActionStore.setState((s) => ({
+    byGate: { ...s.byGate, [runId]: { ...(s.byGate[runId] ?? IDLE_GATE_ACTION), ...part } },
+  }));
+}
+
+// A gate ARRIVING for a run (first sight, or a new ord) is a fresh question —
+// drop any stale decision state so the fresh gate is answerable. The answered
+// state an OPEN decision leaves behind survives its own `clearGate` prune
+// (removal is not arrival), which is what keeps "approved · advancing…" on the
+// chip until the daemon's frame moves the run.
+useGateStore.subscribe((state, prev) => {
+  if (state.gates === prev.gates) return;
+  const stale = Object.entries(state.gates)
+    .filter(([runId, gate]) => {
+      const before = prev.gates[runId];
+      return before === undefined || before.ord !== gate.ord;
+    })
+    .map(([runId]) => runId)
+    .filter((runId) => useGateActionStore.getState().byGate[runId] !== undefined);
+  if (stale.length === 0) return;
+  useGateActionStore.setState((s) => {
+    const byGate = { ...s.byGate };
+    for (const runId of stale) delete byGate[runId];
+    return { byGate };
+  });
+});
+
+/**
+ * Answer a gate — `{approve:true}`, or `{approve:false, amend?}` where the
+ * optional amend is the reject note the daemon's gate audit durably records
+ * (§2.3 wire honesty). Guards double submission exactly as the chip always
+ * has: a second call while the first POST is open, or after it landed, is
+ * dropped rather than sent (a re-sent decision is a 409 at best and a second,
+ * unintended decision at worst). On failure the error is named in the shared
+ * state and the controls stay live — calling again is the retry.
+ */
+export async function decideGate(runId: string, decision: GateDecision): Promise<void> {
+  const cur = useGateActionStore.getState().byGate[runId] ?? IDLE_GATE_ACTION;
+  if (cur.busy || cur.answered !== null) return;
+  patch(runId, { busy: true, error: null });
+  try {
+    await api.confirmGate(runId, decision);
+    patch(runId, { answered: decision.approve ? 'approved' : 'rejected' });
+    // Prune the local gate immediately; the run's own status follows from the
+    // daemon's frame, which is what actually moves the card (§1.4 live).
+    useGateStore.getState().clearGate(runId);
+  } catch (e) {
+    patch(runId, { error: e instanceof Error ? e.message : String(e) });
+  } finally {
+    patch(runId, { busy: false });
+  }
+}
+
+/** A COMPLEX gate's one honest affordance (§2.3): the thread, at the gate. */
+export function gateOpenPath(projectId: string, runId: string): string {
+  return `${modePath(projectId, 'build', runId)}${GATE_HASH}`;
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -8,7 +8,7 @@ import type { ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useGateStore } from '../store/gates.js';
 import { useAppearanceStore } from '../theming/appearance.js';
-import { GATE_HASH } from './GateChip.js';
+import { decideGate, GATE_HASH } from '../board/gateActions.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { Modal } from './Modal.js';
 import { Terminal } from './Terminal.js';
@@ -261,18 +261,21 @@ export function CommandPalette({
           if (selectedRun !== null) onKill(selectedRun.session.id);
         },
       },
+      // The gate verbs answer through the ONE shared action module (slice H,
+      // §2.3): same POST, same double-submit guard, same §3.3 states as the
+      // GateChip's buttons and the triage keys.
       {
         name: 'Approve gate',
         when: status === 'awaiting_human',
         action: () => {
-          if (selectedRun !== null) void api.confirmGate(selectedRun.session.id, { approve: true });
+          if (selectedRun !== null) void decideGate(selectedRun.session.id, { approve: true });
         },
       },
       {
         name: 'Reject gate',
         when: status === 'awaiting_human',
         action: () => {
-          if (selectedRun !== null) void api.confirmGate(selectedRun.session.id, { approve: false });
+          if (selectedRun !== null) void decideGate(selectedRun.session.id, { approve: false });
         },
       },
     ];

--- a/src/components/GateChip.tsx
+++ b/src/components/GateChip.tsx
@@ -1,7 +1,12 @@
-import { useState } from 'react';
-import { api } from '../api/client.js';
-import { modePath, type Navigate } from '../hooks/useRoute.js';
-import { isSimpleGate, useGateStore, type OpenGate } from '../store/gates.js';
+import {
+  decideGate,
+  GATE_HASH,
+  gateOpenPath,
+  IDLE_GATE_ACTION,
+  useGateActionStore,
+} from '../board/gateActions.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { isSimpleGate, type OpenGate } from '../store/gates.js';
 
 /**
  * A waiting gate on a board card, rendered as an ANSWERABLE chip rather than a
@@ -23,8 +28,10 @@ import { isSimpleGate, useGateStore, type OpenGate } from '../store/gates.js';
  * NAMES the error with the controls still adjacent — clicking again is the retry.
  */
 
-/** One-shot focus intent for the thread's gate card, read by `SteeringGate`. */
-export const GATE_HASH = '#gate';
+/** One-shot focus intent for the thread's gate card, read by `SteeringGate`.
+ *  (Slice H moved the definition into `gateActions.ts` — the shared action
+ *  module — and this re-export keeps the chip's old importers working.) */
+export { GATE_HASH };
 
 // DES-VISION-001 §5.1: the gate chip is STATUS furniture, not accent — amber
 // `--status-gate` on `--status-gate-dim`, with the answer buttons in the run
@@ -68,15 +75,16 @@ interface Props {
 }
 
 export function GateChip({ runId, projectId, gate, navigate }: Props): React.ReactElement {
-  const clearGate = useGateStore((s) => s.clearGate);
-  const [busy, setBusy] = useState(false);
-  const [answered, setAnswered] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // The decision state is SHARED with the palette verbs and the triage keys
+  // (slice H, §2.3): one `decideGate` per gate, whoever fires it — so a
+  // keyboard approve shows its "answering…"/answered/error states right here
+  // on the chip, and the double-submit guard holds across input methods.
+  const { busy, answered, error } = useGateActionStore((s) => s.byGate[runId]) ?? IDLE_GATE_ACTION;
 
   if (!isSimpleGate(gate)) {
     // The gate MESSAGE is the destination, not just the run — the hash is what tells
     // the thread's gate card to scroll itself in and take focus.
-    const path = `${modePath(projectId, 'build', runId)}${GATE_HASH}`;
+    const path = gateOpenPath(projectId, runId);
     return (
       <span style={CSS.wrap}>
         <span style={CSS.label}>gate</span>
@@ -93,25 +101,11 @@ export function GateChip({ runId, projectId, gate, navigate }: Props): React.Rea
     );
   }
 
-  async function answer(approve: boolean): Promise<void> {
-    // The one double-submit guard: a second click while the first POST is open, or
-    // after it landed, is dropped rather than sent (a re-sent gate decision is a 409
-    // at best and a second, unintended decision at worst).
-    if (busy || answered !== null) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await api.confirmGate(runId, { approve });
-      setAnswered(approve ? 'approved' : 'rejected');
-      // Prune the local gate immediately; the run's own status follows from the
-      // daemon's frame, which is what actually moves the card (§1.4 live).
-      clearGate(runId);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  }
+  // The double-submit guard, the gate-store prune, and the §3.3 error naming
+  // all live in `decideGate` now — one implementation for every input method.
+  const answer = (approve: boolean): void => {
+    void decideGate(runId, { approve });
+  };
 
   if (answered !== null) {
     return (
@@ -132,7 +126,7 @@ export function GateChip({ runId, projectId, gate, navigate }: Props): React.Rea
       <button
         type="button"
         data-testid={`gate-approve-${runId}`}
-        onClick={() => void answer(true)}
+        onClick={() => answer(true)}
         disabled={busy}
         title={error !== null ? 'Retry approve' : gate?.prompt ?? 'Approve this gate'}
         style={{ ...CSS.approve, opacity: busy ? 0.5 : 1 }}
@@ -142,7 +136,7 @@ export function GateChip({ runId, projectId, gate, navigate }: Props): React.Rea
       <button
         type="button"
         data-testid={`gate-reject-${runId}`}
-        onClick={() => void answer(false)}
+        onClick={() => answer(false)}
         disabled={busy}
         title={error !== null ? 'Retry reject' : 'Reject this gate'}
         style={{ ...CSS.reject, opacity: busy ? 0.5 : 1 }}

--- a/src/components/GateRejectNote.tsx
+++ b/src/components/GateRejectNote.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { decideGate } from '../board/gateActions.js';
+
+/**
+ * The inline reject note (DES-FEEDBACK-002 §2.3, slice H): what `r` opens on a
+ * selected simple-gate card, REPLACING the chip row while it is open —
+ * `[ reason (optional) — ↵ reject · esc cancel ]`, focused immediately. Enter
+ * sends `{approve:false}` through the shared `decideGate`, with the typed note
+ * as `amend` when non-empty (the daemon's gate audit durably records it on the
+ * decision — a real, recorded rejection reason). Escape closes the input and
+ * restores the chip row, firing nothing.
+ *
+ * While this input is focused it IS a typing context: the §1.2 registry guard
+ * makes j/k/a inert with no second mechanism (§2.3) — its own keydown handler
+ * below is the input-local kind the EC21 grep exempts by construction (it is
+ * not a window-level listener).
+ *
+ * Tokens (§2.5): `--surface-raised` ground, `--radius-md`, the input in
+ * `--text-xs --font-sans --ink-high` (placeholder `--ink-dim`, via
+ * `.wk-reject-note` in global.css), the confirm hint in
+ * `--text-2xs --ink-dim --font-mono`.
+ */
+
+const CSS = {
+  wrap: {
+    display: 'flex', alignItems: 'center', gap: '6px', flex: 1,
+    background: 'var(--surface-raised)', borderRadius: 'var(--radius-md)',
+    padding: '3px 8px', minWidth: 0,
+  },
+  input: {
+    flex: 1, minWidth: 0, background: 'transparent', border: 'none', outline: 'none',
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', color: 'var(--ink-high)',
+    padding: 0,
+  },
+  hint: {
+    flexShrink: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)',
+    fontFamily: 'var(--font-mono)', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+interface Props {
+  runId: string;
+  onClose: () => void;
+}
+
+export function GateRejectNote({ runId, onClose }: Props): React.ReactElement {
+  const [note, setNote] = useState('');
+  const ref = useRef<HTMLInputElement>(null);
+
+  // Focused immediately (§2.3) — which is also what flips the typing guard on.
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const amend = note.trim();
+      void decideGate(runId, amend === '' ? { approve: false } : { approve: false, amend });
+      onClose();
+    } else if (e.key === 'Escape') {
+      // Cancel fires nothing; stop the key here so no modal above hears it.
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  };
+
+  return (
+    <div style={CSS.wrap} data-testid={`gate-reject-note-row-${runId}`}>
+      <input
+        ref={ref}
+        type="text"
+        className="wk-reject-note"
+        data-testid="gate-reject-note"
+        placeholder="reason (optional)"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        onKeyDown={onKeyDown}
+        style={CSS.input}
+      />
+      <span style={CSS.hint} aria-hidden>↵ reject · esc cancel</span>
+    </div>
+  );
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -3,7 +3,9 @@ import type { SessionView } from '../api/types.js';
 import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
-import { modePath } from '../hooks/useRoute.js';
+import { modePath, projectPath } from '../hooks/useRoute.js';
+import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
+import { useGateStore } from '../store/gates.js';
 import { GateLatencyChart } from './GateLatencyChart.js';
 import { LiveFeed } from './LiveFeed.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
@@ -81,14 +83,18 @@ interface Props {
   navigate: Navigate;
 }
 
-/** One band's windowed grid — same math as the pre-band board, used twice (D6). */
-function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate }: {
+/** One band's windowed grid — same math as the pre-band board, used twice (D6).
+ *  The NEEDS-YOU instance also carries the slice-H triage cursor (§2.2): the
+ *  selected card's ring, its open reject note. QUIET passes nothing — the
+ *  cursor never enters the quiet band. */
+function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate, cursor }: {
   items: BoardProject[];
   columns: number;
   rowH: number;
   firstRow: number;
   lastRow: number;
   navigate: Navigate;
+  cursor?: TriageCursor;
 }): React.ReactElement {
   const rows = Math.ceil(items.length / columns);
   const visible = lastRow < firstRow ? [] : items.slice(firstRow * columns, (lastRow + 1) * columns);
@@ -102,7 +108,14 @@ function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate }: {
         }}
       >
         {visible.map((item) => (
-          <ProjectCard key={item.project.id} item={item} navigate={navigate} />
+          <ProjectCard
+            key={item.project.id}
+            item={item}
+            navigate={navigate}
+            kbdSelected={cursor?.selectedKey === item.project.id}
+            rejectNoteFor={cursor?.noteFor ?? null}
+            onRejectNoteClose={cursor?.closeNote}
+          />
         ))}
       </div>
     </div>
@@ -140,6 +153,29 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
 
   const needsYou = items.filter((i) => i.band === 'needs-you');
   const quiet = items.filter((i) => i.band === 'quiet');
+
+  // ── Slice H (DES-FEEDBACK-002 §2): the keyboard triage cursor ──────────────
+  // The cursor walks the NEEDS-YOU cards in the order the band already renders
+  // (attention order — reused, never re-derived). Each card's actionable gate
+  // is its LEADING waiting run — the same run whose chip leads the card.
+  const gates = useGateStore((s) => s.gates);
+  const triageItems = useMemo<TriageItem[]>(
+    () =>
+      needsYou.map((i) => {
+        const waiting = i.runs.find((v) => v.session.status === 'awaiting_human');
+        return {
+          key: i.project.id,
+          runId: waiting?.session.id ?? null,
+          gate: waiting === undefined ? undefined : gates[waiting.session.id],
+          // Enter opens what clicking the card's name opens: the dashboard.
+          openPath: projectPath(i.project.id),
+          projectId: i.project.id,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- needsYou derives from items
+    [items, gates],
+  );
+  const cursor = useTriageCursor(triageItems, navigate);
 
   const columns = Math.max(1, Math.floor((box.w || FALLBACK_W) / (MIN_COL + GAP)));
   // Each band windows over its OWN variant's fixed height (DES-UXFIX-001 §2.1.1,
@@ -277,7 +313,21 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                 firstRow={needsWin.firstRow}
                 lastRow={needsWin.lastRow}
                 navigate={navigate}
+                cursor={cursor}
               />
+            )}
+            {/* Slice H (§2.5): the key hint, visible only while a cursor is
+                active — the band teaches the keys exactly when they matter. */}
+            {cursor.selectedKey !== null && (
+              <p
+                data-testid="triage-hint"
+                style={{
+                  fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)',
+                  fontFamily: 'var(--font-mono)', margin: '8px 0 0',
+                }}
+              >
+                j/k select · a approve · r reject · ↵ open
+              </p>
             )}
           </section>
         )}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -7,6 +7,7 @@ import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
 import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
+import { GateRejectNote } from './GateRejectNote.js';
 import { ProjectSparkline } from './ProjectSparkline.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
@@ -268,9 +269,18 @@ function LiveLine({ view }: { view: SessionView }): React.ReactElement {
 interface Props {
   item: BoardProject;
   navigate: Navigate;
+  /** Slice H (DES-FEEDBACK-002 §2.2): the triage cursor sits on this card —
+   *  `data-kbd-selected`, real DOM focus, and the `--accent` ring (EC22). */
+  kbdSelected?: boolean;
+  /** The run whose inline reject note is open (§2.3) — replaces its chip row. */
+  rejectNoteFor?: string | null;
+  /** Close the reject note (Escape inside it, or after Enter submits). */
+  onRejectNoteClose?: (() => void) | undefined;
 }
 
-export function ProjectCard({ item, navigate }: Props): React.ReactElement {
+export function ProjectCard({
+  item, navigate, kbdSelected = false, rejectNoteFor = null, onRejectNoteClose,
+}: Props): React.ReactElement {
   const { project, repo, runs, docs, attention, band, score, signal } = item;
   const gates = useGateStore((s) => s.gates);
   // Relayed interactive status for THIS project — one line, plus the tile date it implies.
@@ -373,6 +383,12 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
   return (
     <section
       {...cardData}
+      // Slice H (§2.2, EC22): the triage cursor is REAL focus — the card takes
+      // programmatic focus (tabIndex -1, never in the tab order) and the ring
+      // is a 2px `--accent` outline (outline, not border: no layout shift).
+      tabIndex={-1}
+      data-kbd-item={project.id}
+      {...(kbdSelected ? { 'data-kbd-selected': 'true' } : {})}
       style={{
         ...CSS.card,
         maxHeight: `${ACTIVE_CARD_H}px`,
@@ -380,6 +396,8 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
         // signal kind, as color, along the whole top edge — glanceable from
         // across the wall, where the pill's word needs focus to read.
         borderTop: `2px solid ${signal !== null ? SIGNAL_BAR[signal.kind] : 'var(--status-done)'}`,
+        outline: kbdSelected ? '2px solid var(--accent)' : 'none',
+        outlineOffset: '2px',
       }}
     >
       {/* The card's own state signal, read from the RUNS rather than from `attention`:
@@ -441,6 +459,17 @@ export function ProjectCard({ item, navigate }: Props): React.ReactElement {
             const gate = gates[session.id];
             const phase = units[session.unit_ix]?.stage ?? units[units.length - 1]?.stage ?? 'planning';
             const waiting = session.status === 'awaiting_human';
+            // Slice H (§2.3): while this run's reject note is open it REPLACES
+            // the chip row; Escape inside it restores the row, firing nothing.
+            if (rejectNoteFor === session.id && waiting) {
+              return (
+                <GateRejectNote
+                  key={session.id}
+                  runId={session.id}
+                  onClose={onRejectNoteClose ?? (() => undefined)}
+                />
+              );
+            }
             return (
               // A waiting gate is ANSWERABLE, not a badge (§1.4) — so the row is a row:
               // the run link, and beside it a chip carrying its own controls. Nesting

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -5,9 +5,11 @@ import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
 import { interactiveRootOf } from '../hooks/useBoardModel.js';
 import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { useTriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
 import { GateChip } from './GateChip.js';
+import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
 import { RunSparkline } from './RunSparkline.js';
@@ -211,6 +213,27 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   /** Where a run row opens: its OWN mode view — Chat for a chat thread, Build otherwise. */
   const runModeOf = (id: string): Mode => (memberKinds[id] === 'crew.chat' ? 'chat' : 'build');
 
+  // ── Slice H (DES-FEEDBACK-002 §2.2): the triage cursor walks the gate-inbox
+  // rows — the tile the surface already renders, in its order. `resetKey`
+  // clears the cursor when the dashboard pivots projects without unmounting.
+  const inboxRows = waiting.slice(0, MAX_ROWS);
+  const triageItems = useMemo<TriageItem[]>(
+    () =>
+      inboxRows.map(({ view }) => {
+        const id = view.session.id;
+        return {
+          key: id,
+          runId: id,
+          gate: gates[id],
+          openPath: modePath(projectId, runModeOf(id), id),
+          projectId,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- inboxRows/runModeOf derive from these
+    [waiting, gates, memberKinds, projectId],
+  );
+  const cursor = useTriageCursor(triageItems, navigate, projectId);
+
   return (
     <div data-testid="project-dashboard" data-project-id={projectId} style={CSS.page}>
       {/* ── Project header: name, the four mode verbs, the meta line (§4.1) ── */}
@@ -313,22 +336,44 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
             <p style={CSS.empty}>Nothing is waiting on you.</p>
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              {waiting.slice(0, MAX_ROWS).map(({ view }) => {
+              {inboxRows.map(({ view }) => {
                 const id = view.session.id;
                 const gate = gates[id];
+                const selected = cursor.selectedKey === id;
                 return (
-                  <div key={id} data-testid="dashboard-gate" data-run-id={id} style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
-                    <span
-                      title={gate?.prompt}
-                      style={{
-                        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
-                        fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
-                      }}
-                    >
-                      {gate?.prompt ?? view.session.problem}
-                    </span>
-                    <GateChip runId={id} projectId={projectId} gate={gate} navigate={navigate} />
+                  <div
+                    key={id}
+                    data-testid="dashboard-gate"
+                    data-run-id={id}
+                    // Slice H (§2.2, EC22): the cursor is real focus — the row
+                    // takes programmatic focus and the 2px `--accent` ring.
+                    tabIndex={-1}
+                    data-kbd-item={id}
+                    {...(selected ? { 'data-kbd-selected': 'true' } : {})}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0,
+                      outline: selected ? '2px solid var(--accent)' : 'none',
+                      outlineOffset: '2px',
+                    }}
+                  >
+                    {cursor.noteFor === id ? (
+                      // §2.3: the open reject note replaces the chip row.
+                      <GateRejectNote runId={id} onClose={cursor.closeNote} />
+                    ) : (
+                      <>
+                        <span
+                          title={gate?.prompt}
+                          style={{
+                            flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                            fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+                          }}
+                        >
+                          {gate?.prompt ?? view.session.problem}
+                        </span>
+                        <GateChip runId={id} projectId={projectId} gate={gate} navigate={navigate} />
+                      </>
+                    )}
                   </div>
                 );
               })}

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { decideGate, gateOpenPath } from '../board/gateActions.js';
+import { isSimpleGate, type OpenGate } from '../store/gates.js';
+import type { Navigate } from './useRoute.js';
+import { useGlobalShortcuts, type ShortcutEntry } from './useGlobalShortcuts.js';
+
+/**
+ * The roving triage cursor (DES-FEEDBACK-002 §2, P0-2, slice H): j/k walk the
+ * gate-bearing rows of the current surface — the HomeBoard's NEEDS-YOU cards,
+ * the ProjectDashboard's gate-inbox rows — `a` approves, `r` opens the inline
+ * reject note, Enter opens, Escape clears. Order is what the surface already
+ * renders (the attention order): the model is untouched, the cursor just
+ * walks it.
+ *
+ * Every key registers through the slice-G registry (`useGlobalShortcuts`), so
+ * the ONE `isTypingContext` guard and the paletteOpen yield run before any of
+ * them (§2.4, EC21) — no unmodified key ever acts while anything editable has
+ * focus, and while the palette is open j/k belong to the palette. The hook is
+ * mounted BY the two surfaces, never globally: the surface check is the mount.
+ *
+ * The selection is keyboard-only, unpersisted state; it dies with the surface
+ * (route change = unmount) and with Escape. It is also REAL focus (§2.2,
+ * EC22): the selected element gets `data-kbd-selected`, DOM focus, and a
+ * scroll into view — screen readers track the cursor by construction.
+ */
+
+export interface TriageItem {
+  /** The DOM anchor: the surface renders `data-kbd-item={key}` on the row. */
+  key: string;
+  /** The answerable waiting run on this row — null when nothing gates here,
+   *  which makes `a`/`r` yield silently (a card can need you for a failure). */
+  runId: string | null;
+  /** The cached gate for `runId` (undefined = daemon restarted, still simple). */
+  gate: OpenGate | undefined;
+  /** Where Enter goes — the same target as clicking the row. */
+  openPath: string;
+  projectId: string;
+}
+
+export interface TriageCursor {
+  /** The selected row's `key`, or null while no cursor is active. */
+  selectedKey: string | null;
+  /** The run whose inline reject note is open (§2.3's `r`), or null. */
+  noteFor: string | null;
+  /** Close the note (Escape inside it, or after its Enter submits). */
+  closeNote: () => void;
+}
+
+export function useTriageCursor(
+  items: TriageItem[],
+  navigate: Navigate,
+  /** Changes reset the cursor without an unmount (the dashboard pivoting projects). */
+  resetKey = '',
+): TriageCursor {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [noteFor, setNoteFor] = useState<string | null>(null);
+
+  // The handlers live in a stable entry table (re-registering on every render
+  // would reorder the registry); they read the current world through refs.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const selRef = useRef(selectedKey);
+  selRef.current = selectedKey;
+  const navRef = useRef(navigate);
+  navRef.current = navigate;
+
+  const first = useRef(true);
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    setSelectedKey(null);
+    setNoteFor(null);
+  }, [resetKey]);
+
+  const focusSelected = (): void => {
+    const key = selRef.current;
+    if (key === null) return;
+    const el = document.querySelector<HTMLElement>(`[data-kbd-item="${CSS.escape(key)}"]`);
+    if (el === null) return;
+    el.focus({ preventScroll: true });
+    el.scrollIntoView({ block: 'nearest' });
+  };
+  const focusRef = useRef(focusSelected);
+  focusRef.current = focusSelected;
+
+  // The cursor IS focus (EC22): follow every selection move with DOM focus +
+  // a scroll into view, so the ring is never off-screen.
+  useEffect(() => {
+    if (selectedKey !== null) focusRef.current();
+  }, [selectedKey]);
+
+  // When the note closes, hand focus back to the selected card so the next
+  // key keeps working from where the operator left off (§2.3 "restores").
+  useEffect(() => {
+    if (noteFor === null) focusRef.current();
+  }, [noteFor]);
+
+  const entries = useMemo<ShortcutEntry[]>(() => {
+    const current = (): TriageItem | null =>
+      itemsRef.current.find((i) => i.key === selRef.current) ?? null;
+
+    const move = (delta: number) => (e: KeyboardEvent): void => {
+      e.preventDefault(); // arrows must move the cursor, not the scroller
+      const list = itemsRef.current;
+      if (list.length === 0) return;
+      const ix = list.findIndex((i) => i.key === selRef.current);
+      // First press selects the first row (§2.2); afterwards the cursor clamps
+      // at both ends — j on the last row stays put, it never wraps.
+      const next = ix < 0 ? 0 : Math.min(list.length - 1, Math.max(0, ix + delta));
+      setSelectedKey(list[next]?.key ?? null);
+    };
+
+    /** `a`/`r` exist only where a gate waits — elsewhere they yield silently. */
+    const gated = (): boolean => current()?.runId != null;
+
+    const openThread = (e: KeyboardEvent, item: TriageItem, runId: string): void => {
+      e.preventDefault();
+      navRef.current(gateOpenPath(item.projectId, runId));
+    };
+
+    return [
+      { id: 'triage-next-j', chord: { key: 'j' }, description: 'Select the next card', handler: move(1) },
+      { id: 'triage-next-down', chord: { key: 'arrowdown' }, description: 'Select the next card', handler: move(1) },
+      { id: 'triage-prev-k', chord: { key: 'k' }, description: 'Select the previous card', handler: move(-1) },
+      { id: 'triage-prev-up', chord: { key: 'arrowup' }, description: 'Select the previous card', handler: move(-1) },
+      {
+        id: 'triage-approve',
+        chord: { key: 'a' },
+        description: 'Approve the selected gate',
+        guard: gated,
+        handler: (e) => {
+          const item = current();
+          if (item === null || item.runId === null) return;
+          // Simple gates approve in place — the chip's own action, via the one
+          // shared module. A complex gate does what the chip's only affordance
+          // does: opens the thread at #gate, never a blind approve (§2.3).
+          if (isSimpleGate(item.gate)) {
+            e.preventDefault();
+            void decideGate(item.runId, { approve: true });
+          } else {
+            openThread(e, item, item.runId);
+          }
+        },
+      },
+      {
+        id: 'triage-reject',
+        chord: { key: 'r' },
+        description: 'Reject the selected gate with a note',
+        guard: gated,
+        handler: (e) => {
+          const item = current();
+          if (item === null || item.runId === null) return;
+          // A blind {approve:false} cancels the run — for a question that
+          // needs prose, the honest reject also starts in the thread.
+          if (isSimpleGate(item.gate)) {
+            e.preventDefault();
+            setNoteFor(item.runId);
+          } else {
+            openThread(e, item, item.runId);
+          }
+        },
+      },
+      {
+        id: 'triage-open',
+        chord: { key: 'enter' },
+        description: 'Open the selected card',
+        guard: () => selRef.current !== null,
+        handler: (e) => {
+          const item = current();
+          if (item === null) return;
+          e.preventDefault();
+          navRef.current(item.openPath);
+        },
+      },
+      {
+        id: 'triage-clear',
+        chord: { key: 'escape' },
+        description: 'Clear the triage cursor',
+        guard: () => selRef.current !== null,
+        handler: () => {
+          setNoteFor(null);
+          setSelectedKey(null);
+        },
+      },
+    ];
+  }, []);
+
+  useGlobalShortcuts(entries);
+
+  return { selectedKey, noteFor, closeNote: () => setNoteFor(null) };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -166,3 +166,7 @@ code, pre, .font-mono {
 @media (max-width: 899px) {
   .wk-metrics-mid { display: none !important; }
 }
+
+/* Slice-H inline reject note (DES-FEEDBACK-002 §2.3/§2.5): the placeholder
+   reads --ink-dim — a pseudo-element needs CSS, so the rule lives here. */
+.wk-reject-note::placeholder { color: var(--ink-dim); }

--- a/tests/GateChip.test.tsx
+++ b/tests/GateChip.test.tsx
@@ -5,6 +5,7 @@ import { ProjectCard } from '../src/components/ProjectCard.js';
 import type { BoardProject } from '../src/hooks/useBoardModel.js';
 import type { Project, SessionStatus } from '../src/api/types.js';
 import * as client from '../src/api/client.js';
+import { useGateActionStore } from '../src/board/gateActions.js';
 import { useGateStore, type OpenGate } from '../src/store/gates.js';
 import { makeUnit, makeView } from './factories.js';
 
@@ -55,6 +56,9 @@ describe('board gate chips (§1.4 — answerable, not a badge)', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     useGateStore.setState({ gates: {} });
+    // The decision state is module-shared since slice H (gateActions.ts) —
+    // reset it so one test's answered gate never bleeds into the next.
+    useGateActionStore.setState({ byGate: {} });
     vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
   });
 

--- a/tests/triageCursor.test.tsx
+++ b/tests/triageCursor.test.tsx
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { GateRejectNote } from '../src/components/GateRejectNote.js';
+import { useTriageCursor, type TriageItem } from '../src/hooks/useTriageCursor.js';
+import { setShortcutsPaletteOpen } from '../src/hooks/useGlobalShortcuts.js';
+import { useGateActionStore } from '../src/board/gateActions.js';
+import { useGateStore, type OpenGate } from '../src/store/gates.js';
+import * as client from '../src/api/client.js';
+import type { Navigate } from '../src/hooks/useRoute.js';
+
+/**
+ * The slice-H triage cursor (DES-FEEDBACK-002 §2): traversal order and the
+ * clamped ends, first-press behavior, Escape, focus + scroll-into-view (EC22),
+ * the `a`/`r` action semantics through the ONE shared `decideGate` (§2.3), the
+ * complex-gate boundary, the no-gate no-op, and the §2.4 composition guards
+ * (typing context, palette open) — all through the slice-G registry, exactly
+ * as the surfaces mount it.
+ */
+
+const gate = (runId: string, over: Partial<OpenGate> = {}): OpenGate => ({
+  runId, ord: 0, prompt: `gate for ${runId}`, lifecycle: 'open', receivedAt: Date.now(), ...over,
+});
+
+/** The harness renders what the surfaces render: a `data-kbd-item` row per
+ *  item, the selection attribute, and the reject note when it is open. */
+function Harness({ items, navigate }: { items: TriageItem[]; navigate: Navigate }): React.ReactElement {
+  const cursor = useTriageCursor(items, navigate);
+  return (
+    <div>
+      {items.map((it) => (
+        <div
+          key={it.key}
+          tabIndex={-1}
+          data-kbd-item={it.key}
+          data-testid={`row-${it.key}`}
+          {...(cursor.selectedKey === it.key ? { 'data-kbd-selected': 'true' } : {})}
+        >
+          {it.runId !== null && cursor.noteFor === it.runId ? (
+            <GateRejectNote runId={it.runId} onClose={cursor.closeNote} />
+          ) : (
+            <span>{it.key}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const press = (key: string, target: HTMLElement | Window = window): void => {
+  const e = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  act(() => {
+    if (target === window) window.dispatchEvent(e);
+    else (target as HTMLElement).dispatchEvent(e);
+  });
+};
+
+const selectedKeys = (): string[] =>
+  Array.from(document.querySelectorAll('[data-kbd-selected="true"]'))
+    .map((el) => el.getAttribute('data-kbd-item') ?? '');
+
+function items3(): TriageItem[] {
+  return [
+    { key: 'p1', runId: 'r1', gate: gate('r1'), openPath: '/p/p1', projectId: 'p1' },
+    { key: 'p2', runId: null, gate: undefined, openPath: '/p/p2', projectId: 'p2' },
+    { key: 'p3', runId: 'r3', gate: gate('r3'), openPath: '/p/p3', projectId: 'p3' },
+  ];
+}
+
+describe('the triage cursor (slice H, §2.2)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setShortcutsPaletteOpen(false);
+    useGateStore.setState({ gates: {} });
+    useGateActionStore.setState({ byGate: {} });
+    // setup.ts stubs scrollIntoView on HTMLElement.prototype — spy THERE, or
+    // the stub shadows a spy placed on Element.prototype.
+    vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {});
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('first j selects the first row; j advances in render order; k returns', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    expect(selectedKeys()).toEqual([]);
+    press('j');
+    expect(selectedKeys()).toEqual(['p1']);
+    press('j');
+    expect(selectedKeys()).toEqual(['p2']);
+    press('k');
+    expect(selectedKeys()).toEqual(['p1']);
+  });
+
+  it('the arrows pair with j/k; the cursor CLAMPS at both ends, never wraps', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('ArrowDown');
+    press('ArrowDown');
+    press('ArrowDown');
+    press('ArrowDown'); // past the end — clamps on p3
+    expect(selectedKeys()).toEqual(['p3']);
+    press('ArrowUp');
+    press('ArrowUp');
+    press('k'); // past the start — clamps on p1
+    expect(selectedKeys()).toEqual(['p1']);
+  });
+
+  it('the selected row takes real DOM focus and scrolls into view (EC22)', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    const row = screen.getByTestId('row-p1');
+    expect(document.activeElement).toBe(row);
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('Escape clears the cursor; selection is keyboard-only state', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('Escape');
+    expect(selectedKeys()).toEqual([]);
+  });
+
+  it('a on a simple-gate row fires the exact POST once — a second a is dropped', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('a');
+    press('a'); // in-flight/answered — the shared double-submit guard drops it
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(1);
+    expect(client.api.confirmGate).toHaveBeenCalledWith('r1', { approve: true });
+  });
+
+  it('a on a row with NO gate is a silent no-op (guard yields)', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('j'); // p2 — needs you for something that is not a gate
+    press('a');
+    press('r');
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('gate-reject-note')).toBeNull();
+  });
+
+  it('a on a COMPLEX gate opens the thread at #gate and posts nothing (§2.3)', () => {
+    const navigate = vi.fn();
+    const items = items3();
+    items[0] = { ...items[0]!, gate: gate('r1', { choices: null }) };
+    render(<Harness items={items} navigate={navigate} />);
+    press('j');
+    press('a');
+    expect(navigate).toHaveBeenCalledWith('/p/p1/build/r1#gate');
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+
+  it('r opens the inline note focused; Enter sends {approve:false, amend} (§2.3)', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('r');
+    const note = screen.getByTestId('gate-reject-note');
+    expect(document.activeElement).toBe(note);
+    await user.keyboard('needs the Q3 numbers first');
+    await user.keyboard('{Enter}');
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(1);
+    expect(client.api.confirmGate).toHaveBeenCalledWith('r1', {
+      approve: false, amend: 'needs the Q3 numbers first',
+    });
+    expect(screen.queryByTestId('gate-reject-note')).toBeNull();
+  });
+
+  it('an empty note rejects WITHOUT an amend field (the note is optional)', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('r');
+    await user.keyboard('{Enter}');
+    expect(client.api.confirmGate).toHaveBeenCalledWith('r1', { approve: false });
+  });
+
+  it('Escape in the note closes it, restores the row, and fires NOTHING', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('r');
+    await user.keyboard('half a reason');
+    await user.keyboard('{Escape}');
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('gate-reject-note')).toBeNull();
+    // Selection survives the cancel — focus returns to the row (§2.3).
+    expect(selectedKeys()).toEqual(['p1']);
+    expect(document.activeElement).toBe(screen.getByTestId('row-p1'));
+  });
+
+  it('while the note is open, j/a are typing-context keys — inert (§2.3/§2.4)', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    press('j');
+    press('r');
+    await user.keyboard('ja'); // land in the input as text, move no cursor
+    expect(screen.getByTestId('gate-reject-note')).toHaveValue('ja');
+    expect(selectedKeys()).toEqual(['p1']);
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+
+  it('any input focus is a typing context: keys pass through untouched (EC21)', () => {
+    render(
+      <div>
+        <input data-testid="outside-input" />
+        <Harness items={items3()} navigate={vi.fn()} />
+      </div>,
+    );
+    const input = screen.getByTestId('outside-input');
+    input.focus();
+    press('j', input);
+    press('a', input);
+    expect(selectedKeys()).toEqual([]);
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+
+  it('while the palette is open the table yields — j/k move nothing here (§2.4)', () => {
+    render(<Harness items={items3()} navigate={vi.fn()} />);
+    setShortcutsPaletteOpen(true);
+    press('j');
+    press('a');
+    expect(selectedKeys()).toEqual([]);
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+    setShortcutsPaletteOpen(false);
+    press('j');
+    expect(selectedKeys()).toEqual(['p1']);
+  });
+
+  it('Enter opens the selected row (the same target as clicking it)', () => {
+    const navigate = vi.fn();
+    render(<Harness items={items3()} navigate={navigate} />);
+    press('j');
+    press('Enter');
+    expect(navigate).toHaveBeenCalledWith('/p/p1');
+  });
+
+  it('with no selection, Enter and Escape yield — other handlers keep them', () => {
+    const navigate = vi.fn();
+    render(<Harness items={items3()} navigate={navigate} />);
+    press('Enter');
+    press('Escape');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('the shared decision state (gateActions.ts, §2.3)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useGateActionStore.setState({ byGate: {} });
+  });
+
+  it('a NEW gate arriving for a run resets its stale decision state', async () => {
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+    const { decideGate } = await import('../src/board/gateActions.js');
+    useGateStore.setState({ gates: { r9: gate('r9') } });
+    await decideGate('r9', { approve: true });
+    expect(useGateActionStore.getState().byGate['r9']?.answered).toBe('approved');
+    // The answered line survives its own clearGate prune…
+    expect(useGateStore.getState().gates['r9']).toBeUndefined();
+    // …but a LATER gate (new ord) is a fresh question with fresh state.
+    act(() => useGateStore.getState().setGate(gate('r9', { ord: 1 })));
+    expect(useGateActionStore.getState().byGate['r9']).toBeUndefined();
+    await decideGate('r9', { approve: false });
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Round-3 operator feedback, P0-2: *"j / k: Select next/previous project or run card. a: Approve selected gate. r: Reject / Request changes with inline prompt focus."*

## What changed (design: `.product/DES-FEEDBACK-002.md` §2)

- **`gateActions.ts` extracted first** — ONE gate-decision module (POST + double-submit guard + shared §3.3 busy/answered/error state): GateChip, the palette's gate verbs, and the new triage keys all answer through it. One wire path, no divergence.
- **`useTriageCursor`**: j/k (and arrows) walk HomeBoard's needs-you cards and ProjectDashboard's gate rows through the slice-G registry (typing guard + palette yield by construction); selection is real DOM focus + `scrollIntoView` + an accent outline ring (EC22); clamp at ends (the doc doesn't specify wrap — pinned as clamp, flagged); Escape clears; a hint row (`j/k select · a approve · r reject · ↵ open`) appears while the cursor is active.
- **a** approves simple gates (complex gates open the thread at `#gate` — same as the chip); **r** opens an inline reject note (focused input, `↵ reject · esc cancel`) whose text rides the `amend` field on `approve:false`; a blind reject on complex gates is deliberately not offered (it would cancel the run).
- GateChip's decision state moved to the shared store so keyboard/palette/mouse show identical busy/answered/error states (resets when a NEW gate ord arrives).

## Verification highlights

The verifier independently derived the expected traversal order from the fixture + attention model and matched the full j-walk; proved **exactly one POST under a rapid triple-press** against a delayed route; captured `{approve:false, amend:"needs the Q3 numbers first"}` off the wire; proved keys dead in typing contexts and while the palette is open (palette arrows move palette selection, board unmoved); EC21 grep still shows one window-level listener; EC22 ring computed-style equals the live `--accent` token; rig fails on origin/main; GateChip's mouse path byte-identical.

## Gates

eslint clean · tsc clean · vitest **1043/1043** (16 new) · new rig `feedback2_sliceH_test.py` (10 steps) + `feedback2_sliceG`, `feedback_sliceD`, `uxfix_slice1` all PASS. (sliceG's `new_chat_verb` step flaked once on a rig typing race untouched by this slice; 2/2 green on re-run.) Fixture gained the additive `POST /runs/:id/gate → 200` route.

Shots: `feedback2-H-triage-cursor.png`, `feedback2-H-reject-note.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)