### PR TITLE
Slice M: five-path accordion rail — Projects / Make / Chat / Repositories / Settings (DES-FEEDBACK-003 §1–§3)

### DIFF
--- a/e2e/feedback3_sliceM_test.py
+++ b/e2e/feedback3_sliceM_test.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""
+feedback3_sliceM_test.py — the DES-FEEDBACK-003 slice-M gate: the five-path
+accordion rail (§1–§3), against the shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py) with the repo switch ON so the Repositories accordion and
+the palette corpus have a real row.
+
+The slice DOM ACs, verbatim from §3.6:
+
+  1. `[data-testid="rail-heading-projects|make|chat|repos|settings"]` all
+     render; settings' row contains NO `heading-dashboard`/`heading-new`
+     child; the other four contain both.
+  2. At most one `[data-testid^="rail-heading-"]` has `aria-expanded="true"`
+     at any time — asserted after clicking two different titles in sequence
+     (EC26).
+  3. Clicking Make's title expands it (chevron rotates, contents render);
+     clicking it again collapses (zero open — legal).
+  4. On load at `/p/q3-review-deck/build`, Projects is expanded and no other;
+     on load at `/`, none.
+  5. Projects' ▦ is an `<a href="/projects">`; Make's ▦ → `/make` (and lands
+     on a real page, never a 404); each ＋ fires its §2.1 action (Make's opens
+     `[data-testid="make-picker"]` with exactly 3 rows).
+  6. The old testids `rail-quick`, `rail-actions`, `rail-runs`,
+     `rail-settings-section` are ABSENT from the DOM (supersession, §8.1).
+  7. Repositories expansion fires at most one `GET /repos` (cold cache), and
+     NO interval poll exists (grep: no `setInterval` in LeftSidebar.tsx).
+  8. Collapsed rail shows exactly 5 glyph links; entering `/p/x/document`
+     auto-collapses (slice-F behavior preserved).
+
+Plus the standing constraints: the RAIL adds zero `GET /repos` outside the
+expand gesture (the board's own mount fetches are the board's — counted from
+a settled page, the idle window must stay at zero),
+the palette corpus still full after the rail data moved (its project/repo
+sources ride the shared stores/cache — §8.4 untouched), and the §3.2
+mid-territory rule: a manual collapse survives moves between one project's
+modes.
+
+Captures (§10.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback3-M-rail-headings.png   five headings, Make expanded, W2 fixture
+  feedback3-M-make-picker.png     the ＋ popover open, 3 rows
+  feedback3-M-rail-collapsed.png  the 48px glyph column
+
+Finally: `npm run lint` must exit 0 with zero raw-color findings (EC15 is
+ERROR repo-wide).
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK3_PORT (default 4361),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK3_PORT = int(os.environ.get("FEEDBACK3_PORT", "4361"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK3_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+HEADING_KEYS = ["projects", "make", "chat", "repos", "settings"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server; repo switch ON (a row for the accordion) ──
+start_server(FEEDBACK3_PORT, dist)
+set_fixture(ORIGIN, repo=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+repo_gets: list[str] = []
+
+EXPANDED = """() => Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+    .filter(h => h.getAttribute('aria-expanded') === 'true')
+    .map(h => h.dataset.testid.replace('rail-heading-', ''))"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda r: repo_gets.append(r.url)
+            if r.method == "GET" and r.url.endswith("/api/v1/repos") else None)
+
+    # Freeze Date.now at NOW0 + 5s BEFORE the app boots so every rendered age
+    # is deterministic in the captures.
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    def expanded() -> list:
+        return page.evaluate(EXPANDED)
+
+    # ── AC 4b + 1 + 6: load at `/` — five closed headings, anatomy, supersession ─
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="left-rail"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    dom = page.evaluate(
+        """keys => {
+             const q = s => document.querySelector(s);
+             const anatomy = {};
+             for (const k of keys) {
+               const h = q(`[data-testid="rail-heading-${k}"]`);
+               anatomy[k] = h === null ? null : {
+                 dash: h.querySelector('[data-testid="heading-dashboard"]')?.getAttribute('href') ?? null,
+                 plus: !!h.querySelector('[data-testid="heading-new"]'),
+                 expanded: h.getAttribute('aria-expanded'),
+               };
+             }
+             return {
+               anatomy,
+               headingOrder: Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+                 .map(h => h.dataset.testid.replace('rail-heading-', '')),
+               // §8.1 supersession: the slice-A zones are GONE from the DOM.
+               quick: !!q('[data-testid="rail-quick"]'),
+               actions: !!q('[data-testid="rail-actions"]'),
+               runs: !!q('[data-testid="rail-runs"]'),
+               settingsSection: !!q('[data-testid="rail-settings-section"]'),
+               // §6.1/§8.2 preserved: bell + chrome anatomy untouched.
+               bell: !!q('[aria-label="Notifications"], [aria-label$="notifications"]'),
+               logoSlot: !!q('[data-testid="logo-slot"]'),
+               connectionDot: q('[data-testid="connection-dot"]')?.dataset.state ?? null,
+             }; }""",
+        HEADING_KEYS,
+    )
+    a = dom["anatomy"]
+    anatomy_ok = (
+        all(a[k] is not None for k in HEADING_KEYS)
+        and a["projects"]["dash"] == "/projects" and a["projects"]["plus"]
+        and a["make"]["dash"] == "/make" and a["make"]["plus"]
+        and a["chat"]["dash"] == "/chats" and a["chat"]["plus"]
+        and a["repos"]["dash"] == "/repos" and a["repos"]["plus"]
+        and a["settings"]["dash"] is None and not a["settings"]["plus"]
+        and dom["headingOrder"] == HEADING_KEYS
+    )
+    none_open_on_home = all(a[k]["expanded"] == "false" for k in HEADING_KEYS)
+    superseded_ok = not (dom["quick"] or dom["actions"] or dom["runs"] or dom["settingsSection"])
+    preserved_ok = dom["bell"] and dom["logoSlot"] and dom["connectionDot"] == "connected"
+    # Page-wide GETs at this point belong to the BOARD (App.tsx ws bootstrap +
+    # useBoardModel's repo join — pre-existing, not the rail's); the rail's own
+    # gesture rule is pinned below (AC 7: zero during idle, ≤1 on expand).
+    mount_repo_gets_page_wide = len(repo_gets)
+
+    # ── AC 3 + 2 (EC26): title clicks — expand, exclusivity, zero-open ─────────
+    page.locator('[data-testid="rail-title-make"]').click()
+    make_expands = settled(
+        """() => { const h = document.querySelector('[data-testid="rail-heading-make"]');
+                   const c = h?.querySelector('[data-testid="rail-chevron"]');
+                   return h?.getAttribute('aria-expanded') === 'true'
+                       && !!c && getComputedStyle(c).transform !== 'none'; }""",
+        timeout=5000,
+    )
+    make_only = expanded() == ["make"]
+
+    # ── Capture 1: five headings, Make expanded, W2 fixture ────────────────────
+    page.locator('[data-testid="left-rail"]').screenshot(
+        path=str(VSHOTS / "feedback3-M-rail-headings.png"))
+
+    page.locator('[data-testid="rail-title-projects"]').click()
+    projects_only = settled(
+        """() => { const open = Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+                     .filter(h => h.getAttribute('aria-expanded') === 'true');
+                   return open.length === 1
+                       && open[0].dataset.testid === 'rail-heading-projects'; }""",
+        timeout=5000,
+    )
+    # Projects' accordion carries the board-ordered rows (C3: reads, never re-sorts).
+    projects_rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+             '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
+             .map(r => r.dataset.projectId)""")
+    projects_rows_ok = projects_rows[:4] == [
+        "q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"] and len(projects_rows) <= 6
+
+    page.locator('[data-testid="rail-title-projects"]').click()
+    zero_open_ok = settled(
+        """() => Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+              .every(h => h.getAttribute('aria-expanded') === 'false')""",
+        timeout=5000,
+    )
+
+    # ── AC 5: the ＋ actions ────────────────────────────────────────────────────
+    # Projects ＋ → the slice-A NewProjectModal, unchanged.
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="heading-new"]').click()
+    modal_ok = settled("""() => !!document.querySelector('[data-testid="new-project-modal"]')""", timeout=5000)
+    page.keyboard.press("Escape")
+    modal_closes = settled("""() => !document.querySelector('[data-testid="new-project-modal"]')""", timeout=5000)
+
+    # Make ＋ → the three-way picker (MODE_SPECS vocabulary, §3.4).
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-new"]').click()
+    picker_opens = settled("""() => !!document.querySelector('[data-testid="make-picker"]')""", timeout=5000)
+    picker = page.evaluate(
+        """() => { const rows = Array.from(document.querySelectorAll(
+                     '[data-testid="make-picker"] [data-testid="make-picker-row"]'));
+                   return { count: rows.length,
+                            modes: rows.map(r => r.dataset.mode),
+                            text: rows.map(r => r.textContent) }; }""")
+    picker_ok = (picker_opens and picker["count"] == 3
+                 and picker["modes"] == ["build", "document", "video"]
+                 and all(g in "".join(picker["text"]) for g in ("⚙", "▤", "▶")))
+
+    # ── Capture 2: the ＋ popover open, 3 rows ─────────────────────────────────
+    page.locator('[data-testid="left-rail"]').screenshot(
+        path=str(VSHOTS / "feedback3-M-make-picker.png"))
+
+    # Build tine → the unbound launch form (slice B semantics).
+    page.locator('[data-testid="make-picker-row"][data-mode="build"]').click()
+    build_tine_ok = settled(
+        """() => window.location.pathname === '/runs/new'
+              && !document.querySelector('[data-testid="make-picker"]')""")
+
+    # Chat ＋ → /chat/new; Repositories ＋ → /repos/new (existing create routes).
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-heading-chat"] [data-testid="heading-new"]').click()
+    chat_plus_ok = settled("""() => window.location.pathname === '/chat/new'""")
+    chat_territory_ok = expanded() == ["chat"]  # /chat/new is Chat's territory (§3.2)
+    page.locator('[data-testid="rail-heading-repos"] [data-testid="heading-new"]').click()
+    repos_plus_ok = settled("""() => window.location.pathname === '/repos/new'""")
+
+    # ── AC 5 (▦): Make's ▦ lands on a real /make page — never a 404 ────────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-dashboard"]').click()
+    make_dash_ok = settled(
+        """() => window.location.pathname === '/make'
+              && !!document.querySelector('[data-testid="make-placeholder"]')""")
+    make_dash_territory_ok = expanded() == ["make"]
+
+    # ── AC 7: fetch-on-expand, at most one GET /repos, no poll ─────────────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-heading-repos"]').wait_for(timeout=30000)
+    # Let the BOARD's own mount fetches (its repo join) land before counting:
+    # the rail's discipline is measured from a settled page.
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.wait_for_timeout(1500)
+    repo_gets.clear()
+    page.wait_for_timeout(6000)  # longer than the retired 5s poll interval
+    gets_before_gesture = len(repo_gets)
+    page.locator('[data-testid="rail-title-repos"]').click()
+    repo_row_ok = settled(
+        """() => document.querySelectorAll(
+             '[data-testid="rail-heading-repos"] [data-testid="rail-repo"]').length === 1""",
+        timeout=10000,
+    )
+    # Collapse and re-expand: the session cache is warm — no second GET.
+    page.locator('[data-testid="rail-title-repos"]').click()
+    page.locator('[data-testid="rail-title-repos"]').click()
+    page.wait_for_timeout(500)
+    gets_after_gestures = len(repo_gets)
+    repos_fetch_ok = gets_before_gesture == 0 and gets_after_gestures <= 1
+    no_interval = "setInterval" not in (REPO / "src" / "components" / "LeftSidebar.tsx").read_text()
+
+    # The palette corpus still opens FULL (§8.4: sources ride the shared
+    # stores/cache the rail now shares — one gesture warmed both).
+    page.keyboard.press("Control+k")
+    palette_ok = settled("""() => !!document.querySelector('[data-testid="command-palette"]')""", timeout=5000)
+    page.locator('[data-testid="palette-input"]').fill("studio-api")
+    palette_repo_ok = settled(
+        """() => Array.from(document.querySelectorAll('[data-testid="palette-row"]'))
+              .some(r => (r.textContent ?? '').includes('studio-api'))""", timeout=5000)
+    page.locator('[data-testid="palette-input"]').fill("q3-review")
+    palette_project_ok = settled(
+        """() => Array.from(document.querySelectorAll('[data-testid="palette-row"]'))
+              .some(r => (r.textContent ?? '').includes('q3-review-deck'))""", timeout=5000)
+    palette_no_new_get = len(repo_gets) <= 1  # the palette reused the rail's warm cache
+    page.keyboard.press("Escape")
+
+    # ── AC 4a: deep-link default — /p/*/build expands Projects and no other ────
+    page.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
+    deep_link_ok = settled(
+        """() => { const open = Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+                     .filter(h => h.getAttribute('aria-expanded') === 'true');
+                   return open.length === 1
+                       && open[0].dataset.testid === 'rail-heading-projects'; }""",
+        timeout=10000,
+    )
+    # §3.2: a manual collapse survives moves WITHIN the project's territory.
+    page.locator('[data-testid="rail-title-projects"]').click()
+    page.locator('[data-testid="mode-tab-chat"]').click()
+    page.locator('[data-testid="mode-surface"][data-mode="chat"]').wait_for(timeout=15000)
+    stays_collapsed_ok = expanded() == []
+
+    # ── AC 8: collapsed rail — exactly 5 glyph links; immersive auto-collapse ──
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="left-rail"]').wait_for(timeout=30000)
+    page.mouse.move(720, 450)  # park mid-board: no hover-peek while measured
+    page.locator('[aria-label="Collapse sidebar"]').click()
+    glyphs = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="rail-collapsed-glyph"]'))
+              .map(g => g.getAttribute('href'))""")
+    collapsed_ok = glyphs == ["/projects", "/make", "/chats", "/repos", "/system"]
+
+    # ── Capture 3: the 48px glyph column ───────────────────────────────────────
+    page.locator('[data-testid="left-rail"]').screenshot(
+        path=str(VSHOTS / "feedback3-M-rail-collapsed.png"))
+
+    # Slice F preserved: entering Document auto-collapses the (re-expanded) rail.
+    page.locator('[aria-label="Expand sidebar"]').click()
+    page.goto(f"{ORIGIN}/p/q3-review-deck/document", wait_until="domcontentloaded")
+    page.mouse.move(720, 450)
+    immersive_ok = settled(
+        """() => { const r = document.querySelector('[data-testid="left-rail"]');
+                   return !!r && r.getBoundingClientRect().width < 80; }""",
+        timeout=15000,
+    )
+
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([
+        fonts_ok, anatomy_ok, none_open_on_home, superseded_ok, preserved_ok,
+        make_expands, make_only, projects_only,
+        projects_rows_ok, zero_open_ok, modal_ok, modal_closes, picker_ok,
+        build_tine_ok, chat_plus_ok, chat_territory_ok, repos_plus_ok,
+        make_dash_ok, make_dash_territory_ok, repo_row_ok, repos_fetch_ok,
+        no_interval, palette_ok, palette_repo_ok, palette_project_ok,
+        palette_no_new_get, deep_link_ok, stays_collapsed_ok, collapsed_ok,
+        immersive_ok,
+    ]),
+    "web_fonts_loaded": fonts_ok,
+    "ac1_heading_anatomy": dom["anatomy"],
+    "ac1_anatomy_ok": anatomy_ok,
+    "heading_order": dom["headingOrder"],
+    "ac4_none_open_on_home": none_open_on_home,
+    "ac6_superseded_testids_absent": superseded_ok,
+    "preserved_bell_chrome": preserved_ok,
+    "repo_gets_on_mount_page_wide_board_owned": mount_repo_gets_page_wide,
+    "ac3_make_expands_chevron_rotates": make_expands,
+    "ac2_make_only_open": make_only,
+    "ac2_projects_collapses_make": projects_only,
+    "projects_accordion_rows": projects_rows,
+    "projects_rows_board_ordered": projects_rows_ok,
+    "ac3_again_click_zero_open": zero_open_ok,
+    "ac5_projects_plus_modal": modal_ok and modal_closes,
+    "ac5_make_picker": picker,
+    "ac5_make_picker_ok": picker_ok,
+    "ac5_build_tine_lands_launch_form": build_tine_ok,
+    "ac5_chat_plus_lands_chat_new": chat_plus_ok,
+    "chat_new_is_chat_territory": chat_territory_ok,
+    "ac5_repos_plus_lands_register": repos_plus_ok,
+    "ac5_make_dash_real_page": make_dash_ok,
+    "make_dash_is_make_territory": make_dash_territory_ok,
+    "ac7_repo_row_after_expand": repo_row_ok,
+    "ac7_repo_gets_before_gesture": gets_before_gesture,
+    "ac7_repo_gets_after_gestures": gets_after_gestures,
+    "ac7_no_setinterval_in_rail": no_interval,
+    "palette_opens": palette_ok,
+    "palette_repo_corpus": palette_repo_ok,
+    "palette_project_corpus": palette_project_ok,
+    "palette_reused_warm_cache": palette_no_new_get,
+    "ac4_deep_link_expands_projects_only": deep_link_ok,
+    "manual_collapse_survives_mode_moves": stays_collapsed_ok,
+    "ac8_collapsed_glyph_hrefs": glyphs,
+    "ac8_collapsed_ok": collapsed_ok,
+    "slice_f_immersive_auto_collapse": immersive_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("feedback3-M-rail-headings.png", "feedback3-M-make-picker.png",
+                     "feedback3-M-rail-collapsed.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-M DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0, zero raw-color findings (EC15 error repo-wide) ───
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+raw_color_findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and raw_color_findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings_repo_wide": raw_color_findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero raw-color findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/feedback_sliceA_test.py
+++ b/e2e/feedback_sliceA_test.py
@@ -1,27 +1,35 @@
 #!/usr/bin/env python3
 """
-feedback_sliceA_test.py — the DES-FEEDBACK-001 slice-A gate: the nav
-restructure (§1, §8.3 slice A), against the shared frozen-NOW0 W2 fixture
-(uxfix_fixture.py) — messy reality, so the rail's runs section has real rows.
+feedback_sliceA_test.py — the DES-FEEDBACK-001 slice-A gate, RE-SCOPED by
+DES-FEEDBACK-003 §8.7 (slice M): the rail slice A built (QUICK verbs, inline
+runs, bottom settings section) is superseded by the five-path accordion rail
+(§3), so this rig now pins what slice A's affordances BECAME — never the
+retired zones themselves. Same shared frozen-NOW0 W2 fixture
+(uxfix_fixture.py) — messy reality, so the accordions have real rows.
 
-The slice DOM ACs, verbatim from §8.3:
+The re-scoped ACs (§8.7's amendment row, against §3.6):
 
-  1. `[data-testid="rail-quick"]` header text is "QUICK";
-  2. `[data-testid="new-project"]` button is present and clicking it opens
-     `[data-testid="new-project-modal"]`;
-  3. no `+` glyph is rendered inside `[data-testid="rail-actions"]` (EC20:
-     no "+" character in any child element);
-  4. `[data-testid="rail-settings-section"]` is collapsed by default and
-     expands on click;
-  5. `[data-testid="rail-runs"]` is present and non-empty when runs exist.
+  1. The five heading rows render — `rail-heading-projects|make|chat|repos|
+     settings` — and Settings is icon-less (no `heading-dashboard` /
+     `heading-new` child) while the other four carry both.
+  2. One-open (EC26): clicking two different titles in sequence leaves at
+     most one `[data-testid^="rail-heading-"]` with `aria-expanded="true"`.
+  3. EC20 (amended): no `+` glyph inside accordion CONTENTS — the
+     heading-level ＋ icons are the sanctioned spelling now.
+  4. The settings menuitem list re-asserts inside the Settings ACCORDION:
+     ≥7 menuitems including Theme and System, plus the version line.
+  5. The modal AC carries over: Projects' ＋ opens
+     `[data-testid="new-project-modal"]`, the name fills, Build is the start
+     default, Create enables, Escape closes.
+  6. Supersession: `rail-quick`, `rail-actions`, `rail-runs`,
+     `rail-settings-section` are ABSENT (§8.1).
 
-Plus the §8.3 preservation list: rail project + repo taxonomies unchanged
-(attention order intact), AppChrome connection dot + logo slot unchanged —
-and the chrome gear GONE (§4.4).
+Plus the preservation list carried from slice A: the Projects accordion lists
+the BOARD's attention order (the same axis, C3), AppChrome connection dot +
+logo slot unchanged — and the chrome gear still GONE (§4.4).
 
 Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
-  feedback-A-rail-expanded.png     the full rail: QUICK, runs, projects, repos,
-                                   settings collapsed
+  feedback-A-rail-expanded.png     the five-path rail, Projects expanded
   feedback-A-new-project-modal.png the new-project modal open, name filled
 
 Finally: `npm run lint` must exit 0 with zero raw-color findings (EC15 is
@@ -53,6 +61,7 @@ ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
 EXPECTED_PROJECT_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+HEADING_KEYS = ["projects", "make", "chat", "repos", "settings"]
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -103,81 +112,105 @@ with sync_playwright() as p:
               && document.fonts.check('12px "JetBrains Mono"')""",
         timeout=20000,
     )
-    # Settle: rail projects reach the W2 attention order (preservation) and the
-    # runs section has rows (AC 5's precondition — the fixture always has runs).
-    rail_settled = settled(
+    # Settle: the board reaches the W2 attention order — the Projects accordion
+    # reads the SAME model, so the board settling settles the rail's source.
+    board_settled = settled(
         """expected => { const ids = Array.from(document.querySelectorAll(
-               '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
-               .map(r => r.dataset.projectId);
-             return JSON.stringify(ids) === JSON.stringify(expected)
-                 && document.querySelectorAll('[data-testid="rail-runs"] [data-testid="rail-run"]').length > 0; }""",
+               '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+               .map(c => c.dataset.projectId);
+             return JSON.stringify(ids) === JSON.stringify(expected); }""",
         EXPECTED_PROJECT_ORDER,
     )
 
-    # ── ACs 1/3/5 + preservation, read off the settled DOM in one pass ────────
+    # ── ACs 1/6 + preservation, read off the settled DOM in one pass ──────────
     dom = page.evaluate(
-        """() => {
+        """keys => {
              const q = s => document.querySelector(s);
-             const runs = Array.from(document.querySelectorAll(
-               '[data-testid="rail-runs"] [data-testid="rail-run"]'));
+             const anatomy = {};
+             for (const k of keys) {
+               const h = q(`[data-testid="rail-heading-${k}"]`);
+               anatomy[k] = h === null ? null : {
+                 dash: !!h.querySelector('[data-testid="heading-dashboard"]'),
+                 plus: !!h.querySelector('[data-testid="heading-new"]'),
+               };
+             }
              return {
-               quickHeader: q('[data-testid="rail-quick"]')?.textContent ?? null,
-               actionLabels: Array.from(document.querySelectorAll(
-                 '[data-testid="rail-actions"] button')).map(b => b.getAttribute('aria-label')),
-               actionsText: q('[data-testid="rail-actions"]')?.textContent ?? null,
-               plusInActions: Array.from(q('[data-testid="rail-actions"]')?.querySelectorAll('*') ?? [])
-                 .some(el => (el.textContent ?? '').includes('+')),
-               runsPresent: !!q('[data-testid="rail-runs"]'),
-               runRows: runs.map(r => ({ id: r.dataset.runId, status: r.dataset.status })),
-               allRunsInSection: !!q('[data-testid="rail-runs"] [data-testid="rail-all-runs"]'),
-               settingsOpenDefault: q('[data-testid="rail-settings-section"]')?.dataset.open ?? null,
-               settingsMenuItems: document.querySelectorAll(
-                 '[data-testid="rail-settings-section"] [role="menuitem"]').length,
-               // §8.3 preserved: taxonomies + chrome anatomy (gear GONE, §4.4).
-               projectsSection: !!q('[data-testid="rail-section-projects"]'),
-               reposSection: !!q('[data-testid="rail-section-repos"]'),
+               anatomy,
+               quick: !!q('[data-testid="rail-quick"]'),
+               actions: !!q('[data-testid="rail-actions"]'),
+               runs: !!q('[data-testid="rail-runs"]'),
+               settingsSection: !!q('[data-testid="rail-settings-section"]'),
                logoSlot: !!q('[data-testid="logo-slot"]'),
                connectionDot: q('[data-testid="connection-dot"]')?.dataset.state ?? null,
                chromeGear: !!q('[data-testid="chrome-settings"]'),
-             }; }""")
+             }; }""",
+        HEADING_KEYS,
+    )
+    a = dom["anatomy"]
+    headings_ok = all(a[k] is not None for k in HEADING_KEYS)
+    settings_iconless_ok = headings_ok and not a["settings"]["dash"] and not a["settings"]["plus"]
+    four_icons_ok = headings_ok and all(
+        a[k]["dash"] and a[k]["plus"] for k in ("projects", "make", "chat", "repos"))
+    superseded_ok = not (dom["quick"] or dom["actions"] or dom["runs"] or dom["settingsSection"])
+    preserved_ok = dom["logoSlot"] and dom["connectionDot"] == "connected" and not dom["chromeGear"]
 
-    quick_ok = dom["quickHeader"] == "QUICK"
-    order_ok = dom["actionLabels"] == ["Project", "Build", "Chat", "Repository"]
-    ec20_ok = (not dom["plusInActions"]) and "+" not in (dom["actionsText"] or "")
-    runs_ok = dom["runsPresent"] and len(dom["runRows"]) > 0 and dom["allRunsInSection"]
-    # §1.4 ordering: active rows lead, terminal rows trail.
-    TERMINAL = {"completed", "cancelled", "failed"}
-    statuses = [r["status"] for r in dom["runRows"]]
-    first_terminal = next((i for i, s in enumerate(statuses) if s in TERMINAL), len(statuses))
-    runs_order_ok = all(s in TERMINAL for s in statuses[first_terminal:])
-    preserved_ok = (dom["projectsSection"] and dom["reposSection"] and dom["logoSlot"]
-                    and dom["connectionDot"] == "connected" and not dom["chromeGear"])
+    # ── AC 2 (EC26) + the preserved attention order, via two title clicks ──────
+    page.locator('[data-testid="rail-title-projects"]').click()
+    projects_open = settled(
+        """expected => { const open = Array.from(document.querySelectorAll(
+               '[data-testid^="rail-heading-"]'))
+               .filter(h => h.getAttribute('aria-expanded') === 'true');
+             if (open.length !== 1 || open[0].dataset.testid !== 'rail-heading-projects') return false;
+             const ids = Array.from(document.querySelectorAll(
+               '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
+               .map(r => r.dataset.projectId);
+             return JSON.stringify(ids.slice(0, 4)) === JSON.stringify(expected); }""",
+        EXPECTED_PROJECT_ORDER,
+        timeout=10000,
+    )
 
-    # ── AC 4: settings collapsed by default, expands on click ─────────────────
-    settings_default_collapsed = dom["settingsOpenDefault"] == "false" and dom["settingsMenuItems"] == 0
-
-    # ── Capture 1: the full rail — QUICK, runs, projects, repos, settings
-    #    collapsed — BEFORE any state-mutating interaction. ─────────────────────
+    # ── Capture 1: the five-path rail, Projects expanded ───────────────────────
     page.locator('[data-testid="left-rail"]').screenshot(
         path=str(VSHOTS / "feedback-A-rail-expanded.png"))
 
-    page.locator('[data-testid="rail-settings-toggle"]').click()
-    settings_expands = settled(
-        """() => { const s = document.querySelector('[data-testid="rail-settings-section"]');
-                   return !!s && s.dataset.open === 'true'
-                       && s.querySelectorAll('[role="menuitem"]').length >= 7; }""",
+    # ── AC 4: the settings menuitem list, inside the Settings ACCORDION ────────
+    page.locator('[data-testid="rail-title-settings"]').click()
+    settings_open = settled(
+        """() => { const open = Array.from(document.querySelectorAll(
+                     '[data-testid^="rail-heading-"]'))
+                     .filter(h => h.getAttribute('aria-expanded') === 'true');
+                   return open.length === 1
+                       && open[0].dataset.testid === 'rail-heading-settings'
+                       && open[0].querySelectorAll('[role="menuitem"]').length >= 7; }""",
         timeout=5000,
     )
-    # Both the Theme and the System shortcuts ride the section (§1.2: it carries
-    # what the retired AppChrome dropdown carried).
+    ec26_state = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'))
+              .filter(h => h.getAttribute('aria-expanded') === 'true').length""")
+    ec26_ok = settings_open and ec26_state == 1
     settings_entries = page.evaluate(
         """() => Array.from(document.querySelectorAll(
-             '[data-testid="rail-settings-section"] [role="menuitem"]')).map(b => b.textContent)""")
+             '[data-testid="rail-heading-settings"] [role="menuitem"]')).map(b => b.textContent)""")
     settings_entries_ok = "Theme" in settings_entries and "System" in settings_entries
-    page.locator('[data-testid="rail-settings-toggle"]').click()  # back to collapsed
+    version_line_ok = page.evaluate(
+        """() => /v\\d+\\.\\d+\\.\\d+/.test(document.querySelector(
+             '[data-testid="rail-heading-settings"]')?.textContent ?? '')""")
 
-    # ── AC 2: the Project quick action opens the modal; fill the name ─────────
-    page.locator('[data-testid="new-project"]').click()
+    # ── AC 3 (EC20 amended): no `+` inside the open accordion's CONTENTS ───────
+    # The heading-level ＋ (U+FF0B) is sanctioned; the ASCII `+` glyph must not
+    # ride inside contents. Check the two accordions this page opened.
+    ec20_ok = page.evaluate(
+        """() => { const openIds = ['projects', 'settings'];
+                   return openIds.every(k => {
+                     const h = document.querySelector(`[data-testid="rail-heading-${k}"]`);
+                     const rows = h?.querySelectorAll('[role="menuitem"], [data-testid="rail-project"]') ?? [];
+                     return Array.from(rows).every(r => !(r.textContent ?? '').includes('+'));
+                   }); }""")
+
+    page.locator('[data-testid="rail-title-settings"]').click()  # back to closed
+
+    # ── AC 5: Projects' ＋ opens the modal; fill the name ──────────────────────
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="heading-new"]').click()
     modal_opens = settled(
         """() => !!document.querySelector('[data-testid="new-project-modal"]')""",
         timeout=5000,
@@ -205,32 +238,32 @@ with sync_playwright() as p:
     browser.close()
 
 report["steps"]["dom_acs"] = {
-    "ok": all([fonts_ok, rail_settled, quick_ok, order_ok, ec20_ok, runs_ok,
-               runs_order_ok, settings_default_collapsed, settings_expands,
-               settings_entries_ok, modal_ok, modal_closes, preserved_ok]),
+    "ok": all([fonts_ok, board_settled, headings_ok, settings_iconless_ok,
+               four_icons_ok, superseded_ok, preserved_ok, projects_open,
+               ec26_ok, settings_entries_ok, version_line_ok, ec20_ok,
+               modal_ok, modal_closes]),
     "web_fonts_loaded": fonts_ok,
-    "rail_settled_w2": rail_settled,
-    "ac1_quick_header": quick_ok,
-    "quick_action_order": dom["actionLabels"],
-    "quick_action_order_ok": order_ok,
-    "ac3_ec20_no_plus_in_actions": ec20_ok,
-    "ac5_runs_nonempty": runs_ok,
-    "run_rows": dom["runRows"],
-    "runs_active_before_terminal": runs_order_ok,
-    "ac4_settings_collapsed_default": settings_default_collapsed,
-    "ac4_settings_expands_on_click": settings_expands,
-    "settings_entries": settings_entries,
-    "settings_carries_theme_and_system": settings_entries_ok,
-    "ac2_modal_opens_name_filled": modal_ok,
+    "board_settled_w2": board_settled,
+    "ac1_five_headings": headings_ok,
+    "ac1_settings_iconless": settings_iconless_ok,
+    "ac1_four_headings_carry_both_icons": four_icons_ok,
+    "ac6_superseded_testids_absent": superseded_ok,
+    "preserved_chrome_no_gear": preserved_ok,
+    "projects_accordion_attention_order": projects_open,
+    "ac2_ec26_one_open_after_two_clicks": ec26_ok,
+    "ac4_settings_entries": settings_entries,
+    "ac4_settings_carries_theme_and_system": settings_entries_ok,
+    "ac4_version_line": version_line_ok,
+    "ac3_ec20_no_plus_in_contents": ec20_ok,
+    "ac5_modal_opens_name_filled": modal_ok,
     "modal_closes_on_escape": modal_closes,
-    "preserved_taxonomies_chrome": preserved_ok,
-    "dom": dom,
+    "anatomy": dom["anatomy"],
     "console_errors": console_errors[:10],
     "screenshots": [str(VSHOTS / n) for n in
                     ("feedback-A-rail-expanded.png", "feedback-A-new-project-modal.png")],
 }
 if not report["steps"]["dom_acs"]["ok"]:
-    fail("dom_acs_verdict", "slice-A DOM assertions did not all hold — see dom_acs")
+    fail("dom_acs_verdict", "re-scoped slice-A DOM assertions did not all hold — see dom_acs")
 
 # ── 4. Lint posture: exit 0, zero raw-color findings (EC15 error repo-wide) ───
 r = subprocess.run([NPM, "run", "lint"], cwd=REPO,

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -1,40 +1,45 @@
 #!/usr/bin/env python3
 """
-uxfix_slice3_test.py — the DES-UXFIX-001 slice-3 gate: the rail consolidated to
-TWO taxonomies (§2.3, F4), proven in a real browser against the W2
-messy-reality fixture (§4.2).
+uxfix_slice3_test.py — the DES-UXFIX-001 slice-3 gate, RE-SCOPED by
+DES-FEEDBACK-003 §8.7 (slice M): the standalone rail taxonomies this rig
+pinned (`rail-section-projects` / `rail-section-repos`) folded into the
+five-path accordion's Projects and Repositories headings, and the QUICK verb
+list became the headings' ＋ icons. What slice 3 actually established — the
+rail agrees with the board's attention order, the retired Chats/Work
+vocabulary stays dead, /runs stays reachable, a project row enters the
+project — is re-asserted against the new anatomy. Same rig pattern: the
+SHARED deterministic fixture server in `uxfix_fixture.py`, no switches
+flipped, so it sees the default W2 board (orphan present, 30s q3 gate).
 
-Same rig pattern as the slice-1/2 gates: the SHARED deterministic fixture
-server in `uxfix_fixture.py` serves the `dist-sameorigin/` build plus every
-endpoint the home route reads, all timestamps computed from one frozen NOW0,
-the live run narrating over the rig's own /ws. No crew daemon is involved
-anywhere. This rig never flips the fixture switches, so it sees the default W2
-board (orphan present, 30s q3 gate).
-
-What it asserts (design §4.3, the slice-3 DOM AC):
-  1. The rail contains data-testid="rail-section-projects" AND
-     "rail-section-repos", and NO rail-section-chats / rail-section-work; the
-     retired section labels and their empty strings ("Chats", "Work",
-     "No chats yet", "No work yet") appear nowhere in the rail's text, and the
-     old near-synonym verbs ("Do Work", "New Chat") appear nowhere on the page.
-  2. Projects lists ATTENTION-ORDERED: the rail's rows settle to the same
-     decayed-score order as the board's NEEDS YOU band — q3-review-deck (gate
-     30s) → api-migration (gate 2m) → auth-refactor (failed 12m) →
-     upload-endpoint (live) — capped at SECTION_MAX (4 of the fixture's 28)
-     with a "view all". legacy-spike (8-day failure, the R3 trap) is NOT among
-     them: the rail agrees with the board, read from the same DOM.
-  3. The creation verbs speak the mode spine (V9/V10): Build / Chat /
-     Repository inside data-testid="rail-actions".
-  4. /runs remains reachable via data-testid="rail-all-runs": a real <a
-     href="/runs"> whose click lands the SPA on /runs (the flat-list escape
-     hatch), with the board unmounted.
-  5. A rail project row enters the project — re-scoped by DES-FEEDBACK-001
-     §4.1 (slice D): clicking q3-review-deck lands on the PROJECT DASHBOARD at
-     /p/q3-review-deck (context before actions), not a remembered mode.
+What it asserts (slice-3 DOM ACs, as amended by §8.7):
+  1. The rail carries the Projects and Repositories HEADINGS (and no retired
+     rail-section-chats / rail-section-work, nor the superseded standalone
+     rail-section-projects / rail-section-repos); the retired section labels
+     and their empty strings ("Chats", "Work", "No chats yet", "No work yet")
+     appear nowhere in the rail's text, and the old near-synonym verb labels
+     ("Do Work", "New Repository") appear nowhere on the page — the headings'
+     ＋ icons carry aria-labels in the §3.1 "New <path>" grammar instead
+     ("New Chat" is that grammar's honest spelling for Chat's ＋ now, so it
+     leaves the banned list).
+  2. The Projects ACCORDION lists ATTENTION-ORDERED rows: expanded, its rows
+     settle to the same decayed-score order as the board's NEEDS YOU band —
+     q3-review-deck → api-migration → auth-refactor → upload-endpoint —
+     capped (≤6 of the fixture's 28) with a "view all ›". legacy-spike (the
+     R3 trap) never cracks the needs-you window (the leading 4): the rail
+     agrees with the board, read from the same DOM.
+  3. The creation affordances are the four heading-level ＋ icons (§8.7: the
+     QUICK assert's replacement) — one per non-Settings heading, none on
+     Settings.
+  4. /runs remains reachable — the flat list renders at its route with the
+     board unmounted. (The rail affordance is slice N's bottom-panel
+     "All runs ›"; between M and N the route itself is the escape hatch.)
+  5. A Projects-accordion row enters the project — the PROJECT DASHBOARD at
+     /p/q3-review-deck (DES-FEEDBACK-001 §4.1, slice D), not a remembered
+     mode.
 
 Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
 data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
-  uxfix-3-rail.png   the consolidated rail beside the settled W2 board
+  uxfix-3-rail.png   the five-path rail, Projects expanded, beside the W2 board
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
 SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4332), SKIP_STUDIO_BUILD.
@@ -79,14 +84,11 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 SHOTS.mkdir(parents=True, exist_ok=True)
 
 EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
-RAIL_ROWS = """() => Array.from(document.querySelectorAll(
-    '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
-    .map(r => r.dataset.projectId)"""
 # Retired vocabulary that must not survive inside the rail (AC 1). "Chats" and
 # "Work" are checked against the RAIL's text only — the board legitimately
 # renders run problems containing the word "work" in prose.
 RAIL_BANNED = ["Chats", "Work", "No chats yet", "No work yet"]
-PAGE_BANNED = ["Do Work", "New Chat", "New Repository"]
+PAGE_BANNED = ["Do Work", "New Repository"]
 
 console_errors: list[str] = []
 
@@ -109,16 +111,9 @@ with sync_playwright() as p:
         except Exception:
             return False
 
-    # ── AC 2: settle on the DECAYED verdict — the rail's rows reach the same
-    # order as the board's NEEDS YOU band (legacy-spike demoted by its 8-day
-    # durable-log tail, the gate leading regardless). Wait on BOTH surfaces.
-    rail_order_ok = settled(
-        """expected => { const ids = Array.from(document.querySelectorAll(
-               '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
-               .map(r => r.dataset.projectId);
-             return JSON.stringify(ids) === JSON.stringify(expected); }""",
-        EXPECTED_ORDER,
-    )
+    # ── AC 2: expand Projects; settle on the DECAYED verdict — the accordion's
+    # rows reach the same order as the board's NEEDS YOU band (legacy-spike
+    # demoted by its 8-day durable-log tail, the gate leading regardless).
     board_order_ok = settled(
         """expected => { const ids = Array.from(document.querySelectorAll(
                '[data-testid="band-needs-you"] [data-testid="project-card"]'))
@@ -126,26 +121,43 @@ with sync_playwright() as p:
              return JSON.stringify(ids) === JSON.stringify(expected); }""",
         EXPECTED_ORDER,
     )
-    rail_rows = page.evaluate(RAIL_ROWS)
-    # The rail and the board AGREE (§2.3: "the same axis as the board").
+    page.locator('[data-testid="rail-title-projects"]').click()
+    rail_order_ok = settled(
+        """expected => { const ids = Array.from(document.querySelectorAll(
+               '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
+               .map(r => r.dataset.projectId);
+             return JSON.stringify(ids.slice(0, 4)) === JSON.stringify(expected); }""",
+        EXPECTED_ORDER,
+    )
+    rail_rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+             '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
+             .map(r => r.dataset.projectId)""")
+    # The rail and the board AGREE (§2.3: "the same axis as the board") — the
+    # accordion's leading rows are the needs-you band verbatim.
     rail_matches_board = page.evaluate(
         """() => { const rail = Array.from(document.querySelectorAll(
-                     '[data-testid="rail-section-projects"] [data-testid="rail-project"]'))
+                     '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
                      .map(r => r.dataset.projectId);
                    const board = Array.from(document.querySelectorAll(
                      '[data-testid="band-needs-you"] [data-testid="project-card"]'))
                      .map(c => c.dataset.projectId);
-                   return JSON.stringify(rail) === JSON.stringify(board); }""")
-    capped_ok = len(rail_rows) == 4 and "legacy-spike" not in rail_rows
+                   return JSON.stringify(rail.slice(0, board.length)) === JSON.stringify(board); }""")
+    # The R3 trap re-stated for the §3.3 cap of 6: legacy-spike (8-day failure,
+    # project touched an hour ago) may trail at the accordion's tail but must
+    # never crack the needs-you window the board leads with.
+    capped_ok = len(rail_rows) <= 6 and "legacy-spike" not in rail_rows[:4]
     view_all_ok = page.evaluate(
-        """() => Array.from(document.querySelectorAll(
-              '[data-testid="rail-section-projects"] button'))
-              .some(b => (b.textContent ?? '').trim() === 'view all')""")
+        """() => { const v = document.querySelector(
+                     '[data-testid="rail-heading-projects"] [data-testid="rail-view-all"]');
+                   return !!v && v.getAttribute('href') === '/projects'; }""")
 
-    # ── AC 1: two taxonomies, and only two ─────────────────────────────────────
+    # ── AC 1: the two headings carry the taxonomies; retired vocabulary dead ───
     sections_ok = page.evaluate(
-        """() => !!document.querySelector('[data-testid="rail-section-projects"]')
-              && !!document.querySelector('[data-testid="rail-section-repos"]')
+        """() => !!document.querySelector('[data-testid="rail-heading-projects"]')
+              && !!document.querySelector('[data-testid="rail-heading-repos"]')
+              && !document.querySelector('[data-testid="rail-section-projects"]')
+              && !document.querySelector('[data-testid="rail-section-repos"]')
               && !document.querySelector('[data-testid="rail-section-chats"]')
               && !document.querySelector('[data-testid="rail-section-work"]')""")
     rail_text = page.evaluate(
@@ -154,32 +166,31 @@ with sync_playwright() as p:
     body_text = page.evaluate("() => document.body.innerText")
     page_banned_hits = [s for s in PAGE_BANNED if s in body_text]
 
-    # ── AC 3: the creation verbs are the mode spine's words — re-scoped to
-    #    DES-FEEDBACK-001 §1.2 (slice A): a VERTICAL QUICK list with Project
-    #    leading; the spine verbs (Build/Chat/Repository) are all still there.
-    verbs_ok = page.evaluate(
-        """() => { const labels = Array.from(document.querySelectorAll(
-                     '[data-testid="rail-actions"] button'))
-                     .map(b => b.getAttribute('aria-label'));
-                   return JSON.stringify(labels)
-                       === JSON.stringify(['Project', 'Build', 'Chat', 'Repository']); }""")
+    # ── AC 3 (§8.7): the creation affordances are the four heading ＋ icons ────
+    plus_labels = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="heading-new"]'))
+              .map(b => b.getAttribute('aria-label'))""")
+    verbs_ok = plus_labels == ["New Projects", "New Make", "New Chat", "New Repositories"]
+    settings_plus_absent = page.evaluate(
+        """() => !document.querySelector(
+             '[data-testid="rail-heading-settings"] [data-testid="heading-new"]')""")
 
-    # ── Capture: the consolidated rail beside the settled W2 board (§4.0) ──────
-    page.locator('[data-testid="rail-all-runs"]').wait_for(timeout=10000)
+    # ── Capture: the five-path rail, Projects expanded, beside the W2 board ────
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="rail-view-all"]').wait_for(timeout=10000)
     page.locator('[data-testid="left-rail"]').screenshot(path=str(SHOTS / "uxfix-3-rail.png"))
 
-    # ── AC 4: the ONE escape hatch — a real link that lands on /runs ───────────
-    hatch_href = page.evaluate(
-        """() => document.querySelector('[data-testid="rail-all-runs"]')?.getAttribute('href')""")
-    page.locator('[data-testid="rail-all-runs"]').click()
+    # ── AC 4: /runs remains reachable — the flat list at its own route ─────────
+    # (The rail affordance is slice N's bottom panel; the route is the M→N
+    # interim escape hatch, per §10.4's sequencing note.)
+    page.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
     hatch_ok = settled(
         """() => window.location.pathname === '/runs'
               && !document.querySelector('[data-testid="project-board"]')""")
 
-    # ── AC 5 (re-scoped by DES-FEEDBACK-001 §4.1, slice D): a rail project row
-    #    enters the project — which now means the PROJECT DASHBOARD, not the
-    #    last-used mode. Context before actions; the mode is chosen there. ──────
+    # ── AC 5 (re-scoped by DES-FEEDBACK-001 §4.1, slice D): a Projects-accordion
+    #    row enters the project — the PROJECT DASHBOARD, not a remembered mode. ──
     page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-title-projects"]').click()
     page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').wait_for(timeout=30000)
     page.locator('[data-testid="rail-project"][data-project-id="q3-review-deck"]').click()
     shell_ok = settled(
@@ -193,22 +204,23 @@ report["steps"]["slice3_rail"] = {
     "ok": all([
         rail_order_ok, board_order_ok, rail_matches_board, capped_ok, view_all_ok,
         sections_ok, not rail_banned_hits, not page_banned_hits, verbs_ok,
-        hatch_href == "/runs", hatch_ok, shell_ok,
+        settings_plus_absent, hatch_ok, shell_ok,
     ]),
     "rail_projects_order": rail_rows,
     "expected_order": EXPECTED_ORDER,
     "rail_order_ok": rail_order_ok,
     "board_order_ok": board_order_ok,
     "rail_matches_board_needs_you": rail_matches_board,
-    "capped_at_section_max_no_stale": capped_ok,
-    "view_all_present": view_all_ok,
-    "two_taxonomies_no_chats_no_work": sections_ok,
+    "capped_no_stale": capped_ok,
+    "view_all_shares_dashboard_target": view_all_ok,
+    "headings_carry_taxonomies_no_retired_sections": sections_ok,
     "rail_banned_strings_found": rail_banned_hits,
     "page_banned_strings_found": page_banned_hits,
-    "creation_verbs_mode_spine": verbs_ok,
-    "all_runs_href": hatch_href,
-    "all_runs_lands_on_flat_list": hatch_ok,
-    "project_row_enters_shell_chat_default": shell_ok,
+    "heading_new_labels": plus_labels,
+    "creation_affordances_four_plus_icons": verbs_ok,
+    "settings_has_no_plus": settings_plus_absent,
+    "runs_route_reachable_flat_list": hatch_ok,
+    "project_row_enters_dashboard": shell_ok,
     "console_errors": console_errors[:10],
     "screenshots": [str(SHOTS / "uxfix-3-rail.png")],
 }

--- a/e2e/vision_slice3_test.py
+++ b/e2e/vision_slice3_test.py
@@ -25,9 +25,13 @@ Plus the slice's checklist reads (§6.1): EC8 (the switcher looks like the
 spine — filled active segment, glyph+label segments, summary on screen), EC11
 (no ornament in the chrome), EC12 (the accent is none of the status colors;
 the dot speaks the status layer), EC15 (chrome computed styles resolve from
-tokens), and the §6.3 preservation list (UXFIX-001 §2.5: glyphs match the
-board quick actions, active summary always visible, unavailable modes stay
-rendered — never hidden). The §2.8 reconciliation is asserted too: the loaded
+tokens), and the §6.3 preservation list (UXFIX-001 §2.5: one glyph
+vocabulary, active summary always visible, unavailable modes stay rendered —
+never hidden). The rail-side glyph cross-check is RE-SCOPED by
+DES-FEEDBACK-003 §8.7 (slice M): QUICK's verbs are gone, so the spine glyphs
+are re-read off the make-picker's three MODE_SPECS rows (§3.4) — the chrome
+asserts (logo slot, connection-dot data-state) are PRESERVED and slice O must
+keep them green (§8.2). The §2.8 reconciliation is asserted too: the loaded
 sans is Inter (the token names it; the legacy Archivo load is gone).
 
 Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
@@ -219,8 +223,6 @@ with sync_playwright() as p:
                glyphsPresent: ['💬','⚙','▤','▶'].every((g, i) => tabs[i].textContent.includes(g)),
                noneHidden: tabs.every(t => t.offsetParent !== null && !t.disabled),
                unavailableFlags: tabs.map(t => t.dataset.unavailable ?? null),
-               railActionGlyphs: (document.querySelector('[data-testid="rail-actions"]')
-                 ?.textContent ?? ''),
              }; }""")
     active_ok = (styles["activeBg"] == styles["accent"]
                  and styles["activeColor"] == styles["accentFg"]
@@ -234,14 +236,30 @@ with sync_playwright() as p:
                and styles["dotBg"] == styles["statusRun"])
     dot_ok = dot_connected and styles["dotState"] == "connected"
     # UXFIX-001 §2.5 preserved: four glyph+label segments (the board's own four
-    # glyphs — the rail's creation verbs carry two of them on this same page),
-    # the active summary ON SCREEN, no mode hidden or inert.
+    # glyphs), the active summary ON SCREEN, no mode hidden or inert.
     preserved_ok = (
         len(styles["tabTexts"]) == 4 and styles["glyphsPresent"]
         and styles["summaryVisible"]
         and (styles["summaryText"] or "").startswith("Governed code work")
-        and styles["noneHidden"]
-        and "⚙" in styles["railActionGlyphs"] and "💬" in styles["railActionGlyphs"])
+        and styles["noneHidden"])
+
+    # The rail-side vocabulary cross-check, re-scoped by DES-FEEDBACK-003 §8.7
+    # (slice M): QUICK's verbs are gone; the spine glyphs now ride the
+    # make-picker's three MODE_SPECS rows (§3.4). Open Make's ＋, read the three
+    # tines, close by clicking outside — the switcher must not have moved.
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="make-picker"]').wait_for(timeout=5000)
+    picker_rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll(
+             '[data-testid="make-picker"] [data-testid="make-picker-row"]'))
+             .map(r => ({ mode: r.dataset.mode, text: r.textContent ?? '' }))""")
+    picker_glyphs_ok = (
+        [r["mode"] for r in picker_rows] == ["build", "document", "video"]
+        and "⚙" in picker_rows[0]["text"] and "▤" in picker_rows[1]["text"]
+        and "▶" in picker_rows[2]["text"])
+    page.mouse.click(140, 850)  # an inert rail spot outside — closes the picker
+    picker_closed = settled(
+        """() => !document.querySelector('[data-testid="make-picker"]')""", timeout=5000)
 
     # ── The named steady-state screenshots (§6.3) — before the transition ─────
     page.locator('[data-testid="app-chrome"]').screenshot(
@@ -294,6 +312,7 @@ with sync_playwright() as p:
 
 report["steps"]["dom_acs"] = {
     "ok": all([fonts_ok, logo_ok, active_ok, ec12_ok, ec15_ok, dot_ok, preserved_ok,
+               picker_glyphs_ok, picker_closed,
                fill_moved, fill_mid, fill_settled, chat_active,
                len(console_errors) == 0]),
     "web_fonts_inter_and_mono": fonts_ok,
@@ -305,6 +324,9 @@ report["steps"]["dom_acs"] = {
     "ec15_chrome_from_tokens": ec15_ok,
     "connection_dot_state_matches_ws": dot_ok,
     "uxfix_2_5_preserved": preserved_ok,
+    "make_picker_spine_glyphs": picker_rows,
+    "make_picker_spine_glyphs_ok": picker_glyphs_ok,
+    "make_picker_closed_on_outside": picker_closed,
     "fill_transition_fired": fill_moved,
     "fill_mid_flight_captured": fill_mid,
     "fill_settled_on_target": fill_settled,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
 const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate, search } = useRoute();
+  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate, search, pathname } = useRoute();
   const { runs, refresh } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestElicitation = useElicitationStore((s) => s.ingest);
@@ -435,6 +435,23 @@ export function App(): React.ReactElement {
         </div>
       );
     }
+    // `/make` — the Make path's dashboard route (DES-FEEDBACK-003 §2.1). The
+    // rail's ▦ links here from slice M on; the real combined list + reporting
+    // surface is slice O (§4.2) — until it lands this placeholder keeps the
+    // link honest (a page, never a 404).
+    if (panel === 'make') {
+      return (
+        <div className="flex-1 overflow-y-auto p-6" data-testid="make-placeholder">
+          <h1 style={{ color: 'var(--ink-high)', fontSize: 'var(--text-lg)', fontFamily: 'var(--font-sans)', fontWeight: 'var(--weight-semi)' }}>
+            Make
+          </h1>
+          <p className="mt-2" style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)' }}>
+            The combined list and reporting dashboard for made things — build runs,
+            documents, demos — lands here (DES-FEEDBACK-003 §4.2, slice O).
+          </p>
+        </div>
+      );
+    }
     // `/projects/:id` redirects into the shell (§1.5); this renders only for the tick
     // before the redirect lands, and is the fallback if the redirect never does.
     if (panel === 'project-detail' && projectId) {
@@ -477,6 +494,7 @@ export function App(): React.ReactElement {
       <LeftSidebar
         runs={runs}
         navigate={navigate}
+        pathname={pathname}
         runPath={runPath}
         immersive={projectId !== null && (mode === 'document' || mode === 'video')}
       />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
 import type { RepoEntry, SessionView } from '../api/types.js';
-import { api } from '../api/client.js';
+import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { fuzzyMatch } from '../palette/fuzzy.js';
 import { modePath, projectPath, type Navigate } from '../hooks/useRoute.js';
 import type { ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
@@ -51,12 +51,9 @@ interface Entry {
   rank: number;
 }
 
-/** Session-scoped repo cache (§1.4): filled on first open, then warm. */
-let repoCache: RepoEntry[] | null = null;
-
-export function clearPaletteRepoCache(): void {
-  repoCache = null;
-}
+/** Session-scoped repo cache (§1.4) — SHARED with the rail's Repositories
+ *  accordion since slice M (DES-FEEDBACK-003 §3.3): one gesture warms both. */
+export { clearRepoCache as clearPaletteRepoCache } from '../store/repoCache.js';
 
 /**
  * The two global chords App registers (§1.2) — exported so the wiring the app
@@ -134,7 +131,7 @@ export function CommandPalette({
 }: Props): React.ReactElement | null {
   const [query, setQuery] = useState('');
   const [sel, setSel] = useState(0);
-  const [repos, setRepos] = useState<RepoEntry[]>(repoCache ?? []);
+  const [repos, setRepos] = useState<RepoEntry[]>(getCachedRepos() ?? []);
   const [showNewProject, setShowNewProject] = useState(false);
   const [showTerminal, setShowTerminal] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -157,19 +154,11 @@ export function CommandPalette({
     }
     restoreRef.current = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
-    if (repoCache === null) {
-      api
-        .listRepos()
-        .then(({ repos: r }) => {
-          repoCache = r;
-          setRepos(r);
-        })
-        .catch(() => {
-          /* no repo surface — the group just stays empty this session */
-        });
-    } else {
-      setRepos(repoCache);
-    }
+    fetchReposCached()
+      .then(setRepos)
+      .catch(() => {
+        /* no repo surface — the group just stays empty this session */
+      });
   }, [open]);
 
   const close = (): void => {

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,41 +1,46 @@
 import { useEffect, useRef, useState } from 'react';
-import { api } from '../api/client.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
+import type { DocSummary } from '../api/interactive.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
-import { projectPath } from '../hooks/useRoute.js';
+import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute.js';
+import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
+import { useProjectsStore } from '../store/projects.js';
 import { AppChrome } from './AppChrome.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { NotificationBell } from './NotificationBell.js';
 import { ATTENTION_DOT } from './ProjectCard.js';
-import { RunsSection } from './RunsSection.js';
-import { SettingsRailSection } from './SettingsRailSection.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
+import { phaseWord, RUN_DOT } from './RunsSection.js';
+import { SettingsShortcutRows } from './SettingsRailSection.js';
 
 /**
- * The rail, consolidated to TWO taxonomies (DES-UXFIX-001 §2.3, slice 3 — F4):
+ * The rail, re-architected around FIVE PRIMARY PATHS (DES-FEEDBACK-003 §2/§3,
+ * slice M): Projects / Make / Chat / Repositories / Settings, each a heading
+ * row with a strict ONE-OPEN accordion (EC26). Each heading (except Settings —
+ * the operator: "setting won't have the dashboard/icons") carries a ▦ dashboard
+ * link and a ＋ create action at heading level (EC20 as amended: heading-level
+ * ＋ icons are the sanctioned spelling; no `+` inside accordion contents).
  *
- *   1. PROJECTS — the same axis as the board, attention-ordered (§2.1.3) off the
- *      SAME model the board reads (`useBoardModel`), so the rail and the board
- *      agree on which project needs you first. Clicking one enters its shell
- *      (last-used mode, Chat default — §1.5).
- *   2. REPOSITORIES — the one cross-project axis a coder genuinely browses by.
- *      Unchanged in behaviour; keeps its search.
+ * What the rail STOPPED being (§1.2/§8.1): a launcher shelf (QUICK gone — the
+ * verbs live on the headings' ＋ and in the palette), a second home board (the
+ * inline runs section gone — run awareness moves to the bottom panel, slice N;
+ * until N lands the flat `/runs` route is the interim home of run lists), and
+ * a junk drawer (both standalone taxonomies fold into their headings).
  *
- * Chats and Work are GONE as rail sections: they were one object (a run) sliced
- * by an internal field (`workflow_id`, V5) into two visually identical truncated
- * lists. A run lives under its project now; the flat cross-project lists survive
- * only behind the single "All runs ›" escape hatch (§1.5).
- *
- * The creation verbs compress to one compact row in the mode spine's own words
- * (V9/V10: Build / Chat — the switcher's glyphs, not "Do Work" vs "New Chat")
- * plus Repository.
+ * Fetch discipline (§3.3): the accordion fetches on EXPAND only — the repo 5s
+ * poll RETIRED; the Repositories accordion shares the palette's session repo
+ * cache (one `GET /repos` per session, gesture-driven). Everything else reads
+ * data the app already holds (`runs` prop, board model, projects store).
  */
 
 interface Props {
   runs: SessionView[];
   navigate: (path: string) => void;
-  /** DES-FEEDBACK-001 §1.4: where a runs-section row navigates — the caller's
-   *  same routing as `selectRun`. Defaults to the flat `/runs/:id` route. */
+  /** The current pathname — drives the route→heading map (§3.2). */
+  pathname: string;
+  /** DES-FEEDBACK-001 §1.4: where a run row navigates — the caller's same
+   *  routing as `selectRun`. Defaults to the flat `/runs/:id` route. */
   runPath?: (id: string) => string;
   /** DES-FEEDBACK-001 §7.3: Document/Video are canvas-first, so entering them
    *  auto-collapses the rail to its icon state; leaving restores what the user had.
@@ -43,133 +48,76 @@ interface Props {
   immersive?: boolean;
 }
 
-// The rail is chrome (§5.1's token table: `--surface-rail → rail, chrome`), so
-// slice 3's chrome conversion moves the whole palette onto the semantic tokens
-// (§2.11) — the legacy teal shell retires with it. Links and the creation verbs
-// are the rail's interactive affordances: on-accent, the §5.3 "Add agents"
-// precedent (low-key but on-accent to signal interactivity).
+// The rail is chrome (`--surface-rail`); the token dress is §3.1/§3.5's.
 const S = {
-  bg:        'var(--surface-rail)',
-  border:    'var(--surface-raised)',
-  ink:       'var(--ink-body)',
-  muted:     'var(--ink-muted)',
-  faint:     'var(--ink-dim)',
-  hover:     'var(--surface-card)',
-  active:    'var(--surface-raised)',
-  accent:    'var(--accent)',
-  accentInk: 'var(--accent-fg)',
-  link:      'var(--accent)',
+  bg:      'var(--surface-rail)',
+  border:  'var(--surface-raised)',
+  ink:     'var(--ink-body)',
+  high:    'var(--ink-high)',
+  muted:   'var(--ink-muted)',
+  faint:   'var(--ink-dim)',
+  hover:   'var(--surface-card)',
+  accent:  'var(--accent)',
 };
 
-const SECTION_MAX = 4;
-/** Collapsed rail: at most this many project dots — a glance strip, not a list. */
-const COLLAPSED_MAX = 12;
+// ── The five paths (§2.1) ─────────────────────────────────────────────────────
 
-// ── Inline SVG icons ──────────────────────────────────────────────────────────
+export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'settings';
 
-function IconSearch(): React.ReactElement {
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
-      <circle cx="10" cy="10" r="7" />
-      <line x1="15.5" y1="15.5" x2="21" y2="21" />
-    </svg>
-  );
+/** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
+ *  links `/system` in the collapsed column — it has no dashboard). */
+interface PathSpec { key: PathKey; title: string; glyph: string; dash: string | null; collapsedHref: string }
+const P_PROJECTS: PathSpec = { key: 'projects', title: 'Projects',     glyph: '◇', dash: '/projects', collapsedHref: '/projects' };
+const P_MAKE: PathSpec     = { key: 'make',     title: 'Make',         glyph: '⚒', dash: '/make',     collapsedHref: '/make' };
+const P_CHAT: PathSpec     = { key: 'chat',     title: 'Chat',         glyph: '💬', dash: '/chats',    collapsedHref: '/chats' };
+const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', glyph: '⬡', dash: '/repos',    collapsedHref: '/repos' };
+const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     glyph: '⚙', dash: null,        collapsedHref: '/system' };
+const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_SETTINGS];
+
+const SETTINGS_ROUTES = new Set(['system', 'theme', 'coverage', 'domain', 'workflows', 'policies', 'rules']);
+
+/**
+ * The route→heading map (§3.2): which primary path owns a pathname. `/` and
+ * `/runs*` map to NONE — five closed headings, the rail's calmest reading.
+ * Exported pure so the default-expansion contract is unit-pinned.
+ */
+export function headingForPath(pathname: string): PathKey | null {
+  const [, first = '', second = ''] = pathname.split('/');
+  if (first === 'projects' || first === 'p') return 'projects';
+  if (first === 'make') return 'make';
+  if (first === 'chats' || (first === 'chat' && second === 'new')) return 'chat';
+  if (first === 'repos' || first === 'repo-detail') return 'repos';
+  if (SETTINGS_ROUTES.has(first)) return 'settings';
+  return null;
 }
+
+/** The Chat predicate — ChatsPage's filter VERBATIM (§3.3: runs with no
+ *  workflow stamp are chats there and must not double-list under Make). */
+const isChatRun = (v: SessionView): boolean =>
+  !v.session.workflow_id || v.session.workflow_id === 'chat';
+
+const RUN_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
+
+/** Active before terminal, incoming order preserved (the RunsSection contract). */
+function orderRuns(runs: SessionView[]): SessionView[] {
+  const active = runs.filter((v) => !RUN_TERMINAL.has(v.session.status));
+  const terminal = runs.filter((v) => RUN_TERMINAL.has(v.session.status));
+  return [...active, ...terminal];
+}
+
+// Accordion caps (§3.3): shortcuts, never a second dashboard.
+const PROJECTS_MAX = 6;
+const MADE_MAX = 5;
+const CHATS_MAX = 5;
+const REPOS_MAX = 4;
+/** Of MADE_MAX, at most this many are doc/demo rows (per-project loaded docs
+ *  only — §4.2.2's scoped rule; the complete census lives on `/make`). */
+const MADE_DOCS_MAX = 2;
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
-/** One QUICK action: the spine glyph and the mode's own word, each on its own
- *  line (DES-FEEDBACK-001 §1.2 — the `+` glyphs are GONE, EC20). `hint` (the
- *  MODE_SPECS sublabel) teaches what the verb produces, on hover. */
-function ActionLink({
-  glyph,
-  label,
-  hint,
-  testId,
-  onClick,
-  collapsed,
-}: {
-  glyph: React.ReactNode;
-  label: string;
-  hint?: string;
-  testId?: string;
-  onClick: () => void;
-  collapsed: boolean;
-}): React.ReactElement {
-  return (
-    <button
-      type="button"
-      data-testid={testId}
-      onClick={onClick}
-      aria-label={label}
-      title={hint !== undefined ? `${label} — ${hint}` : label}
-      className={`flex items-center gap-1.5 rounded text-sm font-semibold transition-opacity hover:opacity-70 ${
-        collapsed ? 'w-9 h-9 justify-center mx-auto' : 'px-1 py-1'
-      }`}
-      style={{ color: S.accent, background: 'transparent' }}
-    >
-      <span aria-hidden>{glyph}</span>
-      {!collapsed && <span>{label}</span>}
-    </button>
-  );
-}
-
-function SectionLabel({
-  label,
-  asLink,
-  onClick,
-  withSearch,
-  searchActive,
-  onToggleSearch,
-}: {
-  label: string;
-  asLink?: boolean;
-  onClick?: () => void;
-  withSearch?: boolean;
-  searchActive?: boolean;
-  onToggleSearch?: () => void;
-}): React.ReactElement {
-  const textEl = (
-    <span
-      className="text-[10px] font-semibold uppercase tracking-widest font-mono select-none"
-      style={{ color: asLink ? S.link : S.muted }}
-    >
-      {label}
-      {asLink && <span className="ml-1 opacity-70">›</span>}
-    </span>
-  );
-
-  return (
-    <div className="flex items-center px-3 pt-3 pb-1">
-      {asLink && onClick ? (
-        <button
-          type="button"
-          onClick={onClick}
-          className="transition-opacity hover:opacity-80"
-          style={{ background: 'transparent' }}
-        >
-          {textEl}
-        </button>
-      ) : (
-        textEl
-      )}
-      {withSearch && (
-        <button
-          type="button"
-          onClick={onToggleSearch}
-          aria-label="Search"
-          className="ml-auto transition-opacity hover:opacity-100"
-          style={{ color: searchActive ? S.accent : S.faint }}
-        >
-          <IconSearch />
-        </button>
-      )}
-    </div>
-  );
-}
-
-/** One rail project row: the board's attention dot + the name. The row is the
- *  board card's one-glance summary, never a second place that explains it. */
+/** One rail project row: the board's attention dot + the name — reused verbatim
+ *  from the slice-3 taxonomy (§3.3: "ProjectRow, reused verbatim"). */
 function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }): React.ReactElement {
   const { project, attention, score, band } = item;
   return (
@@ -200,16 +148,309 @@ function ProjectRow({ item, onOpen }: { item: BoardProject; onOpen: () => void }
   );
 }
 
+/** One run row — the RunsSection row grammar (status dot + intent + phase word),
+ *  reused for the Make and Chat accordions (§3.3). */
+function RunRow({ view, onOpen }: { view: SessionView; onOpen: () => void }): React.ReactElement {
+  return (
+    <button
+      type="button"
+      data-testid="rail-run"
+      data-run-id={view.session.id}
+      data-status={view.session.status}
+      onClick={onOpen}
+      title={view.session.problem}
+      className="w-full text-left px-3 py-1 rounded-md transition-colors"
+      style={{ background: 'transparent' }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = S.hover; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span
+          aria-hidden
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
+        />
+        <span
+          className="truncate leading-tight"
+          style={{ maxWidth: '24ch', fontSize: 'var(--text-xs)', color: S.ink, fontFamily: 'var(--font-sans)' }}
+        >
+          {view.session.problem}
+        </span>
+        <span
+          className="ml-auto shrink-0"
+          style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-mono)' }}
+        >
+          {phaseWord(view)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+/** `view all ›` — the SAME target as the heading's ▦, spelled for the reader
+ *  (§3.3); a real link, like every navigation affordance here. */
+function ViewAll({ href, navigate }: { href: string; navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <a
+      href={href}
+      data-testid="rail-view-all"
+      onClick={(e) => { e.preventDefault(); navigate(href); }}
+      className="block px-3 pt-1 pb-1 text-[11px] font-mono transition-opacity hover:opacity-80"
+      style={{ color: S.accent, textDecoration: 'none' }}
+    >
+      view all ›
+    </a>
+  );
+}
+
+function EmptyRow({ label, href, navigate }: { label: string; href: string; navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(href)}
+      className="px-3 py-1 text-left text-[11px] italic font-mono transition-opacity hover:opacity-70"
+      style={{ color: S.faint }}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** A doc/demo row in the Make accordion: `▤/▶ name · vN` (§3.1's anatomy),
+ *  from the doc lists the board model already loaded — never a new fetch. */
+function DocRow({ doc, projectId, projectName, navigate }: {
+  doc: DocSummary; projectId: string; projectName: string; navigate: (p: string) => void;
+}): React.ReactElement {
+  const mode: Mode = doc.kind === 'demo' ? 'video' : 'document';
+  return (
+    <button
+      type="button"
+      data-testid="rail-doc"
+      data-doc-kind={doc.kind}
+      onClick={() => navigate(versionPath(projectId, doc.name, null, mode))}
+      title={`${doc.name} · ${projectName}`}
+      className="w-full text-left px-3 py-1 rounded-md transition-colors"
+      style={{ background: 'transparent' }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = S.hover; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span aria-hidden className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: S.faint }}>
+          {doc.kind === 'demo' ? '▶' : '▤'}
+        </span>
+        <span
+          className="truncate leading-tight"
+          style={{ maxWidth: '24ch', fontSize: 'var(--text-xs)', color: S.ink, fontFamily: 'var(--font-sans)' }}
+        >
+          {doc.name}
+        </span>
+        <span
+          className="ml-auto shrink-0"
+          style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-mono)' }}
+        >
+          v{doc.head}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+/** The heading row (§3.1): title button (chevron + word, toggles), ▦ dashboard
+ *  link, ＋ create — Settings renders the title only. The container carries the
+ *  testid + `aria-expanded` the EC26 assertions read. */
+function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }: {
+  path: PathSpec;
+  open: boolean;
+  onToggle: () => void;
+  onNew?: () => void;
+  navigate: (p: string) => void;
+  /** Accordion contents, rendered only while open. */
+  children?: React.ReactNode;
+  /** Anchored popover slot (Make's picker) — rendered inside the relative row. */
+  extra?: React.ReactNode;
+}): React.ReactElement {
+  const iconStyle: React.CSSProperties = {
+    color: S.faint,
+    fontSize: 'var(--text-xs)',
+    textDecoration: 'none',
+    outlineColor: S.accent,
+  };
+  const lift = (e: React.MouseEvent<HTMLElement>): void => { e.currentTarget.style.color = S.high; };
+  const drop = (e: React.MouseEvent<HTMLElement>): void => { e.currentTarget.style.color = S.faint; };
+  return (
+    <div data-testid={`rail-heading-${path.key}`} data-open={open} aria-expanded={open}>
+      <div className="relative flex items-center px-2 rounded-md transition-colors"
+        onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+        onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+      >
+        <button
+          type="button"
+          data-testid={`rail-title-${path.key}`}
+          aria-expanded={open}
+          onClick={onToggle}
+          className="flex-1 min-w-0 flex items-center gap-2 px-1 py-1.5 text-left"
+          style={{
+            background: 'transparent',
+            color: open ? S.high : S.muted,
+            fontSize: 'var(--text-sm)',
+            fontFamily: 'var(--font-sans)',
+            fontWeight: 'var(--weight-semi)',
+            outlineColor: S.accent,
+          }}
+        >
+          <span
+            aria-hidden
+            data-testid="rail-heading-chevron"
+            className="inline-block leading-none"
+            style={{
+              transition: 'transform var(--dur-fast)',
+              transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+            }}
+          >
+            ›
+          </span>
+          <span className="truncate">{path.title}</span>
+        </button>
+        {path.dash !== null && (
+          <a
+            href={path.dash}
+            data-testid="heading-dashboard"
+            aria-label={`${path.title} dashboard`}
+            title={`${path.title} dashboard`}
+            onClick={(e) => { e.preventDefault(); navigate(path.dash as string); }}
+            className="w-7 h-7 shrink-0 flex items-center justify-center rounded transition-colors"
+            style={iconStyle}
+            onMouseEnter={lift}
+            onMouseLeave={drop}
+          >
+            ▦
+          </a>
+        )}
+        {onNew && (
+          <button
+            type="button"
+            data-testid="heading-new"
+            aria-label={`New ${path.title}`}
+            title={`New ${path.title}`}
+            onClick={onNew}
+            className="w-7 h-7 shrink-0 flex items-center justify-center rounded transition-colors"
+            style={{ ...iconStyle, background: 'transparent' }}
+            onMouseEnter={lift}
+            onMouseLeave={drop}
+          >
+            ＋
+          </button>
+        )}
+        {extra}
+      </div>
+      {open && (
+        <div className="flex flex-col pb-1" style={{ paddingLeft: 'var(--space-4)' }}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── The make-picker (§3.4): Make's ＋ forks three ways ─────────────────────────
+
+const MAKE_MODES: Mode[] = ['build', 'document', 'video'];
+
+function MakePicker({ navigate, onClose }: { navigate: (p: string) => void; onClose: () => void }): React.ReactElement {
+  /** null = the three rows; a mode = the project-picker stage (Document/Video). */
+  const [stage, setStage] = useState<Mode | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const projects = useProjectsStore((s) => s.projects);
+
+  useEffect(() => {
+    function onOutside(e: MouseEvent): void {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, [onClose]);
+
+  const pick = (m: Mode): void => {
+    if (m === 'build') {
+      // The unbound launch form, Unfiled default — slice B semantics (§3.4).
+      onClose();
+      navigate('/runs/new');
+      return;
+    }
+    // A doc lives in a project — the bridge mounts per project (§3.4): pick one
+    // first. Entering the stage is the gesture that loads the list if cold.
+    if (projects.length === 0) void useProjectsStore.getState().load();
+    setStage(m);
+  };
+
+  const real = projects.filter((p) => p.id !== 'default');
+
+  return (
+    <div
+      ref={ref}
+      data-testid="make-picker"
+      role="menu"
+      className="absolute right-0 top-8 z-30 w-60 py-1"
+      style={{
+        background: 'var(--surface-raised)',
+        boxShadow: 'var(--shadow-raised)',
+        borderRadius: 'var(--radius-md)',
+      }}
+    >
+      {stage === null ? (
+        MAKE_MODES.map((m) => (
+          <button
+            key={m}
+            type="button"
+            role="menuitem"
+            data-testid="make-picker-row"
+            data-mode={m}
+            onClick={() => pick(m)}
+            className="w-full flex items-baseline gap-2 px-3 py-1.5 text-left transition-colors"
+            style={{ background: 'transparent', outlineColor: S.accent }}
+            onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+          >
+            <span aria-hidden style={{ fontSize: 'var(--text-xs)' }}>{MODE_SPECS[m].glyph}</span>
+            <span style={{ fontSize: 'var(--text-xs)', color: S.ink, fontFamily: 'var(--font-sans)', fontWeight: 'var(--weight-semi)' }}>
+              {MODE_SPECS[m].label}
+            </span>
+            <span className="truncate" style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-sans)' }}>
+              {MODE_SPECS[m].sublabel}
+            </span>
+          </button>
+        ))
+      ) : (
+        <div className="px-3 py-1.5 flex flex-col gap-1.5" data-testid="make-picker-project-stage">
+          <p style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-sans)', margin: 0 }}>
+            {real.length === 0
+              ? `A ${MODE_SPECS[stage].label.toLowerCase()} lives in a project — create a project first.`
+              : `A ${MODE_SPECS[stage].label.toLowerCase()} lives in a project — pick one:`}
+          </p>
+          <ProjectSwitcher
+            current={null}
+            projects={projects}
+            onSelect={(pid) => {
+              if (pid === null) return; // a document cannot be Unfiled (§3.4)
+              onClose();
+              navigate(modePath(pid, stage));
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 const flatRunPath = (id: string): string => `/runs/${encodeURIComponent(id)}`;
 
-export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive = false }: Props): React.ReactElement {
+export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, immersive = false }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const [hovered, setHovered] = useState(false);
-  // DES-FEEDBACK-001 §1.3: the QUICK section's Project action opens the
-  // new-project modal — an overlay, not a route.
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [makePickerOpen, setMakePickerOpen] = useState(false);
   // §7.3 auto-collapse: entering an immersive mode stashes the user's state and
   // collapses; leaving restores it. `null` = nothing stashed. The user can still
   // re-expand mid-mode — this fires only on the transition, never per render.
@@ -223,34 +464,53 @@ export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive =
       setCollapsed(prev);
     }
   }, [immersive]);
-  const [searchOpen, setSearchOpen] = useState(false);
+
+  // ── The one-open accordion (§3.2, EC26): zero or one heading expanded. ──────
+  // Default derives from the route; the map re-fires ONLY when the mapped
+  // heading changes, so a manual collapse survives moves within one territory.
+  const mapped = headingForPath(pathname);
+  const [openHeading, setOpenHeading] = useState<PathKey | null>(mapped);
+  const lastMapped = useRef(mapped);
+  useEffect(() => {
+    if (mapped !== lastMapped.current) {
+      lastMapped.current = mapped;
+      setOpenHeading(mapped);
+    }
+  }, [mapped]);
+  const toggle = (k: PathKey): void => setOpenHeading((cur) => (cur === k ? null : k));
+
   const [searchQuery, setSearchQuery] = useState('');
-  const [repos, setRepos] = useState<RepoEntry[]>([]);
-  // The board's own model, attention-ordered (§2.1.3) — the rail's Projects list
-  // is the board's first column, not a fourth taxonomy of its own.
+  const [repos, setRepos] = useState<RepoEntry[]>(() => getCachedRepos() ?? []);
+  // The board's own model, attention-ordered — the Projects accordion is the
+  // board's first column, not a taxonomy of its own (C3: reads, never re-sorts).
   const { items, loading, error } = useBoardModel(runs);
 
   const isExpanded = !collapsed || hovered;
 
+  // Fetch-on-expand (§3.3): expansion is the gesture; the 5s poll retired.
+  // The session cache is shared with the palette — cold: one GET; warm: none.
   useEffect(() => {
+    if (openHeading !== 'repos') return;
     let disposed = false;
-    let inFlight = false;
-    function load(): void {
-      if (inFlight) return;
-      inFlight = true;
-      api.listRepos().then(({ repos: rs }) => {
+    fetchReposCached()
+      .then((rs) => {
         if (disposed) return;
-        const sorted = [...rs].sort((a, b) => b.registered_at - a.registered_at);
-        setRepos(sorted);
-      }).catch(() => { /* sidebar — fail silently */ }).finally(() => { inFlight = false; });
-    }
-    load();
-    const id = setInterval(load, 5_000);
-    return () => { disposed = true; clearInterval(id); };
-  }, []);
+        setRepos([...rs].sort((a, b) => b.registered_at - a.registered_at));
+      })
+      .catch(() => { /* rail — fail silently */ });
+    return () => { disposed = true; };
+  }, [openHeading]);
 
   const q = searchQuery.trim().toLowerCase();
   const filteredRepos = q ? repos.filter(r => r.name.toLowerCase().includes(q)) : repos;
+
+  // The Make/Chat partition invariant (§3.3): every run under exactly ONE path.
+  const chatRuns = orderRuns(runs.filter(isChatRun)).slice(0, CHATS_MAX);
+  const madeDocs = items
+    .flatMap((item) => item.docs.map((doc) => ({ doc, projectId: item.project.id, projectName: item.project.name })))
+    .sort((a, b) => (b.doc.updated_at ?? '').localeCompare(a.doc.updated_at ?? ''))
+    .slice(0, MADE_DOCS_MAX);
+  const madeRuns = orderRuns(runs.filter((v) => !isChatRun(v))).slice(0, MADE_MAX - madeDocs.length);
 
   /** Enter a project: its DASHBOARD (DES-FEEDBACK-001 §4.1) — context before actions. */
   const openProject = (projectId: string): void => {
@@ -266,7 +526,7 @@ export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive =
       onMouseLeave={() => setHovered(false)}
     >
       {/* The app chrome (DES-VISION-001 §6.3 slice 3): logo slot + product name
-          + connection dot + settings — the rail's header region, token-built. */}
+          + connection dot — untouched by the round-4 re-architecture (§8.2). */}
       <div className={`flex shrink-0 ${isExpanded ? 'items-center pr-2' : 'flex-col items-center pt-2 gap-1'}`}>
         <AppChrome collapsed={!isExpanded} navigate={navigate} />
         <button
@@ -280,106 +540,103 @@ export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive =
         </button>
       </div>
 
-      {/* Notification bell — always visible (collapsed: icon-only with badge; expanded: label too) */}
+      {/* Notification bell — stays exactly where it is (§6.1, the operator's word). */}
       <div className={isExpanded ? 'px-4 pb-2' : 'flex justify-center pb-2'}>
         <NotificationBell navigate={navigate} collapsed={!isExpanded} />
       </div>
 
-      {/* QUICK — the creation verbs, VERTICAL under one section header
-          (DES-FEEDBACK-001 §1.2): Project first (opens the new-project flow),
-          then the mode spine's own words. No `+` glyphs anywhere (EC20). */}
-      {isExpanded && (
-        <div
-          data-testid="rail-quick"
-          className="px-4 pt-2 select-none"
-          style={{
-            fontSize: 'var(--text-2xs)',
-            fontWeight: 'var(--weight-medium)',
-            fontFamily: 'var(--font-sans)',
-            color: S.faint,
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-          }}
-        >
-          QUICK
-        </div>
-      )}
-      <div
-        data-testid="rail-actions"
-        className={`flex ${!isExpanded ? 'flex-col px-2 items-center gap-2 mt-1' : 'flex-col items-start px-4 pt-0.5 pb-1 gap-0.5'}`}
-      >
-        <ActionLink glyph="◻" label="Project" hint="start a new project" testId="new-project" onClick={() => setNewProjectOpen(true)} collapsed={!isExpanded} />
-        <ActionLink glyph={MODE_SPECS.build.glyph} label="Build" hint={MODE_SPECS.build.sublabel} testId="new-run" onClick={() => navigate('/runs/new')} collapsed={!isExpanded} />
-        <ActionLink glyph={MODE_SPECS.chat.glyph} label="Chat" hint={MODE_SPECS.chat.sublabel} onClick={() => navigate('/chat/new')} collapsed={!isExpanded} />
-        <ActionLink glyph="⬡" label="Repository" onClick={() => navigate('/repos/new')} collapsed={!isExpanded} />
-      </div>
-
-      {/* Scrollable content */}
-      <div className="flex-1 overflow-y-auto flex flex-col min-h-0 mt-2">
-        {isExpanded ? (
-          <>
-            {/* Search input (repositories) */}
-            {searchOpen && (
-              <div className="px-4 pb-2">
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
-                  placeholder="Search repositories…"
-                  autoFocus
-                  className="w-full bg-transparent text-xs font-mono outline-none border-b"
-                  style={{ color: S.ink, borderColor: S.faint, caretColor: S.accent }}
-                />
-              </div>
-            )}
-
-            {/* ── Runs — the recent 5 inline, below QUICK (DES-FEEDBACK-001 §1.4),
-                   active before terminal, with the ONE "All runs ›" escape hatch
-                   riding at the section's bottom. Same `runs` prop — no new fetch. ── */}
-            <SectionLabel label="Runs" />
-            <RunsSection runs={runs} runPath={runPath} navigate={navigate} />
-
-            {/* ── Taxonomy 1: Projects — the board's axis, attention-ordered ── */}
-            <div data-testid="rail-section-projects">
-              <SectionLabel
-                label="Projects"
-                asLink
-                onClick={() => navigate('/projects')}
-              />
-              {/* Loading/error render nothing here — the board owns those states
-                  (§3.1); the rail never narrates absence it cannot yet know. */}
-              {!loading && error === null && (
-                <SectionList empty="No projects yet" viewAllPath="/projects" navigate={navigate}>
-                  {items.slice(0, SECTION_MAX).map(item => (
+      {isExpanded ? (
+        <div className="flex-1 overflow-y-auto flex flex-col min-h-0 px-2 pt-1" style={{ borderTop: `1px solid ${S.border}` }}>
+          {/* ── Projects ─────────────────────────────────────────────────────── */}
+          <RailHeading
+            path={P_PROJECTS}
+            open={openHeading === 'projects'}
+            onToggle={() => toggle('projects')}
+            onNew={() => setNewProjectOpen(true)}
+            navigate={navigate}
+          >
+            {/* Loading/error render nothing — the board owns those states; the
+                rail never narrates absence it cannot yet know. */}
+            {!loading && error === null && (
+              items.length === 0
+                ? <EmptyRow label="No projects yet" href="/projects" navigate={navigate} />
+                : items.slice(0, PROJECTS_MAX).map(item => (
                     <ProjectRow key={item.project.id} item={item} onOpen={() => openProject(item.project.id)} />
-                  ))}
-                </SectionList>
-              )}
-              {items.length > SECTION_MAX && (
-                <ViewAll onClick={() => navigate('/projects')} />
-              )}
-            </div>
+                  ))
+            )}
+            <ViewAll href="/projects" navigate={navigate} />
+          </RailHeading>
 
-            {/* ── Taxonomy 2: Repositories — the cross-project axis, with search ── */}
-            <div data-testid="rail-section-repos">
-              <SectionLabel
-                label="Repositories"
-                withSearch
-                searchActive={searchOpen}
-                onToggleSearch={() => { setSearchOpen(v => !v); if (searchOpen) setSearchQuery(''); }}
+          {/* ── Make — Build ∪ Document ∪ Video (§2.2 Reading 1) ─────────────── */}
+          <RailHeading
+            path={P_MAKE}
+            open={openHeading === 'make'}
+            onToggle={() => toggle('make')}
+            onNew={() => setMakePickerOpen(v => !v)}
+            navigate={navigate}
+            extra={makePickerOpen
+              ? <MakePicker navigate={navigate} onClose={() => setMakePickerOpen(false)} />
+              : undefined}
+          >
+            {madeRuns.length === 0 && madeDocs.length === 0
+              ? <EmptyRow label="Nothing made yet" href="/make" navigate={navigate} />
+              : (
+                <>
+                  {madeRuns.map((view) => (
+                    <RunRow key={view.session.id} view={view} onOpen={() => navigate(runPath(view.session.id))} />
+                  ))}
+                  {madeDocs.map(({ doc, projectId, projectName }) => (
+                    <DocRow key={`${projectId}:${doc.name}`} doc={doc} projectId={projectId} projectName={projectName} navigate={navigate} />
+                  ))}
+                </>
+              )}
+            <ViewAll href="/make" navigate={navigate} />
+          </RailHeading>
+
+          {/* ── Chat ─────────────────────────────────────────────────────────── */}
+          <RailHeading
+            path={P_CHAT}
+            open={openHeading === 'chat'}
+            onToggle={() => toggle('chat')}
+            onNew={() => navigate('/chat/new')}
+            navigate={navigate}
+          >
+            {chatRuns.length === 0
+              ? <EmptyRow label="No chat threads yet" href="/chats" navigate={navigate} />
+              : chatRuns.map((view) => (
+                  <RunRow key={view.session.id} view={view} onOpen={() => navigate(runPath(view.session.id))} />
+                ))}
+            <ViewAll href="/chats" navigate={navigate} />
+          </RailHeading>
+
+          {/* ── Repositories — rows + search moved inside (§3.3) ─────────────── */}
+          <RailHeading
+            path={P_REPOS}
+            open={openHeading === 'repos'}
+            onToggle={() => toggle('repos')}
+            onNew={() => navigate('/repos/new')}
+            navigate={navigate}
+          >
+            <div className="px-3 pb-1">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                placeholder="Search repositories…"
+                className="w-full bg-transparent text-xs font-mono outline-none border-b"
+                style={{ color: S.ink, borderColor: S.faint, caretColor: S.accent }}
               />
-              <SectionList
-                empty="No repositories yet"
-                viewAllPath="/repos"
-                navigate={navigate}
-              >
-                {filteredRepos.slice(0, SECTION_MAX).map(repo => (
+            </div>
+            {filteredRepos.length === 0
+              ? <EmptyRow label="No repositories yet" href="/repos" navigate={navigate} />
+              : filteredRepos.slice(0, REPOS_MAX).map(repo => (
                   <button
                     key={repo.id}
                     type="button"
+                    data-testid="rail-repo"
                     onClick={() => navigate(`/repo-detail/${encodeURIComponent(repo.id)}`)}
                     title={repo.root_path}
-                    className="w-full text-left px-3 py-2 rounded-md transition-colors"
+                    className="w-full text-left px-3 py-1.5 rounded-md transition-colors"
                     style={{ background: 'transparent' }}
                     onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
                     onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
@@ -394,89 +651,47 @@ export function LeftSidebar({ runs, navigate, runPath = flatRunPath, immersive =
                     </p>
                   </button>
                 ))}
-              </SectionList>
-              {filteredRepos.length > SECTION_MAX && (
-                <ViewAll onClick={() => navigate('/repos')} />
-              )}
-            </div>
+            <ViewAll href="/repos" navigate={navigate} />
+          </RailHeading>
 
-          </>
-        ) : (
-          /* Not expanded: attention dots for the top projects — same axis, same
-             order, same colours as the expanded list and the board. */
-          <div className="px-2 flex flex-col gap-0.5 mt-1">
-            {items.slice(0, COLLAPSED_MAX).map(item => (
-              <button
-                key={item.project.id}
-                type="button"
-                onClick={() => openProject(item.project.id)}
-                aria-label={item.project.name}
-                title={item.project.name}
-                className="w-9 h-9 mx-auto flex items-center justify-center rounded-md transition-colors"
-                style={{ background: 'transparent' }}
-                onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
-                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-              >
-                <span
-                  className={`w-2.5 h-2.5 rounded-full ${item.attention === 'gate' || item.attention === 'running' ? 'animate-pulse' : ''}`}
-                  style={{ background: ATTENTION_DOT[item.attention] }}
-                />
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+          {/* ── Settings — title only, no ▦/＋ (the operator's word, §3.1) ───── */}
+          <RailHeading
+            path={P_SETTINGS}
+            open={openHeading === 'settings'}
+            onToggle={() => toggle('settings')}
+            navigate={navigate}
+          >
+            <SettingsShortcutRows navigate={navigate} />
+          </RailHeading>
+        </div>
+      ) : (
+        /* Collapsed rail (§3.2): the five path glyphs stacked, each an icon
+           LINK to its dashboard route (Settings → /system); accordions don't
+           exist at this width. */
+        <div className="flex-1 px-2 flex flex-col gap-0.5 mt-1">
+          {PATHS.map((path) => (
+            <a
+              key={path.key}
+              href={path.collapsedHref}
+              data-testid="rail-collapsed-glyph"
+              aria-label={path.title}
+              title={path.title}
+              onClick={(e) => { e.preventDefault(); navigate(path.collapsedHref); }}
+              className="w-9 h-9 mx-auto flex items-center justify-center rounded-md transition-colors"
+              style={{ color: S.muted, textDecoration: 'none' }}
+              onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+              onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+            >
+              <span aria-hidden style={{ fontSize: 'var(--text-sm)' }}>{path.glyph}</span>
+            </a>
+          ))}
+        </div>
+      )}
 
-      {/* ── Settings — the expand/collapse section at the rail's bottom
-             (DES-FEEDBACK-001 §1.2, §4.4): the retired AppChrome dropdown's
-             entries as an in-rail shortcut list, collapsed by default. ── */}
-      {isExpanded && <SettingsRailSection navigate={navigate} />}
-
-      {/* The new-project flow (§1.3), opened from QUICK's Project action. */}
+      {/* The new-project flow (§1.3), opened from Projects' ＋ (§3.1). */}
       {newProjectOpen && (
         <NewProjectModal navigate={navigate} onClose={() => setNewProjectOpen(false)} />
       )}
     </div>
-  );
-}
-
-function SectionList({
-  children,
-  empty,
-  viewAllPath,
-  navigate,
-}: {
-  children: React.ReactNode;
-  empty: string;
-  viewAllPath: string;
-  navigate: (p: string) => void;
-}): React.ReactElement {
-  const kids = Array.isArray(children) ? children.filter(Boolean) : (children ? [children] : []);
-  return (
-    <div className="px-2 flex flex-col gap-0.5">
-      {kids.length === 0 ? (
-        <button
-          type="button"
-          onClick={() => navigate(viewAllPath)}
-          className="px-2 py-1 text-left text-[11px] italic font-mono transition-opacity hover:opacity-70"
-          style={{ color: S.faint }}
-        >
-          {empty}
-        </button>
-      ) : kids}
-    </div>
-  );
-}
-
-function ViewAll({ onClick }: { onClick: () => void }): React.ReactElement {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="mx-4 mb-1 text-left text-[11px] font-mono transition-opacity hover:opacity-80"
-      style={{ color: S.link }}
-    >
-      view all
-    </button>
   );
 }

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -332,6 +332,10 @@ function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }:
             data-testid="heading-new"
             aria-label={`New ${path.title}`}
             title={`New ${path.title}`}
+            // Keep the mousedown out of the make-picker's outside-close
+            // listener, so ＋ is a true toggle (open picker + click ＋ again
+            // = closed, not close-then-reopen).
+            onMouseDown={(e) => e.stopPropagation()}
             onClick={onNew}
             className="w-7 h-7 shrink-0 flex items-center justify-center rounded transition-colors"
             style={{ ...iconStyle, background: 'transparent' }}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -300,7 +300,7 @@ function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }:
         >
           <span
             aria-hidden
-            data-testid="rail-heading-chevron"
+            data-testid="rail-chevron"
             className="inline-block leading-none"
             style={{
               transition: 'transform var(--dur-fast)',

--- a/src/components/SettingsRailSection.tsx
+++ b/src/components/SettingsRailSection.tsx
@@ -1,17 +1,14 @@
-import { useState } from 'react';
-
 /**
- * The rail's settings section (DES-FEEDBACK-001 §1.2, §4.4, slice A): the
- * expand/collapse block at the BOTTOM of the rail that carries everything the
- * AppChrome dropdown used to — the gear left the 48px chrome, its menu moved
- * here. Collapsed by default; the chevron rotates 90° on expand
- * (`transition: transform var(--dur-fast)`); the header reads `--ink-muted`
- * collapsed and `--ink-high` open.
+ * The Settings shortcut rows (DES-FEEDBACK-001 §1.2/§4.4, slice A — re-homed by
+ * DES-FEEDBACK-003 §3.1, slice M): Settings is a PRIMARY heading in the rail's
+ * five-path accordion now, and these rows are its expanded contents — the
+ * slice-A list verbatim (rows + version line), moved, not redesigned. The old
+ * rail-bottom wrapper (`rail-settings-section`) retired with the move; its
+ * slot at the rail's foot goes to HealthRailSection (§6.2, slice O).
  *
- * This is a persistent in-rail SHORTCUT LIST — every row is a `navigate()`
- * call to a settings route that already exists (`/system`, `/theme`, …).
- * It is NOT a parallel settings surface (§1.2: "does NOT duplicate the
- * settings route").
+ * This stays a SHORTCUT LIST — every row is a `navigate()` call to a settings
+ * route that already exists (`/system`, `/theme`, …). It is NOT a parallel
+ * settings surface (§1.2: "does NOT duplicate the settings route").
  */
 
 /** The exact entries the AppChrome dropdown exposed (SettingsMenu, retired). */
@@ -29,67 +26,28 @@ interface Props {
   navigate: (path: string) => void;
 }
 
-export function SettingsRailSection({ navigate }: Props): React.ReactElement {
-  const [open, setOpen] = useState(false);
-
+export function SettingsShortcutRows({ navigate }: Props): React.ReactElement {
   return (
-    <div
-      data-testid="rail-settings-section"
-      data-open={open}
-      className="shrink-0 px-2 pb-2 pt-1"
-      style={{ borderTop: '1px solid var(--surface-raised)' }}
-    >
-      <button
-        type="button"
-        data-testid="rail-settings-toggle"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-2 px-1 py-1.5 text-left transition-colors"
-        style={{
-          background: 'transparent',
-          color: open ? 'var(--ink-high)' : 'var(--ink-muted)',
-          fontSize: 'var(--text-xs)',
-          fontFamily: 'var(--font-sans)',
-          fontWeight: 'var(--weight-semi)',
-        }}
-      >
-        <span
-          aria-hidden
-          data-testid="rail-settings-chevron"
-          className="inline-block leading-none"
-          style={{
-            transition: 'transform var(--dur-fast)',
-            transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
-          }}
+    <div role="menu" className="flex flex-col pt-0.5">
+      {SETTINGS_ITEMS.map((item) => (
+        <button
+          key={item.path}
+          type="button"
+          role="menuitem"
+          onClick={() => navigate(item.path)}
+          className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
+          style={{ color: 'var(--ink-muted)' }}
         >
-          ›
-        </span>
-        <span aria-hidden>⚙</span>
-        <span>Settings</span>
-      </button>
-      {open && (
-        <div role="menu" className="flex flex-col pt-0.5">
-          {SETTINGS_ITEMS.map((item) => (
-            <button
-              key={item.path}
-              type="button"
-              role="menuitem"
-              onClick={() => navigate(item.path)}
-              className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
-              style={{ color: 'var(--ink-muted)' }}
-            >
-              {item.label}
-            </button>
-          ))}
-          {/* The quiet version row the retired dropdown carried — moved, not dropped. */}
-          <p
-            className="px-6 pt-1.5 pb-0.5 text-[10px] font-mono select-none"
-            style={{ color: 'var(--ink-dim)', margin: 0 }}
-          >
-            v0.3.2
-          </p>
-        </div>
-      )}
+          {item.label}
+        </button>
+      ))}
+      {/* The quiet version row the retired dropdown carried — moved, not dropped. */}
+      <p
+        className="px-6 pt-1.5 pb-0.5 text-[10px] font-mono select-none"
+        style={{ color: 'var(--ink-dim)', margin: 0 }}
+      >
+        v0.3.2
+      </p>
     </div>
   );
 }

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 
-export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail';
+// `make` is the round-4 primary-path dashboard route (DES-FEEDBACK-003 §2.1) —
+// a CLIENT route (a new panel id in this union), not a wire. Slice M registers
+// it with a placeholder surface; the real dashboard is slice O (§4.2).
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not
@@ -166,6 +169,9 @@ export function useRoute(): Route & {
    *  address document versions; both pathname AND search update on navigate so
    *  components reading either field re-render on every navigation. */
   search: string;
+  /** The current pathname — the rail's route→heading map (DES-FEEDBACK-003
+   *  §3.2) reads it to derive which primary path owns the route. */
+  pathname: string;
 } {
   const [pathname, setPathname] = useState(() => window.location.pathname);
   const [search, setSearch] = useState(() => window.location.search);
@@ -192,5 +198,5 @@ export function useRoute(): Route & {
 
   const panelPath = useCallback((p: Panel) => (p === 'home' ? '/' : `/${p}`), []);
 
-  return { ...parse(pathname), navigate, panelPath, search };
+  return { ...parse(pathname), navigate, panelPath, search, pathname };
 }

--- a/src/store/repoCache.ts
+++ b/src/store/repoCache.ts
@@ -1,0 +1,42 @@
+import { api } from '../api/client.js';
+import type { RepoEntry } from '../api/types.js';
+
+/**
+ * The ONE session-scoped repo cache (DES-FEEDBACK-002 §1.4, re-stated by
+ * DES-FEEDBACK-003 §3.3): the repo list is fetched on the first user GESTURE
+ * that needs it — a palette open, a Repositories-heading expand — never on
+ * mount and never on a timer (the rail's 5s poll retired with slice M).
+ * Both readers share this module, so a warm palette means a warm rail and
+ * vice versa: at most one `GET /repos` per session, however many surfaces ask.
+ */
+
+let cache: RepoEntry[] | null = null;
+let inFlight: Promise<RepoEntry[]> | null = null;
+
+/** The cached list, or null when no gesture has fetched it yet. */
+export function getCachedRepos(): RepoEntry[] | null {
+  return cache;
+}
+
+/** Fetch-once: a warm cache resolves without a request; concurrent cold
+ *  callers share one in-flight GET. A failed fetch caches nothing, so the
+ *  next gesture retries. */
+export function fetchReposCached(): Promise<RepoEntry[]> {
+  if (cache !== null) return Promise.resolve(cache);
+  inFlight ??= api
+    .listRepos()
+    .then(({ repos }) => {
+      cache = repos;
+      return repos;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+/** Test seam: back to cold. */
+export function clearRepoCache(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { BoardProject } from '../src/hooks/useBoardModel.js';
 import { makeView } from './factories.js';
 
 /**
- * The rail consolidated to TWO taxonomies (DES-UXFIX-001 §2.3, slice-3 DOM AC):
- * Projects (attention-ordered, the board's own axis) and Repositories. The
- * Chats/Work sections are gone; the flat lists survive behind ONE "All runs ›"
- * escape hatch; the creation verbs speak the mode spine (Build / Chat), not
- * "Do Work" / "New Chat" (F2's second occurrence, V9/V10).
+ * The five-path accordion rail (DES-FEEDBACK-003 §2/§3, slice M): Projects /
+ * Make / Chat / Repositories / Settings heading rows, a strict ONE-OPEN
+ * accordion (EC26), route-aware default expansion (§3.2), ▦/＋ heading icons
+ * (Settings icon-less — the operator's word), and the slice-A rail zones
+ * (QUICK, inline runs, standalone taxonomies, bottom settings section) GONE
+ * (§8.1). The repo 5s poll is retired: fetch-on-expand through the session
+ * cache shared with the palette (§3.3).
  *
  * The board model is mocked: the rail's contract is "render what the model
  * ordered, verbatim" — the ordering arithmetic itself is pinned in
@@ -16,6 +18,7 @@ import { makeView } from './factories.js';
  */
 
 let boardItems: BoardProject[] = [];
+const listRepos = vi.fn(() => Promise.resolve({ repos: [] }));
 
 vi.mock('../src/hooks/useBoardModel.js', () => ({
   useBoardModel: () => ({ items: boardItems, unfiled: [], loading: false, error: null }),
@@ -24,11 +27,12 @@ vi.mock('../src/hooks/useBoardModel.js', () => ({
 vi.mock('../src/api/client.js', () => ({
   api: {
     getHealth: () => Promise.resolve({ status: 'ok', version: '0.2.0', ping: 'pong' }),
-    listRepos: () => Promise.resolve({ repos: [] }),
+    listRepos: () => listRepos(),
   },
 }));
 
-const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+const { LeftSidebar, headingForPath } = await import('../src/components/LeftSidebar.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
 const { RunLink } = await import('../src/components/RunLink.js');
 
 function bp(id: string, attention: BoardProject['attention'], score: number): BoardProject {
@@ -49,103 +53,310 @@ const W2_ORDERED = [
   bp('auth-refactor', 'failing', 67),
   bp('upload-endpoint', 'running', 40),
   bp('notes', 'drafts', 12),
-  bp('smoke-tests', 'quiet', 0),
+  bp('smoke-tests', 'quiet', 8),
+  bp('scratch', 'quiet', 0),
 ];
+
+const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'settings'] as const;
+
+function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
+  return render(
+    <LeftSidebar
+      runs={props.runs ?? []}
+      navigate={props.navigate ?? (() => {})}
+      pathname={props.pathname ?? '/'}
+    />,
+  );
+}
+
+function expandedKeys(): string[] {
+  return HEADING_KEYS.filter(
+    (k) => screen.getByTestId(`rail-heading-${k}`).getAttribute('aria-expanded') === 'true',
+  );
+}
 
 beforeEach(() => {
   cleanup();
   window.localStorage.clear();
   boardItems = W2_ORDERED;
+  listRepos.mockClear();
+  clearRepoCache();
 });
 
-describe('the rail: two taxonomies (§2.3)', () => {
-  it('carries Projects and Repositories — and NO Chats/Work sections', async () => {
-    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+describe('the route→heading map (§3.2)', () => {
+  it('maps every territory to its heading, and / and /runs* to none', () => {
+    expect(headingForPath('/projects')).toBe('projects');
+    expect(headingForPath('/p/abc/build')).toBe('projects');
+    expect(headingForPath('/p/abc')).toBe('projects');
+    expect(headingForPath('/make')).toBe('make');
+    expect(headingForPath('/chats')).toBe('chat');
+    expect(headingForPath('/chat/new')).toBe('chat');
+    expect(headingForPath('/repos')).toBe('repos');
+    expect(headingForPath('/repos/new')).toBe('repos');
+    expect(headingForPath('/repo-detail/r1')).toBe('repos');
+    for (const p of ['/system', '/theme', '/coverage', '/domain', '/workflows', '/policies', '/rules']) {
+      expect(headingForPath(p)).toBe('settings');
+    }
+    expect(headingForPath('/')).toBeNull();
+    expect(headingForPath('/runs')).toBeNull();
+    expect(headingForPath('/runs/r-1')).toBeNull();
+  });
+});
+
+describe('the five heading rows (§3.1)', () => {
+  it('renders all five headings; Settings is icon-less, the other four carry ▦ and ＋', async () => {
+    rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
-    expect(screen.getByTestId('rail-section-projects')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-section-repos')).toBeInTheDocument();
-    expect(screen.queryByTestId('rail-section-chats')).toBeNull();
-    expect(screen.queryByTestId('rail-section-work')).toBeNull();
-    // The old section labels are gone from the surface entirely.
-    expect(screen.queryByText('Chats')).toBeNull();
-    expect(screen.queryByText('Work')).toBeNull();
-    expect(screen.queryByText('No chats yet')).toBeNull();
-    expect(screen.queryByText('No work yet')).toBeNull();
+    for (const k of HEADING_KEYS) {
+      expect(screen.getByTestId(`rail-heading-${k}`)).toBeInTheDocument();
+    }
+    const settings = screen.getByTestId('rail-heading-settings');
+    expect(within(settings).queryByTestId('heading-dashboard')).toBeNull();
+    expect(within(settings).queryByTestId('heading-new')).toBeNull();
+    for (const k of ['projects', 'make', 'chat', 'repos']) {
+      const h = screen.getByTestId(`rail-heading-${k}`);
+      expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
+      expect(within(h).getByTestId('heading-new')).toBeInTheDocument();
+    }
   });
 
-  it('lists projects in the model\'s attention order, capped with "view all"', async () => {
-    render(<LeftSidebar runs={[]} navigate={() => {}} />);
-    await screen.findByRole('button', { name: 'wicked-studio' });
-
-    const rows = within(screen.getByTestId('rail-section-projects')).getAllByTestId('rail-project');
-    expect(rows.map((r) => r.dataset.projectId)).toEqual([
-      'q3-review-deck', 'api-migration', 'auth-refactor', 'upload-endpoint',
-    ]);
-    expect(screen.getByText('view all')).toBeInTheDocument();
-  });
-
-  it('a project row enters the shell — Chat mode default (§1.5)', async () => {
+  it('▦ icons are real links to the §2.1 dashboard routes', async () => {
     const navigate = vi.fn();
-    render(<LeftSidebar runs={[]} navigate={navigate} />);
+    rail({ navigate });
     await screen.findByRole('button', { name: 'wicked-studio' });
 
-    fireEvent.click(screen.getAllByTestId('rail-project')[0]!);
-    expect(navigate).toHaveBeenCalledWith('/p/q3-review-deck');
+    const hrefOf = (k: string): string | null =>
+      within(screen.getByTestId(`rail-heading-${k}`))
+        .getByTestId('heading-dashboard').getAttribute('href');
+    expect(hrefOf('projects')).toBe('/projects');
+    expect(hrefOf('make')).toBe('/make');
+    expect(hrefOf('chat')).toBe('/chats');
+    expect(hrefOf('repos')).toBe('/repos');
+
+    fireEvent.click(within(screen.getByTestId('rail-heading-make')).getByTestId('heading-dashboard'));
+    expect(navigate).toHaveBeenCalledWith('/make');
+    // The ▦ never toggles expansion (§3.1).
+    expect(expandedKeys()).toEqual([]);
   });
 
-  it('keeps /runs reachable through the ONE escape hatch — at the runs section bottom (§1.4)', async () => {
-    const navigate = vi.fn();
-    render(<LeftSidebar runs={[]} navigate={navigate} />);
+  it('the slice-A zones are GONE: no QUICK, no inline runs, no standalone taxonomies, no bottom settings section (§8.1)', async () => {
+    rail({ runs: [makeView({ id: 'r-live', status: 'executing' })] });
     await screen.findByRole('button', { name: 'wicked-studio' });
 
-    const hatch = within(screen.getByTestId('rail-runs')).getByTestId('rail-all-runs');
-    expect(hatch).toHaveAttribute('href', '/runs');
-    fireEvent.click(hatch);
-    expect(navigate).toHaveBeenCalledWith('/runs');
+    expect(screen.queryByTestId('rail-quick')).toBeNull();
+    expect(screen.queryByTestId('rail-actions')).toBeNull();
+    expect(screen.queryByTestId('rail-runs')).toBeNull();
+    expect(screen.queryByTestId('rail-settings-section')).toBeNull();
+    expect(screen.queryByTestId('rail-section-projects')).toBeNull();
+    expect(screen.queryByTestId('rail-section-repos')).toBeNull();
+    expect(screen.queryByText('QUICK')).toBeNull();
   });
 
-  // Re-scoped to DES-FEEDBACK-001 §1.2 (slice A): the creation verbs are a
-  // VERTICAL list under the QUICK header now, with Project leading — and the
-  // `+` glyphs are gone (EC20).
-  it('QUICK section: Project / Build / Chat / Repository under the QUICK header, no + glyphs (EC20)', async () => {
-    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+  it('keeps the NotificationBell in its slot below the chrome (§6.1 — untouched)', async () => {
+    rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+  });
+});
 
-    expect(screen.getByTestId('rail-quick').textContent).toBe('QUICK');
-    const actions = screen.getByTestId('rail-actions');
-    const labels = within(actions).getAllByRole('button').map((b) => b.getAttribute('aria-label'));
-    expect(labels).toEqual(['Project', 'Build', 'Chat', 'Repository']);
-    expect(actions.textContent).not.toContain('+');
-    expect(screen.queryByText('Do Work')).toBeNull();
-    expect(screen.queryByText('New Chat')).toBeNull();
-    expect(screen.queryByText('New Repository')).toBeNull();
+describe('the one-open accordion (§3.2, EC26)', () => {
+  it('at most one heading is expanded; expanding one collapses the other', async () => {
+    rail();
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(expandedKeys()).toEqual([]); // landing on / — the calm frame
+
+    fireEvent.click(screen.getByTestId('rail-title-make'));
+    expect(expandedKeys()).toEqual(['make']);
+
+    fireEvent.click(screen.getByTestId('rail-title-projects'));
+    expect(expandedKeys()).toEqual(['projects']);
+
+    // Again-click collapses — zero open is legal.
+    fireEvent.click(screen.getByTestId('rail-title-projects'));
+    expect(expandedKeys()).toEqual([]);
   });
 
-  it('Project opens the new-project modal (§1.3)', async () => {
-    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+  it('derives the default from the route: /p/* expands Projects, / expands none, /chats expands Chat', async () => {
+    rail({ pathname: '/p/abc/build' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(expandedKeys()).toEqual(['projects']);
+    cleanup();
+
+    rail({ pathname: '/' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(expandedKeys()).toEqual([]);
+    cleanup();
+
+    rail({ pathname: '/chats' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(expandedKeys()).toEqual(['chat']);
+  });
+
+  it('respects a manual collapse within one territory; re-fires on a territory change (§3.2)', async () => {
+    const view = rail({ pathname: '/p/abc/build' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    expect(expandedKeys()).toEqual(['projects']);
+
+    // Manual collapse, then move between the SAME project's modes: stays collapsed.
+    fireEvent.click(screen.getByTestId('rail-title-projects'));
+    expect(expandedKeys()).toEqual([]);
+    view.rerender(<LeftSidebar runs={[]} navigate={() => {}} pathname="/p/abc/chat" />);
+    expect(expandedKeys()).toEqual([]);
+
+    // A DIFFERENT heading's territory re-fires the map.
+    view.rerender(<LeftSidebar runs={[]} navigate={() => {}} pathname="/repos" />);
+    expect(expandedKeys()).toEqual(['repos']);
+  });
+});
+
+describe('the ＋ create actions (§2.1/§3.4)', () => {
+  it('Projects ＋ opens the new-project modal — the slice-A component unchanged', async () => {
+    rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     expect(screen.queryByTestId('new-project-modal')).toBeNull();
-    fireEvent.click(screen.getByTestId('new-project'));
+    fireEvent.click(within(screen.getByTestId('rail-heading-projects')).getByTestId('heading-new'));
     expect(screen.getByTestId('new-project-modal')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByTestId('new-project-modal')).toBeNull();
   });
 
-  it('renders the recent runs inline below QUICK and the settings section at the bottom (§1.2)', async () => {
+  it('Chat ＋ and Repositories ＋ navigate to their existing create routes', async () => {
+    const navigate = vi.fn();
+    rail({ navigate });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    fireEvent.click(within(screen.getByTestId('rail-heading-chat')).getByTestId('heading-new'));
+    expect(navigate).toHaveBeenCalledWith('/chat/new');
+    fireEvent.click(within(screen.getByTestId('rail-heading-repos')).getByTestId('heading-new'));
+    expect(navigate).toHaveBeenCalledWith('/repos/new');
+  });
+
+  it('Make ＋ opens the three-way make-picker; Build routes to the unbound launch form', async () => {
+    const navigate = vi.fn();
+    rail({ navigate });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    fireEvent.click(within(screen.getByTestId('rail-heading-make')).getByTestId('heading-new'));
+    const picker = screen.getByTestId('make-picker');
+    const rows = within(picker).getAllByTestId('make-picker-row');
+    expect(rows.map((r) => r.dataset.mode)).toEqual(['build', 'document', 'video']);
+
+    fireEvent.click(rows[0]!);
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+    expect(screen.queryByTestId('make-picker')).toBeNull();
+  });
+
+  it('Make ＋ → Document goes through the project picker — a doc lives in a project (§3.4)', async () => {
+    rail();
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    fireEvent.click(within(screen.getByTestId('rail-heading-make')).getByTestId('heading-new'));
+    fireEvent.click(screen.getAllByTestId('make-picker-row')[1]!);
+    expect(screen.getByTestId('make-picker-project-stage')).toBeInTheDocument();
+    expect(screen.getByTestId('project-switcher')).toBeInTheDocument();
+  });
+});
+
+describe('accordion contents (§3.3)', () => {
+  it('Projects: the board model verbatim, capped at 6, with a view-all link sharing the ▦ target', async () => {
+    rail({ pathname: '/projects' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const section = screen.getByTestId('rail-heading-projects');
+    const rows = within(section).getAllByTestId('rail-project');
+    expect(rows.map((r) => r.dataset.projectId)).toEqual([
+      'q3-review-deck', 'api-migration', 'auth-refactor', 'upload-endpoint', 'notes', 'smoke-tests',
+    ]);
+    expect(within(section).getByTestId('rail-view-all')).toHaveAttribute('href', '/projects');
+  });
+
+  it('partitions runs: a workflow-less run is a CHAT (ChatsPage predicate verbatim), never double-listed under Make', async () => {
+    const runs = [
+      makeView({ id: 'r-build', workflow_id: 'wf-1', problem: 'ship the thing', status: 'executing' }),
+      makeView({ id: 'r-chat', workflow_id: 'chat', problem: 'talk it over', status: 'executing' }),
+      makeView({ id: 'r-legacy', workflow_id: undefined as unknown as string, problem: 'old chat', status: 'completed' }),
+    ];
+    rail({ runs, pathname: '/make' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const make = screen.getByTestId('rail-heading-make');
+    const makeIds = within(make).getAllByTestId('rail-run').map((r) => r.dataset.runId);
+    expect(makeIds).toEqual(['r-build']);
+
+    fireEvent.click(screen.getByTestId('rail-title-chat'));
+    const chat = screen.getByTestId('rail-heading-chat');
+    const chatIds = within(chat).getAllByTestId('rail-run').map((r) => r.dataset.runId);
+    expect(chatIds).toEqual(['r-chat', 'r-legacy']); // active before terminal
+  });
+
+  it('a Make run row navigates via runPath; no `+` glyph rides inside accordion contents (EC20 amended)', async () => {
+    const navigate = vi.fn();
     render(
       <LeftSidebar
-        runs={[makeView({ id: 'r-live', status: 'executing', problem: 'add rate-limiting' })]}
-        navigate={() => {}}
+        runs={[makeView({ id: 'r-1', workflow_id: 'wf-1', status: 'executing' })]}
+        navigate={navigate}
+        pathname="/make"
+        runPath={(id) => `/p/abc/build/${id}`}
       />,
     );
     await screen.findByRole('button', { name: 'wicked-studio' });
 
-    const runsSection = screen.getByTestId('rail-runs');
-    expect(within(runsSection).getByTestId('rail-run')).toHaveAttribute('data-run-id', 'r-live');
-    // Settings: collapsed by default, at the rail bottom.
-    expect(screen.getByTestId('rail-settings-section').dataset.open).toBe('false');
+    const make = screen.getByTestId('rail-heading-make');
+    fireEvent.click(within(make).getByTestId('rail-run'));
+    expect(navigate).toHaveBeenCalledWith('/p/abc/build/r-1');
+    // Accordion CONTENTS carry no `+` glyph — the ＋ lives at heading level only.
+    const contents = within(make).getByTestId('rail-run').parentElement!;
+    expect(contents.textContent).not.toContain('+');
+  });
+
+  it('Repositories: fetch on EXPAND only, once per session — the 5s poll is retired (§3.3)', async () => {
+    vi.useFakeTimers();
+    try {
+      rail();
+      expect(listRepos).not.toHaveBeenCalled();
+      await act(async () => { await vi.advanceTimersByTimeAsync(11_000); });
+      expect(listRepos).not.toHaveBeenCalled(); // no poll, no mount fetch
+
+      fireEvent.click(screen.getByTestId('rail-title-repos'));
+      await act(async () => { await vi.advanceTimersByTimeAsync(10); });
+      expect(listRepos).toHaveBeenCalledTimes(1);
+
+      // Collapse and re-expand: the session cache is warm — no second GET.
+      fireEvent.click(screen.getByTestId('rail-title-repos'));
+      fireEvent.click(screen.getByTestId('rail-title-repos'));
+      await act(async () => { await vi.advanceTimersByTimeAsync(10); });
+      expect(listRepos).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('Settings expands to the slice-A shortcut rows (menuitems + version line)', async () => {
+    rail({ pathname: '/system' });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const settings = screen.getByTestId('rail-heading-settings');
+    expect(settings.getAttribute('aria-expanded')).toBe('true');
+    expect(within(settings).getAllByRole('menuitem')).toHaveLength(7);
+    expect(within(settings).getByText(/^v\d+\.\d+\.\d+$/)).toBeInTheDocument();
+  });
+});
+
+describe('the collapsed rail (§3.2)', () => {
+  it('shows exactly five glyph links to the dashboard routes (Settings → /system)', async () => {
+    rail();
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
+    expect(glyphs).toHaveLength(5);
+    expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
+      '/projects', '/make', '/chats', '/repos', '/system',
+    ]);
+    // Accordions don't exist at this width.
+    expect(screen.queryByTestId('rail-heading-projects')).toBeNull();
   });
 });
 

--- a/tests/SettingsRailSection.test.tsx
+++ b/tests/SettingsRailSection.test.tsx
@@ -1,53 +1,27 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { SETTINGS_ITEMS, SettingsRailSection } from '../src/components/SettingsRailSection.js';
+import { SETTINGS_ITEMS, SettingsShortcutRows } from '../src/components/SettingsRailSection.js';
 
 /**
- * The rail's settings section (DES-FEEDBACK-001 §1.2, §4.4, slice A):
- * collapsed by default, expand/collapse on the header, chevron rotating 90°
- * with `--dur-fast`, header ink-muted↔ink-high, and EVERY entry the retired
- * AppChrome dropdown exposed — as navigate() shortcuts, not a new surface.
+ * The Settings shortcut rows (slice A, re-homed by DES-FEEDBACK-003 §3.1
+ * slice M): Settings is a primary heading now and these rows are its expanded
+ * accordion contents — the slice-A list verbatim (rows + version line). The
+ * expand/collapse dress moved to the rail's heading anatomy, pinned in
+ * LeftSidebar.rail.test.tsx; what stays pinned here is the LIST contract:
+ * every entry the retired AppChrome dropdown exposed, as navigate() shortcuts.
  */
 
 afterEach(cleanup);
 
-describe('SettingsRailSection', () => {
-  it('is collapsed by default — no menu, data-open=false, muted header', () => {
-    render(<SettingsRailSection navigate={() => {}} />);
-    const section = screen.getByTestId('rail-settings-section');
-    expect(section.dataset.open).toBe('false');
-    expect(screen.queryByRole('menu')).toBeNull();
-    const toggle = screen.getByTestId('rail-settings-toggle');
-    expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    expect(toggle.style.color).toBe('var(--ink-muted)');
-  });
-
-  it('expands on click: menu renders, header goes ink-high, chevron rotates 90°', () => {
-    render(<SettingsRailSection navigate={() => {}} />);
-    const toggle = screen.getByTestId('rail-settings-toggle');
-    const chevron = screen.getByTestId('rail-settings-chevron');
-    expect(chevron.style.transform).toBe('rotate(0deg)');
-    expect(chevron.style.transition).toBe('transform var(--dur-fast)');
-
-    fireEvent.click(toggle);
-    expect(screen.getByTestId('rail-settings-section').dataset.open).toBe('true');
-    expect(screen.getByRole('menu')).toBeInTheDocument();
-    expect(toggle.style.color).toBe('var(--ink-high)');
-    expect(chevron.style.transform).toBe('rotate(90deg)');
-
-    fireEvent.click(toggle); // collapses again
-    expect(screen.queryByRole('menu')).toBeNull();
-    expect(chevron.style.transform).toBe('rotate(0deg)');
-  });
-
+describe('SettingsShortcutRows', () => {
   it('carries EVERYTHING the retired AppChrome dropdown carried — Theme and System included', () => {
-    // The §1.2 contract: the section holds the dropdown's entries, so both the
+    // The §1.2 contract: the rows hold the dropdown's entries, so both the
     // /system Settings entry AND the /theme entry (PR #64) must be present.
     expect(SETTINGS_ITEMS).toContainEqual({ label: 'System', path: '/system' });
     expect(SETTINGS_ITEMS).toContainEqual({ label: 'Theme', path: '/theme' });
 
-    render(<SettingsRailSection navigate={() => {}} />);
-    fireEvent.click(screen.getByTestId('rail-settings-toggle'));
+    render(<SettingsShortcutRows navigate={() => {}} />);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
     for (const item of SETTINGS_ITEMS) {
       expect(screen.getByRole('menuitem', { name: item.label })).toBeInTheDocument();
     }
@@ -57,8 +31,7 @@ describe('SettingsRailSection', () => {
 
   it('each entry is a navigate() shortcut — never a parallel settings surface', () => {
     const navigate = vi.fn();
-    render(<SettingsRailSection navigate={navigate} />);
-    fireEvent.click(screen.getByTestId('rail-settings-toggle'));
+    render(<SettingsShortcutRows navigate={navigate} />);
     fireEvent.click(screen.getByRole('menuitem', { name: 'System' }));
     expect(navigate).toHaveBeenCalledWith('/system');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Theme' }));

--- a/tests/productName.test.tsx
+++ b/tests/productName.test.tsx
@@ -21,7 +21,7 @@ const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
 
 describe('visible product name', () => {
   it('the sidebar wordmark reads wicked-studio', async () => {
-    render(<LeftSidebar runs={[]} navigate={() => {}} />);
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/" />);
 
     // The wordmark is the home button next to the logo. `findByRole` also settles the
     // health/repos fetches the sidebar kicks off on mount. Matched exactly, so the old


### PR DESCRIPTION
Round-4 operator feedback: *"The left nav just has too much going on… Primary nav will be simple."*

## What changed (design: `.product/DES-FEEDBACK-003.md` §1–§3, §8)

- **Five primary-path headings** in the operator's order, each (except Settings) carrying a **▦ dashboard** link (real anchors → /projects, /make, /chats, /repos; /make lands on a placeholder until slice O) and a **＋ new** create (Projects→modal, Make→three-tine Build/Document/Video picker with a project stage, Chat→/chat/new, Repos→register).
- **Title-click, strict one-open accordion** (EC26), route-aware defaults, manual collapse respected.
- **Superseded per §8**: QUICK, the rail RunsSection (the M→N bridge is the /runs route until the bottom panel lands), both standalone taxonomies, the SettingsRailSection wrapper (its shortcut rows now live inside the Settings accordion), and the 5s repo poll — replaced by a session `repoCache` (one GET /repos per session) shared with the command palette.
- **§8.7 rig re-scopes as dedicated commits**: `feedback_sliceA`, `uxfix_slice3`, `vision_slice3` — all pass on the branch and fail on origin/main at their discriminating assertions.

## Verification highlights

Independent proofs: heading order exact; icon counts 4 ▦ / 4 ＋ / Settings 0; a five-title accordion walk left exactly one expanded at every step; fetch tap showed 0 repo GETs in a 7s idle window (longer than the retired poll), 1 on expand, still 1 after re-expand and after opening the palette; exactly ONE window-level keydown listener (EC21, counted); the slice-H triage cursor and its full rig pass unamended; negative check red on main; palette corpus full off the warm cache.

Built on §2.2 **Reading 1: Make = Build ∪ Document ∪ Video** (the flagged operator default). Net src +232 lines (the rewrite replaces the whole 482-line rail file).

## Gates

eslint clean · tsc clean · vitest **1081/1081** · new rig `feedback3_sliceM_test.py` (30 assertions) + 3 re-scoped rigs + `feedback2_sliceG/H/I`, `feedback_sliceD` all PASS on fresh builds.

Shots: `feedback3-M-rail-headings.png`, `feedback3-M-make-picker.png`, `feedback3-M-rail-collapsed.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)