### PR TITLE
DES-UX-001 slice Y2: run identity

### DIFF
--- a/e2e/ux_sliceY2_test.py
+++ b/e2e/ux_sliceY2_test.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+ux_sliceY2_test.py — the DES-UX-001 slice-Y2 gate: run identity (§7.5, C2,
+EC40 — "five visually identical rows… retries are indistinguishable").
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with its
+`provenance` corpus on, which is ALREADY the slice's corpus (zero fixture
+additions): r-auth (failed) and r-retry (completed) carry IDENTICAL prompts
+("refactor the auth middleware") — the EC40 pair — r-auth's durable event
+tail holds sessionStarted (NOW0-13m) + sessionFailed (NOW0-12m) on the real
+GET /runs/:id/events wire, and r-smoke1 (completed) answers an EMPTY event
+log: the honest-absent-times run. The DTO carries no timestamps (wire
+verdict §7.5) — everything asserted here is CLIENT-derived.
+
+The §7.5 DOM ACs, verbatim mapping:
+
+  1. every /work run row carries `[data-testid="run-title"]` (the synthesized
+     title: truncated intent · short-id · #ordinal) + `[data-testid="run-when"]`
+     (the membership attach clock); the identical-prompt pair r-auth/r-retry
+     renders DISTINGUISHABLE rows — the short-id assert — and r-retry (no
+     membership record) renders the honest "time unknown", never a fabricated
+     clock;
+  2. the runs bottom sheet's rows carry the same run-title + run-when contract;
+  3. palette rows for runs carry it too — and the short-id is now SEARCHABLE:
+     typing `r-retr` finds r-retry (the composed label is the fuzzy corpus);
+  4. run detail renders `[data-testid="run-times"]` derived from the event
+     log — started/ended (data-started/-ended="log") and the duration
+     ("took 1m 0s": NOW0-13m → NOW0-12m) for r-auth;
+  5. r-smoke1 (empty event log) renders the honest absent state — the exact
+     copy "no start or end times survive in this run's event log",
+     data-started="none" — absence stated, never fabricated.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-Y2-run-rows.png    /work with the identical-prompt pair rendered as
+                        distinguishable rows (title + attach clock)
+  ux-Y2-run-times.png   r-auth's detail: the event-log-derived times line
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4387),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4387"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+AUTH_THREAD = "/p/auth-refactor/build/r-auth"
+SMOKE_THREAD = "/p/smoke-tests/build/r-smoke1"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, provenance ON ─────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, provenance=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def nav(path: str) -> None:
+        """CLIENT-side navigation (pushState + popstate) — keeps stores warm."""
+        page.evaluate(
+            """(p) => { history.pushState(null, '', p);
+                        window.dispatchEvent(new PopStateEvent('popstate')); }""",
+            path)
+
+    # ── Scene 1 (AC 1): /work — the identical-prompt pair is distinguishable ────
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="run-link"][data-run-id="r-retry"]').wait_for(timeout=30000)
+    # The attach clock rides the members read (the board model's mirror) —
+    # wait until r-auth's row shows a real age word, not the pre-mirror state.
+    page.wait_for_function(
+        """() => /\\d+[smhd] ago/.test(
+             document.querySelector('[data-testid="run-link"][data-run-id="r-auth"]')
+               ?.querySelector('[data-testid="run-when"]')?.textContent ?? '')""",
+        timeout=15000)
+    rows = page.evaluate(
+        """() => {
+          const rowOf = (rid) => {
+            const row = document.querySelector(`[data-testid="run-link"][data-run-id="${rid}"]`);
+            return row === null ? null : {
+              title: row.querySelector('[data-testid="run-title"]')?.textContent ?? null,
+              when: row.querySelector('[data-testid="run-when"]')?.textContent ?? null,
+              text: row.textContent ?? '',
+            };
+          };
+          return { auth: rowOf('r-auth'), retry: rowOf('r-retry') };
+        }""")
+    auth, retry = rows["auth"], rows["retry"]
+    check("work_rows_distinguishable",
+          auth is not None and retry is not None
+          # the synthesized title: intent · short-id · #ordinal (EC40)
+          and auth["title"] == "refactor the auth middleware · r-auth · #1"
+          and retry["title"] == "refactor the auth middleware · r-retr · #1"
+          and auth["title"] != retry["title"]        # the short-id assert
+          and auth["text"] != retry["text"]          # whole rows differ, not just titles
+          # the attach clock: real for the filed r-auth; the HONEST absent
+          # state for r-retry (no membership record names a clock for it)
+          and re.search(r"\d+[smhd] ago", auth["when"] or "") is not None
+          and retry["when"] == "time unknown",
+          **rows)
+    page.screenshot(path=str(VSHOTS / "ux-Y2-run-rows.png"))
+
+    # ── Scene 2 (AC 2): the bottom sheet rows carry the same contract ───────────
+    page.locator('[data-testid="runs-bar-toggle"]').click()
+    page.locator('[data-testid="runs-bottom-sheet"]').wait_for(timeout=10000)
+    sheet = page.evaluate(
+        """() => {
+          const rows = [...document.querySelectorAll('[data-testid="runs-sheet-row"]')];
+          const authRow = rows.find((r) => r.dataset.runId === 'r-auth');
+          return {
+            total: rows.length,
+            titled: rows.filter((r) => r.querySelector('[data-testid="run-title"]')).length,
+            clocked: rows.filter((r) => r.querySelector('[data-testid="run-when"]')).length,
+            authTitle: authRow?.querySelector('[data-testid="run-title"]')?.textContent ?? null,
+          };
+        }""")
+    check("sheet_rows_identified",
+          sheet["total"] > 0
+          and sheet["titled"] == sheet["total"]      # EVERY row (EC40)
+          and sheet["clocked"] == sheet["total"]
+          and sheet["authTitle"] == "refactor the auth middleware · r-auth · #1",
+          **sheet)
+    page.keyboard.press("Escape")
+
+    # ── Scene 3 (AC 3): palette rows — titled, clocked, short-id searchable ─────
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="command-palette"]').wait_for(timeout=10000)
+    page.locator('[data-testid="palette-input"]').fill("r-retr")
+    page.wait_for_function(
+        """() => [...document.querySelectorAll('[data-testid="palette-row"][data-group="runs"]')]
+              .some((r) => (r.querySelector('[data-testid="run-title"]')?.textContent ?? '')
+                .includes('· r-retr ·'))""",
+        timeout=10000)
+    palette = page.evaluate(
+        """() => {
+          const rows = [...document.querySelectorAll('[data-testid="palette-row"][data-group="runs"]')];
+          const hit = rows.find((r) => (r.querySelector('[data-testid="run-title"]')?.textContent ?? '')
+            .includes('· r-retr ·'));
+          return {
+            runRows: rows.length,
+            hitTitle: hit?.querySelector('[data-testid="run-title"]')?.textContent ?? null,
+            hitWhen: hit?.querySelector('[data-testid="run-when"]')?.textContent ?? null,
+          };
+        }""")
+    check("palette_short_id_finds_run",
+          palette["hitTitle"] == "refactor the auth middleware · r-retr · #1"
+          and palette["hitWhen"] is not None,
+          **palette)
+    page.keyboard.press("Escape")
+
+    # ── Scene 4 (AC 4): run detail — event-log-derived start/end/duration ───────
+    nav(AUTH_THREAD)
+    page.locator('[data-testid="run-times"]').wait_for(timeout=15000)
+    # The FINDING-013 backfill lands the durable tail; both clocks flip to "log".
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="run-times"]')
+              ?.getAttribute('data-started') === 'log'""",
+        timeout=15000)
+    times = page.evaluate(
+        """() => {
+          const el = document.querySelector('[data-testid="run-times"]');
+          return { started: el?.getAttribute('data-started'),
+                   ended: el?.getAttribute('data-ended'),
+                   text: el?.textContent ?? '' };
+        }""")
+    check("detail_times_from_event_log",
+          times["started"] == "log" and times["ended"] == "log"
+          and re.search(r"started \d+[smhd] ago", times["text"]) is not None
+          and re.search(r"ended \d+[smhd] ago", times["text"]) is not None
+          # NOW0-13m → NOW0-12m: the duration is frozen-clock exact
+          and "took 1m 0s" in times["text"]
+          # durable-log clocks are capture-stamped, never "(observed)"
+          and "(observed)" not in times["text"],
+          **times)
+    page.screenshot(path=str(VSHOTS / "ux-Y2-run-times.png"))
+
+    # ── Scene 5 (AC 5): the honest absent state — an empty event log says so ────
+    nav(SMOKE_THREAD)
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="run-times"]')
+              ?.getAttribute('data-started') === 'none'""",
+        timeout=15000)
+    absent = page.evaluate(
+        """() => {
+          const el = document.querySelector('[data-testid="run-times"]');
+          return { started: el?.getAttribute('data-started'),
+                   ended: el?.getAttribute('data-ended'),
+                   text: el?.textContent ?? '' };
+        }""")
+    check("detail_times_honest_absent",
+          absent["started"] == "none" and absent["ended"] == "none"
+          and "no start or end times survive in this run's event log" in absent["text"]
+          # never a fabricated clock on the absent run
+          and "ago" not in absent["text"] and "took" not in absent["text"],
+          **absent)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -16,6 +16,7 @@ import { AgentTerminal } from './AgentTerminal.js';
 import { FailureBanner } from './FailureBanner.js';
 import { FileViewer } from './FileViewer.js';
 import { Markdown } from './Markdown.js';
