### PR TITLE
DES-UX-001 slice S: project scoping that means it

### DIFF
--- a/e2e/ux_sliceS_test.py
+++ b/e2e/ux_sliceS_test.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+ux_sliceS_test.py — the DES-UX-001 slice-S gate: project scoping that means it
+(§2, the campaign's A2 CRITICAL — "runs launched with a project selected record
+as 'Unfiled'… footer counters remain global inside project views").
+
+Runs against the shared W2 fixture with its `project_dto` corpus on (real wire
+shapes only, CREW-UX-2 / api-types 0.8.0): every run DTO carries `project_id`
+(a string echoed from the membership record, or null = GENUINELY unfiled),
+r-unfiled rides the list with a null claim and NO membership record, and
+POST /api/v1/runs is a real launch — `{runId}` answered, the run atomically
+filed into `body.projectId` and echoed back on the next GET /runs.
+
+The §2.5 DOM ACs, verbatim mapping:
+
+  1. launching from `/p/upload-endpoint/build/new` with the chip set: the POST
+     body carries `projectId`, the created run reaches the client within one
+     live-update cycle WITHOUT a reload (the always-mounted bottom bar's
+     `data-working` bumps), and on the project's Build tab
+     `[data-testid="project-run-count"]` equals the rendered
+     `[data-testid="build-run-row"]` count — SET-equal (EC34): both named
+     intents present, every foreign intent absent;
+  2. entry points entered from a project context pre-bind: the rail's Make ＋
+     Build tine and Chat ＋ land on `/p/:id/{build,chat}/new`, the palette's
+     "New Build" verb the same, and Repositories ＋ lands on
+     `/repos/new?project=:id` where the register form's ProjectSwitcher
+     renders `data-locked="true"` naming the project — never Unfiled;
+  3. the footer bar carries `data-scope="project"` inside the shell with
+     counters scoped to ITS runs (1/0/0 for upload-endpoint), and
+     `data-scope="global"` on `/` with the whole-fixture counts (2/2/2 —
+     r-unfiled counts as working GLOBALLY, never inside a project);
+  4. with the DTO echo present, project attribution costs ZERO extra membership
+     fetches: no /members path is read again after the mount passes settle
+     (the pre-S unplaced-run re-read must NOT fire for r-unfiled or the
+     launched run), and opening the runs sheet — whose rows render project
+     names — fires zero /members requests;
+  + the home board's "not in a project" shelf is the DAEMON's unfiled set:
+    exactly r-unfiled (`project_id: null`), never a failed-join artifact.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-S-project-scoped.png   /p/upload-endpoint/build after the launch: the
+                            scoped list (2 rows), the EC34 count beside it,
+                            the project-scoped footer bar
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4377),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4377"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+PROJECT = "upload-endpoint"
+BUILD_TAB = f"/p/{PROJECT}/build"
+LAUNCH_FORM = f"{BUILD_TAB}/new"
+LAUNCH_INTENT = "wire the retry backoff"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, project_dto ON ────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+# orphan=False: r-orphan (a membership-less executing run) would be a SECOND
+# genuinely-unfiled row under DTO truth — one null-claim run (r-unfiled) keeps
+# every count in this rig's scenes deterministic and singular.
+set_fixture(ORIGIN, project_dto=True, orphan=False)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The request tap: every membership read and every launch POST body.
+    member_reads: list[str] = []
+    launch_posts: list[dict] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "GET" and re.search(r"/api/v1/projects/[^/]+/members$", path):
+            member_reads.append(path)
+        elif req.method == "POST" and path == "/api/v1/runs":
+            try:
+                launch_posts.append(json.loads(req.post_data or "{}"))
+            except ValueError:
+                launch_posts.append({"unparseable": req.post_data})
+
+    page.on("request", on_request)
+
+    def member_counts() -> dict:
+        counts: dict = {}
+        for pth in member_reads:
+            counts[pth] = counts.get(pth, 0) + 1
+        return counts
+
+    def goto(path: str) -> None:
+        page.goto(f"{ORIGIN}{path}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def bar() -> dict:
+        return page.evaluate(
+            """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                       return b ? { scope: b.dataset.scope, working: b.dataset.working,
+                                    gates: b.dataset.gates, failed: b.dataset.failed } : null; }""")
+
+    # ── Scene 1 (AC 3 global + the shelf): `/` — global scope, daemon-truth
+    #    unfiled ────────────────────────────────────────────────────────────────
+    goto("/")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.wait_for_function(
+        """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   return !!b && b.dataset.working === '2'
+                       && b.dataset.gates === '2' && b.dataset.failed === '2'; }""",
+        timeout=15000)
+    check("global_scope_counters", (bar() or {}).get("scope") == "global", **(bar() or {}))
+
+    # The shelf is the DTO-null set: exactly r-unfiled, off daemon truth — the
+    # membership-joined seven never look unfiled.
+    page.locator('[data-testid="band-not-in-project"]').wait_for(timeout=15000)
+    # The shelf ships collapsed (F5: it can never lead a real project) — expand
+    # it to read the rows.
+    page.locator('[data-testid="band-not-in-project-toggle"]').click()
+    page.locator('[data-testid="unfiled-run"]').first.wait_for(timeout=5000)
+    shelf = page.evaluate(
+        """() => { const band = document.querySelector('[data-testid="band-not-in-project"]');
+                   return { count: band?.dataset.count ?? null,
+                            rows: Array.from(document.querySelectorAll(
+                              '[data-testid="unfiled-run"]')).map(r => r.innerText) }; }""")
+    check("unfiled_is_daemon_truth", shelf["count"] == "1"
+          and any("poke at the flaky CI job" in t for t in shelf["rows"]), **shelf)
+
+    # ── Scene 2 (AC 4): the DTO claim costs zero placement re-reads — after the
+    #    mount passes settle, NO /members path is read again (pre-S, r-unfiled
+    #    would have triggered a full re-read pass) ───────────────────────────────
+    page.wait_for_timeout(2500)
+    settled_counts = member_counts()
+    page.wait_for_timeout(2000)
+    late_counts = member_counts()
+    check("no_membership_rereads", late_counts == settled_counts,
+          paths_read=len(settled_counts),
+          max_reads_per_path=max(settled_counts.values(), default=0))
+
+    # Opening the runs sheet — whose rows render project names — fires ZERO
+    # membership fetches: the labels come off the DTO claim + the projects
+    # store (§2.5's request-tap AC). r-unfiled's label is honestly blank.
+    before_sheet = len(member_reads)
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-sheet-row"]').first.wait_for(timeout=10000)
+    sheet = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="runs-sheet-row"]'))
+                 .map(r => ({ text: r.innerText.replace(/\\s+/g, ' '),
+                              project: r.querySelector(
+                                '[data-testid="runs-sheet-row-project"]')?.textContent ?? null }))""")
+    unfiled_row = next((r for r in sheet if "poke at the flaky CI job" in r["text"]), None)
+    filed_row = next((r for r in sheet if "add rate-limiting" in r["text"]), None)
+    check("sheet_labels_zero_fetches",
+          len(member_reads) == before_sheet
+          and unfiled_row is not None and (unfiled_row["project"] or "") == ""
+          and filed_row is not None and filed_row["project"] == PROJECT,
+          new_member_reads=len(member_reads) - before_sheet,
+          unfiled_row=unfiled_row, filed_row=filed_row)
+    page.locator('[data-testid="runs-sheet-collapse"]').click()
+
+    # ── Scene 3 (AC 3 project): inside the shell the bar scopes to ITS runs —
+    #    and the Build tab's gate inbox never shows a foreign gate ───────────────
+    goto(BUILD_TAB)
+    page.locator('[data-testid="build-dashboard"]').wait_for(timeout=30000)
+    page.wait_for_function(
+        """() => { const b = document.querySelector('[data-testid="runs-bottom-bar"]');
+                   return !!b && b.dataset.scope === 'project'
+                       && b.dataset.working === '1' && b.dataset.gates === '0'
+                       && b.dataset.failed === '0'; }""",
+        timeout=15000)
+    scoped = page.evaluate(
+        """() => ({
+             rows: Array.from(document.querySelectorAll('[data-testid="build-run-row"]'))
+               .map(r => r.innerText.replace(/\\s+/g, ' ')),
+             count: document.querySelector('[data-testid="project-run-count"]')
+               ?.textContent ?? null,
+             gateInbox: !!document.querySelector('[data-testid="gate-inbox"]'),
+           })""")
+    check("project_scope_before_launch",
+          (bar() or {}).get("scope") == "project"
+          and scoped["count"] == "1" and len(scoped["rows"]) == 1
+          and "add rate-limiting" in scoped["rows"][0]
+          and not scoped["gateInbox"],  # the 2 global gates are FOREIGN here
+          **scoped, bar=bar())
+
+    # ── Scene 4 (AC 2): every entry point carries the ambient binding ───────────
+    # The rail's Make ＋ Build tine → the pre-bound form.
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="make-picker-row"][data-mode="build"]').wait_for(timeout=5000)
+    page.locator('[data-testid="make-picker-row"][data-mode="build"]').click()
+    page.wait_for_function(
+        f"""() => window.location.pathname === '{LAUNCH_FORM}'""", timeout=10000)
+    make_build_ok = True
+
+    # The rail's Chat ＋ → the project's chat form.
+    goto(BUILD_TAB)
+    page.locator('[data-testid="left-rail"]').wait_for(timeout=30000)
+    page.locator('[data-testid="rail-heading-chat"] [data-testid="heading-new"]').click()
+    page.wait_for_function(
+        f"""() => window.location.pathname === '/p/{PROJECT}/chat/new'""", timeout=10000)
+    chat_plus_ok = True
+
+    # The palette's "New Build" verb — the same shared spelling.
+    goto(BUILD_TAB)
+    page.locator('[data-testid="build-dashboard"]').wait_for(timeout=30000)
+    page.keyboard.press("Control+p")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.wait_for_function(
+        "() => document.activeElement?.dataset?.testid === 'palette-input'", timeout=10000)
+    page.keyboard.type("> new build")
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        f"""() => window.location.pathname === '{LAUNCH_FORM}'""", timeout=10000)
+    palette_build_ok = True
+
+    # Repositories ＋ → the ?project= carry; the register form pre-binds + LOCKS.
+    goto(BUILD_TAB)
+    page.locator('[data-testid="left-rail"]').wait_for(timeout=30000)
+    page.locator('[data-testid="rail-heading-repos"] [data-testid="heading-new"]').click()
+    page.wait_for_function(
+        f"""() => window.location.pathname === '/repos/new'
+              && window.location.search === '?project={PROJECT}'""", timeout=10000)
+    page.locator('[data-testid="project-switcher"]').wait_for(timeout=10000)
+    register = page.evaluate(
+        f"""() => {{ const sw = document.querySelector('[data-testid="project-switcher"]');
+                     return {{ locked: sw?.querySelector('[data-locked]')?.dataset.locked
+                                 ?? sw?.dataset.locked ?? null,
+                               lockedAnywhere: !!document.querySelector(
+                                 '[data-testid="project-switcher"] [data-locked="true"], '
+                                 + '[data-testid="project-switcher"][data-locked="true"]'),
+                               names: sw?.innerText ?? '' }}; }}""")
+    check("entry_points_carry_binding",
+          make_build_ok and chat_plus_ok and palette_build_ok
+          and register["lockedAnywhere"] and PROJECT in register["names"],
+          register=register)
+
+    # ── Scene 5 (AC 1): the launch — chip set, POST carries the binding, the
+    #    run reaches the client within one live-update cycle, no reload ─────────
+    goto(LAUNCH_FORM)
+    page.locator('[data-testid="launch-problem"]').wait_for(timeout=30000)
+    prebound = page.evaluate(
+        """() => { const row = document.querySelector('[data-testid="launch-project-row"]');
+                   return { lockedShown: !!row?.querySelector('[data-locked="true"]'),
+                            text: row?.innerText ?? '' }; }""")
+    check("launch_form_prebound", prebound["lockedShown"] and PROJECT in prebound["text"],
+          **prebound)
+
+    pre_launch_members = len(member_reads)
+    page.locator('[data-testid="launch-problem"]').fill(LAUNCH_INTENT)
+    page.locator('[data-testid="launch-submit"]').click()
+    # onLaunched navigates INTO the run (SPA — no reload) and refreshes the run
+    # list; the always-mounted bar's scoped working count bumps 1 → 2 within
+    # one live-update cycle.
+    page.wait_for_function(
+        f"""() => window.location.pathname.startsWith('{BUILD_TAB}/r-launched-')""",
+        timeout=15000)
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="runs-bottom-bar"]')
+                   ?.dataset.working === '2'""",
+        timeout=15000)
+    check("launch_carries_binding",
+          len(launch_posts) == 1 and launch_posts[0].get("projectId") == PROJECT
+          and launch_posts[0].get("problem") == LAUNCH_INTENT
+          # The DTO claim placed it — the launch cost zero membership re-reads.
+          and len(member_reads) == pre_launch_members,
+          posts=launch_posts, new_member_reads=len(member_reads) - pre_launch_members)
+
+    # ── Scene 6 (EC34): the Build tab shows EXACTLY its runs; the count equals
+    #    the rows, set-equal, on the same paint ─────────────────────────────────
+    goto(BUILD_TAB)
+    page.locator('[data-testid="build-dashboard"]').wait_for(timeout=30000)
+    page.wait_for_function(
+        """() => document.querySelectorAll('[data-testid="build-run-row"]').length === 2""",
+        timeout=15000)
+    ec34 = page.evaluate(
+        """() => ({
+             rows: Array.from(document.querySelectorAll('[data-testid="build-run-row"]'))
+               .map(r => r.innerText.replace(/\\s+/g, ' ')),
+             count: document.querySelector('[data-testid="project-run-count"]')
+               ?.textContent ?? null,
+           })""")
+    foreign = [t for t in ec34["rows"]
+               if not ("add rate-limiting" in t or LAUNCH_INTENT in t)]
+    check("count_equals_rows",
+          ec34["count"] == "2" and len(ec34["rows"]) == 2 and foreign == []
+          and any(LAUNCH_INTENT in t for t in ec34["rows"])
+          and any("add rate-limiting" in t for t in ec34["rows"]),
+          **ec34, foreign_rows=foreign, bar=bar())
+    page.screenshot(path=str(VSHOTS / "ux-S-project-scoped.png"))
+
+    # ── Scene 7: the scoped sheet — its rows are the project's, labeled off the
+    #    DTO claim, zero membership fetches on open ──────────────────────────────
+    before_sheet = len(member_reads)
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-sheet-row"]').first.wait_for(timeout=10000)
+    scoped_sheet = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="runs-sheet-row"]'))
+                 .map(r => ({ text: r.innerText.replace(/\\s+/g, ' '),
+                              project: r.querySelector(
+                                '[data-testid="runs-sheet-row-project"]')?.textContent ?? null }))""")
+    check("scoped_sheet",
+          len(scoped_sheet) == 2
+          and all(r["project"] == PROJECT for r in scoped_sheet)
+          and len(member_reads) == before_sheet,
+          rows=scoped_sheet, new_member_reads=len(member_reads) - before_sheet)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -113,6 +113,16 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     ≥1 fetch and reach its own timeout branch). Both failed
                     runs gain one `dataUsed` file so the Files panel offers
                     [Full diff]. Default False.
+  project_dto     — the slice-S CREW-UX-2 corpus (DES-UX-001 §2.3): every run
+                    DTO carries `project_id` (api-types 0.8.0 — a string echoed
+                    from the membership record, or null = GENUINELY unfiled),
+                    the list gains `r-unfiled` (a null-claim run no membership
+                    names), and `POST /api/v1/runs` becomes a REAL launch: the
+                    daemon's `{runId}` answer, the run atomically filed into
+                    `body.projectId` (never a silent unfiled run) and served on
+                    both the runs wire (with its `project_id` echo) and its
+                    project's members wire. Default False: pre-0.8.0 rigs keep
+                    DTOs without the field and a POST that 404s.
 
 A rig that never flips them gets the default W2 board.
 """
