### PR TITLE
Slice K: chat grid/columns + document version compare (DES-FEEDBACK-002 §6–§7)

### DIFF
--- a/e2e/feedback2_sliceK_test.py
+++ b/e2e/feedback2_sliceK_test.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceK_test.py — the DES-FEEDBACK-002 slice-K gate: the chat
+grid/columns toggle (§6, P1-6) and the document version compare lens (§7, P2-7),
+proven in a real browser against the shared W2 fixture (`uxfix_fixture.py`).
+
+Same rig pattern as the slice-G/H/I/J gates: the deterministic fixture server
+serves the `dist-sameorigin/` build plus every endpoint the routes read; no crew
+daemon anywhere. The chat scene flips the NEW `chat_replies` switch (real
+chatReply / chatSessionFailed frame shapes over the one /ws — the daemon's
+fan-out, nothing invented); the document scene drives the REAL composer journey
+(create → continue → continue), so the multi-version manifest is grown exactly
+the way the bridge grows it.
+
+What it asserts (§6.5 + §7.5 DOM ACs, EC18 as amended by §12.1 and
+DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar):
+
+  Chat columns (§6.5):
+   1. First-run: no layout toggle (no replying seats yet). After a 3-seat round
+      the toggle appears; columns mode renders [data-testid="chat-round"] with
+      a [data-testid="chat-round-grid"] of data-columns="3".
+   2. The same seat's cells share a column index across rounds; a seat that
+      died between rounds (real chatSessionFailed) renders
+      [data-testid="chat-cell-empty"] in the next round — never a collapsed
+      column.
+   3. Toggling fires ZERO /api requests (C1), keeps the composer's focus and
+      draft, and Enter still sends from columns mode.
+
+  Version compare (§7.5):
+   4. On the 3-version doc, [data-testid="version-compare-toggle"] enters
+      compare: two [data-testid="compare-pane"] iframes, src ending /doc/3 and
+      /doc/2 (the lineage parent); the pane pair spans >80% viewport width
+      (EC18-as-region); the URL keeps ?v=3 throughout.
+   5. The vs: dropdown lists every OTHER version; picking v1 re-points ONLY the
+      right pane. Overlay stacks the two frames with the opacity slider.
+   6. The slice-F strip machinery survives compare: the strip auto-hides after
+      idle WITH TWO IFRAMES PRESENT and wakes on bottom proximity; the thread
+      drawer still opens/closes.
+   7. Exits: Escape returns to the solo canvas at the selected version; a strip
+      selection while comparing re-points the LEFT pane only; ✕ exits. Entering
+      compare adds no history entry.
+   8. On a fresh v1-only document the toggle is DISABLED with the stated reason.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-K-chat-columns.png    3-seat rounds side by side, one empty cell
+  feedback2-K-compare-split.png   v3 ↔ v2 split with the strip toolbar cluster
+  feedback2-K-compare-overlay.png overlay mode, slider at 50
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4347), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+W2_PORT = int(os.environ.get("W2_PORT", "4347"))
+ORIGIN = f"http://127.0.0.1:{W2_PORT}"
+CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
+DOC_URL = f"{ORIGIN}/p/scratch/document"
+VSHOTS = Path(__file__).resolve().parent / "shots" / "vision"
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def step(name: str, ok: bool, **detail) -> None:
+    report["steps"][name] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    fail("prereq", "python playwright missing — pip install playwright && playwright install chromium")
+
+dist = ensure_build(fail)
+start_server(W2_PORT, dist)
+set_fixture(ORIGIN, chat_replies=True)
+
+console_errors: list[str] = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    api_requests: list[str] = []
+    page.on(
+        "request",
+        lambda r: api_requests.append(f"{r.method} {urlparse(r.url).path}")
+        if "/api/v1/" in r.url else None,
+    )
+
+    # ══ Scene 1 — chat columns (§6.5) ═══════════════════════════════════════════
+    page.goto(CHAT_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # AC: no toggle before anything replied (a single/zero-seat chat has nothing
+    # to compare — the toggle would be dead chrome).
+    step("K1_toggle_absent_firstrun",
+         page.locator('[data-testid="chat-layout-toggle"]').count() == 0)
+
+    # Round 1: the first send warms the default trio; the fixture fans out one
+    # REAL chatReply per seat, then kills the last-warmed seat (chatSessionFailed).
+    composer = page.locator("textarea.wk-composer")
+    composer.fill("How should we refactor the fetch layer?")
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        """() => [...document.querySelectorAll('[data-testid="doc-canvas"], p, div')]
+                 .filter(el => el.childElementCount === 0 && (el.textContent || '').includes('(round 1)'))
+                 .length >= 3""",
+        timeout=30000)
+    # The dying seat's chip goes failed BEFORE round 2 (its title carries the reason).
+    page.locator('[title="session exited unexpectedly (fixture)"]').wait_for(timeout=30000)
+    step("K1_round1_replies", True)
+
+    # The toggle appeared (3 distinct replying seats). Type a draft, then switch
+    # layouts — the composer must keep focus AND the draft (§6.5), and the
+    # toggle must fire ZERO requests (C1).
+    page.locator('[data-testid="chat-layout-toggle"]').wait_for(timeout=30000)
+    composer.click()
+    composer.fill("a draft in progress")
+    before_toggle = list(api_requests)
+    page.locator('[data-testid="chat-layout-columns"]').click()
+    page.locator('[data-testid="chat-round-grid"]').wait_for(timeout=30000)
+    page.locator('[data-testid="chat-layout-list"]').click()
+    page.locator('[data-testid="chat-round-grid"]').wait_for(state="detached", timeout=30000)
+    page.locator('[data-testid="chat-layout-columns"]').click()
+    page.locator('[data-testid="chat-round-grid"]').wait_for(timeout=30000)
+    grid1 = page.evaluate(
+        """() => {
+             const grid = document.querySelector('[data-testid="chat-round-grid"]');
+             const composer = document.querySelector('textarea.wk-composer');
+             return {
+               columns: grid?.getAttribute('data-columns'),
+               agents: [...(grid?.children ?? [])].map(c => c.getAttribute('data-agent')),
+               draft: composer?.value,
+               focused: document.activeElement === composer,
+               rounds: document.querySelectorAll('[data-testid="chat-round"]').length,
+             };
+           }""")
+    step("K1_columns_grid",
+         grid1["columns"] == "3" and grid1["rounds"] == 1 and len(grid1["agents"]) == 3,
+         **grid1)
+    step("K1_toggle_zero_requests_keeps_draft",
+         api_requests == before_toggle
+         and grid1["draft"] == "a draft in progress" and grid1["focused"],
+         new_requests=[r for r in api_requests if r not in before_toggle])
+
+    # Round 2, sent FROM columns mode (Enter still sends — the toggle never
+    # intercepts composer keys): two live seats reply; the dead seat's column
+    # renders the dimmed EMPTY cell, and column indexes hold across rounds.
+    composer.fill("Which part ships first?")
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        """() => [...document.querySelectorAll('div,p')]
+                 .filter(el => el.childElementCount === 0 && (el.textContent || '').includes('(round 2)'))
+                 .length >= 2""",
+        timeout=30000)
+    rounds = page.evaluate(
+        """() => {
+             const grids = [...document.querySelectorAll('[data-testid="chat-round-grid"]')];
+             const empty = [...document.querySelectorAll('[data-testid="chat-cell-empty"]')];
+             return {
+               count: grids.length,
+               columns: grids.map(g => g.getAttribute('data-columns')),
+               agents: grids.map(g => [...g.children].map(c => c.getAttribute('data-agent'))),
+               emptyAgents: empty.map(e => e.getAttribute('data-agent')),
+               emptyInSecond: empty.length === 1 && grids[1]?.contains(empty[0]),
+               noHorizPageScroll: document.documentElement.scrollWidth
+                 <= document.documentElement.clientWidth,
+             };
+           }""")
+    step("K2_empty_cell_stable_columns",
+         rounds["count"] == 2 and rounds["columns"] == ["3", "3"]
+         and rounds["agents"][0] == rounds["agents"][1]
+         and rounds["emptyAgents"] == ["planner"] and rounds["emptyInSecond"]
+         and rounds["noHorizPageScroll"],
+         **rounds)
+    page.screenshot(path=str(VSHOTS / "feedback2-K-chat-columns.png"))
+
+    # ══ Scene 2 — version compare (§7.5) ════════════════════════════════════════
+    # Grow a REAL 3-version lineage through the composer (the W3 journey + one
+    # more continue): v1 from the brief, v2 and v3 as forks-with-steer.
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-picker-empty"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-composer"]').fill("Now rebalance the slide")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-canvas"][data-version="3"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
+    if "?v=3" not in page.url:
+        fail("K3_journey", f"expected the route at ?v=3 after the third landing, got {page.url}")
+
+    # Close the drawer: EC18 measures the canvas-first posture (drawer closed by
+    # default; this journey opened it on the picker and it survived — by design).
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread-drawer"]').wait_for(state="detached", timeout=30000)
+
+    # Enter compare from the strip toolbar (§7.2).
+    wake_strip(page)
+    history_before = page.evaluate("() => history.length")
+    page.locator('[data-testid="version-compare-toggle"]').click()
+    page.locator('[data-testid="compare-pane"]').first.wait_for(timeout=30000)
+    split = page.evaluate(
+        """() => {
+             const panes = [...document.querySelectorAll('[data-testid="compare-pane"]')];
+             const rects = panes.map(p => p.getBoundingClientRect());
+             const left = Math.min(...rects.map(r => r.left));
+             const right = Math.max(...rects.map(r => r.right));
+             return {
+               count: panes.length,
+               srcs: panes.map(p => new URL(p.src).pathname),
+               pairWidthFrac: (right - left) / window.innerWidth,
+               soloGone: !document.querySelector('[data-testid="doc-canvas"]'),
+               cluster: document.querySelector('[data-testid="compare-controls"]')?.textContent || '',
+               parentLabel: [...document.querySelectorAll('span')]
+                 .some(s => (s.textContent || '').trim() === 'v2 (parent)'),
+               url: location.search,
+             };
+           }""")
+    step("K3_compare_split",
+         split["count"] == 2
+         and split["srcs"][0].endswith("/doc/3") and split["srcs"][1].endswith("/doc/2")
+         and split["pairWidthFrac"] > 0.8 and split["soloGone"]
+         and "Comparing v3 ↔ v2" in split["cluster"] and split["parentLabel"]
+         and "v=3" in split["url"],
+         **split)
+    # No history entry was added by entering compare (a lens, not an address).
+    step("K3_no_history_entry",
+         page.evaluate("() => history.length") == history_before,
+         before=history_before, after=page.evaluate("() => history.length"))
+    wake_strip(page)
+    page.screenshot(path=str(VSHOTS / "feedback2-K-compare-split.png"))
+
+    # AC: vs: lists every OTHER version; picking v1 re-points ONLY the right pane.
+    wake_strip(page)
+    vs_options = page.evaluate(
+        """() => [...document.querySelector('[data-testid="compare-vs"]').options].map(o => o.value)""")
+    page.locator('[data-testid="compare-vs"]').select_option("1")
+    page.wait_for_function(
+        """() => {
+             const panes = [...document.querySelectorAll('[data-testid="compare-pane"]')];
+             return panes.length === 2
+               && new URL(panes[0].src).pathname.endsWith('/doc/3')
+               && new URL(panes[1].src).pathname.endsWith('/doc/1');
+           }""",
+        timeout=30000)
+    step("K4_vs_repoints_right_pane", vs_options == ["1", "2"], options=vs_options)
+    page.locator('[data-testid="compare-vs"]').select_option("2")
+
+    # AC: overlay — the same two URLs stacked, slider drives the TOP opacity.
+    wake_strip(page)
+    page.locator('[data-testid="compare-overlay-toggle"]').click()
+    page.locator('[data-testid="overlay-slider"]').wait_for(timeout=30000)
+    overlay = page.evaluate(
+        """() => {
+             const top = document.querySelector('[data-testid="compare-pane"][data-layer="top"]');
+             const under = document.querySelector('[data-testid="compare-pane"][data-layer="under"]');
+             return {
+               stacked: !!top && !!under
+                 && Math.abs(top.getBoundingClientRect().left - under.getBoundingClientRect().left) < 2,
+               topVersion: top?.getAttribute('data-version'),
+               topOpacity: top ? getComputedStyle(top).opacity : null,
+               underPointer: under ? getComputedStyle(under).pointerEvents : null,
+               slider: document.querySelector('[data-testid="overlay-slider"]')?.value,
+             };
+           }""")
+    step("K5_overlay",
+         overlay["stacked"] and overlay["topVersion"] == "2"
+         and overlay["topOpacity"] == "0.5" and overlay["underPointer"] == "none"
+         and overlay["slider"] == "50",
+         **overlay)
+    page.screenshot(path=str(VSHOTS / "feedback2-K-compare-overlay.png"))
+    # Moving the slider changes the top iframe's computed opacity.
+    page.locator('[data-testid="overlay-slider"]').fill("20")
+    page.wait_for_function(
+        """() => getComputedStyle(document.querySelector(
+                 '[data-testid="compare-pane"][data-layer="top"]')).opacity === '0.2'""",
+        timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="compare-overlay-toggle"]').click()
+    page.locator('[data-testid="compare-panes"]').wait_for(timeout=30000)
+
+    # AC 6: the slice-F strip machinery survives compare — the strip auto-hides
+    # after 3s idle WITH TWO IFRAMES PRESENT, and bottom proximity wakes it.
+    page.mouse.move(720, 300)
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="version-strip"]')
+                 ?.getAttribute('data-hidden') === 'true'""",
+        timeout=15000)
+    two_iframes = page.evaluate(
+        "() => document.querySelectorAll('[data-testid=\"compare-pane\"]').length")
+    wake_strip(page)  # asserts data-hidden flips back to 'false'
+    step("K6_strip_hides_and_wakes_in_compare", two_iframes == 2, iframes=two_iframes)
+
+    # …and the thread drawer still opens/closes over the pane pair.
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread-drawer"]').wait_for(timeout=30000)
+    drawer_panes = page.evaluate(
+        "() => document.querySelectorAll('[data-testid=\"compare-pane\"]').length")
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread-drawer"]').wait_for(state="detached", timeout=30000)
+    step("K6_drawer_works_in_compare", drawer_panes == 2, panes_while_open=drawer_panes)
+
+    # AC 7 exits. Escape → solo canvas at the selected version.
+    page.keyboard.press("Escape")
+    page.locator('[data-testid="doc-canvas"][data-version="3"]').wait_for(timeout=30000)
+    step("K7_escape_exits",
+         page.locator('[data-testid="compare-pane"]').count() == 0 and "?v=3" in page.url)
+    # A strip selection while comparing re-points the LEFT pane; the comparand stays.
+    wake_strip(page)
+    page.locator('[data-testid="version-compare-toggle"]').click()
+    page.locator('[data-testid="compare-pane"]').first.wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="version-entry"][data-version="1"] [data-testid="version-select"]').click()
+    page.wait_for_function(
+        """() => {
+             const panes = [...document.querySelectorAll('[data-testid="compare-pane"]')];
+             return panes.length === 2
+               && new URL(panes[0].src).pathname.endsWith('/doc/1')
+               && new URL(panes[1].src).pathname.endsWith('/doc/2');
+           }""",
+        timeout=30000)
+    step("K7_selection_repoints_left_pane", "?v=1" in page.url, url=page.url)
+    # ✕ exits too.
+    wake_strip(page)
+    page.locator('[data-testid="compare-exit"]').click()
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+    step("K7_x_exits", page.locator('[data-testid="compare-pane"]').count() == 0)
+
+    # The invented-wire guard (C1/§7.1): compare shipped on the two EXISTING
+    # version URLs — nothing under /interactive/ beyond the real bridge routes,
+    # and no /compare or /diff route was ever asked of anyone.
+    invented = [r for r in api_requests if "/compare" in r or "/diff" in r]
+    step("K8_zero_invented_wires", invented == [], invented=invented)
+
+    # AC 8: a fresh v1-only document disables the toggle WITH the stated reason.
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-picker"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-composer"]').fill("Write a one-pager on the rollout")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+    wake_strip(page)
+    v1only = page.evaluate(
+        """() => {
+             const t = document.querySelector('[data-testid="version-compare-toggle"]');
+             return { present: !!t, disabled: t?.disabled ?? false, title: t?.title || '' };
+           }""")
+    step("K9_v1_only_disabled_with_reason",
+         v1only["present"] and v1only["disabled"]
+         and v1only["title"] == "only one version exists",
+         **v1only)
+
+    # Zero console errors across both scenes (the standing rig hygiene bar).
+    step("K10_console_clean", console_errors == [], errors=console_errors[:5])
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-K-chat-columns.png"),
+    str(VSHOTS / "feedback2-K-compare-split.png"),
+    str(VSHOTS / "feedback2-K-compare-overlay.png"),
+]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -149,7 +149,16 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # theme-learn readback (interactive#181): how long after a successful
          # theme.requested the learned tokens become readable (the 404→200
          # ripening the studio poll rides). reset_learn clears learned state.
-         "learn_delay_s": 0.75}
+         "learn_delay_s": 0.75,
+         # Slice K (DES-FEEDBACK-002 §6): the multi-agent chat-reply drip.
+         # When on, POST /chats/<id>/messages queues one REAL chatReply frame
+         # per warm seat over /ws (the daemon's fan-out shape: type/chat/
+         # cliKey/text/ok), and after the FIRST round one seat dies with a
+         # real chatSessionFailed — so round 2's warm set shrinks and the
+         # columns grid has a true empty cell to render. Default False: the
+         # standing chat rigs (uxfix slice 4, feedback slice C) assert a
+         # fan-out with NO replies, and must keep seeing exactly that.
+         "chat_replies": False}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -743,6 +752,29 @@ docs_lock = threading.Lock()
 # pid -> docId -> [version entries, manifest-shaped]. Grown by create/fork below.
 docs_created: dict = {}
 
+# ── Slice K (DES-FEEDBACK-002 §6): per-chat reply bookkeeping ─────────────────
+# Which seats each fixture chat warmed, which have since failed, and how many
+# sends it has taken — so the switch-gated reply drip fans out to exactly the
+# seats the daemon would (warm minus failed), never to an invented roster.
+chat_state_lock = threading.Lock()
+chat_warm_seats: dict = {}   # chat_id -> [cliKey, warm order]
+chat_dead_seats: dict = {}   # chat_id -> set of cliKeys that chatSessionFailed
+chat_send_count: dict = {}   # chat_id -> number of message fan-outs so far
+
+# The reply prose per seat — short and distinct, so the columns screenshot reads
+# as three agents disagreeing about the same prompt, not lorem ipsum.
+CHAT_REPLY_LINES = {
+    "claude": "I'd extract the fetch layer first — the retries belong in one place.",
+    "codex": "Start by moving the types out; the refactor falls out of the seams.",
+    "agy": "The seam is the adapter here — invert it and the rest is mechanical.",
+    "pi": "Sketch the interface first; implementations follow.",
+    # The cold-cache fallback trio (DEFAULT_CHAT_AGENTS) — what a first-run
+    # chat warms when nothing has fetched the roster yet this session.
+    "writer": "Draft it end to end first; structure emerges from the prose.",
+    "reviewer": "Name the invariants before touching code — tests pin them.",
+    "planner": "Split it: fetch layer this week, the adapter swap next.",
+}
+
 ws_lock = threading.Lock()
 ws_queue: list = []
 # The NEWEST /ws connection owns the one-shot queues. A rig that navigates
@@ -751,6 +783,20 @@ ws_queue: list = []
 # the live page's socket (it drains before it writes, so the frames die with
 # it). Each connection takes a generation number; only the newest drains.
 ws_gen = [0]
+# Slice K: chat frames BROADCAST to every open /ws connection — the daemon fans
+# CoreEvents out to all subscribers, and the studio opens one socket per
+# useEventStream consumer (App's fold AND GroupChat's own), so newest-only
+# delivery would hand the chat frames to whichever socket connected last and
+# starve the surface that filters them by chat id. Each connection registers
+# its own queue on connect and removes it when its socket dies.
+ws_chat_queues: list = []
+
+
+def broadcast_chat(frame: dict) -> None:
+    """Queue one chat frame for EVERY live /ws connection (the daemon's fan-out)."""
+    with ws_lock:
+        for q in ws_chat_queues:
+            q.append(frame)
 
 
 def queue_interactive(event_type: str, payload: dict) -> None:
@@ -823,9 +869,11 @@ class W2Handler(SimpleHTTPRequestHandler):
             push_usage = state["usage_ws"]
             push_metrics = state["metrics_ws"]
             push_river = state["river"]
+        my_chat_queue: list = []
         with ws_lock:
             ws_gen[0] += 1
             my_gen = ws_gen[0]
+            ws_chat_queues.append(my_chat_queue)
         # Slice-E burn drip: the REAL cliUsage frame shape (costUsd dollars when
         # the CLI reports them, null when unknown — the null one must never fold
         # to $0), one frame per loop tick so the cumulative curve has more than
@@ -878,6 +926,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                         pending, ws_queue[:] = list(ws_queue), []
                 for frame in pending:
                     self.wfile.write(ws_frame(frame))
+                # Slice K: drain THIS connection's chat broadcast (every open
+                # socket gets these — see broadcast_chat above).
+                with ws_lock:
+                    chat_pending, my_chat_queue[:] = list(my_chat_queue), []
+                for frame in chat_pending:
+                    self.wfile.write(ws_frame(frame))
                 # Drain any one-shot narration lines a rig posted mid-page (vision
                 # slice 2: prove a NEW delta reaches the live feed within 2s).
                 extra: list = []
@@ -900,6 +954,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                 time.sleep(1.0)
         except OSError:
             pass
+        finally:
+            # A dead socket must stop receiving broadcasts — and must not pin
+            # frames other connections already consumed copies of.
+            with ws_lock:
+                if my_chat_queue in ws_chat_queues:
+                    ws_chat_queues.remove(my_chat_queue)
         self.close_connection = True
 
     def _api(self, path: str) -> bool:
@@ -1366,14 +1426,45 @@ class W2Handler(SimpleHTTPRequestHandler):
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
         if path == "/api/v1/chats":
             clis = body.get("clis") or [s["key"] for s in ROSTER]
+            chat_id = body.get("chatId") or "fixture-chat"
+            with chat_state_lock:
+                chat_warm_seats[chat_id] = list(clis)
+                chat_dead_seats.setdefault(chat_id, set())
+                chat_send_count.setdefault(chat_id, 0)
             return self._json(201, {
-                "chatId": body.get("chatId") or "fixture-chat",
+                "chatId": chat_id,
                 "seats": [{"cliKey": k, "ok": True} for k in clis],
             })
         # POST /api/v1/chats/<id>/messages — accept the fan-out; replies would
-        # stream over /ws, which this fixture leaves to the narration loop.
+        # stream over /ws, which this fixture leaves to the narration loop —
+        # UNLESS the slice-K `chat_replies` switch is on: then each send queues
+        # one REAL chatReply frame per live seat (the daemon's shape verbatim),
+        # and after round 1 the LAST-warmed seat dies with a chatSessionFailed,
+        # so the next round's warm set truly shrinks (the empty-cell case).
         parts = path.split("/")
         if len(parts) == 6 and parts[3] == "chats" and parts[5] == "messages":
+            with state_lock:
+                replies_on = state["chat_replies"]
+            if replies_on:
+                chat_id = urllib.parse.unquote(parts[4])
+                with chat_state_lock:
+                    warm = chat_warm_seats.get(chat_id, [])
+                    dead = chat_dead_seats.setdefault(chat_id, set())
+                    live = [k for k in warm if k not in dead]
+                    chat_send_count[chat_id] = chat_send_count.get(chat_id, 0) + 1
+                    round_n = chat_send_count[chat_id]
+                    kill = warm[-1] if round_n == 1 and len(warm) >= 2 else None
+                    if kill is not None:
+                        dead.add(kill)
+                for k in live:
+                    line = CHAT_REPLY_LINES.get(k, "Agreed — start small.")
+                    broadcast_chat({"type": "chatReply", "chat": chat_id,
+                                    "cliKey": k, "ok": True,
+                                    "text": f"{line} (round {round_n})"})
+                if kill is not None:
+                    broadcast_chat({"type": "chatSessionFailed", "chat": chat_id,
+                                    "cliKey": kill,
+                                    "reason": "session exited unexpectedly (fixture)"})
             return self._json(200, {"seats": []})
         return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
 

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { threadKey, useDocThreadStore } from '../store/docThread.js';
 import { FeedbackOverlay } from './FeedbackOverlay.js';
@@ -113,6 +114,61 @@ function resolveVersion(manifest: VersionManifest, routed: number | null): numbe
     : manifest.head;
 }
 
