### PR TITLE
DES-UX-001 slice R: failure forensics — failed runs answer "why did this fail"

### DIFF
--- a/e2e/ux_sliceR_test.py
+++ b/e2e/ux_sliceR_test.py
@@ -239,6 +239,12 @@ with sync_playwright() as p:
     term_btn.wait_for(timeout=10000)
     term_btn.click()
     page.locator('[data-testid="term-transcript"]').wait_for(timeout=10000)
+    # The transcript body is fetched per-unit after the container mounts — wait
+    # for the fixture's known transcript line, not just the container.
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="term-transcript"]')
+          ?.innerText ?? '').includes('Mapped the middleware chain')""",
+        timeout=10000)
     term = page.evaluate(
         """() => ({
           transcriptShown: (document.querySelector('[data-testid="term-transcript"]')

--- a/e2e/ux_sliceR_test.py
+++ b/e2e/ux_sliceR_test.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+ux_sliceR_test.py — the DES-UX-001 slice-R gate: failure forensics (§1, the
+campaign's #1 CRITICAL — "a failed run's page shows only a one-line verdict").
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with its
+`forensics` corpus switched on (real wire shapes only): r-auth (failed 13m ago)
+carries a done survey with a captured transcript on the REAL
+GET /runs/:id/units/:unitKey/output wire (citing /w2/auth-evidence/NOTES.md,
+served via extra_write_roots), a rejected review answering the daemon's honest
+outputUnavailable, a gateEvaluated deny with the FINDING-025 vacuous
+default-allow shape, and a workdir-less /diff answering the REAL 409; r-legacy
+(failed 8 days ago) keeps a tail with NO gateEvaluated and a /diff that HANGS.
+The `viewer` corpus rides along only for the r-upload baseline-note scene.
+
+The §1.5 DOM ACs, verbatim mapping:
+
+  1. the failed r-auth renders `[data-testid="work-unit"]` (units-as-spine) and
+     its `[data-testid="unit-transcript"]` auto-opens (the rejected-unit
+     contract, WorkUnitDetail:38) — FailureBanner is the HEADLINE above the
+     list, not the whole story (DOM order asserted);
+  2. `[data-testid="verdict-detail"]` names the deciding phase
+     (`data-phase-ord`), shows the agentReasoning text, and renders
+     `[data-vacuous="true"]` with the "default-allow" label (empty
+     evaluatorPolicies beside evaluatorPass:true);
+  3. r-legacy's verdict card renders `[data-empty="true"]` with the exact copy
+     "no evaluator record survives for this run" — never blank, never a
+     fabricated verdict;
+  4. Full diff on workdir-less r-auth renders `[data-testid="diff-named-cause"]`
+     with the no-repository copy — and the raw strings `API 409` /
+     `has no workdir` NEVER appear in the DOM;
+  5. Full diff on r-legacy (whose /diff never resolves in time) renders
+     `[data-testid="diff-error"]` within the timeout budget, never an
+     indefinite "Loading…" — and the request tap asserts ≥1 /diff fetch was
+     attempted (the zero-request hang is the regression this pins);
+  6. an evidence reference is an <a> that, on click, opens
+     `[data-testid="file-viewer"]` populated from readRunFile (no dead click);
+  7. while CREW-UX-1 is unlanded, the diff view carries
+     `[data-testid="diff-baseline-note"]` naming its HEAD baseline honestly;
+  + the Term tab lands on "View this run's transcript" when captured output
+    exists, with the ungoverned operator shell as the labeled SECONDARY action.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-R-failed-postmortem.png   r-auth: FailureBanner headline + VerdictDetail +
+                               the auto-opened unit spine
+  ux-R-verdict-empty.png       r-legacy: the retention empty state
+  ux-R2-diff-cause.png         the named-cause 409 card (no repository attached)
+  ux-R2-diff-baseline.png      the honest HEAD-baseline note on a resolving diff
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4377),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    FORENSICS_GATE_DENY,
+    FORENSICS_NOTES_PATH,
+    HIDE_GATE_TOASTS,
+    REPO,
+    VIEWER_FILE_TS,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4377"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+AUTH_THREAD = "/p/auth-refactor/build/r-auth"
+LEGACY_THREAD = "/p/legacy-spike/build/r-legacy"
+UPLOAD_THREAD = "/p/upload-endpoint/build/r-upload"
+
+# The client's own diff budget is DIFF_TIMEOUT_MS = 8000 (FileViewer.tsx); the
+# rig grants it a margin but stays far under the fixture's 30s hang.
+DIFF_ERROR_DEADLINE_MS = 12_000
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, forensics ON ──────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, forensics=True, viewer=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The request tap: every unit-output, file, and diff read the page fires.
+    diff_reads: list[str] = []
+    file_reads: list[str] = []
+    output_reads: list[str] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        q = urlparse(req.url).query
+        full = f"{path}?{q}" if q else path
+        if req.method != "GET":
+            return
+        if re.search(r"/api/v1/runs/[^/]+/diff$", path):
+            diff_reads.append(full)
+        elif re.search(r"/api/v1/runs/[^/]+/files$", path):
+            file_reads.append(full)
+        elif re.search(r"/api/v1/runs/[^/]+/units/[^/]+/output$", path):
+            output_reads.append(full)
+
+    page.on("request", on_request)
+
+    def open_thread(thread: str) -> None:
+        page.goto(f"{ORIGIN}{thread}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # ── Scene 1 (AC 1): units-as-spine — the failed run's post-mortem page ──────
+    open_thread(AUTH_THREAD)
+    page.locator('[data-testid="failure-banner"]').first.wait_for(timeout=30000)
+    page.locator('[data-testid="work-unit"]').first.wait_for(timeout=15000)
+    page.locator('[data-testid="unit-transcript"]').first.wait_for(timeout=15000)
+    # Both terminal units' transcripts auto-open (the WorkUnitDetail:38 contract):
+    # the done survey's captured markdown AND the rejected review's honest
+    # outputUnavailable sentence — no clicks made yet.
+    page.get_by_text("Mapped the middleware chain").wait_for(timeout=15000)
+    page.get_by_text("That is the deny-dominates rule holding").wait_for(timeout=15000)
+    spine = page.evaluate(
+        """() => {
+          const banner = document.querySelector('[data-testid="failure-banner"]');
+          const list = document.querySelector('[data-testid="unit-list"]');
+          const units = document.querySelectorAll('[data-testid="work-unit"]');
+          const transcripts = document.querySelectorAll('[data-testid="unit-transcript"]');
+          return {
+            units: units.length,
+            transcripts: transcripts.length,
+            bannerPresent: !!banner,
+            listPresent: !!list,
+            bannerAboveList: !!banner && !!list
+              && !!(banner.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING),
+          };
+        }""")
+    check("units_as_spine", spine["units"] == 2 and spine["transcripts"] >= 2
+          and spine["bannerAboveList"],
+          **spine, output_reads=list(output_reads))
+
+    # ── Scene 2 (AC 2): the VerdictDetail card — deciding phase, reasoning,
+    #    and the FINDING-025 vacuous default-allow label ─────────────────────────
+    page.locator('[data-testid="verdict-detail"]').wait_for(timeout=15000)
+    verdict = page.evaluate(
+        """() => {
+          const card = document.querySelector('[data-testid="verdict-detail"]');
+          const text = card ? card.innerText : '';
+          return {
+            phaseOrd: card?.getAttribute('data-phase-ord') ?? null,
+            vacuous: card?.getAttribute('data-vacuous') ?? null,
+            empty: card?.getAttribute('data-empty') ?? null,
+            namesPhase: text.includes('review'),
+            hasCriterion: !!document.querySelector('[data-testid="verdict-criterion"]'),
+            hasDenial: !!document.querySelector('[data-testid="verdict-denial"]'),
+            hasDefaultAllowLabel: text.includes('default-allow'),
+            hasReasoning: text.includes('drops the token-refresh path'),
+          };
+        }""")
+    check("verdict_detail", verdict["phaseOrd"] == str(FORENSICS_GATE_DENY["ord"])
+          and verdict["vacuous"] == "true" and verdict["empty"] is None
+          and verdict["namesPhase"] and verdict["hasCriterion"] and verdict["hasDenial"]
+          and verdict["hasDefaultAllowLabel"] and verdict["hasReasoning"],
+          **verdict)
+    page.screenshot(path=str(VSHOTS / "ux-R-failed-postmortem.png"))
+
+    # ── Scene 3 (AC 6): the evidence reference resolves — readRunFile, no dead
+    #    click ──────────────────────────────────────────────────────────────────
+    ref = page.locator('[data-testid="evidence-ref"]', has_text="NOTES.md").first
+    ref.wait_for(timeout=10000)
+    is_anchor = page.evaluate(
+        """() => document.querySelector('[data-testid="evidence-ref"]')?.tagName === 'A'""")
+    ref.click()
+    page.locator('[data-testid="file-viewer"]').wait_for(timeout=10000)
+    page.get_by_text("Token refresh").wait_for(timeout=10000)
+    expected_file_read = (
+        f"/api/v1/runs/r-auth/files?path={FORENSICS_NOTES_PATH.replace('/', '%2F')}")
+    check("evidence_ref_opens_viewer", is_anchor and expected_file_read in file_reads,
+          is_anchor=is_anchor, file_reads=list(file_reads))
+    page.keyboard.press("Escape")
+    page.locator('[data-testid="file-viewer"]').wait_for(state="detached", timeout=5000)
+
+    # ── Scene 4 (AC 4): Full diff on the repo-less run → the named-cause card;
+    #    the raw wire strings never reach the DOM ────────────────────────────────
+    page.get_by_role("button", name=re.compile("^Files")).click()
+    page.locator('[data-testid="files-full-diff"]').wait_for(timeout=10000)
+    page.locator('[data-testid="files-full-diff"]').click()
+    page.locator('[data-testid="diff-named-cause"]').wait_for(timeout=10000)
+    cause = page.evaluate(
+        """() => {
+          const card = document.querySelector('[data-testid="diff-named-cause"]');
+          const body = document.body.innerText;
+          return {
+            cause: card?.getAttribute('data-cause') ?? null,
+            copyOk: (card?.innerText ?? '').includes(
+              'This run had no repository attached — nothing was produced to review'),
+            remediation: !!document.querySelector('[data-testid="diff-cause-remediation"]'),
+            raw409InDom: body.includes('API 409'),
+            rawWorkdirInDom: body.includes('has no workdir'),
+          };
+        }""")
+    check("diff_named_cause", cause["cause"] == "no-repo" and cause["copyOk"]
+          and cause["remediation"] and not cause["raw409InDom"]
+          and not cause["rawWorkdirInDom"],
+          **cause, diff_reads=list(diff_reads))
+    page.screenshot(path=str(VSHOTS / "ux-R2-diff-cause.png"))
+    page.keyboard.press("Escape")
+    page.locator('[data-testid="file-viewer"]').wait_for(state="detached", timeout=5000)
+
+    # ── Scene 5: the Term tab lands on the run's transcript; the ungoverned
+    #    shell is the labeled SECONDARY ──────────────────────────────────────────
+    term_btn = page.get_by_role("button", name="View this run's transcript")
+    term_btn.wait_for(timeout=10000)
+    term_btn.click()
+    page.locator('[data-testid="term-transcript"]').wait_for(timeout=10000)
+    term = page.evaluate(
+        """() => ({
+          transcriptShown: (document.querySelector('[data-testid="term-transcript"]')
+            ?.innerText ?? '').includes('Mapped the middleware chain'),
+          shellSecondary: (document.querySelector('[data-testid="term-open-shell"]')
+            ?.innerText ?? '').includes('ungoverned'),
+        })""")
+    check("term_transcript_first", term["transcriptShown"] and term["shellSecondary"], **term)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+
+    # ── Scene 6 (AC 3): the retention empty state on the historical run ─────────
+    open_thread(LEGACY_THREAD)
+    page.locator('[data-testid="verdict-detail"][data-empty="true"]').wait_for(timeout=30000)
+    empty = page.evaluate(
+        """() => {
+          const card = document.querySelector('[data-testid="verdict-detail"]');
+          return {
+            empty: card?.getAttribute('data-empty') ?? null,
+            copyOk: (card?.innerText ?? '').includes(
+              'no evaluator record survives for this run'),
+            fabricated: !!card?.getAttribute('data-phase-ord'),
+          };
+        }""")
+    check("retention_empty_state", empty["empty"] == "true" and empty["copyOk"]
+          and not empty["fabricated"], **empty)
+    page.screenshot(path=str(VSHOTS / "ux-R-verdict-empty.png"))
+
+    # ── Scene 7 (AC 5): the hanging diff — ≥1 fetch attempted, the error branch
+    #    within the client's own budget, never an eternal "Loading…" ─────────────
+    diff_reads.clear()
+    page.get_by_role("button", name=re.compile("^Files")).click()
+    page.locator('[data-testid="files-full-diff"]').wait_for(timeout=10000)
+    page.locator('[data-testid="files-full-diff"]').click()
+    page.locator('[data-testid="diff-error"]').wait_for(timeout=DIFF_ERROR_DEADLINE_MS)
+    legacy_diff_attempts = [r for r in diff_reads if "/runs/r-legacy/diff" in r]
+    hang = page.evaluate(
+        """() => ({
+          errorShown: !!document.querySelector('[data-testid="diff-error"]'),
+          retryOffered: !!document.querySelector('[data-testid="diff-retry"]'),
+          stillLoading: (document.querySelector('[data-testid="file-viewer"]')
+            ?.innerText ?? '').includes('Loading'),
+        })""")
+    check("diff_hang_budget", hang["errorShown"] and hang["retryOffered"]
+          and not hang["stillLoading"] and len(legacy_diff_attempts) >= 1,
+          **hang, diff_attempts=legacy_diff_attempts)
+    page.keyboard.press("Escape")
+
+    # ── Scene 8 (AC 7): the honest HEAD-baseline note on a resolving diff ────────
+    open_thread(UPLOAD_THREAD)
+    page.get_by_role("button", name=re.compile("^Files")).wait_for(timeout=30000)
+    page.get_by_role("button", name=re.compile("^Files")).click()
+    page.locator(f'button[title="View {VIEWER_FILE_TS}"]').wait_for(timeout=15000)
+    page.locator(f'button[title="View {VIEWER_FILE_TS}"]').click()
+    page.locator('[data-testid="file-viewer"]').wait_for(timeout=10000)
+    page.locator('[data-testid="diff-baseline-note"]').wait_for(timeout=10000)
+    note = page.evaluate(
+        """() => (document.querySelector('[data-testid="diff-baseline-note"]')
+            ?.innerText ?? '')""")
+    check("diff_baseline_note",
+          "showing uncommitted changes vs HEAD; committed work is not shown here" in note,
+          note=note)
+    page.screenshot(path=str(VSHOTS / "ux-R2-diff-baseline.png"))
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -93,6 +93,26 @@ Mutable switches (flipped over POST /__fixture between page loads):
   notif_prefs     — replaces the settings store's `studio.notifications`
                     (a dict; None REMOVES the key — the never-persisted
                     default case), same channel as `appearance`.
+  forensics       — the slice-R failure-forensics corpus (DES-UX-001 §1):
+                    r-auth (failed 13m ago) gains TWO real-shape units — a
+                    `done` survey with a captured transcript served on the
+                    REAL `GET /runs/:id/units/:unitKey/output` wire (its
+                    markdown cites /w2/auth-evidence/NOTES.md, served on the
+                    files route via the run's `extra_write_roots`) and a
+                    `rejected` review whose output route answers the daemon's
+                    honest `outputUnavailable` — plus a `gateEvaluated` deny
+                    (agentVerdict/agentReasoning/denialReason, and
+                    `evaluatorPass: true` beside EMPTY `evaluatorPolicies` —
+                    the FINDING-025 vacuous default-allow) in its durable
+                    event tail. r-auth stays workdir-less, so its /diff
+                    answers the REAL 409 "has no workdir" (the named-cause
+                    case). r-legacy (failed 8 DAYS ago) keeps a tail with NO
+                    `gateEvaluated` (the retention empty state) and its
+                    /diff HANGS without answering (the zero-request-hang
+                    regression trap — the client must still have dispatched
+                    ≥1 fetch and reach its own timeout branch). Both failed
+                    runs gain one `dataUsed` file so the Files panel offers
+                    [Full diff]. Default False.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -186,7 +206,11 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # /ws loop (the extra_narration mechanism) — how a rig injects a gate
          # ARRIVAL (the desktop-notification trigger), distinct from the
          # cached-gate GET a page load reconciles.
-         "extra_gates": []}
+         "extra_gates": [],
+         # Slice R (DES-UX-001 §1): the failure-forensics corpus — see the
+         # module docstring. Default False: no standing rig's failed runs
+         # change shape.
+         "forensics": False}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -512,6 +536,124 @@ NOTES_DOCS = [
     {"name": "ideas", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 2 * DAY)},
     {"name": "todo", "kind": "doc", "head": 1, "versions": 1, "updated_at": iso(NOW0 - 3 * DAY)},
 ]
+
+# ── Slice R (DES-UX-001 §1): the failure-forensics corpus, behind `forensics` ──
+#
+# Everything below speaks the REAL crew wire: the unit-output route's exact
+# contract (routes.ts — 200 `{"output": …}` when a transcript survives, 200
+# `{"output": null, "outputUnavailable": <the FINDING-006 sentence>}` for the
+# rejected unit, 404 naming the run's keys for an unknown one), `gateEvaluated`
+# with the api-types field set (incl. the FINDING-025 vacuous shape: EMPTY
+# `evaluatorPolicies` beside `evaluatorPass: true`), and the crew#305 file
+# route serving the cited evidence under r-auth's `extra_write_roots`.
+
+FORENSICS_EVIDENCE_ROOT = "/w2/auth-evidence"
+FORENSICS_NOTES_PATH = f"{FORENSICS_EVIDENCE_ROOT}/NOTES.md"
+FORENSICS_NOTES_CONTENT = """\
+# Auth middleware survey notes
+
+## Token refresh
+The refresh path lives in `src/auth/refresh.ts` and is exercised by
+`auth.refresh.spec` — any refactor that drops the expired-access +
+valid-refresh branch fails it.
+
+## Rollout order
+Middleware order matters: rateLimit -> session -> refresh.
+"""
+
+# The survey transcript CITES the notes file as a markdown link — the evidence
+# reference the run page must make a live click (§1.5 AC 6), exactly as agents
+# write them into transcripts.
+FORENSICS_SURVEY_OUTPUT = """\
+## Survey: the auth middleware surface
+
+Mapped the middleware chain and the token-refresh path.
+
+- `src/auth/middleware.ts` wires session + refresh, in that order
+- the expired-access + valid-refresh branch is covered by `auth.refresh.spec`
+
+Full notes, including the rollout-order constraint, are in
+[NOTES.md](/w2/auth-evidence/NOTES.md).
+"""
+
+# Core's denial prefix shape ("Governance DENIED unit N (key): …") — the one
+# field that distinguishes a gate deny from a worker failure (FINDING-050).
+FORENSICS_REVIEW_DENIAL = (
+    "Governance DENIED unit 1 (review): the refactored middleware drops the "
+    "token-refresh path — auth.refresh.spec fails on the expired-token branch"
+)
+
+# The rejected unit's honest no-transcript answer — routes.ts's
+# outputUnavailableReason wording, verbatim shape (FINDING-006).
+FORENSICS_REVIEW_UNAVAILABLE = (
+    "Unit 1 was REJECTED, so wicked-core stored no transcript for it: a work_output "
+    "record is written only for a unit whose phase resolved approved, and this one's did not. "
+    "That is the deny-dominates rule holding, not a lost or unreadable record — and the text "
+    "the unit streamed is not retained anywhere else, so this is the whole of what survives. "
+    f"Why it was rejected: {FORENSICS_REVIEW_DENIAL}. "
+    "The gate decision and the run's event trail are in GET /api/v1/runs/r-auth/evidence."
+)
+
+
+def _forensics_unit(key: str, ord_: int, desc: str, stage: str, status: str,
+                    denial: str | None = None) -> dict:
+    return {"id": f"r-auth:{key}", "session_id": "r-auth", "ord": ord_,
+            "description": desc, "stage": stage, "assigned_cli": "claude",
+            "assigned_invocation": None, "council_task_ref": None, "routing": None,
+            "denial_reason": denial, "phase_ref": None, "conformance_ref": None,
+            "phase_status": None, "collection_scope": None, "status": status}
+
+
+FORENSICS_AUTH_UNITS = [
+    _forensics_unit("survey", 0, "survey the auth middleware surface", "recon", "done"),
+    _forensics_unit("review", 1, "review the middleware refactor", "review", "rejected",
+                    denial=FORENSICS_REVIEW_DENIAL),
+]
+
+# What each unit's REAL output route answers (GET /runs/r-auth/units/<key>/output).
+FORENSICS_UNIT_OUTPUTS = {
+    "survey": {"output": FORENSICS_SURVEY_OUTPUT},
+    "review": {"output": None, "outputUnavailable": FORENSICS_REVIEW_UNAVAILABLE},
+}
+
+# The gateEvaluated deny in r-auth's durable tail: the deciding phase (ord 1,
+# the review), its criterion, the agent judge's verdict + reasoning, the
+# winning denialReason — and the FINDING-025 vacuous default-allow shape.
+FORENSICS_GATE_DENY = {
+    "type": "gateEvaluated", "session": "r-auth", "ord": 1,
+    "ts": NOW0 - 12 * MIN - 10 * SEC,
+    "criterion": "the middleware refactor keeps every existing auth test green",
+    "hasDeterministicFloor": True, "deterministicPass": True,
+    "agentVerdict": "fail",
+    "agentReasoning": (
+        "The refactored middleware drops the token-refresh path: requests carrying "
+        "an expired access token with a valid refresh token now 401 instead of "
+        "refreshing — auth.refresh.spec fails on that branch."
+    ),
+    "evaluatorPass": True, "evaluatorPolicies": [],  # FINDING-025: vacuous default-allow
+    "denialReason": FORENSICS_REVIEW_DENIAL,
+    "combined": False,
+}
+
+# Appended to the durable tails while `forensics` is on. Both failed runs gain
+# one dataUsed file so their Files panels offer [Full diff] (the escape-hatch
+# entry points); r-legacy's tail stays gateEvaluated-FREE — the retention
+# empty state ("no evaluator record survives for this run").
+FORENSICS_AUTH_EVENTS = [
+    {"type": "dataUsed", "session": "r-auth", "ord": 0,
+     "files": [FORENSICS_NOTES_PATH], "ts": NOW0 - 12 * MIN - 30 * SEC},
+    FORENSICS_GATE_DENY,
+]
+FORENSICS_LEGACY_EVENTS = [
+    {"type": "dataUsed", "session": "r-legacy", "ord": 0,
+     "files": ["/w2/legacy/importer.py"], "ts": NOW0 - 8 * DAY - 30 * SEC},
+]
+
+# How long r-legacy's /diff HANGS before releasing its (daemon) thread with a
+# late answer — well past the client's own timeout budget, so the rig proves
+# the client reached its error branch on its OWN clock, having dispatched ≥1
+# real fetch (the zero-request-hang regression trap, §1.3-4b).
+FORENSICS_DIFF_HANG_SECONDS = 30
 
 # ── The vision-slice-4 Video surface (DES-VISION-001 §5.6): one recorded demo ──
 #
@@ -1049,7 +1191,8 @@ class W2Handler(SimpleHTTPRequestHandler):
                         + (BATCH_RUNS if state["batch_gates"] else [])
                 viewer_on = state["viewer"]
                 repo_refs_on = state["repo_refs"]
-            if viewer_on or repo_refs_on:
+                forensics_on = state["forensics"]
+            if viewer_on or repo_refs_on or forensics_on:
                 runs = json.loads(json.dumps(runs))
                 for r in runs:
                     # Slice I: the live run gains a workdir (the diff route's
@@ -1059,6 +1202,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                     # Slice P: repo-linked runs for the /repos tiles (§4.4).
                     if repo_refs_on and r["session"]["id"] in REPO_REF_RUNS:
                         r["session"]["repo_ref"] = REPO_ID
+                    # Slice R: r-auth's real-shape units + the evidence root
+                    # its survey transcript cites (workdir stays None — its
+                    # /diff answers the REAL 409 named-cause case).
+                    if forensics_on and r["session"]["id"] == "r-auth":
+                        r["units"] = json.loads(json.dumps(FORENSICS_AUTH_UNITS))
+                        r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
             self._json(200, {"runs": runs})
             return True
         # Slice I: the crew#305 file/diff routes (real contract, switch-gated).
@@ -1198,12 +1347,39 @@ class W2Handler(SimpleHTTPRequestHandler):
             with state_lock:
                 viewer_on = state["viewer"]
                 river_on = state["river"]
+                forensics_on = state["forensics"]
             if viewer_on and rid == "r-upload":
                 events = events + VIEWER_EVENTS
             # Slice Q: r-auth's durable tail matches its spread attach clock.
             if river_on and rid == "r-auth":
                 events = list(RIVER_AUTH_EVENTS)
+            # Slice R: the forensics tails — r-auth gains its dataUsed file +
+            # the gateEvaluated deny; r-legacy gains ONLY a dataUsed file (its
+            # tail stays gateEvaluated-free: the retention empty state).
+            if forensics_on and rid == "r-auth":
+                events = events + FORENSICS_AUTH_EVENTS
+            if forensics_on and rid == "r-legacy":
+                events = events + FORENSICS_LEGACY_EVENTS
             self._json(200, {"events": events})
+            return True
+        # Slice R: the REAL unit-transcript wire (routes.ts crew — the studio's
+        # WorkUnitDetail + Term-tab transcript read). Served only while the
+        # forensics corpus is on; otherwise the daemon's unknown-run 404.
+        m = re.match(r"^/api/v1/runs/([^/]+)/units/([^/]+)/output$", path)
+        if m:
+            rid = urllib.parse.unquote(m.group(1))
+            key = urllib.parse.unquote(m.group(2))
+            with state_lock:
+                forensics_on = state["forensics"]
+            if not forensics_on or rid != "r-auth":
+                self._json(404, {"error": "Run not found"})
+                return True
+            served = FORENSICS_UNIT_OUTPUTS.get(key)
+            if served is None:
+                self._json(404, {"error": f"Unit '{key}' not found in run {rid}",
+                                 "units": sorted(FORENSICS_UNIT_OUTPUTS)})
+                return True
+            self._json(200, served)
             return True
         if path.startswith("/api/v1/"):
             self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
@@ -1219,7 +1395,12 @@ class W2Handler(SimpleHTTPRequestHandler):
         with state_lock:
             viewer_on = state["viewer"] and state["file_routes"]
             orphan_on = state["orphan"]
-        if not viewer_on:
+            forensics_on = state["forensics"]
+        # Slice R: the forensics corpus lights these routes for the two failed
+        # runs on its own — r-auth's evidence file + REAL workdir-less 409, and
+        # r-legacy's hanging diff — without dragging the whole viewer corpus in.
+        forensic_rid = forensics_on and rid in ("r-auth", "r-legacy")
+        if not viewer_on and not forensic_rid:
             self._json(404, {"message": f"Route GET:{self.path} not found",
                              "error": "Not Found", "statusCode": 404})
             return
@@ -1244,6 +1425,10 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(400, {"error": "`path` must be an absolute path"})
                 return
             roots = [workdir] if workdir else []
+            # Slice R: r-auth's extra_write_roots — the evidence root its
+            # survey transcript cites (resolveRunPath honors write roots).
+            if forensics_on and rid == "r-auth":
+                roots.append(FORENSICS_EVIDENCE_ROOT)
             if not any(qpath == r or qpath.startswith(r + "/") for r in roots):
                 self._json(403, {"error": "path is outside every allowed root (the "
                                           "run's workdir/write roots and the registered repos)"})
@@ -1253,12 +1438,24 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(400, {"error": "`path` query parameter is required"})
                 return
             served = VIEWER_FILES.get(qpath)
+            if served is None and forensics_on and qpath == FORENSICS_NOTES_PATH:
+                served = {"path": FORENSICS_NOTES_PATH, "content": FORENSICS_NOTES_CONTENT,
+                          "size": len(FORENSICS_NOTES_CONTENT.encode()),
+                          "truncated": False, "binary": False}
             if served is None:
                 self._json(404, {"error": f"no such file: {qpath}"})
                 return
             self._json(200, served)
             return
         # leaf == "diff"
+        if forensics_on and rid == "r-legacy":
+            # Slice R (§1.3-4b): the historical run's diff HANGS — no answer
+            # until well past the client's timeout budget. The client must have
+            # dispatched ≥1 real fetch and reach its OWN error branch; the late
+            # 409 merely releases this daemon thread afterwards.
+            time.sleep(FORENSICS_DIFF_HANG_SECONDS)
+            self._json(409, {"error": f"run {rid}'s workdir no longer exists: /w2/legacy"})
+            return
         if workdir is None:
             self._json(409, {"error": f"run {rid} has no workdir — nothing to diff"})
             return

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -12,7 +12,11 @@ import { STATUS_STYLE } from './RunCard.js';
 import { SteeringGate } from './SteeringGate.js';
 import { ChatInput } from './ChatInput.js';
 import { AgentTerminal } from './AgentTerminal.js';
+import { FailureBanner } from './FailureBanner.js';
+import { FileViewer } from './FileViewer.js';
 import { Markdown } from './Markdown.js';
+import { UnitList } from './UnitList.js';
+import { VerdictDetail } from './VerdictDetail.js';
 import type { RunMode } from './runMode.js';
 import { MODE_LABELS } from './runMode.js';
 export type { RunMode } from './runMode.js';
@@ -752,14 +756,26 @@ function RunChat({
   const [transcripts, setTranscripts] = useState<
     Record<number, { text: string | null; loading: boolean; visible: boolean }>
   >({});
+  // Evidence-reference wiring (DES-UX-001 §1.3-4c): a file link clicked in any
+  // transcript opens the slice-I FileViewer on that path — never a dead click.
+  const [evidenceFile, setEvidenceFile] = useState<string | null>(null);
   const autoLoadedOrds = useRef<Set<number>>(new Set());
   const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Units-as-spine for EVERY terminal failure (DES-UX-001 §1.3-1): a failed or
+  // cancelled run renders the ordered UnitList → WorkUnitDetail post-mortem
+  // (each unit's captured transcript auto-opens, WorkUnitDetail.tsx:38), with
+  // FailureBanner as the HEADLINE above the list — not the whole story.
+  const isPostMortem = session.status === 'failed' || session.status === 'cancelled';
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [timeline.length, log.length]);
 
   useEffect(() => {
+    // Post-mortem runs render the unit spine, whose WorkUnitDetail owns the
+    // per-unit transcript fetch — skipping here avoids a duplicate request.
+    if (isPostMortem) return;
     for (const unit of units) {
       if (unit.status === 'done' && !autoLoadedOrds.current.has(unit.ord)) {
         autoLoadedOrds.current.add(unit.ord);
@@ -789,7 +805,7 @@ function RunChat({
           });
       }
     }
-  }, [units, session.id]);
+  }, [units, session.id, isPostMortem]);
 
   function toggleTranscript(ord: number): void {
     setTranscripts((prev) => {
@@ -886,9 +902,23 @@ function RunChat({
           </div>
         </div>
 
+        {/* The post-mortem spine (DES-UX-001 §1.3, slice R): a failed/cancelled run
+            renders FailureBanner as the headline, the evaluator's VerdictDetail card,
+            and the ordered unit spine — each captured transcript auto-opened — in
+            place of the conversational timeline. The transcripts were on the wire
+            all along (GET /runs/:id/units/:unitKey/output); this is the render path
+            that finally takes them for the statuses that need them most. */}
+        {isPostMortem && (
+          <div className="flex flex-col gap-3">
+            <FailureBanner view={view} log={log} />
+            <VerdictDetail runId={session.id} units={ordered} />
+            <UnitList runId={session.id} units={ordered} onOpenFile={setEvidenceFile} />
+          </div>
+        )}
+
         {/* Phase entries — only phases that have run or are running; gate panel injected
             inline before the unit it blocks when that unit has already entered the thread */}
-        {timeline.flatMap((unit) => {
+        {!isPostMortem && timeline.flatMap((unit) => {
           const tc = transcripts[unit.ord];
           const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' };
           const gateBeforeThis = session.status === 'awaiting_human' && gate?.ord === unit.ord;
@@ -1024,7 +1054,7 @@ function RunChat({
                         <div className="mt-2.5 max-h-[28rem] overflow-y-auto">
                           {tc.loading
                             ? <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>Loading output…</span>
-                            : <Markdown className="whitespace-pre-wrap">{tc.text ?? ''}</Markdown>
+                            : <Markdown className="whitespace-pre-wrap" onOpenFile={setEvidenceFile}>{tc.text ?? ''}</Markdown>
                           }
                         </div>
                       )}
@@ -1102,6 +1132,26 @@ function RunChat({
 
         <div ref={bottomRef} />
       </div>
+
+      {/* The evidence viewer: slice I's FileViewer, reused verbatim — populated
+          from GET /runs/:id/files (readRunFile). Opened only by a clicked
+          evidence reference; a daemon without the route falls back to the
+          external open (which itself copy-falls-back), same as the Files panel. */}
+      {evidenceFile !== null && (
+        <FileViewer
+          runId={session.id}
+          path={evidenceFile}
+          defaultTab="file"
+          onClose={() => setEvidenceFile(null)}
+          onUnsupported={() => {
+            const p = evidenceFile;
+            setEvidenceFile(null);
+            void api.openPath(p, session.id).catch(() => {
+              void navigator.clipboard.writeText(p).catch(() => { /* clipboard unavailable */ });
+            });
+          }}
+        />
+      )}
 
       {agentTerminal && (
         <div className="px-4 pb-3 shrink-0">

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import { api } from '../api/client.js';
 import type { RunDiff, RunFileContent } from '../api/types.js';
@@ -48,6 +48,35 @@ type Fetched<T> =
   | { state: 'loading' }
   | { state: 'error'; message: string }
   | { state: 'ok'; data: T };
+
+/**
+ * The diff's own fetch state (slice R, DES-UX-001 §1.3-4). Distinct from
+ * {@link Fetched} because the diff path owes the operator two more honest
+ * answers: a NAMED CAUSE for the daemon's 409s (never the raw wire string),
+ * and a TIMEOUT branch so a never-resolving request shows "Couldn't load the
+ * diff — retry" instead of an eternal "Loading…".
+ */
+type DiffFetched =
+  | { state: 'loading' }
+  | { state: 'timeout' }
+  | { state: 'cause'; cause: 'no-repo' | 'workdir-gone' }
+  | { state: 'error'; message: string }
+  | { state: 'ok'; data: RunDiff };
+
+/** Budget for a diff request to resolve before the honest error branch shows. */
+export const DIFF_TIMEOUT_MS = 8000;
+
+/**
+ * Map the daemon's diff refusals to their named causes (routes.ts crew#305):
+ * `run <id> has no workdir — nothing to diff` (409, repo-less run) and
+ * `run <id>'s workdir no longer exists: <path>` (409, reaped worktree). The
+ * raw `API 409` / `has no workdir` strings NEVER reach the DOM (EC33).
+ */
+function diffCauseOf(message: string): 'no-repo' | 'workdir-gone' | null {
+  if (/has no workdir/.test(message)) return 'no-repo';
+  if (/workdir no longer exists/.test(message)) return 'workdir-gone';
+  return null;
+}
 
 /** Fastify's default unknown-route 404 carries no named error — the daemon
  *  predates crew#305. Named 404s ("unknown run: …", "no such file: …") are
@@ -113,7 +142,9 @@ function LoadingPane(): React.ReactElement {
 export function FileViewer({ runId, path, defaultTab, onClose, onUnsupported }: Props): React.ReactElement {
   const [tab, setTab] = useState<ViewerTab>(path === undefined ? 'diff' : defaultTab);
   const [file, setFile] = useState<Fetched<RunFileContent> | null>(null);
-  const [diff, setDiff] = useState<Fetched<RunDiff> | null>(null);
+  const [diff, setDiff] = useState<DiffFetched | null>(null);
+  /** Bumped by the retry affordance: resets `diff` so the fetch effect re-fires. */
+  const [diffAttempt, setDiffAttempt] = useState(0);
 
   // Escape closes (the Modal pattern); the caller restores focus to the row.
   useEffect(() => {
@@ -136,16 +167,56 @@ export function FileViewer({ runId, path, defaultTab, onClose, onUnsupported }: 
       });
   }, [tab, path, runId, file, onUnsupported]);
 
+  // The diff fetch (slice R rewrite — DES-UX-001 §1.3-4b). The old shape could
+  // strand the pane on "Loading…" with NO request ever dispatched (the
+  // zero-request hang, brief A1 dead-end 3). This one:
+  //  - dispatches the request SYNCHRONOUSLY inside the effect, on every
+  //    activation while unfetched (`diff === null`), so a mounted diff tab
+  //    always has ≥1 attempted fetch behind it;
+  //  - races it against DIFF_TIMEOUT_MS so a never-resolving request lands in
+  //    an honest, retryable error state instead of an eternal spinner;
+  //  - names the daemon's 409 causes instead of surfacing the raw wire string.
+  // One fetch per (run, path, attempt): keyed through a ref, NOT through the
+  // `diff` state — the old state-guarded shape could cancel its own in-flight
+  // request when the effect re-ran on its own setState. No cleanup either: a
+  // late resolution lands harmlessly (React no-ops setState after unmount),
+  // and the timer stays live so a hung request ALWAYS reaches the error state.
+  const diffFetchKey = useRef<string | null>(null);
   useEffect(() => {
-    if (tab !== 'diff' || diff !== null) return;
+    if (tab !== 'diff') return;
+    const key = `${runId} ${path ?? ''} ${diffAttempt}`;
+    if (diffFetchKey.current === key) return;
+    diffFetchKey.current = key;
+    let settled = false;
     setDiff({ state: 'loading' });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      setDiff({ state: 'timeout' });
+    }, DIFF_TIMEOUT_MS);
     api.getRunDiff(runId, path)
-      .then((data) => setDiff({ state: 'ok', data }))
+      .then((data) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        setDiff({ state: 'ok', data });
+      })
       .catch((e: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
         if (isRouteAbsent(e)) { onUnsupported(); return; }
-        setDiff({ state: 'error', message: e instanceof Error ? e.message : String(e) });
+        const message = e instanceof Error ? e.message : String(e);
+        const cause = diffCauseOf(message);
+        setDiff(cause !== null ? { state: 'cause', cause } : { state: 'error', message });
       });
-  }, [tab, path, runId, diff, onUnsupported]);
+  }, [tab, path, runId, diffAttempt, onUnsupported]);
+
+  /** The retry affordance: clear the state so the effect re-dispatches. */
+  function retryDiff(): void {
+    setDiff(null);
+    setDiffAttempt((n) => n + 1);
+  }
 
   function handleOpenExternally(): void {
     if (path === undefined) return;
@@ -262,7 +333,7 @@ export function FileViewer({ runId, path, defaultTab, onClose, onUnsupported }: 
         {tab === 'file' ? (
           <FileBody file={file} onOpenExternally={handleOpenExternally} />
         ) : (
-          <DiffBody diff={diff} narrowed={path !== undefined} />
+          <DiffBody diff={diff} narrowed={path !== undefined} onRetry={retryDiff} onClose={onClose} />
         )}
       </div>
     </div>
@@ -327,26 +398,116 @@ function FileBody({ file, onOpenExternally }: {
   );
 }
 
-function DiffBody({ diff, narrowed }: {
-  diff: Fetched<RunDiff> | null;
+/**
+ * The named-cause card (DES-UX-001 §1.3-4a): the daemon's 409 refusals become
+ * operator answers with a remediation, on `--surface-raised` with `--ink-muted`
+ * body and an `--accent` remediation link (§1.4). The raw wire strings never
+ * render — the cause card IS the translation (EC33).
+ */
+function DiffCauseCard({ cause, onClose }: {
+  cause: 'no-repo' | 'workdir-gone';
+  onClose: () => void;
+}): React.ReactElement {
+  const headline =
+    cause === 'no-repo'
+      ? 'This run had no repository attached — nothing was produced to review.'
+      : 'This run’s workdir no longer exists.';
+  const body =
+    cause === 'no-repo'
+      ? 'The run executed without a workdir, so there is no worktree to diff. Its captured unit transcripts are the record of what it did.'
+      : 'The worktree was cleaned up after the run ended. The captured unit transcripts and evidence remain the durable record.';
+  const remediation =
+    cause === 'no-repo'
+      ? 'Attach a repository at launch to make future runs reviewable — for this one, review the captured transcripts on the run page.'
+      : 'Review the captured transcripts on the run page.';
+  return (
+    <div
+      data-testid="diff-named-cause"
+      data-cause={cause}
+      className="m-4 rounded-lg p-4 flex flex-col gap-2 self-start"
+      style={{ background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)' }}
+    >
+      <p className="text-xs font-semibold font-mono" style={{ color: 'var(--ink-muted)' }}>{headline}</p>
+      <p className="text-xs" style={{ color: 'var(--ink-muted)' }}>{body}</p>
+      <button
+        type="button"
+        data-testid="diff-cause-remediation"
+        onClick={onClose}
+        className="self-start text-xs font-mono underline transition-opacity hover:opacity-70"
+        style={{ color: 'var(--accent)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+      >
+        {remediation}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The honest interim baseline label (DES-UX-001 §8.1): until CREW-UX-1 lands a
+ * branch-vs-base diff, the daemon diffs the working tree against HEAD — so a
+ * run's COMMITTED work is invisible here by construction. Say so, always,
+ * rather than letting "no changes" read as "did nothing".
+ */
+function BaselineNote(): React.ReactElement {
+  return (
+    <p
+      data-testid="diff-baseline-note"
+      className="px-3 py-1.5 text-[10px] font-mono shrink-0"
+      style={{ color: 'var(--ink-dim)', borderBottom: '1px solid var(--surface-raised)' }}
+    >
+      showing uncommitted changes vs HEAD; committed work is not shown here
+    </p>
+  );
+}
+
+function DiffBody({ diff, narrowed, onRetry, onClose }: {
+  diff: DiffFetched | null;
   narrowed: boolean;
+  onRetry: () => void;
+  onClose: () => void;
 }): React.ReactElement {
   if (diff === null || diff.state === 'loading') return <LoadingPane />;
+  if (diff.state === 'timeout') {
+    // §1.3-4b: a never-resolving diff lands HERE within the timeout budget —
+    // never an indefinite "Loading…". The request WAS dispatched; retry re-fires it.
+    return (
+      <div data-testid="diff-error" className="p-4 flex flex-col items-start gap-2">
+        <p className="text-xs font-mono" style={{ color: 'var(--status-fail)' }}>
+          Couldn&apos;t load the diff — the daemon did not answer in time.
+        </p>
+        <button
+          type="button"
+          data-testid="diff-retry"
+          onClick={onRetry}
+          className="text-xs font-mono underline transition-opacity hover:opacity-70"
+          style={{ color: 'var(--accent)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (diff.state === 'cause') return <DiffCauseCard cause={diff.cause} onClose={onClose} />;
   if (diff.state === 'error') return <ErrorPane message={diff.message} />;
   const { diff: text, truncated } = diff.data;
 
   if (text === '') {
-    // `diff: ""` is a real answer (clean tree), not an error (§3.3).
+    // `diff: ""` is a real answer (clean tree), not an error (§3.3) — but under
+    // the HEAD baseline it only means "no UNCOMMITTED changes" (§8.1).
     return (
-      <p data-testid="viewer-clean-tree" className="p-4 text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
-        {narrowed ? 'no changes to this file.' : 'clean tree — no changes.'}
-      </p>
+      <div className="flex-1 min-h-0 flex flex-col">
+        <BaselineNote />
+        <p data-testid="viewer-clean-tree" className="p-4 text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
+          {narrowed ? 'no changes to this file.' : 'clean tree — no changes.'}
+        </p>
+      </div>
     );
   }
 
   const lines = classifyDiff(text);
   return (
     <div className="flex-1 min-h-0 flex flex-col">
+      <BaselineNote />
       {truncated && (
         <TruncationBanner text="diff truncated at 1 MB — narrow to a single file for the rest" />
       )}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,6 +1,18 @@
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Components } from 'react-markdown';
+
+/**
+ * A file reference, as agents write them into transcripts: any href that is not
+ * an external URL (`https://…`), an anchor, or a mail link. Covers absolute
+ * paths (`/w2/auth/NOTES.md`) and bare relative names (`NOTES.md`) — both used
+ * to render as underlined `target="_blank"` anchors that dead-clicked
+ * (DES-UX-001 §1.1-5: "evidence links do nothing on click").
+ */
+function isFileRef(href: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(href) && !href.startsWith('//') && !href.startsWith('#');
+}
 
 const components: Components = {
   h1: ({ children }) => <h1 className="text-lg font-bold mt-4 mb-2" style={{ color: 'var(--ink-high)' }}>{children}</h1>,
@@ -77,15 +89,53 @@ const components: Components = {
 interface Props {
   children: string;
   className?: string;
+  /**
+   * Evidence-reference wiring (DES-UX-001 §1.3-4c): when provided, a link whose
+   * href is a FILE reference (not an external URL) resolves through this
+   * callback — the run view opens it in the slice-I FileViewer via
+   * `GET /runs/:id/files` — instead of a dead `target="_blank"` click.
+   * External http(s) links keep today's exact behavior.
+   */
+  onOpenFile?: (path: string) => void;
 }
 
-export function Markdown({ children, className }: Props): React.ReactElement {
+export function Markdown({ children, className, onOpenFile }: Props): React.ReactElement {
+  const resolved = useMemo<Components>(() => {
+    if (onOpenFile === undefined) return components;
+    return {
+      ...components,
+      a: ({ href, children: linkChildren }) => {
+        if (typeof href === 'string' && isFileRef(href)) {
+          return (
+            <a
+              href={href}
+              data-testid="evidence-ref"
+              className="underline"
+              style={{ color: 'var(--accent)' }}
+              onClick={(e) => {
+                e.preventDefault();
+                onOpenFile(href);
+              }}
+            >
+              {linkChildren}
+            </a>
+          );
+        }
+        return (
+          <a href={href} target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--accent)' }}>
+            {linkChildren}
+          </a>
+        );
+      },
+    };
+  }, [onOpenFile]);
+
   return (
     <div
       className={`text-sm leading-relaxed ${className ?? ''}`}
       style={{ color: 'var(--ink-high)' }}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={resolved}>
         {children}
       </ReactMarkdown>
     </div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -181,6 +181,76 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
   );
 }
 
+/**
+ * The Term tab's transcript-first landing (DES-UX-001 §1.3-4, slice R): when a
+ * run has captured unit output, a diagnosing operator lands on THAT — the
+ * run's own transcript — not on an empty ungoverned shell. The operator shell
+ * stays available as a labeled, secondary action.
+ *
+ * Fetches ride the same sanctioned wire the run view uses
+ * (`GET /runs/:id/units/:unitKey/output`), gesture-gated on opening the modal.
+ */
+function RunTranscriptView({ runId, units, onOpenShell }: {
+  runId: string;
+  units: SessionView['units'];
+  onOpenShell: () => void;
+}): React.ReactElement {
+  const captured = [...units]
+    .filter((u) => u.status === 'done' || u.status === 'rejected')
+    .sort((a, b) => a.ord - b.ord);
+  const [texts, setTexts] = useState<Record<number, string | null>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    for (const unit of captured) {
+      const unitKey = unit.id.startsWith(`${runId}:`) ? unit.id.slice(runId.length + 1) : `u${unit.ord}`;
+      void api
+        .getUnitOutput(runId, unitKey)
+        .then(({ output, outputUnavailable }) => {
+          if (cancelled) return;
+          setTexts((prev) => ({ ...prev, [unit.ord]: output ?? outputUnavailable ?? '(no transcript captured)' }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setTexts((prev) => ({ ...prev, [unit.ord]: '(transcript unavailable)' }));
+        });
+    }
+    return () => { cancelled = true; };
+    // The captured set is derived from `units`; keying on runId + length keeps the
+    // effect from re-firing per render while still refetching on a run switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId, captured.length]);
+
+  return (
+    <div data-testid="term-transcript" className="flex flex-col gap-3 max-h-[60vh] overflow-y-auto">
+      {captured.map((unit) => (
+        <div key={unit.id}>
+          <p className="text-[10px] font-mono mb-1 uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>
+            unit #{unit.ord} · {unit.stage} · {unit.status}
+          </p>
+          <pre
+            className="rounded-lg p-2 text-[10px] leading-tight whitespace-pre-wrap font-mono overflow-x-auto"
+            style={{ background: 'var(--surface-base)', color: 'var(--ink-body)' }}
+          >
+            {texts[unit.ord] ?? 'Loading…'}
+          </pre>
+        </div>
+      ))}
+      <div className="flex items-center gap-2 pt-1" style={{ borderTop: '1px solid var(--surface-raised)' }}>
+        <button
+          type="button"
+          data-testid="term-open-shell"
+          onClick={onOpenShell}
+          className="text-[11px] font-mono underline transition-opacity hover:opacity-70"
+          style={{ color: 'var(--ink-muted)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+        >
+          Open operator shell (ungoverned) instead
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
   const runId = model.session.id;
   // Slice I: the per-run [Full diff] button at the panel header (§3.4) — the
@@ -323,6 +393,9 @@ export function RightPanel({ view }: Props): React.ReactElement {
   const [openAccordion, setOpenAccordion] = useState<AccordionId | null>('whatwhere');
 
   const [termOpen, setTermOpen] = useState(false);
+  // Slice R (§1.3-4): the Term tab lands on the run's captured transcript when
+  // one exists; the ungoverned operator shell is the labeled SECONDARY action.
+  const [termShell, setTermShell] = useState(false);
   const [coverageOpen, setCoverageOpen] = useState(false);
 
   // Steering INPUT lives in the run thread's composer (ChatInput routes by run
@@ -402,8 +475,12 @@ export function RightPanel({ view }: Props): React.ReactElement {
         <button
           type="button"
           onClick={() => setTermOpen(true)}
-          title="Terminal"
-          aria-label="Open terminal"
+          title={view.units.some((u) => u.status === 'done' || u.status === 'rejected')
+            ? "View this run's transcript"
+            : 'Terminal'}
+          aria-label={view.units.some((u) => u.status === 'done' || u.status === 'rejected')
+            ? "View this run's transcript"
+            : 'Open terminal'}
           className="rounded px-2 py-0.5 text-[11px] font-mono"
           style={{ color: 'var(--ink-muted)' }}
         >
@@ -470,15 +547,33 @@ export function RightPanel({ view }: Props): React.ReactElement {
         ))}
       </div>
 
-      {/* Terminal modal */}
-      {termOpen && (
-        <Modal title="Operator shell" onClose={() => setTermOpen(false)} disableEscapeKey>
-          <Terminal
-            cwd={session.workdir ?? '.'}
-            governed
-          />
-        </Modal>
-      )}
+      {/* Terminal modal — transcript-first when captured output exists (§1.3-4):
+          a diagnosing operator lands on the run's own record, never on an empty
+          shell by default. */}
+      {termOpen && (() => {
+        const hasCaptured = view.units.some((u) => u.status === 'done' || u.status === 'rejected');
+        const showTranscript = hasCaptured && !termShell;
+        return (
+          <Modal
+            title={showTranscript ? "This run's transcript" : 'Operator shell'}
+            onClose={() => { setTermOpen(false); setTermShell(false); }}
+            disableEscapeKey
+          >
+            {showTranscript ? (
+              <RunTranscriptView
+                runId={session.id}
+                units={view.units}
+                onOpenShell={() => setTermShell(true)}
+              />
+            ) : (
+              <Terminal
+                cwd={session.workdir ?? '.'}
+                governed
+              />
+            )}
+          </Modal>
+        );
+      })()}
 
       {/* Coverage modal */}
       {coverageOpen && (

--- a/src/components/UnitList.tsx
+++ b/src/components/UnitList.tsx
@@ -7,6 +7,8 @@ interface Props {
   /** The ord the run is paused before, if any (marks the gated unit for per-unit approve). */
   gateOrd?: number;
   onResolved?: () => void;
+  /** Evidence-reference wiring (slice R): file links in transcripts open the FileViewer. */
+  onOpenFile?: (path: string) => void;
 }
 
 /**
@@ -14,7 +16,7 @@ interface Props {
  * rendered by `ord`; the fixed phase ladder is gone — units are planned from the
  * brief.
  */
-export function UnitList({ runId, units, gateOrd, onResolved }: Props): React.ReactElement {
+export function UnitList({ runId, units, gateOrd, onResolved, onOpenFile }: Props): React.ReactElement {
   if (units.length === 0) {
     return (
       <p data-testid="unit-list" className="text-xs" style={{ color: 'var(--ink-dim)' }}>
@@ -28,10 +30,13 @@ export function UnitList({ runId, units, gateOrd, onResolved }: Props): React.Re
   return (
     <ol className="flex flex-col gap-1.5" data-testid="unit-list">
       {ordered.map((unit) => {
-        const props =
-          onResolved !== undefined
-            ? { runId, unit, isGated: gateOrd === unit.ord, onResolved }
-            : { runId, unit, isGated: gateOrd === unit.ord };
+        const props = {
+          runId,
+          unit,
+          isGated: gateOrd === unit.ord,
+          ...(onResolved !== undefined ? { onResolved } : {}),
+          ...(onOpenFile !== undefined ? { onOpenFile } : {}),
+        };
         return <WorkUnitDetail key={unit.id} {...props} />;
       })}
     </ol>

--- a/src/components/VerdictDetail.tsx
+++ b/src/components/VerdictDetail.tsx
@@ -1,0 +1,165 @@
+import type { CoreEvent, WorkUnit } from '../api/types.js';
+import { useRunEventStore } from '../store/events.js';
+
+/**
+ * The evaluator verdict card (DES-UX-001 §1.3-2, slice R).
+ *
+ * A failed run used to answer "why did this fail" with a one-line rejection; the
+ * evaluator's actual record — which phase gated, what it evaluated, what it
+ * rejected — was on the wire the whole time (`gateEvaluated`, already fetched
+ * into the run event store by the run view's hydrate) and never rendered. This
+ * card reads that log and states, for the deciding phase: the `criterion`
+ * gated, the `agentVerdict` + `agentReasoning`, the `denialReason`, and which
+ * governance layers actually ran.
+ *
+ * FINDING-025: an EMPTY `evaluatorPolicies` beside `evaluatorPass: true` is a
+ * vacuous default-allow — nothing was applied, so the "pass" enforces nothing.
+ * The card labels it as such (`data-vacuous="true"`) instead of letting it read
+ * as an enforced approval.
+ *
+ * The retention empty state (§1.3-3, steering-added): historical runs whose
+ * event logs carry no `gateEvaluated` entries (event retention predates the
+ * run, or the log was pruned) render the card in its empty dress — "no
+ * evaluator record survives for this run" — never a blank card, and never a
+ * verdict fabricated from the one-line status.
+ *
+ * Zero new requests: the card is a pure view over the already-fetched event log.
+ */
+
+interface Props {
+  runId: string;
+  /** The run's units (snapshot) — resolves the deciding ord to a phase name. */
+  units: readonly WorkUnit[];
+}
+
+/** A `gateEvaluated` frame narrowed to the fields the card states. */
+interface GateEvalView {
+  ord: number | null;
+  criterion: string | null;
+  hasDeterministicFloor: boolean;
+  deterministicPass: boolean;
+  agentVerdict: string | null;
+  agentReasoning: string | null;
+  evaluatorPass: boolean | null;
+  evaluatorPolicies: string[];
+  denialReason: string | null;
+  combined: boolean;
+}
+
+function toView(ev: CoreEvent): GateEvalView {
+  return {
+    ord: typeof ev.ord === 'number' ? ev.ord : null,
+    criterion: typeof ev.criterion === 'string' ? ev.criterion : null,
+    hasDeterministicFloor: ev.hasDeterministicFloor === true,
+    deterministicPass: ev.deterministicPass === true,
+    agentVerdict: typeof ev.agentVerdict === 'string' ? ev.agentVerdict : null,
+    agentReasoning: typeof ev.agentReasoning === 'string' ? ev.agentReasoning : null,
+    evaluatorPass: typeof ev.evaluatorPass === 'boolean' ? ev.evaluatorPass : null,
+    evaluatorPolicies: Array.isArray(ev.evaluatorPolicies)
+      ? (ev.evaluatorPolicies as unknown[]).filter((p): p is string => typeof p === 'string')
+      : [],
+    denialReason: typeof ev.denialReason === 'string' ? ev.denialReason : null,
+    combined: ev.combined === true,
+  };
+}
+
+/**
+ * The DECIDING evaluation: the last one that denied (a `denialReason`, or a
+ * combined-deny), else the last evaluation overall — arrival order is the
+ * daemon's order, so "last" is the verdict that stood when the run halted.
+ */
+export function decidingEval(events: readonly CoreEvent[]): GateEvalView | null {
+  const evals = events.filter((e) => e.type === 'gateEvaluated').map(toView);
+  if (evals.length === 0) return null;
+  const denies = evals.filter((g) => g.denialReason !== null || !g.combined);
+  return denies[denies.length - 1] ?? evals[evals.length - 1] ?? null;
+}
+
+/** Phase name for an ord: the unit-key suffix for workflow units, the stage for free-text ones. */
+function phaseLabel(runId: string, units: readonly WorkUnit[], ord: number | null): string {
+  if (ord === null) return 'unknown phase';
+  const unit = units.find((u) => u.ord === ord);
+  if (unit === undefined) return `unit ${ord}`;
+  const key = unit.id.startsWith(`${runId}:`) ? unit.id.slice(runId.length + 1) : `u${unit.ord}`;
+  return /^u\d+$/.test(key) ? unit.stage : key;
+}
+
+const EMPTY_EVENTS: CoreEvent[] = [];
+
+export function VerdictDetail({ runId, units }: Props): React.ReactElement {
+  const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
+  const deciding = decidingEval(events);
+
+  if (deciding === null) {
+    // The empty dress (§1.4): dim ink on a raised surface, NO status color — an
+    // absent record is a retention fact, not a failure signal.
+    return (
+      <div
+        data-testid="verdict-detail"
+        data-empty="true"
+        className="rounded-lg p-3 text-xs font-mono"
+        style={{ background: 'var(--surface-raised)', border: '1px solid var(--surface-raised)' }}
+      >
+        <p style={{ color: 'var(--ink-dim)' }}>no evaluator record survives for this run</p>
+        <p className="mt-1" style={{ color: 'var(--ink-dim)' }}>
+          Event retention predates this run, or its log was pruned — the gate&apos;s reasoning
+          was not kept. The status above is the only record.
+        </p>
+      </div>
+    );
+  }
+
+  const vacuous = deciding.evaluatorPolicies.length === 0 && deciding.evaluatorPass === true;
+  const phase = phaseLabel(runId, units, deciding.ord);
+
+  return (
+    <div
+      data-testid="verdict-detail"
+      {...(deciding.ord !== null ? { 'data-phase-ord': deciding.ord } : {})}
+      {...(vacuous ? { 'data-vacuous': 'true' } : {})}
+      className="rounded-lg p-3 flex flex-col gap-1.5"
+      style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)' }}
+    >
+      <p className="text-xs font-semibold font-mono" style={{ color: 'var(--status-fail)' }}>
+        Evaluator verdict — {phase}
+      </p>
+
+      {deciding.criterion !== null && (
+        <p className="text-[11px] font-mono" data-testid="verdict-criterion" style={{ color: 'var(--ink-muted)' }}>
+          criterion: {deciding.criterion}
+        </p>
+      )}
+
+      {deciding.agentVerdict !== null && (
+        <p className="text-xs" style={{ color: 'var(--ink-body)' }}>
+          <span className="font-mono font-semibold">{deciding.agentVerdict}</span>
+          {deciding.agentReasoning !== null && <span> — {deciding.agentReasoning}</span>}
+        </p>
+      )}
+      {deciding.agentVerdict === null && deciding.agentReasoning !== null && (
+        <p className="text-xs" style={{ color: 'var(--ink-body)' }}>{deciding.agentReasoning}</p>
+      )}
+
+      {deciding.denialReason !== null && (
+        <p className="text-xs font-mono" data-testid="verdict-denial" style={{ color: 'var(--status-fail)' }}>
+          denied: {deciding.denialReason}
+        </p>
+      )}
+
+      {/* Which governance layers actually ran — never overclaimed (FINDING-025). */}
+      <p className="text-[11px] font-mono" style={{ color: 'var(--ink-muted)' }}>
+        {deciding.hasDeterministicFloor
+          ? `deterministic floor: ${deciding.deterministicPass ? 'pass' : 'fail'}`
+          : 'no deterministic floor'}
+        {' · '}
+        {deciding.evaluatorPass === null
+          ? 'evaluator layer did not run'
+          : vacuous
+            ? 'evaluator: default-allow (no policy applied — an unenforced pass, not an approval)'
+            : `evaluator: ${deciding.evaluatorPass ? 'pass' : 'fail'} (${deciding.evaluatorPolicies.length} ${
+                deciding.evaluatorPolicies.length === 1 ? 'policy' : 'policies'
+              })`}
+      </p>
+    </div>
+  );
+}

--- a/src/components/WorkUnitDetail.tsx
+++ b/src/components/WorkUnitDetail.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client.js';
 import type { StageKind, UnitStatus, WorkUnit } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
 import { useRuntimeStore, outputKey } from '../store/runtime.js';
+import { Markdown } from './Markdown.js';
 import { RoutingProvenance } from './RoutingProvenance.js';
 
 const STAGE_STYLE: Record<StageKind, { bg: string; color: string }> = {
@@ -24,9 +25,11 @@ interface Props {
   unit: WorkUnit;
   isGated: boolean;
   onResolved?: () => void;
+  /** Evidence-reference wiring (slice R): file links in the transcript open the FileViewer. */
+  onOpenFile?: (path: string) => void;
 }
 
-export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): React.ReactElement {
+export function WorkUnitDetail({ runId, unit, isGated, onResolved, onOpenFile }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
   const liveOutput = useRuntimeStore((s) => s.outputs[outputKey(runId, unit.ord)]);
   const [transcript, setTranscript] = useState<string | null>(null);
@@ -166,13 +169,25 @@ export function WorkUnitDetail({ runId, unit, isGated, onResolved }: Props): Rea
         </div>
 
         {showTranscript && (
-          <pre
+          <div
             data-testid="unit-transcript"
-            className="mt-1 max-h-96 overflow-auto rounded-lg p-2 text-[10px] leading-tight whitespace-pre-wrap font-mono"
+            className="mt-1 max-h-96 overflow-auto rounded-lg p-2 text-[10px] leading-tight"
             style={{ background: 'var(--surface-base)', color: 'var(--ink-high)' }}
           >
-            {loadingTranscript ? 'Loading…' : transcript}
-          </pre>
+            {/* Markdown, matching the run thread's done-unit treatment — so an evidence
+                reference in the transcript is a live link into the FileViewer, not a
+                dead underline (DES-UX-001 §1.3-4c). */}
+            {loadingTranscript
+              ? <span className="font-mono">Loading…</span>
+              : (
+                <Markdown
+                  className="whitespace-pre-wrap"
+                  {...(onOpenFile !== undefined ? { onOpenFile } : {})}
+                >
+                  {transcript ?? ''}
+                </Markdown>
+              )}
+          </div>
         )}
       </div>
     </li>

--- a/tests/ChatPanel.postmortem.test.tsx
+++ b/tests/ChatPanel.postmortem.test.tsx
@@ -1,0 +1,139 @@
+// Slice R (DES-UX-001 §1.3-1 / §1.5): units-as-spine for EVERY terminal status.
+//
+// A failed run's page used to collapse to a one-line rejection while the
+// transcripts sat on the wire (GET /runs/:id/units/:unitKey/output). These
+// tests pin the post-mortem shape:
+//
+//   1. a FAILED run renders `[data-testid="work-unit"]` for its units, and a
+//      unit with captured output auto-opens `[data-testid="unit-transcript"]`
+//      (the rejected-unit auto-open contract, WorkUnitDetail.tsx:38, preserved);
+//   2. FailureBanner is the HEADLINE — it renders, and it PRECEDES the unit
+//      list in the DOM (demoted from the whole story, never removed);
+//   3. cancelled runs get the same spine;
+//   4. an evidence reference inside a transcript is a live <a> that opens the
+//      FileViewer populated from readRunFile — no dead click (§1.3-4c).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+});
+
+const FAILED_VIEW = makeView({ status: 'failed' }, [
+  makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+  makeUnit({
+    id: 'run-1:review', ord: 1, stage: 'review', status: 'rejected',
+    denial_reason: 'phase produced no reviewable substance',
+  }),
+]);
+
+function renderPanel(view = FAILED_VIEW): void {
+  render(
+    <ChatPanel
+      view={view}
+      onLaunched={vi.fn()}
+      onNavigateBack={vi.fn()}
+      onRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('ChatPanel — the failed-run post-mortem spine (slice R)', () => {
+  it('renders work units for a FAILED run and auto-opens the captured transcript', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockImplementation(
+      async (_id: string, unitKey: string) =>
+        unitKey === 'survey'
+          ? { output: 'captured survey transcript' }
+          : { output: null, outputUnavailable: 'denied — output not retained past a deny' },
+    );
+    renderPanel();
+
+    // The spine renders (§1.5 AC 1) …
+    const units = await screen.findAllByTestId('work-unit');
+    expect(units).toHaveLength(2);
+
+    // … and the transcripts auto-open, INCLUDING the rejected unit's honest
+    // absence reason (WorkUnitDetail.tsx:38's contract, preserved).
+    const panes = await screen.findAllByTestId('unit-transcript');
+    expect(panes.length).toBe(2);
+    expect(await screen.findByText('captured survey transcript')).toBeInTheDocument();
+    expect(await screen.findByText(/output not retained past a deny/)).toBeInTheDocument();
+    expect(client.api.getUnitOutput).toHaveBeenCalledWith('run-1', 'survey');
+    expect(client.api.getUnitOutput).toHaveBeenCalledWith('run-1', 'review');
+  });
+
+  it('FailureBanner is the headline ABOVE the unit list — demoted, not removed', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'x' });
+    renderPanel();
+
+    const banner = await screen.findByTestId('failure-banner');
+    const list = await screen.findByTestId('unit-list');
+    expect(banner).toHaveAttribute('data-kind', 'failed');
+    expect(
+      banner.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('a CANCELLED run renders the same spine under its banner', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'partial work' });
+    renderPanel(makeView({ status: 'cancelled' }, [
+      makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'done' }),
+    ]));
+
+    expect(await screen.findByTestId('failure-banner')).toHaveAttribute('data-kind', 'cancelled');
+    expect(await screen.findByTestId('work-unit')).toBeInTheDocument();
+    expect(await screen.findByText('partial work')).toBeInTheDocument();
+  });
+
+  it('the VerdictDetail card renders on the post-mortem page', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'x' });
+    useRunEventStore.setState({
+      byRun: {
+        'run-1': [{
+          type: 'gateEvaluated', session: 'run-1', ord: 1,
+          criterion: 'review artifacts exist', hasDeterministicFloor: false,
+          deterministicPass: false, agentVerdict: 'deny',
+          agentReasoning: 'nothing to review', evaluatorPass: true,
+          evaluatorPolicies: [], denialReason: 'phase produced no reviewable substance',
+          combined: false,
+        }],
+      },
+    });
+    renderPanel();
+
+    const card = await screen.findByTestId('verdict-detail');
+    expect(card).toHaveAttribute('data-phase-ord', '1');
+    expect(card).toHaveTextContent('nothing to review');
+  });
+
+  it('an evidence reference in a transcript opens the FileViewer via readRunFile — no dead click', async () => {
+    vi.spyOn(client.api, 'getUnitOutput').mockImplementation(
+      async (_id: string, unitKey: string) =>
+        unitKey === 'survey'
+          ? { output: 'see [NOTES.md](/w2/evidence/NOTES.md) for the survey notes' }
+          : { output: null },
+    );
+    const getRunFile = vi.spyOn(client.api, 'getRunFile').mockResolvedValue({
+      path: '/w2/evidence/NOTES.md', content: 'the notes', size: 9, truncated: false, binary: false,
+    });
+    renderPanel();
+
+    const link = await screen.findByTestId('evidence-ref');
+    expect(link.tagName).toBe('A');
+    await userEvent.click(link);
+
+    expect(await screen.findByTestId('file-viewer')).toBeInTheDocument();
+    expect(getRunFile).toHaveBeenCalledWith('run-1', '/w2/evidence/NOTES.md');
+    expect(await screen.findByText('the notes')).toBeInTheDocument();
+  });
+});

--- a/tests/FileViewer.diffhang.test.tsx
+++ b/tests/FileViewer.diffhang.test.tsx
@@ -1,0 +1,72 @@
+// Slice R (DES-UX-001 §1.3-4b / §1.5): the zero-request eternal-Loading diff
+// hang, fixed outright.
+//
+// The regression this pins: "Full diff" on a historical run hung on "Loading…"
+// forever WHILE FIRING ZERO NETWORK REQUESTS. Two falsifiable contracts:
+//
+//   1. opening the diff tab ALWAYS dispatches the request (≥1 getRunDiff call —
+//      the rig's request-tap twin asserts the same on the wire);
+//   2. a request that never resolves lands in `[data-testid="diff-error"]`
+//      within the DIFF_TIMEOUT_MS budget — with a Retry that re-dispatches.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { FileViewer, DIFF_TIMEOUT_MS } from '../src/components/FileViewer.js';
+import * as client from '../src/api/client.js';
+
+describe('FileViewer — the diff hang is dead (slice R)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a never-resolving diff dispatches the request AND reaches diff-error within the budget', async () => {
+    const getRunDiff = vi
+      .spyOn(client.api, 'getRunDiff')
+      .mockImplementation(() => new Promise(() => { /* never resolves */ }));
+    render(<FileViewer runId="r-hist" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    // Contract 1: the request WAS attempted, immediately on activation.
+    expect(getRunDiff).toHaveBeenCalledTimes(1);
+    expect(getRunDiff).toHaveBeenCalledWith('r-hist', undefined);
+
+    // Still honestly loading inside the budget…
+    act(() => { vi.advanceTimersByTime(DIFF_TIMEOUT_MS - 1); });
+    expect(screen.queryByTestId('diff-error')).not.toBeInTheDocument();
+
+    // …and the error branch lands AT the budget — never an indefinite spinner.
+    act(() => { vi.advanceTimersByTime(2); });
+    expect(screen.getByTestId('diff-error')).toHaveTextContent("Couldn't load the diff");
+  });
+
+  it('Retry re-dispatches the request', async () => {
+    const getRunDiff = vi
+      .spyOn(client.api, 'getRunDiff')
+      .mockImplementation(() => new Promise(() => { /* never resolves */ }));
+    render(<FileViewer runId="r-hist" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    act(() => { vi.advanceTimersByTime(DIFF_TIMEOUT_MS + 1); });
+    act(() => { screen.getByTestId('diff-retry').click(); });
+
+    expect(getRunDiff).toHaveBeenCalledTimes(2);
+    // Back to an honest loading state, not a stale error.
+    expect(screen.queryByTestId('diff-error')).not.toBeInTheDocument();
+  });
+
+  it('a resolving diff inside the budget renders normally (no spurious timeout)', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockResolvedValue({ diff: '', truncated: false });
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
+
+    await act(async () => { await vi.runOnlyPendingTimersAsync(); });
+    expect(screen.getByTestId('viewer-clean-tree')).toBeInTheDocument();
+    // The §8.1 interim baseline note rides every resolved diff view.
+    expect(screen.getByTestId('diff-baseline-note')).toHaveTextContent(
+      'showing uncommitted changes vs HEAD; committed work is not shown here',
+    );
+    act(() => { vi.advanceTimersByTime(DIFF_TIMEOUT_MS + 10); });
+    expect(screen.queryByTestId('diff-error')).not.toBeInTheDocument();
+  });
+});

--- a/tests/FileViewer.test.tsx
+++ b/tests/FileViewer.test.tsx
@@ -86,15 +86,39 @@ describe('FileViewer — File tab states', () => {
 });
 
 describe('FileViewer — Diff tab states', () => {
-  it('409 (workdir reaped): honest, verbatim', async () => {
+  // RE-SCOPED by slice R (DES-UX-001 §1.3-4a / §11.2): this assertion used to pin
+  // the 409 surfacing VERBATIM. The design supersedes that — the daemon's two diff
+  // 409s become NAMED-CAUSE cards, and the raw `API 409` / `has no workdir` strings
+  // never reach the DOM (EC33). The verbatim contract still holds for every other
+  // error (the named-404 test below is unchanged).
+  it('409 (workdir reaped): the named-cause card, never the raw wire string', async () => {
     vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new Error(
       "API 409: run r-1's workdir no longer exists: /tmp/wt",
     ));
     render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
 
-    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(
-      "API 409: run r-1's workdir no longer exists: /tmp/wt",
-    );
+    const card = await screen.findByTestId('diff-named-cause');
+    expect(card).toHaveAttribute('data-cause', 'workdir-gone');
+    expect(card).toHaveTextContent('This run’s workdir no longer exists.');
+    expect(document.body.textContent).not.toContain('API 409');
+    expect(screen.queryByTestId('viewer-error')).not.toBeInTheDocument();
+  });
+
+  it('409 (no workdir attached): the no-repository named cause, raw strings absent', async () => {
+    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new Error(
+      'API 409: run r-1 has no workdir — nothing to diff',
+    ));
+    const onClose = vi.fn();
+    render(<FileViewer runId="r-1" defaultTab="diff" onClose={onClose} onUnsupported={() => {}} />);
+
+    const card = await screen.findByTestId('diff-named-cause');
+    expect(card).toHaveAttribute('data-cause', 'no-repo');
+    expect(card).toHaveTextContent('This run had no repository attached — nothing was produced to review.');
+    expect(document.body.textContent).not.toContain('API 409');
+    expect(document.body.textContent).not.toContain('has no workdir');
+    // The remediation link resolves (closes back to the run page's transcripts).
+    screen.getByTestId('diff-cause-remediation').click();
+    expect(onClose).toHaveBeenCalled();
   });
 
   it('colors added/removed/hunk lines from the classifier and banners diff truncation', async () => {

--- a/tests/VerdictDetail.test.tsx
+++ b/tests/VerdictDetail.test.tsx
@@ -1,0 +1,131 @@
+// Slice R (DES-UX-001 §1.3-2 / §1.5): the evaluator verdict card.
+//
+// A failed run's page used to answer "why did this fail" with a one-line
+// rejection while the evaluator's record sat unrendered in the already-fetched
+// event log. These tests pin the card's three contracts:
+//
+//   1. it states the DECIDING phase's record: criterion, agentVerdict +
+//      agentReasoning, denialReason (`data-phase-ord` names the phase);
+//   2. FINDING-025: empty `evaluatorPolicies` beside `evaluatorPass: true` is a
+//      vacuous default-allow — labeled `data-vacuous="true"`, never an implied
+//      enforced approval;
+//   3. the retention empty state (steering-added): a log with NO `gateEvaluated`
+//      entries renders `data-empty="true"` with the EXACT copy "no evaluator
+//      record survives for this run" — never a blank card, never a fabricated
+//      verdict.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VerdictDetail } from '../src/components/VerdictDetail.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeUnit } from './factories.js';
+
+const RUN = 'run-1';
+
+const UNITS = [
+  makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'done' }),
+  makeUnit({ id: 'run-1:review', ord: 1, stage: 'review', status: 'rejected', denial_reason: 'no reviewable substance' }),
+];
+
+/** A real-shape `gateEvaluated` deny (camelCase, per event_to_json). */
+const DENY = {
+  type: 'gateEvaluated',
+  session: RUN,
+  ord: 1,
+  criterion: 'review artifacts exist and cite the diff',
+  hasDeterministicFloor: true,
+  deterministicPass: true,
+  agentVerdict: 'deny',
+  agentReasoning: 'The review phase produced no reviewable substance: no diff hunks were cited.',
+  evaluatorPass: true,
+  evaluatorPolicies: [] as string[],
+  denialReason: 'phase produced no reviewable substance',
+  combined: false,
+};
+
+describe('VerdictDetail — the evaluator verdict card (slice R)', () => {
+  beforeEach(() => {
+    useRunEventStore.setState({ byRun: {} });
+  });
+
+  it('states the deciding phase: criterion, agentVerdict + reasoning, denialReason', () => {
+    useRunEventStore.setState({ byRun: { [RUN]: [DENY] } });
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+
+    const card = screen.getByTestId('verdict-detail');
+    expect(card).toHaveAttribute('data-phase-ord', '1');
+    expect(card).toHaveTextContent('review'); // the phase name, from the unit key
+    expect(screen.getByTestId('verdict-criterion')).toHaveTextContent(
+      'review artifacts exist and cite the diff',
+    );
+    expect(card).toHaveTextContent('The review phase produced no reviewable substance');
+    expect(screen.getByTestId('verdict-denial')).toHaveTextContent(
+      'denied: phase produced no reviewable substance',
+    );
+  });
+
+  it('labels empty evaluatorPolicies beside evaluatorPass:true as the vacuous default-allow (FINDING-025)', () => {
+    useRunEventStore.setState({ byRun: { [RUN]: [DENY] } });
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+
+    const card = screen.getByTestId('verdict-detail');
+    expect(card).toHaveAttribute('data-vacuous', 'true');
+    expect(card).toHaveTextContent('default-allow');
+  });
+
+  it('an ENFORCED evaluator pass (policies applied) is never labeled vacuous', () => {
+    useRunEventStore.setState({
+      byRun: { [RUN]: [{ ...DENY, evaluatorPolicies: ['policy-a', 'policy-b'] }] },
+    });
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+
+    const card = screen.getByTestId('verdict-detail');
+    expect(card).not.toHaveAttribute('data-vacuous');
+    expect(card).not.toHaveTextContent('default-allow');
+    expect(card).toHaveTextContent('2 policies');
+  });
+
+  it('the deciding record is the last DENY, not merely the last evaluation', () => {
+    const earlierAllow = {
+      ...DENY,
+      ord: 0,
+      agentVerdict: 'allow',
+      agentReasoning: 'looks fine',
+      denialReason: null,
+      combined: true,
+    };
+    // Arrival order: deny (ord 1) between two allows — the deny decides.
+    useRunEventStore.setState({ byRun: { [RUN]: [earlierAllow, DENY, { ...earlierAllow, ord: 0 }] } });
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+
+    expect(screen.getByTestId('verdict-detail')).toHaveAttribute('data-phase-ord', '1');
+    expect(screen.getByTestId('verdict-denial')).toHaveTextContent('phase produced no reviewable substance');
+  });
+
+  it('retention empty state: no gateEvaluated in the log → the exact honest copy, never a blank card', () => {
+    // A historical run's surviving log: lifecycle only, no evaluator record.
+    useRunEventStore.setState({
+      byRun: {
+        [RUN]: [
+          { type: 'sessionStarted', session: RUN },
+          { type: 'sessionFailed', session: RUN },
+        ],
+      },
+    });
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+
+    const card = screen.getByTestId('verdict-detail');
+    expect(card).toHaveAttribute('data-empty', 'true');
+    expect(card).toHaveTextContent('no evaluator record survives for this run');
+    // Never fabricated from the one-line status:
+    expect(card).not.toHaveTextContent('denied:');
+    expect(card).not.toHaveAttribute('data-phase-ord');
+  });
+
+  it('an entirely absent log renders the same empty dress (never blank)', () => {
+    render(<VerdictDetail runId={RUN} units={UNITS} />);
+    const card = screen.getByTestId('verdict-detail');
+    expect(card).toHaveAttribute('data-empty', 'true');
+    expect(card.textContent).not.toBe('');
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §1 (slice R + folded R2)** — failure forensics, the campaign's #1 CRITICAL (BRIEF-UX-001 A1: a failed run offered only a one-line rejection; the operator's core triage question was unanswerable).

## What changed
- **Units-as-spine**: failed/cancelled runs render the FailureBanner as a headline *above* the ordered UnitList → WorkUnitDetail spine (same anatomy as completed runs); both terminal transcripts auto-open, the rejected unit preserving its existing auto-open contract.
- **VerdictDetail** (new): reads `gateEvaluated` from the already-hydrated event log — deciding phase, criterion, agentVerdict + reasoning, denialReason. Vacuous default-allow (empty `evaluatorPolicies` + `evaluatorPass:true`) is labeled honestly: "default-allow (no policy applied — an unenforced pass, not an approval)" with `data-vacuous="true"`. Historical runs with no gateEvaluated events get the retention empty state: "no evaluator record survives for this run".
- **Escape hatches all resolve**: 409 diffs → named-cause cards ("no repository attached" / "workdir no longer exists") with remediation links — raw `API 409`/`has no workdir` strings asserted absent DOM-wide; the zero-request eternal-Loading diff hang is fixed outright (8s budget → retryable error state); transcript file references open the FileViewer via `readRunFile`; Term tab lands on the run's transcript with the operator shell as labeled secondary; §8.1 interim baseline note on every resolving diff ("showing uncommitted changes vs HEAD; committed work is not shown here") until CREW-UX-1 (`?base=`) lands.

## Verified at slice time
- eslint --max-warnings 0 · tsc --noEmit · vitest **1266/1266** (3 new suites)
- New rig `e2e/ux_sliceR_test.py` (8 scenes, every §1.5 DOM AC incl. the /diff request-tap) + regression rigs sliceI/sliceN/sliceH — all green; negative check confirms the rig fails on main
- **Live-daemon proof** (read-only): two real failed runs answered "why did this fail" in ~4s from the page alone — 7-unit spine hydrated, vacuous verdict labeled, named-cause card for the reaped workdir, no raw 409 anywhere

## Scope note
§1.3(4) (the doc's R2: diff pipeline + evidence wiring) is folded in — combined src diff sits within the R+R2 LOC budgets. `?base=merge-base` adoption remains the follow-up once CREW-UX-1 ships in crew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
