### PR TITLE
Slice Q: the narrative landing — composed lede + 24h activity river (DES-FEEDBACK-003 §7)

### DIFF
--- a/e2e/feedback3_sliceQ_test.py
+++ b/e2e/feedback3_sliceQ_test.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+feedback3_sliceQ_test.py — the DES-FEEDBACK-003 slice-Q gate: the narrative
+landing (§7) — the data-composed lede, the per-project 24h activity river, the
+margin notes, and the metrics bar's supersession — against the shared W2
+fixture with the slice-Q switches on: `river` (the §10.2 24h-spread activity
+variant: spread attach clocks, the r-auth failure tail at 5h, one relayed
+version.created for q3-review-deck) and `metrics_ws` (the costed burn drip, so
+the spend note and the margin sparkline have real dollars).
+
+The slice DOM ACs, verbatim from §7.6:
+
+  1. `[data-testid="narrative-band"]` replaces `[data-testid="metrics-bar"]`
+     on `/` (old testid absent — supersession).
+  2. `[data-testid="landing-lede"]` text matches the fixture's true counts —
+     COMPUTED here from the fixture's own data via the §7.3 grammar, never
+     snapshotted from the page; each numeric segment is an `<a>`; the
+     all-quiet fixture reads the quiet phrase with no zero-count segment.
+  3. `[data-testid="activity-river"]` renders ≤6 river lanes in board
+     attention order; the live run's span reaches the right edge with the
+     arrowhead; the waiting gate mark's computed fill resolves from
+     `var(--status-gate)` (EC15); clicking it navigates to the run + #gate.
+  4. The lede and river carry their `data-question` attributes (EC19).
+  5. Zero requests beyond what the board already fetches (interception —
+     the band is a pure re-reader).
+  6. The needs-you band, quiet band, and LiveFeed render unchanged below the
+     band (C3/C6); no chart-library <script>; all river geometry inline SVG.
+
+Plus the honest-clock derivations (§7.3): river lane/span/mark counts and the
+margin tiles' totals are re-derived here from the fixture constants — spans on
+attach + observed-frame + failure-tail clocks only, the clockless orphan
+excluded and counted `data-unplaced`.
+
+Captures (§10.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback3-Q-landing-story.png  the money shot: lede, river (live run + gate
+                                 marks + ✗ + doc tick), margin notes, bands below
+  feedback3-Q-landing-quiet.png  the all-quiet fixture: quiet lede, calm river
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK3Q_PORT (default 4366),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NOW0,
+    PROJECTS,
+    REPO,
+    RIVER_ATTACHED_AT,
+    RIVER_AUTH_EVENTS,
+    RUNS,
+    ATTACHED_AT,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+PORT = int(os.environ.get("FEEDBACK3Q_PORT", "4366"))
+ORIGIN = f"http://127.0.0.1:{PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+HOUR = 3_600_000
+
+# ── The independent derivation (§7.6 AC 2: computed, not snapshotted) ──────────
+#
+# The same clocks the page can honestly reach, rebuilt from the fixture's own
+# constants: merged attach clocks (river overrides on), the r-auth failure
+# tail, membership (which lanes exist). The page's "now" is minutes past NOW0
+# at most; every margin below is hours, so NOW0 stands in for it.
+
+CLOCKS = {**ATTACHED_AT, **RIVER_ATTACHED_AT}
+FAIL_TAILS = {"r-auth": RIVER_AUTH_EVENTS[-1]["ts"], "r-legacy": NOW0 - 8 * 24 * HOUR}
+TERMINAL = {"completed", "failed", "cancelled"}
+WINDOW_START = NOW0 - 24 * HOUR
+
+finished = passed = failed = gates = live = 0
+for view in RUNS:  # the orphan is NOT here — it is the clockless unplaced case
+    s = view["session"]
+    if s["status"] == "awaiting_human":
+        gates += 1
+    if s["status"] in ("planning", "distributing", "executing"):
+        live += 1
+    if s["status"] not in TERMINAL:
+        continue
+    points = [c for c in (CLOCKS.get(s["id"]), FAIL_TAILS.get(s["id"])) if c is not None]
+    if not points or max(points) < WINDOW_START:
+        continue
+    finished += 1
+    if s["status"] == "completed":
+        passed += 1
+    else:
+        failed += 1
+
+BOARD_PROJECTS = [p for p in PROJECTS if p["status"] == "active" and p["id"] != "default"]
+
+
+def plural(n: int, word: str) -> str:
+    return f"{n} {word}" + ("" if n == 1 else "s")
+
+
+def compose_lede(finished: int, passed: int, failed: int, gates: int, live: int, projects: int) -> str:
+    """The §7.3 grammar, independently implemented (drop-outs included)."""
+    if finished == 0 and gates == 0 and live == 0:
+        return f"All quiet. {plural(projects, 'project')}, nothing running, nothing waiting."
+    s = "While you were away: "
+    if finished > 0:
+        split = ", ".join(x for x in (
+            f"{passed} passed" if passed else None,
+            f"{failed} failed" if failed else None) if x)
+        s += f"{plural(finished, 'run')} finished — {split}"
+    elif gates == 0:
+        s += f"nothing finished — {plural(live, 'run')} still moving"
+    if gates > 0:
+        if finished > 0:
+            s += " — and "
+        s += f"{plural(gates, 'gate')} {'is' if gates == 1 else 'are'} waiting on you"
+    return s + "."
+
+
+EXPECTED_LEDE = compose_lede(finished, passed, failed, gates, live, len(BOARD_PROJECTS))
+EXPECTED_QUIET_LEDE = compose_lede(0, 0, 0, 0, 0, len(BOARD_PROJECTS))
+
+# Lane-eligible projects: in-window observed activity (spans or the q3 doc
+# landing). With the river clocks: q3 (30s gate), api (2m gate), upload (live
+# 20h), auth (failed 6h→5h), smokes (16h/10h) — legacy is 8 DAYS out.
+EXPECTED_LANES = {"q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint", "smoke-tests"}
+EXPECTED_QUIET_COUNT = len(BOARD_PROJECTS) - len(EXPECTED_LANES)
+# In-window attach clocks for the margin outcome bar; outside/clockless counted.
+OUTCOME_TOTAL = sum(1 for v in RUNS if CLOCKS.get(v["session"]["id"], 0) >= WINDOW_START)
+OUTCOME_UNPLACED = (len(RUNS) + 1) - OUTCOME_TOTAL  # + the clockless orphan
+
+# The board's own fetch budget — the band may add NOTHING to it (§7.6 AC).
+ALLOWED_API = (
+    "/api/v1/settings",
+    "/api/v1/health",
+    "/api/v1/runs",       # + /runs/:id/gate reconciles + /runs/:id/events backfills
+    "/api/v1/projects",   # + /projects/:id/members + .../interactive/api/docs
+    "/api/v1/repos",
+)
+
+report: dict = {"ok": False, "steps": {}, "derived": {
+    "expected_lede": EXPECTED_LEDE, "expected_quiet_lede": EXPECTED_QUIET_LEDE,
+    "lanes": sorted(EXPECTED_LANES), "quiet": EXPECTED_QUIET_COUNT,
+    "outcome_total": OUTCOME_TOTAL, "outcome_unplaced": OUTCOME_UNPLACED,
+}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build ────────────────────────────────────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+
+# ── 2. The shared W2 fixture, slice-Q switches on ──────────────────────────────
+start_server(PORT, dist)
+set_fixture(ORIGIN, river=True, metrics_ws=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN, "now0": NOW0,
+                                     "river": True, "metrics_ws": True}
+
+# ── 3. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+api_requests: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("request", lambda r: api_requests.append(urlparse(r.url).path)
+            if urlparse(r.url).path.startswith("/api/") else None)
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ══ Scene 1 — the story landing (the money shot) ═══════════════════════════
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="narrative-band"]').wait_for(timeout=30000)
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    fonts_ok = settled(
+        """() => document.fonts.status === 'loaded'
+              && document.fonts.check('13px "Inter"')
+              && document.fonts.check('12px "JetBrains Mono"')""",
+        timeout=20000,
+    )
+
+    # Settle each derived surface on its own wire: the lede on the members read
+    # + failure backfill, the doc mark on the relayed /ws frame, the spend note
+    # + margin sparkline on the drained burn drip (4 costed frames = $0.42).
+    lede_ok = settled(
+        """expected => document.querySelector('[data-testid="landing-lede"]')
+                         ?.textContent === expected""",
+        EXPECTED_LEDE,
+    )
+    mark_ok = settled(
+        """() => !!document.querySelector('[data-testid="river-version-mark"]')""")
+    spend_ok = settled(
+        """() => document.querySelector('[data-testid="lede-spend"]')
+                   ?.textContent === '$0.42 observed'""")
+    burn_ok = settled(
+        """() => document.querySelector('[data-testid="river-margin"] '
+                   + '[data-testid="token-burn-sparkline"]')
+                   ?.getAttribute('data-points') === '4'""")
+    fail_mark_ok = settled(
+        """() => !!document.querySelector('[data-testid="river-fail-mark"][data-run-id="r-auth"]')""")
+
+    home = page.evaluate(
+        """(expectedLanes) => {
+             const band = document.querySelector('[data-testid="narrative-band"]');
+             const river = document.querySelector('[data-testid="activity-river"]');
+             const margin = document.querySelector('[data-testid="river-margin"]');
+             const lede = document.querySelector('[data-testid="landing-lede"]');
+             const lanes = Array.from(document.querySelectorAll('[data-testid="river-lane"]'));
+             const laneIds = lanes.map((l) => l.getAttribute('data-project-id'));
+             const probe = (token) => {
+               const el = document.createElement('div');
+               el.style.background = token;
+               document.body.appendChild(el);
+               const c = getComputedStyle(el).backgroundColor;
+               el.remove();
+               return c;
+             };
+             const gateMark = document.querySelector(
+               '[data-testid="river-gate-mark"][data-run-id="r-q3"] polygon');
+             const liveSpan = document.querySelector(
+               '[data-testid="river-span"][data-run-id="r-upload"]');
+             const svg = river ? river.querySelector('svg') : null;
+             const nowArrow = liveSpan ? liveSpan.querySelector('[data-testid="river-now-arrow"]') : null;
+             const shapes = band ? Array.from(band.querySelectorAll(
+               'rect, circle, line, polyline, polygon, stop')) : [];
+             const raw = shapes.filter((el) => ['fill', 'stroke', 'stop-color'].some((a) => {
+               const v = el.getAttribute(a);
+               return v !== null && v !== 'none' && !v.startsWith('var(--') && !v.startsWith('url(#');
+             })).length;
+             const scripts = Array.from(document.querySelectorAll('script'))
+               .map((s) => s.getAttribute('src') || '')
+               .filter((src) => /chart|d3|recharts|echarts|plotly|highcharts/i.test(src));
+             return {
+               bandPresent: !!band,
+               oldBarAbsent: !document.querySelector('[data-testid="metrics-bar"]'),
+               latencyChartAbsent: !document.querySelector('[data-testid="gate-latency-chart"]'),
+               ledeQuestion: lede?.getAttribute('data-question') ?? null,
+               riverQuestion: river?.getAttribute('data-question') ?? null,
+               ledeLinkHrefs: Array.from(lede?.querySelectorAll('a[data-testid="lede-segment"]') ?? [])
+                 .map((a) => a.getAttribute('href')),
+               spendHref: document.querySelector('[data-testid="lede-spend"]')
+                 ?.getAttribute('href') ?? null,
+               laneCount: laneIds.length,
+               laneIds,
+               laneFirst: laneIds[0] ?? null,
+               dataLanes: river?.getAttribute('data-lanes') ?? null,
+               dataQuiet: river?.getAttribute('data-quiet') ?? null,
+               dataUnplaced: river?.getAttribute('data-unplaced') ?? null,
+               quietLabel: document.querySelector('[data-testid="river-quiet"]')?.textContent ?? '',
+               gateMarksWaiting: document.querySelectorAll(
+                 '[data-testid="river-gate-mark"][data-waiting="true"]').length,
+               gateMarkFill: gateMark ? getComputedStyle(gateMark).fill : null,
+               gateToken: probe('var(--status-gate)'),
+               gateMarkPulses: gateMark ? gateMark.classList.contains('wk-river-gate-waiting') : false,
+               failMarks: document.querySelectorAll('[data-testid="river-fail-mark"]').length,
+               versionMarkKind: document.querySelector('[data-testid="river-version-mark"]')
+                 ?.getAttribute('data-kind') ?? null,
+               versionOnQ3: !!document.querySelector(
+                 '[data-testid="river-lane"][data-project-id="q3-review-deck"] [data-testid="river-version-mark"]'),
+               liveSpanLive: liveSpan?.getAttribute('data-live') ?? null,
+               liveHasArrow: !!nowArrow,
+               // The live span's paint reaches the now edge: the arrowhead's tip
+               // sits PAST the right-edge gridline by construction; measure it.
+               arrowReachesEdge: (() => {
+                 if (!nowArrow || !svg) return false;
+                 const a = nowArrow.getBoundingClientRect();
+                 const s = svg.getBoundingClientRect();
+                 return a.right >= s.right - 4;
+               })(),
+               svgOnly: !!svg && !!river && river.querySelectorAll('canvas').length === 0,
+               rawPaints: raw,
+               chartLibScripts: scripts,
+               // C3/C6: the wall + feed beneath, unchanged.
+               needsYou: !!document.querySelector('[data-testid="band-needs-you"]'),
+               needsYouCards: document.querySelectorAll(
+                 '[data-testid="band-needs-you"] [data-testid="project-card"]').length,
+               quietBand: !!document.querySelector('[data-testid="band-quiet"]'),
+               quietChips: document.querySelectorAll('[data-testid="quiet-chip"]').length,
+               liveFeed: !!document.querySelector('[data-testid="live-feed"]'),
+               allRunsLink: !!document.querySelector('[data-testid="all-runs-link"]'),
+             };
+           }""",
+        sorted(EXPECTED_LANES),
+    )
+
+    # ── Capture 1: the money shot ───────────────────────────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-Q-landing-story.png"))
+
+    # ── The request budget: nothing beyond the board's own fetches (§7.6) ──────
+    # Snapshotted BEFORE leaving `/` — later pages own their own budgets.
+    offenders = sorted({p for p in api_requests if not p.startswith(ALLOWED_API)})
+
+    # ── The gate mark is a real link: click → the run, at the gate (§7.6) ──────
+    page.locator('[data-testid="river-gate-mark"][data-run-id="r-q3"]').click()
+    nav_ok = settled(
+        """() => location.pathname === '/p/q3-review-deck/build/r-q3'
+              && location.hash === '#gate'""")
+
+    # ══ Scene 2 — the all-quiet fixture (quiet lede, calm river) ═══════════════
+    set_fixture(ORIGIN, no_runs=True, river=False, metrics_ws=False)
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="narrative-band"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    quiet_lede_ok = settled(
+        """expected => document.querySelector('[data-testid="landing-lede"]')
+                         ?.textContent === expected""",
+        EXPECTED_QUIET_LEDE,
+    )
+    quiet = page.evaluate(
+        """() => ({
+             lede: document.querySelector('[data-testid="landing-lede"]')?.textContent ?? '',
+             spendAbsent: !document.querySelector('[data-testid="lede-spend"]'),
+             dataLanes: document.querySelector('[data-testid="activity-river"]')
+               ?.getAttribute('data-lanes') ?? null,
+             dataQuiet: document.querySelector('[data-testid="activity-river"]')
+               ?.getAttribute('data-quiet') ?? null,
+             spans: document.querySelectorAll('[data-testid="river-span"]').length,
+             marks: document.querySelectorAll(
+               '[data-testid="river-gate-mark"], [data-testid="river-fail-mark"],'
+               + ' [data-testid="river-version-mark"]').length,
+             boardAllQuiet: !!document.querySelector('[data-testid="board-all-quiet"]'),
+             noZeroSegment: !(document.querySelector('[data-testid="landing-lede"]')
+               ?.textContent ?? '').includes('0 '),
+           })"""
+    )
+
+    # ── Capture 2: the quiet landing ────────────────────────────────────────────
+    page.screenshot(path=str(VSHOTS / "feedback3-Q-landing-quiet.png"))
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["steps"]["supersession"] = {
+    "ok": all([home["bandPresent"], home["oldBarAbsent"], home["latencyChartAbsent"]]),
+    **{k: home[k] for k in ("bandPresent", "oldBarAbsent", "latencyChartAbsent")},
+}
+report["steps"]["lede"] = {
+    "ok": all([
+        fonts_ok, lede_ok, spend_ok,
+        home["ledeQuestion"] == "What happened and what needs me?",
+        home["ledeLinkHrefs"] == ["/runs", "#needs-you"],
+        home["spendHref"] == "/make",
+    ]),
+    "web_fonts": fonts_ok, "lede_settled": lede_ok, "spend_settled": spend_ok,
+    **{k: home[k] for k in ("ledeQuestion", "ledeLinkHrefs", "spendHref")},
+}
+report["steps"]["river"] = {
+    "ok": all([
+        mark_ok, fail_mark_ok,
+        home["riverQuestion"] == "What ran, when, and how did it end?",
+        home["laneCount"] <= 6,
+        set(home["laneIds"]) == EXPECTED_LANES,
+        home["laneFirst"] == "q3-review-deck",  # board attention order leads
+        home["dataLanes"] == str(len(EXPECTED_LANES)),
+        home["dataQuiet"] == str(EXPECTED_QUIET_COUNT),
+        home["dataUnplaced"] == "1",            # the clockless orphan — counted, never painted
+        f"({EXPECTED_QUIET_COUNT} quiet)" in home["quietLabel"],
+        home["gateMarksWaiting"] == 2,
+        home["gateMarkFill"] == home["gateToken"],  # EC15: resolves from var(--status-gate)
+        home["gateMarkPulses"],
+        home["failMarks"] == 1,
+        home["versionMarkKind"] == "doc",
+        home["versionOnQ3"],
+        home["liveSpanLive"] == "true",
+        home["liveHasArrow"],
+        home["arrowReachesEdge"],
+        home["svgOnly"],
+    ]),
+    "version_mark_settled": mark_ok, "fail_mark_settled": fail_mark_ok,
+    **{k: home[k] for k in (
+        "riverQuestion", "laneCount", "laneIds", "laneFirst", "dataLanes", "dataQuiet",
+        "dataUnplaced", "quietLabel", "gateMarksWaiting", "gateMarkFill", "gateToken",
+        "gateMarkPulses", "failMarks", "versionMarkKind", "versionOnQ3",
+        "liveSpanLive", "liveHasArrow", "arrowReachesEdge", "svgOnly")},
+}
+report["steps"]["gate_mark_link"] = {"ok": nav_ok, "navigated": nav_ok}
+report["steps"]["margin_notes"] = {
+    "ok": burn_ok,
+    "burn_settled": burn_ok,
+}
+report["steps"]["request_budget"] = {
+    "ok": offenders == [],
+    "offenders": offenders,
+    "api_paths_seen": sorted(set(api_requests))[:30],
+}
+report["steps"]["no_chart_library_ec15"] = {
+    "ok": home["chartLibScripts"] == [] and home["rawPaints"] == 0,
+    "chart_lib_scripts": home["chartLibScripts"],
+    "raw_paints": home["rawPaints"],
+}
+report["steps"]["board_preserved"] = {
+    "ok": all([
+        home["needsYou"], home["needsYouCards"] >= 2, home["quietBand"],
+        home["quietChips"] >= 1, home["liveFeed"], home["allRunsLink"],
+    ]),
+    **{k: home[k] for k in ("needsYou", "needsYouCards", "quietBand",
+                            "quietChips", "liveFeed", "allRunsLink")},
+}
+report["steps"]["quiet_landing"] = {
+    "ok": all([
+        quiet_lede_ok,
+        quiet["lede"] == EXPECTED_QUIET_LEDE,
+        quiet["spendAbsent"],           # no observed dollars → the note drops out
+        quiet["dataLanes"] == "0",
+        quiet["dataQuiet"] == str(len(BOARD_PROJECTS)),
+        quiet["spans"] == 0,
+        quiet["marks"] == 0,
+        quiet["boardAllQuiet"],
+        quiet["noZeroSegment"],
+    ]),
+    "quiet_lede_settled": quiet_lede_ok,
+    **quiet,
+}
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback3-Q-landing-story.png"),
+    str(VSHOTS / "feedback3-Q-landing-quiet.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceQ_verdict", f"slice-Q assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/feedback3_sliceQ_test.py
+++ b/e2e/feedback3_sliceQ_test.py
@@ -313,10 +313,16 @@ with sync_playwright() as p:
     offenders = sorted({p for p in api_requests if not p.startswith(ALLOWED_API)})
 
     # ── The gate mark is a real link: click → the run, at the gate (§7.6) ──────
+    # The href carries `#gate`; on arrival the SteeringGate CONSUMES the hash
+    # (one-shot focus intent, SteeringGate.tsx) after focusing the question —
+    # so the landing proof is: right run path + the hash gone + the gate
+    # message holding focus.
+    gate_href = page.locator(
+        '[data-testid="river-gate-mark"][data-run-id="r-q3"]').get_attribute("href")
     page.locator('[data-testid="river-gate-mark"][data-run-id="r-q3"]').click()
     nav_ok = settled(
         """() => location.pathname === '/p/q3-review-deck/build/r-q3'
-              && location.hash === '#gate'""")
+              && location.hash === ''""") and gate_href == "/p/q3-review-deck/build/r-q3#gate"
 
     # ══ Scene 2 — the all-quiet fixture (quiet lede, calm river) ═══════════════
     set_fixture(ORIGIN, no_runs=True, river=False, metrics_ws=False)
@@ -396,7 +402,7 @@ report["steps"]["river"] = {
         "gateMarkPulses", "failMarks", "versionMarkKind", "versionOnQ3",
         "liveSpanLive", "liveHasArrow", "arrowReachesEdge", "svgOnly")},
 }
-report["steps"]["gate_mark_link"] = {"ok": nav_ok, "navigated": nav_ok}
+report["steps"]["gate_mark_link"] = {"ok": nav_ok, "navigated": nav_ok, "href": gate_href}
 report["steps"]["margin_notes"] = {
     "ok": burn_ok,
     "burn_settled": burn_ok,

--- a/e2e/feedback_sliceE_test.py
+++ b/e2e/feedback_sliceE_test.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
 """
-feedback_sliceE_test.py — the DES-FEEDBACK-001 slice-E gate: home metrics bar
-(§2) + repo profile visuals (§3), against the shared W2 fixture
-(uxfix_fixture.py) with the `metrics_ws` + `repo` switches on.
+feedback_sliceE_test.py — the DES-FEEDBACK-001 slice-E gate, RE-SCOPED by
+DES-FEEDBACK-003 §8.7 (slice Q): the 64px metrics BAR on `/` is superseded by
+the narrative band (§7.3/§8.5), so the landing assertions re-target — the
+derivations all live on. Repo profile visuals (§3) are untouched. Runs against
+the shared W2 fixture (uxfix_fixture.py) with `metrics_ws` + `repo` on.
 
-The slice DOM ACs, verbatim from §8.3:
+The re-scoped landing ACs (§8.7 row Q → §7.6):
 
-  1. `[data-testid="metrics-bar"]` is present on the home board;
-  2. it contains `[data-testid="run-outcome-bar"]`,
-     `[data-testid="gate-latency-chart"]`, `[data-testid="token-burn-sparkline"]`
-     — each with a `data-question` attribute matching its §2.1 named question;
+  1. `[data-testid="narrative-band"]` is present on `/`; the old
+     `[data-testid="metrics-bar"]` is ABSENT (supersession);
+  2. the lede + river carry their §7.3 `data-question`s;
+     `run-outcome-bar` and `token-burn-sparkline` re-assert INSIDE the margin
+     column with their §2.1 questions; the GateLatencyChart assert is DELETED
+     from `/` (its question is answered by the river's gate marks — asserted
+     as the two waiting-gate diamonds);
   3. no `<script>` tags for chart libraries are in the page HTML;
-  4. every `fill`/`stroke` on chart elements resolves from `var()` references
-     (EC15) — EXCEPT the sanctioned linguist hexes on the repo page (§3.3, the
-     ONLY raw-color exemption in the codebase);
+  4. every `fill`/`stroke` on band chart elements resolves from `var()`
+     references (EC15) — EXCEPT the sanctioned linguist hexes on the repo
+     page (§3.3, the ONLY raw-color exemption in the codebase);
   5. `[data-testid="language-bar"]` is present on the repo profile page.
 
 Plus what the slice means beyond its testids:
@@ -22,10 +27,10 @@ Plus what the slice means beyond its testids:
     one per-run timestamp the wire carries), the burn tile folds REAL cliUsage
     frames (`costUsd: null` never becomes $0.00), the cadence chart lives at
     the git-history wire's own resolution (20 commits, %ar relative dates);
