### PR TITLE
DES-UX-001 slice T: thread truth — visible sends, anchored versions, surviving reload

### DIFF
--- a/e2e/feedback2_sliceK_test.py
+++ b/e2e/feedback2_sliceK_test.py
@@ -208,7 +208,7 @@ with sync_playwright() as p:
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
     page.keyboard.press("Enter")
@@ -372,7 +372,7 @@ with sync_playwright() as p:
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-composer"]').fill("Write a one-pager on the rollout")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
     wake_strip(page)
     v1only = page.evaluate(

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -1148,6 +1148,10 @@ try:
     VERSIONS_RE = re.compile(r"^/d/([^/]+)/api/versions$")
     RENDER_RE = re.compile(r"^/d/([^/]+)/doc/(\d+)$")
     FORK_RE = re.compile(r"^/d/([^/]+)/api/fork$")
+    # Slice T (DES-UX-001 §6.3, BRIDGE-UX-1 probe 2): GET /d/:doc/api/conversation
+    # is a REAL bridge read — studio now fetches it once on every doc open, so the
+    # fake bridge answers it (empty history: these fixture docs never had a thread).
+    CONVERSATION_RE = re.compile(r"^/d/([^/]+)/api/conversation$")
     # Slice 15 (§4.4): all three exports are the SERVICE's, and PPTX's python-pptx is a
     # LAZY dependency — absent on this box, as on most — so it answers a clean 400 naming
     # the command that fixes it. HTML and PDF depend on nothing optional and still render.
@@ -1246,6 +1250,10 @@ try:
                 # Video mode is what narrows them to `kind: "demo"`.
                 self._json(200, FIXTURE_DOCS + FIXTURE_DEMOS
                            if project == demo_project else FIXTURE_DOCS)
+                return True
+            if CONVERSATION_RE.match(rest):
+                # Slice T (§6.3): the announce-history read, empty for fixture docs.
+                self._json(200, [])
                 return True
             if INVENTED_THEME_RE.match(rest):
                 # Issue #65: the invented theme routes are 404 — the same answer the

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -1780,18 +1780,25 @@ try:
         docs_created_by_steer = len(created_docs)
         page.screenshot(path=str(SHOTS / "slice10-thread-steering.png"), full_page=True)
 
-        # ── AC (§7.6, client half): the landed version tags the message that caused it ──
+        # ── AC (§7.6 client half, re-scoped by DES-UX-001 slice T / §8.4.1 probe 1):
+        # the bridge QUEUES — the create's generation is the run in flight and the
+        # steer is queued behind it, so landings answer sends FIFO: the first
+        # generated version tags the CREATE message, the next tags the steer. The
+        # fake bridge lands both, exactly as the real one processes its queue.
         page.evaluate(
-            """args => window.__pushFrame({ type: 'interactiveEvent', event: {
-                 event_type: 'wicked.interactive.version.created',
-                 payload: { project_id: args.project, document_id: args.doc,
-                            version: 2, parent: 1, kind: 'generated' } } })""",
+            """args => { for (const version of [1, 2]) {
+                 window.__pushFrame({ type: 'interactiveEvent', event: {
+                   event_type: 'wicked.interactive.version.created',
+                   payload: { project_id: args.project, document_id: args.doc,
+                              version, parent: version - 1, kind: 'generated' } } });
+               } }""",
             {"project": doc_project, "doc": CREATED_DOC},
         )
         tagged_ok, tag_ms = within(
             page,
             """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
-                       return m.length > 0 && m[m.length - 1].getAttribute('data-version') === '2'; }""",
+                       return m.length > 1 && m[0].getAttribute('data-version') === '1'
+                         && m[m.length - 1].getAttribute('data-version') === '2'; }""",
         )
         terminal_state = thread.get_attribute("data-composer-state")
         chip_when_terminal = page.locator('[data-testid="steering-chip"]').count()

--- a/e2e/ux_sliceT_test.py
+++ b/e2e/ux_sliceT_test.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+ux_sliceT_test.py — the DES-UX-001 slice-T gate: thread truth (§6.1 + §6.3).
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) grown with the
+REAL bridge shapes BRIDGE-UX-1 pinned (§8.4.1): `chat.posted` acks
+`200 {ok, event_id, correlation_id}` and QUEUES (`doc_run_ms` slows the FIFO so
+the queue is witnessable), `GET /d/:doc/api/conversation` serves the announce
+history as {role, text, ts[, state]} ONLY (no message ids, no version markers),
+and `restart_bridge` clears process state while the disk (docs + conversation)
+survives.
+
+The §6.1 / §6.3 DOM ACs, verbatim mapping:
+
+  1. §6.1: a send while idle renders `[data-testid="thread-generating"]`, then a
+     `[data-testid="version-marker"]` whose `data-caused-by` equals the send's
+     message id; a send while a run is in flight renders
+     `[data-testid="thread-queued"]` (the honest client-side rendering — the
+     wire carries no queue-position ack) and later its own anchored marker; a
+     refused send renders `[data-testid="thread-send-failed"]` with a retry —
+     never silence (EC36). Every ack on the wire is the pinned real shape.
+  2. EC36 negative: NO version-marker renders whose `data-caused-by` does not
+     match its own containing user message (the gaslight regression pin), and
+     the failed send is never tagged.
+  3. §6.3 same-session reload: the thread's TEXT is back FROM THE WIRE (exactly
+     ONE `GET /d/:doc/api/conversation` on doc open — the one sanctioned mount
+     fetch this slice adds; the other doc-open reads stay the standing manifest
+     + rendered-doc pair), the version markers are back from the session-storage
+     stopgap, the strip's "In thread" is enabled and scrolls, and the stopgap
+     note is ABSENT (nothing is missing).
+  4. §6.3 fresh-session reload (cleared session storage + bridge restart): the
+     text is STILL back from the wire — never an empty state — while the
+     version-anchor gap (the only thing the wire lacks) is stated by
+     `[data-testid="thread-stopgap"]` with the promise-with-a-pointer copy, no
+     marker is faked, and "In thread" disables with the honest reason.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-T-thread-states.png   one thread wearing all three §6.1 send states at once:
+                           generating (head), queued (behind it), failed (retry)
+  ux-T-thread-reload.png   the fresh-session reload: thread text restored from
+                           the wire, stopgap copy on the anchor gap alone
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4383),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4383"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+DOC_URL = f"{ORIGIN}/p/scratch/document"
+BRIEF = "Make me a deck for the Q3 review"
+STEER = "Tighten the headline on slide one"
+FAILING = "Add a closing slide with the roadmap"
+
+# §6.3's stopgap copy — the promise with a pointer, scoped to the anchor gap.
+STOPGAP_MUST_SAY = [
+    "restored from the document’s transcript",
+    "what this session observed",
+    "return when the transcript carries version anchors",
+    "BRIDGE-UX-1",
+]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, slow doc runs ON ──────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, doc_run_ms=6000, send_fail=False)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    console_errors: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # Request/response taps: every interactive GET path (the mount-budget AC) and
+    # every chat.posted ACK body (the pinned real shape).
+    interactive_gets: list[str] = []
+    send_acks: list[dict] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "GET" and "/interactive/" in path:
+            interactive_gets.append(path)
+
+    def on_response(res):
+        path = urlparse(res.url).path
+        if res.request.method == "POST" and path.endswith("/interactive/api/events"):
+            try:
+                body = json.loads(res.request.post_data or "{}")
+            except json.JSONDecodeError:
+                body = {}
+            if body.get("event_type") == "wicked.interactive.chat.posted":
+                ack = None
+                try:
+                    ack = res.json() if res.status == 200 else None
+                except Exception:
+                    ack = None
+                send_acks.append({"status": res.status, "ack": ack})
+
+    page.on("request", on_request)
+    page.on("response", on_response)
+
+    # ── Scene 1 (§6.1): the send lifecycle — generating, queued, failed, anchored ─
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # Send A while IDLE: the create. Its chip must be thread-generating.
+    page.locator('[data-testid="doc-composer"]').fill(BRIEF)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=30000)
+    a_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"]')?.getAttribute('data-message-id')""")
+    check("T1_idle_send_renders_generating", bool(a_id), message_id=a_id)
+
+    # Send B while the run is IN FLIGHT: queued-behind-current-run (§6.1 — the
+    # bridge queues per §8.4.1 probe 1; the queued rendering is client-side).
+    page.locator('[data-testid="doc-composer"]').fill(STEER)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-queued"]').wait_for(timeout=30000)
+    b_id = page.evaluate(
+        """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                   return m[m.length - 1]?.getAttribute('data-message-id'); }""")
+    both = page.evaluate(
+        """() => ({
+             generating: !!document.querySelector('[data-testid="thread-generating"]'),
+             queued: !!document.querySelector('[data-testid="thread-queued"]'),
+           })""")
+    check("T2_midrun_send_renders_queued", both["generating"] and both["queued"] and bool(b_id),
+          **both, message_id=b_id)
+
+    # Send C against a REFUSING bridge: the visible failure with a retry.
+    set_fixture(ORIGIN, send_fail=True)
+    page.locator('[data-testid="doc-composer"]').fill(FAILING)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-send-failed"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread-send-retry"]').wait_for(timeout=30000)
+    set_fixture(ORIGIN, send_fail=False)
+    c_id = page.evaluate(
+        """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                   return m[m.length - 1]?.getAttribute('data-message-id'); }""")
+
+    # The named shot: one thread wearing all three states at once.
+    tri = page.evaluate(
+        """() => ({
+             generating: !!document.querySelector('[data-testid="thread-generating"]'),
+             queued: !!document.querySelector('[data-testid="thread-queued"]'),
+             failed: !!document.querySelector('[data-testid="thread-send-failed"]'),
+           })""")
+    check("T3_all_three_states_visible", all(tri.values()), **tri)
+    page.screenshot(path=str(VSHOTS / "ux-T-thread-states.png"))
+
+    # A's landing anchors to A — data-caused-by equals the send's message id.
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
+    a_marker_cause = page.locator('[data-testid="version-marker"][data-version="1"]') \
+        .get_attribute("data-caused-by")
+    check("T4_idle_send_marker_anchored", a_marker_cause == a_id,
+          caused_by=a_marker_cause, expected=a_id)
+
+    # B's landing anchors to B — the queued send resolves to its OWN marker (FIFO).
+    page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=30000)
+    b_marker_cause = page.locator('[data-testid="version-marker"][data-version="2"]') \
+        .get_attribute("data-caused-by")
+    check("T5_queued_send_marker_anchored", b_marker_cause == b_id,
+          caused_by=b_marker_cause, expected=b_id)
+
+    # C is still failed — never silently tagged — until its retry lands v3.
+    still_failed = page.evaluate(
+        """() => !!document.querySelector('[data-testid="thread-send-failed"]')""")
+    page.locator('[data-testid="thread-send-retry"]').click()
+    page.locator('[data-testid="version-marker"][data-version="3"]').wait_for(timeout=30000)
+    c_marker_cause = page.locator('[data-testid="version-marker"][data-version="3"]') \
+        .get_attribute("data-caused-by")
+    check("T6_retry_resolves_to_anchored_marker",
+          still_failed and c_marker_cause == c_id,
+          was_failed_before_retry=still_failed, caused_by=c_marker_cause, expected=c_id)
+
+    # EC36 negative (the gaslight pin): every marker's data-caused-by matches the
+    # user message IN ITS OWN bubble — no marker under an unrelated request.
+    ec36 = page.evaluate(
+        """() => {
+             const markers = Array.from(document.querySelectorAll('[data-testid="version-marker"]'));
+             const ids = new Set(Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+               .map((m) => m.getAttribute('data-message-id')));
+             return {
+               markers: markers.length,
+               allAnchoredToOwnMessage: markers.every((mk) => {
+                 const cause = mk.getAttribute('data-caused-by');
+                 const own = mk.parentElement?.querySelector('[data-testid="doc-message"]');
+                 return ids.has(cause) && own?.getAttribute('data-message-id') === cause;
+               }),
+               noStrayState: !document.querySelector('[data-testid="thread-generating"]')
+                 && !document.querySelector('[data-testid="thread-queued"]')
+                 && !document.querySelector('[data-testid="thread-send-failed"]'),
+             };
+           }""")
+    check("T7_ec36_no_marker_without_causing_message",
+          ec36["markers"] == 3 and ec36["allAnchoredToOwnMessage"] and ec36["noStrayState"], **ec36)
+
+    # The wire's ack shape, pinned in the client's own traffic (§8.4.1 probe 1):
+    # every accepted send answered 200 {ok, event_id, correlation_id}; the refused
+    # one answered 500 (the send_fail branch) — no other shape exists.
+    accepted = [a for a in send_acks if a["status"] == 200]
+    refused = [a for a in send_acks if a["status"] == 500]
+    ack_ok = (len(accepted) >= 3 and len(refused) == 1
+              and all(sorted((a["ack"] or {}).keys()) == ["correlation_id", "event_id", "ok"]
+                      for a in accepted))
+    check("T8_real_ack_shapes_on_the_wire", ack_ok,
+          accepted=len(accepted), refused=len(refused),
+          ack_keys=[sorted((a["ack"] or {}).keys()) for a in accepted])
+
+    doc_path = urlparse(page.url).path  # /p/scratch/document/<docId>
+    doc_id = doc_path.rsplit("/", 1)[-1]
+
+    # ── Scene 2 (§6.3): same-session reload — text from the wire, anchors from ──
+    # the session-storage stopgap, In-thread enabled, ONE conversation read.
+    interactive_gets.clear()
+    page.reload(wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    # Doc-open budget window (before the drawer opens): the standing manifest +
+    # rendered-doc reads plus EXACTLY ONE sanctioned conversation read — nothing else.
+    page.wait_for_function(
+        """() => !!document.querySelector('[data-testid="version-entry"]')""", timeout=30000)
+    conv_path = f"/api/v1/projects/scratch/interactive/d/{doc_id}/api/conversation"
+    page.wait_for_timeout(800)  # settle one beat so late mount fetches register
+    mount_gets = list(interactive_gets)
+    conv_reads = [g for g in mount_gets if g.endswith("/api/conversation")]
+    sanctioned = {conv_path,
+                  f"/api/v1/projects/scratch/interactive/d/{doc_id}/api/versions"}
+    unsanctioned = [g for g in mount_gets
+                    if g not in sanctioned and not g.startswith(
+                        f"/api/v1/projects/scratch/interactive/d/{doc_id}/doc/")]
+    check("T9_one_sanctioned_conversation_read_on_doc_open",
+          conv_reads == [conv_path] and unsanctioned == [],
+          conversation_reads=conv_reads, unsanctioned=unsanctioned, mount_gets=mount_gets)
+
+    # Open the drawer (closed by default on a doc route) and assert the thread.
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+    same_session = page.evaluate(
+        """(brief) => {
+             const texts = Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+               .map((m) => m.textContent || '');
+             const markers = Array.from(document.querySelectorAll('[data-testid="version-marker"]'))
+               .map((m) => m.getAttribute('data-version'));
+             const ids = new Set(Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+               .map((m) => m.getAttribute('data-message-id')));
+             const anchored = Array.from(document.querySelectorAll('[data-testid="version-marker"]'))
+               .every((mk) => ids.has(mk.getAttribute('data-caused-by')));
+             return {
+               textBack: texts.some((t) => t.includes(brief)),
+               notEmpty: !!texts.length,
+               markers,
+               anchored,
+               stopgapAbsent: !document.querySelector('[data-testid="thread-stopgap"]'),
+             };
+           }""", BRIEF)
+    check("T10_same_session_reload_thread_back",
+          same_session["textBack"] and same_session["anchored"]
+          and set(same_session["markers"]) == {"1", "2", "3"}
+          and same_session["stopgapAbsent"],
+          **same_session)
+
+    # §6.3: the strip's "In thread" is ENABLED for the reloaded session's v1 and
+    # actually scrolls — the anchor survived the reload.
+    wake_strip(page)
+    v1_scroll = page.locator('[data-testid="version-entry"][data-version="1"] [data-testid="version-scroll"]')
+    v1_enabled = v1_scroll.is_enabled()
+    v1_scroll.click()
+    landed_on_msg = page.evaluate(
+        """() => {
+             const el = document.activeElement;
+             return el?.getAttribute('data-testid') === 'doc-message'
+               ? el.getAttribute('data-message-id') : null;
+           }""")
+    v1_cause = page.locator('[data-testid="version-marker"][data-version="1"]') \
+        .get_attribute("data-caused-by")
+    check("T11_in_thread_enabled_and_scrolls_after_reload",
+          v1_enabled and landed_on_msg == v1_cause,
+          enabled=v1_enabled, focused=landed_on_msg, expected=v1_cause)
+
+    # ── Scene 3 (§6.3): FRESH session — cleared session storage + bridge restart ─
+    page.evaluate("() => window.sessionStorage.clear()")
+    set_fixture(ORIGIN, restart_bridge=True)
+    interactive_gets.clear()
+    page.reload(wait_until="domcontentloaded")
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+    page.locator('[data-testid="thread-stopgap"]').wait_for(timeout=30000)
+
+    fresh = page.evaluate(
+        """(args) => {
+             const [brief, steer] = args;
+             const texts = Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+               .map((m) => m.textContent || '');
+             const stopgap = document.querySelector('[data-testid="thread-stopgap"]')?.textContent || '';
+             const scrolls = Array.from(document.querySelectorAll('[data-testid="version-scroll"]'));
+             return {
+               textBack: texts.some((t) => t.includes(brief)) && texts.some((t) => t.includes(steer)),
+               narrationBack: !!document.querySelector('[data-testid="doc-narration"]'),
+               noMarkerFaked: !document.querySelector('[data-testid="version-marker"]'),
+               noEmptyState: !!texts.length,
+               stopgap,
+               inThreadAllDisabled: scrolls.length > 0 && scrolls.every((b) => b.disabled),
+               disabledReasonHonest: (scrolls[0]?.title || '').includes('version anchors'),
+             };
+           }""", [BRIEF, STEER])
+    stopgap_ok = all(phrase in fresh["stopgap"] for phrase in STOPGAP_MUST_SAY)
+    conv_reads = [g for g in interactive_gets if g.endswith("/api/conversation")]
+    check("T12_fresh_session_text_back_stopgap_on_anchor_gap_only",
+          fresh["textBack"] and fresh["narrationBack"] and fresh["noMarkerFaked"]
+          and fresh["noEmptyState"] and stopgap_ok
+          and fresh["inThreadAllDisabled"] and fresh["disabledReasonHonest"]
+          and conv_reads == [conv_path],
+          stopgap_copy_ok=stopgap_ok, conversation_reads=conv_reads,
+          **{k: v for k, v in fresh.items() if k != "stopgap"})
+
+    page.screenshot(path=str(VSHOTS / "ux-T-thread-reload.png"))
+
+    # Console hygiene: the deliberate 500 refusal logs one resource error; nothing
+    # else may.
+    unexpected = [e for e in console_errors
+                  if "500" not in e and "Failed to load resource" not in e]
+    check("T13_no_unexpected_console_errors", unexpected == [], errors=unexpected)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["shots"] = ["ux-T-thread-states.png", "ux-T-thread-reload.png"]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_sliceT_test.py
+++ b/e2e/ux_sliceT_test.py
@@ -235,11 +235,13 @@ with sync_playwright() as p:
           ec36["markers"] == 3 and ec36["allAnchoredToOwnMessage"] and ec36["noStrayState"], **ec36)
 
     # The wire's ack shape, pinned in the client's own traffic (§8.4.1 probe 1):