@@ -229,7 +239,11 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # loop, verbatim (e.g. a sessionFailed that mints a run_failed
          # notification row). Distinct from extra_narration (which wraps
          # its lines in unitOutputDelta) and extra_gates (awaitingHuman).
-         "extra_frames": []}
+         "extra_frames": [],
+         # Slice S (DES-UX-001 §2.3, CREW-UX-2): run DTOs carry `project_id`,
+         # r-unfiled joins the list, POST /runs launches for real. Default
+         # False: no standing rig's DTO shape changes.
+         "project_dto": False}
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -360,6 +374,28 @@ AUDIT_ENTRIES = {
                  "runId": "r-retry",
                  "detail": {"workflow": "wf-w2", "retryOf": "r-auth"}}],
 }
+
+# ── Slice S (DES-UX-001 §2.3): the CREW-UX-2 project_id corpus, behind
+#    `project_dto` ──────────────────────────────────────────────────────────────
+#
+# The run→project truth the DTO echoes (api-types 0.8.0): a string for every
+# membership above, `None` (JSON null) for a run the daemon GENUINELY considers
+# unfiled — never the absent field, which spells a pre-0.8.0 server.
+RUN_PROJECT = {ref: pid for pid, refs in MEMBERS.items() for ref in refs}
+
+# The null-claim run: on the list, filed nowhere, no membership names it. The
+# board's "not in a project" shelf must show it off DTO truth alone — no
+# membership hold-back, no join.
+UNFILED_RUN = session("r-unfiled", "executing", "poke at the flaky CI job",
+                      "poke at the flaky CI job")
+
+# Runs launched over POST /api/v1/runs this server lifetime (project_dto on):
+# each entry rides GET /runs (its session carrying the `project_id` echo) and —
+# when filed — its project's members wire, the atomic attach (routes.ts:148,
+# "never a silent unfiled run"). Guarded by state_lock.
+launched_runs: list = []          # SessionView dicts, project_id already stamped
+launched_members: dict = {}       # pid -> [run ids]
+launched_seq = [0]
 
 # ── Slice P (DES-FEEDBACK-003 §10.2): the two chat runs, behind `chat_runs` ───
 #