-  - the wall + live feed are UNCHANGED beneath the bar (the slice-2 NEEDS YOU
+  - the wall + live feed are UNCHANGED beneath the band (the slice-2 NEEDS YOU
     order and the live feed still hold — §8.3 preservation);
-  - the quiet-band rows carry the 7-day ProjectSparkline (--ink-dim bars);
-  - under 900px the gate-latency tile hides (§2.2).
+  - the quiet-band rows carry the 7-day ProjectSparkline (--ink-dim bars).
+  (The under-900px gate-tile probe died with the bar it probed — §8.5.)
 
 DELIBERATELY NOT frozen-clock: the burn + latency tiles fold ARRIVAL clocks
 (Date.now at ingest); freezing the page clock would collapse every arrival to
@@ -34,7 +39,7 @@ therefore approximate ("35s" not "30s") — every assertion is on structure, not
 rendered ages.
 
 Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
-  feedback-E-home-metrics.png   the W2 board with the metrics bar populated
+  feedback-E-home-metrics.png   the W2 board with the narrative band populated
   feedback-E-repo-profile.png   the repo profile: language bar, cadence, hotspots
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
@@ -60,10 +65,12 @@ FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4355"))
 ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
-# §2.1's named operator questions, verbatim (EC19).
+# The named operator questions, verbatim (EC19): the §7.3 band pair plus the
+# two §2.1 tiles that survive as its margin notes (DES-FEEDBACK-003 §8.5).
 QUESTIONS = {
+    "landing-lede": "What happened and what needs me?",
+    "activity-river": "What ran, when, and how did it end?",
     "run-outcome-bar": "Is the system healthy right now?",
-    "gate-latency-chart": "Am I answering gates quickly or letting things stall?",
     "token-burn-sparkline": "What am I spending, is it accelerating?",
 }
 
@@ -118,9 +125,9 @@ with sync_playwright() as p:
         except Exception:
             return False
 
-    # ══ Scene 1 — home board with the metrics bar (§2) ═════════════════════════
+    # ══ Scene 1 — home board with the narrative band (§8.7 re-scope → §7.6) ═══
     page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
-    page.locator('[data-testid="metrics-bar"]').wait_for(timeout=30000)
+    page.locator('[data-testid="narrative-band"]').wait_for(timeout=30000)
     page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
@@ -132,14 +139,15 @@ with sync_playwright() as p:
     )
 
     # Settle: outcome bar bucketed off the members read (4 in-window W2 runs),
