### PR TITLE
DES-UX-001 slice AC: keyboard coherence + composer preflight

### DIFF
--- a/e2e/feedback2_sliceL_test.py
+++ b/e2e/feedback2_sliceL_test.py
@@ -360,12 +360,22 @@ with sync_playwright() as p:
         """() => ({ pushed: window.__pushed, focused: window.__focused,
                     closed: window.__notifObjs[0].closed })"""
     )
+    # DES-UX-001 slice AC re-scope (§11.2): gate-posture is a LAUNCH-time
+    # control with a non-"none" shipped default (§7.8/§13) — the STEER composer
+    # this click lands on must not render one (a live run's gate is answered,
+    # never re-postured). Re-derived at slice time: the batch-entry assertions
+    # below pin POST /runs/:id/gate bodies, which carry no launch posture, so
+    # none of them move; this negative pin is the one the flip adds here.
+    posture_leak = pageB.evaluate(
+        "() => !!document.querySelector('[data-testid=\"gate-posture\"]')")
     report["steps"]["notification_click_lands_on_gate"] = {
         "ok": all([
             clicked["focused"] >= 1,
             f"/p/{SIMPLE_PROJECT}/build/{SIMPLE_RUN}#gate" in clicked["pushed"],
             clicked["closed"] is True,
+            not posture_leak,
         ]),
+        "gate_posture_absent_on_steer_composer": not posture_leak,
         **clicked,
     }
     pageB.close()

--- a/e2e/feedback_sliceB_test.py
+++ b/e2e/feedback_sliceB_test.py
@@ -124,11 +124,17 @@ with sync_playwright() as p:
                // EC7 preserved: the surface says what it is for, in one line.
                teachesItself: (document.body.innerText || '').includes(
                  'Describe your goal. The council elects a CLI'),
