### PR TITLE
DES-UX-001 slice AB: chat repair

### DIFF
--- a/e2e/feedback2_sliceK_test.py
+++ b/e2e/feedback2_sliceK_test.py
@@ -16,9 +16,12 @@ What it asserts (§6.5 + §7.5 DOM ACs, EC18 as amended by §12.1 and
 DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar):
 
   Chat columns (§6.5):
-   1. First-run: no layout toggle (no replying seats yet). After a 3-seat round
+   1. First-run: no layout toggle (no replying seats yet). After a full round
       the toggle appears; columns mode renders [data-testid="chat-round"] with
-      a [data-testid="chat-round-grid"] of data-columns="3".
+      a [data-testid="chat-round-grid"] of data-columns="4" — since DES-UX-001
+      slice AB (§7.9-1, the §11.2 re-scope) the first pristine cold-cache send
+      is ROSTER-FIRST: it warms the fixture's four roster seats, not the
+      fallback trio.
    2. The same seat's cells share a column index across rounds; a seat that
       died between rounds (real chatSessionFailed) renders
       [data-testid="chat-cell-empty"] in the next round — never a collapsed
@@ -42,7 +45,7 @@ DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar
    8. On a fresh v1-only document the toggle is DISABLED with the stated reason.
 
 Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
-  feedback2-K-chat-columns.png    3-seat rounds side by side, one empty cell
+  feedback2-K-chat-columns.png    4-seat rounds side by side, one empty cell
   feedback2-K-compare-split.png   v3 ↔ v2 split with the strip toolbar cluster
   feedback2-K-compare-overlay.png overlay mode, slider at 50
 
@@ -121,8 +124,9 @@ with sync_playwright() as p:
     step("K1_toggle_absent_firstrun",
          page.locator('[data-testid="chat-layout-toggle"]').count() == 0)
 
-    # Round 1: the first send warms the default trio; the fixture fans out one
-    # REAL chatReply per seat, then kills the last-warmed seat (chatSessionFailed).
+    # Round 1: the first send is roster-first (slice AB §7.9-1) — it warms the
+    # fixture's four roster seats; the fixture fans out one REAL chatReply per
+    # seat, then kills the last-warmed seat (chatSessionFailed → 'pi').
     composer = page.locator("textarea.wk-composer")
     composer.fill("How should we refactor the fetch layer?")
     page.keyboard.press("Enter")
@@ -161,7 +165,7 @@ with sync_playwright() as p:
              };
            }""")
     step("K1_columns_grid",
-         grid1["columns"] == "3" and grid1["rounds"] == 1 and len(grid1["agents"]) == 3,
+         grid1["columns"] == "4" and grid1["rounds"] == 1 and len(grid1["agents"]) == 4,
          **grid1)
     step("K1_toggle_zero_requests_keeps_draft",
          api_requests == before_toggle
@@ -193,9 +197,9 @@ with sync_playwright() as p:
              };
            }""")
     step("K2_empty_cell_stable_columns",
-         rounds["count"] == 2 and rounds["columns"] == ["3", "3"]
+         rounds["count"] == 2 and rounds["columns"] == ["4", "4"]
          and rounds["agents"][0] == rounds["agents"][1]
-         and rounds["emptyAgents"] == ["planner"] and rounds["emptyInSecond"]
+         and rounds["emptyAgents"] == ["pi"] and rounds["emptyInSecond"]
          and rounds["noHorizPageScroll"],
          **rounds)
     page.screenshot(path=str(VSHOTS / "feedback2-K-chat-columns.png"))

--- a/e2e/feedback_sliceC_test.py
+++ b/e2e/feedback_sliceC_test.py
@@ -13,6 +13,13 @@ The slice DOM ACs, verbatim from §8.3:
   4. `[data-testid="add-agent"]` button opens the roster picker;
   5. zero `openChat` requests fire on mount (verified by `page.on('request')`).
 
