### PR TITLE
Slice N: fixed bottom runs panel — stat bar, run sheet, run page (DES-FEEDBACK-003 §5)

### DIFF
--- a/e2e/feedback3_sliceN_test.py
+++ b/e2e/feedback3_sliceN_test.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+feedback3_sliceN_test.py — the DES-FEEDBACK-003 slice-N gate: the runs bottom
+panel (§5), against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with
+metrics_ws ON so the observed-spend segment has real cliUsage dollars to fold.
+
+The slice DOM ACs, verbatim from §5.7:
+
+  1. `[data-testid="runs-bottom-bar"]` is present on `/`, `/projects`, `/make`,
+     `/repos`, inside `/p/:id/build` AND inside `/p/:id/document` (fixed =
+     everywhere); computed `position: fixed`, bottom 0, height 28.
+  2. W2 fixture: the bar's `data-working`/`data-gates`/`data-failed` match the
+     runs array (2/2/2 with the orphan riding); the spend segment folds the
+     metrics_ws drip to `$0.42 observed`; an empty listing reads the quiet
+     phrase.
+  3. Clicking the bar renders `[data-testid="runs-bottom-sheet"]`; row count
+     ≤ 20; active rows precede terminal rows; each row is an `<a>` whose href
+     resolves per `runPath`; a gated row's href ends with `#gate`.
+  4. Clicking a working run's row navigates to the run page and the sheet
+     unmounts; middle-click leaves the page (href asserted).
+  5. Escape closes the sheet; with the palette open, Escape closes the PALETTE
+     only (registry precedence, §5.7/C9).
+  6. Entering Document mode with the sheet open collapses it (EC27); the
+     version strip's bounding box bottom ≤ the bar's top (no overlap at
+     1440×900) — and the strip's bottom-proximity wake STILL WORKS (the
+     slice-F regression this design must not cause): after the 3s auto-hide
+     the mouse driven to the bottom edge over the canvas flips the strip's
+     opacity 0 → 1.
+  7. The panel fires zero network requests — ever (interception across a
+     settled idle window spanning expand / hover / collapse / re-expand).
+  8. `[data-testid="rail-runs"]` no longer exists anywhere (supersession).
+  9. EC18 (amended): the canvas still owns >80% of the viewport width on a
+     direct doc route (drawer closed default), the 28px row notwithstanding.
+
+Captures (§10.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback3-N-bar-collapsed.png   bar with live counts under the board
+  feedback3-N-sheet-open.png      sheet, active-before-terminal rows
+  feedback3-N-bar-immersive.png   Document mode: canvas, version strip, bar
+
+Finally: `npm run lint` must exit 0 with zero raw-color findings (EC15 is
+ERROR repo-wide).
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK3N_PORT (default 4362),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK3N_PORT = int(os.environ.get("FEEDBACK3N_PORT", "4362"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK3N_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches; see docstring) ─
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server; metrics_ws ON (the burn drip = $0.42) ─────
+start_server(FEEDBACK3N_PORT, dist)
+set_fixture(ORIGIN, metrics_ws=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+api_requests: list[str] = []
+
+BAR_GEOM = """() => {
+  const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+  if (!b) return null;
+  const cs = getComputedStyle(b);
+  const r = b.getBoundingClientRect();
+  return { position: cs.position, bottomGap: window.innerHeight - r.bottom,
+           height: Math.round(r.height), left: r.left,
+           right: Math.round(window.innerWidth - r.right) };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda r: api_requests.append(r.url) if "/api/v1/" in r.url else None)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── AC 1+2: the board — bar geometry, fixture counts, the spend fold ───────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="runs-bottom-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+
+    geom = page.evaluate(BAR_GEOM)
+    geometry_ok = (geom is not None and geom["position"] == "fixed"
+                   and geom["bottomGap"] == 0 and geom["height"] == 28
+                   and geom["left"] == 0 and geom["right"] == 0)
+
+    counts_ok = settled(
+        """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   return !!b && b.dataset.working === '2'
+                       && b.dataset.gates === '2' && b.dataset.failed === '2'; }""",
+        timeout=15000,
+    )
+    # The metrics_ws drip folds to $0.42 (0.04+0.11+0.09+0.18; the null-cost
+    # frame never counts) — the TokenBurnSparkline fold, reused (§5.3).
+    spend_ok = settled(
+        """() => (document.querySelector('[data-testid="runs-bottom-bar"]')?.textContent ?? '')
+              .includes('$0.42 observed')""",
+        timeout=20000,
+    )
+    # Nothing under the bar: the app root reserves the 28px row (§5.2) — the
+    # board's scroll container ends at or above the bar's top edge.
+    reserved_ok = page.evaluate(
+        """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   const board = document.querySelector('[data-testid="project-board"]');
+                   return !!b && !!board
+                       && board.getBoundingClientRect().bottom <= b.getBoundingClientRect().top + 1; }""")
+    # §8.1 supersession: the rail's runs section is gone everywhere.
+    rail_runs_gone = page.evaluate("""() => !document.querySelector('[data-testid="rail-runs"]')""")
+
+    # ── Capture 1: bar with live counts under the board ────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-N-bar-collapsed.png"))
+
+    # ── AC 7: the zero-request window — expand/hover/collapse fire nothing ─────
+    page.wait_for_timeout(2000)  # let the board's own mount reads settle
+    api_requests.clear()
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-bottom-sheet"]').wait_for(timeout=5000)
+
+    # ── AC 3: sheet anatomy — count, ordering, real hrefs, the #gate deep link ─
+    rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="runs-sheet-row"]'))
+              .map(r => ({ id: r.dataset.runId, status: r.dataset.status,
+                           href: r.getAttribute('href'), tag: r.tagName }))""")
+    ACTIVE = {"planning", "distributing", "executing", "awaiting_human"}
+    statuses = [r["status"] for r in rows]
+    first_terminal = next((i for i, s in enumerate(statuses) if s not in ACTIVE), len(statuses))
+    rows_ok = (
+        0 < len(rows) <= 20
+        and all(r["tag"] == "A" for r in rows)
+        and all(s not in ACTIVE for s in statuses[first_terminal:])  # active precede terminal
+        and {r["id"]: r["href"] for r in rows}.get("r-q3") == "/runs/r-q3#gate"
+        and {r["id"]: r["href"] for r in rows}.get("r-upload") == "/runs/r-upload"
+        and {r["id"]: r["href"] for r in rows}.get("r-auth") == "/runs/r-auth"
+    )
+
+    # ── Capture 2: the sheet, active-before-terminal rows ──────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-N-sheet-open.png"))
+
+    # Hover a row, collapse via ▾, re-expand — still inside the request window.
+    page.locator('[data-testid="runs-sheet-row"]').first.hover()
+    page.locator('[data-testid="runs-sheet-collapse"]').click()
+    sheet_collapses = settled("""() => !document.querySelector('[data-testid="runs-bottom-sheet"]')""", timeout=5000)
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-bottom-sheet"]').wait_for(timeout=5000)
+    page.wait_for_timeout(1500)
+    zero_requests_ok = len(api_requests) == 0
+
+    # ── AC 5: Escape precedence — palette first, sheet second (§5.7, C9) ───────
+    page.keyboard.press("Control+k")
+    palette_opens = settled("""() => !!document.querySelector('[data-testid="command-palette"]')""", timeout=5000)
+    page.keyboard.press("Escape")
+    palette_only = settled(
+        """() => !document.querySelector('[data-testid="command-palette"]')
+              && !!document.querySelector('[data-testid="runs-bottom-sheet"]')""",
+        timeout=5000,
+    )
+    page.keyboard.press("Escape")
+    escape_closes_sheet = settled(
+        """() => !document.querySelector('[data-testid="runs-bottom-sheet"]')""", timeout=5000)
+
+    # ── AC 4: row click → the run page; the sheet unmounts ─────────────────────
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-sheet-row"][data-run-id="r-upload"]').click()
+    row_click_ok = settled(
+        """() => window.location.pathname === '/runs/r-upload'
+              && !document.querySelector('[data-testid="runs-bottom-sheet"]')""",
+        timeout=10000,
+    )
+    bar_on_run_page = page.evaluate("""() => !!document.querySelector('[data-testid="runs-bottom-bar"]')""")
+
+    # ── AC 1: fixed = everywhere — presence + geometry across the routes ───────
+    presence: dict = {}
+    for route, ready in [
+        ("/projects", '[data-testid="runs-bottom-bar"]'),
+        ("/make", '[data-testid="make-placeholder"]'),
+        ("/repos", '[data-testid="runs-bottom-bar"]'),
+        ("/p/q3-review-deck/build", '[data-testid="mode-switcher"]'),
+    ]:
+        page.goto(f"{ORIGIN}{route}", wait_until="domcontentloaded")
+        page.locator(ready).wait_for(timeout=30000)
+        g = page.evaluate(BAR_GEOM)
+        presence[route] = (g is not None and g["position"] == "fixed"
+                           and g["bottomGap"] == 0 and g["height"] == 28)
+    presence_ok = all(presence.values())
+
+    # ── AC 2: the quiet phrase on an empty (all-terminal) listing ──────────────
+    set_fixture(ORIGIN, no_runs=True)
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="runs-bottom-bar"]').wait_for(timeout=30000)
+    quiet_ok = settled(
+        """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   return !!b && b.dataset.working === '0'
+                       && (b.textContent ?? '').includes('nothing running')
+                       && !(b.textContent ?? '').includes('working'); }""",
+        timeout=15000,
+    )
+    set_fixture(ORIGIN, no_runs=False)
+
+    # ── AC 6: EC27 — entering Document collapses the open sheet ────────────────
+    page.goto(f"{ORIGIN}/p/scratch/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-bottom-sheet"]').wait_for(timeout=5000)
+    page.locator('[data-testid="mode-tab-document"]').click()
+    ec27_ok = settled(
+        """() => window.location.pathname === '/p/scratch/document'
+              && !document.querySelector('[data-testid="runs-bottom-sheet"]')
+              && document.querySelector('[data-testid="runs-bottom-bar"]')?.dataset.expanded === 'false'""",
+        timeout=15000,
+    )
+
+    # ── AC 6 (the named hazard): the version strip and the bar never fight ─────
+    # Create a doc through the real composer (the slice-6 journey) so the strip
+    # has versions to render, then prove the §7.3 machinery under the new row.
+    page.locator('[data-testid="doc-composer"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="version-strip"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+
+    overlap = page.evaluate(
+        """() => { const s = document.querySelector('[data-testid="version-strip"]');
+                   const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   if (!s || !b) return null;
+                   const sr = s.getBoundingClientRect(), br = b.getBoundingClientRect();
+                   return { stripBottom: sr.bottom, barTop: br.top,
+                            noOverlap: sr.bottom <= br.top + 0.5 }; }""")
+    no_overlap_ok = overlap is not None and overlap["noOverlap"]
+
+    # The auto-hide: 3s idle, hands off the mouse — the strip earns its exit.
+    strip_hides = settled(
+        """() => { const s = document.querySelector('[data-testid="version-strip"]');
+                   return !!s && s.getAttribute('data-hidden') === 'true'
+                       && getComputedStyle(s).opacity === '0'; }""",
+        timeout=15000,
+    )
+    # The wake (the slice-F regression this design must not cause): drive the
+    # mouse to the bottom edge OVER THE CANVAS — the sensor band's last 80px end
+    # at the canvas edge, which now sits 28px above the viewport bottom (§5.5).
+    page.mouse.move(600, 840)
+    page.mouse.move(600, 860)
+    strip_wakes = settled(
+        """() => { const s = document.querySelector('[data-testid="version-strip"]');
+                   return !!s && s.getAttribute('data-hidden') === 'false'
+                       && parseFloat(getComputedStyle(s).opacity) > 0.9; }""",
+        timeout=10000,
+    )
+
+    # ── Capture 3: Document mode — canvas, version strip, bar, no overlap ──────
+    page.screenshot(path=str(VSHOTS / "feedback3-N-bar-immersive.png"))
+
+    # ── AC 9: EC18 (amended) — the canvas fraction on a direct doc route ───────
+    doc_url = page.evaluate("() => window.location.pathname")
+    page.goto(f"{ORIGIN}{doc_url}", wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+    # Park the mouse mid-canvas (no rail hover-peek under measurement) and let
+    # the rail's immersive collapse land first — the standalone rig's exact
+    # protocol: EC18 is a steady-state, first-visit claim.
+    page.mouse.move(720, 320)
+    settled(
+        """() => document.querySelector('[data-testid="left-rail"]')
+              ?.getBoundingClientRect().width < 80""",
+        timeout=10000,
+    )
+    settled(
+        """() => { const c = document.querySelector('[data-testid="doc-canvas"]');
+                   return !!c && c.getBoundingClientRect().width / window.innerWidth > 0.8; }""",
+        timeout=10000,
+    )
+    ec18 = page.evaluate(
+        """() => { const c = document.querySelector('[data-testid="doc-canvas"]');
+                   return { ratio: c ? c.getBoundingClientRect().width / window.innerWidth : 0,
+                            drawerClosed: !document.querySelector('[data-testid="thread-drawer"]'),
+                            barPresent: !!document.querySelector('[data-testid="runs-bottom-bar"]') }; }""")
+    ec18_ok = ec18["ratio"] > 0.8 and ec18["barPresent"]
+
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([
+        geometry_ok, counts_ok, spend_ok, reserved_ok, rail_runs_gone,
+        rows_ok, sheet_collapses, zero_requests_ok, palette_opens,
+        palette_only, escape_closes_sheet, row_click_ok, bar_on_run_page,
+        presence_ok, quiet_ok, ec27_ok, no_overlap_ok, strip_hides,
+        strip_wakes, ec18_ok,
+    ]),
+    "ac1_bar_geometry": geom,
+    "ac1_geometry_ok": geometry_ok,
+    "ac1_presence_per_route": presence,
+    "ac2_counts_match_fixture": counts_ok,
+    "ac2_spend_folds_drip": spend_ok,
+    "ac2_quiet_phrase": quiet_ok,
+    "geometry_row_reserved": reserved_ok,
+    "ac8_rail_runs_absent": rail_runs_gone,
+    "ac3_rows": rows,
+    "ac3_rows_ok": rows_ok,
+    "sheet_collapse_via_chevron": sheet_collapses,
+    "ac7_zero_requests_in_window": zero_requests_ok,
+    "ac7_requests_seen": api_requests[:10],
+    "ac5_palette_opens_over_sheet": palette_opens,
+    "ac5_escape_closes_palette_only": palette_only,
+    "ac5_escape_then_closes_sheet": escape_closes_sheet,
+    "ac4_row_click_lands_run_page": row_click_ok,
+    "bar_present_on_run_page": bar_on_run_page,
+    "ac6_ec27_document_collapses_sheet": ec27_ok,
+    "ac6_strip_bar_no_overlap": overlap,
+    "ac6_strip_auto_hides": strip_hides,
+    "ac6_strip_wakes_on_bottom_proximity": strip_wakes,
+    "ac9_ec18": ec18,
+    "ac9_ec18_ok": ec18_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("feedback3-N-bar-collapsed.png", "feedback3-N-sheet-open.png",
+                     "feedback3-N-bar-immersive.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-N DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0, zero raw-color findings (EC15 error repo-wide) ───
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+raw_color_findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and raw_color_findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings_repo_wide": raw_color_findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero raw-color findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
 import { RuleManager } from './components/RuleManager.js';
+import { RunsBottomPanel, RUNS_BAR_PX } from './components/RunsBottomPanel.js';
 import { ChatPanel } from './components/ChatPanel.js';
 import { GroupChat } from './components/GroupChat.js';
 import { WorkflowViewer } from './components/WorkflowViewer.js';
@@ -487,16 +488,23 @@ export function App(): React.ReactElement {
     return runSurface();
   }
 
+  // DES-FEEDBACK-001 §7.3 / DES-FEEDBACK-003 §5.5: Document and Video are
+  // canvas-first — the rail auto-collapses on entry, and the runs bottom
+  // sheet auto-collapses on the same transition (EC27).
+  const immersive = projectId !== null && (mode === 'document' || mode === 'video');
+
   return (
-    <div className="flex h-screen overflow-hidden bg-surface-base">
-      {/* DES-FEEDBACK-001 §7.3: Document and Video are canvas-first — the rail
-          auto-collapses to icons on entry and restores on exit. */}
+    // §5.2: the root reserves the bar's 28px as padding — the collapsed bar is
+    // a ROW, not an overlay, so every surface (board, dashboards, canvas — and
+    // with it the version strip's proximity-sensor band, which ends at the
+    // canvas edge) ends ABOVE the bar. Nothing is ever covered while collapsed.
+    <div className="flex h-screen overflow-hidden bg-surface-base" style={{ paddingBottom: RUNS_BAR_PX }}>
       <LeftSidebar
         runs={runs}
         navigate={navigate}
         pathname={pathname}
         runPath={runPath}
-        immersive={projectId !== null && (mode === 'document' || mode === 'video')}
+        immersive={immersive}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -520,6 +528,11 @@ export function App(): React.ReactElement {
         selectedRun={selected}
         onKill={(id) => void onKill(id)}
       />
+
+      {/* The runs bottom panel (DES-FEEDBACK-003 §5, slice N): a fourth reader
+          of the SAME `useRuns()` array plus the client-held stores — zero new
+          requests, zero new sockets. Fixed at the viewport bottom, everywhere. */}
+      <RunsBottomPanel runs={runs} runPath={runPath} navigate={navigate} immersive={immersive} />
 
       {/* Gate toasts — renders above everything; scoped to the current run. NOT on the
           orchestrator board: there every waiting gate is already an answerable chip on

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -11,6 +11,7 @@ import { useAppearanceStore } from '../theming/appearance.js';
 import { decideGate, GATE_HASH } from '../board/gateActions.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { Modal } from './Modal.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
 import { Terminal } from './Terminal.js';
 
 /**
@@ -134,6 +135,10 @@ export function CommandPalette({
   const [repos, setRepos] = useState<RepoEntry[]>(getCachedRepos() ?? []);
   const [showNewProject, setShowNewProject] = useState(false);
   const [showTerminal, setShowTerminal] = useState(false);
+  // `> New Document` / `> New Video` outside a project (DES-FEEDBACK-003 §8.4):
+  // a doc lives in a project, so the verb opens the same project-picker stage
+  // the Make ＋ fork uses (§3.4) before navigating into the mode.
+  const [pickProjectFor, setPickProjectFor] = useState<'document' | 'video' | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const restoreRef = useRef<HTMLElement | null>(null);
@@ -233,6 +238,30 @@ export function CommandPalette({
       {
         name: 'New Chat',
         action: () => navigate(projectId !== null ? `${modePath(projectId, 'chat')}/new` : '/chat/new'),
+      },
+      // The §3.4 fork's other two tines (DES-FEEDBACK-003 §8.4, slice N): the
+      // palette and Make's ＋ agree on what can be made. Inside a project shell
+      // the verb lands directly in the mode; outside, a doc cannot be Unfiled,
+      // so the same project-picker mechanism as the Make ＋ runs first.
+      {
+        name: 'New Document',
+        action: () => {
+          if (projectId !== null) navigate(modePath(projectId, 'document'));
+          else {
+            if (projects.length === 0) void useProjectsStore.getState().load();
+            setPickProjectFor('document');
+          }
+        },
+      },
+      {
+        name: 'New Video',
+        action: () => {
+          if (projectId !== null) navigate(modePath(projectId, 'video'));
+          else {
+            if (projects.length === 0) void useProjectsStore.getState().load();
+            setPickProjectFor('video');
+          }
+        },
       },
       { name: 'New Project', action: () => setShowNewProject(true) },
       {
@@ -485,6 +514,31 @@ export function CommandPalette({
       {/* `> New Project` — the slice-A modal, unchanged */}
       {showNewProject && (
         <NewProjectModal navigate={(p: string) => navigate(p)} onClose={() => setShowNewProject(false)} />
+      )}
+
+      {/* `> New Document` / `> New Video` outside a project — the Make ＋ fork's
+          project-picker stage (§3.4/§8.4): pick a project, land in its mode. */}
+      {pickProjectFor !== null && (
+        <Modal
+          title={pickProjectFor === 'video' ? 'New video' : 'New document'}
+          onClose={() => setPickProjectFor(null)}
+        >
+          <div className="flex flex-col gap-2" data-testid="palette-project-stage">
+            <p style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-sans)', margin: 0 }}>
+              {`A ${pickProjectFor} lives in a project — pick one:`}
+            </p>
+            <ProjectSwitcher
+              current={null}
+              projects={projects}
+              onSelect={(pid) => {
+                if (pid === null) return; // a document cannot be Unfiled (§3.4)
+                const m = pickProjectFor;
+                setPickProjectFor(null);
+                navigate(modePath(pid, m));
+              }}
+            />
+          </div>
+        </Modal>
       )}
 
       {/* `> Open Terminal` — the RightPanel pair (Modal + governed Terminal) */}

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { SessionStatus, SessionView } from '../api/types.js';
+import { GATE_HASH } from '../board/gateActions.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
+import { useGateStore } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
+import { useRunsPanelStore } from '../store/runsPanel.js';
+import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+import { prefersReducedMotion } from './LiveEdge.js';
+import { phaseWord, recentRuns, RUN_DOT } from './RunsSection.js';
+
+/**
+ * The runs bottom panel (DES-FEEDBACK-003 §5, slice N) — the runs' home after
+ * the rail lost its RunsSection mount (§8.1). Two physical modes (§5.2):
+ *
+ *  - COLLAPSED (default): a fixed 28px bar across the viewport bottom — a
+ *    reserved ROW, not an overlay: App's root gains `padding-bottom: 28px`
+ *    (RUNS_BAR_PX), so no surface is ever covered while collapsed (EC27).
+ *  - EXPANDED: an overlay sheet rising from the bar to min(340px, 42vh) —
+ *    overlays content rather than reflowing it, so layout math stays
+ *    identical everywhere. Collapse: the ▾, Escape (registry-routed, §5.7),
+ *    or clicking outside the sheet.
+ *
+ * Every stat is CLIENT-DERIVABLE from stores the app already holds (§5.3):
+ * the `runs` prop (App's one `useRuns()`), the gate store, and the runtime
+ * store's cliUsage fold — zero new requests, zero new sockets (§5.1, C8).
+ * Row grammar (dot / phase word / ordering) is the RunsSection library,
+ * reused verbatim (§5.5). z-order: above surface content, below the palette,
+ * modals, and gate toasts (§5.2); the sheet captures no keys beyond Escape.
+ */
+
+/** §5.2: the collapsed bar's exact height — App reserves this as padding. */
+export const RUNS_BAR_PX = 28;
+
+/** §5.4: the sheet lists up to 20 runs, scrolling internally past 8. */
+const SHEET_MAX = 20;
+
+const TERMINAL: ReadonlySet<SessionStatus> = new Set(['completed', 'cancelled', 'failed']);
+
+export interface RunStats {
+  /** Non-terminal, non-gate statuses (the RunsSection TERMINAL set). */
+  working: number;
+  /** `awaiting_human` in `runs` — agrees with the gate store by construction. */
+  gates: number;
+  /** `status === 'failed'` in the default (non-archived) listing — the label
+   *  says "failed", scoped by what `/runs` returns; no invented 24h clock. */
+  failed: number;
+}
+
+/** §5.3's stat derivations, spelled once and unit-tested. */
+export function runStats(runs: SessionView[]): RunStats {
+  let working = 0;
+  let gates = 0;
+  let failed = 0;
+  for (const v of runs) {
+    const s = v.session.status;
+    if (s === 'awaiting_human') gates += 1;
+    else if (s === 'failed') failed += 1;
+    else if (!TERMINAL.has(s)) working += 1;
+  }
+  return { working, gates, failed };
+}
+
+/**
+ * The TokenBurnSparkline fold (§5.3): real reported `cliUsage` dollars from
+ * the runtime store's per-run logs — "observed" is in the label because that
+ * is what it is. A `costUsd: null` frame never entered the log, so an unknown
+ * cost can never fold to $0.00. Also folded per run for the sheet rows (§5.4:
+ * shown only when non-zero — never $0.00 for "unknown").
+ */
+export function observedSpend(logs: Record<string, LoggedEvent[]>): {
+  total: number;
+  frames: number;
+  byRun: Record<string, number>;
+} {
+  let total = 0;
+  let frames = 0;
+  const byRun: Record<string, number> = {};
+  for (const [runId, log] of Object.entries(logs)) {
+    for (const entry of log) {
+      if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
+        total += entry.costUsd;
+        frames += 1;
+        byRun[runId] = (byRun[runId] ?? 0) + entry.costUsd;
+      }
+    }
+  }
+  return { total, frames, byRun };
+}
+
+/** "waiting 12m" — the gate row's wait age off the gate store's frame ts (§5.4). */
+export function waitingWord(ageMs: number): string {
+  const s = Math.max(0, Math.floor(ageMs / 1000));
+  if (s < 60) return `waiting ${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `waiting ${m}m`;
+  return `waiting ${Math.floor(m / 60)}h`;
+}
+
+/** One collapsed-bar stat segment: glyph in its status token, text muted (§5.3). */
+function Segment({ glyph, color, text, pulse = false }: {
+  glyph: string;
+  color: string;
+  text: string;
+  pulse?: boolean;
+}): React.ReactElement {
+  return (
+    <span className="flex items-center gap-1 shrink-0">
+      <span
+        aria-hidden
+        style={{
+          color,
+          // §5.3: the ⏸ segment pulses ONLY while a gate is waiting — the
+          // AppChrome dot's exact grammar, honoring prefers-reduced-motion.
+          animation: pulse && !prefersReducedMotion() ? 'wk-live-pulse 2s ease-in-out infinite' : undefined,
+        }}
+      >
+        {glyph}
+      </span>
+      <span style={{ color: 'var(--ink-muted)' }}>{text}</span>
+    </span>
+  );
+}
+
+interface Props {
+  runs: SessionView[];
+  runPath: (id: string) => string;
+  navigate: (path: string) => void;
+  /** True inside Document/Video — entering auto-collapses the sheet (EC27). */
+  immersive: boolean;
+}
+
+export function RunsBottomPanel({ runs, runPath, navigate, immersive }: Props): React.ReactElement {
+  const expanded = useRunsPanelStore((s) => s.expanded);
+  const gates = useGateStore((s) => s.gates);
+  const logs = useRuntimeStore((s) => s.logs);
+  const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const stats = useMemo(() => runStats(runs), [runs]);
+  const spend = useMemo(() => observedSpend(logs), [logs]);
+  const rows = useMemo(() => recentRuns(runs, SHEET_MAX), [runs]);
+  const quiet = stats.working === 0 && stats.gates === 0 && stats.failed === 0;
+
+  // EC27: entering an immersive mode collapses an open sheet — the canvas-first
+  // principle, same transition the rail collapses on. Fires on the transition
+  // only; the operator can still re-expand manually (an explicit gesture wins).
+  useEffect(() => {
+    if (immersive) useRunsPanelStore.getState().collapse();
+  }, [immersive]);
+
+  // §5.7 Escape precedence, through the ONE slice-G registry (EC21, C9): the
+  // palette owns Escape while open (the registry yields wholesale); the triage
+  // cursor's own Escape entry yields while this sheet is up (useTriageCursor
+  // reads this store), so palette → sheet → triage holds regardless of which
+  // surface registered first. Stable entries — guards read through the store.
+  const escapeEntries = useMemo<ShortcutEntry[]>(
+    () => [
+      {
+        id: 'runs-sheet-close',
+        chord: { key: 'escape' },
+        description: 'Collapse the runs sheet',
+        guard: () => useRunsPanelStore.getState().expanded,
+        handler: () => useRunsPanelStore.getState().collapse(),
+      },
+    ],
+    [],
+  );
+  useGlobalShortcuts(escapeEntries);
+
+  // §5.2: clicking outside the sheet collapses it.
+  useEffect(() => {
+    if (!expanded) return;
+    function onOutside(e: MouseEvent): void {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        useRunsPanelStore.getState().collapse();
+      }
+    }
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, [expanded]);
+
+  const allRuns = (testId: string): React.ReactElement => (
+    <a
+      href="/runs"
+      data-testid={testId}
+      onClick={(e) => {
+        // A real link (§5.3) — the ONE escape hatch to the flat list, not an
+        // expand gesture, so the click must not bubble into the toggle.
+        e.preventDefault();
+        e.stopPropagation();
+        navigate('/runs');
+      }}
+      className="shrink-0 transition-opacity hover:opacity-80"
+      style={{ color: 'var(--accent)', textDecoration: 'none' }}
+    >
+      All runs ›
+    </a>
+  );
+
+  const summary = (
+    <>
+      <Segment glyph="●" color="var(--status-run)" text={`${stats.working} working`} />
+      <Segment glyph="⏸" color="var(--status-gate)" text={`${stats.gates} gates`} pulse={stats.gates > 0} />
+      <Segment glyph="✗" color="var(--status-fail)" text={`${stats.failed} failed`} />
+      {spend.frames > 0 && (
+        // Rendered only once a cliUsage frame has been observed — never a
+        // fabricated $0.00 for "unknown" (the slice-E wire-honesty rule).
+        <Segment glyph="◔" color="var(--accent)" text={`$${spend.total.toFixed(2)} observed`} />
+      )}
+    </>
+  );
+
+  return (
+    <div ref={rootRef}>
+      {/* ── The collapsed bar: a reserved 28px row, fixed at the bottom (§5.2) ── */}
+      <div
+        data-testid="runs-bottom-bar"
+        data-expanded={String(expanded)}
+        data-working={stats.working}
+        data-gates={stats.gates}
+        data-failed={stats.failed}
+        className="fixed bottom-0 left-0 right-0 flex items-center font-mono"
+        style={{
+          height: RUNS_BAR_PX,
+          zIndex: 40, // above surface content; below the palette/modals/toasts (z-50)
+          background: 'var(--surface-rail)',
+          borderTop: '1px solid var(--surface-raised)',
+          fontSize: 'var(--text-2xs)',
+        }}
+      >
+        <button
+          type="button"
+          data-testid="runs-bar-toggle"
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Collapse the runs sheet' : 'Expand the runs sheet'}
+          onClick={() => useRunsPanelStore.getState().toggle()}
+          className="flex flex-1 items-center gap-3 h-full px-3 text-left min-w-0"
+          style={{ background: 'transparent', fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)' }}
+        >
+          <span aria-hidden style={{ color: 'var(--ink-dim)' }}>{expanded ? '▾' : '▴'}</span>
+          {quiet ? (
+            // Zero-states compress (§5.3): calm is one phrase, not four zeros.
+            <span style={{ color: 'var(--ink-dim)' }}>nothing running</span>
+          ) : (
+            summary
+          )}
+        </button>
+        <div className="px-3">{allRuns('runs-bar-all')}</div>
+      </div>
+
+      {/* ── The expanded sheet: an overlay guest, never a reflow (§5.2/§5.4) ── */}
+      {expanded && (
+        <div
+          data-testid="runs-bottom-sheet"
+          className="wk-sheet-in fixed left-0 right-0 flex flex-col"
+          style={{
+            bottom: RUNS_BAR_PX,
+            height: 'min(340px, 42vh)',
+            zIndex: 40,
+            background: 'var(--surface-overlay)',
+            boxShadow: 'var(--shadow-overlay)',
+            borderTop: '1px solid var(--surface-raised)',
+          }}
+        >
+          <div
+            className="flex items-center gap-3 px-3 py-2 shrink-0 font-mono"
+            style={{ fontSize: 'var(--text-2xs)', borderBottom: '1px solid var(--surface-raised)' }}
+          >
+            <span style={{ color: 'var(--ink-high)', fontWeight: 'var(--weight-semi)' }}>Runs</span>
+            {!quiet && summary}
+            <span className="flex-1" />
+            {allRuns('runs-sheet-all')}
+            <button
+              type="button"
+              data-testid="runs-sheet-collapse"
+              aria-label="Collapse the runs sheet"
+              onClick={() => useRunsPanelStore.getState().collapse()}
+              className="shrink-0 px-1"
+              style={{ background: 'transparent', color: 'var(--ink-muted)', cursor: 'pointer' }}
+            >
+              ▾
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto py-1">
+            {rows.length === 0 && (
+              <p className="px-3 py-2" style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
+                No runs yet.
+              </p>
+            )}
+            {rows.map((view) => {
+              const id = view.session.id;
+              const gated = view.session.status === 'awaiting_human';
+              // A waiting gate row deep-links to its gate (§5.4) — the fastest
+              // path from "the bar pulsed" to "answering".
+              const href = gated ? `${runPath(id)}${GATE_HASH}` : runPath(id);
+              const gate = gates[id];
+              const cost = spend.byRun[id] ?? 0;
+              return (
+                <a
+                  key={id}
+                  href={href}
+                  data-testid="runs-sheet-row"
+                  data-run-id={id}
+                  data-status={view.session.status}
+                  title={view.session.problem}
+                  onClick={(e) => {
+                    // Row click navigates to the run page and the sheet
+                    // collapses — the destination owns the viewport now (§5.4).
+                    // Real link semantics: middle-click still works via href.
+                    e.preventDefault();
+                    useRunsPanelStore.getState().collapse();
+                    navigate(href);
+                  }}
+                  className="flex items-center gap-2 px-3 py-1 min-w-0 transition-colors"
+                  style={{ background: 'transparent', textDecoration: 'none' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-card)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                >
+                  <span
+                    aria-hidden
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
+                  />
+                  <span
+                    className="truncate leading-tight"
+                    style={{ maxWidth: '48ch', fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}
+                  >
+                    {view.session.problem}
+                  </span>
+                  <span
+                    data-testid="runs-sheet-row-project"
+                    className="truncate shrink-0"
+                    style={{ maxWidth: '20ch', fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}
+                  >
+                    {projectNameByRun[id] ?? ''}
+                  </span>
+                  <span className="flex-1" />
+                  <span
+                    className="shrink-0 font-mono"
+                    style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}
+                  >
+                    {phaseWord(view)}
+                  </span>
+                  {gated && gate !== undefined && (
+                    <span className="shrink-0 font-mono" style={{ fontSize: 'var(--text-2xs)', color: 'var(--status-gate)' }}>
+                      {waitingWord(Date.now() - gate.receivedAt)} ↵
+                    </span>
+                  )}
+                  {cost > 0 && (
+                    <span className="shrink-0 font-mono" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}>
+                      ${cost.toFixed(2)}
+                    </span>
+                  )}
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -10,6 +10,7 @@ import {
   type Signal,
 } from '../board/boardAttention.js';
 import { useGateStore, type OpenGate } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useRuntimeStore } from '../store/runtime.js';
 
@@ -152,6 +153,23 @@ interface Bindings {
 
 const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {} };
 
+/**
+ * Mirror the run→project join into the shared membership store (DES-FEEDBACK-003
+ * §5.4): the runs bottom panel shows each sheet row's project name but may fire
+ * zero requests (§5.1), so the board model — the ONE reader of the members wire —
+ * publishes the join it already fetched. Same pattern as the `useProjectsStore`
+ * mirror above: a store write of already-fetched data, never a new request.
+ */
+function mirrorMembership(projects: Project[], bindings: Record<string, Bindings>): void {
+  const map: Record<string, string> = {};
+  for (const p of projects) {
+    const b = bindings[p.id];
+    if (b === undefined) continue;
+    for (const id of b.runIds) map[id] = p.name;
+  }
+  useMembershipStore.getState().setProjectNames(map);
+}
+
 async function loadBindings(p: Project, repoNames: Map<string, string>): Promise<Bindings> {
   const [members, docs] = await Promise.all([
     api.listProjectMembers(p.id).then((r) => r.members).catch((): ProjectMember[] => []),
@@ -246,7 +264,11 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
       const entries = await Promise.all(
         active.map(async (p) => [p.id, await loadBindings(p, repoNames.current)] as const),
       );
-      if (!cancelled) setBindings(Object.fromEntries(entries));
+      if (!cancelled) {
+        const next = Object.fromEntries(entries);
+        setBindings(next);
+        mirrorMembership(active, next);
+      }
     })();
     return () => { cancelled = true; };
   }, []);
@@ -268,7 +290,11 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
       const entries = await Promise.all(
         projects.map(async (p) => [p.id, await loadBindings(p, repoNames.current)] as const),
       );
-      if (!cancelled) setBindings(Object.fromEntries(entries));
+      if (!cancelled) {
+        const next = Object.fromEntries(entries);
+        setBindings(next);
+        mirrorMembership(projects, next);
+      }
     })();
     return () => { cancelled = true; };
   }, [runs, projects, bindings]);

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { decideGate, gateOpenPath } from '../board/gateActions.js';
 import { isSimpleGate, type OpenGate } from '../store/gates.js';
+import { useRunsPanelStore } from '../store/runsPanel.js';
 import type { Navigate } from './useRoute.js';
 import { useGlobalShortcuts, type ShortcutEntry } from './useGlobalShortcuts.js';
 
@@ -178,7 +179,10 @@ export function useTriageCursor(
         id: 'triage-clear',
         chord: { key: 'escape' },
         description: 'Clear the triage cursor',
-        guard: () => selRef.current !== null,
+        // DES-FEEDBACK-003 §5.7 Escape precedence (palette → sheet → triage):
+        // while the runs sheet is up, this entry YIELDS so the sheet's own
+        // registry entry closes it first — the selection survives the press.
+        guard: () => selRef.current !== null && !useRunsPanelStore.getState().expanded,
         handler: () => {
           setNoteFor(null);
           setSelectedKey(null);

--- a/src/store/membership.ts
+++ b/src/store/membership.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+/**
+ * The run→project-name mirror (DES-FEEDBACK-003 §5.4): the runs bottom
+ * panel's sheet rows show each run's project, "resolved via the board
+ * model's membership" — and the panel is bound by the zero-new-requests
+ * rule (§5.1), so it can never fetch members itself. `useBoardModel`
+ * (mounted app-wide by the rail) already fetches the memberships; it
+ * mirrors the join here exactly the way it already mirrors projects into
+ * `useProjectsStore` — a store WRITE of already-fetched data, no extra
+ * request. Consumers read; only the board model writes.
+ */
+interface MembershipStore {
+  /** run id → owning project's display name. Unlisted = unfiled/unknown. */
+  projectNameByRun: Record<string, string>;
+  /** Replace the mirror wholesale (the board model re-reads memberships whole). */
+  setProjectNames: (map: Record<string, string>) => void;
+}
+
+export const useMembershipStore = create<MembershipStore>((set) => ({
+  projectNameByRun: {},
+  setProjectNames: (map) => set({ projectNameByRun: map }),
+}));

--- a/src/store/runsPanel.ts
+++ b/src/store/runsPanel.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+/**
+ * The runs bottom panel's expanded/collapsed state (DES-FEEDBACK-003 §5.2) —
+ * SESSION-LOCAL by construction: a plain in-memory store, never persisted,
+ * dying with the page. It lives in a store rather than component state for
+ * exactly one reason: the Escape precedence chain (§5.7, C9 — palette →
+ * sheet → triage) needs the triage cursor's own Escape entry to YIELD while
+ * the sheet is open, and the registry's guards are plain closures that must
+ * read this truth from outside the panel's render tree.
+ */
+interface RunsPanelStore {
+  /** true = the overlay sheet is up (§5.4); false = the 28px bar (§5.3). */
+  expanded: boolean;
+  expand: () => void;
+  collapse: () => void;
+  toggle: () => void;
+}
+
+export const useRunsPanelStore = create<RunsPanelStore>((set) => ({
+  expanded: false,
+  expand: () => set({ expanded: true }),
+  collapse: () => set({ expanded: false }),
+  toggle: () => set((s) => ({ expanded: !s.expanded })),
+}));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,6 +110,18 @@ code, pre, .font-mono {
   .wk-palette-in { animation: none; }
 }
 
+/* The runs bottom sheet's rise (DES-FEEDBACK-003 §5.6): --dur-fast --ease-out,
+   one run, no loop — the gates pulse is the bar's only loop (§5.3). */
+@keyframes wk-sheet-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
+}
+.wk-sheet-in { animation: wk-sheet-in var(--dur-fast) var(--ease-out); }
+
+@media (prefers-reduced-motion: reduce) {
+  .wk-sheet-in { animation: none; }
+}
+
 @keyframes wk-feed-in {
   from { opacity: 0; transform: translateY(-4px); }
   to   { opacity: 1; transform: none; }

--- a/tests/RunsBottomPanel.test.tsx
+++ b/tests/RunsBottomPanel.test.tsx
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  observedSpend,
+  RunsBottomPanel,
+  RUNS_BAR_PX,
+  runStats,
+  waitingWord,
+} from '../src/components/RunsBottomPanel.js';
+import { useTriageCursor, type TriageItem } from '../src/hooks/useTriageCursor.js';
+import { setShortcutsPaletteOpen } from '../src/hooks/useGlobalShortcuts.js';
+import { useGateStore, type OpenGate } from '../src/store/gates.js';
+import { useMembershipStore } from '../src/store/membership.js';
+import { useRunsPanelStore } from '../src/store/runsPanel.js';
+import { useRuntimeStore, type LoggedEvent } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * The runs bottom panel (DES-FEEDBACK-003 §5, slice N): the §5.3 stat
+ * derivations against store fixtures, the three-state transitions
+ * (bar → sheet → run page), EC27's immersive auto-collapse, the §5.7
+ * Escape precedence (palette → sheet → triage) through the slice-G
+ * registry, and the §5.1 zero-fetch rule.
+ */
+
+const W2 = [
+  makeView({ id: 'r-q3', status: 'awaiting_human', problem: 'make the Q3 review deck' }),
+  makeView({ id: 'r-api', status: 'awaiting_human', problem: 'migrate the auth tables' }),
+  makeView({ id: 'r-upload', status: 'executing', problem: 'add rate-limiting' }),
+  makeView({ id: 'r-auth', status: 'failed', problem: 'refactor the auth middleware' }),
+  makeView({ id: 'r-smoke1', status: 'completed', problem: 'smoke: login flow' }),
+  makeView({ id: 'r-smoke2', status: 'cancelled', problem: 'smoke: checkout flow' }),
+];
+
+const usage = (costUsd: number, ts = Date.now()): LoggedEvent => ({
+  seq: 1, type: 'cliUsage', ts, costUsd, detail: `usage $${costUsd}`,
+});
+
+const runPath = (id: string): string => `/runs/${id}`;
+
+function mount(over: { runs?: typeof W2; immersive?: boolean } = {}): {
+  navigate: ReturnType<typeof vi.fn>;
+  rerender: (ui: React.ReactElement) => void;
+} {
+  const navigate = vi.fn();
+  const { rerender } = render(
+    <RunsBottomPanel
+      runs={over.runs ?? W2}
+      runPath={runPath}
+      navigate={navigate}
+      immersive={over.immersive ?? false}
+    />,
+  );
+  return { navigate, rerender };
+}
+
+const press = (key: string): void => {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  });
+};
+
+beforeEach(() => {
+  cleanup();
+  useRunsPanelStore.setState({ expanded: false });
+  useGateStore.setState({ gates: {} });
+  useRuntimeStore.setState({ logs: {} });
+  useMembershipStore.setState({ projectNameByRun: {} });
+  setShortcutsPaletteOpen(false);
+  document.body.innerHTML = '';
+});
+
+describe('§5.3 stat derivations — client-derivable, spelled once', () => {
+  it('counts working (non-terminal, non-gate), gates, failed from the runs array', () => {
+    expect(runStats(W2)).toEqual({ working: 1, gates: 2, failed: 1 });
+  });
+
+  it('planning and distributing are working; completed/cancelled count nowhere', () => {
+    const runs = [
+      makeView({ id: 'a', status: 'planning' }),
+      makeView({ id: 'b', status: 'distributing' }),
+      makeView({ id: 'c', status: 'completed' }),
+      makeView({ id: 'd', status: 'cancelled' }),
+    ];
+    expect(runStats(runs)).toEqual({ working: 2, gates: 0, failed: 0 });
+  });
+
+  it('observedSpend folds only numeric cliUsage costs — total, frame count, per-run', () => {
+    const logs: Record<string, LoggedEvent[]> = {
+      'r-upload': [usage(0.04), usage(0.18),
+        { seq: 3, type: 'cliUsage', ts: Date.now(), detail: 'usage reported (no cost)' },
+        { seq: 4, type: 'unitDone', ts: Date.now(), detail: 'unit done' }],
+      'r-smoke1': [usage(0.11)],
+    };
+    const spend = observedSpend(logs);
+    expect(spend.total).toBeCloseTo(0.33);
+    expect(spend.frames).toBe(3);
+    expect(spend.byRun['r-upload']).toBeCloseTo(0.22);
+    expect(spend.byRun['r-smoke1']).toBeCloseTo(0.11);
+  });
+
+  it('waitingWord formats seconds, minutes, hours', () => {
+    expect(waitingWord(12_000)).toBe('waiting 12s');
+    expect(waitingWord(12 * 60_000)).toBe('waiting 12m');
+    expect(waitingWord(3 * 3_600_000)).toBe('waiting 3h');
+  });
+});
+
+describe('the collapsed bar (§5.3)', () => {
+  it('renders the fixture counts as data attributes and segment text', () => {
+    mount();
+    const bar = screen.getByTestId('runs-bottom-bar');
+    expect(bar.getAttribute('data-working')).toBe('1');
+    expect(bar.getAttribute('data-gates')).toBe('2');
+    expect(bar.getAttribute('data-failed')).toBe('1');
+    expect(bar.textContent).toContain('1 working');
+    expect(bar.textContent).toContain('2 gates');
+    expect(bar.textContent).toContain('1 failed');
+    expect(bar.textContent).toContain('All runs ›');
+  });
+
+  it('shows the observed spend segment only once a cliUsage frame exists', () => {
+    mount();
+    expect(screen.getByTestId('runs-bottom-bar').textContent).not.toContain('observed');
+    act(() => {
+      useRuntimeStore.setState({ logs: { 'r-upload': [usage(0.42)] } });
+    });
+    expect(screen.getByTestId('runs-bottom-bar').textContent).toContain('$0.42 observed');
+  });
+
+  it('an all-terminal listing compresses to the quiet phrase', () => {
+    mount({ runs: [makeView({ id: 'a', status: 'completed' }), makeView({ id: 'b', status: 'cancelled' })] });
+    const bar = screen.getByTestId('runs-bottom-bar');
+    expect(bar.textContent).toContain('nothing running');
+    expect(bar.textContent).not.toContain('working');
+  });
+
+  it('the All runs link is a real /runs link that never expands the sheet', () => {
+    const { navigate } = mount();
+    const link = screen.getByTestId('runs-bar-all');
+    expect(link.getAttribute('href')).toBe('/runs');
+    fireEvent.click(link);
+    expect(navigate).toHaveBeenCalledWith('/runs');
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+  });
+});
+
+describe('three-state transitions (§5.2/§5.4)', () => {
+  it('clicking the bar expands the sheet; the toggle collapses it again', () => {
+    mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    expect(screen.getByTestId('runs-bottom-sheet')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+  });
+
+  it('sheet rows: active before terminal, real hrefs per runPath, gate rows deep-link #gate', () => {
+    act(() => {
+      useGateStore.getState().setGate({
+        runId: 'r-q3', ord: 0, prompt: 'Approve?', lifecycle: 'open',
+        receivedAt: Date.now() - 12 * 60_000,
+      } satisfies OpenGate);
+      useMembershipStore.setState({ projectNameByRun: { 'r-upload': 'upload-endpoint' } });
+      useRuntimeStore.setState({ logs: { 'r-upload': [usage(0.18)] } });
+    });
+    mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    const rows = screen.getAllByTestId('runs-sheet-row');
+    const statuses = rows.map((r) => r.getAttribute('data-status'));
+    // Active (gates + executing) precede terminal (failed/completed/cancelled).
+    expect(statuses.slice(0, 3)).toEqual(['awaiting_human', 'awaiting_human', 'executing']);
+    expect(new Set(statuses.slice(3))).toEqual(new Set(['failed', 'completed', 'cancelled']));
+    const byId = Object.fromEntries(rows.map((r) => [r.getAttribute('data-run-id'), r]));
+    expect(byId['r-q3']?.getAttribute('href')).toBe('/runs/r-q3#gate');
+    expect(byId['r-upload']?.getAttribute('href')).toBe('/runs/r-upload');
+    // Per-run stats from data in hand: project name, gate wait age, observed spend.
+    expect(byId['r-upload']?.textContent).toContain('upload-endpoint');
+    expect(byId['r-upload']?.textContent).toContain('$0.18');
+    expect(byId['r-q3']?.textContent).toContain('waiting 12m');
+  });
+
+  it('the sheet lists at most 20 rows', () => {
+    const many = Array.from({ length: 30 }, (_, i) => makeView({ id: `r-${i}`, status: 'executing' }));
+    mount({ runs: many });
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    expect(screen.getAllByTestId('runs-sheet-row').length).toBe(20);
+  });
+
+  it('row click navigates to the run page and the sheet unmounts', () => {
+    const { navigate } = mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    const row = screen.getAllByTestId('runs-sheet-row')
+      .find((r) => r.getAttribute('data-run-id') === 'r-upload');
+    fireEvent.click(row as HTMLElement);
+    expect(navigate).toHaveBeenCalledWith('/runs/r-upload');
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+  });
+
+  it('a mousedown outside the panel collapses the sheet', () => {
+    mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+  });
+});
+
+describe('EC27 — immersive routes auto-collapse the sheet', () => {
+  it('entering Document/Video collapses an open sheet; a manual re-expand stands', () => {
+    const navigate = vi.fn();
+    const ui = (immersive: boolean): React.ReactElement => (
+      <RunsBottomPanel runs={W2} runPath={runPath} navigate={navigate} immersive={immersive} />
+    );
+    const { rerender } = render(ui(false));
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    expect(screen.getByTestId('runs-bottom-sheet')).toBeTruthy();
+    rerender(ui(true));
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+    // The explicit gesture wins (§5.5): the operator can still expand in-mode.
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    expect(screen.getByTestId('runs-bottom-sheet')).toBeTruthy();
+  });
+});
+
+describe('§5.7 Escape precedence — palette → sheet → triage, one registry (EC21)', () => {
+  it('Escape collapses the sheet through the registry', () => {
+    mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    press('Escape');
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+  });
+
+  it('with the palette open, Escape does NOT touch the sheet (the registry yields)', () => {
+    mount();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    setShortcutsPaletteOpen(true);
+    press('Escape');
+    expect(screen.getByTestId('runs-bottom-sheet')).toBeTruthy();
+  });
+
+  it('with a triage selection active, Escape closes the SHEET first, the selection after', () => {
+    // A minimal triage surface (the slice-H harness shape) mounted next to the panel.
+    function Triage({ items }: { items: TriageItem[] }): React.ReactElement {
+      const cursor = useTriageCursor(items, vi.fn());
+      return (
+        <div>
+          {items.map((it) => (
+            <div key={it.key} tabIndex={-1} data-kbd-item={it.key}
+              {...(cursor.selectedKey === it.key ? { 'data-kbd-selected': 'true' } : {})} />
+          ))}
+        </div>
+      );
+    }
+    const items: TriageItem[] = [
+      { key: 'card-1', runId: null, gate: undefined, openPath: '/p/x', projectId: 'x' },
+    ];
+    render(
+      <>
+        <Triage items={items} />
+        <RunsBottomPanel runs={W2} runPath={runPath} navigate={vi.fn()} immersive={false} />
+      </>,
+    );
+    press('j'); // select the first triage row
+    expect(document.querySelector('[data-kbd-selected="true"]')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+    press('Escape'); // sheet first — the selection survives
+    expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
+    expect(document.querySelector('[data-kbd-selected="true"]')).toBeTruthy();
+    press('Escape'); // triage next
+    expect(document.querySelector('[data-kbd-selected="true"]')).toBeNull();
+  });
+});
+
+describe('§5.1 zero new requests — ever', () => {
+  it('mount, expand, row hover, collapse fire no fetch', () => {
+    const spy = vi.fn(() => Promise.reject(new Error('the panel must never fetch')));
+    vi.stubGlobal('fetch', spy);
+    try {
+      mount();
+      fireEvent.click(screen.getByTestId('runs-bar-toggle'));
+      fireEvent.click(screen.getByTestId('runs-sheet-collapse'));
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('the reserved row constant matches the §5.2 geometry', () => {
+    expect(RUNS_BAR_PX).toBe(28);
+  });
+});


### PR DESCRIPTION
Round-4 operator feedback: *"I want to move runs to a bottom panel fixed that shows stats for anything running and when you click it expands to show a list of runs and it's stats; click on it opens up the run page; this will be fixed at bottom of screen."*

## What changed (design: `.product/DES-FEEDBACK-003.md` §5)

- **Fixed 28px stat bar** at the viewport bottom on every route: working / gates / failed counts + observed spend, all derived from client-held stores — the panel fires **zero requests, ever** (run→project names come from a membership mirror the board model already writes).
- **Click expands an overlay run-list sheet** (`min(340px, 42vh)`, reusing the rail's retired row library): active-before-terminal, per-run project name, gate wait age, observed spend, `#gate` deep links; row click opens the run page and collapses; Escape routes through the registry with palette → sheet → triage precedence.
- **EC27**: entering Document/Video auto-collapses the sheet; the app root reserves the bar's 28px so the version strip's proximity sensor stays clear.
- §8.4 rider: the palette gains `> New Document` / `> New Video` through the Make picker's project stage.

## Verification highlights

The verifier derived expected counts from the fixture source itself and matched the bar ($0.42 spend fold with the null-cost frame excluded); proved the bar byte-identical after scrolling every container; measured board bottom == bar top (nothing covered) and sheet overlay without reflow; proved the full Escape precedence chain with a live triage selection; counted exactly one window keydown listener; and — the design's named hazard — **proved the slice-F strip survives**: strip bottom sits 11px above the bar, auto-hide then a hand-driven proximity wake 0→1 with the thread toggle clickable after. Rig fails on origin/main.

## Gates

eslint clean · tsc clean · vitest **1100/1100** (19 new) · new rig `feedback3_sliceN_test.py` (×2 green) + `feedback3_sliceM`, `uxfix_slice6`, `feedback2_sliceH`, `feedback_sliceD` all PASS unamended (§8.7 maps no rig re-scopes to N).

Shots: `feedback3-N-bar-collapsed.png`, `feedback3-N-sheet-open.png`, `feedback3-N-bar-immersive.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)