@@ -981,7 +1017,12 @@ def assemble_runs() -> list:
         repo_refs_on = state["repo_refs"]
         forensics_on = state["forensics"]
         provenance_on = state["provenance"]
-    if viewer_on or repo_refs_on or forensics_on or provenance_on:
+        project_dto_on = state["project_dto"]
+        # Slice S (DES-UX-001 §2.3): the null-claim run + this-lifetime launches
+        # join BOTH wires (list + detail) so the DTO echo decorates identically.
+        if project_dto_on and not state["no_runs"]:
+            runs = runs + [UNFILED_RUN] + launched_runs
+    if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on:
         runs = json.loads(json.dumps(runs))
         for r in runs:
             # Slice V: the CREW-UX-2 DTO echo for the lineage pair — the retry
@@ -1001,6 +1042,13 @@ def assemble_runs() -> list:
             if forensics_on and r["session"]["id"] == "r-auth":
                 r["units"] = json.loads(json.dumps(FORENSICS_AUTH_UNITS))
                 r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
+            # Slice S (CREW-UX-2): the DTO echoes the membership record —
+            # ALWAYS present with the corpus on (string | null), the
+            # api-types 0.8.0 contract. Launched runs arrive pre-stamped;
+            # slice V's explicit lineage-pair stamp above wins when both
+            # corpora are on (this is the membership-derived fallback).
+            if project_dto_on and "project_id" not in r["session"]:
+                r["session"]["project_id"] = RUN_PROJECT.get(r["session"]["id"])
     return runs
 
 
@@ -1359,6 +1407,10 @@ class W2Handler(SimpleHTTPRequestHandler):
             # Slice L: the batch corpus projects' runs.
             if batch_on:
                 refs.extend(BATCH_MEMBERS.get(pid, []))
+            # Slice S: runs launched this lifetime — the atomic attach means the
+            # membership record and the DTO echo agree from the first read.
+            with state_lock:
+                refs.extend(launched_members.get(pid, []))
             # Slice P: the live chat thread is a `crew.chat` member of notes.
             kinds = {}
             if chat_runs_on and pid == "notes":
@@ -1779,6 +1831,25 @@ class W2Handler(SimpleHTTPRequestHandler):
         # The slice-6 document journey's writes (create / fork / bus emit).
         if self._interactive_post(path, body if isinstance(body, dict) else {}):
             return None
+        # POST /api/v1/runs — the REAL launch (slice S, project_dto only): the
+        # daemon's `{runId}` answer; `body.projectId` files the run atomically
+        # (LaunchSchema, routes.ts:148 — "never a silent unfiled run"), and the
+        # DTO the next GET /runs serves carries the CREW-UX-2 `project_id` echo.
+        if path == "/api/v1/runs":
+            with state_lock:
+                if not state["project_dto"]:
+                    return self._json(404, {"error": "w2 fixture: POST /runs needs project_dto"})
+                launched_seq[0] += 1
+                rid = f"r-launched-{launched_seq[0]}"
+                pid = body.get("projectId")
+                run = session(rid, "executing", body.get("problem", ""),
+                              body.get("problem", ""))
+                run["session"]["project_id"] = pid if pid else None
+                launched_runs.append(run)
+                if pid:
+                    launched_members.setdefault(pid, []).append(rid)
+                    ATTACHED_AT[rid] = NOW0
+            return self._json(200, {"runId": rid})
         # POST /api/v1/runs/<id>/gate — the steering-gate decision (slice H,
         # DES-FEEDBACK-002 §2.3). The fixture accepts it so the answered state
         # ("approved · advancing…") renders truthfully after a triage key or a

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1835,21 +1835,39 @@ class W2Handler(SimpleHTTPRequestHandler):
         # daemon's `{runId}` answer; `body.projectId` files the run atomically
         # (LaunchSchema, routes.ts:148 — "never a silent unfiled run"), and the
         # DTO the next GET /runs serves carries the CREW-UX-2 `project_id` echo.
+        # POST /api/v1/runs — the launch, shared by the slice-V (provenance/
+        # retry) and slice-S (project_dto) corpora. retryOf validation first
+        # (CREW-UX-3: 400 on an unknown id, crew routes.ts:588); then a REAL
+        # launch when project_dto is on (the run rides GET /runs with its
+        # project_id echo — atomic filing), else slice V's plain 201.
         if path == "/api/v1/runs":
+            retry_of = body.get("retryOf")
+            if retry_of is not None:
+                with state_lock:
+                    provenance_on = state["provenance"]
+                known = {r["session"]["id"] for r in RUNS} \
+                    | ({RETRY_RUN["session"]["id"]} if provenance_on else set()) \
+                    | {r["session"]["id"] for r in launched_runs}
+                if retry_of not in known:
+                    return self._json(400, {
+                        "error": f"retryOf names an unknown run: {retry_of} — "
+                                 "lineage must point at an existing run id"})
             with state_lock:
-                if not state["project_dto"]:
-                    return self._json(404, {"error": "w2 fixture: POST /runs needs project_dto"})
-                launched_seq[0] += 1
-                rid = f"r-launched-{launched_seq[0]}"
-                pid = body.get("projectId")
-                run = session(rid, "executing", body.get("problem", ""),
-                              body.get("problem", ""))
-                run["session"]["project_id"] = pid if pid else None
-                launched_runs.append(run)
-                if pid:
-                    launched_members.setdefault(pid, []).append(rid)
-                    ATTACHED_AT[rid] = NOW0
-            return self._json(200, {"runId": rid})
+                project_dto_on = state["project_dto"]
+                if project_dto_on:
+                    launched_seq[0] += 1
+                    rid = f"r-launched-{launched_seq[0]}"
+                    pid = body.get("projectId")
+                    run = session(rid, "executing", body.get("problem", ""),
+                                  body.get("problem", ""))
+                    run["session"]["project_id"] = pid if pid else None
+                    launched_runs.append(run)
+                    if pid:
+                        launched_members.setdefault(pid, []).append(rid)
+                        ATTACHED_AT[rid] = NOW0
+            if project_dto_on:
+                return self._json(200, {"runId": rid})
+            return self._json(201, {"runId": "r-new"})
         # POST /api/v1/runs/<id>/gate — the steering-gate decision (slice H,
         # DES-FEEDBACK-002 §2.3). The fixture accepts it so the answered state
         # ("approved · advancing…") renders truthfully after a triage key or a
