### PR TITLE
Slice I: in-studio file & diff viewer on the crew#305 routes (DES-FEEDBACK-002 §3)

### DIFF
--- a/e2e/feedback2_sliceI_test.py
+++ b/e2e/feedback2_sliceI_test.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceI_test.py — the DES-FEEDBACK-002 slice-I gate: the in-studio
+file & diff viewer (§3, P0-3), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py) with its `viewer` corpus switched on: r-upload carries a
+workdir, its Files panel lists a modified TS file, a >512 KB generated file, a
+binary asset and an outside-root path, and the crew#305 routes answer with the
+REAL RunFileContent/RunDiff shapes and error strings.
+
+The slice DOM ACs, from §3.7 (studio side):
+
+  1. clicking a modified-file row opens `[data-testid="file-viewer"]` with the
+     Diff tab active; `[data-testid="diff-line-add"]` computed `color` resolves
+     from `var(--status-run)` and `diff-line-del` from `var(--status-fail)`
+     (EC15); switching to File shows numbered content;
+  2. file/diff requests fire ONLY on user gesture — zero fetches while the
+     panel merely sits open, zero external-open calls from inline viewing;
+  3. the binary file renders the honest state ("binary file — N bytes"), never
+     mojibake; the truncated file renders
+     `[data-testid="viewer-truncation-banner"]` naming the cap + full size (EC23);
+  4. a 403 (outside every allowed root) surfaces the route's error VERBATIM;
+  5. no highlight/grammar library ships in the bundle (the §2.3 precedent's
+     grep gate) — the adversarial `+++`-leading ADDED line in the untracked
+     hunk still colors as an addition (the zero-dep classifier is stateful);
+  6. Escape closes the viewer and focus returns to the FilesPanel row;
+  7. against a daemon WITHOUT the routes (Fastify default 404), the row click
+     falls back to today's exact behavior: `POST /open` external launch (+ the
+     copy feedback when that too is absent) — the viewer never lingers as an
+     empty shell.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-I-diff-view.png       viewer open on the fixture's modified file,
+                                  Diff tab, colored hunks
+  feedback2-I-file-truncated.png  File tab on the >512 KB fixture file with the
+                                  truncation banner
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4361),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    VIEWER_FILE_403,
+    VIEWER_FILE_BIG,
+    VIEWER_FILE_BIN,
+    VIEWER_FILE_TS,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4361"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+PROJECT, RUN = "upload-endpoint", "r-upload"
+THREAD = f"/p/{PROJECT}/build/{RUN}"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build + the §2.3-precedent grep gate ─────────────────────
+dist = ensure_build(fail)
+GRAMMAR_LIBS = re.compile(r"shiki|highlight\.js|hljs|prismjs|Prism\.highlight", re.I)
+offenders = []
+for asset in sorted((dist / "assets").glob("*.js")):
+    if GRAMMAR_LIBS.search(asset.read_text(errors="replace")):
+        offenders.append(asset.name)
+report["steps"]["no_grammar_library_in_bundle"] = {"ok": not offenders, "offenders": offenders}
+if offenders:
+    fail("no_grammar_library_in_bundle", f"grammar-library tokens found in {offenders}")
+
+# ── 2. The shared W2 fixture server, viewer corpus ON ───────────────────────────
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, viewer=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+TOKEN_PROBE = """(token) => {
+  const el = document.createElement('span');
+  el.style.color = `var(${token})`;
+  document.body.appendChild(el);
+  const c = getComputedStyle(el).color;
+  el.remove();
+  return c;
+}"""
+
+
+def open_files_panel(page) -> None:
+    page.goto(f"{ORIGIN}{THREAD}", wait_until="domcontentloaded")
+    page.get_by_role("button", name=re.compile("^Files")).wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.get_by_role("button", name=re.compile("^Files")).click()
+    page.locator(f'button[title="View {VIEWER_FILE_TS}"]').wait_for(timeout=15000)
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # The tap: every viewer read + every external-open the page fires.
+    reads: list[str] = []
+    opens: list[str] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        q = urlparse(req.url).query
+        if req.method == "GET" and re.search(r"/api/v1/runs/[^/]+/(files|diff)$", path):
+            reads.append(f"{path}?{q}" if q else path)
+        if req.method == "POST" and path == "/api/v1/open":
+            opens.append(path)
+
+    page.on("request", on_request)
+
+    # ── Scene 1: the Files panel sits open — NOTHING is prefetched ──────────────
+    open_files_panel(page)
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+    page.wait_for_timeout(1200)  # let the panel's own fetch burst settle
+    report["steps"]["no_prefetch_on_panel_open"] = {
+        "ok": fonts_ok and reads == [] and opens == [],
+        "fonts_ok": fonts_ok, "reads": list(reads), "opens": list(opens),
+    }
+
+    # ── Scene 2 (AC 1): modified row → viewer, Diff tab active, token colors ────
+    status_run = page.evaluate(TOKEN_PROBE, "--status-run")
+    status_fail = page.evaluate(TOKEN_PROBE, "--status-fail")
+    page.locator(f'button[title="View {VIEWER_FILE_TS}"]').click()
+    page.locator('[data-testid="file-viewer"]').wait_for(timeout=10000)
+    page.locator('[data-testid="diff-line-add"]').first.wait_for(timeout=10000)
+    diff_state = page.evaluate(
+        """([run, failc]) => {
+          const add = document.querySelector('[data-testid="diff-line-add"]');
+          const del = document.querySelector('[data-testid="diff-line-del"]');
+          const hunk = document.querySelector('[data-testid="diff-line-hunk"]');
+          return {
+            diffTabActive: document.querySelector('[data-testid="viewer-tab-diff"]')
+              ?.getAttribute('aria-selected') === 'true',
+            addColor: add ? getComputedStyle(add).color : null,
+            addOk: add ? getComputedStyle(add).color === run : false,
+            delOk: del ? getComputedStyle(del).color === failc : false,
+            hunkText: hunk?.textContent ?? null,
+          };
+        }""",
+        [status_run, status_fail],
+    )
+    page.screenshot(path=str(VSHOTS / "feedback2-I-diff-view.png"))
+    report["steps"]["diff_tab_token_colors"] = {
+        "ok": all([
+            diff_state["diffTabActive"],
+            diff_state["addOk"],                       # EC15: added = --status-run
+            diff_state["delOk"],                       # removed = --status-fail
+            diff_state["hunkText"] is not None and diff_state["hunkText"].startswith("@@"),
+            reads == [f"/api/v1/runs/{RUN}/diff?path={VIEWER_FILE_TS.replace('/', '%2F')}"],
+            opens == [],                               # inline view: zero external opens
+        ]),
+        "status_run_resolved": status_run,
+        **diff_state,
+        "reads": list(reads),
+    }
+
+    # ── Scene 3 (AC 1 second half): File tab shows numbered content ─────────────
+    page.locator('[data-testid="viewer-tab-file"]').click()
+    page.get_by_text("export function rateLimit(opts: Opts) {").wait_for(timeout=10000)
+    file_state = page.evaluate(
+        """() => {
+          const pre = document.querySelector('[data-testid="file-viewer"] pre');
+          const nums = pre ? pre.querySelectorAll('span[aria-hidden="true"]') : [];
+          return {
+            lineNumbers: nums.length,
+            firstNum: nums[0]?.textContent ?? null,
+            numsUnselectable: nums[0] ? getComputedStyle(nums[0]).userSelect === 'none' : false,
+          };
+        }"""
+    )
+    report["steps"]["file_tab_numbered_content"] = {
+        "ok": all([
+            file_state["lineNumbers"] >= 15,
+            file_state["firstNum"] == "1",
+            file_state["numsUnselectable"],
+            len(reads) == 2 and reads[1].startswith(f"/api/v1/runs/{RUN}/files?path="),
+        ]),
+        **file_state,
+        "reads": list(reads),
+    }
+
+    # ── Scene 4 (AC 6): Escape closes; focus returns to the row ─────────────────
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"file-viewer\"]') === null", timeout=5000
+    )
+    focus_back = page.evaluate(
+        """(title) => document.activeElement?.getAttribute('title') === title""",
+        f"View {VIEWER_FILE_TS}",
+    )
+    report["steps"]["escape_closes_focus_returns"] = {"ok": bool(focus_back)}
+
+    # ── Scene 5 (AC 3): the >512 KB file — truncation banner on the File tab ────
+    page.locator(f'button[title="View {VIEWER_FILE_BIG}"]').click()
+    page.locator('[data-testid="file-viewer"]').wait_for(timeout=10000)
+    page.locator('[data-testid="viewer-tab-file"]').click()
+    page.locator('[data-testid="viewer-truncation-banner"]').wait_for(timeout=10000)
+    banner = page.locator('[data-testid="viewer-truncation-banner"]').text_content() or ""
+    page.screenshot(path=str(VSHOTS / "feedback2-I-file-truncated.png"))
+    report["steps"]["truncation_banner"] = {
+        "ok": "showing first 512 KB" in banner and "700.0 KB total" in banner,
+        "banner": banner,
+    }
+    page.keyboard.press("Escape")
+
+    # ── Scene 6 (AC 3): the binary file — honest state, never mojibake ──────────
+    page.locator(f'button[title="View {VIEWER_FILE_BIN}"]').click()
+    page.locator('[data-testid="viewer-binary"]').wait_for(timeout=10000)
+    binary_text = page.locator('[data-testid="viewer-binary"]').text_content() or ""
+    report["steps"]["binary_honest_state"] = {
+        "ok": "binary file — 20.0 KB" in binary_text and opens == [],
+        "text": binary_text, "opens": list(opens),
+    }
+    page.keyboard.press("Escape")
+
+    # ── Scene 7 (AC 4): the outside-root file — 403 surfaced VERBATIM ───────────
+    page.locator(f'button[title="View {VIEWER_FILE_403}"]').click()
+    page.locator('[data-testid="viewer-error"]').wait_for(timeout=10000)
+    err_text = page.locator('[data-testid="viewer-error"]').text_content() or ""
+    report["steps"]["forbidden_surfaced_verbatim"] = {
+        "ok": "API 403: path is outside every allowed root (the run's workdir/write roots "
+              "and the registered repos)" in err_text,
+        "text": err_text,
+    }
+    page.keyboard.press("Escape")
+
+    # ── Scene 8 (AC 5): [Full diff] — whole-run diff + the adversarial +++ line ─
+    reads_before = len(reads)
+    page.locator('[data-testid="files-full-diff"]').click()
+    page.locator('[data-testid="file-viewer"]').wait_for(timeout=10000)
+    page.locator('[data-testid="diff-line-add"]').first.wait_for(timeout=10000)
+    adversarial = page.evaluate(
+        """() => {
+          const adds = Array.from(document.querySelectorAll('[data-testid="diff-line-add"]'));
+          const trap = adds.find((el) => el.textContent.includes('staged: bucket first'));
+          const headers = Array.from(document.querySelectorAll('[data-testid="file-viewer"] pre div'))
+            .filter((el) => el.textContent.startsWith('+++ b/'))
+            .map((el) => el.dataset.testid ?? 'none');
+          return {
+            trapIsAddition: !!trap && trap.textContent.startsWith('+++ staged'),
+            fileHeadersNotAdds: headers.every((t) => t === 'none'),
+            addCount: adds.length,
+          };
+        }"""
+    )
+    report["steps"]["full_diff_and_adversarial_classifier"] = {
+        "ok": all([
+            adversarial["trapIsAddition"],       # `+++ staged…` = ADDED content line
+            adversarial["fileHeadersNotAdds"],   # `+++ b/…` headers stay headers
+            adversarial["addCount"] >= 5,
+            reads[reads_before:] == [f"/api/v1/runs/{RUN}/diff"],  # NO ?path
+        ]),
+        **adversarial,
+        "reads": reads[reads_before:],
+    }
+    page.keyboard.press("Escape")
+
+    # ── Scene 9 (AC 7): a daemon WITHOUT the routes — today's exact fallback ────
+    set_fixture(ORIGIN, file_routes=False)
+    opens.clear()
+    open_files_panel(page)
+    page.locator(f'button[title="View {VIEWER_FILE_TS}"]').click()
+    # The viewer never lingers as an empty shell: it yields to the external open,
+    # whose own 404 fallback (this fixture has no /open either) copies the path.
+    page.get_by_text("open unavailable — path copied").wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"file-viewer\"]') === null", timeout=5000
+    )
+    report["steps"]["route_absent_fallback"] = {
+        "ok": opens == ["/api/v1/open"],
+        "opens": list(opens),
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-I-diff-view.png"),
+    str(VSHOTS / "feedback2-I-file-truncated.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceI_verdict", f"slice-I assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -98,6 +98,14 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
          "extra_narration": [], "demo": False,
          "repo": False, "metrics_ws": False,
+         # Slice I (DES-FEEDBACK-002 §3): the in-studio file/diff viewer corpus.
+         #   viewer      — r-upload gains a workdir + file events, and the crew#305
+         #                 routes (GET /runs/:id/files, GET /runs/:id/diff) answer
+         #                 with the REAL contract shapes (default False).
+         #   file_routes — when False the two routes answer Fastify's DEFAULT
+         #                 unknown-route 404 body (a daemon predating crew#305),
+         #                 so the rig can prove the studio's openPath fallback.
+         "viewer": False, "file_routes": True,
          # theme-learn readback (interactive#181): how long after a successful
          # theme.requested the learned tokens become readable (the 404→200
          # ripening the studio poll rides). reset_learn clears learned state.
@@ -215,6 +223,106 @@ LONG_PROMPT = (
     "replayed from the dead-letter store once the schema catches up with the producer"
 )
 LONG_RUN = session("r-long", "executing", LONG_PROMPT, "wire the schema validation")
+
+# ── The slice-I viewer corpus (DES-FEEDBACK-002 §3, crew#305) ─────────────────
+#
+# Behind the `viewer` switch. Everything below speaks the REAL crew wire:
+# `RunFileContent` / `RunDiff` verbatim (wicked-crew-api-types 0.7.0), the
+# routes' exact error LADDER and strings (routes.ts crew#305): 404 `unknown
+# run: <id>` / `no such file: <path>`, 400 non-absolute / repeated `path`,
+# 403 outside every allowed root, 409 workdir-less. The diff is a real
+# `git diff --no-color --no-ext-diff HEAD` shape including an untracked file
+# appended as an all-addition `--no-index` hunk — with one added line whose
+# own text begins `++` (so it renders `+++ …`), the adversarial case the
+# studio's stateful classifier must color as an ADDITION, not a header.
+
+VIEWER_WORKDIR = "/w2/upload"
+VIEWER_FILE_TS = f"{VIEWER_WORKDIR}/src/middleware.ts"
+VIEWER_FILE_BIG = f"{VIEWER_WORKDIR}/src/generated.ts"
+VIEWER_FILE_BIN = f"{VIEWER_WORKDIR}/assets/logo.png"
+VIEWER_FILE_403 = "/outside/secret.txt"
+
+MIDDLEWARE_TS = """\
+// Token-bucket rate limiting for the upload endpoint.
+import { TokenBucket } from './bucket.js';
+
+export interface Opts {
+  capacity: number;
+  refillPerSec: number;
+}
+
+export function rateLimit(opts: Opts) {
+  const bucket = new TokenBucket(opts);
+  return async (req, res, next) => {
+    if (!bucket.take(req.ip)) {
+      return res.status(429).end();
+    }
+    next();
+  };
+}
+"""
+
+VIEWER_FILES = {
+    VIEWER_FILE_TS: {"path": VIEWER_FILE_TS, "content": MIDDLEWARE_TS,
+                     "size": len(MIDDLEWARE_TS.encode()), "truncated": False, "binary": False},
+    # >512 KB: `content` holds only the first 512 KB (stood in by a short head
+    # here — the CONTRACT fields are what the rig asserts), `size` is the FULL
+    # byte count, `truncated: true`.
+    VIEWER_FILE_BIG: {"path": VIEWER_FILE_BIG,
+                      "content": "// AUTO-GENERATED — first 512 KB of the bundle\n"
+                                 + "export const table = [\n" + "  0,\n" * 40,
+                      "size": 716800, "truncated": True, "binary": False},
+    # NUL in the first 8 KB: `binary: true`, `content: ""` — never mojibake.
+    VIEWER_FILE_BIN: {"path": VIEWER_FILE_BIN, "content": "",
+                      "size": 20480, "truncated": False, "binary": True},
+}
+
+_DIFF_MIDDLEWARE = """\
+diff --git a/src/middleware.ts b/src/middleware.ts
+index 3f9c2ab..8d41e0f 100644
+--- a/src/middleware.ts
++++ b/src/middleware.ts
+@@ -10,7 +10,10 @@ export function rateLimit(opts: Opts) {
+   const bucket = new TokenBucket(opts);
+   return async (req, res, next) => {
+-    next();
++    if (!bucket.take(req.ip)) {
++      return res.status(429).end();
++    }
++    next();
+   };
+ }
+"""
+
+# The untracked file appended as an all-addition --no-index hunk (§3.3) — its
+# second added line's own text begins "++", so the diff line begins "+++":
+# the classifier trap.
+_DIFF_UNTRACKED = """\
+diff --git a/dev/null b/notes/plan.md
+new file mode 100644
+index 0000000..9c4e21f
+--- /dev/null
++++ b/notes/plan.md
+@@ -0,0 +1,3 @@
++rate-limit rollout plan
++++ staged: bucket first, then 429s   <- content starts with ++
++done when p99 < 40ms
+"""
+
+VIEWER_DIFF_WHOLE = _DIFF_MIDDLEWARE + _DIFF_UNTRACKED
+VIEWER_DIFF_BY_PATH = {VIEWER_FILE_TS: _DIFF_MIDDLEWARE}
+
+# The run-model events that put the corpus files on the Files panel: unit 0
+# wrote middleware.ts + generated.ts (Write hook fire ⇒ modified set), unit 1
+# only READ the binary + the outside path (referenced set ⇒ File tab default).
+VIEWER_EVENTS = [
+    {"type": "dataUsed", "session": "r-upload", "ord": 0,
+     "files": [VIEWER_FILE_TS, VIEWER_FILE_BIG]},
+    {"type": "governanceHookFired", "session": "r-upload", "ord": 0,
+     "attempt": 0, "toolName": "Write", "decision": "allow"},
+    {"type": "dataUsed", "session": "r-upload", "ord": 1,
+     "files": [VIEWER_FILE_BIN, VIEWER_FILE_403]},
+]
 
 # The durable-log tails (D3 step 2): the ONE honest clock for a failure's age.
 RUN_EVENTS = {
@@ -672,7 +780,20 @@ class W2Handler(SimpleHTTPRequestHandler):
                 else:
                     runs = RUNS + ([ORPHAN] if state["orphan"] else []) \
                         + ([LONG_RUN] if state["long_prompt"] else [])
+                viewer_on = state["viewer"]
+            if viewer_on:
+                # Slice I: the live run gains a workdir (the diff route's 409
+                # gate reads it; AgentSession carries it on the wire).
+                runs = json.loads(json.dumps(runs))
+                for r in runs:
+                    if r["session"]["id"] == "r-upload":
+                        r["session"]["workdir"] = VIEWER_WORKDIR
             self._json(200, {"runs": runs})
+            return True
+        # Slice I: the crew#305 file/diff routes (real contract, switch-gated).
+        m = re.match(r"^/api/v1/runs/([^/]+)/(files|diff)$", path)
+        if m:
+            self._viewer_routes(urllib.parse.unquote(m.group(1)), m.group(2))
             return True
         if path == "/api/v1/projects":
             self._json(200, {"projects": PROJECTS})
@@ -761,12 +882,74 @@ class W2Handler(SimpleHTTPRequestHandler):
         # /api/v1/runs/<id>/events
         if len(parts) == 6 and parts[3] == "runs" and parts[5] == "events":
             rid = urllib.parse.unquote(parts[4])
-            self._json(200, {"events": RUN_EVENTS.get(rid, [])})
+            events = list(RUN_EVENTS.get(rid, []))
+            with state_lock:
+                viewer_on = state["viewer"]
+            if viewer_on and rid == "r-upload":
+                events = events + VIEWER_EVENTS
+            self._json(200, {"events": events})
             return True
         if path.startswith("/api/v1/"):
             self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
             return True
         return False
+
+    def _viewer_routes(self, rid: str, leaf: str) -> None:
+        """The crew#305 file/diff routes with their REAL validation ladder and
+        error strings (routes.ts). With `file_routes` off (or the whole corpus
+        off) they answer Fastify's DEFAULT unknown-route 404 body — exactly what
+        a daemon predating crew#305 sends — so the studio's fallback detection
+        sees the same wire it would in production."""
+        with state_lock:
+            viewer_on = state["viewer"] and state["file_routes"]
+            orphan_on = state["orphan"]
+        if not viewer_on:
+            self._json(404, {"message": f"Route GET:{self.path} not found",
+                             "error": "Not Found", "statusCode": 404})
+            return
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query,
+                                      keep_blank_values=True)
+        paths = query.get("path", [])
+        known = {r["session"]["id"] for r in RUNS} | ({"r-orphan"} if orphan_on else set())
+        # The shared resolveRunPath ladder: 404 unknown run → 400 repeated /
+        # non-absolute → 403 outside every allowed root.
+        if rid not in known:
+            self._json(404, {"error": f"unknown run: {rid}"})
+            return
+        if len(paths) > 1:
+            self._json(400, {"error": "`path` may be given at most once"})
+            return
+        qpath = paths[0].strip() if paths else None
+        if qpath == "":
+            qpath = None
+        workdir = VIEWER_WORKDIR if rid == "r-upload" else None
+        if qpath is not None:
+            if not qpath.startswith("/"):
+                self._json(400, {"error": "`path` must be an absolute path"})
+                return
+            roots = [workdir] if workdir else []
+            if not any(qpath == r or qpath.startswith(r + "/") for r in roots):
+                self._json(403, {"error": "path is outside every allowed root (the "
+                                          "run's workdir/write roots and the registered repos)"})
+                return
+        if leaf == "files":
+            if qpath is None:
+                self._json(400, {"error": "`path` query parameter is required"})
+                return
+            served = VIEWER_FILES.get(qpath)
+            if served is None:
+                self._json(404, {"error": f"no such file: {qpath}"})
+                return
+            self._json(200, served)
+            return
+        # leaf == "diff"
+        if workdir is None:
+            self._json(409, {"error": f"run {rid} has no workdir — nothing to diff"})
+            return
+        if qpath is not None:
+            self._json(200, {"diff": VIEWER_DIFF_BY_PATH.get(qpath, ""), "truncated": False})
+            return
+        self._json(200, {"diff": VIEWER_DIFF_WHOLE, "truncated": False})
 
     def _interactive_get(self, path: str) -> bool:
         """GET half of the slice-6 bridge surface (DES-UXFIX-001 §2.6)."""

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.5.1"
+        "wicked-crew-api-types": "^0.7.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.5.1.tgz",
-      "integrity": "sha512-a0F0jc0P3SlHMnbaPErZ3IX/wYy82W/0iofoPcuNnS+qj+HP36mFMe3yJl+5EeXhTld8J/2KCRN1dK82/GWHRg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.7.0.tgz",
+      "integrity": "sha512-w3ownEiI+3GeKOrJWXZmDLYAWNRSyMwUU7PYCIFpng2PmEXFc/0xtkgtP8we63w/ibXG/Zz9QQM+NfSZvoZIsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
   "version": "0.2.0",
-  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.5.1"
+    "wicked-crew-api-types": "^0.7.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -296,6 +296,30 @@ export const api = {
     }),
 
   /**
+   * A capped, contained file read from the run's allowed roots (crew#305:
+   * `GET /runs/:id/files?path=<absolute>`). 512 KB cap (`truncated: true` past
+   * it, first 512 KB served), NUL-in-first-8KB binary sniff (`binary: true`,
+   * `content: ""`). Error ladder: 404 unknown run / missing file, 400
+   * non-absolute or repeated `path`, 403 outside every allowed root.
+   */
+  getRunFile: (runId: string, path: string) =>
+    apiFetch<import('./types.js').RunFileContent>(
+      `/runs/${encodeURIComponent(runId)}/files?path=${encodeURIComponent(path)}`,
+    ),
+
+  /**
+   * The run worktree's unified diff against HEAD (crew#305: `GET /runs/:id/diff`,
+   * staged + unstaged, untracked appended as all-addition hunks), whole-tree or
+   * narrowed to one absolute in-worktree `path`. 1 MB output cap (`truncated`).
+   * `diff: ""` = clean tree — a real answer, not an error. 409 when the run has
+   * no workdir or it was reaped; 507 past the server's execution buffer.
+   */
+  getRunDiff: (runId: string, path?: string) =>
+    apiFetch<import('./types.js').RunDiff>(
+      `/runs/${encodeURIComponent(runId)}/diff${path === undefined ? '' : `?path=${encodeURIComponent(path)}`}`,
+    ),
+
+  /**
    * Inject a message into one or all active agent sessions (POST /runs/:id/inject).
    * `target` is either `"all"` (broadcast) or a session-specific discriminator.
    * Used by the manager dashboard's send-to-agents panel (crew#73).

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { api } from '../api/client.js';
+import type { RunDiff, RunFileContent } from '../api/types.js';
+import { classifyDiff, isDimLine } from '../viewer/colorize.js';
+import type { DiffLineKind } from '../viewer/colorize.js';
+
+/**
+ * The in-studio file & diff viewer (DES-FEEDBACK-002 §3.4, slice I).
+ *
+ * A canvas-scale overlay — `min(1100px, 86vw) × 82vh` on `--surface-overlay`
+ * (EC18's spirit: a file you are reading deserves the viewport; the 288px
+ * RightPanel cannot show code). Two tabs:
+ *
+ *  - [File] → `GET /runs/:id/files?path=…` — mono text with `--ink-dim` line
+ *    numbers; honest states for binary ("binary file — N bytes", never
+ *    mojibake) and truncation (a labeled banner naming the cap and the full
+ *    size — the viewer never silently amputates, EC23).
+ *  - [Diff] → `GET /runs/:id/diff[?path=…]` — unified diff colored by the
+ *    zero-dependency classifier (§3.5): the diff colors ARE the status tokens
+ *    (added = --status-run family, removed = --status-fail family), no grammar
+ *    library, no new palette.
+ *
+ * Requests fire ONLY on a user gesture: the viewer mounts on a row click and
+ * each tab fetches on its first activation — nothing is prefetched.
+ *
+ * Route errors (400/403/404/409/507) surface VERBATIM — never swallowed. The
+ * one exception is the forward-compat contract every studio wire follows: a
+ * daemon WITHOUT the routes answers Fastify's generic 404 (`Not Found`, no
+ * named error), and that calls `onUnsupported` so the caller can fall back to
+ * today's exact behavior (external open + copy feedback) instead of the
+ * viewer rendering an empty shell.
+ */
+
+export type ViewerTab = 'file' | 'diff';
+
+interface Props {
+  runId: string;
+  /** Absolute path of the viewed file; undefined = the whole-run diff viewer. */
+  path?: string;
+  defaultTab: ViewerTab;
+  onClose: () => void;
+  /** The daemon has no file/diff routes (generic route-absent 404). */
+  onUnsupported: () => void;
+}
+
+type Fetched<T> =
+  | { state: 'loading' }
+  | { state: 'error'; message: string }
+  | { state: 'ok'; data: T };
+
+/** Fastify's default unknown-route 404 carries no named error — the daemon
+ *  predates crew#305. Named 404s ("unknown run: …", "no such file: …") are
+ *  real answers from a daemon WITH the routes and must surface verbatim. */
+function isRouteAbsent(e: unknown): boolean {
+  return e instanceof Error && e.message === 'API 404: Not Found';
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} bytes`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** §3.5/§3.6 — kind → token-resolved dress (EC15: tokens only, never hex). */
+const DIFF_STYLE: Record<DiffLineKind, CSSProperties> = {
+  add: { color: 'var(--status-run)', background: 'var(--status-run-dim)' },
+  del: { color: 'var(--status-fail)', background: 'var(--status-fail-dim)' },
+  hunk: { color: 'var(--ink-dim)', background: 'var(--surface-raised)' },
+  file: { color: 'var(--ink-muted)', fontWeight: 'var(--weight-semi)' as CSSProperties['fontWeight'] },
+  meta: { color: 'var(--ink-dim)' },
+  ctx: { color: 'var(--ink-body)' },
+};
+
+const DIFF_TESTID: Partial<Record<DiffLineKind, string>> = {
+  add: 'diff-line-add',
+  del: 'diff-line-del',
+  hunk: 'diff-line-hunk',
+};
+
+const CODE_STYLE: CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--text-xs)',
+  lineHeight: 'var(--leading-body)',
+};
+
+function TruncationBanner({ text }: { text: string }): React.ReactElement {
+  return (
+    <div
+      data-testid="viewer-truncation-banner"
+      className="px-3 py-1.5 text-[11px] font-mono shrink-0"
+      style={{ color: 'var(--status-gate)', background: 'var(--surface-raised)', borderBottom: '1px solid var(--surface-raised)' }}
+    >
+      {text}
+    </div>
+  );
+}
+
+function ErrorPane({ message }: { message: string }): React.ReactElement {
+  return (
+    <p data-testid="viewer-error" className="p-4 text-xs font-mono break-all" style={{ color: 'var(--status-fail)' }}>
+      {message}
+    </p>
+  );
+}
+
+function LoadingPane(): React.ReactElement {
+  return (
+    <p className="p-4 text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>Loading…</p>
+  );
+}
+
+export function FileViewer({ runId, path, defaultTab, onClose, onUnsupported }: Props): React.ReactElement {
+  const [tab, setTab] = useState<ViewerTab>(path === undefined ? 'diff' : defaultTab);
+  const [file, setFile] = useState<Fetched<RunFileContent> | null>(null);
+  const [diff, setDiff] = useState<Fetched<RunDiff> | null>(null);
+
+  // Escape closes (the Modal pattern); the caller restores focus to the row.
+  useEffect(() => {
+    function handler(e: KeyboardEvent): void {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Fetch on first tab activation only — the user gesture is the trigger.
+  useEffect(() => {
+    if (tab !== 'file' || path === undefined || file !== null) return;
+    setFile({ state: 'loading' });
+    api.getRunFile(runId, path)
+      .then((data) => setFile({ state: 'ok', data }))
+      .catch((e: unknown) => {
+        if (isRouteAbsent(e)) { onUnsupported(); return; }
+        setFile({ state: 'error', message: e instanceof Error ? e.message : String(e) });
+      });
+  }, [tab, path, runId, file, onUnsupported]);
+
+  useEffect(() => {
+    if (tab !== 'diff' || diff !== null) return;
+    setDiff({ state: 'loading' });
+    api.getRunDiff(runId, path)
+      .then((data) => setDiff({ state: 'ok', data }))
+      .catch((e: unknown) => {
+        if (isRouteAbsent(e)) { onUnsupported(); return; }
+        setDiff({ state: 'error', message: e instanceof Error ? e.message : String(e) });
+      });
+  }, [tab, path, runId, diff, onUnsupported]);
+
+  function handleOpenExternally(): void {
+    if (path === undefined) return;
+    api.openPath(path, runId).catch(() => {
+      void navigator.clipboard.writeText(path).catch(() => { /* clipboard unavailable */ });
+    });
+  }
+
+  function handleCopy(): void {
+    if (path === undefined) return;
+    void navigator.clipboard.writeText(path).catch(() => { /* clipboard unavailable */ });
+  }
+
+  const title = path ?? 'whole-run diff';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
+      <div
+        data-testid="file-viewer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="flex flex-col overflow-hidden"
+        style={{
+          width: 'min(1100px, 86vw)',
+          height: '82vh',
+          background: 'var(--surface-overlay)',
+          boxShadow: 'var(--shadow-overlay)',
+          borderRadius: 'var(--radius-xl)',
+        }}
+      >
+        {/* Header: path · tabs · open/copy/esc (the §3.4 anatomy) */}
+        <div
+          className="flex items-center gap-3 px-4 py-2.5 shrink-0"
+          style={{ borderBottom: '1px solid var(--surface-raised)' }}
+        >
+          <span
+            className="min-w-0 flex-1 truncate text-xs font-mono"
+            style={{ color: 'var(--ink-high)' }}
+            title={title}
+          >
+            {title}
+          </span>
+          <div className="flex items-center gap-1 shrink-0" role="tablist" aria-label="Viewer mode">
+            {path !== undefined && (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === 'file'}
+                data-testid="viewer-tab-file"
+                onClick={() => setTab('file')}
+                className="px-2 py-1 text-[11px] font-mono"
+                style={{
+                  color: tab === 'file' ? 'var(--ink-high)' : 'var(--ink-muted)',
+                  borderBottom: tab === 'file' ? '2px solid var(--accent)' : '2px solid transparent',
+                }}
+              >
+                File
+              </button>
+            )}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'diff'}
+              data-testid="viewer-tab-diff"
+              onClick={() => setTab('diff')}
+              className="px-2 py-1 text-[11px] font-mono"
+              style={{
+                color: tab === 'diff' ? 'var(--ink-high)' : 'var(--ink-muted)',
+                borderBottom: tab === 'diff' ? '2px solid var(--accent)' : '2px solid transparent',
+              }}
+            >
+              Diff
+            </button>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {path !== undefined && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleOpenExternally}
+                  aria-label={`Open externally: ${path}`}
+                  title={`Open with system default app: ${path}`}
+                  className="text-[11px] font-mono transition-opacity hover:opacity-70"
+                  style={{ color: 'var(--ink-dim)' }}
+                >
+                  ↗ open
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  aria-label={`Copy path ${path}`}
+                  title="Copy path"
+                  className="text-[11px] font-mono transition-opacity hover:opacity-70"
+                  style={{ color: 'var(--ink-dim)' }}
+                >
+                  ⧉
+                </button>
+              </>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close viewer"
+              className="text-sm leading-none transition-opacity hover:opacity-70"
+              style={{ color: 'var(--ink-dim)' }}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        {tab === 'file' ? (
+          <FileBody file={file} onOpenExternally={handleOpenExternally} />
+        ) : (
+          <DiffBody diff={diff} narrowed={path !== undefined} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FileBody({ file, onOpenExternally }: {
+  file: Fetched<RunFileContent> | null;
+  onOpenExternally: () => void;
+}): React.ReactElement {
+  if (file === null || file.state === 'loading') return <LoadingPane />;
+  if (file.state === 'error') return <ErrorPane message={file.message} />;
+  const { content, size, truncated, binary } = file.data;
+
+  if (binary) {
+    // Honest state — never mojibake (the route serves `content: ""` here).
+    return (
+      <div data-testid="viewer-binary" className="p-4 flex flex-col items-start gap-2">
+        <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+          binary file — {formatBytes(size)}
+        </p>
+        <button
+          type="button"
+          onClick={onOpenExternally}
+          className="text-[11px] font-mono transition-opacity hover:opacity-70"
+          style={{ color: 'var(--accent)' }}
+        >
+          ↗ open externally
+        </button>
+      </div>
+    );
+  }
+
+  const lines = content.split('\n');
+  const numWidth = `${String(lines.length).length + 1}ch`;
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {truncated && (
+        <TruncationBanner
+          text={`showing first 512 KB — open externally for the full file (${formatBytes(size)} total)`}
+        />
+      )}
+      <div className="flex-1 overflow-auto">
+        <pre className="m-0 p-3 min-w-max" style={CODE_STYLE}>
+          {lines.map((line, i) => (
+            <div key={i} className="flex">
+              <span
+                className="shrink-0 text-right pr-3 select-none"
+                aria-hidden="true"
+                style={{ color: 'var(--ink-dim)', width: numWidth, userSelect: 'none' }}
+              >
+                {i + 1}
+              </span>
+              <span style={{ color: isDimLine(line) ? 'var(--ink-dim)' : 'var(--ink-body)' }}>
+                {line}
+              </span>
+            </div>
+          ))}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function DiffBody({ diff, narrowed }: {
+  diff: Fetched<RunDiff> | null;
+  narrowed: boolean;
+}): React.ReactElement {
+  if (diff === null || diff.state === 'loading') return <LoadingPane />;
+  if (diff.state === 'error') return <ErrorPane message={diff.message} />;
+  const { diff: text, truncated } = diff.data;
+
+  if (text === '') {
+    // `diff: ""` is a real answer (clean tree), not an error (§3.3).
+    return (
+      <p data-testid="viewer-clean-tree" className="p-4 text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
+        {narrowed ? 'no changes to this file.' : 'clean tree — no changes.'}
+      </p>
+    );
+  }
+
+  const lines = classifyDiff(text);
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {truncated && (
+        <TruncationBanner text="diff truncated at 1 MB — narrow to a single file for the rest" />
+      )}
+      <div className="flex-1 overflow-auto">
+        <pre className="m-0 p-3 min-w-max" style={CODE_STYLE}>
+          {lines.map((l, i) => (
+            <div key={i} data-testid={DIFF_TESTID[l.kind]} className="px-1" style={DIFF_STYLE[l.kind]}>
+              {l.text === '' ? ' ' : l.text}
+            </div>
+          ))}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -5,6 +5,7 @@ import { useRunModel } from '../hooks/useRunModel.js';
 import type { RunModel } from '../hooks/useRunModel.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { Burn } from './Burn.js';
+import { FileViewer } from './FileViewer.js';
 import { CoverageView } from './CoverageView.js';
 import { DataUsed } from './DataUsed.js';
 import { DecisionsLedger } from './DecisionsLedger.js';
@@ -54,6 +55,11 @@ type FileFeedback = 'opened' | 'copied' | 'open-failed';
 
 function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; runId: string }): React.ReactElement {
   const [feedback, setFeedback] = useState<FileFeedback | null>(null);
+  // Slice I (DES-FEEDBACK-002 §3.4): the row itself opens the INLINE viewer;
+  // external-open (↗) and copy (⧉) move to hover-revealed row-end icons —
+  // the same api.openPath / clipboard calls as before, byte-identical behavior.
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const rowRef = useRef<HTMLButtonElement | null>(null);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current); }, []);
   const parts = path.replace(/\\/g, '/').split('/');
@@ -101,16 +107,31 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
       });
   }
 
+  /** Escape / ✕ closes; focus returns to the row (§3.7). */
+  function closeViewer(): void {
+    setViewerOpen(false);
+    rowRef.current?.focus();
+  }
+
+  /** A daemon WITHOUT the crew#305 routes: fall back to today's exact
+   *  behavior — the external open (which itself copy-falls-back on 404). */
+  function handleUnsupported(): void {
+    setViewerOpen(false);
+    rowRef.current?.focus();
+    handleOpen();
+  }
+
   return (
-    <li title={path} className="flex items-start gap-1.5 min-w-0">
+    <li title={path} className="group flex items-start gap-1.5 min-w-0">
       <span className="shrink-0 mt-0.5 text-[9px] font-mono select-none" style={{ color: glyphColor }}>
         {glyph}
       </span>
       <button
         type="button"
-        onClick={handleOpen}
+        ref={rowRef}
+        onClick={() => setViewerOpen(true)}
         className="min-w-0 flex-1 leading-5 font-mono text-[10px] break-all text-left transition-opacity hover:opacity-70"
-        title={`Open with system default app: ${path}`}
+        title={`View ${path}`}
         style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
       >
         {dir && <span style={{ color: 'var(--ink-dim)' }}>{dir}</span>}
@@ -129,20 +150,45 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
       </button>
       <button
         type="button"
+        onClick={handleOpen}
+        aria-label={`Open externally: ${path}`}
+        title={`Open with system default app: ${path}`}
+        className="shrink-0 mt-0.5 text-[9px] font-mono leading-5 transition-opacity hover:opacity-70 opacity-0 group-hover:opacity-100 focus:opacity-100"
+        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--ink-dim)' }}
+      >
+        ↗
+      </button>
+      <button
+        type="button"
         onClick={handleCopy}
         aria-label={`Copy path ${path}`}
         title="Copy path"
-        className="shrink-0 mt-0.5 text-[9px] font-mono leading-5 transition-opacity hover:opacity-70"
+        className="shrink-0 mt-0.5 text-[9px] font-mono leading-5 transition-opacity hover:opacity-70 opacity-0 group-hover:opacity-100 focus:opacity-100"
         style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--ink-dim)' }}
       >
         ⧉
       </button>
+      {viewerOpen && (
+        <FileViewer
+          runId={runId}
+          path={path}
+          defaultTab={opKind !== undefined ? 'diff' : 'file'}
+          onClose={closeViewer}
+          onUnsupported={handleUnsupported}
+        />
+      )}
     </li>
   );
 }
 
 function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
   const runId = model.session.id;
+  // Slice I: the per-run [Full diff] button at the panel header (§3.4) — the
+  // same viewer, whole-worktree diff (no path). Opens on the click, never
+  // prefetches.
+  const [fullDiffOpen, setFullDiffOpen] = useState(false);
+  const [fullDiffUnsupported, setFullDiffUnsupported] = useState(false);
+  const fullDiffBtnRef = useRef<HTMLButtonElement | null>(null);
   // Build sets of "write units" and "delete units" from governance hook fires.
   // governanceHookFired events carry toolName but not file paths, so we use a unit's
   // entire filesRead set as a proxy for "files touched by write operations".
@@ -196,6 +242,25 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Panel header: the whole-run diff affordance (§3.4) */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          ref={fullDiffBtnRef}
+          data-testid="files-full-diff"
+          onClick={() => { setFullDiffUnsupported(false); setFullDiffOpen(true); }}
+          className="text-[10px] font-mono px-1.5 py-0.5 rounded transition-opacity hover:opacity-70"
+          style={{ color: 'var(--accent)', background: 'var(--accent-subtle)' }}
+        >
+          Full diff
+        </button>
+        {fullDiffUnsupported && (
+          <span className="text-[9px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+            diff unavailable — this daemon predates the diff route
+          </span>
+        )}
+      </div>
+
       {/* Modified / Created section */}
       {(hasModified || isActive) && (
         <div>
@@ -236,6 +301,19 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
       <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
         {allFiles.size} file{allFiles.size !== 1 ? 's' : ''} total
       </p>
+
+      {fullDiffOpen && (
+        <FileViewer
+          runId={runId}
+          defaultTab="diff"
+          onClose={() => { setFullDiffOpen(false); fullDiffBtnRef.current?.focus(); }}
+          onUnsupported={() => {
+            setFullDiffOpen(false);
+            setFullDiffUnsupported(true);
+            fullDiffBtnRef.current?.focus();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/viewer/colorize.ts
+++ b/src/viewer/colorize.ts
@@ -1,0 +1,84 @@
+/**
+ * Zero-dependency diff/file colorizers for the in-studio viewer
+ * (DES-FEEDBACK-002 §3.5 — the §2.3 precedent: NO grammar library ships).
+ *
+ * Two pure string passes, nothing else:
+ *
+ *  1. `classifyDiff` — a STATEFUL unified-diff line classifier. State matters:
+ *     inside a hunk, content lines start with exactly one of `+`/`-`/` `/`\`,
+ *     so an added line whose own text begins `++ …` renders as `+++ …` in the
+ *     diff and must classify as an ADDITION, never as a `+++ b/…` file header.
+ *     Headers are only legal BETWEEN `diff --git` and the first `@@`.
+ *
+ *  2. `isDimLine` — the file-view comment dimmer: separates prose from code
+ *     (~80% of readability) without pretending to tokenize any language; an
+ *     unrecognized language degrades to plain mono, never mis-colors.
+ *
+ * The classifier emits KINDS; the CSS maps kinds to tokens (EC15 — the diff
+ * colors ARE the status layer: added = --status-run family, removed =
+ * --status-fail family, hunk headers --ink-dim on --surface-raised).
+ */
+
+export type DiffLineKind = 'add' | 'del' | 'hunk' | 'file' | 'meta' | 'ctx';
+
+export interface DiffLine {
+  kind: DiffLineKind;
+  text: string;
+}
+
+/** Header/metadata lines legal only OUTSIDE hunks (git's extended headers). */
+const HEADER_META = /^(index |old mode|new mode|new file mode|deleted file mode|similarity index|dissimilarity index|rename from|rename to|copy from|copy to|Binary files )/;
+
+/**
+ * Classify every line of a unified `git diff` for token-mapped rendering.
+ * Pure: string in, kinds out — no DOM, no colors, no dependencies.
+ */
+export function classifyDiff(diff: string): DiffLine[] {
+  if (diff === '') return [];
+  const out: DiffLine[] = [];
+  let inHunk = false;
+  for (const text of diff.split('\n')) {
+    let kind: DiffLineKind;
+    if (text.startsWith('diff --git ')) {
+      // A new file section: header territory until its first @@.
+      inHunk = false;
+      kind = 'file';
+    } else if (text.startsWith('@@')) {
+      inHunk = true;
+      kind = 'hunk';
+    } else if (!inHunk) {
+      if (text.startsWith('--- ') || text.startsWith('+++ ')) kind = 'file';
+      else if (HEADER_META.test(text)) kind = 'meta';
+      else kind = 'ctx';
+    } else if (text.startsWith('+')) {
+      kind = 'add';
+    } else if (text.startsWith('-')) {
+      kind = 'del';
+    } else if (text.startsWith('\\')) {
+      // "\ No newline at end of file"
+      kind = 'meta';
+    } else {
+      kind = 'ctx';
+    }
+    out.push({ kind, text });
+  }
+  return out;
+}
+
+/**
+ * File-view comment dimmer (§3.5 item 2): line comments and block-comment
+ * lines render `--ink-dim`; everything else `--ink-body`. Deliberately NOT
+ * syntax highlighting — a line this misses just stays body-colored.
+ */
+export function isDimLine(line: string): boolean {
+  const t = line.trimStart();
+  return (
+    t.startsWith('//') ||
+    t.startsWith('#') ||
+    t.startsWith('/*') ||
+    t.startsWith('*/') ||
+    t.startsWith('* ') ||
+    t === '*' ||
+    t.startsWith('<!--')
+  );
+}

--- a/tests/FileViewer.test.tsx
+++ b/tests/FileViewer.test.tsx
@@ -1,0 +1,131 @@
+// Unit tests: FileViewer honest states (DES-FEEDBACK-002 §3.4/§3.7, slice I) —
+// text with line numbers, binary (no mojibake), truncation banners, the error
+// ladder surfaced VERBATIM (403/409), the route-absent-404 fallback, and the
+// gesture-gated fetches (no prefetch; the inactive tab never fetches).
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FileViewer } from '../src/components/FileViewer.js';
+import * as client from '../src/api/client.js';
+
+const PATH = '/work/src/foo.ts';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('FileViewer — File tab states', () => {
+  it('renders mono content with line numbers; the Diff tab does NOT fetch until activated', async () => {
+    const getRunFile = vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: PATH, content: 'line one\n// a comment\nline three', size: 32,
+      truncated: false, binary: false,
+    });
+    const getRunDiff = vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({ diff: '', truncated: false });
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={() => {}} />);
+
+    expect(await screen.findByText('line one')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument(); // the third line number
+    expect(getRunFile).toHaveBeenCalledExactlyOnceWith('r-1', PATH);
+    expect(getRunDiff).not.toHaveBeenCalled(); // inactive tab: no fetch
+
+    // Switching IS the gesture — now the diff fetch fires, narrowed to the path.
+    fireEvent.click(screen.getByTestId('viewer-tab-diff'));
+    expect(await screen.findByText('no changes to this file.')).toBeInTheDocument();
+    expect(getRunDiff).toHaveBeenCalledExactlyOnceWith('r-1', PATH);
+  });
+
+  it('binary: honest label with the byte size, never the (empty) content', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: PATH, content: '', size: 20480, truncated: false, binary: true,
+    });
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={() => {}} />);
+
+    const pane = await screen.findByTestId('viewer-binary');
+    expect(pane).toHaveTextContent('binary file — 20.0 KB');
+    expect(screen.getByRole('button', { name: /open externally$/i })).toBeInTheDocument();
+  });
+
+  it('truncated: a labeled banner names the cap and the FULL size', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: PATH, content: 'first half…', size: 700 * 1024, truncated: true, binary: false,
+    });
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={() => {}} />);
+
+    const banner = await screen.findByTestId('viewer-truncation-banner');
+    expect(banner).toHaveTextContent('showing first 512 KB — open externally for the full file (700.0 KB total)');
+    expect(screen.getByText('first half…')).toBeInTheDocument(); // content still shown
+  });
+
+  it('403: the route error surfaces VERBATIM, never swallowed', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error(
+      "API 403: path is outside every allowed root (the run's workdir/write roots and the registered repos)",
+    ));
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={() => {}} />);
+
+    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(
+      "API 403: path is outside every allowed root (the run's workdir/write roots and the registered repos)",
+    );
+  });
+
+  it('route-absent 404 ("Not Found", unnamed) calls onUnsupported instead of rendering a shell', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error('API 404: Not Found'));
+    const onUnsupported = vi.fn();
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={onUnsupported} />);
+
+    await vi.waitFor(() => expect(onUnsupported).toHaveBeenCalledOnce());
+    expect(screen.queryByTestId('viewer-error')).not.toBeInTheDocument();
+  });
+
+  it('a NAMED 404 (real answer from a daemon WITH the route) surfaces verbatim', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error(`API 404: no such file: ${PATH}`));
+    const onUnsupported = vi.fn();
+    render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={onUnsupported} />);
+
+    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(`API 404: no such file: ${PATH}`);
+    expect(onUnsupported).not.toHaveBeenCalled();
+  });
+});
+
+describe('FileViewer — Diff tab states', () => {
+  it('409 (workdir reaped): honest, verbatim', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new Error(
+      "API 409: run r-1's workdir no longer exists: /tmp/wt",
+    ));
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(
+      "API 409: run r-1's workdir no longer exists: /tmp/wt",
+    );
+  });
+
+  it('colors added/removed/hunk lines from the classifier and banners diff truncation', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({
+      diff: 'diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n ctx\n-removed\n+added',
+      truncated: true,
+    });
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    expect(await screen.findByTestId('diff-line-add')).toHaveTextContent('+added');
+    expect(screen.getByTestId('diff-line-del')).toHaveTextContent('-removed');
+    expect(screen.getByTestId('diff-line-hunk')).toHaveTextContent('@@ -1,2 +1,2 @@');
+    expect(screen.getByTestId('viewer-truncation-banner')).toHaveTextContent(
+      'diff truncated at 1 MB — narrow to a single file for the rest',
+    );
+  });
+
+  it('a clean tree ({diff:""}) is a real answer, not an error', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({ diff: '', truncated: false });
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    expect(await screen.findByTestId('viewer-clean-tree')).toHaveTextContent('clean tree — no changes.');
+    expect(screen.queryByTestId('viewer-error')).not.toBeInTheDocument();
+  });
+
+  it('with no path there is no File tab and no open/copy affordance', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({ diff: '', truncated: false });
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    await screen.findByTestId('viewer-clean-tree');
+    expect(screen.queryByTestId('viewer-tab-file')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Open externally/ })).not.toBeInTheDocument();
+  });
+});

--- a/tests/RightPanel.files.test.tsx
+++ b/tests/RightPanel.files.test.tsx
@@ -33,25 +33,44 @@ beforeEach(() => {
 async function renderFilesTab(): Promise<HTMLElement> {
   render(<RightPanel view={seededView()} />);
   fireEvent.click(screen.getByRole('button', { name: /files/i }));
-  return await screen.findByTitle(`Open with system default app: ${FILE}`);
+  // The row itself is the VIEW affordance now (slice I, DES-FEEDBACK-002 §3.4).
+  return await screen.findByTitle(`View ${FILE}`);
 }
 
-describe('RightPanel Files tab — open with the system default app (crew#273)', () => {
-  it('clicking a file asks the daemon to open it with the OS default application', async () => {
+describe('RightPanel Files tab — slice I inline viewer + preserved openPath/copy', () => {
+  it('clicking a file row opens the INLINE viewer (no external-open call)', async () => {
     const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
+    const getRunFile = vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: FILE, content: 'hello\nworld', size: 11, truncated: false, binary: false,
+    });
     const row = await renderFilesTab();
 
+    // Nothing fetched before the gesture (no prefetch on panel mount).
+    expect(getRunFile).not.toHaveBeenCalled();
+
     fireEvent.click(row);
+    expect(await screen.findByTestId('file-viewer')).toBeInTheDocument();
+    // A referenced-only file defaults to the File tab → the content fetch fires.
+    expect(await screen.findByText('hello')).toBeInTheDocument();
+    expect(getRunFile).toHaveBeenCalledWith('run-1', FILE);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('the hover ↗ icon still asks the daemon to open externally (crew#273 preserved)', async () => {
+    const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
+    await renderFilesTab();
+
+    fireEvent.click(screen.getByRole('button', { name: `Open externally: ${FILE}` }));
     expect(openPath).toHaveBeenCalledWith(FILE, 'run-1');
     expect(await screen.findByText('✓ opened')).toBeInTheDocument();
     expect(writeText).not.toHaveBeenCalled();
   });
 
-  it('falls back to copying the path when the daemon has no /open route', async () => {
+  it('↗ falls back to copying the path when the daemon has no /open route', async () => {
     vi.spyOn(client.api, 'openPath').mockRejectedValue(new Error('API 404: Not Found'));
-    const row = await renderFilesTab();
+    await renderFilesTab();
 
-    fireEvent.click(row);
+    fireEvent.click(screen.getByRole('button', { name: `Open externally: ${FILE}` }));
     expect(await screen.findByText(/open unavailable — path copied/)).toBeInTheDocument();
     expect(writeText).toHaveBeenCalledWith(FILE);
   });
@@ -64,5 +83,47 @@ describe('RightPanel Files tab — open with the system default app (crew#273)',
     expect(await screen.findByText('✓ copied')).toBeInTheDocument();
     expect(writeText).toHaveBeenCalledWith(FILE);
     expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('a daemon WITHOUT the file routes (generic 404): the row click falls back to the external open', async () => {
+    // Fastify's route-absent 404 carries no named error — exactly "Not Found".
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error('API 404: Not Found'));
+    const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
+    const row = await renderFilesTab();
+
+    fireEvent.click(row);
+    // The viewer never renders an empty shell — it closes and today's exact
+    // behavior runs (openPath external launch + feedback).
+    expect(await screen.findByText('✓ opened')).toBeInTheDocument();
+    expect(openPath).toHaveBeenCalledWith(FILE, 'run-1');
+    expect(screen.queryByTestId('file-viewer')).not.toBeInTheDocument();
+  });
+
+  it('Escape closes the viewer and focus returns to the row', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: FILE, content: 'x', size: 1, truncated: false, binary: false,
+    });
+    const row = await renderFilesTab();
+
+    fireEvent.click(row);
+    await screen.findByTestId('file-viewer');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('file-viewer')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(row);
+  });
+
+  it('the [Full diff] header button opens the viewer on the whole-run diff', async () => {
+    const getRunDiff = vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({
+      diff: 'diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new',
+      truncated: false,
+    });
+    await renderFilesTab();
+
+    expect(getRunDiff).not.toHaveBeenCalled(); // gesture-gated
+    fireEvent.click(screen.getByTestId('files-full-diff'));
+    expect(await screen.findByTestId('file-viewer')).toBeInTheDocument();
+    expect(await screen.findByTestId('diff-line-add')).toHaveTextContent('+new');
+    // Whole-run: NO path argument rides the call.
+    expect(getRunDiff).toHaveBeenCalledWith('run-1', undefined);
   });
 });

--- a/tests/boardModel.test.ts
+++ b/tests/boardModel.test.ts
@@ -51,7 +51,7 @@ describe('interactiveRootOf', () => {
   it('treats an absent, blank, or non-string root as unbound', () => {
     expect(interactiveRootOf(project({ id: 'c' }))).toBeNull();
     expect(interactiveRootOf(project({ id: 'd', interactiveRoot: '   ' }))).toBeNull();
-    expect(interactiveRootOf(project({ id: 'e', interactiveRoot: 42 }))).toBeNull();
+    expect(interactiveRootOf(project({ id: 'e', interactiveRoot: 42 as unknown as string }))).toBeNull();
   });
 });
 

--- a/tests/clientFiles.test.ts
+++ b/tests/clientFiles.test.ts
@@ -1,0 +1,73 @@
+// Unit tests: the two slice-I client calls (DES-FEEDBACK-002 §3.3, crew#305) —
+// exact URLs and params, typed against wicked-crew-api-types 0.7.0.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../src/api/client.js';
+
+function setLocation(url: string): void {
+  Object.defineProperty(window, 'location', {
+    value: new URL(url),
+    writable: true,
+    configurable: true,
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.stubEnv('VITE_API_HOST', '');
+  setLocation('http://127.0.0.1:7788/');
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({}),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+const calledUrl = (): string => String(fetchMock.mock.calls[0][0]);
+
+describe('api.getRunFile — GET /runs/:id/files?path=<absolute>', () => {
+  it('encodes the run id and the path into the query', async () => {
+    await api.getRunFile('r-1', '/work/src/foo.ts');
+    expect(calledUrl()).toBe(
+      'http://127.0.0.1:7788/api/v1/runs/r-1/files?path=%2Fwork%2Fsrc%2Ffoo.ts',
+    );
+  });
+
+  it('percent-encodes hostile characters in both id and path (never a raw ? or &)', async () => {
+    await api.getRunFile('r/../x', '/work/a b&c?.ts');
+    expect(calledUrl()).toBe(
+      'http://127.0.0.1:7788/api/v1/runs/r%2F..%2Fx/files?path=%2Fwork%2Fa%20b%26c%3F.ts',
+    );
+  });
+});
+
+describe('api.getRunDiff — GET /runs/:id/diff[?path=<absolute>]', () => {
+  it('whole-run: no query string at all when path is omitted', async () => {
+    await api.getRunDiff('r-1');
+    expect(calledUrl()).toBe('http://127.0.0.1:7788/api/v1/runs/r-1/diff');
+  });
+
+  it('per-file narrowing: exactly ONE encoded path param', async () => {
+    await api.getRunDiff('r-1', '/work/src/foo.ts');
+    expect(calledUrl()).toBe(
+      'http://127.0.0.1:7788/api/v1/runs/r-1/diff?path=%2Fwork%2Fsrc%2Ffoo.ts',
+    );
+  });
+
+  it('surfaces the route error ladder verbatim (409 workdir-less example)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      text: () => Promise.resolve(JSON.stringify({ error: 'run r-1 has no workdir — nothing to diff' })),
+    });
+    await expect(api.getRunDiff('r-1')).rejects.toThrow(
+      'API 409: run r-1 has no workdir — nothing to diff',
+    );
+  });
+});

--- a/tests/clientFiles.test.ts
+++ b/tests/clientFiles.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const calledUrl = (): string => String(fetchMock.mock.calls[0][0]);
+const calledUrl = (): string => String(fetchMock.mock.calls[0]?.[0]);
 
 describe('api.getRunFile — GET /runs/:id/files?path=<absolute>', () => {
   it('encodes the run id and the path into the query', async () => {

--- a/tests/colorize.test.ts
+++ b/tests/colorize.test.ts
@@ -1,0 +1,114 @@
+// Unit tests: the zero-dependency diff/file colorizers (DES-FEEDBACK-002 §3.5,
+// slice I). Pure functions — given a unified diff string, the right line KINDS,
+// including the adversarial shapes the classifier must not fumble: `+++`-leading
+// content INSIDE hunks, diff headers, no-newline markers.
+import { describe, expect, it } from 'vitest';
+import { classifyDiff, isDimLine } from '../src/viewer/colorize.js';
+
+const kinds = (diff: string): string[] => classifyDiff(diff).map((l) => l.kind);
+
+describe('classifyDiff — the stateful unified-diff classifier', () => {
+  it('classifies a plain one-hunk git diff', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      'index 1111111..2222222 100644',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -61,6 +61,9 @@ export function x() {',
+      '   const res = await fetch(url);',
+      '-  return res;',
+      '+  return res.json();',
+    ].join('\n');
+    expect(kinds(diff)).toEqual(['file', 'meta', 'file', 'file', 'hunk', 'ctx', 'del', 'add']);
+  });
+
+  it('ADVERSARIAL: a line starting "+++" INSIDE a hunk is an addition, not a header', () => {
+    // An added content line that itself begins "++ …" renders as "+++ …".
+    const diff = [
+      'diff --git a/notes.md b/notes.md',
+      '--- a/notes.md',
+      '+++ b/notes.md',
+      '@@ -1,2 +1,4 @@',
+      ' context',
+      '+++ this added line starts with plus-plus',
+      '--- this REMOVED line starts with dash-dash',
+      '+diff --git is fine as content too? no: leading + wins',
+    ].join('\n');
+    expect(kinds(diff)).toEqual(['file', 'file', 'file', 'hunk', 'ctx', 'add', 'del', 'add']);
+  });
+
+  it('ADVERSARIAL: "diff --git" as a NEW section resets hunk state', () => {
+    const diff = [
+      'diff --git a/a b/a',
+      '@@ -1 +1 @@',
+      '+x',
+      'diff --git a/b b/b',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/b',
+      '@@ -0,0 +1 @@',
+      '+y',
+    ].join('\n');
+    expect(kinds(diff)).toEqual(
+      ['file', 'hunk', 'add', 'file', 'meta', 'file', 'file', 'hunk', 'add'],
+    );
+  });
+
+  it('the no-newline marker is metadata, never a removal', () => {
+    const diff = [
+      'diff --git a/a b/a',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '\\ No newline at end of file',
+    ].join('\n');
+    expect(kinds(diff)).toEqual(['file', 'hunk', 'del', 'add', 'meta']);
+  });
+
+  it('a header-block "--- a/…" line is a file header, not a deletion', () => {
+    const diff = ['diff --git a/f b/f', '--- a/f', '+++ b/f', '@@ -1 +1 @@', '-gone'].join('\n');
+    const lines = classifyDiff(diff);
+    expect(lines[1].kind).toBe('file');
+    expect(lines[4].kind).toBe('del');
+  });
+
+  it('binary-file notices and rename headers classify as metadata', () => {
+    const diff = [
+      'diff --git a/img.png b/img.png',
+      'similarity index 100%',
+      'rename from img.png',
+      'rename to assets/img.png',
+      'Binary files a/img.png and b/img.png differ',
+    ].join('\n');
+    expect(kinds(diff)).toEqual(['file', 'meta', 'meta', 'meta', 'meta']);
+  });
+
+  it('an empty diff (clean tree) classifies to nothing', () => {
+    expect(classifyDiff('')).toEqual([]);
+  });
+
+  it('preserves every line verbatim (text is never rewritten)', () => {
+    const diff = 'diff --git a/a b/a\n@@ -1 +1 @@\n+  spaced   text  ';
+    expect(classifyDiff(diff).map((l) => l.text)).toEqual([
+      'diff --git a/a b/a', '@@ -1 +1 @@', '+  spaced   text  ',
+    ]);
+  });
+});
+
+describe('isDimLine — the comment dimmer (NOT syntax highlighting)', () => {
+  it('dims line comments and block-comment lines', () => {
+    expect(isDimLine('// a comment')).toBe(true);
+    expect(isDimLine('  # python-style')).toBe(true);
+    expect(isDimLine('/* block open')).toBe(true);
+    expect(isDimLine(' * block middle')).toBe(true);
+    expect(isDimLine(' */')).toBe(true);
+    expect(isDimLine('<!-- html -->')).toBe(true);
+  });
+
+  it('leaves code lines body-colored', () => {
+    expect(isDimLine('const x = 1;')).toBe(false);
+    expect(isDimLine('a #= weird-but-code')).toBe(false);
+    expect(isDimLine('x *= 2')).toBe(false);
+    expect(isDimLine('')).toBe(false);
+  });
+});

--- a/tests/colorize.test.ts
+++ b/tests/colorize.test.ts
@@ -68,8 +68,8 @@ describe('classifyDiff — the stateful unified-diff classifier', () => {
   it('a header-block "--- a/…" line is a file header, not a deletion', () => {
     const diff = ['diff --git a/f b/f', '--- a/f', '+++ b/f', '@@ -1 +1 @@', '-gone'].join('\n');
     const lines = classifyDiff(diff);
-    expect(lines[1].kind).toBe('file');
-    expect(lines[4].kind).toBe('del');
+    expect(lines[1]?.kind).toBe('file');
+    expect(lines[4]?.kind).toBe('del');
   });
 
   it('binary-file notices and rename headers classify as metadata', () => {


### PR DESCRIPTION
Round-3 operator feedback, P0-3: *"An FDE reviewing an agent run needs an in-studio diff/syntax viewer to inspect what changed without context-switching to an external editor."* Backend landed in wicked-crew#305; `wicked-crew-api-types` 0.7.0 published.

## What changed (design: `.product/DES-FEEDBACK-002.md` §3)

- **FileViewer overlay** with File and Diff tabs: mono content with unselectable dimmed line numbers; diff lines token-tinted (add `--status-run`, del `--status-fail`, hunk headers dim on raised) via a **zero-dependency stateful unified-diff classifier** — headers are only legal between `diff --git` and the first `@@`, so `+++`/`---` lines *inside* hunks classify as content, proven against a diff-of-a-diff.
- **Honest states everywhere**: binary ("binary file — N bytes", never mojibake), truncation banners naming the cap and the full size, the route's 400/403/404/409/507 errors surfaced **verbatim**, clean tree as a real answer.
- **Gesture-gated**: zero prefetch — a row click fetches exactly that file's diff; tab activation fetches the file once; `[Full diff]` fetches the whole-run diff.
- **Graceful degradation**: against a daemon that predates the routes (Fastify default 404 detected by its exact body), the row falls back to today's `openPath` behavior; ↗ open-externally and copy stay as row affordances.

## Verification highlights

The adversarial verifier drove the built UI **against the live daemon** on a real historical run: zero viewer requests until gesture, exactly one path-scoped diff per row click, the run's real worktree diff rendered with correct token colors, and a live `/etc/passwd` probe returning the exact verbatim 403 the UI renders. Fixture routes are field-identical to crew main including byte-identical error strings. Colorizer survived five hostile cases (diff-of-a-diff, CRLF, mid-hunk truncation, section resets, no-newline markers). Rig fails on origin/main. Only dependency change: api-types `^0.5.1`→`^0.7.0`.

## Gates

eslint clean · tsc clean · vitest **1072/1072** · new rig `feedback2_sliceI_test.py` (11 steps, ×3 green) + `feedback2_sliceG`, `feedback2_sliceH`, `feedback_sliceD` all PASS. DES-FEEDBACK-003 §8.6 confirms this slice is unaffected by the round-4 supersessions.

Shots: `feedback2-I-diff-view.png`, `feedback2-I-file-truncated.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)