### PR TITLE
Slice L: desktop gate notifications + batch gate resolution (DES-FEEDBACK-002 §8–§9) — backlog complete

### DIFF
--- a/e2e/feedback2_sliceL_test.py
+++ b/e2e/feedback2_sliceL_test.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""
+feedback2_sliceL_test.py — the DES-FEEDBACK-002 slice-L gate: desktop
+notifications + chime (§8, P2-8) and batch gate resolution (§9, P2-9),
+against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py).
+
+The §8.4 DOM ACs (notifications):
+  1. on app load with no stored pref: ZERO `Notification.requestPermission`
+     calls (EC25 — the API is tapped by an init script BEFORE load);
+  2. selecting the desktop option calls `requestPermission` exactly once;
+     with the context permission granted, `PUT /settings` fires with the
+     `studio.notifications` key (request tap);
+  3. with prefs on + permission granted + the document forced hidden, an
+     injected `awaitingHuman` frame constructs ONE Notification with
+     `tag` = the run id; a REPLAY of the same frame (same run + ord)
+     constructs none (the reconnect-replay de-dupe); a LATER gate (new ord)
+     constructs one more with the SAME tag (no unbounded stack);
+  4. with the tab visible+focused, the same frame constructs zero;
+  5. with chime on, the notification path creates an `AudioContext`
+     (stub-asserted); the notification click focuses the window and lands on
+     the run thread with the one-shot `#gate` intent;
+  6. a settings blob without the key yields defaults (Off) — no crash,
+     no prompt.
+
+The §9.5 DOM ACs (batch): 3 simple gates in the fixture (`batch_gates`);
+cursor + `x` on two renders `[data-testid="batch-bar"]` `data-count="2"`;
+Approve all fires exactly two sequential `POST /runs/:id/gate`
+`{"approve":true}` bodies in selection order; the complex-gate card renders
+`batch-ineligible`, never a checkbox, and cannot enter the selection via `x`;
+reject-all with the note "wrong branch" rides `amend` on every reject; a
+stubbed 409 leaves `batch-failure-row` naming run + error with retry firing
+ONLY that id; Escape clears the selection, fires nothing.
+
+Captures (1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  feedback2-L-notif-settings.png  the /system Notifications group, permission
+                                  state line visible
+  feedback2-L-batch-bar.png       two gates selected, batch bar docked, the
+                                  complex card's ↗ ineligible marker visible
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 (ensure_build CACHES — delete a stale dist-sameorigin/
+when the source changed). Env knobs: FEEDBACK_PORT (default 4361),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4361"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+SIMPLE_PROJECT = "q3-review-deck"
+SIMPLE_RUN = "r-q3"
+COMPLEX_PROJECT = "api-migration"   # r-api — options:null ⇒ complex (§7.11)
+BATCH1_PROJECT, BATCH1_RUN = "batch-one", "r-batch1"
+BATCH2_RUN = "r-batch2"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture server ────────────────────
+dist = ensure_build(fail)
+report["steps"]["build"] = {"ok": True, "dist": str(dist)}
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN)  # defaults
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+# The Notification/AudioContext tap — installed BEFORE any page script (EC25:
+# a requestPermission on load would be counted). The context permission is
+# granted too, but headless Chromium reports `Notification.permission` as
+# 'denied' regardless (notifications never display headless — verified), so
+# the tap OWNS the permission state: `perm0` is the scene's starting state and
+# the (counted) requestPermission gesture resolves to `grant`.
+def notif_tap(perm0: str, grant: str = "granted") -> str:
+    return """(() => {
+  let perm = '%s';
+  window.__reqPermCalls = 0;
+  window.__notifs = [];
+  window.__notifObjs = [];
+  class TapNotification {
+    static get permission() { return perm; }
+    static requestPermission() {
+      window.__reqPermCalls += 1;
+      perm = '%s';
+      return Promise.resolve(perm);
+    }
+    constructor(title, opts) {
+      this.title = title;
+      this.body = opts && opts.body;
+      this.tag = opts && opts.tag;
+      this.onclick = null;
+      this.closed = false;
+      window.__notifs.push({ title: this.title, body: this.body, tag: this.tag });
+      window.__notifObjs.push(this);
+    }
+    close() { this.closed = true; }
+  }
+  window.Notification = TapNotification;
+  window.__audioCtxCount = 0;
+  window.AudioContext = class {
+    constructor() { window.__audioCtxCount += 1; this.currentTime = 0; this.destination = {}; }
+    createGain() {
+      return { connect: () => {}, gain: {
+        setValueAtTime: () => {}, exponentialRampToValueAtTime: () => {} } };
+    }
+    createOscillator() {
+      return { type: 'sine', frequency: { setValueAtTime: () => {} },
+               connect: () => {}, start: () => {}, stop: () => {} };
+    }
+    close() { return Promise.resolve(); }
+  };
+})();""" % (perm0, grant)
+
+FORCE_HIDDEN = """(() => {
+  Object.defineProperty(Document.prototype, 'visibilityState',
+    { configurable: true, get: () => 'hidden' });
+  Document.prototype.hasFocus = () => false;
+})();"""
+
+FORCE_VISIBLE = """(() => {
+  Object.defineProperty(Document.prototype, 'visibilityState',
+    { configurable: true, get: () => 'visible' });
+  Document.prototype.hasFocus = () => true;
+})();"""
+
+NEEDS_YOU_ORDER = """() => Array.from(document.querySelectorAll(
+  '[data-testid="band-needs-you"] [data-testid="project-card"]'))
+  .map((c) => c.dataset.projectId)"""
+
+
+def make_gate_tap(page, sink: list) -> None:
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and path.startswith("/api/v1/runs/") and path.endswith("/gate"):
+            try:
+                body = json.loads(req.post_data or "null")
+            except json.JSONDecodeError:
+                body = None
+            sink.append((path, body))
+    page.on("request", on_request)
+
+
+def open_board(page) -> list:
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.wait_for_timeout(1500)  # board fetch burst + membership mirror
+    return page.evaluate(NEEDS_YOU_ORDER)
+
+
+def cursor_to(page, order: list, pid: str, cur: int | None) -> int:
+    """Walk the cursor onto `pid` RELATIVELY (never Escape — Escape would clear
+    the batch selection, §9.5); returns the new index. `cur=None` = no cursor."""
+    target = order.index(pid)
+    if cur is None:
+        page.keyboard.press("j")  # first press selects the first row (§2.2)
+        cur = 0
+    key = "j" if target > cur else "k"
+    for _ in range(abs(target - cur)):
+        page.keyboard.press(key)
+    page.wait_for_function(
+        """(pid) => document.querySelector('[data-kbd-selected="true"]')?.dataset?.projectId === pid""",
+        arg=pid, timeout=5000,
+    )
+    return target
+
+
+def select_at(page, order: list, pid: str, cur: int | None) -> int:
+    """Cursor onto `pid`, then `x` (the §9.2 toggle)."""
+    ix = cursor_to(page, order, pid, cur)
+    page.keyboard.press("x")
+    return ix
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+
+    # ════ Scene A: the settings surface — the EC25 gesture (§8.4 ACs 1–2) ═══════
+    ctxA = browser.new_context(
+        viewport={"width": 1440, "height": 900}, device_scale_factor=1,
+        permissions=["notifications"],
+    )
+    pageA = ctxA.new_page()
+    pageA.add_init_script(notif_tap("default"))
+    pageA.add_init_script(FORCE_VISIBLE)  # scene A is the visible-tab case
+    pageA.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    settings_puts: list = []
+
+    def on_put(req):
+        if req.method == "PUT" and urlparse(req.url).path == "/api/v1/settings":
+            try:
+                settings_puts.append(json.loads(req.post_data or "null"))
+            except json.JSONDecodeError:
+                settings_puts.append(None)
+    pageA.on("request", on_put)
+
+    pageA.goto(f"{ORIGIN}/system", wait_until="domcontentloaded")
+    pageA.locator('[data-testid="notif-settings"]').wait_for(timeout=30000)
+    pageA.wait_for_timeout(800)  # the startup settings GET settles
+
+    on_load = pageA.evaluate(
+        """() => ({
+          reqPerm: window.__reqPermCalls,
+          notifs: window.__notifs.length,
+          offChecked: document.querySelector('[data-testid="notif-off"]')?.checked ?? null,
+          desktopChecked: document.querySelector('[data-testid="notif-desktop"]')?.checked ?? null,
+          chimeDisabled: document.querySelector('[data-testid="notif-chime"]')?.disabled ?? null,
+        })"""
+    )
+    report["steps"]["ec25_no_prompt_on_load"] = {
+        "ok": all([
+            on_load["reqPerm"] == 0,          # EC25: NEVER on load
+            on_load["notifs"] == 0,
+            on_load["offChecked"] is True,    # no stored key ⇒ defaults (Off)
+            on_load["desktopChecked"] is False,
+            on_load["chimeDisabled"] is True,
+        ]),
+        **on_load,
+    }
+
+    # The gesture: selecting the desktop option prompts ONCE and persists.
+    pageA.locator('[data-testid="notif-desktop"]').click()
+    pageA.locator('[data-testid="notif-permission"]').wait_for(timeout=10000)
+    pageA.wait_for_timeout(900)  # the 400ms persist debounce + wire
+    after_toggle = pageA.evaluate(
+        """() => ({
+          reqPerm: window.__reqPermCalls,
+          desktopChecked: document.querySelector('[data-testid="notif-desktop"]')?.checked ?? null,
+          permText: document.querySelector('[data-testid="notif-permission"]')?.textContent ?? null,
+        })"""
+    )
+    put_bodies = [b for b in settings_puts if isinstance(b, dict) and "studio.notifications" in b]
+    report["steps"]["gesture_prompts_once_and_persists"] = {
+        "ok": all([
+            after_toggle["reqPerm"] == 1,
+            after_toggle["desktopChecked"] is True,
+            "granted" in (after_toggle["permText"] or ""),
+            len(put_bodies) >= 1,
+            put_bodies[-1]["studio.notifications"] == {"desktop": True, "chime": False},
+        ]),
+        **after_toggle,
+        "puts": put_bodies,
+    }
+
+    # Chime opt-in rides the same key.
+    pageA.locator('[data-testid="notif-chime"]').click()
+    pageA.wait_for_timeout(900)
+    chime_puts = [b for b in settings_puts if isinstance(b, dict) and "studio.notifications" in b]
+    report["steps"]["chime_pref_persists"] = {
+        "ok": chime_puts[-1]["studio.notifications"] == {"desktop": True, "chime": True},
+        "last_put": chime_puts[-1] if chime_puts else None,
+    }
+
+    # ── Capture 1: the settings group with the permission state line ────────────
+    pageA.locator('[data-testid="notif-settings"]').scroll_into_view_if_needed()
+    pageA.screenshot(path=str(VSHOTS / "feedback2-L-notif-settings.png"))
+
+    # §8.4 AC 4: with the tab VISIBLE+focused, an arriving gate fires nothing.
+    posts0 = pageA.evaluate("() => window.__notifs.length")
+    set_fixture(ORIGIN, extra_gates=[{"session": "r-api", "ord": 0,
+                                      "prompt": "How should the tables move?"}])
+    pageA.wait_for_timeout(2500)  # ws tick ≤1s + margin
+    report["steps"]["visible_tab_fires_nothing"] = {
+        "ok": pageA.evaluate("() => window.__notifs.length") == posts0,
+        "count": pageA.evaluate("() => window.__notifs.length"),
+    }
+    pageA.close()
+    ctxA.close()
+
+    # ════ Scene B: the hidden-tab trigger (§8.4 ACs 3+5) ════════════════════════
+    # Prefs were persisted by scene A's PUTs; seed explicitly anyway (chime on).
+    set_fixture(ORIGIN, notif_prefs={"desktop": True, "chime": True})
+    ctxB = browser.new_context(
+        viewport={"width": 1440, "height": 900}, device_scale_factor=1,
+        permissions=["notifications"],
+    )
+    pageB = ctxB.new_page()
+    pageB.add_init_script(notif_tap("granted"))
+    pageB.add_init_script(FORCE_HIDDEN)
+    pageB.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    open_board(pageB)
+
+    # One arrival ⇒ ONE notification, tagged with the run id, project in body.
+    set_fixture(ORIGIN, extra_gates=[{"session": SIMPLE_RUN, "ord": 0,
+                                      "prompt": "Approve the deck outline?"}])
+    pageB.wait_for_function("() => window.__notifs.length === 1", timeout=10000)
+    first_notif = pageB.evaluate("() => window.__notifs[0]")
+    chime_count = pageB.evaluate("() => window.__audioCtxCount")
+
+    # A REPLAY (same run + ord — the reconnect case) must not re-fire.
+    set_fixture(ORIGIN, extra_gates=[{"session": SIMPLE_RUN, "ord": 0,
+                                      "prompt": "Approve the deck outline?"}])
+    pageB.wait_for_timeout(2500)
+    after_replay = pageB.evaluate("() => window.__notifs.length")
+
+    # A LATER gate on the same run (new ord) fires again, SAME tag.
+    set_fixture(ORIGIN, extra_gates=[{"session": SIMPLE_RUN, "ord": 1,
+                                      "prompt": "And the appendix?"}])
+    pageB.wait_for_function("() => window.__notifs.length === 2", timeout=10000)
+    second_notif = pageB.evaluate("() => window.__notifs[1]")
+
+    report["steps"]["hidden_tab_notification"] = {
+        "ok": all([
+            first_notif["tag"] == SIMPLE_RUN,
+            first_notif["title"] == "Gate needs you",
+            "Approve the deck outline?" in (first_notif["body"] or ""),
+            SIMPLE_PROJECT in (first_notif["body"] or ""),   # the project name rode the body
+            chime_count >= 1,                                 # chime on ⇒ AudioContext
+            after_replay == 1,                                # the replay de-duped
+            second_notif["tag"] == SIMPLE_RUN,                # same tag — OS collapses
+            pageB.evaluate("() => window.__reqPermCalls") == 0,  # EC25 everywhere
+        ]),
+        "first": first_notif,
+        "chime_audio_contexts": chime_count,
+        "after_replay": after_replay,
+        "second": second_notif,
+    }
+
+    # AC 5 (click): focus + land on the run's gate. The `#gate` intent is
+    # one-shot (SteeringGate consumes it) — tap pushState like the H rig.
+    pageB.evaluate(
+        """() => {
+          window.__pushed = [];
+          const orig = history.pushState.bind(history);
+          history.pushState = (s, t, url) => { window.__pushed.push(String(url)); orig(s, t, url); };
+          window.__focused = 0;
+          window.focus = () => { window.__focused += 1; };
+        }"""
+    )
+    pageB.evaluate("() => { window.__notifObjs[0].onclick(); }")
+    pageB.wait_for_function(
+        f"""() => window.location.pathname === '/p/{SIMPLE_PROJECT}/build/{SIMPLE_RUN}'""",
+        timeout=10000,
+    )
+    clicked = pageB.evaluate(
+        """() => ({ pushed: window.__pushed, focused: window.__focused,
+                    closed: window.__notifObjs[0].closed })"""
+    )
+    report["steps"]["notification_click_lands_on_gate"] = {
+        "ok": all([
+            clicked["focused"] >= 1,
+            f"/p/{SIMPLE_PROJECT}/build/{SIMPLE_RUN}#gate" in clicked["pushed"],
+            clicked["closed"] is True,
+        ]),
+        **clicked,
+    }
+    pageB.close()
+    ctxB.close()
+
+    # ════ Scene C: batch gate resolution (§9.5) ═════════════════════════════════
+    set_fixture(ORIGIN, notif_prefs=None, batch_gates=True)
+    ctxC = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    pageC = ctxC.new_page()
+    pageC.add_init_script(notif_tap("denied"))  # inert here; prefs are cleared
+    pageC.add_init_script(FORCE_VISIBLE)
+    pageC.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    gate_posts: list = []
+    make_gate_tap(pageC, gate_posts)
+
+    order = open_board(pageC)
+    if not {SIMPLE_PROJECT, COMPLEX_PROJECT, BATCH1_PROJECT, "batch-two"} <= set(order):
+        fail("fixture_shape", f"needs-you band lacks the batch corpus: {order}")
+
+    # `x` on two simple-gate cards → the bar with data-count=2; checkboxes
+    # render on gate-bearing cards; the complex card gets the ↗ marker only.
+    posts_at_select = len(gate_posts)
+    cur = select_at(pageC, order, SIMPLE_PROJECT, None)
+    cur = select_at(pageC, order, BATCH1_PROJECT, cur)
+    pageC.locator('[data-testid="batch-bar"][data-count="2"]').wait_for(timeout=5000)
+
+    # Escape clears the selection and removes the bar, firing nothing (§9.5).
+    pageC.keyboard.press("Escape")
+    pageC.wait_for_timeout(300)
+    escape_state = pageC.evaluate(
+        """() => ({ bar: !!document.querySelector('[data-testid="batch-bar"]') })"""
+    )
+    report["steps"]["escape_clears_selection"] = {
+        "ok": escape_state["bar"] is False and len(gate_posts) == posts_at_select,
+        **escape_state,
+        "posts_during": gate_posts[posts_at_select:],
+    }
+
+    cur = select_at(pageC, order, SIMPLE_PROJECT, None)
+    cur = select_at(pageC, order, BATCH1_PROJECT, cur)
+    pageC.locator('[data-testid="batch-bar"][data-count="2"]').wait_for(timeout=5000)
+    cur = select_at(pageC, order, COMPLEX_PROJECT, cur)  # x on complex — must not enter
+    pageC.wait_for_timeout(300)
+    shape = pageC.evaluate(
+        """(args) => {
+          const [simpleRun, b1, b2, complexProject] = args;
+          const complexCard = document.querySelector(
+            `[data-testid="project-card"][data-project-id="${complexProject}"]`);
+          return {
+            count: document.querySelector('[data-testid="batch-bar"]')?.dataset?.count ?? null,
+            cbSimple: document.querySelector(`[data-testid="batch-select-${simpleRun}"]`)?.checked ?? null,
+            cbB1: document.querySelector(`[data-testid="batch-select-${b1}"]`)?.checked ?? null,
+            cbB2: document.querySelector(`[data-testid="batch-select-${b2}"]`)?.checked ?? null,
+            ineligible: !!complexCard?.querySelector('[data-testid="batch-ineligible"]'),
+            complexCheckbox: !!complexCard?.querySelector('[data-testid^="batch-select-"]'),
+          };
+        }""",
+        [SIMPLE_RUN, BATCH1_RUN, BATCH2_RUN, COMPLEX_PROJECT],
+    )
+    report["steps"]["selection_shape"] = {
+        "ok": all([
+            shape["count"] == "2",            # the complex x was refused
+            shape["cbSimple"] is True,
+            shape["cbB1"] is True,
+            shape["cbB2"] is False,           # visible once ≥1 selected, unchecked
+            shape["ineligible"] is True,      # ↗ needs-the-thread marker
+            shape["complexCheckbox"] is False,  # NEVER a checkbox (§9.5)
+        ]),
+        **shape,
+    }
+
+    # ── Capture 2: two selected, bar docked, ineligible marker visible ──────────
+    pageC.screenshot(path=str(VSHOTS / "feedback2-L-batch-bar.png"))
+
+    # Approve all: exactly two sequential POSTs, selection order, then the bar leaves.
+    posts_before = len(gate_posts)
+    pageC.locator('[data-testid="batch-approve-all"]').click()
+    pageC.wait_for_function(
+        "() => document.querySelector('[data-testid=\"batch-bar\"]') === null", timeout=10000
+    )
+    pageC.wait_for_timeout(300)
+    approve_posts = gate_posts[posts_before:]
+    report["steps"]["approve_all_fans_out"] = {
+        "ok": approve_posts == [
+            (f"/api/v1/runs/{SIMPLE_RUN}/gate", {"approve": True}),
+            (f"/api/v1/runs/{BATCH1_RUN}/gate", {"approve": True}),
+        ],
+        "gate_posts": approve_posts,
+    }
+
+    # ── Scene C2 (fresh load): the 409 partial failure + retry-only-that-id ─────
+    set_fixture(ORIGIN, gate_409=[BATCH1_RUN])
+    order2 = open_board(pageC)
+    cur = select_at(pageC, order2, SIMPLE_PROJECT, None)
+    cur = select_at(pageC, order2, BATCH1_PROJECT, cur)
+    pageC.locator('[data-testid="batch-bar"][data-count="2"]').wait_for(timeout=5000)
+    posts_before = len(gate_posts)
+    pageC.locator('[data-testid="batch-approve-all"]').click()
+    pageC.locator(f'[data-testid="batch-failure-row"][data-run-id="{BATCH1_RUN}"]').wait_for(timeout=10000)
+    pageC.wait_for_timeout(300)
+    failure = pageC.evaluate(
+        """(run) => ({
+          rows: document.querySelectorAll('[data-testid="batch-failure-row"]').length,
+          text: document.querySelector(`[data-testid="batch-failure-row"][data-run-id="${run}"]`)?.textContent ?? '',
+          count: document.querySelector('[data-testid="batch-bar"]')?.dataset?.count ?? null,
+        })""",
+        BATCH1_RUN,
+    )
+    partial_posts = gate_posts[posts_before:]
+    report["steps"]["partial_failure_honesty"] = {
+        "ok": all([
+            len(partial_posts) == 2,          # both were tried
+            failure["rows"] == 1,             # only the 409 id stays listed
+            BATCH1_RUN in failure["text"],
+            "not awaiting a human gate" in failure["text"],
+            failure["count"] == "1",          # the success left the selection
+        ]),
+        **failure,
+        "gate_posts": partial_posts,
+    }
+
+    # Retry fires ONLY the failed id (§9.5) — and succeeds once the 409 lifts.
+    set_fixture(ORIGIN, gate_409=[])
+    posts_before = len(gate_posts)
+    pageC.locator(f'[data-testid="batch-retry-{BATCH1_RUN}"]').click()
+    pageC.wait_for_function(
+        "() => document.querySelector('[data-testid=\"batch-bar\"]') === null", timeout=10000
+    )
+    pageC.wait_for_timeout(300)
+    retry_posts = gate_posts[posts_before:]
+    report["steps"]["retry_fires_only_that_id"] = {
+        "ok": retry_posts == [(f"/api/v1/runs/{BATCH1_RUN}/gate", {"approve": True})],
+        "gate_posts": retry_posts,
+    }
+
+    # ── Scene C3 (fresh load): reject-all — ONE bar-level note rides every amend ─
+    order3 = open_board(pageC)
+    cur = select_at(pageC, order3, SIMPLE_PROJECT, None)
+    cur = select_at(pageC, order3, BATCH1_PROJECT, cur)
+    pageC.locator('[data-testid="batch-bar"][data-count="2"]').wait_for(timeout=5000)
+    posts_before = len(gate_posts)
+    pageC.locator('[data-testid="batch-reject-all"]').click()
+    pageC.locator('[data-testid="batch-reject-note"]').wait_for(timeout=5000)
+    pageC.keyboard.type("wrong branch")
+    pageC.keyboard.press("Enter")
+    pageC.wait_for_function(
+        "() => document.querySelector('[data-testid=\"batch-bar\"]') === null", timeout=10000
+    )
+    pageC.wait_for_timeout(300)
+    reject_posts = gate_posts[posts_before:]
+    report["steps"]["reject_all_rides_amend"] = {
+        "ok": reject_posts == [
+            (f"/api/v1/runs/{SIMPLE_RUN}/gate", {"approve": False, "amend": "wrong branch"}),
+            (f"/api/v1/runs/{BATCH1_RUN}/gate", {"approve": False, "amend": "wrong branch"}),
+        ],
+        "gate_posts": reject_posts,
+    }
+
+    # ── Scene C4: the dashboard's gate-inbox rows carry the same selection ──────
+    pageC.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}", wait_until="domcontentloaded")
+    pageC.locator('[data-testid="dashboard-gates"]').wait_for(timeout=30000)
+    pageC.add_style_tag(content=HIDE_GATE_TOASTS)
+    pageC.wait_for_timeout(1000)
+    pageC.keyboard.press("j")
+    pageC.keyboard.press("x")
+    pageC.locator('[data-testid="batch-bar"][data-count="1"]').wait_for(timeout=5000)
+    dash_cb = pageC.evaluate(
+        f"""() => document.querySelector('[data-testid="batch-select-{SIMPLE_RUN}"]')?.checked ?? null"""
+    )
+    posts_before = len(gate_posts)
+    pageC.keyboard.press("Escape")
+    pageC.wait_for_timeout(300)
+    report["steps"]["dashboard_inbox_selection"] = {
+        "ok": all([
+            dash_cb is True,
+            pageC.evaluate("() => !document.querySelector('[data-testid=\"batch-bar\"]')"),
+            len(gate_posts) == posts_before,
+        ]),
+        "checkbox": dash_cb,
+    }
+
+    pageC.close()
+    ctxC.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [
+    str(VSHOTS / "feedback2-L-notif-settings.png"),
+    str(VSHOTS / "feedback2-L-batch-bar.png"),
+]
+
+bad = [k for k, v in report["steps"].items() if not v["ok"]]
+if bad:
+    fail("sliceL_verdict", f"slice-L assertions did not all hold — see {', '.join(bad)}")
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -79,6 +79,20 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     brand-learn rig to witness the 404→200 transition).
   reset_learn     — POST {"reset_learn": true} clears all learned-theme
                     readback state (back to the 404).
