### PR TITLE
DES-UX-001 slice W: one selector per metric

### DIFF
--- a/e2e/ux_sliceW_test.py
+++ b/e2e/ux_sliceW_test.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+ux_sliceW_test.py — the DES-UX-001 slice-W gate: reconcile the numbers (§5,
+the campaign's A5 MAJOR — "Right rail 'No usage reported yet' beside status bar
+'$0.12 observed'; 'RUNS (24H) 1 failed' vs unlabeled '12 failed'; 'ACTIVE RUNS
+(0)' directly above two listed runs").
+
+One rule, mechanically enforced (§5.3): every displayed metric has exactly one
+selector (`src/board/metrics.ts`), and every count names its window (EC39 —
+"24h", "all", "this session"; the unlabeled number is a defect class).
+
+The §5.5 DOM ACs, verbatim mapping:
+
+  1. With the W2 fixture (metrics_ws burn drip on): the bottom bar's counts,
+     the landing lede's numbers, and the margin notes agree exactly — this rig
+     derives the expected values from the fixture's own constants and asserts
+     all the surfaces render them. The bar's "2 failed (all)" beside the
+     lede's "1 failed (24h)" is two LABELED truths, not a contradiction: both
+     windows are named in the DOM.
+  2. Every element matching `[data-testid$="-count"]` carries `data-window`
+     and a visible window label beside it; a lint-style grep asserts no
+     component folds `cliUsage` frames outside `src/board/metrics.ts`, and
+     that every §5.1 offender imports the shared module.
+  3. A dashboard header's `data-count` equals its list's rendered row count on
+     the same paint (set-equality — the "ACTIVE RUNS (0) over two rows"
+     regression pin), on the project dashboard's tiles AND the Build tab's
+     EC34 count.
+  + silent filters declare themselves (§5.3 adjacency): the Build list's cap
+    says "showing N of M" in the same breath as the rows it clips.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-W-windows.png   the landing: lede + its 24h label, spend + its session
+                     label, the bottom bar's counts + the "all" label — every
+                     number windowed, all agreeing.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4385),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+
+from uxfix_fixture import (
+    ATTACHED_AT,
+    HIDE_GATE_TOASTS,
+    NOW0,
+    PROJECTS,
+    REPO,
+    RUNS,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4385"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+HOUR = 3_600_000
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── The independent derivation (AC 1: computed from the fixture, never
+#    snapshotted from the page) ─────────────────────────────────────────────────
+#
+# Window "all" (the bar): the unwindowed status fold over the run list — the
+# orphan (executing, default ON) rides it.
+TERMINAL = {"completed", "failed", "cancelled"}
+ALL_RUNS = [v["session"] for v in RUNS] + [
+    {"id": "r-orphan", "status": "executing"}]
+EXP_WORKING = sum(1 for s in ALL_RUNS
+                  if s["status"] not in TERMINAL and s["status"] != "awaiting_human")
+EXP_GATES = sum(1 for s in ALL_RUNS if s["status"] == "awaiting_human")
+EXP_FAILED_ALL = sum(1 for s in ALL_RUNS if s["status"] == "failed")
+
+# Window "24h" (the lede + the margin outcome bar): terminal runs whose LAST
+# observed clock is in-window. Clocks the page can honestly reach once the
+# metrics_ws burn drip has fully landed: the attach clocks, the r-auth durable
+# failure tail (13m — same side of the window as its attach), and the drip's
+# ARRIVAL-stamped frames, which pull the two smokes (attach 6 DAYS out) into
+# the observed window. r-legacy stays out (8-day tail, no drip frame).
+DRIP_TOUCHED = {"r-upload", "r-smoke1", "r-smoke2"}
+WINDOW_START = NOW0 - 24 * HOUR
+EXP_FINISHED = EXP_PASSED = EXP_FAILED_24H = 0
+for v in RUNS:  # the orphan is clockless and non-terminal either way
+    s = v["session"]
+    if s["status"] not in TERMINAL:
+        continue
+    attach = ATTACHED_AT.get(s["id"])
+    in_window = (attach is not None and attach >= WINDOW_START) or s["id"] in DRIP_TOUCHED
+    if not in_window:
+        continue
+    EXP_FINISHED += 1
+    if s["status"] == "completed":
+        EXP_PASSED += 1
+    else:
+        EXP_FAILED_24H += 1
+
+BOARD_PROJECTS = [p for p in PROJECTS if p["status"] == "active" and p["id"] != "default"]
+
+# The margin outcome bar buckets on the ATTACH clock alone (no arrival pull):
+# q3 (gate), api (gate), upload (run), auth (fail) in-window; legacy + smokes +
+# orphan unplaced.
+EXP_BAR24_TOTAL = sum(1 for v in RUNS if ATTACHED_AT.get(v["session"]["id"], 0) >= WINDOW_START)
+EXP_BAR24_UNPLACED = len(RUNS) + 1 - EXP_BAR24_TOTAL  # +1 = the clockless orphan
+
+# The drip's costed dollars (uxfix_fixture burn_drip: 0.04 + 0.11 + 0.09 + 0.18;
+# the null-cost frame must never fold to $0).
+EXP_SPEND = "0.42"
+EXP_SPEND_POINTS = "4"
+
+
+def plural(n: int, word: str) -> str:
+    return f"{n} {word}" + ("" if n == 1 else "s")
+
+
+def compose_lede(finished: int, passed: int, failed: int, gates: int, live: int, projects: int) -> str:
+    """The §7.3 grammar, independently implemented (drop-outs included)."""
+    if finished == 0 and gates == 0 and live == 0:
+        return f"All quiet. {plural(projects, 'project')}, nothing running, nothing waiting."
+    s = "While you were away: "
+    if finished > 0:
+        split = ", ".join(x for x in (
+            f"{passed} passed" if passed else None,
+            f"{failed} failed" if failed else None) if x)
+        s += f"{plural(finished, 'run')} finished — {split}"
+    elif gates == 0:
+        s += f"nothing finished — {plural(live, 'run')} still moving"
+    if gates > 0:
+        if finished > 0:
+            s += " — and "
+        s += f"{plural(gates, 'gate')} {'is' if gates == 1 else 'are'} waiting on you"
+    return s + "."
+
+
+EXPECTED_LEDE = compose_lede(EXP_FINISHED, EXP_PASSED, EXP_FAILED_24H,
+                             EXP_GATES, EXP_WORKING, len(BOARD_PROJECTS))
+
+# ── AC 2's lint-style grep: no component folds cliUsage outside the module ─────
+SRC = REPO / "src"
+offender_folds: list[str] = []
+for path in sorted(SRC.rglob("*.tsx")):
+    text = path.read_text(encoding="utf-8")
+    if re.search(r"===\s*['\"]cliUsage['\"]", text):
+        offender_folds.append(str(path.relative_to(REPO)))
+check("no_inline_cliusage_folds", offender_folds == [], folds_found=offender_folds)
+
+MUST_IMPORT = ["components/RunsBottomPanel.tsx", "components/NarrativeBand.tsx",
+               "components/CenterDashboard.tsx", "components/TokenBurnSparkline.tsx",
+               "components/RunOutcomeBar.tsx", "components/NotificationBell.tsx",
+               "components/ProjectDashboard.tsx"]
+missing_imports = [f for f in MUST_IMPORT
+                   if "board/metrics.js" not in (SRC / f).read_text(encoding="utf-8")]
+check("offenders_import_shared_module", missing_imports == [], missing=missing_imports)
+
+# ── The same-origin build + the shared W2 fixture, burn drip ON ────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, metrics_ws=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def goto(path: str) -> None:
+        page.goto(f"{ORIGIN}{path}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # ── Scene 1 (AC 1): the landing — every surface, one set of numbers ────────
+    goto("/")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    # Settle on the drip having FULLY landed (4 costed frames), so every fold
+    # below reads the same final store state on the same paint.
+    page.wait_for_function(
+        f"""() => document.querySelector('[data-testid="token-burn-sparkline"]')
+                    ?.getAttribute('data-points') === '{EXP_SPEND_POINTS}'""",
+        timeout=20000)
+    page.wait_for_function(
+        f"""expected => document.querySelector('[data-testid="landing-lede"]')
+                          ?.textContent === expected""",
+        arg=EXPECTED_LEDE, timeout=15000)
+
+    facts = page.evaluate(
+        """() => {
+             const q = (sel) => document.querySelector(sel);
+             const bar = q('[data-testid="runs-bottom-bar"]');
+             const outcome = q('[data-testid="run-outcome-bar"]');
+             const burn = q('[data-testid="token-burn-sparkline"]');
+             return {
+               barWorking: bar?.dataset.working ?? null,
+               barGates: bar?.dataset.gates ?? null,
+               barFailed: bar?.dataset.failed ?? null,
+               barWindow: bar?.dataset.window ?? null,
+               barText: (bar?.textContent ?? '').replace(/\\s+/g, ' '),
+               barWindowLabel: q('[data-testid="runs-bar-window"]')?.textContent ?? null,
+               barSpendLabel: q('[data-testid="runs-bar-spend-window"]')?.textContent ?? null,
+               lede: q('[data-testid="landing-lede"]')?.textContent ?? null,
+               ledeWindow: q('[data-testid="lede-window"]')?.textContent ?? null,
+               ledeSpend: q('[data-testid="lede-spend"]')?.textContent ?? null,
+               ledeSpendWindow: q('[data-testid="lede-spend-window"]')?.textContent ?? null,
+               outcomeTotal: outcome?.dataset.total ?? null,
+               outcomeUnplaced: outcome?.dataset.unplaced ?? null,
+               outcomeWindow: outcome?.dataset.window ?? null,
+               burnTotal: burn?.dataset.total ?? null,
+               burnWindow: burn?.dataset.window ?? null,
+               burnText: (burn?.textContent ?? '').replace(/\\s+/g, ' '),
+             };
+           }""")
+
+    check("bar_counts_match_fixture",
+          facts["barWorking"] == str(EXP_WORKING)
+          and facts["barGates"] == str(EXP_GATES)
+          and facts["barFailed"] == str(EXP_FAILED_ALL)
+          and f"${EXP_SPEND} observed" in facts["barText"],
+          expected={"working": EXP_WORKING, "gates": EXP_GATES, "failed": EXP_FAILED_ALL},
+          **{k: facts[k] for k in ("barWorking", "barGates", "barFailed", "barText")})
+
+    check("lede_matches_fixture", facts["lede"] == EXPECTED_LEDE,
+          expected=EXPECTED_LEDE, lede=facts["lede"])
+
+    # The §5.1 offender pair, reconciled: bar spend == lede spend == the burn
+    # curve's endpoint — one selector, three surfaces, one number.
+    check("spend_agrees_everywhere",
+          facts["ledeSpend"] == f"${EXP_SPEND} observed"
+          and f"${EXP_SPEND} observed" in facts["barText"]
+          and facts["burnTotal"] == f"{float(EXP_SPEND):.4f}"
+          and f"${EXP_SPEND}" in facts["burnText"],
+          **{k: facts[k] for k in ("ledeSpend", "burnTotal", "burnText")})
+
+    # EC39: "1 failed (24h)" beside "2 failed (all)" — both windows NAMED.
+    check("windows_are_named",
+          facts["barWindow"] == "all"
+          and facts["barWindowLabel"] == "all"
+          and facts["barSpendLabel"] == "this session"
+          and facts["ledeWindow"] == "24h"
+          and facts["ledeSpendWindow"] == "this session"
+          and facts["outcomeWindow"] == "24h"
+          and facts["burnWindow"] == "session"
+          and "this session" in facts["burnText"],
+          **{k: facts[k] for k in ("barWindow", "barWindowLabel", "barSpendLabel",
+                                   "ledeWindow", "ledeSpendWindow", "outcomeWindow",
+                                   "burnWindow")})
+
+    # The margin's 24h outcome bar: the shared selector's totals on the honest
+    # attach clock — in-window vs unplaced derived from the fixture.
+    check("outcome_bar_24h_fold",
+          facts["outcomeTotal"] == str(EXP_BAR24_TOTAL)
+          and facts["outcomeUnplaced"] == str(EXP_BAR24_UNPLACED),
+          expected={"total": EXP_BAR24_TOTAL, "unplaced": EXP_BAR24_UNPLACED},
+          **{k: facts[k] for k in ("outcomeTotal", "outcomeUnplaced")})
+
+    # ── Capture: the money shot — every number on one screen, windowed ─────────
+    page.screenshot(path=str(VSHOTS / "ux-W-windows.png"))
+
+    # ── Scene 2 (AC 2): the `-count` class contract, on a paint that HAS one ───
+    goto("/p/upload-endpoint/build")
+    page.locator('[data-testid="build-dashboard"]').wait_for(timeout=30000)
+    page.locator('[data-testid="build-run-row"]').first.wait_for(timeout=15000)
+    count_class = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid$="-count"]'))
+                 .map(el => ({ id: el.getAttribute('data-testid'),
+                               window: el.getAttribute('data-window'),
+                               // The visible label lives in the same breath —
+                               // the parent's text names the window word.
+                               labeled: (el.parentElement?.textContent ?? '')
+                                 .includes(el.getAttribute('data-window') ?? '\\u0000') }))""")
+    check("count_class_carries_window",
+          len(count_class) > 0 and all(c["window"] and c["labeled"] for c in count_class),
+          counts=count_class)
+
+    ec34 = page.evaluate(
+        """() => ({
+             count: document.querySelector('[data-testid="project-run-count"]')
+               ?.textContent ?? null,
+             rows: document.querySelectorAll('[data-testid="build-run-row"]').length,
+             windowLabel: document.querySelector('[data-testid="project-run-count-window"]')
+               ?.textContent ?? null,
+           })""")
+    check("build_count_equals_rows_and_windowed",
+          ec34["count"] == str(ec34["rows"]) and ec34["windowLabel"] == "30d",
+          **ec34)
+
+    # ── Scene 3 (AC 3): dashboard headers count what their rows render ─────────
+    goto("/p/upload-endpoint")
+    page.locator('[data-testid="project-dashboard"]').wait_for(timeout=30000)
+    page.locator('[data-testid="dashboard-run"]').first.wait_for(timeout=15000)
+    tiles = page.evaluate(
+        """() => {
+             const grab = (tile, row) => {
+               const t = document.querySelector(`[data-testid="${tile}"]`);
+               return { count: t?.dataset.count ?? null,
+                        rows: t ? t.querySelectorAll(`[data-testid="${row}"]`).length : null,
+                        head: (t?.querySelector('p')?.textContent ?? '').replace(/\\s+/g, ' ') };
+             };
+             return { runs: grab('dashboard-runs', 'dashboard-run'),
+                      gates: grab('dashboard-gates', 'dashboard-gate') };
+           }""")
+    check("dashboard_headers_set_equal",
+          tiles["runs"]["count"] == str(tiles["runs"]["rows"])
+          and tiles["gates"]["count"] == str(tiles["gates"]["rows"])
+          # The head names the same collection its rows render — never the old
+          # "Active runs (open-count)" over an all-runs list.
+          and tiles["runs"]["head"].startswith(f"Runs ({tiles['runs']['rows']})"),
+          **tiles)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_slice5_test.py
+++ b/e2e/uxfix_slice5_test.py
@@ -220,7 +220,10 @@ report["steps"]["slice5_build_runs"] = {
         "How should the tables move?" in (working["gateInbox"] or ""),
         "Approve" in (working["gateInbox"] or ""),
         # The stat row survives only as the data-gated footer — real numbers, no `—`.
-        working["footer"] == "3 steps in flight · $0.42 · 98.0k tokens",
+        # Slice W (DES-UX-001 §5.3, EC39) re-scope: the footer now NAMES its
+        # window (the range the pills select) as a dim-mono suffix.
+        (working["footer"] or "").startswith("3 steps in flight · $0.42 · 98.0k tokens"),
+        (working["footer"] or "").endswith("30d"),
     ]),
     "rows": row_texts,
     "footer": working["footer"],

--- a/src/board/metrics.ts
+++ b/src/board/metrics.ts
@@ -222,6 +222,14 @@ export function usageTotals(
   return { totalTokens: totalInput + totalOutput, totalCost: hasCost ? costSum : null };
 }
 
+// ── unreadCount — the bell badge's number, window: "session" ──────────────────
+
+/** The bell badge counts exactly the unread rows its dropdown lists — one
+ *  selector, so badge and list cannot disagree (§5.3's bell↔summary rule). */
+export function unreadCount(notifications: ReadonlyArray<{ read: boolean }>): number {
+  return notifications.filter((n) => !n.read).length;
+}
+
 // ── ledeCounts — the landing lede's numbers, window: "24h" ────────────────────
 
 export interface LedeCounts {

--- a/src/board/metrics.ts
+++ b/src/board/metrics.ts
@@ -1,0 +1,275 @@
+import type { CoreEvent, SessionStatus, SessionView } from '../api/types.js';
+import type { LoggedEvent } from '../store/runtime.js';
+
+/**
+ * THE single derivation module for every displayed metric (DES-UX-001 §5.3,
+ * slice W). One rule, mechanically enforced: **every displayed metric has
+ * exactly one selector here, and every count names its window** (EC39 — the
+ * unlabeled number is retired as a defect class).
+ *
+ * Every §5.1 contradiction was two components deriving the same fact from
+ * different stores or windows — the daemon serves one truth; the client
+ * derived it twice. The known offenders now share these selectors:
+ *
+ *  - bottom bar ↔ landing lede ↔ river margin notes: `runStats` /
+ *    `ledeCounts` / `observedSpend` / `burnSteps` (same frame predicate,
+ *    same status buckets — set-equality by construction);
+ *  - "RUNS (24H)" vs the unwindowed bar: both live here (`outcomeTotals24h`
+ *    vs `runStats`), each labeled with ITS window, so a 24h "1 failed"
+ *    beside an all-time "2 failed" is two labeled truths, not a contradiction;
+ *  - dashboard headers count the collection their rows render (EC34 —
+ *    the "ACTIVE RUNS (0) over two rows" regression class).
+ *
+ * Components may NOT fold `cliUsage` frames or status counts inline — the
+ * slice-W rig greps for exactly that.
+ */
+
+// ── The window vocabulary (EC39) ──────────────────────────────────────────────
+
+/** Every rendered count names one of these windows. */
+export type CountWindow = '24h' | 'all' | 'session' | '30d' | '60d' | '90d';
+
+/** The visible word for a window — "session" reads "this session". */
+export function windowWord(w: CountWindow): string {
+  return w === 'session' ? 'this session' : w;
+}
+
+/** §5.4: the label's dress — `--text-2xs --ink-dim` mono, the same grammar the
+ *  landing's "observed" suffix already wears. */
+export const WINDOW_LABEL_STYLE = {
+  fontSize: 'var(--text-2xs)',
+  color: 'var(--ink-dim)',
+  fontFamily: 'var(--font-mono)',
+} as const;
+
+/** The one 24h span every windowed surface shares (river, outcome bar, lede). */
+export const WINDOW_24H_MS = 24 * 3_600_000;
+
+// ── Status buckets (shared by every selector below) ───────────────────────────
+
+const TERMINAL: ReadonlySet<SessionStatus> = new Set(['completed', 'cancelled', 'failed']);
+
+export type Outcome = 'run' | 'gate' | 'fail' | 'done';
+
+/** One status → outcome mapping (was RunOutcomeBar's; now every fold's). */
+export function outcomeOf(status: string): Outcome {
+  if (status === 'awaiting_human') return 'gate';
+  if (status === 'failed' || status === 'cancelled') return 'fail';
+  if (status === 'completed') return 'done';
+  return 'run';
+}
+
+// ── workingCount / gateCount / failedCountAll — window: "all" ─────────────────
+
+export interface RunStats {
+  /** Non-terminal, non-gate statuses (planning / distributing / executing). */
+  working: number;
+  /** `awaiting_human` — agrees with the gate store by construction. */
+  gates: number;
+  /** `status === 'failed'` in the listing — window "all", and the label says so. */
+  failed: number;
+}
+
+/** The unwindowed status fold (bottom bar, and the lede's live/gate numbers).
+ *  Archived runs never count — the same skip the lede has always made, now
+ *  shared so the two surfaces cannot disagree on scope. */
+export function runStats(runs: SessionView[]): RunStats {
+  let working = 0;
+  let gates = 0;
+  let failed = 0;
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    const s = v.session.status;
+    if (s === 'awaiting_human') gates += 1;
+    else if (s === 'failed') failed += 1;
+    else if (!TERMINAL.has(s)) working += 1;
+  }
+  return { working, gates, failed };
+}
+
+export const workingCount = (runs: SessionView[]): number => runStats(runs).working;
+export const gateCount = (runs: SessionView[]): number => runStats(runs).gates;
+export const failedCountAll = (runs: SessionView[]): number => runStats(runs).failed;
+
+// ── failedCount24h and the outcome-bar fold — window: "24h" ───────────────────
+
+export interface OutcomeTotals {
+  run: number;
+  gate: number;
+  fail: number;
+  done: number;
+  /** Runs with no attach clock inside the window — reported, never painted. */
+  unplaced: number;
+}
+
+/**
+ * The 24h outcome fold on the honest attach clock (`attached_at` — the one
+ * per-run clock the wire carries; `AgentSession` has no timestamps). Was
+ * RunOutcomeBar's inline fold; the bar's buckets derive from this module now.
+ */
+export function outcomeTotals24h(
+  runs: SessionView[],
+  attachedAt: Record<string, number>,
+  now: number,
+): OutcomeTotals {
+  const totals: OutcomeTotals = { run: 0, gate: 0, fail: 0, done: 0, unplaced: 0 };
+  const start = now - WINDOW_24H_MS;
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    const clock = attachedAt[v.session.id];
+    if (clock === undefined || clock < start || clock > now) {
+      totals.unplaced += 1;
+      continue;
+    }
+    totals[outcomeOf(v.session.status)] += 1;
+  }
+  return totals;
+}
+
+export const failedCount24h = (
+  runs: SessionView[],
+  attachedAt: Record<string, number>,
+  now: number,
+): number => outcomeTotals24h(runs, attachedAt, now).fail;
+
+// ── observedSpend / burnSteps — window: "session" (what THIS page observed) ───
+
+/** The one cliUsage frame predicate: real reported dollars, never null-as-$0. */
+const costOf = (entry: LoggedEvent): number | null =>
+  entry.type === 'cliUsage' && typeof entry.costUsd === 'number' ? entry.costUsd : null;
+
+/**
+ * Real reported `cliUsage` dollars from the runtime store's per-run logs —
+ * "observed" is in every label because that is what it is. A `costUsd: null`
+ * frame never entered the log, so an unknown cost can never fold to $0.00.
+ * The bottom bar, the landing lede's spend note, and the sheet's per-run
+ * costs all read THIS fold.
+ */
+export function observedSpend(logs: Record<string, LoggedEvent[]>): {
+  total: number;
+  frames: number;
+  byRun: Record<string, number>;
+} {
+  let total = 0;
+  let frames = 0;
+  const byRun: Record<string, number> = {};
+  for (const [runId, log] of Object.entries(logs)) {
+    for (const entry of log) {
+      const cost = costOf(entry);
+      if (cost !== null) {
+        total += cost;
+        frames += 1;
+        byRun[runId] = (byRun[runId] ?? 0) + cost;
+      }
+    }
+  }
+  return { total, frames, byRun };
+}
+
+/**
+ * The cumulative (arrival-ts, running-total) burn curve — the margin
+ * sparkline's fold, sharing `observedSpend`'s frame predicate so the curve's
+ * endpoint and the spend notes are the same number by construction.
+ */
+export function burnSteps(logs: Record<string, LoggedEvent[]>): {
+  steps: Array<{ ts: number; total: number }>;
+  total: number;
+} {
+  const usages: Array<{ ts: number; cost: number }> = [];
+  for (const log of Object.values(logs)) {
+    for (const entry of log) {
+      const cost = costOf(entry);
+      if (cost !== null) usages.push({ ts: entry.ts, cost });
+    }
+  }
+  usages.sort((a, b) => a.ts - b.ts);
+  let sum = 0;
+  const steps = usages.map((u) => {
+    sum += u.cost;
+    return { ts: u.ts, total: sum };
+  });
+  return { steps, total: sum };
+}
+
+// ── usageTotals — the Build footer's fold over the run event store ────────────
+
+/**
+ * Token/cost totals over a set of runs from the run event store's full frames
+ * (the store that keeps `inputTokens`/`outputTokens`, which the arrival log
+ * does not). `totalCost: null` until a real dollar was reported — never $0.00
+ * for "unknown".
+ */
+export function usageTotals(
+  byRun: Record<string, CoreEvent[]>,
+  runs: SessionView[],
+): { totalTokens: number; totalCost: number | null } {
+  let totalInput = 0;
+  let totalOutput = 0;
+  let costSum = 0;
+  let hasCost = false;
+  for (const v of runs) {
+    for (const ev of byRun[v.session.id] ?? []) {
+      if (ev.type === 'cliUsage') {
+        if (typeof ev.inputTokens === 'number') totalInput += ev.inputTokens;
+        if (typeof ev.outputTokens === 'number') totalOutput += ev.outputTokens;
+        if (typeof ev.costUsd === 'number') {
+          costSum += ev.costUsd;
+          hasCost = true;
+        }
+      }
+    }
+  }
+  return { totalTokens: totalInput + totalOutput, totalCost: hasCost ? costSum : null };
+}
+
+// ── ledeCounts — the landing lede's numbers, window: "24h" ────────────────────
+
+export interface LedeCounts {
+  /** Terminal runs whose last OBSERVED clock is inside the 24h window. */
+  finished: number;
+  passed: number;
+  failed: number;
+  /** Runs waiting on a human right now — `gateCount`, verbatim. */
+  gates: number;
+  /** Runs moving under their own power right now — `workingCount`, verbatim. */
+  live: number;
+  /** Board projects (the quiet phrase's subject). */
+  projects: number;
+}
+
+/**
+ * Fold the honest per-run clocks into the lede's counts. `gates`/`live` are
+ * `runStats`' own numbers — the lede and the bottom bar CANNOT diverge on
+ * them; only `finished/passed/failed` add the lede's stated 24h window.
+ */
+export function ledeCounts(
+  runs: SessionView[],
+  attachedAt: Record<string, number>,
+  logs: Record<string, LoggedEvent[]>,
+  failedAt: Record<string, number>,
+  projects: number,
+  now: number,
+): LedeCounts {
+  const { working, gates } = runStats(runs);
+  const start = now - WINDOW_24H_MS;
+  let finished = 0, passed = 0, failedN = 0;
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    const id = v.session.id;
+    if (!TERMINAL.has(v.session.status)) continue;
+    // A run "finished while you were away" iff its LAST observed clock —
+    // attach, arrival-stamped frames, or the failure tail — is in-window.
+    const points = [
+      attachedAt[id],
+      failedAt[id],
+      ...(logs[id] ?? []).map((e) => e.ts),
+    ].filter((t): t is number => typeof t === 'number');
+    if (points.length === 0) continue; // clockless: the river counts it unplaced
+    const last = Math.max(...points);
+    if (last < start || last > now) continue;
+    finished += 1;
+    if (outcomeOf(v.session.status) === 'fail') failedN += 1;
+    else passed += 1;
+  }
+  return { finished, passed, failed: failedN, gates, live: working, projects };
+}

--- a/src/components/ActivityRiver.tsx
+++ b/src/components/ActivityRiver.tsx
@@ -7,7 +7,7 @@ import { gateOpenPath } from '../board/gateActions.js';
 import type { OpenGate } from '../store/gates.js';
 import type { LoggedEvent } from '../store/runtime.js';
 import type { VersionLanding } from '../store/docThread.js';
-import { outcomeOf } from './RunOutcomeBar.js';
+import { outcomeOf, WINDOW_24H_MS } from '../board/metrics.js';
 
 /**
  * The activity river (DES-FEEDBACK-003 §7.3, slice Q): the landing page's
@@ -25,7 +25,9 @@ import { outcomeOf } from './RunOutcomeBar.js';
  * (`.wk-river-gate-waiting`, reduced-motion honored in global.css).
  */
 
-export const RIVER_WINDOW_MS = 24 * 3_600_000;
+// Slice W (§5.3): the river's window IS the shared 24h window — one constant,
+// so the lede's counts and the river's picture can never disagree on span.
+export const RIVER_WINDOW_MS: number = WINDOW_24H_MS;
 /** §7.3: at most this many lanes; the rest collapse into `({n} quiet)`. */
 export const MAX_LANES = 6;
 

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { unitsInFlight } from '../api/run-state.js';
+import { usageTotals, WINDOW_LABEL_STYLE } from '../board/metrics.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
@@ -824,33 +825,10 @@ export function CenterDashboard({
     return [...active.slice(0, MAX_RUN_ROWS), ...terminal.slice(-room).reverse()];
   }, [workRuns]);
 
-  // ── Stats: aggregate cost/tokens from cliUsage events over the shown runs.
+  // ── Stats: cost/tokens over the shown runs — the metrics module's one
+  // `usageTotals` selector (slice W, §5.3: no inline cliUsage folds).
   // Rendered ONLY as a data-gated footer (§2.7 rule 2) — never an em-dash hero.
-  const stats = useMemo(() => {
-    let totalInput = 0;
-    let totalOutput = 0;
-    let costSum = 0;
-    let hasCost = false;
-
-    for (const v of workRuns) {
-      const events = byRun[v.session.id] ?? [];
-      for (const ev of events) {
-        if (ev.type === 'cliUsage') {
-          if (typeof ev.inputTokens === 'number') totalInput += ev.inputTokens;
-          if (typeof ev.outputTokens === 'number') totalOutput += ev.outputTokens;
-          if (typeof ev.costUsd === 'number') {
-            costSum += ev.costUsd;
-            hasCost = true;
-          }
-        }
-      }
-    }
-
-    return {
-      totalTokens: totalInput + totalOutput,
-      totalCost: hasCost ? costSum : null,
-    };
-  }, [byRun, workRuns]);
+  const stats = useMemo(() => usageTotals(byRun, workRuns), [byRun, workRuns]);
 
   // Counting `distributed` units counted the whole routed plan, not the running part of it
   // (FINDING-052); `unitsInFlight` counts only what is actually running.
@@ -1058,13 +1036,23 @@ export function CenterDashboard({
                 {projectId !== null && (
                   // EC34 (§2.5): the count beside a list equals the rows beneath
                   // it, SET-EQUAL on the same paint — one derivation (`runRows`)
-                  // feeds both, so they cannot disagree.
-                  <span
-                    data-testid="project-run-count"
-                    style={{ marginLeft: '6px', color: 'var(--ink-muted)', fontSize: 'var(--text-2xs)', ...mono }}
-                  >
-                    {runRows.length}
-                  </span>
+                  // feeds both, so they cannot disagree. EC39 (slice W): the
+                  // count names its window — the range the pills select.
+                  <>
+                    <span
+                      data-testid="project-run-count"
+                      data-window={range}
+                      style={{ marginLeft: '6px', color: 'var(--ink-muted)', fontSize: 'var(--text-2xs)', ...mono }}
+                    >
+                      {runRows.length}
+                    </span>
+                    <span
+                      data-testid="project-run-count-window"
+                      style={{ ...WINDOW_LABEL_STYLE, marginLeft: '4px' }}
+                    >
+                      {range}
+                    </span>
+                  </>
                 )}
               </p>
               <TimeRangeSelector value={range} onChange={setRange} />
@@ -1082,6 +1070,7 @@ export function CenterDashboard({
             {workRuns.length > runRows.length && (
               <button
                 type="button"
+                data-testid="build-runs-cap"
                 onClick={() => navigate('/work')}
                 style={{
                   fontSize: 'var(--text-xs)',
@@ -1094,7 +1083,9 @@ export function CenterDashboard({
                   display: 'block',
                 }}
               >
-                view all →
+                {/* §5.3 (slice W): the row cap is a silent filter no longer —
+                    the clipped list says what it holds back, in the same breath. */}
+                showing {runRows.length} of {workRuns.length} — view all →
               </button>
             )}
           </div>
@@ -1138,6 +1129,7 @@ export function CenterDashboard({
           {runRows.length > 0 && footerParts.length > 0 && (
             <p
               data-testid="build-stats-footer"
+              data-window={range}
               style={{
                 fontSize: 'var(--text-xs)',
                 color: 'var(--ink-dim)',
@@ -1146,6 +1138,11 @@ export function CenterDashboard({
               }}
             >
               {footerParts.join(' · ')}
+              {/* EC39 (slice W): the footer's numbers fold the range-filtered
+                  runs — the count names that window. */}
+              <span data-testid="build-stats-footer-window" style={{ ...WINDOW_LABEL_STYLE, marginLeft: '6px' }}>
+                {range}
+              </span>
             </p>
           )}
         </div>

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -381,6 +381,20 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                     </span>
                   </a>
                 ))}
+                {/* Slice W (DES-UX-001 §5.3, EC34): the preview's cap is a
+                    SILENT filter no longer — a "Quiet (9)" head over six chips
+                    says what it holds back, in the same breath. */}
+                {quiet.length > QUIET_PREVIEW && (
+                  <span
+                    data-testid="quiet-preview-cap"
+                    style={{
+                      fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)',
+                      fontFamily: 'var(--font-mono)', alignSelf: 'center',
+                    }}
+                  >
+                    showing {QUIET_PREVIEW} of {quiet.length}
+                  </span>
+                )}
               </div>
             )}
           </section>

--- a/src/components/NarrativeBand.tsx
+++ b/src/components/NarrativeBand.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from 'react';
 import type { SessionView } from '../api/types.js';
+import { ledeCounts, observedSpend, WINDOW_LABEL_STYLE, windowWord, type LedeCounts } from '../board/metrics.js';
 import type { BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { useDocThreadStore } from '../store/docThread.js';
 import { useGateStore } from '../store/gates.js';
-import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+import { useRuntimeStore } from '../store/runtime.js';
 import { ActivityRiver } from './ActivityRiver.js';
-import { RIVER_WINDOW_MS } from './ActivityRiver.js';
-import { outcomeOf, RunOutcomeBar } from './RunOutcomeBar.js';
+import { RunOutcomeBar } from './RunOutcomeBar.js';
 import { TokenBurnSparkline } from './TokenBurnSparkline.js';
 
 /**
@@ -24,56 +24,10 @@ import { TokenBurnSparkline } from './TokenBurnSparkline.js';
  * (§7.3; the wire has no such thing).
  */
 
-const TERMINAL: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled']);
-const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
-
-export interface LedeCounts {
-  /** Terminal runs whose last OBSERVED clock is inside the 24h window. */
-  finished: number;
-  passed: number;
-  failed: number;
-  /** Runs waiting on a human right now. */
-  gates: number;
-  /** Runs moving under their own power right now. */
-  live: number;
-  /** Board projects (the quiet phrase's subject). */
-  projects: number;
-}
-
-/** Fold the honest per-run clocks into the lede's counts — exported for tests. */
-export function ledeCounts(
-  runs: SessionView[],
-  attachedAt: Record<string, number>,
-  logs: Record<string, LoggedEvent[]>,
-  failedAt: Record<string, number>,
-  projects: number,
-  now: number,
-): LedeCounts {
-  const start = now - RIVER_WINDOW_MS;
-  let finished = 0, passed = 0, failedN = 0, gates = 0, live = 0;
-  for (const v of runs) {
-    if (v.session.archived_at != null) continue;
-    const id = v.session.id;
-    const status = v.session.status;
-    if (status === 'awaiting_human') gates += 1;
-    if (ACTIVE.has(status)) live += 1;
-    if (!TERMINAL.has(status)) continue;
-    // A run "finished while you were away" iff its LAST observed clock —
-    // attach, arrival-stamped frames, or the failure tail — is in-window.
-    const points = [
-      attachedAt[id],
-      failedAt[id],
-      ...(logs[id] ?? []).map((e) => e.ts),
-    ].filter((t): t is number => typeof t === 'number');
-    if (points.length === 0) continue; // clockless: the river counts it unplaced
-    const last = Math.max(...points);
-    if (last < start || last > now) continue;
-    finished += 1;
-    if (outcomeOf(status) === 'fail') failedN += 1;
-    else passed += 1;
-  }
-  return { finished, passed, failed: failedN, gates, live, projects };
-}
+// Slice W (DES-UX-001 §5.3): the lede's fold moved to THE one metrics module —
+// its gates/live numbers are now `runStats`' own, so the lede and the bottom
+// bar cannot diverge. Re-exported so standing importers keep one source.
+export { ledeCounts, type LedeCounts } from '../board/metrics.js';
 
 export interface LedeSegment {
   text: string;
@@ -142,18 +96,11 @@ export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now
     [runs, attachedAt, logs, failedAt, items.length, at],
   );
 
-  // Observed spend — the SAME fold as the margin sparkline (real costUsd only).
+  // Observed spend — literally the same selector as the bottom bar and the
+  // margin sparkline's endpoint (slice W: one selector per metric, §5.3).
   const spend = useMemo(() => {
-    let total = 0, seen = false;
-    for (const log of Object.values(logs)) {
-      for (const entry of log) {
-        if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
-          total += entry.costUsd;
-          seen = true;
-        }
-      }
-    }
-    return seen ? total : null;
+    const s = observedSpend(logs);
+    return s.frames > 0 ? s.total : null;
   }, [logs]);
 
   const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
@@ -199,14 +146,26 @@ export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now
             ),
           )}
         </p>
+        {/* EC39 (slice W): the lede's numbers name their window — the river's
+            own stated 24h, worn as the §5.4 dim-mono suffix. */}
+        <span data-testid="lede-window" data-window="24h" style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0 }}>
+          {windowWord('24h')}
+        </span>
         {spend !== null && (
-          <a {...link('/make')} data-testid="lede-spend"
-             style={{
-               marginLeft: 'auto', flexShrink: 0, textDecoration: 'none',
-               fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
-             }}>
-            ${spend.toFixed(2)} observed
-          </a>
+          <>
+            <a {...link('/make')} data-testid="lede-spend"
+               data-window="session"
+               style={{
+                 marginLeft: 'auto', flexShrink: 0, textDecoration: 'none',
+                 fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+               }}>
+              ${spend.toFixed(2)} observed
+            </a>
+            {/* EC39: the spend's window — what this page observed this session. */}
+            <span data-testid="lede-spend-window" data-window="session" style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0 }}>
+              {windowWord('session')}
+            </span>
+          </>
         )}
       </div>
 

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { unreadCount as unreadCountOf, WINDOW_LABEL_STYLE, windowWord } from '../board/metrics.js';
 import { useNotificationStore } from '../store/notifications.js';
 import type { NotifKind } from '../store/notifications.js';
 import { useProvenanceStore } from '../store/provenance.js';
@@ -73,7 +74,9 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  // Slice W (§5.3): the badge's number is the metrics module's `unreadCount` —
+  // the same rows the dropdown lists, so badge and list cannot disagree.
+  const unreadCount = unreadCountOf(notifications);
 
   // Close on outside click
   useEffect(() => {
@@ -181,6 +184,10 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
               }}
             >
               Notifications
+            </span>
+            {/* EC39 (slice W): the badge's window — what this page observed. */}
+            <span data-testid="bell-window" data-window="session" style={WINDOW_LABEL_STYLE}>
+              {windowWord('session')}
             </span>
             {unreadCount > 0 && (
               <button

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -4,6 +4,7 @@ import { listDocs, type DocSummary } from '../api/interactive.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
+import { WINDOW_LABEL_STYLE } from '../board/metrics.js';
 import { sessionProjectId } from '../hooks/ambientProject.js';
 import { interactiveRootOf } from '../hooks/useBoardModel.js';
 import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
@@ -319,8 +320,21 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
 
       <div style={CSS.grid}>
         {/* ── Tile 1: runs, attention-ordered, each a link into its mode view ── */}
-        <section data-testid="dashboard-runs" data-count={myRuns.length} style={CSS.tile}>
-          <p style={CSS.tileHead}>Active runs ({openRuns.length})</p>
+        {/* Slice W (§5.3, EC34): the header counts the SAME collection its rows
+            render — the old "Active runs (open-count)" over an all-runs list was
+            the "ACTIVE RUNS (0) over two rows" contradiction class. `data-count`
+            is the RENDERED row count (set-equal on the same paint); the cap
+            declares itself in the head, and the window is named (EC39). */}
+        <section
+          data-testid="dashboard-runs"
+          data-count={Math.min(myRuns.length, MAX_ROWS)}
+          data-window="all"
+          style={CSS.tile}
+        >
+          <p style={CSS.tileHead}>
+            Runs ({myRuns.length > MAX_ROWS ? `${MAX_ROWS} of ${myRuns.length}` : myRuns.length}){' '}
+            <span data-testid="dashboard-runs-window" style={WINDOW_LABEL_STYLE}>all</span>
+          </p>
           {myRuns.length === 0 ? (
             <p style={CSS.empty}>No runs yet — Build starts one.</p>
           ) : (
@@ -360,8 +374,12 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         </section>
 
         {/* ── Tile 2: documents, from the one listDocs the Document mode makes ── */}
-        <section data-testid="dashboard-docs" data-count={docs.length} style={CSS.tile}>
-          <p style={CSS.tileHead}>Documents ({docs.length})</p>
+        <section data-testid="dashboard-docs" data-count={Math.min(docs.length, MAX_ROWS)} style={CSS.tile}>
+          {/* EC34 (slice W): head + data-count name the RENDERED rows; the cap
+              declares itself in the same breath ("N of M", plus "more" below). */}
+          <p style={CSS.tileHead}>
+            Documents ({docs.length > MAX_ROWS ? `${MAX_ROWS} of ${docs.length}` : docs.length})
+          </p>
           {docs.length === 0 ? (
             <p style={CSS.empty}>No documents yet — Document drafts one.</p>
           ) : (
@@ -389,8 +407,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         </section>
 
         {/* ── Tile 3: the gate inbox — the SAME answerable chip as the board (§4.1) ── */}
-        <section data-testid="dashboard-gates" data-count={waiting.length} style={CSS.tile}>
-          <p style={CSS.tileHead}>Gate inbox ({waiting.length})</p>
+        <section data-testid="dashboard-gates" data-count={Math.min(waiting.length, MAX_ROWS)} style={CSS.tile}>
+          <p style={CSS.tileHead}>
+            Gate inbox ({waiting.length > MAX_ROWS ? `${MAX_ROWS} of ${waiting.length}` : waiting.length})
+          </p>
           {waiting.length === 0 ? (
             <p style={CSS.empty}>Nothing is waiting on you.</p>
           ) : (

--- a/src/components/RepoGraphModal.tsx
+++ b/src/components/RepoGraphModal.tsx
@@ -586,13 +586,15 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
     );
   }
 
-  const localNodes = codeData
-    ? codeData.nodes.filter((n) => {
-        if (!n.file || n.file.startsWith('node_modules/')) return false;
-        if (hideTests && isTestFile(n.file)) return false;
-        return true;
-      })
+  const allLocalNodes = codeData
+    ? codeData.nodes.filter((n) => !!n.file && !n.file.startsWith('node_modules/'))
     : [];
+  const localNodes = hideTests
+    ? allLocalNodes.filter((n) => !isTestFile(n.file ?? ''))
+    : allLocalNodes;
+  // Slice W (§5.3): the hidden-tests default is a SILENT filter no longer —
+  // the count pill declares what it holds back, in the same breath.
+  const hiddenTests = allLocalNodes.length - localNodes.length;
   const codeEmpty = localNodes.length === 0;
 
   // ── Shared tab pill renderer ────────────────────────────────────────────
@@ -682,10 +684,14 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
           {/* Node / edge counts */}
           {codeData && graphType === 'code' && (
             <span
+              data-testid="graph-node-stats"
+              data-hidden-tests={hiddenTests}
               className="text-[10px] font-mono px-2 py-0.5 rounded"
               style={{ background: 'var(--surface-rail)', color: T.muted }}
             >
-              {localNodes.length} nodes · {codeData.stats.edgeCount} edges
+              {localNodes.length} nodes
+              {hiddenTests > 0 ? ` (${hiddenTests} test ${hiddenTests === 1 ? 'file' : 'files'} hidden)` : ''}
+              {' · '}{codeData.stats.edgeCount} edges
             </span>
           )}
 

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 import type { SessionView } from '../api/types.js';
+import { outcomeOf, outcomeTotals24h, WINDOW_24H_MS, type Outcome } from '../board/metrics.js';
 import { MetricTile } from './MetricTile.js';
+
+// Slice W (DES-UX-001 §5.3): the outcome mapping + windowed totals moved to
+// THE one metrics module; this tile renders them. Re-exported for importers.
+export { outcomeOf } from '../board/metrics.js';
 
 /**
  * Run outcome bar (DES-FEEDBACK-001 §2.1/§2.3, slice E): the home metrics-bar
@@ -22,13 +27,11 @@ import { MetricTile } from './MetricTile.js';
  */
 
 const WINDOWS = 12;
-const WINDOW_MS = 2 * 3_600_000; // 2h × 12 = the 24h span
+const WINDOW_MS = WINDOW_24H_MS / WINDOWS; // 2h × 12 = the shared 24h span
 /** ViewBox geometry — stretched to the tile via preserveAspectRatio="none". */
 const W = 168;
 const H = 26;
 const COL_GAP = 2;
-
-type Outcome = 'run' | 'gate' | 'fail' | 'done';
 
 /** Stack order bottom→top, with the fill token each segment means. */
 const SEGMENTS: ReadonlyArray<{ key: Outcome; fill: string }> = [
@@ -37,13 +40,6 @@ const SEGMENTS: ReadonlyArray<{ key: Outcome; fill: string }> = [
   { key: 'fail', fill: 'var(--status-fail)' },
   { key: 'done', fill: 'var(--status-done)' },
 ];
-
-export function outcomeOf(status: string): Outcome {
-  if (status === 'awaiting_human') return 'gate';
-  if (status === 'failed' || status === 'cancelled') return 'fail';
-  if (status === 'completed') return 'done';
-  return 'run';
-}
 
 interface Props {
   runs: SessionView[];
@@ -63,26 +59,24 @@ export function RunOutcomeBar({
   title = 'Runs (24h)',
 }: Props): React.ReactElement {
   const at = now ?? Date.now();
-  const { windows, counts, unplaced } = useMemo(() => {
+  // Slice W (§5.3): the COUNTS are the shared selector's — `outcomeTotals24h`,
+  // the same numbers `failedCount24h` reports everywhere. Only the per-2h
+  // bucket PLACEMENT (chart geometry) is derived here, on the same clock rule.
+  const counts = useMemo(() => outcomeTotals24h(runs, attachedAt, at), [runs, attachedAt, at]);
+  const { windows } = useMemo(() => {
     const buckets = Array.from({ length: WINDOWS }, () => ({ run: 0, gate: 0, fail: 0, done: 0 }));
-    const totals = { run: 0, gate: 0, fail: 0, done: 0 };
-    let outside = 0;
     const start = at - WINDOWS * WINDOW_MS;
     for (const v of runs) {
       if (v.session.archived_at != null) continue;
       const clock = attachedAt[v.session.id];
-      if (clock === undefined || clock < start || clock > at) {
-        outside += 1;
-        continue;
-      }
+      if (clock === undefined || clock < start || clock > at) continue;
       const ix = Math.min(WINDOWS - 1, Math.floor((clock - start) / WINDOW_MS));
-      const outcome = outcomeOf(v.session.status);
       const bucket = buckets[ix];
-      if (bucket !== undefined) bucket[outcome] += 1;
-      totals[outcome] += 1;
+      if (bucket !== undefined) bucket[outcomeOf(v.session.status)] += 1;
     }
-    return { windows: buckets, counts: totals, unplaced: outside };
+    return { windows: buckets };
   }, [runs, attachedAt, at]);
+  const unplaced = counts.unplaced;
 
   const inWindow = counts.run + counts.gate + counts.fail + counts.done;
   const colMax = windows.reduce((m, w) => Math.max(m, w.run + w.gate + w.fail + w.done), 0);
@@ -104,7 +98,7 @@ export function RunOutcomeBar({
       question={question}
       title={title}
       value={value}
-      data={{ 'data-total': inWindow, 'data-unplaced': unplaced }}
+      data={{ 'data-total': inWindow, 'data-unplaced': unplaced, 'data-window': '24h' }}
     >
       {inWindow === 0 ? (
         // Honest emptiness: no bars, one quiet line — never a wall of zero-height

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useRef } from 'react';
-import type { SessionStatus, SessionView } from '../api/types.js';
+import type { SessionView } from '../api/types.js';
 import { GATE_HASH } from '../board/gateActions.js';
+import { observedSpend, runStats, WINDOW_LABEL_STYLE, windowWord } from '../board/metrics.js';
 import { sessionProjectId } from '../hooks/ambientProject.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
-import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+import { useRuntimeStore } from '../store/runtime.js';
 import { prefersReducedMotion } from './LiveEdge.js';
 import { phaseWord, recentRuns, RUN_DOT } from './RunsSection.js';
 
@@ -37,58 +38,10 @@ export const RUNS_BAR_PX = 28;
 /** §5.4: the sheet lists up to 20 runs, scrolling internally past 8. */
 const SHEET_MAX = 20;
 
-const TERMINAL: ReadonlySet<SessionStatus> = new Set(['completed', 'cancelled', 'failed']);
-
-export interface RunStats {
-  /** Non-terminal, non-gate statuses (the RunsSection TERMINAL set). */
-  working: number;
-  /** `awaiting_human` in `runs` — agrees with the gate store by construction. */
-  gates: number;
-  /** `status === 'failed'` in the default (non-archived) listing — the label
-   *  says "failed", scoped by what `/runs` returns; no invented 24h clock. */
-  failed: number;
-}
-
-/** §5.3's stat derivations, spelled once and unit-tested. */
-export function runStats(runs: SessionView[]): RunStats {
-  let working = 0;
-  let gates = 0;
-  let failed = 0;
-  for (const v of runs) {
-    const s = v.session.status;
-    if (s === 'awaiting_human') gates += 1;
-    else if (s === 'failed') failed += 1;
-    else if (!TERMINAL.has(s)) working += 1;
-  }
-  return { working, gates, failed };
-}
-
-/**
- * The TokenBurnSparkline fold (§5.3): real reported `cliUsage` dollars from
- * the runtime store's per-run logs — "observed" is in the label because that
- * is what it is. A `costUsd: null` frame never entered the log, so an unknown
- * cost can never fold to $0.00. Also folded per run for the sheet rows (§5.4:
- * shown only when non-zero — never $0.00 for "unknown").
- */
-export function observedSpend(logs: Record<string, LoggedEvent[]>): {
-  total: number;
-  frames: number;
-  byRun: Record<string, number>;
-} {
-  let total = 0;
-  let frames = 0;
-  const byRun: Record<string, number> = {};
-  for (const [runId, log] of Object.entries(logs)) {
-    for (const entry of log) {
-      if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
-        total += entry.costUsd;
-        frames += 1;
-        byRun[runId] = (byRun[runId] ?? 0) + entry.costUsd;
-      }
-    }
-  }
-  return { total, frames, byRun };
-}
+// Slice W (DES-UX-001 §5.3): the stat derivations moved to THE one metrics
+// module — this surface renders `runStats` / `observedSpend` and may not fold
+// stores inline. Re-exported so standing importers keep one source.
+export { observedSpend, runStats, type RunStats } from '../board/metrics.js';
 
 /** "waiting 12m" — the gate row's wait age off the gate store's frame ts (§5.4). */
 export function waitingWord(ageMs: number): string {
@@ -239,10 +192,22 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
       <Segment glyph="●" color="var(--status-run)" text={`${stats.working} working`} />
       <Segment glyph="⏸" color="var(--status-gate)" text={`${stats.gates} gates`} pulse={stats.gates > 0} />
       <Segment glyph="✗" color="var(--status-fail)" text={`${stats.failed} failed`} />
+      {/* EC39 (slice W): the three counts share one window and SAY it — the
+          unwindowed listing, "all" — so "2 failed" here beside a "1 failed
+          (24h)" elsewhere reads as two labeled truths, not a contradiction. */}
+      <span data-testid="runs-bar-window" data-window="all" style={WINDOW_LABEL_STYLE}>
+        {windowWord('all')}
+      </span>
       {spend.frames > 0 && (
         // Rendered only once a cliUsage frame has been observed — never a
         // fabricated $0.00 for "unknown" (the slice-E wire-honesty rule).
-        <Segment glyph="◔" color="var(--accent)" text={`$${spend.total.toFixed(2)} observed`} />
+        <>
+          <Segment glyph="◔" color="var(--accent)" text={`$${spend.total.toFixed(2)} observed`} />
+          {/* EC39: the spend's window — what THIS page observed this session. */}
+          <span data-testid="runs-bar-spend-window" data-window="session" style={WINDOW_LABEL_STYLE}>
+            {windowWord('session')}
+          </span>
+        </>
       )}
     </>
   );
@@ -254,6 +219,7 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
         data-testid="runs-bottom-bar"
         data-expanded={String(expanded)}
         data-scope={scopeProjectId === null ? 'global' : 'project'}
+        data-window="all"
         data-working={stats.working}
         data-gates={stats.gates}
         data-failed={stats.failed}
@@ -305,6 +271,13 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
             style={{ fontSize: 'var(--text-2xs)', borderBottom: '1px solid var(--surface-raised)' }}
           >
             <span style={{ color: 'var(--ink-high)', fontWeight: 'var(--weight-semi)' }}>Runs</span>
+            {/* §5.3 (slice W): the sheet's cap is a SILENT filter no longer —
+                when the list is clipped it says so in the same breath. */}
+            {scopedRuns.length > rows.length && (
+              <span data-testid="runs-sheet-cap" style={WINDOW_LABEL_STYLE}>
+                showing {rows.length} of {scopedRuns.length}
+              </span>
+            )}
             {!quiet && summary}
             <span className="flex-1" />
             {allRuns('runs-sheet-all')}

--- a/src/components/TokenBurnSparkline.tsx
+++ b/src/components/TokenBurnSparkline.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { burnSteps, windowWord } from '../board/metrics.js';
 import { useRuntimeStore } from '../store/runtime.js';
 import { MetricTile } from './MetricTile.js';
 
@@ -40,23 +41,10 @@ export function TokenBurnSparkline({
   const logs = useRuntimeStore((s) => s.logs);
   const at = now ?? Date.now();
 
-  const { steps, total } = useMemo(() => {
-    const usages: Array<{ ts: number; cost: number }> = [];
-    for (const log of Object.values(logs)) {
-      for (const entry of log) {
-        if (entry.type === 'cliUsage' && typeof entry.costUsd === 'number') {
-          usages.push({ ts: entry.ts, cost: entry.costUsd });
-        }
-      }
-    }
-    usages.sort((a, b) => a.ts - b.ts);
-    let sum = 0;
-    const cumulative = usages.map((u) => {
-      sum += u.cost;
-      return { ts: u.ts, total: sum };
-    });
-    return { steps: cumulative, total: sum };
-  }, [logs]);
+  // Slice W (§5.3): the fold is the metrics module's `burnSteps` — the same
+  // frame predicate as `observedSpend`, so this curve's endpoint and the
+  // spend notes beside it are the same number by construction.
+  const { steps, total } = useMemo(() => burnSteps(logs), [logs]);
 
   // x spans first-observed → now, so the newest edge of the area is "now" and a
   // flattening slope reads as spending slowing down.
@@ -76,8 +64,9 @@ export function TokenBurnSparkline({
       testId="token-burn-sparkline"
       question={question}
       title={title}
-      value={steps.length === 0 ? 'no usage yet' : `$${total.toFixed(2)}`}
-      data={{ 'data-total': total.toFixed(4), 'data-points': steps.length }}
+      // EC39 (slice W): the total names its window — what THIS page observed.
+      value={steps.length === 0 ? 'no usage yet' : `$${total.toFixed(2)} · ${windowWord('session')}`}
+      data={{ 'data-total': total.toFixed(4), 'data-points': steps.length, 'data-window': 'session' }}
     >
       {steps.length === 0 ? (
         // Honest emptiness: the wire reports cost per cliUsage frame and none

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -124,13 +124,15 @@ describe('run rows are labelled by intent, not raw prompt (F7)', () => {
     for (const t of texts) expect(t).not.toMatch(/executing|distributing|awaiting_human/);
   });
 
-  it('caps the list and defers the rest to "view all →"', () => {
+  it('caps the list, DECLARES the cap, and defers the rest to view all (slice W §5.3)', () => {
     const many = Array.from({ length: 12 }, (_, i) =>
       makeView({ id: `r-${i}`, problem: `task ${i}`, status: 'completed' }),
     );
     dash(many);
     expect(screen.getAllByTestId('build-run-row')).toHaveLength(9);
-    expect(screen.getByText('view all →')).toBeTruthy();
+    // The cap is a silent filter no longer: the clipped list says what it
+    // holds back in the same breath as the affordance to see the rest.
+    expect(screen.getByTestId('build-runs-cap').textContent).toBe('showing 9 of 12 — view all →');
   });
 });
 

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+import {
+  burnSteps,
+  failedCount24h,
+  failedCountAll,
+  gateCount,
+  ledeCounts,
+  observedSpend,
+  outcomeOf,
+  outcomeTotals24h,
+  runStats,
+  unreadCount,
+  usageTotals,
+  WINDOW_24H_MS,
+  windowWord,
+  workingCount,
+} from '../src/board/metrics.js';
+import type { LoggedEvent } from '../src/store/runtime.js';
+import { makeView } from './factories.js';
+
+/**
+ * Slice W (DES-UX-001 §5.3): THE single derivation module — one selector per
+ * displayed metric, every count naming its window (EC39). These tests pin the
+ * cross-surface agreements the §5.1 offenders used to break: the lede's
+ * gates/live ARE runStats' numbers, the burn curve's endpoint IS the spend
+ * total, and the 24h fold is a different LABELED window, not a contradiction.
+ */
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+const W2 = [
+  makeView({ id: 'r-gate1', status: 'awaiting_human' }),
+  makeView({ id: 'r-gate2', status: 'awaiting_human' }),
+  makeView({ id: 'r-live', status: 'executing' }),
+  makeView({ id: 'r-fail-new', status: 'failed' }),
+  makeView({ id: 'r-fail-old', status: 'failed' }),
+  makeView({ id: 'r-done', status: 'completed' }),
+];
+
+const usage = (costUsd: number, ts: number): LoggedEvent => ({
+  seq: 1, type: 'cliUsage', ts, costUsd, detail: `usage $${costUsd}`,
+});
+
+describe('the window vocabulary (EC39)', () => {
+  it('names every window visibly — "session" reads "this session"', () => {
+    expect(windowWord('24h')).toBe('24h');
+    expect(windowWord('all')).toBe('all');
+    expect(windowWord('session')).toBe('this session');
+    expect(windowWord('30d')).toBe('30d');
+  });
+});
+
+describe('runStats / workingCount / gateCount / failedCountAll — window "all"', () => {
+  it('counts working (non-terminal, non-gate), gates, failed', () => {
+    expect(runStats(W2)).toEqual({ working: 1, gates: 2, failed: 2 });
+    expect(workingCount(W2)).toBe(1);
+    expect(gateCount(W2)).toBe(2);
+    expect(failedCountAll(W2)).toBe(2);
+  });
+
+  it('archived runs count nowhere — the lede has always skipped them, now everyone does', () => {
+    const runs = [
+      makeView({ id: 'r-a', status: 'failed' }),
+      makeView({ id: 'r-b', status: 'failed', archived_at: NOW }),
+    ];
+    expect(failedCountAll(runs)).toBe(1);
+  });
+});
+
+describe('outcomeTotals24h / failedCount24h — window "24h" on the attach clock', () => {
+  const attached = {
+    'r-gate1': NOW - HOUR,
+    'r-live': NOW - 2 * HOUR,
+    'r-fail-new': NOW - 3 * HOUR,
+    'r-fail-old': NOW - 3 * 24 * HOUR, // outside the window → unplaced
+    'r-done': NOW - 5 * HOUR,
+    // r-gate2 has NO clock → unplaced, never painted at an invented time
+  };
+
+  it('buckets on the honest clock; clockless/outside runs are unplaced', () => {
+    expect(outcomeTotals24h(W2, attached, NOW)).toEqual({
+      run: 1, gate: 1, fail: 1, done: 1, unplaced: 2,
+    });
+  });
+
+  it('failedCount24h vs failedCountAll: two labeled truths, not a contradiction', () => {
+    expect(failedCount24h(W2, attached, NOW)).toBe(1);
+    expect(failedCountAll(W2)).toBe(2);
+  });
+
+  it('outcomeOf maps every status', () => {
+    expect(outcomeOf('executing')).toBe('run');
+    expect(outcomeOf('awaiting_human')).toBe('gate');
+    expect(outcomeOf('failed')).toBe('fail');
+    expect(outcomeOf('cancelled')).toBe('fail');
+    expect(outcomeOf('completed')).toBe('done');
+  });
+});
+
+describe('observedSpend ↔ burnSteps — one frame predicate, window "session"', () => {
+  const logs: Record<string, LoggedEvent[]> = {
+    'r-live': [
+      usage(0.1, NOW - 2 * HOUR),
+      { seq: 2, type: 'cliUsage', ts: NOW - HOUR, detail: 'usage reported (no cost)' },
+      usage(0.32, NOW - HOUR / 2),
+    ],
+    'r-done': [usage(0.08, NOW - 3 * HOUR)],
+  };
+
+  it('null-cost frames never fold to $0.00', () => {
+    const spend = observedSpend(logs);
+    expect(spend.total).toBeCloseTo(0.5);
+    expect(spend.frames).toBe(3);
+    expect(spend.byRun['r-live']).toBeCloseTo(0.42);
+  });
+
+  it("the burn curve's endpoint IS the spend total — same selector family", () => {
+    const { steps, total } = burnSteps(logs);
+    expect(total).toBeCloseTo(observedSpend(logs).total);
+    expect(steps).toHaveLength(3);
+    // Cumulative and time-ordered.
+    expect(steps[0]?.total).toBeCloseTo(0.08);
+    expect(steps[2]?.total).toBeCloseTo(0.5);
+  });
+});
+
+describe('usageTotals — the Build footer fold over the run event store', () => {
+  it('sums tokens and cost only over the given runs; cost null until reported', () => {
+    const byRun: Record<string, CoreEvent[]> = {
+      'r-live': [
+        { type: 'cliUsage', session: 'r-live', inputTokens: 1000, outputTokens: 200, costUsd: 0.42 },
+        { type: 'unitDone', session: 'r-live' },
+      ],
+      'r-foreign': [
+        { type: 'cliUsage', session: 'r-foreign', inputTokens: 9999, costUsd: 9.99 },
+      ],
+    };
+    const mine = [makeView({ id: 'r-live', status: 'executing' })];
+    expect(usageTotals(byRun, mine)).toEqual({ totalTokens: 1200, totalCost: 0.42 });
+    const quiet = [makeView({ id: 'r-quiet', status: 'executing' })];
+    expect(usageTotals(byRun, quiet)).toEqual({ totalTokens: 0, totalCost: null });
+  });
+});
+
+describe('unreadCount — the bell badge counts exactly its own rows', () => {
+  it('counts unread only', () => {
+    expect(unreadCount([{ read: false }, { read: true }, { read: false }])).toBe(2);
+    expect(unreadCount([])).toBe(0);
+  });
+});
+
+describe('ledeCounts — gates/live are runStats\' own numbers (§5.1 offender pin)', () => {
+  it('cannot diverge from the bottom bar on gates/live', () => {
+    const attached = { 'r-fail-new': NOW - HOUR };
+    const c = ledeCounts(W2, attached, {}, {}, 3, NOW);
+    const stats = runStats(W2);
+    expect(c.gates).toBe(stats.gates);
+    expect(c.live).toBe(stats.working);
+    // The 24h-finished fold: only the clocked, in-window terminal run counts.
+    expect(c.finished).toBe(1);
+    expect(c.failed).toBe(1);
+    expect(c.passed).toBe(0);
+    expect(c.projects).toBe(3);
+  });
+
+  it('the shared 24h span is the one constant', () => {
+    expect(WINDOW_24H_MS).toBe(24 * HOUR);
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §5 (slice W)** — one selector per metric (BRIEF-UX-001 A5 MAJOR: "same datum, two derivations").

- `src/board/metrics.ts` is THE single derivation module: bar/lede/spend/burn/badge/footer all import it; zero `cliUsage` folds remain in components (rig-enforced by grep).
- **EC39**: every count names its window ("all", "24h", "this session") as a visible label with `data-window`.
- **EC34 + silent filters**: dashboard tile heads count what their rows render; capped lists declare it ("showing 9 of 12 — view all →").
- The verifier caught one live escape — "Quiet (9)" over 6 silently-capped chips on the real landing — and fixed it with the slice's own declared-cap grammar.

Verified: 1310/1310 unit tests, slice rig ×4, 9 regression rigs green; live read-only check at the real daemon — every number labeled, counts equal rows. LOC overrun (~461 gross vs ~280) disclosed: ~120 lines are relocated folds, partitionable per §11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
