### PR TITLE
Re-review fixes: J3 send-lifecycle honesty + J1 governance-panel contradiction

### DIFF
--- a/e2e/ux_fixJ3J1_test.py
+++ b/e2e/ux_fixJ3J1_test.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+ux_fixJ3J1_test.py — the re-review blocker gate for J3 (client honesty on the
+doc create/iteration path) and J1 (the Governance panel's self-contradiction).
+BRIEF-UX-001 DoD gate; DES-UX-001 governs.
+
+The four ACs, verbatim mapping:
+
+  1. J3 bounded honesty budget: on a bridge that ACKS and then says NOTHING
+     (`doc_silent` — the reproduced 28-min no-answerer), the "generating — this
+     message is being worked now" pill must flip, within
+     GENERATING_SILENCE_BUDGET_MS (90s, docThread.ts) of silence, to
+     `[data-testid="thread-generating-timeout"]` carrying the honest copy
+     ("no worker has picked this up — the generation service may be down") and
+     a WORKING `[data-testid="thread-generating-retry"]`. The composer's own
+     steering chip stops claiming a live run at the same moment
+     (`steering-stalled`). This scene rides the REAL production budget — no
+     shortened test seam — so the rig witnesses the actual bound a user would.
+  2. J3 no premature anchors: on the terminal-continue path (fork + inject),
+     NO `continues as vN` divider and NO new version chip render before the
+     thread OBSERVES a `version.created` arrival — the anchor lands only with
+     the wire's proof, positioned immediately above its continuation message.
+  3. J3 closed-drawer export: with the thread drawer CLOSED, the export click
+     site keeps its answer VISIBLE — the strip must not auto-hide while the
+     export is pending or its READY answer sits un-acted (pre-fix: the whole
+     strip faded to opacity 0 three seconds after the click; zero response).
+  4. J1 governance non-contradiction: on the r-auth-class run (halt banner +
+     Decisions DENY, EMPTY /governance/claims), the Governance panel must NOT
+     say "No governance claims recorded for this run" — it states which wire
+     it reads and that the wire is empty (`governance-wire-empty`), and
+     surfaces the run's own decision record (`governance-run-record`).
+
+Captures (§12.0 contract: 1440x900, dsf 1) into e2e/shots/vision/:
+  ux-fixJ3J1-generating-timeout.png   the honest timeout pill + retry
+  ux-fixJ3J1-export-closed-drawer.png the READY answer, drawer closed, strip up
+  ux-fixJ3J1-governance.png           the non-contradicting Governance panel
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4401), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+
+NOTE scene 1 waits out the real 90s budget — this rig runs ~3 minutes.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4401"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+PID = "scratch"
+
+# The client's budget (docThread.ts GENERATING_SILENCE_BUDGET_MS) and its honest
+# copy (DocumentThread.tsx GENERATING_TIMEOUT_COPY), pinned verbatim.
+BUDGET_MS = 90_000
+TIMEOUT_COPY = "no worker has picked this up — the generation service may be down"
+
+# The J1 forensics deny (uxfix_fixture FORENSICS_REVIEW_DENIAL's head).
+DENY_FRAGMENT = "Governance DENIED unit 1 (review)"
+CONTRADICTION = "No governance claims recorded for this run"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def api_create_doc(name: str, brief: str) -> dict:
+    req = urllib.request.Request(
+        f"{ORIGIN}/api/v1/projects/{PID}/interactive/api/docs", method="POST",
+        data=json.dumps({"name": name, "brief": brief}).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        return json.loads(res.read())
+
+
+# ── The same-origin build + the shared W2 fixture ──────────────────────────────
+dist = ensure_build(lambda step, why: check(step, False, error=why))
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # ── Scene 1 (AC 1): the bounded honesty budget on a silent bridge ──────────
+    set_fixture(ORIGIN, doc_silent=True)
+    page.goto(f"{ORIGIN}/p/{PID}/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    t0 = time.monotonic()
+    page.locator('[data-testid="doc-composer"]').fill("a deck for the quarterly business review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=30000)
+    msg_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"]')?.getAttribute('data-message-id')""")
+    check("silent_create_shows_generating_first", bool(msg_id), message_id=msg_id)
+
+    # INSIDE the budget the working claim stands — the timeout must not be early.
+    # (Checked at 75s: comfortably inside 90s, past any scheduling jitter.)
+    while time.monotonic() - t0 < 75:
+        time.sleep(1)
+    inside = page.evaluate(
+        """() => ({
+             generating: !!document.querySelector('[data-testid="thread-generating"]'),
+             timedOut: !!document.querySelector('[data-testid="thread-generating-timeout"]'),
+           })""")
+    check("no_timeout_inside_the_budget",
+          inside["generating"] and not inside["timedOut"],
+          seconds_elapsed=round(time.monotonic() - t0), **inside)
+
+    # PAST the budget: the visible timeout state, never eternal "being worked now".
+    page.locator('[data-testid="thread-generating-timeout"]').wait_for(timeout=40000)
+    flipped_at = time.monotonic() - t0
+    silence = page.evaluate(
+        """() => ({
+             copy: document.querySelector('[data-testid="thread-generating-timeout"]')?.textContent ?? '',
+             retry: !!document.querySelector('[data-testid="thread-generating-retry"]'),
+             stillGenerating: !!document.querySelector('[data-testid="thread-generating"]'),
+             steeringChip: !!document.querySelector('[data-testid="steering-chip"]'),
+             steeringStalled: !!document.querySelector('[data-testid="steering-stalled"]'),
+           })""")
+    check("silence_resolves_to_honest_timeout",
+          TIMEOUT_COPY in silence["copy"] and silence["retry"]
+          and not silence["stillGenerating"] and not silence["steeringChip"]
+          and silence["steeringStalled"],
+          flipped_after_s=round(flipped_at, 1), **silence)
+
+    page.screenshot(path=str(VSHOTS / "ux-fixJ3J1-generating-timeout.png"))
+
+    # The retry is LIVE: with the bridge speaking again, the same send lands its
+    # version — the pill retires into the real anchor (§3.3: a failure state
+    # always carries its own fix).
+    set_fixture(ORIGIN, doc_silent=False)
+    page.locator('[data-testid="thread-generating-retry"]').click()
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
+    revived = page.evaluate(
+        """() => ({
+             causedBy: document.querySelector('[data-testid="version-marker"][data-version="1"]')
+               ?.getAttribute('data-caused-by'),
+             timedOut: !!document.querySelector('[data-testid="thread-generating-timeout"]'),
+             generating: !!document.querySelector('[data-testid="thread-generating"]'),
+           })""")
+    check("timeout_retry_is_live_and_anchors",
+          revived["causedBy"] == msg_id and not revived["timedOut"] and not revived["generating"],
+          expected_cause=msg_id, **revived)
+
+    # ── Scene 2 (AC 2): no premature anchors on the continue path ──────────────
+    created = api_create_doc("anchor-truth", "the anchor-truth brief")
+    DOC2 = created["name"]
+    set_fixture(ORIGIN, doc_run_ms=2500)
+    page.goto(f"{ORIGIN}/p/{PID}/document/{DOC2}", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    # A reloaded doc with nothing in flight is TERMINAL — the continue path.
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
+
+    page.locator('[data-testid="doc-composer"]').fill("tighten the intro")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
+    cont_id = page.evaluate(
+        """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                   return m[m.length - 1]?.getAttribute('data-message-id'); }""")
+    # The fork has acked (the send chip is up) but nothing has LANDED: no divider,
+    # no version chip on the continuation message — anchors wait for the wire.
+    page.wait_for_timeout(900)  # inside the 2.5s scheduled landing
+    premature = page.evaluate(
+        """(contId) => ({
+             divider: !!document.querySelector('[data-testid="version-divider"]'),
+             chipOnSend: !!document.querySelector(
+               `[data-testid="version-marker"][data-caused-by="${contId}"]`),
+           })""", cont_id)
+    check("no_anchor_before_the_version_arrives",
+          not premature["divider"] and not premature["chipOnSend"], **premature)
+
+    # The version.created arrival materializes the divider ABOVE its message.
+    page.locator('[data-testid="version-divider"]').wait_for(timeout=15000)
+    anchored = page.evaluate(
+        """(contId) => {
+             const divider = document.querySelector('[data-testid="version-divider"]');
+             const next = divider?.nextElementSibling;
+             return {
+               dividerVersion: divider?.getAttribute('data-version'),
+               dividerText: divider?.textContent ?? '',
+               aboveItsMessage: !!next?.querySelector(
+                 `[data-testid="doc-message"][data-message-id="${contId}"]`),
+               chipOnSend: !!document.querySelector(
+                 `[data-testid="version-marker"][data-caused-by="${contId}"]`),
+             };
+           }""", cont_id)
+    check("divider_anchors_on_arrival_above_its_message",
+          anchored["dividerVersion"] == "2"
+          and "continues as v2" in anchored["dividerText"]
+          and anchored["aboveItsMessage"] and anchored["chipOnSend"],
+          **anchored)
+    set_fixture(ORIGIN, doc_run_ms=0)
+
+    # ── Scene 3 (AC 3): the export answers with the drawer CLOSED ──────────────
+    created = api_create_doc("closed-drawer-export", "the closed-drawer brief")
+    DOC3 = created["name"]
+    set_fixture(ORIGIN, export_delay_ms=4500)
+    page.goto(f"{ORIGIN}/p/{PID}/document/{DOC3}", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    drawer_closed = page.evaluate(
+        "() => !document.querySelector('[data-testid=\"thread-drawer\"]')")
+    check("drawer_is_closed_by_default", drawer_closed)
+
+    wake_strip(page)
+    page.locator('[data-testid="export-format"][data-format="html"]').click()
+    # Do NOT move the mouse again: pre-fix, the strip auto-hid 3s from now and
+    # took the pending answer with it. Past the idle budget the click site must
+    # still be answering, visibly.
+    page.wait_for_timeout(3600)
+    mid = page.evaluate(
+        """() => ({
+             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
+             pending: !!document.querySelector('[data-testid="export-pending"]'),
+           })""")
+    check("pending_answer_survives_the_idle_budget",
+          mid["stripHidden"] == "false" and mid["pending"], **mid)
+
+    ready = page.locator('[data-testid="export-ready"][data-format="html"]')
+    ready.wait_for(timeout=15000)
+    page.wait_for_timeout(3600)  # past another idle budget with the mouse still parked
+    landed = page.evaluate(
+        """() => ({
+             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
+             opacity: getComputedStyle(document.querySelector('[data-testid="version-strip"]')).opacity,
+             readyHref: document.querySelector('[data-testid="export-ready"]')?.getAttribute('href'),
+             drawerStillClosed: !document.querySelector('[data-testid="thread-drawer"]'),
+           })""")
+    check("ready_answer_holds_the_strip_visible_drawer_closed",
+          landed["stripHidden"] == "false" and landed["opacity"] == "1"
+          and bool(landed["readyHref"]) and landed["drawerStillClosed"],
+          **landed)
+
+    # The affordance is REAL: its href serves the artifact bytes, attachment-framed.
+    dl = page.request.get(f"{ORIGIN}{landed['readyHref']}"
+                          if landed["readyHref"].startswith("/") else landed["readyHref"])
+    check("closed_drawer_ready_href_serves_bytes",
+          dl.status == 200
+          and "attachment" in (dl.headers.get("content-disposition") or "")
+          and len(dl.body()) > 0,
+          status=dl.status, disposition=dl.headers.get("content-disposition"))
+
+    page.screenshot(path=str(VSHOTS / "ux-fixJ3J1-export-closed-drawer.png"))
+    set_fixture(ORIGIN, export_delay_ms=0)
+
+    # ── Scene 4 (AC 4): the Governance panel does not contradict its page ──────
+    set_fixture(ORIGIN, forensics=True)
+    page.goto(f"{ORIGIN}/p/auth-refactor/build/r-auth", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="failure-banner"]').wait_for(timeout=30000)
+    banner = page.locator('[data-testid="failure-banner"]').text_content() or ""
+    check("halt_banner_carries_the_deny", DENY_FRAGMENT in banner, banner=banner[:200])
+
+    page.get_by_role("button", name="Decisions").click()
+    page.locator('[data-testid="decisions-ledger"]').wait_for(timeout=15000)
+    ledger = page.locator('[data-testid="decisions-ledger"]').text_content() or ""
+    check("decisions_panel_shows_the_deny", "DENY" in ledger, ledger=ledger[:200])
+
+    page.get_by_role("button", name="Governance").click()
+    page.locator('[data-testid="governance-wire-empty"]').wait_for(timeout=15000)
+    governance = page.evaluate(
+        """() => ({
+             wireEmpty: document.querySelector('[data-testid="governance-wire-empty"]')?.textContent ?? '',
+             runRecord: document.querySelector('[data-testid="governance-run-record"]')?.textContent ?? '',
+             contradiction: document.body.textContent.includes(%s),
+           })""" % json.dumps(CONTRADICTION))
+    check("governance_panel_states_the_split_not_a_contradiction",
+          "claims wire" in governance["wireEmpty"]
+          and "holds no claims" in governance["wireEmpty"]
+          and "DENY" in governance["runRecord"]
+          and DENY_FRAGMENT in governance["runRecord"]
+          and "Decisions panel" in governance["runRecord"]
+          and not governance["contradiction"],
+          **{k: (v[:200] if isinstance(v, str) else v) for k, v in governance.items()})
+
+    page.screenshot(path=str(VSHOTS / "ux-fixJ3J1-governance.png"))
+    set_fixture(ORIGIN, forensics=False)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -132,6 +132,10 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     OWN new version FIFO doc_run_ms after the previous landing
                     (BRIDGE-UX-1 probe 1: the bridge queues, never drops), so
                     a rig can witness generating/queued/marker in sequence.
+  doc_silent      — the J3 no-answerer shape (§6.1 honesty budget): create and
+                    chat.posted ACK exactly as the real bridge does, then the
+                    bus says NOTHING (no status.posted, no version.created,
+                    ever) — the reproduced 28-min "generating" silence.
   send_fail       — slice T (§6.1): POST /api/events chat.posted answers a
                     500 {error} — the visible-failure branch (default False).
   restart_bridge  — slice T (§6.3): POST {"restart_bridge": true} simulates a
@@ -289,6 +293,15 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # 500 {error} — the visible-failure branch (a bridge that refuses the
          # send; the client must render thread-send-failed, never silence).
          "send_fail": False,
+         # J3 fix (§6.1 honesty budget): when True, the doc wires ACK exactly as
+         # the real bridge does when its worker never picks the job up — create
+         # answers 201 (v1 committed, brief logged), chat.posted answers 200
+         # {ok} and lands durably — but the bus then says NOTHING: no
+         # status.posted, no version.created, ever. The reproduced no-answerer
+         # shape (28 min of "generating" with zero backend signal); the client's
+         # GENERATING_SILENCE_BUDGET_MS timeout is what stands between the user
+         # and an eternal "being worked now".
+         "doc_silent": False,
          # Slice U (DES-UX-001 §6.2, §8.4.1 probe 3): when True, POST
          # /api/docs answers the bridge's REAL refused-bind shape — a loud
          # 502 {"error": "crew daemon unreachable at …"} with NOTHING created
@@ -1981,6 +1994,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # The brief IS the doc's first user line in the announce history
                 # (the create message the reload scene must get back, §6.3).
                 log_conversation(pid, doc, "user", brief)
+            with state_lock:
+                silent_doc = bool(state["doc_silent"])
+            if silent_doc:
+                # J3 no-answerer shape: the ack is real, the bus never speaks.
+                self._json(201, {"name": doc, "head": 1, "generating": True, "project_id": pid})
+                return True
             queue_interactive("wicked.interactive.status.posted", {
                 "project_id": pid, "document_id": doc, "state": "working",
                 "message": "Planning the deck — outline first, then the slides."})
@@ -2106,6 +2125,7 @@ class W2Handler(SimpleHTTPRequestHandler):
                 with state_lock:
                     refuse = bool(state["send_fail"])
                     run_ms = int(state["doc_run_ms"])
+                    silent_doc = bool(state["doc_silent"])
                 if refuse:
                     self._json(500, {"error": "bridge refused the send (fixture send_fail)"})
                     return True
@@ -2113,6 +2133,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # order (BRIDGE-UX-1 probe 1: the bus is the queue) …
                 if payload.get("role") == "user" and payload.get("text"):
                     log_conversation(pid, doc, "user", str(payload.get("text")))
+                if silent_doc:
+                    # J3 no-answerer shape: 200 {ok}, landed durably — and then
+                    # NOTHING answers it (no status frame, no landing, ever).
+                    self._json(200, {"ok": True, "event_id": "evt-fixture",
+                                     "correlation_id": "c-fixture"})
+                    return True
                 if run_ms > 0:
                     # … and each send's run lands its OWN new version, FIFO,
                     # doc_run_ms after the previous landing (§8.4.1 queue truth).

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -201,7 +201,8 @@ function DocFrame({
   const [loadNonce, setLoadNonce] = useState(0);
   useEffect(() => { setLoaded(false); }, [projectId, docId, version]);
   // §7.3's strip presence: visible now, gone after 3s of idleness, back on proximity.
-  const { hidden, wake } = useStripAutoHide();
+  // `hold` (J3): a strip control holding an un-acted answer pins it visible.
+  const { hidden, wake, hold } = useStripAutoHide();
 
   // ── Compare state (DES-FEEDBACK-002 §7, slice K) — the lens, not an address ──
   // `cmp` is the comparand version; null = solo canvas. The overlay refinement
@@ -453,6 +454,7 @@ function DocFrame({
           onForked={onForked}
           dimmed={hidden}
           onWake={wake}
+          onHold={hold}
           trailing={<ThreadToggle open={threadOpen} onToggle={onToggleThread} />}
           // §7 (slice K): the strip WEARS the compare state this frame owns. The
           // strip's auto-hide/wake and the thread drawer are untouched by compare

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -553,7 +553,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
       if (state === 'terminal') {
         const from = selectedVersion ?? (await getVersions(projectId, docId)).head;
         const forked = await postFork(projectId, docId, from, msgId);
-        store.addDivider(key, forked.version);
+        // §7.10 + the J3 bookkeeping pin: the "continues as vN" divider is an
+        // ANCHOR, so it renders only when the wire shows vN exists — registered
+        // here, inserted above this message by the version.created arrival.
+        store.expectDivider(key, msgId, forked.version);
         store.addUserMsg(key, msgId, body);
         store.setGenState(key, 'generating');
         // §6.1 (EC36): once the message is ON the thread, a refused send fails

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -9,7 +9,7 @@ import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
 import { scrollStripToVersion } from './threadAnchor.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
-import { nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
+import { GENERATING_SILENCE_BUDGET_MS, nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
 
 // Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
 //
@@ -61,8 +61,15 @@ const COMPOSER: Record<GenState, { placeholder: string; submit: string }> = {
 
 /** DES-UX-001 §6.1: where one user message sits in its send lifecycle. Derived from
  *  the store's pending FIFO — head = being worked, rest = queued behind the current
- *  run — plus the message's own `failed` flag. `undefined` = resolved (or historic). */
-export type SendState = 'generating' | 'queued' | 'failed';
+ *  run — plus the message's own `failed` flag. `undefined` = resolved (or historic).
+ *  `stalled` is the honesty-budget expiry (the J3 pin): the head send heard NO
+ *  `wicked.interactive.*` signal for `GENERATING_SILENCE_BUDGET_MS` — the chip must
+ *  say so and offer a retry, never keep claiming "being worked now". */
+export type SendState = 'generating' | 'queued' | 'failed' | 'stalled';
+
+/** The honest-timeout copy, pinned verbatim by the AC and the rig. */
+export const GENERATING_TIMEOUT_COPY =
+  'no worker has picked this up — the generation service may be down';
 
 function Bubble({
   msg, projectId, docId, onShowVersion, sendState, onRetrySend,
@@ -156,6 +163,30 @@ function Bubble({
           >
             <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
             generating — this message is being worked now
+          </span>
+        )}
+        {/* §6.1 honesty budget (J3): the budget ran out with no signal from the
+            service — the chip stops claiming work and says what is known (nothing
+            picked this up), with the retry that re-arms the send AND the budget.
+            Gate-amber, not fail-red: nothing failed loudly, something is missing. */}
+        {sendState === 'stalled' && (
+          <span
+            data-testid="thread-generating-timeout"
+            className="flex items-center gap-2 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)',
+                     border: '1px solid var(--status-gate-dim)' }}
+          >
+            {GENERATING_TIMEOUT_COPY}
+            <button
+              type="button"
+              data-testid="thread-generating-retry"
+              onClick={() => onRetrySend?.(msg)}
+              className="underline font-mono text-[10px]"
+              style={{ background: 'transparent', border: 'none', color: 'var(--status-gate)',
+                       cursor: 'pointer', padding: 0 }}
+            >
+              retry
+            </button>
           </span>
         )}
         {sendState === 'queued' && (
@@ -428,6 +459,32 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   const hydratedFromWire = useDocThreadStore((s) => (key === null ? false : s.hydrated[key] === true));
   // A document that exists with nothing in flight IS case 4: complete, and editable (§7.10).
   const state: GenState = docId === null ? 'idle' : streamed ?? 'terminal';
+  // §6.1 honesty budget (J3): the moment the thread last heard ANY interactive
+  // frame — status, version, chat, export. Silence past the budget while the
+  // head send claims "generating" flips the chip to the visible timeout state.
+  const lastSignal = useDocThreadStore((s) => (key === null ? 0 : s.lastSignalAt[key] ?? 0));
+  const headId: string | undefined = pendingIds[0];
+  const headSentAt = ((): number => {
+    if (headId === undefined) return 0;
+    const head = messages.find((m) => m.kind === 'user' && m.id === headId);
+    return head?.kind === 'user' ? head.sentAt ?? 0 : 0;
+  })();
+  const [stalled, setStalled] = useState(false);
+  // The budget re-arms on every signal and on every (re)send — whichever spoke last.
+  const budgetFrom = Math.max(headSentAt, lastSignal);
+  useEffect(() => {
+    // Nothing to time: no in-flight head send, no working claim, or no clock to
+    // measure from (a restored head with no sentAt cannot be honestly timed).
+    if (state !== 'generating' || headId === undefined || budgetFrom === 0) {
+      setStalled(false);
+      return;
+    }
+    const remaining = budgetFrom + GENERATING_SILENCE_BUDGET_MS - Date.now();
+    if (remaining <= 0) { setStalled(true); return; }
+    setStalled(false);
+    const timer = setTimeout(() => { setStalled(true); }, remaining);
+    return () => { clearTimeout(timer); };
+  }, [state, headId, budgetFrom]);
   // NOTE (issue #65): slice 16's picked theme no longer rides here. The `theme_id` it
   // put on the create body and the injected message was consumed by NOTHING — the theme
   // registry it named never existed on the bridge. A document's look is learned per-doc
@@ -574,7 +631,9 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     if (msg.failed === true) return 'failed';
     const at = pendingIds.indexOf(msg.id);
     if (at === -1) return undefined;
-    return at === 0 ? 'generating' : 'queued';
+    if (at !== 0) return 'queued';
+    // The head send: "being worked now" only while the honesty budget holds (J3).
+    return stalled ? 'stalled' : 'generating';
   }
 
   // The tag's cross-link (§2.6 rule 2): selecting the version IS a navigation — the
@@ -701,7 +760,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
             the folders the service reads in place — stated where the message is composed.
             Document mode only: a demo's look comes from the site it records (§4.5). */}
         {mode === 'document' && <ComposerContext projectId={projectId} docId={docId} />}
-        {state === 'generating' && (
+        {state === 'generating' && !stalled && (
           <span
             data-testid="steering-chip"
             className="self-start flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-mono"
@@ -710,6 +769,18 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
           >
             <span className="w-1 h-1 rounded-full shrink-0" style={{ background: S.live }} />
             steering the live {mode === 'video' ? 'demo' : 'document'} run
+          </span>
+        )}
+        {/* §6.1 (J3): past the honesty budget the composer must not claim a live
+            run either — one page, one truth. The retry lives on the message chip. */}
+        {state === 'generating' && stalled && (
+          <span
+            data-testid="steering-stalled"
+            className="self-start rounded-full px-2.5 py-0.5 text-[10px] font-mono"
+            style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)',
+                     border: '1px solid var(--status-gate-dim)' }}
+          >
+            no live signal from the generation service
           </span>
         )}
         {/* §7.3 (slice X2): the parse, SHOWN before submit — a quoted name in a

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -57,9 +57,17 @@ export interface ExportMenuProps {
    *  §4.2 addresses versions explicitly, and a download is a thing you keep. */
   version: number;
   compact?: boolean;
+  /**
+   * §7.2, the J3 closed-drawer pin: told `true` while this control owes (or is
+   * showing) an answer — an export in flight, a READY download not yet retired,
+   * a FAILED hint. The strip host pins itself visible on it: auto-hide fading the
+   * click site's answer out from under a closed drawer IS the "clicked, nothing
+   * visibly happened" failure. Optional — the board tile has no auto-hide to pin.
+   */
+  onHold?: ((held: boolean) => void) | undefined;
 }
 
-export function ExportMenu({ projectId, docId, version, compact = false }: ExportMenuProps): React.ReactElement {
+export function ExportMenu({ projectId, docId, version, compact = false, onHold }: ExportMenuProps): React.ReactElement {
   const [busy, setBusy] = useState<ExportFormat | null>(null);
   const [ready, setReady] = useState<ReadyArtifact | null>(null);
   const [hint, setHint] = useState<string | null>(null);
@@ -67,6 +75,15 @@ export function ExportMenu({ projectId, docId, version, compact = false }: Expor
   // §7.2: the click site answers for THIS version. A new selection retires the
   // previous answer — a v3 artifact link must not sit under an "Export v4" label.
   useEffect(() => { setReady(null); setHint(null); }, [docId, version]);
+
+  // The J3 hold: pending, ready and failed are all states the user has not acted
+  // on yet — each keeps the click site on screen until it is consumed or retired.
+  const answering = busy !== null || ready !== null || hint !== null;
+  useEffect(() => {
+    if (!answering || onHold === undefined) return;
+    onHold(true);
+    return () => { onHold(false); };
+  }, [answering, onHold]);
 
   function run(format: ExportFormat): void {
     setBusy(format);

--- a/src/components/GovernanceAudit.tsx
+++ b/src/components/GovernanceAudit.tsx
@@ -96,6 +96,49 @@ function ClaimRow({ claim }: { claim: GovernanceClaim }): React.ReactElement {
   );
 }
 
+/**
+ * One governance decision the RUN'S OWN record carries (its snapshot + durable
+ * event tail), independent of the conformance claims wire. The panel derives
+ * these so an empty claims wire can never contradict the page beside it: the
+ * same run whose banner and Decisions panel show a gate deny must never read
+ * "no governance" here (the J1 self-contradiction pin).
+ */
+interface RunRecordDecision {
+  ord: number;
+  source: 'gate' | 'unit' | 'hook';
+  detail: string;
+}
+
+/** The run model's own governance activity: gate denies, unit denial reasons,
+ *  and per-tool-call hook denies — everything the Decisions panel and the halt
+ *  banner render from. Approvals are NOT collected: a vacuous pass proves
+ *  nothing (FINDING-025), and this list exists to prevent contradiction, not
+ *  to overclaim governance. */
+export function runRecordDecisions(model: RunModel): RunRecordDecision[] {
+  const out: RunRecordDecision[] = [];
+  for (const u of model.units) {
+    for (const g of u.gateEvals) {
+      if (!g.combined) {
+        out.push({ ord: u.ord, source: 'gate', detail: g.denialReason ?? g.criterion ?? 'gate denied' });
+      }
+    }
+    // The snapshot's denial_reason, when no gateEvaluated event survived to say
+    // the same thing — one deny, not two rows for one fact.
+    if (u.denialReason !== null && !u.gateEvals.some((g) => !g.combined && g.denialReason === u.denialReason)) {
+      out.push({ ord: u.ord, source: 'unit', detail: u.denialReason });
+    }
+    for (const h of u.hookFires) {
+      if (h.decision === 'deny') {
+        out.push({
+          ord: u.ord, source: 'hook',
+          detail: `${h.toolName} denied${h.denyingPolicy !== null ? ` by ${h.denyingPolicy}` : ''}`,
+        });
+      }
+    }
+  }
+  return out;
+}
+
 export function GovernanceAudit({ model }: Props): React.ReactElement {
   const [claims, setClaims] = useState<GovernanceClaim[]>([]);
   const [loading, setLoading] = useState(true);
@@ -143,6 +186,47 @@ export function GovernanceAudit({ model }: Props): React.ReactElement {
   }
 
   if (claims.length === 0) {
+    // The J1 non-contradiction rule: this panel reads ONE wire (the conformance
+    // store's claims), and the page around it reads another (the run's own
+    // snapshot + event tail). When the claims wire is empty but the run's own
+    // record shows governance activity, the panel must say exactly that split —
+    // never a flat "no governance" beside a halt banner carrying a deny.
+    const recorded = runRecordDecisions(model);
+    if (recorded.length > 0) {
+      return (
+        <div className="flex flex-col gap-2">
+          <p data-testid="governance-wire-empty" className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
+            This panel reads the conformance store’s claims wire, which holds no
+            claims scoped to this run.
+          </p>
+          <div data-testid="governance-run-record" className="flex flex-col gap-1.5">
+            <p className="text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>
+              The run’s own decision record DOES show governance activity — the full
+              gate record is in the Decisions panel:
+            </p>
+            <ul className="flex flex-col gap-1">
+              {recorded.map((d, i) => (
+                <li
+                  key={i}
+                  data-testid="governance-run-decision"
+                  className="rounded p-2 text-[11px] font-mono"
+                  style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+                >
+                  <span
+                    className="inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono mr-2"
+                    style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}
+                  >
+                    DENY
+                  </span>
+                  <span style={{ color: 'var(--ink-muted)' }}>unit #{d.ord} · {d.detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {refreshBtn}
+        </div>
+      );
+    }
     return (
       <div className="flex flex-col gap-1">
         <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>

--- a/src/components/ThreadDrawer.tsx
+++ b/src/components/ThreadDrawer.tsx
@@ -24,23 +24,41 @@ export const STRIP_SENSOR_PX = 80;
  * `STRIP_IDLE_MS` without interaction. `wake` is bound to mousemove on the strip
  * itself and on the bottom-proximity sensor; the sensor exists because the canvas
  * is an iframe, and an iframe swallows the mousemoves the parent would otherwise see.
+ *
+ * `hold` (DES-UX-001 §7.2, the J3 closed-drawer pin): a control ON the strip that
+ * owes the user an answer — an export that is pending, or whose READY/FAILED state
+ * has not been acted on — pins the strip visible. Auto-hide swallowing the click
+ * site's answer is exactly the "clicked, nothing visibly happened" failure the
+ * point-of-action states exist to prevent: with the thread drawer CLOSED the strip
+ * is the ONLY place the answer lives. Ref-counted so several holders compose;
+ * releasing the last hold re-arms the ordinary idle timer.
  */
-export function useStripAutoHide(idleMs: number = STRIP_IDLE_MS): { hidden: boolean; wake: () => void } {
+export function useStripAutoHide(idleMs: number = STRIP_IDLE_MS): {
+  hidden: boolean; wake: () => void; hold: (held: boolean) => void;
+} {
   const [hidden, setHidden] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const holds = useRef(0);
 
   const wake = useCallback((): void => {
     setHidden(false);
     if (timer.current !== null) clearTimeout(timer.current);
-    timer.current = setTimeout(() => { setHidden(true); }, idleMs);
+    // The timer always re-arms, but firing while held must not hide the answer.
+    timer.current = setTimeout(() => { if (holds.current === 0) setHidden(true); }, idleMs);
   }, [idleMs]);
+
+  const hold = useCallback((held: boolean): void => {
+    holds.current = Math.max(0, holds.current + (held ? 1 : -1));
+    if (held) setHidden(false);
+    else if (holds.current === 0) wake(); // the answer was released: earn the exit again
+  }, [wake]);
 
   useEffect(() => {
     wake(); // the mount is an interaction: the strip shows, then earns its exit
     return () => { if (timer.current !== null) clearTimeout(timer.current); };
   }, [wake]);
 
-  return { hidden, wake };
+  return { hidden, wake, hold };
 }
 
 /**

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -156,6 +156,9 @@ export interface VersionStripProps {
   dimmed?: boolean;
   /** Mouse presence on the strip is an interaction: it resets the owner's idle timer. */
   onWake?: (() => void) | undefined;
+  /** §7.2 (the J3 closed-drawer pin): a strip control holding an unanswered/
+   *  un-acted answer pins the strip visible — see `useStripAutoHide().hold`. */
+  onHold?: ((held: boolean) => void) | undefined;
   /** The canvas-first chrome's extra control — the thread-drawer toggle (§7.3). */
   trailing?: React.ReactNode;
   /** DES-FEEDBACK-002 §7 (slice K): the compare toggle/cluster. Absent = no
@@ -165,7 +168,7 @@ export interface VersionStripProps {
 
 export function VersionStrip({
   projectId, docId, manifest, selected, navigate, onForked,
-  mode = 'document', dimmed = false, onWake, trailing, compare,
+  mode = 'document', dimmed = false, onWake, onHold, trailing, compare,
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -437,8 +440,10 @@ export function VersionStrip({
 
       {/* §4.4: export is PER-VERSION, so it belongs to the surface that owns which version
           is addressed. The selection is the subject — exporting "the document" would be
-          exporting whichever version happened to be head when the button was pressed. */}
-      <ExportMenu projectId={projectId} docId={docId} version={selected} />
+          exporting whichever version happened to be head when the button was pressed.
+          §7.2 (J3): its unresolved/un-acted answer HOLDS the strip visible — with the
+          drawer closed, this control is the only place the answer lives. */}
+      <ExportMenu projectId={projectId} docId={docId} version={selected} onHold={onHold} />
 
       {/* DES-FEEDBACK-001 §7.3: the thread-drawer toggle rides the strip's action end. */}
       {trailing}

--- a/src/components/VideoStoryboard.tsx
+++ b/src/components/VideoStoryboard.tsx
@@ -121,7 +121,7 @@ function DemoSurface({
   if (fresh !== null) lastManifest.current = fresh;
   const manifest = fresh ?? lastManifest.current;
   const [loaded, setLoaded] = useState(false);
-  const { hidden, wake } = useStripAutoHide();
+  const { hidden, wake, hold } = useStripAutoHide();
 
   const subject = `“${demoId}”`;
   if (manifest === null) {
@@ -200,6 +200,7 @@ function DemoSurface({
             mode="video"
             dimmed={hidden}
             onWake={wake}
+            onHold={hold}
             trailing={<ThreadToggle open={threadOpen} onToggle={onToggleThread} />}
           />
         </div>

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -164,6 +164,9 @@ interface DocThreadStore {
    * A thread that has never heard anything has no entry.
    */
   lastSignalAt: Record<string, number>;
+  /** Deferred continuation dividers (§7.10, the J3 bookkeeping pin), per thread:
+   *  each waits for the wire to show its version exists. See `expectDivider`. */
+  expectedDividers: Record<string, { msgId: string; version: number }[]>;
   /**
    * The newest version the stream has landed, per thread. The transcript tags its anchor
    * message (§7.6) and does not otherwise care; a mode SURFACE does — a re-authored demo
@@ -208,8 +211,15 @@ interface DocThreadStore {
                 artifact?: { href: string; file?: string }) => void;
   /** Append an §3.3 ACTIONABLE line — a failure that names its fix, and what to retry. */
   addActionable: (key: string, text: string, hint: string, retry?: ExportRetry) => void;
-  /** The version divider a fork+inject continuation renders behind (§7.10). */
-  addDivider: (key: string, version: number) => void;
+  /**
+   * Register the version divider a fork+inject continuation WILL render behind
+   * (§7.10) — deferred to the wire (the J3 bookkeeping pin): "continues as vN"
+   * is an anchor, and no anchor may render before the thread has OBSERVED that
+   * version exist. The divider is inserted immediately above the continuation
+   * message by the first `version.created` arrival at or past `version`; a
+   * continuation whose run never lands anything never grows a divider.
+   */
+  expectDivider: (key: string, msgId: string, version: number) => void;
   setGenState: (key: string, state: GenState) => void;
   clear: (key: string) => void;
 }
@@ -228,6 +238,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   landings: [],
   lastError: {},
   lastSignalAt: {},
+  expectedDividers: {},
 
   ingest: (event) => {
     const frame = frameOf(event);
@@ -361,9 +372,26 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         const queue = s.pending[key] ?? [];
         const anchorId = queue.length > 0 ? queue[0] : undefined;
         const generated = GENERATED.has(kind);
-        const thread = messages[key] ?? [];
+        // §7.10 deferred dividers (the J3 bookkeeping pin): this arrival is the
+        // proof-of-existence a registered continuation waited for. Each divider
+        // whose version the wire has now reached is inserted immediately above
+        // its continuation message — never earlier than this moment.
+        const expected = s.expectedDividers[key] ?? [];
+        const due = expected.filter((e) => version >= e.version);
+        let thread = messages[key] ?? [];
+        for (const e of due) {
+          const divider: DocMsg = { kind: 'divider', id: nextMsgId(), version: e.version };
+          const at = thread.findIndex((m) => m.kind === 'user' && m.id === e.msgId);
+          thread = at === -1
+            ? [...thread, divider]
+            : [...thread.slice(0, at), divider, ...thread.slice(at)];
+        }
+        const dividers = due.length === 0
+          ? {}
+          : { expectedDividers: { ...s.expectedDividers,
+                                  [key]: expected.filter((e) => version < e.version) } };
         const tagged = anchorId === undefined
-          ? messages
+          ? (due.length === 0 ? messages : { ...messages, [key]: thread })
           : {
               ...messages,
               [key]: thread.map((m) =>
@@ -382,6 +410,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         }
         return {
           messages: tagged,
+          ...dividers,
           pending: generated && anchorId !== undefined
             ? { ...s.pending, [key]: queue.slice(1) }
             : s.pending,
@@ -495,8 +524,13 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       }),
     })),
 
-  addDivider: (key, version) =>
-    set((s) => ({ messages: append(s.messages, key, { kind: 'divider', id: nextMsgId(), version }) })),
+  expectDivider: (key, msgId, version) =>
+    set((s) => ({
+      expectedDividers: {
+        ...s.expectedDividers,
+        [key]: [...(s.expectedDividers[key] ?? []), { msgId, version }],
+      },
+    })),
 
   setGenState: (key, state) => set((s) => ({ genState: { ...s.genState, [key]: state } })),
 
@@ -509,6 +543,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       const landed = { ...s.landed }; delete landed[key];
       const lastError = { ...s.lastError }; delete lastError[key];
       const lastSignalAt = { ...s.lastSignalAt }; delete lastSignalAt[key];
-      return { messages, genState, pending, hydrated, landed, lastError, lastSignalAt };
+      const expectedDividers = { ...s.expectedDividers }; delete expectedDividers[key];
+      return { messages, genState, pending, hydrated, landed, lastError, lastSignalAt, expectedDividers };
     }),
 }));

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -28,6 +28,17 @@ export interface FeedbackItem { wid: string; text: string }
 /** What a failed export offers to run again — the same format, at the same version. */
 export interface ExportRetry { format: ExportFormat; version: number }
 
+/**
+ * DES-UX-001 §6.1 honesty budget (the J3 pin): how long a send may wear
+ * "generating — this message is being worked now" with NO
+ * `wicked.interactive.*` signal for its thread before the chip must become a
+ * visible timeout state (honest copy + a working retry). The reproduced
+ * failure was a create whose pill span 28 minutes with zero backend signal —
+ * no run anywhere, Health green. 90s is the budget: long enough for a slow
+ * worker pickup, far shorter than a user abandoning the page.
+ */
+export const GENERATING_SILENCE_BUDGET_MS = 90_000;
+
 export type DocMsg =
   // `items` is set only for a submitted feedback batch: ONE message, N targets (§4.3 —
   // sending each comment separately would produce N versions and N runs). `notRecorded`
@@ -38,8 +49,12 @@ export type DocMsg =
   // message rehydrated from `GET /d/:doc/api/conversation` (§6.3): the wire carries no
   // message ids, so a restored message's id is minted fresh and its version anchor (if
   // any) came from the session-storage stopgap, not the transcript.
+  // `sentAt` is the send's own clock (§6.1 honesty budget): stamped when the
+  // message is enqueued and re-stamped by a retry, it is half of what decides
+  // when the generating chip must stop claiming "being worked now".
   | { kind: 'user';      id: string; text: string; version?: number;
-      items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; restored?: boolean }
+      items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; restored?: boolean;
+      sentAt?: number }
   | { kind: 'narration'; id: string; text: string }
   // `href` + `file` make an agent message DOWNLOADABLE (§4.4): an export is an ordinary
   // message from the service, carrying its artifact — never a toast, never a second origin.
@@ -143,6 +158,13 @@ interface DocThreadStore {
   /** Threads whose rehydration read (§6.3) has run — once per thread per session. */
   hydrated: Record<string, boolean>;
   /**
+   * When the LAST `wicked.interactive.*` frame for each thread arrived (§6.1
+   * honesty budget). Any frame counts — status, chat, version, export: each one
+   * proves something is alive on the other end, so each one re-arms the budget.
+   * A thread that has never heard anything has no entry.
+   */
+  lastSignalAt: Record<string, number>;
+  /**
    * The newest version the stream has landed, per thread. The transcript tags its anchor
    * message (§7.6) and does not otherwise care; a mode SURFACE does — a re-authored demo
    * spec is a new version of the same artifact (§7.10's continuation rhythm), so the
@@ -205,11 +227,15 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   landed: {},
   landings: [],
   lastError: {},
+  lastSignalAt: {},
 
   ingest: (event) => {
     const frame = frameOf(event);
     if (frame === null) return;
     const { key, type, payload } = frame;
+    // §6.1 honesty budget: every parsed frame for this thread is a liveness
+    // signal — stamp it before the fold, whatever the fold does with the frame.
+    set((s) => ({ lastSignalAt: { ...s.lastSignalAt, [key]: Date.now() } }));
     // The anchor the VERSION branch tags, surfaced out of the reducer so the
     // session-storage stopgap (§6.3) records it OUTSIDE the state update.
     let taggedOrd: number | null = null;
@@ -382,7 +408,8 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
 
   addUserMsg: (key, id, text, items) =>
     set((s) => ({
-      messages: append(s.messages, key, { kind: 'user', id, text, ...(items ? { items } : {}) }),
+      messages: append(s.messages, key,
+        { kind: 'user', id, text, sentAt: Date.now(), ...(items ? { items } : {}) }),
       pending: { ...s.pending, [key]: [...(s.pending[key] ?? []), id] },
     })),
 
@@ -401,7 +428,8 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       messages: {
         ...s.messages,
         [key]: (s.messages[key] ?? []).map((m) =>
-          m.kind === 'user' && m.id === id ? { ...m, failed: false } : m),
+          // A retry is a NEW send, so its §6.1 honesty-budget clock restarts too.
+          m.kind === 'user' && m.id === id ? { ...m, failed: false, sentAt: Date.now() } : m),
       },
       pending: { ...s.pending, [key]: [...(s.pending[key] ?? []).filter((p) => p !== id), id] },
     })),
@@ -480,6 +508,7 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       const hydrated = { ...s.hydrated }; delete hydrated[key];
       const landed = { ...s.landed }; delete landed[key];
       const lastError = { ...s.lastError }; delete lastError[key];
-      return { messages, genState, pending, hydrated, landed, lastError };
+      const lastSignalAt = { ...s.lastSignalAt }; delete lastSignalAt[key];
+      return { messages, genState, pending, hydrated, landed, lastError, lastSignalAt };
     }),
 }));

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -5,7 +5,7 @@
 // one: editing a complete version is fork + inject as a SINGLE composer action, rendered
 // as a continuation — a version divider, no new thread header.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DocumentThread } from '../src/components/DocumentThread.js';
 import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
@@ -187,18 +187,42 @@ describe('state 4 — terminal: fork + inject is ONE atomic action (§7.10)', ()
       }),
     }));
 
-    // Rendered as a CONTINUATION: a version divider, and no new thread header.
+    // The J3 bookkeeping pin: "continues as v4" is an ANCHOR — it must NOT
+    // render before the thread observed v4 on the wire. Right after the fork
+    // acks, the divider is only REGISTERED, never shown.
+    expect(screen.queryByTestId('version-divider')).toBeNull();
+    expect((useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind))
+      .toEqual(['user']);
+
+    // The version.created arrival is what materializes it — a CONTINUATION:
+    // a version divider above its message, and no new thread header.
+    act(() => {
+      useDocThreadStore.getState().ingest({
+        type: 'interactiveEvent',
+        event: {
+          event_type: 'wicked.interactive.version.created',
+          payload: { project_id: PROJECT, document_id: DOC, version: 4, parent: 3, kind: 'generated' },
+        },
+      } as never);
+    });
     const divider = screen.getByTestId('version-divider');
     expect(divider).toHaveAttribute('data-version', '4');
     expect(divider).toHaveTextContent('continues as v4');
     expect(screen.queryByTestId('thread-header')).toBeNull();
     expect(screen.getAllByTestId('thread')).toHaveLength(1);
 
-    // The divider precedes the message it continues into, and the composer is live again.
+    // The divider precedes the message it continues into, and the landing
+    // consumed both the anchor and the expectation.
     const order = (useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind);
     expect(order).toEqual(['divider', 'user']);
-    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
     expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=4`);
+  });
+
+  it('the composer is live (generating) after the fork, before anything lands', async () => {
+    mount(DOC, 3);
+    await send('make the closing slide stronger');
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
   });
 
   it('with no routed version it forks from the manifest head, never from v1', async () => {

--- a/tests/DocumentThread.timeout.test.tsx
+++ b/tests/DocumentThread.timeout.test.tsx
@@ -1,0 +1,147 @@
+// DES-UX-001 §6.1 honesty budget (the J3 re-review pin): the "generating — this
+// message is being worked now" chip may spin only while the thread is actually
+// hearing from the service. `GENERATING_SILENCE_BUDGET_MS` of silence flips it
+// to a visible timeout state — honest copy + a working retry — never an eternal
+// claim of work (the reproduced 28-minute pill with zero backend signal).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { DocumentThread, GENERATING_TIMEOUT_COPY } from '../src/components/DocumentThread.js';
+import {
+  GENERATING_SILENCE_BUDGET_MS, threadKey, useDocThreadStore,
+} from '../src/store/docThread.js';
+import type { CoreEvent } from '../src/api/types.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'launch-deck';
+const KEY = threadKey(PROJECT, DOC);
+
+const postEvent = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  createDoc: vi.fn(),
+  docBinding: () => ({}),
+  postFork: vi.fn(),
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (p: string, d: string, text: string, id: string) =>
+    postEvent(p, {
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { role: 'user', text, document_id: d, source_message_id: id },
+    }),
+  getVersions: vi.fn(),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+function statusFrame(message: string): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: {
+      event_type: 'wicked.interactive.status.posted',
+      payload: { project_id: PROJECT, document_id: DOC, state: 'working', message },
+    },
+  } as unknown as CoreEvent;
+}
+
+function versionFrame(version: number): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: {
+      event_type: 'wicked.interactive.version.created',
+      payload: { project_id: PROJECT, document_id: DOC, version, parent: null, kind: 'generated' },
+    },
+  } as unknown as CoreEvent;
+}
+
+/** One in-flight send, exactly as the composer leaves it. */
+function armSend(id = 'm-1'): void {
+  const store = useDocThreadStore.getState();
+  store.addUserMsg(KEY, id, 'a deck for the Q3 review');
+  store.setGenState(KEY, 'generating');
+}
+
+function mount(): void {
+  render(
+    <DocumentThread projectId={PROJECT} docId={DOC} selectedVersion={null} navigate={vi.fn()} />,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  useDocThreadStore.setState({
+    messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastSignalAt: {},
+  });
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('the generating chip has a bounded honesty budget', () => {
+  it('keeps "being worked now" inside the budget, then flips to the visible timeout with retry', () => {
+    armSend();
+    mount();
+    expect(screen.getByTestId('thread-generating')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-chip')).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(GENERATING_SILENCE_BUDGET_MS - 1000); });
+    expect(screen.getByTestId('thread-generating')).toBeInTheDocument();
+    expect(screen.queryByTestId('thread-generating-timeout')).toBeNull();
+
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(screen.queryByTestId('thread-generating')).toBeNull();
+    const timeout = screen.getByTestId('thread-generating-timeout');
+    expect(timeout).toHaveTextContent(GENERATING_TIMEOUT_COPY);
+    expect(screen.getByTestId('thread-generating-retry')).toBeInTheDocument();
+    // The composer's own chip stops claiming a live run too — one page, one truth.
+    expect(screen.queryByTestId('steering-chip')).toBeNull();
+    expect(screen.getByTestId('steering-stalled')).toBeInTheDocument();
+  });
+
+  it('re-arms the budget on ANY interactive signal for the thread', () => {
+    armSend();
+    mount();
+    act(() => { vi.advanceTimersByTime(60_000); });
+    act(() => { useDocThreadStore.getState().ingest(statusFrame('Planning the deck outline.')); });
+    // 60s later the total silence-since-send exceeds the budget, but the signal
+    // reset the clock — still honestly "being worked".
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId('thread-generating')).toBeInTheDocument();
+    // …and a full budget of silence AFTER the last signal still times out.
+    act(() => { vi.advanceTimersByTime(GENERATING_SILENCE_BUDGET_MS); });
+    expect(screen.getByTestId('thread-generating-timeout')).toBeInTheDocument();
+  });
+
+  it('retry re-emits the send on the inject wire and restores the working claim', async () => {
+    armSend('m-9');
+    mount();
+    act(() => { vi.advanceTimersByTime(GENERATING_SILENCE_BUDGET_MS + 1000); });
+    expect(screen.getByTestId('thread-generating-timeout')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('thread-generating-retry'));
+    await act(async () => { await Promise.resolve(); });
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: 'wicked.interactive.chat.posted',
+      payload: expect.objectContaining({ source_message_id: 'm-9' }),
+    }));
+    // The retry restarted the send's own clock: the chip claims work again…
+    expect(screen.getByTestId('thread-generating')).toBeInTheDocument();
+    expect(screen.queryByTestId('thread-generating-timeout')).toBeNull();
+    // …and only for one more budget of silence.
+    act(() => { vi.advanceTimersByTime(GENERATING_SILENCE_BUDGET_MS + 1000); });
+    expect(screen.getByTestId('thread-generating-timeout')).toBeInTheDocument();
+  });
+
+  it('a landed version retires the timeout state entirely', () => {
+    armSend();
+    mount();
+    act(() => { vi.advanceTimersByTime(GENERATING_SILENCE_BUDGET_MS + 1000); });
+    expect(screen.getByTestId('thread-generating-timeout')).toBeInTheDocument();
+
+    act(() => { useDocThreadStore.getState().ingest(versionFrame(1)); });
+    expect(screen.queryByTestId('thread-generating-timeout')).toBeNull();
+    expect(screen.queryByTestId('thread-generating')).toBeNull();
+    expect(screen.getByTestId('version-marker')).toHaveAttribute('data-version', '1');
+  });
+});

--- a/tests/GovernanceAudit.test.tsx
+++ b/tests/GovernanceAudit.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mergeRunModel } from '../src/hooks/useRunModel.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeView, makeUnit } from './factories.js';
+
+// The J1 self-contradiction pin: on a run whose halt banner + Decisions panel
+// carry a governance deny, the Governance panel must never read "No governance
+// claims recorded for this run" — the two surfaces read DIFFERENT wires (the
+// conformance claims store vs the run's own snapshot + event tail), and the
+// panel has to state that split instead of contradicting the page.
+
+const listClaims = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop) => {
+      if (String(prop) === 'listClaims') return listClaims;
+      return vi.fn().mockResolvedValue({});
+    },
+  }),
+}));
+
+import { GovernanceAudit, runRecordDecisions } from '../src/components/GovernanceAudit.js';
+
+const DENIAL =
+  'Governance DENIED unit 1 (review): the refactored middleware drops the token-refresh path';
+
+/** A run shaped like the reproduced 61fcef-class page: gate deny in the tail,
+ *  denial_reason on the unit, nothing on the claims wire. */
+function deniedModel() {
+  const snap = makeView({ id: 'r-auth', status: 'failed' }, [
+    makeUnit({ ord: 0, status: 'done' }),
+    makeUnit({ id: 'r-auth:u1', ord: 1, status: 'rejected', denial_reason: DENIAL }),
+  ]);
+  const events: CoreEvent[] = [{
+    type: 'gateEvaluated', session: 'r-auth', ord: 1,
+    criterion: 'the middleware refactor keeps every existing auth test green',
+    hasDeterministicFloor: true, deterministicPass: true,
+    agentVerdict: 'fail', agentReasoning: 'drops the token-refresh path',
+    evaluatorPass: true, evaluatorPolicies: [],
+    denialReason: DENIAL, combined: false,
+  } as unknown as CoreEvent];
+  return mergeRunModel(snap, events);
+}
+
+beforeEach(() => {
+  listClaims.mockReset();
+});
+
+describe('runRecordDecisions — the run-record derivation', () => {
+  it('collects gate denies and does not double-count the unit denial_reason that matches', () => {
+    const decisions = runRecordDecisions(deniedModel());
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({ ord: 1, source: 'gate', detail: DENIAL });
+  });
+
+  it('collects a snapshot denial_reason when no gate event survived', () => {
+    const model = mergeRunModel(
+      makeView({ id: 'r-x' }, [makeUnit({ ord: 2, denial_reason: 'denied: no evidence' })]),
+      [],
+    );
+    expect(runRecordDecisions(model)).toEqual([
+      { ord: 2, source: 'unit', detail: 'denied: no evidence' },
+    ]);
+  });
+
+  it('collects hook denies and never collects approvals', () => {
+    const model = mergeRunModel(makeView({ id: 'r-h' }, [makeUnit({ ord: 0 })]), [
+      { type: 'governanceHookFired', session: 'run-1', ord: 0, attempt: 0,
+        toolName: 'Write', decision: 'deny', denyingPolicy: 'pol-1' } as unknown as CoreEvent,
+      { type: 'governanceHookFired', session: 'run-1', ord: 0, attempt: 0,
+        toolName: 'Read', decision: 'allow' } as unknown as CoreEvent,
+    ]);
+    expect(runRecordDecisions(model)).toEqual([
+      { ord: 0, source: 'hook', detail: 'Write denied by pol-1' },
+    ]);
+  });
+
+  it('is empty for a run with no governance activity at all', () => {
+    const model = mergeRunModel(makeView({ id: 'r-clean' }, [makeUnit({ ord: 0 })]), []);
+    expect(runRecordDecisions(model)).toEqual([]);
+  });
+});
+
+describe('GovernanceAudit — non-contradiction on an empty claims wire', () => {
+  it('names its own wire as empty AND surfaces the run-record deny, never the flat "no governance" copy', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    render(<GovernanceAudit model={deniedModel()} />);
+
+    await waitFor(() => expect(screen.getByTestId('governance-wire-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('governance-wire-empty').textContent)
+      .toMatch(/claims wire.*holds no claims/s);
+    const record = screen.getByTestId('governance-run-record');
+    expect(record.textContent).toContain('DENY');
+    expect(record.textContent).toContain('unit #1');
+    expect(record.textContent).toContain('token-refresh');
+    expect(record.textContent).toContain('Decisions panel');
+    // The contradiction sentence must be gone on this run.
+    expect(screen.queryByText(/No governance claims recorded for this run/)).toBeNull();
+  });
+
+  it('keeps the honest empty state on a run with no governance activity anywhere', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    const model = mergeRunModel(makeView({ id: 'r-clean' }, [makeUnit({ ord: 0 })]), []);
+    render(<GovernanceAudit model={model} />);
+    await waitFor(() =>
+      expect(screen.getByText(/No governance claims recorded for this run/)).toBeInTheDocument());
+    expect(screen.queryByTestId('governance-run-record')).toBeNull();
+  });
+
+  it('renders the claims themselves when the wire carries them (unchanged path)', async () => {
+    listClaims.mockResolvedValue({ claims: [{
+      claim_id: 'clm-1', scope: 'r-auth', phase: 'review', policy_ids: [],
+      decision: 'deny', obligations: [], evaluated_context_ref: 'ctx',
+      criteria: null, evaluator_identity: 'conformance', evaluated_at: 1,
+    }] });
+    render(<GovernanceAudit model={deniedModel()} />);
+    await waitFor(() => expect(screen.getByText('DENY')).toBeInTheDocument());
+    expect(screen.queryByTestId('governance-wire-empty')).toBeNull();
+  });
+});

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -41,7 +41,10 @@ function state(): string | undefined {
 }
 
 beforeEach(() => {
-  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
+  useDocThreadStore.setState({
+    messages: {}, genState: {}, pending: {}, hydrated: {},
+    lastSignalAt: {}, expectedDividers: {},
+  });
 });
 
 describe('composer state mapping (§2.2)', () => {
@@ -296,5 +299,71 @@ describe('anchor stopgap (threadStopgap)', () => {
     store.addUserMsg(KEY, nextMsgId(), 'the ask');
     ingest(frame('wicked.interactive.version.created', { version: 1, parent: null, kind: 'generated' }));
     expect(readAnchors(KEY)).toEqual([{ ord: 1, version: 1 }]);
+  });
+});
+
+// ── The J3 bookkeeping pin: deferred continuation dividers + the signal clock ──
+
+describe('deferred dividers (§7.10, anchor-on-arrival)', () => {
+  it('expectDivider renders NOTHING until the wire shows the version exists', () => {
+    const store = useDocThreadStore.getState();
+    store.expectDivider(KEY, 'm-1', 4);
+    store.addUserMsg(KEY, 'm-1', 'make the closing slide stronger');
+    expect(messages().map((m) => m.kind)).toEqual(['user']);
+
+    // A lower version arriving is not that proof — the divider stays deferred.
+    ingest(frame('wicked.interactive.version.created', { version: 3, parent: 2, kind: 'generated' }));
+    expect(messages().some((m) => m.kind === 'divider')).toBe(false);
+
+    // The arrival at (or past) the fork's version materializes it, ABOVE its message.
+    ingest(frame('wicked.interactive.version.created', { version: 4, parent: 3, kind: 'generated' }));
+    const kinds = messages().map((m) => m.kind);
+    expect(kinds).toEqual(['divider', 'user']);
+    const divider = messages().find((m) => m.kind === 'divider');
+    expect(divider !== undefined && divider.kind === 'divider' && divider.version).toBe(4);
+  });
+
+  it('the divider lands immediately above its continuation message', () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', 'the first ask');
+    ingest(frame('wicked.interactive.version.created', { version: 1, parent: null, kind: 'generated' }));
+    store.expectDivider(KEY, 'm-2', 2);
+    store.addUserMsg(KEY, 'm-2', 'continue from here');
+    expect(messages().some((m) => m.kind === 'divider')).toBe(false);
+    ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'generated' }));
+    expect(messages().map((m) => m.kind)).toEqual(['user', 'divider', 'user']);
+  });
+
+  it('a continuation whose run never lands anything never grows a divider', () => {
+    const store = useDocThreadStore.getState();
+    store.expectDivider(KEY, 'm-1', 2);
+    store.addUserMsg(KEY, 'm-1', 'continue');
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Rewriting slide 2' }));
+    expect(messages().some((m) => m.kind === 'divider')).toBe(false);
+  });
+});
+
+describe('the signal clock (§6.1 honesty budget)', () => {
+  it('every parsed frame stamps lastSignalAt for its thread', () => {
+    expect(useDocThreadStore.getState().lastSignalAt[KEY]).toBeUndefined();
+    ingest(frame('wicked.interactive.status.posted', { state: 'working', message: 'Planning' }));
+    const first = useDocThreadStore.getState().lastSignalAt[KEY];
+    expect(typeof first).toBe('number');
+  });
+
+  it('a frame naming no document stamps nothing', () => {
+    ingest({ type: 'interactiveEvent', event: { event_type: 'wicked.interactive.status.posted',
+             payload: { state: 'working' } } } as unknown as CoreEvent);
+    expect(useDocThreadStore.getState().lastSignalAt[KEY]).toBeUndefined();
+  });
+
+  it('addUserMsg stamps sentAt; retrySend re-stamps it', () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', 'the ask');
+    const msg = messages().find((m) => m.kind === 'user');
+    expect(msg !== undefined && msg.kind === 'user' && typeof msg.sentAt).toBe('number');
+    store.retrySend(KEY, 'm-1');
+    const retried = messages().find((m) => m.kind === 'user');
+    expect(retried !== undefined && retried.kind === 'user' && typeof retried.sentAt).toBe('number');
   });
 });

--- a/tests/stripHold.test.tsx
+++ b/tests/stripHold.test.tsx
@@ -1,0 +1,91 @@
+// The J3 closed-drawer export pin (DES-UX-001 §7.2/EC37): the version strip is
+// the ONLY place the export answer lives while the thread drawer is closed, so
+// auto-hide must never fade the click site's answer out from under the user.
+// Reproduced: with the drawer closed, the strip (pending answer and all) went
+// opacity-0 three seconds after the click — "zero visible response".
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, renderHook, screen } from '@testing-library/react';
+import { ExportMenu } from '../src/components/ExportMenu.js';
+import { STRIP_IDLE_MS, useStripAutoHide } from '../src/components/ThreadDrawer.js';
+
+const postExport = vi.fn();
+
+const { ServiceHintError } = vi.hoisted(() => ({
+  ServiceHintError: class ServiceHintError extends Error {
+    readonly hint: string;
+    constructor(message: string, hint: string) { super(message); this.hint = hint; }
+  },
+}));
+
+vi.mock('../src/api/interactive.js', () => ({
+  postExport: (...a: unknown[]) => postExport(...a),
+  interactiveUrl: (pid: string, p: string) => `/api/v1/projects/${pid}/interactive${p}`,
+  ServiceHintError,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useStripAutoHide — the hold contract', () => {
+  it('held, the strip stays visible past the idle budget; released, it earns its exit again', () => {
+    const { result } = renderHook(() => useStripAutoHide());
+    expect(result.current.hidden).toBe(false);
+
+    act(() => { result.current.hold(true); });
+    act(() => { vi.advanceTimersByTime(STRIP_IDLE_MS * 5); });
+    expect(result.current.hidden).toBe(false);
+
+    act(() => { result.current.hold(false); });
+    expect(result.current.hidden).toBe(false); // the release re-arms, never snaps
+    act(() => { vi.advanceTimersByTime(STRIP_IDLE_MS + 50); });
+    expect(result.current.hidden).toBe(true);
+  });
+
+  it('holds are ref-counted: the strip hides only after the LAST holder releases', () => {
+    const { result } = renderHook(() => useStripAutoHide());
+    act(() => { result.current.hold(true); result.current.hold(true); });
+    act(() => { result.current.hold(false); });
+    act(() => { vi.advanceTimersByTime(STRIP_IDLE_MS * 2); });
+    expect(result.current.hidden).toBe(false);
+    act(() => { result.current.hold(false); });
+    act(() => { vi.advanceTimersByTime(STRIP_IDLE_MS + 50); });
+    expect(result.current.hidden).toBe(true);
+  });
+});
+
+describe('ExportMenu — holds its host while it owes (or shows) an answer', () => {
+  it('holds through pending AND the un-acted READY answer; a version change releases', async () => {
+    const onHold = vi.fn();
+    let resolveExport: (v: unknown) => void = () => {};
+    postExport.mockImplementation(() => new Promise((res) => { resolveExport = res; }));
+
+    const { rerender } = render(
+      <ExportMenu projectId="p1" docId="roadmap" version={3} onHold={onHold} />,
+    );
+    expect(onHold).not.toHaveBeenCalled();
+
+    act(() => { screen.getAllByTestId('export-format')[0]!.click(); });
+    expect(onHold).toHaveBeenLastCalledWith(true);
+
+    // The export resolves: still held — READY is an answer the user has not acted on.
+    await act(async () => {
+      resolveExport({ format: 'html', path: '/e/f', file: 'roadmap_v3.html', download: '/d/roadmap/f' });
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('export-ready')).toBeInTheDocument();
+    const calls = onHold.mock.calls.map((c) => c[0]);
+    expect(calls.filter((v) => v === true).length - calls.filter((v) => v === false).length).toBe(1);
+
+    // Addressing another version retires the answer — the hold releases with it.
+    rerender(<ExportMenu projectId="p1" docId="roadmap" version={2} onHold={onHold} />);
+    const after = onHold.mock.calls.map((c) => c[0]);
+    expect(after.filter((v) => v === true).length).toBe(after.filter((v) => v === false).length);
+  });
+});


### PR DESCRIPTION
Fixes two blockers from BRIEF-UX-001's six-journey cold re-review.

**J3/B1 — generating-forever honesty**: `GENERATING_SILENCE_BUDGET_MS` (90s) — the head send's pill becomes a visible timeout state ("no worker has picked this up — the generation service may be down") with a live Retry after 90s of bus silence; the composer chip flips to stalled at the same moment (witnessed at 90.3s on the real schedule). "continues as vN" dividers are now deferred anchors — nothing renders before the wire's `version.created` proof. Closed-drawer export answer no longer fades out: the strip holds while pending or un-acted (reproduced the 3s auto-hide eating the answer first).

**J1 — governance panel self-contradiction**: GovernanceAudit now derives run-record denies; when its claims wire is empty but the record is not, it states the split honestly and points at the Decisions rows — the contradiction sentence asserted absent.

Verified: 1420/1420 unit tests; new rig (4 ACs, the 90s scene timed for real, twice); regressions ux_sliceT/X/R; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