+  batch_gates     — two extra projects (batch-one/batch-two) each with one
+                    awaiting_human SIMPLE-gate run ride /projects, /runs,
+                    members and the cached-gate GET (slice L §9.5's "3 simple
+                    gates" board, with r-q3, beside the complex r-api).
+                    Default False.
+  gate_409        — run ids whose POST /runs/:id/gate answers the daemon's
+                    real 409 "not awaiting a human gate" (slice L's partial-
+                    failure case). Default [].
+  extra_gates     — a list of {session, ord?, prompt?}; each is drained ONCE
+                    by the /ws loop as an `awaitingHuman` frame (slice L §8.4:
+                    a gate ARRIVAL, the desktop-notification trigger).
+  notif_prefs     — replaces the settings store's `studio.notifications`
+                    (a dict; None REMOVES the key — the never-persisted
+                    default case), same channel as `appearance`.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -158,7 +172,21 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # columns grid has a true empty cell to render. Default False: the
          # standing chat rigs (uxfix slice 4, feedback slice C) assert a
          # fan-out with NO replies, and must keep seeing exactly that.
-         "chat_replies": False}
+         "chat_replies": False,
+         # Slice L (DES-FEEDBACK-002 §9): the batch-gates corpus — two extra
+         # projects each holding one awaiting_human SIMPLE-gate run, so the
+         # board has §9.5's "3 simple gates" (with r-q3) beside the complex
+         # r-api. Switch-gated: no standing rig's board grows cards.
+         "batch_gates": False,
+         # Slice L (§9.5): run ids whose POST /runs/:id/gate answers the
+         # daemon's real 409 ("not awaiting a human gate") — the partial-
+         # failure case the batch bar must surface per-id.
+         "gate_409": [],
+         # Slice L (§8.4): one-shot awaitingHuman frames drained ONCE by the
+         # /ws loop (the extra_narration mechanism) — how a rig injects a gate
+         # ARRIVAL (the desktop-notification trigger), distinct from the
+         # cached-gate GET a page load reconciles.
+         "extra_gates": []}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -297,6 +325,26 @@ RIVER_AUTH_EVENTS = [
     {"type": "sessionStarted", "session": "r-auth", "ts": NOW0 - 6 * HOUR},
     {"type": "sessionFailed", "session": "r-auth", "ts": NOW0 - 5 * HOUR},
 ]
