### PR TITLE
DES-UX-001 slice Z: live execution + bookmarkability

### DIFF
--- a/e2e/ux_sliceZ_test.py
+++ b/e2e/ux_sliceZ_test.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+ux_sliceZ_test.py — the DES-UX-001 slice-Z gate: live execution +
+bookmarkability (§7.6, C3 — "between 'Run started' and the verdict nothing
+streams; the Term tab is an empty shell during runs; after Send the URL stays
+/build/new so a refresh mid-run drops to a blank composer") + EC41 ("Running
+means visible: between start and verdict, something true streams on the run's
+own page").
+
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the
+`project_dto` corpus on (POST /runs is a REAL launch — the daemon's {runId}
+answer, the run riding the next GET /runs). The live frames are the fixture's
+REAL relay shape: `unitOutputDelta` over the rig's own /ws — the standing
+r-upload narration loop plus one-shot `extra_narration` dicts targeted at the
+run this rig launches ({session, ord, text} — the slice-Z fixture extension).
+
+The §7.6 DOM ACs, verbatim mapping:
+
+  1. submitting the composer changes `location.pathname` to the run's URL
+     before first paint of the run view — the composer is GONE the moment the
+     path flips (what renders under the run URL is the honest pending state or
+     the run view, never `launch-problem`), and history BACK returns to the
+     composer;
+  2. with the fixture dripping `unitOutputDelta` frames,
+     `[data-testid="live-output"]` renders text within one frame cycle and
+     grows monotonically (two one-shot drips, length strictly increases, both
+     lines present) — asserted on the run view AND inside the Term tab's
+     `term-transcript` (the same region, one component, never an empty shell);
+     the region carries the honest label verbatim ("Live output — the full
+     transcript lands when the unit completes.");
+  3. a reload mid-drip re-renders the run view (not the composer) with the
+     live region resuming — the bookmarked run URL is the reload target;
+  + the honest unresolved state (§7.6 banked contract): a run URL the index
+    does not serve renders `run-pending` — never the composer.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-Z-live-output.png   the executing run's own page, live region streaming
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4397),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4397"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# The fixture's standing live run (executing, cursor unit ord 0 still `pending`
+# on the DTO — exactly the status-flip-trails-the-deltas case EC41 exists for);
+# its /ws loop drips one narration line per second. Filed in upload-endpoint,
+# so the bookmarked flat URL redirects INTO the shell (§1.5) — the shell path
+# is the stable reload target.
+UPLOAD_THREAD = "/p/upload-endpoint/build/r-upload"
+
+LAUNCH_INTENT = "wire the webhook retry backoff"
+HONEST_LABEL = "Live output — the full transcript lands when the unit completes."
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, real launches on ─────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, project_dto=True, orphan=False)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+# What renders under a run URL: 'composer' must NEVER appear once the path
+# names a run (the C3 defect); 'pending' and 'thread' are both honest.
+SURFACE_EXPR = """() => ({
+  path: window.location.pathname,
+  composer: !!document.querySelector('[data-testid="launch-problem"]'),
+  pending: !!document.querySelector('[data-testid="run-pending"]'),
+  thread: !!document.querySelector('[data-testid="thread"]'),
+})"""
+
+LIVE_TEXT_EXPR = """() => {
+  const region = document.querySelector('[data-testid="live-output"]');
+  if (!region) return null;
+  const label = region.querySelector('[data-testid="live-output-label"]');
+  const pre = region.querySelector('pre');
+  return { label: label?.textContent ?? null,
+           text: pre?.textContent ?? '',
+           len: (pre?.textContent ?? '').length };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    def surface() -> dict:
+        return page.evaluate(SURFACE_EXPR)
+
+    # ── Scene 1 (AC 1): launch → the run's URL, composer gone, back returns ────
+    page.goto(f"{ORIGIN}/runs/new", wait_until="domcontentloaded")
+    page.locator('[data-testid="launch-problem"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="launch-problem"]').fill(LAUNCH_INTENT)
+    page.locator('[data-testid="launch-submit"]').click()
+
+    # The path flips to the run's URL — and the FIRST surface painted under it
+    # is honest: pending state or run view, never the composer.
+    navigated = settled(
+        """() => window.location.pathname === '/runs/r-launched-1'
+              && !document.querySelector('[data-testid="launch-problem"]')
+              && (!!document.querySelector('[data-testid="run-pending"]')
+                  || !!document.querySelector('[data-testid="thread"]'))""",
+        timeout=15000)
+    check("launch_navigates_to_run_url", navigated, **surface())
+
+    # The run view itself resolves (one live-update cycle: the debounced
+    # GET /runs the launch triggered lists r-launched-1).
+    resolved = settled(
+        """() => window.location.pathname === '/runs/r-launched-1'
+              && !!document.querySelector('[data-testid="thread"]')""",
+        timeout=15000)
+    check("run_view_resolves", resolved, **surface())
+
+    # History honesty: BACK returns to the composer (pushState, never replace).
+    page.go_back()
+    back_ok = settled(
+        """() => window.location.pathname === '/runs/new'
+              && !!document.querySelector('[data-testid="launch-problem"]')""",
+        timeout=15000)
+    check("back_returns_to_composer", back_ok, **surface())
+
+    # ── Scene 2 (AC 2, run view): real unitOutputDelta frames render within one
+    #    frame cycle and grow monotonically ─────────────────────────────────────
+    # The bookmarked run URL, cold (a full load — the runtime store starts
+    # empty; every byte the region shows arrives over /ws from here on).
+    page.goto(f"{ORIGIN}/runs/r-launched-1", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # No frames yet: the live region is absent, not a fake placeholder.
+    pre_drip = page.evaluate(LIVE_TEXT_EXPR)
+    check("live_region_absent_before_frames", pre_drip is None, pre_drip=pre_drip)
+
+    # Drip 1 — one REAL frame at the launched run (the /ws loop drains
+    # extra_narration once per ~1s tick; one frame cycle + margin).
+    t0 = time.time()
+    set_fixture(ORIGIN, extra_narration=[
+        {"session": "r-launched-1", "ord": 0, "text": "Z-LIVE-alpha: probing retry backoff"}])
+    first = settled(
+        """() => {
+          const pre = document.querySelector('[data-testid="live-output"] pre');
+          return !!pre && pre.textContent.includes('Z-LIVE-alpha');
+        }""",
+        timeout=10000)
+    drip1 = page.evaluate(LIVE_TEXT_EXPR)
+    check("live_region_renders_first_frame",
+          first and drip1 is not None and drip1["label"] == HONEST_LABEL,
+          seconds_to_render=round(time.time() - t0, 2), **(drip1 or {}))
+
+    # Drip 2 — the region grows MONOTONICALLY: strictly longer, both lines kept.
+    set_fixture(ORIGIN, extra_narration=[
+        {"session": "r-launched-1", "ord": 0, "text": "Z-LIVE-beta: backoff curve applied"}])
+    grew = settled(
+        """(prevLen) => {
+          const pre = document.querySelector('[data-testid="live-output"] pre');
+          return !!pre && pre.textContent.length > prevLen
+              && pre.textContent.includes('Z-LIVE-alpha')
+              && pre.textContent.includes('Z-LIVE-beta');
+        }""",
+        arg=drip1["len"], timeout=10000)
+    drip2 = page.evaluate(LIVE_TEXT_EXPR)
+    check("live_region_grows_monotonically",
+          grew and drip2["len"] > drip1["len"],
+          len_before=drip1["len"], len_after=drip2["len"])
+
+    # ── Scene 3 (AC 3): a reload mid-drip re-renders the run view, live region
+    #    resuming — never the composer ──────────────────────────────────────────
+    page.reload(wait_until="domcontentloaded")
+    after_reload = settled(
+        """() => !document.querySelector('[data-testid="launch-problem"]')
+              && (!!document.querySelector('[data-testid="run-pending"]')
+                  || !!document.querySelector('[data-testid="thread"]'))""",
+        timeout=15000)
+    check("reload_never_composer", after_reload, **surface())
+    page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    set_fixture(ORIGIN, extra_narration=[
+        {"session": "r-launched-1", "ord": 0, "text": "Z-LIVE-gamma: resumed after reload"}])
+    resumed = settled(
+        """() => {
+          const pre = document.querySelector('[data-testid="live-output"] pre');
+          return !!pre && pre.textContent.includes('Z-LIVE-gamma');
+        }""",
+        timeout=10000)
+    check("reload_live_region_resumes", resumed,
+          **(page.evaluate(LIVE_TEXT_EXPR) or {}), **surface())
+
+    # The honest unresolved state: a run URL the daemon does not serve renders
+    # run-pending (with the index loaded, the honest not-listed copy) — never
+    # the composer.
+    page.goto(f"{ORIGIN}/runs/r-ghost", wait_until="domcontentloaded")
+    ghost_ok = settled(
+        """() => !!document.querySelector('[data-testid="run-pending"]')
+              && !document.querySelector('[data-testid="launch-problem"]')""",
+        timeout=15000)
+    check("unknown_run_renders_pending", ghost_ok, **surface())
+
+    # ── Scene 4 (AC 2, Term tab): the SAME live region leads the Term modal —
+    #    never an empty shell mid-run ───────────────────────────────────────────
+    # The standing executing run: its /ws loop drips one narration line per
+    # second unprompted, so the run view streams on arrival (EC41 on a run
+    # whose cursor unit the DTO still calls `pending`).
+    page.goto(f"{ORIGIN}{UPLOAD_THREAD}", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    upload_live = settled(
+        """() => {
+          const pre = document.querySelector('[data-testid="live-output"] pre');
+          return !!pre && pre.textContent.length > 0;
+        }""",
+        timeout=15000)
+    check("standing_run_streams_on_run_view", upload_live,
+          **(page.evaluate(LIVE_TEXT_EXPR) or {}))
+
+    # ── Capture: the executing run's own page, live region streaming ───────────
+    page.screenshot(path=str(VSHOTS / "ux-Z-live-output.png"))
+
+    # The Term button announces the live record, and the modal leads with it.
+    page.locator("button[aria-label=\"View this run's live output\"]").click()
+    term = settled(
+        """() => {
+          const t = document.querySelector('[data-testid="term-transcript"]');
+          const pre = t?.querySelector('[data-testid="live-output"] pre');
+          return !!t && !!pre && pre.textContent.length > 0;
+        }""",
+        timeout=15000)
+    term_state = page.evaluate(
+        """() => {
+          const t = document.querySelector('[data-testid="term-transcript"]');
+          const label = t?.querySelector('[data-testid="live-output-label"]');
+          const len0 = t?.querySelector('[data-testid="live-output"] pre')?.textContent.length ?? 0;
+          return { label: label?.textContent ?? null, len: len0,
+                   title: Array.from(document.querySelectorAll('h2, h3, [role="dialog"] *'))
+                     .some(el => (el.textContent ?? '').trim() === "This run's live output") };
+        }""")
+    # The modal's region keeps streaming too (the loop drips ~1/s).
+    term_grows = settled(
+        """(prevLen) => {
+          const pre = document.querySelector(
+            '[data-testid="term-transcript"] [data-testid="live-output"] pre');
+          return !!pre && pre.textContent.length > prevLen;
+        }""",
+        arg=term_state["len"], timeout=10000)
+    check("term_tab_leads_with_live_region",
+          term and term_grows and term_state["label"] == HONEST_LABEL and term_state["title"],
+          **term_state)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -25,11 +25,13 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     Build stats footer has real data to gate on (default False)
   long_prompt     — one extra run with a very long problem rides the run list, to
                     prove intent-phrase truncation in pixels (default False)
-  extra_narration — a list of strings; each is drained ONCE by the /ws loop as a
-                    `unitOutputDelta` for r-upload (default []). The vision-slice-2
-                    rig posts one mid-page to prove the live feed updates from the
-                    shared store within the 2s AC — a NEW line, not the loop's
-                    repeated one.
+  extra_narration — a list; each entry is drained ONCE by the /ws loop as a
+                    `unitOutputDelta` (default []). A plain string keeps the
+                    historical target (r-upload ord 0 — the vision-slice-2 rig
+                    posts one mid-page to prove the live feed updates from the
+                    shared store within the 2s AC); a dict {session, ord?, text}
+                    targets any run — the slice-Z rig (DES-UX-001 §7.6) drips
+                    frames at the run it just launched over POST /runs.
   demo            — whether q3-review-deck's doc registry carries the recorded
                     `checkout-demo` (kind "demo") plus its spec / recording /
                     frames, so Video mode has a §5.6 surface to render (vision
@@ -1392,11 +1394,24 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # sessionFailed that mints a run_failed notification row).
                 for frame in frames_extra:
                     self.wfile.write(ws_frame(frame))
+                # A plain string keeps the historical shape (r-upload ord 0 —
+                # every standing rig); a dict targets {session, ord?, text} so
+                # the slice-Z rig can drip REAL frames at a run it just
+                # launched over POST /runs (DES-UX-001 §7.6 / EC41: the live
+                # region on the run's OWN page, not only the standing r-upload).
                 for line in extra:
-                    self.wfile.write(ws_frame({
-                        "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
-                        "text": str(line) + "\n",
-                    }))
+                    if isinstance(line, dict):
+                        self.wfile.write(ws_frame({
+                            "type": "unitOutputDelta",
+                            "session": line["session"],
+                            "ord": line.get("ord", 0),
+                            "text": str(line.get("text", "")) + "\n",
+                        }))
+                    else:
+                        self.wfile.write(ws_frame({
+                            "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                            "text": str(line) + "\n",
+                        }))
                 # Slice L (§8.4): one-shot awaitingHuman ARRIVALS a rig posted —
                 # the desktop-notification trigger is the live frame, never the
                 # cached-gate GET a page load reconciles.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
   const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate, search, pathname } = useRoute();
-  const { runs, refresh } = useRuns();
+  const { runs, refresh, loaded: runsLoaded } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestElicitation = useElicitationStore((s) => s.ingest);
   const ingestNotif = useNotificationStore((s) => s.ingest);
@@ -292,6 +292,11 @@ export function App(): React.ReactElement {
         onKill={onKill}
         navigate={navigate}
         launchProjectId={launchProjectId}
+        // Slice Z (§7.6): the route names a run the index has not resolved —
+        // a just-launched navigation or a mid-run reload racing GET /runs.
+        // ChatPanel holds the honest pending state, never the composer.
+        pendingRunId={selected === null ? runId : null}
+        runsLoaded={runsLoaded}
       />
     </div>
   );

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -38,6 +38,16 @@ interface Props {
    * field pre-fills with this project and LOCKS.
    */
   launchProjectId?: string | null;
+  /**
+   * DES-UX-001 §7.6 (slice Z): the run id the ROUTE names when `view` has not
+   * resolved from the run index yet — a just-launched run navigated to before
+   * the debounced `GET /runs` lands, or a bookmarked run reloaded mid-run.
+   * Non-null renders the honest opening/absent state, never the composer
+   * ("a refresh mid-run drops to a blank composer" is the C3 defect).
+   */
+  pendingRunId?: string | null;
+  /** Whether the run index has completed at least one fetch (useRuns.loaded). */
+  runsLoaded?: boolean;
 }
 
 // Agent identity under the token contract (DES-VISION-001 §2.11): one
@@ -201,8 +211,15 @@ const NARRATION_TAIL = 4096;
  * and windowed to the trailing ~{@link NARRATION_TAIL} bytes so a chatty
  * worker never grows the thread's DOM unbounded (the store keeps its own
  * larger cap for the full-output consumers).
+ *
+ * Exported for the Term tab (DES-UX-001 §7.6, slice Z): during a live run the
+ * terminal modal shows this SAME region — one live-output component, two
+ * mounts, never a fork. The streamed region carries `data-testid="live-output"`
+ * (EC41: between start and verdict, something true streams on the run's own
+ * page) and the honest label for what the deltas are — relayed live output,
+ * not the durable transcript (§13: richer streaming is a crew concern).
  */
-function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phase: string }): React.ReactElement {
+export function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phase: string }): React.ReactElement {
   const live = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
   const [visible, setVisible] = useState(true);
   const scrollRef = useRef<HTMLPreElement>(null);
@@ -236,15 +253,28 @@ function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phas
           </button>
         )}
       </div>
-      {hasText && visible && (
-        <pre
-          ref={scrollRef}
-          data-testid={`live-narration-text-${ord}`}
-          className="mt-2 max-h-64 overflow-auto rounded-lg p-2.5 text-[11px] leading-snug whitespace-pre-wrap break-words font-mono"
-          style={{ background: 'var(--surface-base)', color: 'var(--ink-body)', border: '1px solid var(--surface-raised)' }}
-        >
-          {tail}
-        </pre>
+      {hasText && (
+        <div data-testid="live-output" className="mt-2">
+          {/* The honest label (§7.6): what streams is the relayed delta feed,
+              not the durable record — say exactly that, house grammar. */}
+          <p
+            data-testid="live-output-label"
+            className="mb-1 text-[10px] font-mono"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            Live output — the full transcript lands when the unit completes.
+          </p>
+          {visible && (
+            <pre
+              ref={scrollRef}
+              data-testid={`live-narration-text-${ord}`}
+              className="max-h-64 overflow-auto rounded-lg p-2.5 text-[11px] leading-snug whitespace-pre-wrap break-words font-mono"
+              style={{ background: 'var(--surface-base)', color: 'var(--ink-body)', border: '1px solid var(--surface-raised)' }}
+            >
+              {tail}
+            </pre>
+          )}
+        </div>
       )}
     </div>
   );
@@ -737,13 +767,18 @@ function RunChat({
   // The conversational timeline holds ONLY phases that have run or are running (rejected counts:
   // it ran far enough to be judged). Future work is the stepper's job — a queued unit used to
   // render one tall, empty "Not started" block per phase, which is what the operator flagged.
+  //
+  // The CURSOR unit of an executing run enters regardless of its own status (DES-UX-001
+  // §7.6, slice Z / EC41): a run can be executing while its cursor unit still reads
+  // `pending` on the DTO (the status flip trails the deltas on the wire), and gating the
+  // live region on `distributed` alone left exactly that run's page silent while its
+  // output streamed. `executingOrd` already returns null for a finished cursor, so this
+  // never adds a done/rejected duplicate — and still only the ONE cursor unit, never the
+  // queue (FINDING-052 holds).
   const timeline = useMemo(
     () =>
       ordered.filter(
-        (u) =>
-          u.status === 'done' ||
-          u.status === 'rejected' ||
-          (u.status === 'distributed' && u.ord === executingUnitOrd),
+        (u) => u.status === 'done' || u.status === 'rejected' || u.ord === executingUnitOrd,
       ),
     [ordered, executingUnitOrd],
   );
@@ -1068,10 +1103,12 @@ function RunChat({
                   className="rounded-2xl px-5 py-4"
                   style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
                 >
-                  {/* A `distributed` unit is in the timeline ONLY as the cursor unit of an
+                  {/* A non-terminal unit is in the timeline ONLY as the cursor unit of an
                       executing run (FINDING-052: distributed = routed, not running — queued
-                      units live in the stepper now, never as thread blocks). */}
-                  {unit.status === 'distributed' && (
+                      units live in the stepper now, never as thread blocks). Slice Z widens
+                      the cursor's live region past `distributed`: a pending-status cursor of
+                      an executing run streams too (EC41). */}
+                  {unit.status !== 'done' && unit.status !== 'rejected' && (
                     <LiveNarration runId={session.id} ord={unit.ord} phase={phaseName(session.id, unit)} />
                   )}
                   {unit.status === 'done' && (
@@ -1219,6 +1256,55 @@ function RunChat({
   );
 }
 
+/**
+ * The route names a run the index has not resolved (DES-UX-001 §7.6, slice Z):
+ * a just-launched run whose debounced `GET /runs` reconcile is still in flight,
+ * or a bookmarked/reloaded mid-run URL racing the first fetch. Renders the
+ * honest holding state — never the composer (the C3 "refresh mid-run drops to
+ * a blank composer" defect). Zero requests of its own: the run index App
+ * already owns is the one wire, and the same live-update cycle that lists the
+ * run swaps this for the run view.
+ */
+function RunPendingView({ runId, runsLoaded, navigate }: {
+  runId: string;
+  runsLoaded: boolean;
+  navigate?: (path: string) => void;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col h-full items-center justify-center" data-testid="run-pending">
+      <div className="flex flex-col items-center gap-3 max-w-md px-8 text-center">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full animate-pulse"
+          style={{ background: 'var(--status-run)' }}
+          aria-hidden="true"
+        />
+        <p className="text-sm font-mono" style={{ color: 'var(--ink-body)' }}>
+          Opening run <span className="font-semibold" style={{ color: 'var(--ink-high)' }}>{runId}</span>
+        </p>
+        <p className="text-xs font-mono leading-relaxed" style={{ color: 'var(--ink-dim)' }}>
+          {runsLoaded
+            ? 'Not in the run index yet — a just-launched run appears within one live-update cycle; an id the daemon no longer serves will not.'
+            : 'Fetching the run index…'}
+        </p>
+        {runsLoaded && (
+          <a
+            href="/work"
+            className="text-xs font-mono underline transition-opacity hover:opacity-70"
+            style={{ color: 'var(--ink-muted)' }}
+            onClick={(e) => {
+              if (navigate === undefined) return;
+              e.preventDefault();
+              navigate('/work');
+            }}
+          >
+            All runs ›
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function NewRunView({
   chatMode,
   mode,
@@ -1268,7 +1354,7 @@ function NewRunView({
   );
 }
 
-export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill, navigate, launchProjectId = null }: Props): React.ReactElement {
+export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefresh, onKill, navigate, launchProjectId = null, pendingRunId = null, runsLoaded = false }: Props): React.ReactElement {
   const [mode, setMode] = useState<RunMode>('balanced');
 
   if (view) {
@@ -1297,6 +1383,17 @@ export function ChatPanel({ view, chatMode, onLaunched, onNavigateBack, onRefres
         onNavigateBack={onNavigateBack}
         onRefresh={onRefresh}
         {...(onKill !== undefined ? { onKill } : {})}
+        {...(navigate !== undefined ? { navigate } : {})}
+      />
+    );
+  }
+  // The route names a run the index has not resolved (slice Z): hold with the
+  // honest pending state — never fall through to the composer under a run URL.
+  if (pendingRunId !== null) {
+    return (
+      <RunPendingView
+        runId={pendingRunId}
+        runsLoaded={runsLoaded}
         {...(navigate !== undefined ? { navigate } : {})}
       />
     );

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
+import { executingOrd } from '../api/run-state.js';
 import type { SessionView } from '../api/types.js';
 import { useRunModel } from '../hooks/useRunModel.js';
 import type { RunModel } from '../hooks/useRunModel.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
+import { LiveNarration } from './ChatPanel.js';
 import { Burn } from './Burn.js';
 import { FileViewer } from './FileViewer.js';
 import { CoverageView } from './CoverageView.js';
@@ -213,10 +215,17 @@ function FilePath({ path, opKind, runId, root }: {
  * Fetches ride the same sanctioned wire the run view uses
  * (`GET /runs/:id/units/:unitKey/output`), gesture-gated on opening the modal.
  */
-function RunTranscriptView({ runId, units, onOpenShell }: {
+function RunTranscriptView({ runId, units, onOpenShell, live = null }: {
   runId: string;
   units: SessionView['units'];
   onOpenShell: () => void;
+  /**
+   * Slice Z (DES-UX-001 §7.6): the executing cursor unit, when the run is live —
+   * the modal leads with the SAME `unitOutputDelta` live region the run thread
+   * renders (LiveNarration, one component, never a fork), so the Term tab is
+   * never an empty shell mid-run. Null for terminal runs: captured-only.
+   */
+  live?: { ord: number; phase: string } | null;
 }): React.ReactElement {
   const captured = [...units]
     .filter((u) => u.status === 'done' || u.status === 'rejected')
@@ -246,6 +255,9 @@ function RunTranscriptView({ runId, units, onOpenShell }: {
 
   return (
     <div data-testid="term-transcript" className="flex flex-col gap-3 max-h-[60vh] overflow-y-auto">
+      {live !== null && (
+        <LiveNarration runId={runId} ord={live.ord} phase={live.phase} />
+      )}
       {captured.map((unit) => (
         <div key={unit.id}>
           <p className="text-[10px] font-mono mb-1 uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>
@@ -514,12 +526,16 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
         <button
           type="button"
           onClick={() => setTermOpen(true)}
-          title={view.units.some((u) => u.status === 'done' || u.status === 'rejected')
-            ? "View this run's transcript"
-            : 'Terminal'}
-          aria-label={view.units.some((u) => u.status === 'done' || u.status === 'rejected')
-            ? "View this run's transcript"
-            : 'Open terminal'}
+          title={executingOrd(session, view.units) !== null
+            ? "View this run's live output"
+            : view.units.some((u) => u.status === 'done' || u.status === 'rejected')
+              ? "View this run's transcript"
+              : 'Terminal'}
+          aria-label={executingOrd(session, view.units) !== null
+            ? "View this run's live output"
+            : view.units.some((u) => u.status === 'done' || u.status === 'rejected')
+              ? "View this run's transcript"
+              : 'Open terminal'}
           className="rounded px-2 py-0.5 text-[11px] font-mono"
           style={{ color: 'var(--ink-muted)' }}
         >
@@ -593,15 +609,23 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
         ))}
       </div>
 
-      {/* Terminal modal — transcript-first when captured output exists (§1.3-4):
-          a diagnosing operator lands on the run's own record, never on an empty
-          shell by default. */}
+      {/* Terminal modal — transcript-first when captured output exists (§1.3-4),
+          and LIVE-first while the run executes (DES-UX-001 §7.6, slice Z): a
+          diagnosing operator lands on the run's own record — streamed or
+          captured — never on an empty ungoverned shell by default. The shell
+          stays the labeled secondary inside RunTranscriptView. */}
       {termOpen && (() => {
         const hasCaptured = view.units.some((u) => u.status === 'done' || u.status === 'rejected');
-        const showTranscript = hasCaptured && !termShell;
+        // The executing cursor unit (null unless the run is executing — the
+        // same derivation the run thread's live region keys on).
+        const liveUnitOrd = executingOrd(session, view.units);
+        const liveUnit = view.units.find((u) => u.ord === liveUnitOrd);
+        const showTranscript = (hasCaptured || liveUnitOrd !== null) && !termShell;
         return (
           <Modal
-            title={showTranscript ? "This run's transcript" : 'Operator shell'}
+            title={showTranscript
+              ? (liveUnitOrd !== null ? "This run's live output" : "This run's transcript")
+              : 'Operator shell'}
             onClose={() => { setTermOpen(false); setTermShell(false); }}
             disableEscapeKey
           >
@@ -610,6 +634,9 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                 runId={session.id}
                 units={view.units}
                 onOpenShell={() => setTermShell(true)}
+                live={liveUnitOrd !== null
+                  ? { ord: liveUnitOrd, phase: liveUnit?.stage ?? `unit #${liveUnitOrd}` }
+                  : null}
               />
             ) : (
               <Terminal

--- a/src/hooks/useRuns.ts
+++ b/src/hooks/useRuns.ts
@@ -20,12 +20,16 @@ import { useElicitationStore } from '../store/elicitations.js';
  * pool from being saturated by stacked actor-bound requests, which would starve
  * concurrent read-only operations (getCoverageReport, listConformanceRules, etc.).
  */
-export function useRuns(): { runs: SessionView[]; refresh: () => void } {
+export function useRuns(): { runs: SessionView[]; refresh: () => void; loaded: boolean } {
   const status = useConnectionStore((s) => s.status);
   const setGate = useGateStore((s) => s.setGate);
   const reconcileGates = useGateStore((s) => s.reconcile);
   const reconcileElicitations = useElicitationStore((s) => s.reconcile);
   const [runs, setRuns] = useState<SessionView[]>([]);
+  // Slice Z (DES-UX-001 §7.6): whether at least one GET /runs has RESOLVED —
+  // lets a route naming an unlisted run distinguish "index still in flight"
+  // from "the daemon does not serve this id" (the honest pending copy).
+  const [loaded, setLoaded] = useState(false);
   const [tick, setTick] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -58,6 +62,7 @@ export function useRuns(): { runs: SessionView[]; refresh: () => void } {
       }
       if (cancelled) return;
       setRuns(fetched);
+      setLoaded(true);
 
       const awaiting = fetched
         .filter((v) => v.session.status === 'awaiting_human')
@@ -95,5 +100,5 @@ export function useRuns(): { runs: SessionView[]; refresh: () => void } {
     };
   }, [status, tick, setGate, reconcileGates, reconcileElicitations]);
 
-  return { runs, refresh };
+  return { runs, refresh, loaded };
 }


### PR DESCRIPTION
Implements **DES-UX-001 §7.6 (slice Z)** — live execution + bookmarkability (BRIEF-UX-001 C3, EC41).

- A live region (`data-testid="live-output"` with the honest label) on the run view and Term tab via one exported LiveNarration — real `unitOutputDelta` frames from the existing /ws relay, no invented streaming; pending-status cursor admitted; a run URL never falls back to the composer (honest run-pending state).
- Launch→run-URL navigation confirmed pre-existing on main (audited, not duplicated); back returns to the composer.

Verified: 1364/1364 unit tests; slice rig green twice (first real frame in ~1s, monotonic growth, mid-drip reload resumes, unknown-id honest pending, Term modal leads with the stream); regressions R/V/Y/AA/sliceN + vision_slice2; negative check fails on main at the first live-region assertion; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
