### PR TITLE
DES-UX-001 slice AA: toast lifecycle

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -192,6 +192,11 @@ report: dict = {"ok": False, "steps": {}}
 # the Document-mode composer. They are not this section's surface — same spirit as the
 # `fonts.g` console filter — so the doc sections suppress them rather than fight them.
 # Hiding is display-only: nothing about the asserted behaviour changes.
+# Slice AA re-scope note (DES-UX-001 §11.2): `gate-notification` now names each
+# toast CARD (the layer is `gate-notification-layer`, pointer-events: none), so
+# this selector still hides every card — the mechanism is unchanged. Toasts also
+# self-expire and cap at 3 since slice AA, so the overlap this guards against
+# is bounded; the hider stays because determinism is cheaper than a dwell race.
 HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
 
 def wake_strip(page) -> None:

--- a/e2e/ux_sliceAA_test.py
+++ b/e2e/ux_sliceAA_test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+ux_sliceAA_test.py — the DES-UX-001 slice-AA gate: toast lifecycle (§7.1, EC38, B4).
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with
+`batch_gates` giving four open gates across four projects (r-q3, r-api,
+r-batch1, r-batch2) — enough to exercise the card cap, and to make one
+project's shell see three FOREIGN gates.
+
+The §7.1 DOM ACs, verbatim mapping (the gate EXPERIENCE is §0-protected —
+every scene also asserts the gate RECORD survives its announcement):
+
+  1. every `[data-testid="gate-notification"]` contains a
+     `[data-testid="toast-dismiss"]`; dismissing hides the card but the runs
+     bar's gate count never moves — the toast is an announcement, not the
+     record;
+  2. EC38 layout safety: the toast LAYER reserves no pointer surface (only
+     its visible cards do), the stack caps at 3 cards + an inert overflow
+     line, sits clear of the runs bar (a hit-test at "All runs ›" reaches the
+     link with toasts up), and — the interception pin — with a toast visible
+     on a gated run's own thread, a hit-test at the composer's Steer/Send
+     coordinates reaches the button;
+  3. toasts self-expire after the bounded dwell (20s), and the runs bar's
+     gate count still names every gate afterwards;
+  4. B4: inside `/p/:id/*`, a foreign project's gate paints NO overlay card —
+     it announces as the runs bar's labeled "+N elsewhere" count and the
+     bell's unread badge; a gate ARRIVING from another project mid-session
+     increments that count without a card ever covering the mode surface.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-AA-toast-dismiss.png   /work with the capped toast stack up — each card
+                            carrying its ✕, the overflow line beneath, the
+                            runs bar's own gate count visible under the stack
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4394),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from uxfix_fixture import (
+    NOW0,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4394"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# Mirrors src/components/GateNotifications.tsx — the slice's two constants.
+TOAST_DWELL_MS = 20_000
+MAX_TOAST_CARDS = 3
+
+Q3_SHELL = "/p/q3-review-deck/build"
+Q3_THREAD = "/p/q3-review-deck/build/r-q3"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, batch gates ON ───────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, batch_gates=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+# The full toast census — every card, its dismiss control, and the layer's
+# pointer posture — read in ONE evaluate so the dwell clock can't split it.
+TOAST_CENSUS = """() => {
+  const layer = document.querySelector('[data-testid="gate-notification-layer"]');
+  const cards = [...document.querySelectorAll('[data-testid="gate-notification"]')];
+  const bar = document.querySelector('[data-testid="runs-bottom-bar"]');
+  const overflow = document.querySelector('[data-testid="gate-toast-overflow"]');
+  const lr = layer?.getBoundingClientRect() ?? null;
+  return {
+    cards: cards.map((c) => c.getAttribute('data-run-id')),
+    everyCardDismissible: cards.length > 0
+      && cards.every((c) => !!c.querySelector('[data-testid="toast-dismiss"]')),
+    layerPointerEvents: layer ? getComputedStyle(layer).pointerEvents : null,
+    layerBottom: lr ? Math.round(lr.bottom) : null,
+    overflowText: overflow?.textContent ?? null,
+    overflowPointerEvents: overflow ? getComputedStyle(overflow).pointerEvents : null,
+    barGates: bar?.dataset.gates ?? null,
+    barGatesElsewhere: bar?.dataset.gatesElsewhere ?? null,
+    barTop: bar ? Math.round(bar.getBoundingClientRect().top) : null,
+  };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    # Scenes 1–2 freeze Date (the harness convention) so the 20s dwell can never
+    # expire a card mid-assert; scenes 3–4 use a fresh, unfrozen context because
+    # expiry IS their subject.
+    page.clock.set_fixed_time(datetime.fromtimestamp((NOW0 + 5000) / 1000, tz=timezone.utc))
+
+    # ── Scene 1 (AC 1 + EC38): /work — cap, dismiss contract, layout safety ────
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+    page.locator('[data-testid="gate-notification"]').first.wait_for(timeout=30000)
+    # All four gates announced: 3 cards + the overflow line.
+    page.wait_for_function(
+        """() => document.querySelectorAll('[data-testid="gate-notification"]').length === 3
+              && !!document.querySelector('[data-testid="gate-toast-overflow"]')""",
+        timeout=15000)
+    census = page.evaluate(TOAST_CENSUS)
+    check("cap_and_dismiss_contract",
+          len(census["cards"]) == MAX_TOAST_CARDS
+          and census["everyCardDismissible"]
+          and census["layerPointerEvents"] == "none"
+          and census["overflowText"] is not None and "+1 more waiting" in census["overflowText"]
+          and census["overflowPointerEvents"] == "none"
+          and census["barGates"] == "4",
+          **census)
+    # EC38 geometry: the stack sits clear of the runs bar…
+    check("layer_clears_runs_bar",
+          census["layerBottom"] is not None and census["barTop"] is not None
+          and census["layerBottom"] <= census["barTop"],
+          layer_bottom=census["layerBottom"], bar_top=census["barTop"])
+    # …and reserves no pointer surface over it: the bar's "All runs ›" link is
+    # hit-testable with the full stack up (the OLD stack started at 16px and
+    # physically sat on the 28px bar).
+    allruns_hit = page.evaluate(
+        """() => {
+          const link = document.querySelector('[data-testid="runs-bar-all"]');
+          if (!link) return { found: false };
+          const r = link.getBoundingClientRect();
+          const el = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+          return { found: true, reaches: link === el || link.contains(el),
+                   toastsUp: document.querySelectorAll('[data-testid="gate-notification"]').length > 0 };
+        }""")
+    check("allruns_hit_test", allruns_hit["found"] and allruns_hit["reaches"]
+          and allruns_hit["toastsUp"], **allruns_hit)
+    page.screenshot(path=str(VSHOTS / "ux-AA-toast-dismiss.png"))
+
+    # Dismiss one card: the 4th slides into the cap, the overflow line goes,
+    # and the runs bar's count NEVER moves (§9: the record outlives the toast).
+    first_run = census["cards"][0]
+    page.locator('[data-testid="gate-notification"]').first \
+        .locator('[data-testid="toast-dismiss"]').click()
+    page.wait_for_function(
+        """(rid) => ![...document.querySelectorAll('[data-testid="gate-notification"]')]
+              .some((c) => c.getAttribute('data-run-id') === rid)
+              && !document.querySelector('[data-testid="gate-toast-overflow"]')""",
+        arg=first_run, timeout=10000)
+    after_one = page.evaluate(TOAST_CENSUS)
+    check("dismiss_hides_card_never_gate",
+          len(after_one["cards"]) == 3 and first_run not in after_one["cards"]
+          and after_one["barGates"] == "4",
+          dismissed=first_run, **after_one)
+    # Dismiss the rest: zero cards, the count still names all four gates.
+    for _ in range(3):
+        page.locator('[data-testid="toast-dismiss"]').first.click()
+    page.wait_for_function(
+        "() => document.querySelectorAll('[data-testid=\"gate-notification\"]').length === 0",
+        timeout=10000)
+    check("all_dismissed_record_survives",
+          page.evaluate("() => document.querySelector('[data-testid=\"runs-bottom-bar\"]')?.dataset.gates") == "4")
+
+    # ── Scene 2 (EC38, the interception pin): the composer under a live toast ──
+    page.goto(f"{ORIGIN}{Q3_THREAD}", wait_until="domcontentloaded")
+    page.locator('[data-testid="gate-notification"]').first.wait_for(timeout=30000)
+    page.wait_for_function(
+        """() => [...document.querySelectorAll('button')]
+              .some((b) => (b.textContent ?? '').includes('Steer'))""",
+        timeout=15000)
+    steer_hit = page.evaluate(
+        """() => {
+          const steer = [...document.querySelectorAll('button')]
+            .find((b) => (b.textContent ?? '').includes('Steer'));
+          if (!steer) return { found: false };
+          const r = steer.getBoundingClientRect();
+          const el = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+          const cards = [...document.querySelectorAll('[data-testid="gate-notification"]')];
+          return {
+            found: true,
+            reaches: steer === el || steer.contains(el),
+            hitBy: el ? (el.getAttribute('data-testid') ?? el.tagName) : null,
+            toastVisible: cards.length > 0,
+            everyCardDismissible: cards.every((c) => !!c.querySelector('[data-testid="toast-dismiss"]')),
+          };
+        }""")
+    check("composer_send_hit_test", steer_hit["found"] and steer_hit["reaches"]
+          and steer_hit["toastVisible"] and steer_hit["everyCardDismissible"], **steer_hit)
+
+    # ── Scene 3 (AC: expiry): the announcement dies, the gate does not ──────────
+    # A fresh context: real clocks — the bounded dwell is the assertion here.
+    ctx2 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx2.new_page()
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+    page.locator('[data-testid="gate-notification"]').first.wait_for(timeout=30000)
+    # Real-time dwell: bounded at 20s; give it 30s of budget.
+    page.wait_for_function(
+        "() => document.querySelectorAll('[data-testid=\"gate-notification\"]').length === 0",
+        timeout=TOAST_DWELL_MS + 10_000)
+    check("expiry_bounded_record_survives",
+          page.evaluate("() => document.querySelector('[data-testid=\"runs-bottom-bar\"]')?.dataset.gates") == "4")
+
+    # ── Scene 4 (B4): the cross-project gate announces in the bar, not the canvas ─
+    # `project_dto` on: a gate arriving from a project this session has never
+    # seen resolves through the run DTO's own `project_id` claim (CREW-UX-2) —
+    # the membership mirror alone can't place a project that joined mid-session.
+    set_fixture(ORIGIN, batch_gates=False, project_dto=True)
+    page.goto(f"{ORIGIN}{Q3_SHELL}", wait_until="domcontentloaded")
+    page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
+    # On load: r-q3's own card only; r-api (api-migration) is already a foreign
+    # gate — counted, never painted.
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="runs-bottom-bar"]')
+              ?.dataset.gatesElsewhere === '1'""",
+        timeout=15000)
+    shell = page.evaluate(TOAST_CENSUS)
+    check("foreign_gate_no_card_on_load",
+          shell["cards"] == ["r-q3"] and shell["barGates"] == "1"
+          and shell["barGatesElsewhere"] == "1",
+          **shell)
+    bell_unread_before = page.evaluate(
+        """() => /unread/.test(document.querySelector('button[title="Notifications"]')
+             ?.getAttribute('aria-label') ?? '')""")
+
+    # A gate ARRIVES from another project (the §8.4 one-shot awaitingHuman frame,
+    # plus the batch corpus joining the run list on the refresh it triggers).
+    set_fixture(ORIGIN, batch_gates=True,
+                extra_gates=[{"session": "r-batch1", "ord": 0,
+                              "prompt": "Ship the version bump?"}])
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="runs-bottom-bar"]')
+              ?.dataset.gatesElsewhere === '3'""",
+        timeout=30000)
+    arrival = page.evaluate(TOAST_CENSUS)
+    elsewhere_label = page.evaluate(
+        """() => document.querySelector('[data-testid="runs-bar-gates-elsewhere"]')
+             ?.textContent ?? null""")
+    bell_unread_after = page.evaluate(
+        """() => /unread/.test(document.querySelector('button[title="Notifications"]')
+             ?.getAttribute('aria-label') ?? '')""")
+    check("arrival_increments_bar_never_canvas",
+          all(rid == "r-q3" for rid in arrival["cards"])  # own card may have expired; NO foreign card ever
+          and arrival["barGatesElsewhere"] == "3"
+          and elsewhere_label is not None and "+3 elsewhere" in elsewhere_label
+          and bell_unread_after,
+          bell_unread_before=bell_unread_before, bell_unread_after=bell_unread_after,
+          elsewhere_label=elsewhere_label, **arrival)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -478,6 +478,11 @@ BATCH_RUNS = [
     session("r-batch2", "awaiting_human", "rotate the staging keys", "rotate the staging keys"),
 ]
 BATCH_MEMBERS = {"batch-one": ["r-batch1"], "batch-two": ["r-batch2"]}
+# Slice AA: the CREW-UX-2 DTO echo covers ALL membership records, the batch
+# corpus included — with `project_dto` + `batch_gates` both on, a batch run's
+# session claims its project (the daemon echoes every membership, not just
+# W2's). No standing rig combines the two switches; slice AA's B4 scene does.
+RUN_PROJECT.update({rid: pid for pid, rids in BATCH_MEMBERS.items() for rid in rids})
 BATCH_GATE_PROMPTS = {"r-batch1": ("Ship the version bump?", MIN),
                       "r-batch2": ("Rotate the keys now?", 3 * MIN)}
 ATTACHED_AT["r-batch1"] = NOW0 - MIN

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -161,6 +161,11 @@ NPM = "npm.cmd" if os.name == "nt" else "npm"
 
 # Same rule as the main harness: gate toasts are not these surfaces (and the
 # home route does not render them), but the suppression is cheap and display-only.
+# Slice AA re-scope note (DES-UX-001 §11.2, re-derived by grep 2026-08): no rig
+# asserts toast presence at fixed coordinates — the only coupling is this
+# selector. Since slice AA, `gate-notification` names each toast CARD (the
+# outer layer is `gate-notification-layer`, pointer-events: none), so this
+# hider keeps hiding every card; nothing about its mechanism changed.
 HIDE_GATE_TOASTS = '[data-testid="gate-notification"] { display: none !important; }'
 
 # ── The frozen clock (§4.0 determinism): every age derives from this one NOW0 ──

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -572,8 +572,12 @@ export function App(): React.ReactElement {
       {/* Gate toasts — renders above everything; scoped to the current run. NOT on the
           orchestrator board: there every waiting gate is already an answerable chip on
           its project's card, sorted to the front (§1.4, slice 7), and the unscoped stack
-          would both duplicate those chips and physically cover the cards holding them. */}
-      {panel !== 'home' && <GateNotifications onSelect={selectRun} runId={runId} />}
+          would both duplicate those chips and physically cover the cards holding them.
+          Slice AA (§7.1): inside a project shell only THAT project's gates paint cards —
+          a foreign gate announces in the runs bar + bell instead (B4). */}
+      {panel !== 'home' && (
+        <GateNotifications onSelect={selectRun} runId={runId} projectId={projectId} runs={runs} />
+      )}
 
       {/* Repo graph modal — opened from RepoDetailPage */}
       {graphModalRepo !== null && (

--- a/src/components/GateNotifications.tsx
+++ b/src/components/GateNotifications.tsx
@@ -1,32 +1,125 @@
+import { useEffect, useReducer } from 'react';
+import type { SessionView } from '../api/types.js';
+import { sessionProjectId } from '../hooks/ambientProject.js';
 import { useGateStore } from '../store/gates.js';
+import type { OpenGate } from '../store/gates.js';
+import { useMembershipStore } from '../store/membership.js';
+import { RUNS_BAR_PX } from './RunsBottomPanel.js';
+
+/**
+ * §7.1 (DES-UX-001, slice AA): how long an announcement dwells before it
+ * self-expires. The GATE isn't going anywhere — it stays in the status bar's
+ * gate count, the bottom panel, and the bell; the toast is an announcement,
+ * not the record (§9 — the toast lifecycle changes, never the gate).
+ */
+export const TOAST_DWELL_MS = 20_000;
+
+/** At most this many cards paint; the rest compress into one inert overflow
+ *  line — an unbounded stack is exactly the B4 interception surface. */
+export const MAX_TOAST_CARDS = 3;
+
+/**
+ * The session-local announcement ledger, module-scoped so a route change
+ * (this component unmounts on the board and remounts elsewhere) never
+ * resurrects a dismissed or expired announcement. Keyed `runId:receivedAt`,
+ * so a NEW arrival for the same run announces afresh. `firstSeen` is when
+ * THIS page first painted the toast — deliberately not the wire's
+ * `receivedAt`, which for a daemon-cached gate can be minutes old and would
+ * expire the announcement before it was ever seen.
+ */
+const firstSeen = new Map<string, number>();
+const dismissed = new Set<string>();
+
+const toastKey = (g: OpenGate): string => `${g.runId}:${g.receivedAt}`;
+
+/** Test hook (unit tests only): drop the module-scoped announcement ledger. */
+export function resetToastLedger(): void {
+  firstSeen.clear();
+  dismissed.clear();
+}
 
 interface Props {
   onSelect: (runId: string) => void;
   /** When set, only show the gate toast for this run (fixes studio#10). */
   runId?: string | null;
+  /** The ambient project shell (`/p/:id/*`), when inside one — B4's context
+   *  rule: another project's gate announces in the bottom bar + bell, never
+   *  as an overlay card over this project's canvas. */
+  projectId?: string | null;
+  /** App's one `useRuns()` array — the DTO's own `project_id` claim is the
+   *  first word on which project a gate's run belongs to (mirror fallback). */
+  runs?: SessionView[];
 }
 
-export function GateNotifications({ onSelect, runId }: Props): React.ReactElement {
+export function GateNotifications({ onSelect, runId, projectId = null, runs = [] }: Props): React.ReactElement {
   const gates = useGateStore((s) => s.gates);
-  const all = Object.values(gates);
-  const open = runId ? all.filter((g) => g.runId === runId) : all;
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  // Expiry needs a re-render at the moment a dwell elapses; nothing else here
+  // is stateful — the gate record itself lives (and stays) in the gate store.
+  const [, bump] = useReducer((n: number) => n + 1, 0);
 
-  if (open.length === 0) return <></>;
+  const all = Object.values(gates);
+  const scoped = runId ? all.filter((g) => g.runId === runId) : all;
+
+  // B4 (§7.1): inside a project shell, keep only THIS project's gates as
+  // cards. DTO claim first (CREW-UX-2), membership mirror second; a gate we
+  // genuinely cannot place (pre-0.8.0 daemon, no mirror row) still shows —
+  // suppression requires KNOWING the gate is foreign, never assuming it.
+  const open = projectId === null || runId
+    ? scoped
+    : scoped.filter((g) => {
+        const run = runs.find((r) => r.session.id === g.runId);
+        const claimed = run !== undefined ? sessionProjectId(run.session) : undefined;
+        const pid = claimed !== undefined ? claimed : projectIdByRun[g.runId];
+        return pid === undefined || pid === projectId;
+      });
+
+  // First-paint stamping (idempotent — safe under StrictMode double render).
+  const now = Date.now();
+  for (const g of open) {
+    const key = toastKey(g);
+    if (!firstSeen.has(key)) firstSeen.set(key, now);
+  }
+
+  const visible = open.filter((g) => {
+    const key = toastKey(g);
+    if (dismissed.has(key)) return false;
+    return now - (firstSeen.get(key) ?? now) < TOAST_DWELL_MS;
+  });
+
+  // Wake exactly when the soonest-expiring visible toast crosses its dwell;
+  // prune ledger entries whose gate left the store (answered/terminal runs).
+  useEffect(() => {
+    const live = new Set(all.map(toastKey));
+    for (const key of firstSeen.keys()) if (!live.has(key)) firstSeen.delete(key);
+    for (const key of dismissed) if (!live.has(key)) dismissed.delete(key);
+    if (visible.length === 0) return;
+    const soonest = Math.min(
+      ...visible.map((g) => (firstSeen.get(toastKey(g)) ?? now) + TOAST_DWELL_MS),
+    );
+    const t = setTimeout(bump, Math.max(soonest - Date.now(), 0) + 50);
+    return () => clearTimeout(t);
+  });
+
+  if (visible.length === 0) return <></>;
+
+  const cards = visible.slice(0, MAX_TOAST_CARDS);
 
   return (
     <div
-      className="fixed bottom-4 right-4 flex flex-col gap-2 z-50"
-      data-testid="gate-notification"
-      style={{ pointerEvents: 'none' }}
+      className="fixed right-4 flex flex-col items-end gap-2 z-50"
+      data-testid="gate-notification-layer"
+      // EC38 layout safety: the LAYER reserves no pointer surface — only the
+      // visible cards (pointerEvents: auto below) accept clicks — and it sits
+      // above the runs bar, never over its toggle or "All runs ›".
+      style={{ bottom: RUNS_BAR_PX + 12, pointerEvents: 'none' }}
     >
-      {open.map((gate) => (
-        <button
-          key={gate.runId}
-          type="button"
-          onClick={() => onSelect(gate.runId)}
-          data-testid="gate-toast"
+      {cards.map((gate) => (
+        <div
+          key={toastKey(gate)}
+          data-testid="gate-notification"
           data-run-id={gate.runId}
-          className="w-72 rounded-xl p-3 text-left transition-all"
+          className="relative w-72 rounded-xl p-3 transition-all"
           style={{
             background: 'var(--surface-card)',
             border: '1px solid var(--status-gate-dim)',
@@ -36,19 +129,52 @@ export function GateNotifications({ onSelect, runId }: Props): React.ReactElemen
           onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--status-gate)'; }}
           onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--status-gate-dim)'; }}
         >
-          <div className="flex items-center gap-2 mb-1">
-            <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-gate)' }} />
-            <p className="text-xs font-semibold" style={{ color: 'var(--status-gate)' }}>Run awaiting human</p>
-          </div>
-          <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>
-            {gate.runId.slice(0, 8)} · before unit #{gate.ord}
-          </p>
-          {gate.prompt && (
-            <p className="mt-1 text-xs line-clamp-2" style={{ color: 'var(--ink-muted)' }}>{gate.prompt}</p>
-          )}
-          <p className="mt-1.5 text-[11px] font-mono" style={{ color: 'var(--accent)' }}>Review →</p>
-        </button>
+          <button
+            type="button"
+            data-testid="toast-dismiss"
+            aria-label="Dismiss notification"
+            title="Dismiss — the gate stays in the runs bar"
+            onClick={() => { dismissed.add(toastKey(gate)); bump(); }}
+            className="absolute top-1.5 right-1.5 w-5 h-5 flex items-center justify-center rounded text-xs leading-none"
+            style={{ background: 'transparent', color: 'var(--ink-dim)', cursor: 'pointer' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--ink-high)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--ink-dim)'; }}
+          >
+            ✕
+          </button>
+          <button
+            type="button"
+            onClick={() => onSelect(gate.runId)}
+            data-testid="gate-toast"
+            data-run-id={gate.runId}
+            className="w-full text-left pr-5"
+            style={{ background: 'transparent', cursor: 'pointer' }}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-gate)' }} />
+              <p className="text-xs font-semibold" style={{ color: 'var(--status-gate)' }}>Run awaiting human</p>
+            </div>
+            <p className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+              {gate.runId.slice(0, 8)} · before unit #{gate.ord}
+            </p>
+            {gate.prompt && (
+              <p className="mt-1 text-xs line-clamp-2" style={{ color: 'var(--ink-muted)' }}>{gate.prompt}</p>
+            )}
+            <p className="mt-1.5 text-[11px] font-mono" style={{ color: 'var(--accent)' }}>Review →</p>
+          </button>
+        </div>
       ))}
+      {visible.length > cards.length && (
+        <p
+          data-testid="gate-toast-overflow"
+          className="text-[11px] font-mono px-1"
+          // Inert by design: the overflow line is a pointer, not a control —
+          // the runs bar's gate count is the actionable record.
+          style={{ color: 'var(--ink-dim)', pointerEvents: 'none' }}
+        >
+          +{visible.length - cards.length} more waiting — see the runs bar
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -134,7 +134,18 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
   const stats = useMemo(() => runStats(scopedRuns), [scopedRuns]);
   const spend = useMemo(() => observedSpend(logs), [logs]);
   const rows = useMemo(() => recentRuns(scopedRuns, SHEET_MAX), [scopedRuns]);
-  const quiet = stats.working === 0 && stats.gates === 0 && stats.failed === 0;
+  // Slice AA (DES-UX-001 §7.1, B4): inside a project shell, a gate waiting on a
+  // run OUTSIDE the scope announces HERE — this count plus the bell — never as
+  // an overlay card over the mode surface. Scoped stats stay untouched (EC34:
+  // the sheet's rows still equal `stats.gates`); this is a separate, labeled
+  // count over the same gate store the toasts read.
+  const gatesElsewhere = useMemo(() => {
+    if (scopeProjectId === null) return 0;
+    const scoped = new Set(scopedRuns.map((v) => v.session.id));
+    return Object.keys(gates).filter((id) => !scoped.has(id)).length;
+  }, [gates, scopeProjectId, scopedRuns]);
+  const quiet =
+    stats.working === 0 && stats.gates === 0 && stats.failed === 0 && gatesElsewhere === 0;
 
   // EC27: entering an immersive mode collapses an open sheet — the canvas-first
   // principle, same transition the rail collapses on. Fires on the transition
@@ -198,6 +209,17 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
     <>
       <Segment glyph="●" color="var(--status-run)" text={`${stats.working} working`} />
       <Segment glyph="⏸" color="var(--status-gate)" text={`${stats.gates} gates`} pulse={stats.gates > 0} />
+      {/* §7.1 (slice AA): the cross-project announcement — labeled, beside the
+          scoped count, so "0 gates +2 elsewhere" reads as two truths, not one lie. */}
+      {gatesElsewhere > 0 && (
+        <span
+          data-testid="runs-bar-gates-elsewhere"
+          data-count={gatesElsewhere}
+          style={{ ...WINDOW_LABEL_STYLE, color: 'var(--status-gate)' }}
+        >
+          +{gatesElsewhere} elsewhere
+        </span>
+      )}
       <Segment glyph="✗" color="var(--status-fail)" text={`${stats.failed} failed`} />
       {/* EC39 (slice W): the three counts share one window and SAY it — the
           unwindowed listing, "all" — so "2 failed" here beside a "1 failed
@@ -229,6 +251,7 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
         data-window="all"
         data-working={stats.working}
         data-gates={stats.gates}
+        data-gates-elsewhere={gatesElsewhere}
         data-failed={stats.failed}
         className="fixed bottom-0 left-0 right-0 flex items-center font-mono"
         style={{

--- a/tests/GateNotifications.test.tsx
+++ b/tests/GateNotifications.test.tsx
@@ -1,44 +1,180 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { GateNotifications } from '../src/components/GateNotifications.js';
+// Slice AA (DES-UX-001 §7.1, EC38, B4): the toast LIFECYCLE — dismiss, expiry,
+// layout safety, and the cross-project context rule. The gate experience itself
+// is §0-protected: every case here asserts the gate RECORD survives whatever
+// happens to its announcement.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import userEvent from '@testing-library/user-event';
+import {
+  GateNotifications,
+  MAX_TOAST_CARDS,
+  resetToastLedger,
+  TOAST_DWELL_MS,
+} from '../src/components/GateNotifications.js';
 import { useGateStore } from '../src/store/gates.js';
+import type { OpenGate } from '../src/store/gates.js';
+import { useMembershipStore } from '../src/store/membership.js';
+import { makeView } from './factories.js';
 
-const noop = () => {};
+function gate(runId: string, over: Partial<OpenGate> = {}): OpenGate {
+  return { runId, ord: 0, prompt: `gate for ${runId}`, lifecycle: 'open', receivedAt: Date.now(), ...over };
+}
 
-const seed = () =>
+function seed(...gates: OpenGate[]): void {
   useGateStore.setState({
-    gates: {
-      'run-1': { runId: 'run-1', ord: 1, prompt: 'gate for run-1', lifecycle: 'open', receivedAt: 0 },
-      'run-2': { runId: 'run-2', ord: 2, prompt: 'gate for run-2', lifecycle: 'open', receivedAt: 0 },
-    },
+    gates: Object.fromEntries(gates.map((g) => [g.runId, g])),
+  });
+}
+
+beforeEach(() => {
+  resetToastLedger();
+  useGateStore.setState({ gates: {} });
+  useMembershipStore.setState({ projectIdByRun: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('GateNotifications — dismiss (§7.1)', () => {
+  it('every card contains a toast-dismiss, and dismissing hides the card but never the gate', async () => {
+    seed(gate('r-one'), gate('r-two'));
+    render(<GateNotifications onSelect={() => {}} />);
+
+    const cards = screen.getAllByTestId('gate-notification');
+    expect(cards).toHaveLength(2);
+    for (const card of cards) {
+      expect(card.querySelector('[data-testid="toast-dismiss"]')).not.toBeNull();
+    }
+
+    const first = cards[0]!;
+    await userEvent.click(first.querySelector('[data-testid="toast-dismiss"]')!);
+
+    expect(screen.getAllByTestId('gate-notification')).toHaveLength(1);
+    // §9: the toast lifecycle changes, never the gate — the record survives.
+    expect(Object.keys(useGateStore.getState().gates)).toHaveLength(2);
   });
 
-describe('GateNotifications runId scope (studio#10)', () => {
-  beforeEach(() => useGateStore.setState({ gates: {} }));
+  it('a dismissed announcement stays dismissed across a remount (route change)', async () => {
+    seed(gate('r-one'));
+    const { unmount } = render(<GateNotifications onSelect={() => {}} />);
+    await userEvent.click(screen.getByTestId('toast-dismiss'));
+    unmount();
 
-  it('shows all gates when no runId is provided', () => {
-    seed();
-    render(<GateNotifications onSelect={noop} />);
-    const toasts = screen.getAllByTestId('gate-toast');
-    expect(toasts).toHaveLength(2);
-  });
-
-  it('shows only the matching gate when runId is provided', () => {
-    seed();
-    render(<GateNotifications onSelect={noop} runId="run-1" />);
-    const toasts = screen.getAllByTestId('gate-toast');
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0]).toHaveAttribute('data-run-id', 'run-1');
-  });
-
-  it('shows nothing when runId matches no gate', () => {
-    seed();
-    render(<GateNotifications onSelect={noop} runId="run-99" />);
-    expect(screen.queryByTestId('gate-toast')).toBeNull();
-  });
-
-  it('shows nothing when store is empty', () => {
-    render(<GateNotifications onSelect={noop} runId="run-1" />);
+    render(<GateNotifications onSelect={() => {}} />);
     expect(screen.queryByTestId('gate-notification')).toBeNull();
+  });
+
+  it('a NEW arrival for the same run (new receivedAt) re-announces', async () => {
+    const t0 = Date.now();
+    seed(gate('r-one', { receivedAt: t0 }));
+    render(<GateNotifications onSelect={() => {}} />);
+    await userEvent.click(screen.getByTestId('toast-dismiss'));
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+
+    act(() => {
+      useGateStore.getState().setGate(gate('r-one', { receivedAt: t0 + 1 }));
+    });
+    expect(screen.getByTestId('gate-notification')).toBeInTheDocument();
+  });
+});
+
+describe('GateNotifications — expiry (§7.1)', () => {
+  it('a toast self-expires after the bounded dwell; the gate record survives', () => {
+    vi.useFakeTimers();
+    seed(gate('r-one'));
+    render(<GateNotifications onSelect={() => {}} />);
+    expect(screen.getByTestId('gate-notification')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(TOAST_DWELL_MS + 100);
+    });
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+    expect(useGateStore.getState().gates['r-one']).toBeDefined();
+  });
+
+  it('the dwell clock is first-PAINT, not the wire receivedAt: a stale cached gate still announces', () => {
+    vi.useFakeTimers();
+    // A daemon-cached gate received 12 minutes ago (the reconcile path parses
+    // the daemon's own clock) must still get its full dwell on this page.
+    seed(gate('r-old', { receivedAt: Date.now() - 12 * 60_000 }));
+    render(<GateNotifications onSelect={() => {}} />);
+    expect(screen.getByTestId('gate-notification')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(TOAST_DWELL_MS - 1_000);
+    });
+    expect(screen.getByTestId('gate-notification')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+  });
+});
+
+describe('GateNotifications — layout safety (EC38)', () => {
+  it('the layer reserves no pointer surface; only cards accept clicks; the stack is capped', () => {
+    seed(gate('r-1'), gate('r-2'), gate('r-3'), gate('r-4'), gate('r-5'));
+    render(<GateNotifications onSelect={() => {}} />);
+
+    const layer = screen.getByTestId('gate-notification-layer');
+    expect(layer.style.pointerEvents).toBe('none');
+
+    const cards = screen.getAllByTestId('gate-notification');
+    expect(cards).toHaveLength(MAX_TOAST_CARDS);
+    for (const card of cards) expect(card.style.pointerEvents).toBe('auto');
+
+    const overflow = screen.getByTestId('gate-toast-overflow');
+    expect(overflow.textContent).toContain(`+${5 - MAX_TOAST_CARDS} more waiting`);
+    expect(overflow.style.pointerEvents).toBe('none');
+  });
+});
+
+describe('GateNotifications — cross-project context (B4)', () => {
+  it('inside a project shell, a KNOWN-foreign gate paints no card; own + unplaceable gates do', () => {
+    seed(gate('r-mine'), gate('r-foreign'), gate('r-unknown'));
+    render(
+      <GateNotifications
+        onSelect={() => {}}
+        projectId="proj-a"
+        runs={[
+          makeView({ id: 'r-mine', status: 'awaiting_human', project_id: 'proj-a' }),
+          makeView({ id: 'r-foreign', status: 'awaiting_human', project_id: 'proj-b' }),
+          // r-unknown: pre-0.8.0 DTO (no project_id claim), no mirror row —
+          // suppression requires KNOWING the gate is foreign, never assuming.
+          makeView({ id: 'r-unknown', status: 'awaiting_human' }),
+        ]}
+      />,
+    );
+    const shown = screen.getAllByTestId('gate-notification').map((c) => c.getAttribute('data-run-id'));
+    expect(shown.sort()).toEqual(['r-mine', 'r-unknown']);
+  });
+
+  it('falls back to the membership mirror when the DTO makes no claim', () => {
+    seed(gate('r-legacy'));
+    useMembershipStore.setState({ projectIdByRun: { 'r-legacy': 'proj-b' } });
+    render(
+      <GateNotifications
+        onSelect={() => {}}
+        projectId="proj-a"
+        runs={[makeView({ id: 'r-legacy', status: 'awaiting_human' })]}
+      />,
+    );
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+  });
+
+  it('the run-scoped view keeps its own gate card even inside a project shell', () => {
+    seed(gate('r-mine'));
+    render(
+      <GateNotifications
+        onSelect={() => {}}
+        runId="r-mine"
+        projectId="proj-a"
+        runs={[makeView({ id: 'r-mine', status: 'awaiting_human', project_id: 'proj-a' })]}
+      />,
+    );
+    expect(screen.getByTestId('gate-notification')).toBeInTheDocument();
   });
 });

--- a/tests/GateNotifications.test.tsx
+++ b/tests/GateNotifications.test.tsx
@@ -38,6 +38,35 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+// The pre-slice-AA scope contract (studio#10) — carried forward verbatim: the
+// runId prop still means "only this run's toast".
+describe('GateNotifications runId scope (studio#10)', () => {
+  it('shows all gates when no runId is provided', () => {
+    seed(gate('run-1'), gate('run-2'));
+    render(<GateNotifications onSelect={() => {}} />);
+    expect(screen.getAllByTestId('gate-toast')).toHaveLength(2);
+  });
+
+  it('shows only the matching gate when runId is provided', () => {
+    seed(gate('run-1'), gate('run-2'));
+    render(<GateNotifications onSelect={() => {}} runId="run-1" />);
+    const toasts = screen.getAllByTestId('gate-toast');
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toHaveAttribute('data-run-id', 'run-1');
+  });
+
+  it('shows nothing when runId matches no gate', () => {
+    seed(gate('run-1'), gate('run-2'));
+    render(<GateNotifications onSelect={() => {}} runId="run-99" />);
+    expect(screen.queryByTestId('gate-toast')).toBeNull();
+  });
+
+  it('shows nothing when store is empty', () => {
+    render(<GateNotifications onSelect={() => {}} runId="run-1" />);
+    expect(screen.queryByTestId('gate-notification')).toBeNull();
+  });
+});
+
 describe('GateNotifications — dismiss (§7.1)', () => {
   it('every card contains a toast-dismiss, and dismissing hides the card but never the gate', async () => {
     seed(gate('r-one'), gate('r-two'));


### PR DESCRIPTION
Implements **DES-UX-001 §7.1 (slice AA)** — toast lifecycle (BRIEF-UX-001 B4: the cross-project gate toast hijacks the workspace; EC38).

- Every gate announcement card is dismissible (session-local ledger; new arrivals re-announce), self-expires after a bounded 20s dwell clocked from first paint, and is layout-safe: pointer-events:none layer above the runs bar, 3-card cap with an inert "+N more waiting" line — no pointer surface beyond the visible cards (EC38 proven by elementFromPoint hit-tests through the layer).
- **B4**: inside `/p/:id/*`, only that project's gates card; foreign gates announce as the runs bar's labeled "+N elsewhere" count and the bell badge — never over the canvas.
- The gate RECORD is §0-protected and untouched — store, status bar, bottom panel, bell all keep it; every test asserts the record survives its announcement. HIDE_GATE_TOASTS mechanism preserved (grep-derived §11.2 re-scope: no rig pins coordinates).

Verified: slice rig 10/10 (incl. real-time bounded expiry and a mid-session cross-project arrival that increments bar+bell without painting a card); regressions feedback2_sliceH (gate triage byte-identical), ux_sliceV, feedback3_sliceN; adversarial verifier approved. +184/−31 LOC (~200 budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