+import { RunTimes } from './runIdentity.js';
 import { UnitList } from './UnitList.js';
 import { VerdictDetail } from './VerdictDetail.js';
 import type { RunMode } from './runMode.js';
@@ -905,6 +906,11 @@ function RunChat({
           </button>
         )}
       </div>
+
+      {/* Run times (DES-UX-001 §7.5, slice Y2): started/ended/duration derived
+          from the event log App already backfills — the DTO carries no
+          timestamps; where the log lacks the events the line says so. */}
+      <RunTimes runId={session.id} status={session.status} />
 
       {/* Process stepper — the run's map: every phase, in order, with its state at a glance.
           The timeline below renders only the phases that have entered the conversation. */}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -15,6 +15,7 @@ import { decideGate, GATE_HASH } from '../board/gateActions.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { Modal } from './Modal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
+import { INTENT_MAX, runTitle, runWhenWord, WHEN_TITLE } from './runIdentity.js';
 import { Terminal } from './Terminal.js';
 
 /**
@@ -67,6 +68,9 @@ interface Entry {
   /** Search hits: the mono snippet line (§5.3) + its matched positions. */
   snippet?: string;
   snippetPositions?: number[];
+  /** Run rows only (§7.5, slice Y2): the attach-clock word — presence marks the
+   *  row's label as the synthesized `run-title` (EC40). */
+  when?: string;
 }
 
 /**
@@ -271,6 +275,9 @@ export function CommandPalette({
   const [prompts, setPrompts] = useState<InteractionRequest[]>([]);
   const [showWhy, setShowWhy] = useState(false);
   const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  // §7.5 (slice Y2): the attach clock for run rows — the mirror the board
+  // model already writes; a store read, never a fetch (§1.4's budget holds).
+  const attachedAtByRun = useMembershipStore((s) => s.attachedAtByRun);
   useEffect(() => {
     if (!searchMode) {
       setShowWhy(false);
@@ -304,17 +311,24 @@ export function CommandPalette({
         const m = substringMatch(needle, v.session.problem);
         if (m === null) return;
         const id = v.session.id;
+        // §7.5 (slice Y2): the row displays the SYNTHESIZED title while the
+        // match stays on the full problem (prose corpus, §5.2). Highlight
+        // positions survive only when they land inside the displayed intent
+        // fragment — a hit past the truncation is a real hit with no honest
+        // highlight, never a misplaced one.
+        const intentLen = Math.min(v.session.problem.length, INTENT_MAX);
         hits.push({
           en: {
             id: `s-run-${id}`,
             group: 'search-runs',
-            label: v.session.problem,
+            label: runTitle(v.session),
             context: projectNameByRun[id] ?? v.session.status,
             href: runPath(id),
             rank: i,
             dot: SEARCH_DOT[v.session.status] ?? 'var(--ink-dim)',
+            when: runWhenWord(attachedAtByRun[id], Date.now()),
           },
-          m,
+          m: m.positions.every((p) => p < intentLen) ? m : { score: m.score, positions: [] },
         });
       });
       // Open gates — the event-sourced `awaitingHuman` prompts (§5.1).
@@ -418,10 +432,13 @@ export function CommandPalette({
       entries.push({
         id: `run-${id}`,
         group: 'runs',
-        label: v.session.problem,
+        // §7.5 (slice Y2, EC40): the synthesized title IS the matched label
+        // here — typing a short-id now finds its run.
+        label: runTitle(v.session),
         context: gated ? 'gate' : v.session.status,
         href: gated ? `${runPath(id)}${GATE_HASH}` : runPath(id),
         rank: gated ? 0 : ACTIVE.has(v.session.status) ? 1 : 2,
+        when: runWhenWord(attachedAtByRun[id], Date.now()),
       });
     }
 
@@ -541,7 +558,7 @@ export function CommandPalette({
       return a.en.rank - b.en.rank;
     });
     return matched;
-  }, [runs, projects, repos, gates, claims, prompts, projectNameByRun, scope, needle, runPath, navigate, projectId, selectedRun, onKill]);
+  }, [runs, projects, repos, gates, claims, prompts, projectNameByRun, attachedAtByRun, scope, needle, runPath, navigate, projectId, selectedRun, onKill]);
 
   // Clamp the selection whenever the row set changes.
   const selIx = Math.min(sel, Math.max(0, rows.length - 1));
@@ -739,6 +756,7 @@ export function CommandPalette({
                         </span>
                       )}
                       <span
+                        {...(row.en.when !== undefined ? { 'data-testid': 'run-title' } : {})}
                         className="min-w-0 flex-1 truncate"
                         style={{
                           fontSize: 'var(--text-sm)',
@@ -749,6 +767,17 @@ export function CommandPalette({
                         {row.en.group === 'verbs' ? '> ' : ''}
                         {highlight(row.en.label, row.m.positions)}
                       </span>
+                      {/* §7.5 (slice Y2): run rows carry the attach clock. */}
+                      {row.en.when !== undefined && (
+                        <span
+                          data-testid="run-when"
+                          title={WHEN_TITLE}
+                          className="shrink-0 font-mono"
+                          style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}
+                        >
+                          {row.en.when}
+                        </span>
+                      )}
                       <span
                         className="shrink-0 font-mono"
                         style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-dim)' }}