+
+# ── Slice L (DES-FEEDBACK-002 §9): the batch-gates corpus, behind `batch_gates` ──
+#
+# Two extra projects, each with one awaiting_human run whose cached gate is
+# SIMPLE (no options field — the plain workflow gate), giving the board three
+# simple-gate needs-you cards (with r-q3) beside the complex r-api: §9.5's
+# fixture shape. Gate ages differ so the attention order is deterministic.
+BATCH_PROJECTS = [
+    project("batch-one", "batch-one", NOW0 - MIN),
+    project("batch-two", "batch-two", NOW0 - 3 * MIN),
+]
+BATCH_RUNS = [
+    session("r-batch1", "awaiting_human", "bump the API version", "bump the API version"),
+    session("r-batch2", "awaiting_human", "rotate the staging keys", "rotate the staging keys"),
+]
+BATCH_MEMBERS = {"batch-one": ["r-batch1"], "batch-two": ["r-batch2"]}
+BATCH_GATE_PROMPTS = {"r-batch1": ("Ship the version bump?", MIN),
+                      "r-batch2": ("Rotate the keys now?", 3 * MIN)}
+ATTACHED_AT["r-batch1"] = NOW0 - MIN
+ATTACHED_AT["r-batch2"] = NOW0 - 3 * MIN
 
 # Slice P: which runs the `repo_refs` switch stamps onto the registered repo —
 # a live one and a 6-day-old one for the 7d grouping, plus a fresh failure for
@@ -935,13 +983,23 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # Drain any one-shot narration lines a rig posted mid-page (vision
                 # slice 2: prove a NEW delta reaches the live feed within 2s).
                 extra: list = []
+                gates_extra: list = []
                 if newest:
                     with state_lock:
                         extra, state["extra_narration"] = list(state["extra_narration"]), []
+                        gates_extra, state["extra_gates"] = list(state["extra_gates"]), []
                 for line in extra:
                     self.wfile.write(ws_frame({
                         "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
                         "text": str(line) + "\n",
+                    }))
+                # Slice L (§8.4): one-shot awaitingHuman ARRIVALS a rig posted —
+                # the desktop-notification trigger is the live frame, never the
+                # cached-gate GET a page load reconciles.
+                for g in gates_extra:
+                    self.wfile.write(ws_frame({
+                        "type": "awaitingHuman", "session": g["session"],
+                        "ord": g.get("ord", 0), "prompt": g.get("prompt", "Approve?"),
                     }))
                 # One burn frame per tick until the slice-E drip drains.
                 if newest and burn_drip:
@@ -987,7 +1045,8 @@ class W2Handler(SimpleHTTPRequestHandler):
                 else:
                     runs = RUNS + ([ORPHAN] if state["orphan"] else []) \
                         + ([LONG_RUN] if state["long_prompt"] else []) \
-                        + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else [])
+                        + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else []) \
+                        + (BATCH_RUNS if state["batch_gates"] else [])
                 viewer_on = state["viewer"]
                 repo_refs_on = state["repo_refs"]
             if viewer_on or repo_refs_on:
@@ -1008,7 +1067,9 @@ class W2Handler(SimpleHTTPRequestHandler):
             self._viewer_routes(urllib.parse.unquote(m.group(1)), m.group(2))
             return True
         if path == "/api/v1/projects":
-            self._json(200, {"projects": PROJECTS})
+            with state_lock:
+                batch_on = state["batch_gates"]
+            self._json(200, {"projects": PROJECTS + (BATCH_PROJECTS if batch_on else [])})
             return True
         if path == "/api/v1/repos":
             with state_lock:
@@ -1056,6 +1117,10 @@ class W2Handler(SimpleHTTPRequestHandler):
                 chat_runs_on = state["chat_runs"]
                 river_on = state["river"]
                 repo_member_on = state["repo_member"]
+                batch_on = state["batch_gates"]
+            # Slice L: the batch corpus projects' runs.
+            if batch_on:
+                refs.extend(BATCH_MEMBERS.get(pid, []))
             # Slice P: the live chat thread is a `crew.chat` member of notes.
             kinds = {}
             if chat_runs_on and pid == "notes":
@@ -1118,6 +1183,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
                                  "prompt": CHAT_GATE_PROMPT,
                                  "receivedAt": iso(NOW0 - 5 * MIN)})
+            elif rid in BATCH_GATE_PROMPTS and state["batch_gates"]:
+                # Slice L: the batch corpus's SIMPLE cached gates (no options).
+                prompt, age = BATCH_GATE_PROMPTS[rid]
+                self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
+                                 "prompt": prompt, "receivedAt": iso(NOW0 - age)})
             else:
                 self._json(404, {"error": f"no gate cached for {rid}"})
             return True
@@ -1409,6 +1479,14 @@ class W2Handler(SimpleHTTPRequestHandler):
                     settings_store["studio.appearance"] = (
                         dict(DEFAULT_APPEARANCE) if body["appearance"] is None
                         else body["appearance"])
+                # Slice L: seed `studio.notifications` between page loads the
+                # same way (a dict replaces it; None removes the key — the
+                # "old daemon never persisted one" default case, §8.4).
+                if "notif_prefs" in body:
+                    if body["notif_prefs"] is None:
+                        settings_store.pop("studio.notifications", None)
+                    else:
+                        settings_store["studio.notifications"] = body["notif_prefs"]
                 state.update({k: v for k, v in body.items() if k in state})
                 snapshot = dict(state)
             return self._json(200, {"ok": True, "state": snapshot})
@@ -1421,6 +1499,13 @@ class W2Handler(SimpleHTTPRequestHandler):
         # chip click; the rigs assert the request BODY off the browser tap.
         parts = path.split("/")
         if len(parts) == 6 and parts[3] == "runs" and parts[5] == "gate":
+            rid = urllib.parse.unquote(parts[4])
+            with state_lock:
+                conflict = rid in state["gate_409"]
+            if conflict:
+                # Slice L (§9.5): the daemon's real 409 — the run stopped
+                # awaiting between the selection and the fan-out.
+                return self._json(409, {"error": "not awaiting a human gate"})
             return self._json(200, {"status": "resumed"})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ import { useDocThreadStore } from './store/docThread.js';
 import type { CoreEvent, RepoEntry } from './api/types.js';
 import { api } from './api/client.js';
 import { useAppearanceStore } from './theming/appearance.js';
+import { useNotifPrefsStore } from './store/notifPrefs.js';
+import { notifyGateIfUnfocused } from './board/desktopNotify.js';
 
 /** Frames that change run-list / unit state → trigger a `GET /runs` reconcile. */
 const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
@@ -93,6 +95,9 @@ export function App(): React.ReactElement {
       // Relayed interactive frames feed BOTH altitudes off the one subscription (§3.4):
       // the runtime store's board headline above, the doc transcript here.
       ingestDocThread(event);
+      // Slice L (DES-FEEDBACK-002 §8.2): the desktop layer folds off the SAME
+      // subscription — hidden-tab-only, opt-in, permission-gated, never prompts.
+      notifyGateIfUnfocused(event);
       if (LIFECYCLE_EVENTS.has(event.type)) refresh();
     },
     [ingestGate, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, refresh],
@@ -105,6 +110,10 @@ export function App(): React.ReactElement {
   // overrides on <html> — the cascade seam tokens.css declares for this.
   useEffect(() => {
     void useAppearanceStore.getState().load();
+    // Slice L: `studio.notifications` rides the same settings store — read
+    // once at startup; the defaults (Off) stand if the surface is absent.
+    // Never touches the Notification API (EC25: no prompt on load).
+    void useNotifPrefsStore.getState().load();
   }, []);
 
   // Pre-merge bookmarks (`/runs/:id`, `/projects/:id`) redirect into the shell (§1.5).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -495,6 +495,14 @@ export const api = {
       body: JSON.stringify({ 'studio.appearance': appearance }),
     }),
 
+  /** Slice L (DES-FEEDBACK-002 §8.2): `studio.notifications` rides the SAME
+   *  settings store, same namespaced-key contract as `studio.appearance`. */
+  putNotifSettings: (prefs: import('../store/notifPrefs.js').StudioNotifPrefs) =>
+    apiFetch<{ settings: Record<string, unknown> }>('/settings', {
+      method: 'PUT',
+      body: JSON.stringify({ 'studio.notifications': prefs }),
+    }),
+
   // ── Projects (DES-PROJECT-001) ───────────────────────────────────────────────
 
   /** All projects; `status=active` (default) or `archived` filters. Includes the synthesized "Unfiled" default. */