-    # both open gates reconciled into latency dots, and the burn drip drained
-    # (4 costed frames — the costUsd:null one must NOT count).
+    # both open gates reconciled into WAITING river gate marks (the §8.7
+    # re-target: the latency chart left the landing, the marks answer it),
+    # and the burn drip drained (4 costed frames — costUsd:null must NOT count).
     outcome_ok = settled(
         """() => document.querySelector('[data-testid="run-outcome-bar"]')
                    ?.getAttribute('data-total') === '4'""")
     gates_ok = settled(
-        """() => document.querySelector('[data-testid="gate-latency-chart"]')
-                   ?.getAttribute('data-open') === '2'""")
+        """() => document.querySelectorAll(
+                   '[data-testid="river-gate-mark"][data-waiting="true"]').length === 2""")
     burn_ok = settled(
         """() => document.querySelector('[data-testid="token-burn-sparkline"]')
                    ?.getAttribute('data-points') === '4'""")
@@ -155,7 +163,8 @@ with sync_playwright() as p:
 
     home = page.evaluate(
         """() => {
-             const bar = document.querySelector('[data-testid="metrics-bar"]');
+             const bar = document.querySelector('[data-testid="narrative-band"]');
+             const margin = document.querySelector('[data-testid="river-margin"]');
              const tile = (id) => bar ? bar.querySelector(`[data-testid="${id}"]`) : null;
              const shapes = bar ? Array.from(bar.querySelectorAll(
                'rect, circle, line, polyline, polygon, stop')) : [];
@@ -180,9 +189,12 @@ with sync_playwright() as p:
                .filter((src) => /chart|d3|recharts|echarts|plotly|highcharts/i.test(src));
              const barCs = bar ? getComputedStyle(bar) : null;
              return {
-               barPresent: !!bar,
-               barHeight: bar ? bar.getBoundingClientRect().height : null,
-               barAboveWall: (() => {
+               bandPresent: !!bar,
+               // Supersession (§7.6 AC 1): the old metrics bar is GONE from `/`,
+               // and so is the GateLatencyChart (dashboards keep the component).
+               oldBarAbsent: !document.querySelector('[data-testid="metrics-bar"]'),
+               latencyChartAbsent: !document.querySelector('[data-testid="gate-latency-chart"]'),
+               bandAboveWall: (() => {
                  const wall = document.querySelector('[data-testid="project-board"]');
                  return !!bar && !!wall
                    && bar.getBoundingClientRect().bottom <= wall.getBoundingClientRect().top + 1;
@@ -197,13 +209,15 @@ with sync_playwright() as p:
                  return c;
                })(),
                questions: Object.fromEntries(
-                 ['run-outcome-bar', 'gate-latency-chart', 'token-burn-sparkline']
+                 ['landing-lede', 'activity-river', 'run-outcome-bar', 'token-burn-sparkline']
                    .map((id) => [id, tile(id)?.getAttribute('data-question') ?? null])),
+               // §8.7: the two surviving tiles re-assert INSIDE the margin column.
+               outcomeInMargin: !!margin?.querySelector('[data-testid="run-outcome-bar"]'),
+               burnInMargin: !!margin?.querySelector('[data-testid="token-burn-sparkline"]'),
                outcomeRects: tile('run-outcome-bar')?.querySelectorAll('rect').length ?? 0,
                outcomeUnplaced: tile('run-outcome-bar')?.getAttribute('data-unplaced') ?? null,
-               gateDots: tile('gate-latency-chart')?.querySelectorAll('circle').length ?? 0,
-               thresholdDashed: tile('gate-latency-chart')
-                 ?.querySelector('line')?.getAttribute('stroke-dasharray') ?? null,
+               riverGateMarks: document.querySelectorAll(
+                 '[data-testid="river-gate-mark"][data-waiting="true"]').length,
                burnTotal: tile('token-burn-sparkline')?.getAttribute('data-total') ?? null,
                burnText: tile('token-burn-sparkline')?.textContent ?? '',
                rawPaints: raw,
@@ -214,7 +228,7 @@ with sync_playwright() as p:
            }"""
     )
 
-    # ── Capture 1: the home board with the metrics bar populated ───────────────
+    # ── Capture 1: the home board with the narrative band populated ────────────
     page.screenshot(path=str(VSHOTS / "feedback-E-home-metrics.png"))
 
     # ── The quiet-band 7-day sparkline (§2.1): expand QUIET, find smoke-tests —
@@ -257,18 +271,8 @@ with sync_playwright() as p:
         """() => { const s = document.querySelector('[data-testid="project-board"]');
                    if (s) s.scrollTop = 0; }""")
 
-    # ── §2.2: under 900px the gate-latency tile hides ──────────────────────────
-    page.set_viewport_size({"width": 860, "height": 900})
-    narrow = page.evaluate(
-        """() => {
-             const mid = document.querySelector('.wk-metrics-mid');
-             return {
-               midHidden: mid ? getComputedStyle(mid).display === 'none' : false,
-               barPresent: !!document.querySelector('[data-testid="metrics-bar"]'),
-             };
-           }"""
-    )
-    page.set_viewport_size({"width": 1440, "height": 900})
+    # (The under-900px gate-tile probe is DELETED with the tile it probed —
+    #  DES-FEEDBACK-003 §8.5: the GateLatencyChart left the landing.)
 
     # ══ Scene 2 — the repo profile (§3) ════════════════════════════════════════
     page.goto(f"{ORIGIN}/repo-detail/studio-api", wait_until="domcontentloaded")
@@ -323,26 +327,29 @@ with sync_playwright() as p:
     ctx.close()
     browser.close()
 
