### PR TITLE
DES-UX-001 slice X: act-feedback — export + theme-learn

### DIFF
--- a/e2e/ux_sliceX_test.py
+++ b/e2e/ux_sliceX_test.py
@@ -127,6 +127,12 @@ with sync_playwright() as p:
     set_fixture(ORIGIN, export_delay_ms=1500)
     goto_doc()
     wake_strip(page)
+    # §7.3: the thread is a DRAWER, closed by default when a doc is open — WHY the
+    # click site must answer (EC37). Open it so AC 1's "the thread message remains"
+    # is checked against a visible transcript (and the shot shows both truths).
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread"]').wait_for(timeout=15000)
+    wake_strip(page)
     html_btn = page.locator('[data-testid="export-format"][data-format="html"]')
     html_btn.wait_for(timeout=15000)
     html_btn.click()

--- a/e2e/ux_sliceX_test.py
+++ b/e2e/ux_sliceX_test.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+ux_sliceX_test.py — the DES-UX-001 slice-X gate: act-feedback for export +
+theme-learn (§7.2, the campaign's B5 MAJOR — "Clicking HTML export fires the
+API call but nothing visible happens at the button… a theme learn from a
+trivial URL narrated 'Grabbing the page…' then hung 10+ minutes with no
+progress, timeout, or error").
+
+EC37, mechanically enforced: the control you clicked answers — pending,
+ready, or failed — WHERE you clicked it.
+
+The §7.2 DOM ACs, verbatim mapping:
+
+  1. clicking an export format renders `[data-testid="export-pending"]` on
+     THAT control (the fixture's `export_delay_ms` slows the render so the
+     state is witnessable) and resolves to `[data-testid="export-ready"]` —
+     a REAL download affordance (an anchor whose same-origin href serves the
+     artifact bytes with a Content-Disposition attachment) — at the click
+     site. The thread message remains (§4.4): the click site answering never
+     replaces the transcript's record.
+  2. a refused export (the bridge's real pptx lazy-dependency 400) answers
+     at the click site too: the service's install command verbatim in
+     `[data-testid="export-hint"]`, with the retriable row re-enabled above.
+  3. a theme learn renders `[data-testid="learn-inflight"]` in the Themes
+     popover, staging the bridge's OWN status frame ("Grabbing the page…" —
+     the announce stream, no new wires) — then resolves to `learn-done` when
+     the readback (GET /api/theme/learned, interactive#181) ripens.
+  4. a learn the bridge REFUSES (§8.4.1 probe 4's lifecycle truth,
+     re-verified at slice time against handlers.js materializeThemeRequested:
+     exactly one doc-scoped `status.posted {state:"error", message}`) resolves
+     the popover to `learn-error` carrying the bridge's own sentence VERBATIM,
+     with a retry — never a timeout shrug when the bridge actually spoke.
+  5. on fixture-simulated silence (`learn_silent` — the ack lands, then
+     NOTHING: the brief's real failure mode), the wait resolves to
+     `[data-testid="learn-timeout"]` with retry within the budget (the
+     learnPoll hard cap, ~66s) — never an unresolved "Grabbing…" past it.
+     This scene rides the REAL production schedule: no shortened test seam,
+     so the rig witnesses the actual bound a user would.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into
+e2e/shots/vision/:
+  ux-X-export-ready.png   the version strip: the clicked HTML control now IS
+                          the download (accent anchor), the thread's export
+                          message beside it.
+  ux-X-learn-timeout.png  the Themes popover: the honest timeout copy + Retry
+                          after the bounded wait on a silent bridge.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4388),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+
+NOTE scene 5 waits out the real ~66s poll cap — this rig runs ~2 minutes.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4388"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+PID = "scratch"
+DOC = "uxr-q3-brief"
+
+# The copy contract (§7.2): the client's honest-timeout sentence — shaped to the
+# probe-4 truth that a learn the bridge KNOWS failed reports itself (scene 4),
+# so a timeout only ever means silence. Pinned verbatim against ThemesMenu.tsx.
+TIMEOUT_COPY = ("The learn did not report back — the bridge may still be "
+                "working; retry, or check the thread for progress.")
+
+# The bridge's real pptx lazy-dependency refusal (uxfix_fixture.PPTX_MISSING_ERROR
+# mirrors server.js's catch: 400 {error} with pptx.js's install command inside).
+PPTX_HINT_FRAGMENT = "pip install python-pptx"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── The same-origin build + the shared W2 fixture ──────────────────────────────
+dist = ensure_build(lambda step, why: check(step, False, error=why))
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+# Setup, not the certified journey (slice 6's rig certifies composer-create):
+# the doc this slice's controls act on, created on the real create wire.
+req = urllib.request.Request(
+    f"{ORIGIN}/api/v1/projects/{PID}/interactive/api/docs", method="POST",
+    data=json.dumps({"name": DOC, "brief": "Q3 review one-pager"}).encode())
+req.add_header("Content-Type", "application/json")
+with urllib.request.urlopen(req, timeout=10) as res:
+    created = json.loads(res.read())
+check("doc_created", created.get("name") == DOC, created=created)
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def goto_doc() -> None:
+        page.goto(f"{ORIGIN}/p/{PID}/document/{DOC}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+
+    # ── Scene 1 (AC 1): export answers PENDING then READY at the click site ────
+    set_fixture(ORIGIN, export_delay_ms=1500)
+    goto_doc()
+    wake_strip(page)
+    html_btn = page.locator('[data-testid="export-format"][data-format="html"]')
+    html_btn.wait_for(timeout=15000)
+    html_btn.click()
+    # PENDING lives ON the clicked control — inside the html button, no other.
+    page.locator('[data-testid="export-pending"]').wait_for(timeout=5000)
+    pending = page.evaluate(
+        """() => {
+             const pend = document.querySelector('[data-testid="export-pending"]');
+             const host = pend?.closest('[data-testid="export-format"]');
+             const others = Array.from(
+               document.querySelectorAll('[data-testid="export-format"]'))
+               .filter(b => b.getAttribute('data-format') !== 'html');
+             return { onClickedControl: host?.getAttribute('data-format') === 'html',
+                      siblingsHeld: others.length > 0 && others.every(b => b.disabled) };
+           }""")
+    check("export_pending_at_click_site",
+          pending["onClickedControl"] and pending["siblingsHeld"], **pending)
+
+    # READY: the control that was clicked IS the download now — a real anchor.
+    ready = page.locator('[data-testid="export-ready"][data-format="html"]')
+    ready.wait_for(timeout=15000)
+    facts = page.evaluate(
+        """() => {
+             const a = document.querySelector('[data-testid="export-ready"]');
+             // The transcript's record (§4.4): the export lands as an agent message
+             // (doc-agent) with its own download affordance — the click site
+             // answering never replaces it.
+             const inThread = Array.from(
+               document.querySelectorAll('[data-testid="doc-agent"]'))
+               .some(m => /export ready/i.test(m.textContent || '')
+                          && !!m.querySelector('[data-testid="doc-artifact-download"]'));
+             return { tag: a?.tagName ?? null, href: a?.getAttribute('href') ?? null,
+                      file: a?.getAttribute('download') ?? null,
+                      sameOrigin: (a?.href ?? '').startsWith(location.origin),
+                      threadMessageRemains: inThread };
+           }""")
+    check("export_ready_is_real_anchor",
+          facts["tag"] == "A" and facts["sameOrigin"]
+          and facts["file"] == f"{DOC}_v1.html"
+          and facts["threadMessageRemains"], **facts)
+
+    # The affordance is REAL: its href serves the artifact bytes, attachment-framed.
+    dl = page.request.get(f"{ORIGIN}{facts['href']}" if facts["href"].startswith("/")
+                          else facts["href"])
+    check("export_ready_href_serves_bytes",
+          dl.status == 200
+          and "attachment" in (dl.headers.get("content-disposition") or "")
+          and len(dl.body()) > 0,
+          status=dl.status, disposition=dl.headers.get("content-disposition"))
+
+    page.screenshot(path=str(VSHOTS / "ux-X-export-ready.png"))
+
+    # ── Scene 2 (AC 2): a refused export answers FAILED at the click site ──────
+    set_fixture(ORIGIN, export_delay_ms=0, export_pptx_missing=True)
+    wake_strip(page)
+    page.locator('[data-testid="export-format"][data-format="pptx"]').click()
+    hint = page.locator('[data-testid="export-hint"]')
+    hint.wait_for(timeout=15000)
+    failed = page.evaluate(
+        """() => {
+             const hint = document.querySelector('[data-testid="export-hint"]');
+             const rows = Array.from(
+               document.querySelectorAll('[data-testid="export-format"]'));
+             return { hint: hint?.textContent ?? null,
+                      retriable: rows.length > 0 && rows.every(b => !b.disabled) };
+           }""")
+    check("export_failed_at_click_site",
+          PPTX_HINT_FRAGMENT in (failed["hint"] or "") and failed["retriable"],
+          **failed)
+    set_fixture(ORIGIN, export_pptx_missing=False)
+
+    # ── Scene 3 (AC 3): learn answers IN-FLIGHT (staged) then DONE ─────────────
+    set_fixture(ORIGIN, learn_delay_s=4)  # long enough to witness the stage line
+    wake_strip(page)
+    page.locator('[data-testid="themes-open"]').click()
+    page.locator('[data-testid="themes-panel"]').wait_for(timeout=15000)
+    page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
+    page.locator('[data-testid="themes-submit"]').click()
+    page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
+    # Staged progress is the bridge's OWN status frame, no rotating filler.
+    page.locator('[data-testid="learn-stage"]').wait_for(timeout=15000)
+    inflight = page.evaluate(
+        """() => ({
+             stage: document.querySelector('[data-testid="learn-stage"]')?.textContent ?? null,
+             trigger: document.querySelector('[data-testid="themes-open"]')?.textContent ?? null,
+             inputHeld: !!document.querySelector('[data-testid="themes-input"]')?.disabled,
+           })""")
+    check("learn_inflight_stages_bridge_frame",
+          "Grabbing the page" in (inflight["stage"] or "")
+          and "Themes…" in (inflight["trigger"] or "")
+          and inflight["inputHeld"], **inflight)
+
+    # DONE: the readback ripening is the one completion truth; the popover says so.
+    page.locator('[data-testid="learn-done"]').wait_for(timeout=90000)
+    check("learn_done_at_click_site", True)
+
+    # ── Scene 4 (AC 4): a learn the bridge REFUSES answers with ITS sentence ───
+    # §8.4.1 probe 4 (re-verified at slice time): one doc-scoped status.posted
+    # {state:"error"} — surfaced verbatim, never re-worded into the timeout copy.
+    wake_strip(page)  # §7.3 auto-hide owns the strip; clicks need it awake
+    page.locator('[data-testid="themes-input"]').fill("http://169.254.169.254/")
+    page.locator('[data-testid="themes-submit"]').click()
+    err = page.locator('[data-testid="learn-error"]')
+    err.wait_for(timeout=15000)
+    refusal = page.evaluate(
+        """() => ({
+             reason: document.querySelector('[data-testid="learn-error"]')?.textContent ?? null,
+             retry: !!document.querySelector('[data-testid="learn-retry"]'),
+             timedOut: !!document.querySelector('[data-testid="learn-timeout"]'),
+           })""")
+    check("learn_error_verbatim_with_retry",
+          "Couldn't grab that URL" in (refusal["reason"] or "")
+          and refusal["retry"] and not refusal["timedOut"], **refusal)
+
+    # ── Scene 5 (AC 5): SILENCE resolves to the honest timeout, in budget ──────
+    # learn_silent: the ack lands, then nothing — no status frame, no error, no
+    # readback. The client's bounded poll (~66s hard cap, the REAL schedule) is
+    # the only thing standing between the user and eternal narration.
+    set_fixture(ORIGIN, learn_silent=True, reset_learn=True)
+    wake_strip(page)
+    page.locator('[data-testid="themes-input"]').fill("https://slow.example/never")
+    page.locator('[data-testid="themes-submit"]').click()
+    page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
+    check("silent_learn_shows_inflight_first", True)
+
+    # Within the budget: the poll caps at ~66s — 100s here is the rig's margin,
+    # not the promise. Past the cap there must be NO unresolved in-flight state.
+    timeout_el = page.locator('[data-testid="learn-timeout"]')
+    timeout_el.wait_for(timeout=100000)
+    wake_strip(page)  # the long wait dimmed the strip — wake it for the capture
+    silence = page.evaluate(
+        """() => ({
+             copy: document.querySelector('[data-testid="learn-timeout"]')?.textContent ?? '',
+             retry: !!document.querySelector('[data-testid="learn-retry"]'),
+             stillInflight: !!document.querySelector('[data-testid="learn-inflight"]'),
+             triggerSettled: (document.querySelector('[data-testid="themes-open"]')
+                              ?.textContent ?? '').trim() === 'Themes',
+           })""")
+    check("silence_resolves_to_honest_timeout",
+          TIMEOUT_COPY in silence["copy"] and silence["retry"]
+          and not silence["stillInflight"] and silence["triggerSettled"],
+          **silence)
+
+    page.screenshot(path=str(VSHOTS / "ux-X-learn-timeout.png"))
+
+    # The retry is LIVE: with the bridge speaking again, the same control lands
+    # the learn — the §3.3 rule that a failure state always carries its own fix.
+    set_fixture(ORIGIN, learn_silent=False, reset_learn=True, learn_delay_s=0.75)
+    wake_strip(page)
+    page.locator('[data-testid="learn-retry"]').click()
+    page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
+    page.locator('[data-testid="learn-done"]').wait_for(timeout=90000)
+    check("timeout_retry_is_live", True)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_sliceX_test.py
+++ b/e2e/ux_sliceX_test.py
@@ -212,8 +212,13 @@ with sync_playwright() as p:
     page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
     page.locator('[data-testid="themes-submit"]').click()
     page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
-    # Staged progress is the bridge's OWN status frame, no rotating filler.
-    page.locator('[data-testid="learn-stage"]').wait_for(timeout=15000)
+    # Staged progress is the bridge's OWN status frame, no rotating filler. The
+    # client's send subject ("Queued — …") renders first; the bridge's frame
+    # SUPERSEDES it — wait for that supersession, the thing this AC is about.
+    page.wait_for_function(
+        """() => /Grabbing the page/.test(
+                 document.querySelector('[data-testid="learn-stage"]')?.textContent ?? '')""",
+        timeout=15000)
     inflight = page.evaluate(
         """() => ({
              stage: document.querySelector('[data-testid="learn-stage"]')?.textContent ?? null,

--- a/e2e/ux_sliceX_test.py
+++ b/e2e/ux_sliceX_test.py
@@ -268,6 +268,12 @@ with sync_playwright() as p:
     timeout_el = page.locator('[data-testid="learn-timeout"]')
     timeout_el.wait_for(timeout=100000)
     wake_strip(page)  # the long wait dimmed the strip — wake it for the capture
+    # …and let the strip's opacity transition FINISH: data-hidden flips at the
+    # start of the fade-in, and a capture mid-fade ghosts the popover.
+    page.wait_for_function(
+        """() => getComputedStyle(
+                 document.querySelector('[data-testid="version-strip"]')).opacity === '1'""",
+        timeout=10000)
     silence = page.evaluate(
         """() => ({
              copy: document.querySelector('[data-testid="learn-timeout"]')?.textContent ?? '',

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -286,6 +286,20 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # rows join GET /projects. Default False: no standing rig's project
          # list grows a row it never asserted.
          "project_create": False,
+         # Slice X (DES-UX-001 §7.2): how long POST /d/:doc/api/export takes
+         # before answering the REAL {format, path, file, download} shape —
+         # 0 (default) keeps it instant; >0 lets a rig witness export-pending.
+         "export_delay_ms": 0,
+         # Slice X (§7.2 / DES-MERGE-001 §4.4): when True, a pptx export
+         # answers the bridge's real lazy-dependency refusal — server.js's
+         # catch is `400 {error: e.message}` with pptx.js's install command
+         # in the message (no separate hint field on this wire).
+         "export_pptx_missing": False,
+         # Slice X (§7.2): when True, theme.requested still acks {ok,...} but
+         # the bridge then says NOTHING — no status frame, no theme.learned,
+         # no readback ripening. The brief's real failure mode (a learn that
+         # hangs silently), for the client's bounded-timeout branch.
+         "learn_silent": False,
          }
 state_lock = threading.Lock()
 
@@ -1252,6 +1266,30 @@ def schedule_doc_run(pid: str, doc: str, delay_s: float, fixed_version: int | No
     threading.Timer(max(fire_at - time.time(), 0.0), land).start()
 
 
+# ── Slice X (DES-UX-001 §7.2): the REAL export wire, as server.js serves it ───
+#
+# POST /api/export (per-doc mount) answers `{format, path, file, download}` with
+# `download` bridge-root-relative (`/d/<doc>/api/export/file/<name>` — req.baseUrl
+# is the doc mount), and GET /api/export/file/:name serves the bytes with a
+# Content-Disposition attachment. The pptx lazy-dependency refusal is the bridge's
+# real catch shape: `400 {error}` carrying pptx.js's install command in the message.
+# Standing rigs never POST this route, so serving it changes no standing board.
+exports_lock = threading.Lock()
+exports_created: dict = {}  # (pid, doc, file) -> format
+
+PPTX_MISSING_ERROR = "PowerPoint export needs python-pptx — run: pip install python-pptx"
+
+
+def export_bytes(doc: str, version: int, fmt: str) -> bytes:
+    """The artifact's bytes — enough to make the download REAL (a saved file with
+    content), without faking a renderer the fixture does not have."""
+    if fmt == "html":
+        return doc_html(doc, version).encode()
+    if fmt == "pdf":
+        return b"%PDF-1.4\n% wicked-studio fixture export of " + doc.encode() + b"\n%%EOF\n"
+    return b"PK\x03\x04 wicked-studio fixture pptx export of " + doc.encode()
+
+
 def slug(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "doc"
 
@@ -1812,6 +1850,32 @@ class W2Handler(SimpleHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
             return True
+        # Slice X (§7.2): GET /d/<doc>/api/export/file/<name> — the artifact bytes,
+        # exactly as server.js serves them (Content-Disposition attachment), so the
+        # click site's ready affordance is a REAL download on the one origin (§5.3).
+        m = re.match(
+            r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/export/file/([^/]+)$", path)
+        if m:
+            pid, doc, name = (urllib.parse.unquote(g) for g in m.groups())
+            with exports_lock:
+                fmt = exports_created.get((pid, doc, name))
+            if fmt is None:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b"not found")
+                return True
+            version_m = re.search(r"_v(\d+)\.", name)
+            body = export_bytes(doc, int(version_m.group(1)) if version_m else 1, fmt)
+            ctype = {"pdf": "application/pdf",
+                     "pptx": "application/vnd.openxmlformats-officedocument"
+                             ".presentationml.presentation"}.get(fmt, "text/html; charset=utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Disposition", f'attachment; filename="{name}"')
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return True
         # /api/v1/projects/<pid>/interactive/d/<doc>/doc/<v> — the rendered document.
         # A DEMO's version HTML is its STORYBOARD (DES-FEEDBACK-001 §7.4): chapters and
         # the embedded recording live IN the document, exactly as the real bridge's
@@ -1900,6 +1964,40 @@ class W2Handler(SimpleHTTPRequestHandler):
         if m:
             self._json(404, {"error": f"no such route on the bridge: {path}"})
             return True
+        # Slice X (§7.2): POST /d/<doc>/api/export — the real export wire (see the
+        # module-level note). `export_delay_ms` slows the render so a rig can
+        # witness the pending state; `export_pptx_missing` answers the real 400.
+        m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/export$", path)
+        if m:
+            pid, doc = (urllib.parse.unquote(g) for g in m.groups())
+            version = body.get("version")
+            fmt = str(body.get("format") or "html").lower()
+            if not isinstance(version, int):
+                self._json(400, {"error": "version (number) required"})
+                return True
+            if fmt not in ("html", "pdf", "pptx"):
+                self._json(400, {"error": "format must be html, pdf, or pptx"})
+                return True
+            with state_lock:
+                delay_ms = int(state["export_delay_ms"])
+                pptx_missing = bool(state["export_pptx_missing"])
+            if delay_ms > 0:
+                time.sleep(delay_ms / 1000.0)  # the render, slowed for the rig
+            if fmt == "pptx" and pptx_missing:
+                self._json(400, {"error": PPTX_MISSING_ERROR})
+                return True
+            file = f"{doc}_v{version}.{fmt}"
+            with exports_lock:
+                exports_created[(pid, doc, file)] = fmt
+            download = f"/d/{doc}/api/export/file/{urllib.parse.quote(file)}"
+            result = {"format": fmt, "path": f"/docs/{doc}/exports/{file}",
+                      "file": file, "download": download}
+            # The bridge announces the artifact on the bus too (export.generated);
+            # the client deduplicates the echo on `href` (docThread.ts EXPORTED).
+            queue_interactive("wicked.interactive.export.generated", {
+                "project_id": pid, "document_id": doc, "version": version, **result})
+            self._json(200, result)
+            return True
         # POST /api/v1/projects/<pid>/interactive/api/events — the inject wire (§5.4).
         # A chat.posted steer regenerates the doc's head version: narrate, then land it.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/api/events$", path)
@@ -1914,6 +2012,15 @@ class W2Handler(SimpleHTTPRequestHandler):
             if body.get("event_type") == "wicked.interactive.theme.requested" and doc:
                 url = str(payload.get("url") or "").strip()
                 file_path = str(payload.get("path") or "").strip()
+                with state_lock:
+                    silent = bool(state["learn_silent"])
+                if silent:
+                    # Slice X (§7.2): the ack lands, then NOTHING — no status
+                    # frame, no readback. The client's bounded timeout is the
+                    # only thing standing between the user and eternal narration.
+                    self._json(200, {"ok": True, "event_id": "evt-fixture",
+                                     "correlation_id": "c-fixture"})
+                    return True
                 reason = ssrf_reject_reason(url) if url and not file_path else None
                 if reason is not None:
                     queue_interactive("wicked.interactive.status.posted", {

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -312,23 +312,25 @@ with sync_playwright() as p:
     wake_strip(page)  # the panel rides the strip — keep it awake for the submit
     page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
     page.locator('[data-testid="themes-submit"]').click()
-    # A queued learn closes the popover (the ack resolved), and the submission is a
-    # MESSAGE (§2.3): the ask lands in the thread verbatim.
-    page.locator('[data-testid="themes-panel"]').wait_for(state="detached", timeout=30000)
+    # DES-UX-001 §7.2 (slice X, EC37) SUPERSEDES the close-on-submit here: the popover
+    # now STAYS OPEN and answers — in-flight, then done when the readback ripens. The
+    # submission is still a MESSAGE (§2.3): the ask lands in the thread verbatim.
+    page.locator('[data-testid="learn-inflight"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-message"]').last.wait_for(timeout=30000)
     learned = page.evaluate(
         """() => ({
              askInThread: Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
                .some(m => (m.textContent || '').includes('Learn a theme from https://acme.example/brand')),
-             panelClosed: !document.querySelector('[data-testid="themes-panel"]'),
+             panelAnswers: !!document.querySelector('[data-testid="themes-panel"]'),
              chipCount: document.querySelectorAll('[data-chip-kind="theme"]').length,
            })"""
     )
+    page.locator('[data-testid="learn-done"]').wait_for(timeout=90000)
     # The ASYNC guard (issue #65): a link-local source is refused by the SERVICE, in
     # its own status line, arriving over the bus — never an HTTP 4xx on the ack. The
-    # fixture emits exactly the frame materializeThemeRequested writes.
+    # fixture emits exactly the frame materializeThemeRequested writes. The panel is
+    # still open (slice X) — editing the input starts the fresh ask.
     wake_strip(page)
-    page.locator('[data-testid="themes-open"]').click()
     page.locator('[data-testid="themes-input"]').fill("http://169.254.169.254/")
     page.locator('[data-testid="themes-submit"]').click()
     page.locator('[data-testid="doc-narration"]', has_text="Couldn't grab that URL") \
@@ -352,7 +354,7 @@ with sync_playwright() as p:
             themes["rowCount"] == 0,          # the invented library's rows are gone
             themes["chipCount"] == 0,
             learned["askInThread"],
-            learned["panelClosed"],
+            learned["panelAnswers"],  # slice X (§7.2): the popover stays and answers
             learned["chipCount"] == 0,        # no pick, so no chip — ever
             len(theme_events) == 2,           # the good learn + the refused one
             (theme_events[0] or {}).get("payload", {}).get("document_id") not in (None, ""),

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -316,7 +316,9 @@ with sync_playwright() as p:
     # now STAYS OPEN and answers — in-flight, then done when the readback ripens. The
     # submission is still a MESSAGE (§2.3): the ask lands in the thread verbatim.
     page.locator('[data-testid="learn-inflight"]').wait_for(timeout=30000)
-    page.locator('[data-testid="doc-message"]').last.wait_for(timeout=30000)
+    page.locator('[data-testid="doc-message"]',
+                 has_text="Learn a theme from https://acme.example/brand") \
+        .first.wait_for(timeout=30000)
     learned = page.evaluate(
         """() => ({
              askInThread: Array.from(document.querySelectorAll('[data-testid="doc-message"]'))

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { interactiveUrl } from '../api/interactive.js';
 import type { ExportFormat } from '../api/interactive.js';
 import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
 
@@ -10,8 +11,11 @@ import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
 //
 // Everything a READER needs lands in the thread (§4.4, §2.5): the in-flight line, the
 // downloadable artifact, and the install hint of an export that could not run. What stays
-// here is only what the pressed button owes the finger that pressed it — which format is
-// running, and, on the board where no thread is on screen, the reason it stopped.
+// here is what the pressed button owes the finger that pressed it — DES-UX-001 §7.2
+// (B5, EC37) makes that a contract: the clicked control answers PENDING (a spinner on
+// the control), READY (the control itself becomes the download affordance), or FAILED
+// (the reason, adjacent, with the retriable row above it) — where the click happened,
+// never only in a thread that may be off screen.
 
 // DES-VISION-001 §2.11: semantic tokens only. The RUNNING format speaks the
 // brand accent (an affordance state); the hint below is an actionable install
@@ -36,6 +40,16 @@ const COMPACT: React.CSSProperties = {
   fontFamily: 'var(--font-mono)', fontSize: '9px', padding: 0,
 };
 
+/** The READY state at the click site (§7.2): a real anchor, wearing the accent —
+ *  the finished artifact is the affordance now, not a report about one. */
+const READY: React.CSSProperties = {
+  border: '1px solid var(--accent-subtle)', color: S.accent,
+  textDecoration: 'none',
+};
+
+/** What the click site holds once its export finished: the artifact itself. */
+interface ReadyArtifact { format: ExportFormat; href: string; file: string }
+
 export interface ExportMenuProps {
   projectId: string;
   docId: string;
@@ -47,13 +61,28 @@ export interface ExportMenuProps {
 
 export function ExportMenu({ projectId, docId, version, compact = false }: ExportMenuProps): React.ReactElement {
   const [busy, setBusy] = useState<ExportFormat | null>(null);
+  const [ready, setReady] = useState<ReadyArtifact | null>(null);
   const [hint, setHint] = useState<string | null>(null);
+
+  // §7.2: the click site answers for THIS version. A new selection retires the
+  // previous answer — a v3 artifact link must not sit under an "Export v4" label.
+  useEffect(() => { setReady(null); setHint(null); }, [docId, version]);
 
   function run(format: ExportFormat): void {
     setBusy(format);
+    setReady(null);
     setHint(null);
     void runExport({ projectId, docId, version, format })
-      .then((outcome) => { if (!outcome.ok) setHint(outcome.hint); })
+      .then((outcome) => {
+        if (outcome.ok) {
+          // READY at the click site: the service's `download` is bridge-root-relative;
+          // resolved through the proxy it stays on the one origin (§5.3).
+          setReady({ format, href: interactiveUrl(projectId, outcome.result.download),
+                     file: outcome.file });
+        } else {
+          setHint(outcome.hint);
+        }
+      })
       .finally(() => setBusy(null));
   }
 
@@ -75,24 +104,44 @@ export function ExportMenu({ projectId, docId, version, compact = false }: Expor
           </span>
         )}
         {EXPORT_FORMATS.map((format) => (
-          <button
-            key={format}
-            type="button"
-            data-testid="export-format"
-            data-format={format}
-            disabled={busy !== null}
-            onClick={() => run(format)}
-            title={`Export “${docId}” v${version} as ${format.toUpperCase()} — it lands in the thread as a download`}
-            style={{ ...(compact ? COMPACT : BUTTON),
-                     color: busy === format ? S.accent : S.muted,
-                     opacity: busy !== null && busy !== format ? 0.4 : 1 }}
-          >
-            {busy === format ? `${format}…` : compact ? format : format.toUpperCase()}
-          </button>
+          // §7.2 READY: the control that was clicked IS the download now — a real
+          // anchor with the artifact's name, at the click site. The thread message
+          // remains; this is the click site answering (EC37).
+          ready !== null && ready.format === format ? (
+            <a
+              key={format}
+              data-testid="export-ready"
+              data-format={format}
+              href={ready.href}
+              download={ready.file}
+              title={`${format.toUpperCase()} ready — download ${ready.file}`}
+              style={{ ...(compact ? COMPACT : BUTTON), ...READY }}
+            >
+              {compact ? `${format} ↓` : `${format.toUpperCase()} ↓`}
+            </a>
+          ) : (
+            <button
+              key={format}
+              type="button"
+              data-testid="export-format"
+              data-format={format}
+              disabled={busy !== null}
+              onClick={() => run(format)}
+              title={`Export “${docId}” v${version} as ${format.toUpperCase()} — it lands in the thread as a download`}
+              style={{ ...(compact ? COMPACT : BUTTON),
+                       color: busy === format ? S.accent : S.muted,
+                       opacity: busy !== null && busy !== format ? 0.4 : 1 }}
+            >
+              {/* §7.2 PENDING: the spinner lives ON the clicked control. */}
+              {busy === format
+                ? <span data-testid="export-pending" className="animate-pulse">{format}…</span>
+                : compact ? format : format.toUpperCase()}
+            </button>
+          )
         ))}
       </div>
-      {/* §3.3: the reason is stated and the control that retries it is the row above —
-          adjacent, not a toast that takes the fix away with it when it fades. */}
+      {/* §7.2 FAILED, §3.3: the reason is stated and the control that retries it is the
+          row above — adjacent, not a toast that takes the fix away with it when it fades. */}
       {hint !== null && (
         <span
           data-testid="export-hint"

--- a/src/components/ThemesMenu.tsx
+++ b/src/components/ThemesMenu.tsx
@@ -1,25 +1,37 @@
-import { useState } from 'react';
-import { type LearnKind } from '../api/interactive.js';
+import { useEffect, useRef, useState } from 'react';
+import { getLearnedTheme, type LearnKind } from '../api/interactive.js';
 import {
   learnReady, learnThemeFromThread, LEARN_KINDS, LEARN_LABEL,
 } from '../interactive/themeWire.js';
+import { pollLearnedTheme } from '../theming/learnPoll.js';
+import { threadKey, useDocThreadStore } from '../store/docThread.js';
 
-// The Themes control (DES-UXFIX-001 §2.6 rule 4, V19), CORRECTED by issue #65.
+// The Themes control (DES-UXFIX-001 §2.6 rule 4, V19), CORRECTED by issue #65,
+// grown an honest lifecycle by DES-UX-001 §7.2 (B5, EC37).
 //
 // Slice 16 built this menu on an invented wire: `GET /api/themes` listed a "theme
 // library" and picking a row rode a `theme_id` with the next generation. The real
-// wicked-interactive bridge serves NO theme registry — no list route, no theme ids,
-// and nothing that consumed `theme_id` (verified against src/service/server.js and
-// the assist skill). What the bridge CAN do is learn a look FOR THIS DOCUMENT:
-// `wicked.interactive.theme.requested {document_id, url|path}` grabs the source,
-// the agent reads its design, and every subsequent version of the document wears it
-// (theme-source.js applies <doc>/theme/learned.theme.json at each version creation).
+// wicked-interactive bridge serves NO theme registry — what it CAN do is learn a look
+// FOR THIS DOCUMENT: `wicked.interactive.theme.requested {document_id, url|path}`
+// grabs the source, the agent reads its design, and every subsequent version of the
+// document wears it (theme-source.js applies <doc>/theme/learned.theme.json).
 //
-// So the control keeps its V19 duties — it reads "Themes", sits on the strip beside
-// Export, and explains itself in one line on open — but the popover now offers the
-// capability that exists: teach this document a look from a site, a PDF or an image.
-// There is no picking, because there is nothing to pick from; the learned look sticks
-// server-side, and the submission narrates in the thread (§2.3: it is a message).
+// §7.2's repair: the brief's theme-learn "narrated 'Grabbing the page…' then hung
+// 10+ minutes". The ack is an EventAck — fire-and-forget — so the popover used to
+// close on submit and the user was left watching narration with no end. Now the
+// popover ITSELF answers (EC37):
+//   - IN-FLIGHT: `learn-inflight` renders in the popover, carrying the bridge's own
+//     newest status line (staged progress — the announce stream, no new wires);
+//   - DONE: the readback (`GET /d/:doc/api/theme/learned`, interactive#181) turning
+//     200 is the one completion truth — the same bounded, cancellable poll the
+//     /theme page rides (learnPoll.ts, hard-capped ~66s);
+//   - FAILED: a failed learn emits exactly ONE doc-scoped `status.posted
+//     {state:"error", message}` (verified at slice time against handlers.js
+//     materializeThemeRequested — §8.4.1 probe 4's lifecycle finding), which the
+//     thread index (`lastError`) surfaces here VERBATIM, with a retry;
+//   - TIMEOUT: past the poll's hard cap with neither tokens nor an error frame, the
+//     wait resolves to the honest copy — the bridge may still be working, it has
+//     just said nothing — with a retry. Never an unresolved "Grabbing…" past it.
 
 const S = {
   ink:    'var(--ink-high)',
@@ -30,6 +42,8 @@ const S = {
   picked: 'var(--accent-subtle)',
   card:   'var(--surface-raised)',
   border: 'var(--surface-raised)',
+  fail:   'var(--status-fail)',
+  done:   'var(--status-done)',
 };
 
 const BUTTON: React.CSSProperties = {
@@ -51,6 +65,22 @@ export const THEMES_EXPLAINER = 'Borrow a look from a site, PDF, or image.';
 /** The real model, said where the user acts on it (§3.3: informative, in the UI). */
 export const THEMES_STICKS = 'The learned look sticks to this document — every new version wears it.';
 
+/** §7.2's honest timeout copy — shaped to the probe-4 truth: a FAILED learn reports
+ *  itself (one doc-scoped error frame, rendered above verbatim), so a timeout means
+ *  the bridge has simply said nothing yet — not that the learn is known dead. */
+export const LEARN_TIMEOUT_COPY =
+  'The learn did not report back — the bridge may still be working; retry, or check the thread for progress.';
+
+export const LEARN_DONE_COPY = 'Learned — every new version of this document wears it.';
+
+/** Where one learn is, popover-side. `error.timeout` picks the §7.2 timeout rendering
+ *  (retry with the honest silence copy) over the bridge's own verbatim reason. */
+type LearnPhase =
+  | { kind: 'form' }
+  | { kind: 'inflight' }
+  | { kind: 'learned' }
+  | { kind: 'error'; reason: string; timeout: boolean };
+
 export interface ThemesMenuProps {
   projectId: string;
   docId: string;
@@ -60,16 +90,74 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
   const [open, setOpen] = useState(false);
   const [kind, setKind] = useState<LearnKind>('url');
   const [value, setValue] = useState('');
-  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<LearnPhase>({ kind: 'form' });
+  // Where the thread stood when this learn fired — everything after it is THIS
+  // learn's narration, which is what the in-flight line stages (§7.2).
+  const baseRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => { abortRef.current?.abort(); }, []); // unmount ends any poll
+
+  const key = threadKey(projectId, docId);
+  // Staged progress = the bridge's own status frames, as the thread already folds
+  // them (no new wires): the newest narration since this learn was fired.
+  const thread = useDocThreadStore((s) => s.messages[key]);
+  const stage = (thread ?? [])
+    .slice(baseRef.current)
+    .filter((m) => m.kind === 'narration')
+    .at(-1)?.text ?? null;
+
+  const busy = phase.kind === 'inflight';
 
   async function submit(): Promise<void> {
     if (busy || !learnReady(kind, value)) return;
-    setBusy(true);
-    // Both outcomes are already IN the thread (informative, or actionable with the
-    // service's own reason) — the popover's job is only to stop offering the same submit.
+    abortRef.current?.abort();
+    const ctl = new AbortController();
+    abortRef.current = ctl;
+    const store = useDocThreadStore.getState();
+    baseRef.current = (store.messages[key] ?? []).length;
+    // The bridge reports a failed learn ASYNC as ONE doc-scoped status.posted
+    // {state:"error"} (§8.4.1 probe 4, re-verified at slice time); snapshot the
+    // newest error so only a NEW arrival ends this learn (identity comparison).
+    const errorBaseline = store.lastError[key];
+    setPhase({ kind: 'inflight' });
+    // The readback answers 200 for a PREVIOUS learn too, so snapshot what is
+    // already there: only a learned_at that MOVED counts as THIS learn landing.
+    // A failed baseline read is not a failed learn — the poll retries anyway.
+    const before = await getLearnedTheme(projectId, docId).catch(() => null);
+    if (ctl.signal.aborted) return;
     const outcome = await learnThemeFromThread({ projectId, docId, kind, value });
-    setBusy(false);
-    if (outcome.ok) { setValue(''); setOpen(false); }
+    if (ctl.signal.aborted) return;
+    if (!outcome.ok) {
+      // The SYNC refusals (unknown doc, 403, the typed 503) — the thread already
+      // carries the actionable line; the click site answers too (EC37).
+      setPhase({ kind: 'error', reason: outcome.reason, timeout: false });
+      return;
+    }
+    const polled = await pollLearnedTheme({
+      fetchLearned: async () => {
+        const r = await getLearnedTheme(projectId, docId);
+        if (r === null) return null;
+        return before !== null && r.learned_at === before.learned_at ? null : r;
+      },
+      bridgeError: () => {
+        const current = useDocThreadStore.getState().lastError[key];
+        return current !== undefined && current !== errorBaseline ? current.text : null;
+      },
+      signal: ctl.signal,
+    });
+    if (ctl.signal.aborted || polled.kind === 'cancelled') return;
+    if (polled.kind === 'learned') { setPhase({ kind: 'learned' }); setValue(''); return; }
+    if (polled.kind === 'bridge-error') {
+      setPhase({ kind: 'error', reason: polled.reason, timeout: false });
+      return;
+    }
+    setPhase({ kind: 'error', reason: LEARN_TIMEOUT_COPY, timeout: true });
+  }
+
+  /** Editing the source starts a fresh ask — a stale verdict must not sit beside it. */
+  function edit(next: string): void {
+    setValue(next);
+    if (phase.kind === 'learned' || phase.kind === 'error') setPhase({ kind: 'form' });
   }
 
   return (
@@ -80,9 +168,10 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
         aria-expanded={open}
         onClick={() => setOpen(!open)}
         title={`${THEMES_EXPLAINER} ${THEMES_STICKS}`}
-        style={BUTTON}
+        style={{ ...BUTTON, ...(busy ? { color: S.accent } : {}) }}
       >
-        Themes
+        {/* The in-flight state survives a closed popover — the control still answers. */}
+        {busy ? <span className="animate-pulse">Themes…</span> : 'Themes'}
       </button>
 
       {open && (
@@ -110,7 +199,8 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
           <div className="flex gap-1.5">
             {LEARN_KINDS.map((k) => (
               <button key={k} type="button" data-testid="themes-kind" data-kind={k}
-                      aria-pressed={kind === k} onClick={() => setKind(k)}
+                      aria-pressed={kind === k} disabled={busy}
+                      onClick={() => { setKind(k); if (phase.kind !== 'inflight') setPhase({ kind: 'form' }); }}
                       className="rounded-full px-2 py-0.5 text-[10px] font-mono"
                       style={kind === k ? KIND_ON : KIND_OFF}>
                 {k}
@@ -124,7 +214,8 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
             aria-label={`Theme source ${LEARN_LABEL[kind].noun}`}
             placeholder={LEARN_LABEL[kind].placeholder}
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            disabled={busy}
+            onChange={(e) => edit(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submit(); } }}
           />
           {/* §4.6 asks for this to be SAID in the UI, not only honoured on the wire. */}
@@ -138,6 +229,52 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
              style={{ color: S.faint, margin: 0 }}>
             {THEMES_STICKS}
           </p>
+
+          {/* §7.2 IN-FLIGHT: the popover answers while the bridge works — the line is
+              the bridge's own newest status frame, never rotating filler (§3.2). */}
+          {phase.kind === 'inflight' && (
+            <div data-testid="learn-inflight" className="flex flex-col gap-0.5">
+              <span className="animate-pulse text-[10px] font-mono" style={{ color: S.accent }}>
+                Learning…
+              </span>
+              {stage !== null && (
+                <span data-testid="learn-stage" className="text-[10px] font-mono"
+                      style={{ color: S.muted }}>
+                  {stage}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* §7.2 DONE: the readback landed — the popover says so where the click was. */}
+          {phase.kind === 'learned' && (
+            <p data-testid="learn-done" className="text-[10px] font-mono"
+               style={{ color: S.done, margin: 0 }}>
+              {LEARN_DONE_COPY}
+            </p>
+          )}
+
+          {/* §7.2 FAILED / TIMEOUT: the bridge's own sentence verbatim, or the honest
+              silence copy — either way with the retry beside it (§3.3: never a dead end). */}
+          {phase.kind === 'error' && (
+            <div data-testid={phase.timeout ? 'learn-timeout' : 'learn-error'}
+                 className="flex flex-col gap-1">
+              <p className="text-[10px] font-mono" style={{ color: S.fail, margin: 0 }}>
+                {phase.reason}
+              </p>
+              <button
+                type="button"
+                data-testid="learn-retry"
+                className="self-start rounded-lg px-2 py-0.5 text-[10px] font-semibold"
+                style={{ background: 'transparent', color: S.accent,
+                         border: '1px solid var(--accent-subtle)', cursor: 'pointer' }}
+                onClick={() => void submit()}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
           <button
             type="button"
             data-testid="themes-submit"
@@ -146,7 +283,7 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
             disabled={busy || !learnReady(kind, value)}
             onClick={() => void submit()}
           >
-            {busy ? 'Submitting…' : `Learn from this ${LEARN_LABEL[kind].noun}`}
+            {busy ? 'Learning…' : `Learn from this ${LEARN_LABEL[kind].noun}`}
           </button>
         </div>
       )}

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -28,6 +28,8 @@ const { ServiceHintError } = vi.hoisted(() => ({
 vi.mock('../src/api/interactive.js', () => ({
   postExport: (...a: unknown[]) => postExport(...a),
   postFork: (...a: unknown[]) => postFork(...a),
+  // The real resolver's shape (interactive.ts): proxy mount + bridge-root-relative path.
+  interactiveUrl: (pid: string, p: string) => `/api/v1/projects/${pid}/interactive${p}`,
   ServiceHintError,
 }));
 
@@ -114,13 +116,56 @@ describe('the version strip exports the SELECTED version (§4.4, §4.2)', () => 
     await waitFor(() => expect(postExport).toHaveBeenCalledWith(PROJECT, DOC, 1, 'pdf'));
   });
 
-  it('the artifact lands in the thread as a download — the strip itself reports nothing', async () => {
+  it('the artifact lands in the thread as a download — and no failure hint renders', async () => {
     strip();
     await press('html');
     postExport.mockResolvedValue(reply('roadmap_v3.html', 'html'));
 
     await waitFor(() => expect(messages().some((m) => m.kind === 'agent')).toBe(true));
     expect(screen.queryByTestId('export-hint')).toBeNull();
+  });
+
+  // DES-UX-001 §7.2 (B5, EC37): the control the finger pressed answers WHERE it
+  // was pressed — pending on the clicked control, then the click site itself
+  // becoming the download affordance. The thread message still lands (above).
+  it('AC §7.2: the clicked control renders export-pending, then BECOMES the download (export-ready)', async () => {
+    let release: (v: unknown) => void = () => {};
+    postExport.mockImplementation(() => new Promise((res) => { release = res; }));
+    strip();
+    await press('pdf');
+
+    // PENDING, on that control: the spinner is inside the pdf button itself.
+    const pending = screen.getByTestId('export-pending');
+    expect(pending.closest('[data-format="pdf"]')).not.toBeNull();
+
+    release(reply('roadmap_v3.pdf'));
+    // READY, at the click site: a REAL anchor — href through the one-origin proxy,
+    // download attribute naming the artifact — where the pdf button was.
+    const ready = await screen.findByTestId('export-ready');
+    expect(ready.tagName).toBe('A');
+    expect(ready).toHaveAttribute('data-format', 'pdf');
+    expect(ready).toHaveAttribute(
+      'href', `/api/v1/projects/${PROJECT}/interactive/d/${DOC}/download/roadmap_v3.pdf`);
+    expect(ready).toHaveAttribute('download', 'roadmap_v3.pdf');
+    // The other formats are still offered beside it.
+    expect(screen.getAllByTestId('export-format')).toHaveLength(2);
+  });
+
+  it('§7.2: a new version selection retires the previous READY answer', async () => {
+    const { rerender } = render(
+      <VersionStrip projectId={PROJECT} docId={DOC} manifest={MANIFEST}
+                    selected={3} navigate={() => {}} onForked={() => {}} />,
+    );
+    await press('pdf');
+    await screen.findByTestId('export-ready');
+
+    rerender(
+      <VersionStrip projectId={PROJECT} docId={DOC} manifest={MANIFEST}
+                    selected={2} navigate={() => {}} onForked={() => {}} />,
+    );
+    // A v3 artifact link must not sit under an "Export v2" label.
+    expect(screen.queryByTestId('export-ready')).toBeNull();
+    expect(screen.getAllByTestId('export-format')).toHaveLength(3);
   });
 });
 

--- a/tests/ThemesMenu.test.tsx
+++ b/tests/ThemesMenu.test.tsx
@@ -1,22 +1,35 @@
 // The Themes control on the version strip — DES-UXFIX-001 §2.6 rule 4 / V19,
-// CORRECTED by issue #65.
+// CORRECTED by issue #65, grown the DES-UX-001 §7.2 lifecycle (B5, EC37).
 //
 // What is asserted here is the honest contract: the control is named "Themes", it
 // EXPLAINS itself in one line the moment it opens, and the popover offers the ONE
 // capability the real bridge has — learn a look for THIS document, which then sticks
-// server-side. There is no list and no picking, because the "theme library" those
-// implied was an invented wire (`GET /api/themes` never existed on the bridge); a
-// mock of that route here would be the bug reproduced, so the mock below speaks the
-// corrected themeWire seam and nothing else.
+// server-side. §7.2 adds the point-of-action answers: an in-flight state while the
+// bridge works, the bridge's own error sentence VERBATIM when a learn fails (the
+// probe-4 truth: one doc-scoped status.posted {state:"error"}), and a bounded
+// timeout with honest retry copy — never an unresolved "Grabbing…" past it.
+//
+// The submission seam (themeWire), the readback (getLearnedTheme) and the bounded
+// poll (learnPoll) are stubbed at their module boundaries; the poll's own schedule
+// arithmetic is pinned in learnPoll.test.ts — here the claim is what the POPOVER
+// says for each outcome, plus the exact deps the component wires into the poll
+// (the stale-readback guard and the error-identity watch).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ThemesMenu, THEMES_EXPLAINER, THEMES_STICKS } from '../src/components/ThemesMenu.js';
+import {
+  LEARN_DONE_COPY, LEARN_TIMEOUT_COPY, ThemesMenu, THEMES_EXPLAINER, THEMES_STICKS,
+} from '../src/components/ThemesMenu.js';
+import { threadKey, useDocThreadStore } from '../src/store/docThread.js';
+import type { LearnPollDeps, LearnPollOutcome } from '../src/theming/learnPoll.js';
 
 const PROJECT = 'proj-abc';
 const DOC = 'q3-report';
+const KEY = threadKey(PROJECT, DOC);
 
 const learnThemeFromThread = vi.fn();
+const getLearnedTheme = vi.fn();
+const pollLearnedTheme = vi.fn();
 
 vi.mock('../src/interactive/themeWire.js', async (importOriginal) => {
   // The pure helpers (learnReady, LEARN_KINDS, LEARN_LABEL) are the real ones — only
@@ -24,14 +37,35 @@ vi.mock('../src/interactive/themeWire.js', async (importOriginal) => {
   const real = await importOriginal<typeof import('../src/interactive/themeWire.js')>();
   return { ...real, learnThemeFromThread: (...a: unknown[]) => learnThemeFromThread(...a) };
 });
+vi.mock('../src/api/interactive.js', () => ({
+  getLearnedTheme: (...a: unknown[]) => getLearnedTheme(...a),
+  // themeWire (loaded REAL below) names these at import time; none fire here —
+  // the submission seam itself is stubbed.
+  requestThemeLearn: vi.fn(),
+  attachSource: vi.fn(),
+  ServiceHintError: class extends Error {},
+}));
+vi.mock('../src/theming/learnPoll.js', () => ({
+  pollLearnedTheme: (...a: unknown[]) => pollLearnedTheme(...a),
+}));
 
 function mount(): ReturnType<typeof render> {
   return render(<ThemesMenu projectId={PROJECT} docId={DOC} />);
 }
 
+/** Open the popover, type a URL, submit — the shared gesture under every outcome. */
+async function submitUrl(user: ReturnType<typeof userEvent.setup>, url = 'https://acme.example/brand'): Promise<void> {
+  await user.click(screen.getByTestId('themes-open'));
+  await user.type(screen.getByTestId('themes-input'), url);
+  await user.click(screen.getByTestId('themes-submit'));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastError: {} });
   learnThemeFromThread.mockResolvedValue({ ok: true });
+  getLearnedTheme.mockResolvedValue(null); // no previous learn on this doc
+  pollLearnedTheme.mockResolvedValue({ kind: 'learned', result: { document_id: DOC, learned_at: 'T2', tokens: {} } });
 });
 afterEach(cleanup);
 
@@ -75,15 +109,11 @@ describe('Themes — named, placed, and explained (V19), speaking the real capab
   it('submitting a URL learns it FOR THIS DOCUMENT through the corrected seam', async () => {
     const user = userEvent.setup();
     mount();
-    await user.click(screen.getByTestId('themes-open'));
-    await user.type(screen.getByTestId('themes-input'), 'https://acme.example/brand');
-    await user.click(screen.getByTestId('themes-submit'));
+    await submitUrl(user);
 
     expect(learnThemeFromThread).toHaveBeenCalledWith({
       projectId: PROJECT, docId: DOC, kind: 'url', value: 'https://acme.example/brand',
     });
-    // A queued learn closes the popover — the outcome already narrates in the thread.
-    expect(screen.queryByTestId('themes-panel')).toBeNull();
   });
 
   it('the local kinds submit a PATH and say the no-upload guarantee in the UI', async () => {
@@ -108,17 +138,116 @@ describe('Themes — named, placed, and explained (V19), speaking the real capab
     expect(screen.getByTestId('themes-submit')).toBeDisabled();
     expect(learnThemeFromThread).not.toHaveBeenCalled();
   });
+});
 
-  it('a refused learn keeps the popover open — the thread carries the reason', async () => {
+describe('the §7.2 lifecycle (B5, EC37): the popover answers where the click was', () => {
+  it('AC: a submitted learn renders learn-inflight IN THE POPOVER — no silent close', async () => {
+    let release: (v: LearnPollOutcome) => void = () => {};
+    pollLearnedTheme.mockImplementation(() => new Promise((res) => { release = res; }));
+    const user = userEvent.setup();
+    mount();
+    await submitUrl(user);
+
+    // The popover STAYS, wearing the in-flight state (the old close-on-ack was
+    // exactly the brief's act-and-nothing-happens).
+    expect(screen.getByTestId('themes-panel')).toBeInTheDocument();
+    expect(await screen.findByTestId('learn-inflight')).toBeInTheDocument();
+    expect(screen.getByTestId('themes-submit')).toBeDisabled();
+
+    // Staged progress = the bridge's own newest status line, folded by the thread.
+    act(() => { useDocThreadStore.getState().addNarration(KEY, 'Grabbing the page to read its design…'); });
+    expect(screen.getByTestId('learn-stage')).toHaveTextContent('Grabbing the page');
+
+    act(() => { release({ kind: 'learned', result: { document_id: DOC, learned_at: 'T2', tokens: {} } }); });
+    await screen.findByTestId('learn-done');
+  });
+
+  it('AC: the readback landing resolves to learn-done with the sticks promise', async () => {
+    const user = userEvent.setup();
+    mount();
+    await submitUrl(user);
+
+    const done = await screen.findByTestId('learn-done');
+    expect(done).toHaveTextContent(LEARN_DONE_COPY);
+    // The source cleared — the ask completed; the popover is ready for the next one.
+    expect(screen.getByTestId('themes-input')).toHaveValue('');
+  });
+
+  it('AC: a failed learn renders the bridge\'s OWN sentence verbatim, with a retry (probe 4)', async () => {
+    pollLearnedTheme.mockResolvedValue({
+      kind: 'bridge-error',
+      reason: "Couldn't grab that URL: refusing to fetch 169.254.169.254: loopback, private and link-local addresses are blocked (SSRF guard)",
+    });
+    const user = userEvent.setup();
+    mount();
+    await submitUrl(user);
+
+    const error = await screen.findByTestId('learn-error');
+    expect(error).toHaveTextContent('SSRF guard'); // the guard's words, not a paraphrase
+    expect(screen.getByTestId('learn-retry')).toBeInTheDocument();
+    expect(screen.queryByTestId('learn-timeout')).toBeNull(); // a REPORTED failure is not a timeout
+  });
+
+  it('AC: fixture-simulated silence resolves to learn-timeout with the honest retry copy', async () => {
+    pollLearnedTheme.mockResolvedValue({ kind: 'timeout', attempts: 16, lastFetchError: null });
+    const user = userEvent.setup();
+    mount();
+    await submitUrl(user);
+
+    const timeout = await screen.findByTestId('learn-timeout');
+    expect(timeout).toHaveTextContent(LEARN_TIMEOUT_COPY);
+    expect(timeout).toHaveTextContent(/may still be working/);
+
+    // Retry re-fires the SAME ask — the value survived the failure.
+    learnThemeFromThread.mockClear();
+    pollLearnedTheme.mockResolvedValue({ kind: 'learned', result: { document_id: DOC, learned_at: 'T3', tokens: {} } });
+    await user.click(screen.getByTestId('learn-retry'));
+    expect(learnThemeFromThread).toHaveBeenCalledWith({
+      projectId: PROJECT, docId: DOC, kind: 'url', value: 'https://acme.example/brand',
+    });
+    await screen.findByTestId('learn-done');
+  });
+
+  it('a SYNC refusal (unknown doc, 403, 503) keeps the popover open with the reason and retry', async () => {
     learnThemeFromThread.mockResolvedValue({ ok: false, reason: 'unknown doc' });
     const user = userEvent.setup();
     mount();
-    await user.click(screen.getByTestId('themes-open'));
-    await user.type(screen.getByTestId('themes-input'), 'https://acme.example');
-    await user.click(screen.getByTestId('themes-submit'));
+    await submitUrl(user, 'https://acme.example');
 
+    expect(await screen.findByTestId('learn-error')).toHaveTextContent('unknown doc');
     expect(screen.getByTestId('themes-panel')).toBeInTheDocument();
     // The value survives so the user can correct rather than retype.
     expect(screen.getByTestId('themes-input')).toHaveValue('https://acme.example');
+    expect(pollLearnedTheme).not.toHaveBeenCalled(); // nothing was queued — nothing to watch
+  });
+
+  it('wires the poll honestly: the stale-readback guard and the error-identity watch', async () => {
+    // A PREVIOUS learn already answers the readback (learned_at T1): the baseline.
+    getLearnedTheme.mockResolvedValue({ document_id: DOC, learned_at: 'T1', tokens: {} });
+    let deps: LearnPollDeps | null = null;
+    pollLearnedTheme.mockImplementation((d: LearnPollDeps) => {
+      deps = d;
+      return new Promise(() => {}); // hold the poll open — the deps are the claim
+    });
+    const user = userEvent.setup();
+    mount();
+    await submitUrl(user);
+    await waitFor(() => expect(deps).not.toBeNull());
+    const d = deps as unknown as LearnPollDeps;
+
+    // Stale readback: the SAME learned_at is NOT this learn landing.
+    await expect(d.fetchLearned()).resolves.toBeNull();
+    // A moved learned_at IS.
+    getLearnedTheme.mockResolvedValue({ document_id: DOC, learned_at: 'T2', tokens: {} });
+    await expect(d.fetchLearned()).resolves.toMatchObject({ learned_at: 'T2' });
+
+    // Error identity: only an error that ARRIVED after the snapshot ends the learn.
+    expect(d.bridgeError?.()).toBeNull();
+    act(() => {
+      useDocThreadStore.setState((s) => ({
+        lastError: { ...s.lastError, [KEY]: { text: "Couldn't grab that URL: boom" } },
+      }));
+    });
+    expect(d.bridgeError?.()).toBe("Couldn't grab that URL: boom");
   });
 });


### PR DESCRIPTION
Implements **DES-UX-001 §7.2 (slice X)** — act-feedback: export + theme-learn (BRIEF-UX-001 B5, EC37).

- **Export**: pending (spinner on the clicked control) → ready (real anchor, attachment-framed bytes) → failed (install hint adjacent, rows re-enabled) — all at the point of action.
- **Theme-learn**: in-flight (the bridge's own status frame) → done (readback ripening) → error (bridge's sentence verbatim, matching §8.4.1 probe 4's doc-scoped `status.posted {state:error}`) → bounded ~66s timeout with honest silence copy + live Retry. No unbounded spinner path exists (typed resolution throughout).
- X2's error-translation layer reused, not forked (zero diffs to errors.ts; imports verified).
- uxfix_slice6's "queued learn closes the popover" assertion superseded per §7.2/EC37 (the popover now stays open and answers) — dedicated rig commits.

Verified: 1371/1371 unit tests; slice rig 12/12 twice incl. the real ~66s production-schedule timeout scene; regressions uxfix_slice6/ux_sliceX2/ux_sliceT/vision_slice4; negative check fails on main at export-pending; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
