### PR TITLE
DES-UX-001 slice X2: affordance honesty + the copy pass

### DIFF
--- a/e2e/feedback2_sliceI_test.py
+++ b/e2e/feedback2_sliceI_test.py
@@ -18,7 +18,8 @@ The slice DOM ACs, from §3.7 (studio side):
   3. the binary file renders the honest state ("binary file — N bytes"), never
      mojibake; the truncated file renders
      `[data-testid="viewer-truncation-banner"]` naming the cap + full size (EC23);
-  4. a 403 (outside every allowed root) surfaces the route's error VERBATIM;
+  4. a 403 (outside every allowed root) surfaces the route's sentence WHOLE —
+     in slice X2's EC33 translated frame, never the raw `API 403:` framing;
   5. no highlight/grammar library ships in the bundle (the §2.3 precedent's
      grep gate) — the adversarial `+++`-leading ADDED line in the untracked
      hunk still colors as an addition (the zero-dep classifier is stateful);
@@ -247,13 +248,18 @@ with sync_playwright() as p:
     }
     page.keyboard.press("Escape")
 
-    # ── Scene 7 (AC 4): the outside-root file — 403 surfaced VERBATIM ───────────
+    # ── Scene 7 (AC 4): the outside-root file — the daemon's sentence surfaces
+    # WHOLE, never swallowed. RE-SCOPED by slice X2 (DES-UX-001 §7.10, EC33):
+    # the `API 403:` framing retires — the refusal now arrives in the translated
+    # frame ("the daemon refused this — …") with the route's own words intact.
     page.locator(f'button[title="View {VIEWER_FILE_403}"]').click()
     page.locator('[data-testid="viewer-error"]').wait_for(timeout=10000)
     err_text = page.locator('[data-testid="viewer-error"]').text_content() or ""
     report["steps"]["forbidden_surfaced_verbatim"] = {
-        "ok": "API 403: path is outside every allowed root (the run's workdir/write roots "
-              "and the registered repos)" in err_text,
+        "ok": "path is outside every allowed root (the run's workdir/write roots "
+              "and the registered repos)" in err_text
+              and "the daemon refused this" in err_text
+              and "API 403" not in err_text,
         "text": err_text,
     }
     page.keyboard.press("Escape")