-    # every accepted send answered 200 {ok, event_id, correlation_id}; the refused
-    # one answered 500 (the send_fail branch) — no other shape exists.
+    # every accepted chat.posted answered 200 {ok, event_id, correlation_id}; the
+    # refused one answered 500 (the send_fail branch) — no other shape exists.
+    # (A is a CREATE — POST /api/docs — so exactly two sends ride chat.posted:
+    # B's steer and C's retry; C's first attempt is the one refusal.)
     accepted = [a for a in send_acks if a["status"] == 200]
     refused = [a for a in send_acks if a["status"] == 500]
-    ack_ok = (len(accepted) >= 3 and len(refused) == 1
+    ack_ok = (len(accepted) == 2 and len(refused) == 1
               and all(sorted((a["ack"] or {}).keys()) == ["correlation_id", "event_id", "ok"]
                       for a in accepted))
     check("T8_real_ack_shapes_on_the_wire", ack_ok,
@@ -253,6 +255,7 @@ with sync_playwright() as p:
     # the session-storage stopgap, In-thread enabled, ONE conversation read.
     interactive_gets.clear()
     page.reload(wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)  # re-add: styles die with the reload
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
     # Doc-open budget window (before the drawer opens): the standing manifest +
     # rendered-doc reads plus EXACTLY ONE sanctioned conversation read — nothing else.
@@ -262,11 +265,17 @@ with sync_playwright() as p:
     page.wait_for_timeout(800)  # settle one beat so late mount fetches register
     mount_gets = list(interactive_gets)
     conv_reads = [g for g in mount_gets if g.endswith("/api/conversation")]
-    sanctioned = {conv_path,
-                  f"/api/v1/projects/scratch/interactive/d/{doc_id}/api/versions"}
-    unsanctioned = [g for g in mount_gets
-                    if g not in sanctioned and not g.startswith(
-                        f"/api/v1/projects/scratch/interactive/d/{doc_id}/doc/")]
+    # The budget is scoped to THIS DOC'S MOUNT: the doc-open reads stay the standing
+    # manifest + rendered-doc pair plus EXACTLY ONE sanctioned conversation read —
+    # the one new fetch this slice adds. (App-boot reads outside the mount — the
+    # preflight gate, the board's docs-cache warms for other projects — are the
+    # standing pre-slice set and ride the reload, not the doc open.)
+    doc_mount = f"/api/v1/projects/scratch/interactive/d/{doc_id}/"
+    mount_scoped = [g for g in mount_gets if g.startswith(doc_mount)]
+    unsanctioned = [g for g in mount_scoped
+                    if g != conv_path
+                    and g != f"{doc_mount}api/versions"
+                    and not g.startswith(f"{doc_mount}doc/")]
     check("T9_one_sanctioned_conversation_read_on_doc_open",
           conv_reads == [conv_path] and unsanctioned == [],
           conversation_reads=conv_reads, unsanctioned=unsanctioned, mount_gets=mount_gets)
@@ -322,6 +331,7 @@ with sync_playwright() as p:
     set_fixture(ORIGIN, restart_bridge=True)
     interactive_gets.clear()
     page.reload(wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)  # re-add: styles die with the reload
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
     wake_strip(page)
     page.locator('[data-testid="thread-toggle"]').click()

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -124,6 +124,20 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     project's members wire. Default False: pre-0.8.0 rigs keep
                     DTOs without the field and a POST that 404s.
 
+  doc_run_ms      — slice T (DES-UX-001 §6.1): how long one doc "run" takes.
+                    0 (default) keeps the instant landings every standing rig
+                    assumes; >0 makes each accepted chat.posted send land its
+                    OWN new version FIFO doc_run_ms after the previous landing
+                    (BRIDGE-UX-1 probe 1: the bridge queues, never drops), so
+                    a rig can witness generating/queued/marker in sequence.
+  send_fail       — slice T (§6.1): POST /api/events chat.posted answers a
+                    500 {error} — the visible-failure branch (default False).
+  restart_bridge  — slice T (§6.3): POST {"restart_bridge": true} simulates a
+                    FULL bridge restart: process-scoped state (relay queue,
+                    run schedule) clears; the docs registry and the
+                    conversation announce history — the disk — survive,
+                    exactly the split BRIDGE-UX-1 probe 2 verified.
+
 A rig that never flips them gets the default W2 board.
 """
 
@@ -243,7 +257,19 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # Slice S (DES-UX-001 §2.3, CREW-UX-2): run DTOs carry `project_id`,
          # r-unfiled joins the list, POST /runs launches for real. Default
          # False: no standing rig's DTO shape changes.
-         "project_dto": False}
+         "project_dto": False,
+         # Slice T (DES-UX-001 §6.1, BRIDGE-UX-1 probe 1): how long one doc
+         # "run" takes. 0 (default) keeps the historical instant landing every
+         # standing rig assumes. >0 makes each accepted chat.posted send land
+         # its OWN new version doc_run_ms after the previous landing — the
+         # bridge's real queue semantics (sends ack 200 and land FIFO), slowed
+         # down enough for a rig to witness generating/queued states.
+         "doc_run_ms": 0,
+         # Slice T (§6.1): when True, POST /api/events chat.posted answers a
+         # 500 {error} — the visible-failure branch (a bridge that refuses the
+         # send; the client must render thread-send-failed, never silence).
+         "send_fail": False,
+         }
 state_lock = threading.Lock()
 
 # ── The crew settings store (DES-VISION-001 §3.3, vision slice 7) ──────────────
@@ -1122,11 +1148,76 @@ def broadcast_chat(frame: dict) -> None:
             q.append(frame)
 
 
+# ── Slice T (DES-UX-001 §6.3): the doc's announce history, as the REAL bridge
+# keeps it (BRIDGE-UX-1 probe 2 pinned the shape): user chat + agent narration
+# (error states included) as {role, text, ts[, state]} — no message ids, no
+# version markers. It lives OUTSIDE process-restart scope by design: the real
+# store is conversation.jsonl on disk and survives a full bridge restart, which
+# is what the `restart_bridge` control simulates (ws state clears, this stays).
+conversations_lock = threading.Lock()
+conversations: dict = {}  # (pid, doc) -> [{role, text, ts[, state]}]
+
+
+def log_conversation(pid: str, doc: str, role: str, text: str, state_val: str | None = None) -> None:
+    entry = {"role": role, "text": text, "ts": iso(int(time.time() * 1000))}
+    if state_val == "error":
+        entry["state"] = state_val
+    with conversations_lock:
+        conversations.setdefault((pid, doc), []).append(entry)
+
+
 def queue_interactive(event_type: str, payload: dict) -> None:
     """Queue one relayed interactive frame for the /ws loop's next tick."""
+    # Slice T: doc-scoped narration is ALSO appended to the durable announce
+    # history — the same dual-write the real bridge does (SSE relay + JSONL),
+    # so GET /d/:doc/api/conversation reads back what the stream said.
+    if event_type == "wicked.interactive.status.posted":
+        pid, doc = payload.get("project_id"), payload.get("document_id")
+        text = payload.get("message")
+        if pid and doc and text:
+            log_conversation(pid, doc, "agent", str(text), payload.get("state"))
     with ws_lock:
         ws_queue.append({"type": "interactiveEvent",
                          "event": {"event_type": event_type, "payload": payload}})
+
+
+# Slice T (§6.1): the per-doc "agent" is BUSY between a send and its landing —
+# a second send queues behind it, exactly the FIFO the probe pinned. Each
+# scheduled landing appends a NEW version and emits the same two frames the
+# instant path emits, doc_run_ms after the previous landing completes.
+doc_sched_lock = threading.Lock()
+doc_next_free: dict = {}  # (pid, doc) -> unix seconds when the agent frees up
+
+
+def schedule_doc_run(pid: str, doc: str, delay_s: float, fixed_version: int | None = None) -> None:
+    """Land one version after `delay_s` of FIFO-queued work. `fixed_version`
+    re-announces an existing manifest version (the create path, whose v1 is
+    committed at POST time); None appends head+1 (a steer send's own landing)."""
+    with doc_sched_lock:
+        start = max(time.time(), doc_next_free.get((pid, doc), 0.0))
+        fire_at = start + delay_s
+        doc_next_free[(pid, doc)] = fire_at
+
+    def land() -> None:
+        if fixed_version is None:
+            with docs_lock:
+                versions = docs_created.get(pid, {}).get(doc)
+                if versions is None:
+                    return
+                v = max(e["version"] for e in versions) + 1
+                versions.append({"version": v, "parent": v - 1, "feedback_file": None,
+                                 "html_file": f"v{v}.html", "created_at": iso(NOW0 + v * SEC)})
+            parent = v - 1
+        else:
+            v, parent = fixed_version, None
+        queue_interactive("wicked.interactive.status.posted", {
+            "project_id": pid, "document_id": doc, "state": "working",
+            "message": f"Applying the change — landing v{v}."})
+        queue_interactive("wicked.interactive.version.created", {
+            "project_id": pid, "document_id": doc,
+            "version": v, "parent": parent, "kind": "generated"})
+
+    threading.Timer(max(fire_at - time.time(), 0.0), land).start()
 
 
 def slug(name: str) -> str:
@@ -1635,6 +1726,18 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"document_id": doc, "learned_at": iso(ready_at),
                                  "tokens": LEARNED_TOKENS})
             return True
