### PR TITLE
DES-UX-001 slice Y: one canonical runs surface

### DIFF
--- a/e2e/feedback3_sliceQ_test.py
+++ b/e2e/feedback3_sliceQ_test.py
@@ -367,7 +367,9 @@ report["steps"]["lede"] = {
     "ok": all([
         fonts_ok, lede_ok, spend_ok,
         home["ledeQuestion"] == "What happened and what needs me?",
-        home["ledeLinkHrefs"] == ["/runs", "#needs-you"],
+        # Slice Y (DES-UX-001 §7.4): the all-runs number re-points to /work —
+        # the ONE canonical runs surface; the bare /runs listing is retired.
+        home["ledeLinkHrefs"] == ["/work", "#needs-you"],
         home["spendHref"] == "/make",
     ]),
     "web_fonts": fonts_ok, "lede_settled": lede_ok, "spend_settled": spend_ok,

--- a/e2e/ux_sliceY_test.py
+++ b/e2e/ux_sliceY_test.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+ux_sliceY_test.py — the DES-UX-001 slice-Y gate: ONE canonical runs surface
+(§7.4, C1 — "every 'All runs ›' affordance lands on /runs: done-only, no
+timestamps, no filters — 13 failed runs invisible").
+
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the
+`river` corpus on (real attach clocks, so the landing lede has finished runs
+to link). The §7.4 DOM ACs, verbatim mapping:
+
+  1. every anchor whose text matches /All runs/ resolves to `/work` (DOM-wide
+     assert, sheet expanded so runs-bar-all AND runs-sheet-all are both in the
+     DOM; the landing's all-runs-link rides the same sweep) — and every
+     lede-segment number lands on /work or the in-page #needs-you anchor,
+     never the retired /runs listing;
+  2. navigating `/runs` lands on `/work` (a REPLACE redirect; the search
+     string rides along — /runs?filter=failed keeps its failure context);
+  3. following a failed run's "All runs" entry point (the FailureBanner's
+     failure-context link) renders the Failed filter active
+     (`data-filter="failed"` on the tablist, Failed tab aria-selected);
+  + the protections (§9/§11.1): `/runs/:id` (run detail) and `/runs/new`
+    (the composer) stay routable — only the bare listing retires.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-Y-work-canonical.png   /work reached via the retired /runs route — the one
+                            canonical runs surface: tabs, search, metrics
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4386),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4386"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# r-auth is the fixture's fresh failed run; its thread renders FailureBanner.
+AUTH_THREAD = "/p/auth-refactor/build/r-auth"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, river clocks on ──────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, river=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── Scene 1 (AC "every affordance"): the DOM-wide all-runs sweep ───────────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # Expand the sheet so BOTH its all-runs anchors (bar + sheet header) are in
+    # the DOM for the sweep — the sheet itself is otherwise untouched (§9).
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-bottom-sheet"]').wait_for(timeout=5000)
+    sweep = page.evaluate(
+        """() => {
+          const anchors = Array.from(document.querySelectorAll('a'))
+            .filter(a => /All runs/.test(a.textContent ?? ''));
+          const ledes = Array.from(
+            document.querySelectorAll('[data-testid="lede-segment"]'));
+          return {
+            allRunsCount: anchors.length,
+            allRunsTargets: anchors.map(a => new URL(a.href).pathname),
+            allRunsToWork: anchors.length > 0
+              && anchors.every(a => new URL(a.href).pathname === '/work'),
+            ledeHrefs: ledes.map(a => a.getAttribute('href')),
+            ledeClean: ledes.every(a => {
+              const h = a.getAttribute('href') ?? '';
+              return h === '#needs-you' || h === '/work' || h.startsWith('/work?');
+            }),
+            bareRunsHrefs: Array.from(document.querySelectorAll('a[href="/runs"]')).length,
+          };
+        }""")
+    check("all_runs_sweep",
+          sweep["allRunsToWork"] and sweep["allRunsCount"] >= 3
+          and sweep["ledeClean"] and sweep["bareRunsHrefs"] == 0,
+          **sweep)
+    page.keyboard.press("Escape")
+
+    # The landing's header affordance actually NAVIGATES to /work (real link).
+    page.locator('[data-testid="all-runs-link"]').click()
+    landed = settled("""() => window.location.pathname === '/work'
+        && !!document.querySelector('[role="tablist"][data-filter]')""")
+    check("landing_affordance_lands_on_work", landed,
+          path=page.evaluate("() => location.pathname"))
+
+    # ── Scene 2 (AC "navigating /runs lands on /work"): the replace redirect ───
+    page.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
+    redirected = settled(
+        """() => window.location.pathname === '/work'
+              && document.querySelector('[role="tablist"]')?.getAttribute('data-filter') === 'all'
+              && !document.querySelector('[data-testid="project-board"]')""")
+    check("runs_redirects_to_work", redirected,
+          path=page.evaluate("() => location.pathname + location.search"))
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # ── Capture: the one canonical runs surface, reached via the retired route ─
+    page.screenshot(path=str(VSHOTS / "ux-Y-work-canonical.png"))
+
+    # The search string rides the redirect (context-sensitive entry, §7.4).
+    page.goto(f"{ORIGIN}/runs?filter=failed", wait_until="domcontentloaded")
+    carried = settled(
+        """() => window.location.pathname === '/work'
+              && window.location.search === '?filter=failed'
+              && document.querySelector('[role="tablist"]')?.getAttribute('data-filter') === 'failed'""")
+    check("redirect_carries_filter", carried,
+          path=page.evaluate("() => location.pathname + location.search"))
+
+    # ── Scene 3 (AC "failure context"): the FailureBanner's All-runs entry ─────
+    page.goto(f"{ORIGIN}{AUTH_THREAD}", wait_until="domcontentloaded")
+    page.locator('[data-testid="failure-banner"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    banner_href = page.locator('[data-testid="failure-all-runs"]').get_attribute("href")
+    page.locator('[data-testid="failure-all-runs"]').click()
+    failed_lens = settled(
+        """() => window.location.pathname === '/work'
+              && window.location.search === '?filter=failed'
+              && document.querySelector('[role="tablist"]')?.getAttribute('data-filter') === 'failed'""")
+    failed_tab = page.evaluate(
+        """() => ({
+          selected: document.getElementById('work-tab-failed')?.getAttribute('aria-selected'),
+          rows: Array.from(document.querySelectorAll('[data-testid="run-link"], [role="tabpanel"] a'))
+            .length,
+          panelText: document.querySelector('[role="tabpanel"]')?.textContent ?? '',
+        })""")
+    check("failure_context_lands_failed",
+          failed_lens and banner_href == "/work?filter=failed"
+          and failed_tab["selected"] == "true"
+          and "refactor the auth middleware" in failed_tab["panelText"],
+          banner_href=banner_href, **failed_tab)
+
+    # ── Scene 4 (the protections): /runs/:id and /runs/new stay routable ───────
+    # A filed run's flat bookmark keeps its §1.5 legacy redirect INTO THE SHELL
+    # (never to /work); the run view renders.
+    page.goto(f"{ORIGIN}/runs/r-auth", wait_until="domcontentloaded")
+    detail_ok = settled(
+        """() => window.location.pathname.endsWith('/r-auth')
+              && window.location.pathname !== '/work'
+              && !!document.querySelector('[data-testid="failure-banner"]')""")
+    check("run_detail_stays_routable", detail_ok,
+          path=page.evaluate("() => location.pathname"))
+
+    # The composer keeps its route: /runs/new never redirects.
+    page.goto(f"{ORIGIN}/runs/new", wait_until="domcontentloaded")
+    composer_ok = settled(
+        """() => window.location.pathname === '/runs/new'
+              && !!document.querySelector('[data-testid="launch-problem"]')""")
+    check("composer_stays_routable", composer_ok,
+          path=page.evaluate("() => location.pathname"))
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -30,9 +30,10 @@ What it asserts (slice-3 DOM ACs, as amended by §8.7):
   3. The creation affordances are the four heading-level ＋ icons (§8.7: the
      QUICK assert's replacement) — one per non-Settings heading, none on
      Settings.
-  4. /runs remains reachable — the flat list renders at its route with the
+  4. the flat list remains reachable — /runs now REDIRECTS to /work, the ONE
+     canonical runs surface (DES-UX-001 §7.4, slice Y), which renders with the
      board unmounted. (The rail affordance is slice N's bottom-panel
-     "All runs ›"; between M and N the route itself is the escape hatch.)
+     "All runs ›"; the redirect replaces the old bare listing.)
   5. A Projects-accordion row enters the project — the PROJECT DASHBOARD at
      /p/q3-review-deck (DES-FEEDBACK-001 §4.1, slice D), not a remembered
      mode.
@@ -179,12 +180,12 @@ with sync_playwright() as p:
     page.locator('[data-testid="rail-heading-projects"] [data-testid="rail-view-all"]').wait_for(timeout=10000)
     page.locator('[data-testid="left-rail"]').screenshot(path=str(SHOTS / "uxfix-3-rail.png"))
 
-    # ── AC 4: /runs remains reachable — the flat list at its own route ─────────
-    # (The rail affordance is slice N's bottom panel; the route is the M→N
-    # interim escape hatch, per §10.4's sequencing note.)
+    # ── AC 4 (re-scoped by DES-UX-001 §7.4, slice Y): the flat list remains
+    #    reachable, but /runs is now a replace-redirect onto /work — the ONE
+    #    canonical runs surface — with the board unmounted. ──
     page.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
     hatch_ok = settled(
-        """() => window.location.pathname === '/runs'
+        """() => window.location.pathname === '/work'
               && !document.querySelector('[data-testid="project-board"]')""")
 
     # ── AC 5 (re-scoped by DES-FEEDBACK-001 §4.1, slice D): a Projects-accordion

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,9 +175,11 @@ export function App(): React.ReactElement {
   );
 
   // Outside the project shell, "back" belongs to the list the run was opened from —
-  // `/runs`, not the board (§1.5): `/` is now a different surface, not this one's parent.
+  // `/work`, the ONE canonical runs surface (DES-UX-001 §7.4, slice Y — the bare
+  // `/runs` listing retired into a redirect): `/` is a different surface, not this
+  // one's parent.
   const onNavigateBack = useCallback(
-    () => navigate(projectId && mode ? modePath(projectId, mode) : '/runs'),
+    () => navigate(projectId && mode ? modePath(projectId, mode) : '/work'),
     [navigate, projectId, mode],
   );
 
@@ -455,7 +457,9 @@ export function App(): React.ReactElement {
     if (panel === 'work') {
       return (
         <div className="flex-1 overflow-y-auto">
-          <WorkPage runs={runs} selectedRunId={runId} onSelect={selectRun} navigate={navigate} />
+          {/* `search` carries §7.4's context-sensitive entry (slice Y): arriving
+              from a failure context (`?filter=failed`) lands with that tab active. */}
+          <WorkPage runs={runs} selectedRunId={runId} onSelect={selectRun} navigate={navigate} search={search} />
         </div>
       );
     }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -946,7 +946,9 @@ function RunChat({
             that finally takes them for the statuses that need them most. */}
         {isPostMortem && (
           <div className="flex flex-col gap-3">
-            <FailureBanner view={view} log={log} />
+            {/* slice Y (§7.4): the banner's "All runs ›" is a FAILURE-CONTEXT
+                entry — it lands on /work with the Failed filter active. */}
+            <FailureBanner view={view} log={log} navigate={navigate} />
             <VerdictDetail runId={session.id} units={ordered} />
             <UnitList runId={session.id} units={ordered} onOpenFile={setEvidenceFile} />
           </div>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -948,7 +948,7 @@ function RunChat({
           <div className="flex flex-col gap-3">
             {/* slice Y (§7.4): the banner's "All runs ›" is a FAILURE-CONTEXT
                 entry — it lands on /work with the Failed filter active. */}
-            <FailureBanner view={view} log={log} navigate={navigate} />
+            <FailureBanner view={view} log={log} {...(navigate === undefined ? {} : { navigate })} />
             <VerdictDetail runId={session.id} units={ordered} />
             <UnitList runId={session.id} units={ordered} onOpenFile={setEvidenceFile} />
           </div>

--- a/src/components/FailureBanner.tsx
+++ b/src/components/FailureBanner.tsx
@@ -4,9 +4,28 @@ import type { LoggedEvent } from '../store/runtime.js';
 interface Props {
   view: SessionView;
   log: LoggedEvent[];
+  /** When provided, the banner carries the §7.4 failure-context "All runs ›"
+   *  link (DES-UX-001 slice Y): it lands on /work with the Failed filter
+   *  active — arriving FROM a failure keeps the failure lens. */
+  navigate?: (path: string) => void;
 }
 
-export function FailureBanner({ view, log }: Props): React.ReactElement | null {
+/** The failure-context all-runs entry (§7.4): /work, Failed filter active. */
+function AllRunsLink({ navigate }: { navigate: (path: string) => void }): React.ReactElement {
+  return (
+    <a
+      href="/work?filter=failed"
+      data-testid="failure-all-runs"
+      onClick={(e) => { e.preventDefault(); navigate('/work?filter=failed'); }}
+      className="mt-2 inline-block transition-opacity hover:opacity-80"
+      style={{ color: 'var(--accent)', textDecoration: 'none' }}
+    >
+      All runs ›
+    </a>
+  );
+}
+
+export function FailureBanner({ view, log, navigate }: Props): React.ReactElement | null {
   const { status } = view.session;
   if (status !== 'failed' && status !== 'cancelled') return null;
 
@@ -26,6 +45,7 @@ export function FailureBanner({ view, log }: Props): React.ReactElement | null {
         }}
       >
         Run cancelled.
+        {navigate !== undefined && <div><AllRunsLink navigate={navigate} /></div>}
       </div>
     );
   }
@@ -52,6 +72,7 @@ export function FailureBanner({ view, log }: Props): React.ReactElement | null {
           ))}
         </ul>
       )}
+      {navigate !== undefined && <AllRunsLink navigate={navigate} />}
     </div>
   );
 }

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -247,10 +247,11 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
         <p style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: 0 }}>
           Sorted by what needs you first.
         </p>
-        {/* The flat run list this board replaced stays reachable (§1.5 escape hatch). */}
+        {/* The flat run list stays reachable (§1.5 escape hatch) — at /work,
+            the ONE canonical runs surface (DES-UX-001 §7.4, slice Y). */}
         <a
-          href="/runs"
-          onClick={(e) => { e.preventDefault(); navigate('/runs'); }}
+          href="/work"
+          onClick={(e) => { e.preventDefault(); navigate('/work'); }}
           data-testid="all-runs-link"
           style={{ marginLeft: 'auto', fontSize: 'var(--text-xs)', color: 'var(--ink-muted)' }}
         >

--- a/src/components/NarrativeBand.tsx
+++ b/src/components/NarrativeBand.tsx
@@ -104,11 +104,13 @@ export function composeLede(c: LedeCounts): { quiet: boolean; segments: LedeSegm
       c.passed > 0 ? `${c.passed} passed` : null,
       c.failed > 0 ? `${c.failed} failed` : null,
     ].filter((s) => s !== null).join(', ');
-    segments.push({ text: `${plural(c.finished, 'run')} finished — ${split}`, href: '/runs' });
+    // Every all-runs number lands on /work — the ONE canonical runs surface
+    // (DES-UX-001 §7.4, slice Y; the bare /runs listing retired into a redirect).
+    segments.push({ text: `${plural(c.finished, 'run')} finished — ${split}`, href: '/work' });
   } else if (c.gates === 0) {
     // Nothing finished, nothing waiting — but something is moving: say that,
     // with the number still derived (EC29), never an empty "away:" stub.
-    segments.push({ text: `nothing finished — ${plural(c.live, 'run')} still moving`, href: '/runs' });
+    segments.push({ text: `nothing finished — ${plural(c.live, 'run')} still moving`, href: '/work' });
   }
   if (c.gates > 0) {
     if (c.finished > 0) segments.push({ text: ' — and ', href: null });

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -218,14 +218,16 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
 
   const allRuns = (testId: string): React.ReactElement => (
     <a
-      href="/runs"
+      href="/work"
       data-testid={testId}
       onClick={(e) => {
         // A real link (§5.3) — the ONE escape hatch to the flat list, not an
         // expand gesture, so the click must not bubble into the toggle.
+        // Target: /work, the ONE canonical runs surface (DES-UX-001 §7.4,
+        // slice Y — only the href moved; the sheet itself is untouched, §9).
         e.preventDefault();
         e.stopPropagation();
-        navigate('/runs');
+        navigate('/work');
       }}
       className="shrink-0 transition-opacity hover:opacity-80"
       style={{ color: 'var(--accent)', textDecoration: 'none' }}

--- a/src/components/RunsSection.tsx
+++ b/src/components/RunsSection.tsx
@@ -107,13 +107,14 @@ export function RunsSection({ runs, runPath, navigate }: Props): React.ReactElem
           </div>
         </button>
       ))}
-      {/* The ONE escape hatch to the flat cross-project run lists (§2.3) — it
-          stays at the bottom of the section (§1.4). */}
+      {/* The ONE escape hatch to the flat cross-project run list (§2.3) — it
+          stays at the bottom of the section (§1.4). Target: /work, the ONE
+          canonical runs surface (DES-UX-001 §7.4, slice Y). */}
       <div className="px-3 pt-1 pb-1">
         <a
-          href="/runs"
+          href="/work"
           data-testid="rail-all-runs"
-          onClick={(e) => { e.preventDefault(); navigate('/runs'); }}
+          onClick={(e) => { e.preventDefault(); navigate('/work'); }}
           className="text-[11px] font-mono transition-opacity hover:opacity-80"
           style={{ color: 'var(--accent)', textDecoration: 'none' }}
         >

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -12,6 +12,16 @@ interface Props {
   selectedRunId: string | null;
   onSelect: (id: string) => void;
   navigate: (path: string) => void;
+  /** The current URL search string — §7.4's context-sensitive entry (slice Y):
+   *  `?filter=failed` (an all-runs affordance in a failure context) lands with
+   *  the Failed tab active. Anything not a tab id is ignored. */
+  search?: string;
+}
+
+/** The routed status filter, or null when the search carries none/garbage. */
+function routedFilter(search: string): StatusTab | null {
+  const raw = new URLSearchParams(search).get('filter');
+  return raw !== null && TABS.some((t) => t.id === raw) ? (raw as StatusTab) : null;
 }
 
 const isTerminal = (s: string) => ['completed', 'failed', 'cancelled'].includes(s);
@@ -26,9 +36,16 @@ const TABS: { id: StatusTab; label: string }[] = [
   { id: 'failed', label: 'Failed' },
 ];
 
-export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): React.ReactElement {
+export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
-  const [tab, setTab] = useState<StatusTab>('all');
+  const entryFilter = routedFilter(search);
+  const [tab, setTab] = useState<StatusTab>(entryFilter ?? 'all');
+  // The page stays mounted across /work navigations, so a LATER entry that
+  // carries `?filter=` (a failure-context affordance clicked while already
+  // here) re-points the tab too; tab clicks afterwards win as local state.
+  useEffect(() => {
+    if (entryFilter !== null) setTab(entryFilter);
+  }, [entryFilter]);
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
   // Archived runs (crew#265) are WRITTEN OFF: excluded from the default list server-side, so the
@@ -185,6 +202,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate }: Props): Re
       <div
         role="tablist"
         aria-label="Filter by status"
+        data-filter={tab}
         className="px-8 pb-3 flex items-center gap-2"
         onKeyDown={e => {
           const ids = TABS.map(t => t.id);

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -49,6 +49,11 @@ interface LegacyRoute {
  *
  *   /projects/:id  →  /p/:id                    (the project dashboard, §4.1)
  *   /runs/:id      →  /p/<project>/build/:id   (when the run is filed under one)
+ *   /runs          →  /work                     (DES-UX-001 §7.4, slice Y: the bare
+ *                     listing retires — /work is the ONE canonical runs surface.
+ *                     /runs/:id and /runs/new stay routable; only the listing goes.
+ *                     Query params carry over, so a failure-context entry like
+ *                     /runs?filter=failed lands with the Failed filter active.)
  *
  * A bare `/p/:id` is NOT redirected any more — it IS the project dashboard
  * (DES-FEEDBACK-001 §4.1, slice D). The last-used-mode redirect is gone.
@@ -71,7 +76,13 @@ export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void 
       return;
     }
 
-    if (panel !== 'runs' || runId === null || showLaunch) return;
+    if (panel !== 'runs' || showLaunch) return;
+    if (runId === null) {
+      // §7.4 (slice Y): the bare `/runs` listing retires into a redirect — `/work`
+      // is canonical. The search string rides along (context-sensitive filters).
+      navigate(`/work${window.location.search}`, { replace: true });
+      return;
+    }
     let cancelled = false;
     void resolveRunProject(runId)
       .then((pid) => {

--- a/tests/FailureBanner.test.tsx
+++ b/tests/FailureBanner.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { FailureBanner } from '../src/components/FailureBanner.js';
 import type { LoggedEvent } from '../src/store/runtime.js';
 import { makeView, makeUnit } from './factories.js';
@@ -32,5 +32,21 @@ describe('FailureBanner (§11.5 — run-halted explainer)', () => {
     const banner = screen.getByTestId('failure-banner');
     expect(banner).toHaveAttribute('data-kind', 'cancelled');
     expect(banner).toHaveTextContent('Run cancelled');
+  });
+
+  // Slice Y (DES-UX-001 §7.4): the banner's All-runs is a FAILURE-CONTEXT entry —
+  // it lands on /work with the Failed filter active, never on the retired /runs.
+  it('carries the failure-context "All runs ›" link to /work?filter=failed', () => {
+    const navigate = vi.fn();
+    render(<FailureBanner view={makeView({ status: 'failed' })} log={errorLog} navigate={navigate} />);
+    const link = screen.getByTestId('failure-all-runs');
+    expect(link).toHaveAttribute('href', '/work?filter=failed');
+    fireEvent.click(link);
+    expect(navigate).toHaveBeenCalledWith('/work?filter=failed');
+  });
+
+  it('omits the link when no navigate is wired (no dead affordance)', () => {
+    render(<FailureBanner view={makeView({ status: 'failed' })} log={errorLog} />);
+    expect(screen.queryByTestId('failure-all-runs')).toBeNull();
   });
 });

--- a/tests/NarrativeBand.test.tsx
+++ b/tests/NarrativeBand.test.tsx
@@ -78,7 +78,7 @@ describe('composeLede — §7.3 grammar, every drop-out case', () => {
   it('each numeric segment names a real destination (§7.3 links)', () => {
     const full = composeLede({ finished: 4, passed: 3, failed: 1, gates: 2, live: 0, projects: 5 });
     const hrefs = full.segments.filter((s) => s.href !== null).map((s) => s.href);
-    expect(hrefs).toEqual(['/runs', '#needs-you']);
+    expect(hrefs).toEqual(['/work', '#needs-you']);
   });
 });
 
@@ -153,7 +153,7 @@ describe('<NarrativeBand> — composition on screen', () => {
       'While you were away: 1 run finished — 1 passed — and 1 gate is waiting on you.',
     );
     const links = [...lede.querySelectorAll('a[data-testid="lede-segment"]')];
-    expect(links.map((a) => a.getAttribute('href'))).toEqual(['/runs', '#needs-you']);
+    expect(links.map((a) => a.getAttribute('href'))).toEqual(['/work', '#needs-you']);
     // §8.5: the two surviving slice-E tiles live on as margin notes.
     const margin = screen.getByTestId('river-margin');
     expect(margin.querySelector('[data-testid="run-outcome-bar"]')).not.toBeNull();

--- a/tests/RunsBottomPanel.test.tsx
+++ b/tests/RunsBottomPanel.test.tsx
@@ -136,12 +136,13 @@ describe('the collapsed bar (§5.3)', () => {
     expect(bar.textContent).not.toContain('working');
   });
 
-  it('the All runs link is a real /runs link that never expands the sheet', () => {
+  // Slice Y (DES-UX-001 §7.4): the target re-pointed to /work, the canonical surface.
+  it('the All runs link is a real /work link that never expands the sheet', () => {
     const { navigate } = mount();
     const link = screen.getByTestId('runs-bar-all');
-    expect(link.getAttribute('href')).toBe('/runs');
+    expect(link.getAttribute('href')).toBe('/work');
     fireEvent.click(link);
-    expect(navigate).toHaveBeenCalledWith('/runs');
+    expect(navigate).toHaveBeenCalledWith('/work');
     expect(screen.queryByTestId('runs-bottom-sheet')).toBeNull();
   });
 });

--- a/tests/RunsSection.test.tsx
+++ b/tests/RunsSection.test.tsx
@@ -118,12 +118,13 @@ describe('RunsSection (§1.4 DOM)', () => {
     expect(navigate).toHaveBeenCalledWith('/p/proj/build/r-42');
   });
 
-  it('keeps "All runs ›" at the bottom of the section as a real /runs link', () => {
+  // Slice Y (DES-UX-001 §7.4): the target re-pointed to /work, the canonical surface.
+  it('keeps "All runs ›" at the bottom of the section as a real /work link', () => {
     const navigate = vi.fn();
     render(<RunsSection runs={[]} runPath={flat} navigate={navigate} />);
     const hatch = screen.getByTestId('rail-all-runs');
-    expect(hatch).toHaveAttribute('href', '/runs');
+    expect(hatch).toHaveAttribute('href', '/work');
     fireEvent.click(hatch);
-    expect(navigate).toHaveBeenCalledWith('/runs');
+    expect(navigate).toHaveBeenCalledWith('/work');
   });
 });

--- a/tests/WorkPage.filter.test.tsx
+++ b/tests/WorkPage.filter.test.tsx
@@ -1,0 +1,75 @@
+// DES-UX-001 §7.4 (slice Y) — context-sensitive entry on the ONE canonical
+// runs surface: `?filter=<tab>` in the search string lands with that status
+// tab active (`data-filter` on the tablist), garbage is ignored, and a later
+// search change re-points the tab while the page stays mounted.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkPage } from '../src/components/WorkPage.js';
+import { makeView } from './factories.js';
+
+const listRuns = vi.fn();
+const archiveRun = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRuns: (...a: unknown[]) => listRuns(...a),
+    archiveRun: (...a: unknown[]) => archiveRun(...a),
+  },
+}));
+
+const RUNS = [
+  makeView({ id: 'r-live', workflow_id: 'feature', problem: 'live work', status: 'executing' }),
+  makeView({ id: 'r-done', workflow_id: 'feature', problem: 'done work', status: 'completed' }),
+  makeView({ id: 'r-bad', workflow_id: 'feature', problem: 'broken work', status: 'failed' }),
+];
+
+beforeEach(() => {
+  listRuns.mockReset();
+  archiveRun.mockReset();
+});
+
+function mount(search?: string) {
+  return render(
+    <WorkPage
+      runs={RUNS}
+      selectedRunId={null}
+      onSelect={() => {}}
+      navigate={() => {}}
+      {...(search === undefined ? {} : { search })}
+    />,
+  );
+}
+
+describe('WorkPage — §7.4 context-sensitive entry (slice Y)', () => {
+  it('defaults to the All tab with data-filter="all"', () => {
+    mount();
+    expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'all');
+    expect(screen.getByRole('tab', { name: /^All/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('?filter=failed lands with the Failed tab active — the failure lens holds', () => {
+    mount('?filter=failed');
+    expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'failed');
+    expect(screen.getByRole('tab', { name: /^Failed/ })).toHaveAttribute('aria-selected', 'true');
+    // Only the failed run renders in the panel.
+    expect(screen.getByText('broken work')).toBeInTheDocument();
+    expect(screen.queryByText('live work')).toBeNull();
+  });
+
+  it('ignores a filter that is not a tab id', () => {
+    mount('?filter=bogus');
+    expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'all');
+  });
+
+  it('a later ?filter= entry re-points the tab; a tab click afterwards wins', async () => {
+    const { rerender } = mount();
+    rerender(
+      <WorkPage runs={RUNS} selectedRunId={null} onSelect={() => {}} navigate={() => {}} search="?filter=failed" />,
+    );
+    expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'failed');
+    await userEvent.click(screen.getByRole('tab', { name: /^Active/ }));
+    expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'active');
+  });
+});

--- a/tests/legacyRedirect.test.ts
+++ b/tests/legacyRedirect.test.ts
@@ -131,3 +131,23 @@ describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () =>
     expect(listProjects).not.toHaveBeenCalled();
   });
 });
+
+describe('slice Y (DES-UX-001 §7.4): the bare /runs listing retires into /work', () => {
+  const bare = { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: false };
+
+  it('/runs → /work, replacing the history entry, with no membership lookup', () => {
+    window.history.replaceState(null, '', '/runs');
+    const navigate = vi.fn();
+    renderHook(() => useLegacyRedirect(bare, navigate));
+    expect(navigate).toHaveBeenCalledWith('/work', { replace: true });
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+
+  it('carries the search string — /runs?filter=failed keeps its failure context', () => {
+    window.history.replaceState(null, '', '/runs?filter=failed');
+    const navigate = vi.fn();
+    renderHook(() => useLegacyRedirect(bare, navigate));
+    expect(navigate).toHaveBeenCalledWith('/work?filter=failed', { replace: true });
+    window.history.replaceState(null, '', '/');
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §7.4 (slice Y)** — one canonical runs surface (BRIEF-UX-001 C1).

- Bare `/runs` replace-redirects to `/work` (search string carried — bookmarks land true); `/runs/:id` and `/runs/new` stay routable (both driven in the rig).
- Every all-runs affordance (rail hatch, landing link, bottom panel bar+sheet, lede segments) targets `/work`; FailureBanner gains the failure-context "All runs ›" to `/work?filter=failed`; WorkPage reads `?filter=` with `data-filter` on the tablist.
- §11.2 re-scopes as a dedicated commit (feedback3_sliceQ ledeLinkHrefs, uxfix_slice3 AC-4).

Verified: 1306/1306 unit tests; rigs ux_sliceY, sliceN, sliceQ, uxfix_slice3, ux_sliceV, ux_sliceR all green; grep proves zero bare-/runs navigations remain in src; negative check fails on main. ~62 net LOC of the ~180 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
