### PR TITLE
Slice P: /projects, /chats, /repos — combined list + reporting dashboards (DES-FEEDBACK-003 §4)

### DIFF
--- a/e2e/feedback3_sliceP_test.py
+++ b/e2e/feedback3_sliceP_test.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+feedback3_sliceP_test.py — the DES-FEEDBACK-003 slice-P gate: the three
+remaining path dashboards — /projects (§4.1), /chats (§4.3), /repos (§4.4) —
+each "a combined list and reporting dashboard" (§4.5), against the shared
+frozen-NOW0 W2 fixture with the slice-P switches on: `chat_runs` (2 chat runs —
+one placed, one clockless legacy thread with a cached gate) and `repo_refs` +
+`repo` (three runs stamped onto the registered studio-api repo).
+
+The slice DOM ACs, from §4.5 + the §10.3 slice-P block:
+
+  /projects (reached via the rail ▦):
+  1. `[data-testid="projects-dashboard-tiles"]` renders ABOVE the register,
+     every tile carrying its §4.1 `data-question` verbatim (EC19/EC28).
+  2. The register is COMPLETE — every fixture project renders a card (the
+     board mirror's active-only subset never truncates it) — and the create
+     affordance survives.
+  3. Register rows carry the 7-day ProjectSparkline where the board holds
+     in-window runs; tile fills resolve from `var()` tokens (EC15).
+  4. The gates tile counts every open gate (r-q3 + r-api + the chat gate);
+     the outcome bar buckets on the merged attach clocks with the honest
+     unplaced count; a row click lands on the project dashboard.
+
+  /chats:
+  5. `[data-testid="chats-dashboard-tiles"]` above the untouched list; the
+     list is EXACTLY the isChatRun partition (2 rows); navigation there rides
+     zero gesture-gated requests (no repos/health/roster/docs).
+  6. Honesty: chats-over-time places only the clocked chat (total 1,
+     unplaced 1); gates-from-chats counts ONLY the chat gate (1) and never
+     the build gates; search still filters; a row click opens the thread.
+
+  /repos:
+  7. `[data-testid="repos-dashboard-tiles"]` above the register; runs-per-repo
+     groups the three stamped runs onto studio-api; failing-repos flags the
+     24h failure; repo-count counts the register.
+  8. The fetch budget: the visit costs exactly the page's own GET /repos +
+     GET /runs (plus the rail accordion's one cached GET /repos on expand) and
+     ZERO per-repo graph GETs — the old Tracked-card fan-out is retired.
+     Register/search/add affordances survive; a card click lands on the
+     detail page.
+
+Captures (§10.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback3-P-projects-dashboard.png  tile band above the complete register
+  feedback3-P-chats-dashboard.png     tile band above the chat partition
+  feedback3-P-repos-dashboard.png     tile band above the repo register
+
+Finally: `npm run lint` must exit 0 with zero raw-color findings (EC15).
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK3P_PORT (default 4364),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    NPM,
+    PROJECTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK3P_PORT = int(os.environ.get("FEEDBACK3P_PORT", "4364"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK3P_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+ALL_PROJECT_IDS = {p["id"] for p in PROJECTS}
+CHAT_GATE_PROMPT = "Pick the auth flow the chat should explore"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build (shared dist — ensure_build caches) ──────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture; the slice-P switches on ─────────────────────────
+start_server(FEEDBACK3P_PORT, dist)
+set_fixture(ORIGIN, chat_runs=True, repo_refs=True, repo=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+api_paths: list[str] = []
+
+
+def n_of(pred) -> int:
+    return sum(1 for p in api_paths if pred(p))
+
+
+def n_repos() -> int:
+    return n_of(lambda p: p == "/api/v1/repos")
+
+
+def n_graph() -> int:
+    return n_of(lambda p: p.startswith("/api/v1/repos/") and p.endswith("/graph"))
+
+
+def n_gesture_gated() -> tuple:
+    """The endpoints /chats must NOT touch: repos, health, roster, doc lists."""
+    return (
+        n_repos(),
+        n_of(lambda p: p == "/api/v1/health"),
+        n_of(lambda p: p == "/api/v1/roster"),
+        n_of(lambda p: p.endswith("/interactive/api/docs")),
+    )
+
+
+QUESTIONS_JS = """(band) =>
+    Object.fromEntries(Array.from(band.querySelectorAll('[data-question]'))
+        .map(el => [el.dataset.testid, el.dataset.question]))"""
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda r: api_paths.append(urlparse(r.url).path)
+            if "/api/v1/" in r.url and r.method == "GET" else None)
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.wait_for_timeout(2500)  # let the mount reads + gate backfills settle
+
+    # ── ACs 1–4: /projects, reached through its rail ▦ ─────────────────────────
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="heading-dashboard"]').click()
+    page.locator('[data-testid="projects-dashboard-tiles"]').wait_for(timeout=30000)
+    page.locator('[data-testid="projects-list"]').wait_for(timeout=30000)
+    # The page's own board model settles when the split tile counts the board.
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="attention-split-tile"]')
+                 ?.dataset.total === '28'""", timeout=30000)
+    page.wait_for_timeout(1000)
+
+    projects_facts = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const band = q('[data-testid="projects-dashboard-tiles"]');
+             const list = q('[data-testid="projects-list"]');
+             const cards = Array.from(document.querySelectorAll('[data-testid="project-card"]'));
+             const split = q('[data-testid="attention-split-tile"]');
+             const bar = q('[data-testid="run-outcome-bar"]');
+             const gatesTile = q('[data-testid="gates-waiting-tile"]');
+             const q3 = cards.find(c => c.dataset.projectId === 'q3-review-deck');
+             const probeBg = name => { const el = document.createElement('div');
+                 el.style.background = `var(${name})`;
+                 document.body.appendChild(el);
+                 const v = getComputedStyle(el).backgroundColor;
+                 el.remove(); return v; };
+             const rect = split?.querySelector('svg rect');
+             return {
+               questions: (%s)(band),
+               bandAboveList: !!band && !!list
+                 && !!(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING),
+               cardIds: cards.map(c => c.dataset.projectId),
+               split: { total: split?.dataset.total, needsYou: split?.dataset.needsYou,
+                        quiet: split?.dataset.quiet },
+               outcome: { total: bar?.dataset.total, unplaced: bar?.dataset.unplaced },
+               gates: gatesTile?.dataset.count,
+               q3Sparkline: !!q3?.querySelector('[data-testid="project-sparkline"]'),
+               createAffordance: Array.from(document.querySelectorAll('button'))
+                 .some(b => (b.textContent ?? '').includes('New project')),
+               rectFill: rect ? getComputedStyle(rect).fill : null,
+               statusGate: rect ? (() => {
+                 // Resolve the token THROUGH the same property: a probe rect in
+                 // the same SVG, so computed `fill` strings compare exactly.
+                 const probe = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+                 probe.style.fill = 'var(--status-gate)';
+                 rect.ownerSVGElement.appendChild(probe);
+                 const v = getComputedStyle(probe).fill;
+                 probe.remove(); return v; })() : probeBg('--status-gate'),
+             }; }""" % QUESTIONS_JS)
+
+    projects_ok = (
+        projects_facts["questions"].get("attention-split-tile") == "How much of my estate needs me?"
+        and projects_facts["questions"].get("run-outcome-bar") == "Is the system healthy right now?"
+        and projects_facts["questions"].get("gates-waiting-tile") == "Am I the blocker anywhere?"
+        and projects_facts["bandAboveList"]
+        # The COMPLETE register: every fixture project, exactly once.
+        and set(projects_facts["cardIds"]) == ALL_PROJECT_IDS
+        and len(projects_facts["cardIds"]) == len(ALL_PROJECT_IDS)
+        and projects_facts["split"]["total"] == "28"
+        and int(projects_facts["split"]["needsYou"]) >= 3
+        # In the 24h window: r-q3, r-api, r-upload, r-auth, r-chat-live; the
+        # 6d/8d/clockless five are the honest unplaced remainder.
+        and projects_facts["outcome"] == {"total": "5", "unplaced": "5"}
+        and projects_facts["gates"] == "3"  # r-q3 + r-api + the chat gate
+        and projects_facts["q3Sparkline"]
+        and projects_facts["createAffordance"]
+    )
+    # EC15: the split bar's needs-you segment resolves from the status token.
+    ec15_ok = (projects_facts["rectFill"] is not None
+               and projects_facts["rectFill"] == projects_facts["statusGate"])
+
+    page.screenshot(path=str(VSHOTS / "feedback3-P-projects-dashboard.png"))
+
+    # Row navigation: a card lands on its project dashboard.
+    # A card lands on the project dashboard: /projects/:id, which the standing
+    # legacy redirect (§1.5) replaces with the dashboard route /p/:id.
+    page.locator('[data-testid="project-card"][data-project-id="q3-review-deck"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/q3-review-deck'", timeout=15000)
+    projects_nav_ok = True
+    # Let the project dashboard's OWN mount reads land before the /chats budget
+    # window opens — they are that surface's cost, not this navigation's.
+    page.wait_for_timeout(2000)
+
+    # ── ACs 5–6: /chats — zero gesture-gated requests ride the navigation ──────
+    pre_chats = n_gesture_gated()
+    page.locator('[data-testid="rail-heading-chat"] [data-testid="heading-dashboard"]').click()
+    page.locator('[data-testid="chats-dashboard-tiles"]').wait_for(timeout=30000)
+    page.wait_for_timeout(1500)
+    chats_zero_ok = n_gesture_gated() == pre_chats
+
+    chats_facts = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const band = q('[data-testid="chats-dashboard-tiles"]');
+             const list = q('[data-testid="chats-list"]');
+             const rows = Array.from(document.querySelectorAll('[data-testid="chat-row"]'));
+             const over = q('[data-testid="chats-over-time-tile"]');
+             const active = q('[data-testid="chats-active-tile"]');
+             const gates = q('[data-testid="chats-gates-tile"]');
+             return {
+               questions: (%s)(band),
+               bandAboveList: !!band && !!list
+                 && !!(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING),
+               rowIds: rows.map(r => r.dataset.runId),
+               overTime: { total: over?.dataset.total, unplaced: over?.dataset.unplaced },
+               activeCount: active?.dataset.count,
+               gates: { count: gates?.dataset.count, text: gates?.textContent ?? '' },
+             }; }""" % QUESTIONS_JS)
+
+    chats_ok = (
+        chats_facts["questions"].get("chats-over-time-tile") == "Is conversation increasing or drying up?"
+        and chats_facts["questions"].get("chats-active-tile") == "How many threads are warm?"
+        and chats_facts["questions"].get("chats-gates-tile") == "Did a conversation stall on me?"
+        and chats_facts["bandAboveList"]
+        # The partition: exactly the two chat runs, never a build run.
+        and set(chats_facts["rowIds"]) == {"r-chat-live", "r-chat-gated"}
+        # Honesty: only the placed chat is painted; the legacy thread is counted.
+        and chats_facts["overTime"] == {"total": "1", "unplaced": "1"}
+        and chats_facts["activeCount"] == "2"
+        # Gate scoping: the chat gate only — the two build gates never count here.
+        and chats_facts["gates"]["count"] == "1"
+        and CHAT_GATE_PROMPT in chats_facts["gates"]["text"]
+        and "Approve the deck outline?" not in chats_facts["gates"]["text"]
+    )
+
+    page.screenshot(path=str(VSHOTS / "feedback3-P-chats-dashboard.png"))
+
+    # Preserved affordances: search filters; a row opens the thread.
+    page.locator('input[placeholder="Search chats…"]').fill("auth")
+    page.wait_for_timeout(300)
+    filtered = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="chat-row"]'))
+              .map(r => r.dataset.runId)""")
+    chats_search_ok = filtered == ["r-chat-gated"]
+    page.locator('input[placeholder="Search chats…"]').fill("")
+    # A row opens the thread (`/runs/:id`; the standing legacy redirect may
+    # then file it into its project's shell — either way the run is reached).
+    page.locator('[data-testid="chat-row"][data-run-id="r-chat-live"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname.includes('r-chat-live')", timeout=15000)
+    chats_nav_ok = True
+
+    # ── ACs 7–8: /repos — the tiles + the retired fan-out ──────────────────────
+    pre_repos, pre_graph = n_repos(), n_graph()
+    page.locator('[data-testid="rail-heading-repos"] [data-testid="heading-dashboard"]').click()
+    page.locator('[data-testid="repos-dashboard-tiles"]').wait_for(timeout=30000)
+    page.locator('[data-testid="repos-list"]').wait_for(timeout=30000)
+    page.wait_for_timeout(1500)
+    # The visit's budget: the page's one GET /repos + the rail accordion's one
+    # cached GET on its route-mapped expand — and NOT ONE graph GET (the old
+    # Tracked-card per-repo fan-out is retired).
+    repos_budget = {"repos": n_repos() - pre_repos, "graph": n_graph() - pre_graph}
+    repos_budget_ok = repos_budget["repos"] == 2 and repos_budget["graph"] == 0
+
+    repos_facts = page.evaluate(
+        """() => {
+             const q = s => document.querySelector(s);
+             const band = q('[data-testid="repos-dashboard-tiles"]');
+             const list = q('[data-testid="repos-list"]');
+             const per = q('[data-testid="runs-per-repo-tile"]');
+             const count = q('[data-testid="repo-count-tile"]');
+             const failing = q('[data-testid="failing-repos-tile"]');
+             const cards = Array.from(document.querySelectorAll('[data-testid="repo-card"]'));
+             return {
+               questions: (%s)(band),
+               bandAboveList: !!band && !!list
+                 && !!(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING),
+               perRepo: { total: per?.dataset.total, repos: per?.dataset.repos,
+                          text: per?.textContent ?? '' },
+               repoCount: count?.dataset.count,
+               failing: { count: failing?.dataset.count, failures: failing?.dataset.failures,
+                          text: failing?.textContent ?? '' },
+               cardIds: cards.map(c => c.dataset.repoId),
+               addAffordance: Array.from(document.querySelectorAll('button'))
+                 .some(b => (b.textContent ?? '').includes('+ Add Repository')),
+               searchBox: !!q('input[placeholder="Search repos…"]'),
+             }; }""" % QUESTIONS_JS)
+
+    repos_ok = (
+        repos_facts["questions"].get("runs-per-repo-tile") == "Where is the work concentrating?"
+        and repos_facts["questions"].get("repo-count-tile") == "Is the estate growing?"
+        and repos_facts["questions"].get("failing-repos-tile") == "Is any repo a failure hotspot?"
+        and repos_facts["bandAboveList"]
+        # r-upload (1h) + r-auth (13m) + r-smoke1 (6d) — all in the 7d window.
+        and repos_facts["perRepo"]["total"] == "3"
+        and repos_facts["perRepo"]["repos"] == "1"
+        and "studio-api leads (3)" in repos_facts["perRepo"]["text"]
+        and repos_facts["repoCount"] == "1"
+        # r-auth failed 13m ago; r-legacy's 8-day failure stays honest-outside.
+        and repos_facts["failing"]["count"] == "1"
+        and repos_facts["failing"]["failures"] == "1"
+        and "studio-api (1)" in repos_facts["failing"]["text"]
+        and repos_facts["cardIds"] == ["studio-api"]
+        and repos_facts["addAffordance"]
+        and repos_facts["searchBox"]
+    )
+
+    page.screenshot(path=str(VSHOTS / "feedback3-P-repos-dashboard.png"))
+
+    page.locator('[data-testid="repo-card"][data-repo-id="studio-api"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/repo-detail/studio-api'", timeout=15000)
+    repos_nav_ok = True
+
+    browser.close()
+
+report["steps"]["dom_acs"] = {
+    "ok": all([
+        projects_ok, ec15_ok, projects_nav_ok,
+        chats_zero_ok, chats_ok, chats_search_ok, chats_nav_ok,
+        repos_budget_ok, repos_ok, repos_nav_ok,
+    ]),
+    "projects": projects_facts,
+    "projects_ok": projects_ok,
+    "ec15_split_fill": {"fill": projects_facts["rectFill"],
+                        "statusGate": projects_facts["statusGate"], "ok": ec15_ok},
+    "chats_zero_gesture_gated": chats_zero_ok,
+    "chats": chats_facts,
+    "chats_ok": chats_ok,
+    "chats_search_ok": chats_search_ok,
+    "repos_budget": repos_budget,
+    "repos_budget_ok": repos_budget_ok,
+    "repos": repos_facts,
+    "repos_ok": repos_ok,
+    "console_errors": console_errors[:10],
+    "screenshots": [str(VSHOTS / n) for n in
+                    ("feedback3-P-projects-dashboard.png",
+                     "feedback3-P-chats-dashboard.png",
+                     "feedback3-P-repos-dashboard.png")],
+}
+if not report["steps"]["dom_acs"]["ok"]:
+    fail("dom_acs_verdict", "slice-P DOM assertions did not all hold — see dom_acs")
+
+# ── 4. Lint posture: exit 0, zero raw-color findings (EC15 error repo-wide) ───
+r = subprocess.run([NPM, "run", "lint"], cwd=REPO,
+                   capture_output=True, text=True, timeout=600)
+out = r.stdout + r.stderr
+raw_color_findings = out.count("(DES-VISION-001 §2.11)")
+report["steps"]["lint"] = {
+    "ok": r.returncode == 0 and raw_color_findings == 0,
+    "exit_code": r.returncode,
+    "raw_color_findings_repo_wide": raw_color_findings,
+    "tail": out[-400:],
+}
+if not report["steps"]["lint"]["ok"]:
+    fail("lint_verdict", "lint must exit 0 with zero raw-color findings — see lint")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -52,6 +52,15 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     5-frame burn drains (slice E's token-burn tile; default
                     False). Same real frame shape as usage_ws; drip-fed so
                     the cumulative fold has more than one arrival instant.
+  chat_runs       — 2 chat runs ride GET /runs (DES-FEEDBACK-003 §10.2): a
+                    'chat'-stamped live thread (crew.chat member of notes,
+                    real attach clock) and a legacy unstamped thread awaiting
+                    a human with a cached gate but no membership (default
+                    False — the slice-P /chats dashboard rig's partition +
+                    unplaced-honesty cases).
+  repo_refs       — r-upload / r-auth / r-smoke1 gain repo_ref "studio-api"
+                    on the runs wire (flip `repo` on with it; default False —
+                    the slice-P /repos tiles' grouping cases).
   learn_delay_s   — how long after a successful theme.requested the learned
                     tokens ripen into GET /d/<doc>/api/theme/learned
                     (interactive#181; default 0.75 — long enough for the
@@ -98,6 +107,18 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
          "extra_narration": [], "demo": False,
          "repo": False, "metrics_ws": False,
+         # Slice P (DES-FEEDBACK-003 §10.2 fixture additions, switch-gated so
+         # no standing rig's board grows rows it never asserted):
+         #   chat_runs — 2 chat runs ride GET /runs: one 'chat'-stamped live
+         #               thread (a notes member, real attach clock) and one
+         #               legacy UNSTAMPED thread awaiting a human with a
+         #               cached gate but no membership (the unplaced-honesty
+         #               case). Default False.
+         #   repo_refs — r-upload / r-auth / r-smoke1 gain repo_ref
+         #               "studio-api" (flip `repo` on with it so the id
+         #               resolves), giving §4.4's runs-per-repo / failing-
+         #               repos tiles something true to group. Default False.
+         "chat_runs": False, "repo_refs": False,
          # Slice I (DES-FEEDBACK-002 §3): the in-studio file/diff viewer corpus.
          #   viewer      — r-upload gains a workdir + file events, and the crew#305
          #                 routes (GET /runs/:id/files, GET /runs/:id/diff) answer
@@ -213,6 +234,28 @@ RUNS = [
 ]
 ORPHAN = session("r-orphan", "executing", "stranded work from another client",
                  "stranded work from another client")
+
+# ── Slice P (DES-FEEDBACK-003 §10.2): the two chat runs, behind `chat_runs` ───
+#
+# The /chats dashboard's partition + honesty cases: CHAT_LIVE is a
+# 'chat'-stamped live thread attached to `notes` (a real clock for the
+# chats-over-time tile); CHAT_GATED is a legacy thread with NO workflow stamp
+# (isChatRun's other arm) awaiting a human — it has a cached gate but no
+# membership, so it is the tile's honest UNPLACED count, while its gate still
+# lands on the gates-from-chats tile.
+CHAT_LIVE = session("r-chat-live", "executing",
+                    "talk through the uploader design", "chat turn")
+CHAT_LIVE["session"]["workflow_id"] = "chat"
+CHAT_GATED = session("r-chat-gated", "awaiting_human",
+                     "which auth flow should we take?", "chat turn")
+CHAT_GATED["session"]["workflow_id"] = None
+CHAT_GATE_PROMPT = "Pick the auth flow the chat should explore"
+ATTACHED_AT["r-chat-live"] = NOW0 - 10 * MIN
+
+# Slice P: which runs the `repo_refs` switch stamps onto the registered repo —
+# a live one and a 6-day-old one for the 7d grouping, plus a fresh failure for
+# the 24h hotspot tile. Clocks are the ATTACHED_AT ones already served above.
+REPO_REF_RUNS = {"r-upload", "r-auth", "r-smoke1"}
 
 # The long-prompt run (slice 5, F7): its problem is a full paragraph, so the Build
 # runs list must render the INTENT PHRASE (truncated, leading) and never the raw
@@ -795,15 +838,20 @@ class W2Handler(SimpleHTTPRequestHandler):
                     runs = []
                 else:
                     runs = RUNS + ([ORPHAN] if state["orphan"] else []) \
-                        + ([LONG_RUN] if state["long_prompt"] else [])
+                        + ([LONG_RUN] if state["long_prompt"] else []) \
+                        + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else [])
                 viewer_on = state["viewer"]
-            if viewer_on:
-                # Slice I: the live run gains a workdir (the diff route's 409
-                # gate reads it; AgentSession carries it on the wire).
+                repo_refs_on = state["repo_refs"]
+            if viewer_on or repo_refs_on:
                 runs = json.loads(json.dumps(runs))
                 for r in runs:
-                    if r["session"]["id"] == "r-upload":
+                    # Slice I: the live run gains a workdir (the diff route's
+                    # 409 gate reads it; AgentSession carries it on the wire).
+                    if viewer_on and r["session"]["id"] == "r-upload":
                         r["session"]["workdir"] = VIEWER_WORKDIR
+                    # Slice P: repo-linked runs for the /repos tiles (§4.4).
+                    if repo_refs_on and r["session"]["id"] in REPO_REF_RUNS:
+                        r["session"]["repo_ref"] = REPO_ID
             self._json(200, {"runs": runs})
             return True
         # Slice I: the crew#305 file/diff routes (real contract, switch-gated).
@@ -851,11 +899,19 @@ class W2Handler(SimpleHTTPRequestHandler):
         # /api/v1/projects/<id>/members
         if len(parts) == 6 and parts[3] == "projects" and parts[5] == "members":
             pid = urllib.parse.unquote(parts[4])
+            refs = list(MEMBERS.get(pid, []))
+            with state_lock:
+                chat_runs_on = state["chat_runs"]
+            # Slice P: the live chat thread is a `crew.chat` member of notes.
+            kinds = {}
+            if chat_runs_on and pid == "notes":
+                refs.append("r-chat-live")
+                kinds["r-chat-live"] = "crew.chat"
             self._json(200, {"members": [
-                {"id": f"{pid}:crew.run:{ref}", "project_id": pid, "member_kind": "crew.run",
-                 "member_ref": ref, "meta": None,
+                {"id": f"{pid}:{kinds.get(ref, 'crew.run')}:{ref}", "project_id": pid,
+                 "member_kind": kinds.get(ref, "crew.run"), "member_ref": ref, "meta": None,
                  "attached_at": ATTACHED_AT.get(ref, 1), "attached_by": "studio"}
-                for ref in MEMBERS.get(pid, [])
+                for ref in refs
             ]})
             return True
         # /api/v1/projects/<id>/interactive/api/docs — the registry: the notes seeds
@@ -892,6 +948,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
                                  "prompt": "How should the tables move?",
                                  "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
+            elif rid == "r-chat-gated" and state["chat_runs"]:
+                # Slice P: the stalled chat's cached gate (§4.3 row 3).
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": CHAT_GATE_PROMPT,
+                                 "receivedAt": iso(NOW0 - 5 * MIN)})
             else:
                 self._json(404, {"error": f"no gate cached for {rid}"})
             return True

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -433,7 +433,7 @@ export function App(): React.ReactElement {
     if (panel === 'projects') {
       return (
         <div className="flex-1 overflow-y-auto">
-          <ProjectsPage navigate={navigate} />
+          <ProjectsPage runs={runs} navigate={navigate} />
         </div>
       );
     }

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useState } from 'react';
 import type { SessionView } from '../api/types.js';
-import { useTimeRange } from '../hooks/useTimeRange.js';
+import { useTimeRange, type TimeRange } from '../hooks/useTimeRange.js';
+import { useGateStore } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
+import { GatesWaitingTile, TileBand } from './DashboardTiles.js';
+import { MetricTile } from './MetricTile.js';
+import { RunSparkline } from './RunSparkline.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
 interface Props {
@@ -20,6 +25,63 @@ const terminal = (s: string): boolean =>
 export const isChatRun = (v: SessionView): boolean =>
   !v.session.workflow_id || v.session.workflow_id === 'chat';
 
+// ── The chats-over-time tile (DES-FEEDBACK-003 §4.3 row 1, slice P) ───────────
+
+const RANGE_DAYS: Record<TimeRange, number> = { '30d': 30, '60d': 60, '90d': 90 };
+const BUCKETS = 12;
+const DAY_MS = 86_400_000;
+
+/**
+ * "Is conversation increasing or drying up?" — the range-filtered chat runs,
+ * bucketed over the range's span on the membership attach clock (the one
+ * honest per-run clock; `AgentSession` carries no timestamps — the same
+ * wire-honesty note RunOutcomeBar carries). Chats the mirror cannot place in
+ * the window (unfiled, or older than the range) are excluded from the bars
+ * and counted in `data-unplaced` rather than painted at an invented time.
+ * Reads the mirror + the `runs` prop only: zero requests.
+ */
+function ChatsOverTimeTile({ chats, range, now }: {
+  chats: SessionView[];
+  range: TimeRange;
+  now?: number;
+}): React.ReactElement {
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const at = now ?? Date.now();
+  const days = RANGE_DAYS[range];
+  const { counts, placed } = useMemo(() => {
+    const span = days * DAY_MS;
+    const start = at - span;
+    const buckets = new Array<number>(BUCKETS).fill(0);
+    let inWindow = 0;
+    for (const v of chats) {
+      const clock = attachedAt[v.session.id];
+      if (clock === undefined || clock < start || clock > at) continue;
+      const ix = Math.min(BUCKETS - 1, Math.floor(((clock - start) / span) * BUCKETS));
+      buckets[ix] = (buckets[ix] ?? 0) + 1;
+      inWindow += 1;
+    }
+    return { counts: buckets, placed: inWindow };
+  }, [chats, attachedAt, at, days]);
+
+  return (
+    <MetricTile
+      testId="chats-over-time-tile"
+      question="Is conversation increasing or drying up?"
+      title={`Chats (${range})`}
+      value={placed === 0 ? `no placed chats in ${range}` : `${placed} in ${range}`}
+      data={{ 'data-total': placed, 'data-unplaced': chats.length - placed }}
+    >
+      {placed === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No chats with an attach clock in the window.
+        </p>
+      ) : (
+        <RunSparkline counts={counts} width={168} height={26} color="var(--accent)" />
+      )}
+    </MetricTile>
+  );
+}
+
 export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
@@ -31,13 +93,14 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
 
   const active = useMemo(() => chats.filter(v => !terminal(v.session.status)), [chats]);
 
-  // Avg units per chat session (round to 1 decimal)
-  const avgUnits = useMemo(() => {
-    if (chats.length === 0) return '—';
-    const total = chats.reduce((sum, v) => sum + v.units.length, 0);
-    const avg = total / chats.length;
-    return avg % 1 === 0 ? String(avg) : avg.toFixed(1);
-  }, [chats]);
+  // Gates from chats (§4.3 row 3): the gate store filtered to THIS partition —
+  // "Did a conversation stall on me?" is asked of every chat, not just the
+  // range-filtered slice, so the filter is the partition predicate alone.
+  const gates = useGateStore((s) => s.gates);
+  const chatGates = useMemo(() => {
+    const ids = new Set(allChats.map((v) => v.session.id));
+    return Object.values(gates).filter((g) => ids.has(g.runId));
+  }, [gates, allChats]);
 
   const filtered = useMemo(
     () => query
@@ -78,36 +141,38 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
         </div>
       </div>
 
-      {/* ── Stat cards ── */}
-      <div className="px-8 grid grid-cols-3 gap-4">
-        {([
-          { label: 'Total Chats', value: String(chats.length),  accent: undefined   },
-          { label: 'Active',      value: String(active.length), accent: 'var(--status-run)'   },
-          { label: 'Avg Units',   value: avgUnits,              accent: 'var(--accent)'   },
-        ] as const).map(s => (
-          <div
-            key={s.label}
-            className="rounded-2xl px-6 py-4"
-            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+      {/* ── The reporting band (DES-FEEDBACK-003 §4.3, slice P): the page's
+             derived numbers promoted into the shared MetricTile dress, ABOVE
+             the untouched list (EC28); every tile answers its named question
+             (EC19); the old stat cards are superseded by this band. ── */}
+      <div className="px-8">
+        <TileBand testId="chats-dashboard-tiles">
+          <ChatsOverTimeTile chats={chats} range={range} />
+          <MetricTile
+            testId="chats-active-tile"
+            question="How many threads are warm?"
+            title="Active now"
+            value={`${active.length} of ${chats.length}`}
+            data={{ 'data-count': active.length }}
           >
             <p
-              className="text-xs font-mono uppercase tracking-widest"
-              style={{ color: 'var(--ink-dim)' }}
+              className="text-lg font-semibold leading-none"
+              style={{ margin: 0, color: active.length > 0 ? 'var(--status-run)' : 'var(--ink-dim)' }}
             >
-              {s.label}
+              {active.length}
             </p>
-            <p
-              className="text-3xl font-semibold mt-1"
-              style={{ color: s.accent ?? 'var(--ink-high)' }}
-            >
-              {s.value}
-            </p>
-          </div>
-        ))}
+          </MetricTile>
+          <GatesWaitingTile
+            gates={chatGates}
+            question="Did a conversation stall on me?"
+            title="Gates from chats"
+            testId="chats-gates-tile"
+          />
+        </TileBand>
       </div>
 
-      {/* ── List / Empty state ── */}
-      <div className="px-8 pb-8 flex flex-col gap-2">
+      {/* ── List / Empty state (untouched below the band, §4.3) ── */}
+      <div className="px-8 pb-8 flex flex-col gap-2" data-testid="chats-list">
         {filtered.length === 0 ? (
           <div
             className="rounded-2xl p-10 text-center"
@@ -137,6 +202,8 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
             <button
               key={v.session.id}
               type="button"
+              data-testid="chat-row"
+              data-run-id={v.session.id}
               onClick={() => onSelect(v.session.id)}
               className="w-full text-left rounded-2xl px-5 py-4 transition-colors"
               style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}

--- a/src/components/DashboardTiles.tsx
+++ b/src/components/DashboardTiles.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react';
+import type { OpenGate } from '../store/gates.js';
+import { MetricTile } from './MetricTile.js';
+
+/**
+ * Shared dress for the path dashboards' reporting bands (DES-FEEDBACK-003 §4,
+ * slice P): the same 64px `--surface-rail` band the Make dashboard wears
+ * (MakeDashboard.tsx), so the five paths read as one system — "visual parity
+ * is what makes the five paths read as one system" (§4.3). Every tile inside
+ * answers a named operator question via `data-question` (EC19/EC28), SVG-first,
+ * tokens only (EC15), and derives from data the page already holds — a band
+ * never costs a request.
+ */
+
+export function TileBand({ testId, children }: {
+  testId: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      className="flex items-stretch"
+      style={{
+        height: '64px',
+        flexShrink: 0,
+        background: 'var(--surface-rail)',
+        borderRadius: 'var(--radius-md)',
+        padding: '0 var(--space-3)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Coarse age word for a waiting gate — "how long have I been the blocker". */
+export function ageWord(ms: number): string {
+  if (ms < 60_000) return `${Math.max(0, Math.floor(ms / 1_000))}s`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h`;
+  return `${Math.floor(ms / 86_400_000)}d`;
+}
+
+/**
+ * Gates-waiting tile (§4.1 row 3 / §4.3 row 3): count + oldest age off the
+ * gate store — the store the app's one `/ws` subscription and run reconcile
+ * already fill, so the tile reads state, never the wire. The caller scopes
+ * the gates (all runs on /projects; the chat partition on /chats) and names
+ * its own §4-table question verbatim (EC19).
+ */
+export function GatesWaitingTile({ gates, question, title, testId, now }: {
+  gates: OpenGate[];
+  question: string;
+  title: string;
+  testId: string;
+  now?: number;
+}): React.ReactElement {
+  const at = now ?? Date.now();
+  const oldest = useMemo(
+    () => gates.reduce<OpenGate | null>(
+      (acc, g) => (acc === null || g.receivedAt < acc.receivedAt ? g : acc),
+      null,
+    ),
+    [gates],
+  );
+
+  return (
+    <MetricTile
+      testId={testId}
+      question={question}
+      title={title}
+      value={oldest === null
+        ? 'none waiting'
+        : `${gates.length} waiting · oldest ${ageWord(at - oldest.receivedAt)}`}
+      data={{ 'data-count': gates.length }}
+    >
+      {oldest === null ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          Nothing is waiting on you.
+        </p>
+      ) : (
+        <p
+          title={oldest.prompt}
+          style={{
+            margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--status-gate)',
+            fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {oldest.prompt}
+        </p>
+      )}
+    </MetricTile>
+  );
+}

--- a/src/components/ProjectsPage.tsx
+++ b/src/components/ProjectsPage.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { Project } from '../api/types.js';
+import type { Project, SessionView } from '../api/types.js';
+import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
+import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
+import { GatesWaitingTile, TileBand } from './DashboardTiles.js';
+import { MetricTile } from './MetricTile.js';
+import { ProjectSparkline } from './ProjectSparkline.js';
+import { RunOutcomeBar } from './RunOutcomeBar.js';
 
 const S = {
   bg:     'var(--surface-base)',
@@ -132,7 +138,69 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
   );
 }
 
-function ProjectCard({ project, onClick }: { project: Project; onClick: () => void }): React.ReactElement {
+// ── The attention-split tile (DES-FEEDBACK-003 §4.1 row 1, slice P) ───────────
+
+const SPLIT_W = 168;
+const SPLIT_H = 26;
+const BAR_H = 10;
+
+/**
+ * "How much of my estate needs me?" — the board model's OWN bands, counted,
+ * as a proportional bar (needs-you vs quiet). The bands are read, never
+ * re-derived (C3): `/projects` reports the split; the wall itself stays on `/`
+ * (§4.1's landing-vs-register line — this dashboard never re-implements bands).
+ */
+function AttentionSplitTile({ items }: { items: BoardProject[] }): React.ReactElement {
+  const needsYou = items.filter((i) => i.band === 'needs-you').length;
+  const quiet = items.length - needsYou;
+  const total = items.length;
+  return (
+    <MetricTile
+      testId="attention-split-tile"
+      question="How much of my estate needs me?"
+      title="Attention split"
+      value={total === 0 ? 'no projects yet' : `${needsYou} need you · ${quiet} quiet · ${total} total`}
+      data={{ 'data-needs-you': needsYou, 'data-quiet': quiet, 'data-total': total }}
+    >
+      {total === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          Nothing on the board yet.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={SPLIT_H}
+          viewBox={`0 0 ${SPLIT_W} ${SPLIT_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`attention split: ${needsYou} need you, ${quiet} quiet, of ${total}`}
+          style={{ display: 'block' }}
+        >
+          {needsYou > 0 && (
+            <rect
+              x={0} y={(SPLIT_H - BAR_H) / 2}
+              width={(needsYou / total) * SPLIT_W} height={BAR_H} rx={2}
+              fill="var(--status-gate)"
+            />
+          )}
+          {quiet > 0 && (
+            <rect
+              x={(needsYou / total) * SPLIT_W} y={(SPLIT_H - BAR_H) / 2}
+              width={(quiet / total) * SPLIT_W} height={BAR_H} rx={2}
+              fill="var(--ink-dim)"
+            />
+          )}
+        </svg>
+      )}
+    </MetricTile>
+  );
+}
+
+function ProjectCard({ project, onClick, sparkline }: {
+  project: Project;
+  onClick: () => void;
+  sparkline?: React.ReactNode;
+}): React.ReactElement {
   const [hovered, setHovered] = useState(false);
   const isArchived = project.status === 'archived';
   const isDefault = project.id === 'default';
@@ -140,6 +208,9 @@ function ProjectCard({ project, onClick }: { project: Project; onClick: () => vo
   return (
     <button
       type="button"
+      data-testid="project-card"
+      data-project-id={project.id}
+      data-status={project.status}
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -181,6 +252,14 @@ function ProjectCard({ project, onClick }: { project: Project; onClick: () => vo
                 default
               </span>
             )}
+            {/* The 7-day activity sparkline (§4.1) — the list half of
+                "combined list and reporting". Absent when the board holds no
+                in-window runs for this project (absence stays absent). */}
+            {sparkline != null && (
+              <span style={{ marginLeft: 'auto', flexShrink: 0, display: 'inline-flex' }}>
+                {sparkline}
+              </span>
+            )}
           </div>
           {project.description && (
             <p style={{
@@ -202,22 +281,66 @@ function ProjectCard({ project, onClick }: { project: Project; onClick: () => vo
 }
 
 interface Props {
+  runs: SessionView[];
   navigate: (path: string) => void;
 }
 
-export function ProjectsPage({ navigate }: Props): React.ReactElement {
-  const { projects, loading, error, load, addProject } = useProjectsStore();
+export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
+  // The COMPLETE register (DES-FEEDBACK-003 §4.1: "/projects is the REGISTER —
+  // every project, complete") is held locally: the shared projects store is
+  // also the board model's mirror target (active, non-default only), so a
+  // store read here could lose the archived rows to a mirror write mid-race.
+  // One GET, page-owned; creates land in both the register and the store.
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    let cancelled = false;
+    api.listProjects()
+      .then(({ projects: all }) => { if (!cancelled) { setProjects(all); setLoading(false); } })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setLoading(false);
+        }
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // The reporting half (§4.1): the board's own model — bands read, never
+  // re-derived (C3); its per-project attach clocks feed the row sparklines
+  // and, merged, the 24h outcome bar (the honest clock, reused).
+  const board = useBoardModel(runs);
+  const byProjectId = useMemo(
+    () => new Map(board.items.map((i) => [i.project.id, i])),
+    [board.items],
+  );
+  const attachedAt = useMemo(() => {
+    const merged: Record<string, number> = {};
+    for (const item of board.items) Object.assign(merged, item.attachedAt);
+    return merged;
+  }, [board.items]);
+  const gates = useGateStore((s) => s.gates);
+  const openGates = useMemo(() => Object.values(gates), [gates]);
 
   const active = projects.filter((p) => p.status === 'active');
   const archived = projects.filter((p) => p.status === 'archived');
 
   function handleCreated(p: Project): void {
-    addProject(p);
+    setProjects((prev) => [p, ...prev.filter((x) => x.id !== p.id)]);
+    useProjectsStore.getState().addProject(p); // keep the shared corpus warm
     setShowCreate(false);
+  }
+
+  /** The row's 7-day sparkline off the board item — null when the board holds
+   *  no entry (archived / default / still loading): absence stays absent. */
+  function sparklineFor(p: Project): React.ReactNode {
+    const item = byProjectId.get(p.id);
+    if (item === undefined) return null;
+    return <ProjectSparkline runs={item.runs} attachedAt={item.attachedAt} />;
   }
 
   return (
@@ -242,6 +365,21 @@ export function ProjectsPage({ navigate }: Props): React.ReactElement {
         >
           <IconPlus /> New project
         </button>
+      </div>
+
+      {/* ── The reporting band (§4.1, EC28): three tiles ABOVE the register,
+             every number derived from state the app already holds. ── */}
+      <div style={{ marginBottom: '16px' }}>
+        <TileBand testId="projects-dashboard-tiles">
+          <AttentionSplitTile items={board.items} />
+          <RunOutcomeBar runs={runs} attachedAt={attachedAt} title="Run outcomes (24h)" />
+          <GatesWaitingTile
+            gates={openGates}
+            question="Am I the blocker anywhere?"
+            title="Gates waiting"
+            testId="gates-waiting-tile"
+          />
+        </TileBand>
       </div>
 
       {showCreate && (
@@ -275,11 +413,12 @@ export function ProjectsPage({ navigate }: Props): React.ReactElement {
       )}
 
       {active.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
+        <div data-testid="projects-list" style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
           {active.map((p) => (
             <ProjectCard
               key={p.id}
               project={p}
+              sparkline={sparklineFor(p)}
               onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
             />
           ))}
@@ -306,6 +445,7 @@ export function ProjectsPage({ navigate }: Props): React.ReactElement {
                 <ProjectCard
                   key={p.id}
                   project={p}
+                  sparkline={sparklineFor(p)}
                   onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
                 />
               ))}

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, RepoEntry, SessionView } from '../api/types.js';
+import { useMembershipStore } from '../store/membership.js';
+import { TileBand } from './DashboardTiles.js';
+import { MetricTile } from './MetricTile.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
 
@@ -35,20 +38,144 @@ const inputCss: React.CSSProperties = {
   width: '100%',
 };
 
-function StatCard({ label, value, hint }: { label: string; value: number; hint?: string }): React.ReactElement {
+// ── The §4.4 reporting tiles (DES-FEEDBACK-003, slice P) ──────────────────────
+//
+// Every number derives from data this page ALREADY fetches (its own
+// `GET /repos` + `GET /runs`) or the membership mirror the board model keeps
+// warm — the tiles never cost a request. Runs are placed in time on the
+// membership attach clock (the one honest per-run clock; `AgentSession`
+// carries no timestamps), exactly as every other dashboard buckets; runs the
+// mirror cannot place inside the window are excluded, never painted at an
+// invented time. Per-repo language bars stay on the detail page (§4.4: a
+// cross-repo language wall answers no asked question — rejected per EC19).
+
+const DAY_MS = 86_400_000;
+const TILE_W = 168;
+const TILE_H = 26;
+const TOP_REPOS = 6;
+
+/** Group in-window runs by `repo_ref`, joined to display names via the page's
+ *  repo list; count desc. Runs without a repo_ref or an in-window attach
+ *  clock are excluded (and reported by the callers' data attributes). */
+function groupByRepo(
+  runs: SessionView[],
+  repos: RepoEntry[],
+  attachedAt: Record<string, number>,
+  windowMs: number,
+  at: number,
+): Array<{ id: string; name: string; count: number }> {
+  const names = new Map(repos.map((r) => [r.id, r.name]));
+  const counts = new Map<string, number>();
+  for (const v of runs) {
+    const ref = v.session.repo_ref;
+    if (ref === null) continue;
+    const clock = attachedAt[v.session.id];
+    if (clock === undefined || clock < at - windowMs || clock > at) continue;
+    counts.set(ref, (counts.get(ref) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([id, count]) => ({ id, name: names.get(id) ?? id, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+/** §4.4 row 1 — "Where is the work concentrating?": 7d runs per repo, top 6,
+ *  horizontal bars. */
+function RunsPerRepoTile({ runs, repos, attachedAt, now }: {
+  runs: SessionView[];
+  repos: RepoEntry[];
+  attachedAt: Record<string, number>;
+  now?: number;
+}): React.ReactElement {
+  const at = now ?? Date.now();
+  const grouped = useMemo(
+    () => groupByRepo(runs, repos, attachedAt, 7 * DAY_MS, at),
+    [runs, repos, attachedAt, at],
+  );
+  const top = grouped.slice(0, TOP_REPOS);
+  const placed = grouped.reduce((a, g) => a + g.count, 0);
+  const max = top[0]?.count ?? 0;
+  const rowH = TILE_H / Math.max(1, top.length);
   return (
-    <div
-      className="rounded-2xl p-5 flex flex-col gap-1"
-      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    <MetricTile
+      testId="runs-per-repo-tile"
+      question="Where is the work concentrating?"
+      title="Runs per repo (7d)"
+      value={top.length === 0 ? 'no repo-linked runs in 7d' : `${top[0]!.name} leads (${top[0]!.count})`}
+      data={{ 'data-total': placed, 'data-repos': grouped.length }}
     >
-      <p className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'var(--ink-dim)' }}>
-        {label}
-      </p>
-      <p className="text-3xl font-mono font-bold" style={{ color: 'var(--ink-high)' }}>{value}</p>
-      {hint && (
-        <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{hint}</p>
+      {top.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No runs carried a repo in the last 7 days.
+        </p>
+      ) : (
+        <svg
+          width="100%"
+          height={TILE_H}
+          viewBox={`0 0 ${TILE_W} ${TILE_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`runs per repo, 7d: ${top.map((g) => `${g.name} ${g.count}`).join(', ')}`}
+          style={{ display: 'block' }}
+        >
+          {top.map((g, i) => (
+            <rect
+              key={g.id}
+              x={0}
+              y={i * rowH + 1}
+              width={(g.count / max) * TILE_W}
+              height={Math.max(2, rowH - 2)}
+              rx={1}
+              fill="var(--accent)"
+            >
+              <title>{`${g.name}: ${g.count}`}</title>
+            </rect>
+          ))}
+        </svg>
       )}
-    </div>
+    </MetricTile>
+  );
+}
+
+/** §4.4 row 3 — "Is any repo a failure hotspot?": 24h failed runs by repo. */
+function FailingReposTile({ runs, repos, attachedAt, now }: {
+  runs: SessionView[];
+  repos: RepoEntry[];
+  attachedAt: Record<string, number>;
+  now?: number;
+}): React.ReactElement {
+  const at = now ?? Date.now();
+  const failing = useMemo(
+    () => groupByRepo(
+      runs.filter((v) => v.session.status === 'failed'),
+      repos, attachedAt, DAY_MS, at,
+    ),
+    [runs, repos, attachedAt, at],
+  );
+  const failures = failing.reduce((a, g) => a + g.count, 0);
+  return (
+    <MetricTile
+      testId="failing-repos-tile"
+      question="Is any repo a failure hotspot?"
+      title="Failing repos (24h)"
+      value={failing.length === 0 ? 'none' : `${failures} failed in ${failing.length} repo${failing.length === 1 ? '' : 's'}`}
+      data={{ 'data-count': failing.length, 'data-failures': failures }}
+    >
+      {failing.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+          No repo-linked failures in the last 24h.
+        </p>
+      ) : (
+        <p
+          style={{
+            margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--status-fail)',
+            fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {failing.map((g) => `${g.name} (${g.count})`).join(' · ')}
+        </p>
+      )}
+    </MetricTile>
   );
 }
 
@@ -58,7 +185,9 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [trackedCount, setTrackedCount] = useState(0);
+  // Attach clocks off the membership mirror (the board model keeps it warm) —
+  // a store read, never a request (§4.4: tiles derive from data already held).
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
 
   const [rerunning, setRerunning] = useState<Record<string, boolean>>({});
   const [rerunError, setRerunError] = useState<Record<string, string>>({});
@@ -103,14 +232,6 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
       .catch((err) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setLoading(false));
   }, []);
-
-  useEffect(() => {
-    if (repos.length === 0) { setTrackedCount(0); return; }
-    let cancelled = false;
-    Promise.all(repos.map(r => api.getRepoGraph(r.id).then(({ graph }) => graph != null).catch(() => false)))
-      .then(flags => { if (!cancelled) setTrackedCount(flags.filter(Boolean).length); });
-    return () => { cancelled = true; };
-  }, [repos]);
 
   function deriveName(value: string): void {
     if (nameEditedRef.current) return;
@@ -357,20 +478,32 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
       </div>
 
       <div className="px-8 pb-10">
-        {/* ── Stats row ── */}
+        {/* ── The reporting band (§4.4, EC19/EC28): three tiles ABOVE the
+               register, from data this page already fetched + the membership
+               mirror — never a new request. The old stat cards (numbers
+               without named questions) are superseded by this band; their
+               Total Repos count lives on in the repo-count tile, and the
+               Tracked card's per-repo graph fan-out on mount is retired with
+               it (a mount cost the fetch budget bans). ── */}
         {!loading && !error && (
-          <div className="grid grid-cols-3 gap-4 mb-6">
-            <StatCard label="Total Repos" value={repos.length} hint="registered with wicked-crew" />
-            <StatCard
-              label="Active Runs"
-              value={activeRuns.length}
-              hint={activeRuns.length === 1 ? '1 run in progress' : `${activeRuns.length} runs in progress`}
-            />
-            <StatCard
-              label="Tracked"
-              value={trackedCount}
-              hint="onboarded and graph-indexed"
-            />
+          <div className="mb-6">
+            <TileBand testId="repos-dashboard-tiles">
+              <RunsPerRepoTile runs={runs} repos={repos} attachedAt={attachedAt} />
+              <MetricTile
+                testId="repo-count-tile"
+                question="Is the estate growing?"
+                title="Repositories"
+                value={repos.length === 0 ? 'none registered' : `${repos.length} registered`}
+                data={{ 'data-count': repos.length }}
+              >
+                <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+                  {repos.length === 0
+                    ? 'Register the first repository to grow the estate.'
+                    : `newest: ${relativeTime(Math.max(...repos.map((r) => r.registered_at)))}`}
+                </p>
+              </MetricTile>
+              <FailingReposTile runs={runs} repos={repos} attachedAt={attachedAt} />
+            </TileBand>
           </div>
         )}
 
@@ -411,7 +544,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
           </p>
         ) : (
           /* Repo cards grid */
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-4" data-testid="repos-list">
             {filteredRepos.map((repo) => {
               const activeCount = repoActiveRunCount(repo.id);
               const isRerunning = rerunning[repo.id] ?? false;
@@ -419,6 +552,8 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
               return (
                 <div
                   key={repo.id}
+                  data-testid="repo-card"
+                  data-repo-id={repo.id}
                   className="rounded-2xl p-5 flex flex-col gap-3 cursor-pointer transition-colors"
                   style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
                   onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}

--- a/tests/ChatsPage.dashboard.test.tsx
+++ b/tests/ChatsPage.dashboard.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { makeView } from './factories.js';
+
+/**
+ * The /chats dashboard (DES-FEEDBACK-003 §4.3, slice P): the page's derived
+ * numbers promoted into the tile band, above the untouched list. Pinned here:
+ * the three §4.3 tiles with their named questions (EC19/EC28), the partition
+ * invariant (the list is exactly the isChatRun set), the attach-clock honesty
+ * of the chats-over-time tile, gate scoping to the chat partition, the
+ * preserved search/time-range/list affordances, and the zero-requests-on-
+ * mount discipline (the page reads props + loaded stores only).
+ */
+
+const { ChatsPage, isChatRun } = await import('../src/components/ChatsPage.js');
+const { useGateStore } = await import('../src/store/gates.js');
+const { useMembershipStore } = await import('../src/store/membership.js');
+
+const NOW = Date.now();
+
+/** 3 chat runs (one active, one legacy-unstamped, one done) + 2 build runs. */
+const RUNS = [
+  makeView({ id: 'c-live', workflow_id: 'chat', status: 'executing', problem: 'talk through the uploader' }),
+  makeView({ id: 'c-gated', workflow_id: 'chat', status: 'awaiting_human', problem: 'which auth flow?' }),
+  makeView({ id: 'c-legacy', workflow_id: undefined as unknown as string, status: 'completed', problem: 'old thread' }),
+  makeView({ id: 'b-build', workflow_id: 'wf-w2', status: 'executing', problem: 'build the thing' }),
+  makeView({ id: 'b-gated', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'approve the plan?' }),
+];
+
+function gate(runId: string, prompt: string, receivedAt: number): void {
+  useGateStore.getState().setGate({ runId, ord: 0, prompt, lifecycle: 'open', receivedAt });
+}
+
+function page(onSelect: (id: string) => void = () => {}): ReturnType<typeof render> {
+  return render(<ChatsPage runs={RUNS} onSelect={onSelect} navigate={() => {}} />);
+}
+
+beforeEach(() => {
+  useGateStore.setState({ gates: {} });
+  useMembershipStore.setState({
+    projectNameByRun: {},
+    // c-live placed 2h ago, c-gated 3 days ago; c-legacy has NO attach clock
+    // (unfiled) — the tile must exclude it honestly, never invent a time.
+    attachedAtByRun: { 'c-live': NOW - 2 * 3_600_000, 'c-gated': NOW - 3 * 86_400_000 },
+  });
+});
+afterEach(() => cleanup());
+
+describe('the tile band (§4.3, EC19/EC28)', () => {
+  it('renders the three tiles with their named questions, above the untouched list', () => {
+    page();
+    const band = screen.getByTestId('chats-dashboard-tiles');
+    const q = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
+    expect(q('chats-over-time-tile')).toBe('Is conversation increasing or drying up?');
+    expect(q('chats-active-tile')).toBe('How many threads are warm?');
+    expect(q('chats-gates-tile')).toBe('Did a conversation stall on me?');
+    const list = screen.getByTestId('chats-list');
+    expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('buckets chats on the attach clock and reports the clockless honestly', () => {
+    page();
+    const tile = screen.getByTestId('chats-over-time-tile');
+    // c-live + c-gated placed; c-legacy has no clock → unplaced, not painted.
+    expect(tile.getAttribute('data-total')).toBe('2');
+    expect(tile.getAttribute('data-unplaced')).toBe('1');
+  });
+
+  it('counts warm threads off the existing active derivation', () => {
+    page();
+    const tile = screen.getByTestId('chats-active-tile');
+    expect(tile.getAttribute('data-count')).toBe('2'); // c-live + c-gated
+  });
+
+  it('scopes the gates tile to the chat partition — a build gate never counts', () => {
+    gate('c-gated', 'which auth flow?', NOW - 5 * 60_000);
+    gate('b-gated', 'approve the plan?', NOW - 60 * 60_000);
+    page();
+    const tile = screen.getByTestId('chats-gates-tile');
+    expect(tile.getAttribute('data-count')).toBe('1');
+    expect(tile.textContent).toContain('1 waiting');
+    expect(tile.textContent).toContain('oldest 5m');
+    expect(tile.textContent).toContain('which auth flow?');
+    expect(tile.textContent).not.toContain('approve the plan?');
+  });
+
+  it('says "none waiting" honestly when no chat gate is open', () => {
+    gate('b-gated', 'approve the plan?', NOW - 60_000);
+    page();
+    expect(screen.getByTestId('chats-gates-tile').textContent).toContain('none waiting');
+  });
+});
+
+describe('the register below (§4.3: "the list below is the existing ChatsPage list, untouched")', () => {
+  it('lists exactly the chat partition — the verbatim isChatRun set', () => {
+    page();
+    const ids = screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'));
+    const expected = RUNS.filter(isChatRun).map((v) => v.session.id);
+    expect(new Set(ids)).toEqual(new Set(expected));
+    for (const v of RUNS) expect(ids.includes(v.session.id)).toBe(isChatRun(v));
+  });
+
+  it('preserves search, the time-range selector, New Chat, and row navigation', () => {
+    const onSelect = vi.fn();
+    page(onSelect);
+    expect(screen.getByPlaceholderText('Search chats…')).toBeInTheDocument();
+    expect(screen.getByText('New Chat')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Time range' })).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search chats…'), { target: { value: 'auth' } });
+    const rows = screen.getAllByTestId('chat-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.getAttribute('data-run-id')).toBe('c-gated');
+    fireEvent.click(rows[0]!);
+    expect(onSelect).toHaveBeenCalledWith('c-gated');
+  });
+
+  it('fires zero requests on mount — props and loaded stores only (fetch untouched)', () => {
+    const spy = vi.fn();
+    vi.stubGlobal('fetch', spy);
+    page();
+    expect(spy).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/ProjectsPage.dashboard.test.tsx
+++ b/tests/ProjectsPage.dashboard.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { Project, ProjectMember } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * The /projects dashboard (DES-FEEDBACK-003 §4.1, slice P): the complete
+ * register + the three-tile reporting band. Pinned here: the §4.1 tiles with
+ * their named questions (EC19/EC28) above the list, the REGISTER completeness
+ * (every project incl. archived — never the board mirror's active-only
+ * subset), the row sparklines off the board's attach clocks, and the
+ * preserved create/archive-toggle/navigation affordances.
+ */
+
+const NOW = Date.now();
+
+const project = (over: Partial<Project> & { id: string; name: string }): Project => ({
+  description: null, status: 'active', scope: `project:${over.id}`,
+  created_at: 1, updated_at: 1, ...over,
+});
+
+const PROJECTS: Project[] = [
+  project({ id: 'default', name: 'Unfiled' }),
+  project({ id: 'p-hot', name: 'auth-refactor', updated_at: NOW }),
+  project({ id: 'p-cold', name: 'smoke-tests', updated_at: NOW - 30 * 86_400_000 }),
+  project({ id: 'p-old', name: 'retired-spike', status: 'archived', updated_at: 1 }),
+];
+
+const member = (project_id: string, ref: string, attached_at: number): ProjectMember => ({
+  id: `${project_id}:crew.run:${ref}`, project_id, member_kind: 'crew.run',
+  member_ref: ref, meta: null, attached_at, attached_by: 'studio',
+});
+
+const MEMBERS: Record<string, ProjectMember[]> = {
+  'p-hot': [member('p-hot', 'r-gated', NOW - 60_000)],
+  'p-cold': [member('p-cold', 'r-done', NOW - 2 * 86_400_000)],
+};
+
+const listProjects = vi.fn(() => Promise.resolve({ projects: PROJECTS }));
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => listProjects(),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: MEMBERS[id] ?? [] }),
+    getRunEvents: () => Promise.resolve({ events: [] }),
+  },
+}));
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: () => Promise.resolve([]),
+}));
+
+const { ProjectsPage } = await import('../src/components/ProjectsPage.js');
+const { useGateStore } = await import('../src/store/gates.js');
+
+const RUNS = [
+  makeView({ id: 'r-gated', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'refactor auth' }),
+  makeView({ id: 'r-done', workflow_id: 'wf-w2', status: 'completed', problem: 'smoke it' }),
+];
+
+async function page(navigate: (p: string) => void = () => {}): Promise<void> {
+  render(<ProjectsPage runs={RUNS} navigate={navigate} />);
+  // The register (page-owned GET) and the board model both settle async.
+  await screen.findByTestId('projects-list');
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('attention-split-tile').getAttribute('data-total')).toBe('2');
+  });
+}
+
+beforeEach(() => {
+  listProjects.mockClear();
+  useGateStore.setState({ gates: {} });
+});
+afterEach(() => cleanup());
+
+describe('the tile band (§4.1, EC19/EC28)', () => {
+  it('renders the three tiles with their named questions, above the register', async () => {
+    useGateStore.getState().setGate({
+      runId: 'r-gated', ord: 0, prompt: 'Approve the refactor?', lifecycle: 'open',
+      receivedAt: NOW - 3 * 60_000,
+    });
+    await page();
+    const band = screen.getByTestId('projects-dashboard-tiles');
+    const q = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
+    expect(q('attention-split-tile')).toBe('How much of my estate needs me?');
+    expect(q('run-outcome-bar')).toBe('Is the system healthy right now?');
+    expect(q('gates-waiting-tile')).toBe('Am I the blocker anywhere?');
+    const list = screen.getByTestId('projects-list');
+    expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('reads the board bands, never re-deriving them: a fresh gate = needs-you', async () => {
+    await page();
+    const split = screen.getByTestId('attention-split-tile');
+    expect(split.getAttribute('data-needs-you')).toBe('1'); // p-hot's waiting run
+    expect(split.getAttribute('data-quiet')).toBe('1');
+    expect(split.textContent).toContain('1 need you · 1 quiet · 2 total');
+  });
+
+  it('buckets the outcome bar on the merged attach clocks (24h window)', async () => {
+    await page();
+    const bar = screen.getByTestId('run-outcome-bar');
+    // r-gated attached 1min ago (in window); r-done 2 days ago (outside).
+    expect(bar.getAttribute('data-total')).toBe('1');
+    expect(bar.getAttribute('data-unplaced')).toBe('1');
+  });
+
+  it('counts waiting gates with the oldest age', async () => {
+    useGateStore.getState().setGate({
+      runId: 'r-gated', ord: 0, prompt: 'Approve the refactor?', lifecycle: 'open',
+      receivedAt: NOW - 3 * 60_000,
+    });
+    await page();
+    const tile = screen.getByTestId('gates-waiting-tile');
+    expect(tile.getAttribute('data-count')).toBe('1');
+    expect(tile.textContent).toContain('1 waiting');
+    expect(tile.textContent).toContain('Approve the refactor?');
+  });
+});
+
+describe('the complete register (§4.1: every project, incl. archived)', () => {
+  it('lists every active project (default included) and archived behind the toggle', async () => {
+    await page();
+    const activeIds = within(screen.getByTestId('projects-list'))
+      .getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
+    expect(new Set(activeIds)).toEqual(new Set(['default', 'p-hot', 'p-cold']));
+    // Archived: present, behind the existing toggle — completeness survives the
+    // board mirror's active-only store write.
+    fireEvent.click(screen.getByText(/Show 1 archived project/));
+    const all = screen.getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
+    expect(all).toContain('p-old');
+    expect(all).toHaveLength(4);
+  });
+
+  it('rows carry the 7-day sparkline where the board holds in-window runs', async () => {
+    await page();
+    const hot = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-hot')!;
+    expect(within(hot as HTMLElement).getByTestId('project-sparkline')).toBeInTheDocument();
+    // p-old (archived) has no board entry — absence stays absent.
+    fireEvent.click(screen.getByText(/Show 1 archived project/));
+    const old = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-old')!;
+    expect(within(old as HTMLElement).queryByTestId('project-sparkline')).toBeNull();
+  });
+
+  it('preserves create and row navigation', async () => {
+    const navigate = vi.fn();
+    await page(navigate);
+    expect(screen.getByText('New project')).toBeInTheDocument();
+    const hot = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-hot')!;
+    fireEvent.click(hot);
+    expect(navigate).toHaveBeenCalledWith('/projects/p-hot');
+  });
+});

--- a/tests/RepositoriesPanel.dashboard.test.tsx
+++ b/tests/RepositoriesPanel.dashboard.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { RepoEntry } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * The /repos dashboard (DES-FEEDBACK-003 §4.4, slice P): the repo register +
+ * the three-tile reporting band. Pinned here: the §4.4 tiles with their named
+ * questions (EC19/EC28), the repo_ref×attach-clock grouping honesty (clockless
+ * or windowless runs excluded, never painted), the preserved register /
+ * search / navigation affordances, and the fetch budget — exactly the page's
+ * existing GET /repos + GET /runs, with the old Tracked card's per-repo graph
+ * fan-out RETIRED.
+ */
+
+const NOW = Date.now();
+
+const repo = (id: string, name: string, registered_at: number): RepoEntry => ({
+  id, name, root_path: `/tmp/${id}`, default_branch: 'main', registered_at,
+});
+
+const REPOS = [
+  repo('studio-api', 'studio-api', 1_700_000_000),
+  repo('billing', 'billing', 1_760_000_000),
+];
+
+const RUNS = [
+  makeView({ id: 'r-a1', repo_ref: 'studio-api', status: 'executing', problem: 'wire uploads' }),
+  makeView({ id: 'r-a2', repo_ref: 'studio-api', status: 'failed', problem: 'refactor auth' }),
+  makeView({ id: 'r-b1', repo_ref: 'billing', status: 'completed', problem: 'invoice math' }),
+  makeView({ id: 'r-old', repo_ref: 'billing', status: 'failed', problem: 'stale failure' }),
+  makeView({ id: 'r-none', repo_ref: null, status: 'executing', problem: 'no repo' }),
+  makeView({ id: 'r-unclocked', repo_ref: 'billing', status: 'executing', problem: 'no clock' }),
+];
+
+const listRepos = vi.fn(() => Promise.resolve({ repos: REPOS }));
+const listRuns = vi.fn(() => Promise.resolve({ runs: RUNS }));
+const getRepoGraph = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: () => listRepos(),
+    listRuns: () => listRuns(),
+    getRepoGraph: (...a: unknown[]) => getRepoGraph(...a),
+    listProjects: () => Promise.resolve({ projects: [] }),
+  },
+}));
+
+const { RepositoriesPanel } = await import('../src/components/RepositoriesPanel.js');
+const { useMembershipStore } = await import('../src/store/membership.js');
+
+async function panel(navigate: (p: string) => void = () => {}): Promise<void> {
+  render(<RepositoriesPanel navigate={navigate} />);
+  await screen.findByTestId('repos-dashboard-tiles');
+  await screen.findByTestId('repos-list');
+}
+
+beforeEach(() => {
+  listRepos.mockClear();
+  listRuns.mockClear();
+  getRepoGraph.mockClear();
+  useMembershipStore.setState({
+    projectNameByRun: {},
+    attachedAtByRun: {
+      'r-a1': NOW - 3_600_000,            // studio-api, in 7d + 24h
+      'r-a2': NOW - 2 * 3_600_000,        // studio-api failed, in 24h
+      'r-b1': NOW - 3 * 86_400_000,       // billing, in 7d, outside 24h
+      'r-old': NOW - 8 * 86_400_000,      // billing failed, OUTSIDE 7d and 24h
+      // r-unclocked: no attach clock — excluded everywhere, never invented.
+    },
+  });
+});
+afterEach(() => cleanup());
+
+describe('the tile band (§4.4, EC19/EC28)', () => {
+  it('renders the three tiles with their named questions, above the register', async () => {
+    await panel();
+    const band = screen.getByTestId('repos-dashboard-tiles');
+    const q = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
+    expect(q('runs-per-repo-tile')).toBe('Where is the work concentrating?');
+    expect(q('repo-count-tile')).toBe('Is the estate growing?');
+    expect(q('failing-repos-tile')).toBe('Is any repo a failure hotspot?');
+    const list = screen.getByTestId('repos-list');
+    expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('groups 7d runs by repo_ref on the attach clock, names joined via the repo list', async () => {
+    await panel();
+    const tile = screen.getByTestId('runs-per-repo-tile');
+    // r-a1 + r-a2 + r-b1 placed; r-old (outside 7d), r-none (no ref) and
+    // r-unclocked (no clock) excluded.
+    expect(tile.getAttribute('data-total')).toBe('3');
+    expect(tile.getAttribute('data-repos')).toBe('2');
+    expect(tile.textContent).toContain('studio-api leads (2)');
+  });
+
+  it('counts the register and names the newest registration', async () => {
+    await panel();
+    const tile = screen.getByTestId('repo-count-tile');
+    expect(tile.getAttribute('data-count')).toBe('2');
+    expect(tile.textContent).toContain('2 registered');
+    expect(tile.textContent).toContain('newest:');
+  });
+
+  it('flags only 24h repo-linked failures as hotspots', async () => {
+    await panel();
+    const tile = screen.getByTestId('failing-repos-tile');
+    // r-a2 (failed, 2h ago) counts; r-old (failed, 3d ago) does not.
+    expect(tile.getAttribute('data-count')).toBe('1');
+    expect(tile.getAttribute('data-failures')).toBe('1');
+    expect(tile.textContent).toContain('studio-api (1)');
+    expect(tile.textContent).not.toContain('billing (');
+  });
+});
+
+describe('the register below — affordances preserved, budget held (§4.4)', () => {
+  it('keeps the register/search/add affordances and row navigation', async () => {
+    const navigate = vi.fn();
+    await panel(navigate);
+    expect(screen.getByText('+ Add Repository')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search repos…'), { target: { value: 'bill' } });
+    const cards = screen.getAllByTestId('repo-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.getAttribute('data-repo-id')).toBe('billing');
+    fireEvent.click(cards[0]!);
+    expect(navigate).toHaveBeenCalledWith('/repo-detail/billing');
+  });
+
+  it('fires exactly the existing GET /repos + GET /runs — the graph fan-out is retired', async () => {
+    await panel();
+    expect(listRepos).toHaveBeenCalledTimes(1);
+    expect(listRuns).toHaveBeenCalledTimes(1);
+    expect(getRepoGraph).not.toHaveBeenCalled();
+  });
+});

--- a/tests/RepositoriesPanel.project.test.tsx
+++ b/tests/RepositoriesPanel.project.test.tsx
@@ -30,7 +30,8 @@ beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
   vi.spyOn(client.api, 'listRuns').mockResolvedValue({ runs: [] });
-  vi.spyOn(client.api, 'getRepoGraph').mockResolvedValue({ graph: null } as never);
+  // getRepoGraph is no longer mocked: the Tracked card's per-repo graph
+  // fan-out on mount retired with slice P (DES-FEEDBACK-003 §4.4).
   vi.spyOn(client.api, 'listProjects').mockResolvedValue({
     projects: [proj('q3-review-deck', 9), proj('api-migration', 5), proj('default', 99)],
   });


### PR DESCRIPTION
Round-4 operator feedback: each rail heading's ▦ links to *"a combined list and reporting dashboard."* /make landed in slice O; this completes the other three.

## What changed

- **/projects**: the complete register (incl. archived; now page-owned state — fixing a latent race where the board's active-only store mirror could drop archived rows) + attention-split / run-outcomes / gates-waiting tiles, and a 7-day sparkline per register row. Create/archive/navigation preserved.
- **/chats**: the page's derived stats promoted into the tile band (chats-over-time on the attach clock with clockless threads honestly counted as data-unplaced, active-now, gates scoped to the shared `isChatRun` partition); "Avg Units" retired (no named question, EC19). Search/range/new-chat preserved.
- **/repos**: runs-per-repo (7d, `repo_ref` × attach clock), repo count + last registered, failing-repos-24h tiles over the preserved register/search/add. **No language tile** — the repo wire carries none (per-repo estate data stays on the detail page). The old "Tracked" stat card's per-repo graph fan-out ON MOUNT is retired (pinned at 0 graph GETs).
- Shared `DashboardTiles.tsx` gives all four path dashboards one 64px band grammar.

## Verification highlights

Register completeness set-equality against 29 independently-counted fixture projects; partition and unplaced honesty asserted; fetch budgets exact (/chats zero extra, /repos exactly 2 repo GETs + 0 graph GETs); negative check properly re-done against main's src with the branch rig (not the trivial missing-file case); shots regenerated from the branch build.

**Size note**: ~513 production LOC as one PR vs the ≤350 guideline — the verifier asked for a split or an explicit exception. Claiming the exception by this arc's standing precedent (M 648, N 528, O 709, all single disclosed PRs); the diff partitions cleanly per-dashboard (~200/~160/~205 per commit) and can be split on request.

## Gates

eslint clean · tsc clean · vitest **1138/1138** · new rig `feedback3_sliceP_test.py` + `feedback3_sliceM/N/O`, `feedback_sliceD`, `uxfix_slice2` all PASS.

Shots: `feedback3-P-projects-dashboard.png`, `feedback3-P-chats-dashboard.png`, `feedback3-P-repos-dashboard.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)