+        # Slice T (DES-UX-001 §6.3, BRIDGE-UX-1 probe 2): the REAL thread-history
+        # read — GET /d/:doc/api/conversation returns the announce history (user
+        # chat + agent narration, error states included) as {role, text, ts[,
+        # state]} ONLY: no message ids, no version markers — the fidelity the
+        # probe pinned. The store survives `restart_bridge` (it is the disk).
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/conversation$", path)
+        if m:
+            pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            with conversations_lock:
+                entries = [dict(e) for e in conversations.get((pid, doc), [])]
+            self._json(200, entries)
+            return True
         # /api/v1/projects/<pid>/interactive/d/<doc>/api/versions — the manifest.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/versions$", path)
         if m:
@@ -1701,18 +1804,32 @@ class W2Handler(SimpleHTTPRequestHandler):
         if m:
             pid = urllib.parse.unquote(m.group(1))
             doc = slug(str(body.get("name") or "doc"))
-            anchor = body.get("source_message_id")
+            # Slice T (§8.4.1 probe 1): the REAL bridge DROPS source_message_id —
+            # no `meta.sourceMessageId` ever reaches the manifest (the interactive.ts
+            # claim was aspirational). The client's anchor is client-side; the
+            # fixture must not serve a correlation the wire does not carry.
             with docs_lock:
                 docs_created.setdefault(pid, {})[doc] = [
                     {"version": 1, "parent": None, "feedback_file": None,
-                     "html_file": "v1.html", "created_at": iso(NOW0),
-                     "meta": {"sourceMessageId": anchor}}]
+                     "html_file": "v1.html", "created_at": iso(NOW0)}]
+            brief = str(body.get("brief") or "")
+            if brief:
+                # The brief IS the doc's first user line in the announce history
+                # (the create message the reload scene must get back, §6.3).
+                log_conversation(pid, doc, "user", brief)
             queue_interactive("wicked.interactive.status.posted", {
                 "project_id": pid, "document_id": doc, "state": "working",
                 "message": "Planning the deck — outline first, then the slides."})
-            queue_interactive("wicked.interactive.version.created", {
-                "project_id": pid, "document_id": doc,
-                "version": 1, "parent": None, "kind": "generated"})
+            with state_lock:
+                run_ms = int(state["doc_run_ms"])
+            if run_ms > 0:
+                # Slice T: v1 is committed now but LANDS (the frame) after the
+                # run — long enough for the rig to witness thread-generating.
+                schedule_doc_run(pid, doc, run_ms / 1000.0, fixed_version=1)
+            else:
+                queue_interactive("wicked.interactive.version.created", {
+                    "project_id": pid, "document_id": doc,
+                    "version": 1, "parent": None, "kind": "generated"})
             self._json(201, {"name": doc, "head": 1, "generating": True, "project_id": pid})
             return True
         # POST /api/v1/projects/<pid>/interactive/d/<doc>/api/fork — branch (§7.10).
@@ -1726,10 +1843,10 @@ class W2Handler(SimpleHTTPRequestHandler):
                     self._json(404, {"error": f"no such doc {doc}"})
                     return True
                 v = max(e["version"] for e in versions) + 1
+                # Slice T (§8.4.1): no meta.sourceMessageId — the bridge drops it.
                 versions.append(
                     {"version": v, "parent": frm, "feedback_file": None,
-                     "html_file": f"v{v}.html", "created_at": iso(NOW0 + v * SEC),
-                     "meta": {"sourceMessageId": body.get("source_message_id")}})
+                     "html_file": f"v{v}.html", "created_at": iso(NOW0 + v * SEC)})
             self._json(200, {"version": v, "parent": frm})
             return True
         # Issue #65: the invented POST /api/theme/learn 404s, exactly as the real
@@ -1777,15 +1894,34 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
                 return True
             if body.get("event_type") == "wicked.interactive.chat.posted" and doc:
-                versions = doc_versions(pid, doc)
-                head = max((e["version"] for e in versions), default=1)
-                queue_interactive("wicked.interactive.status.posted", {
-                    "project_id": pid, "document_id": doc, "state": "working",
-                    "message": "Tightening the headline and rebalancing the slide."})
-                queue_interactive("wicked.interactive.version.created", {
-                    "project_id": pid, "document_id": doc,
-                    "version": head, "parent": head - 1 if head > 1 else None,
-                    "kind": "generated"})
+                # Slice T (§6.1): a refused send is a LOUD 500 — the client's
+                # visible-failure branch. Real shape: the bridge reports {error}.
+                with state_lock:
+                    refuse = bool(state["send_fail"])
+                    run_ms = int(state["doc_run_ms"])
+                if refuse:
+                    self._json(500, {"error": "bridge refused the send (fixture send_fail)"})
+                    return True
+                # The accepted send lands durably in the announce history in send
+                # order (BRIDGE-UX-1 probe 1: the bus is the queue) …
+                if payload.get("role") == "user" and payload.get("text"):
+                    log_conversation(pid, doc, "user", str(payload.get("text")))
+                if run_ms > 0:
+                    # … and each send's run lands its OWN new version, FIFO,
+                    # doc_run_ms after the previous landing (§8.4.1 queue truth).
+                    schedule_doc_run(pid, doc, run_ms / 1000.0)
+                else:
+                    # Historical instant path, unchanged for every standing rig:
+                    # re-announce the head as the regenerated version.
+                    versions = doc_versions(pid, doc)
+                    head = max((e["version"] for e in versions), default=1)
+                    queue_interactive("wicked.interactive.status.posted", {
+                        "project_id": pid, "document_id": doc, "state": "working",
+                        "message": "Tightening the headline and rebalancing the slide."})
+                    queue_interactive("wicked.interactive.version.created", {
+                        "project_id": pid, "document_id": doc,
+                        "version": head, "parent": head - 1 if head > 1 else None,
+                        "kind": "generated"})
             self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
             return True
         return False
@@ -1809,6 +1945,16 @@ class W2Handler(SimpleHTTPRequestHandler):
             if body.get("reset_learn"):
                 with learned_lock:
                     learned_themes.clear()
+            # Slice T (§6.3): `restart_bridge` simulates a FULL bridge restart —
+            # everything process-scoped clears (the relay queue, the agent's
+            # in-flight schedule), while the disk survives: the docs registry
+            # and the conversation.jsonl-backed announce history stay, exactly
+            # the split BRIDGE-UX-1 probe 2 verified on the real bridge.
+            if body.get("restart_bridge"):
+                with ws_lock:
+                    ws_queue.clear()
+                with doc_sched_lock:
+                    doc_next_free.clear()
             with state_lock:
                 # `appearance` rides the same control channel but lands in the
                 # settings store: a dict replaces studio.appearance wholesale,

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -26,7 +26,7 @@ by DES-FEEDBACK-001 §7.3, which made Document mode canvas-first):
      whose empty state points at it, and the drawer state survives the
      navigation the composer makes.)
   2. Thread tags: each message that produced a version carries
-     data-testid="thread-version-tag" with its data-version, reading
+     data-testid="version-marker" with its data-version, reading
      "▤ v<N> landed"; a tag click navigates to that version (?v=N) and the
      strip entry highlights — the thread→strip direction.
   3. The slice-9 regression guard (§7.6): selecting a strip entry swaps the
@@ -147,7 +147,7 @@ with sync_playwright() as p:
     # ── Scene A: W3 — create from the brief, watch v1 land ────────────────────────
     page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="version-entry"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
 
@@ -155,7 +155,7 @@ with sync_playwright() as p:
     page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
     page.keyboard.press("Enter")
     page.locator('[data-testid="version-divider"][data-version="2"]').wait_for(timeout=30000)