+RE-SCOPED by DES-UX-001 slice AB (§11.2): chip seeding is ROSTER-FIRST with
+the cold-cache fallback — this route fetches no roster before Chat mounts, so
+what this rig pins IS the cold-cache fallback arm (the trio, zero requests,
+`data-source="fallback"` on the chips bar). The roster-first arm — a warm
+cache seeding the chips, the first send fetching the roster on its own
+gesture — is pinned by ux_sliceAB_test.py and the GroupChat unit suites.
+
 "Without any network request" is measured as the slice-B rig measured it: the
 app-shell rail fires its own requests identically on main (projects, runs —
 they are not this slice's), so the tap records EVERY /api/v1/* request and the
@@ -142,6 +149,7 @@ with sync_playwright() as p:
              const add = document.querySelector('[data-testid="add-agent"]');
              return {
                barCount: bar ? bar.dataset.count : null,
+               barSource: bar ? bar.dataset.source : null,
                chipKeys: chips.map(c => c.dataset.agent),
                chipRadius: c0 ? c0.borderRadius : null,
                chipFontSize: c0 ? c0.fontSize : null,
@@ -151,7 +159,7 @@ with sync_playwright() as p:
                xBackground: xs ? xs.backgroundColor : null,
                addPresent: !!add,
                addDashed: add ? getComputedStyle(add).borderTopStyle === 'dashed' : false,
-               noThread: !document.querySelector('[title="ready"], [title="warming"]'),
+               noThread: !document.querySelector('[data-testid="seat-chip"]'),
                teachPresent: !!document.querySelector('[data-testid="chat-firstrun"]'),
                pickerClosed: !document.querySelector('[data-testid="agent-picker"]'),
              };
@@ -205,6 +213,7 @@ report["steps"]["chips_first_render"] = {
     "ok": all([
         fonts_ok,
         first_render["barCount"] == "3",
+        first_render["barSource"] == "fallback",  # slice AB §7.9-1's honesty attr
         first_render["chipKeys"] == FALLBACK,
         # §6.3 anatomy in tokens: --radius-full → 9999px, --text-xs → 11px,
         # EC13: the chip label reads in the SANS (Inter stack), 3px 8px 3px 6px.

--- a/e2e/ux_sliceAB_test.py
+++ b/e2e/ux_sliceAB_test.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+ux_sliceAB_test.py — the DES-UX-001 slice-AB gate: chat repair (§7.9, EC44, C6).
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the
+slice-AB corpus: `chat_deltas` (buffered interleaved chunk rounds + a flush
+control — the §7.9-3 splice corpus) and `chat_reject_seats=["codex"]` (the
+open-time failed-with-reason seat, §7.9-4).
+
+The §7.9 DOM ACs, verbatim mapping:
+
+  1. roster-true chips (§7.9-1, re-scoped per §11.2 to roster-first with the
+     cold-cache fallback): a fresh /chat/new mounts with the FALLBACK trio and
+     ZERO chat-surface requests (`data-source="fallback"` — the §2.4 budget
+     holds); the FIRST SEND fetches the roster ON THE GESTURE (exactly one
+     GET /roster) and opens with the ROSTER's seats — the daemon accepts them,
+     no rejected-chip error renders, and ≥1 reply frame lands after flush;
+  2. a fixture-failed send (chat_send_fail) leaves the composer text INTACT,
+     retracts the optimistic bubbles, and renders inline retry (§7.9-2);
+     retry after the failure clears resends exactly the failed text;
+  3. chunk routing (§7.9-3): turn 1's interleaved chunks arrive AFTER turn 2
+     opened its pending bubbles — every chunk lands in the bubble matching its
+     seat+turn (round-1 text never appears in a data-turn="2" bubble);
+  4. seat chips wear explicit state badges (§7.9-4/EC44): working while a
+     reply is pending, replied when it lands, and failed-with-reason carrying
+     the daemon's own open-time error for the rejected seat;
+  5. /chats lists the live session (GET /chats riding the navigation — the one
+     declared fetch, nothing gesture-gated fires) and flags it "streaming now"
+     from its first observed frame; End tears it down in place (§7.9-5);
+  6. the zombie pin: with the chat's tab CLOSED, a fresh page's bottom-bar
+     working count equals the pre-chat baseline — no orphan increment, and the
+     session is findable in /chats rather than haunting a counter;
+  7. the conversation→action bridge: Continue in Build lands on /runs/new with
+     the transcript prefilled as context and ZERO POST /runs fired.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-AB-chat-states.png   the chat thread after two answered rounds + one
+                          failed send: replied chips beside the
+                          failed-with-reason chip, the inline retry row, the
+                          surviving draft in the composer
+  ux-AB-chats-list.png    /chats with the live-session band up — the streaming
+                          session flagged, endable, above the dashboard tiles'
+                          untouched list
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4398),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4398"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# The fixture's roster (uxfix_fixture.ROSTER keys) and the §6.2 fallback trio.
+ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
+FALLBACK = ["writer", "reviewer", "planner"]
+REJECTED = "codex"  # chat_reject_seats — the open-time failed-with-reason seat
+WARM = [k for k in ROSTER_KEYS if k != REJECTED]
+
+MSG1 = "compare the auth options"
+MSG2 = "now sketch the migration plan"
+MSG3 = "and the rollback risks?"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def api_get(path: str) -> dict:
+    with urllib.request.urlopen(f"{ORIGIN}{path}", timeout=10) as res:
+        return json.loads(res.read())
+
+
+def api_post(path: str, body: dict) -> dict:
+    req = urllib.request.Request(
+        f"{ORIGIN}{path}", method="POST", data=json.dumps(body).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        return json.loads(res.read())
+
+
+# ── 1. Build + the shared fixture with the slice-AB corpus ────────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, chat_deltas=True, chat_reject_seats=[REJECTED])
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+
+def tap(page) -> list:
+    net: list = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if not path.startswith("/api/"):
+            return
+        body = None
+        if req.post_data:
+            try:
+                body = json.loads(req.post_data)
+            except ValueError:
+                body = None
+        net.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return net
+
+
+def is_chat_surface(path: str) -> bool:
+    """The §2.4 mount delta: what the chat surface itself could fire."""
+    return path.startswith("/api/v1/chats") or path == "/api/v1/roster"
+
+
+# One evaluate for the whole seat/bubble census, so no frame can split it.
+CHAT_CENSUS = """() => {
+  const chips = [...document.querySelectorAll('[data-testid="seat-chip"]')];
+  const bubbles = [...document.querySelectorAll('[data-testid="seat-bubble"]')];
+  const users = [...document.querySelectorAll('[data-testid="user-bubble"]')];
+  const bar = document.querySelector('[data-testid="agent-chips-bar"]');
+  return {
+    chips: Object.fromEntries(chips.map((c) => [c.dataset.agent, c.dataset.state])),
+    failedChipText: chips.find((c) => c.dataset.state === 'failed')?.textContent ?? null,
+    bubbles: bubbles.map((b) => ({ agent: b.dataset.agent, turn: b.dataset.turn,
+                                   pending: b.dataset.pending, text: b.textContent })),
+    users: users.map((u) => ({ turn: u.dataset.turn, text: u.textContent })),
+    chipsBar: bar ? { count: bar.dataset.count, source: bar.dataset.source } : null,
+    composer: document.querySelector('textarea')?.value ?? null,
+    openError: document.body.innerText.includes('Could not open chat'),
+    sendFailed: !!document.querySelector('[data-testid="chat-send-failed"]'),
+  };
+}"""
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    # ── Scene 1: /chat/new — roster-true first send, states, routing, draft ───
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net = tap(page)
+    page.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.locator('[data-testid="agent-chips-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    baseline_working = page.locator('[data-testid="runs-bottom-bar"]').get_attribute("data-working")
+
+    mount = page.evaluate(CHAT_CENSUS)
+    mount_chat_requests = [(m, q) for (m, q, _b) in net if is_chat_surface(q)]
+    check("mount_fallback_zero_requests",
+          mount["chipsBar"] is not None
+          and mount["chipsBar"]["source"] == "fallback"
+          and mount["chipsBar"]["count"] == str(len(FALLBACK))
+          and len(mount_chat_requests) == 0,
+          chips_bar=mount["chipsBar"], mount_chat_requests=mount_chat_requests)
+
+    # AC 1 — the first send is roster-first: ONE /roster GET rides the gesture,
+    # the open names the roster's seats, and no rejected-chip error renders.
+    page.locator("textarea").fill(MSG1)
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        f"""() => document.querySelectorAll('[data-testid="seat-bubble"][data-turn="1"]').length === {len(WARM)}
+               && document.querySelector('textarea')?.value === ''""",
+        timeout=30000)  # the composer clears only when the daemon ACCEPTS (§7.9-2)
+    roster_gets = [(m, q) for (m, q, _b) in net if q == "/api/v1/roster"]
+    opens = [(m, q, b) for (m, q, b) in net if m == "POST" and q == "/api/v1/chats"]
+    sent1 = page.evaluate(CHAT_CENSUS)
+    chat_id = (opens[0][2] or {}).get("chatId") if opens else None
+    check("roster_first_send",
+          len(roster_gets) == 1
+          and len(opens) == 1
+          and (opens[0][2] or {}).get("clis") == ROSTER_KEYS
+          and not sent1["openError"]
+          and sent1["chips"].get(REJECTED) == "failed"
+          and all(sent1["chips"].get(k) == "working" for k in WARM)
+          and f"unknown agent '{REJECTED}'" in (sent1["failedChipText"] or "")
+          and sent1["composer"] == ""  # the ACCEPTED draft left the composer
+          and chat_id is not None,
+          roster_gets=len(roster_gets), open_body=opens[0][2] if opens else None,
+          chips=sent1["chips"], failed_chip=sent1["failedChipText"])
+
+    # AC 3 setup — turn 2 opens BEFORE turn 1's chunks arrive (chat_deltas
+    # buffers them until the flush): the splice scenario, live.
+    page.locator("textarea").fill(MSG2)
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        f"""() => document.querySelectorAll('[data-testid="seat-bubble"][data-turn="2"]').length === {len(WARM)}""",
+        timeout=30000)
+    set_fixture(ORIGIN, chat_flush=True)
+    page.wait_for_function(
+        """() => [...document.querySelectorAll('[data-testid="seat-bubble"]')]
+                 .every((b) => b.dataset.pending === 'false')""",
+        timeout=30000)
+    routed = page.evaluate(CHAT_CENSUS)
+    by_key = {(b["agent"], b["turn"]): b for b in routed["bubbles"]}
+    splice_free = (
+        all(by_key[(k, "1")]["text"].endswith("(round 1)") for k in WARM)
+        and all(by_key[(k, "2")]["text"].endswith("(round 2)") for k in WARM)
+        and not any("(round 1)" in b["text"] for b in routed["bubbles"] if b["turn"] == "2")
+        and not any("(round 2)" in b["text"] for b in routed["bubbles"] if b["turn"] == "1")
+    )
+    check("chunk_routing_seat_turn",
+          splice_free
+          and len(routed["bubbles"]) == 2 * len(WARM)
+          and all(routed["chips"].get(k) == "replied" for k in WARM)
+          and routed["chips"].get(REJECTED) == "failed",
+          bubbles=routed["bubbles"], chips=routed["chips"])
+
+    # AC 2 — a refused fan-out keeps the draft and renders inline retry.
+    set_fixture(ORIGIN, chat_send_fail=True)
+    page.locator("textarea").fill(MSG3)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)
+    failed = page.evaluate(CHAT_CENSUS)
+    check("failed_send_keeps_draft",
+          failed["composer"] == MSG3
+          and failed["sendFailed"]
+          and all(u["text"] != MSG3 for u in failed["users"])  # no phantom turn
+          and len([b for b in failed["bubbles"] if b["turn"] == "3"]) == 0
+          # EC44: no seat claims to be WORKING on a message that never went out
+          # (the revert lands on warm-idle "ready"; a frame would re-correct).
+          and all(failed["chips"].get(k) in ("ready", "replied") for k in WARM),
+          composer=failed["composer"], users=failed["users"], chips=failed["chips"])
+
+    page.screenshot(path=str(VSHOTS / "ux-AB-chat-states.png"))
+
+    # Retry after the failure clears: exactly the failed text goes out.
+    set_fixture(ORIGIN, chat_send_fail=False)
+    page.locator('[data-testid="chat-send-retry"]').click()
+    page.wait_for_function(
+        f"""() => [...document.querySelectorAll('[data-testid="user-bubble"]')]
+                  .some((u) => u.textContent === {json.dumps(MSG3)})
+               && !document.querySelector('[data-testid="chat-send-failed"]')
+               && document.querySelector('textarea')?.value === ''""",
+        timeout=30000)  # acceptance clears the composer (§7.9-2)
+    retried = page.evaluate(CHAT_CENSUS)
+    check("retry_resends_draft",
+          retried["composer"] == "" and not retried["sendFailed"],
+          composer=retried["composer"])
+
+    # AC 7 — the conversation→action bridge: prefill, never a launch.
+    page.locator('[data-testid="chat-promote"]').click()
+    page.locator('[data-testid="launch-problem"]').wait_for(timeout=30000)
+    prefill_value = page.locator('[data-testid="launch-problem"]').input_value()
+    run_posts = [(m, q) for (m, q, _b) in net if m == "POST" and q == "/api/v1/runs"]
+    check("promote_prefills_composer",
+          page.evaluate("() => location.pathname") == "/runs/new"
+          and "Continue from this chat" in prefill_value
+          and f"operator: {MSG1}" in prefill_value
+          and len(run_posts) == 0,
+          pathname=page.evaluate("() => location.pathname"),
+          prefill_head=prefill_value[:120], run_posts=len(run_posts))
+
+    # The chat's tab closes — the session must stay findable, not haunt counters.
+    page.close()
+
+    # ── Scene 2: /chats on a fresh page — listing, streaming flag, End, zombie ─
+    page2 = ctx.new_page()
+    page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net2 = tap(page2)
+    page2.goto(f"{ORIGIN}/chats", wait_until="domcontentloaded")
+    page2.locator('[data-testid="chats-dashboard-tiles"]').wait_for(timeout=30000)
+    page2.locator('[data-testid="live-chat-row"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # The budget is THIS PAGE's delta (the slice-P convention): the app shell
+    # fires its own startup reads (repos, doc registries) identically on main —
+    # reported, never asserted. ChatsPage may add exactly ONE GET /chats and
+    # must not touch the gesture-gated roster/health.
+    lists = [(m, q) for (m, q, _b) in net2 if m == "GET" and q == "/api/v1/chats"]
+    gesture_gated = [(m, q) for (m, q, _b) in net2
+                     if q in ("/api/v1/roster", "/api/v1/health")]
+    shell_owned = sorted({q for (_m, q, _b) in net2
+                          if q == "/api/v1/repos" or q.endswith("/interactive/api/docs")})
+    listed = page2.evaluate(
+        """() => {
+          const row = document.querySelector('[data-testid="live-chat-row"]');
+          const bar = document.querySelector('[data-testid="runs-bottom-bar"]');
+          return { chatId: row?.dataset.chatId ?? null,
+                   streaming: row?.dataset.streaming ?? null,
+                   text: row?.textContent ?? null,
+                   endPresent: !!row?.querySelector('[data-testid="live-chat-end"]'),
+                   working: bar?.dataset.working ?? null };
+        }""")
+    check("chats_lists_live_session",
+          listed["chatId"] == chat_id
+          and listed["streaming"] == "false"
+          and listed["endPresent"]
+          and all(k in (listed["text"] or "") for k in WARM)
+          and len(lists) == 1 and len(gesture_gated) == 0,
+          **listed, list_gets=len(lists), gesture_gated=gesture_gated,
+          shell_owned_requests_ignored=shell_owned)
+
+    # AC 6 — the zombie pin: the closed tab left NO orphan working increment.
+    check("no_orphan_working_count",
+          listed["working"] == baseline_working,
+          baseline=baseline_working, fresh_page=listed["working"])
+
+    # AC 5 — streaming-now from the first observed frame: a send lands on the
+    # warm session from OUTSIDE this tab, the flush broadcasts its frames.
+    api_post(f"/api/v1/chats/{chat_id}/messages", {"text": "still with me?"})
+    set_fixture(ORIGIN, chat_flush=True)
+    page2.locator('[data-testid="live-chat-row"][data-streaming="true"]').wait_for(timeout=30000)
+    check("streaming_now_flag",
+          page2.locator('[data-testid="live-chat-streaming"]').text_content() == "streaming now")
+
+    page2.screenshot(path=str(VSHOTS / "ux-AB-chats-list.png"))
+
+    # AC 5 — End tears the session down in place; the daemon's pool empties.
+    page2.locator('[data-testid="live-chat-end"]').click()
+    page2.wait_for_function(
+        """() => !document.querySelector('[data-testid="live-chat-row"]')""",
+        timeout=30000)
+    deletes = [(m, q) for (m, q, _b) in net2 if m == "DELETE" and q.startswith("/api/v1/chats/")]
+    pool = api_get("/api/v1/chats")
+    check("end_cleans_up",
+          len(deletes) == 1 and pool.get("chats") == [],
+          deletes=deletes, pool=pool)
+
+    page2.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [str(VSHOTS / "ux-AB-chat-states.png"),
+                         str(VSHOTS / "ux-AB-chats-list.png")]
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -140,6 +140,19 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     conversation announce history — the disk — survive,
                     exactly the split BRIDGE-UX-1 probe 2 verified.
 
+  chat_reject_seats — slice AB (DES-UX-001 §7.9-4): cliKeys POST /chats
+                    answers ok:false + a per-seat error (open-time
+                    failed-with-reason). Default [].
+  chat_send_fail  — slice AB (§7.9-2): POST /chats/<id>/messages answers a
+                    500 {error} — the draft-surviving failure. Default False.
+  chat_deltas     — slice AB (§7.9-3): sends BUFFER interleaved chatDelta
+                    chunks + a chatReply per live seat; POST /__fixture
+                    {"chat_flush": true} broadcasts the buffered rounds in
+                    send order (so turn 2 can open before turn 1's chunks
+                    arrive — the splice corpus). GET /api/v1/chats lists the
+                    live pool unconditionally (the FINDING-027 wire).
+                    Default False.
+
 A rig that never flips them gets the default W2 board.
 """
 
@@ -302,6 +315,19 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # no readback ripening. The brief's real failure mode (a learn that
          # hangs silently), for the client's bounded-timeout branch.
          "learn_silent": False,
+         # Slice AB (DES-UX-001 §7.9): the chat-repair corpus, all default-off.
+         #   chat_reject_seats — cliKeys POST /chats answers ok:false with the
+         #                       daemon's per-seat error (open-time
+         #                       failed-with-reason, §7.9-4).
+         #   chat_send_fail    — POST /chats/<id>/messages answers 500 {error}
+         #                       (the draft-surviving failure, §7.9-2).
+         #   chat_deltas       — sends BUFFER interleaved chatDelta chunks +
+         #                       chatReply per live seat instead of replying;
+         #                       POST /__fixture {"chat_flush": true} broadcasts
+         #                       the buffered rounds in order — so a rig can
+         #                       open turn 2 BEFORE turn 1's chunks arrive (the
+         #                       §7.9-3 splice corpus).
+         "chat_reject_seats": [], "chat_send_fail": False, "chat_deltas": False,
          }
 state_lock = threading.Lock()
 
@@ -1157,6 +1183,10 @@ chat_state_lock = threading.Lock()
 chat_warm_seats: dict = {}   # chat_id -> [cliKey, warm order]
 chat_dead_seats: dict = {}   # chat_id -> set of cliKeys that chatSessionFailed
 chat_send_count: dict = {}   # chat_id -> number of message fan-outs so far
+# Slice AB (§7.9-3): rounds buffered while `chat_deltas` is on — each entry is
+# the ordered frame list one send produced (interleaved chunks, then replies).
+# POST /__fixture {"chat_flush": true} broadcasts them in send order.
+chat_round_buffer: list = []
 
 # The reply prose per seat — short and distinct, so the columns screenshot reads
 # as three agents disagreeing about the same prompt, not lorem ipsum.
@@ -1567,6 +1597,16 @@ class W2Handler(SimpleHTTPRequestHandler):
         # Slice J (§5.2): the decisions corpus — read on the search GESTURE only.
         if path == "/api/v1/governance/claims":
             self._json(200, {"claims": GOVERNANCE_CLAIMS})
+            return True
+        # /api/v1/chats — every live chat (the FINDING-027 wire: chatId, seats,
+        # idleSecs number|null). Slice AB's /chats live-session band reads it.
+        if path == "/api/v1/chats":
+            with chat_state_lock:
+                rows = [{"chatId": cid,
+                         "seats": [k for k in seats if k not in chat_dead_seats.get(cid, set())],
+                         "idleSecs": 5}
+                        for cid, seats in chat_warm_seats.items()]
+            self._json(200, {"chats": rows})
             return True
         # /api/v1/chats/<id> — seats of a chat. Empty for a chat we never opened
         # (the daemon does not 404 an unknown id; empty means reclaimed/none).
@@ -2122,6 +2162,14 @@ class W2Handler(SimpleHTTPRequestHandler):
                     ws_queue.clear()
                 with doc_sched_lock:
                     doc_next_free.clear()
+            # Slice AB (§7.9-3): broadcast the buffered chat rounds in send
+            # order — the rig decides WHEN turn 1's chunks arrive.
+            if body.get("chat_flush"):
+                with chat_state_lock:
+                    rounds, chat_round_buffer[:] = list(chat_round_buffer), []
+                for frames in rounds:
+                    for frame in frames:
+                        broadcast_chat(frame)
             with state_lock:
                 # `appearance` rides the same control channel but lands in the
                 # settings store: a dict replaces studio.appearance wholesale,
@@ -2224,13 +2272,22 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/chats":
             clis = body.get("clis") or [s["key"] for s in ROSTER]
             chat_id = body.get("chatId") or "fixture-chat"
+            # Slice AB (§7.9-4): seats named by `chat_reject_seats` answer the
+            # daemon's real per-seat shape — ok:false with an error the chip
+            # must wear as failed-with-reason. Only accepted seats warm.
+            with state_lock:
+                reject = set(state["chat_reject_seats"])
             with chat_state_lock:
-                chat_warm_seats[chat_id] = list(clis)
+                chat_warm_seats[chat_id] = [k for k in clis if k not in reject]
                 chat_dead_seats.setdefault(chat_id, set())
                 chat_send_count.setdefault(chat_id, 0)
             return self._json(201, {
                 "chatId": chat_id,
-                "seats": [{"cliKey": k, "ok": True} for k in clis],
+                "seats": [
+                    {"cliKey": k, "ok": True} if k not in reject
+                    else {"cliKey": k, "ok": False, "error": f"unknown agent '{k}'"}
+                    for k in clis
+                ],
             })
         # POST /api/v1/chats/<id>/messages — accept the fan-out; replies would
         # stream over /ws, which this fixture leaves to the narration loop —
@@ -2242,6 +2299,39 @@ class W2Handler(SimpleHTTPRequestHandler):
         if len(parts) == 6 and parts[3] == "chats" and parts[5] == "messages":
             with state_lock:
                 replies_on = state["chat_replies"]
+                send_fail = state["chat_send_fail"]
+                deltas_on = state["chat_deltas"]
+            # Slice AB (§7.9-2): the daemon refuses the fan-out — the client's
+            # draft must survive and the failure must render inline with retry.
+            if send_fail:
+                return self._json(500, {"error": "chat send refused (fixture)"})
+            # Slice AB (§7.9-3): buffer this round's interleaved chunk frames +
+            # replies; nothing is broadcast until the rig flushes — so a second
+            # send can open its turn BEFORE the first turn's chunks arrive.
+            if deltas_on:
+                chat_id = urllib.parse.unquote(parts[4])
+                with chat_state_lock:
+                    warm = chat_warm_seats.get(chat_id, [])
+                    dead = chat_dead_seats.setdefault(chat_id, set())
+                    live = [k for k in warm if k not in dead]
+                    chat_send_count[chat_id] = chat_send_count.get(chat_id, 0) + 1
+                    round_n = chat_send_count[chat_id]
+                    per_seat = []
+                    for k in live:
+                        line = CHAT_REPLY_LINES.get(k, "Agreed — start small.") + f" (round {round_n})"
+                        third = max(1, len(line) // 3)
+                        per_seat.append((k, [line[:third], line[third:2 * third], line[2 * third:]], line))
+                    frames = []
+                    for i in range(3):
+                        for (k, chunks, _line) in per_seat:
+                            if chunks[i]:
+                                frames.append({"type": "chatDelta", "chat": chat_id,
+                                               "cliKey": k, "text": chunks[i]})
+                    for (k, _chunks, line) in per_seat:
+                        frames.append({"type": "chatReply", "chat": chat_id,
+                                       "cliKey": k, "ok": True, "text": line})
+                    chat_round_buffer.append(frames)
+                return self._json(200, {"seats": live})
             if replies_on:
                 chat_id = urllib.parse.unquote(parts[4])
                 with chat_state_lock:
@@ -2281,6 +2371,14 @@ class W2Handler(SimpleHTTPRequestHandler):
     def do_DELETE(self):  # noqa: N802 (stdlib naming)
         path = urllib.parse.urlparse(self.path).path
         if path.startswith("/api/v1/chats/"):
+            # Slice AB (§7.9-5): the teardown is real — the chat leaves the
+            # live listing, exactly as the daemon reaps a closed pool entry.
+            chat_id = urllib.parse.unquote(path.split("/")[4]) if len(path.split("/")) == 5 else None
+            if chat_id is not None:
+                with chat_state_lock:
+                    chat_warm_seats.pop(chat_id, None)
+                    chat_dead_seats.pop(chat_id, None)
+                    chat_send_count.pop(chat_id, None)
             return self._json(200, {"ok": True})
         return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
 

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -33,25 +33,29 @@ What it asserts (design §4.3 as amended by DES-FEEDBACK-001 §6/§8.3):
      this route), no WARM seat chips, no Close, and no "Group chat"/"End chat"
      copy anywhere.
   3. [+ Add] is the roster opt-in now (§6.2): clicking add-agent fires exactly
-     ONE GET /api/v1/roster (a user action, not a mount), the picker lists the
-     roster, and an added agent joins the selection (data-count 4); the first
-     send then fires exactly ONE POST /api/v1/chats whose `clis` is the
-     selection (trio + addition), the four-seat chip strip appears all-ready,
-     Close appears, the chips bar retires.
+     ONE GET /api/v1/roster (a user action, not a mount) and the picker lists
+     the roster. RE-SCOPED by DES-UX-001 slice AB (§7.9-1): that deposit
+     re-seeds the still-PRISTINE fallback selection to the full roster (warm
+     roster beats the trio), so the bar reads data-count 4 with claude already
+     included; the first send fires exactly ONE POST /api/v1/chats whose
+     `clis` is the roster, the four-seat strip appears, every fanned-out seat
+     reads WORKING (EC44 — no reply ever lands in this fixture scene), Close
+     appears, the chips bar retires.
   4. Typing is the warm opt-in: in a FRESH tab (own sessionStorage), typing a
-     message and pressing Enter fires exactly ONE POST /api/v1/chats whose
-     `clis` is the DEFAULT selection (the fallback trio — §6.2's "defaults +
-     additions − removals" with nothing touched) — then POSTs the message to
-     /chats/<id>/messages; the user bubble renders and the chips bar retires
-     (the header's warm seat chips are the truth now).
+     message and pressing Enter is ROSTER-FIRST (slice AB §7.9-1): one GET
+     /roster rides the send gesture, then exactly ONE POST /api/v1/chats whose
+     `clis` is the ROSTER (the fallback trio ships only when the roster is
+     unreachable) — then POSTs the message to /chats/<id>/messages; the user
+     bubble renders and the chips bar retires (the header's warm seat chips
+     are the truth now).
 
 Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
 data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
   uxfix-4-switcher.png        the weighted segmented control (element shot)
   uxfix-4-chat-firstrun.png   the teaching first-run Chat surface with the
                               §6.2 default chips (full page)
-  uxfix-4-chat-multiagent.png the warmed multi-agent strip + Close after a
-                              picker-add and first send (full page)
+  uxfix-4-chat-multiagent.png the warmed multi-agent strip + Close after the
+                              picker re-seed and first send (full page)
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
 SKIP_STUDIO_BUILD=1. Env knobs: W2_PORT (default 4333), SKIP_STUDIO_BUILD.
@@ -220,21 +224,29 @@ with sync_playwright() as p:
         arg=len(ROSTER_KEYS), timeout=10000,
     )
     picker_roster_gets = len([1 for (m, q, _b) in net if q == "/api/v1/roster"])
-    page.locator('[data-testid="agent-picker-option"][data-agent-key="claude"]').click()
+    # Slice AB (§7.9-1): the picker's deposit re-seeds the pristine selection to
+    # the ROSTER — claude is already included (offered disabled, ✓-marked).
+    page.wait_for_function(
+        """n => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count === String(n)""",
+        arg=len(ROSTER_KEYS), timeout=10000,
+    )
     added_count = page.evaluate(
         """() => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null""")
 
     page.locator("textarea").fill("warm the whole selection")
     page.keyboard.press("Enter")
     page.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
+    # Slice AB (§7.9-4/EC44): the fanned-out seats SAY working — no reply ever
+    # lands in this scene, and a chip claiming "ready" here would be the lie
+    # the old rig pinned by accident.
     page.wait_for_function(
-        """n => document.querySelectorAll('[title="ready"]').length === n""",
-        arg=len(FALLBACK) + 1, timeout=30000,
+        """n => document.querySelectorAll('[data-testid="seat-chip"][data-state="working"]').length === n""",
+        arg=len(ROSTER_KEYS), timeout=30000,
     )
     disclosed = page.evaluate(
         """keys => {
-             const chips = Array.from(document.querySelectorAll('[title="ready"]'))
-               .map(c => c.textContent.trim());
+             const chips = Array.from(document.querySelectorAll('[data-testid="seat-chip"]'))
+               .map(c => c.dataset.agent);
              return {
                chips,
                allSeats: keys.every(k => chips.includes(k)),
@@ -243,7 +255,7 @@ with sync_playwright() as p:
                firstrunGone: !document.querySelector('[data-testid="chat-firstrun"]'),
              };
            }""",
-        FALLBACK + ["claude"],
+        ROSTER_KEYS,
     )
     disclosed_opens = opens(net)
     page.screenshot(path=str(SHOTS / "uxfix-4-chat-multiagent.png"))
@@ -263,8 +275,9 @@ with sync_playwright() as p:
     typed = page2.evaluate(
         """() => ({
              userBubble: document.body.innerText.includes('make me a deck'),
-             readyChips: Array.from(document.querySelectorAll('[title="ready"]'))
-               .map(c => c.textContent.trim()),
+             workingChips: Array.from(
+               document.querySelectorAll('[data-testid="seat-chip"][data-state="working"]'))
+               .map(c => c.dataset.agent),
              chipsBarRetired: !document.querySelector('[data-testid="agent-chips-bar"]'),
            })"""
     )
@@ -305,11 +318,11 @@ report["steps"]["slice4_add_agent_picker"] = {
     "ok": all([
         # The picker's roster fetch rode the CLICK — exactly one, none on mount.
         picker_roster_gets == 1,
-        added_count == str(len(FALLBACK) + 1),
+        added_count == str(len(ROSTER_KEYS)),
         disclosed["allSeats"], disclosed["chipsBarRetired"], disclosed["closePresent"],
         disclosed["firstrunGone"],
         len(disclosed_opens) == 1,
-        (disclosed_opens[0] or {}).get("clis") == FALLBACK + ["claude"],
+        (disclosed_opens[0] or {}).get("clis") == ROSTER_KEYS,
     ]),
     **disclosed,
     "roster_gets_after_picker_open": picker_roster_gets,
@@ -320,10 +333,10 @@ report["steps"]["slice4_add_agent_picker"] = {
 report["steps"]["slice4_first_send"] = {
     "ok": all([
         typed["userBubble"],
-        typed["readyChips"] == FALLBACK,
+        typed["workingChips"] == ROSTER_KEYS,
         typed["chipsBarRetired"],
         len(typed_opens) == 1,
-        (typed_opens[0] or {}).get("clis") == FALLBACK,
+        (typed_opens[0] or {}).get("clis") == ROSTER_KEYS,
         len(sent) == 1,
         (sent[0][2] or {}).get("text") == "make me a deck",
     ]),

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
+import { useEventStream } from '../hooks/useEventStream.js';
 import { useTimeRange, type TimeRange } from '../hooks/useTimeRange.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
@@ -82,9 +84,88 @@ function ChatsOverTimeTile({ chats, range, now }: {
   );
 }
 
+/** One warm chat session on the daemon (`GET /chats` — the FINDING-027 wire). */
+interface LiveChatRow {
+  chatId: string;
+  seats: string[];
+  idleSecs: number | null;
+  /** When this page last SAW a stream frame for the chat (0 = never). */
+  lastFrameAt: number;
+}
+
+/** A frame this recent reads as "streaming now" — observed, never asserted. */
+const STREAMING_WINDOW_MS = 30_000;
+
 export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const { range, setRange, filter: filterByRange } = useTimeRange('30d');
+
+  // ── Live sessions (DES-UX-001 §7.9-5): the warm seat pool, findable ────────
+  // The review's zombie class — "abandoned tabs leak working agents nothing
+  // points at" — dies here: every live chat the daemon holds is LISTED on
+  // /chats (one GET /chats riding this navigation — a page-load read, not a
+  // mount ambush on another surface), each with its seats, idle age, and an
+  // End control (`DELETE /chats/:id`, the same teardown Chat's Close uses).
+  // Streams announce themselves: a chatDelta/chatReply frame flags its session
+  // "streaming now" from the FIRST frame — a session is visible here while it
+  // streams, even one this list fetch predates.
+  const [liveChats, setLiveChats] = useState<LiveChatRow[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listChats()
+      .then(({ chats }) => {
+        if (cancelled) return;
+        setLiveChats(chats.map((c) => ({ ...c, lastFrameAt: 0 })));
+      })
+      .catch(() => {
+        if (!cancelled) setLiveChats([]); // unreachable — the band stays absent
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEventStream((ev) => {
+    const frame = ev as { type: string; chat?: string; cliKey?: string; reason?: string };
+    if (typeof frame.chat !== 'string' || frame.chat === '') return;
+    if (frame.type === 'chatClosed') {
+      setLiveChats((prev) => (prev === null ? prev : prev.filter((c) => c.chatId !== frame.chat)));
+      return;
+    }
+    if (!['chatDelta', 'chatReply', 'chatSessionReady'].includes(frame.type)) return;
+    setLiveChats((prev) => {
+      const now = Date.now();
+      const list = prev ?? [];
+      const found = list.find((c) => c.chatId === frame.chat);
+      if (found === undefined) {
+        // §7.9-5: listed from its FIRST frame — a session the fetch predates.
+        return [
+          ...list,
+          { chatId: frame.chat!, seats: frame.cliKey ? [frame.cliKey] : [], idleSecs: null, lastFrameAt: now },
+        ];
+      }
+      return list.map((c) =>
+        c.chatId === frame.chat
+          ? {
+              ...c,
+              lastFrameAt: now,
+              seats: frame.cliKey && !c.seats.includes(frame.cliKey) ? [...c.seats, frame.cliKey] : c.seats,
+            }
+          : c,
+      );
+    });
+  });
+
+  /** End a warm session from the list — the zombie-cleanup affordance. */
+  function endLiveChat(chatId: string): void {
+    void api
+      .closeChat(chatId)
+      .then(() => setLiveChats((prev) => (prev === null ? prev : prev.filter((c) => c.chatId !== chatId))))
+      .catch(() => {
+        /* teardown is best-effort — the daemon's idle reaper collects either way */
+      });
+  }
 
   // Strict filter: include 'chat' runs and legacy runs with no workflow stamp as a transitional fallback.
   const allChats = useMemo(() => runs.filter(isChatRun), [runs]);
@@ -170,6 +251,65 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
           />
         </TileBand>
       </div>
+
+      {/* ── Live sessions (DES-UX-001 §7.9-5): warm seats, findable + endable.
+             Absent entirely when the daemon holds none — the run list below is
+             history; this band is the NOW. ── */}
+      {liveChats !== null && liveChats.length > 0 && (
+        <div className="px-8 flex flex-col gap-2" data-testid="live-chats" data-count={liveChats.length}>
+          <p
+            className="text-[10px] font-mono uppercase tracking-widest m-0"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            Live sessions — warm agent seats on the daemon
+          </p>
+          {liveChats.map((c) => {
+            const streaming = c.lastFrameAt !== 0 && Date.now() - c.lastFrameAt < STREAMING_WINDOW_MS;
+            return (
+              <div
+                key={c.chatId}
+                data-testid="live-chat-row"
+                data-chat-id={c.chatId}
+                data-streaming={streaming}
+                className="w-full flex items-center gap-3 rounded-2xl px-5 py-3"
+                style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+              >
+                <span className="text-sm font-mono truncate" style={{ color: 'var(--ink-high)' }}>
+                  {c.chatId.slice(0, 8)}
+                </span>
+                <span className="text-xs font-mono truncate" style={{ color: 'var(--ink-muted)' }}>
+                  {c.seats.length > 0 ? c.seats.join(' · ') : 'seats unknown'}
+                </span>
+                {streaming ? (
+                  <span
+                    data-testid="live-chat-streaming"
+                    title="A reply frame from this session was observed in the last 30s"
+                    className="text-[10px] font-mono px-2 py-0.5 rounded-full shrink-0"
+                    style={{ color: 'var(--status-run)', border: '1px solid var(--status-run-dim)' }}
+                  >
+                    streaming now
+                  </span>
+                ) : (
+                  <span className="text-[10px] font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>
+                    {c.idleSecs === null ? 'idle (age unknown)' : `idle ${Math.round(c.idleSecs)}s`}
+                  </span>
+                )}
+                <div className="flex-1" />
+                <button
+                  type="button"
+                  data-testid="live-chat-end"
+                  title="Disconnect this session's agents and end it"
+                  onClick={() => endLiveChat(c.chatId)}
+                  className="text-[11px] px-2.5 py-1 rounded-lg shrink-0"
+                  style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-overlay)' }}
+                >
+                  End
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* ── List / Empty state (untouched below the band, §4.3) ── */}
       <div className="px-8 pb-8 flex flex-col gap-2" data-testid="chats-list">

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
-import { getCachedRoster, setCachedRoster } from '../store/rosterCache.js';
+import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
+import { setRetryPrefill } from '../store/retryPrefill.js';
 import { Markdown } from './Markdown.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
@@ -58,11 +59,26 @@ function defaultSelection(): string[] {
  */
 const SEAT_CHIP = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
 
-type SeatState = 'warming' | 'ready' | 'failed';
+/**
+ * The explicit seat lifecycle (DES-UX-001 §7.9-4, EC44): connecting (an open
+ * in flight) → ready (the seat answered ok) → working (a reply is pending) →
+ * replied (its turn finished) — and failed-with-reason, whose reason is the
+ * daemon's own open-time answer (`POST /chats` per-seat `error`) or a
+ * `chatSessionFailed` frame's reason. The wire carries NO per-seat mid-stream
+ * lifecycle (BRIDGE-UX-1 probe 4: seat identity is absent from the interactive
+ * vocabulary), so mid-stream failure reasons beyond those two wires are not
+ * invented here — the state machine ships, the reasons stay honest.
+ */
+type SeatState = 'connecting' | 'ready' | 'working' | 'replied' | 'failed';
+
+/** States in which the seat can receive a message (warm on the daemon). */
+const WARM_STATES: ReadonlySet<SeatState> = new Set(['ready', 'working', 'replied']);
 
 const SEAT_DOT: Record<SeatState, string> = {
-  warming: 'var(--status-gate)',
+  connecting: 'var(--status-gate)',
   ready: 'var(--status-run)',
+  working: 'var(--status-gate)',
+  replied: 'var(--status-run)',
   failed: 'var(--status-fail)',
 };
 
@@ -105,6 +121,8 @@ function clearStoredChatId(repoId?: string | null): void {
 export interface UserMsg {
   kind: 'user';
   text: string;
+  /** The send ordinal this message opened (1-based) — §7.9-3 turn identity. */
+  turn?: number;
 }
 export interface SeatMsg {
   kind: 'seat';
@@ -112,6 +130,8 @@ export interface SeatMsg {
   text: string;
   pending: boolean;
   ok: boolean;
+  /** The send ordinal this reply answers — chunk routing keys on seat+turn. */
+  turn?: number;
 }
 export type Msg = UserMsg | SeatMsg;
 
@@ -241,6 +261,15 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   const [selectedAgents, setSelectedAgents] = useState<string[]>(defaultSelection);
   const selectedAgentsRef = useRef<string[]>(selectedAgents);
   selectedAgentsRef.current = selectedAgents;
+  // §7.9-1: whether the operator has EDITED the selection (✕ / picker add).
+  // While untouched, a warm roster arriving later re-seeds the chips — the
+  // fallback trio only ever reaches the daemon when the cache stayed cold AND
+  // the roster proved unreachable at send time. An edit pins the selection.
+  const chipsTouchedRef = useRef(false);
+  // §7.9-2: a failed send keeps its draft; the failure renders inline with retry.
+  const [sendFailed, setSendFailed] = useState<{ text: string; reason: string } | null>(null);
+  // §7.9-3: the send ordinal — every bubble is stamped with the turn it belongs to.
+  const turnRef = useRef(0);
   // [+ Add] opens the roster picker; ITS roster read is allowed to fetch —
   // opening the picker is a user action, not a mount (§2.4).
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -333,6 +362,9 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // So does the chip selection (§6.2: per-run, never persisted): the new
     // repo's create flow starts from the defaults again.
     setSelectedAgents(defaultSelection());
+    chipsTouchedRef.current = false;
+    setSendFailed(null);
+    turnRef.current = 0;
     setPickerOpen(false);
     // The id goes too, and it is the one reset that is not cosmetic. Resolving the new repo's chat
     // is ASYNC — a stored id costs a probe round-trip — and until it lands, a `chatId` still holding
@@ -400,12 +432,29 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // nothing but `repoId` and module-scope helpers, so the dep list is genuinely complete.)
   }, [repoId]);
 
+  // §7.9-1 (the seeding-order fix): a roster deposited AFTER this surface
+  // seeded its chips from the cold-cache fallback re-seeds them — warm roster
+  // beats the fallback trio — but only while the selection is still pristine
+  // (untouched, nothing warmed, no thread). Never a fetch: this only HEARS
+  // deposits other surfaces already paid for (§2.4's budget holds unchanged).
+  useEffect(() => {
+    return subscribeRoster((roster) => {
+      if (chipsTouchedRef.current || chatIdRef.current !== null) return;
+      if (roster.length === 0) return;
+      setSelectedAgents(roster.map((s) => s.key));
+    });
+  }, []);
+
   useEventStream((ev) => {
     const frame = ev as { type: string; chat?: string; cliKey?: string; text?: string; ok?: boolean; reason?: string };
     if (frame.chat !== chatIdRef.current) return;
     switch (frame.type) {
       case 'chatSessionReady':
-        if (frame.cliKey) setSeats((s) => ({ ...s, [frame.cliKey!]: 'ready' }));
+        // Never demote a working seat: its warm-up ready can arrive after the
+        // first fan-out already put a reply in flight.
+        if (frame.cliKey) {
+          setSeats((s) => (s[frame.cliKey!] === 'working' ? s : { ...s, [frame.cliKey!]: 'ready' }));
+        }
         break;
       case 'chatSessionFailed':
         if (frame.cliKey) {
@@ -417,40 +466,55 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         if (frame.cliKey && frame.text) appendToPending(frame.cliKey, frame.text);
         break;
       case 'chatReply':
-        if (frame.cliKey) finalizePending(frame.cliKey, frame.text ?? '', frame.ok ?? false);
+        if (frame.cliKey) {
+          finalizePending(frame.cliKey, frame.text ?? '', frame.ok ?? false);
+          setSeats((s) => (s[frame.cliKey!] === 'failed' ? s : { ...s, [frame.cliKey!]: 'replied' }));
+        }
         break;
       default:
         break;
     }
   });
 
-  /** Deltas attach to the seat's LATEST pending bubble (one in-flight turn per seat). */
+  /**
+   * §7.9-3 chunk routing: a seat's frames belong to its OLDEST unfinished
+   * turn — the wire carries no turn field (chatDelta is {chat, cliKey, text}),
+   * and a warm seat answers its queue in send order, so per-seat FIFO IS the
+   * turn correlation. The pre-slice-AB code walked backward (newest pending),
+   * which spliced a still-streaming turn's chunks into the NEXT turn's bubble
+   * the moment a second send appended its pending row — the mid-word splice
+   * the review observed. A chunk with no pending bubble opens its own (text
+   * is never silently dropped).
+   */
   function appendToPending(cliKey: string, text: string): void {
     setMessages((prev) => {
       const next = [...prev];
-      for (let i = next.length - 1; i >= 0; i--) {
+      for (let i = 0; i < next.length; i++) {
         const m = next[i];
         if (m && m.kind === 'seat' && m.cliKey === cliKey && m.pending) {
           next[i] = { ...m, text: m.text + text };
           return next;
         }
       }
-      return prev;
+      next.push({ kind: 'seat', cliKey, text, pending: true, ok: false, turn: turnRef.current });
+      return next;
     });
   }
 
-  /** The terminal reply text is authoritative — it replaces accumulated deltas. */
+  /** The terminal reply text is authoritative — it replaces the accumulated
+   *  deltas of the seat's OLDEST pending turn (the same FIFO as the chunks). */
   function finalizePending(cliKey: string, text: string, ok: boolean): void {
     setMessages((prev) => {
       const next = [...prev];
-      for (let i = next.length - 1; i >= 0; i--) {
+      for (let i = 0; i < next.length; i++) {
         const m = next[i];
         if (m && m.kind === 'seat' && m.cliKey === cliKey && m.pending) {
-          next[i] = { kind: 'seat', cliKey, text, pending: false, ok };
+          next[i] = { ...m, text, pending: false, ok };
           return next;
         }
       }
-      return prev;
+      next.push({ kind: 'seat', cliKey, text, pending: false, ok, turn: turnRef.current });
+      return next;
     });
   }
 
@@ -477,12 +541,14 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         chatIdRef.current = id;
         writeStoredChatId(repoId, id);
       }
-      // Optimistic chips: each seat being warmed shows as warming while the open is in
-      // flight; ready/failed events (and the open response) correct them as truth arrives.
+      // Optimistic chips: each seat being warmed shows as connecting while the open is
+      // in flight; ready/failed events (and the open response) correct them as truth arrives.
       setSeats((prev) => ({
         ...prev,
         ...Object.fromEntries(
-          agents.filter((k) => prev[k] !== 'ready').map((k) => [k, 'warming' as SeatState]),
+          agents
+            .filter((k) => !WARM_STATES.has(prev[k] ?? 'failed'))
+            .map((k) => [k, 'connecting' as SeatState]),
         ),
       }));
       try {
@@ -533,41 +599,126 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     }
   }
 
-  async function send(): Promise<void> {
-    const text = input.trim();
+  /** One send in flight at a time — Enter held down must not double-post the draft
+   *  (the draft now stays in the composer until the daemon ACCEPTS it, §7.9-2). */
+  const sendingRef = useRef(false);
+
+  async function send(retryText?: string): Promise<void> {
+    const text = (retryText ?? input).trim();
     // `resolving` waits out the rejoin probe: until it answers, "no chat id" does NOT
     // mean first-run, and treating it as one would mint over the stored id (FINDING-027).
-    if (text === '' || ended || arming || resolving) return;
+    if (text === '' || ended || arming || resolving || sendingRef.current) return;
     let warm = Object.entries(seats)
-      .filter(([, st]) => st === 'ready')
+      .filter(([, st]) => WARM_STATES.has(st))
       .map(([k]) => k);
-    // Nothing ready with nothing selected: nobody would receive this (§6.2's
+    // Nothing warm with nothing selected: nobody would receive this (§6.2's
     // selection is the send's audience) — the disabled Send already says so.
     if (warm.length === 0 && chatIdRef.current === null && selectedAgentsRef.current.length === 0) return;
-    setInput('');
-    setMessages((prev) => [...prev, { kind: 'user', text }]);
-    if (warm.length === 0) {
-      // Typing IS the opt-in (§2.4): the first send warms the SELECTED agents —
-      // the §6.2 chips (defaults + additions − removals). Also the retry path
-      // after a rejected open (stale default chip): the re-arm reuses the same
-      // chat id with the corrected selection, so recovery is just "send again".
-      warm = await armChat(selectedAgentsRef.current);
-      if (warm.length === 0) return; // armChat surfaced why (openError / failed chip)
-    }
-    const id = chatIdRef.current;
-    if (id === null) return; // repo switched under the send
-    setMessages((prev) => [
-      ...prev,
-      ...warm.map((cliKey): SeatMsg => ({ kind: 'seat', cliKey, text: '', pending: true, ok: false })),
-    ]);
+    sendingRef.current = true;
+    setSendFailed(null);
     try {
-      await api.sendChatMessage(id, text);
-    } catch (e: unknown) {
-      const err = e instanceof Error ? e.message : String(e);
-      setMessages((prev) =>
-        prev.map((m) => (m.kind === 'seat' && m.pending ? { ...m, pending: false, ok: false, text: `(send failed: ${err})` } : m)),
-      );
+      // §7.9-1 roster-first: a first send from a PRISTINE fallback selection with a
+      // still-cold cache fetches the roster ON THIS GESTURE (never on mount — §2.4
+      // holds) so the send names seats the daemon accepts. The fallback trio goes
+      // to the daemon only when the roster is genuinely unreachable.
+      if (warm.length === 0 && chatIdRef.current === null && !chipsTouchedRef.current
+        && getCachedRoster() === null) {
+        try {
+          const { roster } = await api.getRoster();
+          setCachedRoster(roster);
+          if (roster.length > 0) {
+            const keys = roster.map((s) => s.key);
+            setSelectedAgents(keys);
+            selectedAgentsRef.current = keys;
+          }
+        } catch {
+          /* roster unreachable — the trio is the honest audience (§7.9-1) */
+        }
+      }
+      const turn = turnRef.current + 1;
+      turnRef.current = turn;
+      setMessages((prev) => [...prev, { kind: 'user', text, turn }]);
+      // §7.9-2: a failed send retracts its optimistic bubbles (nothing went out),
+      // keeps the draft in the composer, and renders the failure inline with retry.
+      const failSend = (reason: string): void => {
+        setMessages((prev) => prev.filter((m) => m.turn !== turn));
+        setSendFailed({ text, reason });
+      };
+      if (warm.length === 0) {
+        // Typing IS the opt-in (§2.4): the first send warms the SELECTED agents —
+        // the §6.2 chips (defaults + additions − removals). Also the retry path
+        // after a rejected open (stale chip): the re-arm reuses the same chat id
+        // with the corrected selection, so recovery is just "send again".
+        warm = await armChat(selectedAgentsRef.current);
+        if (warm.length === 0) {
+          // armChat surfaced WHY (openError / failed chips); the user bubble
+          // retracts and the draft survives — nothing was fanned out.
+          setMessages((prev) => prev.filter((m) => m.turn !== turn));
+          return;
+        }
+      }
+      const id = chatIdRef.current;
+      if (id === null) return; // repo switched under the send
+      setMessages((prev) => [
+        ...prev,
+        ...warm.map((cliKey): SeatMsg => ({ kind: 'seat', cliKey, text: '', pending: true, ok: false, turn })),
+      ]);
+      // §7.9-4: the fan-out audience is WORKING until its reply lands.
+      setSeats((prev) => ({
+        ...prev,
+        ...Object.fromEntries(warm.filter((k) => prev[k] !== 'failed').map((k) => [k, 'working' as SeatState])),
+      }));
+      try {
+        await api.sendChatMessage(id, text);
+        // Accepted — the draft leaves the composer only now (§7.9-2). A mid-flight
+        // edit is the operator's newer draft and is left alone.
+        setInput((cur) => (cur.trim() === text ? '' : cur));
+      } catch (e: unknown) {
+        failSend(e instanceof Error ? e.message : String(e));
+        // The message never reached the daemon: this turn's audience is not
+        // working on it. (A seat still streaming an OLDER turn re-corrects on
+        // its next frame — replied/failed arrive from the wire.)
+        setSeats((prev) => ({
+          ...prev,
+          ...Object.fromEntries(
+            warm.filter((k) => prev[k] === 'working').map((k) => [k, 'ready' as SeatState]),
+          ),
+        }));
+      }
+    } finally {
+      sendingRef.current = false;
     }
+  }
+
+  /**
+   * The conversation→action bridge (§7.9): promote this chat into a BUILD with
+   * the transcript as context. Rides the composer's existing prefill machinery
+   * (the §4.3 retry store, consumed once at the launch form's mount) — a
+   * prefill, never a hidden launch: the operator edits before send. No lineage
+   * claim is invented (`retryOf: null` — chats are not runs).
+   */
+  function promoteToBuild(): void {
+    if (navigate === undefined) return;
+    const transcript = messages
+      .filter((m) => m.kind === 'user' || !m.pending)
+      .map((m) => (m.kind === 'user' ? `operator: ${m.text}` : `${m.cliKey}: ${m.text}`))
+      .join('\n');
+    const MAX = 6000; // keep the prefill a context, not a payload
+    const clipped = transcript.length > MAX ? `…${transcript.slice(-MAX)}` : transcript;
+    setRetryPrefill({
+      retryOf: null,
+      problem: `Continue from this chat — the transcript is context, the last ask is the intent:\n\n${clipped}`,
+      clis: (() => {
+        const warm = Object.entries(seats).filter(([, st]) => WARM_STATES.has(st)).map(([k]) => k);
+        return warm.length > 0 ? warm : selectedAgentsRef.current;
+      })(),
+      workflowId: null,
+      repoRef: repoId ?? null,
+      entityMode: 'shared',
+      humanConfirm: 'none',
+      projectId: projectId ?? selectedProjectRef.current,
+    });
+    navigate('/runs/new');
   }
 
   async function endChat(): Promise<void> {
@@ -586,21 +737,34 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     onBack();
   }
 
+  // §7.9-4 / EC44: every seat chip SAYS its state — connecting / ready /
+  // working / replied / failed — and a failed seat carries its reason inline
+  // (the daemon's open-time answer or the chatSessionFailed frame), truncated
+  // in CSS with the full text on the title. No unlabeled "working" anywhere.
   const seatChip = (cliKey: string, st: SeatState): React.ReactElement => (
     // wk-disclose: the roster disclosure animates in at --dur-base ease-out
     // (§5.3 motion) — once per chip mount, never a loop (§1.6).
     <span
       key={cliKey}
+      data-testid="seat-chip"
+      data-agent={cliKey}
+      data-state={st}
       title={st === 'failed' ? seatErrors[cliKey] : st}
       className="wk-disclose inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-[11px] font-mono"
       style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg, opacity: st === 'failed' ? 0.5 : 1 }}
     >
       <span
-        className={`inline-block w-1.5 h-1.5 rounded-full ${st === 'warming' ? 'animate-pulse' : ''}`}
+        className={`inline-block w-1.5 h-1.5 rounded-full ${st === 'connecting' || st === 'working' ? 'animate-pulse' : ''}`}
         style={{ background: SEAT_DOT[st] }}
       />
       {cliKey}
-      {st === 'failed' ? ' ✕' : ''}
+      <span
+        data-testid="seat-state"
+        className="truncate"
+        style={{ color: st === 'failed' ? 'var(--status-fail)' : 'var(--ink-dim)', maxWidth: '180px' }}
+      >
+        {st === 'failed' && seatErrors[cliKey] ? `failed — ${seatErrors[cliKey]}` : st}
+      </span>
     </span>
   );
 
@@ -649,6 +813,8 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // keeps the bubble shape without claiming a surface of its own.
     <div
       key={key}
+      data-testid="user-bubble"
+      data-turn={m.turn}
       className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
       style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
     >
@@ -660,6 +826,12 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     <div
       // §5.3 token usage: agent bubbles sit on --surface-card; the
       // border speaks status while a reply is pending or failed.
+      // §7.9-3: the bubble WEARS its seat+turn identity, so chunk routing
+      // is assertable in the DOM (data-turn matches the causing send).
+      data-testid="seat-bubble"
+      data-agent={m.cliKey}
+      data-turn={m.turn}
+      data-pending={m.pending}
       className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
       style={{
         background: 'var(--surface-card)',
@@ -688,7 +860,7 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     </span>
   );
 
-  const anyReady = Object.values(seats).some((st) => st === 'ready');
+  const anyReady = Object.values(seats).some((st) => WARM_STATES.has(st));
   // V8: a teardown control exists only once there is something armed to tear down —
   // warm agents, or a kept-on-error chat id the operator may want to disconnect.
   const closable = chatId !== null && (anyReady || openError !== null);
@@ -701,7 +873,8 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   // Not first-run while the rejoin probe is unresolved — teaching "nothing here yet"
   // over a chat that may be about to pop back in would be a lie held for milliseconds.
   const firstRun =
-    messages.length === 0 && Object.keys(seats).length === 0 && openError === null && !resolving;
+    messages.length === 0 && Object.keys(seats).length === 0 && openError === null &&
+    sendFailed === null && !resolving;
   // The create-flow project field (§5.2) shows only while the chat is still being
   // CREATED (binding happens at open time) and only outside the project shell —
   // in the shell the context IS the project (§4.3) and rides `projectId` silently.
@@ -739,6 +912,19 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
           </div>
         )}
         <div className="flex-1" />
+        {/* §7.9 conversation→action: visible once there is a transcript to carry. */}
+        {messages.length > 0 && navigate !== undefined && !ended && (
+          <button
+            type="button"
+            data-testid="chat-promote"
+            title="Open the Build composer prefilled with this conversation as context — editable before launch"
+            onClick={promoteToBuild}
+            className="text-[11px] px-2.5 py-1 rounded-lg"
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)', border: '1px solid var(--surface-overlay)' }}
+          >
+            Continue in Build →
+          </button>
+        )}
         {closable && (
           <button
             type="button"
@@ -757,6 +943,29 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
       <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3">
         {openError !== null && (
           <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
+        )}
+        {/* §7.9-2: a failed send is a visible, retryable fact — the draft is
+            still in the composer, nothing was fanned out, and Retry re-sends
+            exactly what failed. Never a cleared composer, never silence. */}
+        {sendFailed !== null && (
+          <div
+            data-testid="chat-send-failed"
+            className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[12px] font-mono flex items-center gap-3"
+            style={{ border: '1px solid var(--status-fail-dim)', color: 'var(--ink-body)' }}
+          >
+            <span style={{ color: 'var(--status-fail)' }}>
+              Send failed — {sendFailed.reason}. Your draft is still in the composer.
+            </span>
+            <button
+              type="button"
+              data-testid="chat-send-retry"
+              onClick={() => void send(sendFailed.text)}
+              className="shrink-0 px-2 py-0.5 rounded-lg"
+              style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px solid var(--surface-overlay)' }}
+            >
+              Retry
+            </button>
+          </div>
         )}
         {firstRun && (
           // §2.4: the first-run state TEACHES — what Chat is, what typing does, and the
@@ -886,6 +1095,10 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
           <div
             data-testid="agent-chips-bar"
             data-count={selectedAgents.length}
+            // §7.9-1 honesty: where this seeding came from — the live roster
+            // cache, or the cold-cache fallback trio (roster-first, fallback
+            // only while nothing has fetched a roster this session).
+            data-source={(getCachedRoster()?.length ?? 0) > 0 ? 'roster' : 'fallback'}
             className="flex items-center gap-1.5 flex-wrap pb-2"
           >
             {selectedAgents.map((key) => (
@@ -913,7 +1126,10 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
                   type="button"
                   aria-label={`Remove ${key}`}
                   title={`Remove ${key} from this chat`}
-                  onClick={() => setSelectedAgents((prev) => prev.filter((a) => a !== key))}
+                  onClick={() => {
+                    chipsTouchedRef.current = true; // §7.9-1: an edit pins the selection
+                    setSelectedAgents((prev) => prev.filter((a) => a !== key));
+                  }}
                   // §6.3: 12×12, transparent, --ink-dim → --ink-high on hover
                   // (the wk-chip-x pair in global.css — hover needs CSS).
                   className="wk-chip-x inline-flex items-center justify-center leading-none"
@@ -974,6 +1190,7 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
                           data-testid="agent-picker-option"
                           data-agent-key={seat.key}
                           onClick={() => {
+                            chipsTouchedRef.current = true; // §7.9-1: an edit pins the selection
                             setSelectedAgents((prev) => (prev.includes(seat.key) ? prev : [...prev, seat.key]));
                             setPickerOpen(false);
                           }}

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -944,29 +944,6 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
         {openError !== null && (
           <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
         )}
-        {/* §7.9-2: a failed send is a visible, retryable fact — the draft is
-            still in the composer, nothing was fanned out, and Retry re-sends
-            exactly what failed. Never a cleared composer, never silence. */}
-        {sendFailed !== null && (
-          <div
-            data-testid="chat-send-failed"
-            className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[12px] font-mono flex items-center gap-3"
-            style={{ border: '1px solid var(--status-fail-dim)', color: 'var(--ink-body)' }}
-          >
-            <span style={{ color: 'var(--status-fail)' }}>
-              Send failed — {sendFailed.reason}. Your draft is still in the composer.
-            </span>
-            <button
-              type="button"
-              data-testid="chat-send-retry"
-              onClick={() => void send(sendFailed.text)}
-              className="shrink-0 px-2 py-0.5 rounded-lg"
-              style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px solid var(--surface-overlay)' }}
-            >
-              Retry
-            </button>
-          </div>
-        )}
         {firstRun && (
           // §2.4: the first-run state TEACHES — what Chat is, what typing does, and the
           // product's central trick (choose a mode by conversation). Never a warmed roster.
@@ -1052,6 +1029,29 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
                 </div>
               ),
             )}
+        {/* §7.9-2: a failed send is a visible, retryable fact — the draft is
+            still in the composer, nothing was fanned out, and Retry re-sends
+            exactly what failed. Never a cleared composer, never silence. */}
+        {sendFailed !== null && (
+          <div
+            data-testid="chat-send-failed"
+            className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[12px] font-mono flex items-center gap-3"
+            style={{ border: '1px solid var(--status-fail-dim)', color: 'var(--ink-body)' }}
+          >
+            <span style={{ color: 'var(--status-fail)' }}>
+              Send failed — {sendFailed.reason}. Your draft is still in the composer.
+            </span>
+            <button
+              type="button"
+              data-testid="chat-send-retry"
+              onClick={() => void send(sendFailed.text)}
+              className="shrink-0 px-2 py-0.5 rounded-lg"
+              style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px solid var(--surface-overlay)' }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
         <div ref={bottomRef} />
       </div>
 

--- a/src/store/retryPrefill.ts
+++ b/src/store/retryPrefill.ts
@@ -9,8 +9,13 @@ import type { EntityMode, HumanConfirm } from '../api/types.js';
  * recorded in the system of record, not inferred from prompt equality.
  */
 export interface RetryPrefill {
-  /** The run being retried — rides the launch body as `retryOf`. */
-  retryOf: string;
+  /**
+   * The run being retried — rides the launch body as `retryOf`. `null` when
+   * the prefill is not a retry at all: the chat→build promotion (DES-UX-001
+   * §7.9's conversation→action bridge) rides the same machinery with the
+   * transcript as context and NO lineage claim (chats are not runs).
+   */
+  retryOf: string | null;
   problem: string;
   clis: readonly string[];
   /** The original `workflow_id`; `null` = free-text (nothing to prefill). */

--- a/src/store/rosterCache.ts
+++ b/src/store/rosterCache.ts
@@ -18,6 +18,7 @@ import type { RosterSeat } from '../api/types.js';
  */
 
 let cached: RosterSeat[] | null = null;
+const listeners = new Set<(roster: RosterSeat[]) => void>();
 
 /** The last roster any surface fetched, or `null` when none has yet. */
 export function getCachedRoster(): RosterSeat[] | null {
@@ -27,9 +28,23 @@ export function getCachedRoster(): RosterSeat[] | null {
 /** Deposit a freshly fetched roster for later synchronous reads. */
 export function setCachedRoster(roster: RosterSeat[]): void {
   cached = roster;
+  for (const fn of listeners) fn(roster);
+}
+
+/**
+ * Warm-roster notification (DES-UX-001 §7.9-1): a surface whose defaults were
+ * seeded while the cache was cold (the fallback trio) hears the deposit that
+ * arrives later — e.g. the launch form's startup fetch landing after Chat
+ * mounted — so a warm roster beats the fallback without any new fetch. The
+ * subscription itself can never fire a request (§2.4 holds unchanged).
+ */
+export function subscribeRoster(fn: (roster: RosterSeat[]) => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
 }
 
 /** Test hook: return to the cold-start state. */
 export function clearCachedRoster(): void {
   cached = null;
+  listeners.clear();
 }

--- a/tests/ChatsPage.dashboard.test.tsx
+++ b/tests/ChatsPage.dashboard.test.tsx
@@ -115,11 +115,19 @@ describe('the register below (§4.3: "the list below is the existing ChatsPage l
     expect(onSelect).toHaveBeenCalledWith('c-gated');
   });
 
-  it('fires zero requests on mount — props and loaded stores only (fetch untouched)', () => {
-    const spy = vi.fn();
+  it('fires exactly ONE declared request on mount — GET /chats, the §7.9-5 live-session listing (re-scoped by DES-UX-001 slice AB)', async () => {
+    // Pre-slice-AB this page read props + loaded stores only. Slice AB adds the
+    // ONE named exception (the §3.3-style declared fetch): the live-session
+    // listing rides the /chats navigation so warm seats are findable (the
+    // zombie-cleanup wire, FINDING-027's GET /chats). Nothing else may fire.
+    const spy = vi.fn().mockRejectedValue(new Error('offline'));
     vi.stubGlobal('fetch', spy);
     page();
-    expect(spy).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    const url = String(spy.mock.calls[0]?.[0] ?? '');
+    expect(url.endsWith('/api/v1/chats')).toBe(true);
+    // An unreachable daemon keeps the band absent — the page still renders.
+    expect(screen.queryByTestId('live-chats')).toBeNull();
     vi.unstubAllGlobals();
   });
 });

--- a/tests/ChatsPage.live.test.tsx
+++ b/tests/ChatsPage.live.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * DES-UX-001 §7.9-5 (slice AB) — the /chats live-session band: every warm
+ * chat the daemon holds is FINDABLE (the review's zombie class — working
+ * agents nothing points at — dies here), listed with its seats and idle age,
+ * flagged "streaming now" from its FIRST observed frame, and endable in place
+ * (`DELETE /chats/:id`). One declared `GET /chats` rides the navigation; the
+ * stream adds sessions the fetch predates — never another fetch.
+ */
+
+const listChats = vi.fn();
+const closeChat = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listChats: (...a: unknown[]) => listChats(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+let emit: ((ev: unknown) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (fn: (ev: unknown) => void): void => {
+    emit = fn;
+  },
+}));
+
+const { ChatsPage } = await import('../src/components/ChatsPage.js');
+
+function page(): ReturnType<typeof render> {
+  return render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
+}
+
+beforeEach(() => {
+  listChats.mockReset();
+  closeChat.mockReset();
+  listChats.mockResolvedValue({
+    chats: [{ chatId: 'warm-chat-1', seats: ['claude', 'codex'], idleSecs: 42 }],
+  });
+  closeChat.mockResolvedValue({ ok: true });
+  emit = null;
+});
+afterEach(() => cleanup());
+
+describe('the live-session band (§7.9-5)', () => {
+  it('lists every warm session from GET /chats — seats, idle age, endable', async () => {
+    page();
+    const row = await screen.findByTestId('live-chat-row');
+    expect(row.dataset['chatId']).toBe('warm-chat-1');
+    expect(row).toHaveTextContent('claude · codex');
+    expect(row).toHaveTextContent('idle 42s');
+    expect(row.dataset['streaming']).toBe('false');
+    expect(screen.getByTestId('live-chats').dataset['count']).toBe('1');
+  });
+
+  it('a session is listed from its FIRST frame — visible while it streams, even when the fetch predates it', async () => {
+    listChats.mockResolvedValue({ chats: [] });
+    page();
+    await waitFor(() => expect(listChats).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('live-chats')).toBeNull();
+
+    act(() => {
+      emit!({ type: 'chatDelta', chat: 'fresh-chat', cliKey: 'claude', text: 'Hel' });
+    });
+    const row = await screen.findByTestId('live-chat-row');
+    expect(row.dataset['chatId']).toBe('fresh-chat');
+    expect(row.dataset['streaming']).toBe('true');
+    expect(screen.getByTestId('live-chat-streaming')).toHaveTextContent('streaming now');
+    expect(listChats).toHaveBeenCalledTimes(1); // the stream never re-fetches
+  });
+
+  it('End tears the session down in place (DELETE /chats/:id) and the row leaves', async () => {
+    const user = userEvent.setup();
+    page();
+    await screen.findByTestId('live-chat-row');
+    await user.click(screen.getByTestId('live-chat-end'));
+    expect(closeChat).toHaveBeenCalledWith('warm-chat-1');
+    await waitFor(() => expect(screen.queryByTestId('live-chat-row')).toBeNull());
+  });
+
+  it('a chatClosed frame removes its row — the list tracks the daemon, not this tab', async () => {
+    page();
+    await screen.findByTestId('live-chat-row');
+    act(() => {
+      emit!({ type: 'chatClosed', chat: 'warm-chat-1', reason: 'closed elsewhere' });
+    });
+    await waitFor(() => expect(screen.queryByTestId('live-chat-row')).toBeNull());
+  });
+});

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -123,13 +123,17 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
+    // Slice AB (§7.9-1): an edit pins the selection first — otherwise the
+    // picker's own roster deposit would re-seed the pristine fallback trio
+    // to the full roster (the warm-roster-wins rule) before the click lands.
+    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
     await user.click(screen.getByTestId('add-agent'));
     await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
     const options = await screen.findAllByTestId('agent-picker-option');
     expect(options.map((o) => o.dataset['agentKey'])).toEqual(['claude', 'codex', 'agy', 'pi']);
 
     await user.click(options[1]!); // codex
-    expect(chipKeys()).toEqual([...DEFAULT_CHAT_AGENTS, 'codex']);
+    expect(chipKeys()).toEqual(['reviewer', 'planner', 'codex']);
 
     // Re-opening reads the now-warm cache — no second fetch.
     await user.click(screen.getByTestId('add-agent'));
@@ -144,13 +148,17 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([
-      ...DEFAULT_CHAT_AGENTS,
+      'reviewer',
+      'planner',
       'codex',
     ]);
   });
 
   it('a stale default the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
     const user = userEvent.setup();
+    // Slice AB (§7.9-1): the stale-trio-reaches-the-daemon case now REQUIRES
+    // an unreachable roster — a reachable one would have re-seeded the send.
+    getRoster.mockRejectedValue(new Error('daemon unreachable'));
     // First open: every requested seat is rejected (stale fallback names).
     openChat.mockImplementationOnce((body: { chatId: string; clis?: string[] }) =>
       Promise.resolve({
@@ -176,7 +184,10 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     await user.click(screen.getByRole('button', { name: 'Remove writer' }));
     await user.click(screen.getByRole('button', { name: 'Remove reviewer' }));
 
-    // The retry re-arms the SAME chat id with the corrected selection, then sends.
+    // §7.9-2: the failed send's DRAFT survived in the composer — clear it for
+    // the corrected resend (the retry re-arms the SAME chat id, then sends).
+    expect(screen.getByRole('textbox')).toHaveValue('hello?');
+    await user.clear(screen.getByRole('textbox'));
     await user.type(screen.getByRole('textbox'), 'try again');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
-import { clearCachedRoster } from '../src/store/rosterCache.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import type { RosterSeat } from '../src/api/types.js';
 
 /**
  * DES-UXFIX-001 slice 4 (§2.4, F6) — Chat's first-run moment teaches — as
@@ -43,10 +44,13 @@ const ROSTER = [
   { key: 'claude', enabled_for_council: true },
   { key: 'codex', enabled_for_council: true },
   { key: 'agy', enabled_for_council: false },
-];
+] as unknown as RosterSeat[];
 
 /** §6.2's hardcoded fallback — what the chips show when the cache is cold. */
 const FALLBACK = ['writer', 'reviewer', 'planner'];
+
+const chipAgents = (): (string | undefined)[] =>
+  screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent']);
 
 beforeEach(() => {
   openChat.mockReset();
@@ -91,29 +95,44 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + 
     expect(getChat, 'nothing stored, so nothing to probe').not.toHaveBeenCalled();
   });
 
-  it('the first send warms the SELECTED agents — the default chips — then sends', async () => {
+  it('the first send is roster-first (DES-UX-001 §7.9-1): a pristine cold-cache send fetches the roster ON THE GESTURE and warms ITS seats', async () => {
     const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    // Mount stayed request-free (pinned above); the SEND is the opt-in gesture
+    // the roster fetch rides, so the open names seats the daemon accepts.
+    await user.type(screen.getByRole('textbox'), 'make me a deck');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
+    expect(body.clis).toEqual(ROSTER.map((s) => s.key));
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, 'make me a deck'));
+
+    // The message and the warm seats are on screen; the teaching state and the
+    // selection chips are done — the header seat chips are the truth now, and
+    // every fanned-out seat SAYS it is working until its reply lands (EC44).
+    expect(screen.getByText('make me a deck')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-firstrun')).toBeNull();
+    await waitFor(() => expect(screen.getAllByTitle('working')).toHaveLength(ROSTER.length));
+    expect(screen.queryByTestId('agent-chips-bar')).toBeNull();
+    // Agents are warm now, so the teardown control may exist (V8).
+    await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
+  });
+
+  it('the fallback trio reaches the daemon ONLY when the roster is unreachable (§7.9-1)', async () => {
+    const user = userEvent.setup();
+    getRoster.mockRejectedValue(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     await user.type(screen.getByRole('textbox'), 'make me a deck');
     await user.keyboard('{Enter}');
 
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
-    // §6.2: defaults + additions − removals ride the open's clis array (wire unchanged).
-    expect(body.clis).toEqual(FALLBACK);
-    // No roster fetch on the send either: the selection IS the answer (§6.1).
-    expect(getRoster).not.toHaveBeenCalled();
-    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, 'make me a deck'));
-
-    // The message and the warm seats are on screen; the teaching state and the
-    // selection chips are done — the header seat chips are the truth now.
-    expect(screen.getByText('make me a deck')).toBeInTheDocument();
-    expect(screen.queryByTestId('chat-firstrun')).toBeNull();
-    await waitFor(() => expect(screen.getAllByTitle('ready')).toHaveLength(FALLBACK.length));
-    expect(screen.queryByTestId('agent-chips-bar')).toBeNull();
-    // Agents are warm now, so the teardown control may exist (V8).
-    await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    // Cold cache AND unreachable roster: the trio is the honest audience.
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(FALLBACK);
   });
 
   it('[+ Add] opens the roster picker (fetch rides the user action) and the addition joins the send', async () => {
@@ -121,6 +140,9 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + 
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     expect(getRoster).not.toHaveBeenCalled();
+    // An edit PINS the selection (§7.9-1): the roster deposit from the picker
+    // open must not re-seed over the operator's removal.
+    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
     await user.click(screen.getByTestId('add-agent'));
     // Opening the picker is a USER action — the one place the roster may be fetched here.
     await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
@@ -128,12 +150,24 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + 
     expect(options.map((o) => o.dataset['agentKey'])).toEqual(ROSTER.map((s) => s.key));
 
     await user.click(options[0]!); // add claude
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '4');
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '3');
 
     await user.type(screen.getByRole('textbox'), 'all hands');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([...FALLBACK, 'claude']);
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner', 'claude']);
+  });
+
+  it('a warm roster deposited AFTER mount re-seeds a PRISTINE selection — warm roster beats the fallback trio (§7.9-1)', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    expect(chipAgents()).toEqual(FALLBACK);
+
+    // Another surface (the launch form's startup fetch) deposits the roster.
+    const { act } = await import('@testing-library/react');
+    act(() => setCachedRoster(ROSTER));
+    await waitFor(() => expect(chipAgents()).toEqual(ROSTER.map((s) => s.key)));
+    // Still zero requests from THIS surface — it only heard the deposit.
+    expect(getRoster).not.toHaveBeenCalled();
   });
 
   it('Send is enabled by text alone on first-run — typing is the opt-in', async () => {

--- a/tests/GroupChat.repair.test.tsx
+++ b/tests/GroupChat.repair.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import { clearRetryPrefill, peekRetryPrefill } from '../src/store/retryPrefill.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+/**
+ * DES-UX-001 §7.9 (slice AB) — chat repair, the unit half (the e2e rig
+ * re-proves these against a real build with a network tap):
+ *
+ *   - §7.9-2: a failed send NEVER clears the composer — the draft survives,
+ *     the optimistic bubbles retract, the failure renders inline with Retry;
+ *   - §7.9-3: chunk→bubble routing is per-seat FIFO (seat+turn) — a chunk from
+ *     a still-streaming turn lands in ITS bubble, never the next turn's (the
+ *     mid-word splice regression), and an orphan chunk is never dropped;
+ *   - §7.9-4 / EC44: seats wear explicit states — working while a reply is
+ *     pending, replied when it lands, failed-with-reason from the daemon's
+ *     open-time answer (mid-stream reasons stay honest: BRIDGE-UX-1 probe 4
+ *     pinned that no per-seat mid-stream lifecycle exists on the wire);
+ *   - the conversation→action bridge: Continue in Build deposits the
+ *     transcript as context on the §4.3 prefill store, no lineage claim.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+/** Capture the event-stream handler so tests can drip real frame shapes. */
+let emit: ((ev: unknown) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (fn: (ev: unknown) => void): void => {
+    emit = fn;
+  },
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+] as unknown as RosterSeat[];
+
+beforeEach(() => {
+  for (const spy of [openChat, getChat, closeChat, getRoster, sendChatMessage]) spy.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ['claude', 'codex']).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+  clearCachedRoster();
+  clearRetryPrefill();
+  emit = null;
+  setCachedRoster(ROSTER); // warm cache: chips are roster-true from first paint
+});
+
+const chatId = (): string => (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+
+function bubble(agent: string, turn: number): HTMLElement | null {
+  return document.querySelector(`[data-testid="seat-bubble"][data-agent="${agent}"][data-turn="${turn}"]`);
+}
+
+async function sendText(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.type(screen.getByRole('textbox'), text);
+  await user.keyboard('{Enter}');
+  await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(chatId(), text));
+}
+
+describe('§7.9-2 — a failed send never clears the composer', () => {
+  it('keeps the draft, retracts the optimistic bubbles, renders inline retry — and Retry re-sends exactly the failed text', async () => {
+    const user = userEvent.setup();
+    sendChatMessage.mockRejectedValueOnce(new Error('daemon refused the fan-out'));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await user.type(screen.getByRole('textbox'), 'first ask');
+    await user.keyboard('{Enter}');
+    const failure = await screen.findByTestId('chat-send-failed');
+    expect(failure).toHaveTextContent('daemon refused the fan-out');
+    expect(failure).toHaveTextContent(/draft is still in the composer/);
+    // The draft SURVIVED — and the transcript carries no phantom turn.
+    expect(screen.getByRole('textbox')).toHaveValue('first ask');
+    expect(screen.queryByTestId('user-bubble')).toBeNull();
+    expect(screen.queryByTestId('seat-bubble')).toBeNull();
+    // The audience is not "working" on a message that never went out (EC44).
+    expect(document.querySelector('[data-state="working"]')).toBeNull();
+
+    sendChatMessage.mockResolvedValueOnce({ seats: [] });
+    await user.click(screen.getByTestId('chat-send-retry'));
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+    expect(sendChatMessage).toHaveBeenLastCalledWith(chatId(), 'first ask');
+    // Accepted now: the failure row retires, the draft leaves the composer.
+    await waitFor(() => expect(screen.queryByTestId('chat-send-failed')).toBeNull());
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByTestId('user-bubble')).toHaveTextContent('first ask');
+  });
+});
+
+describe('§7.9-3 — chunk routing keys on seat+turn (per-seat FIFO)', () => {
+  it('a still-streaming turn keeps its chunks when a second send opens the next turn — no mid-word splice', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    await sendText(user, 'first ask');
+    await user.type(screen.getByRole('textbox'), 'second ask');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+
+    // Two pending bubbles per seat now (turn 1 and turn 2). Turn 1's chunks
+    // arrive AFTER turn 2 opened — the exact splice scenario.
+    act(() => {
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text: 'Hel' });
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'codex', text: 'Sta' });
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text: 'lo' });
+    });
+    expect(bubble('claude', 1)).toHaveTextContent('Hello');
+    expect(bubble('codex', 1)).toHaveTextContent('Sta');
+    expect(bubble('claude', 2)).toHaveTextContent('thinking…');
+
+    // The terminal reply closes turn 1; the NEXT chunk belongs to turn 2.
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'Hello world', ok: true });
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text: 'Second answer' });
+    });
+    expect(bubble('claude', 1)).toHaveTextContent('Hello world');
+    expect(bubble('claude', 1)!.dataset['pending']).toBe('false');
+    expect(bubble('claude', 2)).toHaveTextContent('Second answer');
+  });
+
+  it('an orphan chunk opens its own bubble — streamed text is never silently dropped', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'ask');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'done', ok: true });
+      // A late chunk with no pending bubble left for this seat:
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text: 'stray tail' });
+    });
+    const bubbles = screen.getAllByTestId('seat-bubble').filter((b) => b.dataset['agent'] === 'claude');
+    expect(bubbles.some((b) => b.textContent?.includes('stray tail'))).toBe(true);
+  });
+});
+
+describe('§7.9-4 / EC44 — explicit seat states', () => {
+  it('working while a reply is pending, replied when it lands', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'ask');
+
+    const chip = (agent: string): HTMLElement =>
+      document.querySelector(`[data-testid="seat-chip"][data-agent="${agent}"]`) as HTMLElement;
+    expect(chip('claude').dataset['state']).toBe('working');
+    expect(chip('claude')).toHaveTextContent('working');
+
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'done', ok: true });
+    });
+    expect(chip('claude').dataset['state']).toBe('replied');
+    expect(chip('codex').dataset['state']).toBe('working');
+  });
+
+  it('an open-time rejection is failed-WITH-REASON — the daemon\'s own POST /chats answer, visible on the chip', async () => {
+    const user = userEvent.setup();
+    openChat.mockImplementationOnce((body: { chatId: string; clis?: string[] }) =>
+      Promise.resolve({
+        chatId: body.chatId,
+        seats: [
+          { cliKey: 'claude', ok: true },
+          { cliKey: 'codex', ok: false, error: 'quota exceeded for this seat' },
+        ],
+      }),
+    );
+    const user2 = user;
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user2, 'ask');
+
+    const failed = document.querySelector('[data-testid="seat-chip"][data-agent="codex"]') as HTMLElement;
+    expect(failed.dataset['state']).toBe('failed');
+    expect(failed).toHaveTextContent('failed — quota exceeded for this seat');
+    expect(failed.title).toBe('quota exceeded for this seat');
+  });
+});
+
+describe('the conversation→action bridge (§7.9)', () => {
+  it('Continue in Build deposits the transcript as context — a prefill, never a launch, no lineage claim', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    render(<GroupChat repoId={null} onBack={() => undefined} navigate={navigate} />);
+    await sendText(user, 'sketch the uploader');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'start with the seams', ok: true });
+    });
+
+    await user.click(screen.getByTestId('chat-promote'));
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+    const prefill = peekRetryPrefill();
+    expect(prefill).not.toBeNull();
+    expect(prefill!.retryOf).toBeNull(); // chats are not runs — no lineage claim
+    expect(prefill!.problem).toContain('operator: sketch the uploader');
+    expect(prefill!.problem).toContain('claude: start with the seams');
+    expect(prefill!.clis).toEqual(['claude', 'codex']); // the warm seats
+    // Nothing launched: the composer consumes this on ITS mount, editable first.
+    expect(sendChatMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/GroupChat.tokens.test.tsx
+++ b/tests/GroupChat.tokens.test.tsx
@@ -129,7 +129,8 @@ describe('GroupChat — the §5.3 visual language', () => {
     const pending = screen.getAllByText('thinking…')[0]!.closest('div') as HTMLElement;
     expect(pending.style.background).toBe('var(--surface-card)');
     // The seat chips animate in via wk-disclose (§5.3 motion, one run, no loop).
-    const chip = screen.getAllByTitle('ready')[0]!;
+    // Slice AB (§7.9-4): a fanned-out seat SAYS "working" until its reply lands.
+    const chip = screen.getAllByTitle('working')[0]!;
     expect(chip.className).toContain('wk-disclose');
   });
 });


### PR DESCRIPTION
Implements **DES-UX-001 §7.9 (slice AB)** — chat repair (BRIEF-UX-001 C6, EC44), shaped by §8.4.1 probe 4.

- **Roster-true chips**: warm deposits re-seed a pristine selection; a cold-cache first send fetches /roster on the gesture; the fallback trio reaches the daemon only when the roster is unreachable (`data-source=roster|fallback`); zero-mount budget holds.
- **Failed sends keep the draft**: optimistic bubbles retract, inline failure + Retry resends the exact text; composer clears only on acceptance.
- **Seat states** connecting/ready/working/replied/failed-with-reason — reasons only from open-time POST /chats errors + the real chatSessionFailed frame (no invented per-seat mid-stream lifecycle, per probe 4).
- **Chunk routing** keyed seat+turn via per-seat FIFO; orphan chunks never drop.
- **/chats live-session band**: one declared GET rides the navigation; tab-closed sessions findable and endable (End fires a real DELETE); zombie pin holds. Chat→build prefill bridge included.

Verified: 1383/1383 unit tests (16 new); slice rig 11 steps ×3 stable; re-scoped rigs sliceC/K/P + uxfix_slice4 + studio_standalone (real daemon) green; negative check fails on main; adversarial verifier approved. LOC +427/−50 disclosed vs ~350 (comment-heavy per house style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