--- a/src/components/RunLink.tsx
+++ b/src/components/RunLink.tsx
@@ -1,5 +1,7 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
+import { useMembershipStore } from '../store/membership.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
+import { runTitle, runWhenWord, WHEN_TITLE } from './runIdentity.js';
 
 interface Props {
   view: SessionView;
@@ -22,9 +24,12 @@ const TITLE_MAX = 35;
 export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactElement {
   const { session, units } = view;
   const isActive = selectedRunId === session.id;
-  const title = session.problem.length > TITLE_MAX
-    ? session.problem.slice(0, TITLE_MAX) + '…'
-    : session.problem;
+  // §7.5 (slice Y2, EC40): the synthesized display title — truncated intent +
+  // short-id + attempt ordinal — so identical prompts never render identical
+  // rows. The short-id moves INTO the title; the meta line gains the attach
+  // clock (the membership mirror — a store read, never a fetch).
+  const title = runTitle(session, TITLE_MAX);
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun[session.id]);
   const unitCount = units.length;
   const pulse = session.status === 'awaiting_human' || session.status === 'executing'
     || session.status === 'distributing' || session.status === 'planning';
@@ -51,6 +56,7 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
           {spec.glyph}
         </span>
         <span
+          data-testid="run-title"
           className="flex-1 truncate text-xs leading-tight font-mono"
           style={{ color: isActive ? 'var(--ink-high)' : 'var(--ink-muted)' }}
           title={session.problem}
@@ -63,7 +69,8 @@ export function RunLink({ view, selectedRunId, onSelect }: Props): React.ReactEl
         />
       </div>
       <p className="text-[10px] mt-0.5 font-mono" style={{ color: 'var(--ink-dim)' }}>
-        {spec.label} · {unitCount} task{unitCount === 1 ? '' : 's'} · {session.id.slice(0, 8)}
+        {spec.label} · {unitCount} task{unitCount === 1 ? '' : 's'} ·{' '}
+        <span data-testid="run-when" title={WHEN_TITLE}>{runWhenWord(attachedAt, Date.now())}</span>
       </p>
     </button>
   );

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -9,6 +9,7 @@ import { useProjectsStore } from '../store/projects.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
 import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
 import { prefersReducedMotion } from './LiveEdge.js';