+               // DES-UX-001 §7.8 (slice AC re-scope): the gate control sits at
+               // top level and its SHIPPED default is not "none" — human_confirm
+               // before the first gate-bearing unit (§13's adopted position).
+               gatePosture: q('[data-testid="gate-posture"]')?.value ?? null,
              }; }""")
 
     ac1_unfiled = (closed["fieldText"] or "").strip().startswith("Unfiled") \
         and closed["locked"] == "false" and not closed["listOpen"]
     intent_ok = closed["intentPlaceholder"] == "What do you need built?" and closed["rowFirst"]
+    # Slice AC (§7.8/§13): the composer's top-level gate-posture default.
+    gate_posture_ok = closed["gatePosture"] == "before"
 
     # ── Capture 1: the Unfiled default, BEFORE any interaction ────────────────
     page.screenshot(path=str(VSHOTS / "feedback-B-build-unfiled.png"))
@@ -183,12 +189,15 @@ with sync_playwright() as p:
     report["steps"]["build_unfiled"] = {
         "ok": all([fonts_ok, ac1_unfiled, intent_ok, list_opens, ac2_names,
                    default_hidden, ac4_add, anatomy_ok, select_ok, unfiled_back,
-                   closed["teachesItself"]]),
+                   closed["teachesItself"], gate_posture_ok]),
         "web_fonts_loaded": fonts_ok,
         "ac1_field_defaults_unfiled": ac1_unfiled,
         "field_text": closed["fieldText"],
         "intent_input_preserved": intent_ok,
         "ec7_surface_teaches_itself": closed["teachesItself"],
+        # DES-UX-001 slice AC re-scope (§11.2): the shipped gate-posture default.
+        "gate_posture_default_not_none": gate_posture_ok,
+        "gate_posture_value": closed["gatePosture"],
         "ac2_dropdown_lists_projects": ac2_names,
         "dropdown_names_head": dropdown["names"][:8],
         "synthesized_default_hidden": default_hidden,

--- a/e2e/ux_sliceAC_test.py
+++ b/e2e/ux_sliceAC_test.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+ux_sliceAC_test.py — the DES-UX-001 slice-AC gate: keyboard coherence (§7.7,
+EC42) + composer preflight (§7.8, EC43), against the shared frozen-NOW0 W2
+fixture (uxfix_fixture.py).
+
+§7.7 DOM ACs:
+  1. '?' renders [shortcut-overlay] on every route — board, project shell,
+     doc surface — and the overlay is REGISTRY-rendered: the entries it lists
+     are the slice-G registrations live on that surface (triage keys appear on
+     the board, not on the doc surface), never a hand list;
+  2. with the gate panel focused, 'a' fires the same POST /runs/:id/gate the
+     Approve button fires (tap, exactly once — a double-tap is dropped); 'r'
+     fires the reject; unfocused, both yield;
+  3. ONE Escape contract: Escape closes the '?' overlay FIRST (an expanded
+     runs sheet survives that press and collapses on the next), closes the
+     bell popover, and closes the Operator-shell modal (the old
+     disableEscapeKey opt-out is gone);
+  4. the shell takes focus on open: xterm's helper textarea is
+     document.activeElement without any click.
+
+§7.8 DOM ACs:
+  5. a code-shaped intent launched with no repo renders [preflight-block] and
+     fires ZERO POST /runs until the override;
+  6. entering the composer from a repo-bound project auto-attaches the repo
+     chip ([repo-chip][data-auto-attached="true"], removable);
+  7. [gate-posture] sits at top level and its shipped default is not "none"
+     (COMPOSER_DEFAULT_GATE_POSTURE = before:1 — the launch body carries
+     humanConfirm "before:1");
+  8. named actions carry [action-preview] (Run Onboarding on the repo page).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-AC-shortcut-overlay.png  the board with the '?' overlay up, its grouped
+                              registry-fed sections visible
+  ux-AC-preflight.png         the composer blocked on a repo-less code intent —
+                              warn copy, Attach / Launch-anyway, gate posture
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4399),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4399"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+SIMPLE_PROJECT = "q3-review-deck"
+SIMPLE_RUN = "r-q3"
+BOUND_PROJECT = "upload-endpoint"   # repo_member=True binds studio-api here
+REPO_ID = "studio-api"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+OVERLAY_STATE = """() => {
+  const ov = document.querySelector('[data-testid="shortcut-overlay"]');
+  const groups = Array.from(document.querySelectorAll('[data-testid^="shortcut-group-"]'))
+    .map((g) => g.dataset.testid.replace('shortcut-group-', ''));
+  return { open: !!ov, groups, text: ov ? ov.textContent : '' };
+}"""
+
+
+def open_overlay(page) -> dict:
+    page.keyboard.press("?")
+    page.wait_for_function(
+        "() => !!document.querySelector('[data-testid=\"shortcut-overlay\"]')", timeout=5000
+    )
+    return page.evaluate(OVERLAY_STATE)
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # ════ Scene 1 (§7.7 AC1): '?' answers on every route, from the registry ════
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="band-needs-you"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    board = open_overlay(page)
+    # Registry-rendered on the BOARD: triage + gates entries are mounted here,
+    # and the palette chords + the overlay's own keys ride along.
+    board_ok = all([
+        board["open"],
+        "triage" in board["groups"],
+        "gates" in board["groups"],
+        "palette" in board["groups"],
+        "panels" in board["groups"],
+        "Select the next card" in board["text"],          # useTriageCursor's entry
+        "Approve the selected gate" in board["text"],     # its 'a' entry
+        "Open the command palette" in board["text"],      # paletteShortcutEntries
+        "Keyboard shortcuts (this overlay)" in board["text"],  # self-documenting
+    ])
+    page.screenshot(path=str(VSHOTS / "ux-AC-shortcut-overlay.png"))
+
+    # Escape closes the overlay (chain rung 1).
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"shortcut-overlay\"]') === null", timeout=5000
+    )
+
+    # Project shell.
+    page.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}/build", wait_until="domcontentloaded")
+    page.locator('[data-testid="runs-bottom-bar"]').wait_for(timeout=30000)
+    page.wait_for_timeout(300)
+    shell_ov = open_overlay(page)
+    page.keyboard.press("Escape")
+
+    # Doc surface — the registry truth cuts the other way here: no triage
+    # cursor is mounted, so the overlay documents NO triage keys.
+    page.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}/document", wait_until="domcontentloaded")
+    page.wait_for_timeout(500)
+    doc_ov = open_overlay(page)
+    doc_ok = doc_ov["open"] and "triage" not in doc_ov["groups"]
+    page.keyboard.press("Escape")
+
+    check("overlay_every_route_from_registry",
+          board_ok and shell_ov["open"] and doc_ok,
+          board_groups=board["groups"], shell_groups=shell_ov["groups"],
+          doc_groups=doc_ov["groups"],
+          screenshot=str(VSHOTS / "ux-AC-shortcut-overlay.png"))
+
+    # ════ Scene 2 (§7.7 AC2): the gate panel honors a / r ═════════════════════
+    gate_posts: list = []
+    page.on("request", lambda r: gate_posts.append(r.post_data)
+            if r.method == "POST" and r.url.endswith(f"/runs/{SIMPLE_RUN}/gate") else None)
+
+    page.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}/build/{SIMPLE_RUN}", wait_until="domcontentloaded")
+    page.locator('[data-testid="steering-gate"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # Unfocused first: 'a' yields silently.
+    page.evaluate("() => document.activeElement?.blur?.()")
+    page.keyboard.press("a")
+    page.wait_for_timeout(300)
+    unfocused_posts = len(gate_posts)
+
+    # Focus the panel (click arms the keys), double-tap 'a' — exactly one POST.
+    page.locator('[data-testid="steering-gate"]').click()
+    page.keyboard.press("a")
+    page.keyboard.press("a")
+    page.wait_for_function("() => window.__done === undefined || true", timeout=1000)
+    page.wait_for_timeout(600)
+    approve_posts = [json.loads(b) for b in gate_posts[unfocused_posts:]]
+
+    check("gate_panel_a_approves_once",
+          unfocused_posts == 0
+          and len(approve_posts) == 1
+          and approve_posts[0].get("approve") is True,
+          unfocused_posts=unfocused_posts, posts=approve_posts)
+
+    # Reload: the fixture still answers awaiting_human, so the panel re-renders;
+    # focused 'r' fires the reject POST.
+    gate_posts.clear()
+    page.goto(f"{ORIGIN}/p/{SIMPLE_PROJECT}/build/{SIMPLE_RUN}", wait_until="domcontentloaded")
+    page.locator('[data-testid="steering-gate"]').wait_for(timeout=30000)
+    page.locator('[data-testid="steering-gate"]').click()
+    page.keyboard.press("r")
+    page.wait_for_timeout(600)
+    reject_posts = [json.loads(b) for b in gate_posts]
+    check("gate_panel_r_rejects",
+          len(reject_posts) == 1 and reject_posts[0].get("approve") is False,
+          posts=reject_posts)
+
+    # ════ Scene 3 (§7.7 AC3/AC4): the one Escape contract + shell focus ═══════
+    # 3a. Overlay closes BEFORE the expanded runs sheet (chain order).
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+    page.locator('[data-testid="runs-bottom-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.get_by_label("Expand the runs sheet").click()
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"runs-bottom-bar\"]')?.dataset?.expanded === 'true'",
+        timeout=5000)
+    open_overlay(page)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(200)
+    after_first = page.evaluate(
+        """() => ({
+          overlay: !!document.querySelector('[data-testid="shortcut-overlay"]'),
+          sheet: document.querySelector('[data-testid="runs-bottom-bar"]')?.dataset?.expanded ?? null,
+        })""")
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"runs-bottom-bar\"]')?.dataset?.expanded === 'false'",
+        timeout=5000)
+    check("escape_chain_overlay_before_sheet",
+          after_first["overlay"] is False and after_first["sheet"] == "true",
+          after_first=after_first)
+
+    # 3b. The bell popover closes on Escape (the brief's named gap).
+    page.get_by_title("Notifications").click()
+    page.locator('[data-testid="bell-popover"]').wait_for(timeout=5000)
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"bell-popover\"]') === null", timeout=5000)
+    report["steps"]["escape_closes_bell"] = {"ok": True}
+
+    # 3c. The Operator shell: opens focused, closes on Escape.
+    page.keyboard.press("Control+k")
+    page.locator('[data-testid="palette-input"]').wait_for(timeout=5000)
+    page.keyboard.type("> open terminal")
+    page.wait_for_function(
+        """() => Array.from(document.querySelectorAll('[data-testid="palette-row"]'))
+              .some((r) => (r.textContent || '').includes('Open Terminal'))""",
+        timeout=5000)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="terminal"]').wait_for(timeout=10000)
+    # §7.7: the shell TAKES focus on open — xterm's helper textarea is the
+    # active element with no click (xterm opens on the next animation frame).
+    focused = page.wait_for_function(
+        """() => document.activeElement?.classList?.contains('xterm-helper-textarea')""",
+        timeout=5000)
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.querySelector('[data-testid=\"terminal\"]') === null", timeout=5000)
+    check("shell_focused_and_escape_closes", bool(focused))
+
+    # ════ Scene 4 (§7.8): preflight, auto-attach, gate posture, previews ══════
+    set_fixture(ORIGIN, repo=True, repo_member=True, project_dto=True)
+    run_posts: list = []
+    pageB = ctx.new_page()
+    pageB.on("request", lambda r: run_posts.append(r.post_data)
+             if r.method == "POST" and r.url.endswith("/api/v1/runs") else None)
+    pageB.goto(f"{ORIGIN}/runs/new", wait_until="domcontentloaded")
+    pageB.locator('[data-testid="launch-problem"]').wait_for(timeout=30000)
+    pageB.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # AC7: gate posture at top level, shipped default ≠ none.
+    posture = pageB.evaluate(
+        "() => document.querySelector('[data-testid=\"gate-posture\"]')?.value ?? null")
+    check("gate_posture_top_level_default", posture == "before", value=posture)
+
+    # AC5: code intent, no repo → warn-and-block, ZERO POST /runs.
+    pageB.locator('[data-testid="launch-problem"]').fill("fix the login crash bug")
+    pageB.locator('[data-testid="launch-submit"]').click()
+    pageB.locator('[data-testid="preflight-block"]').wait_for(timeout=10000)
+    pageB.wait_for_timeout(400)
+    blocked_posts = len(run_posts)
+    pageB.screenshot(path=str(VSHOTS / "ux-AC-preflight.png"))
+    check("preflight_blocks_with_zero_posts", blocked_posts == 0,
+          posts=blocked_posts, screenshot=str(VSHOTS / "ux-AC-preflight.png"))
+
+    # …and the override launches, carrying the default posture on the wire.
+    pageB.locator('[data-testid="preflight-override"]').click()
+    pageB.wait_for_function("() => window.location.pathname !== '/runs/new'", timeout=10000)
+    launched = [json.loads(b) for b in run_posts]
+    check("override_launches_with_default_posture",
+          len(launched) == 1 and launched[0].get("humanConfirm") == "before:1",
+          bodies=launched)
+
+    # AC6: the bound project's crew.repo auto-attaches as a removable chip.
+    pageB.goto(f"{ORIGIN}/p/{BOUND_PROJECT}/build/new", wait_until="domcontentloaded")
+    pageB.locator('[data-testid="repo-chip"]').wait_for(timeout=15000)
+    chip = pageB.evaluate(
+        """() => {
+          const c = document.querySelector('[data-testid="repo-chip"]');
+          return { auto: c?.dataset?.autoAttached ?? null, text: c?.textContent ?? '',
+                   removable: !!c?.querySelector('button') };
+        }""")
+    pageB.locator('[data-testid="repo-chip"] button').click()
+    pageB.wait_for_function(
+        "() => document.querySelector('[data-testid=\"repo-chip\"]') === null", timeout=5000)
+    check("repo_auto_attach_chip",
+          chip["auto"] == "true" and REPO_ID in chip["text"] and chip["removable"],
+          chip=chip)
+
+    # AC8: the named action previews what it does and writes.
+    pageB.goto(f"{ORIGIN}/repo-detail/{REPO_ID}", wait_until="domcontentloaded")
+    pageB.locator('[data-testid="action-preview"]').wait_for(timeout=15000)
+    preview = pageB.evaluate(
+        "() => document.querySelector('[data-testid=\"action-preview\"]')?.textContent ?? ''")
+    check("named_action_preview",
+          "governed run" in preview and "writes" in preview.replace("rewrites", "writes"),
+          preview=preview.strip())
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_sliceAC_test.py
+++ b/e2e/ux_sliceAC_test.py
@@ -250,6 +250,39 @@ with sync_playwright() as p:
         "() => document.querySelector('[data-testid=\"terminal\"]') === null", timeout=5000)
     check("shell_focused_and_escape_closes", bool(focused))
 
+    # 3d. Stacked layers — ONE press, ONE layer (§7.7's "one contract"): bell
+    # popover + Operator-shell modal + palette stacked; each Escape closes
+    # exactly the top rung — palette first, then the modal, then the popover.
+    STACK = """() => ({
+      palette: !!document.querySelector('[data-testid="palette-input"]'),
+      modal: !!document.querySelector('[data-testid="terminal"]'),
+      bell: !!document.querySelector('[data-testid="bell-popover"]'),
+    })"""
+    page.get_by_title("Notifications").click()
+    page.locator('[data-testid="bell-popover"]').wait_for(timeout=5000)
+    page.keyboard.press("Control+k")           # palette over the popover (no mousedown)
+    page.locator('[data-testid="palette-input"]').wait_for(timeout=5000)
+    page.keyboard.type("> open terminal")
+    page.keyboard.press("Enter")               # modal opens; palette closes itself
+    page.locator('[data-testid="terminal"]').wait_for(timeout=10000)
+    page.wait_for_timeout(300)
+    page.evaluate("() => (document.activeElement)?.blur?.()")
+    page.keyboard.press("Control+k")           # palette re-opens over the modal
+    page.locator('[data-testid="palette-input"]').wait_for(timeout=5000)
+    stack0 = page.evaluate(STACK)
+    presses = []
+    for _ in range(3):
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(250)
+        presses.append(page.evaluate(STACK))
+    check(
+        "escape_one_press_one_layer",
+        stack0 == {"palette": True, "modal": True, "bell": True}
+        and presses[0] == {"palette": False, "modal": True, "bell": True}
+        and presses[1] == {"palette": False, "modal": False, "bell": True}
+        and presses[2] == {"palette": False, "modal": False, "bell": False},
+        stack=stack0, presses=presses)
+
     # ════ Scene 4 (§7.8): preflight, auto-attach, gate posture, previews ══════
     set_fixture(ORIGIN, repo=True, repo_member=True, project_dto=True)
     run_posts: list = []

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { ChatPanel } from './components/ChatPanel.js';
 import { GroupChat } from './components/GroupChat.js';
 import { WorkflowViewer } from './components/WorkflowViewer.js';
 import { WorkPage } from './components/WorkPage.js';
+import { ShortcutOverlay } from './components/ShortcutOverlay.js';
 import { SystemSettings } from './components/SystemSettings.js';
 import { ThemePage } from './components/ThemePage.js';
 import { ambientProjectId } from './hooks/ambientProject.js';
@@ -578,6 +579,11 @@ export function App(): React.ReactElement {
       {panel !== 'home' && (
         <GateNotifications onSelect={selectRun} runId={runId} projectId={projectId} runs={runs} />
       )}
+
+      {/* The '?' shortcut overlay (DES-UX-001 §7.7, EC42) — every route: this
+          root renders on all of them, and the overlay's corpus is the registry
+          itself, so each surface documents exactly the keys it registered. */}
+      <ShortcutOverlay />
 
       {/* Repo graph modal — opened from RepoDetailPage */}
       {graphModalRepo !== null && (

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
+import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
 import { useGateStore } from '../store/gates.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { clearRetryPrefill, confirmModeOf, peekRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
@@ -69,12 +70,16 @@ function detectWorkflow(text: string): string | null {
 function ActivePill({
   label,
   onClear,
+  attrs,
 }: {
   label: string;
   onClear: () => void;
+  /** Extra data-* attributes (the §7.8 repo chip's auto-attached marker). */
+  attrs?: Record<string, string>;
 }): React.ReactElement {
   return (
     <span
+      {...attrs}
       className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-mono"
       style={{
         background: 'var(--surface-raised)',
@@ -144,10 +149,38 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const [repos, setRepos] = useState<RepoEntry[]>([]);
   const [repoRefs, setRepoRefs] = useState<string[]>(prefill?.repoRef ? [prefill.repoRef] : []);
   const [entityMode, setEntityMode] = useState<EntityMode>(prefill?.entityMode ?? 'shared');
+  // Gate posture (DES-UX-001 §7.8 + §13, slice AC): the shipped default is
+  // COMPOSER_DEFAULT_GATE_POSTURE (human_confirm before the first gate-bearing
+  // unit — no longer "none"); a retry prefill still reproduces the ORIGINAL
+  // run's posture, whatever it was (§4.3 — the prefill is the original).
   const prefillGate = confirmModeOf(prefill?.humanConfirm);
-  const [confirmMode, setConfirmMode] = useState<ConfirmMode>(prefillGate.mode);
-  const [beforeOrd, setBeforeOrd] = useState(prefillGate.beforeOrd);
+  const [confirmMode, setConfirmMode] = useState<ConfirmMode>(
+    prefill !== null ? prefillGate.mode : COMPOSER_DEFAULT_GATE_POSTURE.mode,
+  );
+  const [beforeOrd, setBeforeOrd] = useState(
+    prefill !== null ? prefillGate.beforeOrd : COMPOSER_DEFAULT_GATE_POSTURE.beforeOrd,
+  );
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
+
+  // ── Preflight (DES-UX-001 §7.8, EC43, slice AC) ────────────────────────────
+  // A code-shaped intent with no repo attached warns-and-blocks: zero POST
+  // /runs until the operator attaches one or explicitly overrides.
+  const [preflightBlocked, setPreflightBlocked] = useState(false);
+
+  // Auto-attach (§7.8): a project's bound repo (`crew.repo` membership) rides
+  // the launch by default — visibly, as a removable chip (auto is a default,
+  // not a lock). `reposTouched` = the operator has spoken; auto never wins.
+  const [autoAttached, setAutoAttached] = useState(false);
+  const reposTouched = useRef(prefill?.repoRef != null);
+  const repoRefsRef = useRef(repoRefs);
+  repoRefsRef.current = repoRefs;
+  const autoTriedFor = useRef<string | null>(null);
+
+  function touchRepoRefs(refs: string[]): void {
+    reposTouched.current = true;
+    setAutoAttached(false);
+    setRepoRefs(refs);
+  }
 
   // ── Project binding (DES-FEEDBACK-001 §5, slice B) ─────────────────────────
   // `null` = Unfiled (§5.1): no `projectId` key in the POST body, the backend
@@ -232,6 +265,34 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // (loadProjects is ref-guarded and single-shot, so listing only the lock is safe.)
   }, [lockedProjectId, prefill]);
 
+  // §7.8 auto-attach: entering the composer bound to a project reads that
+  // project's members once (the same wire ProjectDashboard already reads) and
+  // attaches its `crew.repo` refs — only while the operator hasn't touched the
+  // repo selection, and never over an existing selection or a retry prefill.
+  useEffect(() => {
+    if (runId) return; // launch form only — steer/inject composers never attach
+    const pid = lockedProjectId ?? selectedProjectId;
+    if (pid == null || pid === 'default') return;
+    if (reposTouched.current || autoTriedFor.current === pid) return;
+    autoTriedFor.current = pid;
+    let cancelled = false;
+    api
+      .listProjectMembers(pid)
+      .then(({ members }) => {
+        if (cancelled || reposTouched.current || repoRefsRef.current.length > 0) return;
+        const refs = members.filter((m) => m.member_kind === 'crew.repo').map((m) => m.member_ref);
+        if (refs.length === 0) return;
+        setRepoRefs(refs);
+        setAutoAttached(true);
+      })
+      .catch(() => {
+        autoTriedFor.current = null; // transient — retry on the next binding change
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId, lockedProjectId, selectedProjectId]);
+
   // ── Elapsed-time ticker ────────────────────────────────────────────────────
   useEffect(() => {
     if (submitting) {
@@ -312,8 +373,18 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   }
 
   // ── Submit ─────────────────────────────────────────────────────────────────
-  async function submit(): Promise<void> {
+  async function submit(preflightOverride = false): Promise<void> {
     if (!problem.trim() || selectedClis.size === 0 || submitting) return;
+    // §7.8 preflight (EC43): a code-shaped intent — an explicit workflow, or
+    // the detector reading one from the text — launched with no repo attached
+    // cannot produce reviewable work. Warn-and-block: ZERO POST /runs until a
+    // repo attaches or the operator overrides ("Launch anyway").
+    const codeShaped = Boolean(workflowOverride?.trim() || workflow || detectWorkflow(problem));
+    if (!preflightOverride && codeShaped && repoRefs.length === 0) {
+      setPreflightBlocked(true);
+      return;
+    }
+    setPreflightBlocked(false);
     setSubmitting(true);
     setError(null);
 
@@ -589,7 +660,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     [...selectedClis].some((k) => !defaultCliSet.has(k));
 
   // Collect active non-default option pills
-  const activePills: Array<{ label: string; onClear: () => void }> = [];
+  const activePills: Array<{ label: string; onClear: () => void; attrs?: Record<string, string> }> = [];
 
   // The lineage claim leads the pills (§4.3): visible, and clearable — a retry
   // is a composer prefill the operator may edit down to a fresh launch.
@@ -629,8 +700,15 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   for (const rid of repoRefs) {
     const found = repos.find((r) => r.id === rid);
     activePills.push({
-      label: `Repo: ${found?.name ?? rid}`,
-      onClear: () => setRepoRefs((prev) => prev.filter((id) => id !== rid)),
+      label: `Repo: ${found?.name ?? rid}${autoAttached ? ' (from project)' : ''}`,
+      // Removing an auto-attached chip is the operator speaking (§7.8: auto is
+      // a default, not a lock) — auto never re-attaches afterwards.
+      onClear: () => touchRepoRefs(repoRefs.filter((id) => id !== rid)),
+      attrs: {
+        'data-testid': 'repo-chip',
+        'data-repo-ref': rid,
+        'data-auto-attached': autoAttached ? 'true' : 'false',
+      },
     });
   }
   if (clisDirty && roster.length > 0) {
@@ -671,6 +749,33 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           // Docked (non-embedded) forms sit at the pane's bottom edge — open up.
           dropUp={!embedded}
         />
+
+        {/* ── Gate posture at top level (§7.8, slice AC) — the + drawer keeps
+            the full matrix; this is the always-visible control whose shipped
+            default is COMPOSER_DEFAULT_GATE_POSTURE (never "none"). ── */}
+        <span
+          className="text-[11px] font-mono uppercase tracking-widest ml-auto"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Gate
+        </span>
+        <select
+          data-testid="gate-posture"
+          aria-label="Gate posture"
+          title="When a human confirms this run's units — default: before the first gate-bearing unit"
+          className="rounded-lg px-2 py-1 text-[11px] font-mono"
+          style={{
+            background: 'var(--surface-card)',
+            border: '1px solid var(--surface-raised)',
+            color: 'var(--ink-high)',
+          }}
+          value={confirmMode}
+          onChange={(e) => setConfirmMode(e.target.value as ConfirmMode)}
+        >
+          <option value="before">{beforeOrd === 1 ? 'First gate' : `Before unit #${beforeOrd}`}</option>
+          <option value="all">Every unit</option>
+          <option value="none">No gates</option>
+        </select>
       </div>
 
       {showNewProject && (
@@ -742,6 +847,48 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         </div>
       )}
 
+      {/* ── Preflight warn-and-block (§7.8, EC43) — a code intent with no repo
+          fired zero POST /runs to get here; the override is the only way past
+          without attaching. ── */}
+      {preflightBlocked && repoRefs.length === 0 && (
+        <div
+          data-testid="preflight-block"
+          className="flex items-center gap-2 text-xs rounded-xl px-4 py-2 font-mono"
+          style={{
+            background: 'var(--status-gate-dim)',
+            border: '1px solid var(--status-gate-dim)',
+            color: 'var(--status-gate)',
+          }}
+        >
+          <span className="flex-1">
+            ⚠ No repository attached — the run cannot produce reviewable work.
+            Attach one, or launch anyway.
+          </span>
+          <button
+            type="button"
+            data-testid="preflight-attach"
+            onClick={() => setPopoverOpen(true)}
+            className="rounded-lg px-3 py-1 font-semibold text-xs shrink-0"
+            style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+          >
+            Attach a repo
+          </button>
+          <button
+            type="button"
+            data-testid="preflight-override"
+            onClick={() => void submit(true)}
+            className="rounded-lg px-3 py-1 font-semibold text-xs shrink-0"
+            style={{
+              background: 'var(--surface-raised)',
+              color: 'var(--ink-muted)',
+              border: '1px solid var(--ink-dim)',
+            }}
+          >
+            Launch anyway
+          </button>
+        </div>
+      )}
+
       {/* ── Main input bubble ────────────────────────────────────────────── */}
       <div
         className="flex items-end gap-2 rounded-2xl px-4 py-3 transition-all"
@@ -777,7 +924,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
                 }}
                 repos={repos}
                 repoRefs={repoRefs}
-                onRepoRefsChange={setRepoRefs}
+                onRepoRefsChange={touchRepoRefs}
                 attachedFiles={attachedFiles}
                 onFilesChange={setAttachedFiles}
               />
@@ -850,7 +997,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       {activePills.length > 0 && (
         <div className="flex flex-wrap gap-1.5 px-1">
           {activePills.map((pill, i) => (
-            <ActivePill key={i} label={pill.label} onClear={pill.onClear} />
+            <ActivePill key={i} label={pill.label} onClear={pill.onClear} {...(pill.attrs ? { attrs: pill.attrs } : {})} />
           ))}
         </div>
       )}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
+import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
+import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { clearRetryPrefill, confirmModeOf, peekRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
 import { setCachedRoster } from '../store/rosterCache.js';
@@ -347,10 +349,16 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   }, [popoverOpen]);
 
   // ── Close popover on Escape ────────────────────────────────────────────────
+  // §7.7 (slice AC): a popover rung — yields to the '?' overlay, the palette,
+  // and any open modal above it (one press, one layer).
   useEffect(() => {
     if (!popoverOpen) return;
     function handleKey(e: KeyboardEvent): void {
-      if (e.key === 'Escape') setPopoverOpen(false);
+      if (e.key !== 'Escape') return;
+      if (useLayerStore.getState().shortcutOverlayOpen) return;
+      if (isShortcutsPaletteOpen()) return;
+      if (anyModalOpen()) return;
+      setPopoverOpen(false);
     }
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -883,7 +883,7 @@ export function CommandPalette({
 
       {/* `> Open Terminal` — the RightPanel pair (Modal + governed Terminal) */}
       {showTerminal && (
-        <Modal title="Operator shell" onClose={() => setShowTerminal(false)} disableEscapeKey>
+        <Modal title="Operator shell" onClose={() => setShowTerminal(false)}>
           <Terminal cwd={selectedRun?.session.workdir ?? '.'} governed />
         </Modal>
       )}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -123,6 +123,7 @@ export function paletteShortcutEntries(opts: {
   return [
     {
       id: 'palette-toggle-k',
+      group: 'palette',
       chord: { key: 'k', ctrlOrMeta: true },
       description: 'Open the command palette',
       handler: toggle,
@@ -130,6 +131,7 @@ export function paletteShortcutEntries(opts: {
     },
     {
       id: 'palette-toggle-p',
+      group: 'palette',
       chord: { key: 'p', ctrlOrMeta: true },
       description: 'Open the command palette',
       handler: toggle,
@@ -139,6 +141,7 @@ export function paletteShortcutEntries(opts: {
       // §5.2: global search is the palette's DEEP MODE — Cmd+Shift+F opens the
       // palette with the `?` prefix pre-typed (registered in the §1.2 table).
       id: 'palette-search',
+      group: 'palette',
       chord: { key: 'f', ctrlOrMeta: true, shift: true },
       description: 'Global search',
       handler: (e) => {
@@ -148,6 +151,7 @@ export function paletteShortcutEntries(opts: {
     },
     {
       id: 'kill-run',
+      group: 'palette',
       chord: { key: 'k', ctrlOrMeta: true, shift: true },
       description: 'Cancel the selected run',
       guard: opts.killEligible,

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -223,6 +223,7 @@ function DocFrame({
   const compareShortcuts = useMemo<ShortcutEntry[]>(() => [{
     id: 'doc-compare-exit',
     chord: { key: 'escape' },
+    group: 'panels',
     description: 'Exit the version compare lens',
     guard: () => cmpRef.current !== null,
     handler: () => {

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { getConversation, getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
 import { readAnchors } from '../interactive/threadStopgap.js';
 import { useDocsCache } from '../store/docsCache.js';
+import { useLayerStore } from '../store/layers.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
@@ -225,7 +226,8 @@ function DocFrame({
     chord: { key: 'escape' },
     group: 'panels',
     description: 'Exit the version compare lens',
-    guard: () => cmpRef.current !== null,
+    // §7.7 chain: the '?' overlay closes before the compare lens (slice AC).
+    guard: () => cmpRef.current !== null && !useLayerStore.getState().shortcutOverlayOpen,
     handler: () => {
       setCmp(null);
       setOverlayOn(false);

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { getConversation, getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
 import { readAnchors } from '../interactive/threadStopgap.js';
 import { useDocsCache } from '../store/docsCache.js';
-import { useLayerStore } from '../store/layers.js';
+import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
@@ -226,8 +226,11 @@ function DocFrame({
     chord: { key: 'escape' },
     group: 'panels',
     description: 'Exit the version compare lens',
-    // §7.7 chain: the '?' overlay closes before the compare lens (slice AC).
-    guard: () => cmpRef.current !== null && !useLayerStore.getState().shortcutOverlayOpen,
+    // §7.7 chain: the '?' overlay and any modal close before the compare lens.
+    guard: () =>
+      cmpRef.current !== null &&
+      !useLayerStore.getState().shortcutOverlayOpen &&
+      !anyModalOpen(),
     handler: () => {
       setCmp(null);
       setOverlayOn(false);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -25,8 +25,10 @@ export function Modal({ title, onClose, children }: Props): React.ReactElement {
       if (useLayerStore.getState().shortcutOverlayOpen) return; // overlay closes first
       onClose();
     }
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    // CAPTURE phase: an embedded widget (xterm cancels the keydown it handles)
+    // must not be able to eat the contract — Escape closes the modal, always.
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
   }, [onClose]);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,7 @@
-import { useId, useEffect } from 'react';
+import { useId, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
-import { useLayerStore } from '../store/layers.js';
+import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
+import { isTopModal, useLayerStore } from '../store/layers.js';
 
 interface Props {
   title: string;
@@ -16,13 +17,37 @@ interface Props {
  * and sign-in terminals included. The one yield is the '?' overlay, which sits
  * above modals in the §7.7 chain and closes first.
  */
-export function Modal({ title, onClose, children }: Props): React.ReactElement {
-  const titleId = useId();
+/**
+ * The modal family's shared Escape wiring (§7.7, one press = one layer):
+ * registers the mounted modal in the layer ledger (so the bell, the runs
+ * sheet, and the triage selection yield beneath it) and closes it on Escape —
+ * yielding to the '?' overlay and the palette above it in the chain, and to
+ * any LATER-opened modal (only the topmost answers). Used by every
+ * modal-family component: Modal, RepoGraphModal, NewProjectModal.
+ */
+export function useModalEscape(onClose: () => void): void {
+  const modalId = useRef<number | null>(null);
+  useEffect(() => {
+    const { pushModal, popModal } = useLayerStore.getState();
+    const id = pushModal();
+    modalId.current = id;
+    return () => {
+      modalId.current = null;
+      popModal(id);
+    };
+  }, []);
 
   useEffect(() => {
     function handler(e: KeyboardEvent): void {
       if (e.key !== 'Escape') return;
       if (useLayerStore.getState().shortcutOverlayOpen) return; // overlay closes first
+      if (isShortcutsPaletteOpen()) return; // palette closes before modal (§7.7 chain)
+      if (!isTopModal(modalId.current)) return; // a later-opened modal closes first
+      // One press, one layer: this modal CLAIMS the press — the registry's
+      // window-bubble dispatch (bell, sheet, triage) never sees it. (React
+      // may flush this modal's unmount between the capture and bubble phases,
+      // so a ledger check downstream is not enough.)
+      e.stopPropagation();
       onClose();
     }
     // CAPTURE phase: an embedded widget (xterm cancels the keydown it handles)
@@ -30,6 +55,11 @@ export function Modal({ title, onClose, children }: Props): React.ReactElement {
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
   }, [onClose]);
+}
+
+export function Modal({ title, onClose, children }: Props): React.ReactElement {
+  const titleId = useId();
+  useModalEscape(onClose);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
       <div

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,23 +1,33 @@
 import { useId, useEffect } from 'react';
 import type { ReactNode } from 'react';
+import { useLayerStore } from '../store/layers.js';
 
 interface Props {
   title: string;
   onClose: () => void;
   children: ReactNode;
-  /** Opt out of the document-level Escape-to-close handler (e.g. modals that embed a terminal). */
-  disableEscapeKey?: boolean;
 }
 
-export function Modal({ title, onClose, children, disableEscapeKey }: Props): React.ReactElement {
+/**
+ * The modal family's document-level Escape listener (EC21-exempt: local, not
+ * registry-routed, so it fires even from typing contexts inside the modal).
+ * DES-UX-001 §7.7 (slice AC) made it universal — the former `disableEscapeKey`
+ * opt-out is gone: ONE Escape contract closes every layer, the Operator-shell
+ * and sign-in terminals included. The one yield is the '?' overlay, which sits
+ * above modals in the §7.7 chain and closes first.
+ */
+export function Modal({ title, onClose, children }: Props): React.ReactElement {
   const titleId = useId();
 
   useEffect(() => {
-    if (disableEscapeKey) return;
-    function handler(e: KeyboardEvent): void { if (e.key === 'Escape') onClose(); }
+    function handler(e: KeyboardEvent): void {
+      if (e.key !== 'Escape') return;
+      if (useLayerStore.getState().shortcutOverlayOpen) return; // overlay closes first
+      onClose();
+    }
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [onClose, disableEscapeKey]);
+  }, [onClose]);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
       <div

--- a/src/components/NewProjectModal.tsx
+++ b/src/components/NewProjectModal.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useId, useState } from 'react';
+import { useId, useState } from 'react';
 import { api } from '../api/client.js';
 import { modePath } from '../hooks/useRoute.js';
 import { useProjectsStore } from '../store/projects.js';
+import { useModalEscape } from './Modal.js';
 
 /**
  * The new-project flow (DES-FEEDBACK-001 §1.3, slice A): a minimal inline
@@ -49,11 +50,8 @@ export function NewProjectModal({ navigate, onClose }: Props): React.ReactElemen
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  useEffect(() => {
-    function handler(e: KeyboardEvent): void { if (e.key === 'Escape') onClose(); }
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [onClose]);
+  // §7.7 (slice AC): the shared modal-family Escape — one press, one layer.
+  useModalEscape(onClose);
 
   const nameValid = PROJECT_NAME_RE.test(name);
 

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { unreadCount as unreadCountOf, WINDOW_LABEL_STYLE, windowWord } from '../board/metrics.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
+import { useLayerStore } from '../store/layers.js';
 import { useNotificationStore } from '../store/notifications.js';
 import type { NotifKind } from '../store/notifications.js';
 import { useProvenanceStore } from '../store/provenance.js';
+import { useRunsPanelStore } from '../store/runsPanel.js';
 import { ProvenanceLine } from './ProvenanceLine.js';
 
 interface Props {
@@ -71,8 +74,28 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
   // was never opened simply carries no line yet.
   const provByRun = useProvenanceStore((s) => s.byRun);
 
-  const [open, setOpen] = useState(false);
+  // Open state lives in the layer ledger (DES-UX-001 §7.7, slice AC) so the
+  // Escape chain's other rungs (the triage selection) can yield while the
+  // popover is up — the bell is the chain's modal/popover rung.
+  const open = useLayerStore((s) => s.bellOpen);
+  const setOpen = useLayerStore((s) => s.setBellOpen);
   const ref = useRef<HTMLDivElement>(null);
+
+  // §7.7: Escape closes the bell popover — the brief's named gap. Registered
+  // through the ONE slice-G registry; yields while the '?' overlay or the runs
+  // sheet is up (their entries close them first, per the chain).
+  const escapeEntries = useMemo<ShortcutEntry[]>(() => [{
+    id: 'bell-close',
+    chord: { key: 'escape' },
+    group: 'panels',
+    description: 'Close the notifications popover',
+    guard: () =>
+      useLayerStore.getState().bellOpen &&
+      !useLayerStore.getState().shortcutOverlayOpen &&
+      !useRunsPanelStore.getState().expanded,
+    handler: () => useLayerStore.getState().setBellOpen(false),
+  }], []);
+  useGlobalShortcuts(escapeEntries);
 
   // Slice W (§5.3): the badge's number is the metrics module's `unreadCount` —
   // the same rows the dropdown lists, so badge and list cannot disagree.
@@ -88,7 +111,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
     }
     document.addEventListener('mousedown', onOutside);
     return () => document.removeEventListener('mousedown', onOutside);
-  }, [open]);
+  }, [open, setOpen]);
 
   function handleNotifClick(id: string, runId: string): void {
     markRead(id);
@@ -109,7 +132,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
         aria-expanded={open}
         aria-haspopup="true"
         title="Notifications"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(!open)}
         className="relative flex items-center rounded transition-opacity hover:opacity-70"
         style={{
           gap: collapsed ? 0 : '6px',

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { unreadCount as unreadCountOf, WINDOW_LABEL_STYLE, windowWord } from '../board/metrics.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
-import { useLayerStore } from '../store/layers.js';
+import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useNotificationStore } from '../store/notifications.js';
 import type { NotifKind } from '../store/notifications.js';
 import { useProvenanceStore } from '../store/provenance.js';
@@ -92,6 +92,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
     guard: () =>
       useLayerStore.getState().bellOpen &&
       !useLayerStore.getState().shortcutOverlayOpen &&
+      !anyModalOpen() && // a stacked modal closes first (one press, one layer)
       !useRunsPanelStore.getState().expanded,
     handler: () => useLayerStore.getState().setBellOpen(false),
   }], []);

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -170,6 +170,7 @@ export function NotificationBell({ navigate, collapsed = false }: Props): React.
       {/* Dropdown */}
       {open && (
         <div
+          data-testid="bell-popover"
           role="menu"
           aria-label="Notifications"
           style={{

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -181,6 +181,15 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
               >
                 {onboarding ? 'Starting…' : '↺ Run Onboarding'}
               </button>
+              {/* §7.8 (slice AC, EC43): named actions preview what they do and write. */}
+              <span
+                data-testid="action-preview"
+                className="text-[10px] font-mono"
+                style={{ color: 'var(--ink-dim)' }}
+              >
+                re-indexes this repo as a governed run (index → annotate → domain) —
+                rewrites its code graph + domain model; typically minutes
+              </span>
               <button
                 type="button"
                 onClick={() => onOpenGraph()}

--- a/src/components/RepoGraphModal.tsx
+++ b/src/components/RepoGraphModal.tsx
@@ -779,6 +779,11 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
                   >
                     {annotating ? 'Starting…' : 'Run annotation workflow →'}
                   </button>
+                  {/* §7.8 (slice AC, EC43): the named action's blast radius. */}
+                  <p data-testid="action-preview" className="text-[10px] font-mono" style={{ color: T.faint }}>
+                    launches the annotation workflow as a governed run — writes behavior
+                    annotations into this repo's domain model; typically minutes
+                  </p>
                   {annotateError && (
                     <p className="text-[11px] font-mono" style={{ color: T.deny }}>{annotateError}</p>
                   )}

--- a/src/components/RepoGraphModal.tsx
+++ b/src/components/RepoGraphModal.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client.js';
 import type { RepoEntry, CodeGraphNode, CodeGraphEdge, CodeGraphData, DomainGraph, DomainCoverage } from '../api/types.js';
 import { CytoGraph } from './CytoGraph.js';
 import { HotspotsView } from './HotspotsView.js';
+import { useModalEscape } from './Modal.js';
 
 interface Props {
   repo: RepoEntry;
@@ -466,11 +467,8 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
     }
   }
 
-  useEffect(() => {
-    function handler(e: KeyboardEvent): void { if (e.key === 'Escape') onClose(); }
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [onClose]);
+  // §7.7 (slice AC): the shared modal-family Escape — one press, one layer.
+  useModalEscape(onClose);
 
   useEffect(() => {
     setLoading(true);

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -470,10 +470,12 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
               </>
             )}
 
-            <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+            {/* §7.8 (slice AC, EC43): the named action previews what it does,
+                what it writes, and roughly how long it takes. */}
+            <p data-testid="action-preview" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
               {sourceMode === 'remote'
-                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run.`
-                : 'Runs the onboarding workflow (index → annotate → domain) as a governed run.'}
+                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run — writes the repo's code graph + domain model; typically minutes.`
+                : "Runs the onboarding workflow (index → annotate → domain) as a governed run — writes the repo's code graph + domain model; typically minutes."}
             </p>
 
             {registerError && (

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -603,7 +603,6 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
           <Modal
             title={showTranscript ? "This run's transcript" : 'Operator shell'}
             onClose={() => { setTermOpen(false); setTermShell(false); }}
-            disableEscapeKey
           >
             {showTranscript ? (
               <RunTranscriptView

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -5,6 +5,7 @@ import { observedSpend, runStats, WINDOW_LABEL_STYLE, windowWord } from '../boar
 import { sessionProjectId } from '../hooks/ambientProject.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
+import { useLayerStore } from '../store/layers.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
@@ -166,7 +167,10 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
         chord: { key: 'escape' },
         group: 'panels',
         description: 'Collapse the runs sheet',
-        guard: () => useRunsPanelStore.getState().expanded,
+        // §7.7 chain: the '?' overlay closes before the sheet (slice AC).
+        guard: () =>
+          useRunsPanelStore.getState().expanded &&
+          !useLayerStore.getState().shortcutOverlayOpen,
         handler: () => useRunsPanelStore.getState().collapse(),
       },
     ],

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -164,6 +164,7 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
       {
         id: 'runs-sheet-close',
         chord: { key: 'escape' },
+        group: 'panels',
         description: 'Collapse the runs sheet',
         guard: () => useRunsPanelStore.getState().expanded,
         handler: () => useRunsPanelStore.getState().collapse(),

--- a/src/components/RunsBottomPanel.tsx
+++ b/src/components/RunsBottomPanel.tsx
@@ -5,7 +5,7 @@ import { observedSpend, runStats, WINDOW_LABEL_STYLE, windowWord } from '../boar
 import { sessionProjectId } from '../hooks/ambientProject.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
-import { useLayerStore } from '../store/layers.js';
+import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
@@ -167,10 +167,12 @@ export function RunsBottomPanel({ runs, runPath, navigate, immersive, scopeProje
         chord: { key: 'escape' },
         group: 'panels',
         description: 'Collapse the runs sheet',
-        // §7.7 chain: the '?' overlay closes before the sheet (slice AC).
+        // §7.7 chain: the '?' overlay closes before the sheet (slice AC), and
+        // a modal's scrim sits above the sheet — the modal closes first.
         guard: () =>
           useRunsPanelStore.getState().expanded &&
-          !useLayerStore.getState().shortcutOverlayOpen,
+          !useLayerStore.getState().shortcutOverlayOpen &&
+          !anyModalOpen(),
         handler: () => useRunsPanelStore.getState().collapse(),
       },
     ],

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from 'react';
+import {
+  listShortcuts,
+  useGlobalShortcuts,
+  type ShortcutChord,
+  type ShortcutEntry,
+  type ShortcutGroup,
+} from '../hooks/useGlobalShortcuts.js';
+import { useLayerStore } from '../store/layers.js';
+
+/**
+ * The global '?' shortcut overlay (DES-UX-001 §7.7, EC42): '?' opens it on
+ * every route, and its corpus is `listShortcuts()` — the slice-G registry's
+ * OWN registrations at open time, grouped by each entry's declared section —
+ * so it can never drift from what the keys actually do, and a key that only
+ * exists on some surface (the triage cursor) is documented exactly where it
+ * works. Escape closes it first in the §7.7 chain (every other Escape entry
+ * yields while it is up, via `useLayerStore.shortcutOverlayOpen`).
+ */
+
+const GROUP_ORDER: readonly ShortcutGroup[] = ['triage', 'gates', 'palette', 'panels'];
+const GROUP_LABEL: Record<ShortcutGroup, string> = {
+  triage: 'Triage',
+  gates: 'Gates',
+  palette: 'Palette',
+  panels: 'Panels & layers',
+};
+
+const KEY_LABEL: Record<string, string> = {
+  ' ': 'Space',
+  arrowdown: '↓',
+  arrowup: '↑',
+  escape: 'Esc',
+  enter: 'Enter',
+};
+
+export function chordLabel(chord: ShortcutChord): string {
+  const parts: string[] = [];
+  if (chord.ctrlOrMeta) parts.push('Ctrl/⌘');
+  if (chord.shift) parts.push('Shift');
+  const base = KEY_LABEL[chord.key] ?? chord.key.toUpperCase();
+  // '?' already spells its shift — "Shift+?" would document a chord nobody types.
+  parts.push(base);
+  return (chord.key === '?' ? [base] : parts).join('+');
+}
+
+interface Row {
+  description: string;
+  keys: string[];
+}
+
+/** Fold the registry snapshot into overlay rows: same group + description = one
+ *  row listing every chord (j and ↓ are one action, not two). */
+export function overlayRows(
+  entries: readonly ShortcutEntry[],
+): Array<{ group: ShortcutGroup; rows: Row[] }> {
+  const byGroup = new Map<ShortcutGroup, Row[]>();
+  for (const e of entries) {
+    const group: ShortcutGroup = e.group ?? 'panels';
+    const rows = byGroup.get(group) ?? [];
+    if (rows.length === 0) byGroup.set(group, rows);
+    const label = chordLabel(e.chord);
+    const existing = rows.find((r) => r.description === e.description);
+    if (existing) {
+      if (!existing.keys.includes(label)) existing.keys.push(label);
+    } else {
+      rows.push({ description: e.description, keys: [label] });
+    }
+  }
+  return GROUP_ORDER.filter((g) => byGroup.has(g)).map((g) => ({ group: g, rows: byGroup.get(g)! }));
+}
+
+export function ShortcutOverlay(): React.ReactElement | null {
+  const open = useLayerStore((s) => s.shortcutOverlayOpen);
+  const setOpen = useLayerStore((s) => s.setShortcutOverlayOpen);
+  // Snapshot the registry AT OPEN — the overlay documents what is registered
+  // now, and its own entries below are part of that truth.
+  const [snapshot, setSnapshot] = useState<readonly ShortcutEntry[]>([]);
+
+  const entries = useMemo<ShortcutEntry[]>(() => {
+    const toggle = (e: KeyboardEvent): void => {
+      e.preventDefault();
+      const next = !useLayerStore.getState().shortcutOverlayOpen;
+      if (next) setSnapshot(listShortcuts());
+      useLayerStore.getState().setShortcutOverlayOpen(next);
+    };
+    return [
+      // Both spellings: layouts that report '?' with shiftKey and those that
+      // don't each match exactly one entry (chordMatches is shift-strict).
+      { id: 'help-overlay', chord: { key: '?', shift: true }, group: 'panels', description: 'Keyboard shortcuts (this overlay)', handler: toggle },
+      { id: 'help-overlay-noshift', chord: { key: '?' }, group: 'panels', description: 'Keyboard shortcuts (this overlay)', handler: toggle },
+      {
+        id: 'help-overlay-close',
+        chord: { key: 'escape' },
+        group: 'panels',
+        description: 'Close the topmost layer',
+        // First rung of the §7.7 chain — no other guard: while open, the
+        // overlay owns Escape (every later entry yields on this same store).
+        guard: () => useLayerStore.getState().shortcutOverlayOpen,
+        handler: () => useLayerStore.getState().setShortcutOverlayOpen(false),
+      },
+    ];
+  }, []);
+  useGlobalShortcuts(entries);
+
+  if (!open) return null;
+  const groups = overlayRows(snapshot);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center"
+      style={{ background: 'var(--scrim)', paddingTop: '10vh' }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) setOpen(false);
+      }}
+    >
+      <div
+        data-testid="shortcut-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        className="flex flex-col overflow-y-auto"
+        style={{
+          width: 640,
+          maxHeight: '75vh',
+          background: 'var(--surface-overlay)',
+          boxShadow: 'var(--shadow-overlay)',
+          borderRadius: 'var(--radius-xl)',
+          padding: '20px 24px',
+        }}
+      >
+        <div className="flex items-baseline justify-between mb-3">
+          <h2 className="text-sm font-semibold font-mono" style={{ color: 'var(--ink-high)' }}>
+            Keyboard shortcuts
+          </h2>
+          <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+            what's registered on this surface · ? or Esc closes
+          </span>
+        </div>
+        <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+          {groups.map(({ group, rows }) => (
+            <section key={group} data-testid={`shortcut-group-${group}`}>
+              <h3
+                className="text-[10px] font-mono uppercase tracking-widest mb-1.5"
+                style={{ color: 'var(--ink-dim)' }}
+              >
+                {GROUP_LABEL[group]}
+              </h3>
+              <ul className="flex flex-col gap-1 m-0 p-0" style={{ listStyle: 'none' }}>
+                {rows.map((row) => (
+                  <li key={row.description} className="flex items-center justify-between gap-3">
+                    <span className="text-xs font-mono" style={{ color: 'var(--ink-body)' }}>
+                      {row.description}
+                    </span>
+                    <span className="flex gap-1 shrink-0">
+                      {row.keys.map((k) => (
+                        <kbd
+                          key={k}
+                          className="text-[10px] font-mono rounded px-1.5 py-0.5"
+                          style={{
+                            background: 'var(--surface-raised)',
+                            color: 'var(--ink-high)',
+                            border: '1px solid var(--surface-raised)',
+                          }}
+                        >
+                          {k}
+                        </kbd>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { api, type GateDecision } from '../api/client.js';
 import type { CoverageReport } from '../api/types.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
 import { GATE_HASH } from './GateChip.js';
@@ -39,6 +40,10 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
   const [error, setError] = useState<string | null>(null);
   const [coverage, setCoverage] = useState<CoverageReport | null>(null);
   const message = useRef<HTMLParagraphElement>(null);
+  const root = useRef<HTMLDivElement>(null);
+  /** Synchronous double-fire guard for the keyboard path — `loading` is a
+   *  render-cycle behind a fast second keydown. */
+  const inflight = useRef(false);
 
   // Arrived from a board gate chip (§1.4 complex gate): put the MESSAGE in view and
   // give it focus, so a keyboard lands on the question rather than wherever the
@@ -66,6 +71,8 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
     action: () => Promise<unknown>,
     intervention: { kind: SteeringAction; amend?: string },
   ): Promise<void> {
+    if (inflight.current) return;
+    inflight.current = true;
     setLoading(true);
     setError(null);
     try {
@@ -81,6 +88,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      inflight.current = false;
       setLoading(false);
     }
   }
@@ -101,6 +109,45 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
   const cancel = (): Promise<void> =>
     run(() => api.cancelRun(runId), { kind: 'cancel' });
 
+  // DES-UX-001 §7.7 (slice AC): the gate panel honors a / r — the same
+  // POST /runs/:id/gate its buttons fire, through the ONE slice-G registry
+  // (the shared typing guard keeps the steer textarea's letters as letters).
+  // Guarded on the panel HOLDING focus: a is approve exactly where approve
+  // matters most, and nowhere else on the page.
+  const actions = useRef({ approve, reject });
+  actions.current = { approve, reject };
+  const keyEntries = useMemo<ShortcutEntry[]>(() => {
+    const focused = (): boolean =>
+      !inflight.current &&
+      root.current !== null &&
+      root.current.contains(document.activeElement);
+    return [
+      {
+        id: 'gate-panel-approve',
+        chord: { key: 'a' },
+        group: 'gates',
+        description: 'Approve the focused gate',
+        guard: focused,
+        handler: (e) => {
+          e.preventDefault();
+          void actions.current.approve();
+        },
+      },
+      {
+        id: 'gate-panel-reject',
+        chord: { key: 'r' },
+        group: 'gates',
+        description: 'Reject the focused gate',
+        guard: focused,
+        handler: (e) => {
+          e.preventDefault();
+          void actions.current.reject();
+        },
+      },
+    ];
+  }, []);
+  useGlobalShortcuts(keyEntries);
+
   const { headline, footnote } = cleanPrompt(
     prompt ?? 'Prompt unavailable (daemon restarted) — you can still approve or reject.',
   );
@@ -109,11 +156,16 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
 
   return (
     <div
+      ref={root}
+      // Programmatically/click focusable, not a tab stop: clicking anywhere on
+      // the card arms the a/r keys (§7.7) without adding a tab-order entry.
+      tabIndex={-1}
       className="rounded-xl p-4"
       style={{
         background: 'var(--surface-rail)',
         border: '1px solid var(--status-gate-dim)',
         boxShadow: '0 0 0 1px var(--status-gate-dim)',
+        outline: 'none',
       }}
       data-testid="steering-gate"
       data-run-id={runId}
@@ -233,6 +285,7 @@ export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props)
       {/* Mode-selector note: workflow gates are always HITL regardless of run-level human_confirm */}
       <p className="text-[10px] font-mono mt-2" style={{ color: 'var(--ink-dim)' }}>
         Workflow-declared gate — run-level human_confirm setting does not apply here.
+        {' '}· a approve · r reject while this card holds focus
       </p>
     </div>
   );

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -384,7 +384,6 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
         <Modal
           title={`Sign in — ${signInSeat.display_name}`}
           onClose={() => setSignInSeat(null)}
-          disableEscapeKey
         >
           <div className="flex flex-col gap-3">
             <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -95,6 +95,10 @@ export function Terminal({ cwd, cmd, governed = true, initialInput }: Props): Re
     const rafHandle = requestAnimationFrame(() => {
       if (disposed) return;
       term.open(host);
+      // DES-UX-001 §7.7 (slice AC): the shell takes focus on open — the first
+      // keystroke lands in the terminal, never swallowed by whatever the modal
+      // trigger left focused.
+      term.focus();
       try {
         fit.fit();
       } catch {

--- a/src/components/composerDefaults.ts
+++ b/src/components/composerDefaults.ts
@@ -1,0 +1,17 @@
+import type { ConfirmMode } from './ContextPopover.js';
+
+/**
+ * The composer's shipped gate-posture default (DES-UX-001 §7.8 + §13, slice
+ * AC): `human_confirm` before the FIRST gate-bearing unit — `before:1` on the
+ * wire — per the product's own tagline ("governed, verified work"), replacing
+ * the pre-slice default of "none".
+ *
+ * §13 marks this flip operator-confirmable: it is implemented per the
+ * document's adopted position, and THIS constant is the veto point — reverting
+ * to the old default is the one-line change `mode: 'none'`. Prefills (retry)
+ * and the Ask/Autonomous run modes still override it, as they always did.
+ */
+export const COMPOSER_DEFAULT_GATE_POSTURE: { mode: ConfirmMode; beforeOrd: number } = {
+  mode: 'before',
+  beforeOrd: 1,
+};

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -82,6 +82,12 @@ export function setShortcutsPaletteOpen(open: boolean): void {
   paletteOpen = open;
 }
 
+/** §7.7 chain: the modal family's local listeners yield while the palette is
+ *  open (palette closes before modal/popover) — this is their read. */
+export function isShortcutsPaletteOpen(): boolean {
+  return paletteOpen;
+}
+
 function dispatch(e: KeyboardEvent): void {
   if (isTypingContext(e)) return;
   for (const entry of table) {

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -21,11 +21,16 @@ export interface ShortcutChord {
   shift?: boolean;
 }
 
+/** The '?' overlay's section headings (DES-UX-001 §7.7, slice AC). */
+export type ShortcutGroup = 'triage' | 'palette' | 'gates' | 'panels';
+
 export interface ShortcutEntry {
   id: string;
   chord: ShortcutChord;
-  /** Human-readable, for future discoverability surfaces. */
+  /** Human-readable — rendered verbatim by the '?' overlay (§7.7). */
   description: string;
+  /** Overlay section (§7.7). Untagged entries land under "panels". */
+  group?: ShortcutGroup;
   /** Extra availability gate, evaluated after the typing guard. `false` means
    *  the entry YIELDS silently — no preventDefault, no handler (the kill
    *  shortcut's silent-fail contract). */
@@ -59,6 +64,16 @@ export function chordMatches(e: KeyboardEvent, chord: ShortcutChord): boolean {
 
 /** The ordered handler table — registration order is precedence. */
 const table: ShortcutEntry[] = [];
+
+/**
+ * The overlay's corpus (§7.7, EC42): a snapshot of what is REGISTERED right
+ * now — the '?' overlay renders from this, never from a hand-kept list, so a
+ * key that exists is documented and a key that unmounted disappears with its
+ * surface. Read on open; entries are live references, never mutated here.
+ */
+export function listShortcuts(): readonly ShortcutEntry[] {
+  return [...table];
+}
 
 /** §1.2: while open, the palette owns the keyboard; the table yields. */
 let paletteOpen = false;

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -129,13 +129,14 @@ export function useTriageCursor(
     };
 
     return [
-      { id: 'triage-next-j', chord: { key: 'j' }, description: 'Select the next card', handler: move(1) },
-      { id: 'triage-next-down', chord: { key: 'arrowdown' }, description: 'Select the next card', handler: move(1) },
-      { id: 'triage-prev-k', chord: { key: 'k' }, description: 'Select the previous card', handler: move(-1) },
-      { id: 'triage-prev-up', chord: { key: 'arrowup' }, description: 'Select the previous card', handler: move(-1) },
+      { id: 'triage-next-j', chord: { key: 'j' }, group: 'triage', description: 'Select the next card', handler: move(1) },
+      { id: 'triage-next-down', chord: { key: 'arrowdown' }, group: 'triage', description: 'Select the next card', handler: move(1) },
+      { id: 'triage-prev-k', chord: { key: 'k' }, group: 'triage', description: 'Select the previous card', handler: move(-1) },
+      { id: 'triage-prev-up', chord: { key: 'arrowup' }, group: 'triage', description: 'Select the previous card', handler: move(-1) },
       {
         id: 'triage-approve',
         chord: { key: 'a' },
+        group: 'gates',
         description: 'Approve the selected gate',
         guard: gated,
         handler: (e) => {
@@ -155,6 +156,7 @@ export function useTriageCursor(
       {
         id: 'triage-reject',
         chord: { key: 'r' },
+        group: 'gates',
         description: 'Reject the selected gate with a note',
         guard: gated,
         handler: (e) => {
@@ -177,6 +179,7 @@ export function useTriageCursor(
       ...(['x', ' '] as const).map((key): ShortcutEntry => ({
         id: `batch-toggle-${key === ' ' ? 'space' : key}`,
         chord: { key },
+        group: 'gates',
         description: 'Select the gate for batch resolution',
         guard: () => {
           const item = current();
@@ -192,6 +195,7 @@ export function useTriageCursor(
       {
         id: 'triage-open',
         chord: { key: 'enter' },
+        group: 'triage',
         description: 'Open the selected card',
         guard: () => selRef.current !== null,
         handler: (e) => {
@@ -204,6 +208,7 @@ export function useTriageCursor(
       {
         id: 'triage-clear',
         chord: { key: 'escape' },
+        group: 'triage',
         description: 'Clear the triage cursor and batch selection',
         // DES-FEEDBACK-003 §5.7 Escape precedence (palette → sheet → triage):
         // while the runs sheet is up, this entry YIELDS so the sheet's own

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { clearBatchSelection, toggleBatchSelect, useBatchGateStore } from '../board/batchGates.js';
 import { decideGate, gateOpenPath } from '../board/gateActions.js';
 import { isSimpleGate, type OpenGate } from '../store/gates.js';
+import { useLayerStore } from '../store/layers.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
 import type { Navigate } from './useRoute.js';
 import { useGlobalShortcuts, type ShortcutEntry } from './useGlobalShortcuts.js';
@@ -210,12 +211,15 @@ export function useTriageCursor(
         chord: { key: 'escape' },
         group: 'triage',
         description: 'Clear the triage cursor and batch selection',
-        // DES-FEEDBACK-003 §5.7 Escape precedence (palette → sheet → triage):
-        // while the runs sheet is up, this entry YIELDS so the sheet's own
-        // registry entry closes it first — the selection survives the press.
+        // §7.7 Escape chain (overlay → palette → sheet → modal/popover →
+        // triage): the triage selection is the LAST rung — this entry yields
+        // while the '?' overlay, the runs sheet, or the bell popover is up so
+        // their own entries close them first; the selection survives the press.
         guard: () =>
           (selRef.current !== null || useBatchGateStore.getState().selected.length > 0) &&
-          !useRunsPanelStore.getState().expanded,
+          !useRunsPanelStore.getState().expanded &&
+          !useLayerStore.getState().shortcutOverlayOpen &&
+          !useLayerStore.getState().bellOpen,
         handler: () => {
           setNoteFor(null);
           setSelectedKey(null);

--- a/src/hooks/useTriageCursor.ts
+++ b/src/hooks/useTriageCursor.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { clearBatchSelection, toggleBatchSelect, useBatchGateStore } from '../board/batchGates.js';
 import { decideGate, gateOpenPath } from '../board/gateActions.js';
 import { isSimpleGate, type OpenGate } from '../store/gates.js';
-import { useLayerStore } from '../store/layers.js';
+import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useRunsPanelStore } from '../store/runsPanel.js';
 import type { Navigate } from './useRoute.js';
 import { useGlobalShortcuts, type ShortcutEntry } from './useGlobalShortcuts.js';
@@ -219,7 +219,8 @@ export function useTriageCursor(
           (selRef.current !== null || useBatchGateStore.getState().selected.length > 0) &&
           !useRunsPanelStore.getState().expanded &&
           !useLayerStore.getState().shortcutOverlayOpen &&
-          !useLayerStore.getState().bellOpen,
+          !useLayerStore.getState().bellOpen &&
+          !anyModalOpen(),
         handler: () => {
           setNoteFor(null);
           setSelectedKey(null);

--- a/src/store/layers.ts
+++ b/src/store/layers.ts
@@ -19,13 +19,40 @@ interface LayerStore {
   shortcutOverlayOpen: boolean;
   /** The bell's notifications popover — the modal/popover rung of the chain. */
   bellOpen: boolean;
+  /** The open modal family, in mount (= open) order — last is topmost. The
+   *  rungs beneath modal/popover (bell, sheet, triage, compare lens) yield
+   *  while ANY modal is open, and only the TOP modal answers Escape, so one
+   *  press closes exactly one layer even when layers stack. */
+  modalIds: number[];
   setShortcutOverlayOpen: (open: boolean) => void;
   setBellOpen: (open: boolean) => void;
+  pushModal: () => number;
+  popModal: (id: number) => void;
 }
+
+let nextModalId = 1;
 
 export const useLayerStore = create<LayerStore>((set) => ({
   shortcutOverlayOpen: false,
   bellOpen: false,
+  modalIds: [],
   setShortcutOverlayOpen: (open) => set({ shortcutOverlayOpen: open }),
   setBellOpen: (open) => set({ bellOpen: open }),
+  pushModal: () => {
+    const id = nextModalId++;
+    set((s) => ({ modalIds: [...s.modalIds, id] }));
+    return id;
+  },
+  popModal: (id) => set((s) => ({ modalIds: s.modalIds.filter((m) => m !== id) })),
 }));
+
+/** True while any modal-family layer is open (the registry guards' read). */
+export function anyModalOpen(): boolean {
+  return useLayerStore.getState().modalIds.length > 0;
+}
+
+/** True when `id` is the topmost open modal — the one Escape may close. */
+export function isTopModal(id: number | null): boolean {
+  const ids = useLayerStore.getState().modalIds;
+  return id !== null && ids[ids.length - 1] === id;
+}

--- a/src/store/layers.ts
+++ b/src/store/layers.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+/**
+ * The Escape-contract layer ledger (DES-UX-001 §7.7, slice AC): the ONE place
+ * the open/closed state of the keyboard-owning layers lives, so every Escape
+ * entry in the slice-G registry can encode the §7.7 precedence chain —
+ *
+ *   overlay → palette → sheet → modal/popover → triage selection
+ *
+ * — through explicit guards instead of registration order. The palette needs
+ * no row here (the registry already yields wholesale while it is open, and it
+ * closes itself from its focused input); the runs sheet keeps its own store
+ * (`useRunsPanelStore.expanded`) and the guards read both. Modals stay on
+ * their local document-level listeners (the EC21-exempt modal family) but
+ * yield to the overlay via `shortcutOverlayOpen`.
+ */
+interface LayerStore {
+  /** The '?' shortcut overlay (§7.7) — the topmost layer while open. */
+  shortcutOverlayOpen: boolean;
+  /** The bell's notifications popover — the modal/popover rung of the chain. */
+  bellOpen: boolean;
+  setShortcutOverlayOpen: (open: boolean) => void;
+  setBellOpen: (open: boolean) => void;
+}
+
+export const useLayerStore = create<LayerStore>((set) => ({
+  shortcutOverlayOpen: false,
+  bellOpen: false,
+  setShortcutOverlayOpen: (open) => set({ shortcutOverlayOpen: open }),
+  setBellOpen: (open) => set({ bellOpen: open }),
+}));

--- a/tests/ChatInput.preflight.test.tsx
+++ b/tests/ChatInput.preflight.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import { COMPOSER_DEFAULT_GATE_POSTURE } from '../src/components/composerDefaults.js';
+import * as client from '../src/api/client.js';
+import type { LaunchRunBody } from '../src/api/types.js';
+
+/**
+ * DES-UX-001 §7.8 (slice AC, EC43) — composer preflight intelligence:
+ *   - a code-shaped intent with no repo attached warn-and-blocks: ZERO
+ *     POST /runs until override;
+ *   - a bound project's crew.repo member auto-attaches as a removable chip
+ *     (`data-auto-attached="true"`);
+ *   - the gate control sits at top level and its shipped default is NOT
+ *     "none" — it is COMPOSER_DEFAULT_GATE_POSTURE (§13's one-line veto point).
+ */
+
+const MEMBER = {
+  id: 'api-migration:crew.repo:studio-api', project_id: 'api-migration',
+  member_kind: 'crew.repo', member_ref: 'studio-api', meta: null,
+  attached_at: 1, attached_by: 'studio',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({
+    repos: [{ id: 'studio-api', name: 'studio-api', root_path: '/tmp/studio-api' } as never],
+  });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
+  vi.spyOn(client.api, 'listProjectMembers').mockResolvedValue({ members: [] });
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  localStorage.clear();
+});
+
+async function typeAndSend(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.type(screen.getByTestId('launch-problem'), text);
+  await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+  await user.click(screen.getByTestId('launch-submit'));
+}
+
+describe('ChatInput preflight (§7.8, EC43)', () => {
+  it('blocks a repo-less code intent — zero POST /runs — and the override launches', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await typeAndSend(user, 'fix the login bug');
+
+    // Warn-and-block: the block renders and NO launch fired.
+    expect(screen.getByTestId('preflight-block')).toBeInTheDocument();
+    expect(client.api.launchRun).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('preflight-override'));
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('preflight-block')).toBeNull();
+  });
+
+  it('a non-code intent launches without preflight', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await typeAndSend(user, 'summarize the release notes');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('preflight-block')).toBeNull();
+  });
+
+  it("auto-attaches the bound project's crew.repo as a removable chip, and the launch carries it", async () => {
+    vi.mocked(client.api.listProjectMembers).mockResolvedValue({ members: [MEMBER as never] });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} lockedProjectId="api-migration" />);
+
+    const chip = await screen.findByTestId('repo-chip');
+    expect(chip.dataset.autoAttached).toBe('true');
+    expect(chip.textContent).toContain('studio-api');
+
+    // The attached repo satisfies preflight: the code intent launches directly.
+    await typeAndSend(user, 'fix the login bug');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    expect(body.repoRef).toBe('studio-api');
+  });
+
+  it('removing the auto chip is the operator speaking — auto never re-attaches', async () => {
+    vi.mocked(client.api.listProjectMembers).mockResolvedValue({ members: [MEMBER as never] });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} lockedProjectId="api-migration" />);
+    await screen.findByTestId('repo-chip');
+
+    await user.click(screen.getByLabelText(/Clear Repo: studio-api/));
+    expect(screen.queryByTestId('repo-chip')).toBeNull();
+    // §7.8: with the chip removed, the code intent hits the block again.
+    await typeAndSend(user, 'fix the login bug');
+    expect(screen.getByTestId('preflight-block')).toBeInTheDocument();
+    expect(client.api.launchRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatInput gate posture (§7.8 + §13)', () => {
+  it('the top-level control ships a non-"none" default and the launch body carries it', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+
+    const posture = screen.getByTestId('gate-posture');
+    expect((posture as HTMLSelectElement).value).toBe(COMPOSER_DEFAULT_GATE_POSTURE.mode);
+    expect((posture as HTMLSelectElement).value).not.toBe('none');
+
+    await typeAndSend(user, 'summarize the release notes');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    expect(body.humanConfirm).toBe(`before:${COMPOSER_DEFAULT_GATE_POSTURE.beforeOrd}`);
+  });
+
+  it('the §13 veto point is the one named constant', () => {
+    // A veto is a one-line revert of this object — pin its shape so the revert
+    // stays one line.
+    expect(COMPOSER_DEFAULT_GATE_POSTURE).toEqual({ mode: 'before', beforeOrd: 1 });
+  });
+
+  it('switching the top-level control to "none" restores the old wire shape', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
+    await typeAndSend(user, 'summarize the release notes');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    expect('humanConfirm' in body).toBe(false);
+  });
+});

--- a/tests/ShortcutOverlay.test.tsx
+++ b/tests/ShortcutOverlay.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShortcutOverlay, chordLabel, overlayRows } from '../src/components/ShortcutOverlay.js';
+import { registerShortcuts, type ShortcutEntry } from '../src/hooks/useGlobalShortcuts.js';
+import { useLayerStore } from '../src/store/layers.js';
+
+/**
+ * DES-UX-001 §7.7 (slice AC, EC42) — the '?' overlay renders FROM the slice-G
+ * registry's own registrations (never a hand list), '?' toggles it on any
+ * surface, and Escape closes it FIRST in the layer chain.
+ */
+
+let unregister: (() => void) | null = null;
+
+beforeEach(() => {
+  useLayerStore.setState({ shortcutOverlayOpen: false, bellOpen: false });
+});
+
+afterEach(() => {
+  unregister?.();
+  unregister = null;
+});
+
+describe('overlayRows / chordLabel (the registry fold)', () => {
+  it('groups by the entry group and folds same-description chords into one row', () => {
+    const entries: ShortcutEntry[] = [
+      { id: 'a1', chord: { key: 'j' }, group: 'triage', description: 'Next card', handler: () => {} },
+      { id: 'a2', chord: { key: 'arrowdown' }, group: 'triage', description: 'Next card', handler: () => {} },
+      { id: 'b', chord: { key: 'k', ctrlOrMeta: true }, group: 'palette', description: 'Open palette', handler: () => {} },
+      { id: 'c', chord: { key: 'escape' }, description: 'Close something', handler: () => {} },
+    ];
+    const groups = overlayRows(entries);
+    expect(groups.map((g) => g.group)).toEqual(['triage', 'palette', 'panels']);
+    const triage = groups[0]!.rows;
+    expect(triage).toHaveLength(1);
+    expect(triage[0]!.keys).toEqual(['J', '↓']);
+    // Untagged entries land under "panels" — nothing registered is ever omitted.
+    expect(groups[2]!.rows[0]!.description).toBe('Close something');
+  });
+
+  it('spells chords the way they are typed', () => {
+    expect(chordLabel({ key: 'k', ctrlOrMeta: true })).toBe('Ctrl/⌘+K');
+    expect(chordLabel({ key: 'f', ctrlOrMeta: true, shift: true })).toBe('Ctrl/⌘+Shift+F');
+    expect(chordLabel({ key: ' ' })).toBe('Space');
+    expect(chordLabel({ key: 'escape' })).toBe('Esc');
+    // '?' already spells its shift — never "Shift+?".
+    expect(chordLabel({ key: '?', shift: true })).toBe('?');
+  });
+});
+
+describe('ShortcutOverlay (the ? surface)', () => {
+  it("'?' opens the overlay and it lists what the registry holds right now", () => {
+    const spy = vi.fn();
+    unregister = registerShortcuts([
+      { id: 'test-key', chord: { key: 'g' }, group: 'gates', description: 'A registered test key', handler: spy },
+    ]);
+    render(<ShortcutOverlay />);
+    expect(screen.queryByTestId('shortcut-overlay')).toBeNull();
+
+    fireEvent.keyDown(window, { key: '?', shiftKey: true });
+    expect(screen.getByTestId('shortcut-overlay')).toBeInTheDocument();
+    // Registry-rendered, not hand-kept: the entry registered above is listed.
+    expect(screen.getByTestId('shortcut-group-gates').textContent).toContain('A registered test key');
+    // …and the overlay documents itself.
+    expect(screen.getByText('Keyboard shortcuts (this overlay)')).toBeInTheDocument();
+  });
+
+  it("Escape closes the overlay (first rung of the §7.7 chain); '?' toggles", () => {
+    render(<ShortcutOverlay />);
+    fireEvent.keyDown(window, { key: '?', shiftKey: true });
+    expect(screen.getByTestId('shortcut-overlay')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('shortcut-overlay')).toBeNull();
+
+    // layouts that emit '?' without shift open it too, and '?' closes it again
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByTestId('shortcut-overlay')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.queryByTestId('shortcut-overlay')).toBeNull();
+  });
+
+  it('never opens from a typing context (the one EC21 guard)', () => {
+    render(
+      <>
+        <input data-testid="field" />
+        <ShortcutOverlay />
+      </>,
+    );
+    const field = screen.getByTestId('field');
+    field.focus();
+    fireEvent.keyDown(field, { key: '?', shiftKey: true });
+    expect(screen.queryByTestId('shortcut-overlay')).toBeNull();
+  });
+});

--- a/tests/SteeringGate.keys.test.tsx
+++ b/tests/SteeringGate.keys.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SteeringGate } from '../src/components/SteeringGate.js';
+import * as client from '../src/api/client.js';
+
+/**
+ * DES-UX-001 §7.7 (slice AC) — the gate panel honors a / r: with the panel
+ * holding focus, 'a' fires the SAME POST the Approve button fires (exactly
+ * once), 'r' the Reject one; unfocused or typing, the keys yield.
+ */
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'resumed' } as never);
+  vi.spyOn(client.api, 'cancelRun').mockResolvedValue({ ok: true } as never);
+});
+
+function renderGate(): void {
+  render(<SteeringGate runId="r-gate" ord={2} prompt="Proceed with unit 2?" />);
+}
+
+describe('SteeringGate a/r keys (§7.7)', () => {
+  it("'a' with the panel focused fires the approve POST exactly once", async () => {
+    renderGate();
+    screen.getByTestId('steering-gate').focus();
+    fireEvent.keyDown(window, { key: 'a' });
+    fireEvent.keyDown(window, { key: 'a' }); // double-tap: the in-flight guard drops it
+    await waitFor(() => expect(client.api.confirmGate).toHaveBeenCalledTimes(1));
+    expect(client.api.confirmGate).toHaveBeenCalledWith('r-gate', { approve: true });
+  });
+
+  it("'r' with the panel focused fires the reject POST", async () => {
+    renderGate();
+    screen.getByTestId('steering-approve').focus(); // any focus INSIDE the panel arms the keys
+    fireEvent.keyDown(window, { key: 'r' });
+    await waitFor(() => expect(client.api.confirmGate).toHaveBeenCalledTimes(1));
+    expect(client.api.confirmGate).toHaveBeenCalledWith('r-gate', { approve: false });
+  });
+
+  it('yields silently while the panel does not hold focus', () => {
+    renderGate();
+    (document.activeElement as HTMLElement | null)?.blur();
+    fireEvent.keyDown(window, { key: 'a' });
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+
+  it('typing a and r into the steer textarea stays typing (EC21 guard)', () => {
+    renderGate();
+    const ta = screen.getByTestId('steering-amend');
+    ta.focus();
+    fireEvent.keyDown(ta, { key: 'a' });
+    fireEvent.keyDown(ta, { key: 'r' });
+    expect(client.api.confirmGate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-001 §7.7 + §7.8 (slice AC)** — keyboard coherence + composer preflight (BRIEF-UX-001 C4 + C5; EC42, EC43, EC21).

- **'?' overlay rendered FROM the shortcut registry** on every route (surface-true, never a hand list); gate-panel a/r; ONE Escape contract across every layer (overlay→palette→sheet→modal/popover→triage; capture-phase so xterm can't eat it — Operator-shell and sign-in modals now close); shell focuses xterm on open. Still exactly one window-level keydown listener (EC21).
- **Preflight**: repo-less code intents warn-and-block with the named reason (zero POST until override); `crew.repo` auto-attach chip (removable, operator wins); action previews on named actions.
- **⚠ §13 gate-posture flip (operator-confirmable)**: the composer's shipped default is now `human_confirm` on the first gate-bearing phase, per the design's adopted position — spelled as `COMPOSER_DEFAULT_GATE_POSTURE` in `src/components/composerDefaults.ts`. **Veto = one-line revert there.** The posture control still offers "none" — the flip changes the default, never removes choice.

Verified: 1380 unit tests; slice rig ×2; regressions B/L/H/Q/AA + studio_standalone (real daemon); registry-truth proven by a temp-entry unit test; negative check fails on main; adversarial verifier approved (fixed one real defect in the process). LOC +561 gross (~422 non-comment) disclosed vs ~350, split at the §7.7/§7.8 commit seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