@@ -1864,21 +1882,6 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # awaiting between the selection and the fan-out.
                 return self._json(409, {"error": "not awaiting a human gate"})
             return self._json(200, {"status": "resumed"})
-        # Slice V (DES-UX-001 §4 / CREW-UX-3): POST /runs — the launch. retryOf
-        # must name an EXISTING run id (the daemon's 400 with a named error,
-        # crew routes.ts:588) — never a silently unrecorded lineage.
-        if path == "/api/v1/runs":
-            retry_of = body.get("retryOf")
-            if retry_of is not None:
-                with state_lock:
-                    provenance_on = state["provenance"]
-                known = {r["session"]["id"] for r in RUNS} \
-                    | ({RETRY_RUN["session"]["id"]} if provenance_on else set())
-                if retry_of not in known:
-                    return self._json(400, {
-                        "error": f"retryOf names an unknown run: {retry_of} — "
-                                 "lineage must point at an existing run id"})
-            return self._json(201, {"runId": "r-new"})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
         if path == "/api/v1/chats":

--- a/e2e/uxfix_slice5_test.py
+++ b/e2e/uxfix_slice5_test.py
@@ -17,7 +17,8 @@ What it asserts (design §4.3, the slice-5 DOM AC):
      OMITTED (empty-state budget — the purpose IS the empty state, §3.4); the
      ONE primary action is "+ Build something" — the only accent-filled control
      inside the surface (EC1 within the mode surface).
-  2. Build with work (usage_ws + long_prompt): rows are labelled by
+  2. Build with work (usage_ws + long_prompt; on the FLAT `/runs` home since
+     DES-UX-001 slice S scoped project Build tabs to their own runs): rows are labelled by
      INTENT phrase, never the raw prompt (the long-prompt run truncates with
      the intent leading; the full prompt survives on the row's title) and never
      by the engine's workflow id; statuses read in user words (working · phase
@@ -152,10 +153,14 @@ with sync_playwright() as p:
     }
 
     # ── Scene B: Build with work — one intent-labelled list, inbox, footer ────
+    # Re-scoped by DES-UX-001 slice S (§2.3 rule 2): a project's Build tab now
+    # shows EXACTLY its runs, so the whole-fixture list this scene asserts
+    # lives on the FLAT run home (`/runs`) — the same surface, unscoped, where
+    # every global-list assertion below keeps its original meaning.
     set_fixture(ORIGIN, no_runs=False, usage_ws=True, long_prompt=True)
     page2 = ctx.new_page()
     page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
-    page2.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page2.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
     page2.locator('[data-testid="build-purpose"]').wait_for(timeout=30000)
     page2.locator('[data-testid="gate-inbox"]').wait_for(timeout=30000)
     page2.locator('[data-testid="build-stats-footer"]').wait_for(timeout=30000)  # ws cliUsage

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -228,8 +228,11 @@ with sync_playwright() as p:
     }
 
     # ══ Scene 2 — Build (§5.4): left-border status, purpose, gate inbox, footer ═
+    # Re-scoped by DES-UX-001 slice S (§2.3 rule 2): a project's Build tab now
+    # shows exactly its runs, so the multi-status whole-fixture list (gate +
+    # working + failed edges, the $0.42 footer) lives on the FLAT `/runs` home.
     set_fixture(ORIGIN, usage_ws=True)
-    page.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
     page.locator('[data-testid="build-run-row"][data-status="gate"]').first.wait_for(timeout=30000)
     page.locator('[data-testid="build-stats-footer"]').wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { WorkflowViewer } from './components/WorkflowViewer.js';
 import { WorkPage } from './components/WorkPage.js';
 import { SystemSettings } from './components/SystemSettings.js';
 import { ThemePage } from './components/ThemePage.js';
+import { ambientProjectId } from './hooks/ambientProject.js';
 import { useEventStream } from './hooks/useEventStream.js';
 import { setShortcutsPaletteOpen, useGlobalShortcuts } from './hooks/useGlobalShortcuts.js';
 import { useLegacyRedirect } from './hooks/useLegacyRedirect.js';