--- a/src/board/batchGates.ts
+++ b/src/board/batchGates.ts
@@ -1,0 +1,119 @@
+import { create } from 'zustand';
+import type { GateDecision } from '../api/types.js';
+import { decideGate, IDLE_GATE_ACTION, useGateActionStore } from './gateActions.js';
+
+/**
+ * Batch gate resolution (DES-FEEDBACK-002 §9, P2-9, slice L): a selection
+ * model over ANSWERABLE SIMPLE gates plus a sequential client-side fan-out of
+ * the EXISTING per-run `POST /runs/:id/gate` — through `decideGate`, the ONE
+ * audited wire path (slice H), so every batched decision keeps its per-run
+ * audit record and the shared double-submit guard. No batch endpoint exists
+ * (§9.1 wire check); §9.4's future route is deliberately NOT a prerequisite,
+ * and this module is shaped so swapping it in is a one-function change.
+ *
+ * Sequential, not parallel (§9.2): each response (or 409) updates its own
+ * card live through the shared gate-action store, and the single-writer
+ * daemon gains nothing from a request burst.
+ *
+ * Per-id outcomes, the bulk-archive precedent client-side (§9.2): a failure
+ * stays listed (run + named error, retry fires ONLY that id); a success
+ * leaves the selection as its decision lands — never all-or-nothing, never
+ * an optimistic lie.
+ *
+ * Selection lifecycle: toggled by the triage cursor's `x`/Space and the
+ * checkboxes (mouse); cleared by Escape, by the surface unmounting (route
+ * change), and per-id as decisions land. Eligibility (simple gates only) is
+ * enforced at the toggle call sites, which hold the gate object (§7.11's
+ * `isSimpleGate`) — a complex gate can never enter the selection.
+ */
+
+export interface BatchFailure {
+  runId: string;
+  error: string;
+}
+
+interface BatchGateStore {
+  /** Selected run ids, in selection order — the fan-out order. */
+  selected: string[];
+  /** A fan-out is in flight — the bar's `2/3…` state; re-entry is dropped. */
+  running: boolean;
+  /** Completed POSTs of the current/last fan-out, out of `total`. */
+  done: number;
+  total: number;
+  /** Per-id failures of the last fan-out (§9.2's honesty rows). */
+  failures: BatchFailure[];
+  /** What the last fan-out sent — retry re-sends exactly this. */
+  lastDecision: GateDecision | null;
+}
+
+const IDLE = { selected: [], running: false, done: 0, total: 0, failures: [], lastDecision: null };
+
+export const useBatchGateStore = create<BatchGateStore>(() => ({ ...IDLE }));
+
+/** Toggle one run's membership. Callers guard eligibility (simple + answerable). */
+export function toggleBatchSelect(runId: string): void {
+  useBatchGateStore.setState((s) => {
+    if (s.running) return s; // the selection is frozen while a fan-out runs
+    return s.selected.includes(runId)
+      ? { selected: s.selected.filter((id) => id !== runId) }
+      : { selected: [...s.selected, runId] };
+  });
+}
+
+/** Escape / route change: drop everything, fire nothing (§9.5). */
+export function clearBatchSelection(): void {
+  const s = useBatchGateStore.getState();
+  if (s.running) return;
+  if (s.selected.length === 0 && s.failures.length === 0 && s.lastDecision === null) return;
+  useBatchGateStore.setState({ ...IDLE });
+}
+
+/** One decision for one id through the shared path; returns the named error or null. */
+async function decideOne(runId: string, decision: GateDecision): Promise<string | null> {
+  await decideGate(runId, decision);
+  const after = useGateActionStore.getState().byGate[runId] ?? IDLE_GATE_ACTION;
+  if (after.answered !== null) return null;
+  return after.error ?? 'not sent — already answered or still in flight';
+}
+
+/**
+ * The fan-out: N sequential `POST /runs/:id/gate` calls in selection order.
+ * A second call while one runs is dropped (plus `decideGate`'s own per-run
+ * guard underneath — the shared-store double-submit contract).
+ */
+export async function runBatchDecision(decision: GateDecision): Promise<void> {
+  const s = useBatchGateStore.getState();
+  if (s.running || s.selected.length === 0) return;
+  const ids = [...s.selected];
+  useBatchGateStore.setState({
+    running: true, done: 0, total: ids.length, failures: [], lastDecision: decision,
+  });
+  for (const runId of ids) {
+    const error = await decideOne(runId, decision);
+    useBatchGateStore.setState((cur) => ({
+      done: cur.done + 1,
+      // Success leaves the selection (its answered state now shows on the
+      // card, and the daemon's frame will move the run); failure stays, named.
+      selected: error === null ? cur.selected.filter((id) => id !== runId) : cur.selected,
+      failures: error === null ? cur.failures : [...cur.failures, { runId, error }],
+    }));
+  }
+  useBatchGateStore.setState({ running: false });
+}
+
+/** Retry exactly one failed id with the decision the fan-out used (§9.5). */
+export async function retryBatchOne(runId: string): Promise<void> {
+  const s = useBatchGateStore.getState();
+  if (s.running || s.lastDecision === null) return;
+  if (!s.failures.some((f) => f.runId === runId)) return;
+  const decision = s.lastDecision;
+  useBatchGateStore.setState({ running: true });
+  const error = await decideOne(runId, decision);
+  useBatchGateStore.setState((cur) => ({
+    running: false,
+    selected: error === null ? cur.selected.filter((id) => id !== runId) : cur.selected,
+    failures: error === null
+      ? cur.failures.filter((f) => f.runId !== runId)
+      : cur.failures.map((f) => (f.runId === runId ? { runId, error } : f)),
+  }));
+}