-report["steps"]["metrics_bar"] = {
+report["steps"]["narrative_band"] = {
     "ok": all([
         fonts_ok, outcome_ok, gates_ok, burn_ok,
-        home["barPresent"],
-        home["barHeight"] == 64,
-        home["barAboveWall"],
-        home["barBg"] == home["railBg"],  # --surface-rail band (§2.2)
+        home["bandPresent"],
+        home["oldBarAbsent"],            # §7.6 AC 1 — supersession
+        home["latencyChartAbsent"],      # §8.7 — the chart left the landing
+        home["bandAboveWall"],
+        home["barBg"] == home["railBg"],  # --surface-rail band (§7.5, chrome family)
         home["questions"] == QUESTIONS,   # EC19, verbatim
+        home["outcomeInMargin"],          # §8.5 — margin notes, same components
+        home["burnInMargin"],
         home["outcomeRects"] >= 3,        # run/gate/fail stacks over the 4 in-window runs
         home["outcomeUnplaced"] == "4",   # legacy(8d) + smokes(6d) + clockless orphan: excluded, counted
-        home["gateDots"] == 2,
-        home["thresholdDashed"] == "3 3",
+        home["riverGateMarks"] == 2,      # the latency question, answered by the river
         home["burnTotal"] == "0.4200",    # 0.04+0.11+0.09+0.18 — the null-cost frame did NOT fold
         "$0.42" in home["burnText"],
     ]),
     "web_fonts": fonts_ok,
     "outcome_settled": outcome_ok, "gates_settled": gates_ok, "burn_settled": burn_ok,
-    **{k: home[k] for k in ("barPresent", "barHeight", "barAboveWall", "barBg", "railBg",
-                            "questions", "outcomeRects", "outcomeUnplaced", "gateDots",
-                            "thresholdDashed", "burnTotal")},
+    **{k: home[k] for k in ("bandPresent", "oldBarAbsent", "latencyChartAbsent",
+                            "bandAboveWall", "barBg", "railBg", "questions",
+                            "outcomeInMargin", "burnInMargin", "outcomeRects",
+                            "outcomeUnplaced", "riverGateMarks", "burnTotal")},
     "screenshot": str(VSHOTS / "feedback-E-home-metrics.png"),
 }
 report["steps"]["no_chart_library_and_ec15"] = {
@@ -369,10 +376,6 @@ report["steps"]["quiet_sparkline"] = {
         all(f == "var(--ink-dim)" for f in quiet_spark["fills"]),
     ]),
     **quiet_spark,
-}
-report["steps"]["narrow_hides_gate_tile"] = {
-    "ok": narrow["midHidden"] and narrow["barPresent"],
-    **narrow,
 }
 report["steps"]["repo_profile"] = {
     "ok": all([

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -52,6 +52,14 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     5-frame burn drains (slice E's token-burn tile; default
                     False). Same real frame shape as usage_ws; drip-fed so
                     the cumulative fold has more than one arrival instant.
+  river           — the DES-FEEDBACK-003 §10.2 "24h-spread activity" variant
+                    for slice Q's landing river: the members wire serves
+                    SPREAD attach clocks (r-upload live 20h ago, r-auth 6h,
+                    the smokes 16h/10h — all inside the window), r-auth's
+                    durable tail moves its failure to 5h ago, and /ws pushes
+                    ONE `wicked.interactive.version.created` frame for
+                    q3-review-deck on connect (the doc-landed river mark).
+                    Default False — every standing rig keeps the W2 clocks.
   chat_runs       — 2 chat runs ride GET /runs (DES-FEEDBACK-003 §10.2): a
                     'chat'-stamped live thread (crew.chat member of notes,
                     real attach clock) and a legacy unstamped thread awaiting
@@ -119,6 +127,8 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #               resolves), giving §4.4's runs-per-repo / failing-
          #               repos tiles something true to group. Default False.
          "chat_runs": False, "repo_refs": False,
+         # Slice Q (DES-FEEDBACK-003 §10.2): the 24h-spread river variant.
+         "river": False,
          # Slice I (DES-FEEDBACK-002 §3): the in-studio file/diff viewer corpus.
          #   viewer      — r-upload gains a workdir + file events, and the crew#305
          #                 routes (GET /runs/:id/files, GET /runs/:id/diff) answer
@@ -251,6 +261,24 @@ CHAT_GATED = session("r-chat-gated", "awaiting_human",
 CHAT_GATED["session"]["workflow_id"] = None
 CHAT_GATE_PROMPT = "Pick the auth flow the chat should explore"
 ATTACHED_AT["r-chat-live"] = NOW0 - 10 * MIN
+
+# ── Slice Q (DES-FEEDBACK-003 §10.2): the 24h-spread river clocks ─────────────
+#
+# Served on the MEMBERS wire only while the `river` switch is on: observed
+# activity spread across the window so the lanes have a picture — one live run
+# spanning 20h and breaching "now" (r-upload), one failure at 6h→5h (r-auth,
+# tail below), and the two completed smokes inside the window (the lede's
+# "passed" counts). r-legacy stays 8 DAYS out — the entirely-outside case.
+RIVER_ATTACHED_AT = {
+    "r-upload": NOW0 - 20 * HOUR,
+    "r-auth": NOW0 - 6 * HOUR,
+    "r-smoke1": NOW0 - 16 * HOUR,
+    "r-smoke2": NOW0 - 10 * HOUR,
+}
+RIVER_AUTH_EVENTS = [
+    {"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 6 * HOUR},
+    {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 5 * HOUR},
+]
 
 # Slice P: which runs the `repo_refs` switch stamps onto the registered repo —
 # a live one and a 6-day-old one for the 7d grouping, plus a fresh failure for
@@ -746,6 +774,7 @@ class W2Handler(SimpleHTTPRequestHandler):
         with state_lock:
             push_usage = state["usage_ws"]
             push_metrics = state["metrics_ws"]
+            push_river = state["river"]
         with ws_lock:
             ws_gen[0] += 1
             my_gen = ws_gen[0]
@@ -773,6 +802,17 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self.wfile.write(ws_frame({
                     "type": "cliUsage", "session": "r-upload", "ord": 0,
                     "inputTokens": 84000, "outputTokens": 14000, "costUsd": 0.42,
+                }))
+                self.wfile.flush()
+            # Slice Q: ONE relayed version.created on connect — the river's
+            # doc-landed mark on q3-review-deck's lane (arrival-clocked, §7.3).
+            if push_river:
+                self.wfile.write(ws_frame({
+                    "type": "interactiveEvent",
+                    "event": {"event_type": "wicked.interactive.version.created",
+                              "payload": {"project_id": "q3-review-deck",
+                                          "document_id": "q3-deck",
+                                          "version": 2, "kind": "generated"}},
                 }))
                 self.wfile.flush()
             while True:
@@ -902,15 +942,18 @@ class W2Handler(SimpleHTTPRequestHandler):
             refs = list(MEMBERS.get(pid, []))
             with state_lock:
                 chat_runs_on = state["chat_runs"]
+                river_on = state["river"]
             # Slice P: the live chat thread is a `crew.chat` member of notes.
             kinds = {}
             if chat_runs_on and pid == "notes":
                 refs.append("r-chat-live")
                 kinds["r-chat-live"] = "crew.chat"
+            # Slice Q: the 24h-spread clocks override the W2 defaults (river on).
+            clocks = {**ATTACHED_AT, **(RIVER_ATTACHED_AT if river_on else {})}
             self._json(200, {"members": [
                 {"id": f"{pid}:{kinds.get(ref, 'crew.run')}:{ref}", "project_id": pid,
                  "member_kind": kinds.get(ref, "crew.run"), "member_ref": ref, "meta": None,
-                 "attached_at": ATTACHED_AT.get(ref, 1), "attached_by": "studio"}
+                 "attached_at": clocks.get(ref, 1), "attached_by": "studio"}
                 for ref in refs
             ]})
             return True
@@ -962,8 +1005,12 @@ class W2Handler(SimpleHTTPRequestHandler):
             events = list(RUN_EVENTS.get(rid, []))
             with state_lock:
                 viewer_on = state["viewer"]
+                river_on = state["river"]
             if viewer_on and rid == "r-upload":
                 events = events + VIEWER_EVENTS
+            # Slice Q: r-auth's durable tail matches its spread attach clock.
+            if river_on and rid == "r-auth":
+                events = list(RIVER_AUTH_EVENTS)
             self._json(200, {"events": events})
             return True
         if path.startswith("/api/v1/"):

--- a/src/components/ActivityRiver.tsx
+++ b/src/components/ActivityRiver.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { SessionView } from '../api/types.js';
+import type { BoardProject } from '../hooks/useBoardModel.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { modePath, projectPath } from '../hooks/useRoute.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import type { OpenGate } from '../store/gates.js';
+import type { LoggedEvent } from '../store/runtime.js';
+import type { VersionLanding } from '../store/docThread.js';
+import { outcomeOf } from './RunOutcomeBar.js';
+
+/**
+ * The activity river (DES-FEEDBACK-003 §7.3, slice Q): the landing page's
+ * graphical center — a per-project laned timeline of the last 24h. SVG-first,
+ * no chart library (the §2.3 precedent at larger scale).
+ *
+ * THE HONEST CLOCKS, stated (§7.3): a span runs from a run's first observed
+ * activity to its last — the membership `attached_at` the board already
+ * fetched, extended by the runtime store's arrival-stamped frame clocks and
+ * the backfilled failure tail (D3 step 2). Nothing is painted at an invented
+ * time: a run with NO observed clock at all is excluded from the lanes and
+ * counted in `data-unplaced` instead; live (non-terminal) runs end at `now`
+ * and breach the now-edge with an arrowhead — the picture says "still moving"
+ * without animation. The ONE loop is the waiting gate mark's pulse
+ * (`.wk-river-gate-waiting`, reduced-motion honored in global.css).
+ */
+
+export const RIVER_WINDOW_MS = 24 * 3_600_000;
+/** §7.3: at most this many lanes; the rest collapse into `({n} quiet)`. */
+export const MAX_LANES = 6;
+
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled']);
+
+export interface SpanMark {
+  kind: 'gate' | 'fail';
+  at: number;
+  /** Gate marks only: still waiting on a human → the mark pulses. */
+  waiting: boolean;
+}
+
+export interface RiverSpan {
+  runId: string;
+  projectId: string;
+  problem: string;
+  status: string;
+  outcome: ReturnType<typeof outcomeOf>;
+  /** First observed activity, clamped to the window's left edge. */
+  start: number;
+  /** Last observed activity; `now` for live (non-terminal) runs. */
+  end: number;
+  live: boolean;
+  marks: SpanMark[];
+}
+
+export interface LaneMark { kind: 'doc' | 'demo'; at: number; version: number }
+
+export interface RiverLane {
+  projectId: string;
+  name: string;
+  spans: RiverSpan[];
+  /** Version landings (docThread observations) on the project's own lane. */
+  marks: LaneMark[];
+}
+
+export interface RiverModel {
+  lanes: RiverLane[];
+  /** Projects with no in-window activity (plus any beyond the lane cap). */
+  quiet: number;
+  /** Non-archived runs with NO observed clock at all — never painted (§7.3). */
+  unplaced: number;
+}
+
+interface ModelInput {
+  /** Board order (attention order, C3) — the lanes never re-sort it. */
+  items: BoardProject[];
+  runs: SessionView[];
+  gates: Record<string, OpenGate>;
+  logs: Record<string, LoggedEvent[]>;
+  failedAt: Record<string, number>;
+  landings: VersionLanding[];
+  now: number;
+}
+
+/** Every observed clock a run has — attach, arrival-stamped frames, failure tail. */
+function clocksOf(v: SessionView, attach: number | undefined,
+                  logs: Record<string, LoggedEvent[]>, failedAt: Record<string, number>): number[] {
+  const points: number[] = [];
+  if (attach !== undefined) points.push(attach);
+  for (const entry of logs[v.session.id] ?? []) points.push(entry.ts);
+  const failed = failedAt[v.session.id];
+  if (failed !== undefined) points.push(failed);
+  return points;
+}
+
+/** The pure lane model — exported for the slice's unit tests. */
+export function buildRiver({ items, runs, gates, logs, failedAt, landings, now }: ModelInput): RiverModel {
+  const start = now - RIVER_WINDOW_MS;
+  const lanes: RiverLane[] = [];
+  let quiet = 0;
+
+  for (const item of items) {
+    const spans: RiverSpan[] = [];
+    for (const v of item.runs) {
+      if (v.session.archived_at != null) continue;
+      const points = clocksOf(v, item.attachedAt[v.session.id], logs, failedAt);
+      if (points.length === 0) continue; // clockless — counted below, never painted
+      const live = !TERMINAL.has(v.session.status);
+      const first = Math.min(...points);
+      const last = live ? now : Math.max(...points);
+      if (last < start || first > now) continue; // entirely outside the window
+      const id = v.session.id;
+      const marks: SpanMark[] = [];
+      // Gate marks: the open gate's receivedAt (waiting → pulses), plus every
+      // answered `awaitingHuman` the arrival-stamped log observed.
+      const open = v.session.status === 'awaiting_human' ? gates[id] : undefined;
+      if (open !== undefined) marks.push({ kind: 'gate', at: open.receivedAt, waiting: true });
+      for (const entry of logs[id] ?? []) {
+        // The live frame that OPENED the still-waiting gate landed in both
+        // stores at the same arrival instant — skip its log twin, keep only
+        // genuinely answered (earlier) gates as non-pulsing marks.
+        if (entry.type === 'awaitingHuman' &&
+            (open === undefined || Math.abs(entry.ts - open.receivedAt) > 2_000)) {
+          marks.push({ kind: 'gate', at: entry.ts, waiting: false });
+        }
+      }
+      const outcome = outcomeOf(v.session.status);
+      // The failure ✗: the backfilled durable-log tail when the board has it;
+      // otherwise the span's last OBSERVED point (the failure is known no
+      // earlier than the last thing seen — still an observed clock).
+      if (outcome === 'fail') marks.push({ kind: 'fail', at: failedAt[id] ?? last, waiting: false });
+      spans.push({
+        runId: id, projectId: item.project.id, problem: v.session.problem,
+        status: v.session.status, outcome,
+        start: Math.max(first, start), end: Math.min(last, now), live,
+        marks: marks.filter((m) => m.at >= start && m.at <= now),
+      });
+    }
+    const laneMarks: LaneMark[] = landings
+      .filter((l) => l.projectId === item.project.id && l.at >= start && l.at <= now)
+      .map((l) => ({ kind: l.kind === 'demo' ? 'demo' : 'doc', at: l.at, version: l.version }));
+    if ((spans.length > 0 || laneMarks.length > 0) && lanes.length < MAX_LANES) {
+      lanes.push({ projectId: item.project.id, name: item.project.name, spans, marks: laneMarks });
+    } else {
+      quiet += 1;
+    }
+  }
+
+  // Unplaced honesty (§7.3): every non-archived run with no observed clock —
+  // no attach (unfiled/orphaned) and no observed frame — is counted, not drawn.
+  const attached = new Map<string, number>();
+  for (const item of items) {
+    for (const [id, at] of Object.entries(item.attachedAt)) attached.set(id, at);
+  }
+  const unplaced = runs.filter((v) =>
+    v.session.archived_at == null &&
+    clocksOf(v, attached.get(v.session.id), logs, failedAt).length === 0,
+  ).length;
+
+  return { lanes, quiet, unplaced };
+}
+
+// ── Geometry ──────────────────────────────────────────────────────────────────
+const LANE_H = 20;
+const QUIET_H = 14;
+const AXIS_H = 16;
+/** The now edge sits this far in from the right so live spans can BREACH it. */
+const BREACH = 12;
+const FALLBACK_W = 960;
+/** Axis ticks, hours before now. 0 = the now edge (4 gridlines total). */
+const TICKS = [18, 12, 6, 0] as const;
+
+const LABEL: React.CSSProperties = {
+  fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+  height: `${LANE_H}px`, display: 'flex', alignItems: 'center',
+  textDecoration: 'none', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+};
+
+interface Props {
+  items: BoardProject[];
+  runs: SessionView[];
+  gates: Record<string, OpenGate>;
+  logs: Record<string, LoggedEvent[]>;
+  failedAt: Record<string, number>;
+  landings: VersionLanding[];
+  navigate: Navigate;
+  /** Injectable clock for tests; defaults to the real one. */
+  now?: number;
+}
+
+export function ActivityRiver({ items, runs, gates, logs, failedAt, landings, navigate, now }: Props): React.ReactElement {
+  const at = now ?? Date.now();
+  const model = useMemo(
+    () => buildRiver({ items, runs, gates, logs, failedAt, landings, now: at }),
+    [items, runs, gates, logs, failedAt, landings, at],
+  );
+
+  // True pixel coordinates (no viewBox stretch — marks keep their shape), the
+  // board's own measure idiom: observe the plot column, fall back for jsdom.
+  const plotRef = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(0);
+  useEffect(() => {
+    const el = plotRef.current;
+    if (el === null) return;
+    const measure = (): void => setW(el.clientWidth);
+    measure();
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(measure);
+      ro.observe(el);
+      return () => ro.disconnect();
+    }
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
+  const W = w || FALLBACK_W;
+  const nowX = W - BREACH;
+  const x = (t: number): number => ((t - (at - RIVER_WINDOW_MS)) / RIVER_WINDOW_MS) * nowX;
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
+
+  const lanesH = model.lanes.length * LANE_H;
+  const H = lanesH + QUIET_H;
+
+  return (
+    <div
+      data-testid="activity-river"
+      data-question="What ran, when, and how did it end?"
+      data-lanes={model.lanes.length}
+      data-quiet={model.quiet}
+      data-unplaced={model.unplaced}
+      style={{ display: 'flex', gap: '10px', flex: 1, minWidth: 0, alignItems: 'flex-start' }}
+    >
+      {/* The label column — every project name is a real link to its dashboard. */}
+      <div style={{ width: '148px', flexShrink: 0 }}>
+        {model.lanes.map((lane) => (
+          <a key={lane.projectId} {...link(projectPath(lane.projectId))}
+             data-testid="river-lane-label" data-project-id={lane.projectId} style={LABEL}>
+            {lane.name}
+          </a>
+        ))}
+        <span data-testid="river-quiet" data-count={model.quiet}
+              style={{ ...LABEL, height: `${QUIET_H}px`, color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)' }}>
+          ({model.quiet} quiet)
+        </span>
+        {/* §7.4's honesty word as the axis row's own label: what the window IS. */}
+        <span style={{ ...LABEL, height: `${AXIS_H}px`, color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)' }}>
+          observed
+        </span>
+      </div>
+
+      <div ref={plotRef} style={{ flex: 1, minWidth: 0 }}>
+        <svg width="100%" height={H + AXIS_H} style={{ display: 'block' }} role="img"
+             aria-label={`activity over the last 24h: ${model.lanes.length} projects with activity, ${model.quiet} quiet`}>
+          {/* 4 dim gridlines (§7.3), the now edge last so live spans read against it. */}
+          {TICKS.map((h) => (
+            <line key={h} x1={x(at - h * 3_600_000)} x2={x(at - h * 3_600_000)} y1={0} y2={H}
+                  stroke="var(--surface-raised)" strokeWidth={1} />
+          ))}
+
+          {model.lanes.map((lane, i) => {
+            const top = i * LANE_H;
+            const mid = top + LANE_H / 2;
+            return (
+              <g key={lane.projectId} data-testid="river-lane" data-project-id={lane.projectId}>
+                {/* Lane separator (§7.5). */}
+                <line x1={0} x2={W} y1={top + LANE_H} y2={top + LANE_H}
+                      stroke="var(--surface-raised)" strokeWidth={1} />
+                {lane.spans.map((span) => {
+                  const x0 = x(span.start);
+                  const x1 = Math.max(x(span.end), x0 + 2); // a point of activity stays visible
+                  const body = span.live
+                    ? 'var(--status-run-dim)'
+                    : span.outcome === 'fail' ? 'var(--status-fail-dim)' : 'var(--status-done)';
+                  return (
+                    <a key={span.runId} {...link(modePath(span.projectId, 'build', span.runId))}
+                       data-testid="river-span" data-run-id={span.runId}
+                       data-live={span.live} data-outcome={span.outcome}>
+                      <title>{`${span.problem} · ${span.status} · ${lane.name}`}</title>
+                      <rect x={x0} y={mid - 4} width={x1 - x0} height={8} rx={2} fill={body} />
+                      {/* Live: --status-run leading edge + the now-edge breach arrowhead. */}
+                      {span.live && (
+                        <>
+                          <rect x={Math.max(x1 - 3, x0)} y={mid - 4} width={3} height={8} fill="var(--status-run)" />
+                          <polygon data-testid="river-now-arrow"
+                                   points={`${nowX},${mid - 5} ${nowX + 9},${mid} ${nowX},${mid + 5}`}
+                                   fill="var(--status-run)" />
+                        </>
+                      )}
+                    </a>
+                  );
+                })}
+                {lane.spans.flatMap((span) =>
+                  span.marks.map((mark, j) => {
+                    const mx = x(mark.at);
+                    const my = mid;
+                    return mark.kind === 'gate' ? (
+                      // ⏸-diamond in --status-gate; still waiting → the one loop.
+                      <a key={`${span.runId}-g${j}`} {...link(gateOpenPath(span.projectId, span.runId))}
+                         data-testid="river-gate-mark" data-run-id={span.runId} data-waiting={mark.waiting}>
+                        <title>{`gate ${mark.waiting ? 'waiting' : 'answered'} · ${span.problem}`}</title>
+                        <polygon
+                          className={mark.waiting ? 'wk-river-gate-waiting' : undefined}
+                          points={`${mx},${my - 5} ${mx + 5},${my} ${mx},${my + 5} ${mx - 5},${my}`}
+                          fill="var(--status-gate)"
+                        />
+                      </a>
+                    ) : (
+                      // ✗ in --status-fail.
+                      <a key={`${span.runId}-f${j}`} {...link(modePath(span.projectId, 'build', span.runId))}
+                         data-testid="river-fail-mark" data-run-id={span.runId}>
+                        <title>{`failed · ${span.problem}`}</title>
+                        <line x1={mx - 4} y1={my - 4} x2={mx + 4} y2={my + 4} stroke="var(--status-fail)" strokeWidth={1.5} />
+                        <line x1={mx - 4} y1={my + 4} x2={mx + 4} y2={my - 4} stroke="var(--status-fail)" strokeWidth={1.5} />
+                      </a>
+                    );
+                  }),
+                )}
+                {lane.marks.map((mark, j) => {
+                  const mx = x(mark.at);
+                  return (
+                    // ▤ / ▶ version-landed tick in --ink-muted (§7.3).
+                    <a key={`v${j}`} {...link(projectPath(lane.projectId))}
+                       data-testid="river-version-mark" data-kind={mark.kind}>
+                      <title>{`${mark.kind === 'demo' ? 'demo' : 'doc'} v${mark.version} landed · ${lane.name}`}</title>
+                      {mark.kind === 'demo' ? (
+                        <polygon points={`${mx - 3},${mid - 8} ${mx + 4},${mid - 4.5} ${mx - 3},${mid - 1}`}
+                                 fill="var(--ink-muted)" />
+                      ) : (
+                        <g stroke="var(--ink-muted)" strokeWidth={1} fill="none">
+                          <rect x={mx - 3.5} y={mid - 8} width={7} height={7} />
+                          <line x1={mx - 3.5} y1={mid - 5.5} x2={mx + 3.5} y2={mid - 5.5} />
+                        </g>
+                      )}
+                    </a>
+                  );
+                })}
+              </g>
+            );
+          })}
+
+          {/* The compressed quiet lane: a dotted rest, never a grid of absence. */}
+          <line x1={0} x2={W} y1={lanesH + QUIET_H / 2} y2={lanesH + QUIET_H / 2}
+                stroke="var(--surface-raised)" strokeWidth={1} strokeDasharray="1 4" />
+
+          {/* Axis labels — relative, mono, dim (§7.3). */}
+          {TICKS.map((h) => (
+            <text key={h} x={x(at - h * 3_600_000)} y={H + AXIS_H - 4}
+                  textAnchor={h === 0 ? 'end' : 'middle'}
+                  style={{ fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)' }}
+                  fill="var(--ink-dim)">
+              {h === 0 ? 'now' : `-${h}h`}
+            </text>
+          ))}
+          <text x={x(at - RIVER_WINDOW_MS)} y={H + AXIS_H - 4} textAnchor="start"
+                style={{ fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)' }}
+                fill="var(--ink-dim)">
+            -24h
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -6,12 +6,10 @@ import type { Navigate } from '../hooks/useRoute.js';
 import { modePath, projectPath } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
-import { GateLatencyChart } from './GateLatencyChart.js';
 import { LiveFeed } from './LiveFeed.js';
+import { NarrativeBand } from './NarrativeBand.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 import { ProjectSparkline } from './ProjectSparkline.js';
-import { RunOutcomeBar } from './RunOutcomeBar.js';
-import { TokenBurnSparkline } from './TokenBurnSparkline.js';
 
 /**
  * The orchestrator home board (DES-MERGE-001 §1.2/§1.4; bands per DES-UXFIX-001
@@ -35,12 +33,13 @@ import { TokenBurnSparkline } from './TokenBurnSparkline.js';
  * narration aggregates — and every color on the surface resolves from a semantic
  * token (§2.11, lint-enforced at ERROR for this file).
  *
- * Feedback slice E (DES-FEEDBACK-001 §2): a 64px METRICS BAR sits between the
- * chrome and the wall — three SVG-first tiles, each answering a §2.1 named
- * operator question (EC19), all derived from stores the page already holds
- * (zero new requests). The bar AUGMENTS the wall and the live feed; neither
- * changes beneath it. The gate-latency tile hides under 900px (§2.2 — the
- * least critical at a glance; `.wk-metrics-mid` in global.css).
+ * Feedback slice Q (DES-FEEDBACK-003 §7): slice E's 64px metrics bar is
+ * SUPERSEDED by the ~200px NARRATIVE BAND (§8.5) — a data-composed lede plus
+ * the per-project activity river, with the two surviving slice-E tiles as its
+ * margin notes (the GateLatencyChart leaves the landing; its question is
+ * answered by the river's gate marks, and the component survives for
+ * dashboards). Everything below the band — wall, bands, cursor, live feed —
+ * is byte-identical (§7.4, C3/C6).
  */
 
 /** Card gap — §1.3's composition (blocks and cards sit 8px apart, `--space-2`). */
@@ -123,7 +122,7 @@ function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate, cursor }:
 }
 
 export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
-  const { items, unfiled, loading, error } = useBoardModel(runs);
+  const { items, unfiled, failedAt, loading, error } = useBoardModel(runs);
   const scroller = useRef<HTMLDivElement>(null);
   const [box, setBox] = useState({ w: 0, h: 0 });
   const [scrollTop, setScrollTop] = useState(0);
@@ -209,7 +208,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     onClick: (e) => { e.preventDefault(); navigate(path); },
   });
 
-  // The run-outcome tile buckets on the one honest per-run clock the board
+  // The band's charts bucket on the one honest per-run clock the board
   // already fetched — the membership attach times, merged across projects.
   const attachedAt = useMemo(() => {
     const merged: Record<string, number> = {};
@@ -218,22 +217,15 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   }, [items]);
 
   return (
-    // §1.3's composition — with slice E's metrics bar (§2.2) banded above it.
+    // §1.3's composition — with slice Q's narrative band (§7.3) above it.
     <div className="flex flex-1 flex-col overflow-hidden" style={{ background: 'var(--surface-base)' }}>
-      <div
-        data-testid="metrics-bar"
-        style={{
-          height: '64px', flexShrink: 0, display: 'flex', alignItems: 'stretch',
-          background: 'var(--surface-rail)', padding: '0 var(--space-3)',
-        }}
-      >
-        <RunOutcomeBar runs={runs} attachedAt={attachedAt} />
-        {/* Hidden under 900px (§2.2) — the media query lives in global.css. */}
-        <div className="wk-metrics-mid" style={{ display: 'flex', flex: 1, minWidth: 0 }}>
-          <GateLatencyChart />
-        </div>
-        <TokenBurnSparkline />
-      </div>
+      <NarrativeBand
+        items={items}
+        runs={runs}
+        attachedAt={attachedAt}
+        failedAt={failedAt}
+        navigate={navigate}
+      />
 
       <div className="flex min-w-0 flex-1 overflow-hidden">
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">

--- a/src/components/NarrativeBand.tsx
+++ b/src/components/NarrativeBand.tsx
@@ -1,0 +1,233 @@
+import { useMemo } from 'react';
+import type { SessionView } from '../api/types.js';
+import type { BoardProject } from '../hooks/useBoardModel.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { useDocThreadStore } from '../store/docThread.js';
+import { useGateStore } from '../store/gates.js';
+import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+import { ActivityRiver } from './ActivityRiver.js';
+import { RIVER_WINDOW_MS } from './ActivityRiver.js';
+import { outcomeOf, RunOutcomeBar } from './RunOutcomeBar.js';
+import { TokenBurnSparkline } from './TokenBurnSparkline.js';
+
+/**
+ * The narrative band (DES-FEEDBACK-003 §7.3, slice Q): ~200px that REPLACE the
+ * 64px metrics bar — the landing's first two story acts (§7.2). The lede is one
+ * sentence COMPOSED from store data (EC29 — every number derives, zero-count
+ * segments drop out, the quiet phrase renders on quiet systems); the activity
+ * river below it is the picture; the two surviving slice-E tiles fold in as
+ * margin notes (§8.5 — the GateLatencyChart retires from the landing, its
+ * question answered by the river's gate marks).
+ *
+ * "While you were away" is honest because its window is the river's own stated
+ * 24h of OBSERVED activity — no "since your last visit" clock is invented
+ * (§7.3; the wire has no such thing).
+ */
+
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled']);
+const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+export interface LedeCounts {
+  /** Terminal runs whose last OBSERVED clock is inside the 24h window. */
+  finished: number;
+  passed: number;
+  failed: number;
+  /** Runs waiting on a human right now. */
+  gates: number;
+  /** Runs moving under their own power right now. */
+  live: number;
+  /** Board projects (the quiet phrase's subject). */
+  projects: number;
+}
+
+/** Fold the honest per-run clocks into the lede's counts — exported for tests. */
+export function ledeCounts(
+  runs: SessionView[],
+  attachedAt: Record<string, number>,
+  logs: Record<string, LoggedEvent[]>,
+  failedAt: Record<string, number>,
+  projects: number,
+  now: number,
+): LedeCounts {
+  const start = now - RIVER_WINDOW_MS;
+  let finished = 0, passed = 0, failedN = 0, gates = 0, live = 0;
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    const id = v.session.id;
+    const status = v.session.status;
+    if (status === 'awaiting_human') gates += 1;
+    if (ACTIVE.has(status)) live += 1;
+    if (!TERMINAL.has(status)) continue;
+    // A run "finished while you were away" iff its LAST observed clock —
+    // attach, arrival-stamped frames, or the failure tail — is in-window.
+    const points = [
+      attachedAt[id],
+      failedAt[id],
+      ...(logs[id] ?? []).map((e) => e.ts),
+    ].filter((t): t is number => typeof t === 'number');
+    if (points.length === 0) continue; // clockless: the river counts it unplaced
+    const last = Math.max(...points);
+    if (last < start || last > now) continue;
+    finished += 1;
+    if (outcomeOf(status) === 'fail') failedN += 1;
+    else passed += 1;
+  }
+  return { finished, passed, failed: failedN, gates, live, projects };
+}
+
+export interface LedeSegment {
+  text: string;
+  /** Where the number leads (§7.3: every number is a real link). */
+  href: string | null;
+}
+
+const plural = (n: number, word: string): string => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/**
+ * §7.3's composition grammar, drop-outs included — exported for tests:
+ * zero-count segments vanish; the all-quiet system gets the quiet phrase.
+ */
+export function composeLede(c: LedeCounts): { quiet: boolean; segments: LedeSegment[] } {
+  if (c.finished === 0 && c.gates === 0 && c.live === 0) {
+    return {
+      quiet: true,
+      segments: [
+        { text: 'All quiet. ', href: null },
+        { text: plural(c.projects, 'project'), href: '/projects' },
+        { text: ', nothing running, nothing waiting.', href: null },
+      ],
+    };
+  }
+  const segments: LedeSegment[] = [{ text: 'While you were away: ', href: null }];
+  if (c.finished > 0) {
+    const split = [
+      c.passed > 0 ? `${c.passed} passed` : null,
+      c.failed > 0 ? `${c.failed} failed` : null,
+    ].filter((s) => s !== null).join(', ');
+    segments.push({ text: `${plural(c.finished, 'run')} finished — ${split}`, href: '/runs' });
+  } else if (c.gates === 0) {
+    // Nothing finished, nothing waiting — but something is moving: say that,
+    // with the number still derived (EC29), never an empty "away:" stub.
+    segments.push({ text: `nothing finished — ${plural(c.live, 'run')} still moving`, href: '/runs' });
+  }
+  if (c.gates > 0) {
+    if (c.finished > 0) segments.push({ text: ' — and ', href: null });
+    segments.push({
+      text: `${plural(c.gates, 'gate')} ${c.gates === 1 ? 'is' : 'are'} waiting on you`,
+      href: '#needs-you',
+    });
+  }
+  segments.push({ text: '.', href: null });
+  return { quiet: false, segments };
+}
+
+interface Props {
+  items: BoardProject[];
+  runs: SessionView[];
+  /** Merged run id → attach clock (the board's own merge, HomeBoard). */
+  attachedAt: Record<string, number>;
+  failedAt: Record<string, number>;
+  navigate: Navigate;
+  now?: number;
+}
+
+export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now }: Props): React.ReactElement {
+  const gates = useGateStore((s) => s.gates);
+  const logs = useRuntimeStore((s) => s.logs);
+  const landings = useDocThreadStore((s) => s.landings);
+  const at = now ?? Date.now();
+
+  const lede = useMemo(
+    () => composeLede(ledeCounts(runs, attachedAt, logs, failedAt, items.length, at)),
+    [runs, attachedAt, logs, failedAt, items.length, at],
+  );
+
+  // Observed spend — the SAME fold as the margin sparkline (real costUsd only).
+  const spend = useMemo(() => {
+    let total = 0, seen = false;
+    for (const log of Object.values(logs)) {
+      for (const entry of log) {
+        if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
+          total += entry.costUsd;
+          seen = true;
+        }
+      }
+    }
+    return seen ? total : null;
+  }, [logs]);
+
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => {
+      e.preventDefault();
+      if (path === '#needs-you') {
+        // The gate number lands on the needs-you band itself (§7.3).
+        document.querySelector('[data-testid="band-needs-you"]')?.scrollIntoView({ block: 'start' });
+      } else {
+        navigate(path);
+      }
+    },
+  });
+
+  return (
+    <div
+      data-testid="narrative-band"
+      style={{
+        flexShrink: 0, background: 'var(--surface-rail)',
+        padding: 'var(--space-3) var(--space-6)',
+        display: 'flex', flexDirection: 'column', gap: '10px',
+      }}
+    >
+      {/* Element 1 — the lede (§7.3): the page's largest text besides the H1. */}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '16px' }}>
+        <p
+          data-testid="landing-lede"
+          data-question="What happened and what needs me?"
+          style={{
+            margin: 0, fontSize: 'var(--text-md)', fontFamily: 'var(--font-sans)',
+            color: 'var(--ink-high)', minWidth: 0,
+          }}
+        >
+          {lede.segments.map((seg, i) =>
+            seg.href === null ? (
+              <span key={i}>{seg.text}</span>
+            ) : (
+              <a key={i} {...link(seg.href)} data-testid="lede-segment"
+                 style={{ color: 'var(--ink-high)', textDecoration: 'none', borderBottom: '1px solid var(--surface-raised)' }}>
+                {seg.text}
+              </a>
+            ),
+          )}
+        </p>
+        {spend !== null && (
+          <a {...link('/make')} data-testid="lede-spend"
+             style={{
+               marginLeft: 'auto', flexShrink: 0, textDecoration: 'none',
+               fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+             }}>
+            ${spend.toFixed(2)} observed
+          </a>
+        )}
+      </div>
+
+      {/* Element 2 — the river; element 3 — the margin notes (§7.3/§8.5). */}
+      <div style={{ display: 'flex', gap: 'var(--space-4)', alignItems: 'stretch' }}>
+        <ActivityRiver
+          items={items} runs={runs} gates={gates} logs={logs} failedAt={failedAt}
+          landings={landings} navigate={navigate} {...(now === undefined ? {} : { now })}
+        />
+        <div
+          data-testid="river-margin"
+          style={{
+            width: '176px', flexShrink: 0, display: 'flex', flexDirection: 'column',
+            justifyContent: 'flex-start', gap: '6px',
+            borderLeft: '1px solid var(--surface-raised)',
+          }}
+        >
+          <RunOutcomeBar runs={runs} attachedAt={attachedAt} />
+          <TokenBurnSparkline />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -207,6 +207,12 @@ export interface BoardModel {
   items: BoardProject[];
   /** Runs no non-default project claims — the "Not in a project" shelf (D4). */
   unfiled: SessionView[];
+  /**
+   * Backfilled durable-log tail per FAILED run id (D3 step 2) — the one honest
+   * failure clock. Exposed so the landing's activity river (DES-FEEDBACK-003
+   * §7.3) can place its ✗ marks on the clock this hook already fetched.
+   */
+  failedAt: Record<string, number>;
   loading: boolean;
   error: string | null;
 }
@@ -378,5 +384,5 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
     return runs.filter((v) => !known.has(v.session.id));
   }, [runs, projects, bindings, loading]);
 