@@ -298,9 +299,10 @@ export function App(): React.ReactElement {
    * interactive canvas (§6.3, slice 8); Video still states what is coming and the action
    * that enables it; Chat and Build reuse the existing surfaces above.
    *
-   * Build with nothing open is the existing run home, UNSCOPED: scoping a project's runs
-   * is the board's data plumbing (slices 5-6) and needs launch to file the run it creates,
-   * so filtering here first would hide a run the user had just launched.
+   * Build with nothing open is the run home SCOPED to the project (DES-UX-001 §2.3
+   * rule 2, slice S — superseding the old "unscoped until launch files" caveat: launch
+   * DOES file the run now, and the DTO echoes `project_id` back, so a just-launched run
+   * appears in its project's list within one live-update cycle instead of vanishing).
    */
   function renderModeSurface(m: Mode, pid: string): React.ReactElement {
     // The document's VERSION rides in the query (`?v=N`, slice 9) — the artifact is the
@@ -419,7 +421,15 @@ export function App(): React.ReactElement {
     if (panel === 'repos') {
       return (
         <div className="flex-1 overflow-hidden">
-          <RepositoriesPanel onSelectRun={selectRun} autoShowRegister={showRegisterRepo} navigate={navigate} />
+          <RepositoriesPanel
+            onSelectRun={selectRun}
+            autoShowRegister={showRegisterRepo}
+            navigate={navigate}
+            // Slice S (DES-UX-001 §2.3 rule 1): `/repos/new?project=<id>` — the
+            // ambient-project carry from an entry point inside a project context.
+            // The ONE shared derivation; the panel itself never re-parses the URL.
+            ambientProject={ambientProjectId(pathname, search)}
+          />
         </div>
       );
     }
@@ -544,8 +554,16 @@ export function App(): React.ReactElement {
 
       {/* The runs bottom panel (DES-FEEDBACK-003 §5, slice N): a fourth reader
           of the SAME `useRuns()` array plus the client-held stores — zero new
-          requests, zero new sockets. Fixed at the viewport bottom, everywhere. */}
-      <RunsBottomPanel runs={runs} runPath={runPath} navigate={navigate} immersive={immersive} />
+          requests, zero new sockets. Fixed at the viewport bottom, everywhere.
+          Inside a project route its counters scope to THAT project's runs
+          (DES-UX-001 §2.3 rule 2, slice S — `data-scope="project"`). */}
+      <RunsBottomPanel
+        runs={runs}
+        runPath={runPath}
+        navigate={navigate}
+        immersive={immersive}
+        scopeProjectId={projectId}
+      />
 
       {/* Gate toasts — renders above everything; scoped to the current run. NOT on the
           orchestrator board: there every waiting gate is already an answerable chip on

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -17,10 +17,11 @@ import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { unitsInFlight } from '../api/run-state.js';
 import { useGateStore } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
 import { useSteeringStore } from '../store/steering.js';
+import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
-import { modePath } from '../hooks/useRoute.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -782,7 +783,24 @@ export function CenterDashboard({
 
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
 
-  const filteredRuns = useMemo(() => filterByRange(runs), [runs, filterByRange]);
+  // ── Project scoping (DES-UX-001 §2.3 rule 2, slice S) ─────────────────────
+  // Inside a project shell (`/p/:id/build`) this surface shows EXACTLY the
+  // project's runs — the run DTO's own `project_id` (CREW-UX-2 daemon truth),
+  // with the board model's membership mirror answering only for pre-0.8.0
+  // daemons whose DTOs never carry the field. Never the global list filtered
+  // by nothing. Outside a project (`/runs`) it stays the flat cross-project home.
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  const scopedRuns = useMemo(() => {
+    if (projectId === null) return runs;
+    return runs.filter((v) => {
+      const claimed = sessionProjectId(v.session);
+      return claimed !== undefined
+        ? claimed === projectId
+        : projectIdByRun[v.session.id] === projectId;
+    });
+  }, [runs, projectId, projectIdByRun]);
+
+  const filteredRuns = useMemo(() => filterByRange(scopedRuns), [scopedRuns, filterByRange]);
 
   // ── Derived: active sessions only (feed + send panel scope) ──────────────
   const activeRuns = useMemo(
@@ -929,11 +947,15 @@ export function CenterDashboard({
     return entries;
   }, [byRun, activeRuns]);
 
-  // ── Open gates (sorted newest-first by receivedAt) ────────────────────────
-  const openGates = useMemo(
-    () => Object.values(gates).sort((a, b) => b.receivedAt - a.receivedAt),
-    [gates],
-  );
+  // ── Open gates (sorted newest-first by receivedAt) — inside a project,
+  // scoped to ITS runs (§2.3 rule 2: a project page shows exactly its runs;
+  // a foreign gate belongs to the bar/toasts, not this inbox). ──────────────
+  const openGates = useMemo(() => {
+    const all = Object.values(gates).sort((a, b) => b.receivedAt - a.receivedAt);
+    if (projectId === null) return all;
+    const mine = new Set(scopedRuns.map((v) => v.session.id));
+    return all.filter((g) => mine.has(g.runId));
+  }, [gates, projectId, scopedRuns]);
 
   /** The last recorded `sessionFailed` message for a run, if the store holds one. */
   const failReasonOf = useCallback(
@@ -1031,7 +1053,20 @@ export function CenterDashboard({
                 marginBottom: '10px',
               }}
             >
-              <p style={sectionLabel}>Runs</p>
+              <p style={sectionLabel}>
+                Runs
+                {projectId !== null && (
+                  // EC34 (§2.5): the count beside a list equals the rows beneath
+                  // it, SET-EQUAL on the same paint — one derivation (`runRows`)
+                  // feeds both, so they cannot disagree.
+                  <span
+                    data-testid="project-run-count"
+                    style={{ marginLeft: '6px', color: 'var(--ink-muted)', fontSize: 'var(--text-2xs)', ...mono }}
+                  >
+                    {runRows.length}
+                  </span>
+                )}
+              </p>
               <TimeRangeSelector value={range} onChange={setRange} />
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
@@ -1083,8 +1118,9 @@ export function CenterDashboard({
           <button
             type="button"
             data-testid="build-something"
-            // §4.3: from project context the launch form opens pre-bound and locked.
-            onClick={() => navigate(projectId ? modePath(projectId, 'build', 'new') : '/runs/new')}
+            // §4.3: from project context the launch form opens pre-bound and
+            // locked — the shared `launchPath` spelling (slice S, §2.3 rule 1).
+            onClick={() => navigate(launchPath(projectId, 'build'))}
             style={{
               background: 'var(--accent)',
               color: 'var(--accent-fg)',

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@ import type { GovernanceClaim, InteractionRequest, RepoEntry, SessionView } from
 import { api } from '../api/client.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { fuzzyMatch, type FuzzyResult } from '../palette/fuzzy.js';
+import { launchPath } from '../hooks/ambientProject.js';
 import { modePath, projectPath, type Navigate } from '../hooks/useRoute.js';
 import type { ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useMembershipStore } from '../store/membership.js';
@@ -454,13 +455,15 @@ export function CommandPalette({
 
     // Verbs (§1.3's table — each names its existing mechanism, none invents one).
     const verbs: Array<{ name: string; action: () => void; when?: boolean }> = [
+      // Slice S: the pre-bound-vs-flat fork is the shared `launchPath` spelling
+      // (DES-UX-001 §2.3 rule 1) — the palette may not hand-roll it.
       {
         name: 'New Build',
-        action: () => navigate(projectId !== null ? `${modePath(projectId, 'build')}/new` : '/runs/new'),
+        action: () => navigate(launchPath(projectId, 'build')),
       },
       {
         name: 'New Chat',
-        action: () => navigate(projectId !== null ? `${modePath(projectId, 'chat')}/new` : '/chat/new'),
+        action: () => navigate(launchPath(projectId, 'chat')),
       },
       // The §3.4 fork's other two tines (DES-FEEDBACK-003 §8.4, slice N): the
       // palette and Make's ＋ agree on what can be made. Inside a project shell

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { RepoEntry, SessionView } from '../api/types.js';
 import type { DocSummary } from '../api/interactive.js';
+import { ambientProjectId, launchPath, registerRepoPath } from '../hooks/ambientProject.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
@@ -361,7 +362,13 @@ function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }:
 
 const MAKE_MODES: Mode[] = ['build', 'document', 'video'];
 
-function MakePicker({ navigate, onClose }: { navigate: (p: string) => void; onClose: () => void }): React.ReactElement {
+function MakePicker({ navigate, onClose, ambient }: {
+  navigate: (p: string) => void;
+  onClose: () => void;
+  /** The ambient project (shared derivation, DES-UX-001 §2.3 rule 1) — Build
+   *  from inside a project context opens the PRE-BOUND form, never Unfiled. */
+  ambient: string | null;
+}): React.ReactElement {
   /** null = the three rows; a mode = the project-picker stage (Document/Video). */
   const [stage, setStage] = useState<Mode | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -377,9 +384,11 @@ function MakePicker({ navigate, onClose }: { navigate: (p: string) => void; onCl
 
   const pick = (m: Mode): void => {
     if (m === 'build') {
-      // The unbound launch form, Unfiled default — slice B semantics (§3.4).
+      // Slice S (DES-UX-001 §2.3 rule 1): inside a project context the launch
+      // form opens PRE-BOUND (`/p/:id/build/new`, the slice-B lock); outside
+      // one, the flat Unfiled-default form — the old slice-B semantics (§3.4).
       onClose();
-      navigate('/runs/new');
+      navigate(launchPath(ambient, 'build'));
       return;
     }
     // A doc lives in a project — the bridge mounts per project (§3.4): pick one
@@ -480,6 +489,11 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
   // ── The one-open accordion (§3.2, EC26): zero or one heading expanded. ──────
   // Default derives from the route; the map re-fires ONLY when the mapped
   // heading changes, so a manual collapse survives moves within one territory.
+  // The ambient project (slice S, DES-UX-001 §2.3 rule 1): every "+" verb on
+  // this rail derives "which project am I standing in" from the ONE shared
+  // helper — inside `/p/:id/*` the new-run / new-chat / register-repo gestures
+  // carry the binding instead of resetting to Unfiled (the review's J5 resets).
+  const ambient = ambientProjectId(pathname);
   const mapped = headingForPath(pathname);
   const [openHeading, setOpenHeading] = useState<PathKey | null>(mapped);
   const lastMapped = useRef(mapped);
@@ -587,7 +601,7 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             onNew={() => setMakePickerOpen(v => !v)}
             navigate={navigate}
             extra={makePickerOpen
-              ? <MakePicker navigate={navigate} onClose={() => setMakePickerOpen(false)} />
+              ? <MakePicker navigate={navigate} onClose={() => setMakePickerOpen(false)} ambient={ambient} />
               : undefined}
           >
             {madeRuns.length === 0 && madeDocs.length === 0
@@ -610,7 +624,7 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             path={P_CHAT}
             open={openHeading === 'chat'}
             onToggle={() => toggle('chat')}
-            onNew={() => navigate('/chat/new')}
+            onNew={() => navigate(launchPath(ambient, 'chat'))}
             navigate={navigate}
           >
             {chatRuns.length === 0
@@ -626,7 +640,7 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             path={P_REPOS}
             open={openHeading === 'repos'}
             onToggle={() => toggle('repos')}
-            onNew={() => navigate('/repos/new')}
+            onNew={() => navigate(registerRepoPath(ambient))}
             navigate={navigate}
           >
             <div className="px-3 pb-1">

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -4,6 +4,7 @@ import { listDocs, type DocSummary } from '../api/interactive.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
+import { sessionProjectId } from '../hooks/ambientProject.js';
 import { interactiveRootOf } from '../hooks/useBoardModel.js';
 import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
@@ -175,7 +176,15 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   const myRuns = useMemo(() => {
     const now = Date.now();
     return runs
-      .filter((v) => v.session.id in memberKinds && v.session.archived_at == null)
+      // Slice S (DES-UX-001 §2.3 rule 3): the run DTO's own `project_id` claim
+      // (CREW-UX-2) places a run here the instant `GET /runs` reconciles — no
+      // waiting on the mount-time members snapshot. The membership join stays
+      // as the pre-0.8.0 fallback (field absent) and as the kind/clock source.
+      .filter((v) => {
+        if (v.session.archived_at != null) return false;
+        const claimed = sessionProjectId(v.session);
+        return claimed !== undefined ? claimed === projectId : v.session.id in memberKinds;
+      })
       .map((v) => {
         const signal = runSignal(v, gates[v.session.id]?.receivedAt, attachedAt[v.session.id] ?? fallbackAt);
         return {
@@ -189,7 +198,7 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         { score: a.score, at: a.at, name: a.view.session.problem },
         { score: b.score, at: b.at, name: b.view.session.problem },
       ));
-  }, [runs, memberKinds, attachedAt, gates, fallbackAt]);
+  }, [runs, memberKinds, attachedAt, gates, fallbackAt, projectId]);
 
   const openRuns = myRuns.filter(({ view }) => !['completed', 'cancelled', 'failed'].includes(view.session.status));
   const waiting = myRuns.filter(({ view }) => view.session.status === 'awaiting_human');

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -13,6 +13,14 @@ interface Props {
   onSelectRun?: (runId: string) => void;
   autoShowRegister?: boolean;
   navigate: (path: string) => void;
+  /**
+   * Slice S (DES-UX-001 §2.3 rule 1): the ambient project carried into
+   * `/repos/new?project=<id>` by an entry point inside a project context —
+   * derived by the ONE shared helper (`ambientProjectId`), passed down, never
+   * re-parsed here. When set, the register form's project field pre-binds to
+   * it and LOCKS (the slice-B contract) — never a silent reset to Unfiled.
+   */
+  ambientProject?: string | null;
 }
 
 const TERMINAL = new Set(['completed', 'cancelled', 'failed']);
@@ -179,7 +187,7 @@ function FailingReposTile({ runs, repos, attachedAt, now }: {
   );
 }
 
-export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: Props): React.ReactElement {
+export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, ambientProject = null }: Props): React.ReactElement {
   const [repos, setRepos] = useState<RepoEntry[]>([]);
   const [runs, setRuns] = useState<SessionView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -206,9 +214,21 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
   // binds via POST /projects/:id/members (`crew.repo`) right after registration.
   // `null` = Unfiled: register exactly as before, attach nothing.
   const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(ambientProject);
   const [showNewProject, setShowNewProject] = useState(false);
   const projectsRequested = useRef(false);
+
+  // The ambient carry pre-binds and LOCKS the field (§2.5's AC: entered from a
+  // project context, the form renders `data-locked` — never Unfiled). Resolve
+  // the project's NAME up front, exactly like the composer's §4.3 pre-bind.
+  const locked = ambientProject !== null;
+  useEffect(() => {
+    if (ambientProject !== null) {
+      setSelectedProjectId(ambientProject);
+      loadProjects();
+    }
+    // loadProjects is ref-guarded and single-shot, so listing only the carry is safe.
+  }, [ambientProject]);
 
   function loadProjects(): void {
     if (projectsRequested.current) return;
@@ -287,7 +307,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
       setNewGitUrl('');
       setCheckoutPath('');
       setSourceMode('local');
-      setSelectedProjectId(null);
+      setSelectedProjectId(ambientProject);
       nameEditedRef.current = false;
 
       navigate('/repo-detail/' + encodeURIComponent(repo.id));
@@ -369,11 +389,19 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate }: P
                 Project
               </span>
               <ProjectSwitcher
-                current={projects.find((p) => p.id === selectedProjectId) ?? null}
+                current={
+                  projects.find((p) => p.id === selectedProjectId)
+                  // Locked-but-still-resolving: show the id rather than a false
+                  // "Unfiled" while the one name-resolving read is in flight.
+                  ?? (locked && selectedProjectId !== null
+                    ? { id: selectedProjectId, name: selectedProjectId, description: null, status: 'active', scope: '', created_at: 0, updated_at: 0 }
+                    : null)
+                }
                 projects={projects}
                 onSelect={setSelectedProjectId}
                 onNewProject={() => setShowNewProject(true)}
                 onOpen={loadProjects}
+                locked={locked}
               />
             </div>
 

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef } from 'react';
 import type { SessionStatus, SessionView } from '../api/types.js';
 import { GATE_HASH } from '../board/gateActions.js';
+import { sessionProjectId } from '../hooks/ambientProject.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
+import { useProjectsStore } from '../store/projects.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
 import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
 import { prefersReducedMotion } from './LiveEdge.js';
@@ -128,18 +130,52 @@ interface Props {
   navigate: (path: string) => void;
   /** True inside Document/Video — entering auto-collapses the sheet (EC27). */
   immersive: boolean;
+  /**
+   * Slice S (DES-UX-001 §2.3 rule 2): inside a project route the counters
+   * scope to THAT project's runs — `data-scope="project"` — derived from the
+   * run DTO's `project_id` (CREW-UX-2 daemon truth; the membership mirror
+   * answers only for pre-0.8.0 daemons). `null` = the global counters
+   * (`data-scope="global"`), everywhere outside a project.
+   */
+  scopeProjectId: string | null;
 }
 
-export function RunsBottomPanel({ runs, runPath, navigate, immersive }: Props): React.ReactElement {
+export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProjectId }: Props): React.ReactElement {
   const expanded = useRunsPanelStore((s) => s.expanded);
   const gates = useGateStore((s) => s.gates);
   const logs = useRuntimeStore((s) => s.logs);
   const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  const projects = useProjectsStore((s) => s.projects);
   const rootRef = useRef<HTMLDivElement>(null);
 
-  const stats = useMemo(() => runStats(runs), [runs]);
+  // Zero-new-requests scoping (§5.1 still holds): a pure filter over the runs
+  // prop — DTO truth first, mirror fallback — never a fetch of its own.
+  const scopedRuns = useMemo(() => {
+    if (scopeProjectId === null) return runs;
+    return runs.filter((v) => {
+      const claimed = sessionProjectId(v.session);
+      return claimed !== undefined
+        ? claimed === scopeProjectId
+        : projectIdByRun[v.session.id] === scopeProjectId;
+    });
+  }, [runs, scopeProjectId, projectIdByRun]);
+
+  /** A sheet row's project label: the DTO's own claim resolved against the
+   *  already-loaded projects store (zero membership fetches — §2.5's AC),
+   *  falling back to the board model's mirror for pre-0.8.0 daemons. */
+  const projectLabelOf = (view: SessionView): string => {
+    const claimed = sessionProjectId(view.session);
+    if (claimed === null) return '';
+    if (claimed !== undefined) {
+      return projects.find((p) => p.id === claimed)?.name ?? claimed;
+    }
+    return projectNameByRun[view.session.id] ?? '';
+  };
+
+  const stats = useMemo(() => runStats(scopedRuns), [scopedRuns]);
   const spend = useMemo(() => observedSpend(logs), [logs]);
-  const rows = useMemo(() => recentRuns(runs, SHEET_MAX), [runs]);
+  const rows = useMemo(() => recentRuns(scopedRuns, SHEET_MAX), [scopedRuns]);
   const quiet = stats.working === 0 && stats.gates === 0 && stats.failed === 0;
 
   // EC27: entering an immersive mode collapses an open sheet — the canvas-first
@@ -217,6 +253,7 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive }: Props): 
       <div
         data-testid="runs-bottom-bar"
         data-expanded={String(expanded)}
+        data-scope={scopeProjectId === null ? 'global' : 'project'}
         data-working={stats.working}
         data-gates={stats.gates}
         data-failed={stats.failed}
@@ -334,7 +371,7 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive }: Props): 
                     className="truncate shrink-0"
                     style={{ maxWidth: '20ch', fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}
                   >
-                    {projectNameByRun[id] ?? ''}
+                    {projectLabelOf(view)}
                   </span>
                   <span className="flex-1" />
                   <span

--- a/src/hooks/ambientProject.ts
+++ b/src/hooks/ambientProject.ts
@@ -1,0 +1,67 @@
+import type { AgentSession } from '../api/types.js';
+import { modePath } from './useRoute.js';
+
+/**
+ * The ONE ambient-project derivation (DES-UX-001 §2.3 rule 1, slice S): every
+ * launch entry point — the composer route, the make-picker, the rail's "+"
+ * verbs, the palette rows, the repo-register form — derives "which project am
+ * I standing in" from HERE, never by hand-rolling its own parse. The review's
+ * J5 observation was exactly a hand-rolled entry point resetting to Unfiled.
+ *
+ * Two spellings of ambience, in precedence order:
+ *   1. the project shell's path segment — `/p/:projectId[/...]`;
+ *   2. the `?project=<id>` carry — for surfaces that live OUTSIDE the shell
+ *      (the flat `/repos/new` register form) but are ENTERED from a project
+ *      context: the navigating entry point spells the carry via
+ *      `registerRepoPath`, and the form re-derives it from its own URL.
+ *
+ * `default` (the daemon's synthesized Unfiled bucket) is never ambient — a
+ * helper hit there means *no project*, the same exclusion the board applies.
+ */
+export function ambientProjectId(pathname: string, search = ''): string | null {
+  const [, first = '', second = ''] = pathname.split('/');
+  const fromPath = first === 'p' && second !== '' ? safeDecode(second) : null;
+  const fromSearch = new URLSearchParams(search).get('project');
+  const id = fromPath ?? (fromSearch !== null && fromSearch !== '' ? fromSearch : null);
+  return id === 'default' ? null : id;
+}
+
+function safeDecode(s: string): string {
+  try { return decodeURIComponent(s); } catch { return s; }
+}
+
+/**
+ * Where a "new run" / "new chat" gesture lands (§2.3 rule 1): inside a project
+ * context, the shell's pre-bound create route (`/p/:id/build/new`, `/p/:id/
+ * chat/new` — the slice-B lock); outside one, the flat Unfiled-default forms.
+ */
+export function launchPath(ambient: string | null, verb: 'build' | 'chat'): string {
+  if (ambient !== null) return `${modePath(ambient, verb)}/new`;
+  return verb === 'chat' ? '/chat/new' : '/runs/new';
+}
+
+/**
+ * Where a "register repo" gesture lands: the flat form, carrying the ambient
+ * project as `?project=` so the form pre-binds instead of resetting to Unfiled.
+ */
+export function registerRepoPath(ambient: string | null): string {
+  return ambient === null ? '/repos/new' : `/repos/new?project=${encodeURIComponent(ambient)}`;
+}
+
+/**
+ * The run DTO's own project claim (CREW-UX-2, api-types 0.8.0 — `project_id`
+ * echoed from the membership record on BOTH `GET /runs` and `GET /runs/:id`).
+ * Three-valued on purpose, matching the wire contract exactly:
+ *
+ *   string     — filed into that project (daemon truth);
+ *   null       — GENUINELY unfiled (the daemon's word, not a failed join);
+ *   undefined  — a pre-0.8.0 daemon that never joins: the caller must fall
+ *                back to the client-side membership join, never assume unfiled.
+ *
+ * The synthesized `default` bucket is normalized to `null` — it IS Unfiled.
+ */
+export function sessionProjectId(s: AgentSession): string | null | undefined {
+  const pid = s.project_id;
+  if (pid === undefined) return undefined;
+  return pid === null || pid === 'default' ? null : pid;
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -9,6 +9,7 @@ import {
   type Band,
   type Signal,
 } from '../board/boardAttention.js';
+import { sessionProjectId } from './ambientProject.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { useGateStore, type OpenGate } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
@@ -25,11 +26,16 @@ import { useRuntimeStore } from '../store/runtime.js';
  * and doc status come from the shared runtime store, which the cards subscribe to
  * directly (§3.5: one socket, one store, no polling).
  *
- * Runs are joined to projects through MEMBERSHIP (`crew.run` / `crew.chat` refs) —
- * `AgentSession` carries no project id, so this is the only binding that exists.
- * Memberships are re-read when a run the board has never placed shows up in the
- * run list (slice 6): a run launched from a card's quick action, or by any other
- * client, must land on its project's card without a reload.
+ * Runs are placed on projects by the DTO's own `project_id` (CREW-UX-2,
+ * api-types 0.8.0: the daemon echoes the membership record at DTO assembly —
+ * DES-UX-001 §2.3 rule 3, "one truth, one source"). Against a pre-0.8.0 daemon
+ * the field is ABSENT and the client-side MEMBERSHIP join (`crew.run` /
+ * `crew.chat` refs) stands as the fallback. The members wire is still read
+ * either way — it is the only source of the repo binding and the `attached_at`
+ * clocks — and is re-read when a run the board cannot place shows up in the
+ * run list (slice 6): a run launched by another client must land on its
+ * project's card without a reload. A run CARRYING `project_id` never needs
+ * that placement re-read: the daemon already answered.
  *
  * Ordering is by DECAYED attention score (`boardAttention.ts`), not by a fixed
  * bucket — the F3 fix: a failure from last week no longer outranks a run that is
@@ -153,6 +159,16 @@ interface Bindings {
 }
 
 const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {} };
+
+/**
+ * DTO-truth placement (DES-UX-001 §2.3 rule 3): the run's own `project_id`
+ * claim wins wherever the daemon echoes one; the client-side membership join
+ * answers only for pre-0.8.0 daemons whose DTOs never carry the field.
+ */
+function belongsTo(v: SessionView, projectId: string, joined: ReadonlySet<string>): boolean {
+  const claimed = sessionProjectId(v.session);
+  return claimed !== undefined ? claimed === projectId : joined.has(v.session.id);
+}
 
 /**
  * Mirror the run→project join into the shared membership store (DES-FEEDBACK-003
@@ -299,13 +315,17 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   // A run the board cannot place yet (launched from a quick action, or by another
   // client) means the membership snapshot is stale — re-read it. Guarded per run id,
   // so the unfiled runs that legitimately belong to no project cost exactly one pass
-  // each rather than one per `GET /runs` reconcile.
+  // each rather than one per `GET /runs` reconcile. A run whose DTO CARRIES
+  // `project_id` (string OR null — CREW-UX-2) is never "unplaced": the daemon
+  // already answered, so it costs zero membership fetches (§2.5's request-tap AC).
   useEffect(() => {
     // Nothing is "unplaced" until the first membership read has landed — without this
     // the initial run list would fan out a second, identical read behind the first.
     if (projects.length === 0 || Object.keys(bindings).length === 0) return;
     const known = new Set(Object.values(bindings).flatMap((b) => [...b.runIds]));
-    const unplaced = runs.filter((v) => !known.has(v.session.id) && !placed.current.has(v.session.id));
+    const unplaced = runs.filter((v) =>
+      sessionProjectId(v.session) === undefined
+      && !known.has(v.session.id) && !placed.current.has(v.session.id));
     if (unplaced.length === 0) return;
     for (const v of unplaced) placed.current.add(v.session.id);
     let cancelled = false;
@@ -358,7 +378,7 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
       return projects
         .map((project): BoardProject => {
           const b = bindings[project.id] ?? EMPTY;
-          const mine = runs.filter((v) => b.runIds.has(v.session.id));
+          const mine = runs.filter((v) => belongsTo(v, project.id, b.runIds));
           const { score, signal } = topSignal(
             signalsOf(project, mine, b.docs, gates, logTail, failedAt, docActivity[project.id]?.at),
             now,
@@ -379,13 +399,20 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
     [projects, bindings, runs, gates, docActivity, failedAt, now],
   );
 
-  // The unfiled set (F5): what the run list holds that no membership claims. Held
-  // back until the first membership read lands — before that, EVERY run would look
-  // unfiled and the shelf would flash into existence on each load.
+  // The unfiled set (F5, re-pointed by DES-UX-001 §2.3 rule 3): a run whose DTO
+  // carries `project_id: null` is what the DAEMON considers unfiled — daemon
+  // truth needs no hold-back. Only the pre-0.8.0 fallback (field absent, the
+  // client-side join) stays held back until the first membership read lands —
+  // before that, EVERY such run would look unfiled and the shelf would flash
+  // into existence on each load.
   const unfiled = useMemo(() => {
-    if (loading || (projects.length > 0 && Object.keys(bindings).length === 0)) return [];
+    const joinReady = !loading && !(projects.length > 0 && Object.keys(bindings).length === 0);
     const known = new Set(Object.values(bindings).flatMap((b) => [...b.runIds]));
-    return runs.filter((v) => !known.has(v.session.id));
+    return runs.filter((v) => {
+      const claimed = sessionProjectId(v.session);
+      if (claimed !== undefined) return claimed === null;
+      return joinReady && !known.has(v.session.id);
+    });
   }, [runs, projects, bindings, loading]);
 
   return { items, unfiled, failedAt, loading, error };

--- a/tests/RunsBottomPanel.test.tsx
+++ b/tests/RunsBottomPanel.test.tsx
@@ -38,7 +38,7 @@ const usage = (costUsd: number, ts = Date.now()): LoggedEvent => ({
 
 const runPath = (id: string): string => `/runs/${id}`;
 
-function mount(over: { runs?: typeof W2; immersive?: boolean } = {}): {
+function mount(over: { runs?: typeof W2; immersive?: boolean; scope?: string | null } = {}): {
   navigate: ReturnType<typeof vi.fn>;
   rerender: (ui: React.ReactElement) => void;
 } {
@@ -49,6 +49,7 @@ function mount(over: { runs?: typeof W2; immersive?: boolean } = {}): {
       runPath={runPath}
       navigate={navigate}
       immersive={over.immersive ?? false}
+      scopeProjectId={over.scope ?? null}
     />,
   );
   return { navigate, rerender };
@@ -208,7 +209,7 @@ describe('EC27 — immersive routes auto-collapse the sheet', () => {
   it('entering Document/Video collapses an open sheet; a manual re-expand stands', () => {
     const navigate = vi.fn();
     const ui = (immersive: boolean): React.ReactElement => (
-      <RunsBottomPanel runs={W2} runPath={runPath} navigate={navigate} immersive={immersive} />
+      <RunsBottomPanel runs={W2} runPath={runPath} navigate={navigate} immersive={immersive} scopeProjectId={null} />
     );
     const { rerender } = render(ui(false));
     fireEvent.click(screen.getByTestId('runs-bar-toggle'));
@@ -256,7 +257,7 @@ describe('§5.7 Escape precedence — palette → sheet → triage, one registry
     render(
       <>
         <Triage items={items} />
-        <RunsBottomPanel runs={W2} runPath={runPath} navigate={vi.fn()} immersive={false} />
+        <RunsBottomPanel runs={W2} runPath={runPath} navigate={vi.fn()} immersive={false} scopeProjectId={null} />
       </>,
     );
     press('j'); // select the first triage row

--- a/tests/ambientProject.test.ts
+++ b/tests/ambientProject.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ambientProjectId,
+  launchPath,
+  registerRepoPath,
+  sessionProjectId,
+} from '../src/hooks/ambientProject.js';
+import { makeSession } from './factories.js';
+
+/**
+ * Slice S (DES-UX-001 §2.3 rule 1): the ONE ambient-project derivation every
+ * launch entry point shares — plus the three-valued CREW-UX-2 DTO reader.
+ */
+
+describe('ambientProjectId — the shared route derivation', () => {
+  it('derives the project from a /p/:id/* path, any depth', () => {
+    expect(ambientProjectId('/p/upload-endpoint')).toBe('upload-endpoint');
+    expect(ambientProjectId('/p/upload-endpoint/build')).toBe('upload-endpoint');
+    expect(ambientProjectId('/p/upload-endpoint/build/new')).toBe('upload-endpoint');
+    expect(ambientProjectId('/p/q3-review-deck/document/deck')).toBe('q3-review-deck');
+  });
+
+  it('decodes an encoded id exactly like the router', () => {
+    expect(ambientProjectId('/p/a%20b/chat')).toBe('a b');
+  });
+
+  it('reads the ?project= carry for surfaces outside the shell', () => {
+    expect(ambientProjectId('/repos/new', '?project=upload-endpoint')).toBe('upload-endpoint');
+    expect(ambientProjectId('/repos/new', '')).toBeNull();
+    expect(ambientProjectId('/repos/new', '?project=')).toBeNull();
+  });
+
+  it('the path segment wins over the search carry', () => {
+    expect(ambientProjectId('/p/alpha/build', '?project=beta')).toBe('alpha');
+  });
+
+  it('never returns the synthesized default bucket — that means NO project', () => {
+    expect(ambientProjectId('/p/default/build')).toBeNull();
+    expect(ambientProjectId('/repos/new', '?project=default')).toBeNull();
+  });
+
+  it('flat routes have no ambient project', () => {
+    expect(ambientProjectId('/')).toBeNull();
+    expect(ambientProjectId('/runs')).toBeNull();
+    expect(ambientProjectId('/work')).toBeNull();
+    expect(ambientProjectId('/p/')).toBeNull();
+  });
+});
+
+describe('launchPath / registerRepoPath — the shared entry-point spellings', () => {
+  it('inside a project: the pre-bound create routes (the slice-B lock)', () => {
+    expect(launchPath('upload-endpoint', 'build')).toBe('/p/upload-endpoint/build/new');
+    expect(launchPath('upload-endpoint', 'chat')).toBe('/p/upload-endpoint/chat/new');
+  });
+
+  it('outside a project: the flat Unfiled-default forms', () => {
+    expect(launchPath(null, 'build')).toBe('/runs/new');
+    expect(launchPath(null, 'chat')).toBe('/chat/new');
+  });
+
+  it('register-repo carries the ambient project as ?project=', () => {
+    expect(registerRepoPath('upload-endpoint')).toBe('/repos/new?project=upload-endpoint');
+    expect(registerRepoPath('a b')).toBe('/repos/new?project=a%20b');
+    expect(registerRepoPath(null)).toBe('/repos/new');
+  });
+});
+
+describe('sessionProjectId — the three-valued CREW-UX-2 DTO reader', () => {
+  it('a string claim is daemon truth', () => {
+    expect(sessionProjectId(makeSession({ project_id: 'upload-endpoint' }))).toBe('upload-endpoint');
+  });
+
+  it('null = GENUINELY unfiled (the daemon said so)', () => {
+    expect(sessionProjectId(makeSession({ project_id: null }))).toBeNull();
+  });
+
+  it('absent = a pre-0.8.0 daemon — undefined, so callers fall back to the join', () => {
+    expect(sessionProjectId(makeSession())).toBeUndefined();
+  });
+
+  it('the synthesized default bucket normalizes to null — it IS Unfiled', () => {
+    expect(sessionProjectId(makeSession({ project_id: 'default' }))).toBeNull();
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §2 (slice S)** — project scoping that means it (BRIEF-UX-001 A2 CRITICAL: "the chip sends, the DTO forgets, the views read the wrong source").

## What changed
- **One ambient-project derivation** (`src/hooks/ambientProject.ts`): every launch entry point (rail Make/Chat/Repo ＋, palette New Build/Chat, dashboard CTA, repo register pre-bind+lock) routes through the same helper — no more per-surface guesswork.
- **DTO truth** (CREW-UX-2 adoption): the three-valued `sessionProjectId` reader — string = filed, null = genuinely unfiled, absent = pre-0.8.0 fallback to the membership join. Board placement, the unfiled shelf, dashboards, and the bottom panel all re-pointed; DTO-carrying runs skip the membership re-read.
- **EC34 (counts equal rows)**: the project Build tab's count derives from the same `runRows` array it renders, same paint; footer counters fork `data-scope=project|global`.
- api-types ^0.7.0→^0.8.0.

## Verified at slice time
- eslint --max-warnings 0 · tsc --noEmit · vitest **1298/1298** (post-rebase, union with slice V's suites)
- Slice rig `ux_sliceS_test.py` 11/11 scenes (real 0.8.0 wire shapes, launch POST carrying projectId, zero membership re-reads request-tapped) + 27 regression rigs incl. studio_standalone 22/22 against a real local daemon
- **Live-daemon proof** (read-only): project ux-trust-spine's Build tab showed exactly its 5 runs, count == rows, footer scoped
- Adversarial verifier approved; negative check confirms the rig fails on main
- §11.2 re-scopes as a dedicated commit: uxfix_slice5 scene B + vision_slice4 scene 2 re-pointed from the global-list-on-/p/:id/build assertion (the exact behavior §2.3 removes) to /runs

## Post-rebase reconciliation (dedicated commit)
Rebased over slices V + BRIDGE-UX-1: the shared fixture's `assemble_runs()` gains the `project_dto` corpus and the two colliding `POST /api/v1/runs` handlers merged into one (retryOf validation always; real launch under project_dto; V's 201 otherwise) — V/S/R slice rigs + slice5/vision4/N/H all green on the merged fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