+import { runTitle, runWhenWord, WHEN_TITLE } from './runIdentity.js';
 import { phaseWord, recentRuns, RUN_DOT } from './RunsSection.js';
 
 /**
@@ -146,6 +147,10 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
   const logs = useRuntimeStore((s) => s.logs);
   const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
   const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  // §7.5 (slice Y2): the attach clock for the sheet rows — the same mirror the
+  // Make dashboard buckets on. A store read: the §5.1 zero-new-requests budget
+  // holds unchanged.
+  const attachedAtByRun = useMembershipStore((s) => s.attachedAtByRun);
   const projects = useProjectsStore((s) => s.projects);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -360,11 +365,22 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
                     className="w-2 h-2 rounded-full shrink-0"
                     style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
                   />
+                  {/* §7.5 (EC40): the synthesized title — identical prompts
+                      never render identical rows — plus the attach clock. */}
                   <span
+                    data-testid="run-title"
                     className="truncate leading-tight"
                     style={{ maxWidth: '48ch', fontSize: 'var(--text-xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}
                   >
-                    {view.session.problem}
+                    {runTitle(view.session)}
+                  </span>
+                  <span
+                    data-testid="run-when"
+                    title={WHEN_TITLE}
+                    className="shrink-0 font-mono"
+                    style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}
+                  >
+                    {runWhenWord(attachedAtByRun[id], Date.now())}
                   </span>
                   <span
                     data-testid="runs-sheet-row-project"

--- a/src/components/runIdentity.tsx
+++ b/src/components/runIdentity.tsx
@@ -1,0 +1,156 @@
+import type { AgentSession, CoreEvent } from '../api/types.js';
+import { useRunEventStore } from '../store/events.js';
+import { useRuntimeStore, type LoggedEvent } from '../store/runtime.js';
+import { ageWord } from './DashboardTiles.js';
+
+/**
+ * Run identity (DES-UX-001 §7.5, slice Y2 — EC40): "five visually identical
+ * rows… retries are indistinguishable". The wire verdict is CLIENT: the run
+ * DTO (`AgentSession`) carries NO timestamps, so
+ *
+ *  - every run LIST row renders a **synthesized display title** — truncated
+ *    intent + short-id + attempt ordinal (`fix the auth flow · 3eda21 · #1`) —
+ *    plus the membership **attach clock** already mirrored into
+ *    `useMembershipStore.attachedAtByRun` (the one honest per-run clock a
+ *    list can have, no new fetches);
+ *  - the run DETAIL derives started/ended/duration from the run's **event
+ *    log** (`GET /runs/:id/events`, already fetched by App's FINDING-013
+ *    backfill into `useRunEventStore`), falling back to the runtime store's
+ *    arrival-stamped log for live runs — labeled "observed", the house
+ *    grammar — and where the log lacks the events it SAYS SO, never
+ *    fabricates (§13: this derivation is the honest v1; a durable
+ *    `started_at` on the DTO is a non-requested follow-up).
+ *
+ * Model-generated titles are explicitly out of scope this round (§13).
+ */
+
+/** The composed title's short-id width (§7.5's `3eda21` example). */
+const SHORT_ID = 6;
+
+/** Longest intent fragment kept inside a composed title (the F7 rule: the
+ *  intent phrase leads, truncated — never the raw paragraph). Exported so the
+ *  palette can clip match-highlight positions to the intent it displays. */
+export const INTENT_MAX = 40;
+
+export function runShortId(id: string): string {
+  return id.slice(0, SHORT_ID);
+}
+
+/**
+ * §7.5's synthesized display title: `truncated intent · short-id · #ordinal`.
+ * The attempt ordinal is 1-based off the DTO's 0-based `attempt`, so five
+ * identical prompts stop being quintuplets — the short-id alone already
+ * distinguishes them; the ordinal names reworks.
+ */
+export function runTitle(session: AgentSession, intentMax: number = INTENT_MAX): string {
+  const intent = session.problem.length > intentMax
+    ? `${session.problem.slice(0, intentMax)}…`
+    : session.problem;
+  return `${intent} · ${runShortId(session.id)} · #${session.attempt + 1}`;
+}
+
+/**
+ * The list row's attach-clock word ("13m ago"). `undefined` = the membership
+ * mirror names no clock for this run (unfiled, or members not yet read) — the
+ * honest absent state is stated, never a fabricated "0s ago".
+ */
+export function runWhenWord(attachedAtMs: number | undefined, now: number): string {
+  return attachedAtMs === undefined ? 'time unknown' : `${ageWord(Math.max(0, now - attachedAtMs))} ago`;
+}
+
+/** Hover copy for the attach clock — names WHICH clock this is (wire honesty). */
+export const WHEN_TITLE =
+  'when this run entered its project (the membership attach clock — the run record itself carries no timestamps)';
+
+/** Event types that end a run, durable-log and live alike. */
+const END_TYPES: ReadonlySet<string> = new Set(['sessionCompleted', 'sessionFailed', 'runCancelled']);
+
+/** One derived clock: epoch ms + whether it is arrival-stamped ("observed"). */
+export interface DerivedClock {
+  ms: number;
+  observed: boolean;
+}
+
+export interface RunClocks {
+  started: DerivedClock | null;
+  ended: DerivedClock | null;
+}
+
+/**
+ * §7.5's detail derivation, spelled once and unit-tested. Durable-log frames
+ * (`ts` = capture time) win; the runtime store's arrival-stamped log covers
+ * the live-run case ("observed" — the frame's arrival IS the clock we have).
+ * A `null` half means the log records no such event — the caller says so.
+ */
+export function deriveRunClocks(durable: readonly CoreEvent[], live: readonly LoggedEvent[]): RunClocks {
+  let started: DerivedClock | null = null;
+  let ended: DerivedClock | null = null;
+  for (const e of durable) {
+    if (typeof e.ts !== 'number') continue;
+    if (e.type === 'sessionStarted' && started === null) started = { ms: e.ts, observed: false };
+    if (END_TYPES.has(e.type)) ended = { ms: e.ts, observed: false };
+  }
+  for (const e of live) {
+    if (e.type === 'sessionStarted' && started === null) started = { ms: e.ts, observed: true };
+    if (END_TYPES.has(e.type) && ended === null) ended = { ms: e.ts, observed: true };
+  }
+  return { started, ended };
+}
+
+/** "1m 40s" / "2h 5m" — a duration between two derived clocks. */
+export function durationWord(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled']);
+
+/**
+ * The run detail's times line (§7.5 DOM AC: `[data-testid="run-times"]`).
+ * Reads the two stores the app already fills for the selected run — zero new
+ * requests. Every absent half is stated in operator language.
+ */
+export function RunTimes({ runId, status }: { runId: string; status: string }): React.ReactElement {
+  const durable = useRunEventStore((s) => s.byRun[runId]);
+  const live = useRuntimeStore((s) => s.logs[runId]);
+  const { started, ended } = deriveRunClocks(durable ?? [], live ?? []);
+  const now = Date.now();
+  const terminal = TERMINAL.has(status);
+
+  const parts: string[] = [];
+  if (started !== null) {
+    parts.push(`started ${ageWord(now - started.ms)} ago${started.observed ? ' (observed)' : ''}`);
+  }
+  if (ended !== null) {
+    parts.push(`ended ${ageWord(now - ended.ms)} ago${ended.observed ? ' (observed)' : ''}`);
+  } else if (!terminal && started !== null) {
+    parts.push('running');
+  } else if (terminal && started !== null) {
+    parts.push('end not in the event log');
+  }
+  if (started !== null && ended !== null) {
+    parts.push(`took ${durationWord(ended.ms - started.ms)}`);
+  }
+  const line = parts.length > 0
+    ? parts.join(' · ')
+    : terminal
+      ? "no start or end times survive in this run's event log"
+      : "no start time in this run's event log yet";
+
+  const iso = (c: DerivedClock | null): string => (c === null ? '—' : new Date(c.ms).toISOString());
+  return (
+    <p
+      data-testid="run-times"
+      data-started={started === null ? 'none' : started.observed ? 'observed' : 'log'}
+      data-ended={ended === null ? (terminal ? 'none' : 'running') : ended.observed ? 'observed' : 'log'}
+      className="px-6 py-1 text-[11px] font-mono truncate shrink-0"
+      style={{ color: 'var(--ink-dim)', margin: 0, borderBottom: '1px solid var(--surface-raised)' }}
+      title={`derived from the run's event log (the run record carries no timestamps) — started: ${iso(started)} · ended: ${iso(ended)}`}
+    >
+      {line}
+    </p>
+  );
+}

--- a/tests/WorkPage.archived.test.tsx
+++ b/tests/WorkPage.archived.test.tsx
@@ -52,10 +52,12 @@ describe('WorkPage — Archived chip (crew#265)', () => {
     listRuns.mockResolvedValue({ runs: [live, archived] });
     renderPage();
     await userEvent.click(screen.getByRole('button', { name: /^Archived/ }));
-    await waitFor(() => expect(screen.getByText('campaign leftover')).toBeInTheDocument());
+    // Slice Y2 (DES-UX-001 §7.5): rows render the SYNTHESIZED title —
+    // intent · short-id · #ordinal — so the lookups match on the intent lead.
+    await waitFor(() => expect(screen.getByText(/campaign leftover · old-1/)).toBeInTheDocument());
     expect(listRuns).toHaveBeenCalledWith(true);
     // The live run appears once (its normal group), not duplicated into the archived group.
-    expect(screen.getAllByText('live work')).toHaveLength(1);
+    expect(screen.getAllByText(/live work · live-1/)).toHaveLength(1);
     expect(screen.getByRole('button', { name: /^Archived 1$/ })).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -64,9 +66,9 @@ describe('WorkPage — Archived chip (crew#265)', () => {
     archiveRun.mockResolvedValue({ runId: 'old-1', archived: false });
     renderPage();
     await userEvent.click(screen.getByRole('button', { name: /^Archived/ }));
-    await waitFor(() => expect(screen.getByText('campaign leftover')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/campaign leftover · old-1/)).toBeInTheDocument());
     await userEvent.click(screen.getByRole('button', { name: 'Unarchive' }));
     expect(archiveRun).toHaveBeenCalledWith('old-1', false);
-    await waitFor(() => expect(screen.queryByText('campaign leftover')).toBeNull());
+    await waitFor(() => expect(screen.queryByText(/campaign leftover/)).toBeNull());
   });
 });

--- a/tests/runIdentity.test.ts
+++ b/tests/runIdentity.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentSession, CoreEvent } from '../src/api/types.js';
+import type { LoggedEvent } from '../src/store/runtime.js';
+import {
+  deriveRunClocks,
+  durationWord,
+  runShortId,
+  runTitle,
+  runWhenWord,
+} from '../src/components/runIdentity.js';
+
+/**
+ * DES-UX-001 §7.5 (slice Y2, EC40): the synthesized-title + event-log-clock
+ * derivations, pure and spelled once. The DOM rigs assert the rendered rows;
+ * these pin the math the rows share.
+ */
+
+function session(id: string, problem: string, attempt = 0): AgentSession {
+  return { id, problem, attempt } as unknown as AgentSession;
+}
+
+describe('runTitle (EC40: identical prompts never render identical titles)', () => {
+  it('composes truncated intent · short-id · #ordinal (attempt is 0-based)', () => {
+    expect(runTitle(session('3eda2129abcd', 'fix the auth flow', 1)))
+      .toBe('fix the auth flow · 3eda21 · #2');
+  });
+
+  it('truncates a paragraph intent, keeping the short-id visible past it', () => {
+    const long = 'refactor the ingestion pipeline so that every incoming webhook payload is validated';
+    const t = runTitle(session('r-long-000', long));
+    expect(t).toBe(`${long.slice(0, 40)}… · r-long · #1`);
+  });
+
+  it('two identical prompts differ by short-id alone', () => {
+    const a = runTitle(session('r-auth-1234', 'refactor the auth middleware'));
+    const b = runTitle(session('r-retry-999', 'refactor the auth middleware'));
+    expect(a).not.toBe(b);
+    expect(runShortId('r-auth-1234')).toBe('r-auth');
+  });
+});
+
+describe('runWhenWord (the attach clock, honestly absent)', () => {
+  const now = 1_000_000_000;
+  it('renders the age word off the membership attach clock', () => {
+    expect(runWhenWord(now - 13 * 60_000, now)).toBe('13m ago');
+  });
+  it('an unmirrored run says so — never a fabricated 0s', () => {
+    expect(runWhenWord(undefined, now)).toBe('time unknown');
+  });
+});
+
+describe('deriveRunClocks (§7.5: durable log wins; live arrival is "observed")', () => {
+  const durable: CoreEvent[] = [
+    { type: 'sessionStarted', session: 'r', ts: 1000 },
+    { type: 'unitDone', session: 'r', ts: 2000 },
+    { type: 'sessionFailed', session: 'r', ts: 61_000 },
+  ];
+  const live: LoggedEvent[] = [
+    { seq: 1, type: 'sessionStarted', ts: 5000, detail: '' },
+    { seq: 2, type: 'sessionCompleted', ts: 9000, detail: '' },
+  ];
+
+  it('reads start/end from durable ts, never arrival-stamped', () => {
+    const c = deriveRunClocks(durable, live);
+    expect(c.started).toEqual({ ms: 1000, observed: false });
+    expect(c.ended).toEqual({ ms: 61_000, observed: false });
+  });
+
+  it('falls back to the arrival-stamped live log, labeled observed', () => {
+    const c = deriveRunClocks([], live);
+    expect(c.started).toEqual({ ms: 5000, observed: true });
+    expect(c.ended).toEqual({ ms: 9000, observed: true });
+  });
+
+  it('an empty log yields null halves — the caller states the absence', () => {
+    expect(deriveRunClocks([], [])).toEqual({ started: null, ended: null });
+  });
+
+  it('a live /ws frame without ts never becomes a clock', () => {
+    const c = deriveRunClocks([{ type: 'sessionStarted', session: 'r' }], []);
+    expect(c.started).toBeNull();
+  });
+});
+
+describe('durationWord', () => {
+  it('spells seconds, minutes+seconds, hours+minutes', () => {
+    expect(durationWord(59_000)).toBe('59s');
+    expect(durationWord(60_000)).toBe('1m 0s');
+    expect(durationWord(3_600_000 + 5 * 60_000)).toBe('1h 5m');
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §7.5 (slice Y2)** — run identity (BRIEF-UX-001 C2: indistinguishable rows).

- Synthesized titles + attach-clock timestamps on every run row (**EC40**: identical prompts never render identical rows — asserted on the distinguishing cells in the rig).
- Event-log-derived start/end/duration on run detail with honest absent states — no fabricated timestamps (verifier grep-audited the diff for Date.now/invented fallbacks).

Verified: 1308/1308 unit tests; slice rig ×3 (incl. a fresh-dist rebuild to rule out stale passes); regressions ux_sliceR/V/S + feedback3_sliceN green; live read-only check at the real daemon — real rows carry titles + timestamps, real detail shows derived times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
