### PR TITLE
DES-UX-001 slice U: the Unfiled path — make-Unfiled-work

### DIFF
--- a/e2e/ux_sliceU_test.py
+++ b/e2e/ux_sliceU_test.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""
+ux_sliceU_test.py — the DES-UX-001 slice-U gate: the Unfiled path (§6.2, B2).
+
+BRIDGE-UX-1 probe 3 (§8.4.1) fixed the shape: make-Unfiled-work IS the design —
+the bridge hosts a project-unbound doc natively (`POST /api/docs` with NO
+`project` field), crew's proxy synthesizes the `default` project's interactive
+mount by design (proxy-routes.ts `rootFor()` skips the existence check for
+`default`), and a refused bind is a loud 502 with NOTHING created.
+
+Two halves, both mandatory:
+
+PART A — the crew-proxy hop (§8.4.1 probe 3's named verify-at-slice-time
+obligation: "end-to-end creation THROUGH crew's default mount was not driven
+by this rig — slice U's own rig verifies that hop at slice time"). A REAL
+wicked-interactive bridge on a temp root (crew lookups pinned to a dead port,
+the wire-contract rig's hermeticity rule — never the live 7701 daemon) is
+ADOPTED by a REAL crew daemon (`CREW_CLI`, stub engine, throwaway db,
+`WICKED_INTERACTIVE_ROOT` = the same root), and the rig drives:
+  A1  crew synthesizes `default` (named "Unfiled") on GET /projects;
+  A2  POST /api/v1/projects/default/interactive/api/docs with NO `project`
+      field → created; listed; the rendered doc serves text/html THROUGH the
+      proxy; the doc dir exists in THIS rig's root (the adopted bridge, not a
+      stray npx spawn);
+  A3  the refused bind through the same mount (a `project` field while the
+      bridge's crew lookup points at the dead port) → 502 whose body names
+      "unreachable", and NOTHING was created (doc 404s, no dir on disk).
+
+PART B — the studio surface (§6.2's DOM ACs), on the shared W2 fixture:
+  B1  Make ＋ → Document → the picker stage says Unfiled works; selecting
+      Unfiled BY MOUSE navigates to /p/default/document within the
+      interaction (the dead-end regression pin: never a silent close), the
+      context header labels it "Unfiled" (the run-surface labeling), and the
+      doc surface renders;
+  B2  a brief sent from that surface POSTs the create to the DEFAULT mount
+      with NO `project` key in the body (the unbound contract on the studio's
+      own traffic) and lands on /p/default/document/<doc>;
+  B3  the doc is FINDABLE: the default mount's doc picker lists it, and the
+      Make dashboard's doc corpus lists it labeled "Unfiled" (in-session
+      navigation — the docsCache is session state);
+  B4  selecting Unfiled BY KEYBOARD (trigger Enter → ArrowDown → Enter)
+      navigates the same way — §6.2 asserts both drive paths;
+  B5  the refused bind surfaces HONESTLY on a real-project mount: with the
+      fixture answering the bridge's real 502 refused-bind shape, the send
+      renders the composer error naming the cause — no navigation, no thread
+      row, nothing created (`create_fail`, reset after).
+
+Capture (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-U-unfiled.png   the created unfiled doc open at /p/default/document/<doc>,
+                     context header reading "Unfiled"
+
+Prereqs: Python Playwright; a built crew CLI (CREW_CLI, default
+../wicked-crew/packages/crew/dist/cli/index.js); the wicked-interactive
+checkout (WICKED_INTERACTIVE_DIR, default ../wicked-interactive). Builds
+dist-sameorigin/ itself unless SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT
+(default 4392), CREW_CLI, WICKED_INTERACTIVE_DIR, SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4392"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+CREW_CLI = Path(os.environ.get(
+    "CREW_CLI",
+    REPO.parent / "wicked-crew" / "packages" / "crew" / "dist" / "cli" / "index.js"))
+WI_DIR = Path(os.environ.get("WICKED_INTERACTIVE_DIR", str(REPO.parent / "wicked-interactive")))
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def http(method: str, url: str, body: dict | None = None) -> tuple[int, str, str]:
+    """status, text, content-type — non-2xx answers return, never raise."""
+    req = urllib.request.Request(url, method=method)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, data, timeout=30) as res:
+            return res.status, res.read().decode(), res.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(), e.headers.get("Content-Type", "")
+
+
+# ═══ PART A — the crew-proxy hop (§8.4.1 probe 3's slice-time obligation) ═══════
+
+if not CREW_CLI.is_file():
+    fail("crew_cli", f"{CREW_CLI} missing — build wicked-crew first, or set CREW_CLI")
+wi_cli = WI_DIR / "bin" / "wicked-interactive.js"
+if not wi_cli.is_file():
+    fail("bridge_checkout",
+         f"wicked-interactive not found at {WI_DIR} — set WICKED_INTERACTIVE_DIR")
+
+tmp = Path(os.path.realpath(tempfile.mkdtemp(prefix="ux-sliceU-")))
+docs_root = tmp / "docs"
+docs_root.mkdir(parents=True)
+bridge_port = free_port()
+crew_port = free_port()
+# Hermeticity (the wire-contract rig's rule): the BRIDGE's crew lookups pin to a
+# port nothing listens on, so the refused-bind leg can never reach — let alone
+# write into — the operator's live daemon on 7701. The synthesized-default hop
+# under test is crew→bridge; the bridge only dials crew when a `project` field
+# asks it to bind, which is exactly the leg that must refuse loudly here.
+dead_crew_port = free_port()
+
+bridge_log = (tmp / "bridge.log").open("w")
+bridge = subprocess.Popen(
+    ["node", str(wi_cli), "serve", "--root", str(docs_root), "--port", str(bridge_port)],
+    cwd=str(WI_DIR),
+    env=dict(os.environ, WICKED_BUS_DATA_DIR=str(tmp / "bus"),
+             WICKED_CREW_API=f"http://127.0.0.1:{dead_crew_port}"),
+    stdout=bridge_log, stderr=bridge_log,
+)
+daemon: subprocess.Popen | None = None
+
+try:
+    deadline = time.time() + 30
+    bridge_up = False
+    while time.time() < deadline:
+        if bridge.poll() is not None:
+            fail("bridge_start", f"bridge exited rc={bridge.returncode}:\n"
+                 + (tmp / "bridge.log").read_text()[-2000:])
+        try:
+            s, t, _ = http("GET", f"http://127.0.0.1:{bridge_port}/api/health")
+            if s == 200 and json.loads(t).get("ok") is True:
+                bridge_up = True
+                break
+        except OSError:
+            pass
+        time.sleep(0.2)
+    if not bridge_up:
+        fail("bridge_start", "bridge /api/health never answered ok:true")
+    report["steps"]["bridge_start"] = {"ok": True, "root": str(docs_root), "port": bridge_port}
+
+    # The REAL crew daemon (studio_standalone's spawn pattern) with its shared
+    # default root pointed at the SAME directory, so the pool ADOPTS the bridge
+    # above via <root>/.wi-serve.json instead of npx-spawning a second one.
+    daemon = subprocess.Popen(
+        ["node", str(CREW_CLI), "serve", "--port", str(crew_port),
+         "--db", str(tmp / "core.db"), "--stub"],
+        cwd=str(tmp),
+        env=dict(os.environ, WICKED_MEMORY_EMBEDDER="hash",
+                 WICKED_INTERACTIVE_ROOT=str(docs_root)),
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    ready = False
+    deadline = time.time() + 60
+    assert daemon.stdout is not None
+    while time.time() < deadline:
+        line = daemon.stdout.readline()
+        if not line:
+            break
+        if "WICKED_CREW_READY" in line:
+            ready = True
+            break
+    if not ready:
+        fail("crew_daemon", "daemon never printed WICKED_CREW_READY within 60s")
+    threading.Thread(target=lambda: [None for _ in daemon.stdout], daemon=True).start()
+    CREW = f"http://127.0.0.1:{crew_port}/api/v1"
+    report["steps"]["crew_daemon"] = {"ok": True, "port": crew_port, "stub": True}
+
+    # A1 — crew synthesizes `default`, named "Unfiled" (the labeling truth the
+    # studio's context header renders from the projects list).
+    s, t, _ = http("GET", f"{CREW}/projects")
+    rows = json.loads(t).get("projects", []) if s == 200 else []
+    default_row = next((p for p in rows if p.get("id") == "default"), None)
+    check("A1_crew_synthesizes_default_named_unfiled",
+          s == 200 and default_row is not None and default_row.get("name") == "Unfiled",
+          status=s, default_row=default_row)
+
+    # A2 — end-to-end creation THROUGH crew's default mount: no `project` field.
+    MOUNT = f"{CREW}/projects/default/interactive"
+    DOC = "ux-u-unfiled-doc"
+    s_create, t_create, _ = http("POST", f"{MOUNT}/api/docs", {
+        "name": DOC,
+        "html": "<!DOCTYPE html><html><body><h1>unfiled</h1><p>slice U</p></body></html>",
+    })
+    created = s_create == 200 and json.loads(t_create).get("name") == DOC
+    s_list, t_list, _ = http("GET", f"{MOUNT}/api/docs")
+    listed = s_list == 200 and any(d.get("name") == DOC for d in json.loads(t_list))
+    s_doc, _, ct_doc = http("GET", f"{MOUNT}/d/{DOC}/doc")
+    served = s_doc == 200 and ct_doc.startswith("text/html")
+    # The doc landed in THIS rig's root — crew adopted the pre-started bridge
+    # (an npx-spawned stray would have written somewhere else entirely).
+    on_disk = (docs_root / DOC).is_dir()
+    check("A2_create_through_crews_default_mount",
+          created and listed and served and on_disk,
+          create_status=s_create, listed=listed, doc_status=s_doc,
+          content_type=ct_doc, adopted_bridge_root_has_doc=on_disk)
+
+    # A3 — the refused bind through the SAME mount is loud and creates nothing:
+    # a `project` field makes the bridge dial crew (pinned dead above) BEFORE
+    # any disk write; the 502 rides back through crew's proxy verbatim.
+    GHOST = "ux-u-ghost-doc"
+    s_bind, t_bind, _ = http("POST", f"{MOUNT}/api/docs", {
+        "name": GHOST, "html": "<html><body>x</body></html>", "project": "default",
+    })
+    s_ghost, _, _ = http("GET", f"{MOUNT}/d/{GHOST}/doc")
+    check("A3_refused_bind_is_loud_502_creating_nothing",
+          s_bind == 502 and "unreachable" in t_bind and s_ghost == 404
+          and not (docs_root / GHOST).exists(),
+          bind_status=s_bind, body=t_bind[:200], ghost_doc_status=s_ghost,
+          ghost_on_disk=(docs_root / GHOST).exists())
+finally:
+    if daemon is not None:
+        daemon.kill()
+    bridge.kill()
+
+# ═══ PART B — the studio surface (§6.2 DOM ACs), on the shared W2 fixture ═══════
+
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, create_fail=False)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    console_errors: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # Tap every create POST: B2 pins the studio's OWN traffic to the unbound
+    # contract (no `project` key through the default mount), B5 the bound one.
+    create_posts: list[dict] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and path.endswith("/interactive/api/docs"):
+            try:
+                body = json.loads(req.post_data or "{}")
+            except json.JSONDecodeError:
+                body = {}
+            create_posts.append({"path": path, "body": body})
+
+    page.on("request", on_request)
+
+    # ── B1: Make ＋ → Document → Unfiled BY MOUSE lands on the doc surface ──────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="rail-heading-make"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="make-picker-row"][data-mode="document"]').click()
+    page.locator('[data-testid="make-picker-project-stage"]').wait_for(timeout=10000)
+    stage_copy = page.locator('[data-testid="make-picker-project-stage"] p').first.text_content() or ""
+    page.locator('[data-testid="project-field"]').click()
+    page.locator('[data-testid="project-switcher-unfiled"]').click()
+    page.wait_for_function(
+        """() => window.location.pathname === '/p/default/document'
+              && !document.querySelector('[data-testid="make-picker"]')""", timeout=10000)
+    # The surface labels it the way run surfaces label Unfiled runs (§6.2): the
+    # context header's project name renders the synthesized row's name.
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="project-name"]')?.textContent ?? '')
+                   .includes('Unfiled')""", timeout=10000)
+    surface = page.evaluate(
+        """() => ({
+             path: window.location.pathname,
+             pickerGone: !document.querySelector('[data-testid="make-picker"]'),
+             docSurface: !!document.querySelector('[data-testid="mode-surface"][data-mode="document"]'),
+             header: document.querySelector('[data-testid="project-name"]')?.textContent ?? null,
+             composer: !!document.querySelector('[data-testid="doc-composer"]'),
+           })""")
+    check("B1_mouse_unfiled_navigates_not_dead_end",
+          surface["path"] == "/p/default/document" and surface["pickerGone"]
+          and surface["docSurface"] and surface["composer"]
+          and "Unfiled" in (surface["header"] or "")
+          and "Unfiled" in stage_copy,
+          stage_copy=stage_copy, **surface)
+
+    # ── B2: the create rides the DEFAULT mount UNBOUND, and lands ──────────────
+    BRIEF = "Collect the unfiled meeting notes into a brief"
+    page.locator('[data-testid="doc-composer"]').fill(BRIEF)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    doc_path = urlparse(page.url).path
+    doc_id = doc_path.rsplit("/", 1)[-1]
+    unfiled_creates = [c for c in create_posts
+                       if c["path"] == "/api/v1/projects/default/interactive/api/docs"]
+    check("B2_create_unbound_through_default_mount",
+          doc_path.startswith("/p/default/document/") and len(unfiled_creates) == 1
+          and "project" not in unfiled_creates[0]["body"]
+          and unfiled_creates[0]["body"].get("brief") == BRIEF,
+          doc_path=doc_path, create_bodies=[c["body"] for c in unfiled_creates])
+
+    # The named shot: the unfiled doc open, context header reading "Unfiled".
+    page.screenshot(path=str(VSHOTS / "ux-U-unfiled.png"))
+
+    # ── B3: findable — the mount's doc picker AND the Make dashboard corpus ────
+    page.go_back()  # SPA history → /p/default/document (the picker re-lists + deposits)
+    page.locator(f'[data-testid="doc-picker-row"][data-doc-id="{doc_id}"]').wait_for(timeout=10000)
+    # In-session navigation (the docsCache is session state): header ‹ Projects
+    # → the rail → the Make dashboard.
+    page.locator('[data-testid="project-context-header"] button').first.click()
+    page.locator('[data-testid="rail-heading-make"]').wait_for(timeout=10000)
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-dashboard"]').click()
+    page.locator('[data-testid="make-list"]').wait_for(timeout=10000)
+    make_row = page.evaluate(
+        """(doc) => {
+             const row = Array.from(document.querySelectorAll('[data-testid="make-doc-row"]'))
+               .find((r) => (r.getAttribute('href') ?? '').includes(doc));
+             return row === undefined ? null : {
+               href: row.getAttribute('href'),
+               label: row.textContent ?? '',
+             };
+           }""", doc_id)
+    check("B3_doc_findable_in_picker_and_make_corpus",
+          make_row is not None
+          and make_row["href"] == f"/p/default/document/{doc_id}"
+          and "Unfiled" in make_row["label"],
+          doc_id=doc_id, make_row=make_row)
+
+    # ── B4: the KEYBOARD drive of the same selection (§6.2: both paths) ────────
+    page.locator('[data-testid="rail-heading-make"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="make-picker-row"][data-mode="document"]').click()
+    page.locator('[data-testid="make-picker-project-stage"]').wait_for(timeout=10000)
+    page.locator('[data-testid="project-field"]').press("Enter")   # open the list
+    page.locator('[data-testid="project-switcher-list"]').wait_for(timeout=5000)
+    page.keyboard.press("ArrowDown")                               # focus the Unfiled row
+    focused = page.evaluate(
+        """() => document.activeElement?.getAttribute('data-testid') ?? null""")
+    page.keyboard.press("Enter")                                   # select it
+    page.wait_for_function(
+        """() => window.location.pathname === '/p/default/document'
+              && !document.querySelector('[data-testid="make-picker"]')""", timeout=10000)
+    check("B4_keyboard_unfiled_navigates",
+          focused == "project-switcher-unfiled"
+          and urlparse(page.url).path == "/p/default/document",
+          focused=focused, path=urlparse(page.url).path)
+
+    # ── B5: the refused bind surfaces HONESTLY on a real-project mount ─────────
+    page.goto(f"{ORIGIN}/p/scratch/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    set_fixture(ORIGIN, create_fail=True)
+    create_posts.clear()
+    page.locator('[data-testid="doc-composer"]').fill("A deck that cannot be filed")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-composer-error"]').wait_for(timeout=10000)
+    refused = page.evaluate(
+        """() => ({
+             path: window.location.pathname,
+             error: document.querySelector('[data-testid="doc-composer-error"]')?.textContent ?? '',
+             noThreadRow: !document.querySelector('[data-testid="doc-message"]'),
+             noCanvas: !document.querySelector('[data-testid="doc-canvas"]'),
+           })""")
+    bound = [c for c in create_posts if c["path"].endswith("/scratch/interactive/api/docs")]
+    check("B5_refused_bind_loud_on_the_surface",
+          refused["path"] == "/p/scratch/document"
+          and "unreachable" in refused["error"]
+          and refused["noThreadRow"] and refused["noCanvas"]
+          and len(bound) == 1 and bound[0]["body"].get("project") == "scratch",
+          bound_bodies=[c["body"] for c in bound], **refused)
+    set_fixture(ORIGIN, create_fail=False)
+
+    # Console hygiene: the deliberate 502 logs one resource error; nothing else may.
+    unexpected = [e for e in console_errors
+                  if "502" not in e and "Failed to load resource" not in e]
+    check("B6_no_unexpected_console_errors", unexpected == [], errors=unexpected)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["shots"] = ["ux-U-unfiled.png"]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -269,6 +269,13 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # 500 {error} — the visible-failure branch (a bridge that refuses the
          # send; the client must render thread-send-failed, never silence).
          "send_fail": False,
+         # Slice U (DES-UX-001 §6.2, §8.4.1 probe 3): when True, POST
+         # /api/docs answers the bridge's REAL refused-bind shape — a loud
+         # 502 {"error": "crew daemon unreachable at …"} with NOTHING created
+         # (server.js validates attachability BEFORE any disk write). The rig
+         # drives it against a real-project mount; the Unfiled (`default`)
+         # mount never binds — its create body carries no `project` field.
+         "create_fail": False,
          }
 state_lock = threading.Lock()
 
@@ -1803,6 +1810,16 @@ class W2Handler(SimpleHTTPRequestHandler):
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/docs$", path)
         if m:
             pid = urllib.parse.unquote(m.group(1))
+            # Slice U (§8.4.1 probe 3): the refused-bind branch — the REAL
+            # 502 shape server.js returns from assertProjectAttachable, BEFORE
+            # any state is written ("nothing created on a refused bind").
+            with state_lock:
+                refuse_create = bool(state["create_fail"])
+            if refuse_create:
+                self._json(502, {"error": "crew daemon unreachable at "
+                                          "http://127.0.0.1:9/api/v1 (ECONNREFUSED) — "
+                                          "start crew, or create the doc without a project"})
+                return True
             doc = slug(str(body.get("name") or "doc"))
             # Slice T (§8.4.1 probe 1): the REAL bridge DROPS source_message_id —
             # no `meta.sourceMessageId` ever reaches the manifest (the interactive.ts

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -113,6 +113,25 @@ export interface CreateDocBody {
   // `requestThemeLearn` and sticks server-side.
 }
 
+/**
+ * The synthesized Unfiled mount (DES-UX-001 §6.2, slice U): crew's proxy
+ * synthesizes `/projects/default/interactive` by design — `proxy-routes.ts`
+ * `rootFor()` skips the existence check for `default` — so the picker's
+ * Unfiled routes THERE, the daemon's own unfiled home.
+ */
+export const UNFILED_MOUNT = 'default';
+
+/**
+ * The create body's binding half (§8.4.1 probe 3): a real project binds
+ * (`project` present — registration is the authority, a refused bind is the
+ * loud 502 with nothing created); the Unfiled mount OMITS the field, because
+ * a project-unbound doc is the bridge's native shape there — `default` is
+ * synthesized, and asking crew to register against it would be refused.
+ */
+export function docBinding(projectId: string): Pick<CreateDocBody, 'project'> {
+  return projectId === UNFILED_MOUNT ? {} : { project: projectId };
+}
+
 export interface CreateDocResult {
   name: string;
   head: number;

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Search } from 'lucide-react';
 import type { GovernanceClaim, InteractionRequest, RepoEntry, SessionView } from '../api/types.js';
 import { api } from '../api/client.js';
+import { UNFILED_MOUNT } from '../api/interactive.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { fuzzyMatch, type FuzzyResult } from '../palette/fuzzy.js';
 import { launchPath } from '../hooks/ambientProject.js';
@@ -858,16 +859,18 @@ export function CommandPalette({
         >
           <div className="flex flex-col gap-2" data-testid="palette-project-stage">
             <p style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-sans)', margin: 0 }}>
-              {`A ${pickProjectFor} lives in a project — pick one:`}
+              Pick a project — or keep it Unfiled:
             </p>
             <ProjectSwitcher
               current={null}
               projects={projects}
               onSelect={(pid) => {
-                if (pid === null) return; // a document cannot be Unfiled (§3.4)
+                // DES-UX-001 §6.2 (slice U): Unfiled routes to the `default`
+                // project's mount — the daemon's unfiled home — never a silent
+                // close (the same repair as the Make ＋ picker's stage).
                 const m = pickProjectFor;
                 setPickProjectFor(null);
-                navigate(modePath(pid, m));
+                navigate(modePath(pid ?? UNFILED_MOUNT, m));
               }}
             />
           </div>

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { createDoc, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { createDoc, docBinding, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
 import { ComposerContext } from './ComposerContext.js';
 import { DemoWizard } from './DemoWizard.js';
 import { recordFromThread } from '../interactive/demoWire.js';
@@ -466,8 +466,12 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
 
       // 1 — LAUNCH. The message IS the brief; the doc's generation run opens with it.
       if (docId === null || key === null) {
+        // §6.2 (slice U): the Unfiled mount creates UNBOUND (no `project`
+        // field — `docBinding`); real projects bind as before. A refused
+        // create lands in the catch below — the visible composer error,
+        // never a silent close (the loud-502 contract, §8.4.1 probe 3).
         const created = await createDoc(projectId, {
-          name: docName(body), kind: 'source', brief: body, project: projectId,
+          name: docName(body), kind: 'source', brief: body, ...docBinding(projectId),
           source_message_id: msgId,
         });
         const opened = threadKey(projectId, created.name);

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { RepoEntry, SessionView } from '../api/types.js';
-import type { DocSummary } from '../api/interactive.js';
+import { UNFILED_MOUNT, type DocSummary } from '../api/interactive.js';
 import { ambientProjectId, launchPath, registerRepoPath } from '../hooks/ambientProject.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute.js';
@@ -438,16 +438,18 @@ function MakePicker({ navigate, onClose, ambient }: {
         <div className="px-3 py-1.5 flex flex-col gap-1.5" data-testid="make-picker-project-stage">
           <p style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-sans)', margin: 0 }}>
             {real.length === 0
-              ? `A ${MODE_SPECS[stage].label.toLowerCase()} lives in a project — create a project first.`
-              : `A ${MODE_SPECS[stage].label.toLowerCase()} lives in a project — pick one:`}
+              ? `No projects yet — a ${MODE_SPECS[stage].label.toLowerCase()} can start Unfiled, or create one:`
+              : 'Pick a project — or keep it Unfiled:'}
           </p>
           <ProjectSwitcher
             current={null}
             projects={projects}
             onSelect={(pid) => {
-              if (pid === null) return; // a document cannot be Unfiled (§3.4)
+              // DES-UX-001 §6.2 (slice U): Unfiled is NO dead end — it routes to
+              // the `default` project's mount, the daemon's own unfiled home
+              // (crew synthesizes that mount; the doc is created UNBOUND there).
               onClose();
-              navigate(modePath(pid, stage));
+              navigate(modePath(pid ?? UNFILED_MOUNT, stage));
             }}
           />
         </div>

--- a/src/components/MakeDashboard.tsx
+++ b/src/components/MakeDashboard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import type { SessionView } from '../api/types.js';
-import type { DocSummary } from '../api/interactive.js';
+import { UNFILED_MOUNT, type DocSummary } from '../api/interactive.js';
 import { versionPath, type Mode } from '../hooks/useRoute.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { useMembershipStore } from '../store/membership.js';
@@ -165,7 +165,12 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
   // The known corpus: doc rows off the session cache, newest first.
   const docRows = useMemo(
     () => Object.entries(byProject)
-      .flatMap(([pid, docs]) => docs.map((doc) => ({ doc, projectId: pid, projectName: projectNameById[pid] ?? pid })))
+      // Slice U (§6.2): the default bucket never rides the board's store mirror
+      // (F5), so its docs label "Unfiled" — the run rows' exact grammar above.
+      .flatMap(([pid, docs]) => docs.map((doc) => ({
+        doc, projectId: pid,
+        projectName: projectNameById[pid] ?? (pid === UNFILED_MOUNT ? 'Unfiled' : pid),
+      })))
       .sort((a, b) => (b.doc.updated_at ?? '').localeCompare(a.doc.updated_at ?? '')),
     [byProject, projectNameById],
   );

--- a/src/components/ProjectShell.tsx
+++ b/src/components/ProjectShell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
+import { UNFILED_MOUNT } from '../api/interactive.js';
 import { usePreflight } from '../hooks/usePreflight.js';
 import { MODES, modePath, projectPath, type Mode, type Navigate } from '../hooks/useRoute.js';
 import { useConnectionStore } from '../store/connection.js';
@@ -77,7 +78,11 @@ export function ProjectShell({ projectId, mode, artifactId, navigate, children }
   );
 
   const project = projects.find((p) => p.id === projectId) ?? null;
-  const name = project?.name ?? projectId;
+  // Slice U (DES-UX-001 §6.2): the synthesized `default` bucket never rides the
+  // board's store mirror (F5 — it is not a project card), so at /p/default the
+  // shell labels it the way run surfaces label Unfiled runs — the daemon's own
+  // name for the bucket, "Unfiled" — instead of leaking the raw id.
+  const name = project?.name ?? (projectId === UNFILED_MOUNT ? 'Unfiled' : projectId);
 
   // ── The merged readiness model (§5.6, slice 17) ───────────────────────────
   usePreflight(projectId);

--- a/src/interactive/demoWire.ts
+++ b/src/interactive/demoWire.ts
@@ -11,7 +11,7 @@
 // too (§2.3): a recording the user asked for that leaves no trace in the transcript makes
 // the transcript stop being the record of why v4 became v5.
 
-import { createDoc, requestRecord, type CreateDocBody, type DemoStepDraft } from '../api/interactive.js';
+import { createDoc, docBinding, requestRecord, type CreateDocBody, type DemoStepDraft } from '../api/interactive.js';
 import { nextMsgId, threadKey, useDocThreadStore } from '../store/docThread.js';
 import { submitFeedbackBatch, type SubmitBatchResult } from './feedbackBatch.js';
 
@@ -84,7 +84,8 @@ export function demoDraftBody(
     url: draft.targetUrl.trim(),
     brief: demoBrief(draft),
     demo_steps: steps,
-    project: projectId,
+    // §6.2 (slice U): the Unfiled mount creates unbound; real projects bind.
+    ...docBinding(projectId),
     source_message_id: sourceMessageId,
   };
 }

--- a/src/theming/scratchDoc.ts
+++ b/src/theming/scratchDoc.ts
@@ -1,4 +1,4 @@
-import { createDoc, listDocs, type CreateDocResult, type DocSummary } from '../api/interactive.js';
+import { createDoc, docBinding, listDocs, type CreateDocResult, type DocSummary } from '../api/interactive.js';
 
 /**
  * The studio-owned scratch document a brand learn rides (one per project).
@@ -27,7 +27,7 @@ export interface ScratchDocDeps {
   listDocs: (projectId: string) => Promise<DocSummary[]>;
   createDoc: (
     projectId: string,
-    body: { name: string; kind: 'source'; brief: string; project: string },
+    body: { name: string; kind: 'source'; brief: string; project?: string },
   ) => Promise<CreateDocResult>;
 }
 
@@ -40,7 +40,8 @@ export async function ensureScratchDoc(
   if (docs.some((d) => d.name === SCRATCH_DOC_NAME)) return SCRATCH_DOC_NAME;
   try {
     const created = await deps.createDoc(projectId, {
-      name: SCRATCH_DOC_NAME, kind: 'source', brief: SCRATCH_DOC_BRIEF, project: projectId,
+      // §6.2 (slice U): the Unfiled mount creates unbound; real projects bind.
+      name: SCRATCH_DOC_NAME, kind: 'source', brief: SCRATCH_DOC_BRIEF, ...docBinding(projectId),
     });
     return created.name;
   } catch (e: unknown) {

--- a/tests/BrandLearn.test.tsx
+++ b/tests/BrandLearn.test.tsx
@@ -30,6 +30,8 @@ const getLearnedTheme = vi.fn();
 vi.mock('../src/api/interactive.js', () => ({
   listDocs: (...a: unknown[]) => listDocs(...a) as unknown,
   createDoc: (...a: unknown[]) => createDoc(...a) as unknown,
+  // Slice U (§6.2): the REAL binding rule, mirrored — real projects bind.
+  docBinding: (pid: string) => (pid === 'default' ? {} : { project: pid }),
   requestThemeLearn: (...a: unknown[]) => requestThemeLearn(...a) as unknown,
   getLearnedTheme: (...a: unknown[]) => getLearnedTheme(...a) as unknown,
   attachSource: vi.fn(),

--- a/tests/ComposerContext.test.tsx
+++ b/tests/ComposerContext.test.tsx
@@ -32,6 +32,8 @@ vi.mock('../src/api/interactive.js', async (importOriginal) => {
   return {
     ServiceHintError: actual.ServiceHintError,
     BridgeUnavailableError: actual.BridgeUnavailableError,
+    docBinding: actual.docBinding, // slice U (§6.2): the real binding rule
+
     requestThemeLearn: (...a: unknown[]) => requestThemeLearn(...a),
     attachSource: (...a: unknown[]) => attachSource(...a),
     createDoc: (...a: unknown[]) => createDoc(...a),

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -21,6 +21,8 @@ const getVersions = vi.fn();
 
 vi.mock('../src/api/interactive.js', () => ({
   createDoc: (...a: unknown[]) => createDoc(...a),
+  // Slice U (§6.2): the REAL binding rule, mirrored — real projects bind.
+  docBinding: (pid: string) => (pid === 'default' ? {} : { project: pid }),
   postFork: (...a: unknown[]) => postFork(...a),
   postEvent: (...a: unknown[]) => postEvent(...a),
   // The real wrapper, mirrored: `injectDocMessage` IS one `postEvent` (slices 11+12

--- a/tests/DocumentThread.video.test.tsx
+++ b/tests/DocumentThread.video.test.tsx
@@ -22,6 +22,8 @@ const postFork = vi.fn();
 
 vi.mock('../src/api/interactive.js', () => ({
   createDoc: (...a: unknown[]) => createDoc(...a),
+  // Slice U (§6.2): the REAL binding rule, mirrored — real projects bind.
+  docBinding: (pid: string) => (pid === 'default' ? {} : { project: pid }),
   requestRecord: (...a: unknown[]) => requestRecord(...a),
   postEvent: (...a: unknown[]) => postEvent(...a),
   getVersions: (...a: unknown[]) => getVersions(...a),

--- a/tests/demoWire.test.ts
+++ b/tests/demoWire.test.ts
@@ -21,6 +21,9 @@ vi.mock('../src/api/interactive.js', () => ({
   requestRecord: (...a: unknown[]) => requestRecord(...a),
   postEvent: (...a: unknown[]) => postEvent(...a),
   injectDocMessage: (...a: unknown[]) => injectDocMessage(...a),
+  // Slice U (§6.2): the REAL binding rule — the mock must not change it, or
+  // the "bound to its project" AC below would assert against a stub.
+  docBinding: (pid: string) => (pid === 'default' ? {} : { project: pid }),
 }));
 
 const PROJECT = 'proj-abc-123';

--- a/tests/docBinding.test.ts
+++ b/tests/docBinding.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * DES-UX-001 §6.2 (slice U): the Unfiled path's binding contract.
+ *
+ * BRIDGE-UX-1 probe 3 (§8.4.1): the bridge hosts a project-unbound doc
+ * natively — `POST /api/docs` with NO `project` field — while a bind is a
+ * crew registration that `default` (synthesized, never stored) would refuse
+ * with the loud 502. So a create THROUGH the default mount must omit the
+ * field, and a create through a real project's mount must keep binding.
+ */
+import { docBinding, UNFILED_MOUNT } from '../src/api/interactive.js';
+import { ensureScratchDoc } from '../src/theming/scratchDoc.js';
+import { demoDraftBody } from '../src/interactive/demoWire.js';
+
+describe('docBinding (§6.2 slice U)', () => {
+  it('omits `project` on the Unfiled mount — unbound is the native shape', () => {
+    expect(UNFILED_MOUNT).toBe('default');
+    expect(docBinding(UNFILED_MOUNT)).toEqual({});
+    expect('project' in docBinding(UNFILED_MOUNT)).toBe(false);
+  });
+
+  it('binds real projects exactly as before — registration stays the authority', () => {
+    expect(docBinding('q3-review-deck')).toEqual({ project: 'q3-review-deck' });
+  });
+
+  it('a demo draft through the default mount carries no binding field', () => {
+    const body = demoDraftBody(UNFILED_MOUNT, {
+      name: 'unfiled-demo', targetUrl: 'https://example.com',
+      steps: [{ subject: 'the storefront', action: 'open it' }],
+    }, 'msg-1');
+    expect(body.project).toBeUndefined();
+    expect(body.kind).toBe('demo');
+  });
+
+  it('the scratch doc on the default mount is created unbound', async () => {
+    const listDocs = vi.fn().mockResolvedValue([]);
+    const createDoc = vi.fn().mockResolvedValue({ name: 'brand-learn', head: 1 });
+    await ensureScratchDoc(UNFILED_MOUNT, { listDocs, createDoc });
+    const [, body] = createDoc.mock.calls[0] as [string, { project?: string }];
+    expect(body.project).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §6.2 (slice U)** — the Unfiled path, shaped by §8.4.1 probe 3: **make-Unfiled-work** (BRIEF-UX-001 B2 CRITICAL: "the Unfiled path is a dead end in Make → Document").

- Unfiled in the Make ＋ picker and palette now navigates to `/p/default/<mode>` (crew's synthesized default mount) instead of silently closing; creates through that mount omit the `project` field (probe 3's unbound-native shape); a refused bind surfaces as the visible composer error naming the cause. The default bucket labels "Unfiled" everywhere it renders.
- **§8.4.1's verify-at-slice-time obligation discharged**: the rig's PART A spawns a REAL crew daemon (stub engine, throwaway db) adopting a REAL wicked-interactive bridge and proves end-to-end unfiled doc creation THROUGH `/api/v1/projects/default/interactive` — created, listed, served, on disk — plus the loud refused bind (502, ghost 404s, nothing created).

Verified: 1339/1339 unit tests; slice rig 12/12; regressions ux_sliceT, uxfix_slice6, studio_standalone; adversarial verifier re-drove PART A itself and confirmed the negative check (main dead-ends at the exact pinned line). ~60 LOC of the 180 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