+// ── Version compare (DES-FEEDBACK-002 §7, slice K) ───────────────────────────
+//
+// Compare is a LENS, not an address (§7.2): the LEFT pane stays the `?v=N`
+// navigation exactly as today; the comparand is ephemeral component state, reset
+// on exit, never a history entry — so the back button after entering compare
+// exits to the prior ROUTE, and deep links never carry a comparand. Both panes
+// are two instances of the already-real version URL (`interactiveDocUrl` —
+// wire verdict EXISTS, §7.1): zero new routes, zero new requests beyond the
+// second pane's own document load.
+//
+// EC18 as amended (§12.1 + DES-FEEDBACK-003 §8.6): the two panes TOGETHER are
+// the canvas — they render inside the same canvas REGION the single iframe
+// owned (which ends above the fixed bottom bar), so the >80%-width measurement
+// holds for the pane pair, each pane narrower by the operator's explicit trade.
+
+/**
+ * §7.2's default comparand: the selected version's PARENT — the manifest's
+ * lineage pointer, because "v(N) vs v(N−1)" is lineage-parent, not
+ * ordinal-minus-one, and for forked documents those differ. With no usable
+ * parent (v1, or a parent the manifest no longer lists) the nearest OTHER
+ * version stands in — closest below first, else closest above. Null only when
+ * there is nothing else to compare against (§7.5: the v1-only disabled case).
+ */
+export function defaultComparand(manifest: VersionManifest, selected: number): number | null {
+  const entry = manifest.versions.find((v) => v.version === selected);
+  const parent = entry?.parent ?? null;
+  if (parent !== null && parent !== selected
+      && manifest.versions.some((v) => v.version === parent)) {
+    return parent;
+  }
+  const others = manifest.versions.map((v) => v.version).filter((v) => v !== selected);
+  if (others.length === 0) return null;
+  const below = others.filter((v) => v < selected);
+  return below.length > 0 ? Math.max(...below) : Math.min(...others);
+}
+
+/** Pane-header dress (§7.4): --text-2xs --font-mono; the selected version's dot
+ *  is --accent (the strip's addressed-version grammar), the comparand's muted. */
+function PaneHeader({ label, accent }: { label: string; accent: boolean }): React.ReactElement {
+  return (
+    <span style={{
+      alignItems: 'center', color: accent ? 'var(--ink-high)' : 'var(--ink-muted)',
+      display: 'inline-flex', flexShrink: 0, gap: '5px',
+      fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)', padding: '4px 8px',
+    }}>
+      <span style={{
+        background: accent ? 'var(--accent)' : 'var(--ink-muted)',
+        borderRadius: 'var(--radius-full)', display: 'inline-block',
+        flexShrink: 0, height: '6px', width: '6px',
+      }} />
+      {label}
+    </span>
+  );
+}
+
 function DocFrame({
   projectId, docId, version, navigate, threadOpen, onToggleThread, children,
 }: {
@@ -145,6 +201,37 @@ function DocFrame({
   // §7.3's strip presence: visible now, gone after 3s of idleness, back on proximity.
   const { hidden, wake } = useStripAutoHide();
 
+  // ── Compare state (DES-FEEDBACK-002 §7, slice K) — the lens, not an address ──
+  // `cmp` is the comparand version; null = solo canvas. The overlay refinement
+  // and its opacity are sub-state, reset with it on exit (§7.2).
+  const [cmp, setCmp] = useState<number | null>(null);
+  const [overlayOn, setOverlayOn] = useState(false);
+  const [overlayPct, setOverlayPct] = useState(50);
+  const cmpRef = useRef<number | null>(null);
+  cmpRef.current = cmp;
+  const exitCompare = (): void => {
+    setCmp(null);
+    setOverlayOn(false);
+    setOverlayPct(50);
+  };
+  // §7.2 exit paths: ✕ / the strip cluster — and Escape, registered through the
+  // ONE shortcut registry (EC21: no stray key listeners; the shared typing-context
+  // guard keeps the doc thread's composer keys untouched). The guard yields
+  // silently while not comparing, so later Escape entries (the runs sheet) still
+  // see the key.
+  const compareShortcuts = useMemo<ShortcutEntry[]>(() => [{
+    id: 'doc-compare-exit',
+    chord: { key: 'escape' },
+    description: 'Exit the version compare lens',
+    guard: () => cmpRef.current !== null,
+    handler: () => {
+      setCmp(null);
+      setOverlayOn(false);
+      setOverlayPct(50);
+    },
+  }], []);
+  useGlobalShortcuts(compareShortcuts);
+
   const subject = `“${docId}”`;
   // Failure / loading occupy the CANVAS pane only — the thread beside them stays up
   // (§1.2: the one conversation is always present), and with no manifest there is no
@@ -173,6 +260,22 @@ function DocFrame({
   // Version-addressed: the VersionStrip swaps this number through the route, nothing else.
   const src = interactiveDocUrl(projectId, docId, shown);
 
+  // The comparand the panes actually use, DERIVED each render: clicking a strip
+  // entry while comparing re-points the LEFT pane and keeps the comparand
+  // (§7.2) — unless the navigation lands ON the comparand (or a manifest
+  // re-read dropped it), where the default (lineage parent) stands in rather
+  // than comparing a version with itself.
+  const comparand = cmp === null
+    ? null
+    : cmp !== shown && manifest.versions.some((v) => v.version === cmp)
+      ? cmp
+      : defaultComparand(manifest, shown);
+  const comparing = comparand !== null;
+  // §7.5's disabled-with-reason: a v1-only document has nothing to compare.
+  const compareDisabledReason =
+    manifest.versions.length < 2 ? 'only one version exists' : null;
+  const parentOfShown = manifest.versions.find((v) => v.version === shown)?.parent ?? null;
+
   // A fork is committed by the service, so the strip re-reads the manifest (`retry`
   // is that same one load) and routes to the version the service reports — the UI
   // never invents the new version number or its parent.
@@ -194,41 +297,141 @@ function DocFrame({
           margin: '10px', background: 'var(--surface-base)',
         }}
       >
-      <iframe
-        // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
-        // src. Mutating it navigates the frame, and a frame navigation lands in the
-        // joint session history — so Back undid the frame's move rather than the route's
-        // (§4.2: the version lives in the URL, and Back must rewind it in one press).
-        // A freshly created frame's first load replaces its own entry instead.
-        key={shown}
-        ref={setFrameEl}
-        data-testid="doc-canvas"
-        data-doc-id={docId}
-        data-version={shown}
-        src={src}
-        title={`Document ${docId}, version ${shown}`}
-        onLoad={() => { setLoaded(true); setLoadNonce((n) => n + 1); }}
-        // §5.5, §7.3: `allow-scripts` because documents ARE interactive HTML, and NOTHING
-        // else. `allow-same-origin` is not "not yet" here — it is gone, and the overlay
-        // below is what made removing it possible. Pinned by a regression test.
-        sandbox="allow-scripts"
-        style={{ border: 'none', display: 'block', height: '100%', width: '100%' }}
-      />
-      {/* The frame is in the DOM while it loads, so the named status sits over it. */}
-      {loaded ? null : (
-        <div style={{ background: 'var(--surface-base)', inset: 0, position: 'absolute' }}>
-          <Loading surface="doc" subject={subject} />
+      {comparing ? (
+        // §7.2 the compare lens: the two panes TOGETHER are the canvas (EC18 as
+        // amended — same region, same >80% width the single iframe had). Split
+        // is the primary; overlay stacks the same two iframes. Both srcs are the
+        // already-real version URL — the §7.1 EXISTS verdict, zero new wires.
+        <div
+          data-testid={overlayOn ? 'compare-overlay' : 'compare-split'}
+          style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}
+        >
+          {overlayOn ? (
+            <>
+              {/* One header row: which version is on top, and the opacity slider
+                  (§7.2: the slider states which version is on top). Slider tokens
+                  (§7.4): thumb --accent via accentColor, track --surface-raised. */}
+              <div style={{
+                alignItems: 'center', display: 'flex', flexShrink: 0, gap: '10px',
+                justifyContent: 'center', padding: '0 8px',
+              }}>
+                <PaneHeader label={`v${shown} (selected, under)`} accent />
+                <PaneHeader
+                  label={`v${comparand} (${comparand === parentOfShown ? 'parent' : 'vs'}, on top)`}
+                  accent={false}
+                />
+                <input
+                  type="range"
+                  data-testid="overlay-slider"
+                  min={0}
+                  max={100}
+                  value={overlayPct}
+                  onChange={(e) => setOverlayPct(Number(e.target.value))}
+                  title={`v${comparand} opacity: ${overlayPct}%`}
+                  style={{ accentColor: 'var(--accent)', background: 'var(--surface-raised)', width: '160px' }}
+                />
+              </div>
+              <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+                {/* The under iframe takes no pointer events — they go to the top
+                    iframe only (§7.2). Keyed on version: a re-point REPLACES the
+                    element, never mutates src (the history rule the solo frame pins). */}
+                <iframe
+                  key={`under-${shown}`}
+                  data-testid="compare-pane"
+                  data-version={shown}
+                  data-layer="under"
+                  src={interactiveDocUrl(projectId, docId, shown)}
+                  title={`Document ${docId}, version ${shown}`}
+                  sandbox="allow-scripts"
+                  style={{ border: 'none', height: '100%', inset: 0, pointerEvents: 'none',
+                           position: 'absolute', width: '100%' }}
+                />
+                <iframe
+                  key={`top-${comparand}`}
+                  data-testid="compare-pane"
+                  data-version={comparand}
+                  data-layer="top"
+                  src={interactiveDocUrl(projectId, docId, comparand)}
+                  title={`Document ${docId}, version ${comparand}`}
+                  sandbox="allow-scripts"
+                  style={{ border: 'none', height: '100%', inset: 0, opacity: overlayPct / 100,
+                           position: 'absolute', width: '100%' }}
+                />
+              </div>
+            </>
+          ) : (
+            <div data-testid="compare-panes" style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+              <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0 }}>
+                <PaneHeader label={`v${shown} (selected)`} accent />
+                <iframe
+                  key={`left-${shown}`}
+                  data-testid="compare-pane"
+                  data-version={shown}
+                  src={interactiveDocUrl(projectId, docId, shown)}
+                  title={`Document ${docId}, version ${shown}`}
+                  sandbox="allow-scripts"
+                  style={{ border: 'none', display: 'block', flex: 1, width: '100%' }}
+                />
+              </div>
+              {/* §7.4 divider between the panes. */}
+              <div style={{ background: 'var(--surface-raised)', flexShrink: 0, width: '1px' }} />
+              <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0 }}>
+                <PaneHeader
+                  label={`v${comparand} (${comparand === parentOfShown ? 'parent' : 'vs'})`}
+                  accent={false}
+                />
+                <iframe
+                  key={`right-${comparand}`}
+                  data-testid="compare-pane"
+                  data-version={comparand}
+                  src={interactiveDocUrl(projectId, docId, comparand)}
+                  title={`Document ${docId}, version ${comparand}`}
+                  sandbox="allow-scripts"
+                  style={{ border: 'none', display: 'block', flex: 1, width: '100%' }}
+                />
+              </div>
+            </div>
+          )}
         </div>
+      ) : (
+        <>
+          <iframe
+            // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
+            // src. Mutating it navigates the frame, and a frame navigation lands in the
+            // joint session history — so Back undid the frame's move rather than the route's
+            // (§4.2: the version lives in the URL, and Back must rewind it in one press).
+            // A freshly created frame's first load replaces its own entry instead.
+            key={shown}
+            ref={setFrameEl}
+            data-testid="doc-canvas"
+            data-doc-id={docId}
+            data-version={shown}
+            src={src}
+            title={`Document ${docId}, version ${shown}`}
+            onLoad={() => { setLoaded(true); setLoadNonce((n) => n + 1); }}
+            // §5.5, §7.3: `allow-scripts` because documents ARE interactive HTML, and NOTHING
+            // else. `allow-same-origin` is not "not yet" here — it is gone, and the overlay
+            // below is what made removing it possible. Pinned by a regression test.
+            sandbox="allow-scripts"
+            style={{ border: 'none', display: 'block', height: '100%', width: '100%' }}
+          />
+          {/* The frame is in the DOM while it loads, so the named status sits over it. */}
+          {loaded ? null : (
+            <div style={{ background: 'var(--surface-base)', inset: 0, position: 'absolute' }}>
+              <Loading surface="doc" subject={subject} />
+            </div>
+          )}
+          {/* Point-and-comment (§4.3). A document whose bridge never answers leaves this
+              disabled-with-a-reason; the canvas above is unaffected either way. */}
+          <FeedbackOverlay
+            frame={frameEl}
+            loadNonce={loadNonce}
+            projectId={projectId}
+            docId={docId}
+            version={shown}
+          />
+        </>
       )}
-      {/* Point-and-comment (§4.3). A document whose bridge never answers leaves this
-          disabled-with-a-reason; the canvas above is unaffected either way. */}
-      <FeedbackOverlay
-        frame={frameEl}
-        loadNonce={loadNonce}
-        projectId={projectId}
-        docId={docId}
-        version={shown}
-      />
       {/* §7.3: while the strip is away, the bottom band listens for the mouse. */}
       <StripSensor hidden={hidden} wake={wake} />
       {/* pointerEvents none on the WRAPPER: the strip re-enables itself while visible;
@@ -244,6 +447,23 @@ function DocFrame({
           dimmed={hidden}
           onWake={wake}
           trailing={<ThreadToggle open={threadOpen} onToggle={onToggleThread} />}
+          // §7 (slice K): the strip WEARS the compare state this frame owns. The
+          // strip's auto-hide/wake and the thread drawer are untouched by compare
+          // — the panes live inside the same canvas container the sensor guards.
+          compare={{
+            active: comparing,
+            comparand,
+            disabledReason: compareDisabledReason,
+            overlay: overlayOn,
+            onToggle: () => {
+              if (comparing) { exitCompare(); return; }
+              const def = defaultComparand(manifest, shown);
+              if (def !== null) setCmp(def);
+            },
+            onComparand: setCmp,
+            onOverlay: setOverlayOn,
+            onExit: exitCompare,
+          }}
         />
       </div>
       </div>

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -102,18 +102,86 @@ function clearStoredChatId(repoId?: string | null): void {
   }
 }
 
-interface UserMsg {
+export interface UserMsg {
   kind: 'user';
   text: string;
 }
-interface SeatMsg {
+export interface SeatMsg {
   kind: 'seat';
   cliKey: string;
   text: string;
   pending: boolean;
   ok: boolean;
 }
-type Msg = UserMsg | SeatMsg;
+export type Msg = UserMsg | SeatMsg;
+
+// ── Chat layout: list vs columns (DES-FEEDBACK-002 §6, slice K) ──────────────
+//
+// A round = a user message plus every seat message before the next user message
+// (§6.1: the flat `messages` array already groups naturally — a send appends one
+// UserMsg then N pending SeatMsgs that fill in place). Columns mode re-renders
+// each round as a grid; the grouping below is PURE derivation over transcript
+// state — it can never fire a request (§6.3: the toggle reads and re-arranges
+// `messages` only).
+
+export type ChatLayout = 'list' | 'columns';
+
+export interface ChatRound {
+  user: UserMsg | null;
+  seats: SeatMsg[];
+}
+
+/** §6.1's grouping rule: a new round starts at each user message; replies to
+ *  DIFFERENT prompts (non-siblings) land in different rounds and stay linear —
+ *  only same-round (same-prompt) replies ever sit side by side. */
+export function groupRounds(messages: Msg[]): ChatRound[] {
+  const rounds: ChatRound[] = [];
+  for (const m of messages) {
+    if (m.kind === 'user') {
+      rounds.push({ user: m, seats: [] });
+    } else {
+      let last = rounds[rounds.length - 1];
+      if (last === undefined) {
+        // Defensive: a seat message with no user message before it (cannot
+        // happen via `send`, but the grouping must not throw on it).
+        last = { user: null, seats: [] };
+        rounds.push(last);
+      }
+      last.seats.push(m);
+    }
+  }
+  return rounds;
+}
+
+/** §6.2: column order is stable across rounds — first-seen seat order — so the
+ *  same agent is always in the same column. */
+export function seatColumnOrder(messages: Msg[]): string[] {
+  const order: string[] = [];
+  for (const m of messages) {
+    if (m.kind === 'seat' && !order.includes(m.cliKey)) order.push(m.cliKey);
+  }
+  return order;
+}
+
+/** §6.2: the choice persists per-session — a reading posture, not configuration,
+ *  so it is deliberately NOT a crew setting (a settings write would violate the
+ *  surface's request frugality). sessionStorage, wrapped like the chat id above:
+ *  private-mode browsers degrade to per-mount state, never to a broken surface. */
+const CHAT_LAYOUT_KEY = 'wicked.chat.layout';
+function readStoredLayout(): ChatLayout {
+  try {
+    return sessionStorage.getItem(CHAT_LAYOUT_KEY) === 'columns' ? 'columns' : 'list';
+  } catch {
+    return 'list';
+  }
+}
+function writeStoredLayout(layout: ChatLayout): void {
+  try {
+    sessionStorage.setItem(CHAT_LAYOUT_KEY, layout);
+  } catch {
+    /* non-fatal — see readStoredChatId */
+  }
+}
 
 interface Props {
   repoId?: string | null;
@@ -155,6 +223,16 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
+
+  // ── Transcript layout (DES-FEEDBACK-002 §6, slice K) ────────────────────────
+  // List is the default; columns re-arranges rounds side by side. Initialized
+  // synchronously from sessionStorage — reading it can never fire a request, and
+  // switching it touches nothing but how `messages` is rendered (§6.3).
+  const [layout, setLayout] = useState<ChatLayout>(readStoredLayout);
+  function chooseLayout(next: ChatLayout): void {
+    setLayout(next);
+    writeStoredLayout(next);
+  }
 
   // ── Default agent chips (DES-FEEDBACK-001 §6, slice C) ─────────────────────
   // The agents that will join on the first send: defaults (cached roster or
@@ -526,6 +604,90 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     </span>
   );
 
+  // §6.2: the toggle is visible only when the chat has ≥2 distinct REPLYING
+  // seats — a single-agent transcript has nothing to compare, and the toggle
+  // would be dead chrome. Derived from the transcript, zero requests.
+  const seatOrder = seatColumnOrder(messages);
+  const showLayoutToggle = seatOrder.length >= 2;
+  const rounds = layout === 'columns' ? groupRounds(messages) : [];
+
+  // §6.4: the segmented pair in the mode-switcher grammar — active segment
+  // --surface-raised + --ink-high, inactive --ink-muted.
+  const layoutSegment = (value: ChatLayout, glyph: string, label: string): React.ReactElement => (
+    <button
+      key={value}
+      type="button"
+      data-testid={`chat-layout-${value}`}
+      aria-pressed={layout === value}
+      title={value === 'columns'
+        ? 'Arrange each prompt’s agent replies side by side'
+        : 'Show the transcript as one linear column'}
+      // The composer must keep focus and its draft across a layout switch
+      // (§6.5): preventDefault on mousedown stops the click from stealing focus.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => chooseLayout(value)}
+      style={{
+        background: layout === value ? 'var(--surface-raised)' : 'transparent',
+        border: 'none',
+        borderRadius: 'var(--radius-md)',
+        color: layout === value ? 'var(--ink-high)' : 'var(--ink-muted)',
+        cursor: 'pointer',
+        fontFamily: 'var(--font-sans)',
+        fontSize: 'var(--text-2xs)',
+        lineHeight: 1.6,
+        padding: '1px 7px',
+      }}
+    >
+      {glyph} {label}
+    </button>
+  );
+
+  /** The list-mode bubbles, verbatim (§6.3: list mode is untouched); columns
+   *  mode reuses the same bubble tokens with the avatar promoted to a header. */
+  const userBubble = (m: UserMsg, key: React.Key): React.ReactElement => (
+    // §5.3 token usage: user messages are transparent — the hairline
+    // keeps the bubble shape without claiming a surface of its own.
+    <div
+      key={key}
+      className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
+      style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+    >
+      {m.text}
+    </div>
+  );
+
+  const bubbleBody = (m: SeatMsg): React.ReactElement => (
+    <div
+      // §5.3 token usage: agent bubbles sit on --surface-card; the
+      // border speaks status while a reply is pending or failed.
+      className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
+      style={{
+        background: 'var(--surface-card)',
+        border: `1px solid ${m.pending ? 'var(--status-run-dim)' : m.ok ? 'var(--surface-raised)' : 'var(--status-fail-dim)'}`,
+      }}
+    >
+      {m.pending && m.text === '' ? (
+        <span className="opacity-50 font-mono text-[11px] animate-pulse">thinking…</span>
+      ) : (
+        <Markdown>{m.text}</Markdown>
+      )}
+    </div>
+  );
+
+  /** §6.2 column header: the seat chip in the existing chip dress — monogram
+   *  avatar + cliKey, SEAT_CHIP tokens verbatim. */
+  const columnHeader = (cliKey: string): React.ReactElement => (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span
+        className="shrink-0 w-5 h-5 rounded-md flex items-center justify-center text-[9px] font-mono font-bold"
+        style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
+      >
+        {cliKey.slice(0, 2).toUpperCase()}
+      </span>
+      <span className="truncate text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>{cliKey}</span>
+    </span>
+  );
+
   const anyReady = Object.values(seats).some((st) => st === 'ready');
   // V8: a teardown control exists only once there is something armed to tear down —
   // warm agents, or a kept-on-error chat id the operator may want to disconnect.
@@ -557,6 +719,25 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         <div className="flex items-center gap-1.5 flex-wrap">
           {Object.entries(seats).map(([k, st]) => seatChip(k, st))}
         </div>
+        {/* §6.2: the layout toggle sits right of the seat chips — a two-state
+            segmented pair, present only with ≥2 distinct replying seats. */}
+        {showLayoutToggle && (
+          <div
+            data-testid="chat-layout-toggle"
+            data-layout={layout}
+            role="group"
+            aria-label="Transcript layout"
+            className="inline-flex items-center gap-0.5 shrink-0"
+            style={{
+              border: '1px solid var(--surface-raised)',
+              borderRadius: 'var(--radius-md)',
+              padding: '1px',
+            }}
+          >
+            {layoutSegment('list', '≡', 'list')}
+            {layoutSegment('columns', '⫼', 'columns')}
+          </div>
+        )}
         <div className="flex-1" />
         {closable && (
           <button
@@ -594,43 +775,74 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
             </p>
           </div>
         )}
-        {messages.map((m, i) =>
-          m.kind === 'user' ? (
-            // §5.3 token usage: user messages are transparent — the hairline
-            // keeps the bubble shape without claiming a surface of its own.
-            <div
-              key={i}
-              className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
-              style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
-            >
-              {m.text}
-            </div>
-          ) : (
-            <div key={i} className="self-start max-w-[80%] flex gap-2">
-              <span
-                className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-mono font-bold mt-0.5"
-                style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
-              >
-                {m.cliKey.slice(0, 2).toUpperCase()}
-              </span>
-              <div
-                // §5.3 token usage: agent bubbles sit on --surface-card; the
-                // border speaks status while a reply is pending or failed.
-                className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
-                style={{
-                  background: 'var(--surface-card)',
-                  border: `1px solid ${m.pending ? 'var(--status-run-dim)' : m.ok ? 'var(--surface-raised)' : 'var(--status-fail-dim)'}`,
-                }}
-              >
-                {m.pending && m.text === '' ? (
-                  <span className="opacity-50 font-mono text-[11px] animate-pulse">thinking…</span>
-                ) : (
-                  <Markdown>{m.text}</Markdown>
-                )}
+        {layout === 'columns' && showLayoutToggle
+          ? // §6.2 columns mode: each round renders its user bubble (unchanged)
+            // then a grid of the round's replies — one column per seat, order
+            // stable across rounds (first-seen), an empty dimmed cell where a
+            // seat did not answer this round (absence is information). The grid
+            // scrolls horizontally INSIDE its round container past 3 columns —
+            // the page never scrolls horizontally. No motion is added here, so
+            // the arrangement is reduced-motion safe by construction.
+            rounds.map((round, ri) => (
+              <div key={ri} data-testid="chat-round" className="flex flex-col gap-3">
+                {round.user !== null && userBubble(round.user, 'u')}
+                <div
+                  data-testid="chat-round-grid"
+                  data-columns={seatOrder.length}
+                  style={{
+                    display: 'grid',
+                    gap: '8px',
+                    gridTemplateColumns: `repeat(${seatOrder.length}, minmax(260px, 1fr))`,
+                    overflowX: 'auto',
+                  }}
+                >
+                  {seatOrder.map((cliKey) => {
+                    const reply = round.seats.find((s) => s.cliKey === cliKey);
+                    return reply === undefined ? (
+                      <div
+                        key={cliKey}
+                        data-testid="chat-cell-empty"
+                        data-agent={cliKey}
+                        className="flex flex-col gap-1.5 min-w-0"
+                      >
+                        {columnHeader(cliKey)}
+                        <div
+                          className="rounded-xl px-4 py-2 text-[13px] font-mono"
+                          style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
+                        >
+                          —
+                        </div>
+                      </div>
+                    ) : (
+                      <div
+                        key={cliKey}
+                        data-testid="chat-cell"
+                        data-agent={cliKey}
+                        className="flex flex-col gap-1.5 min-w-0"
+                      >
+                        {columnHeader(cliKey)}
+                        {bubbleBody(reply)}
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          ),
-        )}
+            ))
+          : messages.map((m, i) =>
+              m.kind === 'user' ? (
+                userBubble(m, i)
+              ) : (
+                <div key={i} className="self-start max-w-[80%] flex gap-2">
+                  <span
+                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-mono font-bold mt-0.5"
+                    style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
+                  >
+                    {m.cliKey.slice(0, 2).toUpperCase()}
+                  </span>
+                  {bubbleBody(m)}
+                </div>
+              ),
+            )}
         <div ref={bottomRef} />
       </div>
 

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -81,6 +81,39 @@ const ACTION: React.CSSProperties = {
   fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
 };
 
+/**
+ * The compare lens (DES-FEEDBACK-002 §7, slice K): the strip's toolbar carries the
+ * `[⇆ Compare]` toggle and, while comparing, the `v(N) ↔ v(M) · overlay · vs: · ✕`
+ * cluster. The strip only WEARS the state — the panes (and the state itself) are
+ * the canvas owner's (DocumentCanvas), because comparing is a lens on the canvas,
+ * not an address (§7.2: the left pane stays the `?v=N` navigation; the comparand
+ * is ephemeral UI state). Video mode never passes this prop, so the storyboard's
+ * strip is untouched.
+ */
+export interface CompareControl {
+  /** Comparing right now. */
+  active: boolean;
+  /** The right pane's version (null only while inactive). */
+  comparand: number | null;
+  /** §7.5/§7.6 disabled-with-reason: non-null renders the toggle disabled with
+   *  the reason as its title ("only one version exists" on a v1-only doc). */
+  disabledReason: string | null;
+  /** The `[▣ overlay]` sub-toggle inside compare (§7.2). */
+  overlay: boolean;
+  onToggle: () => void;
+  onComparand: (version: number) => void;
+  onOverlay: (on: boolean) => void;
+  onExit: () => void;
+}
+
+/** §6.4 segmented dress (shared by §7.4): active = --surface-raised + --ink-high,
+ *  inactive = --ink-muted; --radius-md. */
+const SEGMENT: React.CSSProperties = {
+  background: 'transparent', border: 'none', borderRadius: 'var(--radius-md)',
+  color: S.muted, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-2xs)', lineHeight: 1.6, padding: '1px 7px',
+};
+
 export interface VersionStripProps {
   projectId: string;
   docId: string;
@@ -100,11 +133,14 @@ export interface VersionStripProps {
   onWake?: (() => void) | undefined;
   /** The canvas-first chrome's extra control — the thread-drawer toggle (§7.3). */
   trailing?: React.ReactNode;
+  /** DES-FEEDBACK-002 §7 (slice K): the compare toggle/cluster. Absent = no
+   *  compare affordance (Video mode reuses the strip without one). */
+  compare?: CompareControl;
 }
 
 export function VersionStrip({
   projectId, docId, manifest, selected, navigate, onForked,
-  mode = 'document', dimmed = false, onWake, trailing,
+  mode = 'document', dimmed = false, onWake, trailing, compare,
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -278,6 +314,94 @@ export function VersionStrip({
       >
         selecting a version scrolls the thread to the message that made it ▸
       </span>
+
+      {/* DES-FEEDBACK-002 §7.2 (slice K): the compare toggle rides the toolbar
+          beside [Themes] [Export]. Inactive: one button (disabled with a stated
+          reason on a v1-only doc — §7.6's rule). Active: the comparing cluster —
+          what is compared, the overlay sub-toggle, the `vs:` comparand picker
+          (every OTHER version), and the ✕ exit. */}
+      {compare !== undefined && !compare.active && (
+        <button
+          type="button"
+          data-testid="version-compare-toggle"
+          disabled={compare.disabledReason !== null}
+          onClick={compare.onToggle}
+          title={compare.disabledReason
+            ?? `Compare v${selected} with another version side by side`}
+          style={{
+            ...ACTION,
+            alignSelf: 'center', flexShrink: 0,
+            cursor: compare.disabledReason !== null ? 'not-allowed' : 'pointer',
+            opacity: compare.disabledReason !== null ? 0.4 : 1,
+          }}
+        >
+          ⇆ Compare
+        </button>
+      )}
+      {compare !== undefined && compare.active && compare.comparand !== null && (
+        <span
+          data-testid="compare-controls"
+          style={{
+            alignItems: 'center', alignSelf: 'center',
+            border: `1px solid ${S.border}`, borderRadius: 'var(--radius-md)',
+            display: 'inline-flex', flexShrink: 0, gap: '6px', padding: '1px 6px',
+          }}
+        >
+          <span style={{
+            color: S.ink, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)',
+          }}>
+            ⇆ Comparing v{selected} ↔ v{compare.comparand}
+          </span>
+          <button
+            type="button"
+            data-testid="compare-overlay-toggle"
+            aria-pressed={compare.overlay}
+            onClick={() => compare.onOverlay(!compare.overlay)}
+            title={compare.overlay
+              ? 'Back to the side-by-side split'
+              : 'Stack the two versions with adjustable opacity — spot layout shifts'}
+            style={{
+              ...SEGMENT,
+              background: compare.overlay ? 'var(--surface-raised)' : 'transparent',
+              color: compare.overlay ? S.ink : S.muted,
+            }}
+          >
+            ▣ overlay
+          </button>
+          <label style={{
+            alignItems: 'center', color: S.faint, display: 'inline-flex', gap: '4px',
+            fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)',
+          }}>
+            vs:
+            <select
+              data-testid="compare-vs"
+              value={compare.comparand}
+              onChange={(e) => compare.onComparand(Number(e.target.value))}
+              title="Pick which version the right pane shows"
+              style={{
+                background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
+                borderRadius: 'var(--radius-sm)', color: S.ink,
+                fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)', padding: '0 2px',
+              }}
+            >
+              {[...manifest.versions].sort(byVersion)
+                .filter((e) => e.version !== selected)
+                .map((e) => (
+                  <option key={e.version} value={e.version}>v{e.version}</option>
+                ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            data-testid="compare-exit"
+            onClick={compare.onExit}
+            title="Exit compare — back to the solo canvas (Escape works too)"
+            style={{ ...SEGMENT, padding: '1px 4px' }}
+          >
+            ✕
+          </button>
+        </span>
+      )}
 
       {/* The canvas toolbar (§2.6 rule 4): [Themes] [Export], acting on the document. */}
       <ThemesMenu projectId={projectId} docId={docId} />

--- a/tests/DocumentCanvas.compare.test.tsx
+++ b/tests/DocumentCanvas.compare.test.tsx
@@ -1,0 +1,184 @@
+// DES-FEEDBACK-002 §7 (slice K) — the version compare lens.
+//
+// These pin the §7.5 ACs:
+//   - defaultComparand is the LINEAGE PARENT ("v(N) vs v(N−1)" is parent, not
+//     ordinal-minus-one — a forked v3 with parent v1 compares against v1);
+//   - the toggle is disabled WITH A REASON on a v1-only document;
+//   - entering compare renders two compare-pane iframes whose src end /doc/N
+//     and /doc/parent — two instances of the already-real version URL, no new
+//     routes (§7.1 EXISTS);
+//   - the vs: dropdown lists every OTHER version and re-points ONLY the right
+//     pane; overlay stacks the two iframes and the slider drives the top one's
+//     opacity;
+//   - every exit path (✕ / registry Escape / the toggle) returns to the solo
+//     canvas at the selected version, with the comparand state reset.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocumentCanvas, defaultComparand } from '../src/components/DocumentCanvas.js';
+import type { VersionManifest } from '../src/api/interactive.js';
+
+const PROJECT = 'proj-abc-123';
+const DOC = 'q3-report';
+
+function setLocation(url: string): void {
+  Object.defineProperty(window, 'location', {
+    value: new URL(url), writable: true, configurable: true,
+  });
+}
+
+function prodOrigin(): void {
+  vi.stubEnv('VITE_API_HOST', '');
+  setLocation('http://127.0.0.1:7788/');
+}
+
+type Reply = { status?: number; body: unknown };
+
+function stubFetch(routes: Record<string, Reply>): string[] {
+  const seen: string[] = [];
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    seen.push(url);
+    const hit = Object.entries(routes).find(([k]) => url.includes(k));
+    if (hit === undefined) return Promise.reject(new Error(`unrouted fetch: ${url}`));
+    const { status = 200, body } = hit[1];
+    return Promise.resolve({
+      ok: status >= 200 && status < 300, status, statusText: String(status),
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    });
+  }));
+  return seen;
+}
+
+function entry(version: number, parent: number | null) {
+  return { version, parent, feedback_file: null, html_file: `v${version}.html`,
+           created_at: `2026-08-1${version}T09:00:00Z` };
+}
+
+const LINEAR: VersionManifest = { head: 3, versions: [entry(1, null), entry(2, 1), entry(3, 2)] };
+const FORKED: VersionManifest = { head: 3, versions: [entry(1, null), entry(2, 1), entry(3, 1)] };
+const V1ONLY: VersionManifest = { head: 1, versions: [entry(1, null)] };
+
+beforeEach(prodOrigin);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// ── The default comparand, pure (§7.2) ───────────────────────────────────────
+
+describe('defaultComparand — lineage parent, not ordinal-minus-one', () => {
+  it('linear lineage: v3 defaults to its parent v2', () => {
+    expect(defaultComparand(LINEAR, 3)).toBe(2);
+  });
+
+  it('FORKED lineage: v3 with parent v1 defaults to v1 — the operator words are lineage', () => {
+    expect(defaultComparand(FORKED, 3)).toBe(1);
+  });
+
+  it('no parent (v1 selected among others): nearest OTHER version stands in', () => {
+    expect(defaultComparand(LINEAR, 1)).toBe(2);
+  });
+
+  it('v1-only document: nothing to compare — null (the disabled case)', () => {
+    expect(defaultComparand(V1ONLY, 1)).toBeNull();
+  });
+});
+
+// ── The component (§7.5) ─────────────────────────────────────────────────────
+
+async function mountDoc(manifest: VersionManifest, version: number | null = null) {
+  stubFetch({ '/api/versions': { body: manifest } });
+  const navigate = vi.fn();
+  render(<DocumentCanvas projectId={PROJECT} docId={DOC} version={version} navigate={navigate} />);
+  await screen.findByTestId('doc-canvas');
+  return navigate;
+}
+
+describe('DocumentCanvas compare (§7.5)', () => {
+  it('AC: on a v1-only document the toggle is DISABLED with the stated reason', async () => {
+    await mountDoc(V1ONLY);
+    const toggle = screen.getByTestId('version-compare-toggle');
+    expect((toggle as HTMLButtonElement).disabled).toBe(true);
+    expect(toggle.getAttribute('title')).toBe('only one version exists');
+  });
+
+  it('AC: entering compare renders two panes — /doc/3 (selected) and /doc/2 (parent)', async () => {
+    await mountDoc(LINEAR, 3);
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    const panes = screen.getAllByTestId('compare-pane');
+    expect(panes).toHaveLength(2);
+    expect(panes[0]!.getAttribute('src')).toMatch(/\/doc\/3$/);
+    expect(panes[1]!.getAttribute('src')).toMatch(/\/doc\/2$/);
+    // The solo canvas retired for the lens; the strip cluster names the pair.
+    expect(screen.queryByTestId('doc-canvas')).toBeNull();
+    expect(screen.getByTestId('compare-controls').textContent).toContain('Comparing v3 ↔ v2');
+    // The comparand header names the lineage relation.
+    expect(screen.getByText('v2 (parent)')).toBeTruthy();
+  });
+
+  it('AC: the vs: dropdown lists every OTHER version and re-points ONLY the right pane', async () => {
+    await mountDoc(LINEAR, 3);
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    const vs = screen.getByTestId('compare-vs') as HTMLSelectElement;
+    expect([...vs.options].map((o) => o.value)).toEqual(['1', '2']);
+    await userEvent.selectOptions(vs, '1');
+    const panes = screen.getAllByTestId('compare-pane');
+    expect(panes[0]!.getAttribute('src')).toMatch(/\/doc\/3$/); // left untouched
+    expect(panes[1]!.getAttribute('src')).toMatch(/\/doc\/1$/); // right re-pointed
+  });
+
+  it('AC: overlay stacks the two iframes; the slider drives the TOP frame opacity', async () => {
+    await mountDoc(LINEAR, 3);
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    await userEvent.click(screen.getByTestId('compare-overlay-toggle'));
+    const panes = screen.getAllByTestId('compare-pane');
+    expect(panes).toHaveLength(2);
+    const top = panes.find((p) => p.getAttribute('data-layer') === 'top')!;
+    const under = panes.find((p) => p.getAttribute('data-layer') === 'under')!;
+    expect(top.getAttribute('data-version')).toBe('2');
+    expect((top as HTMLIFrameElement).style.opacity).toBe('0.5'); // slider default 50
+    // Pointer events go to the top iframe only (§7.2).
+    expect((under as HTMLIFrameElement).style.pointerEvents).toBe('none');
+    const slider = screen.getByTestId('overlay-slider') as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: '20' } });
+    expect((screen.getAllByTestId('compare-pane')
+      .find((p) => p.getAttribute('data-layer') === 'top') as HTMLIFrameElement).style.opacity)
+      .toBe('0.2');
+  });
+
+  it('AC exit paths: ✕, registry Escape, and the toggle all return to the solo canvas', async () => {
+    await mountDoc(LINEAR, 3);
+    // ✕
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    await userEvent.click(screen.getByTestId('compare-exit'));
+    expect(screen.queryByTestId('compare-pane')).toBeNull();
+    expect(screen.getByTestId('doc-canvas').getAttribute('data-version')).toBe('3');
+    // Escape — through the ONE shortcut registry (EC21), so a focused input yields.
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    expect(screen.getAllByTestId('compare-pane')).toHaveLength(2);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('compare-pane')).toBeNull());
+    // Overlay state resets on exit (§7.2: reset on exit) — re-entering is split mode.
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    await userEvent.click(screen.getByTestId('compare-overlay-toggle'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('compare-pane')).toBeNull());
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    expect(screen.getByTestId('compare-split')).toBeTruthy();
+    expect(screen.queryByTestId('overlay-slider')).toBeNull();
+  });
+
+  it('Escape NEVER steals a typing context (the registry guard, EC21)', async () => {
+    await mountDoc(LINEAR, 3);
+    await userEvent.click(screen.getByTestId('version-compare-toggle'));
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    // Compare stays: the key belonged to the editable element.
+    expect(screen.getAllByTestId('compare-pane')).toHaveLength(2);
+    input.remove();
+  });
+});

--- a/tests/GroupChat.columns.test.tsx
+++ b/tests/GroupChat.columns.test.tsx
@@ -1,0 +1,210 @@
+// DES-FEEDBACK-002 §6 (slice K) — the chat grid/columns toggle.
+//
+// Operator: "GroupChat grid/columns toggle: side-by-side comparison when
+// multiple agents reply to the same prompt." These pin the §6.5 ACs:
+//   - the GROUPING RULE (§6.1): a round = one user message + every seat message
+//     before the next user message — 2 and 3 sibling replies group; interleaved
+//     non-siblings (replies to different prompts) stay in separate rounds;
+//   - the toggle is present only with ≥2 distinct replying seats, absent with 1;
+//   - columns mode renders chat-round / chat-round-grid with data-columns=N and
+//     STABLE per-seat column indexes across rounds; a seat absent from a round
+//     renders chat-cell-empty (absence is information, §6.2);
+//   - toggling fires ZERO network requests (C1) and keeps the composer's draft;
+//   - the choice persists per-session (sessionStorage), never a crew setting.
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  GroupChat, groupRounds, seatColumnOrder, type Msg,
+} from '../src/components/GroupChat.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const listProjects = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+/** Capture the event-stream fold so tests can land chat frames like /ws would. */
+let streamHandler: ((ev: unknown) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (cb: (ev: unknown) => void) => { streamHandler = cb; },
+}));
+
+const ALL_SPIES = { openChat, getChat, closeChat, getRoster, sendChatMessage, listProjects };
+
+function user(text: string): Msg { return { kind: 'user', text }; }
+function seat(cliKey: string, text = 'reply', pending = false): Msg {
+  return { kind: 'seat', cliKey, text, pending, ok: !pending };
+}
+
+function apiCallCount(): number {
+  return Object.values(ALL_SPIES).reduce((n, spy) => n + spy.mock.calls.length, 0);
+}
+
+beforeEach(() => {
+  for (const spy of Object.values(ALL_SPIES)) spy.mockReset();
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+  clearCachedRoster();
+  streamHandler = null;
+});
+afterEach(cleanup);
+
+// ── The grouping rule, pure (§6.1) ───────────────────────────────────────────
+
+describe('groupRounds — the §6.1 same-prompt grouping rule', () => {
+  it('AC: 2 sibling replies to one prompt land in ONE round', () => {
+    const rounds = groupRounds([user('p1'), seat('claude'), seat('codex')]);
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]!.user?.text).toBe('p1');
+    expect(rounds[0]!.seats.map((s) => s.cliKey)).toEqual(['claude', 'codex']);
+  });
+
+  it('AC: 3 sibling replies land in ONE round, in arrival order', () => {
+    const rounds = groupRounds([user('p1'), seat('claude'), seat('codex'), seat('agy')]);
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0]!.seats.map((s) => s.cliKey)).toEqual(['claude', 'codex', 'agy']);
+  });
+
+  it('AC: interleaved NON-siblings stay linear — replies to different prompts never merge', () => {
+    const rounds = groupRounds([
+      user('p1'), seat('claude'), seat('codex'),
+      user('p2'), seat('claude'),
+      user('p3'), seat('codex'), seat('agy'),
+    ]);
+    expect(rounds).toHaveLength(3);
+    expect(rounds[0]!.seats.map((s) => s.cliKey)).toEqual(['claude', 'codex']);
+    expect(rounds[1]!.seats.map((s) => s.cliKey)).toEqual(['claude']);
+    expect(rounds[2]!.seats.map((s) => s.cliKey)).toEqual(['codex', 'agy']);
+  });
+
+  it('column order is FIRST-SEEN and stable across rounds (§6.2)', () => {
+    const order = seatColumnOrder([
+      user('p1'), seat('codex'), seat('claude'),
+      user('p2'), seat('claude'), seat('codex'), seat('agy'),
+    ]);
+    expect(order).toEqual(['codex', 'claude', 'agy']);
+  });
+});
+
+// ── The component (§6.5) ─────────────────────────────────────────────────────
+
+/** First send with the given chip set warmed; replies land via the stream fold. */
+async function warmAndSend(prompt: string, seats: string[]): Promise<void> {
+  openChat.mockResolvedValue({ seats: seats.map((k) => ({ cliKey: k, ok: true })) });
+  const composer = screen.getByPlaceholderText(/Describe what you want/);
+  await userEvent.type(composer, prompt);
+  await userEvent.keyboard('{Enter}');
+  await waitFor(() => expect(sendChatMessage).toHaveBeenCalled());
+}
+
+function landReply(cliKey: string, text: string): void {
+  const chat = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+  act(() => { streamHandler?.({ type: 'chatReply', chat, cliKey, text, ok: true }); });
+}
+
+describe('GroupChat columns toggle (§6.5)', () => {
+  it('AC: with 1 replying seat the toggle is ABSENT; with 2 it appears', async () => {
+    setCachedRoster([{ key: 'solo' }] as unknown as RosterSeat[]);
+    render(<GroupChat repoId="repo-1" onBack={() => {}} />);
+    await warmAndSend('hello', ['solo']);
+    expect(screen.queryByTestId('chat-layout-toggle')).toBeNull();
+    cleanup();
+
+    for (const spy of Object.values(ALL_SPIES)) spy.mockReset();
+    sendChatMessage.mockResolvedValue({ seats: [] });
+    setCachedRoster([{ key: 'claude' }, { key: 'codex' }] as unknown as RosterSeat[]);
+    render(<GroupChat repoId="repo-2" onBack={() => {}} />);
+    await warmAndSend('hello', ['claude', 'codex']);
+    expect(screen.getByTestId('chat-layout-toggle')).toBeTruthy();
+  });
+
+  it('AC: columns mode renders rounds as grids — data-columns=3, stable column index, empty cell', async () => {
+    setCachedRoster([{ key: 'claude' }, { key: 'codex' }, { key: 'agy' }] as unknown as RosterSeat[]);
+    render(<GroupChat repoId="repo-3" onBack={() => {}} />);
+    await warmAndSend('round one', ['claude', 'codex', 'agy']);
+    landReply('claude', 'A1');
+    landReply('codex', 'B1');
+    landReply('agy', 'C1');
+    // agy's seat dies (a real chatSessionFailed frame) — round 2's warm set shrinks.
+    const chat = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    act(() => {
+      streamHandler?.({ type: 'chatSessionFailed', chat, cliKey: 'agy', reason: 'crashed' });
+    });
+    const composer = screen.getByPlaceholderText(/Describe what you want/);
+    await userEvent.type(composer, 'round two');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+    landReply('claude', 'A2');
+    landReply('codex', 'B2');
+
+    await userEvent.click(screen.getByTestId('chat-layout-columns'));
+    const roundEls = screen.getAllByTestId('chat-round');
+    expect(roundEls).toHaveLength(2);
+    const grids = screen.getAllByTestId('chat-round-grid');
+    expect(grids.map((g) => g.getAttribute('data-columns'))).toEqual(['3', '3']);
+    // The same seat's cells share a column index across rounds (§6.2).
+    const cellsOf = (grid: HTMLElement): (string | null)[] =>
+      [...grid.children].map((c) => c.getAttribute('data-agent'));
+    expect(cellsOf(grids[0]!)).toEqual(['claude', 'codex', 'agy']);
+    expect(cellsOf(grids[1]!)).toEqual(['claude', 'codex', 'agy']);
+    // Round 2's agy column is the dimmed EMPTY cell, not a collapsed column.
+    const empty = screen.getAllByTestId('chat-cell-empty');
+    expect(empty).toHaveLength(1);
+    expect(empty[0]!.getAttribute('data-agent')).toBe('agy');
+    expect(grids[1]!.contains(empty[0]!)).toBe(true);
+    // A pending cell keeps the pulse: round 3, replies not yet landed.
+    await userEvent.type(composer, 'round three');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(3));
+    expect(screen.getAllByText('thinking…').length).toBeGreaterThan(0);
+  });
+
+  it('AC: toggling fires ZERO requests, keeps the composer draft, and persists per-session', async () => {
+    setCachedRoster([{ key: 'claude' }, { key: 'codex' }] as unknown as RosterSeat[]);
+    render(<GroupChat repoId="repo-4" onBack={() => {}} />);
+    await warmAndSend('prompt', ['claude', 'codex']);
+    landReply('claude', 'A');
+    landReply('codex', 'B');
+
+    const composer = screen.getByPlaceholderText(/Describe what you want/) as HTMLTextAreaElement;
+    await userEvent.type(composer, 'a draft in progress');
+    const before = apiCallCount();
+    await userEvent.click(screen.getByTestId('chat-layout-columns'));
+    expect(screen.getByTestId('chat-layout-toggle').getAttribute('data-layout')).toBe('columns');
+    await userEvent.click(screen.getByTestId('chat-layout-list'));
+    await userEvent.click(screen.getByTestId('chat-layout-columns'));
+    // C1: the toggle reads and re-arranges `messages` state only — zero requests.
+    expect(apiCallCount()).toBe(before);
+    // §6.5: the composer keeps its draft text across the switches.
+    expect(composer.value).toBe('a draft in progress');
+    // §6.2: a reading posture persisted per-session — sessionStorage, no settings write.
+    expect(sessionStorage.getItem('wicked.chat.layout')).toBe('columns');
+    // List mode is the untouched default rendering: switching back re-linearizes.
+    await userEvent.click(screen.getByTestId('chat-layout-list'));
+    expect(screen.queryByTestId('chat-round-grid')).toBeNull();
+  });
+
+  it('a stored columns preference survives a remount (per-session, §6.2)', async () => {
+    sessionStorage.setItem('wicked.chat.layout', 'columns');
+    setCachedRoster([{ key: 'claude' }, { key: 'codex' }] as unknown as RosterSeat[]);
+    render(<GroupChat repoId="repo-5" onBack={() => {}} />);
+    await warmAndSend('prompt', ['claude', 'codex']);
+    expect(screen.getByTestId('chat-round-grid')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Round-3 operator feedback, P1-6 + P2-7: side-by-side comparison of simultaneous agent replies, and a `[Compare: v(N) vs v(N-1)]` toggle in the version strip.

## What changed

- **Chat columns (§6)**: a `[≡ list][⫼ columns]` toggle (visible at ≥2 replying seats) arranges sibling replies to the same prompt as side-by-side columns per round — stable first-seen seat order, dimmed empty cells for seats absent from a round, session-local persistence (`sessionStorage`, deliberately not a crew setting), composer keeps focus and draft, zero requests. List mode renders byte-identically.
- **Version compare (§7, EC18 as amended)**: `[⇆ Compare]` in the strip toolbar (disabled at v1) splits the canvas into two `interactiveDocUrl` iframes — the selection vs its **lineage parent** (forked docs compare against their parent, not ordinal−1), a `vs:` dropdown re-points the right pane, strip selection re-points the left, an `[▣ overlay]` sub-mode stacks the frames with an opacity slider; exits via ✕/Escape (registry-routed, typing-guarded)/toggle; no history entries; strip auto-hide + wake and the thread drawer proven working with two iframes present.
- Fixture fix that mattered: the studio opens one WebSocket per consumer, and the fixture's newest-connection-only drain starved GroupChat's socket — chat frames now broadcast per-connection, mirroring the daemon's real fan-out (all prior rigs still green).

## Verification highlights

Independent geometry: sibling cells share a top edge with non-overlapping x-ranges and stable cross-round column alignment; pane-pair at 94.6% of viewport with the region ending above the fixed bottom bar; the slice-F strip wake driven by hand with both iframes present; Escape in the composer does NOT exit compare while Escape outside does; entering compare adds no history entry. Negative check red on main.

**Packaging note**: ~494 production LOC vs the ≤350/PR budget — the verifier asked for a two-PR split or a waiver. Claiming the standing waiver by this arc's precedent (M/N/O/P/Q all landed as single disclosed PRs); the commits partition cleanly by surface (columns 194 / compare ~300) and can be split on request.

## Gates

eslint clean · tsc clean · vitest **1213/1213** (18 new) · new rig `feedback2_sliceK_test.py` (18 steps) + `feedback_sliceC`, `uxfix_slice6`, `feedback3_sliceN`, `feedback2_sliceG` (and `feedback_sliceB`) all PASS. 003 §8.7 assigns K no rig amendments.

Shots: `feedback2-K-chat-columns.png`, `feedback2-K-compare-split.png`, `feedback2-K-compare-overlay.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)