### PR TITLE
Slice J: header project pivot + honest global search + feed/dashboard gap notes (DES-FEEDBACK-002 §4–§5)

### DIFF
--- a/e2e/feedback2_sliceJ_test.py
+++ b/e2e/feedback2_sliceJ_test.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceJ_test.py — the DES-FEEDBACK-002 slice-J gate: project pivot on
+the context header (§4, P1-4), cross-project global search — the palette's
+`?` deep mode (§5, P1-5) — and the two gap notes: LiveFeed lines deep-link to
+the run (§10.1) and the project dashboard surfaces bound repos (§10.2).
+Against the shared frozen-NOW0 W2 fixture with `repo` + `repo_member` on.
+
+The slice DOM ACs, verbatim from §4.4 / §5.5 / §10.1 / §10.2:
+
+  1. inside /p/A/build, clicking [data-testid="project-name"] opens
+     [data-testid="project-switcher-list"]; choosing project B navigates to
+     /p/B/build (URL asserted — mode verb retained, no artifact segment);
+     the same pivot from /p/A/document lands on /p/B/document;
+  2. [data-testid="switcher-dashboard-row"] navigates to /p/A; zero network
+     requests fire on dropdown open (projects store already warm);
+  3. keyboard: the trigger opens on Enter, ArrowDown walks rows with REAL
+     focus (EC22), Escape closes and restores focus to the trigger;
+  4. typing `?auth` renders [data-testid="search-corpus-label"] naming the
+     four searched corpora and the not-searched clause (EC24 — archived runs
+     included); run hits whose problem contains "auth" appear accent-marked;
+  5. a word from the W2 gated run's prompt returns a gate hit that navigates
+     to the run with #gate (observed on the pushState, the slice-H pattern —
+     the legacy redirect then rewrites into the shell);
+  6. entering search mode fires at most GET /governance/claims (+ /repos on a
+     cold palette cache); ten keystrokes fire zero further requests; inside
+     /p/A/* the label adds "prompts: this project" and ONE
+     GET /projects/A/prompts fires; no request to any /search route EVER;
+  7. Cmd+Shift+F opens the palette pre-seeded with `?` (search mode);
+  8. every [data-testid="feed-line"] is an <a href> ending with its
+     data-run-id (middle-clickable — a real href); clicking navigates;
+  9. with the fixture's crew.repo member, [data-testid="dashboard-repos"]
+     renders one chip linking to that repo's page; a project without one
+     renders no testid at all.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-J-crumb-pivot.png     context-header dropdown open inside Build,
+                                  current project checked
+  feedback2-J-search-corpus.png   search mode with the corpus label and a gate hit
+  feedback2-J-dashboard-repos.png dashboard with the bound-repo chip row
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4361),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4361"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. Build + the shared W2 fixture server, repo + repo_member ON ─────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, repo=True, repo_member=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN,
+                                     "repo": True, "repo_member": True}
+
+# ── 2. The browser gate ────────────────────────────────────────────────────────
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+TOKEN_PROBE = """() => {
+  const resolve = (token) => {
+    const el = document.createElement('span');
+    el.style.color = `var(${token})`;
+    document.body.appendChild(el);
+    const c = getComputedStyle(el).color;
+    el.remove();
+    return c;
+  };
+  return { statusGate: resolve('--status-gate'), accent: resolve('--accent'),
+           inkMuted: resolve('--ink-muted') };
+}"""
+
+SWITCHER_STATE = """() => {
+  const list = document.querySelector('[data-testid="project-switcher-list"]');
+  const opts = Array.from(document.querySelectorAll('[data-testid="project-switcher-option"]'));
+  return {
+    listOpen: !!list,
+    options: opts.map((o) => o.dataset.projectId),
+    checked: opts.filter((o) => o.getAttribute('aria-selected') === 'true')
+      .map((o) => o.dataset.projectId),
+    checkGlyph: opts.find((o) => o.getAttribute('aria-selected') === 'true')
+      ?.textContent?.includes('✓') ?? false,
+    unfiledRow: !!document.querySelector('[data-testid="project-switcher-unfiled"]'),
+    addRow: !!document.querySelector('[data-testid="project-switcher-add"]'),
+    dashRow: document.querySelector('[data-testid="switcher-dashboard-row"]')?.getAttribute('href') ?? null,
+  };
+}"""
+
+SEARCH_STATE = """() => {
+  const label = document.querySelector('[data-testid="search-corpus-label"]');
+  const rows = Array.from(document.querySelectorAll('[data-testid="palette-row"]'));
+  const notLine = label ? Array.from(label.querySelectorAll('p'))
+    .find((p) => (p.textContent ?? '').startsWith('Not searched')) : null;
+  return {
+    labelText: label?.textContent ?? null,
+    notSearchedColor: notLine ? getComputedStyle(notLine).color : null,
+    groups: rows.map((r) => r.dataset.group),
+    labels: rows.map((r) => r.textContent ?? ''),
+    hrefs: rows.map((r) => r.getAttribute('href')),
+    inputValue: document.querySelector('[data-testid="palette-input"]')?.value ?? null,
+  };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # The tap: every request the page makes, by API path.
+    requests: list[tuple[str, str]] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if path.startswith("/api/") or path == "/ws":
+            requests.append((req.method, path))
+
+    page.on("request", on_request)
+
+    def gets(path: str) -> int:
+        return sum(1 for m, p_ in requests if m == "GET" and p_ == path)
+
+    def foreign(since: int) -> list[tuple[str, str]]:
+        """New requests since `since`, minus the app's own cadence (the
+        debounced GET /runs reconcile + gate-cache reads and /ws)."""
+        return [
+            (m, p_) for m, p_ in requests[since:]
+            if p_ != "/ws" and not (m == "GET" and p_.startswith("/api/v1/runs"))
+        ]
+
+    # ── Scene 1: the crumb pivot inside Build (§4.4 ACs 1–2) ───────────────────
+    page.goto(f"{ORIGIN}/p/api-migration/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1500)  # the surface's own fetch burst settles
+
+    try:
+        page.wait_for_function(
+            """() => document.fonts.status === 'loaded'
+                  && document.fonts.check('12px "Inter"')""",
+            timeout=20000,
+        )
+        fonts_ok = True
+    except Exception:
+        fonts_ok = False
+
+    before_open = len(requests)
+    page.locator('[data-testid="project-name"]').click()
+    page.locator('[data-testid="project-switcher-list"]').wait_for(timeout=10000)
+    page.wait_for_timeout(700)  # request-settle tick for the tap
+    sw = page.evaluate(SWITCHER_STATE)
+    dropdown_reqs = foreign(before_open)
+
+    report["steps"]["crumb_opens_zero_requests"] = {
+        "ok": all([
+            fonts_ok,
+            sw["listOpen"],
+            "upload-endpoint" in sw["options"],
+            # The current project renders checked, with the ✓ (§4.2).
+            sw["checked"] == ["api-migration"],
+            sw["checkGlyph"],
+            # No Unfiled row, no + New project — a pivot, not a binding field.
+            not sw["unfiledRow"],
+            not sw["addRow"],
+            # The dashboard row is a REAL link to /p/api-migration.
+            sw["dashRow"] == "/p/api-migration",
+            # §4.4: zero requests on dropdown open — the store is warm.
+            dropdown_reqs == [],
+        ]),
+        "web_fonts_loaded": fonts_ok,
+        **sw,
+        "requests_on_open": dropdown_reqs,
+    }
+
+    # ── Capture 1: dropdown open inside Build, current project checked ─────────
+    page.screenshot(path=str(VSHOTS / "feedback2-J-crumb-pivot.png"))
+
+    # Choosing project B lands on /p/B/build — mode retained, no artifact.
+    page.locator('[data-testid="project-switcher-option"][data-project-id="upload-endpoint"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/upload-endpoint/build'", timeout=10000
+    )
+    pivot_build = page.evaluate("() => window.location.pathname")
+
+    # The same pivot from Document retains Document.
+    page.goto(f"{ORIGIN}/p/api-migration/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="project-name"]').click()
+    page.locator('[data-testid="project-switcher-list"]').wait_for(timeout=10000)
+    page.locator('[data-testid="project-switcher-option"][data-project-id="upload-endpoint"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/upload-endpoint/document'", timeout=10000
+    )
+    pivot_doc = page.evaluate("() => window.location.pathname")
+
+    # The dashboard row navigates to the project dashboard.
+    page.locator('[data-testid="project-name"]').click()
+    page.locator('[data-testid="switcher-dashboard-row"]').wait_for(timeout=10000)
+    page.locator('[data-testid="switcher-dashboard-row"]').click()
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=10000)
+    dash_landed = page.evaluate("() => window.location.pathname")
+
+    report["steps"]["pivot_retains_mode"] = {
+        "ok": all([
+            pivot_build == "/p/upload-endpoint/build",
+            pivot_doc == "/p/upload-endpoint/document",
+            dash_landed == "/p/upload-endpoint",
+        ]),
+        "build": pivot_build, "document": pivot_doc, "dashboard": dash_landed,
+    }
+
+    # ── Scene 2: keyboard — Enter opens, arrows walk REAL focus, Escape restores
+    page.goto(f"{ORIGIN}/p/api-migration/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-name"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.evaluate("() => document.querySelector('[data-testid=\"project-name\"]').focus()")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="project-switcher-list"]').wait_for(timeout=10000)
+    page.keyboard.press("ArrowDown")
+    kbd_row = page.evaluate(
+        """() => ({
+             isRow: document.activeElement?.classList?.contains('wk-switcher-row') ?? false,
+             projectId: document.activeElement?.dataset?.projectId ?? null,
+             outline: document.activeElement
+               ? getComputedStyle(document.activeElement).outlineStyle : null,
+           })"""
+    )
+    page.keyboard.press("ArrowDown")
+    kbd_row2 = page.evaluate("() => document.activeElement?.dataset?.projectId ?? null")
+    page.keyboard.press("Escape")
+    kbd_after = page.evaluate(
+        """() => ({
+             closed: document.querySelector('[data-testid="project-switcher-list"]') === null,
+             triggerFocused: document.activeElement?.dataset?.testid === 'project-name',
+           })"""
+    )
+    report["steps"]["switcher_keyboard"] = {
+        "ok": all([
+            kbd_row["isRow"],
+            kbd_row["projectId"] is not None,
+            kbd_row2 is not None and kbd_row2 != kbd_row["projectId"],
+            kbd_after["closed"],
+            kbd_after["triggerFocused"],
+        ]),
+        "first_row": kbd_row, "second_row": kbd_row2, **kbd_after,
+    }
+
+    # ── Scene 3: global search on the home board (§5.5) ────────────────────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1500)  # board fetch burst + gate-cache reconcile
+
+    claims_before = gets("/api/v1/governance/claims")
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    entry_mark = len(requests)
+    page.keyboard.type("?auth")
+    page.locator('[data-testid="search-corpus-label"]').wait_for(timeout=10000)
+    page.wait_for_timeout(700)
+    s1 = page.evaluate(SEARCH_STATE)
+    tokens = page.evaluate(TOKEN_PROBE)
+    entry_reqs = foreign(entry_mark)
+    accent_marked = page.evaluate(
+        """accent => {
+             const row = Array.from(document.querySelectorAll(
+               '[data-testid="palette-row"][data-group="search-runs"]'))[0];
+             if (!row) return false;
+             return Array.from(row.querySelectorAll('span span'))
+               .some((s) => getComputedStyle(s).color === accent);
+           }""",
+        tokens["accent"],
+    )
+
+    run_hits = [l for g, l in zip(s1["groups"], s1["labels"]) if g == "search-runs"]
+    report["steps"]["search_corpus_label"] = {
+        "ok": all([
+            s1["labelText"] is not None,
+            "Searching: runs (all non-archived) · open gates · decisions (governance claims) · repos"
+            in s1["labelText"],
+            "Not searched: archived runs, transcripts, historical events —" in s1["labelText"],
+            "prompts: this project" not in s1["labelText"],  # not inside a shell
+            # EC15/EC24: the honesty clause earns the attention color.
+            s1["notSearchedColor"] == tokens["statusGate"],
+            # Run hits whose problem contains "auth", accent-marked matches.
+            any("migrate the auth tables" in l for l in run_hits),
+            any("refactor the auth middleware" in l for l in run_hits),
+            accent_marked,
+        ]),
+        "label": s1["labelText"],
+        "not_searched_color": s1["notSearchedColor"],
+        "resolved_tokens": tokens,
+        "run_hits": run_hits,
+        "accent_marked": accent_marked,
+    }
+
+    # The [why?] popover states the wire truth.
+    page.locator('[data-testid="search-why"]').click()
+    why = page.evaluate(
+        "() => document.querySelector('[data-testid=\"search-why-popover\"]')?.textContent ?? null"
+    )
+    report["steps"]["why_popover"] = {
+        "ok": why == "The crew daemon has no search index yet; the studio searches what it holds.",
+        "text": why,
+    }
+
+    # §5.5 budget: entry fired exactly one claims GET (repos was warmed by the
+    # palette OPEN — cold cache on this page load — before search mode).
+    claims_after_entry = gets("/api/v1/governance/claims")
+    keystrokes_mark = len(requests)
+    page.keyboard.type(" middleware")  # ten more keystrokes
+    page.wait_for_timeout(700)
+    keystroke_reqs = foreign(keystrokes_mark)
+    report["steps"]["search_budget"] = {
+        "ok": all([
+            claims_after_entry == claims_before + 1,
+            [p_ for _, p_ in entry_reqs if not p_.startswith("/api/v1/governance/claims")] == [],
+            keystroke_reqs == [],
+        ]),
+        "claims_gets_on_entry": claims_after_entry - claims_before,
+        "entry_requests": entry_reqs,
+        "keystroke_requests": keystroke_reqs,
+    }
+
+    # ── A gate hit: a word from the W2 gated run's prompt → run + #gate ────────
+    # Tap pushState (the slice-H pattern): the legacy redirect immediately
+    # rewrites /runs/:id into the shell, so the #gate intent is observable on
+    # the push, and the settled hash still carries it.
+    page.evaluate(
+        """() => {
+             window.__pushed = [];
+             const orig = history.pushState.bind(history);
+             history.pushState = (s, t, url) => { window.__pushed.push(String(url)); return orig(s, t, url); };
+           }"""
+    )
+    page.locator('[data-testid="palette-input"]').fill("?deck outline")
+    page.wait_for_selector('[data-testid="palette-row"][data-group="search-gates"]', timeout=10000)
+    s2 = page.evaluate(SEARCH_STATE)
+    gate_hrefs = [h for g, h in zip(s2["groups"], s2["hrefs"]) if g == "search-gates"]
+
+    # ── Capture 2: search mode with the corpus label and a gate hit ────────────
+    page.screenshot(path=str(VSHOTS / "feedback2-J-search-corpus.png"))
+
+    page.locator('[data-testid="palette-row"][data-group="search-gates"]').first.click()
+    page.wait_for_function("() => (window.__pushed ?? []).length > 0", timeout=10000)
+    pushed = page.evaluate("() => window.__pushed")
+    page.wait_for_timeout(800)
+    settled = page.evaluate("() => ({ path: window.location.pathname, hash: window.location.hash })")
+    report["steps"]["gate_hit_navigates"] = {
+        "ok": all([
+            len(gate_hrefs) == 1,
+            gate_hrefs[0] == "/runs/r-q3#gate",
+            any(u.endswith("/runs/r-q3#gate") for u in pushed),
+            "r-q3" in settled["path"],
+        ]),
+        "gate_hrefs": gate_hrefs,
+        "pushed": pushed,
+        "settled": settled,
+    }
+
+    # ── Scoped prompts inside the shell (§5.5) ─────────────────────────────────
+    page.goto(f"{ORIGIN}/p/api-migration/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-context-header"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1200)
+    prompts_before = gets("/api/v1/projects/api-migration/prompts")
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    page.keyboard.type("?tables")
+    page.locator('[data-testid="search-corpus-label"]').wait_for(timeout=10000)
+    page.wait_for_timeout(700)
+    s3 = page.evaluate(SEARCH_STATE)
+    prompts_after = gets("/api/v1/projects/api-migration/prompts")
+    prompt_rows = [h for g, h in zip(s3["groups"], s3["hrefs"]) if g == "search-prompts"]
+    report["steps"]["scoped_prompts"] = {
+        "ok": all([
+            "prompts: this project" in (s3["labelText"] or ""),
+            prompts_after == prompts_before + 1,
+            len(prompt_rows) == 1,
+            prompt_rows[0].endswith("#gate"),
+        ]),
+        "label": s3["labelText"],
+        "prompts_gets": prompts_after - prompts_before,
+        "prompt_rows": prompt_rows,
+    }
+    page.keyboard.press("Escape")
+    # The chord below routes through the GLOBAL registry, which yields while the
+    # palette input has focus — wait for the close to land first.
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"command-palette\"]') === null",
+        timeout=10000,
+    )
+
+    # ── Cmd+Shift+F opens pre-seeded with `?` (§5.5 / the §1.2 table) ──────────
+    page.keyboard.press("Control+Shift+F")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.locator('[data-testid="search-corpus-label"]').wait_for(timeout=10000)
+    seeded = page.evaluate(SEARCH_STATE)
+    report["steps"]["cmd_shift_f"] = {
+        "ok": seeded["inputValue"] == "?" and seeded["labelText"] is not None,
+        "input_value": seeded["inputValue"],
+    }
+    page.keyboard.press("Escape")
+
+    # ── The invented-wire guard: no /search route EVER fired ───────────────────
+    search_requests = [p_ for _, p_ in requests if "/search" in p_]
+    report["steps"]["no_search_route"] = {
+        "ok": search_requests == [],
+        "search_requests": search_requests,
+    }
+
+    # ── Scene 4: LiveFeed lines are real links to the run (§10.1) ──────────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="live-feed"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_function(
+        "() => document.querySelectorAll('[data-testid=\"feed-line\"]').length > 0",
+        timeout=15000,
+    )
+    feed = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="feed-line"]')).map((l) => ({
+             tag: l.tagName,
+             runId: l.dataset.runId ?? null,
+             href: l.getAttribute('href'),
+           }))"""
+    )
+    feed_ok = len(feed) > 0 and all(
+        f["tag"] == "A" and f["href"] is not None and f["runId"] is not None
+        and f["href"].endswith("/" + f["runId"])
+        for f in feed
+    )
+    # Clicking a narration line lands on the run view.
+    page.locator('[data-testid="feed-line"][data-run-id="r-upload"]').first.click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/upload-endpoint/build/r-upload'", timeout=10000
+    )
+    feed_landed = page.evaluate("() => window.location.pathname")
+    report["steps"]["feed_deep_links"] = {
+        "ok": feed_ok and feed_landed == "/p/upload-endpoint/build/r-upload",
+        "lines": feed,
+        "landed": feed_landed,
+    }
+
+    # ── Scene 5: dashboard bound repos (§10.2) ─────────────────────────────────
+    # Warm the palette repo cache with a real gesture IN THIS page load, then
+    # navigate in-app to the dashboard — the chip resolves the repo NAME from
+    # the same cache, zero requests of its own.
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000
+    )
+    page.wait_for_timeout(600)  # the one GET /repos lands, cache warm
+    page.keyboard.type("p: upload")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=10000)
+    repos_mark = len(requests)
+    page.locator('[data-testid="dashboard-repos"]').wait_for(timeout=10000)
+    page.wait_for_timeout(600)
+    chip = page.evaluate(
+        """muted => {
+             const chips = Array.from(document.querySelectorAll('[data-testid="dashboard-repo"]'));
+             return chips.map((c) => ({
+               href: c.getAttribute('href'),
+               text: c.textContent ?? '',
+               color: getComputedStyle(c).color,
+             }));
+           }""",
+        tokens["inkMuted"],
+    )
+    chip_reqs = [
+        (m, p_) for m, p_ in requests[repos_mark:]
+        if p_ == "/api/v1/repos"
+    ]
+
+    # ── Capture 3: the dashboard with the bound-repo chip row ──────────────────
+    page.screenshot(path=str(VSHOTS / "feedback2-J-dashboard-repos.png"))
+
+    # The absence case: q3-review-deck has no crew.repo member.
+    page.goto(f"{ORIGIN}/p/q3-review-deck", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=30000)
+    page.wait_for_timeout(1000)
+    absent = page.evaluate(
+        "() => document.querySelector('[data-testid=\"dashboard-repos\"]') === null"
+    )
+
+    report["steps"]["dashboard_repos"] = {
+        "ok": all([
+            len(chip) == 1,
+            chip[0]["href"] == "/repo-detail/studio-api",
+            "studio-api" in chip[0]["text"],
+            # Resolved from the warm cache: muted ink, and NO repos GET of its own.
+            chip[0]["color"] == tokens["inkMuted"],
+            chip_reqs == [],
+            absent,
+        ]),
+        "chips": chip,
+        "repo_gets_from_dashboard": chip_reqs,
+        "absent_without_member": absent,
+    }
+
+    page.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-J-crumb-pivot.png"),
+    str(VSHOTS / "feedback2-J-search-corpus.png"),
+    str(VSHOTS / "feedback2-J-dashboard-repos.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceJ_verdict", f"slice-J assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/feedback_sliceD_test.py
+++ b/e2e/feedback_sliceD_test.py
@@ -216,8 +216,12 @@ with sync_playwright() as p:
              const mcs = mode ? getComputedStyle(mode) : null;
              return {
                height: h ? h.getBoundingClientRect().height : null,
-               nameText: name?.textContent ?? null,
-               nameHref: name?.getAttribute('href') ?? null,
+               nameText: name?.querySelector('span')?.textContent ?? name?.textContent ?? null,
+               // Slice J (DES-FEEDBACK-002 §4.2): the name is the switcher
+               // TRIGGER now; the deep-linkable dashboard href moved to the ⌂
+               // real link directly after it.
+               nameHref: document.querySelector('[data-testid="project-home"]')
+                 ?.getAttribute('href') ?? null,
                nameColor: ncs?.color ?? null,
                modeText: mode?.textContent ?? null,
                modeColor: mcs?.color ?? null,
@@ -234,8 +238,12 @@ with sync_playwright() as p:
     # ── Capture 2: Build mode with the context header ───────────────────────────
     page.screenshot(path=str(VSHOTS / "feedback-D-build-with-header.png"))
 
-    # ── AC 4: clicking the project name lands back on the dashboard ────────────
+    # ── AC 4 (as amended by DES-FEEDBACK-002 §4.2, slice J): the name now opens
+    # the project switcher; the dashboard stays one click away via the
+    # dropdown's ⌂ row (and the ⌂ real link asserted above as nameHref). ──────
     page.locator('[data-testid="project-name"]').click()
+    page.locator('[data-testid="switcher-dashboard-row"]').wait_for(timeout=30000)
+    page.locator('[data-testid="switcher-dashboard-row"]').click()
     page.locator('[data-testid="project-dashboard"]').wait_for(timeout=30000)
     back_path = page.evaluate("() => window.location.pathname")
 
@@ -248,7 +256,9 @@ with sync_playwright() as p:
         page.add_style_tag(content=HIDE_GATE_TOASTS)
         got = page.evaluate(
             """() => ({
-                 name: document.querySelector('[data-testid="project-name"]')?.textContent ?? null,
+                 // Slice J: the name span inside the switcher trigger (the raw
+                 // textContent would also carry the ▾ caret).
+                 name: document.querySelector('[data-testid="project-name"] span')?.textContent ?? null,
                  mode: document.querySelector('[data-testid="context-mode"]')?.textContent ?? null,
                  visible: (() => {
                    const h = document.querySelector('[data-testid="project-context-header"]');

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -69,6 +69,10 @@ Mutable switches (flipped over POST /__fixture between page loads):
   repo_refs       — r-upload / r-auth / r-smoke1 gain repo_ref "studio-api"
                     on the runs wire (flip `repo` on with it; default False —
                     the slice-P /repos tiles' grouping cases).
+  repo_member     — upload-endpoint gains ONE `crew.repo` member (studio-api)
+                    on the members wire (DES-FEEDBACK-002 §10.2 — the slice-J
+                    dashboard bound-repos row; flip `repo` on with it so the
+                    name resolves from the palette cache; default False).
   learn_delay_s   — how long after a successful theme.requested the learned
                     tokens ripen into GET /d/<doc>/api/theme/learned
                     (interactive#181; default 0.75 — long enough for the
@@ -127,6 +131,11 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #               resolves), giving §4.4's runs-per-repo / failing-
          #               repos tiles something true to group. Default False.
          "chat_runs": False, "repo_refs": False,
+         # Slice J (DES-FEEDBACK-002 §10.2): upload-endpoint gains ONE
+         # crew.repo member (studio-api) on the members wire — the dashboard's
+         # bound-repos row corpus. Switch-gated so no standing rig's member
+         # list grows a kind it never asserted. Default False.
+         "repo_member": False,
          # Slice Q (DES-FEEDBACK-003 §10.2): the 24h-spread river variant.
          "river": False,
          # Slice I (DES-FEEDBACK-002 §3): the in-studio file/diff viewer corpus.
@@ -394,6 +403,45 @@ VIEWER_EVENTS = [
     {"type": "dataUsed", "session": "r-upload", "ord": 1,
      "files": [VIEWER_FILE_BIN, VIEWER_FILE_403]},
 ]
+
+# ── Slice J (DES-FEEDBACK-002 §5): the search-mode wires ──────────────────────
+#
+# GET /governance/claims — the decisions corpus (real `GovernanceClaim` shape,
+# wicked-crew-api-types): one claim NAMES a client-held run in its scope (the
+# hit navigates to the run), one names only a repo (the hit falls back to
+# /policies). Served unconditionally: the studio only reads it on the search
+# gesture, so no standing rig sees a new request.
+GOVERNANCE_CLAIMS = [
+    {"claim_id": "clm-w2-001", "scope": "run:r-upload", "phase": "build",
+     "policy_ids": ["pol-rate-limit"], "decision": "allow", "obligations": [],
+     "evaluated_context_ref": "ctx-upload-0",
+     "criteria": "rate-limiting middleware guards the upload endpoint",
+     "evaluator_identity": "conformance", "evaluated_at": (NOW0 - HOUR) // 1000},
+    {"claim_id": "clm-w2-002", "scope": "repo:studio-api", "phase": "design",
+     "policy_ids": ["pol-authz-review"], "decision": "deny",
+     "obligations": ["schedule an authz review"],
+     "evaluated_context_ref": "ctx-repo-1",
+     "criteria": "the schema rollback plan is missing from the design",
+     "evaluator_identity": "conformance", "evaluated_at": (NOW0 - 2 * HOUR) // 1000},
+]
+
+# GET /projects/<id>/prompts — the per-project open prompt inbox (real
+# `InteractionRequest` shape). Only the projects whose runs hold open gates
+# have entries; an unknown project answers an empty inbox (the daemon's shape).
+PROJECT_PROMPTS = {
+    "q3-review-deck": [
+        {"id": "ir-q3-0", "session_id": "r-q3", "kind": "gate", "ord": 0,
+         "reviewing_ord": None, "prompt": "Approve the deck outline?",
+         "status": "open", "answer": None,
+         "created_at": NOW0 - 30 * SEC, "resolved_at": None},
+    ],
+    "api-migration": [
+        {"id": "ir-api-0", "session_id": "r-api", "kind": "gate", "ord": 0,
+         "reviewing_ord": None, "prompt": "How should the tables move?",
+         "status": "open", "answer": None,
+         "created_at": NOW0 - 2 * MIN, "resolved_at": None},
+    ],
+}
 
 # The durable-log tails (D3 step 2): the ONE honest clock for a failure's age.
 RUN_EVENTS = {
@@ -930,6 +978,10 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/roster":
             self._json(200, {"roster": ROSTER})
             return True
+        # Slice J (§5.2): the decisions corpus — read on the search GESTURE only.
+        if path == "/api/v1/governance/claims":
+            self._json(200, {"claims": GOVERNANCE_CLAIMS})
+            return True
         # /api/v1/chats/<id> — seats of a chat. Empty for a chat we never opened
         # (the daemon does not 404 an unknown id; empty means reclaimed/none).
         if path.startswith("/api/v1/chats/") and len(path.split("/")) == 5:
@@ -943,11 +995,16 @@ class W2Handler(SimpleHTTPRequestHandler):
             with state_lock:
                 chat_runs_on = state["chat_runs"]
                 river_on = state["river"]
+                repo_member_on = state["repo_member"]
             # Slice P: the live chat thread is a `crew.chat` member of notes.
             kinds = {}
             if chat_runs_on and pid == "notes":
                 refs.append("r-chat-live")
                 kinds["r-chat-live"] = "crew.chat"
+            # Slice J (§10.2): upload-endpoint's bound repo, a `crew.repo` member.
+            if repo_member_on and pid == "upload-endpoint":
+                refs.append(REPO_ID)
+                kinds[REPO_ID] = "crew.repo"
             # Slice Q: the 24h-spread clocks override the W2 defaults (river on).
             clocks = {**ATTACHED_AT, **(RIVER_ATTACHED_AT if river_on else {})}
             self._json(200, {"members": [
@@ -956,6 +1013,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                  "attached_at": clocks.get(ref, 1), "attached_by": "studio"}
                 for ref in refs
             ]})
+            return True
+        # Slice J (§5.2): the scoped per-project prompt inbox.
+        if len(parts) == 6 and parts[3] == "projects" and parts[5] == "prompts":
+            pid = urllib.parse.unquote(parts[4])
+            self._json(200, {"projectId": pid, "prompts": PROJECT_PROMPTS.get(pid, [])})
             return True
         # /api/v1/projects/<id>/interactive/api/docs — the registry: the notes seeds
         # plus whatever the slice-6 journey has created in this server's lifetime.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,6 +191,9 @@ export function App(): React.ReactElement {
   // guards and silent-fail contract intact, and also rides the palette as the
   // `> Cancel run` verb. One listener, one guard — `useGlobalShortcuts`.
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // §5.2 (slice J): Cmd+Shift+F opens the palette in SEARCH mode — the seed is
+  // the pre-typed `?` prefix; the plain toggles seed nothing.
+  const [paletteSeed, setPaletteSeed] = useState('');
   const paletteOpenRef = useRef(paletteOpen);
   useEffect(() => {
     paletteOpenRef.current = paletteOpen;
@@ -201,7 +204,14 @@ export function App(): React.ReactElement {
     () =>
       paletteShortcutEntries({
         isOpen: () => paletteOpenRef.current,
-        setOpen: setPaletteOpen,
+        setOpen: (next: boolean) => {
+          setPaletteSeed('');
+          setPaletteOpen(next);
+        },
+        openSearch: () => {
+          setPaletteSeed('?');
+          setPaletteOpen(true);
+        },
         killEligible: () => {
           if (!runId) return false;
           const run = runs.find((r) => r.session.id === runId);
@@ -513,7 +523,8 @@ export function App(): React.ReactElement {
           from already-loaded stores + the runs prop; repos cached on first open. */}
       <CommandPalette
         open={paletteOpen}