--- a/e2e/ux_sliceX2_test.py
+++ b/e2e/ux_sliceX2_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+ux_sliceX2_test.py — the DES-UX-001 slice-X2 gate: affordance honesty + the
+copy pass (§7.3 B6/EC45 + §7.10 D/EC33).
+
+Runs against the shared frozen-NOW0 W2 fixture with the `viewer` corpus (the
+r-upload workdir + the crew#305 file/diff routes, incl. the real 403) and the
+new `project_create` switch (POST /api/v1/projects answers the daemon's real
+contract: 201 {project} with a proj_-minted id, the engine's verbatim 409
+sentence on an active-name collision).
+
+The §7.10 + §7.3 DOM ACs, verbatim mapping:
+
+  1. GRAMMAR: the rail ＋ affordances carry the corrected singular strings —
+     Projects' ＋ is "New Project", Repositories' ＋ is "New Repository"
+     (the "New Projects"/"New Repositories" plurals retire).
+  2. THE WALK: across /, /projects, /work and the r-upload run detail (What/
+     Where + Files open), the strings `API 4`, `API 5`, `DTO`, `work_output`,
+     `instrument bridge`, `(core#`, and `/private/var` appear NOWHERE in
+     user-visible text, and no rendered text carries a raw `proj_` id.
+  3. HYDRATION: a project created through the modal renders its DISPLAY NAME
+     in the shell breadcrumb immediately (no reload) — never the proj_ id;
+     re-creating the same name surfaces the daemon's 409 as the translated
+     sentence ("the daemon refused this — project name '…' is already in use
+     by an active project"), with `API 409` nowhere in the DOM.
+  4. EC33 FALLBACK: the viewer's 403 (outside every allowed root) renders as
+     "the daemon refused this — path is outside every allowed root (…)" — the
+     daemon's sentence whole, the `API 403` framing gone. (The two diff 409s
+     stay slice R's named-cause cards; ux_sliceR pins those exact strings.)
+  5. RELATIVE PATHS: Files rows render WORKTREE-RELATIVE text (src/…, not
+     /w2/upload/src/…) while `title`/copy/open keep the absolute path (the
+     sliceI locators still resolve).
+  6. §7.3 QUOTED-NAME: on the launch composer, `a deck named "uxr-x" …` shows
+     the parse BEFORE submit (create-parse names uxr-x + the remainder), and
+     the submitted POST /api/docs body carries name=uxr-x with the remainder
+     as its brief (fixture-received, tapped off the wire); the landed doc's
+     URL carries uxr-x.
+  7. EC45: the doc's Comment button, disabled because the fixture document
+     never answers the bridge, says WHY in operator language with a next step
+     ("Comments need the document's preview to finish loading — reopen the
+     document or regenerate this version…"); the wire phrase "instrument
+     bridge" appears nowhere in the DOM (attributes included).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-X2-copy.png   the r-upload Files panel (relative rows) with the translated
+                   403 sentence in the open viewer — the EC33 frame at work
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4396), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    VIEWER_FILE_403,
+    VIEWER_FILE_TS,
+    VIEWER_WORKDIR,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4396"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+UPLOAD_THREAD = "/p/upload-endpoint/build/r-upload"
+LAUNCH_COMPOSER = "/p/scratch/document"
+QUOTED_ASK = 'a deck named "uxr-x" summarizing the Q3 results'
+EXPECTED_BRIEF = "a deck summarizing the Q3 results"
+NEW_NAME = "uxr quarterly"
+
+# What must never render (§7.10's DOM-wide assert + this round's retirements).
+FORBIDDEN_TEXT = ["API 4", "API 5", "DTO", "work_output", "instrument bridge",
+                  "(core#", "/private/var"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture ─────────────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, viewer=True, project_create=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+# The innerText scan: forbidden strings + any rendered proj_ id.
+SCAN = """(forbidden) => {
+  const text = document.body.innerText;
+  const hits = forbidden.filter((s) => text.includes(s));
+  if (/\\bproj_[0-9]/.test(text)) hits.push('proj_<id> rendered as text');
+  return { hits, sample: text.slice(0, 120) };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The wire tap: the create-doc POST body (AC 6's fixture-received parse).
+    doc_creates: list[dict] = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if req.method == "POST" and path.endswith("/interactive/api/docs"):
+            try:
+                doc_creates.append(json.loads(req.post_data or "{}"))
+            except json.JSONDecodeError:
+                doc_creates.append({})
+
+    page.on("request", on_request)
+
+    def open_route(route: str, waitfor: str) -> None:
+        page.goto(f"{ORIGIN}{route}", wait_until="domcontentloaded")
+        page.locator(waitfor).first.wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # ── Scene 1 (AC 1): the corrected grammar on the rail's ＋ affordances ──────
+    open_route("/", '[data-testid="left-rail"]')
+    labels = page.evaluate(
+        """() => {
+          const grab = (key) => document.querySelector(
+            `[data-testid="rail-heading-${key}"] [data-testid="heading-new"]`)
+            ?.getAttribute('title') ?? null;
+          return { projects: grab('projects'), repos: grab('repos') };
+        }""")
+    check("grammar_singular",
+          labels["projects"] == "New Project" and labels["repos"] == "New Repository",
+          **labels)
+
+    # ── Scene 2 (AC 2, part 1): the walk — board, /projects, /work ─────────────
+    walk_hits: dict = {}
+    for route, waitfor in [("/", '[data-testid="project-board"]'),
+                           ("/projects", '[data-testid="left-rail"]'),
+                           ("/work", '[data-testid="left-rail"]')]:
+        open_route(route, waitfor)
+        page.wait_for_timeout(400)  # let the route's own fetch burst paint
+        walk_hits[route] = page.evaluate(SCAN, FORBIDDEN_TEXT)
+    check("copy_walk_clean",
+          all(len(v["hits"]) == 0 for v in walk_hits.values()),
+          **{k.replace("/", "_") or "_root": v for k, v in walk_hits.items()})
+
+    # ── Scene 3 (AC 3): fresh-entity hydration + the translated 409 ────────────
+    open_route("/", '[data-testid="rail-heading-projects"]')
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="new-project-modal"]').wait_for(timeout=10000)
+    page.locator('[data-testid="new-project-name"]').fill(NEW_NAME)
+    page.locator('[data-testid="new-project-create"]').click()
+    page.wait_for_url(re.compile(r"/p/proj_\d+/build$"), timeout=15000)
+    page.locator('[data-testid="project-name"]').wait_for(timeout=15000)
+    crumb = page.locator('[data-testid="project-name"]').inner_text().strip()
+    fresh = page.evaluate(SCAN, FORBIDDEN_TEXT)
+    check("created_project_hydrates",
+          NEW_NAME in crumb and len(fresh["hits"]) == 0,
+          crumb=crumb, scan=fresh, url=page.url)
+
+    # The collision: same name again → the translated daemon sentence, no API 409.
+    page.locator('[data-testid="rail-heading-projects"] [data-testid="heading-new"]').click()
+    page.locator('[data-testid="new-project-modal"]').wait_for(timeout=10000)
+    page.locator('[data-testid="new-project-name"]').fill(NEW_NAME)
+    page.locator('[data-testid="new-project-create"]').click()
+    page.locator('[data-testid="new-project-error"]').wait_for(timeout=10000)
+    err = page.locator('[data-testid="new-project-error"]').inner_text()
+    check("collision_translated",
+          f"the daemon refused this — project name '{NEW_NAME}' is already in use" in err
+          and "API 409" not in page.evaluate("() => document.body.innerText"),
+          error_text=err)
+    page.keyboard.press("Escape")
+
+    # ── Scene 4 (ACs 4 + 5): the run detail — relative rows, translated 403 ────
+    open_route(UPLOAD_THREAD, '[data-testid="left-rail"]')
+    page.get_by_role("button", name=re.compile("^Files")).click()
+    row = page.locator(f'button[title="View {VIEWER_FILE_TS}"]')
+    row.wait_for(timeout=15000)
+    row_text = row.inner_text()
+    rel = VIEWER_FILE_TS[len(VIEWER_WORKDIR) + 1:]  # src/middleware.ts
+    detail_scan = page.evaluate(SCAN, FORBIDDEN_TEXT)
+    check("files_rows_relative",
+          rel in row_text and VIEWER_WORKDIR not in row_text
+          and len(detail_scan["hits"]) == 0,
+          row_text=row_text, expected_rel=rel, scan=detail_scan)
+
+    page.locator(f'button[title="View {VIEWER_FILE_403}"]').click()
+    page.locator('[data-testid="viewer-error"]').wait_for(timeout=10000)
+    err403 = page.locator('[data-testid="viewer-error"]').inner_text()
+    check("forbidden_translated",
+          err403.startswith("the daemon refused this — path is outside every allowed root")
+          and "API 403" not in page.evaluate("() => document.body.innerText"),
+          error_text=err403)
+    page.screenshot(path=str(VSHOTS / "ux-X2-copy.png"))
+    page.keyboard.press("Escape")
+    page.locator('[data-testid="file-viewer"]').wait_for(state="detached", timeout=5000)
+
+    # ── Scene 5 (AC 6): the quoted-name create — parse shown, then honored ─────
+    open_route(LAUNCH_COMPOSER, '[data-testid="thread"][data-composer-state="idle"]')
+    page.locator('[data-testid="doc-composer"]').fill(QUOTED_ASK)
+    parse_line = page.locator('[data-testid="create-parse"]')
+    parse_line.wait_for(timeout=10000)
+    preview = parse_line.inner_text()
+    check("create_parse_preview",
+          "uxr-x" in preview and EXPECTED_BRIEF in preview,
+          preview=preview)
+    page.keyboard.press("Enter")
+    page.wait_for_url(re.compile(r"/document/uxr-x"), timeout=30000)
+    check("create_parse_honored",
+          len(doc_creates) == 1
+          and doc_creates[0].get("name") == "uxr-x"
+          and doc_creates[0].get("brief") == EXPECTED_BRIEF,
+          doc_creates=doc_creates, url=page.url)
+
+    # ── Scene 6 (AC 7, EC45): the disabled Comment says why, operator-voiced ───
+    toggle = page.locator('[data-testid="feedback-toggle"]')
+    toggle.wait_for(timeout=15000)
+    # The fixture document never answers the bridge — wait past GIVE_UP_MS for
+    # the degraded title to settle on the still-disabled control.
+    page.wait_for_function(
+        """() => {
+          const t = document.querySelector('[data-testid="feedback-toggle"]');
+          return !!t && t.disabled && (t.getAttribute('title') ?? '').includes('preview');
+        }""", timeout=20000)
+    title = toggle.get_attribute("title") or ""
+    bridge_free = page.evaluate(
+        """() => !document.body.innerHTML.includes('instrument bridge')""")
+    check("disabled_comment_operator_copy",
+          "Comments need the document’s preview to finish loading" in title
+          and "reopen the document or regenerate this version" in title
+          and bridge_free,
+          title=title, bridge_free=bridge_free)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -281,6 +281,11 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # drives it against a real-project mount; the Unfiled (`default`)
          # mount never binds — its create body carries no `project` field.
          "create_fail": False,
+         # Slice X2 (DES-UX-001 §7.10): POST /api/v1/projects creates for real —
+         # a proj_-minted id + the engine's real 409 collision sentence; created
+         # rows join GET /projects. Default False: no standing rig's project
+         # list grows a row it never asserted.
+         "project_create": False,
          }
 state_lock = threading.Lock()
 
@@ -434,6 +439,16 @@ UNFILED_RUN = session("r-unfiled", "executing", "poke at the flaky CI job",
 launched_runs: list = []          # SessionView dicts, project_id already stamped
 launched_members: dict = {}       # pid -> [run ids]
 launched_seq = [0]
+
+# ── Slice X2 (DES-UX-001 §7.10): projects created over POST /api/v1/projects ──
+# Behind the `project_create` switch (default False — no standing rig's project
+# list grows a row). The route mirrors the REAL daemon contract verbatim:
+# 201 {project} with a wicked-core-shaped `proj_<millis:013><seq:05>` id
+# (project.rs:189 — never derived from the name) and the engine's real 409
+# sentence on an active-name collision (project.rs:236). Created rows join
+# GET /projects for this server lifetime. Guarded by state_lock.
+created_projects: list = []       # Project dicts, proj_-minted ids
+created_seq = [100000]            # the engine's seq starts fresh per process
 
 # ── Slice P (DES-FEEDBACK-003 §10.2): the two chat runs, behind `chat_runs` ───
 #
@@ -1463,7 +1478,10 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/projects":
             with state_lock:
                 batch_on = state["batch_gates"]
-            self._json(200, {"projects": PROJECTS + (BATCH_PROJECTS if batch_on else [])})
+                # Slice X2: this-lifetime created projects ride the list too.
+                created = json.loads(json.dumps(created_projects))
+            self._json(200, {"projects": PROJECTS
+                             + (BATCH_PROJECTS if batch_on else []) + created})
             return True
         if path == "/api/v1/repos":
             with state_lock:
@@ -2004,6 +2022,30 @@ class W2Handler(SimpleHTTPRequestHandler):
         # The slice-6 document journey's writes (create / fork / bus emit).
         if self._interactive_post(path, body if isinstance(body, dict) else {}):
             return None
+        # POST /api/v1/projects — create (slice X2, project_create only): the
+        # daemon's real contract — 201 {project} with a proj_-minted id
+        # (project.rs:189) and the engine's verbatim 409 sentence on an
+        # active-name collision (project.rs:236). See created_projects above.
+        if path == "/api/v1/projects":
+            with state_lock:
+                create_on = state["project_create"]
+            if not create_on:
+                return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
+            name = str(body.get("name") or "").strip()
+            if not name:
+                return self._json(400, {"error": "name must be a non-empty string"})
+            with state_lock:
+                taken = {p["name"] for p in PROJECTS} | {p["name"] for p in created_projects}
+                if name in taken:
+                    return self._json(409, {
+                        "error": f"project name '{name}' is already in use by an active project"})
+                created_seq[0] += 1
+                pid = f"proj_{NOW0:013d}{created_seq[0]:05d}"
+                row = project(pid, name, NOW0,
+                              **({"description": str(body["description"])}
+                                 if body.get("description") else {}))
+                created_projects.append(row)
+            return self._json(201, {"project": row})
         # POST /api/v1/runs — the REAL launch (slice S, project_dto only): the
         # daemon's `{runId}` answer; `body.projectId` files the run atomically
         # (LaunchSchema, routes.ts:148 — "never a silent unfiled run"), and the

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -17,10 +17,11 @@ What it asserts (slice-3 DOM ACs, as amended by §8.7):
      rail-section-projects / rail-section-repos); the retired section labels
      and their empty strings ("Chats", "Work", "No chats yet", "No work yet")
      appear nowhere in the rail's text, and the old near-synonym verb labels
-     ("Do Work", "New Repository") appear nowhere on the page — the headings'
-     ＋ icons carry aria-labels in the §3.1 "New <path>" grammar instead
-     ("New Chat" is that grammar's honest spelling for Chat's ＋ now, so it
-     leaves the banned list).
+     ("Do Work") appear nowhere on the page — the headings' ＋ icons carry
+     aria-labels in the "New <noun>" grammar instead ("New Chat" left the
+     banned list when it became Chat's honest ＋ spelling; "New Repository"
+     left it with slice X2's §7.10 singular-grammar fix, where it became the
+     Repositories ＋'s own corrected label).
   2. The Projects ACCORDION lists ATTENTION-ORDERED rows: expanded, its rows
      settle to the same decayed-score order as the board's NEEDS YOU band —
      q3-review-deck → api-migration → auth-refactor → upload-endpoint —
@@ -89,7 +90,11 @@ EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-en
 # "Work" are checked against the RAIL's text only — the board legitimately
 # renders run problems containing the word "work" in prose.
 RAIL_BANNED = ["Chats", "Work", "No chats yet", "No work yet"]
-PAGE_BANNED = ["Do Work", "New Repository"]
+# RE-SCOPED by slice X2 (DES-UX-001 §7.10): "New Repository" leaves the banned
+# list — it is now the CORRECTED singular grammar of the Repositories ＋ itself
+# (the old standalone verb affordance it used to catch is long retired; the
+# heading-count assert below still pins that anatomy). "Do Work" stays banned.
+PAGE_BANNED = ["Do Work"]
 
 console_errors: list[str] = []
 

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -176,7 +176,9 @@ with sync_playwright() as p:
     plus_labels = page.evaluate(
         """() => Array.from(document.querySelectorAll('[data-testid="heading-new"]'))
               .map(b => b.getAttribute('aria-label'))""")
-    verbs_ok = plus_labels == ["New Projects", "New Make", "New Chat", "New Repositories"]
+    # RE-SCOPED by slice X2 (DES-UX-001 §7.10 grammar fix): the ＋ labels are
+    # the SINGULAR noun each affordance creates — never the heading's plural.
+    verbs_ok = plus_labels == ["New Project", "New Document", "New Chat", "New Repository"]
     settings_plus_absent = page.evaluate(
         """() => !document.querySelector(
              '[data-testid="rail-heading-settings"] [data-testid="heading-new"]')""")

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,7 +20,7 @@ import type {
   UpdateProjectBody,
 } from './types.js';
 
-import { ApiError } from './errors.js';
+import { ApiError, apiStatus } from './errors.js';
 
 export type * from './types.js';
 export { ApiError, apiStatus, apiWire, isRouteAbsent, translateWireError } from './errors.js';
@@ -233,8 +233,9 @@ export const api = {
       return await apiFetch<ElicitationInfo>(`/runs/${encodeURIComponent(id)}/elicitation`);
     } catch (e) {
       // A 404 is the normal "nothing pending" answer, not a failure. Anything else propagates —
-      // swallowing a 500 here would show an empty panel for a broken daemon.
-      if (e instanceof Error && /\b404\b/.test(e.message)) return null;
+      // swallowing a 500 here would show an empty panel for a broken daemon. Matched on the
+      // typed status (slice X2, EC33): the translated message no longer carries the number.
+      if (apiStatus(e) === 404) return null;
       throw e;
     }
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,7 +20,10 @@ import type {
   UpdateProjectBody,
 } from './types.js';
 
+import { ApiError } from './errors.js';
+
 export type * from './types.js';
+export { ApiError, apiStatus, apiWire, isRouteAbsent, translateWireError } from './errors.js';
 
 /**
  * Origin-aware API base resolution (DES-STUDIO-SERVING-001 §4.2).
@@ -76,8 +79,11 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
       const raw = body.error ?? body.message ?? text;
       msg = typeof raw === 'string' ? raw : JSON.stringify(raw);
     } catch { msg = text; }
-    if (!msg) msg = res.statusText || String(res.status);
-    throw new Error(`API ${res.status}: ${msg}`);
+    if (!msg) msg = res.statusText;
+    // EC33 (DES-UX-001 §7.10): the raw `API NNN:` framing never reaches the
+    // DOM — ApiError's message is the translated operator sentence; matchers
+    // read the typed `status`/`wire` fields instead of parsing a prefix.
+    throw new ApiError(res.status, msg);
   }
   return res.json() as Promise<T>;
 }
@@ -100,7 +106,7 @@ export async function downloadRunEvidence(runId: string): Promise<void> {
       const body = JSON.parse(text) as { error?: unknown };
       if (typeof body.error === 'string') msg = body.error;
     } catch { /* not JSON — keep the raw text */ }
-    throw new Error(`API ${res.status}: ${msg || res.statusText || String(res.status)}`);
+    throw new ApiError(res.status, msg || res.statusText);
   }
   const filename =
     /filename="([^"]+)"/.exec(res.headers.get('Content-Disposition') ?? '')?.[1]

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,0 +1,70 @@
+/**
+ * The wire-error translation layer (DES-UX-001 §7.10, EC33 — slice X2).
+ *
+ * House rule: **no raw wire error reaches the DOM.** Every daemon refusal a
+ * component renders is either a NAMED CAUSE (slice R's diff cause cards are
+ * the pattern — the caller matches on the raw sentence and renders its own
+ * operator copy) or the honest translated fallback this module mints:
+ *
+ *     the daemon refused this — {the daemon's own sentence}
+ *
+ * The daemon's sentence is carried WHOLE inside the fallback — translation
+ * never paraphrases a refusal, it only retires the `API NNN:` framing that
+ * made the product read unfinished (BRIEF-UX-001 §D). Callers that need the
+ * status code or the verbatim sentence (matchers, transcripts that quote the
+ * service) read the TYPED fields — never the display message:
+ *
+ *  - `ApiError.status` — the HTTP status, for `status === 409`-style matching
+ *    (replaces every `/^API 409: /.test(e.message)` in the codebase).
+ *  - `ApiError.wire`   — the daemon's raw sentence, verbatim, for named-cause
+ *    classification (FileViewer's diff causes) and service-voice transcripts
+ *    (themeWire's `serviceReason`).
+ *
+ * Both fetch boundaries throw through here: `apiFetch` (crew's /api/v1) and
+ * `iFetch` (the interactive bridge behind crew's proxy).
+ */
+
+/** Translate one wire refusal to its operator-facing sentence (EC33). */
+export function translateWireError(status: number, wire: string): string {
+  const detail = wire.trim();
+  if (detail === '') {
+    // A body-less refusal still gets an honest, complete sentence — the code
+    // is stated in words, never as the bare `API NNN:` framing EC33 retires.
+    return `the daemon refused this — it answered HTTP ${status} with no detail`;
+  }
+  return `the daemon refused this — ${detail}`;
+}
+
+/** A non-2xx answer from either daemon surface. `message` is ALREADY the
+ *  translated operator sentence — render it as-is; match on the fields. */
+export class ApiError extends Error {
+  readonly status: number;
+  /** The daemon's raw sentence, verbatim — matching + quoting only, never rendered bare. */
+  readonly wire: string;
+  constructor(status: number, wire: string) {
+    super(translateWireError(status, wire));
+    this.name = 'ApiError';
+    this.status = status;
+    this.wire = wire;
+  }
+}
+
+/** The refusal's HTTP status, or null when `e` is not a wire refusal. */
+export function apiStatus(e: unknown): number | null {
+  return e instanceof ApiError ? e.status : null;
+}
+
+/** The daemon's verbatim sentence, or null when `e` is not a wire refusal. */
+export function apiWire(e: unknown): string | null {
+  return e instanceof ApiError ? e.wire : null;
+}
+
+/**
+ * Fastify's default unknown-route 404 carries no named error — the daemon
+ * predates the route the caller asked for. Named 404s ("unknown run: …",
+ * "no such file: …") are real answers from a daemon WITH the route and must
+ * surface. Shared by every forward-compat fallback (FileViewer, openPath).
+ */
+export function isRouteAbsent(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 404 && e.wire === 'Not Found';
+}

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -12,6 +12,7 @@
 // the bus-emit bridge are top-level, while per-document state/commands live
 // under a `/d/<docId>` prefix.
 import { apiBase } from './client.js';
+import { ApiError } from './errors.js';
 
 // ── Wire shapes ─────────────────────────────────────────────────────────────
 // Narrow by intent: only the fields the UI consumes. The bridge is a Node
@@ -179,11 +180,13 @@ export class BridgeUnavailableError extends Error {
  * install command — never a crash, and never the install gate that blocks ordinary
  * documents. `hint` is carried verbatim so the UI renders an *actionable* message rather
  * than a bare failure (§3.3), exactly as `BridgeUnavailableError` does for the 503.
+ * An `ApiError` (slice X2) so the shared status/wire matchers and the EC33
+ * translated message apply to hinted refusals too.
  */
-export class ServiceHintError extends Error {
+export class ServiceHintError extends ApiError {
   readonly hint: string;
-  constructor(message: string, hint: string) {
-    super(message);
+  constructor(status: number, wire: string, hint: string) {
+    super(status, wire);
     this.name = 'ServiceHintError';
     this.hint = hint;
   }
@@ -245,13 +248,13 @@ async function iFetch<T>(url: string, init?: RequestInit): Promise<T> {
     }
     // The bridge reports failures as `{error}`; crew's own layers use `{message}`.
     const raw = body?.error ?? body?.message ?? text;
-    const msg = (typeof raw === 'string' ? raw : JSON.stringify(raw))
-      || res.statusText || String(res.status);
+    const msg = (typeof raw === 'string' ? raw : JSON.stringify(raw)) || res.statusText;
     // A refusal that NAMED its fix keeps that name typed all the way to the surface.
     if (typeof body?.hint === 'string' && body.hint.trim() !== '') {
-      throw new ServiceHintError(`API ${res.status}: ${msg}`, body.hint.trim());
+      throw new ServiceHintError(res.status, msg, body.hint.trim());
     }
-    throw new Error(`API ${res.status}: ${msg}`);
+    // EC33: the translated ApiError — never the raw `API NNN:` framing.
+    throw new ApiError(res.status, msg);
   }
   return res.json() as Promise<T>;
 }
@@ -436,7 +439,7 @@ export function getLearnedTheme(
 ): Promise<LearnedTheme | null> {
   return iFetch<LearnedTheme>(`${docBase(projectId, docId)}/api/theme/learned`)
     .catch((e: unknown) => {
-      if (e instanceof Error && e.message === 'API 404: no learned theme') return null;
+      if (e instanceof ApiError && e.status === 404 && e.wire === 'no learned theme') return null;
       throw e;
     });
 }

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createDoc, docBinding, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
+import { parseCreateAsk } from '../interactive/createAsk.js';
 import { ComposerContext } from './ComposerContext.js';
 import { DemoWizard } from './DemoWizard.js';
 import { recordFromThread } from '../interactive/demoWire.js';
@@ -464,14 +465,20 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         return;
       }
 
-      // 1 — LAUNCH. The message IS the brief; the doc's generation run opens with it.
+      // 1 — LAUNCH. The message IS the brief; the doc's generation run opens with
+      // it. §7.3 (slice X2): a QUOTED name in the ask becomes the doc's name and
+      // the remainder stays the brief (the parse the composer previewed) — no
+      // more whole sentences slugified into names. Unquoted asks keep the
+      // first-six-words derivation unchanged.
       if (docId === null || key === null) {
         // §6.2 (slice U): the Unfiled mount creates UNBOUND (no `project`
         // field — `docBinding`); real projects bind as before. A refused
         // create lands in the catch below — the visible composer error,
         // never a silent close (the loud-502 contract, §8.4.1 probe 3).
+        const parsed = parseCreateAsk(body);
         const created = await createDoc(projectId, {
-          name: docName(body), kind: 'source', brief: body, ...docBinding(projectId),
+          name: parsed?.name ?? docName(body), kind: 'source',
+          brief: parsed?.brief ?? body, ...docBinding(projectId),
           source_message_id: msgId,
         });
         const opened = threadKey(projectId, created.name);
@@ -705,6 +712,23 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
             steering the live {mode === 'video' ? 'demo' : 'document'} run
           </span>
         )}
+        {/* §7.3 (slice X2): the parse, SHOWN before submit — a quoted name in a
+            create ask becomes the doc's name, the rest stays the brief. Renders
+            only on the launch composer (no doc yet) when a quoted name parses. */}
+        {(docId === null || key === null) && mode !== 'video' && (() => {
+          const parsed = parseCreateAsk(text);
+          if (parsed === null) return null;
+          return (
+            <p
+              data-testid="create-parse"
+              className="text-[10px] font-mono"
+              style={{ color: 'var(--ink-dim)', margin: 0 }}
+            >
+              will create <span style={{ color: 'var(--ink-muted)' }}>“{parsed.name}”</span>
+              {' '}— brief: {parsed.brief}
+            </p>
+          );
+        })()}
         {/* §5.3's composer contract, worn by every mode: --surface-raised at
             --radius-xl, the wk-composer focus ring (--accent-dim via
             :focus-within — never the full accent), an accent-filled submit. */}

--- a/src/components/ElicitationPrompt.tsx
+++ b/src/components/ElicitationPrompt.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { api } from '../api/client.js';
+import { api, apiStatus } from '../api/client.js';
 import { useElicitationStore, type OpenElicitation } from '../store/elicitations.js';
 
 /**
@@ -43,7 +43,7 @@ export function ElicitationPrompt({ e }: { e: OpenElicitation }): React.ReactEle
       clearElicitation(e.runId);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (/\b409\b/.test(msg)) {
+      if (apiStatus(err) === 409) {
         // Stale tab: refetch and swap in whatever the server has now (null clears).
         // `.catch(() => null)` here would treat a 500 or a dropped connection as "nothing
         // pending" and CLEAR the prompt — hiding a broken daemon behind an empty panel, which is

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -41,9 +41,11 @@ const CARD_W = 260;
 /** The anchoring budget the AC pins: the box sits within this of the element's rect. */
 const GAP = 4;
 
+/** EC45 (DES-UX-001 §7.3): the disabled state says why in OPERATOR language
+ *  with a next step — wire jargon ("instrument bridge") never reaches the DOM. */
 const DEGRADED_TITLE =
-  'Point-and-comment is unavailable: this document did not answer the instrument bridge. '
-  + 'The document still renders, versions and exports normally.';
+  'Comments need the document’s preview to finish loading — reopen the document '
+  + 'or regenerate this version. It still renders, versions and exports normally.';
 
 interface Inventory { widMap: Record<string, WidRect>; measured: ScrollState }
 

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
-import { api } from '../api/client.js';
+import { api, apiWire, isRouteAbsent } from '../api/client.js';
 import type { RunDiff, RunFileContent } from '../api/types.js';
 import { classifyDiff, isDimLine } from '../viewer/colorize.js';
 import type { DiffLineKind } from '../viewer/colorize.js';
@@ -24,8 +24,10 @@ import type { DiffLineKind } from '../viewer/colorize.js';
  * Requests fire ONLY on a user gesture: the viewer mounts on a row click and
  * each tab fetches on its first activation — nothing is prefetched.
  *
- * Route errors (400/403/404/409/507) surface VERBATIM — never swallowed. The
- * one exception is the forward-compat contract every studio wire follows: a
+ * Route errors (400/403/404/409/507) surface — never swallowed — carrying the
+ * daemon's own sentence inside the EC33 translated frame (slice X2: "the
+ * daemon refused this — …", never the raw `API NNN:` framing). The one
+ * exception is the forward-compat contract every studio wire follows: a
  * daemon WITHOUT the routes answers Fastify's generic 404 (`Not Found`, no
  * named error), and that calls `onUnsupported` so the caller can fall back to
  * today's exact behavior (external open + copy feedback) instead of the
@@ -71,18 +73,13 @@ export const DIFF_TIMEOUT_MS = 8000;
  * `run <id> has no workdir — nothing to diff` (409, repo-less run) and
  * `run <id>'s workdir no longer exists: <path>` (409, reaped worktree). The
  * raw `API 409` / `has no workdir` strings NEVER reach the DOM (EC33).
+ * Classified on the shared layer's VERBATIM `wire` sentence (slice X2 —
+ * `ApiError.message` is already translated; matchers never parse it).
  */
-function diffCauseOf(message: string): 'no-repo' | 'workdir-gone' | null {
-  if (/has no workdir/.test(message)) return 'no-repo';
-  if (/workdir no longer exists/.test(message)) return 'workdir-gone';
+function diffCauseOf(wire: string): 'no-repo' | 'workdir-gone' | null {
+  if (/has no workdir/.test(wire)) return 'no-repo';
+  if (/workdir no longer exists/.test(wire)) return 'workdir-gone';
   return null;
-}
-
-/** Fastify's default unknown-route 404 carries no named error — the daemon
- *  predates crew#305. Named 404s ("unknown run: …", "no such file: …") are
- *  real answers from a daemon WITH the routes and must surface verbatim. */
-function isRouteAbsent(e: unknown): boolean {
-  return e instanceof Error && e.message === 'API 404: Not Found';
 }
 
 function formatBytes(n: number): string {
@@ -207,7 +204,7 @@ export function FileViewer({ runId, path, defaultTab, onClose, onUnsupported }: 
         clearTimeout(timer);
         if (isRouteAbsent(e)) { onUnsupported(); return; }
         const message = e instanceof Error ? e.message : String(e);
-        const cause = diffCauseOf(message);
+        const cause = diffCauseOf(apiWire(e) ?? '');
         setDiff(cause !== null ? { state: 'cause', cause } : { state: 'error', message });
       });
   }, [tab, path, runId, diffAttempt, onUnsupported]);

--- a/src/components/GovernanceAudit.tsx
+++ b/src/components/GovernanceAudit.tsx
@@ -149,7 +149,8 @@ export function GovernanceAudit({ model }: Props): React.ReactElement {
           No governance claims recorded for this run.
         </p>
         <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
-          Claims appear when wicked-core runs governance decisions (core#24/#26).
+          {/* §7.10: issue numbers are internal notes, not user copy. */}
+          Claims appear once wicked-core runs governance decisions for a run.
         </p>
         {refreshBtn}
       </div>

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -68,13 +68,15 @@ const S = {
 export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'settings';
 
 /** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
- *  links `/system` in the collapsed column — it has no dashboard). */
-interface PathSpec { key: PathKey; title: string; glyph: string; dash: string | null; collapsedHref: string }
-const P_PROJECTS: PathSpec = { key: 'projects', title: 'Projects',     glyph: '◇', dash: '/projects', collapsedHref: '/projects' };
-const P_MAKE: PathSpec     = { key: 'make',     title: 'Make',         glyph: '⚒', dash: '/make',     collapsedHref: '/make' };
-const P_CHAT: PathSpec     = { key: 'chat',     title: 'Chat',         glyph: '💬', dash: '/chats',    collapsedHref: '/chats' };
-const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', glyph: '⬡', dash: '/repos',    collapsedHref: '/repos' };
-const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     glyph: '⚙', dash: null,        collapsedHref: '/system' };
+ *  links `/system` in the collapsed column — it has no dashboard). `noun` is
+ *  the SINGULAR the ＋ affordance creates (DES-UX-001 §7.10's grammar fix:
+ *  "New Project", never "New Projects"). */
+interface PathSpec { key: PathKey; title: string; noun: string; glyph: string; dash: string | null; collapsedHref: string }
+const P_PROJECTS: PathSpec = { key: 'projects', title: 'Projects',     noun: 'Project',    glyph: '◇', dash: '/projects', collapsedHref: '/projects' };
+const P_MAKE: PathSpec     = { key: 'make',     title: 'Make',         noun: 'Document',   glyph: '⚒', dash: '/make',     collapsedHref: '/make' };
+const P_CHAT: PathSpec     = { key: 'chat',     title: 'Chat',         noun: 'Chat',       glyph: '💬', dash: '/chats',    collapsedHref: '/chats' };
+const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Repository', glyph: '⬡', dash: '/repos',    collapsedHref: '/repos' };
+const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
 const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_SETTINGS];
 
 const SETTINGS_ROUTES = new Set(['system', 'theme', 'coverage', 'domain', 'workflows', 'policies', 'rules']);
@@ -332,8 +334,8 @@ function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }:
           <button
             type="button"
             data-testid="heading-new"
-            aria-label={`New ${path.title}`}
-            title={`New ${path.title}`}
+            aria-label={`New ${path.noun}`}
+            title={`New ${path.noun}`}
             // Keep the mousedown out of the make-picker's outside-close
             // listener, so ＋ is a true toggle (open picker + click ＋ again
             // = closed, not close-then-reopen).

--- a/src/components/NewProjectModal.tsx
+++ b/src/components/NewProjectModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState } from 'react';
 import { api } from '../api/client.js';
 import { modePath } from '../hooks/useRoute.js';
+import { useProjectsStore } from '../store/projects.js';
 
 /**
  * The new-project flow (DES-FEEDBACK-001 §1.3, slice A): a minimal inline
@@ -64,6 +65,10 @@ export function NewProjectModal({ navigate, onClose }: Props): React.ReactElemen
       const { project } = await api.createProject(
         description.trim() === '' ? { name } : { name, description: description.trim() },
       );
+      // Fresh-entity hydration (DES-UX-001 §7.10): the created project joins the
+      // store BEFORE navigation, so the rail row and the shell breadcrumb render
+      // its display name immediately — never the raw `proj_…` id until a reload.
+      useProjectsStore.getState().addProject(project);
       onClose();
       navigate(startPath(project.id, start));
     } catch (e) {

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -73,7 +73,17 @@ export function NotificationSettings(): React.ReactElement {
       };
     }
     if (permission === 'granted') return { text: 'permission granted ✓', color: 'var(--status-run)' };
-    return null; // 'default': nothing to report until the operator opts in
+    if (prefs.desktop) {
+      // §7.10 (slice X2): the on-load truth. The crew-persisted pref says
+      // desktop-on, but THIS browser has never granted (state 'default') —
+      // notifications will not fire here until re-enabled, so say so with the
+      // next step instead of silently rendering an On radio that does nothing.
+      return {
+        text: 'permission not granted in this browser — click the desktop option to grant it',
+        color: 'var(--status-gate)',
+      };
+    }
+    return null; // 'default' + off: nothing to report until the operator opts in
   })();
 
   return (

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -16,6 +16,36 @@ interface Props {
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
+/**
+ * §7.10 (slice X2): contributor identity de-duplicates. Git histories routinely
+ * carry one person under several author rows (work + noreply emails, case
+ * drift). Rows merge when they share an email OR a display name
+ * (case-insensitive); commits sum; the most-committed spelling of the name
+ * wins. Pure + exported for the unit spine.
+ */
+export function dedupeContributors(rows: readonly GitContributor[]): GitContributor[] {
+  const merged: GitContributor[] = [];
+  const byEmail = new Map<string, GitContributor>();
+  const byName = new Map<string, GitContributor>();
+  for (const row of rows) {
+    const email = row.email.trim().toLowerCase();
+    const name = row.name.trim().toLowerCase();
+    const hit = (email !== '' ? byEmail.get(email) : undefined) ?? byName.get(name);
+    if (hit === undefined) {
+      const copy = { ...row };
+      merged.push(copy);
+      if (email !== '') byEmail.set(email, copy);
+      if (name !== '') byName.set(name, copy);
+    } else {
+      if (row.commits > hit.commits) hit.name = row.name; // the busier spelling wins
+      hit.commits += row.commits;
+      if (email !== '') byEmail.set(email, hit);
+      if (name !== '') byName.set(name, hit);
+    }
+  }
+  return merged.sort((a, b) => b.commits - a.commits);
+}
+
 export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: Props): React.ReactElement {
   const [requirementsOpen, setRequirementsOpen] = useState(false);
   const [repo, setRepo] = useState<RepoEntry | null>(null);
@@ -54,7 +84,7 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
     }).finally(() => { if (!cancelled) setLoading(false); });
     // Git sections are decoupled — they don't block the page skeleton
     api.getRepoGitHistory(repoId).then(({ commits: c }) => { if (!cancelled) setCommits(c); }).catch(() => {});
-    api.getRepoContributors(repoId).then(({ contributors: c }) => { if (!cancelled) setContributors(c); }).catch(() => {});
+    api.getRepoContributors(repoId).then(({ contributors: c }) => { if (!cancelled) setContributors(dedupeContributors(c)); }).catch(() => {});
     return () => { cancelled = true; };
   }, [repoId]);
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -57,7 +57,25 @@ type FileOpKind = 'write' | 'delete';
 
 type FileFeedback = 'opened' | 'copied' | 'open-failed';
 
-function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; runId: string }): React.ReactElement {
+/**
+ * §7.10 (slice X2): Files rows render WORKTREE-RELATIVE paths — the 5-line
+ * absolute /private/var wrap retires from the visible text. Only the display
+ * changes: `path` stays absolute for the viewer fetch, external open, copy,
+ * and every `title`/aria attribute (the full path is one hover away).
+ */
+function relativeToRoot(path: string, root: string | undefined): string {
+  if (root === undefined || root === '') return path;
+  const norm = path.replace(/\\/g, '/');
+  const rootNorm = root.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (norm === rootNorm) return '.';
+  return norm.startsWith(`${rootNorm}/`) ? norm.slice(rootNorm.length + 1) : path;
+}
+
+function FilePath({ path, opKind, runId, root }: {
+  path: string; opKind?: FileOpKind; runId: string;
+  /** The run's worktree root (`session.workdir`) — the display-relativity base. */
+  root?: string | undefined;
+}): React.ReactElement {
   const [feedback, setFeedback] = useState<FileFeedback | null>(null);
   // Slice I (DES-FEEDBACK-002 §3.4): the row itself opens the INLINE viewer;
   // external-open (↗) and copy (⧉) move to hover-revealed row-end icons —
@@ -66,8 +84,9 @@ function FilePath({ path, opKind, runId }: { path: string; opKind?: FileOpKind; 
   const rowRef = useRef<HTMLButtonElement | null>(null);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current); }, []);
-  const parts = path.replace(/\\/g, '/').split('/');
-  const name = parts.pop() ?? path;
+  const display = relativeToRoot(path, root);
+  const parts = display.replace(/\\/g, '/').split('/');
+  const name = parts.pop() ?? display;
   const dir = parts.length > 0 ? `${parts.join('/')}/` : '';
 
   const glyph = opKind === 'delete' ? '−' : opKind === 'write' ? '±' : '~';
@@ -257,6 +276,8 @@ function RunTranscriptView({ runId, units, onOpenShell }: {
 
 function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
   const runId = model.session.id;
+  // §7.10: rows display worktree-relative paths (absolute stays on title/copy/open).
+  const root = model.session.workdir ?? undefined;
   // Slice I: the per-run [Full diff] button at the panel header (§3.4) — the
   // same viewer, whole-worktree diff (no path). Opens on the click, never
   // prefetches.
@@ -348,10 +369,10 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
           ) : (
             <ul className="flex flex-col gap-1">
               {sortedModified.map((f) => (
-                <FilePath key={f} path={f} opKind="write" runId={runId} />
+                <FilePath key={f} path={f} opKind="write" runId={runId} root={root} />
               ))}
               {sortedDeleted.map((f) => (
-                <FilePath key={f} path={f} opKind="delete" runId={runId} />
+                <FilePath key={f} path={f} opKind="delete" runId={runId} root={root} />
               ))}
             </ul>
           )}
@@ -366,7 +387,7 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
           </p>
           <ul className="flex flex-col gap-1">
             {sortedReferenced.map((f) => (
-              <FilePath key={f} path={f} runId={runId} />
+              <FilePath key={f} path={f} runId={runId} root={root} />
             ))}
           </ul>
         </div>

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -70,7 +70,8 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
   useEffect(() => {
     api.getSettings()
       .then(({ settings: s }) => setSettings(s))
-      .catch((e: unknown) => setError(String(e)));
+      // EC33: the translated message, never `String(Error)`'s "Error: …" framing.
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
     api.getRoster()
       .then(({ roster: seats }) => {
         // Deposit for Chat's default chips (DES-FEEDBACK-001 §6.1).

--- a/src/components/WhatWhere.tsx
+++ b/src/components/WhatWhere.tsx
@@ -11,18 +11,32 @@ interface Props {
   onSelectRun?: (id: string) => void;
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): React.ReactElement {
+function Row({ label, value, mono, title }: {
+  label: string; value: string; mono?: boolean; title?: string;
+}): React.ReactElement {
   return (
     <div className="flex gap-2 text-[11px]">
       <span className="w-20 shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>{label}</span>
       <span
         className={mono ? 'font-mono break-all' : ''}
         style={{ color: 'var(--ink-muted)' }}
+        {...(title !== undefined ? { title } : {})}
       >
         {value}
       </span>
     </div>
   );
+}
+
+/**
+ * §7.10 (slice X2): long absolute worktree paths retire from the visible text —
+ * the 5-line /private/var wrap read as debug output. The visible value is the
+ * path's meaningful tail; the full path stays one hover away (title).
+ */
+export function compactPath(p: string): string {
+  const parts = p.replace(/\\/g, '/').split('/').filter((s) => s !== '');
+  if (parts.length <= 3) return p;
+  return `…/${parts.slice(-2).join('/')}`;
 }
 
 export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props): React.ReactElement {
@@ -43,15 +57,18 @@ export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props):
       />
       <Row label="intent" value={session.problem} />
       <Row label="repo" value={session.repo_ref ?? '—'} mono />
-      <Row label="worktree" value={session.workdir ?? '—'} mono />
+      {/* §7.10: the compact tail, full path on hover — never the 5-line wrap.
+          The DTO debug note that used to sit below ("work_output pending daemon
+          surface") is retired: internal notes are not user copy; the diff lives
+          behind Files → Full diff. */}
+      <Row
+        label="worktree"
+        value={session.workdir !== undefined && session.workdir !== null ? compactPath(session.workdir) : '—'}
+        mono
+        {...(session.workdir !== undefined && session.workdir !== null ? { title: session.workdir } : {})}
+      />
       <Row label="roster" value={session.clis.length > 0 ? session.clis.join(', ') : '—'} mono />
       <Row label="entity" value={session.entity_mode} />
-      <div
-        className="mt-1 rounded p-1.5 text-[10px] font-mono"
-        style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
-      >
-        diff: not exposed on the run DTO (<code>work_output</code> pending daemon surface)
-      </div>
     </div>
   );
 }

--- a/src/interactive/createAsk.ts
+++ b/src/interactive/createAsk.ts
@@ -1,0 +1,36 @@
+/**
+ * Quoted-name extraction for the create flows (DES-UX-001 §7.3, slice X2).
+ *
+ * The brief's gaslight: `a deck named "uxr-quarterly-brief" …` used to have the
+ * WHOLE sentence slugified into the doc's name by the bridge. The fix is a
+ * client-side parse: a quoted name in the ask BECOMES the name, the rest of the
+ * sentence stays the brief — and the parse is SHOWN before submit (the
+ * `create-parse` line under the composer), so the operator sees what will be
+ * created before pressing Enter.
+ *
+ * Deliberately conservative: only a quoted span parses (straight or curly
+ * quotes), 1–60 chars, no newline. An unquoted ask is untouched — the existing
+ * first-six-words derivation stays the fallback. When removing the quoted span
+ * (and an immediately preceding naming cue: named/called/titled) empties the
+ * sentence, the full ask stays the brief — a name alone is not a brief.
+ */
+
+export interface CreateAskParse {
+  /** The quoted name, exactly as the operator wrote it (quotes stripped). */
+  name: string;
+  /** The ask with the quoted span (and its naming cue) removed — the brief. */
+  brief: string;
+}
+
+const QUOTED = /(?:named|called|titled)?\s*["“”'‘’]([^"“”'‘’\n]{1,60})["“”'‘’]/i;
+
+export function parseCreateAsk(ask: string): CreateAskParse | null {
+  const m = QUOTED.exec(ask);
+  if (m === null) return null;
+  const name = (m[1] ?? '').trim();
+  if (name === '') return null;
+  const brief = (ask.slice(0, m.index) + ' ' + ask.slice(m.index + m[0].length))
+    .replace(/\s+/g, ' ')
+    .trim();
+  return { name, brief: brief === '' ? ask.trim() : brief };
+}

--- a/src/interactive/createAsk.ts
+++ b/src/interactive/createAsk.ts
@@ -9,7 +9,9 @@
  * created before pressing Enter.
  *
  * Deliberately conservative: only a quoted span parses (straight or curly
- * quotes), 1–60 chars, no newline. An unquoted ask is untouched — the existing
+ * quotes), 1–60 chars, no newline — and BOTH quote marks must sit on word
+ * edges, so apostrophe contractions ("last week's numbers, don't…") never
+ * false-parse as a name. An unquoted ask is untouched — the existing
  * first-six-words derivation stays the fallback. When removing the quoted span
  * (and an immediately preceding naming cue: named/called/titled) empties the
  * sentence, the full ask stays the brief — a name alone is not a brief.
@@ -22,7 +24,9 @@ export interface CreateAskParse {
   brief: string;
 }
 
-const QUOTED = /(?:named|called|titled)?\s*["“”'‘’]([^"“”'‘’\n]{1,60})["“”'‘’]/i;
+// `\b` on the cue keeps "renamed" from half-matching as a cue; the lookarounds
+// keep an apostrophe INSIDE a word (week's, don't) from opening/closing a span.
+const QUOTED = /(?:\b(?:named|called|titled)\s+)?(?<!\w)["“”'‘’]([^"“”'‘’\n]{1,60})["“”'‘’](?!\w)/i;
 
 export function parseCreateAsk(ask: string): CreateAskParse | null {
   const m = QUOTED.exec(ask);

--- a/src/interactive/themeWire.ts
+++ b/src/interactive/themeWire.ts
@@ -30,6 +30,7 @@
 //   - the learn is DOC-SCOPED: the learned tokens stick to THIS document and every later
 //     version of it wears them (theme-source.js reads <doc>/theme/learned.theme.json).
 
+import { apiWire } from '../api/errors.js';
 import {
   attachSource, requestThemeLearn, ServiceHintError,
   type LearnKind, type LearnThemeBody, type SourceEntry,
@@ -89,9 +90,13 @@ export function learnSubject(kind: LearnKind, value: string): string {
       + 'The file is not uploaded.';
 }
 
-/** The service's own sentence, unwrapped from the client's `API <status>: ` framing so
- *  the refusal a human reads is the refusal the guard wrote (§4.6). */
+/** The service's own sentence, so the refusal a human reads is the refusal the
+ *  guard wrote (§4.6). The shared layer carries it verbatim as `ApiError.wire`
+ *  (slice X2); the legacy `API <status>: ` strip stays as the fallback for
+ *  errors minted outside the wire layer. */
 export function serviceReason(e: unknown): string {
+  const wire = apiWire(e);
+  if (wire !== null) return wire;
   const message = e instanceof Error ? e.message : String(e);
   return message.replace(/^API \d{3}: /, '');
 }

--- a/src/theming/scratchDoc.ts
+++ b/src/theming/scratchDoc.ts
@@ -1,3 +1,4 @@
+import { apiStatus } from '../api/errors.js';
 import { createDoc, docBinding, listDocs, type CreateDocResult, type DocSummary } from '../api/interactive.js';
 
 /**
@@ -46,7 +47,7 @@ export async function ensureScratchDoc(
     return created.name;
   } catch (e: unknown) {
     // Raced another creator: the bridge's 409 means the doc now exists — use it.
-    if (e instanceof Error && /^API 409: /.test(e.message)) return SCRATCH_DOC_NAME;
+    if (apiStatus(e) === 409) return SCRATCH_DOC_NAME;
     throw e;
   }
 }

--- a/tests/FeedbackOverlay.test.tsx
+++ b/tests/FeedbackOverlay.test.tsx
@@ -93,9 +93,13 @@ describe('FeedbackOverlay — the instrumentation handshake (§5.5)', () => {
 
     const toggle = screen.getByTestId('feedback-toggle');
     expect(toggle).toBeDisabled();
-    // §3.3: a disabled control says WHY, and says the canvas is still fine.
-    expect(toggle.getAttribute('title')).toMatch(/did not answer the instrument bridge/i);
+    // §3.3 + EC45 (DES-UX-001 §7.3 re-scope): a disabled control says WHY in
+    // OPERATOR language with a next step — the wire phrase "instrument bridge"
+    // never reaches the DOM — and says the canvas is still fine.
+    expect(toggle.getAttribute('title')).toMatch(/preview to finish loading/i);
+    expect(toggle.getAttribute('title')).toMatch(/reopen the document or regenerate/i);
     expect(toggle.getAttribute('title')).toMatch(/still renders/i);
+    expect(document.body.innerHTML).not.toContain('instrument bridge');
     expect(screen.getByTestId('feedback-overlay')).toHaveAttribute('data-ready', 'false');
     // And nothing was rendered over the document that could swallow a click.
     expect(screen.queryByTestId('feedback-hitlayer')).toBeNull();

--- a/tests/FileViewer.test.tsx
+++ b/tests/FileViewer.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FileViewer } from '../src/components/FileViewer.js';
 import * as client from '../src/api/client.js';
+import { ApiError } from '../src/api/errors.js';
 
 const PATH = '/work/src/foo.ts';
 
@@ -55,19 +56,23 @@ describe('FileViewer — File tab states', () => {
     expect(screen.getByText('first half…')).toBeInTheDocument(); // content still shown
   });
 
-  it('403: the route error surfaces VERBATIM, never swallowed', async () => {
-    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error(
-      "API 403: path is outside every allowed root (the run's workdir/write roots and the registered repos)",
+  it('403: the daemon sentence surfaces whole in the EC33 translated frame, never swallowed', async () => {
+    // Slice X2 re-scope (DES-UX-001 §7.10): the raw `API 403:` framing retires;
+    // the daemon's own sentence still surfaces verbatim inside the translation.
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new ApiError(
+      403, "path is outside every allowed root (the run's workdir/write roots and the registered repos)",
     ));
     render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={() => {}} />);
 
-    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(
-      "API 403: path is outside every allowed root (the run's workdir/write roots and the registered repos)",
+    const el = await screen.findByTestId('viewer-error');
+    expect(el).toHaveTextContent(
+      "the daemon refused this — path is outside every allowed root (the run's workdir/write roots and the registered repos)",
     );
+    expect(document.body.textContent).not.toContain('API 403');
   });
 
   it('route-absent 404 ("Not Found", unnamed) calls onUnsupported instead of rendering a shell', async () => {
-    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error('API 404: Not Found'));
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new ApiError(404, 'Not Found'));
     const onUnsupported = vi.fn();
     render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={onUnsupported} />);
 
@@ -75,12 +80,13 @@ describe('FileViewer — File tab states', () => {
     expect(screen.queryByTestId('viewer-error')).not.toBeInTheDocument();
   });
 
-  it('a NAMED 404 (real answer from a daemon WITH the route) surfaces verbatim', async () => {
-    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error(`API 404: no such file: ${PATH}`));
+  it('a NAMED 404 (real answer from a daemon WITH the route) surfaces, translated', async () => {
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new ApiError(404, `no such file: ${PATH}`));
     const onUnsupported = vi.fn();
     render(<FileViewer runId="r-1" path={PATH} defaultTab="file" onClose={() => {}} onUnsupported={onUnsupported} />);
 
-    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(`API 404: no such file: ${PATH}`);
+    expect(await screen.findByTestId('viewer-error')).toHaveTextContent(
+      `the daemon refused this — no such file: ${PATH}`);
     expect(onUnsupported).not.toHaveBeenCalled();
   });
 });
@@ -92,8 +98,8 @@ describe('FileViewer — Diff tab states', () => {
   // never reach the DOM (EC33). The verbatim contract still holds for every other
   // error (the named-404 test below is unchanged).
   it('409 (workdir reaped): the named-cause card, never the raw wire string', async () => {
-    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new Error(
-      "API 409: run r-1's workdir no longer exists: /tmp/wt",
+    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new ApiError(
+      409, "run r-1's workdir no longer exists: /tmp/wt",
     ));
     render(<FileViewer runId="r-1" defaultTab="diff" onClose={() => {}} onUnsupported={() => {}} />);
 
@@ -105,8 +111,8 @@ describe('FileViewer — Diff tab states', () => {
   });
 
   it('409 (no workdir attached): the no-repository named cause, raw strings absent', async () => {
-    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new Error(
-      'API 409: run r-1 has no workdir — nothing to diff',
+    vi.spyOn(client.api, 'getRunDiff').mockRejectedValue(new ApiError(
+      409, 'run r-1 has no workdir — nothing to diff',
     ));
     const onClose = vi.fn();
     render(<FileViewer runId="r-1" defaultTab="diff" onClose={onClose} onUnsupported={() => {}} />);

--- a/tests/RightPanel.files.test.tsx
+++ b/tests/RightPanel.files.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { RightPanel } from '../src/components/RightPanel.js';
 import * as client from '../src/api/client.js';
+import { ApiError } from '../src/api/errors.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { makeView, makeUnit } from './factories.js';
 import type { SessionView } from '../src/api/types.js';
@@ -67,7 +68,7 @@ describe('RightPanel Files tab — slice I inline viewer + preserved openPath/co
   });
 
   it('↗ falls back to copying the path when the daemon has no /open route', async () => {
-    vi.spyOn(client.api, 'openPath').mockRejectedValue(new Error('API 404: Not Found'));
+    vi.spyOn(client.api, 'openPath').mockRejectedValue(new ApiError(404, 'Not Found'));
     await renderFilesTab();
 
     fireEvent.click(screen.getByRole('button', { name: `Open externally: ${FILE}` }));
@@ -87,7 +88,7 @@ describe('RightPanel Files tab — slice I inline viewer + preserved openPath/co
 
   it('a daemon WITHOUT the file routes (generic 404): the row click falls back to the external open', async () => {
     // Fastify's route-absent 404 carries no named error — exactly "Not Found".
-    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new Error('API 404: Not Found'));
+    vi.spyOn(client.api, 'getRunFile').mockRejectedValue(new ApiError(404, 'Not Found'));
     const openPath = vi.spyOn(client.api, 'openPath').mockResolvedValue({ status: 'opened' });
     const row = await renderFilesTab();
 

--- a/tests/clientFiles.test.ts
+++ b/tests/clientFiles.test.ts
@@ -78,3 +78,30 @@ describe('api.getRunDiff — GET /runs/:id/diff[?path=<absolute>]', () => {
     expect((err as ApiError).wire).toBe('run r-1 has no workdir — nothing to diff');
   });
 });
+
+describe('api.getElicitation — 404 means "nothing pending", matched on the typed status', () => {
+  it('answers null on the daemon 404 even though the translated message names no number', async () => {
+    // Regression pin (slice X2 verification): the old `/\b404\b/.test(e.message)`
+    // matcher went dead once the message became the translated sentence — the
+    // nothing-pending answer must ride ApiError.status, not the display string.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: () => Promise.resolve(JSON.stringify({ error: 'Not Found' })),
+    });
+    await expect(api.getElicitation('r-1')).resolves.toBeNull();
+  });
+
+  it('a 500 still propagates — a broken daemon never renders as an empty panel', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve(JSON.stringify({ error: 'boom' })),
+    });
+    const err = await api.getElicitation('r-1').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+  });
+});

--- a/tests/clientFiles.test.ts
+++ b/tests/clientFiles.test.ts
@@ -1,7 +1,7 @@
 // Unit tests: the two slice-I client calls (DES-FEEDBACK-002 §3.3, crew#305) —
 // exact URLs and params, typed against wicked-crew-api-types 0.7.0.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { api } from '../src/api/client.js';
+import { api, ApiError } from '../src/api/client.js';
 
 function setLocation(url: string): void {
   Object.defineProperty(window, 'location', {
@@ -59,15 +59,22 @@ describe('api.getRunDiff — GET /runs/:id/diff[?path=<absolute>]', () => {
     );
   });
 
-  it('surfaces the route error ladder verbatim (409 workdir-less example)', async () => {
+  it('surfaces the route error ladder through the EC33 translation (409 workdir-less example)', async () => {
+    // Slice X2 (DES-UX-001 §7.10): the thrown message is the TRANSLATED operator
+    // sentence carrying the daemon's own words whole; the raw status + verbatim
+    // sentence ride the typed ApiError fields for matchers (FileViewer's causes).
     fetchMock.mockResolvedValue({
       ok: false,
       status: 409,
       statusText: 'Conflict',
       text: () => Promise.resolve(JSON.stringify({ error: 'run r-1 has no workdir — nothing to diff' })),
     });
-    await expect(api.getRunDiff('r-1')).rejects.toThrow(
-      'API 409: run r-1 has no workdir — nothing to diff',
+    const err = await api.getRunDiff('r-1').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).message).toBe(
+      'the daemon refused this — run r-1 has no workdir — nothing to diff',
     );
+    expect((err as ApiError).status).toBe(409);
+    expect((err as ApiError).wire).toBe('run r-1 has no workdir — nothing to diff');
   });
 });

--- a/tests/cockpitPanels.test.tsx
+++ b/tests/cockpitPanels.test.tsx
@@ -159,12 +159,15 @@ describe('DataUsed (FR-8)', () => {
 });
 
 describe('WhatWhere (FR-8)', () => {
-  it('renders intent + roster and labels the missing diff honestly', () => {
+  it('renders intent + roster; the DTO debug note is retired (DES-UX-001 §7.10)', () => {
     render(<WhatWhere model={modelWith()} />);
     const el = screen.getByTestId('what-where');
     expect(el).toHaveTextContent('do the thing');
     expect(el).toHaveTextContent('claude');
-    expect(el).toHaveTextContent('work_output');
+    // Slice X2 re-scope: "work_output pending daemon surface" was an internal
+    // note, not user copy — it must NOT render (the diff lives in Files).
+    expect(el.textContent).not.toContain('work_output');
+    expect(el.textContent).not.toContain('DTO');
   });
 });
 

--- a/tests/copyPass.test.ts
+++ b/tests/copyPass.test.ts
@@ -1,0 +1,89 @@
+// Slice X2's unit spine (DES-UX-001 §7.3 + §7.10): the error-translation layer,
+// quoted-name extraction, compact paths, contributor de-dup.
+import { describe, expect, it } from 'vitest';
+import { ApiError, apiStatus, apiWire, isRouteAbsent, translateWireError } from '../src/api/errors.js';
+import { parseCreateAsk } from '../src/interactive/createAsk.js';
+import { compactPath } from '../src/components/WhatWhere.js';
+import { dedupeContributors } from '../src/components/RepoDetailPage.js';
+
+describe('the EC33 translation layer', () => {
+  it('carries the daemon sentence whole, without the API NNN: framing', () => {
+    const e = new ApiError(409, 'not awaiting a human gate');
+    expect(e.message).toBe('the daemon refused this — not awaiting a human gate');
+    expect(e.message).not.toContain('API 4');
+    expect(e.status).toBe(409);
+    expect(e.wire).toBe('not awaiting a human gate');
+  });
+
+  it('a body-less refusal still gets an honest sentence naming the code in words', () => {
+    expect(translateWireError(500, '  ')).toBe(
+      'the daemon refused this — it answered HTTP 500 with no detail');
+  });
+
+  it('matchers read the typed fields, and non-wire errors answer null', () => {
+    const e = new ApiError(404, 'Not Found');
+    expect(apiStatus(e)).toBe(404);
+    expect(apiWire(e)).toBe('Not Found');
+    expect(isRouteAbsent(e)).toBe(true);
+    expect(isRouteAbsent(new ApiError(404, 'unknown run: r-9'))).toBe(false);
+    expect(apiStatus(new Error('API 409: legacy'))).toBeNull();
+    expect(apiWire('boom')).toBeNull();
+  });
+});
+
+describe('parseCreateAsk (§7.3 quoted-name extraction)', () => {
+  it('the brief AC verbatim: a deck named "uxr-x" → name uxr-x, remainder = brief', () => {
+    const p = parseCreateAsk('a deck named "uxr-x" summarizing the Q3 results');
+    expect(p).toEqual({ name: 'uxr-x', brief: 'a deck summarizing the Q3 results' });
+  });
+
+  it('curly quotes parse; the naming cue is removed with the span', () => {
+    const p = parseCreateAsk('a one-pager called “uxr-quarterly-brief” for the leads');
+    expect(p).toEqual({ name: 'uxr-quarterly-brief', brief: 'a one-pager for the leads' });
+  });
+
+  it('no quotes → null (the first-six-words fallback stays in charge)', () => {
+    expect(parseCreateAsk('summarize the Q3 results as a deck')).toBeNull();
+  });
+
+  it('a name-only ask keeps the full ask as the brief — a name is not a brief', () => {
+    const p = parseCreateAsk('"uxr-x"');
+    expect(p).toEqual({ name: 'uxr-x', brief: '"uxr-x"' });
+  });
+
+  it('an empty quoted span is no name', () => {
+    expect(parseCreateAsk('a deck named "" about nothing')).toBeNull();
+  });
+});
+
+describe('compactPath (§7.10 — the 5-line wrap retires)', () => {
+  it('long absolute paths compact to their tail', () => {
+    expect(compactPath('/private/var/folders/ab/T/wicked/worktrees/r-auth')).toBe(
+      '…/worktrees/r-auth');
+  });
+  it('short paths stay whole', () => {
+    expect(compactPath('/w2/upload')).toBe('/w2/upload');
+  });
+});
+
+describe('dedupeContributors (§7.10 — one person, one row)', () => {
+  it('merges by email (case-insensitive), sums commits, busier spelling wins', () => {
+    const rows = dedupeContributors([
+      { name: 'Mika P', email: 'mika@example.com', commits: 3 },
+      { name: 'mika', email: 'MIKA@example.com', commits: 9 },
+      { name: 'Someone Else', email: 'else@example.com', commits: 4 },
+    ]);
+    expect(rows).toEqual([
+      { name: 'mika', email: 'mika@example.com', commits: 12 },
+      { name: 'Someone Else', email: 'else@example.com', commits: 4 },
+    ]);
+  });
+
+  it('merges by display name when the emails differ (work + noreply)', () => {
+    const rows = dedupeContributors([
+      { name: 'Mika P', email: 'mika@work.com', commits: 5 },
+      { name: 'Mika P', email: '123+mika@users.noreply.github.com', commits: 2 },
+    ]);
+    expect(rows).toEqual([{ name: 'Mika P', email: 'mika@work.com', commits: 7 }]);
+  });
+});

--- a/tests/copyPass.test.ts
+++ b/tests/copyPass.test.ts
@@ -54,6 +54,16 @@ describe('parseCreateAsk (§7.3 quoted-name extraction)', () => {
   it('an empty quoted span is no name', () => {
     expect(parseCreateAsk('a deck named "" about nothing')).toBeNull();
   });
+
+  it('apostrophe contractions never false-parse as a quoted name', () => {
+    expect(parseCreateAsk("summarize last week's numbers, don't include drafts")).toBeNull();
+    expect(parseCreateAsk('summarize last week’s numbers, don’t include drafts')).toBeNull();
+  });
+
+  it('"renamed" is not the naming cue — the quoted span still parses alone', () => {
+    const p = parseCreateAsk('a doc renamed "x-1" please');
+    expect(p).toEqual({ name: 'x-1', brief: 'a doc renamed please' });
+  });
 });
 
 describe('compactPath (§7.10 — the 5-line wrap retires)', () => {

--- a/tests/exportWire.test.ts
+++ b/tests/exportWire.test.ts
@@ -16,11 +16,17 @@ const postExport = vi.fn();
 /** The real class, mirrored ONCE and shared with the mocked module: `exportHint` narrows
  *  on it, so a test that constructed a different class would pass for the wrong reason. */
 const { ServiceHintError } = vi.hoisted(() => ({
+  // Mirrors the real (status, wire, hint) ApiError shape (slice X2): the message
+  // is the EC33 translated sentence, exactly what the layer would mint.
   ServiceHintError: class ServiceHintError extends Error {
     readonly hint: string;
-    constructor(message: string, hint: string) {
-      super(message);
+    readonly status: number;
+    readonly wire: string;
+    constructor(status: number, wire: string, hint: string) {
+      super(`the daemon refused this — ${wire}`);
       this.name = 'ServiceHintError';
+      this.status = status;
+      this.wire = wire;
       this.hint = hint;
     }
   },
@@ -162,7 +168,7 @@ describe('a completed export is an ordinary downloadable message (§2.5, §4.4)'
 
 describe('a PPTX export with python-pptx absent is ACTIONABLE, not a crash (§4.4, §3.3)', () => {
   beforeEach(() => {
-    postExport.mockRejectedValue(new ServiceHintError('API 400: pptx export unavailable', PPTX_HINT));
+    postExport.mockRejectedValue(new ServiceHintError(400, 'pptx export unavailable', PPTX_HINT));
   });
 
   it('AC: the service’s 400 becomes a message naming the install command VERBATIM', async () => {
@@ -195,6 +201,6 @@ describe('a PPTX export with python-pptx absent is ACTIONABLE, not a crash (§4.
     await runExport({ projectId: PROJECT, docId: DOC, version: 2, format: 'pdf' });
 
     expect(messages()[1]).toMatchObject({ kind: 'actionable', hint: 'API 500: renderer crashed' });
-    expect(exportHint(new ServiceHintError('API 400: nope', PPTX_HINT))).toBe(PPTX_HINT);
+    expect(exportHint(new ServiceHintError(400, 'nope', PPTX_HINT))).toBe(PPTX_HINT);
   });
 });

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -418,7 +418,7 @@ describe('happy-path shapes', () => {
     // error, thrown in the EC33 translated frame carrying the service's sentence.
     stubFetch('Cannot GET /d/absent/api/theme/learned', 404);
     await expect(getLearnedTheme(PROJECT, 'absent')).rejects.toThrow(
-      'the daemon refused this — Cannot GET /d/absent/api/theme/learned');
+      /the daemon refused this — .*Cannot GET \/d\/absent\/api\/theme\/learned/);
     // A dead bridge stays the typed 503, exactly as every other wrapper.
     stubFetch({ code: 'bridge_unavailable', hint: 'npm i -g wicked-interactive' }, 503);
     await expect(getLearnedTheme(PROJECT, DOC)).rejects.toBeInstanceOf(BridgeUnavailableError);

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -177,12 +177,12 @@ describe('BridgeUnavailableError', () => {
     const err = await listDocs(PROJECT).catch((e: unknown) => e);
     expect(err).not.toBeInstanceOf(BridgeUnavailableError);
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toBe('API 503: service overloaded');
+    expect((err as Error).message).toBe('the daemon refused this — service overloaded');
   });
 
   it("surfaces the bridge's {error} message on ordinary failures", async () => {
     stubFetch({ error: 'doc already exists' }, 409);
-    await expect(createDoc(PROJECT, { name: DOC })).rejects.toThrow('API 409: doc already exists');
+    await expect(createDoc(PROJECT, { name: DOC })).rejects.toThrow('the daemon refused this — doc already exists');
   });
 });
 
@@ -208,9 +208,11 @@ describe('ServiceHintError', () => {
     const err = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
     expect(err).toBeInstanceOf(ServiceHintError);
     expect((err as ServiceHintError).hint).toBe(hint);
-    // The message keeps the status and the service's own reason for a bare render.
+    // The message keeps the service's own reason, in the EC33 translated frame,
+    // for a bare render; the status rides the typed field (slice X2).
     expect((err as ServiceHintError).message).toBe(
-      'API 400: pptx export unavailable: python-pptx is not importable');
+      'the daemon refused this — pptx export unavailable: python-pptx is not importable');
+    expect((err as ServiceHintError).status).toBe(400);
   });
 
   it('trims the hint, and a whitespace-only hint is no hint — stays a generic Error', async () => {
@@ -222,7 +224,7 @@ describe('ServiceHintError', () => {
     const blank = await postExport(PROJECT, DOC, 3, 'pptx').catch((e: unknown) => e);
     expect(blank).not.toBeInstanceOf(ServiceHintError);
     expect(blank).toBeInstanceOf(Error);
-    expect((blank as Error).message).toBe('API 400: nope');
+    expect((blank as Error).message).toBe('the daemon refused this — nope');
   });
 
   it('the 503 bridge_unavailable branch wins even when a hint is present', async () => {
@@ -412,9 +414,11 @@ describe('happy-path shapes', () => {
   });
 
   it('getLearnedTheme still throws on any OTHER failure — unknown doc, dead bridge', async () => {
-    // An unknown doc is an express-default 404 (no JSON error to match) — a real error.
+    // An unknown doc is an express-default 404 (no JSON error to match) — a real
+    // error, thrown in the EC33 translated frame carrying the service's sentence.
     stubFetch('Cannot GET /d/absent/api/theme/learned', 404);
-    await expect(getLearnedTheme(PROJECT, 'absent')).rejects.toThrow(/404/);
+    await expect(getLearnedTheme(PROJECT, 'absent')).rejects.toThrow(
+      'the daemon refused this — Cannot GET /d/absent/api/theme/learned');
     // A dead bridge stays the typed 503, exactly as every other wrapper.
     stubFetch({ code: 'bridge_unavailable', hint: 'npm i -g wicked-interactive' }, 503);
     await expect(getLearnedTheme(PROJECT, DOC)).rejects.toBeInstanceOf(BridgeUnavailableError);

--- a/tests/scratchDoc.test.ts
+++ b/tests/scratchDoc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ensureScratchDoc, SCRATCH_DOC_NAME } from '../src/theming/scratchDoc.js';
 import type { DocSummary } from '../src/api/interactive.js';
+import { ApiError } from '../src/api/errors.js';
 
 /**
  * The per-project scratch doc a brand learn rides: created once through the
@@ -50,7 +51,7 @@ describe('ensureScratchDoc', () => {
 
   it('a concurrent 409 ("doc already exists") resolves to the doc, not an error', async () => {
     const listDocs = vi.fn().mockResolvedValue([]);
-    const createDoc = vi.fn().mockRejectedValue(new Error('API 409: doc already exists'));
+    const createDoc = vi.fn().mockRejectedValue(new ApiError(409, 'doc already exists'));
     await expect(ensureScratchDoc('proj-1', { listDocs, createDoc }))
       .resolves.toBe(SCRATCH_DOC_NAME);
   });


### PR DESCRIPTION
Implements **DES-UX-001 §7.3 + §7.10 (slice X2)** — affordance honesty + the copy pass (BRIEF-UX-001 B6 + D; EC33, EC45).

- The apiFetch error-translation layer: no raw wire error reaches the DOM — every daemon refusal surfaces as a named cause or the honest translated fallback, generalizing slice R's named-cause pattern; translation preserves the cause, never hides failure.
- Disabled controls say why, in operator language, with the next step (EC45); quoted-name extraction; display names/paths/grammar/hydration fixes per §7.10.
- R's and V's pinned strings routed through the shared layer byte-identically (their rigs prove it).

Verified: slice rig green with raw wire strings asserted absent DOM-wide; regressions ux_sliceR (exact named-cause strings), ux_sliceV, feedback2_sliceI, feedback3_sliceN; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