-    page.locator('[data-testid="thread-version-tag"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
     # The canvas is LOADED (its named loading state has retired) before any capture.
@@ -204,7 +204,7 @@ with sync_playwright() as p:
     # AC 2 — the tags: both landed versions are tagged, legibly, on their messages.
     tags = page.evaluate(
         """() => {
-             const tags = Array.from(document.querySelectorAll('[data-testid="thread-version-tag"]'));
+             const tags = Array.from(document.querySelectorAll('[data-testid="version-marker"]'));
              const msgs = Array.from(document.querySelectorAll('[data-testid="doc-message"]'));
              return {
                tagTexts: tags.map(t => t.textContent.trim()),
@@ -272,7 +272,7 @@ with sync_playwright() as p:
     page.screenshot(path=str(SHOTS / "uxfix-6-version-crosslink.png"))
 
     # thread → strip: clicking a tag navigates to ITS version; the strip follows.
-    page.locator('[data-testid="thread-version-tag"][data-version="2"]').click()
+    page.locator('[data-testid="version-marker"][data-version="2"]').click()
     page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
     thread_to_strip = page.evaluate("() => location.pathname + location.search")

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -42,8 +42,10 @@ cross-link; Video narration naming its subject). The §5.5 cross-link flash
 
 Captures (§6.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
   vision-4-chat-firstrun.png   Chat mode, first-run state (§5.3)
-  vision-4-build-runs.png      Build mode: W2's running + gate runs, left-border
-                               status coloring, gate inbox, cost footer (§5.4)
+  vision-4-build-runs.png      Build mode: q3-review-deck's Build tab — the gate
+                               run's left-border coloring, gate inbox, purpose,
+                               primary action (§5.4; scene 2 visits the project
+                               tabs that own each status edge — see the scene)
   vision-5-document.png        Document mode, three-pane, v2 selected, version
                                tags in thread (§5.5)
   vision-5-video.png           Video mode: player + storyboard chapters (§5.6)
@@ -228,71 +230,151 @@ with sync_playwright() as p:
     }
 
     # ══ Scene 2 — Build (§5.4): left-border status, purpose, gate inbox, footer ═
-    # Re-scoped by DES-UX-001 slice S (§2.3 rule 2): a project's Build tab now
-    # shows exactly its runs, so the multi-status whole-fixture list (gate +
-    # working + failed edges, the $0.42 footer) lives on the FLAT `/runs` home.
+    # Re-scope history — this scene has followed the §5.4 anatomy twice:
+    #   · DES-UX-001 slice S (§2.3 rule 2) scoped a project's Build tab to
+    #     exactly its own runs, so the multi-status whole-fixture list (gate +
+    #     working + failed edges beside one $0.42 footer) moved to the FLAT
+    #     `/runs` home — this scene's §11.2 re-scope (slice W) pointed here.
+    #   · DES-UX-001 slice Y then retired bare `/runs` outright: it is a
+    #     replace-redirect to `/work`, whose rows are run-LINK anatomy, and the
+    #     unscoped CenterDashboard now sits behind the legacy-redirect fallback
+    #     — URL-unreachable. No `build-run-row` renders at ANY URL outside a
+    #     project shell.
+    # So this scene follows the anatomy to where it truly renders: the project
+    # Build tabs (`/p/:id/build`, slice S), visiting the tab that OWNS each
+    # status edge — q3-review-deck (gate, plus purpose/pill/action: the named
+    # capture), upload-endpoint (working, plus the ONLY real cost footer),
+    # auth-refactor (failed). Token contracts unchanged; the footer is asserted
+    # per-project because that is what each page truly folds (see below).
     set_fixture(ORIGIN, usage_ws=True)
-    page.goto(f"{ORIGIN}/runs", wait_until="domcontentloaded")
-    page.locator('[data-testid="build-run-row"][data-status="gate"]').first.wait_for(timeout=30000)
-    page.locator('[data-testid="build-stats-footer"]').wait_for(timeout=30000)
-    page.add_style_tag(content=HIDE_GATE_TOASTS)
 
-    build = page.evaluate(
-        f"""() => {{
-             const probes = ({PROBES})();
-             const purpose = document.querySelector('[data-testid="build-purpose"]');
-             const row = st => document.querySelector(
-               `[data-testid="build-run-row"][data-status="${{st}}"]`);
-             const edge = el => el ? {{
-               color: getComputedStyle(el).borderLeftColor,
-               width: getComputedStyle(el).borderLeftWidth }} : null;
-             const gateRow = row('gate');
-             const spans = gateRow ? gateRow.querySelectorAll('span') : [];
-             const pill = document.querySelector('[data-testid="gate-inbox-pill"]');
-             const footer = document.querySelector('[data-testid="build-stats-footer"]');
-             const action = document.querySelector('[data-testid="build-something"]');
-             return {{
-               probes,
-               purposeVisible: !!purpose && purpose.offsetParent !== null,
-               purposeColor: purpose ? getComputedStyle(purpose).color : null,
-               purposeFont: purpose ? getComputedStyle(purpose).fontFamily : null,
-               gateEdge: edge(row('gate')),
-               workingEdge: edge(row('working')),
-               failedEdge: edge(row('failed')),
-               intentFont: spans[1] ? getComputedStyle(spans[1]).fontFamily : null,
-               intentText: spans[1] ? spans[1].textContent : null,
-               statusFont: spans[2] ? getComputedStyle(spans[2]).fontFamily : null,
-               pillBg: pill ? getComputedStyle(pill).backgroundColor : null,
-               pillColor: pill ? getComputedStyle(pill).color : null,
-               footerFont: footer ? getComputedStyle(footer).fontFamily : null,
-               footerColor: footer ? getComputedStyle(footer).color : null,
-               footerText: footer ? footer.textContent : null,
-               actionBg: action ? getComputedStyle(action).backgroundColor : null,
-               campaignsAbsent: !document.body.innerText.toLowerCase().includes('campaign'),
-             }}; }}""")
-    pb = build["probes"]
-    build_ok = all([
-        build["purposeVisible"],
-        build["purposeColor"] == pb["inkBody"],                    # AC 1
-        "Inter" in (build["purposeFont"] or ""),
-        (build["gateEdge"] or {}).get("color") == pb["statusGate"],   # AC 2
-        (build["gateEdge"] or {}).get("width") == "2px",
-        (build["workingEdge"] or {}).get("color") == pb["statusRun"],
-        (build["failedEdge"] or {}).get("color") == pb["statusFail"],
-        "Inter" in (build["intentFont"] or ""),                    # EC13
-        "JetBrains Mono" in (build["statusFont"] or ""),
-        build["pillBg"] == pb["statusGateDim"],
-        build["pillColor"] == pb["statusGate"],
-        "JetBrains Mono" in (build["footerFont"] or ""),
-        build["footerColor"] == pb["inkDim"],
-        "$0.42" in (build["footerText"] or ""),
-        build["actionBg"] == pb["accent"],
-        build["campaignsAbsent"],
+    # The same §5.4 extraction, run on each project's Build tab.
+    BUILD_READ = f"""() => {{
+         const probes = ({PROBES})();
+         const purpose = document.querySelector('[data-testid="build-purpose"]');
+         const row = st => document.querySelector(
+           `[data-testid="build-run-row"][data-status="${{st}}"]`);
+         const edge = el => el ? {{
+           color: getComputedStyle(el).borderLeftColor,
+           width: getComputedStyle(el).borderLeftWidth }} : null;
+         const gateRow = row('gate');
+         const spans = gateRow ? gateRow.querySelectorAll('span') : [];
+         const pill = document.querySelector('[data-testid="gate-inbox-pill"]');
+         const footer = document.querySelector('[data-testid="build-stats-footer"]');
+         const action = document.querySelector('[data-testid="build-something"]');
+         return {{
+           probes,
+           purposeVisible: !!purpose && purpose.offsetParent !== null,
+           purposeColor: purpose ? getComputedStyle(purpose).color : null,
+           purposeFont: purpose ? getComputedStyle(purpose).fontFamily : null,
+           gateEdge: edge(row('gate')),
+           workingEdge: edge(row('working')),
+           failedEdge: edge(row('failed')),
+           intentFont: spans[1] ? getComputedStyle(spans[1]).fontFamily : null,
+           intentText: spans[1] ? spans[1].textContent : null,
+           statusFont: spans[2] ? getComputedStyle(spans[2]).fontFamily : null,
+           pillBg: pill ? getComputedStyle(pill).backgroundColor : null,
+           pillColor: pill ? getComputedStyle(pill).color : null,
+           footerPresent: !!footer,
+           footerWindow: footer ? footer.getAttribute('data-window') : null,
+           footerFont: footer ? getComputedStyle(footer).fontFamily : null,
+           footerColor: footer ? getComputedStyle(footer).color : null,
+           footerText: footer ? footer.textContent : null,
+           actionBg: action ? getComputedStyle(action).backgroundColor : null,
+           campaignsAbsent: !document.body.innerText.toLowerCase().includes('campaign'),
+         }}; }}"""
+
+    # ── 2a. The gate project (q3-review-deck → r-q3 at awaiting_human) ────────
+    page.goto(f"{ORIGIN}/p/q3-review-deck/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="build-run-row"][data-status="gate"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    gate_page = page.evaluate(BUILD_READ)
+    pb = gate_page["probes"]
+    gate_ok = all([
+        gate_page["purposeVisible"],
+        gate_page["purposeColor"] == pb["inkBody"],                # AC 1
+        "Inter" in (gate_page["purposeFont"] or ""),
+        (gate_page["gateEdge"] or {}).get("color") == pb["statusGate"],  # AC 2
+        (gate_page["gateEdge"] or {}).get("width") == "2px",
+        "Inter" in (gate_page["intentFont"] or ""),                # EC13
+        "JetBrains Mono" in (gate_page["statusFont"] or ""),
+        gate_page["pillBg"] == pb["statusGateDim"],
+        gate_page["pillColor"] == pb["statusGate"],
+        gate_page["actionBg"] == pb["accent"],
+        # r-q3 is parked at its gate (`awaiting_human` — core: paused BEFORE a
+        # not-yet-done unit, so nothing is in flight) and no cliUsage frame has
+        # ever addressed it, so the data-gated footer (§2.7 rule 2) renders
+        # NOTHING on this page — never a $0.00 or an em-dash.
+        not gate_page["footerPresent"],
+        gate_page["campaignsAbsent"],
         # EC12: the accent is none of the status colors.
         pb["accent"] not in (pb["statusGate"], pb["statusRun"], pb["statusFail"]),
     ])
     page.screenshot(path=str(VSHOTS / "vision-4-build-runs.png"))
-    report["steps"]["build_runs"] = {"ok": build_ok, **build}
+
+    # ── 2b. The working project (upload-endpoint → r-upload executing) ────────
+    page.goto(f"{ORIGIN}/p/upload-endpoint/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="build-run-row"][data-status="working"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # This page's footer TRUTH, derived from the fixture's usage wires (the
+    # flat home's old "$0.42" was ALREADY this project's spend — the one
+    # `usage_ws` cliUsage frame is addressed to r-upload, and the REST events
+    # backfill carries no cliUsage for any run):
+    #   /ws pushes ONE frame on connect: {session: "r-upload",
+    #     inputTokens: 84000, outputTokens: 14000, costUsd: 0.42}
+    #   → usageTotals: tokens = 84000 + 14000 = 98000 → formatTokens "98.0k";
+    #                  cost = 0.42 → formatCost "$0.42";
+    #   → unitsInFlight: r-upload is `executing` with its cursor unit pending
+    #     → 1 → "1 step in flight";
+    #   → footerParts.join(' · ') = "1 step in flight · $0.42 · 98.0k tokens",
+    #     windowed "30d" (the useTimeRange default, EC39).
+    footer_folded = settled(
+        """() => { const f = document.querySelector('[data-testid="build-stats-footer"]');
+             return !!f && (f.textContent || '').includes('$0.42'); }""",
+        timeout=30000,
+    )
+    working_page = page.evaluate(BUILD_READ)
+    pw = working_page["probes"]
+    working_ok = all([
+        footer_folded,
+        (working_page["workingEdge"] or {}).get("color") == pw["statusRun"],  # AC 2
+        (working_page["workingEdge"] or {}).get("width") == "2px",
+        working_page["purposeVisible"],
+        working_page["footerPresent"],
+        "JetBrains Mono" in (working_page["footerFont"] or ""),
+        working_page["footerColor"] == pw["inkDim"],
+        "1 step in flight" in (working_page["footerText"] or ""),
+        "$0.42" in (working_page["footerText"] or ""),
+        "98.0k tokens" in (working_page["footerText"] or ""),
+        working_page["footerWindow"] == "30d",                     # EC39
+        working_page["campaignsAbsent"],
+    ])
+
+    # ── 2c. The failed project (auth-refactor → r-auth failed) ────────────────
+    page.goto(f"{ORIGIN}/p/auth-refactor/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="build-run-row"][data-status="failed"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    failed_page = page.evaluate(BUILD_READ)
+    pf = failed_page["probes"]
+    failed_ok = all([
+        (failed_page["failedEdge"] or {}).get("color") == pf["statusFail"],  # AC 2
+        (failed_page["failedEdge"] or {}).get("width") == "2px",
+        failed_page["purposeVisible"],
+        # r-auth is terminal-failed (nothing in flight) and its events backfill
+        # holds no cliUsage — the data-gated footer renders nothing here too.
+        not failed_page["footerPresent"],
+        failed_page["campaignsAbsent"],
+    ])
+
+    build_ok = gate_ok and working_ok and failed_ok
+    report["steps"]["build_runs"] = {
+        "ok": build_ok,
+        "gate_ok": gate_ok, "working_ok": working_ok, "failed_ok": failed_ok,
+        "gate_project": {k: v for k, v in gate_page.items() if k != "probes"},
+        "working_project": {k: v for k, v in working_page.items() if k != "probes"},
+        "failed_project": {k: v for k, v in failed_page.items() if k != "probes"},
+        "footer_folded": footer_folded,
+    }
 
     # ══ Scene 3 — Document (§5.5): drive the W3 journey, then read the tokens ══
     page.goto(f"{ORIGIN}/p/scratch/document", wait_until="domcontentloaded")

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -300,11 +300,11 @@ with sync_playwright() as p:
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-composer"]').fill("Make me a deck for the Q3 review")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="thread-version-tag"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="thread-version-tag"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
@@ -315,7 +315,7 @@ with sync_playwright() as p:
              const strip = document.querySelector('[data-testid="version-strip"]');
              const dot = document.querySelector('[data-testid="version-active-dot"]');
              const selected = document.querySelector('[data-testid="version-entry"][data-selected="true"]');
-             const tag = document.querySelector('[data-testid="thread-version-tag"][data-version="2"]');
+             const tag = document.querySelector('[data-testid="version-marker"][data-version="2"]');
              const thread = document.querySelector('[data-testid="thread"]');
              const stamp = document.querySelector('[data-testid="version-stamp"]');
              return {{
@@ -371,7 +371,7 @@ with sync_playwright() as p:
     page.locator('[data-testid="themes-open"]').click()  # toggle shut for the capture
 
     # Back to v2 for the named capture (the slice entry: v2 selected, tags visible).
-    page.locator('[data-testid="thread-version-tag"][data-version="2"]').click()
+    page.locator('[data-testid="version-marker"][data-version="2"]').click()
     page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -287,6 +287,38 @@ export function postExport(
   );
 }
 
+/**
+ * One line of `GET /d/:docId/api/conversation` — the doc's announce history
+ * (user chat + agent narration, error states included), read from disk
+ * (`conversation.jsonl`) so it survives a full bridge restart. Fidelity is
+ * PINNED by BRIDGE-UX-1 probe 2 (§8.4.1): `{role, text, ts[, state]}` ONLY —
+ * `source_message_id` is dropped at append and `version.created` never enters
+ * the transcript, so version anchors CANNOT be rehydrated from this surface;
+ * they stay the session-storage stopgap (threadStopgap.ts).
+ */
+export interface ConversationEntry {
+  role: string;
+  text: string;
+  ts?: string | number;
+  /** Set on error narration (`status.posted {state:"error"}` at append time). */
+  state?: string;
+}
+
+/**
+ * `GET /d/:docId/api/conversation` — the §6.3 thread-history read (BRIDGE-UX-1
+ * probe 2: a REAL surface, verified against the live bridge). The ONE sanctioned
+ * doc-open fetch slice T adds: called once per thread per session, only while
+ * the client projection is empty. Entries the wire returns malformed are
+ * dropped rather than rendered under a guessed shape.
+ */
+export function getConversation(projectId: string, docId: string): Promise<ConversationEntry[]> {
+  return iFetch<unknown>(`${docBase(projectId, docId)}/api/conversation`)
+    .then((body) => (Array.isArray(body) ? body : []).filter((e): e is ConversationEntry =>
+      typeof e === 'object' && e !== null
+      && typeof (e as ConversationEntry).role === 'string'
+      && typeof (e as ConversationEntry).text === 'string'));
+}
+
 /** `GET /d/:docId/api/sources` — attached reference files and their index status. */
 export function getSources(projectId: string, docId: string): Promise<SourceEntry[]> {
   return iFetch<{ sources: SourceEntry[] }>(`${docBase(projectId, docId)}/api/sources`)

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
+import { getConversation, getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
+import { readAnchors } from '../interactive/threadStopgap.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
@@ -491,6 +492,30 @@ export interface DocumentCanvasProps {
 export function DocumentCanvas({
   projectId, docId, version = null, navigate, children,
 }: DocumentCanvasProps): React.ReactElement {
+  // §6.3 rehydration (DES-UX-001 slice T, BRIDGE-UX-1 probe 2): opening a doc reads
+  // its announce history from `GET /d/:doc/api/conversation` — the ONE sanctioned
+  // doc-open fetch this slice adds — so the thread's TEXT survives a reload from the
+  // wire, not from tab memory. It fires on DOC OPEN (here, not in the thread pane):
+  // the drawer mounts/unmounts on toggle, and toggling must stay a zero-request
+  // gesture. Guarded once per thread per session; a projection that already holds
+  // live messages is kept verbatim (`hydrate` only fills an empty thread). A bridge
+  // without the route — or a dead one — degrades to the live-only projection.
+  useEffect(() => {
+    if (docId === null) return;
+    const key = threadKey(projectId, docId);
+    const store = useDocThreadStore.getState();
+    if (store.hydrated[key] === true) return;
+    let cancelled = false;
+    getConversation(projectId, docId)
+      .then((entries) => {
+        if (!cancelled) useDocThreadStore.getState().hydrate(key, entries, readAnchors(key));
+      })
+      .catch(() => {
+        if (!cancelled) useDocThreadStore.getState().hydrate(key, [], []);
+      });
+    return () => { cancelled = true; };
+  }, [projectId, docId]);
+
   // §7.3: the drawer's state lives on the Document surface. Default CLOSED when a doc
   // is open (the canvas is full-width on first visit); default OPEN on the picker,
   // whose empty state points at the thread — a pointer at a hidden pane would be a

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -58,12 +58,21 @@ const COMPOSER: Record<GenState, { placeholder: string; submit: string }> = {
 
 // ── Message renderers ────────────────────────────────────────────────────────
 
+/** DES-UX-001 §6.1: where one user message sits in its send lifecycle. Derived from
+ *  the store's pending FIFO — head = being worked, rest = queued behind the current
+ *  run — plus the message's own `failed` flag. `undefined` = resolved (or historic). */
+export type SendState = 'generating' | 'queued' | 'failed';
+
 function Bubble({
-  msg, projectId, docId, onShowVersion,
+  msg, projectId, docId, onShowVersion, sendState, onRetrySend,
 }: {
   msg: DocMsg; projectId: string; docId: string | null;
   /** The tag's cross-link (DES-UXFIX-001 §2.6 rule 2): show this version on the strip. */
   onShowVersion?: (version: number) => void;
+  /** §6.1 lifecycle chip for a user message still in flight (or refused). */
+  sendState?: SendState | undefined;
+  /** Re-arm a refused send — §6.1's "visible failure with a retry". */
+  onRetrySend?: (msg: Extract<DocMsg, { kind: 'user' }>) => void;
 }): React.ReactElement | null {
   if (msg.kind === 'user') {
     return (
@@ -110,13 +119,17 @@ function Bubble({
             is TAGGED with it, and the tag cross-links to the strip — the same seam the
             strip's "In thread" crosses the other way. The eye can trace canvas ↔ strip ↔
             thread in both directions. */}
-        {/* §5.5: the version tag is HISTORY — --status-done ink on a
-            --radius-sm badge (Video's "recording complete" tag mirrors it). */}
+        {/* §5.5: the version marker is HISTORY — --status-done ink on a
+            --radius-sm badge (Video's "recording complete" tag mirrors it).
+            DES-UX-001 §6.1: `data-caused-by` names the message that produced the
+            version — the marker renders ON its causing message, so the anchor is
+            structural: no marker can render under an unrelated request (EC36). */}
         {msg.version !== undefined && (
           <button
             type="button"
-            data-testid="thread-version-tag"
+            data-testid="version-marker"
             data-version={String(msg.version)}
+            data-caused-by={msg.id}
             onClick={() => { if (msg.version !== undefined) onShowVersion?.(msg.version); }}
             title={`This message made v${msg.version} — show it on the canvas and the strip`}
             className="px-2 py-0.5 text-[10px] font-mono"
@@ -126,6 +139,53 @@ function Bubble({
           >
             ▤ v{msg.version} landed
           </button>
+        )}
+        {/* DES-UX-001 §6.1 (EC36): every send resolves VISIBLY. The chip beneath a
+            user message says where the send is — being worked now (run-emerald, the
+            live pair), queued behind the current run (the honest client-side rendering
+            of the bridge's FIFO — §8.4.1 probe 1: the wire acks 200 and queues, but
+            carries no queue-position, so the position is the client's own order), or
+            refused with a retry (fail-red). It clears when the marker above lands. */}
+        {sendState === 'generating' && (
+          <span
+            data-testid="thread-generating"
+            className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'var(--status-run-dim)', color: S.live,
+                     border: '1px solid var(--status-run-dim)' }}
+          >
+            <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
+            generating — this message is being worked now
+          </span>
+        )}
+        {sendState === 'queued' && (
+          <span
+            data-testid="thread-queued"
+            className="rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'transparent', color: S.muted,
+                     border: `1px solid ${S.border}` }}
+          >
+            queued behind the current run
+          </span>
+        )}
+        {sendState === 'failed' && (
+          <span
+            data-testid="thread-send-failed"
+            className="flex items-center gap-2 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'var(--status-fail-dim)', color: S.danger,
+                     border: '1px solid var(--status-fail-dim)' }}
+          >
+            send failed — nothing landed for this message
+            <button
+              type="button"
+              data-testid="thread-send-retry"
+              onClick={() => onRetrySend?.(msg)}
+              className="underline font-mono text-[10px]"
+              style={{ background: 'transparent', border: 'none', color: S.danger,
+                       cursor: 'pointer', padding: 0 }}
+            >
+              retry
+            </button>
+          </span>
         )}
       </div>
     );
@@ -361,6 +421,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   const key = docId === null ? null : threadKey(projectId, docId);
   const messages = useDocThreadStore((s) => (key === null ? EMPTY : s.messages[key] ?? EMPTY));
   const streamed = useDocThreadStore((s) => (key === null ? undefined : s.genState[key]));
+  // §6.1: the send FIFO — head is being worked, the rest are queued behind it.
+  const pendingIds = useDocThreadStore((s) => (key === null ? EMPTY_IDS : s.pending[key] ?? EMPTY_IDS));
+  // §6.3: whether this thread's text was rehydrated from the conversation read.
+  const hydratedFromWire = useDocThreadStore((s) => (key === null ? false : s.hydrated[key] === true));
   // A document that exists with nothing in flight IS case 4: complete, and editable (§7.10).
   const state: GenState = docId === null ? 'idle' : streamed ?? 'terminal';
   // NOTE (issue #65): slice 16's picked theme no longer rides here. The `theme_id` it
@@ -424,7 +488,13 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         store.addDivider(key, forked.version);
         store.addUserMsg(key, msgId, body);
         store.setGenState(key, 'generating');
-        await injectDocMessage(projectId, docId, body, msgId);
+        // §6.1 (EC36): once the message is ON the thread, a refused send fails
+        // THERE — the failed chip with its retry, never a silent transcript row.
+        try {
+          await injectDocMessage(projectId, docId, body, msgId);
+        } catch {
+          failVisibly(msgId);
+        }
         setText('');
         navigate(versionPath(projectId, docId, forked.version));
         return;
@@ -432,14 +502,18 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
 
       // 2 / 3 — STEER, and answer a gate WITH a steer in the same submit.
       store.addUserMsg(key, msgId, body);
-      if (state === 'gated' && gate !== null) {
-        await postEvent(projectId, {
-          event_type: 'wicked.interactive.question.answered',
-          payload: { request_id: gate.requestId, answer: body, document_id: docId },
-        });
-        store.setGenState(key, 'generating');
-      } else {
-        await injectDocMessage(projectId, docId, body, msgId);
+      try {
+        if (state === 'gated' && gate !== null) {
+          await postEvent(projectId, {
+            event_type: 'wicked.interactive.question.answered',
+            payload: { request_id: gate.requestId, answer: body, document_id: docId },
+          });
+          store.setGenState(key, 'generating');
+        } else {
+          await injectDocMessage(projectId, docId, body, msgId);
+        }
+      } catch {
+        failVisibly(msgId);
       }
       setText('');
     } catch (e: unknown) {
@@ -447,6 +521,49 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     } finally {
       setBusy(false);
     }
+  }
+
+  /** §6.1's visible failure: the message stays on the thread wearing the failed
+   *  chip; the working state retires when nothing else is pending behind it. */
+  function failVisibly(msgId: string): void {
+    if (key === null) return;
+    const store = useDocThreadStore.getState();
+    store.markSendFailed(key, msgId);
+    if ((useDocThreadStore.getState().pending[key] ?? []).length === 0
+        && useDocThreadStore.getState().genState[key] === 'generating') {
+      store.setGenState(key, 'terminal');
+    }
+  }
+
+  /** §6.1's retry: a re-send is a NEW send — re-enqueued at the tail, re-emitted on
+   *  the same wire the message originally rode (the gate's answer wire while the
+   *  gate is still open, the inject wire otherwise). */
+  async function retrySend(msg: Extract<DocMsg, { kind: 'user' }>): Promise<void> {
+    if (docId === null || key === null) return;
+    const store = useDocThreadStore.getState();
+    store.retrySend(key, msg.id);
+    try {
+      if (state === 'gated' && gate !== null) {
+        await postEvent(projectId, {
+          event_type: 'wicked.interactive.question.answered',
+          payload: { request_id: gate.requestId, answer: msg.text, document_id: docId },
+        });
+      } else {
+        await injectDocMessage(projectId, docId, msg.text, msg.id);
+      }
+      useDocThreadStore.getState().setGenState(key, 'generating');
+    } catch {
+      failVisibly(msg.id);
+    }
+  }
+
+  /** Where a user message sits in its §6.1 lifecycle (see `SendState`). */
+  function sendStateOf(msg: DocMsg): SendState | undefined {
+    if (msg.kind !== 'user') return undefined;
+    if (msg.failed === true) return 'failed';
+    const at = pendingIds.indexOf(msg.id);
+    if (at === -1) return undefined;
+    return at === 0 ? 'generating' : 'queued';
   }
 
   // The tag's cross-link (§2.6 rule 2): selecting the version IS a navigation — the
@@ -491,6 +608,25 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         />
       )}
       <div className="flex-1 overflow-y-auto px-3.5 py-4 flex flex-col gap-3">
+        {/* §6.3's stopgap note, scoped to the ONE gap the wire still has: the thread's
+            TEXT is back from `GET /d/:doc/api/conversation` (BRIDGE-UX-1 probe 2 — a
+            real read), but the transcript carries no version anchors, so markers are
+            session-observed only. A promise with a pointer, never a shrug — and it
+            renders only while a restored message actually lacks its marker. */}
+        {hydratedFromWire
+          && messages.some((m) => m.kind === 'user' && m.restored === true && m.version === undefined)
+          && (
+            <p
+              data-testid="thread-stopgap"
+              className="text-[11px] leading-relaxed rounded-lg px-3 py-2"
+              style={{ color: S.muted, background: S.card, border: `1px solid ${S.border}`,
+                       margin: 0, fontFamily: 'var(--font-sans)' }}
+            >
+              Thread restored from the document’s transcript. Version markers show what
+              this session observed — markers from before this session return when the
+              transcript carries version anchors (BRIDGE-UX-1 §8.4.1).
+            </p>
+          )}
         {messages.length === 0 && (
           <p className="leading-relaxed" style={{ color: S.body, fontSize: 'var(--text-sm)' }}>
             {docId === null
@@ -511,7 +647,17 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                   onAnswered={() => useDocThreadStore.getState().setGenState(key, 'generating')}
                 />
               )) || null
-            : <Bubble key={m.id} msg={m} projectId={projectId} docId={docId} onShowVersion={showVersion} />,
+            : (
+                <Bubble
+                  key={m.id}
+                  msg={m}
+                  projectId={projectId}
+                  docId={docId}
+                  onShowVersion={showVersion}
+                  sendState={sendStateOf(m)}
+                  onRetrySend={(msg) => void retrySend(msg)}
+                />
+              ),
         )}
         <div ref={bottom} />
       </div>
@@ -599,6 +745,9 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
 
 /** Stable identity for "no messages" so the selector never returns a fresh array. */
 const EMPTY: DocMsg[] = [];
+
+/** Stable identity for "nothing pending" — same rule as EMPTY. */
+const EMPTY_IDS: string[] = [];
 
 /** The doc's name is DERIVED from the ask (§4.1) — the bridge slugifies what it gets. */
 function docName(brief: string): string {

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { postFork } from '../api/interactive.js';
 import type { ForkResult, VersionEntry, VersionManifest } from '../api/interactive.js';
 import { versionPath, type Navigate } from '../hooks/useRoute.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../store/docThread.js';
 import { ExportMenu } from './ExportMenu.js';
 import { ThemesMenu } from './ThemesMenu.js';
 import { scrollThreadToMessage } from './threadAnchor.js';
@@ -44,10 +45,14 @@ const S = {
   danger:   'var(--status-fail)',
 };
 
-/** §7.6: no anchor recorded ⇒ nothing to scroll to, and the reason is the tooltip. */
+/** §7.6: no anchor known ⇒ nothing to scroll to, and the reason is the tooltip.
+ *  DES-UX-001 §6.3: the transcript read carries no version anchors (BRIDGE-UX-1
+ *  §8.4.1), so anchors survive only for what this session observed. */
 const NO_ANCHOR_TITLE =
-  'This version was committed without a source message, so there is nothing to scroll to. '
-  + 'Documents created before the merge have no anchor.';
+  'The message that produced this version is not known to this session, so there is '
+  + 'nothing to scroll to. The transcript carries no version anchors (BRIDGE-UX-1) — '
+  + 'they survive for what this session observed; documents created before the merge '
+  + 'have no anchor.';
 
 /** Compact, locale-formatted; an unparseable stamp falls back to what the manifest said. */
 function stamp(iso: string): string {
@@ -71,9 +76,29 @@ function forkedFrom(entry: VersionEntry): number | null {
   return entry.parent !== null && entry.parent !== entry.version - 1 ? entry.parent : null;
 }
 
-function anchorOf(entry: VersionEntry): string | null {
-  return entry.meta?.sourceMessageId ?? null;
+/**
+ * The version→message anchor, resolved CLIENT-side (DES-UX-001 §6.1/§6.3, slice T).
+ * BRIDGE-UX-1 probe 1 (§8.4.1) pinned that the bridge DROPS `source_message_id` —
+ * the manifest's `meta.sourceMessageId` is aspirational, not wire truth — so the
+ * real anchor is the thread's own tagged message: the docThread store correlates
+ * landings to sends by order live, and rehydrates the tags from the session-storage
+ * stopgap after a reload. `meta` stays the first look for any bridge that does echo
+ * it; the store map is what actually answers today.
+ */
+function anchorOf(entry: VersionEntry, byVersion: Map<number, string>): string | null {
+  return entry.meta?.sourceMessageId ?? byVersion.get(entry.version) ?? null;
 }
+
+/** version → the id of the user message tagged with it, from one thread's transcript. */
+function anchorsFrom(msgs: DocMsg[]): Map<number, string> {
+  const map = new Map<number, string>();
+  for (const m of msgs) {
+    if (m.kind === 'user' && m.version !== undefined) map.set(m.version, m.id);
+  }
+  return map;
+}
+
+const NO_MSGS: DocMsg[] = [];
 
 const ACTION: React.CSSProperties = {
   background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
@@ -144,13 +169,17 @@ export function VersionStrip({
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // The thread's own version→message tags (§6.1/§6.3): the anchor source that is
+  // actually on the wire's side of truth — see anchorOf.
+  const msgs = useDocThreadStore((s) => s.messages[threadKey(projectId, docId)] ?? NO_MSGS);
+  const anchorsByVersion = useMemo(() => anchorsFrom(msgs), [msgs]);
 
   function select(entry: VersionEntry): void {
     navigate(versionPath(projectId, docId, entry.version, mode));
     // The cross-link rides ALONG with the selection (§7.6) — the frame swap does not
     // depend on it, so a thread that is not on screen (Document mode's own thread is
     // slice 10) costs the user nothing.
-    const anchor = anchorOf(entry);
+    const anchor = anchorOf(entry, anchorsByVersion);
     if (anchor !== null) scrollThreadToMessage(anchor);
   }
 
@@ -200,7 +229,7 @@ export function VersionStrip({
       {[...manifest.versions].sort(byVersion).map((entry) => {
         const isSelected = entry.version === selected;
         const branchOf = forkedFrom(entry);
-        const anchor = anchorOf(entry);
+        const anchor = anchorOf(entry, anchorsByVersion);
         return (
           <div
             key={entry.version}

--- a/src/interactive/threadStopgap.ts
+++ b/src/interactive/threadStopgap.ts
@@ -1,0 +1,63 @@
+// The session-storage half of thread persistence (DES-UX-001 §6.3, slice T).
+//
+// BRIDGE-UX-1 probe 2 (§8.4.1) fixed the split: the bridge's
+// `GET /d/:doc/api/conversation` is a REAL history read — role/text/ts(/state)
+// only — so thread TEXT rehydrates from the wire on doc open. What the wire
+// genuinely lacks is the version↔message correlation (`source_message_id` is
+// dropped at append and `version.created` never enters the transcript), so the
+// VERSION ANCHORS — and only they — stay in session-scoped storage: what this
+// browser session observed, keyed by thread.
+//
+// The correlation is by USER-MESSAGE ORDINAL (1-based, counting only `kind:
+// "user"` messages): the wire returns every user line in send order, and the
+// bridge processes sends FIFO (probe 1), so "the Nth user message" is a stable
+// address across a reload — the same order-correlation the live anchor queue
+// rides. No message ids are persisted because they are minted per session.
+
+/** One observed landing: the Nth user message produced this version. */
+export interface StoredAnchor { ord: number; version: number }
+
+function storageKey(threadKey: string): string {
+  return `wk-thread-anchors:${threadKey}`;
+}
+
+/** Session storage can be absent (jsdom configs) or full — both degrade to the
+ *  honest gap the stopgap banner states, never a throw. */
+function safeStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** The anchors this session (and its reloads) observed for one thread. */
+export function readAnchors(threadKey: string): StoredAnchor[] {
+  const storage = safeStorage();
+  if (storage === null) return [];
+  try {
+    const raw = storage.getItem(storageKey(threadKey));
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((a): a is StoredAnchor =>
+      typeof a === 'object' && a !== null
+      && Number.isInteger((a as StoredAnchor).ord)
+      && Number.isInteger((a as StoredAnchor).version));
+  } catch {
+    return [];
+  }
+}
+
+/** Record one landing at tag time. A re-tag of the same ordinal (fork, then the
+ *  generation that follows it, §7.10) replaces the earlier entry. */
+export function recordAnchor(threadKey: string, ord: number, version: number): void {
+  const storage = safeStorage();
+  if (storage === null) return;
+  try {
+    const kept = readAnchors(threadKey).filter((a) => a.ord !== ord);
+    storage.setItem(storageKey(threadKey), JSON.stringify([...kept, { ord, version }]));
+  } catch {
+    // Full or refused storage: the anchor is simply not restorable next reload.
+  }
+}

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -12,7 +12,8 @@
 
 import { create } from 'zustand';
 import { isFiller } from './narration.js';
-import type { ExportFormat } from '../api/interactive.js';
+import { recordAnchor, type StoredAnchor } from '../interactive/threadStopgap.js';
+import type { ConversationEntry, ExportFormat } from '../api/interactive.js';
 import type { CoreEvent } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
@@ -32,8 +33,13 @@ export type DocMsg =
   // sending each comment separately would produce N versions and N runs). `notRecorded`
   // is §7.7's failure shape: the bus event landed and the document still updates, but the
   // inject that puts this message in the run did not — retryable, never silent.
+  // `failed` is DES-UX-001 §6.1's visible-failure state: the send itself was refused
+  // before the bridge accepted it — retryable, never silent (EC36). `restored` marks a
+  // message rehydrated from `GET /d/:doc/api/conversation` (§6.3): the wire carries no
+  // message ids, so a restored message's id is minted fresh and its version anchor (if
+  // any) came from the session-storage stopgap, not the transcript.
   | { kind: 'user';      id: string; text: string; version?: number;
-      items?: FeedbackItem[]; notRecorded?: boolean }
+      items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; restored?: boolean }
   | { kind: 'narration'; id: string; text: string }
   // `href` + `file` make an agent message DOWNLOADABLE (§4.4): an export is an ordinary
   // message from the service, carrying its artifact — never a toast, never a second origin.
@@ -124,8 +130,18 @@ interface DocThreadStore {
    *  readback route. The transcript keeps carrying the same line as a
    *  narration message; this is an index into it, not a second author. */
   lastError: Record<string, ThreadError>;
-  /** The user message a landing version will be tagged with (§7.6, client half). */
-  anchor: Record<string, string>;
+  /**
+   * The FIFO of user-message ids awaiting a landed version, per thread
+   * (DES-UX-001 §6.1 + §8.4.1 probe 1). The bridge QUEUES sends — every
+   * `chat.posted` acks 200 and lands durably in send order — but `version.created`
+   * carries no `source_message_id`, so the anchor is a CLIENT-side correlation
+   * by order: the oldest pending send is the one the next generated version
+   * answers. Head of the queue = the message being worked (`thread-generating`);
+   * the rest are queued behind the current run (`thread-queued`).
+   */
+  pending: Record<string, string[]>;
+  /** Threads whose rehydration read (§6.3) has run — once per thread per session. */
+  hydrated: Record<string, boolean>;
   /**
    * The newest version the stream has landed, per thread. The transcript tags its anchor
    * message (§7.6) and does not otherwise care; a mode SURFACE does — a re-authored demo
@@ -137,10 +153,26 @@ interface DocThreadStore {
   landings: VersionLanding[];
   /** Fold one CoreEvent — every non-interactive frame is ignored. */
   ingest: (event: CoreEvent) => void;
-  /** Append the user's message and make it the pending version anchor. */
+  /** Append the user's message and enqueue it as a pending version anchor (§6.1). */
   addUserMsg: (key: string, id: string, text: string, items?: FeedbackItem[]) => void;
   /** Flag/clear §7.7's "not recorded in the run" chip on one already-rendered message. */
   markNotRecorded: (key: string, id: string, notRecorded: boolean) => void;
+  /** §6.1's visible failure: the send was refused — drop it from the pending queue
+   *  and mark the message failed, so it renders `thread-send-failed` with a retry. */
+  markSendFailed: (key: string, id: string) => void;
+  /** Re-arm a failed send: clear the flag and re-enqueue at the TAIL — a retry is a
+   *  new send in queue order, never a jump back to its original position. */
+  retrySend: (key: string, id: string) => void;
+  /**
+   * §6.3 rehydration, from `GET /d/:doc/api/conversation` (BRIDGE-UX-1 probe 2):
+   * rebuild the transcript TEXT from the wire — user lines as user messages,
+   * agent narration as narration (the §3.2 filler seam still applies) — and
+   * re-attach version anchors from the session-storage stopgap by user-message
+   * ordinal (the only correlation the wire supports). Applies only while the
+   * projection is empty; a thread with live messages keeps them and just marks
+   * itself hydrated, so the read never doubles what this session already saw.
+   */
+  hydrate: (key: string, entries: ConversationEntry[], anchors: StoredAnchor[]) => void;
   /** Append a client-authored informative line (§3.3) — an action the user took. */
   addNarration: (key: string, text: string) => void;
   /**
@@ -168,7 +200,8 @@ function append(messages: Record<string, DocMsg[]>, key: string, msg: DocMsg): R
 export const useDocThreadStore = create<DocThreadStore>((set) => ({
   messages: {},
   genState: {},
-  anchor: {},
+  pending: {},
+  hydrated: {},
   landed: {},
   landings: [],
   lastError: {},
@@ -177,6 +210,10 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
     const frame = frameOf(event);
     if (frame === null) return;
     const { key, type, payload } = frame;
+    // The anchor the VERSION branch tags, surfaced out of the reducer so the
+    // session-storage stopgap (§6.3) records it OUTSIDE the state update.
+    let taggedOrd: number | null = null;
+    let taggedVersion = 0;
 
     set((s) => {
       const messages = s.messages;
@@ -206,15 +243,33 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         const failed = state === 'error' && text !== null
           ? { lastError: { ...s.lastError, [key]: { text } } }
           : {};
+        // §6.1 (EC36): a run that DIES takes its backlog with it — every send still
+        // pending resolves to the VISIBLE failed state (with its retry) rather than
+        // a chip that generates forever. Probe 4 (§8.4.1): the death is one
+        // doc-scoped `status.posted {state:"error"}`; nothing else will answer them.
+        const backlog = state === 'error' ? new Set(s.pending[key] ?? []) : null;
+        const base = backlog === null || backlog.size === 0
+          ? messages
+          : {
+              ...messages,
+              [key]: (messages[key] ?? []).map((m) =>
+                m.kind === 'user' && backlog.has(m.id) ? { ...m, failed: true } : m),
+            };
+        const pending = backlog !== null && backlog.size > 0
+          ? { pending: { ...s.pending, [key]: [] } }
+          : {};
         // §3.2/§3.3: filler never reaches the transcript — rotating flavour text and a
         // subject-less `Working…` are both dropped AT THE SEAM, so an upstream bridge that
         // still speaks either cannot put it on screen. A filtered frame still carries the
         // state transition it rode in on: dropping the LINE is not dropping the fact.
-        if (text === null || isFiller(text)) return { genState: { ...s.genState, [key]: next }, ...failed };
+        if (text === null || isFiller(text)) {
+          return { messages: base, genState: { ...s.genState, [key]: next }, ...failed, ...pending };
+        }
         return {
-          messages: append(messages, key, { kind: 'narration', id: nextMsgId(), text }),
+          messages: append(base, key, { kind: 'narration', id: nextMsgId(), text }),
           genState: { ...s.genState, [key]: next },
           ...failed,
+          ...pending,
         };
       }
 
@@ -265,25 +320,45 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       // message that triggered it, so slice 9's strip has a message to scroll to. The
       // service half writes the same id into `versions.json`; this is what makes the
       // anchor resolvable in the session that produced it.
+      // §6.1 + §8.4.1 probe 1: `version.created` carries NO source_message_id, so
+      // the anchor is a client-side ORDER correlation — the bridge queues sends
+      // FIFO, so the landed version answers the OLDEST pending send. A `generated`
+      // landing consumes that anchor; a fork tags it but leaves it pending (the
+      // generation that follows the fork is what answers it, §7.10). No pending
+      // send ⇒ nothing is tagged: a marker never renders under an unrelated
+      // request (the EC36 gaslight pin).
       if (type === VERSION) {
         const raw = payload.version;
         const version = typeof raw === 'number' ? raw : Number(pick(payload, 'version') ?? NaN);
         const kind = pick(payload, 'kind') ?? '';
         if (!Number.isInteger(version)) return s;
-        const anchorId = s.anchor[key];
+        const queue = s.pending[key] ?? [];
+        const anchorId = queue.length > 0 ? queue[0] : undefined;
         const generated = GENERATED.has(kind);
+        const thread = messages[key] ?? [];
         const tagged = anchorId === undefined
           ? messages
           : {
               ...messages,
-              [key]: (messages[key] ?? []).map((m) =>
+              [key]: thread.map((m) =>
                 m.kind === 'user' && m.id === anchorId ? { ...m, version } : m),
             };
-        const anchor = { ...s.anchor };
-        if (generated) delete anchor[key];
+        if (anchorId !== undefined && generated) {
+          // The session-storage stopgap's address (§6.3): the tagged message's
+          // 1-based ordinal among USER messages — the only spelling that survives
+          // a reload, because message ids are minted per session.
+          let ord = 0;
+          for (const m of thread) {
+            if (m.kind === 'user') ord += 1;
+            if (m.kind === 'user' && m.id === anchorId) { taggedOrd = ord; break; }
+          }
+          taggedVersion = version;
+        }
         return {
           messages: tagged,
-          anchor,
+          pending: generated && anchorId !== undefined
+            ? { ...s.pending, [key]: queue.slice(1) }
+            : s.pending,
           landed: { ...s.landed, [key]: version },
           // The river's mark (§7.3): project id is the thread key's first
           // segment (`threadKey` = `${projectId}:${docId}`), clock = arrival.
@@ -291,19 +366,76 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
             ...s.landings,
             { projectId: key.slice(0, key.indexOf(':')), version, kind, at: Date.now() },
           ].slice(-LANDINGS_CAP),
-          genState: generated ? { ...s.genState, [key]: 'terminal' } : s.genState,
+          // Terminal only when nothing is queued behind the landing (§6.1): a
+          // queued send means the bridge is still working the thread's backlog.
+          genState: generated && queue.length <= 1
+            ? { ...s.genState, [key]: 'terminal' }
+            : s.genState,
         };
       }
 
       return s;
     });
+    if (taggedOrd !== null) recordAnchor(key, taggedOrd, taggedVersion);
   },
 
   addUserMsg: (key, id, text, items) =>
     set((s) => ({
       messages: append(s.messages, key, { kind: 'user', id, text, ...(items ? { items } : {}) }),
-      anchor: { ...s.anchor, [key]: id },
+      pending: { ...s.pending, [key]: [...(s.pending[key] ?? []), id] },
     })),
+
+  markSendFailed: (key, id) =>
+    set((s) => ({
+      messages: {
+        ...s.messages,
+        [key]: (s.messages[key] ?? []).map((m) =>
+          m.kind === 'user' && m.id === id ? { ...m, failed: true } : m),
+      },
+      pending: { ...s.pending, [key]: (s.pending[key] ?? []).filter((p) => p !== id) },
+    })),
+
+  retrySend: (key, id) =>
+    set((s) => ({
+      messages: {
+        ...s.messages,
+        [key]: (s.messages[key] ?? []).map((m) =>
+          m.kind === 'user' && m.id === id ? { ...m, failed: false } : m),
+      },
+      pending: { ...s.pending, [key]: [...(s.pending[key] ?? []).filter((p) => p !== id), id] },
+    })),
+
+  hydrate: (key, entries, anchors) =>
+    set((s) => {
+      // Once per thread per session, and never over a live projection: the read
+      // restores what the wire holds, it must not double what this tab saw.
+      if (s.hydrated[key] === true) return s;
+      if ((s.messages[key] ?? []).length > 0) return { hydrated: { ...s.hydrated, [key]: true } };
+      const byOrd = new Map(anchors.map((a) => [a.ord, a.version]));
+      const restored: DocMsg[] = [];
+      let ord = 0;
+      for (const e of entries) {
+        const text = typeof e.text === 'string' ? e.text.trim() : '';
+        if (text === '') continue;
+        if (e.role === 'user') {
+          ord += 1;
+          const version = byOrd.get(ord);
+          restored.push({
+            kind: 'user', id: nextMsgId(), text, restored: true,
+            ...(version === undefined ? {} : { version }),
+          });
+        } else if (!isFiller(text)) {
+          // Agent narration (including error states) at the same seam live frames
+          // cross: filler is dropped here too — one rule, both sources (§3.2).
+          restored.push({ kind: 'narration', id: nextMsgId(), text });
+        }
+      }
+      if (restored.length === 0) return { hydrated: { ...s.hydrated, [key]: true } };
+      return {
+        messages: { ...s.messages, [key]: restored },
+        hydrated: { ...s.hydrated, [key]: true },
+      };
+    }),
 
   markNotRecorded: (key, id, notRecorded) =>
     set((s) => ({
@@ -343,9 +475,10 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
     set((s) => {
       const messages = { ...s.messages }; delete messages[key];
       const genState = { ...s.genState }; delete genState[key];
-      const anchor = { ...s.anchor }; delete anchor[key];
+      const pending = { ...s.pending }; delete pending[key];
+      const hydrated = { ...s.hydrated }; delete hydrated[key];
       const landed = { ...s.landed }; delete landed[key];
       const lastError = { ...s.lastError }; delete lastError[key];
-      return { messages, genState, anchor, landed, lastError };
+      return { messages, genState, pending, hydrated, landed, lastError };
     }),
 }));

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -367,9 +367,10 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
             { projectId: key.slice(0, key.indexOf(':')), version, kind, at: Date.now() },
           ].slice(-LANDINGS_CAP),
           // Terminal only when nothing is queued behind the landing (§6.1): a
-          // queued send means the bridge is still working the thread's backlog.
-          genState: generated && queue.length <= 1
-            ? { ...s.genState, [key]: 'terminal' }
+          // queued send means the bridge is still working the thread's backlog,
+          // so the thread stays (or becomes) GENERATING until the queue drains.
+          genState: generated
+            ? { ...s.genState, [key]: queue.length <= 1 ? 'terminal' : 'generating' }
             : s.genState,
         };
       }

--- a/tests/BrandLearn.test.tsx
+++ b/tests/BrandLearn.test.tsx
@@ -82,7 +82,7 @@ beforeEach(() => {
   getLearnedTheme.mockReset().mockResolvedValue(LEARNED);
   vi.mocked(api.putAppearanceSettings).mockClear();
   useAppearanceStore.setState({ appearance: DEFAULT_APPEARANCE, loaded: true });
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {}, lastError: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastError: {} });
   useProjectsStore.setState({
     projects: [
       project('default'),

--- a/tests/ComposerContext.test.tsx
+++ b/tests/ComposerContext.test.tsx
@@ -67,7 +67,7 @@ function chips(): HTMLElement[] {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   useDocContextStore.setState({ sources: {} });
   requestThemeLearn.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
   attachSource.mockResolvedValue({

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -319,7 +319,7 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
   const thread = <aside data-testid="fake-thread">the thread pane</aside>;
 
   beforeEach(() => {
-    useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+    useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   });
 
   it('AC: with a doc open the thread drawer is CLOSED by default and the strip lives INSIDE the canvas container', async () => {

--- a/tests/DocumentSurfaces.tokens.test.tsx
+++ b/tests/DocumentSurfaces.tokens.test.tsx
@@ -139,7 +139,7 @@ describe('DocumentThread — the §5.5 tokens', () => {
 
   it('the version tag is history: --status-done ink on a --radius-sm badge', () => {
     mountWithVersionTag();
-    const tag = screen.getByTestId('thread-version-tag');
+    const tag = screen.getByTestId('version-marker');
     expect(tag).toHaveTextContent('▤ v1 landed');
     expect(tag.style.color).toBe('var(--status-done)');
     expect(tag.style.borderRadius).toBe('var(--radius-sm)');

--- a/tests/DocumentSurfaces.tokens.test.tsx
+++ b/tests/DocumentSurfaces.tokens.test.tsx
@@ -55,7 +55,7 @@ function manifest(versions: VersionEntry[]): VersionManifest {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
 });
 
 describe('VersionStrip — the §5.5 tokens', () => {

--- a/tests/DocumentThread.export.test.tsx
+++ b/tests/DocumentThread.export.test.tsx
@@ -49,7 +49,7 @@ function mount(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
 });
 afterEach(cleanup);
 

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -278,8 +278,12 @@ describe('the ▤ v<N> landed tag — the thread half of the doc↔canvas↔thre
     landVersion(7);
     mount(DOC);
 
-    const tag = screen.getByTestId('thread-version-tag');
+    const tag = screen.getByTestId('version-marker');
     expect(tag).toHaveAttribute('data-version', '7');
+    // DES-UX-001 §6.1 (EC36): the marker names its CAUSING message — and it renders
+    // on that message, so a marker under an unrelated request is structurally
+    // impossible.
+    expect(tag).toHaveAttribute('data-caused-by', 'dmsg-anchor');
     // The tag is the wireframe's literal words — legible, not attribute-only (EC9).
     expect(tag).toHaveTextContent('▤ v7 landed');
   });
@@ -288,7 +292,7 @@ describe('the ▤ v<N> landed tag — the thread half of the doc↔canvas↔thre
     landVersion(7);
     mount(DOC);
 
-    await userEvent.click(screen.getByTestId('thread-version-tag'));
+    await userEvent.click(screen.getByTestId('version-marker'));
     // The same `?v=N` route the strip selects by: the canvas swaps, the strip entry
     // highlights, and Back rewinds the move — a navigation, never local state.
     expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=7`);
@@ -299,6 +303,6 @@ describe('the ▤ v<N> landed tag — the thread half of the doc↔canvas↔thre
     mount(DOC);
 
     expect(screen.getByTestId('doc-message')).not.toHaveAttribute('data-version');
-    expect(screen.queryByTestId('thread-version-tag')).toBeNull();
+    expect(screen.queryByTestId('version-marker')).toBeNull();
   });
 });

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -61,7 +61,7 @@ async function send(text: string): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
   createDoc.mockResolvedValue({ name: DOC, head: 0, generating: true });
   postFork.mockResolvedValue({ version: 4, parent: 3 });
   postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });

--- a/tests/DocumentThread.video.test.tsx
+++ b/tests/DocumentThread.video.test.tsx
@@ -49,7 +49,7 @@ function thread(key = KEY): DocMsg[] {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   createDoc.mockResolvedValue({ name: DEMO, head: 1, kind: 'demo' });
   requestRecord.mockResolvedValue({ queued: true });
   postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
@@ -125,7 +125,7 @@ describe('case 1 — the ask opens the wizard, and nothing is created until it s
     expect(thread()[0]).toMatchObject({ kind: 'user', text: expect.stringContaining('1. the storefront — open it') });
     expect(thread()[1]?.kind).toBe('narration');
     // §7.6: the message the composer minted BEFORE the wizard is the version's anchor.
-    expect(useDocThreadStore.getState().anchor[KEY]).toBe(thread()[0]?.id);
+    expect(useDocThreadStore.getState().pending[KEY]).toContain(thread()[0]?.id);
   });
 
   it('cancelling creates nothing and leaves the composer where it was', async () => {

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -94,7 +94,7 @@ async function press(format: string, scope?: HTMLElement): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   postExport.mockResolvedValue(reply('roadmap_v3.pdf'));
 });
 afterEach(cleanup);

--- a/tests/WorkPage.filter.test.tsx
+++ b/tests/WorkPage.filter.test.tsx
@@ -53,9 +53,11 @@ describe('WorkPage — §7.4 context-sensitive entry (slice Y)', () => {
     mount('?filter=failed');
     expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'failed');
     expect(screen.getByRole('tab', { name: /^Failed/ })).toHaveAttribute('aria-selected', 'true');
-    // Only the failed run renders in the panel.
-    expect(screen.getByText('broken work')).toBeInTheDocument();
-    expect(screen.queryByText('live work')).toBeNull();
+    // Only the failed run renders in the panel. Rows carry the slice-Y2
+    // synthesized title (`intent · short-id · #ordinal`, EC40), so the raw
+    // problem text is a prefix, not the whole text node.
+    expect(screen.getByText(/broken work/)).toBeInTheDocument();
+    expect(screen.queryByText(/live work/)).toBeNull();
   });
 
   it('ignores a filter that is not a tab id', () => {

--- a/tests/demoWire.test.ts
+++ b/tests/demoWire.test.ts
@@ -42,7 +42,7 @@ function messages(key = KEY): DocMsg[] {
 }
 
 beforeEach(() => {
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   createDoc.mockResolvedValue({ name: DEMO, head: 1, kind: 'demo' });
   requestRecord.mockResolvedValue({ queued: true });
   postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
@@ -119,7 +119,7 @@ describe('the ordered demo wizard — order is the thing it exists to carry', ()
       .toBe(`Authored “${DEMO}” — 3 steps against https://shop.example/. `
         + 'Recording runs them in a real browser.');
     // §7.6: the version this generation lands tags the message that triggered it.
-    expect(useDocThreadStore.getState().anchor[KEY]).toBe('dmsg-7');
+    expect(useDocThreadStore.getState().pending[KEY]).toContain('dmsg-7');
   });
 });
 

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -165,15 +165,27 @@ describe('version anchors (§7.6, client half)', () => {
     expect(messages()[0]).toMatchObject({ kind: 'user', id, version: 7 });
   });
 
-  it('tags the LAST user message before generation started, not an earlier one', () => {
+  // Re-scoped by DES-UX-001 slice T (§6.1 + §8.4.1 probe 1): the bridge QUEUES —
+  // sends land durably in send order — and `version.created` carries no
+  // source_message_id, so the anchor is an ORDER correlation: the oldest pending
+  // send is what the next generated version answers, never the newest.
+  it('correlates landings to sends FIFO: the OLDEST pending send is tagged first', () => {
     const first = nextMsgId();
     useDocThreadStore.getState().addUserMsg(KEY, first, 'first ask');
     const second = nextMsgId();
-    useDocThreadStore.getState().addUserMsg(KEY, second, 'actually, do this instead');
+    useDocThreadStore.getState().addUserMsg(KEY, second, 'and then this');
     ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
-    const tagged = messages().filter((m) => m.kind === 'user' && m.version !== undefined);
+    let tagged = messages().filter((m) => m.kind === 'user' && m.version !== undefined);
     expect(tagged).toHaveLength(1);
-    expect(tagged[0]).toMatchObject({ id: second, version: 2 });
+    expect(tagged[0]).toMatchObject({ id: first, version: 2 });
+    // The queue is still working the second send, so the thread is not terminal…
+    expect(state()).toBe('generating');
+    // …and the NEXT landing answers it.
+    ingest(frame('wicked.interactive.version.created', { version: 3, parent: 2, kind: 'generated' }));
+    tagged = messages().filter((m) => m.kind === 'user' && m.version !== undefined);
+    expect(tagged).toHaveLength(2);
+    expect(tagged[1]).toMatchObject({ id: second, version: 3 });
+    expect(state()).toBe('terminal');
   });
 
   it('a fork version tags the message but leaves it anchored for the generation to come', () => {
@@ -188,5 +200,101 @@ describe('version anchors (§7.6, client half)', () => {
   it('a version with no message behind it tags nothing and throws nothing', () => {
     ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
     expect(messages()).toEqual([]);
+  });
+});
+
+// ── DES-UX-001 slice T (§6.1): the send lifecycle — every send resolves visibly ──
+
+describe('send lifecycle (§6.1, EC36)', () => {
+  it('a refused send leaves the pending queue and wears the failed flag', () => {
+    const store = useDocThreadStore.getState();
+    const a = nextMsgId();
+    const b = nextMsgId();
+    store.addUserMsg(KEY, a, 'first');
+    store.addUserMsg(KEY, b, 'second');
+    store.markSendFailed(KEY, a);
+    expect(useDocThreadStore.getState().pending[KEY]).toEqual([b]);
+    expect(messages()[0]).toMatchObject({ id: a, failed: true });
+    // A later landing answers the SURVIVING send, never the failed one.
+    ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
+    expect(messages()[0]).not.toHaveProperty('version');
+    expect(messages()[1]).toMatchObject({ id: b, version: 2 });
+  });
+
+  it('a retry re-enqueues at the TAIL — a new send in queue order', () => {
+    const store = useDocThreadStore.getState();
+    const a = nextMsgId();
+    const b = nextMsgId();
+    store.addUserMsg(KEY, a, 'first');
+    store.addUserMsg(KEY, b, 'second');
+    store.markSendFailed(KEY, a);
+    store.retrySend(KEY, a);
+    expect(useDocThreadStore.getState().pending[KEY]).toEqual([b, a]);
+    expect(messages()[0]).toMatchObject({ id: a, failed: false });
+  });
+
+  it('a run death fails its whole backlog visibly — no chip generates forever', () => {
+    const store = useDocThreadStore.getState();
+    const a = nextMsgId();
+    const b = nextMsgId();
+    store.addUserMsg(KEY, a, 'first');
+    store.addUserMsg(KEY, b, 'second');
+    ingest(frame('wicked.interactive.status.posted', { state: 'error', message: 'theme file not found' }));
+    expect(useDocThreadStore.getState().pending[KEY]).toEqual([]);
+    const users = messages().filter((m) => m.kind === 'user');
+    expect(users[0]).toMatchObject({ id: a, failed: true });
+    expect(users[1]).toMatchObject({ id: b, failed: true });
+    expect(state()).toBe('terminal');
+  });
+});
+
+// ── DES-UX-001 slice T (§6.3): rehydration from GET /d/:doc/api/conversation ──
+
+describe('rehydration (§6.3, BRIDGE-UX-1 probe 2)', () => {
+  it('restores user text and agent narration in wire order, anchors by ordinal', () => {
+    useDocThreadStore.getState().hydrate(KEY, [
+      { role: 'user', text: 'a deck for the Q3 review', ts: 1 },
+      { role: 'agent', text: 'Planning the deck — outline first.', ts: 2 },
+      { role: 'user', text: 'tighten the headline', ts: 3 },
+      { role: 'agent', text: 'Something broke', ts: 4, state: 'error' },
+    ], [{ ord: 1, version: 1 }]);
+    const restored = messages();
+    expect(restored.map((m) => m.kind)).toEqual(['user', 'narration', 'user', 'narration']);
+    // The 1st user message wears the session-observed anchor; the 2nd has the
+    // honest gap — the wire carries no version anchors (§8.4.1).
+    expect(restored[0]).toMatchObject({ text: 'a deck for the Q3 review', version: 1, restored: true });
+    expect(restored[2]).not.toHaveProperty('version');
+    expect(useDocThreadStore.getState().hydrated[KEY]).toBe(true);
+  });
+
+  it('never doubles a live projection, and runs once per thread', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, nextMsgId(), 'live message');
+    useDocThreadStore.getState().hydrate(KEY, [{ role: 'user', text: 'from the wire' }], []);
+    expect(messages()).toHaveLength(1);
+    expect(useDocThreadStore.getState().hydrated[KEY]).toBe(true);
+    // A second hydrate is a no-op even against an empty-ish store slot.
+    useDocThreadStore.getState().hydrate(KEY, [{ role: 'user', text: 'again' }], []);
+    expect(messages()).toHaveLength(1);
+  });
+
+  it('drops filler narration at the same seam live frames cross (§3.2)', () => {
+    useDocThreadStore.getState().hydrate(KEY, [
+      { role: 'agent', text: 'Reticulating splines…' },
+      { role: 'agent', text: 'Rewriting slide 3' },
+    ], []);
+    expect(texts()).toEqual(['Rewriting slide 3']);
+  });
+});
+
+// ── DES-UX-001 slice T (§6.3): the session-storage anchor stopgap ──
+
+describe('anchor stopgap (threadStopgap)', () => {
+  it('a landed version records its user-message ordinal, readable back', async () => {
+    const { readAnchors } = await import('../src/interactive/threadStopgap.js');
+    window.sessionStorage.clear();
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, nextMsgId(), 'the ask');
+    ingest(frame('wicked.interactive.version.created', { version: 1, parent: null, kind: 'generated' }));
+    expect(readAnchors(KEY)).toEqual([{ ord: 1, version: 1 }]);
   });
 });

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -41,7 +41,7 @@ function state(): string | undefined {
 }
 
 beforeEach(() => {
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
 });
 
 describe('composer state mapping (§2.2)', () => {

--- a/tests/exportWire.test.ts
+++ b/tests/exportWire.test.ts
@@ -47,7 +47,7 @@ function reply(file: string): Record<string, string> {
 }
 
 beforeEach(() => {
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   postExport.mockResolvedValue(reply('launch-deck_v3.pdf'));
 });
 afterEach(() => { vi.clearAllMocks(); });

--- a/tests/feedbackBatch.test.ts
+++ b/tests/feedbackBatch.test.ts
@@ -90,7 +90,7 @@ describe('submitFeedbackBatch — §7.7: the client authors BOTH writes', () => 
     expect(injectDocMessage).toHaveBeenCalledWith(PROJECT, DOC, text, msgId);
     // §7.6: the same id is the pending version anchor, so the version this feedback
     // produces tags the message that asked for it.
-    expect(useDocThreadStore.getState().anchor[KEY]).toBe(msgId);
+    expect(useDocThreadStore.getState().pending[KEY]).toContain(msgId);
   });
 
   it('a batch of one is still one message and one event', async () => {

--- a/tests/narration.bare.test.ts
+++ b/tests/narration.bare.test.ts
@@ -64,7 +64,7 @@ describe('a status with no subject is filler (§3.3)', () => {
 describe('the filter is applied at the seam, so no surface can render it', () => {
   it('AC: a bare status never reaches the transcript — but its state transition does', () => {
     const { ingest } = useDocThreadStore.getState();
-    useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+    useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
 
     for (const line of BARE) ingest(frame({ state: 'working', message: line }));
     expect(useDocThreadStore.getState().messages[KEY] ?? []).toEqual([]);

--- a/tests/themeWire.test.ts
+++ b/tests/themeWire.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'location', {
     value: new URL('http://127.0.0.1:7788/'), writable: true, configurable: true,
   });
-  useDocThreadStore.setState({ messages: {}, genState: {}, anchor: {}, landed: {} });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
 });
 afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
 


### PR DESCRIPTION
Implements **DES-UX-001 §6.1 + §6.3 (slice T)** — thread truth (BRIEF-UX-001 B1 + B3 CRITICALs), built on the recorded BRIDGE-UX-1 outcomes (§8.4.1).

## What changed
- **§6.1 send lifecycle (EC36)**: the docThread store's single anchor slot became a per-thread pending FIFO — the honest client-side order-correlation the probes fixed (the bridge queues; `version.created` carries no `source_message_id`). Every send renders its state beneath it: generating (FIFO head), "queued behind the current run", or failed with a working retry. Version markers render ON their causing message (`data-caused-by`) — a stray marker is structurally impossible. A run death fails its whole backlog visibly instead of leaving chips spinning forever.
- **§6.3 rehydration**: `GET /d/:doc/api/conversation` (the probe-confirmed real surface, via crew's proxy mount) hydrates the thread text once per doc open; session storage keeps ONLY what the wire lacks (version anchors). After a fresh session the text is back from the wire — the stopgap copy appears only on the genuine version-anchor gap, never over restored text.

## Verified at slice time
1335/1335 unit tests · slice rig 13/13 twice · interactive_wire_contract green against the real bridge (incl. all §8.4.1 probes) · regressions uxfix_slice6, feedback2_sliceK, vision_slice4, feedback3_sliceN, studio_standalone · all seven sibling slice rigs (R/V/S/W/Y/Y2/T) green on the merged fixture · adversarial verifier approved.

## Riding along (dedicated commits, both post-merge collisions on main)
- **WorkPage filter test (Y↔Y2)**: Y asserted raw problem text in rows; Y2's synthesized titles made it a prefix — matchers re-scoped. Main's unit suite was red at the intersection.
- **vision_slice4 scene 2 (W↔Y)**: W pointed the scene at flat `/runs`; Y retired `/runs` into a redirect — scene re-scoped to the project Build tabs that own each status edge, with per-project footer truths derived from fixture constants in visible comments. Main's rig only looked green via a stale cached dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
