### PR TITLE
DES-UX-001 slice V: provenance + retry

### DIFF
--- a/e2e/ux_sliceV_test.py
+++ b/e2e/ux_sliceV_test.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+ux_sliceV_test.py — the DES-UX-001 slice-V gate: provenance + retry (§3, §4).
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with its
+`provenance` corpus on (real wire shapes only): GET /audit?runId= serves REAL
+AuditEntry rows (actor{id,kind,trust} + the run.launched detail, crew
+routes.ts:266/570) for r-auth and r-retry — r-retry's detail carries
+`retryOf: "r-auth"` (CREW-UX-3) and its session echoes `retry_of` (api-types
+0.8.0) — while r-legacy answers an EMPTY audit page: the degraded no-audit run.
+`repo`+`repo_refs` ride along so r-auth carries repo_ref studio-api (the retry
+prefill's repo field has something true to carry).
+
+The §3.5 / §4.5 DOM ACs, verbatim mapping:
+
+  1. r-auth's detail renders `[data-testid="run-provenance"]` naming actor id +
+     kind + channel ("launched by mika · human via API"), and exactly ONE
+     `GET /audit?runId=r-auth` fires per detail view (request-tap, cached on a
+     client-side revisit);
+  2. r-legacy (no matching audit entry) renders the EXACT degraded copy
+     "launched via API (actor unknown)" — the line is never absent;
+  3. notification rows for run events carry `[data-testid="notif-provenance"]`
+     with the same contract (named for r-auth, degraded for r-legacy), read
+     from the cache only — opening the bell fires NO audit fetch (no fan-out);
+  4. lineage cross-links: r-retry's line renders "retry of r-auth" and
+     navigates back to r-auth on click; r-auth's line renders "retried as
+     r-retry" from the loaded index;
+  5. the failed r-auth renders `[data-testid="run-retry"]`; the completed
+     r-retry does NOT (the loop closes failures, not successes);
+  6. clicking Retry opens the composer PREFILLED — intent textarea equal to
+     the original `problem`, workflow/roster/repo pills matching the original
+     run — with ZERO `POST /runs` until the operator sends; the send's body
+     carries `retryOf: "r-auth"` (request-tap).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-V-provenance.png   r-auth: the named provenance line + "retried as" link
+                        in the What/Where card, beside the failed post-mortem
+  ux-V-retry.png        the composer prefilled from Retry — intent, workflow,
+                        repo, roster and the clearable "Retry of r-auth" pill
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4382),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4382"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+AUTH_THREAD = "/p/auth-refactor/build/r-auth"
+LEGACY_THREAD = "/p/legacy-spike/build/r-legacy"
+RETRY_THREAD = "/runs/r-retry"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, provenance ON ─────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, provenance=True, repo=True, repo_refs=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The request tap: every audit read (by runId) and every launch POST.
+    audit_reads: list[str] = []
+    launch_posts: list[dict] = []
+
+    def on_request(req):
+        u = urlparse(req.url)
+        if u.path == "/api/v1/audit" and req.method == "GET":
+            audit_reads.append((parse_qs(u.query).get("runId") or [""])[0])
+        elif u.path == "/api/v1/runs" and req.method == "POST":
+            try:
+                launch_posts.append(json.loads(req.post_data or "{}"))
+            except json.JSONDecodeError:
+                launch_posts.append({"__unparseable__": req.post_data})
+
+    page.on("request", on_request)
+
+    def nav(path: str) -> None:
+        """CLIENT-side navigation (pushState + popstate) — a full page.goto
+        would drop the in-memory provenance cache the revisit AC pins."""
+        page.evaluate(
+            """(p) => { history.pushState(null, '', p);
+                        window.dispatchEvent(new PopStateEvent('popstate')); }""",
+            path)
+
+    # ── Scene 1 (AC 1): the named provenance line, first row of What/Where ──────
+    page.goto(f"{ORIGIN}{AUTH_THREAD}", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="run-provenance"]').wait_for(timeout=30000)
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="run-provenance"]')
+          ?.innerText ?? '').includes('launched by')""",
+        timeout=15000)
+    named = page.evaluate(
+        """() => {
+          const line = document.querySelector('[data-testid="run-provenance"]');
+          const text = line?.innerText ?? '';
+          const fwd = document.querySelector('[data-testid="lineage-retried-as"]');
+          return {
+            namesActor: text.includes('launched by mika'),
+            namesKind: /human/i.test(text),
+            namesChannel: text.includes('via API'),
+            degradedCopyAbsent: !text.includes('actor unknown'),
+            retriedAs: fwd?.innerText ?? null,
+            retriedAsRun: fwd?.getAttribute('data-run-id') ?? null,
+          };
+        }""")
+    check("provenance_named", named["namesActor"] and named["namesKind"]
+          and named["namesChannel"] and named["degradedCopyAbsent"]
+          and named["retriedAsRun"] == "r-retry"
+          and audit_reads.count("r-auth") == 1,
+          **named, audit_reads=list(audit_reads))
+    page.screenshot(path=str(VSHOTS / "ux-V-provenance.png"))
+
+    # ── Scene 2 (AC 2): the degraded run — the exact copy, never an absent line ─
+    nav(LEGACY_THREAD)
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="run-provenance"]')
+          ?.innerText ?? '').includes('launched via API (actor unknown)')""",
+        timeout=15000)
+    check("provenance_degraded", audit_reads.count("r-legacy") == 1,
+          audit_reads=list(audit_reads))
+
+    # ── Scene 3 (AC 1): the revisit is served from the cache — no second fetch ──
+    nav(AUTH_THREAD)
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="run-provenance"]')
+          ?.innerText ?? '').includes('launched by mika')""",
+        timeout=15000)
+    check("provenance_cached_on_revisit", audit_reads.count("r-auth") == 1,
+          audit_reads=list(audit_reads))
+
+    # ── Scene 4 (AC 4): lineage — r-retry links back to r-auth ──────────────────
+    nav(RETRY_THREAD)
+    page.locator('[data-testid="lineage-retry-of"]').wait_for(timeout=15000)
+    back = page.evaluate(
+        """() => {
+          const el = document.querySelector('[data-testid="lineage-retry-of"]');
+          return { text: el?.innerText ?? '', runId: el?.getAttribute('data-run-id') ?? null };
+        }""")
+    page.locator('[data-testid="lineage-retry-of"]').click()
+    page.wait_for_function("() => location.pathname === '/runs/r-auth'", timeout=10000)
+    check("lineage_back_link", back["runId"] == "r-auth"
+          and "retry of r-auth" in back["text"],
+          **back, landed=page.evaluate("() => location.pathname"))
+
+    # ── Scene 5 (AC 3): notification rows — same contract, cache only ───────────
+    audit_before_bell = len(audit_reads)
+    set_fixture(ORIGIN, extra_frames=[
+        {"type": "sessionFailed", "session": "r-auth"},
+        {"type": "sessionFailed", "session": "r-legacy"},
+    ])
+    bell = page.locator('button[title="Notifications"]')
+    bell.wait_for(timeout=10000)
+    # The one-shot frames drain on the next 1s WS tick; the unread badge lands.
+    page.wait_for_function(
+        """() => /unread notification/.test(
+             document.querySelector('button[title="Notifications"]')
+               ?.getAttribute('aria-label') ?? '')""",
+        timeout=15000)
+    bell.click()
+    page.locator('[data-testid="notif-provenance"]').first.wait_for(timeout=10000)
+    rows = page.evaluate(
+        """() => {
+          const items = [...document.querySelectorAll('[role="menuitem"]')];
+          const rowFor = (rid) => items.find((el) => el.innerText.includes(rid));
+          const prov = (el) =>
+            el?.querySelector('[data-testid="notif-provenance"]')?.innerText ?? null;
+          return { auth: prov(rowFor('r-auth')), legacy: prov(rowFor('r-legacy')) };
+        }""")
+    check("notif_provenance_rows",
+          rows["auth"] is not None and "launched by mika" in rows["auth"]
+          and rows["legacy"] is not None
+          and "launched via API (actor unknown)" in rows["legacy"]
+          and len(audit_reads) == audit_before_bell,  # cache only — no fan-out
+          **rows, audit_reads=list(audit_reads))
+    page.keyboard.press("Escape")
+
+    # ── Scene 6 (AC 5): Retry renders on the failed run, never on the completed ─
+    nav(RETRY_THREAD)
+    page.locator('[data-testid="run-provenance"]').wait_for(timeout=15000)
+    retry_on_completed = page.evaluate(
+        "() => !!document.querySelector('[data-testid=\"run-retry\"]')")
+    nav(AUTH_THREAD)
+    page.locator('[data-testid="run-retry"]').wait_for(timeout=15000)
+    check("retry_failed_only", not retry_on_completed, retry_on_completed=retry_on_completed)
+
+    # ── Scene 7 (AC 6): Retry-as-prefill — editable, zero launch until send ─────
+    page.locator('[data-testid="run-retry"]').click()
+    page.wait_for_function("() => location.pathname === '/runs/new'", timeout=10000)
+    page.locator('[data-testid="launch-problem"]').wait_for(timeout=10000)
+    prefill = page.evaluate(
+        """() => {
+          const pills = [...document.querySelectorAll('span')].map((s) => s.innerText);
+          const has = (t) => pills.some((p) => p.startsWith(t));
+          return {
+            problem: document.querySelector('[data-testid="launch-problem"]')?.value ?? '',
+            retryPill: has('Retry of r-auth'),
+            workflowPill: has('Workflow: wf-w2'),
+            repoPill: has('Repo: studio-api'),
+            cliPill: has('CLIs: claude'),
+            project: document.querySelector('[data-testid="project-field"]')?.innerText ?? '',
+          };
+        }""")
+    check("retry_prefill", prefill["problem"] == "refactor the auth middleware"
+          and prefill["retryPill"] and prefill["workflowPill"] and prefill["repoPill"]
+          and prefill["cliPill"] and "auth-refactor" in prefill["project"]
+          and len(launch_posts) == 0,
+          **prefill, launch_posts=list(launch_posts))
+    page.screenshot(path=str(VSHOTS / "ux-V-retry.png"))
+
+    # The operator sends — the launch body carries the lineage (CREW-UX-3).
+    page.locator('[data-testid="launch-submit"]').click()
+    page.wait_for_function("() => location.pathname !== '/runs/new'", timeout=15000)
+    body = launch_posts[0] if launch_posts else {}
+    check("retry_launch_body", len(launch_posts) == 1
+          and body.get("retryOf") == "r-auth"
+          and body.get("problem") == "refactor the auth middleware"
+          and body.get("workflow") == "wf-w2"
+          and body.get("repoRef") == "studio-api"
+          and body.get("projectId") == "auth-refactor",
+          body=body)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -210,7 +210,26 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # Slice R (DES-UX-001 §1): the failure-forensics corpus — see the
          # module docstring. Default False: no standing rig's failed runs
          # change shape.
-         "forensics": False}
+         "forensics": False,
+         # Slice V (DES-UX-001 §3/§4): the provenance + retry corpus.
+         #   provenance — GET /audit?runId= gains REAL AuditEntry rows for
+         #                r-auth and r-retry (actor{id,kind,trust} + the
+         #                run.launched detail; r-retry's detail carries
+         #                retryOf per CREW-UX-3) while r-legacy answers an
+         #                EMPTY page — the degraded no-audit run. The run
+         #                index gains r-retry (completed) whose session
+         #                echoes retry_of:"r-auth" (api-types 0.8.0), the
+         #                lineage pair both cross-links render from. POST
+         #                /runs validates retryOf against the known ids
+         #                (400 with the daemon's named error otherwise) and
+         #                answers 201 {runId:"r-new"}. Default False: no
+         #                standing rig's board grows a run.
+         "provenance": False,
+         # Slice V: one-shot RAW CoreEvent frames drained ONCE by the /ws
+         # loop, verbatim (e.g. a sessionFailed that mints a run_failed
+         # notification row). Distinct from extra_narration (which wraps
+         # its lines in unitOutputDelta) and extra_gates (awaitingHuman).
+         "extra_frames": []}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -314,6 +333,33 @@ RUNS = [
 ]
 ORPHAN = session("r-orphan", "executing", "stranded work from another client",
                  "stranded work from another client")
+
+# ── Slice V (DES-UX-001 §3/§4): the provenance + retry corpus, behind `provenance` ──
+#
+# The lineage pair: r-auth (failed, above) was retried as r-retry, which
+# COMPLETED — so the back-link ("retry of r-auth") and the forward link
+# ("retried as r-retry") both have a true record to render, and the completed
+# retry also pins §4.5's "terminal-but-completed runs do not render Retry".
+# `retry_of` is the api-types 0.8.0 DTO echo: ABSENT (never null) on non-retries.
+RETRY_RUN = session("r-retry", "completed", "refactor the auth middleware",
+                    "refactor the auth middleware")
+RETRY_RUN["session"]["retry_of"] = "r-auth"
+RETRY_RUN["units"][0]["status"] = "done"
+
+# GET /audit?runId= — REAL AuditEntry shapes (wicked-crew-api-types: ts, action,
+# actor{id,kind,trust}, runId, detail), newest first. r-legacy deliberately has
+# NO entry: the degraded "launched via API (actor unknown)" run. r-retry's
+# detail carries retryOf — the CREW-UX-3 system-of-record lineage record
+# (crew routes.ts:601 writes exactly this shape).
+AUDIT_ACTOR = {"id": "mika", "kind": "human", "trust": "operator"}
+AUDIT_ENTRIES = {
+    "r-auth": [{"ts": NOW0 - 13 * MIN, "action": "run.launched", "actor": AUDIT_ACTOR,
+                "runId": "r-auth",
+                "detail": {"workflow": "wf-w2", "projectId": "auth-refactor"}}],
+    "r-retry": [{"ts": NOW0 - 5 * MIN, "action": "run.launched", "actor": AUDIT_ACTOR,
+                 "runId": "r-retry",
+                 "detail": {"workflow": "wf-w2", "retryOf": "r-auth"}}],
+}
 
 # ── Slice P (DES-FEEDBACK-003 §10.2): the two chat runs, behind `chat_runs` ───
 #
@@ -919,6 +965,45 @@ learned_lock = threading.Lock()
 learned_themes: dict = {}
 
 
+def assemble_runs() -> list:
+    """The run corpus under the CURRENT switches — shared by GET /runs and the
+    slice-V single-run GET /runs/<id> so both wires decorate identically."""
+    with state_lock:
+        if state["no_runs"]:
+            runs = []
+        else:
+            runs = RUNS + ([ORPHAN] if state["orphan"] else []) \
+                + ([LONG_RUN] if state["long_prompt"] else []) \
+                + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else []) \
+                + (BATCH_RUNS if state["batch_gates"] else []) \
+                + ([RETRY_RUN] if state["provenance"] else [])
+        viewer_on = state["viewer"]
+        repo_refs_on = state["repo_refs"]
+        forensics_on = state["forensics"]
+        provenance_on = state["provenance"]
+    if viewer_on or repo_refs_on or forensics_on or provenance_on:
+        runs = json.loads(json.dumps(runs))
+        for r in runs:
+            # Slice V: the CREW-UX-2 DTO echo for the lineage pair — the retry
+            # prefill's project binding reads it (`project_id`, api-types 0.8.0).
+            if provenance_on and r["session"]["id"] in ("r-auth", "r-retry"):
+                r["session"]["project_id"] = "auth-refactor"
+            # Slice I: the live run gains a workdir (the diff route's
+            # 409 gate reads it; AgentSession carries it on the wire).
+            if viewer_on and r["session"]["id"] == "r-upload":
+                r["session"]["workdir"] = VIEWER_WORKDIR
+            # Slice P: repo-linked runs for the /repos tiles (§4.4).
+            if repo_refs_on and r["session"]["id"] in REPO_REF_RUNS:
+                r["session"]["repo_ref"] = REPO_ID
+            # Slice R: r-auth's real-shape units + the evidence root
+            # its survey transcript cites (workdir stays None — its
+            # /diff answers the REAL 409 named-cause case).
+            if forensics_on and r["session"]["id"] == "r-auth":
+                r["units"] = json.loads(json.dumps(FORENSICS_AUTH_UNITS))
+                r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
+    return runs
+
+
 def ssrf_reject_reason(url: str) -> str | None:
     """The bridge-side guard (DES-MERGE-001 §4.6): why this URL is refused, or None."""
     try:
@@ -1126,10 +1211,16 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # slice 2: prove a NEW delta reaches the live feed within 2s).
                 extra: list = []
                 gates_extra: list = []
+                frames_extra: list = []
                 if newest:
                     with state_lock:
                         extra, state["extra_narration"] = list(state["extra_narration"]), []
                         gates_extra, state["extra_gates"] = list(state["extra_gates"]), []
+                        frames_extra, state["extra_frames"] = list(state["extra_frames"]), []
+                # Slice V: raw one-shot CoreEvent frames, verbatim (e.g. a
+                # sessionFailed that mints a run_failed notification row).
+                for frame in frames_extra:
+                    self.wfile.write(ws_frame(frame))
                 for line in extra:
                     self.wfile.write(ws_frame({
                         "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
@@ -1181,34 +1272,32 @@ class W2Handler(SimpleHTTPRequestHandler):
             self.wfile.write(LOGO_TEST_SVG)
             return True
         if path == "/api/v1/runs":
+            self._json(200, {"runs": assemble_runs()})
+            return True
+        # Slice V: GET /runs/<id> — one run's detail (`{run: SessionView}`), the
+        # real daemon contract useRunModel re-hydrates on. Same corpus assembly
+        # as the list, so the switches decorate both wires identically; an
+        # unknown id answers the daemon's 404.
+        m = re.match(r"^/api/v1/runs/([^/]+)$", path)
+        if m:
+            rid = urllib.parse.unquote(m.group(1))
+            found = next((r for r in assemble_runs() if r["session"]["id"] == rid), None)
+            if found is None:
+                self._json(404, {"error": f"Run {rid} not found"})
+            else:
+                self._json(200, {"run": found})
+            return True
+        # Slice V (DES-UX-001 §3.2): the audit trail — always present (the real
+        # daemon serves it unconditionally, crew routes.ts:286); the corpus
+        # switch only decides which runs have entries. `?runId=` filters;
+        # newest first; an unmatched run answers an EMPTY page, never a 404.
+        if path == "/api/v1/audit":
+            q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            run_id = (q.get("runId") or [""])[0]
             with state_lock:
-                if state["no_runs"]:
-                    runs = []
-                else:
-                    runs = RUNS + ([ORPHAN] if state["orphan"] else []) \
-                        + ([LONG_RUN] if state["long_prompt"] else []) \
-                        + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else []) \
-                        + (BATCH_RUNS if state["batch_gates"] else [])
-                viewer_on = state["viewer"]
-                repo_refs_on = state["repo_refs"]
-                forensics_on = state["forensics"]
-            if viewer_on or repo_refs_on or forensics_on:
-                runs = json.loads(json.dumps(runs))
-                for r in runs:
-                    # Slice I: the live run gains a workdir (the diff route's
-                    # 409 gate reads it; AgentSession carries it on the wire).
-                    if viewer_on and r["session"]["id"] == "r-upload":
-                        r["session"]["workdir"] = VIEWER_WORKDIR
-                    # Slice P: repo-linked runs for the /repos tiles (§4.4).
-                    if repo_refs_on and r["session"]["id"] in REPO_REF_RUNS:
-                        r["session"]["repo_ref"] = REPO_ID
-                    # Slice R: r-auth's real-shape units + the evidence root
-                    # its survey transcript cites (workdir stays None — its
-                    # /diff answers the REAL 409 named-cause case).
-                    if forensics_on and r["session"]["id"] == "r-auth":
-                        r["units"] = json.loads(json.dumps(FORENSICS_AUTH_UNITS))
-                        r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
-            self._json(200, {"runs": runs})
+                provenance_on = state["provenance"]
+            entries = AUDIT_ENTRIES.get(run_id, []) if provenance_on else []
+            self._json(200, {"entries": entries})
             return True
         # Slice I: the crew#305 file/diff routes (real contract, switch-gated).
         m = re.match(r"^/api/v1/runs/([^/]+)/(files|diff)$", path)
@@ -1704,6 +1793,21 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # awaiting between the selection and the fan-out.
                 return self._json(409, {"error": "not awaiting a human gate"})
             return self._json(200, {"status": "resumed"})
+        # Slice V (DES-UX-001 §4 / CREW-UX-3): POST /runs — the launch. retryOf
+        # must name an EXISTING run id (the daemon's 400 with a named error,
+        # crew routes.ts:588) — never a silently unrecorded lineage.
+        if path == "/api/v1/runs":
+            retry_of = body.get("retryOf")
+            if retry_of is not None:
+                with state_lock:
+                    provenance_on = state["provenance"]
+                known = {r["session"]["id"] for r in RUNS} \
+                    | ({RETRY_RUN["session"]["id"]} if provenance_on else set())
+                if retry_of not in known:
+                    return self._json(400, {
+                        "error": f"retryOf names an unknown run: {retry_of} — "
+                                 "lineage must point at an existing run id"})
+            return self._json(201, {"runId": "r-new"})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
         if path == "/api/v1/chats":

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.7.0"
+        "wicked-crew-api-types": "^0.8.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.7.0.tgz",
-      "integrity": "sha512-w3ownEiI+3GeKOrJWXZmDLYAWNRSyMwUU7PYCIFpng2PmEXFc/0xtkgtP8we63w/ibXG/Zz9QQM+NfSZvoZIsQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.8.0.tgz",
+      "integrity": "sha512-xlMVonpDuZ5jRgzZB05kyzAHnlwB+P0YY+/t2bYyBQrwND3GHl1HSs6kyYU9UI7SrHVdX0faVUwPlLZUAFB8gg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.7.0"
+    "wicked-crew-api-types": "^0.8.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -525,7 +525,7 @@ export function App(): React.ReactElement {
 
       {/* Right panel only when a run is selected */}
       {selected !== null && (
-        <RightPanel view={selected} />
+        <RightPanel view={selected} runs={runs} onSelectRun={selectRun} />
       )}
 
       {/* The universal command palette (DES-FEEDBACK-002 §1, slice G) — corpus

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   ActivityPage,
   AttachMemberBody,
+  AuditPage,
   CoreEvent,
   CreateProjectBody,
   GateDecision,
@@ -137,6 +138,15 @@ export const api = {
 
   /** One run's detail (`SessionView`). */
   getRun: (id: string) => apiFetch<{ run: SessionView }>(`/runs/${encodeURIComponent(id)}`),
+
+  /**
+   * The daemon's audit trail filtered to one run (`GET /audit?runId=`, newest
+   * first) — the system of record for "who launched that run" (DES-UX-001 §3.2;
+   * crew routes.ts:266/570). One fetch per detail view, cached per run id in
+   * the provenance store — the §3.3-sanctioned exception, named in its AC.
+   */
+  getAudit: (runId: string) =>
+    apiFetch<AuditPage>(`/audit?runId=${encodeURIComponent(runId)}`),
 
   /** A run's durably-persisted event trail (`GET /runs/:id/events`). Used to backfill the event
    * store on a reload with no live `/ws` replay so Burn/insight panels are not empty (FINDING-013).

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
+import { useProvenanceStore } from '../store/provenance.js';
+import { confirmModeOf, takeRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
@@ -101,6 +103,13 @@ const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domai
 export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget, navigate, lockedProjectId = null }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
 
+  // Retry-as-prefill (DES-UX-001 §4.3): the LAUNCH-FORM composer consumes a
+  // pending retry prefill ONCE at mount (lazy state init — never re-taken on a
+  // re-render). Run-selected composers (steer/inject) never consume it.
+  const [prefill] = useState<RetryPrefill | null>(() => (runId ? null : takeRetryPrefill()));
+  /** Lineage claim carried to the launch (`retryOf`, CREW-UX-3) — clearable. */
+  const [retryOf, setRetryOf] = useState<string | null>(prefill?.retryOf ?? null);
+
   // ── Steer mode state ───────────────────────────────────────────────────────
   const [steerText, setSteerText] = useState('');
   const [steering, setSteering] = useState(false);
@@ -115,9 +124,10 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // setInjecting(true) call re-renders the disabled state.
   const injectInflightRef = useRef(false);
 
-  // ── Launch form state ──────────────────────────────────────────────────────
-  const [problem, setProblem] = useState('');
-  const [workflow, setWorkflow] = useState('');
+  // ── Launch form state — a retry prefill seeds the initial values (§4.3);
+  //    everything stays fully editable before send. ──────────────────────────
+  const [problem, setProblem] = useState(prefill?.problem ?? '');
+  const [workflow, setWorkflow] = useState(prefill?.workflowId ?? '');
   const [roster, setRoster] = useState<RosterSeat[]>([]);
   const [workflows, setWorkflows] = useState<WorkflowDef[]>([]);
   const selectableWorkflows = useMemo(
@@ -126,10 +136,11 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   );
   const [selectedClis, setSelectedClis] = useState<Set<string>>(new Set());
   const [repos, setRepos] = useState<RepoEntry[]>([]);
-  const [repoRefs, setRepoRefs] = useState<string[]>([]);
-  const [entityMode, setEntityMode] = useState<EntityMode>('shared');
-  const [confirmMode, setConfirmMode] = useState<ConfirmMode>('none');
-  const [beforeOrd, setBeforeOrd] = useState(1);
+  const [repoRefs, setRepoRefs] = useState<string[]>(prefill?.repoRef ? [prefill.repoRef] : []);
+  const [entityMode, setEntityMode] = useState<EntityMode>(prefill?.entityMode ?? 'shared');
+  const prefillGate = confirmModeOf(prefill?.humanConfirm);
+  const [confirmMode, setConfirmMode] = useState<ConfirmMode>(prefillGate.mode);
+  const [beforeOrd, setBeforeOrd] = useState(prefillGate.beforeOrd);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
 
   // ── Project binding (DES-FEEDBACK-001 §5, slice B) ─────────────────────────
@@ -137,7 +148,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // default — byte-identical to the pre-slice request. The list loads lazily on
   // the dropdown's first open (or on mount when pre-bound, to resolve the name).
   const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(prefill?.projectId ?? null);
   const [showNewProject, setShowNewProject] = useState(false);
   const projectsRequested = useRef(false);
 
@@ -177,6 +188,12 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         // Deposit for Chat's default chips (§6.1: cached, never fetched on mount).
         setCachedRoster(seats);
         setRoster(seats);
+        // A retry prefill's roster wins over the stored/default selection —
+        // §4.3: the composer opens matching the ORIGINAL run, editable after.
+        if (prefill !== null) {
+          setSelectedClis(new Set(prefill.clis));
+          return;
+        }
         try {
           const stored = localStorage.getItem('wicked_default_clis');
           if (stored) {
@@ -197,14 +214,17 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       .listWorkflows()
       .then(({ workflows: wfs }) => setWorkflows(wfs))
       .catch(() => {});
-  }, []);
+    // `prefill` is lazy-initialized state: stable for the component's lifetime,
+    // so this still runs exactly once per mount.
+  }, [prefill]);
 
   // §4.3 pre-bound: resolve the locked project's NAME up front — the field must
   // show the name, not the id. Unbound forms load nothing until the first open.
+  // A retry prefill's project binding needs the same name resolution (§4.3).
   useEffect(() => {
-    if (lockedProjectId != null) loadProjects();
+    if (lockedProjectId != null || prefill?.projectId != null) loadProjects();
     // (loadProjects is ref-guarded and single-shot, so listing only the lock is safe.)
-  }, [lockedProjectId]);
+  }, [lockedProjectId, prefill]);
 
   // ── Elapsed-time ticker ────────────────────────────────────────────────────
   useEffect(() => {
@@ -313,9 +333,16 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
     if (boundProject) body.projectId = boundProject;
+    // Lineage (§4.3, CREW-UX-3): recorded in the system of record at launch —
+    // never inferred from prompt equality. The pill above is the operator's
+    // way to drop the claim before sending.
+    if (retryOf) body.retryOf = retryOf;
 
     try {
       const { runId: newRunId } = await api.launchRun(body);
+      // The studio witnessed this launch — the provenance line's honest
+      // 'via studio' channel derives from exactly this record (§3.3).
+      useProvenanceStore.getState().markLaunchedHere(newRunId);
       setProblem('');
       onLaunched(newRunId);
     } catch (err) {
@@ -558,6 +585,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // Collect active non-default option pills
   const activePills: Array<{ label: string; onClear: () => void }> = [];
 
+  // The lineage claim leads the pills (§4.3): visible, and clearable — a retry
+  // is a composer prefill the operator may edit down to a fresh launch.
+  if (retryOf) {
+    activePills.push({
+      label: `Retry of ${retryOf.slice(0, 8)}`,
+      onClear: () => setRetryOf(null),
+    });
+  }
   if (attachedFiles.length > 0) {
     activePills.push({
       label: `${attachedFiles.length} file${attachedFiles.length !== 1 ? 's' : ''} attached`,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -3,7 +3,7 @@ import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { useGateStore } from '../store/gates.js';
 import { useProvenanceStore } from '../store/provenance.js';
-import { confirmModeOf, takeRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
+import { clearRetryPrefill, confirmModeOf, peekRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
@@ -104,9 +104,15 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const clearGate = useGateStore((s) => s.clearGate);
 
   // Retry-as-prefill (DES-UX-001 §4.3): the LAUNCH-FORM composer consumes a
-  // pending retry prefill ONCE at mount (lazy state init — never re-taken on a
-  // re-render). Run-selected composers (steer/inject) never consume it.
-  const [prefill] = useState<RetryPrefill | null>(() => (runId ? null : takeRetryPrefill()));
+  // pending retry prefill ONCE at mount. PEEK in the lazy initializer (which
+  // StrictMode double-invokes in dev — an initializer-side take() would
+  // consume on the discarded first pass and commit an EMPTY composer), then
+  // clear in the commit effect below. Run-selected composers (steer/inject)
+  // never consume it.
+  const [prefill] = useState<RetryPrefill | null>(() => (runId ? null : peekRetryPrefill()));
+  useEffect(() => {
+    if (prefill !== null) clearRetryPrefill();
+  }, [prefill]);
   /** Lineage claim carried to the launch (`retryOf`, CREW-UX-3) — clearable. */
   const [retryOf, setRetryOf] = useState<string | null>(prefill?.retryOf ?? null);
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { useGateStore } from '../store/gates.js';
 import { useElicitationStore } from '../store/elicitations.js';
 import { ElicitationPrompt } from './ElicitationPrompt.js';
 import { useRuntimeStore, outputKey, type CouncilStatus } from '../store/runtime.js';
+import { setRetryPrefill } from '../store/retryPrefill.js';
 import { LiveEdge } from './LiveEdge.js';
 import { STATUS_STYLE } from './RunCard.js';
 import { SteeringGate } from './SteeringGate.js';
@@ -826,6 +827,27 @@ function RunChat({
     void onKill?.(session.id);
   }
 
+  /**
+   * Retry (DES-UX-001 §4.3): reopen the standard composer PREFILLED with this
+   * run's intent + configuration — fully editable before send, nothing
+   * auto-launches. The launch will carry `retryOf` (CREW-UX-3) so both runs'
+   * provenance lines cross-link from the system of record.
+   */
+  function startRetry(): void {
+    setRetryPrefill({
+      retryOf: session.id,
+      problem: session.problem,
+      clis: session.clis,
+      // 'chat' is a system workflow, not a launchable choice — leave it unset.
+      workflowId: session.workflow_id && session.workflow_id !== 'chat' ? session.workflow_id : null,
+      repoRef: session.repo_ref,
+      entityMode: session.entity_mode,
+      humanConfirm: session.human_confirm,
+      projectId: typeof session.project_id === 'string' ? session.project_id : null,
+    });
+    navigate?.('/runs/new');
+  }
+
   return (
     <div className="flex flex-col h-full">
       {/* Run header */}
@@ -852,6 +874,20 @@ function RunChat({
           {session.problem}
         </p>
         <span className="text-xs font-medium shrink-0 font-mono" style={{ color: style.color }}>{style.label}</span>
+        {/* Retry — failed/cancelled only (§4.5: the loop closes failures, not
+            successes). A standard secondary button (§4.4 tokens). */}
+        {isPostMortem && navigate !== undefined && (
+          <button
+            type="button"
+            data-testid="run-retry"
+            onClick={startRetry}
+            title="Reopen the composer prefilled with this run's intent and configuration — editable before send"
+            className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold font-mono transition-opacity hover:opacity-80"
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)' }}
+          >
+            Retry
+          </button>
+        )}
         <ModePill mode={mode} onChange={onModeChange} readOnly={isTerminal} />
         <ExportEvidenceButton runId={session.id} disabled={!isTerminal} />
         {!isTerminal && onKill && (

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNotificationStore } from '../store/notifications.js';
 import type { NotifKind } from '../store/notifications.js';
+import { useProvenanceStore } from '../store/provenance.js';
+import { ProvenanceLine } from './ProvenanceLine.js';
 
 interface Props {
   navigate: (path: string) => void;
@@ -63,6 +65,10 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
   const notifications = useNotificationStore((s) => s.notifications);
   const markRead      = useNotificationStore((s) => s.markRead);
   const markAllRead   = useNotificationStore((s) => s.markAllRead);
+  // Run provenance for the rows (DES-UX-001 §3.3): read the ALREADY-CACHED
+  // audit answers only — a list never fans out audit fetches. A row whose run
+  // was never opened simply carries no line yet.
+  const provByRun = useProvenanceStore((s) => s.byRun);
 
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -296,6 +302,14 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
                     >
                       {n.message}
                     </p>
+                    {/* Provenance — the same contract as the run detail's line
+                        (§3.3/§3.5): named actor when the cached audit entry
+                        matches, the honest degraded copy when it does not. */}
+                    {provByRun[n.runId] !== undefined && (
+                      <div style={{ marginBottom: '3px' }}>
+                        <ProvenanceLine provenance={provByRun[n.runId]} testId="notif-provenance" />
+                      </div>
+                    )}
                     {/* Run id + link */}
                     <span
                       style={{

--- a/src/components/ProvenanceLine.tsx
+++ b/src/components/ProvenanceLine.tsx
@@ -1,0 +1,103 @@
+import type { Provenance } from '../store/provenance.js';
+
+/**
+ * The one provenance line (DES-UX-001 §3.3/§3.4): "launched by {actor.id} ·
+ * {actor.kind} via {channel}", degrading to the brief's own words — "launched
+ * via API (actor unknown)" — when no audit entry matches. The line always
+ * renders; only its content degrades. Lineage cross-links (§4.3, CREW-UX-3)
+ * ride inside it: "retry of {short-id}" back to the original, "retried as
+ * {short-id}" forward where the loaded index shows a child.
+ *
+ * Token usage (§3.4): `--ink-muted` sans with the actor kind as a `--text-2xs`
+ * uppercase badge on `--surface-raised`; "actor unknown" in `--ink-dim`; the
+ * lineage cross-links are `--accent`. No status colors — provenance is
+ * context, not signal.
+ */
+
+const short = (id: string): string => id.slice(0, 8);
+
+function LineageLink({
+  label,
+  runId,
+  testId,
+  onSelectRun,
+}: {
+  label: string;
+  runId: string;
+  testId: string;
+  onSelectRun?: ((id: string) => void) | undefined;
+}): React.ReactElement {
+  const text = `${label} ${short(runId)}`;
+  if (onSelectRun === undefined) {
+    return (
+      <span data-testid={testId} data-run-id={runId} style={{ color: 'var(--accent)' }}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      data-run-id={runId}
+      onClick={() => onSelectRun(runId)}
+      className="underline transition-opacity hover:opacity-70"
+      style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', font: 'inherit' }}
+      title={`Open run ${runId}`}
+    >
+      {text}
+    </button>
+  );
+}
+
+interface Props {
+  /** `null`/`undefined` = not (yet) derived — renders the degraded copy, never nothing. */
+  provenance: Provenance | null | undefined;
+  /** Back lineage from the run DTO (`AgentSession.retry_of`, CREW-UX-3). */
+  retryOf?: string | undefined;
+  /** Forward lineage — run ids the loaded index shows as retries of this run. */
+  retriedAs?: readonly string[] | undefined;
+  onSelectRun?: ((id: string) => void) | undefined;
+  testId: 'run-provenance' | 'notif-provenance';
+}
+
+export function ProvenanceLine({ provenance, retryOf, retriedAs, onSelectRun, testId }: Props): React.ReactElement {
+  const known = provenance != null && provenance.state === 'known';
+  // Lineage prefers the DTO echo (present even when the audit trail degraded);
+  // the audit detail's retryOf is the same record read from the other side.
+  const backLink = retryOf ?? (known && provenance.retryOf !== undefined ? provenance.retryOf : undefined);
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px]"
+      style={{ color: 'var(--ink-muted)' }}
+    >
+      {known ? (
+        <>
+          <span>launched by {provenance.actorId}</span>
+          <span
+            className="rounded px-1 py-px font-mono uppercase tracking-wider"
+            style={{ fontSize: 'var(--text-2xs)', background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {provenance.actorKind}
+          </span>
+          <span>via {provenance.channel}</span>
+        </>
+      ) : (
+        <span style={{ color: 'var(--ink-dim)' }}>launched via API (actor unknown)</span>
+      )}
+      {backLink !== undefined && (
+        <>
+          <span aria-hidden style={{ color: 'var(--ink-dim)' }}>·</span>
+          <LineageLink label="retry of" runId={backLink} testId="lineage-retry-of" onSelectRun={onSelectRun} />
+        </>
+      )}
+      {(retriedAs ?? []).map((id) => (
+        <span key={id} className="flex items-center gap-x-1.5">
+          <span aria-hidden style={{ color: 'var(--ink-dim)' }}>·</span>
+          <LineageLink label="retried as" runId={id} testId="lineage-retried-as" onSelectRun={onSelectRun} />
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { useRunModel } from '../hooks/useRunModel.js';
 import type { RunModel } from '../hooks/useRunModel.js';
+import { useProvenanceStore } from '../store/provenance.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { Burn } from './Burn.js';
 import { FileViewer } from './FileViewer.js';
@@ -17,6 +18,9 @@ import { WhatWhere } from './WhatWhere.js';
 
 interface Props {
   view: SessionView;
+  /** The loaded run index (App's one `useRuns()` array) — forward lineage only, no new fetch. */
+  runs?: SessionView[];
+  onSelectRun?: (id: string) => void;
 }
 
 type AccordionId =
@@ -388,9 +392,23 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
   );
 }
 
-export function RightPanel({ view }: Props): React.ReactElement {
+export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const [openAccordion, setOpenAccordion] = useState<AccordionId | null>('whatwhere');
+
+  // Provenance rides the run-detail load: ONE `GET /audit?runId=` per detail
+  // view, cached per run id (DES-UX-001 §3.3 — the sanctioned exception,
+  // named in its AC). Notification rows read the same cache — no fan-out.
+  const provenance = useProvenanceStore((s) => s.byRun[view.session.id] ?? null);
+  useEffect(() => {
+    useProvenanceStore.getState().load(view.session.id);
+  }, [view.session.id]);
+
+  // Forward lineage (§4.3): retries of THIS run, from the already-loaded index.
+  const retriedAs = useMemo(
+    () => (runs ?? []).filter((r) => r.session.retry_of === view.session.id).map((r) => r.session.id),
+    [runs, view.session.id],
+  );
 
   const [termOpen, setTermOpen] = useState(false);
   // Slice R (§1.3-4): the Term tab lands on the run's captured transcript when
@@ -533,7 +551,14 @@ export function RightPanel({ view }: Props): React.ReactElement {
                 {id === 'burn' && <Burn model={model} />}
                 {id === 'data' && <DataUsed model={model} />}
                 {id === 'steering' && <SteeringTimeline runId={model.session.id} />}
-                {id === 'whatwhere' && <WhatWhere model={model} />}
+                {id === 'whatwhere' && (
+                  <WhatWhere
+                    model={model}
+                    provenance={provenance}
+                    retriedAs={retriedAs}
+                    {...(onSelectRun !== undefined ? { onSelectRun } : {})}
+                  />
+                )}
                 {id === 'assumptions' && <AssumptionsPanel model={model} />}
                 {id === 'files' && <FilesPanel model={model} />}
               </div>

--- a/src/components/WhatWhere.tsx
+++ b/src/components/WhatWhere.tsx
@@ -1,7 +1,14 @@
 import type { RunModel } from '../hooks/useRunModel.js';
+import type { Provenance } from '../store/provenance.js';
+import { ProvenanceLine } from './ProvenanceLine.js';
 
 interface Props {
   model: RunModel;
+  /** Derived audit provenance (DES-UX-001 §3.3) — `null`/absent degrades honestly. */
+  provenance?: Provenance | null;
+  /** Forward lineage: run ids the loaded index shows as retries of this run (§4.3). */
+  retriedAs?: readonly string[];
+  onSelectRun?: (id: string) => void;
 }
 
 function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): React.ReactElement {
@@ -18,11 +25,22 @@ function Row({ label, value, mono }: { label: string; value: string; mono?: bool
   );
 }
 
-export function WhatWhere({ model }: Props): React.ReactElement {
+export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props): React.ReactElement {
   const { session } = model;
 
   return (
     <div data-testid="what-where" className="flex flex-col gap-1.5">
+      {/* The provenance line — FIRST row of the card (DES-UX-001 §3.3): who or
+          what launched this run, degrading to "launched via API (actor
+          unknown)" rather than omitting the line. Lineage cross-links (§4.3)
+          ride inside it. */}
+      <ProvenanceLine
+        provenance={provenance ?? null}
+        retryOf={session.retry_of}
+        retriedAs={retriedAs}
+        onSelectRun={onSelectRun}
+        testId="run-provenance"
+      />
       <Row label="intent" value={session.problem} />
       <Row label="repo" value={session.repo_ref ?? '—'} mono />
       <Row label="worktree" value={session.workdir ?? '—'} mono />

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -1,0 +1,113 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+import type { ActorKind, AuditEntry } from '../api/types.js';
+
+/**
+ * Run provenance — "launched by X via Y" (DES-UX-001 §3).
+ *
+ * The daemon's audit trail (`GET /audit?runId=`) is the declared system of
+ * record for who launched a run: the engine's `LaunchOptions` carries no actor
+ * field, so crew writes a `run.launched` entry with the AUTHENTICATED actor
+ * at launch time (crew routes.ts:570). This store holds one derived
+ * {@link Provenance} per run id:
+ *
+ *  - ONE fetch per detail view, cached per run id (§3.3's declared exception
+ *    to the zero-requests-on-mount budgets — named in its AC). A failed fetch
+ *    caches the degraded answer too: revisits never re-fire.
+ *  - List rows (notifications) read ONLY this cache — no fan-out.
+ *  - Absence degrades honestly: no matching audit entry (or an unreachable
+ *    trail) is `{state:'unknown'}`, rendered as the brief's own words —
+ *    "launched via API (actor unknown)" — never an omitted line.
+ */
+export type Provenance =
+  | {
+      state: 'known';
+      actorId: string;
+      actorKind: ActorKind;
+      /**
+       * The launch channel. The audit detail carries no channel marker, so the
+       * honest derivation is: a run THIS studio session launched is `studio`
+       * (we witnessed the POST); anything else can only truthfully be called
+       * the API — a curl, another skin, a schedule all look identical here.
+       */
+      channel: 'studio' | 'API';
+      /** Lineage from the audit detail (CREW-UX-3): the run this one retries. */
+      retryOf?: string;
+    }
+  | { state: 'unknown' };
+
+/**
+ * Pure derivation over the audit page (unit-tested): the NEWEST `run.launched`
+ * entry for this run wins (`GET /audit` serves newest-first). Anything short of
+ * a well-formed actor is the degraded answer — never a fabricated name.
+ */
+export function deriveProvenance(
+  entries: readonly AuditEntry[],
+  runId: string,
+  launchedHere: boolean,
+): Provenance {
+  const launched = entries.find(
+    (e) =>
+      e.action === 'run.launched' &&
+      e.runId === runId &&
+      typeof e.actor === 'object' &&
+      e.actor !== null &&
+      typeof e.actor.id === 'string' &&
+      typeof e.actor.kind === 'string',
+  );
+  if (launched === undefined) return { state: 'unknown' };
+  const detail = (launched.detail ?? {}) as Record<string, unknown>;
+  const retryOf = typeof detail['retryOf'] === 'string' ? detail['retryOf'] : undefined;
+  return {
+    state: 'known',
+    actorId: launched.actor.id,
+    actorKind: launched.actor.kind,
+    channel: launchedHere ? 'studio' : 'API',
+    ...(retryOf !== undefined ? { retryOf } : {}),
+  };
+}
+
+interface ProvenanceStore {
+  /** Derived provenance per run id — the cache list rows read (no fan-out). */
+  byRun: Record<string, Provenance>;
+  /** Run ids THIS studio session launched (the `studio` channel witness). */
+  launchedHere: Record<string, true>;
+  markLaunchedHere: (runId: string) => void;
+  /** The one sanctioned audit fetch per detail view; cached + in-flight-deduped. */
+  load: (runId: string) => void;
+}
+
+/** In-flight guard so a re-render during the fetch never doubles it. */
+const inflight = new Set<string>();
+
+export const useProvenanceStore = create<ProvenanceStore>((set, get) => ({
+  byRun: {},
+  launchedHere: {},
+
+  markLaunchedHere: (runId) =>
+    set((s) => ({ launchedHere: { ...s.launchedHere, [runId]: true } })),
+
+  load: (runId) => {
+    if (get().byRun[runId] !== undefined || inflight.has(runId)) return;
+    inflight.add(runId);
+    api
+      .getAudit(runId)
+      .then(({ entries }) => {
+        set((s) => ({
+          byRun: {
+            ...s.byRun,
+            [runId]: deriveProvenance(entries, runId, s.launchedHere[runId] === true),
+          },
+        }));
+      })
+      .catch(() => {
+        // Audit unreachable — the degraded answer is cached too, so the one-
+        // fetch-per-detail-view budget holds on revisit (ConnectionStatus owns
+        // reporting the outage; this line just stays honest).
+        set((s) => ({ byRun: { ...s.byRun, [runId]: { state: 'unknown' } } }));
+      })
+      .finally(() => {
+        inflight.delete(runId);
+      });
+  },
+}));

--- a/src/store/retryPrefill.ts
+++ b/src/store/retryPrefill.ts
@@ -1,0 +1,50 @@
+import type { EntityMode, HumanConfirm } from '../api/types.js';
+
+/**
+ * Retry-as-prefill (DES-UX-001 §4.3): a failed/cancelled run's Retry button
+ * deposits the original run's launch configuration here and navigates to the
+ * standard composer, which consumes it ONCE at mount — a prefill, never a
+ * hidden relaunch. Nothing auto-launches; the operator's tweak-before-send is
+ * the point. The launch then carries `retryOf` (CREW-UX-3) so lineage is
+ * recorded in the system of record, not inferred from prompt equality.
+ */
+export interface RetryPrefill {
+  /** The run being retried — rides the launch body as `retryOf`. */
+  retryOf: string;
+  problem: string;
+  clis: readonly string[];
+  /** The original `workflow_id`; `null` = free-text (nothing to prefill). */
+  workflowId: string | null;
+  repoRef: string | null;
+  entityMode: EntityMode;
+  humanConfirm: HumanConfirm;
+  /** From the DTO's `project_id` echo (CREW-UX-2); `null` = unfiled. */
+  projectId: string | null;
+}
+
+let pending: RetryPrefill | null = null;
+
+export function setRetryPrefill(prefill: RetryPrefill): void {
+  pending = prefill;
+}
+
+/** Consume-once: the first composer to mount takes it; later mounts see null. */
+export function takeRetryPrefill(): RetryPrefill | null {
+  const taken = pending;
+  pending = null;
+  return taken;
+}
+
+/**
+ * Map the wire's `HumanConfirm` onto the composer's gate-posture controls
+ * (`ConfirmMode` + the before-ordinal). Pure — unit-tested.
+ */
+export function confirmModeOf(
+  hc: HumanConfirm | undefined,
+): { mode: 'none' | 'all' | 'before'; beforeOrd: number } {
+  if (hc === 'all') return { mode: 'all', beforeOrd: 1 };
+  if (typeof hc === 'object' && hc !== null && typeof hc.before === 'number') {
+    return { mode: 'before', beforeOrd: hc.before };
+  }
+  return { mode: 'none', beforeOrd: 1 };
+}

--- a/src/store/retryPrefill.ts
+++ b/src/store/retryPrefill.ts
@@ -36,6 +36,21 @@ export function takeRetryPrefill(): RetryPrefill | null {
 }
 
 /**
+ * Read WITHOUT consuming — for lazy `useState` initializers, which React's
+ * StrictMode double-invokes in dev: an initializer-side take() would consume
+ * on the discarded first pass and commit null (an empty composer, dev only).
+ * The taking mount pairs peek with {@link clearRetryPrefill} in an effect.
+ */
+export function peekRetryPrefill(): RetryPrefill | null {
+  return pending;
+}
+
+/** The second half of peek-then-clear: drop the deposit once a mount took it. */
+export function clearRetryPrefill(): void {
+  pending = null;
+}
+
+/**
  * Map the wire's `HumanConfirm` onto the composer's gate-posture controls
  * (`ConfirmMode` + the before-ordinal). Pure — unit-tested.
  */

--- a/tests/ChatInput.retry.test.tsx
+++ b/tests/ChatInput.retry.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StrictMode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatInput } from '../src/components/ChatInput.js';
@@ -87,6 +88,22 @@ describe('ChatInput — retry-as-prefill (§4.3)', () => {
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
     const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect('retryOf' in body, 'cleared pill = no lineage key at all').toBe(false);
+  });
+
+  it('the prefill survives StrictMode dev double-invoked initializers', () => {
+    // StrictMode double-invokes lazy useState initializers in dev and commits
+    // the SECOND pass — an initializer-side take() would consume on the
+    // discarded first pass and open an empty composer. Peek-then-clear holds.
+    depositPrefill();
+    render(
+      <StrictMode>
+        <ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />
+      </StrictMode>,
+    );
+    expect(screen.getByTestId('launch-problem')).toHaveValue('refactor the auth middleware');
+    expect(screen.getByText('Retry of r-origin')).toBeInTheDocument();
+    // …and the deposit is still consumed once the mount commits.
+    expect(takeRetryPrefill()).toBeNull();
   });
 
   it('the prefill is consume-once — a second mount opens clean', () => {

--- a/tests/ChatInput.retry.test.tsx
+++ b/tests/ChatInput.retry.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import * as client from '../src/api/client.js';
+import type { LaunchRunBody } from '../src/api/types.js';
+import { confirmModeOf, setRetryPrefill, takeRetryPrefill } from '../src/store/retryPrefill.js';
+import { useProvenanceStore } from '../src/store/provenance.js';
+
+/**
+ * DES-UX-001 §4.3/§4.5 — Retry is a composer PREFILL, not a hidden relaunch:
+ * the launch form opens with the original intent/workflow/roster/repo/gate
+ * posture, fully editable, fires NO launch until the operator sends, and the
+ * send carries `retryOf` (CREW-UX-3).
+ */
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  takeRetryPrefill(); // drain any leftover deposit between tests
+  useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [
+      { key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true },
+      { key: 'codex', display_name: 'codex', binary: 'codex', enabled_for_council: true },
+    ],
+  });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  localStorage.clear();
+});
+
+function depositPrefill(): void {
+  setRetryPrefill({
+    retryOf: 'r-original',
+    problem: 'refactor the auth middleware',
+    clis: ['claude'],
+    workflowId: 'feature',
+    repoRef: 'studio-api',
+    entityMode: 'shared',
+    humanConfirm: 'all',
+    projectId: null,
+  });
+}
+
+describe('ChatInput — retry-as-prefill (§4.3)', () => {
+  it('seeds the composer from the prefill and fires no launch until send', async () => {
+    depositPrefill();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    // Intent equals the original problem (§4.5 AC).
+    expect(screen.getByTestId('launch-problem')).toHaveValue('refactor the auth middleware');
+    // Workflow / repo / gate posture surface as the editable pills.
+    expect(screen.getByText('Workflow: feature')).toBeInTheDocument();
+    expect(screen.getByText('Repo: studio-api')).toBeInTheDocument();
+    expect(screen.getByText('Gate: every unit')).toBeInTheDocument();
+    // The lineage claim is visible and clearable.
+    expect(screen.getByText('Retry of r-origin')).toBeInTheDocument();
+    // Nothing auto-launched (§4.5: zero POST /runs until the operator sends).
+    expect(client.api.launchRun).not.toHaveBeenCalled();
+
+    const user = userEvent.setup();
+    await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+    await user.click(screen.getByTestId('launch-submit'));
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    expect(body.retryOf).toBe('r-original');
+    expect(body.problem).toBe('refactor the auth middleware');
+    expect(body.workflow).toBe('feature');
+    expect(body.repoRef).toBe('studio-api');
+    expect(body.humanConfirm).toBe('all');
+    // The prefilled roster (not the stored default) rides clisJson.
+    const seats = JSON.parse(body.clisJson ?? '[]') as { key: string }[];
+    expect(seats.map((s) => s.key)).toEqual(['claude']);
+    // The launch is marked as studio-witnessed for the provenance channel.
+    expect(useProvenanceStore.getState().launchedHere['r-new']).toBe(true);
+  });
+
+  it('clearing the pill drops the lineage claim from the launch body', async () => {
+    depositPrefill();
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.click(screen.getByLabelText('Clear Retry of r-origin'));
+    await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+    await user.click(screen.getByTestId('launch-submit'));
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    expect('retryOf' in body, 'cleared pill = no lineage key at all').toBe(false);
+  });
+
+  it('the prefill is consume-once — a second mount opens clean', () => {
+    depositPrefill();
+    const first = render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    first.unmount();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    expect(screen.getByTestId('launch-problem')).toHaveValue('');
+    expect(screen.queryByText('Retry of r-origin')).not.toBeInTheDocument();
+  });
+
+  it('a run-selected composer never consumes the deposit', () => {
+    depositPrefill();
+    render(<ChatInput runId="r-live" runStatus="executing" onLaunched={vi.fn()} />);
+    expect(takeRetryPrefill()?.retryOf, 'deposit still pending').toBe('r-original');
+  });
+});
+
+describe('confirmModeOf (§4.3 gate-posture mapping)', () => {
+  it('maps the three wire spellings', () => {
+    expect(confirmModeOf('all')).toEqual({ mode: 'all', beforeOrd: 1 });
+    expect(confirmModeOf('none')).toEqual({ mode: 'none', beforeOrd: 1 });
+    expect(confirmModeOf({ before: 3 })).toEqual({ mode: 'before', beforeOrd: 3 });
+    expect(confirmModeOf(undefined)).toEqual({ mode: 'none', beforeOrd: 1 });
+  });
+});

--- a/tests/ProvenanceLine.test.tsx
+++ b/tests/ProvenanceLine.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProvenanceLine } from '../src/components/ProvenanceLine.js';
+
+/**
+ * DES-UX-001 §3.4/§3.5 — the one provenance line: named when known, the
+ * brief's exact degraded copy when not; the line never renders nothing.
+ * Lineage cross-links (§4.3) ride inside it and navigate.
+ */
+
+describe('ProvenanceLine', () => {
+  it('renders actor id, kind badge, and channel when known', () => {
+    render(<ProvenanceLine
+      provenance={{ state: 'known', actorId: 'mika', actorKind: 'human', channel: 'studio' }}
+      testId="run-provenance"
+    />);
+    const line = screen.getByTestId('run-provenance');
+    expect(line).toHaveTextContent('launched by mika');
+    expect(line).toHaveTextContent('human');
+    expect(line).toHaveTextContent('via studio');
+  });
+
+  it('degrades to the exact copy — the line is never absent', () => {
+    render(<ProvenanceLine provenance={{ state: 'unknown' }} testId="run-provenance" />);
+    expect(screen.getByTestId('run-provenance'))
+      .toHaveTextContent('launched via API (actor unknown)');
+  });
+
+  it('renders the degraded copy while the audit answer is still null', () => {
+    render(<ProvenanceLine provenance={null} testId="notif-provenance" />);
+    expect(screen.getByTestId('notif-provenance'))
+      .toHaveTextContent('launched via API (actor unknown)');
+  });
+
+  it('lineage cross-links render short ids and navigate on click', async () => {
+    const user = userEvent.setup();
+    const onSelectRun = vi.fn();
+    render(<ProvenanceLine
+      provenance={{ state: 'known', actorId: 'mika', actorKind: 'human', channel: 'API' }}
+      retryOf="r-original-run"
+      retriedAs={['r-child-run-1']}
+      onSelectRun={onSelectRun}
+      testId="run-provenance"
+    />);
+    const back = screen.getByTestId('lineage-retry-of');
+    expect(back).toHaveTextContent('retry of r-origin');
+    await user.click(back);
+    expect(onSelectRun).toHaveBeenCalledWith('r-original-run');
+    const fwd = screen.getByTestId('lineage-retried-as');
+    expect(fwd).toHaveTextContent('retried as r-child-');
+    await user.click(fwd);
+    expect(onSelectRun).toHaveBeenCalledWith('r-child-run-1');
+  });
+
+  it('DTO lineage renders even when the audit answer degraded', () => {
+    render(<ProvenanceLine provenance={{ state: 'unknown' }} retryOf="r-original-run"
+      testId="run-provenance" />);
+    const line = screen.getByTestId('run-provenance');
+    expect(line).toHaveTextContent('launched via API (actor unknown)');
+    expect(screen.getByTestId('lineage-retry-of')).toHaveTextContent('retry of r-origin');
+  });
+});

--- a/tests/provenance.store.test.ts
+++ b/tests/provenance.store.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import * as client from '../src/api/client.js';
+import type { AuditEntry } from '../src/api/types.js';
+import { deriveProvenance, useProvenanceStore } from '../src/store/provenance.js';
+
+/**
+ * DES-UX-001 §3 — provenance derivation over the REAL audit wire shape
+ * (`AuditEntry {ts, action, actor{id,kind,trust}, runId, detail}`), and the
+ * store's one-fetch-per-run-id contract (§3.3's sanctioned exception).
+ */
+
+function launched(runId: string, over: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    ts: 1_700_000_000_000,
+    action: 'run.launched',
+    actor: { id: 'mika', kind: 'human', trust: 'operator' },
+    runId,
+    detail: { workflow: 'feature' },
+    ...over,
+  };
+}
+
+describe('deriveProvenance (§3.3)', () => {
+  it('derives actor + kind from the newest run.launched entry', () => {
+    const p = deriveProvenance([launched('r-1')], 'r-1', false);
+    expect(p).toEqual({ state: 'known', actorId: 'mika', actorKind: 'human', channel: 'API' });
+  });
+
+  it('a launch this studio session witnessed derives channel "studio"', () => {
+    const p = deriveProvenance([launched('r-1')], 'r-1', true);
+    expect(p.state === 'known' && p.channel).toBe('studio');
+  });
+
+  it('carries retryOf from the audit detail (CREW-UX-3)', () => {
+    const p = deriveProvenance(
+      [launched('r-2', { detail: { retryOf: 'r-1' } })], 'r-2', false);
+    expect(p.state === 'known' && p.retryOf).toBe('r-1');
+  });
+
+  it('no matching entry degrades to unknown — never a fabricated actor', () => {
+    expect(deriveProvenance([], 'r-1', false)).toEqual({ state: 'unknown' });
+    // Other actions and other runs never match.
+    expect(deriveProvenance(
+      [launched('r-1', { action: 'gate.decided' }), launched('r-other')],
+      'r-1', false)).toEqual({ state: 'unknown' });
+  });
+
+  it('a malformed actor degrades rather than half-rendering', () => {
+    const bad = launched('r-1');
+    (bad as Record<string, unknown>)['actor'] = { id: 42 };
+    expect(deriveProvenance([bad], 'r-1', false)).toEqual({ state: 'unknown' });
+  });
+});
+
+describe('useProvenanceStore.load (§3.5: one fetch per run id, cached)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+  });
+
+  it('fetches once, caches, and never re-fires on revisit', async () => {
+    const spy = vi.spyOn(client.api, 'getAudit')
+      .mockResolvedValue({ entries: [launched('r-1')] });
+    useProvenanceStore.getState().load('r-1');
+    useProvenanceStore.getState().load('r-1'); // in-flight dedup
+    await waitFor(() =>
+      expect(useProvenanceStore.getState().byRun['r-1']?.state).toBe('known'));
+    useProvenanceStore.getState().load('r-1'); // cached revisit
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('an unreachable audit trail caches the degraded answer', async () => {
+    const spy = vi.spyOn(client.api, 'getAudit').mockRejectedValue(new Error('API 500: down'));
+    useProvenanceStore.getState().load('r-1');
+    await waitFor(() =>
+      expect(useProvenanceStore.getState().byRun['r-1']).toEqual({ state: 'unknown' }));
+    useProvenanceStore.getState().load('r-1');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('markLaunchedHere before the load yields the studio channel', async () => {
+    vi.spyOn(client.api, 'getAudit').mockResolvedValue({ entries: [launched('r-9')] });
+    useProvenanceStore.getState().markLaunchedHere('r-9');
+    useProvenanceStore.getState().load('r-9');
+    await waitFor(() => {
+      const p = useProvenanceStore.getState().byRun['r-9'];
+      expect(p?.state === 'known' && p.channel).toBe('studio');
+    });
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §3 + §4 (slice V)** — provenance + retry (BRIEF-UX-001 A3/A4 MAJOR).

- **Provenance line** on run detail (first row of What/Where) + notification rows: "launched by X via Y" derived from the real `GET /audit?runId=` wire; one cached fetch per detail view (§3.3's sanctioned exception); honest degradation to "launched via API (actor unknown)" — the line is never absent (EC35). Lineage fully adopted: "retry of {short-id}" back-links (DTO `retry_of` / audit detail), "retried as" forward from the loaded index.
- **Retry-as-prefill**: failed/cancelled runs get a Retry button that deposits a consume-once prefill and opens the standard composer — intent/workflow/roster/repo/gate-posture/project all prefilled and editable, a clearable "Retry of" pill, nothing auto-launches; the send carries `retryOf` (CREW-UX-3).
- api-types 0.7.0→0.8.0 (retry_of + project_id).

**Verified**: 1284/1284 unit tests; new rig `ux_sliceV_test.py` (9 steps, real audit shapes incl. degraded no-audit run + retry pair, daemon's retryOf-unknown 400); regression rigs sliceR/B/M/L green; adversarial verifier approved incl. live read-only daemon check; 287 production LOC (≤320 budget).

Honest limits (by design): channel says "via studio" only for launches this session witnessed — the audit entry carries no channel marker; everything else renders "via API" truthfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