-  return { items, unfiled, loading, error };
+  return { items, unfiled, failedAt, loading, error };
 }

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -102,6 +102,18 @@ export function threadKey(projectId: string, docId: string): string {
  *  arrive since I started?" needs no clock — snapshot the entry, watch it change. */
 export interface ThreadError { text: string }
 
+/**
+ * One OBSERVED version landing (DES-FEEDBACK-003 §7.3): the landing page's
+ * activity river marks "a doc/demo version landed" on the owning project's
+ * lane. The frame itself carries no timestamp, so the clock is the ARRIVAL
+ * time — the same honest stamp the runtime log and the gate store already use
+ * (observed by this page, never invented).
+ */
+export interface VersionLanding { projectId: string; version: number; kind: string; at: number }
+
+/** Ring cap on the observed-landings list — a lens over recent activity, not a ledger. */
+const LANDINGS_CAP = 200;
+
 interface DocThreadStore {
   messages: Record<string, DocMsg[]>;
   /** What the stream last said the generation is doing, per thread. */
@@ -121,6 +133,8 @@ interface DocThreadStore {
    * storyboard re-reads the service rather than showing the steps it was fed at mount.
    */
   landed: Record<string, number>;
+  /** Every version landing this page has observed, arrival-stamped (§7.3 river marks). */
+  landings: VersionLanding[];
   /** Fold one CoreEvent — every non-interactive frame is ignored. */
   ingest: (event: CoreEvent) => void;
   /** Append the user's message and make it the pending version anchor. */
@@ -156,6 +170,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   genState: {},
   anchor: {},
   landed: {},
+  landings: [],
   lastError: {},
 
   ingest: (event) => {
@@ -270,6 +285,12 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
           messages: tagged,
           anchor,
           landed: { ...s.landed, [key]: version },
+          // The river's mark (§7.3): project id is the thread key's first
+          // segment (`threadKey` = `${projectId}:${docId}`), clock = arrival.
+          landings: [
+            ...s.landings,
+            { projectId: key.slice(0, key.indexOf(':')), version, kind, at: Date.now() },
+          ].slice(-LANDINGS_CAP),
           genState: generated ? { ...s.genState, [key]: 'terminal' } : s.genState,
         };
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,11 +172,12 @@ code, pre, .font-mono {
   .wk-anchor-flash { animation: none; }
 }
 
-/* Slice-E metrics bar (DES-FEEDBACK-001 §2.2): under 900px the gate-latency
-   tile — the least critical at a glance — hides, and the two remaining tiles
-   share the band. A media query needs CSS, so the rule lives here. */
-@media (max-width: 899px) {
-  .wk-metrics-mid { display: none !important; }
+/* Slice-Q activity river (DES-FEEDBACK-003 §7.3): a STILL-WAITING gate mark is
+   the landing's one loop — it pulses until answered. Reduced motion gets a
+   solid, full-opacity diamond instead (same contract as the live edge above). */
+.wk-river-gate-waiting { animation: wk-live-pulse 2s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .wk-river-gate-waiting { animation: none; opacity: 1; }
 }
 
 /* Slice-H inline reject note (DES-FEEDBACK-002 §2.3/§2.5): the placeholder

--- a/tests/ActivityRiver.test.tsx
+++ b/tests/ActivityRiver.test.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach } from 'vitest';
+import type { Project } from '../src/api/types.js';
+import {
+  ActivityRiver,
+  buildRiver,
+  MAX_LANES,
+  RIVER_WINDOW_MS,
+} from '../src/components/ActivityRiver.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { OpenGate } from '../src/store/gates.js';
+import type { LoggedEvent } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * The activity river's lane model + marks (DES-FEEDBACK-003 §7.3, slice Q):
+ * spans on the HONEST observed clocks only — attach times, arrival-stamped
+ * frames, the failure tail — clamped at the window edges; clockless runs are
+ * excluded and counted; live runs reach "now"; marks sit at observed times in
+ * status tokens.
+ */
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+function project(id: string, name = id): Project {
+  return {
+    id, name, description: null, status: 'active', scope: `project:${id}`,
+    created_at: 1, updated_at: 1,
+  };
+}
+
+function item(id: string, runs: ReturnType<typeof makeView>[], attachedAt: Record<string, number>): BoardProject {
+  return {
+    project: project(id), repo: null, runs, docs: [], attachedAt,
+    attention: 'quiet', score: 0, band: 'quiet', signal: null,
+  };
+}
+
+function gate(runId: string, receivedAt: number): OpenGate {
+  return { runId, ord: 0, prompt: 'approve?', lifecycle: 'open', receivedAt };
+}
+
+function log(ts: number, type = 'cliUsage'): LoggedEvent {
+  return { seq: 1, type, ts, detail: type };
+}
+
+const EMPTY = { gates: {}, logs: {}, failedAt: {}, landings: [], now: NOW };
+
+describe('buildRiver — lane math on the honest clocks', () => {
+  it('a span runs first-observed → last-observed; a live run reaches now', () => {
+    const items = [
+      item('p-live', [makeView({ id: 'r-live', status: 'executing' })], { 'r-live': NOW - 20 * HOUR }),
+      item('p-done', [makeView({ id: 'r-done', status: 'completed' })], { 'r-done': NOW - 10 * HOUR }),
+    ];
+    const logs = { 'r-done': [log(NOW - 8 * HOUR)] };
+    const m = buildRiver({ items, runs: items.flatMap((i) => i.runs), ...EMPTY, logs });
+    expect(m.lanes.map((l) => l.projectId)).toEqual(['p-live', 'p-done']);
+    const live = m.lanes[0]!.spans[0]!;
+    expect(live.start).toBe(NOW - 20 * HOUR);
+    expect(live.end).toBe(NOW); // live → the span reaches "now"
+    expect(live.live).toBe(true);
+    const done = m.lanes[1]!.spans[0]!;
+    expect(done.start).toBe(NOW - 10 * HOUR);
+    expect(done.end).toBe(NOW - 8 * HOUR); // last OBSERVED frame, not now
+    expect(done.live).toBe(false);
+  });
+
+  it('clamps spans at the window edges and drops runs entirely outside it', () => {
+    const items = [
+      // Attached 30h ago but still executing — the span clamps to the left edge.
+      item('p-old-live', [makeView({ id: 'r-a', status: 'executing' })], { 'r-a': NOW - 30 * HOUR }),
+      // Terminal with every clock older than 24h — entirely outside, no lane.
+      item('p-gone', [makeView({ id: 'r-b', status: 'failed' })], { 'r-b': NOW - 30 * HOUR }),
+    ];
+    const m = buildRiver({ items, runs: items.flatMap((i) => i.runs), ...EMPTY });
+    expect(m.lanes.map((l) => l.projectId)).toEqual(['p-old-live']);
+    expect(m.lanes[0]!.spans[0]!.start).toBe(NOW - RIVER_WINDOW_MS); // clamped
+    expect(m.quiet).toBe(1); // p-gone has nothing in-window
+  });
+
+  it('excludes clockless runs from every lane and counts them data-unplaced', () => {
+    const orphan = makeView({ id: 'r-orphan', status: 'executing' });
+    const items = [item('p', [makeView({ id: 'r-1', status: 'executing' })], { 'r-1': NOW - HOUR })];
+    const m = buildRiver({ items, runs: [...items[0]!.runs, orphan], ...EMPTY });
+    expect(m.lanes).toHaveLength(1);
+    expect(m.lanes[0]!.spans.map((s) => s.runId)).toEqual(['r-1']); // never painted
+    expect(m.unplaced).toBe(1);
+  });
+
+  it('caps lanes at 6 in the given (board) order; the rest count quiet', () => {
+    const items = Array.from({ length: 9 }, (_, i) =>
+      item(`p-${i}`, [makeView({ id: `r-${i}`, status: 'executing' })], { [`r-${i}`]: NOW - HOUR }));
+    const m = buildRiver({ items, runs: items.flatMap((i) => i.runs), ...EMPTY });
+    expect(m.lanes).toHaveLength(MAX_LANES);
+    expect(m.lanes.map((l) => l.projectId)).toEqual(['p-0', 'p-1', 'p-2', 'p-3', 'p-4', 'p-5']);
+    expect(m.quiet).toBe(3);
+  });
+
+  it('places marks at observed clocks: waiting gate at receivedAt, ✗ at the failure tail', () => {
+    const items = [
+      item('p-gate', [makeView({ id: 'r-gate', status: 'awaiting_human' })], { 'r-gate': NOW - 2 * HOUR }),
+      item('p-fail', [makeView({ id: 'r-fail', status: 'failed' })], { 'r-fail': NOW - 6 * HOUR }),
+    ];
+    const m = buildRiver({
+      items, runs: items.flatMap((i) => i.runs), ...EMPTY,
+      gates: { 'r-gate': gate('r-gate', NOW - HOUR) },
+      failedAt: { 'r-fail': NOW - 5 * HOUR },
+    });
+    const gateMarks = m.lanes[0]!.spans[0]!.marks;
+    expect(gateMarks).toEqual([{ kind: 'gate', at: NOW - HOUR, waiting: true }]);
+    const failSpan = m.lanes[1]!.spans[0]!;
+    expect(failSpan.end).toBe(NOW - 5 * HOUR); // the tail extends the span
+    expect(failSpan.marks).toEqual([{ kind: 'fail', at: NOW - 5 * HOUR, waiting: false }]);
+  });
+
+  it('a failed run with no backfilled tail marks ✗ at its last OBSERVED point — never an invented time', () => {
+    const items = [item('p', [makeView({ id: 'r-f', status: 'failed' })], { 'r-f': NOW - 3 * HOUR })];
+    const m = buildRiver({ items, runs: items[0]!.runs, ...EMPTY });
+    expect(m.lanes[0]!.spans[0]!.marks).toEqual([{ kind: 'fail', at: NOW - 3 * HOUR, waiting: false }]);
+  });
+
+  it('version landings mark the owning project lane — doc vs demo kinds, window-scoped', () => {
+    const items = [item('p-doc', [makeView({ id: 'r-1', status: 'executing' })], { 'r-1': NOW - HOUR })];
+    const m = buildRiver({
+      items, runs: items[0]!.runs, ...EMPTY,
+      landings: [
+        { projectId: 'p-doc', version: 2, kind: 'generated', at: NOW - 2 * HOUR },
+        { projectId: 'p-doc', version: 1, kind: 'demo', at: NOW - 3 * HOUR },
+        { projectId: 'p-doc', version: 1, kind: 'generated', at: NOW - 30 * HOUR }, // outside
+        { projectId: 'p-other', version: 1, kind: 'generated', at: NOW - HOUR },    // not this lane
+      ],
+    });
+    expect(m.lanes[0]!.marks).toEqual([
+      { kind: 'doc', at: NOW - 2 * HOUR, version: 2 },
+      { kind: 'demo', at: NOW - 3 * HOUR, version: 1 },
+    ]);
+  });
+
+  it('a lane can exist on a version landing alone (a doc landed, no runs moved)', () => {
+    const items = [item('p-only-doc', [], {})];
+    const m = buildRiver({
+      items, runs: [], ...EMPTY,
+      landings: [{ projectId: 'p-only-doc', version: 1, kind: 'generated', at: NOW - HOUR }],
+    });
+    expect(m.lanes.map((l) => l.projectId)).toEqual(['p-only-doc']);
+    expect(m.quiet).toBe(0);
+  });
+
+  it('skips archived runs entirely', () => {
+    const items = [item('p', [makeView({ id: 'r-x', status: 'completed', archived_at: 123 })], { 'r-x': NOW - HOUR })];
+    const m = buildRiver({ items, runs: items[0]!.runs, ...EMPTY });
+    expect(m.lanes).toHaveLength(0);
+    expect(m.unplaced).toBe(0);
+  });
+});
+
+describe('<ActivityRiver> — the SVG picture (EC15 tokens, EC19 question, the one loop)', () => {
+  afterEach(cleanup);
+
+  const items = [
+    item('p-live', [makeView({ id: 'r-live', status: 'executing', problem: 'ship it' })], { 'r-live': NOW - 20 * HOUR }),
+    item('p-gate', [makeView({ id: 'r-gate', status: 'awaiting_human' })], { 'r-gate': NOW - 2 * HOUR }),
+  ];
+
+  function draw(): HTMLElement {
+    const { container } = render(
+      <ActivityRiver
+        items={items}
+        runs={items.flatMap((i) => i.runs)}
+        gates={{ 'r-gate': gate('r-gate', NOW - HOUR) }}
+        logs={{}}
+        failedAt={{}}
+        landings={[{ projectId: 'p-live', version: 2, kind: 'generated', at: NOW - 4 * HOUR }]}
+        navigate={() => {}}
+        now={NOW}
+      />,
+    );
+    return container;
+  }
+
+  it('carries the §7.3 named question, lane counts, and lanes in board order', () => {
+    const c = draw();
+    const river = c.querySelector('[data-testid="activity-river"]')!;
+    expect(river.getAttribute('data-question')).toBe('What ran, when, and how did it end?');
+    expect(river.getAttribute('data-lanes')).toBe('2');
+    const lanes = [...c.querySelectorAll('[data-testid="river-lane"]')];
+    expect(lanes.map((l) => l.getAttribute('data-project-id'))).toEqual(['p-live', 'p-gate']);
+  });
+
+  it('a live span reaches the now edge and carries the breach arrowhead', () => {
+    const c = draw();
+    const live = c.querySelector('[data-testid="river-span"][data-run-id="r-live"]')!;
+    expect(live.getAttribute('data-live')).toBe('true');
+    expect(live.querySelector('[data-testid="river-now-arrow"]')).not.toBeNull();
+    // Every span is a real link with a title tooltip (intent · phase · project).
+    expect(live.getAttribute('href')).toBe('/p/p-live/build/r-live');
+    expect(live.querySelector('title')!.textContent).toContain('ship it');
+  });
+
+  it('the waiting gate mark is a --status-gate diamond that pulses (the one loop) and links run+#gate', () => {
+    const c = draw();
+    const mark = c.querySelector('[data-testid="river-gate-mark"]')!;
+    expect(mark.getAttribute('data-waiting')).toBe('true');
+    expect(mark.getAttribute('href')).toBe('/p/p-gate/build/r-gate#gate');
+    const diamond = mark.querySelector('polygon')!;
+    expect(diamond.getAttribute('fill')).toBe('var(--status-gate)');
+    expect(diamond.getAttribute('class')).toBe('wk-river-gate-waiting');
+  });
+
+  it('renders version marks in --ink-muted, the quiet-lane count, and only token paints (EC15)', () => {
+    const c = draw();
+    const version = c.querySelector('[data-testid="river-version-mark"]')!;
+    expect(version.getAttribute('data-kind')).toBe('doc');
+    expect(c.querySelector('[data-testid="river-quiet"]')!.getAttribute('data-count')).toBe('0');
+    // EC15: every painted fill/stroke in the river is a var() reference.
+    const painted = [...c.querySelectorAll('rect, line, polygon, circle')];
+    expect(painted.length).toBeGreaterThan(4);
+    for (const el of painted) {
+      for (const attr of ['fill', 'stroke'] as const) {
+        const v = el.getAttribute(attr);
+        expect(v === null || v === 'none' || v.startsWith('var(--')).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/HomeBoard.bands.test.tsx
+++ b/tests/HomeBoard.bands.test.tsx
@@ -189,7 +189,9 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
     await vi.waitFor(() => {
       expect(needsYouIds()).toEqual(['ancient-gate', 'fresh-failure']);
     });
-    const gateCard = document.querySelector('[data-project-id="ancient-gate"]');
+    // Scoped to the CARD: slice Q's river lanes above the wall carry the same
+    // data-project-id (the card itself is unchanged — C3/C6).
+    const gateCard = document.querySelector('[data-testid="project-card"][data-project-id="ancient-gate"]');
     expect(gateCard).toHaveAttribute('data-score', '100.00');
     expect(gateCard).toHaveAttribute('data-signal', 'gate');
   });

--- a/tests/HomeBoard.narrative.test.tsx
+++ b/tests/HomeBoard.narrative.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Project, ProjectMember } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * Slice Q (DES-FEEDBACK-003 §7.6): on `/` the NARRATIVE BAND replaces the
+ * metrics bar — old testid absent (supersession), GateLatencyChart unmounted
+ * from the landing — while the wall, bands, and live feed render unchanged
+ * beneath it (C3/C6).
+ */
+
+let projects: Project[] = [];
+let members: Record<string, ProjectMember[]> = {};
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjectMembers: (id: string) => Promise.resolve({ members: members[id] ?? [] }),
+    getRunEvents: () => Promise.reject(new Error('no log')),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  listDocs: () => Promise.resolve([]),
+}));
+
+const { HomeBoard } = await import('../src/components/HomeBoard.js');
+
+function project(id: string): Project {
+  return { id, name: id, description: null, status: 'active', scope: `project:${id}`, created_at: 1, updated_at: Date.now() };
+}
+
+function member(project_id: string, member_ref: string, attached_at: number): ProjectMember {
+  return { id: `${project_id}:crew.run:${member_ref}`, project_id, member_kind: 'crew.run', member_ref, meta: null, attached_at, attached_by: 'studio' };
+}
+
+describe('HomeBoard — the narrative landing (slice Q)', () => {
+  beforeEach(() => {
+    projects = [];
+    members = {};
+  });
+
+  it('mounts the narrative band where the metrics bar was; the old band is GONE', async () => {
+    const now = Date.now();
+    projects = [project('p-live')];
+    members = { 'p-live': [member('p-live', 'r-live', now - 3_600_000)] };
+    const runs = [makeView({ id: 'r-live', status: 'executing' })];
+    render(<HomeBoard runs={runs} navigate={() => {}} />);
+    await screen.findByTestId('project-board');
+
+    // Supersession (§7.6 AC 1 + §8.5): new band in, old bar out, latency chart off `/`.
+    expect(await screen.findByTestId('narrative-band')).toBeInTheDocument();
+    expect(screen.queryByTestId('metrics-bar')).toBeNull();
+    expect(screen.queryByTestId('gate-latency-chart')).toBeNull();
+
+    // The band's parts: lede + river + the two margin notes.
+    expect(screen.getByTestId('landing-lede')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-river')).toBeInTheDocument();
+    const margin = screen.getByTestId('river-margin');
+    expect(margin.querySelector('[data-testid="run-outcome-bar"]')).not.toBeNull();
+    expect(margin.querySelector('[data-testid="token-burn-sparkline"]')).not.toBeNull();
+
+    // The band sits ABOVE the wall in the document flow.
+    const band = screen.getByTestId('narrative-band');
+    const wall = screen.getByTestId('project-board');
+    expect(band.compareDocumentPosition(wall) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('preserves the wall structure beneath the band (C3/C6): bands, chips, feed', async () => {
+    const now = Date.now();
+    projects = [project('p-gate'), project('p-move'), project('p-quiet')];
+    members = {
+      'p-gate': [member('p-gate', 'r-gate', now - 60_000)],
+      // A MOVING run so the live feed mounts (it is absent when nothing runs);
+      // p-quiet stays runless so the QUIET band renders too.
+      'p-move': [member('p-move', 'r-live', now - 120_000)],
+    };
+    const runs = [
+      makeView({ id: 'r-gate', status: 'awaiting_human' }),
+      makeView({ id: 'r-live', status: 'executing' }),
+    ];
+    render(<HomeBoard runs={runs} navigate={() => {}} />);
+    await screen.findByTestId('project-board');
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('band-needs-you')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('band-quiet')).toBeInTheDocument();
+    expect(screen.getByTestId('band-quiet-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('live-feed')).toBeInTheDocument();
+    expect(screen.getByTestId('all-runs-link')).toBeInTheDocument();
+  });
+});

--- a/tests/NarrativeBand.test.tsx
+++ b/tests/NarrativeBand.test.tsx
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { composeLede, ledeCounts, NarrativeBand, type LedeCounts } from '../src/components/NarrativeBand.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { Project } from '../src/api/types.js';
+import { useDocThreadStore } from '../src/store/docThread.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore, type LoggedEvent } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * The narrative band's lede (DES-FEEDBACK-003 §7.3, slice Q / EC29): one
+ * sentence COMPOSED from store data — every number derives, every zero-count
+ * segment drops out, the quiet phrase renders on quiet systems, and every
+ * number is a real link.
+ */
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+const text = (c: Partial<LedeCounts>): string =>
+  composeLede({ finished: 0, passed: 0, failed: 0, gates: 0, live: 0, projects: 5, ...c })
+    .segments.map((s) => s.text).join('');
+
+describe('composeLede — §7.3 grammar, every drop-out case', () => {
+  it('the full sentence: finished with both outcomes, and gates', () => {
+    expect(text({ finished: 4, passed: 3, failed: 1, gates: 2 })).toBe(
+      'While you were away: 4 runs finished — 3 passed, 1 failed — and 2 gates are waiting on you.',
+    );
+  });
+
+  it('zero failed drops the failed half', () => {
+    expect(text({ finished: 4, passed: 4, gates: 2 })).toBe(
+      'While you were away: 4 runs finished — 4 passed — and 2 gates are waiting on you.',
+    );
+  });
+
+  it('zero passed drops the passed half', () => {
+    expect(text({ finished: 2, failed: 2, gates: 1 })).toBe(
+      'While you were away: 2 runs finished — 2 failed — and 1 gate is waiting on you.',
+    );
+  });
+
+  it('zero gates drops the whole gates clause', () => {
+    expect(text({ finished: 4, passed: 3, failed: 1 })).toBe(
+      'While you were away: 4 runs finished — 3 passed, 1 failed.',
+    );
+  });
+
+  it('zero finished keeps the gates clause, un-conjoined', () => {
+    expect(text({ gates: 2, live: 1 })).toBe(
+      'While you were away: 2 gates are waiting on you.',
+    );
+  });
+
+  it('nothing finished, nothing waiting, something moving — the number still derives', () => {
+    expect(text({ live: 3 })).toBe(
+      'While you were away: nothing finished — 3 runs still moving.',
+    );
+  });
+
+  it('singular grammar throughout', () => {
+    expect(text({ finished: 1, passed: 1, gates: 1 })).toBe(
+      'While you were away: 1 run finished — 1 passed — and 1 gate is waiting on you.',
+    );
+    expect(text({ live: 1 })).toBe('While you were away: nothing finished — 1 run still moving.');
+  });
+
+  it('the all-quiet system reads the quiet phrase — no zero-count segment renders', () => {
+    const quiet = composeLede({ finished: 0, passed: 0, failed: 0, gates: 0, live: 0, projects: 28 });
+    expect(quiet.quiet).toBe(true);
+    expect(quiet.segments.map((s) => s.text).join('')).toBe(
+      'All quiet. 28 projects, nothing running, nothing waiting.',
+    );
+    expect(text({})).not.toContain('0 ');
+  });
+
+  it('each numeric segment names a real destination (§7.3 links)', () => {
+    const full = composeLede({ finished: 4, passed: 3, failed: 1, gates: 2, live: 0, projects: 5 });
+    const hrefs = full.segments.filter((s) => s.href !== null).map((s) => s.href);
+    expect(hrefs).toEqual(['/runs', '#needs-you']);
+  });
+});
+
+describe('ledeCounts — honest clocks only (EC29: no invented clock)', () => {
+  const log = (ts: number, type = 'cliUsage'): LoggedEvent => ({ seq: 1, type, ts, detail: type });
+
+  it('counts a run finished only when its LAST observed clock is in-window', () => {
+    const runs = [
+      makeView({ id: 'r-in', status: 'completed' }),
+      makeView({ id: 'r-out', status: 'failed' }),      // clock 30h ago — out
+      makeView({ id: 'r-clockless', status: 'completed' }), // no clock — never counted
+      makeView({ id: 'r-gate', status: 'awaiting_human' }),
+      makeView({ id: 'r-live', status: 'executing' }),
+      makeView({ id: 'r-archived', status: 'completed', archived_at: 1 }),
+    ];
+    const c = ledeCounts(
+      runs,
+      { 'r-in': NOW - 5 * HOUR, 'r-out': NOW - 30 * HOUR, 'r-archived': NOW - HOUR },
+      {}, {}, 7, NOW,
+    );
+    expect(c).toEqual({ finished: 1, passed: 1, failed: 0, gates: 1, live: 1, projects: 7 });
+  });
+
+  it('the failure tail and arrival-stamped frames extend a run into the window', () => {
+    const runs = [makeView({ id: 'r-f', status: 'failed' }), makeView({ id: 'r-d', status: 'completed' })];
+    const c = ledeCounts(
+      runs,
+      { 'r-f': NOW - 30 * HOUR, 'r-d': NOW - 30 * HOUR },
+      { 'r-d': [log(NOW - 2 * HOUR)] },
+      { 'r-f': NOW - 3 * HOUR },
+      2, NOW,
+    );
+    expect(c.finished).toBe(2);
+    expect(c.failed).toBe(1);
+    expect(c.passed).toBe(1);
+  });
+});
+
+describe('<NarrativeBand> — composition on screen', () => {
+  beforeEach(() => {
+    useGateStore.setState({ gates: {} });
+    useRuntimeStore.setState({ logs: {} });
+    useDocThreadStore.setState({ landings: [] });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function project(id: string): Project {
+    return { id, name: id, description: null, status: 'active', scope: `project:${id}`, created_at: 1, updated_at: 1 };
+  }
+  function item(id: string, runs: ReturnType<typeof makeView>[], attachedAt: Record<string, number>): BoardProject {
+    return { project: project(id), repo: null, runs, docs: [], attachedAt, attention: 'quiet', score: 0, band: 'quiet', signal: null };
+  }
+
+  it('renders the lede with its EC19 question, links as <a>, and the margin notes', () => {
+    const runs = [
+      makeView({ id: 'r-done', status: 'completed' }),
+      makeView({ id: 'r-gate', status: 'awaiting_human' }),
+    ];
+    const attached = { 'r-done': NOW - 2 * HOUR, 'r-gate': NOW - HOUR };
+    render(
+      <NarrativeBand
+        items={[item('p', runs, attached)]}
+        runs={runs} attachedAt={attached} failedAt={{}} navigate={() => {}} now={NOW}
+      />,
+    );
+    const lede = screen.getByTestId('landing-lede');
+    expect(lede.getAttribute('data-question')).toBe('What happened and what needs me?');
+    expect(lede.textContent).toBe(
+      'While you were away: 1 run finished — 1 passed — and 1 gate is waiting on you.',
+    );
+    const links = [...lede.querySelectorAll('a[data-testid="lede-segment"]')];
+    expect(links.map((a) => a.getAttribute('href'))).toEqual(['/runs', '#needs-you']);
+    // §8.5: the two surviving slice-E tiles live on as margin notes.
+    const margin = screen.getByTestId('river-margin');
+    expect(margin.querySelector('[data-testid="run-outcome-bar"]')).not.toBeNull();
+    expect(margin.querySelector('[data-testid="token-burn-sparkline"]')).not.toBeNull();
+    // No spend observed → the spend note drops out rather than inventing $0.00.
+    expect(screen.queryByTestId('lede-spend')).toBeNull();
+  });
+
+  it('shows observed spend as a /make link only when a real costUsd was observed', () => {
+    useRuntimeStore.setState({
+      logs: { 'r-x': [
+        { seq: 1, type: 'cliUsage', ts: NOW - HOUR, costUsd: 0.3, detail: 'usage' },
+        { seq: 2, type: 'cliUsage', ts: NOW - HOUR / 2, costUsd: 0.12, detail: 'usage' },
+      ] },
+    });
+    render(
+      <NarrativeBand items={[]} runs={[]} attachedAt={{}} failedAt={{}} navigate={() => {}} now={NOW} />,
+    );
+    const spend = screen.getByTestId('lede-spend');
+    expect(spend.textContent).toBe('$0.42 observed');
+    expect(spend.getAttribute('href')).toBe('/make');
+  });
+
+  it('the gates link lands on the needs-you band anchor', () => {
+    const runs = [makeView({ id: 'r-gate', status: 'awaiting_human' })];
+    const attached = { 'r-gate': NOW - HOUR };
+    const target = document.createElement('section');
+    target.setAttribute('data-testid', 'band-needs-you');
+    const scrolled = vi.fn();
+    target.scrollIntoView = scrolled;
+    document.body.appendChild(target);
+    const navigate = vi.fn();
+    render(
+      <NarrativeBand items={[item('p', runs, attached)]} runs={runs} attachedAt={attached}
+                     failedAt={{}} navigate={navigate} now={NOW} />,
+    );
+    screen.getByText('1 gate is waiting on you').click();
+    expect(scrolled).toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled(); // an anchor scroll, not a route change
+    target.remove();
+  });
+
+  it('renders the quiet phrase on an all-quiet system', () => {
+    render(
+      <NarrativeBand
+        items={[item('p-1', [], {}), item('p-2', [], {})]}
+        runs={[]} attachedAt={{}} failedAt={{}} navigate={() => {}} now={NOW}
+      />,
+    );
+    expect(screen.getByTestId('landing-lede').textContent).toBe(
+      'All quiet. 2 projects, nothing running, nothing waiting.',
+    );
+  });
+});


### PR DESCRIPTION
Round-4 operator feedback, second push on this surface: *"The landing page is still far from graphical and telling a story of what's happening."*

## What changed (design: `.product/DES-FEEDBACK-003.md` §7)

The 64px metrics bar is **replaced** by a ~200px story band:

- **The lede**: a data-composed sentence ("While you were away: 3 runs finished — 2 passed, 1 failed — and 2 gates are waiting on you.") with §7.3's drop-out grammar for absent facts, an all-quiet phrase, and every number a real link (finished→/runs, gates→the needs-you wall, spend→/make).
- **The ActivityRiver**: SVG per-project 24h lanes in board attention order (≤6 + a collapsed "(n quiet)" lane) — run spans strictly on **observed clocks** (attach + arrival-stamped frames + the failedAt backfill), clamped at window edges, clockless runs excluded and counted; live runs breach the "now" edge with an arrowhead; pulsing gate diamonds (reduced-motion honored), ✗ failure marks, ▤/▶ version-landed ticks; a relative axis labeled **"observed"**; every span/mark a real link (gate marks land on the run with `#gate`).
- Outcome + burn demote to margin notes; GateLatencyChart leaves the landing (alive for dashboards — its question is answered by the river's gate marks). Wall, feed, and triage byte-untouched.

## Verification highlights

The verifier judged the ambition question directly on pixels ("a genuine time narrative, not a rearranged metrics bar"), **independently re-derived the lede from fixture constants** (exact DOM match) and **pixel-measured span geometry against the fixture's real clocks**; the rig's lede grammar is a second independent Python implementation. Zero added requests; negative check red on main; EC15 computed token fills; wall/feed/triage diff-untouched with the triage rig green.

One wording call unspecified by the doc (flagged): finished=0 ∧ gates=0 ∧ live>0 composes as "While you were away: nothing finished — {n} runs still moving."

## Gates

eslint clean · tsc clean · vitest **1168/1168** (30 new) · new rig `feedback3_sliceQ_test.py` (incl. a quiet-state variant) + the re-scoped `feedback_sliceE`, `feedback3_sliceM/N`, `uxfix_slice1`, `feedback2_sliceH` all PASS.

Shots: `feedback3-Q-landing-story.png`, `feedback3-Q-landing-quiet.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)