-        onClose={() => setPaletteOpen(false)}
+        onClose={() => { setPaletteOpen(false); setPaletteSeed(''); }}
+        seed={paletteSeed}
         runs={runs}
         navigate={navigate}
         runPath={runPath}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -522,6 +522,13 @@ export const api = {
   listProjectMembers: (id: string) =>
     apiFetch<{ members: ProjectMember[] }>(`/projects/${encodeURIComponent(id)}/members`),
 
+  /** The project's open prompt inbox (durable interaction requests) — the
+   *  per-project wire used the way it scales (DES-FEEDBACK-002 §5.2): search
+   *  mode queries it for the CURRENT project only, never as a cross-project
+   *  fan-out. */
+  listProjectPrompts: (id: string) =>
+    apiFetch<import('./types.js').ProjectPrompts>(`/projects/${encodeURIComponent(id)}/prompts`),
+
   /** Attach a member (run, chat, repo, doc …) to a project. */
   attachProjectMember: (id: string, body: AttachMemberBody) =>
     apiFetch<{ member: ProjectMember }>(`/projects/${encodeURIComponent(id)}/members`, {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
-import type { RepoEntry, SessionView } from '../api/types.js';
+import type { GovernanceClaim, InteractionRequest, RepoEntry, SessionView } from '../api/types.js';
+import { api } from '../api/client.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
-import { fuzzyMatch } from '../palette/fuzzy.js';
+import { fuzzyMatch, type FuzzyResult } from '../palette/fuzzy.js';
 import { modePath, projectPath, type Navigate } from '../hooks/useRoute.js';
 import type { ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
+import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useGateStore } from '../store/gates.js';
 import { useAppearanceStore } from '../theming/appearance.js';
@@ -28,13 +30,21 @@ import { Terminal } from './Terminal.js';
 const TERMINAL: ReadonlySet<string> = new Set(['completed', 'cancelled', 'failed']);
 const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
 
-type Group = 'runs' | 'projects' | 'repos' | 'verbs';
+type Group =
+  | 'runs' | 'projects' | 'repos' | 'verbs'
+  // §5.2 search mode's corpora — grouped exactly as the corpus label names them.
+  | 'search-runs' | 'search-gates' | 'search-decisions' | 'search-repos' | 'search-prompts';
 
 const GROUP_LABEL: Record<Group, string> = {
   runs: 'RUNS & GATES',
   projects: 'PROJECTS',
   repos: 'REPOSITORIES',
   verbs: 'VERBS',
+  'search-runs': 'RUNS',
+  'search-gates': 'OPEN GATES',
+  'search-decisions': 'DECISIONS',
+  'search-repos': 'REPOSITORIES',
+  'search-prompts': 'PROMPTS: THIS PROJECT',
 };
 
 interface Entry {
@@ -50,7 +60,36 @@ interface Entry {
   action?: () => void;
   /** Group-internal rank: lower first (gates before active before terminal). */
   rank: number;
+  /** Search hits: a status dot (token) or glyph before the label. */
+  dot?: string;
+  glyph?: string;
+  /** Search hits: the mono snippet line (§5.3) + its matched positions. */
+  snippet?: string;
+  snippetPositions?: number[];
 }
+
+/**
+ * §5.2's prose matcher: a plain case-insensitive SUBSTRING pass for prose
+ * fields (run problems, gate prompts, claim subjects) — subsequence matching
+ * on prose produces false-positive noise; substring on prose + fuzzy on
+ * identifiers is the honest pairing. Positions feed the same accent-render
+ * seam the fuzzy scorer uses.
+ */
+export function substringMatch(needle: string, haystack: string): FuzzyResult | null {
+  if (needle === '') return { score: 0, positions: [] };
+  const at = haystack.toLowerCase().indexOf(needle.toLowerCase());
+  if (at === -1) return null;
+  return { score: 1, positions: Array.from({ length: needle.length }, (_, i) => at + i) };
+}
+
+/** Search-hit status dots — the board's status layer, read as tokens (EC15). */
+const SEARCH_DOT: Record<string, string> = {
+  awaiting_human: 'var(--status-gate)',
+  failed: 'var(--status-fail)',
+  planning: 'var(--status-run)',
+  distributing: 'var(--status-run)',
+  executing: 'var(--status-run)',
+};
 
 /** Session-scoped repo cache (§1.4) — SHARED with the rail's Repositories
  *  accordion since slice M (DES-FEEDBACK-003 §3.3): one gesture warms both. */
@@ -66,6 +105,8 @@ export { clearRepoCache as clearPaletteRepoCache } from '../store/repoCache.js';
 export function paletteShortcutEntries(opts: {
   isOpen: () => boolean;
   setOpen: (open: boolean) => void;
+  /** §5.2: open the palette in SEARCH mode (the `?` prefix pre-typed). */
+  openSearch: () => void;
   killEligible: () => boolean;
   kill: () => void;
 }): ShortcutEntry[] {
@@ -89,6 +130,17 @@ export function paletteShortcutEntries(opts: {
       allowWhilePaletteOpen: true,
     },
     {
+      // §5.2: global search is the palette's DEEP MODE — Cmd+Shift+F opens the
+      // palette with the `?` prefix pre-typed (registered in the §1.2 table).
+      id: 'palette-search',
+      chord: { key: 'f', ctrlOrMeta: true, shift: true },
+      description: 'Global search',
+      handler: (e) => {
+        e.preventDefault(); // suppress the browser's find-in-page variants
+        opts.openSearch();
+      },
+    },
+    {
       id: 'kill-run',
       chord: { key: 'k', ctrlOrMeta: true, shift: true },
       description: 'Cancel the selected run',
@@ -99,6 +151,22 @@ export function paletteShortcutEntries(opts: {
       },
     },
   ];
+}
+
+/** §5.3: snippet matches lift to `--ink-high` — the snippet line is muted mono,
+ *  so the matched substring reads as the found thing, not as the accent. */
+function highlightSnippet(text: string, positions: number[]): React.ReactNode {
+  if (positions.length === 0) return text;
+  const set = new Set(positions);
+  return text.split('').map((ch, i) =>
+    set.has(i) ? (
+      <span key={i} style={{ color: 'var(--ink-high)' }}>
+        {ch}
+      </span>
+    ) : (
+      ch
+    ),
+  );
 }
 
 /** Accent-highlight the fuzzy-matched characters (§1.5 — the row's only accent). */
@@ -125,10 +193,12 @@ interface Props {
   projectId: string | null;
   selectedRun: SessionView | null;
   onKill: (id: string) => void;
+  /** Pre-typed query on OPEN (§5.2: Cmd+Shift+F seeds `?` — search mode). */
+  seed?: string;
 }
 
 export function CommandPalette({
-  open, onClose, runs, navigate, runPath, projectId, selectedRun, onKill,
+  open, onClose, runs, navigate, runPath, projectId, selectedRun, onKill, seed = '',
 }: Props): React.ReactElement | null {
   const [query, setQuery] = useState('');
   const [sel, setSel] = useState(0);
@@ -159,11 +229,16 @@ export function CommandPalette({
     }
     restoreRef.current = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
+    // §5.2: Cmd+Shift+F opens WITH the `?` prefix pre-typed — same overlay,
+    // deep mode. A plain toggle seeds '' and lands in the normal grammar.
+    if (seed !== '') setQuery(seed);
     fetchReposCached()
       .then(setRepos)
       .catch(() => {
         /* no repo surface — the group just stays empty this session */
       });
+    // `seed` is read only at the open edge — a re-render must not re-seed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const close = (): void => {
@@ -174,6 +249,7 @@ export function CommandPalette({
   // ── The corpus (§1.3/§1.4): stores + props only — zero fetching here ────────
   const { scope, needle } = useMemo(() => {
     const q = query.trimStart();
+    if (q.startsWith('?')) return { scope: 'search' as const, needle: q.slice(1).trim() };
     if (q.startsWith('>')) return { scope: 'verbs' as const, needle: q.slice(1).trim() };
     if (q.startsWith('p:')) return { scope: 'projects' as const, needle: q.slice(2).trim() };
     if (q.startsWith('run:')) return { scope: 'runs' as const, needle: q.slice(4).trim() };
@@ -181,7 +257,154 @@ export function CommandPalette({
     return { scope: 'all' as const, needle: q.trim() };
   }, [query]);
 
+  // ── §5.2 search mode: the gesture-fetched legs ──────────────────────────────
+  // ENTERING search mode fires at most two GETs (`/governance/claims`, plus
+  // `/repos` if the palette cache was cold — already handled by the open
+  // effect above), both cached for the session and refreshed on the next
+  // entry. Keystrokes fire nothing — filtering below is in-memory. Inside a
+  // project shell it ALSO queries the CURRENT project's prompt inbox (one
+  // request, labeled) — the per-project wire used the way it scales, never a
+  // cross-project fan-out.
+  const searchMode = open && scope === 'search';
+  const [claims, setClaims] = useState<GovernanceClaim[]>([]);
+  const [prompts, setPrompts] = useState<InteractionRequest[]>([]);
+  const [showWhy, setShowWhy] = useState(false);
+  const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  useEffect(() => {
+    if (!searchMode) {
+      setShowWhy(false);
+      return;
+    }
+    let cancelled = false;
+    api.listClaims()
+      .then(({ claims: got }) => { if (!cancelled) setClaims(got); })
+      .catch(() => { /* no conformance store — the decisions group stays empty */ });
+    if (projectId !== null) {
+      api.listProjectPrompts(projectId)
+        .then(({ prompts: got }) => { if (!cancelled) setPrompts(got); })
+        .catch(() => { /* inbox unreadable — the prompts group stays empty */ });
+    } else {
+      setPrompts([]);
+    }
+    return () => { cancelled = true; };
+  }, [searchMode, projectId]);
+
   const rows = useMemo(() => {
+    // ── §5.2 search mode: the honest v1 corpus, grouped as the label names it.
+    // Substring on prose (problems, prompts, claim subjects), fuzzy on names
+    // (repos) — and NOTHING is fetched from here: claims/prompts arrived on
+    // entry, runs/gates/repos are the already-held stores.
+    if (scope === 'search') {
+      const hits: Array<{ en: Entry; m: FuzzyResult }> = [];
+      // Runs — all non-archived (the default `GET /runs` listing; archived
+      // runs are named in the not-searched clause).
+      runs.forEach((v, i) => {
+        if (v.session.archived_at != null) return;
+        const m = substringMatch(needle, v.session.problem);
+        if (m === null) return;
+        const id = v.session.id;
+        hits.push({
+          en: {
+            id: `s-run-${id}`,
+            group: 'search-runs',
+            label: v.session.problem,
+            context: projectNameByRun[id] ?? v.session.status,
+            href: runPath(id),
+            rank: i,
+            dot: SEARCH_DOT[v.session.status] ?? 'var(--ink-dim)',
+          },
+          m,
+        });
+      });
+      // Open gates — the event-sourced `awaitingHuman` prompts (§5.1).
+      Object.values(gates).forEach((g, i) => {
+        const m = substringMatch(needle, g.prompt);
+        if (m === null) return;
+        hits.push({
+          en: {
+            id: `s-gate-${g.runId}`,
+            group: 'search-gates',
+            label: g.prompt,
+            context: projectNameByRun[g.runId] ?? 'gate',
+            href: `${runPath(g.runId)}${GATE_HASH}`,
+            rank: i,
+            glyph: '⏸',
+          },
+          m,
+        });
+      });
+      // Decisions — governance claims: substring on the subject (criteria),
+      // fuzzy on the policy ids (identifiers); the hit navigates to the run
+      // when the claim names one the client holds, else to /policies.
+      claims.forEach((c, i) => {
+        const subject = substringMatch(needle, c.criteria);
+        const ident = subject === null ? fuzzyMatch(needle, c.policy_ids.join(' ')) : null;
+        if (subject === null && ident === null) return;
+        const named = runs.find(
+          (v) => c.scope.includes(v.session.id) || c.evaluated_context_ref.includes(v.session.id),
+        );
+        hits.push({
+          en: {
+            id: `s-claim-${c.claim_id}`,
+            group: 'search-decisions',
+            label: `${c.policy_ids[0] ?? c.claim_id} · ${c.decision}`,
+            context: c.phase,
+            href: named !== undefined ? runPath(named.session.id) : '/policies',
+            rank: i,
+            glyph: '§',
+            snippet: c.criteria,
+            snippetPositions: subject?.positions ?? [],
+          },
+          m: subject ?? { score: ident?.score ?? 0, positions: [] },
+        });
+      });
+      // Repos — names are identifiers: the §1.5 fuzzy scorer.
+      repos.forEach((r) => {
+        const m = fuzzyMatch(needle, r.name);
+        if (m === null) return;
+        hits.push({
+          en: {
+            id: `s-repo-${r.id}`,
+            group: 'search-repos',
+            label: r.name,
+            context: r.default_branch,
+            href: `/repo-detail/${encodeURIComponent(r.id)}`,
+            rank: 0,
+            glyph: '⬡',
+          },
+          m,
+        });
+      });
+      // Prompts — THIS project only (the scoped wire, §5.2).
+      prompts.forEach((p, i) => {
+        if (p.status !== 'open') return;
+        const m = substringMatch(needle, p.prompt);
+        if (m === null) return;
+        hits.push({
+          en: {
+            id: `s-prompt-${p.id}`,
+            group: 'search-prompts',
+            label: p.prompt,
+            context: p.kind,
+            href: `${runPath(p.session_id)}${p.kind === 'gate' ? GATE_HASH : ''}`,
+            rank: i,
+            glyph: '✉',
+          },
+          m,
+        });
+      });
+      const searchOrder: Group[] = [
+        'search-runs', 'search-gates', 'search-decisions', 'search-repos', 'search-prompts',
+      ];
+      hits.sort((a, b) => {
+        const g = searchOrder.indexOf(a.en.group) - searchOrder.indexOf(b.en.group);
+        if (g !== 0) return g;
+        if (b.m.score !== a.m.score) return b.m.score - a.m.score;
+        return a.en.rank - b.en.rank;
+      });
+      return hits;
+    }
+
     const status = selectedRun?.session.status ?? '';
     const entries: Entry[] = [];
 
@@ -315,7 +538,7 @@ export function CommandPalette({
       return a.en.rank - b.en.rank;
     });
     return matched;
-  }, [runs, projects, repos, gates, scope, needle, runPath, navigate, projectId, selectedRun, onKill]);
+  }, [runs, projects, repos, gates, claims, prompts, projectNameByRun, scope, needle, runPath, navigate, projectId, selectedRun, onKill]);
 
   // Clamp the selection whenever the row set changes.
   const selIx = Math.min(sel, Math.max(0, rows.length - 1));
@@ -377,7 +600,8 @@ export function CommandPalette({
             data-testid="command-palette"
             className="wk-palette-in flex flex-col self-start overflow-hidden"
             style={{
-              width: 560,
+              // §5.2: search is the palette's deep mode — wider result rows.
+              width: searchMode ? 680 : 560,
               maxHeight: 420,
               background: 'var(--surface-overlay)',
               boxShadow: 'var(--shadow-overlay)',
@@ -399,7 +623,7 @@ export function CommandPalette({
                   setSel(0);
                 }}
                 onKeyDown={onKeyDown}
-                placeholder="type to search…  p: run: repo: >"
+                placeholder="type to search…  p: run: repo: > ?"
                 aria-label="Command palette search"
                 className="flex-1 bg-transparent outline-none"
                 style={{
@@ -415,6 +639,51 @@ export function CommandPalette({
                 esc
               </span>
             </div>
+
+            {/* §5.2/EC24: the corpus label is a first-class UI element, ALWAYS
+                visible in search mode — what IS and IS NOT searched, with the
+                wire truth one [why?] away. The not-searched clause earns the
+                attention color: an honesty marker. */}
+            {searchMode && (
+              <div
+                data-testid="search-corpus-label"
+                style={{
+                  padding: '6px 16px', flexShrink: 0,
+                  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-sans)',
+                  borderBottom: '1px solid var(--surface-raised)',
+                }}
+              >
+                <p style={{ margin: 0, color: 'var(--ink-dim)' }}>
+                  Searching: runs (all non-archived) · open gates · decisions (governance claims) · repos
+                  {projectId !== null ? ' · prompts: this project' : ''}
+                </p>
+                <p style={{ margin: 0, color: 'var(--status-gate)' }}>
+                  Not searched: archived runs, transcripts, historical events —{' '}
+                  <button
+                    type="button"
+                    data-testid="search-why"
+                    aria-expanded={showWhy}
+                    onClick={() => setShowWhy((v) => !v)}
+                    style={{
+                      background: 'transparent', border: 'none', padding: 0,
+                      color: 'var(--status-gate)', cursor: 'pointer',
+                      fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-sans)',
+                      textDecoration: 'underline',
+                    }}
+                  >
+                    [why?]
+                  </button>
+                </p>
+                {showWhy && (
+                  <p
+                    data-testid="search-why-popover"
+                    style={{ margin: '4px 0 0', color: 'var(--ink-muted)' }}
+                  >
+                    The crew daemon has no search index yet; the studio searches what it holds.
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* grouped results */}
             <div ref={listRef} role="listbox" aria-label="Palette results" className="flex-1 overflow-y-auto py-1">
@@ -439,7 +708,7 @@ export function CommandPalette({
                     activate(row);
                   },
                   onMouseEnter: () => setSel(i),
-                  className: 'flex w-full items-baseline gap-3 px-4 py-1.5 text-left',
+                  className: 'block w-full px-4 py-1.5 text-left',
                   style: {
                     background: i === selIx ? 'var(--accent-subtle)' : 'transparent',
                     outline: i === selIx ? '2px solid var(--accent)' : 'none',
@@ -448,23 +717,55 @@ export function CommandPalette({
                 } as const;
                 const body = (
                   <>
-                    <span
-                      className="min-w-0 flex-1 truncate"
-                      style={{
-                        fontSize: 'var(--text-sm)',
-                        fontFamily: 'var(--font-sans)',
-                        color: 'var(--ink-high)',
-                      }}
-                    >
-                      {row.en.group === 'verbs' ? '> ' : ''}
-                      {highlight(row.en.label, row.m.positions)}
+                    <span className="flex w-full min-w-0 items-baseline gap-3">
+                      {/* §5.2 hit anatomy: a status dot for runs, a glyph for
+                          gates/decisions/repos/prompts — before the label. */}
+                      {row.en.dot !== undefined && (
+                        <span
+                          aria-hidden
+                          style={{
+                            width: '6px', height: '6px', flexShrink: 0,
+                            borderRadius: 'var(--radius-full)', alignSelf: 'center',
+                            background: row.en.dot,
+                          }}
+                        />
+                      )}
+                      {row.en.glyph !== undefined && (
+                        <span aria-hidden className="shrink-0" style={{ color: 'var(--ink-dim)' }}>
+                          {row.en.glyph}
+                        </span>
+                      )}
+                      <span
+                        className="min-w-0 flex-1 truncate"
+                        style={{
+                          fontSize: 'var(--text-sm)',
+                          fontFamily: 'var(--font-sans)',
+                          color: 'var(--ink-high)',
+                        }}
+                      >
+                        {row.en.group === 'verbs' ? '> ' : ''}
+                        {highlight(row.en.label, row.m.positions)}
+                      </span>
+                      <span
+                        className="shrink-0 font-mono"
+                        style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}
+                      >
+                        {row.en.context}
+                      </span>
                     </span>
-                    <span
-                      className="shrink-0 font-mono"
-                      style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}
-                    >
-                      {row.en.context}
-                    </span>
+                    {/* §5.3: the snippet line — muted mono, matches in --ink-high. */}
+                    {row.en.snippet !== undefined && (
+                      <span
+                        data-testid="search-snippet"
+                        className="block w-full truncate"
+                        style={{
+                          fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+                          color: 'var(--ink-muted)',
+                        }}
+                      >
+                        {highlightSnippet(row.en.snippet, row.en.snippetPositions ?? [])}
+                      </span>
+                    )}
                   </>
                 );
                 return (

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -48,20 +48,32 @@ const CSS = {
     fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', textDecoration: 'none',
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
+  // Base ink lives on `.wk-feed-link` (global.css) so the §10.1 hover lift —
+  // --ink-body → --ink-high — can win; the failure line overrides it inline.
   line: {
-    fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)', color: 'var(--ink-body)',
+    fontFamily: 'var(--font-mono)', fontSize: 'var(--text-xs)',
     margin: '0 0 2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
 } as const satisfies Record<string, React.CSSProperties>;
 
-type Link = (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+/** Real-link props for a run's view (§10.1): href + in-app onClick. */
+type Link = (runId: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+
+/** Real-link props for an arbitrary path (the block header's project link). */
+type PathLink = (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
 
 /**
  * One moving run's narration window: the newest distinct lines of its active
  * unit's delta buffer, newest first; before any output has streamed, the run's
  * headline (§3.4(b)) — a truthful subject, never a blank block.
+ *
+ * Since slice J (DES-FEEDBACK-002 §10.1) every line is the same real link the
+ * failure line already was: an anchor to the run's view — middle-clickable,
+ * deep-linkable. The operator sees a run narrating and CAN click the words.
+ * No underline at rest (mono narration must not read as prose links); hover
+ * lifts the ink and fades in the ↗ at line-end (`.wk-feed-link`, global.css).
  */
-function RunLines({ view, max }: { view: SessionView; max: number }): React.ReactElement {
+function RunLines({ view, max, link }: { view: SessionView; max: number; link: Link }): React.ReactElement {
   const runId = view.session.id;
   const ord = activeUnit(view)?.ord ?? 0;
   const text = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
@@ -73,16 +85,18 @@ function RunLines({ view, max }: { view: SessionView; max: number }): React.Reac
       {shown.map((line) => (
         // Keyed by content: a NEW line remounts and plays the §1.6 fade-in once;
         // a repeated frame carrying the same status is the same element, no motion.
-        <p
+        <a
           key={line}
+          {...link(runId)}
           data-testid="feed-line"
           data-run-id={runId}
           title={line}
-          className="wk-feed-line"
+          className="wk-feed-line wk-feed-link"
           style={CSS.line}
         >
           {line}
-        </p>
+          <span aria-hidden className="wk-feed-goto">↗</span>
+        </a>
       ))}
     </>
   );
@@ -94,10 +108,13 @@ function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate 
   const failing = signal !== null && signal.kind === 'failing'
     ? runs.find((v) => v.session.status === 'failed')
     : undefined;
-  const link: Link = (path) => ({
+  const pathLink: PathLink = (path) => ({
     href: path,
     onClick: (e) => { e.preventDefault(); navigate(path); },
   });
+  // §10.1: MOVING runs are build runs today — the run-kind rule applies if the
+  // feed ever narrates a chat thread.
+  const runLink: Link = (runId) => pathLink(modePath(project.id, 'build', runId));
   return (
     <section
       data-testid={`live-feed-block-${project.id}`}
@@ -109,26 +126,30 @@ function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate 
           aria-hidden
           style={{ ...CSS.dot, background: signal !== null ? SIGNAL_BAR[signal.kind] : 'var(--ink-dim)' }}
         />
-        <a {...link(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
+        {/* The block header keeps its project-level link — two altitudes, both real. */}
+        <a {...pathLink(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
       </p>
       {moving.slice(0, MAX_RUNS).map((v, i) => (
-        <RunLines key={v.session.id} view={v} max={i === 0 ? MAX_LINES : 1} />
+        <RunLines key={v.session.id} view={v} max={i === 0 ? MAX_LINES : 1} link={runLink} />
       ))}
       {failing !== undefined && signal !== null && (
-        <p
+        // §10.1: the whole failure line is now the run link (anchors don't
+        // nest); `[open run]` stays as the visible affordance inside it.
+        <a
+          {...runLink(failing.session.id)}
           data-testid="feed-line"
           data-run-id={failing.session.id}
+          className="wk-feed-link"
           style={{ ...CSS.line, color: 'var(--status-fail)' }}
         >
           failed {ago(signal.at)} ago
-          <a
-            {...link(modePath(project.id, 'build', failing.session.id))}
+          <span
             data-testid="feed-open-run"
             style={{ marginLeft: '6px', color: 'var(--status-fail)', textDecoration: 'underline' }}
           >
             [open run]
-          </a>
-        </p>
+          </span>
+        </a>
       )}
     </section>
   );

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -95,7 +95,6 @@ function RunLines({ view, max, link }: { view: SessionView; max: number; link: L
           style={CSS.line}
         >
           {line}
-          <span aria-hidden className="wk-feed-goto">↗</span>
         </a>
       ))}
     </>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -9,6 +9,7 @@ import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
+import { getCachedRepos } from '../store/repoCache.js';
 import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
@@ -123,6 +124,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   // honest per-run clock this wire carries; `AgentSession` has no timestamps).
   const [memberKinds, setMemberKinds] = useState<Record<string, string>>({});
   const [attachedAt, setAttachedAt] = useState<Record<string, number>>({});
+  // Slice J (DES-FEEDBACK-002 §10.2): the same read already returns the
+  // project's `crew.repo` members — the wire grammar names the kind — and the
+  // RUN_KINDS filter used to drop them on the floor. Zero new requests.
+  const [repoRefs, setRepoRefs] = useState<string[]>([]);
   useEffect(() => {
     let cancelled = false;
     api.listProjectMembers(projectId)
@@ -130,13 +135,19 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         if (cancelled) return;
         const kinds: Record<string, string> = {};
         const at: Record<string, number> = {};
+        const repos: string[] = [];
         for (const m of members) {
+          if (m.member_kind === 'crew.repo') {
+            repos.push(m.member_ref);
+            continue;
+          }
           if (!RUN_KINDS.has(m.member_kind)) continue;
           kinds[m.member_ref] = m.member_kind;
           at[m.member_ref] = m.attached_at;
         }
         setMemberKinds(kinds);
         setAttachedAt(at);
+        setRepoRefs(repos);
       })
       .catch(() => { /* members unreadable — the tiles simply stay empty */ });
     return () => { cancelled = true; };
@@ -260,6 +271,36 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         <p style={CSS.meta} data-testid="dashboard-meta">
           last activity {ago(lastActivity)} ago · {openRuns.length} open {openRuns.length === 1 ? 'run' : 'runs'}
         </p>
+        {/* ── Slice J (§10.2): bound repos in the header's meta-line region —
+            not a fifth tile (the 2×2 grid is a load-bearing §4.1 shape). Names
+            resolve from the SAME session repo cache the palette holds (§1.4) —
+            never a fetch; an unresolvable ref renders the raw ref in --ink-dim
+            (membership is the truth even when the repo listing lags). Zero
+            repos = the row is absent (empty-state budget). ── */}
+        {repoRefs.length > 0 && (
+          <p data-testid="dashboard-repos" style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', margin: '6px 0 0' }}>
+            {repoRefs.map((ref) => {
+              const known = getCachedRepos()?.find((r) => r.id === ref || r.name === ref);
+              return (
+                <a
+                  key={ref}
+                  {...link(`/repo-detail/${encodeURIComponent(known?.id ?? ref)}`)}
+                  data-testid="dashboard-repo"
+                  data-repo-ref={ref}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: '4px',
+                    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+                    color: known !== undefined ? 'var(--ink-muted)' : 'var(--ink-dim)',
+                    textDecoration: 'none',
+                  }}
+                >
+                  <span aria-hidden>⬡</span>
+                  {known?.name ?? ref}
+                </a>
+              );
+            })}
+          </p>
+        )}
       </header>
 
       <div style={CSS.grid}>

--- a/src/components/ProjectShell.tsx
+++ b/src/components/ProjectShell.tsx
@@ -8,6 +8,7 @@ import {
 } from '../store/readiness.js';
 import { InstallGate } from './InstallGate.js';
 import { ModeSwitcher } from './ModeSwitcher.js';
+import { ProjectSwitcher } from './ProjectSwitcher.js';
 
 // The shell's breadcrumb bar is chrome (DES-VISION-001 §5.2: breadcrumb, mode
 // switcher, mode surface, connection status) — token-resolved per §2.11.
@@ -75,7 +76,8 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
     [navigate, projectId],
   );
 
-  const name = projects.find((p) => p.id === projectId)?.name ?? projectId;
+  const project = projects.find((p) => p.id === projectId) ?? null;
+  const name = project?.name ?? projectId;
 
   // ── The merged readiness model (§5.6, slice 17) ───────────────────────────
   usePreflight(projectId);
@@ -117,16 +119,40 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
         >
           ‹ Projects
         </button>
-        {/* The project name is CONTEXT, not the current focus (§4.2): muted ink,
-            and a real link — deep-linkable, middle-clickable — to the dashboard. */}
+        {/* The project name is CONTEXT, not the current focus (§4.2): muted ink —
+            and since slice J (DES-FEEDBACK-002 §4) it is the ProjectSwitcher's
+            trigger in the crumb dress: 1-click pivot to a sibling project
+            RETAINING the current mode verb. Selecting a sibling navigates to
+            `modePath(nextId, mode)` — the SAME verb, no artifact id (the
+            artifact belongs to the old project; carrying it would 404 or worse,
+            silently show the wrong project's run). Selecting the current
+            project is a no-op close. Zero requests: the projects store is
+            already warm (loaded above) — no `onOpen` is passed. */}
+        <ProjectSwitcher
+          variant="crumb"
+          triggerTestId="project-name"
+          current={project ?? { id: projectId, name, description: null, status: 'active', scope: '', created_at: 0, updated_at: 0 }}
+          projects={projects}
+          onSelect={(nextId) => {
+            if (nextId === null || nextId === projectId) return;
+            navigate(modePath(nextId, mode));
+          }}
+          dashboard={{
+            href: projectPath(projectId),
+            onGo: () => navigate(projectPath(projectId)),
+          }}
+        />
+        {/* The deep-linkable-real-link contract (DES-FEEDBACK-001 §4.2) the
+            name used to carry: a small ⌂ directly after it stays a REAL link —
+            middle-clickable — to the project dashboard. */}
         <a
-          data-testid="project-name"
+          data-testid="project-home"
           href={projectPath(projectId)}
           onClick={(e) => { e.preventDefault(); navigate(projectPath(projectId)); }}
           title={`${name} — project dashboard`}
-          style={{ ...CRUMB, color: S.muted, textDecoration: 'none', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          style={{ ...CRUMB, color: S.dim, textDecoration: 'none' }}
         >
-          {name}
+          ⌂
         </a>
         <span aria-hidden style={{ ...CRUMB, color: S.dim }}>›</span>
         <span data-testid="context-mode" style={{ ...CRUMB, color: S.ink }}>

--- a/src/components/ProjectSwitcher.tsx
+++ b/src/components/ProjectSwitcher.tsx
@@ -11,6 +11,17 @@ import type { Project } from '../api/types.js';
  * `onSelect(null)` means Unfiled — no `project_id` in the eventual POST body,
  * the backend default (§5.1). The component owns no data fetch: the caller
  * passes the projects it already has.
+ *
+ * Slice J (DES-FEEDBACK-002 §4) adds the header-flavored dress: a
+ * `variant="crumb"` trigger — SAME behavior, breadcrumb typography instead of
+ * the form-field box — for the project-context header's 1-click pivot. The
+ * crumb is a pivot between projects, not a binding field, so it renders no
+ * Unfiled row (Unfiled is not a project you can stand in) and marks the
+ * current project with a ✓; an optional `⌂ Project dashboard` last row keeps
+ * the dashboard reachable from the dropdown. The keyboard repair (§4.3) lands
+ * for EVERY call site: ArrowDown/ArrowUp walk the rows with real DOM focus
+ * (EC22 — the `--accent` ring rides `.wk-switcher-row` in global.css), and
+ * Escape closes and restores focus to the trigger.
  */
 
 interface Props {
@@ -31,12 +42,26 @@ interface Props {
   /** Open the list ABOVE the field — for fields docked at the viewport bottom
    *  (Chat's composer), where a downward list would fall below the fold. */
   dropUp?: boolean;
+  /** The trigger's dress (DES-FEEDBACK-002 §4.2): `field` is the slice-A/B
+   *  form-field box; `crumb` is the context header's breadcrumb typography —
+   *  same behavior, no Unfiled row, current project checked. */
+  variant?: 'field' | 'crumb';
+  /** The trigger's testid — the context header keeps `project-name` (§4.4). */
+  triggerTestId?: string;
+  /** When set, the dropdown's last row is `⌂ Project dashboard` — a real link
+   *  (`href`) that also navigates in-app via `onGo` (§4.2). */
+  dashboard?: { href: string; onGo: () => void };
 }
 
-export function ProjectSwitcher({ current, projects, onSelect, onNewProject, locked = false, onOpen, dropUp = false }: Props): React.ReactElement {
+export function ProjectSwitcher({
+  current, projects, onSelect, onNewProject, locked = false, onOpen, dropUp = false,
+  variant = 'field', triggerTestId = 'project-field', dashboard,
+}: Props): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -53,11 +78,38 @@ export function ProjectSwitcher({ current, projects, onSelect, onNewProject, loc
 
   const pick = (id: string | null): void => { onSelect(id); setOpen(false); setFilter(''); };
 
+  // §4.3's keyboard repair, every call site: the rows are real buttons/anchors,
+  // and the arrows move real DOM focus among them (EC22 — the cursor IS focus).
+  const onListKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+      setFilter('');
+      triggerRef.current?.focus();
+      return;
+    }
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const rows = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>('.wk-switcher-row') ?? [],
+    );
+    if (rows.length === 0) return;
+    const at = rows.findIndex((r) => r === document.activeElement);
+    const next = e.key === 'ArrowDown'
+      ? rows[Math.min(at + 1, rows.length - 1)]
+      : at <= 0 ? rows[0] : rows[at - 1];
+    next?.focus();
+  };
+
+  const crumb = variant === 'crumb';
+
   return (
-    <div ref={ref} className="relative inline-block" data-testid="project-switcher">
+    <div ref={ref} className="relative inline-block" data-testid="project-switcher" onKeyDown={onListKeyDown}>
       <button
+        ref={triggerRef}
         type="button"
-        data-testid="project-field"
+        data-testid={triggerTestId}
         data-locked={locked ? 'true' : 'false'}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -66,19 +118,36 @@ export function ProjectSwitcher({ current, projects, onSelect, onNewProject, loc
           if (!open) onOpen?.();
           setOpen(!open);
         }}
-        className="flex items-center gap-1 px-2 py-1 rounded text-xs transition-opacity hover:opacity-80"
-        style={{
-          background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)',
-          color: 'var(--ink-body)', fontFamily: 'var(--font-sans)',
-          cursor: locked ? 'default' : 'pointer',
-        }}
+        className={crumb
+          ? 'wk-crumb-trigger flex items-center gap-1 p-0'
+          : 'flex items-center gap-1 px-2 py-1 rounded text-xs transition-opacity hover:opacity-80'}
+        style={crumb
+          ? {
+              // The context header's CRUMB spec (§4.3): sans, sm, medium, muted —
+              // the exact dress the plain project-name link wore before slice J.
+              background: 'transparent', border: 'none',
+              fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-medium)',
+              fontFamily: 'var(--font-sans)', color: 'var(--ink-muted)',
+              cursor: locked ? 'default' : 'pointer',
+            }
+          : {
+              background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)',
+              color: 'var(--ink-body)', fontFamily: 'var(--font-sans)',
+              cursor: locked ? 'default' : 'pointer',
+            }}
       >
         <span className="truncate" style={{ maxWidth: '24ch' }}>{current?.name ?? 'Unfiled'}</span>
-        {!locked && <span aria-hidden style={{ color: 'var(--ink-dim)' }}>▾</span>}
+        {!locked && (
+          <span aria-hidden className={crumb ? 'wk-crumb-caret' : undefined}
+            style={{ color: crumb && open ? 'var(--ink-high)' : 'var(--ink-dim)' }}>
+            ▾
+          </span>
+        )}
       </button>
 
       {open && (
         <div
+          ref={listRef}
           role="listbox"
           data-testid="project-switcher-list"
           className={`absolute left-0 w-56 rounded-lg py-1 z-50 max-h-64 overflow-y-auto ${dropUp ? 'bottom-full mb-1' : 'top-full mt-1'}`}
@@ -99,42 +168,70 @@ export function ProjectSwitcher({ current, projects, onSelect, onNewProject, loc
               style={{ color: 'var(--ink-body)', borderColor: 'var(--ink-dim)', caretColor: 'var(--accent)' }}
             />
           </div>
-          <button
-            type="button"
-            role="option"
-            aria-selected={current === null}
-            data-testid="project-switcher-unfiled"
-            onClick={() => pick(null)}
-            className="w-full text-left px-3 py-1.5 text-xs font-mono transition-colors hover:bg-surface-card"
-            style={{ color: current === null ? 'var(--ink-high)' : 'var(--ink-muted)' }}
-          >
-            Unfiled
-          </button>
-          {visible.map((p) => (
+          {/* No Unfiled row in the crumb (§4.2): a pivot between projects, not a
+              binding field — Unfiled is not a project you can stand in. */}
+          {!crumb && (
             <button
-              key={p.id}
               type="button"
               role="option"
-              aria-selected={current?.id === p.id}
-              data-testid="project-switcher-option"
-              data-project-id={p.id}
-              onClick={() => pick(p.id)}
-              className="w-full text-left px-3 py-1.5 text-xs font-mono truncate transition-colors hover:bg-surface-card"
-              style={{ color: current?.id === p.id ? 'var(--ink-high)' : 'var(--ink-muted)' }}
+              aria-selected={current === null}
+              data-testid="project-switcher-unfiled"
+              onClick={() => pick(null)}
+              className="wk-switcher-row w-full text-left px-3 py-1.5 text-xs font-mono transition-colors hover:bg-surface-card"
+              style={{ color: current === null ? 'var(--ink-high)' : 'var(--ink-muted)' }}
             >
-              {p.name}
+              Unfiled
             </button>
-          ))}
+          )}
+          {visible.map((p) => {
+            const isCurrent = current?.id === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="option"
+                aria-selected={isCurrent}
+                data-testid="project-switcher-option"
+                data-project-id={p.id}
+                onClick={() => pick(p.id)}
+                className="wk-switcher-row w-full text-left px-3 py-1.5 text-xs font-mono truncate transition-colors hover:bg-surface-card"
+                style={{ color: isCurrent ? 'var(--ink-high)' : 'var(--ink-muted)' }}
+              >
+                {p.name}
+                {/* The current project renders with a ✓ (§4.2) — `--accent`,
+                    selecting it is a no-op close (the caller ignores same-id). */}
+                {crumb && isCurrent && (
+                  <span aria-hidden style={{ color: 'var(--accent)', marginLeft: '6px' }}>✓</span>
+                )}
+              </button>
+            );
+          })}
           {onNewProject !== undefined && (
             <button
               type="button"
               data-testid="project-switcher-add"
               onClick={() => { setOpen(false); onNewProject(); }}
-              className="w-full text-left px-3 py-1.5 text-xs font-mono transition-opacity hover:opacity-80"
+              className="wk-switcher-row w-full text-left px-3 py-1.5 text-xs font-mono transition-opacity hover:opacity-80"
               style={{ color: 'var(--accent)', borderTop: '1px solid var(--surface-card)' }}
             >
               + New project
             </button>
+          )}
+          {/* The dashboard link the name used to be does not vanish (§4.2): the
+              dropdown's last row keeps it — a REAL link, middle-clickable. */}
+          {dashboard !== undefined && (
+            <a
+              data-testid="switcher-dashboard-row"
+              href={dashboard.href}
+              onClick={(e) => { e.preventDefault(); setOpen(false); setFilter(''); dashboard.onGo(); }}
+              className="wk-switcher-row block w-full text-left px-3 py-1.5 text-xs font-mono transition-opacity hover:opacity-80"
+              style={{
+                color: 'var(--ink-muted)', textDecoration: 'none',
+                borderTop: '1px solid var(--surface-card)',
+              }}
+            >
+              ⌂ Project dashboard
+            </a>
           )}
         </div>
       )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -183,3 +183,24 @@ code, pre, .font-mono {
 /* Slice-H inline reject note (DES-FEEDBACK-002 §2.3/§2.5): the placeholder
    reads --ink-dim — a pseudo-element needs CSS, so the rule lives here. */
 .wk-reject-note::placeholder { color: var(--ink-dim); }
+
+/* Slice-J switcher keyboard repair (DES-FEEDBACK-002 §4.3, EC22): the arrows
+   move REAL DOM focus among the dropdown's rows, and focus wears the visible
+   --accent ring — the cursor is focus, on every ProjectSwitcher call site. */
+.wk-switcher-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Slice-J feed deep-links (DES-FEEDBACK-002 §10.1): every narration line is a
+   real link to its run. No underline at rest — mono narration must not read
+   as prose links — the affordance whisper is the hover ink lift plus an ↗
+   glyph fading in at --dur-instant at line-end. */
+.wk-feed-link       { color: var(--ink-body); text-decoration: none; display: block; }
+.wk-feed-link:hover { color: var(--ink-high); }
+.wk-feed-goto {
+  opacity: 0;
+  transition: opacity var(--dur-instant) var(--ease-out);
+  margin-left: 4px;
+}
+.wk-feed-link:hover .wk-feed-goto { opacity: 1; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -198,9 +198,12 @@ code, pre, .font-mono {
    glyph fading in at --dur-instant at line-end. */
 .wk-feed-link       { color: var(--ink-body); text-decoration: none; display: block; }
 .wk-feed-link:hover { color: var(--ink-high); }
-.wk-feed-goto {
+/* The ↗ is a pseudo-element on purpose: it never pollutes the line's
+   textContent (narration is data), and it costs no DOM. */
+.wk-feed-link::after {
+  content: '↗';
   opacity: 0;
   transition: opacity var(--dur-instant) var(--ease-out);
   margin-left: 4px;
 }
-.wk-feed-link:hover .wk-feed-goto { opacity: 1; }
+.wk-feed-link:hover::after { opacity: 1; }

--- a/tests/CommandPalette.search.test.tsx
+++ b/tests/CommandPalette.search.test.tsx
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GovernanceClaim, InteractionRequest } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * The palette's SEARCH mode (DES-FEEDBACK-002 §5, slice J): the `?` prefix is
+ * the deep mode — the EC24 corpus label always visible, the honest v1 corpus
+ * (runs / open gates / decisions / repos, prompts scoped to the current
+ * project), substring-on-prose + fuzzy-on-identifiers matching, and the §5.2
+ * request budget: at most two GETs on ENTRY, zero per keystroke, and never a
+ * request to any /search route.
+ */
+
+const listRepos = vi.fn();
+const listClaims = vi.fn();
+const listProjectPrompts = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: new Proxy(
+    {},
+    {
+      // EVERY api surface is a spy — the budget assertions are "nothing but
+      // the named calls fired", not a hand-picked subset.
+      get: (_t, prop) => {
+        const name = String(prop);
+        if (name === 'listRepos') return listRepos;
+        if (name === 'listClaims') return listClaims;
+        if (name === 'listProjectPrompts') return listProjectPrompts;
+        return calls(name);
+      },
+    },
+  ),
+}));
+
+const otherCalls = new Map<string, ReturnType<typeof vi.fn>>();
+function calls(prop: string): ReturnType<typeof vi.fn> {
+  let fn = otherCalls.get(prop);
+  if (fn === undefined) {
+    fn = vi.fn(() => Promise.resolve({}));
+    otherCalls.set(prop, fn);
+  }
+  return fn;
+}
+
+const { CommandPalette, clearPaletteRepoCache, substringMatch } = await import('../src/components/CommandPalette.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useGateStore } = await import('../src/store/gates.js');
+const { useMembershipStore } = await import('../src/store/membership.js');
+
+const RUNS = [
+  makeView({ id: 'r-gate', problem: 'migrate the auth tables', status: 'awaiting_human' }),
+  makeView({ id: 'r-live', problem: 'add rate-limiting to the upload endpoint', status: 'executing' }),
+  makeView({ id: 'r-done', problem: 'smoke the auth login flow', status: 'completed' }),
+];
+
+const CLAIMS: GovernanceClaim[] = [
+  {
+    claim_id: 'clm-1', scope: 'run:r-live', phase: 'build', policy_ids: ['pol-rate-limit'],
+    decision: 'allow', obligations: [], evaluated_context_ref: 'ctx-1',
+    criteria: 'rate-limiting middleware added before merge', evaluator_identity: 'conformance',
+    evaluated_at: 1,
+  },
+  {
+    claim_id: 'clm-2', scope: 'repo:studio-api', phase: 'design', policy_ids: ['pol-authz'],
+    decision: 'deny', obligations: [], evaluated_context_ref: 'ctx-2',
+    criteria: 'the migration lacks a rollback plan', evaluator_identity: 'conformance',
+    evaluated_at: 2,
+  },
+];
+
+const PROMPTS: InteractionRequest[] = [
+  {
+    id: 'ir-1', session_id: 'r-gate', kind: 'gate', ord: 0, reviewing_ord: null,
+    prompt: 'Approve the migration outline?', status: 'open', answer: null,
+    created_at: 1, resolved_at: null,
+  },
+  {
+    id: 'ir-2', session_id: 'r-done', kind: 'gate', ord: 0, reviewing_ord: null,
+    prompt: 'already answered — must not surface', status: 'answered', answer: '{}',
+    created_at: 1, resolved_at: 2,
+  },
+];
+
+function renderPalette(over: Partial<Parameters<typeof CommandPalette>[0]> = {}) {
+  const navigate = vi.fn();
+  const utils = render(
+    <CommandPalette
+      open
+      onClose={() => {}}
+      runs={RUNS}
+      navigate={navigate}
+      runPath={(id) => `/runs/${id}`}
+      projectId={null}
+      selectedRun={null}
+      onKill={() => {}}
+      {...over}
+    />,
+  );
+  return { navigate, ...utils };
+}
+
+function type(text: string): void {
+  fireEvent.change(screen.getByTestId('palette-input'), { target: { value: text } });
+}
+
+function rows(): HTMLElement[] {
+  return screen.queryAllByTestId('palette-row');
+}
+
+beforeEach(() => {
+  clearPaletteRepoCache();
+  listRepos.mockReset();
+  listClaims.mockReset();
+  listProjectPrompts.mockReset();
+  otherCalls.clear();
+  listRepos.mockResolvedValue({
+    repos: [{ id: 'studio-api', name: 'studio-api', root_path: '/x', default_branch: 'main', registered_at: 1 }],
+  });
+  listClaims.mockResolvedValue({ claims: CLAIMS });
+  listProjectPrompts.mockResolvedValue({ projectId: 'p1', prompts: PROMPTS });
+  useProjectsStore.setState({ projects: [] });
+  useGateStore.setState({
+    gates: {
+      'r-gate': { runId: 'r-gate', ord: 0, prompt: 'How should the tables move?', lifecycle: 'open', receivedAt: 5 },
+    },
+  });
+  useMembershipStore.setState({ projectNameByRun: { 'r-gate': 'api-migration', 'r-live': 'upload-endpoint' }, attachedAtByRun: {} });
+});
+afterEach(cleanup);
+
+describe('the EC24 corpus label (§5.2)', () => {
+  it('renders the always-visible label naming what IS and IS NOT searched — verbatim, archived runs included', async () => {
+    renderPalette();
+    type('?auth');
+    const label = screen.getByTestId('search-corpus-label');
+    expect(label.textContent).toContain(
+      'Searching: runs (all non-archived) · open gates · decisions (governance claims) · repos',
+    );
+    expect(label.textContent).toContain(
+      'Not searched: archived runs, transcripts, historical events —',
+    );
+    // Outside a project shell there is NO prompts clause — the scoped wire only.
+    expect(label.textContent).not.toContain('prompts: this project');
+    await waitFor(() => expect(listClaims).toHaveBeenCalledTimes(1));
+  });
+
+  it('the [why?] popover states the wire truth in one sentence', () => {
+    renderPalette();
+    type('?x');
+    expect(screen.queryByTestId('search-why-popover')).toBeNull();
+    fireEvent.click(screen.getByTestId('search-why'));
+    expect(screen.getByTestId('search-why-popover').textContent).toBe(
+      'The crew daemon has no search index yet; the studio searches what it holds.',
+    );
+  });
+
+  it('inside a project shell the label adds "prompts: this project" and the scoped wire fires once', async () => {
+    renderPalette({ projectId: 'p1' });
+    type('?migration');
+    expect(screen.getByTestId('search-corpus-label').textContent).toContain('prompts: this project');
+    await waitFor(() => expect(listProjectPrompts).toHaveBeenCalledTimes(1));
+    expect(listProjectPrompts).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('the request budget (§5.2/§5.5)', () => {
+  it('entering search mode fires GET /governance/claims once; ten keystrokes fire nothing further', async () => {
+    renderPalette();
+    type('?');
+    await waitFor(() => expect(listClaims).toHaveBeenCalledTimes(1));
+    for (const q of ['?a', '?au', '?aut', '?auth', '?auth ', '?auth t', '?auth ta', '?auth tab', '?auth tabl', '?auth table']) {
+      type(q);
+    }
+    await waitFor(() => rows().length >= 0);
+    expect(listClaims).toHaveBeenCalledTimes(1);
+    expect(listProjectPrompts).not.toHaveBeenCalled();
+    // The invented-wire guard: no /search anything, ever — every OTHER api
+    // surface is a spy and none fired.
+    for (const [name, fn] of otherCalls) {
+      expect(fn, name).not.toHaveBeenCalled();
+    }
+  });
+
+  it('outside a project no prompts request fires at all', async () => {
+    renderPalette({ projectId: null });
+    type('?anything');
+    await waitFor(() => expect(listClaims).toHaveBeenCalled());
+    expect(listProjectPrompts).not.toHaveBeenCalled();
+  });
+});
+
+describe('the corpus & matching (§5.1/§5.2)', () => {
+  it('substring on prose: run hits whose problem CONTAINS the needle, accent positions contiguous', () => {
+    expect(substringMatch('auth', 'migrate the auth tables')?.positions).toEqual([12, 13, 14, 15]);
+    expect(substringMatch('xyz', 'migrate the auth tables')).toBeNull();
+    // Subsequence would match 'mat' scattered — substring must NOT.
+    expect(substringMatch('mtt', 'migrate the tables')).toBeNull();
+  });
+
+  it('?auth returns run hits with project-name context, grouped under RUNS', async () => {
+    renderPalette();
+    type('?auth');
+    await waitFor(() => {
+      const runRows = rows().filter((r) => r.dataset.group === 'search-runs');
+      expect(runRows.length).toBe(2); // r-gate + r-done ('smoke the auth login flow')
+    });
+    const first = rows().find((r) => r.dataset.group === 'search-runs') as HTMLElement;
+    expect(first.textContent).toContain('migrate the auth tables');
+    expect(first.textContent).toContain('api-migration'); // the run's project
+    expect(first.getAttribute('href')).toBe('/runs/r-gate');
+  });
+
+  it('a word from an open gate prompt returns a gate hit that navigates to the run with #gate', async () => {
+    const { navigate } = renderPalette();
+    type('?tables move');
+    let gateRow: HTMLElement | undefined;
+    await waitFor(() => {
+      gateRow = rows().find((r) => r.dataset.group === 'search-gates');
+      expect(gateRow).toBeDefined();
+    });
+    expect(gateRow?.getAttribute('href')).toBe('/runs/r-gate#gate');
+    fireEvent.click(gateRow as HTMLElement);
+    expect(navigate).toHaveBeenCalledWith('/runs/r-gate#gate');
+  });
+
+  it('decisions: substring on the claim subject; the hit targets the run the claim names, else /policies', async () => {
+    renderPalette();
+    type('?rate-limiting middleware');
+    let hit: HTMLElement | undefined;
+    await waitFor(() => {
+      hit = rows().find((r) => r.dataset.group === 'search-decisions');
+      expect(hit).toBeDefined();
+    });
+    // clm-1 names run r-live in its scope — the hit goes to the run.
+    expect(hit?.getAttribute('href')).toBe('/runs/r-live');
+    expect(hit?.textContent).toContain('pol-rate-limit');
+    expect(hit?.textContent).toContain('allow');
+
+    type('?rollback plan');
+    await waitFor(() => {
+      const h = rows().find((r) => r.dataset.group === 'search-decisions');
+      // clm-2 names no run the client holds — the ledger surface answers.
+      expect(h?.getAttribute('href')).toBe('/policies');
+    });
+  });
+
+  it('repos match by the fuzzy scorer and open the repo page', async () => {
+    renderPalette();
+    type('?stapi'); // subsequence of studio-api — identifiers stay fuzzy
+    await waitFor(() => {
+      const repo = rows().find((r) => r.dataset.group === 'search-repos');
+      expect(repo?.getAttribute('href')).toBe('/repo-detail/studio-api');
+    });
+  });
+
+  it('scoped prompts: only OPEN prompts surface, targeting the run at its gate', async () => {
+    renderPalette({ projectId: 'p1' });
+    type('?migration outline');
+    let prompt: HTMLElement | undefined;
+    await waitFor(() => {
+      prompt = rows().find((r) => r.dataset.group === 'search-prompts');
+      expect(prompt).toBeDefined();
+    });
+    expect(prompt?.getAttribute('href')).toBe('/runs/r-gate#gate');
+    // The answered one never surfaces, whatever the needle.
+    type('?already answered');
+    await waitFor(() => {
+      expect(rows().find((r) => r.dataset.group === 'search-prompts')).toBeUndefined();
+    });
+  });
+
+  it('archived runs are excluded from the corpus — the label names them as not searched', async () => {
+    const archived = makeView({ id: 'r-arch', problem: 'archived auth spike', status: 'completed' });
+    archived.session.archived_at = 123;
+    renderPalette({ runs: [...RUNS, archived] });
+    type('?auth');
+    await waitFor(() => expect(rows().length).toBeGreaterThan(0));
+    expect(rows().some((r) => (r.getAttribute('href') ?? '').includes('r-arch'))).toBe(false);
+  });
+});
+
+describe('the seed (Cmd+Shift+F lands here, §5.2)', () => {
+  it('opening with seed="?" starts in search mode with the corpus label visible', () => {
+    renderPalette({ seed: '?' });
+    expect((screen.getByTestId('palette-input') as HTMLInputElement).value).toBe('?');
+    expect(screen.getByTestId('search-corpus-label')).toBeInTheDocument();
+  });
+});

--- a/tests/LiveFeed.test.tsx
+++ b/tests/LiveFeed.test.tsx
@@ -153,8 +153,32 @@ describe('LiveFeed — the home route heartbeat (vision slice 2)', () => {
     });
     const fresh = block('p-fresh') as HTMLElement;
     expect(fresh).toHaveTextContent(/failed \d+[smhd] ago/);
-    expect(within(fresh).getByTestId('feed-open-run'))
-      .toHaveAttribute('href', '/p/p-fresh/build/run-f');
+    // Slice J (DES-FEEDBACK-002 §10.1): the whole failure LINE is the run link
+    // now (anchors don't nest); [open run] stays as the visible affordance.
+    const failLine = within(fresh).getByTestId('feed-line');
+    expect(failLine.tagName).toBe('A');
+    expect(failLine).toHaveAttribute('href', '/p/p-fresh/build/run-f');
+    expect(within(failLine).getByTestId('feed-open-run')).toBeInTheDocument();
     expect(block('p-stale')).toBeNull();
+  });
+
+  it('every narration line is a real link to its run — href ends with data-run-id (§10.1, slice J)', async () => {
+    projects = [project('p-b')];
+    members = { 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-b')]);
+
+    push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'wiring the anchor\n' } as CoreEvent);
+
+    await vi.waitFor(() => {
+      expect(block('p-b') as HTMLElement).toHaveTextContent('wiring the anchor');
+    });
+    const lines = within(block('p-b') as HTMLElement).getAllByTestId('feed-line');
+    for (const line of lines) {
+      expect(line.tagName).toBe('A');
+      const runId = line.getAttribute('data-run-id') ?? '';
+      expect(runId).not.toBe('');
+      expect(line.getAttribute('href') ?? '').toMatch(new RegExp(`/${runId}$`));
+      expect(line.className).toContain('wk-feed-link');
+    }
   });
 });

--- a/tests/ProjectDashboard.test.tsx
+++ b/tests/ProjectDashboard.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
+import { clearRepoCache, fetchReposCached } from '../src/store/repoCache.js';
 import { useGateStore } from '../src/store/gates.js';
 import { useProjectsStore } from '../src/store/projects.js';
 import type { Project, ProjectMember, SessionStatus } from '../src/api/types.js';
@@ -14,12 +15,14 @@ import { makeUnit, makeView } from './factories.js';
 
 const listProjectMembers = vi.fn();
 const confirmGate = vi.fn();
+const listRepos = vi.fn();
 
 vi.mock('../src/api/client.js', () => ({
   api: {
     listProjects: () => Promise.resolve({ projects: [] }),
     listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
     confirmGate: (...a: unknown[]) => confirmGate(...a),
+    listRepos: (...a: unknown[]) => listRepos(...a),
   },
 }));
 
@@ -202,5 +205,54 @@ describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
     // Two buckets with counts ⇒ two bars; the max bucket (2) renders full height.
     expect(svg.querySelectorAll('rect')).toHaveLength(2);
     expect(screen.getByTestId('dashboard-activity')).toHaveTextContent('3 runs this week');
+  });
+});
+
+describe('bound repos row (DES-FEEDBACK-002 §10.2, slice J)', () => {
+  beforeEach(() => {
+    clearRepoCache();
+    listRepos.mockReset();
+    listRepos.mockResolvedValue({
+      repos: [{ id: 'studio-api', name: 'studio-api', root_path: '/x', default_branch: 'main', registered_at: 1 }],
+    });
+  });
+
+  it('a crew.repo member renders one chip linking to the repo page — name resolved from the warm §1.4 cache, ZERO new requests', async () => {
+    await fetchReposCached(); // the palette/rail gesture already warmed it
+    const fetchesBefore = listRepos.mock.calls.length;
+    listProjectMembers.mockResolvedValue({
+      members: [member('studio-api', 'crew.repo'), member('r-a', 'crew.run')],
+    });
+    render(<ProjectDashboard projectId="proj-1" runs={[run('r-a', 'executing')]} navigate={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-repos')).toBeInTheDocument());
+    const chips = screen.getAllByTestId('dashboard-repo');
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveAttribute('href', '/repo-detail/studio-api');
+    expect(chips[0]).toHaveTextContent('studio-api');
+    // Zero new requests: the SAME membership read, the SAME repo cache.
+    expect(listRepos.mock.calls.length).toBe(fetchesBefore);
+    // And the repo member never leaks into the runs tile.
+    expect(screen.getByTestId('dashboard-runs')).toHaveAttribute('data-count', '1');
+  });
+
+  it('a cold cache renders the raw ref in --ink-dim — membership is the truth, still a link, still no fetch', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('studio-api', 'crew.repo')] });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-repos')).toBeInTheDocument());
+    const chip = screen.getByTestId('dashboard-repo');
+    expect(chip).toHaveTextContent('studio-api'); // the raw ref
+    expect(chip).toHaveAttribute('href', '/repo-detail/studio-api');
+    expect((chip as HTMLElement).style.color).toBe('var(--ink-dim)');
+    expect(listRepos).not.toHaveBeenCalled();
+  });
+
+  it('with no crew.repo member the testid is ABSENT — the empty-state budget', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-a', 'crew.run')] });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
+    expect(screen.queryByTestId('dashboard-repos')).toBeNull();
   });
 });

--- a/tests/ProjectShell.test.tsx
+++ b/tests/ProjectShell.test.tsx
@@ -17,6 +17,10 @@ beforeEach(() => {
     projects: [{
       id: 'proj-1', name: 'Merge the skins', description: null, status: 'active',
       scope: 'project:proj-1', created_at: 1, updated_at: 1,
+    }, {
+      // The pivot target (slice J §4.2): a sibling the crumb switcher lists.
+      id: 'proj-2', name: 'The other project', description: null, status: 'active',
+      scope: 'project:proj-2', created_at: 1, updated_at: 2,
     }],
     loading: false,
     error: null,
@@ -104,17 +108,56 @@ describe('ProjectShell (DES-MERGE-001 §1.2)', () => {
     },
   );
 
-  it('the header project name links back to the project dashboard (§4.2)', () => {
+  // Superseded by DES-FEEDBACK-002 §4.2 (slice J): the name is now the
+  // ProjectSwitcher's trigger; the dashboard stays reachable two REAL ways —
+  // the ⌂ link right after the name, and the dropdown's last row.
+  it('the header keeps the dashboard reachable: the ⌂ real link and the dropdown row (§4.2, slice J)', () => {
     const navigate = vi.fn();
     render(
       <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={navigate}>
         <p>surface</p>
       </ProjectShell>,
     );
-    const crumb = screen.getByTestId('project-name');
-    expect(crumb).toHaveAttribute('href', '/p/proj-1');
-    fireEvent.click(crumb);
+    const home = screen.getByTestId('project-home');
+    expect(home).toHaveAttribute('href', '/p/proj-1');
+    fireEvent.click(home);
     expect(navigate).toHaveBeenCalledWith('/p/proj-1');
+
+    fireEvent.click(screen.getByTestId('project-name'));
+    const row = screen.getByTestId('switcher-dashboard-row');
+    expect(row).toHaveAttribute('href', '/p/proj-1');
+    fireEvent.click(row);
+    expect(navigate).toHaveBeenLastCalledWith('/p/proj-1');
+  });
+
+  it('the name is the mode-retaining pivot: choosing a sibling lands on ITS same mode verb, no artifact (§4.2/§4.4)', () => {
+    const navigate = vi.fn();
+    render(
+      <ProjectShell projectId="proj-1" mode="document" artifactId="doc-3" navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    fireEvent.click(screen.getByTestId('project-name'));
+    expect(screen.getByTestId('project-switcher-list')).toBeInTheDocument();
+    // No Unfiled row in the crumb — a pivot between projects, not a binding field.
+    expect(screen.queryByTestId('project-switcher-unfiled')).toBeNull();
+    fireEvent.click(screen.getByTestId('project-switcher-list')
+      .querySelector('[data-project-id="proj-2"]') as HTMLElement);
+    expect(navigate).toHaveBeenCalledWith('/p/proj-2/document');
+  });
+
+  it('selecting the CURRENT project is a no-op close (§4.2)', () => {
+    const navigate = vi.fn();
+    render(
+      <ProjectShell projectId="proj-1" mode="build" artifactId={null} navigate={navigate}>
+        <p>surface</p>
+      </ProjectShell>,
+    );
+    fireEvent.click(screen.getByTestId('project-name'));
+    fireEvent.click(screen.getByTestId('project-switcher-list')
+      .querySelector('[data-project-id="proj-1"]') as HTMLElement);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('project-switcher-list')).toBeNull();
   });
 
   it('no longer writes a last-used-mode memory — the dashboard replaced the redirect (slice D)', () => {

--- a/tests/ProjectSwitcher.crumb.test.tsx
+++ b/tests/ProjectSwitcher.crumb.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Project } from '../src/api/types.js';
+import { ProjectSwitcher } from '../src/components/ProjectSwitcher.js';
+
+/**
+ * The crumb variant + the keyboard repair (DES-FEEDBACK-002 §4, slice J):
+ * `variant="crumb"` is the context header's dress — same behavior, breadcrumb
+ * typography, NO Unfiled row (a pivot between projects, not a binding field),
+ * the current project checked, an optional real-link dashboard row. The
+ * keyboard repair benefits EVERY call site: arrows move real DOM focus among
+ * the rows (EC22), Escape closes and restores the trigger.
+ */
+
+afterEach(cleanup);
+
+function proj(id: string, name: string): Project {
+  return {
+    id, name, description: null, status: 'active',
+    scope: `project:${id}`, created_at: 1, updated_at: 1,
+  };
+}
+
+const PROJECTS = [proj('p1', 'api-migration'), proj('p2', 'q3-review-deck'), proj('default', 'Unfiled')];
+
+function renderCrumb(over: Partial<Parameters<typeof ProjectSwitcher>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onGo = vi.fn();
+  const utils = render(
+    <ProjectSwitcher
+      variant="crumb"
+      triggerTestId="project-name"
+      current={PROJECTS[0] as Project}
+      projects={PROJECTS}
+      onSelect={onSelect}
+      dashboard={{ href: '/p/p1', onGo }}
+      {...over}
+    />,
+  );
+  return { onSelect, onGo, ...utils };
+}
+
+describe('variant="crumb" (§4.2)', () => {
+  it('the trigger wears the crumb testid and the CRUMB type spec; clicking opens the list', () => {
+    renderCrumb();
+    const trigger = screen.getByTestId('project-name');
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger.style.fontSize).toBe('var(--text-sm)');
+    expect(trigger.style.fontWeight).toBe('var(--weight-medium)');
+    expect(trigger.style.color).toBe('var(--ink-muted)');
+    expect(trigger.textContent).toContain('api-migration');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('project-switcher-list')).toBeInTheDocument();
+  });
+
+  it('renders NO Unfiled row — a pivot between projects, not a binding field', () => {
+    renderCrumb();
+    fireEvent.click(screen.getByTestId('project-name'));
+    expect(screen.queryByTestId('project-switcher-unfiled')).toBeNull();
+    // And no "+ New project" — onNewProject is simply not passed by the header.
+    expect(screen.queryByTestId('project-switcher-add')).toBeNull();
+  });
+
+  it('the current project renders with the ✓ and aria-selected', () => {
+    renderCrumb();
+    fireEvent.click(screen.getByTestId('project-name'));
+    const rows = screen.getAllByTestId('project-switcher-option');
+    const current = rows.find((r) => r.dataset.projectId === 'p1') as HTMLElement;
+    expect(current.getAttribute('aria-selected')).toBe('true');
+    expect(current.textContent).toContain('✓');
+    const other = rows.find((r) => r.dataset.projectId === 'p2') as HTMLElement;
+    expect(other.textContent).not.toContain('✓');
+  });
+
+  it('the dashboard row is a REAL link that closes and navigates', () => {
+    const { onGo } = renderCrumb();
+    fireEvent.click(screen.getByTestId('project-name'));
+    const row = screen.getByTestId('switcher-dashboard-row');
+    expect(row.tagName).toBe('A');
+    expect(row).toHaveAttribute('href', '/p/p1');
+    fireEvent.click(row);
+    expect(onGo).toHaveBeenCalled();
+    expect(screen.queryByTestId('project-switcher-list')).toBeNull();
+  });
+
+  it('the field variant is untouched: Unfiled row present, no dashboard row unless passed', () => {
+    render(
+      <ProjectSwitcher current={null} projects={PROJECTS} onSelect={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId('project-field'));
+    expect(screen.getByTestId('project-switcher-unfiled')).toBeInTheDocument();
+    expect(screen.queryByTestId('switcher-dashboard-row')).toBeNull();
+  });
+});
+
+describe('the keyboard repair (§4.3, EC22 — every call site)', () => {
+  it('ArrowDown walks real DOM focus down the rows; ArrowUp walks back', () => {
+    renderCrumb();
+    fireEvent.click(screen.getByTestId('project-name'));
+    const list = screen.getByTestId('project-switcher-list');
+    const rows = Array.from(list.querySelectorAll<HTMLElement>('.wk-switcher-row'));
+    expect(rows.length).toBe(3); // p1, p2, dashboard row
+
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[0]);
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[1]);
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[2]);
+    // Clamped at the end.
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[2]);
+    fireEvent.keyDown(list, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(rows[1]);
+  });
+
+  it('Escape closes the list and restores focus to the trigger', () => {
+    renderCrumb();
+    const trigger = screen.getByTestId('project-name');
+    fireEvent.click(trigger);
+    const list = screen.getByTestId('project-switcher-list');
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    fireEvent.keyDown(list, { key: 'Escape' });
+    expect(screen.queryByTestId('project-switcher-list')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('a focused row activates on Enter (native button) — selecting a sibling pivots', () => {
+    const { onSelect } = renderCrumb();
+    fireEvent.click(screen.getByTestId('project-name'));
+    const list = screen.getByTestId('project-switcher-list');
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    // jsdom does not synthesize click from Enter on buttons — assert the row
+    // is a real <button> (Enter-activatable) and click it as the activation.
+    const focused = document.activeElement as HTMLElement;
+    expect(focused.tagName).toBe('BUTTON');
+    fireEvent.click(focused);
+    expect(onSelect).toHaveBeenCalledWith('p2');
+  });
+});


### PR DESCRIPTION
Round-3 operator feedback, P1-4 + P1-5 + the review's two gap notes, built against the round-4 supersession table (003 §8.6 leaves J behaviorally unaffected; §8.7 assigns it no rig rows).

## What changed

- **Header pivot (P1-4)**: the context-header project name is now the ProjectSwitcher in a `crumb` dress — one click pivots to a sibling project **retaining the mode verb** (artifact dropped), current project checked, no Unfiled row, a real-link `⌂ Project dashboard` row plus the ⌂ crumb glyph preserving the dashboard contract; the §4.3 keyboard repair (arrow-driven real focus with the accent ring, Escape restores) lands for every switcher call site. Zero requests on open.
- **Global search (P1-5)**: the palette's `?` deep mode (also Cmd+Shift+F via the one registry) over exactly the doc's honest corpus — non-archived runs, open gates, decisions (`GET /governance/claims` per gesture entry), repos, and in-shell scoped prompts (never fanned out) — with the **always-visible EC24 corpus label** (archived-runs caveat verbatim, wire-truth [why?] popover). Substring-on-prose + fuzzy-on-identifiers with match marks. No `/search` route exists; deferred FTS not built.
- **LiveFeed deep-links**: every feed line is a real anchor to the run's build view.
- **Dashboard repos**: `crew.repo` members render as ⬡ chips under the meta line with **zero added requests** (cold-load request sets byte-identical with the member on vs off), linking to `/repo-detail/:id`; cold caches honestly show the raw ref dim.

## Verification highlights

Independent Playwright: pivot from build AND document modes with zero API requests on open; the five search groups seeded and hit; exactly one claims GET on gesture, one scoped prompts GET in-shell, zero across keystrokes; feed click landed on the run's build view; negative check red on main at a functional pin. `feedback_sliceD`'s superseded name-click pin amended in a dedicated commit per §8.7's rule.

## Gates

eslint clean · tsc clean · vitest **1195/1195** · new rig `feedback2_sliceJ_test.py` + rigs M/N/Q/G/D green (plus prudence runs of H and vision_slice2). Known watch item: sliceG's `new_chat_verb` step flaked 1/5 on a timing race untouched by this slice (did not reproduce for the verifier).

Shots: `feedback2-J-crumb-pivot.png`, `feedback2-J-search-corpus.png`, `feedback2-J-dashboard-repos.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)