### PR TITLE
Slice O: health rail-foot section + the /make dashboard (DES-FEEDBACK-003 §4.2, §6.2)

### DIFF
--- a/e2e/feedback3_sliceM_test.py
+++ b/e2e/feedback3_sliceM_test.py
@@ -259,9 +259,11 @@ with sync_playwright() as p:
     # ── AC 5 (▦): Make's ▦ lands on a real /make page — never a 404 ────────────
     page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
     page.locator('[data-testid="rail-heading-make"] [data-testid="heading-dashboard"]').click()
+    # (Amended by slice O: the placeholder retired — the ▦ lands on the real
+    # combined list + reporting dashboard, DES-FEEDBACK-003 §4.2.)
     make_dash_ok = settled(
         """() => window.location.pathname === '/make'
-              && !!document.querySelector('[data-testid="make-placeholder"]')""")
+              && !!document.querySelector('[data-testid="make-dashboard"]')""")
     make_dash_territory_ok = expanded() == ["make"]
 
     # ── AC 7: fetch-on-expand, at most one GET /repos, no poll ─────────────────

--- a/e2e/feedback3_sliceN_test.py
+++ b/e2e/feedback3_sliceN_test.py
@@ -214,7 +214,7 @@ with sync_playwright() as p:
     presence: dict = {}
     for route, ready in [
         ("/projects", '[data-testid="runs-bottom-bar"]'),
-        ("/make", '[data-testid="make-placeholder"]'),
+        ("/make", '[data-testid="make-dashboard"]'),  # slice O: the real dashboard
         ("/repos", '[data-testid="runs-bottom-bar"]'),
         ("/p/q3-review-deck/build", '[data-testid="mode-switcher"]'),
     ]:

--- a/e2e/feedback3_sliceO_test.py
+++ b/e2e/feedback3_sliceO_test.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+feedback3_sliceO_test.py — the DES-FEEDBACK-003 slice-O gate: the rail-foot
+health section (§6.2/§6.3) + the /make combined list-and-reporting dashboard
+(§4.2/§4.5), against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py, its
+roster extended with the REAL crew#274 SeatHealth shape) with metrics_ws ON so
+the Spend tile has real cliUsage dollars to fold.
+
+The slice DOM ACs, from §6.3 + §4.5:
+
+  1. `[data-testid="rail-health-section"]` renders at the rail bottom with
+     `data-open="false"` by default; `rail-settings-section` is gone from that
+     slot; ZERO `GET /health` / `GET /roster` requests fire on app mount (EC30).
+  2. Expanding fires exactly one `GET /health` and one `GET /roster`;
+     collapsing and re-expanding refetches (staleness by gesture).
+  3. Registry rows: the fixture's inactive seat (codex) shows `✗` + the 40ch
+     message excerpt with the full text on `title`; the health-less seat (pi)
+     shows the dim `·` / `data-health="unknown"` — never a fabricated active;
+     `[data-testid="rail-health-summary-dot"]` renders on the COLLAPSED header
+     in computed `var(--status-fail)` (EC15).
+  4. Clicking `[data-testid="connection-dot"]` expands the health section; no
+     popover element mounts (the old "Health checks" DOM is absent). The dot's
+     `data-state` glance contract and the logo slot are PRESERVED (§8.2), and
+     the NotificationBell sits directly under the chrome (§6.1).
+  5. `/make` renders `[data-testid="make-dashboard-tiles"]` ABOVE the list,
+     every tile carrying its §4.2.1 `data-question` (EC19/EC28); navigating
+     there fires no health/roster/docs requests (loaded stores only).
+  6. `[data-testid="make-corpus-label"]` names both corpora and the not-listed
+     clause (EC24); `[load docs for all projects]` fires exactly P
+     `GET .../interactive/api/docs` requests on click and zero before
+     (request interception; P = non-default projects), then collapses to the
+     session-cached quiet note; the landed doc rows render `▤/▶ name · vN ·
+     project` links.
+  7. The run list is the non-chat spine — every fixture run (all carry a real
+     workflow stamp), active before terminal, each row an `<a href=runPath>`.
+
+Captures (§10.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback3-O-health-open.png     registry expanded, one inactive seat
+  feedback3-O-make-dashboard.png  tiles + corpus label + list, W2 fixture
+
+Finally: `npm run lint` must exit 0 with zero raw-color findings (EC15 is
+ERROR repo-wide).
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK3O_PORT (default 4363),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    CODEX_HEALTH_MESSAGE,
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    PROJECTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK3O_PORT = int(os.environ.get("FEEDBACK3O_PORT", "4363"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK3O_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+P_PROJECTS = [p["id"] for p in PROJECTS if p["id"] != "default"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches) ──────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture server; metrics_ws ON (the Spend tile's dollars) ─
+start_server(FEEDBACK3O_PORT, dist)
+set_fixture(ORIGIN, metrics_ws=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+api_paths: list[str] = []
+
+
+def n_health() -> int:
+    return sum(1 for p in api_paths if p == "/api/v1/health")
+
+
+def n_roster() -> int:
+    return sum(1 for p in api_paths if p == "/api/v1/roster")
+
+
+def n_docs() -> int:
+    return sum(1 for p in api_paths if p.endswith("/interactive/api/docs"))
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda r: api_paths.append(urlparse(r.url).path)
+            if "/api/v1/" in r.url and r.method == "GET" else None)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── AC 1: cold `/` — the section at the rail foot, zero gesture-gated GETs ─
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.locator('[data-testid="rail-health-section"]').wait_for(timeout=30000)
+    page.wait_for_timeout(2500)  # let every mount read settle before counting
+
+    foot = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const section = q('[data-testid="rail-health-section"]');
+             const rail = q('[data-testid="left-rail"]');
+             const headings = Array.from(document.querySelectorAll('[data-testid^="rail-heading-"]'));
+             const lastHeading = headings[headings.length - 1];
+             const chrome = q('[data-testid="app-chrome"]');
+             const bell = q('[aria-label="Notifications"], [aria-label$="notifications"]');
+             return {
+               open: section?.dataset.open ?? null,
+               settingsSection: !!q('[data-testid="rail-settings-section"]'),
+               inRail: !!section && !!rail && rail.contains(section),
+               belowHeadings: !!section && !!lastHeading
+                 && section.getBoundingClientRect().top
+                    >= lastHeading.getBoundingClientRect().bottom - 1,
+               // §6.1/§6.3: the bell sits directly under the chrome, above the headings.
+               bellUnderChrome: !!bell && !!chrome && !!lastHeading
+                 && !!(chrome.compareDocumentPosition(bell) & Node.DOCUMENT_POSITION_FOLLOWING)
+                 && !!(bell.compareDocumentPosition(headings[0]) & Node.DOCUMENT_POSITION_FOLLOWING),
+             }; }""")
+    mount_health, mount_roster = n_health(), n_roster()
+    ac1_ok = (foot["open"] == "false" and not foot["settingsSection"] and foot["inRail"]
+              and foot["belowHeadings"] and foot["bellUnderChrome"]
+              and mount_health == 0 and mount_roster == 0)
+
+    # ── AC 2+3: expand — one GET each; the registry's honest anatomy ───────────
+    page.locator('[data-testid="rail-health-toggle"]').click()
+    page.locator('[data-testid="rail-seat-row"]').first.wait_for(timeout=15000)
+    page.wait_for_timeout(1000)
+    expand_health, expand_roster = n_health(), n_roster()
+
+    seats = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="rail-seat-row"]'))
+              .map(r => ({ seat: r.dataset.seat, health: r.dataset.health,
+                           title: r.getAttribute('title'), text: r.textContent }))""")
+    by_seat = {s["seat"]: s for s in seats}
+    excerpt = CODEX_HEALTH_MESSAGE[:40] + "…"
+    seats_ok = (
+        [s["seat"] for s in seats] == ["claude", "codex", "agy", "pi"]
+        and by_seat["claude"]["health"] == "active"
+        and "✓" in by_seat["claude"]["text"] and "signed in" in by_seat["claude"]["text"]
+        and by_seat["codex"]["health"] == "inactive"
+        and "✗" in by_seat["codex"]["text"] and excerpt in by_seat["codex"]["text"]
+        and CODEX_HEALTH_MESSAGE not in by_seat["codex"]["text"]
+        and by_seat["codex"]["title"] == CODEX_HEALTH_MESSAGE
+        and by_seat["pi"]["health"] == "unknown"
+        and "·" in by_seat["pi"]["text"] and "active" not in by_seat["pi"]["text"]
+    )
+
+    # ── Capture 1: the registry expanded, one inactive seat ────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-O-health-open.png"))
+
+    # Collapse: the answers stay, the summary dot says "look inside" (EC15).
+    page.locator('[data-testid="rail-health-toggle"]').click()
+    dot = page.evaluate(
+        """() => { const probeBg = name => { const el = document.createElement('div');
+                     el.style.background = `var(${name})`;
+                     document.body.appendChild(el);
+                     const v = getComputedStyle(el).backgroundColor;
+                     el.remove(); return v; };
+                   const section = document.querySelector('[data-testid="rail-health-section"]');
+                   const d = document.querySelector('[data-testid="rail-health-summary-dot"]');
+                   return { open: section?.dataset.open ?? null,
+                            present: !!d,
+                            bg: d ? getComputedStyle(d).backgroundColor : null,
+                            statusFail: probeBg('--status-fail') }; }""")
+    summary_dot_ok = dot["open"] == "false" and dot["present"] and dot["bg"] == dot["statusFail"]
+
+    # Re-expand refetches — staleness by gesture (§6.3).
+    page.locator('[data-testid="rail-health-toggle"]').click()
+    page.wait_for_timeout(1000)
+    refetch_ok = n_health() == expand_health + 1 and n_roster() == expand_roster + 1
+    page.locator('[data-testid="rail-health-toggle"]').click()  # collapsed again
+
+    # ── AC 4: the chrome dot hands off; the popover is gone; §8.2 preserved ────
+    chrome_facts = page.evaluate(
+        """() => ({ dotState: document.querySelector('[data-testid="connection-dot"]')?.dataset.state ?? null,
+                    logoSlot: !!document.querySelector('[data-testid="logo-slot"]') })""")
+    page.locator('[data-testid="connection-dot"]').click()
+    dot_click = page.evaluate(
+        """() => ({ open: document.querySelector('[data-testid="rail-health-section"]')?.dataset.open ?? null,
+                    popover: Array.from(document.querySelectorAll('p'))
+                      .some(el => (el.textContent ?? '').trim() === 'Health checks') })""")
+    dot_click_ok = (dot_click["open"] == "true" and not dot_click["popover"]
+                    and chrome_facts["dotState"] == "connected" and chrome_facts["logoSlot"])
+
+    # ── AC 5: /make — tiles above the list, zero requests ride the navigation ──
+    page.wait_for_timeout(1200)  # let the dot-click expand's own gesture fetch land
+    pre_nav = (n_health(), n_roster(), n_docs())
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-dashboard"]').click()
+    page.locator('[data-testid="make-dashboard"]').wait_for(timeout=30000)
+    page.locator('[data-testid="make-run-row"]').first.wait_for(timeout=15000)
+    page.wait_for_timeout(1500)
+    nav_zero_ok = (n_health(), n_roster(), n_docs()) == pre_nav
+
+    make = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const band = q('[data-testid="make-dashboard-tiles"]');
+             const list = q('[data-testid="make-list"]');
+             const question = tid => band?.querySelector(`[data-testid="${tid}"]`)?.dataset.question ?? null;
+             const rows = Array.from(document.querySelectorAll('[data-testid="make-run-row"]'))
+               .map(r => ({ id: r.dataset.runId, status: r.dataset.status,
+                            href: r.getAttribute('href'), tag: r.tagName }));
+             return {
+               bandAboveList: !!band && !!list
+                 && !!(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING),
+               questions: { made: question('made-tile'),
+                            outcome: question('run-outcome-bar'),
+                            spend: question('token-burn-sparkline') },
+               corpusLabel: q('[data-testid="make-corpus-label"]')?.textContent ?? null,
+               fanoutButton: !!q('[data-testid="make-load-all-docs"]'),
+               rows,
+             }; }""")
+    ACTIVE = {"planning", "distributing", "executing", "awaiting_human"}
+    statuses = [r["status"] for r in make["rows"]]
+    first_terminal = next((i for i, s in enumerate(statuses) if s not in ACTIVE), len(statuses))
+    EXPECTED_IDS = {"r-q3", "r-api", "r-upload", "r-auth", "r-legacy", "r-smoke1", "r-smoke2", "r-orphan"}
+    rows_ok = (
+        {r["id"] for r in make["rows"]} == EXPECTED_IDS  # the complete non-chat spine
+        and all(r["tag"] == "A" for r in make["rows"])
+        and all(s not in ACTIVE for s in statuses[first_terminal:])  # active precede terminal
+        and {r["id"]: r["href"] for r in make["rows"]}.get("r-upload") == "/runs/r-upload"
+    )
+    tiles_ok = (
+        make["bandAboveList"]
+        and make["questions"]["made"] == "What is the shop producing, and of what kind?"
+        and make["questions"]["outcome"] == "Are makes landing or failing?"
+        and make["questions"]["spend"] == "What is making costing?"
+    )
+    label_ok = (
+        make["corpusLabel"] is not None
+        and "Listing: build runs (all projects) · documents (projects opened this session)"
+            in make["corpusLabel"]
+        and make["fanoutButton"]
+    )
+
+    # ── Capture 2: tiles + corpus label + list ─────────────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-O-make-dashboard.png"))
+
+    # ── AC 6: the fan-out gesture — exactly P doc GETs on click, zero before ───
+    docs_before = n_docs()
+    page.locator('[data-testid="make-load-all-docs"]').click()
+    fanout_settles = settled(
+        """() => !document.querySelector('[data-testid="make-load-all-docs"]')
+              && !document.querySelector('[data-testid="make-fanout-progress"]')""",
+        timeout=30000,
+    )
+    page.wait_for_timeout(1000)
+    fanout_paths = [p for p in api_paths if p.endswith("/interactive/api/docs")]
+    fanout_delta = n_docs() - docs_before
+    fanout_ok = (fanout_settles and fanout_delta == len(P_PROJECTS)
+                 # one GET per project, no repeats inside the gesture
+                 and len(set(fanout_paths[docs_before:])) == len(P_PROJECTS))
+    cached_note_ok = settled(
+        """() => Array.from(document.querySelectorAll('p'))
+              .some(el => (el.textContent ?? '') === 'docs loaded for all projects')""",
+        timeout=5000,
+    )
+    doc_rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="make-doc-row"]'))
+              .map(r => ({ kind: r.dataset.docKind, href: r.getAttribute('href'),
+                           text: r.textContent }))""")
+    # The notes project's registry (2 seed docs); the fixture's demo switch is off.
+    doc_rows_ok = (
+        len(doc_rows) == 2
+        and {r["href"] for r in doc_rows}
+            == {"/p/notes/document/ideas", "/p/notes/document/todo"}
+        and all("v1" in r["text"] and "notes" in r["text"] for r in doc_rows)
+    )
+
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([
+        ac1_ok, expand_health == 1, expand_roster == 1, seats_ok,
+        summary_dot_ok, refetch_ok, dot_click_ok, nav_zero_ok,
+        tiles_ok, label_ok, rows_ok, fanout_ok, cached_note_ok, doc_rows_ok,
+    ]),
+    "ac1_rail_foot": foot,
+    "ac1_zero_mount_requests": {"health": mount_health, "roster": mount_roster},
+    "ac1_ok": ac1_ok,
+    "ac2_expand_counts": {"health": expand_health, "roster": expand_roster},
+    "ac2_reexpand_refetches": refetch_ok,
+    "ac3_seat_rows": seats,
+    "ac3_seats_ok": seats_ok,
+    "ac3_summary_dot": dot,
+    "ac3_summary_dot_ok": summary_dot_ok,
+    "ac4_dot_click": dot_click,
+    "ac4_chrome_preserved": chrome_facts,
+    "ac4_ok": dot_click_ok,
+    "ac5_nav_fires_nothing": nav_zero_ok,
+    "ac5_tiles": make["questions"],
+    "ac5_tiles_ok": tiles_ok,
+    "ac6_corpus_label": make["corpusLabel"],
+    "ac6_label_ok": label_ok,
+    "ac6_fanout": {"delta": fanout_delta, "expected": len(P_PROJECTS)},
+    "ac6_fanout_ok": fanout_ok,
+    "ac6_cached_note": cached_note_ok,
+    "ac6_doc_rows": doc_rows,
+    "ac6_doc_rows_ok": doc_rows_ok,
+    "ac7_run_rows": make["rows"],
+    "ac7_rows_ok": rows_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("feedback3-O-health-open.png", "feedback3-O-make-dashboard.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-O DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0, zero raw-color findings (EC15 error repo-wide) ───
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+raw_color_findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and raw_color_findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings_repo_wide": raw_color_findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero raw-color findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -522,9 +522,25 @@ REPO_CONTRIBUTORS = [
 # GET /chats/<id> answers an EMPTY seat list (a 200, not a 404) for a chat this
 # fixture has never been told about, which is the "reclaimed" signal the rejoin
 # probe distinguishes from an error.
+# Each seat carries the REAL crew#274 additions the daemon's /roster serves
+# (routes.ts:308): `health: SeatHealth` (status + bounded error excerpt +
+# since/lastErrorAt) and the `signed_in` heuristic. `pi` deliberately carries
+# NEITHER — the additive-wire case (a daemon predating crew#274) the slice-O
+# health registry must render as unknown, never as a fabricated "active".
+CODEX_HEALTH_MESSAGE = ("quota exceeded: the monthly usage limit for this "
+                        "seat has been reached upstream")
 ROSTER = [
-    {"key": k, "display_name": k, "binary": k, "enabled_for_council": True}
-    for k in ("claude", "codex", "agy", "pi")
+    {"key": "claude", "display_name": "claude", "binary": "claude",
+     "enabled_for_council": True, "signed_in": True,
+     "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
+    {"key": "codex", "display_name": "codex", "binary": "codex",
+     "enabled_for_council": True, "signed_in": False,
+     "health": {"status": "inactive", "message": CODEX_HEALTH_MESSAGE,
+                "since": iso(NOW0 - 2 * HOUR), "lastErrorAt": iso(NOW0 - 2 * HOUR)}},
+    {"key": "agy", "display_name": "agy", "binary": "agy",
+     "enabled_for_council": True, "signed_in": True,
+     "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
+    {"key": "pi", "display_name": "pi", "binary": "pi", "enabled_for_council": True},
 ]
 
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
 import { GateNotifications } from './components/GateNotifications.js';
 import { HomeBoard } from './components/HomeBoard.js';
+import { MakeDashboard } from './components/MakeDashboard.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
 import { DocumentCanvas } from './components/DocumentCanvas.js';
 import { DocumentThread } from './components/DocumentThread.js';
@@ -436,20 +437,12 @@ export function App(): React.ReactElement {
         </div>
       );
     }
-    // `/make` — the Make path's dashboard route (DES-FEEDBACK-003 §2.1). The
-    // rail's ▦ links here from slice M on; the real combined list + reporting
-    // surface is slice O (§4.2) — until it lands this placeholder keeps the
-    // link honest (a page, never a 404).
+    // `/make` — the Make path's combined list + reporting dashboard
+    // (DES-FEEDBACK-003 §4.2, slice O; the slice-M placeholder retired).
     if (panel === 'make') {
       return (
-        <div className="flex-1 overflow-y-auto p-6" data-testid="make-placeholder">
-          <h1 style={{ color: 'var(--ink-high)', fontSize: 'var(--text-lg)', fontFamily: 'var(--font-sans)', fontWeight: 'var(--weight-semi)' }}>
-            Make
-          </h1>
-          <p className="mt-2" style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)' }}>
-            The combined list and reporting dashboard for made things — build runs,
-            documents, demos — lands here (DES-FEEDBACK-003 §4.2, slice O).
-          </p>
+        <div className="flex-1 overflow-y-auto" data-testid="make-dashboard">
+          <MakeDashboard runs={runs} navigate={navigate} runPath={runPath} />
         </div>
       );
     }

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
-import { api } from '../api/client.js';
 import { useConnectionStore } from '../store/connection.js';
 import { useAppearanceStore } from '../theming/appearance.js';
 import { prefersReducedMotion } from './LiveEdge.js';
@@ -30,14 +28,20 @@ import { WickedLogo } from './WickedLogo.js';
  * is the STATUS layer, not the accent (§2.6): live = run-emerald, connecting =
  * gate-amber, lost = fail-red. The reconnecting pulse is the ONE loop the
  * motion grammar allows (§1.6) — it is state communication, and it stops for
- * `prefers-reduced-motion`. The health popover it opens is the same one the
- * rail's old pill owned — moved, not removed.
+ * `prefers-reduced-motion`.
+ *
+ * The health POPOVER retired (DES-FEEDBACK-003 §6.2/§8.2, slice O): the dot
+ * stays as glanceable ws state, and clicking it now expands the rail-foot
+ * HealthRailSection (one surface for health detail, not two) — CheckRow and
+ * the `getHealth()` fetch moved there verbatim.
  */
 
 interface Props {
   /** The rail's collapsed state: icon-only column instead of the header row. */
   collapsed: boolean;
   navigate: (path: string) => void;
+  /** Clicking the dot expands the rail-foot Health section (§6.2, slice O). */
+  onDotClick?: () => void;
 }
 
 const DOT_COLOR = {
@@ -52,60 +56,23 @@ const DOT_WORD = {
   disconnected: 'offline',
 } as const;
 
-interface HealthInfo {
-  status: string;
-  version: string;
-  ping: string;
-}
-
-function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; detail: string }): React.ReactElement {
-  const icon = ok === null ? '·' : ok ? '✓' : '✗';
-  const color = ok === null ? 'var(--ink-dim)' : ok ? 'var(--status-run)' : 'var(--status-fail)';
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}>
-      <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{icon}</span>
-      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-mono)', flex: 1 }}>{label}</span>
-      <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>{detail}</span>
-    </div>
-  );
-}
-
-/** The connection status dot + the health popover (moved from the rail pill). */
-function ConnectionDot({ collapsed }: { collapsed: boolean }): React.ReactElement {
+/**
+ * The connection status dot — glanceable ws state. Its old health popover is
+ * RETIRED (§8.2): a click hands off to the rail-foot Health section instead.
+ */
+function ConnectionDot({ collapsed, onClick }: { collapsed: boolean; onClick?: (() => void) | undefined }): React.ReactElement {
   const wsStatus = useConnectionStore((s) => s.status);
-  const [open, setOpen] = useState(false);
-  const [health, setHealth] = useState<HealthInfo | null>(null);
-  const [healthError, setHealthError] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    setHealth(null);
-    setHealthError(false);
-    api.getHealth()
-      .then((h) => setHealth(h))
-      .catch(() => setHealthError(true));
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onOutside(e: MouseEvent): void {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener('click', onOutside);
-    return () => document.removeEventListener('click', onOutside);
-  }, [open]);
 
   const pillLabel =
     wsStatus === 'connected' ? 'Connected' :
     wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
 
   return (
-    <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+    <div style={{ position: 'relative', flexShrink: 0 }}>
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        title={`Connection: ${pillLabel}`}
+        onClick={onClick}
+        title={`Connection: ${pillLabel} — health details below`}
         aria-label={`Connection: ${pillLabel}`}
         style={{
           display: 'flex', alignItems: 'center', gap: '5px', background: 'transparent',
@@ -129,39 +96,11 @@ function ConnectionDot({ collapsed }: { collapsed: boolean }): React.ReactElemen
           </span>
         )}
       </button>
-
-      {open && (
-        <div style={{
-          position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 100,
-          background: 'var(--surface-overlay)', border: '1px solid var(--surface-raised)',
-          borderRadius: 'var(--radius-md)', padding: 'var(--space-3) 14px', minWidth: '220px',
-          boxShadow: 'var(--shadow-overlay)',
-        }}>
-          <p style={{
-            fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', textTransform: 'uppercase',
-            letterSpacing: '0.1em', color: 'var(--ink-dim)', marginBottom: 'var(--space-2)',
-            fontFamily: 'var(--font-mono)',
-          }}>
-            Health checks
-          </p>
-          <CheckRow label="WebSocket" ok={wsStatus === 'connected'} detail={pillLabel} />
-          {healthError ? (
-            <CheckRow label="API server" ok={false} detail="unreachable" />
-          ) : health ? (
-            <>
-              <CheckRow label="API server" ok={health.status === 'ok'} detail={health.status} />
-              <CheckRow label="wicked-core" ok detail={health.version} />
-            </>
-          ) : (
-            <CheckRow label="API server" ok={null} detail="checking…" />
-          )}
-        </div>
-      )}
     </div>
   );
 }
 
-export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
+export function AppChrome({ collapsed, navigate, onDotClick }: Props): React.ReactElement {
   const logoUrl = useAppearanceStore((s) => s.appearance.logo_url);
 
   // The §3.1 slot: 32×32 exactly, clearspace by margin, contain-fit custom
@@ -195,7 +134,7 @@ export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
         style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-1)' }}
       >
         {logoSlot}
-        <ConnectionDot collapsed />
+        <ConnectionDot collapsed onClick={onDotClick} />
       </div>
     );
   }
@@ -222,7 +161,7 @@ export function AppChrome({ collapsed, navigate }: Props): React.ReactElement {
       >
         wicked-studio
       </button>
-      <ConnectionDot collapsed={false} />
+      <ConnectionDot collapsed={false} onClick={onDotClick} />
     </div>
   );
 }

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -12,15 +12,20 @@ interface Props {
 const terminal = (s: string): boolean =>
   ['completed', 'failed', 'cancelled'].includes(s);
 
+/**
+ * The Chat predicate — exported so Make's complement is VERBATIM this filter
+ * (DES-FEEDBACK-003 §4.2/§3.3: every run under exactly one path): chat runs
+ * are 'chat'-stamped runs plus legacy runs with no workflow stamp.
+ */
+export const isChatRun = (v: SessionView): boolean =>
+  !v.session.workflow_id || v.session.workflow_id === 'chat';
+
 export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
 
   // Strict filter: include 'chat' runs and legacy runs with no workflow stamp as a transitional fallback.
-  const allChats = useMemo(
-    () => runs.filter((v) => !v.session.workflow_id || v.session.workflow_id === 'chat'),
-    [runs],
-  );
+  const allChats = useMemo(() => runs.filter(isChatRun), [runs]);
 
   const chats = useMemo(() => filterByRange(allChats), [allChats, filterByRange]);
 

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
+import { useDocsCache } from '../store/docsCache.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { threadKey, useDocThreadStore } from '../store/docThread.js';
@@ -37,7 +38,11 @@ function byRecency(a: DocSummary, b: DocSummary): number {
 }
 
 function DocPicker({ projectId, navigate }: { projectId: string; navigate: Navigate }): React.ReactElement {
-  const [docs, failure, retry] = useLoad(() => listDocs(projectId), [projectId]);
+  const [docs, failure, retry] = useLoad(
+    // The landed list feeds the session doc cache too (slice O §4.2.2).
+    () => listDocs(projectId).then((d) => { useDocsCache.getState().deposit(projectId, d); return d; }),
+    [projectId],
+  );
 
   if (failure) return <Failed surface="doc" subject="this project's documents" failure={failure} onRetry={retry} />;
   if (docs === null) return <Loading surface="doc" subject="this project's documents" />;

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+import type { RosterSeat } from '../api/types.js';
+import { useConnectionStore } from '../store/connection.js';
+import { setCachedRoster } from '../store/rosterCache.js';
+
+/**
+ * The rail-foot health section (DES-FEEDBACK-003 §6.2, slice O): the operator —
+ * "move health down to where settings was and behaving the same (just with it's
+ * health registry)". The dress is the slice-A SettingsRailSection VERBATIM
+ * (collapsed by default, chevron rotates 90°, header `--ink-muted` closed /
+ * `--ink-high` open) in the rail-bottom slot Settings vacated when it became a
+ * primary heading (§2.1/§8.1) — with `♥ Health` in place of `⚙ Settings`.
+ *
+ * Expanded contents are THE HEALTH REGISTRY: the two chrome check rows
+ * (WebSocket / API server — CheckRow + the `getHealth()` fetch moved verbatim
+ * from the retired AppChrome popover, §8.2) plus one row per council seat off
+ * `GET /roster` (`display_name`, `health: SeatHealth`, `signed_in` —
+ * routes.ts:308, crew#274).
+ *
+ * Fetch discipline (EC30): `GET /health` and `GET /roster` fire ON EXPAND — a
+ * gesture, like the popover this replaces; never on mount, never on a timer.
+ * Collapsing keeps the answers (the summary dot reads them); re-expanding
+ * refetches (staleness by gesture, §6.3).
+ *
+ * `health` is OPTIONAL on the wire (additive, absent on a daemon predating
+ * crew#274): an absent `health` renders a dim `·` glyph and no message — never
+ * a fabricated "active".
+ */
+
+interface HealthInfo {
+  status: string;
+  version: string;
+  ping: string;
+}
+
+/** Moved verbatim from the retired AppChrome popover (§6.2/§8.2). */
+function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; detail: string }): React.ReactElement {
+  const icon = ok === null ? '·' : ok ? '✓' : '✗';
+  const color = ok === null ? 'var(--ink-dim)' : ok ? 'var(--status-run)' : 'var(--status-fail)';
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}>
+      <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{icon}</span>
+      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-mono)', flex: 1 }}>{label}</span>
+      <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>{detail}</span>
+    </div>
+  );
+}
+
+const EXCERPT_CH = 40;
+
+/** One registry row (§6.2's anatomy): glyph, name, the honest detail. */
+function SeatRow({ seat }: { seat: RosterSeat }): React.ReactElement {
+  const h = seat.health;
+  // Absent health (a daemon predating crew#274) is UNKNOWN — a dim `·`, no
+  // message, never a fabricated "active" (§6.2).
+  const glyph = h === undefined ? '·' : h.status === 'active' ? '✓' : '✗';
+  const color = h === undefined ? 'var(--ink-dim)' : h.status === 'active' ? 'var(--status-run)' : 'var(--status-fail)';
+  const signedIn = seat.signed_in === true ? 'signed in' : seat.signed_in === false ? 'signed out' : null;
+  const message = h?.status === 'inactive' && h.message !== undefined ? h.message : null;
+  const detail = message !== null
+    ? message.length > EXCERPT_CH ? `${message.slice(0, EXCERPT_CH)}…` : message
+    : [h?.status, signedIn].filter((s): s is string => s != null).join(' · ');
+  return (
+    <div
+      data-testid="rail-seat-row"
+      data-seat={seat.key}
+      data-health={h?.status ?? 'unknown'}
+      title={message ?? undefined}
+      style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}
+    >
+      <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{glyph}</span>
+      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-mono)', flexShrink: 0 }}>
+        {seat.display_name}
+      </span>
+      <span
+        className="truncate"
+        style={{ marginLeft: 'auto', fontSize: 'var(--text-2xs)', color: message !== null ? 'var(--status-fail)' : 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+      >
+        {detail}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  /** Controlled by the rail so the chrome dot can expand this section (§6.2). */
+  open: boolean;
+  onToggle: () => void;
+}
+
+export function HealthRailSection({ open, onToggle }: Props): React.ReactElement {
+  const wsStatus = useConnectionStore((s) => s.status);
+  const [health, setHealth] = useState<HealthInfo | null>(null);
+  const [healthError, setHealthError] = useState(false);
+  const [roster, setRoster] = useState<RosterSeat[] | null>(null);
+  const [rosterError, setRosterError] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // EC30: the expand IS the fetch gesture — one GET /health + one GET /roster
+  // per expansion (the retired popover's exact `[open]` effect, moved); the
+  // answers survive a collapse so the summary dot can keep reading them.
+  useEffect(() => {
+    if (!open) return;
+    setHealthError(false);
+    setRosterError(false);
+    api.getHealth()
+      .then((h) => setHealth(h))
+      .catch(() => setHealthError(true));
+    api.getRoster()
+      .then(({ roster: seats }) => { setRoster(seats); setCachedRoster(seats); })
+      .catch(() => setRosterError(true));
+    // Opened from the chrome dot: bring the foot into view (§6.2).
+    ref.current?.scrollIntoView({ block: 'nearest' });
+  }, [open]);
+
+  const wsDown = wsStatus === 'disconnected';
+  const pillLabel = wsStatus === 'connected' ? 'Connected' : wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
+  // The passive header summary (§6.2): fail-red if any seat is inactive or the
+  // socket is down — the rail's foot says "look inside" without being opened.
+  const sick = wsDown || (roster ?? []).some((s) => s.health?.status === 'inactive');
+
+  return (
+    <div
+      ref={ref}
+      data-testid="rail-health-section"
+      data-open={open}
+      className="shrink-0 px-2 pb-2 pt-1"
+      style={{ borderTop: '1px solid var(--surface-raised)' }}
+    >
+      <button
+        type="button"
+        data-testid="rail-health-toggle"
+        aria-expanded={open}
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-1 py-1.5 text-left transition-colors"
+        style={{
+          background: 'transparent',
+          color: open ? 'var(--ink-high)' : 'var(--ink-muted)',
+          fontSize: 'var(--text-xs)',
+          fontFamily: 'var(--font-sans)',
+          fontWeight: 'var(--weight-semi)',
+        }}
+      >
+        <span
+          aria-hidden
+          data-testid="rail-health-chevron"
+          className="inline-block leading-none"
+          style={{
+            transition: 'transform var(--dur-fast)',
+            transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+          }}
+        >
+          ›
+        </span>
+        <span aria-hidden>♥</span>
+        <span>Health</span>
+        {sick && (
+          <span
+            data-testid="rail-health-summary-dot"
+            aria-label="a health check needs attention"
+            className="w-2 h-2 rounded-full shrink-0 ml-auto"
+            style={{ background: 'var(--status-fail)' }}
+          />
+        )}
+      </button>
+      {open && (
+        <div className="flex flex-col pt-0.5 px-1">
+          <CheckRow label="WebSocket" ok={wsStatus === 'connected'} detail={pillLabel} />
+          {healthError ? (
+            <CheckRow label="API server" ok={false} detail="unreachable" />
+          ) : health ? (
+            <CheckRow label="API server" ok={health.status === 'ok'} detail={`${health.status} · ${health.version}`} />
+          ) : (
+            <CheckRow label="API server" ok={null} detail="checking…" />
+          )}
+          <p
+            aria-hidden
+            className="select-none"
+            style={{ margin: '2px 0 5px', fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+          >
+            ── seats ─────────────
+          </p>
+          {rosterError ? (
+            <CheckRow label="seats" ok={false} detail="unreachable" />
+          ) : roster === null ? (
+            <CheckRow label="seats" ok={null} detail="checking…" />
+          ) : (
+            roster.map((seat) => <SeatRow key={seat.key} seat={seat} />)
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -6,6 +6,7 @@ import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useProjectsStore } from '../store/projects.js';
 import { AppChrome } from './AppChrome.js';
+import { HealthRailSection } from './HealthRailSection.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { NotificationBell } from './NotificationBell.js';
@@ -455,6 +456,13 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
   const [hovered, setHovered] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [makePickerOpen, setMakePickerOpen] = useState(false);
+  // The rail-foot health section (§6.2, slice O) — controlled here so the
+  // chrome's connection dot can expand it (its old popover retired, §8.2).
+  const [healthOpen, setHealthOpen] = useState(false);
+  const onDotClick = (): void => {
+    setCollapsed(false);
+    setHealthOpen(true);
+  };
   // §7.3 auto-collapse: entering an immersive mode stashes the user's state and
   // collapses; leaving restores it. `null` = nothing stashed. The user can still
   // re-expand mid-mode — this fires only on the transition, never per render.
@@ -532,7 +540,7 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
       {/* The app chrome (DES-VISION-001 §6.3 slice 3): logo slot + product name
           + connection dot — untouched by the round-4 re-architecture (§8.2). */}
       <div className={`flex shrink-0 ${isExpanded ? 'items-center pr-2' : 'flex-col items-center pt-2 gap-1'}`}>
-        <AppChrome collapsed={!isExpanded} navigate={navigate} />
+        <AppChrome collapsed={!isExpanded} navigate={navigate} onDotClick={onDotClick} />
         <button
           type="button"
           onClick={() => setCollapsed(v => !v)}
@@ -690,6 +698,12 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             </a>
           ))}
         </div>
+      )}
+
+      {/* The rail's FOOT — the slot Settings vacated (§8.1): the health
+          registry, dressed exactly like the section it replaces (§6.2). */}
+      {isExpanded && (
+        <HealthRailSection open={healthOpen} onToggle={() => setHealthOpen((v) => !v)} />
       )}
 
       {/* The new-project flow (§1.3), opened from Projects' ＋ (§3.1). */}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -6,6 +6,7 @@ import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useProjectsStore } from '../store/projects.js';
 import { AppChrome } from './AppChrome.js';
+import { isChatRun } from './ChatsPage.js';
 import { HealthRailSection } from './HealthRailSection.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NewProjectModal } from './NewProjectModal.js';
@@ -92,10 +93,9 @@ export function headingForPath(pathname: string): PathKey | null {
   return null;
 }
 
-/** The Chat predicate — ChatsPage's filter VERBATIM (§3.3: runs with no
- *  workflow stamp are chats there and must not double-list under Make). */
-const isChatRun = (v: SessionView): boolean =>
-  !v.session.workflow_id || v.session.workflow_id === 'chat';
+// The Chat predicate — ChatsPage's filter VERBATIM (§3.3: runs with no
+// workflow stamp are chats there and must not double-list under Make);
+// imported from its one source so the partition cannot drift.
 
 const RUN_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
 

--- a/src/components/MakeDashboard.tsx
+++ b/src/components/MakeDashboard.tsx
@@ -1,0 +1,347 @@
+import { useMemo, useState } from 'react';
+import type { SessionView } from '../api/types.js';
+import type { DocSummary } from '../api/interactive.js';
+import { versionPath, type Mode } from '../hooks/useRoute.js';
+import { useDocsCache } from '../store/docsCache.js';
+import { useMembershipStore } from '../store/membership.js';
+import { useProjectsStore } from '../store/projects.js';
+import { isChatRun } from './ChatsPage.js';
+import { MetricTile } from './MetricTile.js';
+import { RunOutcomeBar } from './RunOutcomeBar.js';
+import { phaseWord, RUN_DOT } from './RunsSection.js';
+import { TokenBurnSparkline } from './TokenBurnSparkline.js';
+
+/**
+ * The Make dashboard — `/make` (DES-FEEDBACK-003 §4.2, slice O): the combined
+ * list + reporting over MADE THINGS — build runs and their deliverables,
+ * documents, demos. Make = the verbatim complement of ChatsPage's filter
+ * (§3.3/§4.2: every run under exactly one path).
+ *
+ * Reporting discipline (EC19/EC28): the tile band sits ABOVE the list, every
+ * tile answers its §4.2.1 named question via `data-question`, SVG-first, no
+ * chart library, tokens only.
+ *
+ * Data discipline: ZERO requests on mount. Runs ride the app's one `GET /runs`
+ * (the `runs` prop); attach clocks and project names read the membership
+ * mirror; spend reads the runtime store's observed `cliUsage` frames; doc
+ * lists read the session docsCache — the honest corpus (§4.2.2), which the
+ * EC24-grammar label says out loud. The one fan-out (`[load docs for all
+ * projects]`) is an explicit gesture: P known-shape GETs, progress named,
+ * cached for the session — a button the operator presses, never a mount cost.
+ */
+
+interface Props {
+  runs: SessionView[];
+  navigate: (path: string) => void;
+  /** Where a run row lands — the caller's routing (flat `/runs/:id` here). */
+  runPath: (id: string) => string;
+}
+
+const RUN_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
+
+/** Active before terminal, incoming order preserved (the RunsSection contract). */
+function orderRuns(runs: SessionView[]): SessionView[] {
+  const active = runs.filter((v) => !RUN_TERMINAL.has(v.session.status));
+  const terminal = runs.filter((v) => RUN_TERMINAL.has(v.session.status));
+  return [...active, ...terminal];
+}
+
+// ── The Made (7d) tile (§4.2.1 row 1) ─────────────────────────────────────────
+
+const DAYS = 7;
+const DAY_MS = 24 * 3_600_000;
+const W = 168;
+const H = 26;
+const COL_GAP = 3;
+
+type MadeKind = 'builds' | 'docs' | 'demos';
+/** Kind → its fill. Kinds, not statuses — the accent family + one status
+ *  token keep the three producible things tellable apart (C2: tokens only). */
+const KIND_FILL: ReadonlyArray<{ key: MadeKind; fill: string }> = [
+  { key: 'builds', fill: 'var(--status-run)' },
+  { key: 'docs', fill: 'var(--accent)' },
+  { key: 'demos', fill: 'var(--accent-dim)' },
+];
+
+function MadeTile({ builds, docs, attachedAt, now }: {
+  builds: SessionView[];
+  docs: Array<{ doc: DocSummary }>;
+  attachedAt: Record<string, number>;
+  now?: number;
+}): React.ReactElement {
+  const at = now ?? Date.now();
+  const { buckets, totals } = useMemo(() => {
+    const start = at - DAYS * DAY_MS;
+    const days = Array.from({ length: DAYS }, () => ({ builds: 0, docs: 0, demos: 0 }));
+    const sums = { builds: 0, docs: 0, demos: 0 };
+    const place = (clock: number | undefined, kind: MadeKind): void => {
+      if (clock === undefined || Number.isNaN(clock) || clock < start || clock > at) return;
+      const ix = Math.min(DAYS - 1, Math.floor((clock - start) / DAY_MS));
+      const day = days[ix];
+      if (day !== undefined) day[kind] += 1;
+      sums[kind] += 1;
+    };
+    for (const v of builds) {
+      if (v.session.archived_at != null) continue;
+      place(attachedAt[v.session.id], 'builds');
+    }
+    // Doc/demo versions counted from LOADED manifests only (§4.2.1) — each doc
+    // at its newest update; the corpus label below owns the honesty.
+    for (const { doc } of docs) {
+      place(doc.updated_at === null ? undefined : Date.parse(doc.updated_at), doc.kind === 'demo' ? 'demos' : 'docs');
+    }
+    return { buckets: days, totals: sums };
+  }, [builds, docs, attachedAt, at]);
+
+  const total = totals.builds + totals.docs + totals.demos;
+  const colMax = buckets.reduce((m, d) => Math.max(m, d.builds + d.docs + d.demos), 0);
+  const colW = (W - COL_GAP * (DAYS - 1)) / DAYS;
+  const value = total === 0
+    ? 'nothing made in 7d'
+    : [
+        totals.builds > 0 ? `${totals.builds} builds` : null,
+        totals.docs > 0 ? `${totals.docs} docs` : null,
+        totals.demos > 0 ? `${totals.demos} demos` : null,
+      ].filter((s) => s !== null).join(' · ');
+
+  return (
+    <MetricTile
+      testId="made-tile"
+      question="What is the shop producing, and of what kind?"
+      title="Made (7d) · docs from loaded projects"
+      value={value}
+      data={{ 'data-total': total }}
+    >
+      {total === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          Nothing made in the last 7 days.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={H}
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`made over the last 7 days: ${value}`}
+          style={{ display: 'block' }}
+        >
+          {buckets.map((d, i) => {
+            let y = H;
+            return KIND_FILL.map(({ key, fill }) => {
+              if (d[key] === 0) return null;
+              const h = Math.max(2, (d[key] / colMax) * H);
+              y -= h;
+              return <rect key={`${i}-${key}`} x={i * (colW + COL_GAP)} y={y} width={colW} height={h} fill={fill} />;
+            });
+          })}
+        </svg>
+      )}
+    </MetricTile>
+  );
+}
+
+// ── The dashboard ─────────────────────────────────────────────────────────────
+
+export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const byProject = useDocsCache((s) => s.byProject);
+  const fanoutDone = useDocsCache((s) => s.fanoutDone);
+  const fanoutProgress = useDocsCache((s) => s.fanoutProgress);
+  const [whyOpen, setWhyOpen] = useState(false);
+
+  // The spine (§4.2.2): non-chat runs — complete, all projects, active first.
+  const made = useMemo(
+    () => orderRuns(runs.filter((v) => !isChatRun(v) && v.session.archived_at == null)),
+    [runs],
+  );
+
+  const projectNameById = useMemo(
+    () => Object.fromEntries(projects.map((p) => [p.id, p.name])),
+    [projects],
+  );
+  // The known corpus: doc rows off the session cache, newest first.
+  const docRows = useMemo(
+    () => Object.entries(byProject)
+      .flatMap(([pid, docs]) => docs.map((doc) => ({ doc, projectId: pid, projectName: projectNameById[pid] ?? pid })))
+      .sort((a, b) => (b.doc.updated_at ?? '').localeCompare(a.doc.updated_at ?? '')),
+    [byProject, projectNameById],
+  );
+
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
+
+  // The explicit fan-out (§4.2.2): every real project, one known-shape GET each.
+  const fanout = (): void => {
+    void useDocsCache.getState().loadAll(projects.filter((p) => p.id !== 'default').map((p) => p.id));
+  };
+
+  return (
+    <div className="flex flex-col" style={{ color: 'var(--ink-high)' }}>
+      <div className="px-8 pt-8 pb-4 flex items-baseline justify-between gap-4">
+        <h1 className="text-2xl font-semibold font-mono">Make</h1>
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
+          build runs · documents · demos
+        </p>
+      </div>
+
+      {/* ── The reporting band (§4.2.1) — tiles ABOVE the list (EC28) ────────── */}
+      <div
+        data-testid="make-dashboard-tiles"
+        className="mx-8 mb-6 flex items-stretch"
+        style={{ height: '64px', flexShrink: 0, background: 'var(--surface-rail)', borderRadius: 'var(--radius-md)', padding: '0 var(--space-3)' }}
+      >
+        <MadeTile builds={made} docs={docRows} attachedAt={attachedAt} />
+        <RunOutcomeBar
+          runs={made}
+          attachedAt={attachedAt}
+          question="Are makes landing or failing?"
+          title="Outcome split (24h)"
+        />
+        <TokenBurnSparkline
+          question="What is making costing?"
+          title="Spend (observed)"
+        />
+      </div>
+
+      {/* ── The corpus label (EC24 grammar, §4.2.2) heads the list ───────────── */}
+      <div className="relative px-8 pb-2 flex items-center gap-3 flex-wrap">
+        <p
+          data-testid="make-corpus-label"
+          style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+        >
+          Listing: build runs (all projects) · documents (projects opened this session)
+          {' — '}
+          <button
+            type="button"
+            data-testid="make-corpus-why"
+            aria-expanded={whyOpen}
+            onClick={() => setWhyOpen((v) => !v)}
+            style={{ background: 'transparent', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit', color: 'var(--ink-muted)' }}
+          >
+            [why?]
+          </button>
+        </p>
+        {whyOpen && (
+          <p
+            data-testid="make-corpus-why-popover"
+            className="absolute left-8 top-6 z-20 max-w-md"
+            style={{
+              margin: 0, padding: 'var(--space-2) var(--space-3)',
+              background: 'var(--surface-overlay)', border: '1px solid var(--surface-raised)',
+              borderRadius: 'var(--radius-md)', boxShadow: 'var(--shadow-overlay)',
+              fontSize: 'var(--text-2xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)',
+            }}
+          >
+            Documents live behind each project's bridge; the studio lists what it
+            has loaded rather than querying every project on page-open.
+          </p>
+        )}
+        {fanoutProgress !== null ? (
+          <p
+            data-testid="make-fanout-progress"
+            style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+          >
+            loading docs… {fanoutProgress.done}/{fanoutProgress.total}
+          </p>
+        ) : fanoutDone ? (
+          <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+            docs loaded for all projects
+          </p>
+        ) : (
+          <button
+            type="button"
+            data-testid="make-load-all-docs"
+            onClick={fanout}
+            className="rounded px-2 py-0.5 transition-opacity hover:opacity-80"
+            style={{
+              background: 'transparent', border: '1px solid var(--surface-raised)',
+              fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
+            }}
+          >
+            load docs for all projects
+          </button>
+        )}
+      </div>
+
+      {/* ── The list: run spine, then the known doc corpus (§4.2.2) ──────────── */}
+      <div className="px-8 pb-8 flex flex-col gap-1" data-testid="make-list">
+        {made.length === 0 && (
+          <p style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)', fontStyle: 'italic' }}>
+            Nothing made yet — Make's ＋ forks Build / Document / Video.
+          </p>
+        )}
+        {made.map((view) => (
+          <a
+            key={view.session.id}
+            data-testid="make-run-row"
+            data-run-id={view.session.id}
+            data-status={view.session.status}
+            {...link(runPath(view.session.id))}
+            title={view.session.problem}
+            className="flex items-center gap-2 min-w-0 px-3 py-1.5 rounded-md transition-colors hover:bg-surface-card"
+            style={{ textDecoration: 'none' }}
+          >
+            <span
+              aria-hidden
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
+            />
+            <span className="truncate" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
+              {view.session.problem}
+            </span>
+            <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}>
+              {projectNameByRun[view.session.id] ?? 'Unfiled'}
+            </span>
+            <span className="ml-auto shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+              {phaseWord(view)}
+            </span>
+          </a>
+        ))}
+
+        {docRows.length > 0 && (
+          <p
+            className="pt-3 pb-1"
+            style={{
+              margin: 0, fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', textTransform: 'uppercase',
+              letterSpacing: '0.08em', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)',
+            }}
+          >
+            documents · demos
+          </p>
+        )}
+        {docRows.map(({ doc, projectId, projectName }) => {
+          const mode: Mode = doc.kind === 'demo' ? 'video' : 'document';
+          return (
+            <a
+              key={`${projectId}:${doc.name}`}
+              data-testid="make-doc-row"
+              data-doc-kind={doc.kind}
+              {...link(versionPath(projectId, doc.name, null, mode))}
+              title={`${doc.name} · ${projectName}`}
+              className="flex items-center gap-2 min-w-0 px-3 py-1.5 rounded-md transition-colors hover:bg-surface-card"
+              style={{ textDecoration: 'none' }}
+            >
+              <span aria-hidden className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}>
+                {doc.kind === 'demo' ? '▶' : '▤'}
+              </span>
+              <span className="truncate" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
+                {doc.name}
+              </span>
+              <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+                v{doc.head}
+              </span>
+              <span className="ml-auto shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}>
+                {projectName}
+              </span>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api } from '../api/client.js';
 import { listDocs, type DocSummary } from '../api/interactive.js';
+import { useDocsCache } from '../store/docsCache.js';
 import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
 import { interactiveRootOf } from '../hooks/useBoardModel.js';
@@ -149,7 +150,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
     if (project === null || interactiveRootOf(project) === null) return;
     let cancelled = false;
     listDocs(projectId)
-      .then((d) => { if (!cancelled) setDocs(d); })
+      .then((d) => {
+        useDocsCache.getState().deposit(projectId, d); // slice O §4.2.2: the session doc cache
+        if (!cancelled) setDocs(d);
+      })
       .catch(() => { /* bridge cold/unreachable — no doc tiles, never an error wall */ });
     return () => { cancelled = true; };
   }, [projectId, project]);

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -51,9 +51,17 @@ interface Props {
   attachedAt: Record<string, number>;
   /** Injectable clock for tests; defaults to the real one. */
   now?: number;
+  /** Dashboard reuse (DES-FEEDBACK-003 §4): each surface's own §4 table row
+   *  names its question/title (EC19); defaults stay the home bar's. */
+  question?: string;
+  title?: string;
 }
 
-export function RunOutcomeBar({ runs, attachedAt, now }: Props): React.ReactElement {
+export function RunOutcomeBar({
+  runs, attachedAt, now,
+  question = 'Is the system healthy right now?',
+  title = 'Runs (24h)',
+}: Props): React.ReactElement {
   const at = now ?? Date.now();
   const { windows, counts, unplaced } = useMemo(() => {
     const buckets = Array.from({ length: WINDOWS }, () => ({ run: 0, gate: 0, fail: 0, done: 0 }));
@@ -93,8 +101,8 @@ export function RunOutcomeBar({ runs, attachedAt, now }: Props): React.ReactElem
   return (
     <MetricTile
       testId="run-outcome-bar"
-      question="Is the system healthy right now?"
-      title="Runs (24h)"
+      question={question}
+      title={title}
       value={value}
       data={{ 'data-total': inWindow, 'data-unplaced': unplaced }}
     >

--- a/src/components/TokenBurnSparkline.tsx
+++ b/src/components/TokenBurnSparkline.tsx
@@ -26,9 +26,17 @@ const GRAD_ID = 'wk-burn-grad';
 
 interface Props {
   now?: number;
+  /** Dashboard reuse (DES-FEEDBACK-003 §4): the surface's §4 table row names
+   *  the question (EC19); "observed" stays in every title — wire honesty. */
+  question?: string;
+  title?: string;
 }
 
-export function TokenBurnSparkline({ now }: Props): React.ReactElement {
+export function TokenBurnSparkline({
+  now,
+  question = 'What am I spending, is it accelerating?',
+  title = 'Token burn (observed)',
+}: Props): React.ReactElement {
   const logs = useRuntimeStore((s) => s.logs);
   const at = now ?? Date.now();
 
@@ -66,8 +74,8 @@ export function TokenBurnSparkline({ now }: Props): React.ReactElement {
   return (
     <MetricTile
       testId="token-burn-sparkline"
-      question="What am I spending, is it accelerating?"
-      title="Token burn (observed)"
+      question={question}
+      title={title}
       value={steps.length === 0 ? 'no usage yet' : `$${total.toFixed(2)}`}
       data={{ 'data-total': total.toFixed(4), 'data-points': steps.length }}
     >

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -9,6 +9,7 @@ import {
   type Band,
   type Signal,
 } from '../board/boardAttention.js';
+import { useDocsCache } from '../store/docsCache.js';
 import { useGateStore, type OpenGate } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
@@ -162,12 +163,18 @@ const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {
  */
 function mirrorMembership(projects: Project[], bindings: Record<string, Bindings>): void {
   const map: Record<string, string> = {};
+  const clocks: Record<string, number> = {};
   for (const p of projects) {
     const b = bindings[p.id];
     if (b === undefined) continue;
     for (const id of b.runIds) map[id] = p.name;
+    Object.assign(clocks, b.attachedAt);
   }
-  useMembershipStore.getState().setProjectNames(map);
+  const store = useMembershipStore.getState();
+  store.setProjectNames(map);
+  // The attach clocks ride the same mirror (slice O): the Make dashboard's
+  // tiles bucket on them with zero requests of their own (§4.2.1).
+  store.setAttachedAt(clocks);
 }
 
 async function loadBindings(p: Project, repoNames: Map<string, string>): Promise<Bindings> {
@@ -175,7 +182,13 @@ async function loadBindings(p: Project, repoNames: Map<string, string>): Promise
     api.listProjectMembers(p.id).then((r) => r.members).catch((): ProjectMember[] => []),
     // No interactive root ⇒ no bridge to ask. A project WITH one whose bridge cannot be
     // started (§7.12) simply shows no tiles rather than failing the whole board.
-    interactiveRootOf(p) ? listDocs(p.id).catch((): DocSummary[] => []) : Promise.resolve([]),
+    // A landed doc list is DEPOSITED into the session cache (slice O §4.2.2):
+    // the Make dashboard lists what the session has loaded, never refetching.
+    interactiveRootOf(p)
+      ? listDocs(p.id)
+          .then((d) => { useDocsCache.getState().deposit(p.id, d); return d; })
+          .catch((): DocSummary[] => [])
+      : Promise.resolve([]),
   ]);
   const repoRef = members.find((m) => m.member_kind === 'crew.repo')?.member_ref ?? null;
   const runMembers = members.filter((m) => RUN_KINDS.has(m.member_kind));

--- a/src/store/docsCache.ts
+++ b/src/store/docsCache.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand';
+import { listDocs, type DocSummary } from '../api/interactive.js';
+
+/**
+ * The session doc-list cache (DES-FEEDBACK-003 §4.2.2, slice O).
+ *
+ * Documents and demos live behind each project's bridge (`GET
+ * /projects/:id/interactive/api/docs`) — a complete cross-project census is an
+ * N-request fan-out, banned as a mount cost. The Make dashboard therefore
+ * lists the CURRENTLY KNOWN doc lists only: whatever some surface has already
+ * loaded this session (the board model's root-guarded reads, project
+ * dashboards, Document/Video mode visits) deposits here, and `/make` reads the
+ * deposits with zero requests of its own. The corpus label (EC24 grammar)
+ * says this limit out loud.
+ *
+ * `loadAll` is the ONE sanctioned fan-out — the `[load docs for all projects]`
+ * button's explicit gesture (§4.2.2): P known-shape GETs, progress named,
+ * cached for the session; never a mount cost. A bridge that cannot answer
+ * (no interactive root, cold bridge) counts as an honest empty list.
+ */
+
+interface DocsCacheStore {
+  /** Project id → its last-listed docs. Unlisted project = UNKNOWN, not empty. */
+  byProject: Record<string, DocSummary[]>;
+  /** The fan-out ran this session — the button collapses to a quiet note. */
+  fanoutDone: boolean;
+  /** Fan-out progress while running: fetches landed / fetches fired. */
+  fanoutProgress: { done: number; total: number } | null;
+  /** Deposit an already-fetched doc list (a store write, never a request). */
+  deposit: (projectId: string, docs: DocSummary[]) => void;
+  /** The explicit fan-out gesture: one GET per given project id. */
+  loadAll: (projectIds: string[]) => Promise<void>;
+}
+
+export const useDocsCache = create<DocsCacheStore>((set, get) => ({
+  byProject: {},
+  fanoutDone: false,
+  fanoutProgress: null,
+
+  deposit: (projectId, docs) =>
+    set((s) => ({ byProject: { ...s.byProject, [projectId]: docs } })),
+
+  loadAll: async (projectIds) => {
+    if (get().fanoutProgress !== null) return; // one fan-out at a time
+    set({ fanoutProgress: { done: 0, total: projectIds.length } });
+    await Promise.all(projectIds.map(async (pid) => {
+      const docs = await listDocs(pid).catch((): DocSummary[] => []);
+      set((s) => ({
+        byProject: { ...s.byProject, [pid]: docs },
+        fanoutProgress: s.fanoutProgress === null
+          ? null
+          : { done: s.fanoutProgress.done + 1, total: s.fanoutProgress.total },
+      }));
+    }));
+    set({ fanoutDone: true, fanoutProgress: null });
+  },
+}));

--- a/src/store/membership.ts
+++ b/src/store/membership.ts
@@ -13,11 +13,21 @@ import { create } from 'zustand';
 interface MembershipStore {
   /** run id → owning project's display name. Unlisted = unfiled/unknown. */
   projectNameByRun: Record<string, string>;
+  /**
+   * run id → membership `attached_at` (epoch ms) — the one honest per-run
+   * clock (AgentSession carries no timestamps), merged across projects. The
+   * Make dashboard's tiles bucket on it (DES-FEEDBACK-003 §4.2.1) exactly as
+   * the board's own RunOutcomeBar does — read from the mirror, never refetched.
+   */
+  attachedAtByRun: Record<string, number>;
   /** Replace the mirror wholesale (the board model re-reads memberships whole). */
   setProjectNames: (map: Record<string, string>) => void;
+  setAttachedAt: (map: Record<string, number>) => void;
 }
 
 export const useMembershipStore = create<MembershipStore>((set) => ({
   projectNameByRun: {},
+  attachedAtByRun: {},
   setProjectNames: (map) => set({ projectNameByRun: map }),
+  setAttachedAt: (map) => set({ attachedAtByRun: map }),
 }));

--- a/tests/HealthRailSection.test.tsx
+++ b/tests/HealthRailSection.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import type { RosterSeat } from '../src/api/types.js';
+import { useConnectionStore } from '../src/store/connection.js';
+
+/**
+ * The rail-foot health section (DES-FEEDBACK-003 §6.2/§6.3, slice O): the
+ * SettingsRailSection dress with the HEALTH REGISTRY inside — GET /health +
+ * GET /roster fetched ON EXPAND only (EC30), seat-row anatomy honest about an
+ * absent SeatHealth (additive wire field), the passive fail-red summary dot,
+ * and the chrome dot's click expanding the section (its popover retired, §8.2).
+ */
+
+const getHealth = vi.fn(() => Promise.resolve({ status: 'ok', version: '0.6.0', ping: 'pong' }));
+let rosterAnswer: RosterSeat[] = [];
+const getRoster = vi.fn(() => Promise.resolve({ roster: rosterAnswer }));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => getHealth(),
+    getRoster: () => getRoster(),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+}));
+
+vi.mock('../src/hooks/useBoardModel.js', () => ({
+  useBoardModel: () => ({ items: [], unfiled: [], loading: false, error: null }),
+}));
+
+const { HealthRailSection } = await import('../src/components/HealthRailSection.js');
+const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+const { clearCachedRoster, getCachedRoster } = await import('../src/store/rosterCache.js');
+
+const LONG_MESSAGE =
+  'quota exceeded: the monthly usage limit for this seat has been reached upstream';
+
+const SEATS: RosterSeat[] = [
+  { key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true,
+    health: { status: 'active', since: '2026-08-20T00:00:00Z' }, signed_in: true },
+  { key: 'codex', display_name: 'codex', binary: 'codex', enabled_for_council: true,
+    health: { status: 'inactive', message: LONG_MESSAGE, since: '2026-08-20T01:00:00Z',
+              lastErrorAt: '2026-08-20T01:00:00Z' }, signed_in: false },
+  // The additive-wire case: a daemon predating crew#274 sends NO health.
+  { key: 'pi', display_name: 'pi', binary: 'pi', enabled_for_council: true },
+];
+
+/** The rail's controlled-open harness (LeftSidebar owns the state, §6.2). */
+function Harness({ initialOpen = false }: { initialOpen?: boolean }): React.ReactElement {
+  const [open, setOpen] = useState(initialOpen);
+  return <HealthRailSection open={open} onToggle={() => setOpen((v) => !v)} />;
+}
+
+beforeEach(() => {
+  rosterAnswer = SEATS;
+  getHealth.mockClear();
+  getRoster.mockClear();
+  clearCachedRoster();
+  useConnectionStore.setState({ status: 'connected' });
+});
+afterEach(() => cleanup());
+
+describe('fetch on gesture (EC30, §6.3)', () => {
+  it('fires ZERO /health and /roster requests before the expand', () => {
+    render(<Harness />);
+    expect(screen.getByTestId('rail-health-section')).toHaveAttribute('data-open', 'false');
+    expect(getHealth).not.toHaveBeenCalled();
+    expect(getRoster).not.toHaveBeenCalled();
+  });
+
+  it('expanding fires exactly one of each; the answer is cached, never polled', async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByTestId('rail-health-toggle'));
+    await screen.findAllByTestId('rail-seat-row');
+    expect(getHealth).toHaveBeenCalledTimes(1);
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    // Settled and open: no timer, no re-fetch — one gesture, one answer.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    // The landed roster deposits into the session cache (its contract: every
+    // call site deposits).
+    expect(getCachedRoster()?.map((s) => s.key)).toEqual(['claude', 'codex', 'pi']);
+  });
+
+  it('collapsing and re-expanding refetches — staleness by gesture (§6.3)', async () => {
+    render(<Harness />);
+    const toggle = screen.getByTestId('rail-health-toggle');
+    fireEvent.click(toggle);
+    await screen.findAllByTestId('rail-seat-row');
+    fireEvent.click(toggle); // collapse — keeps the answers, fires nothing
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    fireEvent.click(toggle); // the next gesture refetches
+    await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(2));
+    expect(getHealth).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('the registry rows (§6.2 anatomy)', () => {
+  it('renders check rows + one row per seat with glyph/name/status', async () => {
+    render(<Harness initialOpen />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    expect(rows.map((r) => r.getAttribute('data-seat'))).toEqual(['claude', 'codex', 'pi']);
+    // Active + signed in: ✓ in the run token, the quiet suffix.
+    const claude = rows[0]!;
+    expect(claude).toHaveAttribute('data-health', 'active');
+    expect(claude.textContent).toContain('✓');
+    expect(claude.textContent).toContain('active · signed in');
+    // The WebSocket/API check rows moved from the popover verbatim.
+    expect(screen.getByText('WebSocket')).toBeInTheDocument();
+    expect(screen.getByText('API server')).toBeInTheDocument();
+    await screen.findByText('ok · 0.6.0');
+  });
+
+  it('an inactive seat shows ✗ + the 40ch excerpt, full message on title', async () => {
+    render(<Harness initialOpen />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    const codex = rows[1]!;
+    expect(codex).toHaveAttribute('data-health', 'inactive');
+    expect(codex.textContent).toContain('✗');
+    expect(codex.textContent).toContain(`${LONG_MESSAGE.slice(0, 40)}…`);
+    expect(codex.textContent).not.toContain(LONG_MESSAGE);
+    expect(codex).toHaveAttribute('title', LONG_MESSAGE);
+  });
+
+  it('an ABSENT health renders the dim · glyph and no message — never a fabricated "active"', async () => {
+    render(<Harness initialOpen />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    const pi = rows[2]!;
+    expect(pi).toHaveAttribute('data-health', 'unknown');
+    expect(pi.textContent).toContain('·');
+    expect(pi.textContent).not.toContain('active');
+    expect(pi.textContent).not.toContain('✓');
+  });
+});
+
+describe('the passive summary dot (§6.2/§6.3)', () => {
+  it('renders fail-red on the collapsed header once an inactive seat is known', async () => {
+    render(<Harness />);
+    expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
+    const toggle = screen.getByTestId('rail-health-toggle');
+    fireEvent.click(toggle);
+    await screen.findAllByTestId('rail-seat-row');
+    fireEvent.click(toggle); // collapse — the dot keeps saying "look inside"
+    const dot = screen.getByTestId('rail-health-summary-dot');
+    expect(dot.style.background).toBe('var(--status-fail)');
+  });
+
+  it('renders when the socket is down, even with no roster fetched', () => {
+    useConnectionStore.setState({ status: 'disconnected' });
+    render(<Harness />);
+    expect(screen.getByTestId('rail-health-summary-dot')).toBeInTheDocument();
+  });
+
+  it('absent on an all-healthy roster with a live socket', async () => {
+    rosterAnswer = [SEATS[0]!, SEATS[2]!];
+    render(<Harness initialOpen />);
+    await screen.findAllByTestId('rail-seat-row');
+    expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
+  });
+});
+
+describe('the chrome dot hands off to the section (§6.2/§8.2)', () => {
+  it('renders the section at the rail foot, collapsed, with the old testid gone', () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/" />);
+    expect(screen.getByTestId('rail-health-section')).toHaveAttribute('data-open', 'false');
+    expect(screen.queryByTestId('rail-settings-section')).toBeNull();
+    expect(getRoster).not.toHaveBeenCalled();
+  });
+
+  it('clicking the connection dot expands the section; no popover mounts', async () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/" />);
+    fireEvent.click(screen.getByTestId('connection-dot'));
+    expect(screen.getByTestId('rail-health-section')).toHaveAttribute('data-open', 'true');
+    await screen.findAllByTestId('rail-seat-row');
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    // The retired popover's DOM is absent: health detail has ONE surface now.
+    expect(screen.queryByText('Health checks')).toBeNull();
+  });
+});

--- a/tests/MakeDashboard.test.tsx
+++ b/tests/MakeDashboard.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Project } from '../src/api/types.js';
+import type { DocSummary } from '../src/api/interactive.js';
+import { makeView } from './factories.js';
+
+/**
+ * The /make dashboard (DES-FEEDBACK-003 §4.2, slice O): combined list +
+ * reporting over made things. Pinned here: the EC24 corpus label + why
+ * popover, the explicit fan-out gesture (zero doc requests on render, exactly
+ * P on click), the §4.2.1 tile band with its named questions (EC19/EC28), and
+ * the partition invariant — Make lists exactly the complement of ChatsPage's
+ * verbatim filter.
+ */
+
+const listDocs = vi.fn((pid: string): Promise<DocSummary[]> =>
+  Promise.resolve(pid === 'p-notes'
+    ? [{ name: 'roadmap', kind: 'doc', head: 3, versions: 3, updated_at: '2026-08-21T00:00:00Z' },
+       { name: 'launch-demo', kind: 'demo', head: 1, versions: 1, updated_at: '2026-08-21T01:00:00Z' }]
+    : []));
+
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (pid: string) => listDocs(pid),
+}));
+
+const { MakeDashboard } = await import('../src/components/MakeDashboard.js');
+const { isChatRun } = await import('../src/components/ChatsPage.js');
+const { useDocsCache } = await import('../src/store/docsCache.js');
+const { useMembershipStore } = await import('../src/store/membership.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useRuntimeStore } = await import('../src/store/runtime.js');
+
+const project = (id: string, name: string): Project => ({
+  id, name, description: null, status: 'active', scope: `project:${id}`,
+  created_at: 1, updated_at: 1,
+});
+
+/** 2 chat runs + 3 make runs — the partition's mixed W2-shaped input. */
+const RUNS = [
+  makeView({ id: 'r-build-1', workflow_id: 'wf-w2', status: 'executing', problem: 'build the uploader' }),
+  makeView({ id: 'r-chat-1', workflow_id: 'chat', status: 'executing', problem: 'talk it through' }),
+  makeView({ id: 'r-build-2', workflow_id: 'wf-w2', status: 'completed', problem: 'migrate the API' }),
+  makeView({ id: 'r-chat-2', workflow_id: undefined as unknown as string, status: 'completed', problem: 'legacy thread' }),
+  makeView({ id: 'r-build-3', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'refactor auth' }),
+];
+
+const flatRunPath = (id: string): string => `/runs/${id}`;
+
+function dash(navigate: (p: string) => void = () => {}): ReturnType<typeof render> {
+  return render(<MakeDashboard runs={RUNS} navigate={navigate} runPath={flatRunPath} />);
+}
+
+beforeEach(() => {
+  listDocs.mockClear();
+  useDocsCache.setState({ byProject: {}, fanoutDone: false, fanoutProgress: null });
+  useProjectsStore.setState({
+    projects: [project('default', 'Unfiled'), project('p-notes', 'notes'), project('p-api', 'api-migration'), project('p-auth', 'auth-refactor')],
+  });
+  useMembershipStore.setState({
+    projectNameByRun: { 'r-build-1': 'api-migration', 'r-build-3': 'auth-refactor' },
+    attachedAtByRun: { 'r-build-1': Date.now() - 3_600_000, 'r-build-3': Date.now() - 7_200_000 },
+  });
+  useRuntimeStore.setState({ logs: {} });
+});
+afterEach(() => cleanup());
+
+describe('the partition invariant (§4.2/§3.3)', () => {
+  it('lists exactly the non-chat runs — the verbatim ChatsPage complement', () => {
+    dash();
+    const rowIds = screen.getAllByTestId('make-run-row').map((r) => r.getAttribute('data-run-id'));
+    const complement = RUNS.filter((v) => !isChatRun(v)).map((v) => v.session.id);
+    expect(new Set(rowIds)).toEqual(new Set(complement));
+    // Every run lands under exactly ONE path: Make ∪ Chat = all, Make ∩ Chat = ∅.
+    for (const v of RUNS) {
+      expect(rowIds.includes(v.session.id)).toBe(!isChatRun(v));
+    }
+  });
+
+  it('rows are real links to runPath, active before terminal, with project names off the mirror', () => {
+    dash();
+    const rows = screen.getAllByTestId('make-run-row');
+    expect(rows.map((r) => r.getAttribute('href'))).toEqual(
+      ['/runs/r-build-1', '/runs/r-build-3', '/runs/r-build-2'], // active first
+    );
+    expect(rows[0]!.textContent).toContain('api-migration');
+    expect(rows[2]!.textContent).toContain('Unfiled'); // unmapped run stays honest
+  });
+});
+
+describe('the tile band (§4.2.1, EC19/EC28)', () => {
+  it('renders the three tiles above the list, each with its named data-question', () => {
+    dash();
+    const band = screen.getByTestId('make-dashboard-tiles');
+    const q = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
+    expect(q('made-tile')).toBe('What is the shop producing, and of what kind?');
+    expect(q('run-outcome-bar')).toBe('Are makes landing or failing?');
+    expect(q('token-burn-sparkline')).toBe('What is making costing?');
+    // EC28: the band precedes the list in DOM order.
+    const list = screen.getByTestId('make-list');
+    expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe('the corpus label + fan-out gesture (§4.2.2, EC24)', () => {
+  it('heads the list with the two-corpus label and the why popover', () => {
+    dash();
+    expect(screen.getByTestId('make-corpus-label').textContent).toContain(
+      'Listing: build runs (all projects) · documents (projects opened this session)',
+    );
+    expect(screen.queryByTestId('make-corpus-why-popover')).toBeNull();
+    fireEvent.click(screen.getByTestId('make-corpus-why'));
+    expect(screen.getByTestId('make-corpus-why-popover').textContent).toContain(
+      "Documents live behind each project's bridge; the studio lists what it",
+    );
+  });
+
+  it('fires ZERO doc requests on render; the fan-out click fires exactly P (non-default projects)', async () => {
+    dash();
+    expect(listDocs).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('make-load-all-docs'));
+    await waitFor(() => expect(screen.queryByTestId('make-load-all-docs')).toBeNull());
+    expect(listDocs).toHaveBeenCalledTimes(3);
+    expect(new Set(listDocs.mock.calls.map((c) => c[0]))).toEqual(new Set(['p-notes', 'p-api', 'p-auth']));
+    // Cached for the session: the button collapses to the quiet note.
+    expect(screen.getByText('docs loaded for all projects')).toBeInTheDocument();
+    // The landed corpus renders: ▤/▶ name · vN · project rows.
+    const docRows = screen.getAllByTestId('make-doc-row');
+    expect(docRows).toHaveLength(2);
+    expect(docRows[0]!.getAttribute('data-doc-kind')).toBe('demo');
+    expect(docRows[0]!.textContent).toContain('launch-demo');
+    expect(docRows[0]!.textContent).toContain('v1');
+    expect(docRows[0]!.textContent).toContain('notes');
+    expect(docRows[0]!.getAttribute('href')).toBe('/p/p-notes/video/launch-demo');
+    expect(docRows[1]!.getAttribute('href')).toBe('/p/p-notes/document/roadmap');
+  });
+
+  it('renders session-known docs WITHOUT any gesture when the cache already holds them', () => {
+    useDocsCache.getState().deposit('p-notes', [
+      { name: 'roadmap', kind: 'doc', head: 2, versions: 2, updated_at: '2026-08-20T00:00:00Z' },
+    ]);
+    dash();
+    expect(listDocs).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId('make-doc-row')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Round-4 operator feedback: *"move health down to where settings was and behaving the same (just with it's health registry)"* — plus /make's ▦ target, the one dashboard still serving slice M's placeholder.

## What changed

- **HealthRailSection** at the rail foot in the old settings section's exact dress (collapsed default, chevron, muted↔high header): WebSocket/API checks + the seat registry from the real `GET /roster` (SeatHealth per crew#274) — inactive seats show their error excerpt, seats without health data render an honest dim "unknown", never a fabricated active. Fetch on expand only (EC30), refetch per expand gesture (§6.3). The chrome connection dot keeps its glance contract; its click now expands and scrolls to the section (the old popover DOM is deleted per §8.2). Notifications and the Settings heading untouched (zero-line diffs, asserted).
- **MakeDashboard** replaces the placeholder: combined list + reporting per §4.2 — Made (7d) stacked bars, Outcome split, Spend (observed) tiles each with their named data-question (EC19); the honest corpus label ("build runs (all projects) · documents (projects opened this session)") with a [why?] popover and the explicit **[load docs for all projects]** fan-out (exactly P gesture-gated GETs, session-cached, button collapses after); the non-chat run spine via the exported `isChatRun` complement (partition pinned) + document/demo rows.

## Verification highlights

Independent gesture proofs: 0 roster/health GETs on mount and through full rail interaction; 1+1 on expand; 2+2 on re-expand; dot-click handoff with the popover absent; fan-out fired exactly 28 GETs (the fixture's non-default project count) with zero before the click. Fixture roster verified field-for-field against crew's real route + api-types, including the additive health-less seat case. EC21 still one listener; M's accordion and N's 28px bar intact; negative check red on main.

## Gates

eslint clean · tsc clean · vitest **1117/1117** (17 new) · new rig `feedback3_sliceO_test.py` + `feedback3_sliceM/N`, `feedback2_sliceG`, `feedback_sliceD`, `vision_slice3` all PASS (placeholder pins re-targeted in a dedicated §8.7 commit).

Shots: `feedback3-O-health-open.png`, `feedback3-O-make-dashboard.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)