--- a/src/board/desktopNotify.ts
+++ b/src/board/desktopNotify.ts
@@ -1,0 +1,129 @@
+import type { CoreEvent } from '../api/types.js';
+import { useMembershipStore } from '../store/membership.js';
+import { useNotifPrefsStore } from '../store/notifPrefs.js';
+import { gateOpenPath } from './gateActions.js';
+
+/**
+ * The desktop-notification trigger (DES-FEEDBACK-002 §8.2, P2-8, slice L) —
+ * one function folded into the app's existing `/ws` ingest (App.tsx), beside
+ * the in-app stores. Additive and hidden-tab-only: the in-app
+ * GateNotifications toasts own the visible tab, this layer exists ONLY for
+ * the operator who tabbed away.
+ *
+ * Fires iff ALL hold:
+ *   - the frame is `awaitingHuman` (exactly that — §8.2 "no invented events");
+ *   - the tab is unfocused: `document.visibilityState === 'hidden'` OR
+ *     `document.hasFocus() === false` (the visible-but-unfocused window);
+ *   - the operator opted in (`studio.notifications.desktop`) AND the browser
+ *     permission is `granted` — NEVER prompts here (EC25: the one
+ *     `requestPermission` call in the app lives on the settings toggle);
+ *   - this exact gate (runId + ord) has not already fired — a reconnect
+ *     replaying the same `awaitingHuman` must not re-notify; a LATER gate on
+ *     the same run (new ord) is a new question and may. The OS `tag` (the run
+ *     id) additionally collapses same-run notifications at the OS level.
+ *
+ * Body: the prompt's first line, `· <project name>` when the membership
+ * mirror knows it. Click focuses the window and lands on the run's gate —
+ * `…/build/<run>#gate` when the run's project is known (the same one-shot
+ * `#gate` intent the triage cursor uses), else the legacy `/runs/:id` route,
+ * which resolves the project itself.
+ *
+ * The chime (§8.2): ~0.4s two-tone (sine, 880→1175 Hz, gain-enveloped) built
+ * with the Web Audio API — zero asset bytes, no `<audio>`, CSP-clean. Played
+ * only when a notification actually fires (same guards), and skipped under
+ * `prefers-reduced-motion: reduce` (the OS-level "calm down" preference).
+ */
+
+/** (runId → ord) of gates that already raised a notification this session. */
+const fired = new Map<string, number>();
+
+/** Test-only: forget the per-gate de-dupe state. */
+export function resetDesktopNotify(): void {
+  fired.clear();
+}
+
+/** The tab-unfocused test (§8.2): hidden, or visible but not the focused window. */
+function tabUnfocused(): boolean {
+  return document.visibilityState === 'hidden' || !document.hasFocus();
+}
+
+function reducedMotion(): boolean {
+  try {
+    return typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false;
+  }
+}
+
+/** The synthesized two-tone chime — created per fire, closed when done. */
+function playChime(): void {
+  const Ctor = (window as unknown as { AudioContext?: typeof AudioContext }).AudioContext;
+  if (Ctor === undefined) return;
+  try {
+    const ctx = new Ctor();
+    const gain = ctx.createGain();
+    gain.connect(ctx.destination);
+    const t0 = ctx.currentTime;
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(0.12, t0 + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + 0.4);
+    for (const [freq, at] of [[880, 0], [1175, 0.18]] as const) {
+      const osc = ctx.createOscillator();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(freq, t0 + at);
+      osc.connect(gain);
+      osc.start(t0 + at);
+      osc.stop(t0 + 0.4);
+    }
+    setTimeout(() => { void ctx.close().catch(() => undefined); }, 600);
+  } catch {
+    /* no audio device / autoplay refusal — the notification already fired */
+  }
+}
+
+/** Navigation from a Notification.onclick — no React tree in scope, so push
+ *  the path the way the app's own `navigate` does and let useRoute's popstate
+ *  listener pick it up. */
+function goTo(path: string): void {
+  history.pushState(null, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+/**
+ * Fold one CoreEvent (App.tsx's ingest). Never throws; never prompts (EC25).
+ */
+export function notifyGateIfUnfocused(event: CoreEvent): void {
+  if (event.type !== 'awaitingHuman') return;
+  const runId = typeof event.session === 'string' ? event.session : undefined;
+  if (runId === undefined) return;
+  const ord = typeof event.ord === 'number' ? event.ord : 0;
+
+  if (typeof Notification === 'undefined') return;
+  const { prefs } = useNotifPrefsStore.getState();
+  if (!prefs.desktop || Notification.permission !== 'granted') return;
+  if (!tabUnfocused()) return;
+  if (fired.get(runId) === ord) return; // a replayed frame, not a new gate
+
+  const { projectNameByRun, projectIdByRun } = useMembershipStore.getState();
+  const prompt = typeof event.prompt === 'string' && event.prompt !== ''
+    ? event.prompt
+    : 'A run is awaiting your review';
+  const firstLine = prompt.split('\n', 1)[0] ?? prompt;
+  const projectName = projectNameByRun[runId];
+  const body = projectName !== undefined ? `${firstLine} · ${projectName}` : firstLine;
+
+  try {
+    const n = new Notification('Gate needs you', { body, tag: runId });
+    fired.set(runId, ord);
+    n.onclick = () => {
+      window.focus();
+      const pid = useMembershipStore.getState().projectIdByRun[runId] ?? projectIdByRun[runId];
+      goTo(pid !== undefined ? gateOpenPath(pid, runId) : `/runs/${runId}`);
+      n.close();
+    };
+  } catch {
+    return; // a refusing constructor must not block the ingest fold
+  }
+
+  if (prefs.chime && !reducedMotion()) playChime();
+}

--- a/src/components/BatchGateBar.tsx
+++ b/src/components/BatchGateBar.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  clearBatchSelection,
+  retryBatchOne,
+  runBatchDecision,
+  toggleBatchSelect,
+  useBatchGateStore,
+} from '../board/batchGates.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { isSimpleGate, type OpenGate } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
+
+/**
+ * The batch bar (DES-FEEDBACK-002 §9.2, slice L): docks above the board /
+ * gate inbox while ≥1 simple gate is selected.
+ *
+ *   3 gates selected   [Approve all]  [Reject all…]  [clear]
+ *
+ * The safety asymmetry (§9.2): Approve all fires directly — approving a
+ * routine gate is the routine act. Reject all… PAUSES: the ellipsis opens the
+ * §2.3 inline note ONCE at bar level, and the typed reason rides every reject
+ * in the fan-out as `amend` (reject cancels runs — never a single silent
+ * key). In flight the bar counts `2/3…`; failures stay listed per-id with the
+ * named error, a retry that fires ONLY that id, and the honest open-the-
+ * thread door.
+ *
+ * Tokens (§9.3): `--surface-raised` ground under `--shadow-raised`,
+ * `--radius-lg`; approve in the `--status-run` pair and reject in the
+ * `--status-fail` pair — status semantics, not accent (these are run-state
+ * actions). Failure lines `--text-xs --font-mono --status-fail`.
+ */
+
+const CSS = {
+  bar: {
+    display: 'flex', flexDirection: 'column', gap: '6px',
+    background: 'var(--surface-raised)', boxShadow: 'var(--shadow-raised)',
+    borderRadius: 'var(--radius-lg)', padding: '8px 12px',
+    margin: '0 var(--space-6) var(--space-2)',
+  },
+  row: { display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 },
+  count: {
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-high)', margin: 0, flexShrink: 0,
+  },
+  btn: {
+    border: 'none', cursor: 'pointer', borderRadius: 'var(--radius-md)',
+    fontSize: 'var(--text-xs)', fontWeight: 'var(--weight-semi)', padding: '4px 10px',
+  },
+  clear: {
+    background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+  },
+  fail: {
+    display: 'flex', alignItems: 'center', gap: '8px', margin: 0,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--status-fail)',
+    minWidth: 0,
+  },
+  failBtn: {
+    background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-body)', textDecoration: 'underline', flexShrink: 0,
+  },
+  noteInput: {
+    flex: 1, minWidth: 0, background: 'var(--surface-card)',
+    border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)',
+    outline: 'none', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)',
+    color: 'var(--ink-high)', padding: '3px 8px',
+  },
+  hint: {
+    flexShrink: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)',
+    fontFamily: 'var(--font-mono)', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+/**
+ * The per-row selection slot (§9.2): renders NOTHING until ≥1 gate is
+ * selected (the first selection is the cursor's `x` — after that, mouse users
+ * click these directly). A simple gate gets the checkbox (`--radius-sm` box,
+ * checked fill `--accent`); a complex gate gets the `↗` "needs the thread"
+ * marker instead — it cannot be batch-answered for the same reason its chip
+ * has no inline buttons (§2.3).
+ */
+export function BatchSelectBox({ runId, gate }: {
+  runId: string;
+  gate: OpenGate | undefined;
+}): React.ReactElement | null {
+  const any = useBatchGateStore((s) => s.selected.length > 0);
+  const checked = useBatchGateStore((s) => s.selected.includes(runId));
+  const running = useBatchGateStore((s) => s.running);
+  if (!any) return null;
+  if (!isSimpleGate(gate)) {
+    return (
+      <span
+        data-testid="batch-ineligible"
+        title="needs the thread — open it to answer"
+        aria-hidden
+        style={{ flexShrink: 0, fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}
+      >
+        ↗
+      </span>
+    );
+  }
+  return (
+    <input
+      type="checkbox"
+      data-testid={`batch-select-${runId}`}
+      aria-label="Select this gate for batch resolution"
+      checked={checked}
+      disabled={running}
+      onChange={() => toggleBatchSelect(runId)}
+      onClick={(e) => e.stopPropagation()}
+      style={{ flexShrink: 0, accentColor: 'var(--accent)', borderRadius: 'var(--radius-sm)', margin: 0 }}
+    />
+  );
+}
+
+export function BatchGateBar({ navigate }: { navigate: Navigate }): React.ReactElement | null {
+  const { selected, running, done, total, failures } = useBatchGateStore();
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  const [noteOpen, setNoteOpen] = useState(false);
+  const [note, setNote] = useState('');
+  const noteRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (noteOpen) noteRef.current?.focus();
+  }, [noteOpen]);
+
+  if (selected.length === 0 && failures.length === 0) return null;
+
+  const submitRejects = (): void => {
+    setNoteOpen(false);
+    const amend = note.trim();
+    setNote('');
+    void runBatchDecision(amend === '' ? { approve: false } : { approve: false, amend });
+  };
+
+  return (
+    <div
+      data-testid="batch-bar"
+      data-count={selected.length}
+      data-running={running ? 'true' : 'false'}
+      style={CSS.bar}
+    >
+      <div style={CSS.row}>
+        <p style={CSS.count}>
+          {running
+            ? `${done}/${total}…`
+            : `${selected.length} ${selected.length === 1 ? 'gate' : 'gates'} selected`}
+        </p>
+        {noteOpen ? (
+          // §9.2: the reject note opens ONCE at bar level; its text rides
+          // every reject in the fan-out as `amend`. Escape cancels, firing
+          // nothing — the same contract as the per-card note (§2.3).
+          <>
+            <input
+              ref={noteRef}
+              type="text"
+              data-testid="batch-reject-note"
+              placeholder="reason (optional)"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  submitRejects();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setNoteOpen(false);
+                  setNote('');
+                }
+              }}
+              style={CSS.noteInput}
+            />
+            <span style={CSS.hint} aria-hidden>↵ reject all · esc cancel</span>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              data-testid="batch-approve-all"
+              disabled={running || selected.length === 0}
+              onClick={() => void runBatchDecision({ approve: true })}
+              style={{ ...CSS.btn, background: 'var(--status-run-dim)', color: 'var(--status-run)' }}
+            >
+              Approve all
+            </button>
+            <button
+              type="button"
+              data-testid="batch-reject-all"
+              disabled={running || selected.length === 0}
+              onClick={() => setNoteOpen(true)}
+              style={{ ...CSS.btn, background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}
+            >
+              Reject all…
+            </button>
+            <button
+              type="button"
+              data-testid="batch-clear"
+              disabled={running}
+              onClick={clearBatchSelection}
+              style={CSS.clear}
+            >
+              [ clear ]
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* §9.2 per-id honesty: which ids failed, why, retry-just-this-one. */}
+      {failures.map((f) => {
+        const pid = projectIdByRun[f.runId];
+        return (
+          <p key={f.runId} data-testid="batch-failure-row" data-run-id={f.runId} style={CSS.fail}>
+            <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              failed: {f.runId} ({f.error})
+            </span>
+            <button
+              type="button"
+              data-testid={`batch-retry-${f.runId}`}
+              disabled={running}
+              onClick={() => void retryBatchOne(f.runId)}
+              style={CSS.failBtn}
+            >
+              retry
+            </button>
+            {pid !== undefined && (
+              <button
+                type="button"
+                data-testid={`batch-open-${f.runId}`}
+                onClick={() => navigate(gateOpenPath(pid, f.runId))}
+                style={CSS.failBtn}
+              >
+                open
+              </button>
+            )}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -6,6 +6,7 @@ import type { Navigate } from '../hooks/useRoute.js';
 import { modePath, projectPath } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
+import { BatchGateBar } from './BatchGateBar.js';
 import { LiveFeed } from './LiveFeed.js';
 import { NarrativeBand } from './NarrativeBand.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
@@ -256,6 +257,10 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
           All runs ›
         </a>
       </header>
+
+      {/* Slice L (§9.2): the batch bar docks above the board while ≥1 simple
+          gate is selected — approve/reject fan-out, per-id honesty rows. */}
+      <BatchGateBar navigate={navigate} />
 
       <div
         ref={scroller}

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useNotifPrefsStore } from '../store/notifPrefs.js';
+
+/**
+ * The Notifications group of the `/system` settings surface (DES-FEEDBACK-002
+ * §8.2, slice L; placed per DES-FEEDBACK-003 §8.6 — the route is unchanged,
+ * it is reached under the rail's Settings heading).
+ *
+ * Opt-in and permission-gated IN THE RIGHT ORDER (EC25): the browser's
+ * permission prompt fires only on the desktop option's own click — never on
+ * app load, never from the ingest fold. `denied` renders the state honestly
+ * ("blocked in browser settings — the studio cannot re-ask") and the radio
+ * reverts to Off. Persistence is `studio.notifications` on the crew settings
+ * wire — the appearance pattern verbatim (`useNotifPrefsStore`).
+ *
+ * Tokens (§8.3): the existing settings dress — labels `--text-sm --font-sans
+ * --ink-body`; the permission state line `--text-xs --font-mono`, in
+ * `--status-run` when granted, `--status-fail` when denied. No other visual
+ * surface: the feature's output is the OS's, not ours.
+ */
+
+type PermState = NotificationPermission | 'unsupported';
+
+function permissionNow(): PermState {
+  return typeof Notification === 'undefined' ? 'unsupported' : Notification.permission;
+}
+
+const CSS = {
+  row: { display: 'flex', alignItems: 'flex-start', gap: '8px', padding: '6px 0' },
+  label: {
+    fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)',
+    color: 'var(--ink-body)', cursor: 'pointer',
+  },
+  status: { fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', margin: '8px 0 0' },
+} as const satisfies Record<string, React.CSSProperties>;
+
+export function NotificationSettings(): React.ReactElement {
+  const prefs = useNotifPrefsStore((s) => s.prefs);
+  const update = useNotifPrefsStore((s) => s.update);
+  const [permission, setPermission] = useState<PermState>(permissionNow);
+  const [denied, setDenied] = useState(false);
+
+  /** EC25: THE one requestPermission call site in the app — this click. */
+  async function chooseDesktop(): Promise<void> {
+    if (typeof Notification === 'undefined') return;
+    let result: NotificationPermission = Notification.permission;
+    if (result !== 'granted') {
+      try {
+        result = await Notification.requestPermission();
+      } catch {
+        result = Notification.permission;
+      }
+    }
+    setPermission(result);
+    if (result === 'granted') {
+      setDenied(false);
+      update({ desktop: true });
+    } else {
+      // The radio reverts to Off; a `denied` is named honestly below.
+      setDenied(result === 'denied');
+      update({ desktop: false });
+    }
+  }
+
+  const statusLine = ((): { text: string; color: string } | null => {
+    if (permission === 'unsupported') {
+      return { text: 'this browser does not support desktop notifications', color: 'var(--ink-dim)' };
+    }
+    if (permission === 'denied' || denied) {
+      return {
+        text: 'permission blocked in browser settings — the studio cannot re-ask',
+        color: 'var(--status-fail)',
+      };
+    }
+    if (permission === 'granted') return { text: 'permission granted ✓', color: 'var(--status-run)' };
+    return null; // 'default': nothing to report until the operator opts in
+  })();
+
+  return (
+    <section
+      data-testid="notif-settings"
+      className="rounded-xl px-5 mb-6 pb-4"
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    >
+      <h2
+        className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
+        style={{ color: 'var(--ink-dim)' }}
+      >
+        Notifications
+      </h2>
+
+      <div style={CSS.row}>
+        <input
+          type="radio"
+          id="notif-off"
+          name="notif-mode"
+          data-testid="notif-off"
+          checked={!prefs.desktop}
+          onChange={() => { setDenied(false); update({ desktop: false }); }}
+          style={{ accentColor: 'var(--accent)', marginTop: '2px' }}
+        />
+        <label htmlFor="notif-off" style={CSS.label}>Off — in-app toasts only</label>
+      </div>
+
+      <div style={CSS.row}>
+        <input
+          type="radio"
+          id="notif-desktop"
+          name="notif-mode"
+          data-testid="notif-desktop"
+          checked={prefs.desktop}
+          disabled={permission === 'unsupported'}
+          onChange={() => { void chooseDesktop(); }}
+          style={{ accentColor: 'var(--accent)', marginTop: '2px' }}
+        />
+        <label htmlFor="notif-desktop" style={CSS.label}>
+          Desktop notification when a gate needs you and this tab is hidden
+        </label>
+      </div>
+
+      <div style={{ ...CSS.row, paddingLeft: '24px' }}>
+        <input
+          type="checkbox"
+          id="notif-chime"
+          data-testid="notif-chime"
+          checked={prefs.chime}
+          disabled={!prefs.desktop}
+          onChange={(e) => update({ chime: e.target.checked })}
+          style={{ accentColor: 'var(--accent)', marginTop: '2px' }}
+        />
+        <label
+          htmlFor="notif-chime"
+          style={{ ...CSS.label, color: prefs.desktop ? 'var(--ink-body)' : 'var(--ink-dim)' }}
+        >
+          Also play a chime
+        </label>
+      </div>
+
+      {statusLine !== null && (
+        <p data-testid="notif-permission" style={{ ...CSS.status, color: statusLine.color }}>
+          {statusLine.text}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -5,6 +5,7 @@ import { modePath, MODES, projectPath, type Navigate } from '../hooks/useRoute.j
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore } from '../store/runtime.js';
+import { BatchSelectBox } from './BatchGateBar.js';
 import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
@@ -286,6 +287,9 @@ export function ProjectCard({
   // Relayed interactive status for THIS project — one line, plus the tile date it implies.
   const activity = useRuntimeStore((s) => s.docActivity[project.id]);
   const live = runs.filter(isLive);
+  // Slice L (§9.2): the card's batch-selectable gate is its LEADING waiting
+  // run — the same run the triage cursor's `x` toggles (TriageItem.runId).
+  const leadingWaiting = runs.find((v) => v.session.status === 'awaiting_human')?.session.id;
   const empty = runs.length === 0 && docs.length === 0;
   /** The §2.1.2 exception: empty AND just created — not merely empty. */
   const firstRun = empty && Date.now() - project.created_at < FIRST_RUN_MS;
@@ -475,6 +479,12 @@ export function ProjectCard({
               // the run link, and beside it a chip carrying its own controls. Nesting
               // buttons inside the link would be neither valid nor operable.
               <div key={session.id} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                {/* Slice L (§9.2): the selection slot — checkbox for a simple
+                    gate, the ↗ needs-the-thread marker for a complex one;
+                    renders only once ≥1 gate is selected anywhere. */}
+                {waiting && session.id === leadingWaiting && (
+                  <BatchSelectBox runId={session.id} gate={gate} />
+                )}
                 <a
                   {...link(modePath(project.id, 'build', session.id))}
                   data-testid="run-chip"

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -10,6 +10,7 @@ import { useTriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
 import { getCachedRepos } from '../store/repoCache.js';
+import { BatchGateBar, BatchSelectBox } from './BatchGateBar.js';
 import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
@@ -303,6 +304,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         )}
       </header>
 
+      {/* Slice L (§9.2): the batch bar docks above the tiles while ≥1 simple
+          gate is selected — the same bar (and fan-out) as the home board. */}
+      <BatchGateBar navigate={navigate} />
+
       <div style={CSS.grid}>
         {/* ── Tile 1: runs, attention-ordered, each a link into its mode view ── */}
         <section data-testid="dashboard-runs" data-count={myRuns.length} style={CSS.tile}>
@@ -406,6 +411,8 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
                       <GateRejectNote runId={id} onClose={cursor.closeNote} />
                     ) : (
                       <>
+                        {/* Slice L (§9.2): checkbox / ↗ marker, once ≥1 selected. */}
+                        <BatchSelectBox runId={id} gate={gate} />
                         <span
                           title={gate?.prompt}
                           style={{

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 import { Modal } from './Modal.js';
+import { NotificationSettings } from './NotificationSettings.js';
 import { Terminal } from './Terminal.js';
 
 const CLI_DEFAULTS_KEY = 'wicked_default_clis';
@@ -185,6 +186,11 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
           Theme ›
         </a>
       </div>
+
+      {/* Slice L (DES-FEEDBACK-002 §8.2): the desktop-notification opt-in —
+          crew-persisted (`studio.notifications`), permission asked only on
+          the toggle's own gesture (EC25). */}
+      <NotificationSettings />
 
       <section
         className="rounded-xl px-5 mb-6"

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -163,15 +163,19 @@ const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {
  */
 function mirrorMembership(projects: Project[], bindings: Record<string, Bindings>): void {
   const map: Record<string, string> = {};
+  const ids: Record<string, string> = {};
   const clocks: Record<string, number> = {};
   for (const p of projects) {
     const b = bindings[p.id];
     if (b === undefined) continue;
-    for (const id of b.runIds) map[id] = p.name;
+    for (const id of b.runIds) { map[id] = p.name; ids[id] = p.id; }
     Object.assign(clocks, b.attachedAt);
   }
   const store = useMembershipStore.getState();
   store.setProjectNames(map);
+  // Slice L (DES-FEEDBACK-002 §8.2): the id join rides the same read — the
+  // desktop notification's click target resolves from it, zero new requests.
+  store.setProjectIds(ids);
   // The attach clocks ride the same mirror (slice O): the Make dashboard's
   // tiles bucket on them with zero requests of their own (§4.2.1).
   store.setAttachedAt(clocks);

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { clearBatchSelection, toggleBatchSelect, useBatchGateStore } from '../board/batchGates.js';
 import { decideGate, gateOpenPath } from '../board/gateActions.js';
 import { isSimpleGate, type OpenGate } from '../store/gates.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
@@ -73,7 +74,13 @@ export function useTriageCursor(
     }
     setSelectedKey(null);
     setNoteFor(null);
+    clearBatchSelection(); // §9.2: pivoting projects is a surface change too
   }, [resetKey]);
+
+  // Slice L (§9.2): the batch selection dies with the surface — a route
+  // change unmounts the cursor's owner, and a selection must never survive
+  // onto a surface that does not render its checkboxes.
+  useEffect(() => clearBatchSelection, []);
 
   const focusSelected = (): void => {
     const key = selRef.current;
@@ -163,6 +170,25 @@ export function useTriageCursor(
           }
         },
       },
+      // Slice L (§9.2): `x` (or Space) toggles the cursor row's gate into the
+      // batch selection. Only a SIMPLE gate may enter (§7.11 — a complex gate
+      // cannot be batch-answered for the same reason its chip has no inline
+      // buttons); on a complex or gateless row the key yields silently.
+      ...(['x', ' '] as const).map((key): ShortcutEntry => ({
+        id: `batch-toggle-${key === ' ' ? 'space' : key}`,
+        chord: { key },
+        description: 'Select the gate for batch resolution',
+        guard: () => {
+          const item = current();
+          return item !== null && item.runId !== null && isSimpleGate(item.gate);
+        },
+        handler: (e) => {
+          const item = current();
+          if (item === null || item.runId === null) return;
+          e.preventDefault(); // Space must select, never scroll
+          toggleBatchSelect(item.runId);
+        },
+      })),
       {
         id: 'triage-open',
         chord: { key: 'enter' },
@@ -178,14 +204,17 @@ export function useTriageCursor(
       {
         id: 'triage-clear',
         chord: { key: 'escape' },
-        description: 'Clear the triage cursor',
+        description: 'Clear the triage cursor and batch selection',
         // DES-FEEDBACK-003 §5.7 Escape precedence (palette → sheet → triage):
         // while the runs sheet is up, this entry YIELDS so the sheet's own
         // registry entry closes it first — the selection survives the press.
-        guard: () => selRef.current !== null && !useRunsPanelStore.getState().expanded,
+        guard: () =>
+          (selRef.current !== null || useBatchGateStore.getState().selected.length > 0) &&
+          !useRunsPanelStore.getState().expanded,
         handler: () => {
           setNoteFor(null);
           setSelectedKey(null);
+          clearBatchSelection(); // §9.5: removes the bar, fires nothing
         },
       },
     ];

--- a/src/store/membership.ts
+++ b/src/store/membership.ts
@@ -14,6 +14,15 @@ interface MembershipStore {
   /** run id → owning project's display name. Unlisted = unfiled/unknown. */
   projectNameByRun: Record<string, string>;
   /**
+   * run id → owning project's ID, off the SAME members read (slice L,
+   * DES-FEEDBACK-002 §8.2): the desktop notification's click must land on the
+   * run's gate — `gateOpenPath(projectId, runId)` — synchronously, from a
+   * context with no React tree (a `Notification.onclick`). Same mirror rule:
+   * only the board model writes; unlisted = unfiled (the click falls back to
+   * the legacy `/runs/:id` route, which resolves the project itself).
+   */
+  projectIdByRun: Record<string, string>;
+  /**
    * run id → membership `attached_at` (epoch ms) — the one honest per-run
    * clock (AgentSession carries no timestamps), merged across projects. The
    * Make dashboard's tiles bucket on it (DES-FEEDBACK-003 §4.2.1) exactly as
@@ -22,12 +31,15 @@ interface MembershipStore {
   attachedAtByRun: Record<string, number>;
   /** Replace the mirror wholesale (the board model re-reads memberships whole). */
   setProjectNames: (map: Record<string, string>) => void;
+  setProjectIds: (map: Record<string, string>) => void;
   setAttachedAt: (map: Record<string, number>) => void;
 }
 
 export const useMembershipStore = create<MembershipStore>((set) => ({
   projectNameByRun: {},
+  projectIdByRun: {},
   attachedAtByRun: {},
   setProjectNames: (map) => set({ projectNameByRun: map }),
+  setProjectIds: (map) => set({ projectIdByRun: map }),
   setAttachedAt: (map) => set({ attachedAtByRun: map }),
 }));

--- a/src/store/notifPrefs.ts
+++ b/src/store/notifPrefs.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+
+/**
+ * Desktop-notification preferences (DES-FEEDBACK-002 §8, P2-8, slice L):
+ * whether an `awaitingHuman` arriving while the tab is hidden raises an OS
+ * notification, and whether a chime rides it. Persisted in crew's settings
+ * store under the namespaced key `studio.notifications` — the
+ * `useAppearanceStore` pattern verbatim (§8.2): load-once at startup,
+ * optimistic update, debounced fire-and-forget persist with one silent retry.
+ * A daemon whose settings blob lacks the key yields the defaults (Off) —
+ * no crash, and NEVER a permission prompt (EC25: the browser prompt fires
+ * only on the settings toggle's own click gesture, nowhere else).
+ */
+
+/** The `studio.notifications` wire object — what crew persists verbatim.
+ *  Shaped to grow (§13: a future `kinds: []` field) without migration. */
+export interface StudioNotifPrefs {
+  /** OS notification when a gate needs you and this tab is hidden. */
+  desktop: boolean;
+  /** Also play the synthesized chime when a notification fires. */
+  chime: boolean;
+}
+
+export const NOTIF_PREFS_KEY = 'studio.notifications';
+
+/** §8.2's default: Off — in-app toasts only. Opt-in, never assumed. */
+export const DEFAULT_NOTIF_PREFS: StudioNotifPrefs = { desktop: false, chime: false };
+
+const PERSIST_DEBOUNCE_MS = 400;
+const RETRY_MS = 2000;
+
+/** Never trust the stored shape (§3.3 rule — an external store): default hard. */
+export function sanitizeNotifPrefs(raw: unknown): StudioNotifPrefs {
+  const o = (raw !== null && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    desktop: o.desktop === true,
+    chime: o.chime === true,
+  };
+}
+
+interface NotifPrefsStore {
+  prefs: StudioNotifPrefs;
+  /** True once the startup GET settled (either way). */
+  loaded: boolean;
+  /** Startup read (App.tsx): GET the settings store, take `studio.notifications`.
+   *  A daemon without a settings surface fails silently — defaults stand. */
+  load: () => Promise<void>;
+  /** Optimistic partial update: apply NOW, persist after the debounce. */
+  update: (patch: Partial<StudioNotifPrefs>) => void;
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function persistSoon(read: () => StudioNotifPrefs): void {
+  if (persistTimer !== null) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    // Fire-and-forget with ONE silent retry; the retry re-reads the store so
+    // a newer edit is never clobbered by a stale snapshot (§3.3).
+    api.putNotifSettings(read()).catch(() => {
+      setTimeout(() => {
+        api.putNotifSettings(read()).catch(() => { /* stay silent */ });
+      }, RETRY_MS);
+    });
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+export const useNotifPrefsStore = create<NotifPrefsStore>((set, get) => ({
+  prefs: DEFAULT_NOTIF_PREFS,
+  loaded: false,
+
+  load: async () => {
+    try {
+      const { settings } = await api.getAppearanceSettings();
+      const stored = (settings as Record<string, unknown>)[NOTIF_PREFS_KEY];
+      set({ prefs: sanitizeNotifPrefs(stored), loaded: true });
+    } catch {
+      set({ loaded: true }); // no settings surface — Off stands
+    }
+  },
+
+  update: (patch) => {
+    const prefs = { ...get().prefs, ...patch };
+    set({ prefs });
+    persistSoon(() => get().prefs);
+  },
+}));

--- a/tests/NotificationSettings.test.tsx
+++ b/tests/NotificationSettings.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+/**
+ * The Notifications settings group (DES-FEEDBACK-002 §8.2, slice L): the
+ * permission-gesture flow. EC25 is the hazard this file pins: rendering the
+ * surface NEVER calls `Notification.requestPermission` — only the desktop
+ * option's own click does, exactly once; `granted` persists the pref over the
+ * settings wire, `denied` reverts the radio to Off and names the state
+ * honestly ("blocked in browser settings").
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn(),
+    putNotifSettings: vi.fn().mockResolvedValue({ settings: {} }),
+  },
+}));
+
+class FakeNotification {
+  static permission: NotificationPermission = 'default';
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+}
+vi.stubGlobal('Notification', FakeNotification);
+
+const { api } = await import('../src/api/client.js');
+const { NotificationSettings } = await import('../src/components/NotificationSettings.js');
+const { DEFAULT_NOTIF_PREFS, useNotifPrefsStore } = await import('../src/store/notifPrefs.js');
+
+const putNotif = vi.mocked(api.putNotifSettings);
+
+beforeEach(() => {
+  FakeNotification.permission = 'default';
+  FakeNotification.requestPermission.mockClear();
+  putNotif.mockClear();
+  useNotifPrefsStore.setState({ prefs: DEFAULT_NOTIF_PREFS, loaded: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('EC25 — the permission gesture', () => {
+  it('renders (default Off) without touching requestPermission', () => {
+    render(<NotificationSettings />);
+    expect(screen.getByTestId('notif-off')).toBeChecked();
+    expect(screen.getByTestId('notif-desktop')).not.toBeChecked();
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+    // 'default' permission before opting in: no status line to report yet.
+    expect(screen.queryByTestId('notif-permission')).toBeNull();
+  });
+
+  it('selecting the desktop option prompts exactly once; granted → pref on + persisted', async () => {
+    vi.useFakeTimers();
+    FakeNotification.requestPermission.mockResolvedValue('granted');
+    render(<NotificationSettings />);
+
+    await act(async () => {
+      screen.getByTestId('notif-desktop').click();
+    });
+    expect(FakeNotification.requestPermission).toHaveBeenCalledTimes(1);
+    expect(useNotifPrefsStore.getState().prefs.desktop).toBe(true);
+    expect(screen.getByTestId('notif-desktop')).toBeChecked();
+    expect(screen.getByTestId('notif-permission').textContent).toContain('granted');
+
+    // The pref rides the settings wire under the studio key (debounced).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(putNotif).toHaveBeenCalledWith({ desktop: true, chime: false });
+  });
+
+  it('denied → the radio reverts to Off and the state is named honestly', async () => {
+    FakeNotification.requestPermission.mockResolvedValue('denied');
+    render(<NotificationSettings />);
+
+    await act(async () => {
+      screen.getByTestId('notif-desktop').click();
+    });
+    expect(useNotifPrefsStore.getState().prefs.desktop).toBe(false);
+    expect(screen.getByTestId('notif-off')).toBeChecked();
+    expect(screen.getByTestId('notif-permission').textContent).toContain('blocked in browser settings');
+  });
+
+  it('an already-granted permission never re-prompts (the browser would throw it away)', async () => {
+    FakeNotification.permission = 'granted';
+    render(<NotificationSettings />);
+    await act(async () => {
+      screen.getByTestId('notif-desktop').click();
+    });
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+    expect(useNotifPrefsStore.getState().prefs.desktop).toBe(true);
+  });
+});
+
+describe('the chime checkbox', () => {
+  it('is disabled while desktop is Off, and toggles the pref when on', async () => {
+    render(<NotificationSettings />);
+    expect(screen.getByTestId('notif-chime')).toBeDisabled();
+
+    act(() => {
+      useNotifPrefsStore.setState({ prefs: { desktop: true, chime: false } });
+    });
+    expect(screen.getByTestId('notif-chime')).toBeEnabled();
+    await act(async () => {
+      screen.getByTestId('notif-chime').click();
+    });
+    expect(useNotifPrefsStore.getState().prefs.chime).toBe(true);
+  });
+});

--- a/tests/batchCursor.test.tsx
+++ b/tests/batchCursor.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { useBatchGateStore } from '../src/board/batchGates.js';
+import { useGateActionStore } from '../src/board/gateActions.js';
+import { useTriageCursor, type TriageItem } from '../src/hooks/useTriageCursor.js';
+import { setShortcutsPaletteOpen } from '../src/hooks/useGlobalShortcuts.js';
+import type { OpenGate } from '../src/store/gates.js';
+import type { Navigate } from '../src/hooks/useRoute.js';
+
+/**
+ * Slice L's selection keys on the slice-H cursor (DES-FEEDBACK-002 §9.2):
+ * `x`/Space toggle the cursor row's gate into the batch selection; a COMPLEX
+ * gate cannot enter (§9.5 — the same §7.11 boundary as its chip); Escape
+ * clears the selection with the cursor, firing nothing; the selection dies
+ * with the surface (unmount = route change).
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: { confirmGate: vi.fn() },
+}));
+
+const gate = (runId: string, over: Partial<OpenGate> = {}): OpenGate => ({
+  runId, ord: 0, prompt: `gate for ${runId}`, lifecycle: 'open', receivedAt: Date.now(), ...over,
+});
+
+function Harness({ items, navigate }: { items: TriageItem[]; navigate: Navigate }): React.ReactElement {
+  const cursor = useTriageCursor(items, navigate);
+  return (
+    <div>
+      {items.map((it) => (
+        <div key={it.key} tabIndex={-1} data-kbd-item={it.key}
+          {...(cursor.selectedKey === it.key ? { 'data-kbd-selected': 'true' } : {})} />
+      ))}
+    </div>
+  );
+}
+
+const press = (key: string): void => {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  });
+};
+
+const item = (key: string, runId: string | null, g?: OpenGate): TriageItem => ({
+  key, runId, gate: g, openPath: `/p/${key}`, projectId: key,
+});
+
+const ITEMS: TriageItem[] = [
+  item('p-simple', 'r-simple', gate('r-simple')),               // ≤2 choices ⇒ simple
+  item('p-complex', 'r-complex', gate('r-complex', { choices: null })), // free text ⇒ complex
+  item('p-cached', 'r-cached', undefined),                      // daemon restarted ⇒ still simple
+  item('p-idle', null, undefined),                              // nothing gates here
+];
+
+const selected = (): string[] => useBatchGateStore.getState().selected;
+
+beforeEach(() => {
+  setShortcutsPaletteOpen(false);
+  useGateActionStore.setState({ byGate: {} });
+  useBatchGateStore.setState({
+    selected: [], running: false, done: 0, total: 0, failures: [], lastDecision: null,
+  });
+});
+
+describe('x / Space on the cursor (§9.2)', () => {
+  it('toggles the SIMPLE gate under the cursor — x on, x off; Space too', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); // cursor → p-simple
+    press('x');
+    expect(selected()).toEqual(['r-simple']);
+    press('x');
+    expect(selected()).toEqual([]);
+    press(' ');
+    expect(selected()).toEqual(['r-simple']);
+  });
+
+  it('a cached-gate-less run is still simple (§7.11) and selectable', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); press('j'); press('j'); // → p-cached
+    press('x');
+    expect(selected()).toEqual(['r-cached']);
+  });
+
+  it('a COMPLEX gate cannot enter the selection via x (§9.5)', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); press('j'); // → p-complex
+    press('x');
+    press(' ');
+    expect(selected()).toEqual([]);
+  });
+
+  it('a gateless row yields silently', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); press('j'); press('j'); press('j'); // → p-idle
+    press('x');
+    expect(selected()).toEqual([]);
+  });
+});
+
+describe('clearing (§9.5)', () => {
+  it('Escape clears the selection with the cursor and fires nothing', async () => {
+    const { api } = await import('../src/api/client.js');
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); press('x');
+    expect(selected()).toEqual(['r-simple']);
+    press('Escape');
+    expect(selected()).toEqual([]);
+    expect(document.querySelector('[data-kbd-selected="true"]')).toBeNull();
+    expect(vi.mocked(api.confirmGate)).not.toHaveBeenCalled();
+  });
+
+  it('Escape works for a mouse-made selection even with no cursor active', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    act(() => useBatchGateStore.setState({ selected: ['r-simple'] })); // checkbox path
+    press('Escape');
+    expect(selected()).toEqual([]);
+  });
+
+  it('the selection dies with the surface (unmount = route change)', () => {
+    const { unmount } = render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j'); press('x');
+    expect(selected()).toEqual(['r-simple']);
+    unmount();
+    expect(selected()).toEqual([]);
+  });
+
+  it('while the palette is open, x belongs to the palette — no toggle', () => {
+    render(<Harness items={ITEMS} navigate={vi.fn()} />);
+    press('j');
+    setShortcutsPaletteOpen(true);
+    press('x');
+    expect(selected()).toEqual([]);
+    setShortcutsPaletteOpen(false);
+  });
+});

--- a/tests/batchGates.test.ts
+++ b/tests/batchGates.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Batch gate resolution (DES-FEEDBACK-002 §9, slice L): the selection model,
+ * the SEQUENTIAL fan-out through the ONE audited `decideGate` path (exact
+ * POST count and order — never a parallel burst), per-id failure honesty
+ * (the bulk-archive precedent client-side), the shared double-submit guard,
+ * and retry-fires-only-that-id.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: { confirmGate: vi.fn() },
+}));
+
+const { api } = await import('../src/api/client.js');
+const {
+  clearBatchSelection, retryBatchOne, runBatchDecision, toggleBatchSelect, useBatchGateStore,
+} = await import('../src/board/batchGates.js');
+const { useGateActionStore } = await import('../src/board/gateActions.js');
+
+const confirmGate = vi.mocked(api.confirmGate);
+
+beforeEach(() => {
+  confirmGate.mockReset().mockResolvedValue({ status: 'resumed' });
+  useGateActionStore.setState({ byGate: {} });
+  useBatchGateStore.setState({
+    selected: [], running: false, done: 0, total: 0, failures: [], lastDecision: null,
+  });
+});
+
+describe('the selection model (§9.2)', () => {
+  it('toggles in selection order; a second toggle removes', () => {
+    toggleBatchSelect('r-a');
+    toggleBatchSelect('r-b');
+    expect(useBatchGateStore.getState().selected).toEqual(['r-a', 'r-b']);
+    toggleBatchSelect('r-a');
+    expect(useBatchGateStore.getState().selected).toEqual(['r-b']);
+  });
+
+  it('clear drops everything and fires nothing (§9.5)', () => {
+    toggleBatchSelect('r-a');
+    clearBatchSelection();
+    expect(useBatchGateStore.getState().selected).toEqual([]);
+    expect(confirmGate).not.toHaveBeenCalled();
+  });
+});
+
+describe('the sequential fan-out (§9.2)', () => {
+  it('fires exactly one POST per selected id, in selection order, one at a time', async () => {
+    const resolvers: Array<() => void> = [];
+    confirmGate.mockImplementation(
+      () => new Promise((resolve) => resolvers.push(() => resolve({ status: 'resumed' }))),
+    );
+    toggleBatchSelect('r-a');
+    toggleBatchSelect('r-b');
+    toggleBatchSelect('r-c');
+
+    const run = runBatchDecision({ approve: true });
+    await vi.waitFor(() => expect(confirmGate).toHaveBeenCalledTimes(1)); // strictly sequential
+    expect(useBatchGateStore.getState().running).toBe(true);
+    resolvers[0]!();
+    await vi.waitFor(() => expect(confirmGate).toHaveBeenCalledTimes(2));
+    resolvers[1]!();
+    await vi.waitFor(() => expect(confirmGate).toHaveBeenCalledTimes(3));
+    resolvers[2]!();
+    await run;
+
+    expect(confirmGate.mock.calls.map((c) => c[0])).toEqual(['r-a', 'r-b', 'r-c']);
+    expect(confirmGate.mock.calls.every((c) => c[1]?.approve === true)).toBe(true);
+    const s = useBatchGateStore.getState();
+    expect(s).toMatchObject({ running: false, done: 3, total: 3, failures: [], selected: [] });
+  });
+
+  it('the reject fan-out carries the ONE bar-level note as amend on every id (§9.2)', async () => {
+    toggleBatchSelect('r-a');
+    toggleBatchSelect('r-b');
+    await runBatchDecision({ approve: false, amend: 'wrong branch' });
+    expect(confirmGate.mock.calls.map((c) => c[1])).toEqual([
+      { approve: false, amend: 'wrong branch' },
+      { approve: false, amend: 'wrong branch' },
+    ]);
+  });
+
+  it('a second fan-out while one runs is dropped (the shared double-submit guard)', async () => {
+    let release: () => void = () => undefined;
+    confirmGate.mockImplementation(
+      () => new Promise((resolve) => { release = () => resolve({ status: 'resumed' }); }),
+    );
+    toggleBatchSelect('r-a');
+    const first = runBatchDecision({ approve: true });
+    await vi.waitFor(() => expect(confirmGate).toHaveBeenCalledTimes(1));
+    await runBatchDecision({ approve: true }); // dropped — returns without a POST
+    expect(confirmGate).toHaveBeenCalledTimes(1);
+    release();
+    await first;
+    expect(confirmGate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('per-id failure honesty (§9.2/§9.5)', () => {
+  it('a 409 on one id stays listed with its named error; successes leave', async () => {
+    confirmGate.mockImplementation(async (id: string) => {
+      if (id === 'r-b') throw new Error('API 409: run resumed');
+      return { status: 'resumed' };
+    });
+    toggleBatchSelect('r-a');
+    toggleBatchSelect('r-b');
+    toggleBatchSelect('r-c');
+    await runBatchDecision({ approve: true });
+
+    const s = useBatchGateStore.getState();
+    expect(s.failures).toEqual([{ runId: 'r-b', error: 'API 409: run resumed' }]);
+    expect(s.selected).toEqual(['r-b']); // the failed id is still answerable
+    expect(s.done).toBe(3);
+  });
+
+  it('retry fires ONLY the failed id, with the decision the fan-out used', async () => {
+    confirmGate.mockRejectedValueOnce(new Error('API 409: not awaiting a human gate'));
+    toggleBatchSelect('r-a');
+    await runBatchDecision({ approve: true });
+    expect(useBatchGateStore.getState().failures).toHaveLength(1);
+
+    confirmGate.mockClear().mockResolvedValue({ status: 'resumed' });
+    await retryBatchOne('r-a');
+    expect(confirmGate).toHaveBeenCalledTimes(1);
+    expect(confirmGate).toHaveBeenCalledWith('r-a', { approve: true });
+    const s = useBatchGateStore.getState();
+    expect(s.failures).toEqual([]);
+    expect(s.selected).toEqual([]);
+  });
+
+  it('retry of an id that never failed is a no-op', async () => {
+    toggleBatchSelect('r-a');
+    await runBatchDecision({ approve: true });
+    confirmGate.mockClear();
+    await retryBatchOne('r-a');
+    expect(confirmGate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/desktopNotify.test.ts
+++ b/tests/desktopNotify.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+
+/**
+ * The desktop-notification trigger (DES-FEEDBACK-002 §8.2/§8.4, slice L):
+ * fires ONLY for `awaitingHuman` + unfocused tab + opted-in + `granted` —
+ * and NEVER calls `Notification.requestPermission` itself (EC25: the one
+ * prompt call site is the settings toggle). De-dupes per gate (runId + ord):
+ * a reconnect replaying the same frame must not re-notify; a LATER gate on
+ * the same run may (same OS `tag`, so no unbounded stack either way). The
+ * click focuses the window and lands on the run's gate; the chime is Web
+ * Audio, played only when a notification actually fired and the chime pref
+ * is on.
+ */
+
+class FakeNotification {
+  static permission: NotificationPermission = 'granted';
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+  static instances: FakeNotification[] = [];
+  title: string;
+  body: string | undefined;
+  tag: string | undefined;
+  onclick: (() => void) | null = null;
+  closed = false;
+  constructor(title: string, opts?: { body?: string; tag?: string }) {
+    this.title = title;
+    this.body = opts?.body;
+    this.tag = opts?.tag;
+    FakeNotification.instances.push(this);
+  }
+  close(): void { this.closed = true; }
+}
+
+class FakeAudioContext {
+  static created = 0;
+  currentTime = 0;
+  destination = {};
+  constructor() { FakeAudioContext.created += 1; }
+  createGain() {
+    return {
+      connect: () => undefined,
+      gain: {
+        setValueAtTime: () => undefined,
+        exponentialRampToValueAtTime: () => undefined,
+      },
+    };
+  }
+  createOscillator() {
+    return {
+      type: 'sine',
+      frequency: { setValueAtTime: () => undefined },
+      connect: () => undefined,
+      start: () => undefined,
+      stop: () => undefined,
+    };
+  }
+  close(): Promise<void> { return Promise.resolve(); }
+}
+
+vi.stubGlobal('Notification', FakeNotification);
+vi.stubGlobal('AudioContext', FakeAudioContext);
+
+const { notifyGateIfUnfocused, resetDesktopNotify } = await import('../src/board/desktopNotify.js');
+const { useNotifPrefsStore, DEFAULT_NOTIF_PREFS } = await import('../src/store/notifPrefs.js');
+const { useMembershipStore } = await import('../src/store/membership.js');
+
+let visibility: DocumentVisibilityState = 'hidden';
+let focused = false;
+let reducedMotion = false;
+
+const gateEvent = (runId: string, ord = 0, prompt = 'Approve the deck outline?\nmore detail'): CoreEvent =>
+  ({ type: 'awaitingHuman', session: runId, ord, prompt } as unknown as CoreEvent);
+
+beforeEach(() => {
+  visibility = 'hidden';
+  focused = false;
+  reducedMotion = false;
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true, get: () => visibility,
+  });
+  document.hasFocus = () => focused;
+  vi.stubGlobal('matchMedia', (q: string) => ({
+    matches: q.includes('prefers-reduced-motion') ? reducedMotion : false,
+  }));
+  FakeNotification.permission = 'granted';
+  FakeNotification.requestPermission.mockClear();
+  FakeNotification.instances = [];
+  FakeAudioContext.created = 0;
+  resetDesktopNotify();
+  useNotifPrefsStore.setState({ prefs: { desktop: true, chime: false }, loaded: true });
+  useMembershipStore.setState({
+    projectNameByRun: { 'r-q3': 'q3-review-deck' },
+    projectIdByRun: { 'r-q3': 'q3-review-deck' },
+  });
+});
+
+afterEach(() => {
+  useNotifPrefsStore.setState({ prefs: DEFAULT_NOTIF_PREFS, loaded: false });
+  useMembershipStore.setState({ projectNameByRun: {}, projectIdByRun: {} });
+});
+
+describe('the guard set (§8.2)', () => {
+  it('fires one Notification for a hidden-tab awaitingHuman — tag = run id, body = prompt first line · project', () => {
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+    expect(FakeNotification.instances).toHaveLength(1);
+    const n = FakeNotification.instances[0]!;
+    expect(n.title).toBe('Gate needs you');
+    expect(n.tag).toBe('r-q3');
+    expect(n.body).toBe('Approve the deck outline? · q3-review-deck');
+    // EC25: this path NEVER prompts.
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('a visible, focused tab fires nothing — the in-app toasts own it', () => {
+    visibility = 'visible';
+    focused = true;
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+    expect(FakeNotification.instances).toHaveLength(0);
+  });
+
+  it('visible but UNFOCUSED window still fires (the OR-condition, §8.2)', () => {
+    visibility = 'visible';
+    focused = false;
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+    expect(FakeNotification.instances).toHaveLength(1);
+  });
+
+  it('pref off / permission not granted / other events fire nothing', () => {
+    useNotifPrefsStore.setState({ prefs: { desktop: false, chime: false } });
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+
+    useNotifPrefsStore.setState({ prefs: { desktop: true, chime: false } });
+    FakeNotification.permission = 'denied';
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+
+    FakeNotification.permission = 'granted';
+    notifyGateIfUnfocused({ type: 'sessionFailed', session: 'r-q3' } as unknown as CoreEvent);
+
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('an unfiled run still notifies — body is the bare prompt line', () => {
+    notifyGateIfUnfocused(gateEvent('r-orphan'));
+    expect(FakeNotification.instances[0]?.body).toBe('Approve the deck outline?');
+  });
+});
+
+describe('per-gate de-dupe (§8.4 + the reconnect-replay rule)', () => {
+  it('a replayed frame (same runId + ord) does not re-fire', () => {
+    notifyGateIfUnfocused(gateEvent('r-q3', 0));
+    notifyGateIfUnfocused(gateEvent('r-q3', 0));
+    expect(FakeNotification.instances).toHaveLength(1);
+  });
+
+  it('a LATER gate on the same run (new ord) fires again, with the SAME tag', () => {
+    notifyGateIfUnfocused(gateEvent('r-q3', 0));
+    notifyGateIfUnfocused(gateEvent('r-q3', 1, 'Second question'));
+    expect(FakeNotification.instances).toHaveLength(2);
+    expect(FakeNotification.instances[1]?.tag).toBe('r-q3'); // OS-level collapse
+  });
+});
+
+describe('the click (§8.2: focus + land on the gate)', () => {
+  it('focuses the window and navigates to the run thread at #gate', () => {
+    const focus = vi.spyOn(window, 'focus').mockImplementation(() => undefined);
+    notifyGateIfUnfocused(gateEvent('r-q3'));
+    FakeNotification.instances[0]?.onclick?.();
+    expect(focus).toHaveBeenCalled();
+    expect(window.location.pathname + window.location.hash).toBe('/p/q3-review-deck/build/r-q3#gate');
+    expect(FakeNotification.instances[0]?.closed).toBe(true);
+    focus.mockRestore();
+  });
+
+  it('falls back to the legacy /runs/:id route when the project is unknown', () => {
+    const focus = vi.spyOn(window, 'focus').mockImplementation(() => undefined);
+    notifyGateIfUnfocused(gateEvent('r-orphan'));
+    FakeNotification.instances[0]?.onclick?.();
+    expect(window.location.pathname).toBe('/runs/r-orphan');
+    focus.mockRestore();
+  });
+});
+
+describe('the chime (§8.2)', () => {
+  it('creates an AudioContext only when the chime pref is on', () => {
+    notifyGateIfUnfocused(gateEvent('r-a'));
+    expect(FakeAudioContext.created).toBe(0);
+
+    useNotifPrefsStore.setState({ prefs: { desktop: true, chime: true } });
+    notifyGateIfUnfocused(gateEvent('r-b'));
+    expect(FakeAudioContext.created).toBe(1);
+  });
+
+  it('never chimes without a notification, and yields to prefers-reduced-motion', () => {
+    useNotifPrefsStore.setState({ prefs: { desktop: true, chime: true } });
+    visibility = 'visible';
+    focused = true;
+    notifyGateIfUnfocused(gateEvent('r-c')); // no notification ⇒ no chime
+    expect(FakeAudioContext.created).toBe(0);
+
+    visibility = 'hidden';
+    reducedMotion = true;
+    notifyGateIfUnfocused(gateEvent('r-d'));
+    expect(FakeNotification.instances).toHaveLength(1); // notification still fires
+    expect(FakeAudioContext.created).toBe(0);           // …the chime yields
+  });
+});

--- a/tests/notifPrefs.store.test.ts
+++ b/tests/notifPrefs.store.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The notification-prefs store (DES-FEEDBACK-002 §8.2, slice L): the
+ * `useAppearanceStore` shape verbatim on the `studio.notifications` key —
+ * load-once (defaults stand on a missing key OR a failed surface, no crash,
+ * and NEVER a Notification API touch), optimistic update, 400ms-debounced
+ * fire-and-forget persist with one silent retry.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn(),
+    putNotifSettings: vi.fn(),
+  },
+}));
+
+const { api } = await import('../src/api/client.js');
+const {
+  DEFAULT_NOTIF_PREFS, NOTIF_PREFS_KEY, sanitizeNotifPrefs, useNotifPrefsStore,
+} = await import('../src/store/notifPrefs.js');
+
+const getSettings = vi.mocked(api.getAppearanceSettings);
+const putNotif = vi.mocked(api.putNotifSettings);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getSettings.mockReset().mockResolvedValue({ settings: {} });
+  putNotif.mockReset().mockResolvedValue({ settings: {} });
+  useNotifPrefsStore.setState({ prefs: DEFAULT_NOTIF_PREFS, loaded: false });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('sanitizeNotifPrefs (§3.3 rule: never trust an external store)', () => {
+  it('defaults hard on garbage and coerces to strict booleans', () => {
+    expect(sanitizeNotifPrefs(undefined)).toEqual({ desktop: false, chime: false });
+    expect(sanitizeNotifPrefs('nonsense')).toEqual({ desktop: false, chime: false });
+    expect(sanitizeNotifPrefs({ desktop: 1, chime: 'yes' })).toEqual({ desktop: false, chime: false });
+    expect(sanitizeNotifPrefs({ desktop: true })).toEqual({ desktop: true, chime: false });
+    expect(sanitizeNotifPrefs({ desktop: true, chime: true })).toEqual({ desktop: true, chime: true });
+  });
+});
+
+describe('load (§8.2 startup)', () => {
+  it('takes the stored key and never writes back', async () => {
+    getSettings.mockResolvedValue({ settings: { [NOTIF_PREFS_KEY]: { desktop: true, chime: true } } });
+    await useNotifPrefsStore.getState().load();
+    expect(useNotifPrefsStore.getState().prefs).toEqual({ desktop: true, chime: true });
+    expect(useNotifPrefsStore.getState().loaded).toBe(true);
+    expect(putNotif).not.toHaveBeenCalled();
+  });
+
+  it('a settings blob WITHOUT the key yields the defaults (Off) — §8.4', async () => {
+    getSettings.mockResolvedValue({ settings: { graphNodeLimit: 150 } });
+    await useNotifPrefsStore.getState().load();
+    expect(useNotifPrefsStore.getState().prefs).toEqual(DEFAULT_NOTIF_PREFS);
+    expect(useNotifPrefsStore.getState().loaded).toBe(true);
+  });
+
+  it('a daemon without a settings surface fails silently — defaults stand', async () => {
+    getSettings.mockRejectedValue(new Error('API 404: nope'));
+    await useNotifPrefsStore.getState().load();
+    expect(useNotifPrefsStore.getState().prefs).toEqual(DEFAULT_NOTIF_PREFS);
+    expect(useNotifPrefsStore.getState().loaded).toBe(true);
+  });
+});
+
+describe('update (optimistic + debounced persist)', () => {
+  it('applies now, PUTs the studio.notifications key once after the debounce', async () => {
+    useNotifPrefsStore.getState().update({ desktop: true });
+    useNotifPrefsStore.getState().update({ chime: true });
+    expect(useNotifPrefsStore.getState().prefs).toEqual({ desktop: true, chime: true });
+    expect(putNotif).not.toHaveBeenCalled(); // still inside the debounce
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putNotif).toHaveBeenCalledTimes(1); // the two edits collapsed
+    expect(putNotif).toHaveBeenCalledWith({ desktop: true, chime: true });
+  });
+
+  it('retries ONCE, silently, re-reading the store (never a stale snapshot)', async () => {
+    putNotif.mockRejectedValueOnce(new Error('API 500'));
+    useNotifPrefsStore.getState().update({ desktop: true });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putNotif).toHaveBeenCalledTimes(1);
+
+    // An edit landing between the failure and the retry rides the retry.
+    useNotifPrefsStore.getState().update({ chime: true });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(putNotif.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(putNotif.mock.calls.at(-1)?.[0]).toEqual({ desktop: true, chime: true });
+  });
+});


### PR DESCRIPTION
Round-3 operator feedback, P2-8 + P2-9 — the final slice of the entire feedback backlog.

## What changed

- **Desktop notifications (§8)**: an opt-in group in /system (persisted as `studio.notifications` on the same crew-settings wire as appearance); when the tab is hidden and a gate arrives, one Web Notification fires ("Gate needs you" · the run's prompt · project name) with a synthesized two-tone chime option (zero assets, yields to reduced-motion); click focuses the window and lands on the run's `#gate`. **Permission is requested only on the desktop radio's own gesture** (EC25) — one call site in all of src/, denied reverts honestly to Off. De-dupe per (runId, ord): reconnect replays never re-fire; a later gate on the same run does, replacing via the OS tag.
- **Batch gates (§9)**: x/Space on the slice-H triage cursor selects answerable simple gates (complex gates carry an ↗ ineligible marker, never a checkbox); a docked bar on HomeBoard and ProjectDashboard approves N **strictly sequentially through the one audited `decideGate` path** — per-id failure rows with retry-only-that-id (the bulk-archive precedent), a mid-batch failure halts nothing and duplicates nothing; "Reject all…" pauses into one bar-level note riding `amend` on every reject; double-submit structurally guarded twice.

## Verification highlights

The tap counted `requestPermission` calls: 0 on cold load and full navigation, 1 on the toggle gesture, 0 everywhere after. Notification proofs: hidden-tab fire exact-once, replay zero, later-ord once, visible-tab zero, click target `/p/q3-review-deck/build/r-q3#gate`. Batch trace: exact POST arrays in selection order, the 409 case surfacing "r-batch1 (API 409: …)" with the success leaving the selection, retry firing only that id. Grep proves zero new gate-POST call sites. The slice-H rig stays green **byte-unamended** (the 003 §8.3 guarantee held). Negative check red on main.

**Size note**: ~815 raw insertions (comment-heavy house style; the plan's ~300 was logic LOC) — the two halves partition cleanly (commits 13e2a4a / db1003e) if a split is preferred; claiming the arc's standing single-PR precedent.

## Gates

eslint clean · tsc clean · vitest **1251/1251** (38 new) · new rig `feedback2_sliceL_test.py` (15 steps) + `feedback2_sliceH` (unamended), `feedback3_sliceN/O`, `feedback2_sliceG` all PASS.

Shots: `feedback2-L-notif-settings.png`, `feedback2-L-batch-bar.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)