### PR TITLE
Re-review fixes: J4 chat findability + J5 metric reconciliation

### DIFF
--- a/e2e/feedback3_sliceQ_test.py
+++ b/e2e/feedback3_sliceQ_test.py
@@ -369,7 +369,11 @@ report["steps"]["lede"] = {
         home["ledeQuestion"] == "What happened and what needs me?",
         # Slice Y (DES-UX-001 §7.4): the all-runs number re-points to /work —
         # the ONE canonical runs surface; the bare /runs listing is retired.
-        home["ledeLinkHrefs"] == ["/work", "#needs-you"],
+        # Fix slice J4/J5 (BRIEF-UX-001 re-review): each OUTCOME number now
+        # links to ITS /work filter, so a count is reproducible from the rows
+        # it names. This fixture finishes 3 passed + 1 failed, no cancelled.
+        home["ledeLinkHrefs"] == [
+            "/work", "/work?filter=completed", "/work?filter=failed", "#needs-you"],
         home["spendHref"] == "/make",
     ]),
     "web_fonts": fonts_ok, "lede_settled": lede_ok, "spend_settled": spend_ok,

--- a/e2e/ux_fixJ4J5_test.py
+++ b/e2e/ux_fixJ4J5_test.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+ux_fixJ4J5_test.py — the BRIEF-UX-001 re-review fix gate for the two blockers:
+
+J4/C6 (CRITICAL) — the chat session is unfindable after navigating away:
+  1. an opened chat gets a REAL URL: the first send mints the session and the
+     address becomes /chat/:id (replace — Back never re-enters /chat/new);
+  2. /chats live rows are DOORS: clicking one lands on /chat/:id, where the
+     surface REJOINS the warm session (GET /chats/:id probe) and states the
+     honest boundary — the wire keeps seats, not history (crew routes.ts:
+     chatSeats), so earlier messages are not replayed and the page SAYS so
+     (chat-rejoined-note), never a silent empty;
+  3. a routed id the daemon no longer holds renders the honest ended boundary
+     (chat-session-ended) — transcripts are not persisted beyond the live
+     session; a send starts fresh and the URL follows the new session;
+  4. one truth per screen: the /chats empty-state copy ("No chat sessions
+     yet") never renders beside a non-empty live band — the live-band variant
+     (chats-empty-live) states the persistence boundary instead.
+
+J5/A5 (MAJOR) — "failed" had two definitions:
+  5. ONE outcome partition (src/board/metrics.ts outcomeOf): cancelled ≠
+     failed on every surface — this rig derives the expected counts from the
+     fixture's own corpus (j5_runs: cancelled in/out of the 24h window +
+     undatable terminal rows) and asserts them independently;
+  6. reconciliation: the bottom bar's all-window failed count EQUALS the
+     /work Failed filter's rendered rows (set equality on run ids); the
+     landing's 24h failed count is a labeled subset of those rows; cancelled
+     rows live under their OWN /work filter, absent from Failed;
+  7. EC39 honesty: windowed counts STATE their exclusions — the lede wears
+     "excludes N undated runs" and the outcome bar its no-clock note — so no
+     number exists that a user cannot rebuild from a visible list.
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4402),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    ATTACHED_AT,
+    HIDE_GATE_TOASTS,
+    J5_RUNS,
+    NOW0,
+    ORPHAN,
+    REPO,
+    RUNS,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4402"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+HOUR = 3_600_000
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── The independent derivation (never snapshotted from the page) ──────────────
+#
+# The served corpus with j5_runs on: RUNS + ORPHAN (default) + J5_RUNS.
+ALL = [v["session"] for v in RUNS + [ORPHAN] + J5_RUNS]
+TERMINAL = {"completed", "failed", "cancelled"}
+
+# Window "all": status === 'failed' ALONE (the ONE partition) — and cancelled.
+EXP_FAILED_ALL_IDS = sorted(s["id"] for s in ALL if s["status"] == "failed")
+EXP_CANCELLED_ALL_IDS = sorted(s["id"] for s in ALL if s["status"] == "cancelled")
+EXP_WORKING = sum(1 for s in ALL if s["status"] not in TERMINAL and s["status"] != "awaiting_human")
+EXP_GATES = sum(1 for s in ALL if s["status"] == "awaiting_human")
+
+# Window "24h" (the lede): terminal runs whose LAST observed clock is
+# in-window. Clocks reachable here (no metrics_ws drip): the attach clocks and
+# the failed-run event tails the board backfills (RUN_EVENTS holds tails only
+# for r-auth/r-legacy, both the same side of the window as their attach).
+WINDOW_START = NOW0 - 24 * HOUR
+EXP_24H = {"finished": 0, "passed": 0, "failed": 0, "cancelled": 0, "undatable": 0}
+for s in ALL:
+    if s["status"] not in TERMINAL:
+        continue
+    attach = ATTACHED_AT.get(s["id"])
+    if attach is None:
+        EXP_24H["undatable"] += 1
+        continue
+    if attach < WINDOW_START:
+        continue
+    EXP_24H["finished"] += 1
+    key = ("failed" if s["status"] == "failed"
+           else "cancelled" if s["status"] == "cancelled" else "passed")
+    EXP_24H[key] += 1
+
+# The outcome bar (attach clock alone): in-window vs unplaced.
+EXP_BAR_TOTAL = sum(1 for s in ALL if ATTACHED_AT.get(s["id"], 0) >= WINDOW_START)
+EXP_BAR_UNPLACED = len(ALL) - EXP_BAR_TOTAL
+
+# Sanity: the corpus really carries the blocker's shape.
+assert EXP_24H["cancelled"] == 1 and EXP_24H["failed"] == 1, EXP_24H
+assert EXP_24H["undatable"] == 2, EXP_24H
+assert len(EXP_FAILED_ALL_IDS) == 3 and len(EXP_CANCELLED_ALL_IDS) == 3
+
+MSG1 = "compare the auth options"
+MSG2 = "still with me after the round trip?"
+MSG3 = "start a fresh thread here"
+
+# ── 1. Build + the fixture with the J5 corpus ─────────────────────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, j5_runs=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+
+def tap(page) -> list:
+    net: list = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if not path.startswith("/api/"):
+            return
+        body = None
+        if req.post_data:
+            try:
+                body = json.loads(req.post_data)
+            except ValueError:
+                body = None
+        net.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return net
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+
+    # ── Scene 1 (J5): the landing — one partition, labeled windows, stated
+    #    exclusions ──────────────────────────────────────────────────────────────
+    page = ctx.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="landing-lede"]').wait_for(timeout=30000)
+    page.locator('[data-testid="runs-bottom-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # The failed-tail backfill (r-auth/r-legacy) settles within a tick; the
+    # numbers below are attach-clock stable either way.
+    page.wait_for_timeout(500)
+
+    facts = page.evaluate(
+        """() => {
+             const q = (sel) => document.querySelector(sel);
+             const lede = q('[data-testid="landing-lede"]');
+             const bar = q('[data-testid="runs-bottom-bar"]');
+             const outcome = q('[data-testid="run-outcome-bar"]');
+             const segs = [...document.querySelectorAll('[data-testid="lede-segment"]')]
+               .map((a) => ({ text: a.textContent, href: a.getAttribute('href') }));
+             return {
+               lede: lede?.textContent ?? null,
+               segs,
+               undatable: q('[data-testid="lede-undatable"]')?.textContent ?? null,
+               ledeWindow: q('[data-testid="lede-window"]')?.textContent ?? null,
+               barWorking: bar?.dataset.working ?? null,
+               barGates: bar?.dataset.gates ?? null,
+               barFailed: bar?.dataset.failed ?? null,
+               outcomeTotal: outcome?.dataset.total ?? null,
+               outcomeUnplaced: outcome?.dataset.unplaced ?? null,
+               outcomeText: outcome?.textContent ?? null,
+               unplacedNote: q('[data-testid="outcome-unplaced-note"]')?.textContent ?? null,
+             };
+           }""")
+
+    # 5 — cancelled ≠ failed in the lede, and both numbers link to THEIR filter.
+    exp_lede = (f"While you were away: {EXP_24H['finished']} runs finished — "
+                f"{EXP_24H['failed']} failed, {EXP_24H['cancelled']} cancelled — and "
+                f"{EXP_GATES} gates are waiting on you.")
+    check("lede_partitions_cancelled",
+          facts["lede"] == exp_lede and facts["ledeWindow"] == "24h",
+          expected=exp_lede, lede=facts["lede"], window=facts["ledeWindow"])
+    seg_by_text = {s["text"]: s["href"] for s in facts["segs"]}
+    check("lede_numbers_link_their_filters",
+          seg_by_text.get(f"{EXP_24H['failed']} failed") == "/work?filter=failed"
+          and seg_by_text.get(f"{EXP_24H['cancelled']} cancelled") == "/work?filter=cancelled",
+          segs=facts["segs"])
+
+    # 7 — the stated exclusions (EC39): the lede names its undatable rows, the
+    # outcome bar its no-clock rows.
+    check("windowed_counts_state_exclusions",
+          facts["undatable"] == f"· excludes {EXP_24H['undatable']} undated runs"
+          and facts["unplacedNote"] == f"excludes {EXP_BAR_UNPLACED} runs with no clock in this window",
+          undatable=facts["undatable"], unplaced_note=facts["unplacedNote"])
+
+    # The outcome bar's fold on the honest attach clock, cancelled as its own
+    # named bucket in the visible value.
+    check("outcome_bar_partition",
+          facts["outcomeTotal"] == str(EXP_BAR_TOTAL)
+          and facts["outcomeUnplaced"] == str(EXP_BAR_UNPLACED)
+          and f"{EXP_24H['failed']} failed" in (facts["outcomeText"] or "")
+          and f"{EXP_24H['cancelled']} cancelled" in (facts["outcomeText"] or ""),
+          expected={"total": EXP_BAR_TOTAL, "unplaced": EXP_BAR_UNPLACED},
+          **{k: facts[k] for k in ("outcomeTotal", "outcomeUnplaced", "outcomeText")})
+
+    # The bottom bar's all-window counts (the other labeled truth).
+    check("bottom_bar_all_window",
+          facts["barWorking"] == str(EXP_WORKING)
+          and facts["barGates"] == str(EXP_GATES)
+          and facts["barFailed"] == str(len(EXP_FAILED_ALL_IDS)),
+          expected={"working": EXP_WORKING, "gates": EXP_GATES,
+                    "failed": len(EXP_FAILED_ALL_IDS)},
+          **{k: facts[k] for k in ("barWorking", "barGates", "barFailed")})
+
+    page.screenshot(path=str(VSHOTS / "ux-fixJ4J5-landing.png"))
+
+    # ── Scene 2 (J5): /work — the failed count is REPRODUCIBLE from rows ──────
+    def work_rows(filter_id: str) -> dict:
+        page.goto(f"{ORIGIN}/work?filter={filter_id}", wait_until="domcontentloaded")
+        page.locator('[role="tablist"][data-filter="' + filter_id + '"]').wait_for(timeout=30000)
+        return page.evaluate(
+            """() => ({
+                 filter: document.querySelector('[role="tablist"]')?.dataset.filter ?? null,
+                 rows: [...document.querySelectorAll('[role="tabpanel"] [data-testid="run-link"]')]
+                   .map((r) => r.dataset.runId).sort(),
+               })""")
+
+    failed_view = work_rows("failed")
+    # 6 — set equality: the bar's all-window "N failed" IS these rows; the
+    # lede's 24h failed run (r-auth) is among them; no cancelled id intrudes.
+    check("work_failed_rows_reconcile",
+          failed_view["rows"] == EXP_FAILED_ALL_IDS
+          and str(len(failed_view["rows"])) == facts["barFailed"]
+          and "r-auth" in failed_view["rows"]
+          and not any(r in failed_view["rows"] for r in EXP_CANCELLED_ALL_IDS),
+          expected=EXP_FAILED_ALL_IDS, **failed_view)
+    page.screenshot(path=str(VSHOTS / "ux-fixJ4J5-work-failed.png"))
+
+    cancelled_view = work_rows("cancelled")
+    check("work_cancelled_own_filter",
+          cancelled_view["rows"] == EXP_CANCELLED_ALL_IDS,
+          expected=EXP_CANCELLED_ALL_IDS, **cancelled_view)
+    page.close()
+
+    # ── Scene 3 (J4): the chat session gets a real URL and stays findable ─────
+    page2 = ctx.new_page()
+    page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net2 = tap(page2)
+    page2.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    page2.locator("textarea").fill(MSG1)
+    page2.keyboard.press("Enter")
+    # 1 — the URL names the session the moment it exists.
+    page2.wait_for_function(
+        """() => location.pathname.startsWith('/chat/') && location.pathname !== '/chat/new'""",
+        timeout=30000)
+    opens = [(m, q, b) for (m, q, b) in net2 if m == "POST" and q == "/api/v1/chats"]
+    chat_id = (opens[0][2] or {}).get("chatId") if opens else None
+    url_id = page2.evaluate("() => decodeURIComponent(location.pathname.split('/')[2])")
+    check("open_chat_gets_real_url",
+          len(opens) == 1 and chat_id is not None and url_id == chat_id,
+          opens=len(opens), chat_id=chat_id, url_id=url_id,
+          pathname=page2.evaluate("() => location.pathname"))
+
+    # 4 — /chats: the live band lists the session, its row is a DOOR, and the
+    # empty-state copy tells ONE truth (no "No chat sessions yet" beside it).
+    page2.goto(f"{ORIGIN}/chats", wait_until="domcontentloaded")
+    page2.locator('[data-testid="live-chat-row"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+    chats_screen = page2.evaluate(
+        """() => ({
+             rowChatId: document.querySelector('[data-testid="live-chat-row"]')?.dataset.chatId ?? null,
+             staleEmpty: document.body.innerText.includes('No chat sessions yet'),
+             liveEmpty: document.querySelector('[data-testid="chats-empty-live"]')?.textContent ?? null,
+           })""")
+    check("chats_one_truth_per_screen",
+          chats_screen["rowChatId"] == chat_id
+          and not chats_screen["staleEmpty"]
+          and "aren’t stored beyond the live session" in (chats_screen["liveEmpty"] or ""),
+          **chats_screen)
+    page2.screenshot(path=str(VSHOTS / "ux-fixJ4J5-chats.png"))
+
+    # 2 — click through: the row opens /chat/:id, the surface rejoins the warm
+    # session and states the honest history boundary; a send still works.
+    page2.locator('[data-testid="live-chat-row"]').click()
+    page2.wait_for_function(
+        f"""() => location.pathname === '/chat/{chat_id}'""", timeout=30000)
+    page2.locator('[data-testid="chat-rejoined-note"]').wait_for(timeout=30000)
+    rejoined = page2.evaluate(
+        """() => ({
+             note: document.querySelector('[data-testid="chat-rejoined-note"]')?.textContent ?? null,
+             ready: [...document.querySelectorAll('[data-testid="seat-chip"][data-state="ready"]')].length,
+             firstrun: !!document.querySelector('[data-testid="chat-firstrun"]'),
+           })""")
+    check("row_click_rejoins_with_honest_boundary",
+          "can’t be replayed" in (rejoined["note"] or "")
+          and rejoined["ready"] > 0 and not rejoined["firstrun"],
+          **rejoined)
+
+    page2.locator("textarea").fill(MSG2)
+    page2.keyboard.press("Enter")
+    page2.wait_for_function(
+        f"""() => [...document.querySelectorAll('[data-testid="user-bubble"]')]
+                  .some((u) => u.textContent === {json.dumps(MSG2)})""",
+        timeout=30000)
+    sends = [(m, q) for (m, q, _b) in net2
+             if m == "POST" and q == f"/api/v1/chats/{chat_id}/messages"]
+    reopens = [(m, q) for (m, q, _b) in net2 if m == "POST" and q == "/api/v1/chats"]
+    # The tap spans this page's whole life: MSG1's fan-out plus MSG2's — both
+    # into the SAME session — and exactly the ONE open from scene 3's mint.
+    # A re-mint on rejoin (the FINDING-027 regression) would show opens == 2.
+    check("rejoined_send_reattaches_not_remints",
+          len(sends) == 2 and len(reopens) == 1,
+          sends=len(sends), opens_total=len(reopens))
+    page2.screenshot(path=str(VSHOTS / "ux-fixJ4J5-rejoined.png"))
+
+    # ── Scene 4 (J4): a dead routed id says so — honestly ─────────────────────
+    page2.goto(f"{ORIGIN}/chat/ghost-session-1", wait_until="domcontentloaded")
+    page2.locator('[data-testid="chat-session-ended"]').wait_for(timeout=30000)
+    ended = page2.evaluate(
+        """() => ({
+             text: document.querySelector('[data-testid="chat-session-ended"]')?.textContent ?? null,
+             firstrun: !!document.querySelector('[data-testid="chat-firstrun"]'),
+           })""")
+    check("dead_routed_id_states_the_boundary",
+          "aren’t stored beyond the live session" in (ended["text"] or "")
+          and not ended["firstrun"],
+          **ended)
+    page2.screenshot(path=str(VSHOTS / "ux-fixJ4J5-ended.png"))
+
+    # 3 — a send from the ended boundary starts a NEW session; the URL follows.
+    page2.locator("textarea").fill(MSG3)
+    page2.keyboard.press("Enter")
+    page2.wait_for_function(
+        """() => location.pathname.startsWith('/chat/')
+              && location.pathname !== '/chat/ghost-session-1'""",
+        timeout=30000)
+    new_id = page2.evaluate("() => decodeURIComponent(location.pathname.split('/')[2])")
+    check("ended_send_starts_fresh_and_url_follows",
+          new_id not in ("", "new", "ghost-session-1") and new_id != chat_id,
+          new_id=new_id, old_id=chat_id)
+
+    page2.close()
+    ctx.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [str(VSHOTS / n) for n in (
+    "ux-fixJ4J5-landing.png", "ux-fixJ4J5-work-failed.png",
+    "ux-fixJ4J5-chats.png", "ux-fixJ4J5-rejoined.png", "ux-fixJ4J5-ended.png")]
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -209,6 +209,12 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #               resolves), giving §4.4's runs-per-repo / failing-
          #               repos tiles something true to group. Default False.
          "chat_runs": False, "repo_refs": False,
+         # Fix slice J4/J5 (BRIEF-UX-001 re-review): the outcome-partition
+         # corpus — cancelled runs in AND out of the 24h window plus undatable
+         # terminal runs (no attach clock anywhere), so a rig can prove
+         # cancelled ≠ failed on every surface and that windowed counts state
+         # their exclusions. Switch-gated: no standing rig's board grows rows.
+         "j5_runs": False,
          # Slice J (DES-FEEDBACK-002 §10.2): upload-endpoint gains ONE
          # crew.repo member (studio-api) on the members wire — the dashboard's
          # bound-repos row corpus. Switch-gated so no standing rig's member
@@ -432,6 +438,30 @@ RUNS = [
 ]
 ORPHAN = session("r-orphan", "executing", "stranded work from another client",
                  "stranded work from another client")
+
+# ── Fix slice J4/J5: the outcome-partition corpus, behind `j5_runs` ───────────
+#
+# Cancelled ≠ failed (the J5/A5 blocker): one cancelled run INSIDE the 24h
+# attach window and one outside it, plus two undatable terminal runs (failed /
+# cancelled with NO membership and no clock anywhere) — so a rig can derive,
+# independently: the landing's 24h failed count (1: r-auth alone), the
+# all-window failed count (3: r-auth, r-legacy, r-fail-undated), the cancelled
+# counts (24h: 1, all: 2), and the stated exclusions for the undatable pair.
+J5_RUNS = [
+    session("r-cxl-new", "cancelled", "prototype the CSV importer",
+            "prototype the CSV importer"),
+    session("r-cxl-old", "cancelled", "trial the queue migration",
+            "trial the queue migration"),
+    session("r-fail-undated", "failed", "probe the flaky webhook",
+            "probe the flaky webhook"),
+    session("r-cxl-undated", "cancelled", "sketch the export format",
+            "sketch the export format"),
+]
+# The dated pair is filed under smoke-tests; the undated pair is filed NOWHERE
+# (no membership → no attach clock → honest "unplaced"/"undatable").
+J5_MEMBER_REFS = ["r-cxl-new", "r-cxl-old"]
+ATTACHED_AT["r-cxl-new"] = NOW0 - 2 * HOUR
+ATTACHED_AT["r-cxl-old"] = NOW0 - 3 * DAY
 
 # ── Slice V (DES-UX-001 §3/§4): the provenance + retry corpus, behind `provenance` ──
 #
@@ -1112,7 +1142,8 @@ def assemble_runs() -> list:
                 + ([LONG_RUN] if state["long_prompt"] else []) \
                 + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else []) \
                 + (BATCH_RUNS if state["batch_gates"] else []) \
-                + ([RETRY_RUN] if state["provenance"] else [])
+                + ([RETRY_RUN] if state["provenance"] else []) \
+                + (J5_RUNS if state["j5_runs"] else [])
         viewer_on = state["viewer"]
         repo_refs_on = state["repo_refs"]
         forensics_on = state["forensics"]
@@ -1608,10 +1639,16 @@ class W2Handler(SimpleHTTPRequestHandler):
                         for cid, seats in chat_warm_seats.items()]
             self._json(200, {"chats": rows})
             return True
-        # /api/v1/chats/<id> — seats of a chat. Empty for a chat we never opened
-        # (the daemon does not 404 an unknown id; empty means reclaimed/none).
+        # /api/v1/chats/<id> — seats of a chat, the POOL truth (crew's
+        # `chatSeats`): the live seats of a chat this server opened, EMPTY for
+        # one it never did (the daemon does not 404 an unknown id; empty means
+        # reclaimed/none). Fix slice J4 reads this as the rejoin probe.
         if path.startswith("/api/v1/chats/") and len(path.split("/")) == 5:
-            self._json(200, {"chatId": urllib.parse.unquote(path.split("/")[4]), "seats": []})
+            cid = urllib.parse.unquote(path.split("/")[4])
+            with chat_state_lock:
+                seats = [k for k in chat_warm_seats.get(cid, [])
+                         if k not in chat_dead_seats.get(cid, set())]
+            self._json(200, {"chatId": cid, "seats": seats})
             return True
         parts = path.split("/")
         # /api/v1/projects/<id>/members
@@ -1623,6 +1660,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                 river_on = state["river"]
                 repo_member_on = state["repo_member"]
                 batch_on = state["batch_gates"]
+                j5_on = state["j5_runs"]
+            # Fix slice J4/J5: the dated cancelled pair is filed under
+            # smoke-tests (real attach clocks); the undated pair stays unfiled.
+            if j5_on and pid == "smoke-tests":
+                refs.extend(J5_MEMBER_REFS)
             # Slice L: the batch corpus projects' runs.
             if batch_on:
                 refs.extend(BATCH_MEMBERS.get(pid, []))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,7 @@ export function App(): React.ReactElement {
   }, []);
 
   // Pre-merge bookmarks (`/runs/:id`, `/projects/:id`) redirect into the shell (§1.5).
-  useLegacyRedirect({ panel, runId, projectId, mode, showLaunch }, navigate);
+  useLegacyRedirect({ panel, runId, projectId, mode, showLaunch, chatMode }, navigate);
 
   // FINDING-013: /ws has no late-join replay, so a page reloaded against a run shows an empty Burn
   // panel even though usage was durably recorded. When the selected run has no frames yet (a reload
@@ -272,9 +272,25 @@ export function App(): React.ReactElement {
   // In the project shell the new chat is FILED into the project at open time
   // (DES-FEEDBACK-001 §5.1 — `projectId` on the POST body, never a silent unfiled
   // thread); outside it, GroupChat renders its own ProjectSwitcher (§5.2).
-  const groupChatSurface = (repo: string | null, pid: string | null = null): React.ReactElement => (
+  // `routedChatId`/`reflectUrl` (J4/C6): on the FLAT chat routes the session's
+  // id lives in the URL — `/chat/:id` the moment the session exists — so an
+  // opened chat is findable again after navigating away. The project shell's
+  // chat keeps its own `/p/:pid/chat` address and does not reflect.
+  const groupChatSurface = (
+    repo: string | null,
+    pid: string | null = null,
+    routedChatId: string | null = null,
+    reflectUrl = false,
+  ): React.ReactElement => (
     <div className="flex-1 overflow-hidden">
-      <GroupChat repoId={repo} onBack={onNavigateBack} projectId={pid} navigate={navigate} />
+      <GroupChat
+        repoId={repo}
+        onBack={onNavigateBack}
+        projectId={pid}
+        navigate={navigate}
+        routedChatId={routedChatId}
+        reflectUrl={reflectUrl}
+      />
     </div>
   );
 
@@ -508,13 +524,16 @@ export function App(): React.ReactElement {
         </div>
       );
     }
+    // CHAT: the group-chat surface (warm seats + fan-out), not a run (crew#165).
+    // Checked BEFORE the home-dashboard fallback: `/chat/:id` (J4/C6) carries no
+    // runId/showLaunch and must land here, not on the dashboard. `artifactId`
+    // is the routed session id; the flat routes reflect the live id in the URL.
+    if (chatMode && selected === null) {
+      return groupChatSurface(repoId, null, artifactId, true);
+    }
     // Home dashboard: no run selected and not launching — three-panel home view + manager controls
     if (panel === 'runs' && !runId && !selected && !showLaunch) {
       return dashboardSurface();
-    }
-    // NEW CHAT: the group-chat surface (warm seats + fan-out), not a run (crew#165).
-    if (chatMode && selected === null) {
-      return groupChatSurface(repoId);
     }
     // Run selected or launch form
     return runSurface();

--- a/src/board/metrics.ts
+++ b/src/board/metrics.ts
@@ -49,12 +49,20 @@ export const WINDOW_24H_MS = 24 * 3_600_000;
 
 const TERMINAL: ReadonlySet<SessionStatus> = new Set(['completed', 'cancelled', 'failed']);
 
-export type Outcome = 'run' | 'gate' | 'fail' | 'done';
+export type Outcome = 'run' | 'gate' | 'fail' | 'cancelled' | 'done';
 
-/** One status → outcome mapping (was RunOutcomeBar's; now every fold's). */
+/**
+ * THE one status → outcome partition (J5/A5: "failed" had two definitions —
+ * the landing's 24h fold counted cancelled runs as failed while every list
+ * surface counted `status === 'failed'` alone, so the fold said 10 where the
+ * lists said 2). Cancelled is its OWN outcome now — an operator's decision,
+ * not a failure — and every consumer (outcome bar, lede, river, /work tabs)
+ * reads this mapping, so a "failed" count is the same set everywhere.
+ */
 export function outcomeOf(status: string): Outcome {
   if (status === 'awaiting_human') return 'gate';
-  if (status === 'failed' || status === 'cancelled') return 'fail';
+  if (status === 'failed') return 'fail';
+  if (status === 'cancelled') return 'cancelled';
   if (status === 'completed') return 'done';
   return 'run';
 }
@@ -97,6 +105,8 @@ export interface OutcomeTotals {
   run: number;
   gate: number;
   fail: number;
+  /** Cancelled ≠ failed (the J5/A5 partition) — its own bucket everywhere. */
+  cancelled: number;
   done: number;
   /** Runs with no attach clock inside the window — reported, never painted. */
   unplaced: number;
@@ -112,7 +122,7 @@ export function outcomeTotals24h(
   attachedAt: Record<string, number>,
   now: number,
 ): OutcomeTotals {
-  const totals: OutcomeTotals = { run: 0, gate: 0, fail: 0, done: 0, unplaced: 0 };
+  const totals: OutcomeTotals = { run: 0, gate: 0, fail: 0, cancelled: 0, done: 0, unplaced: 0 };
   const start = now - WINDOW_24H_MS;
   for (const v of runs) {
     if (v.session.archived_at != null) continue;
@@ -236,13 +246,20 @@ export interface LedeCounts {
   /** Terminal runs whose last OBSERVED clock is inside the 24h window. */
   finished: number;
   passed: number;
+  /** `status === 'failed'` only — the same set /work's Failed filter lists. */
   failed: number;
+  /** Cancelled ≠ failed (J5/A5) — its own count, its own /work filter. */
+  cancelled: number;
   /** Runs waiting on a human right now — `gateCount`, verbatim. */
   gates: number;
   /** Runs moving under their own power right now — `workingCount`, verbatim. */
   live: number;
   /** Board projects (the quiet phrase's subject). */
   projects: number;
+  /** Terminal runs with NO observed clock at all — excluded from the windowed
+   *  counts, and the label must SAY so (EC39: a count a user cannot reproduce
+   *  from a visible list is a defect; the exclusion is stated, never silent). */
+  undatable: number;
 }
 
 /**
@@ -260,7 +277,7 @@ export function ledeCounts(
 ): LedeCounts {
   const { working, gates } = runStats(runs);
   const start = now - WINDOW_24H_MS;
-  let finished = 0, passed = 0, failedN = 0;
+  let finished = 0, passed = 0, failedN = 0, cancelledN = 0, undatable = 0;
   for (const v of runs) {
     if (v.session.archived_at != null) continue;
     const id = v.session.id;
@@ -272,12 +289,22 @@ export function ledeCounts(
       failedAt[id],
       ...(logs[id] ?? []).map((e) => e.ts),
     ].filter((t): t is number => typeof t === 'number');
-    if (points.length === 0) continue; // clockless: the river counts it unplaced
+    if (points.length === 0) {
+      // Clockless: excluded from the windowed fold — COUNTED so the label can
+      // state the exclusion (EC39), never silently dropped.
+      undatable += 1;
+      continue;
+    }
     const last = Math.max(...points);
     if (last < start || last > now) continue;
     finished += 1;
-    if (outcomeOf(v.session.status) === 'fail') failedN += 1;
+    const outcome = outcomeOf(v.session.status);
+    if (outcome === 'fail') failedN += 1;
+    else if (outcome === 'cancelled') cancelledN += 1;
     else passed += 1;
   }
-  return { finished, passed, failed: failedN, gates, live: working, projects };
+  return {
+    finished, passed, failed: failedN, cancelled: cancelledN,
+    gates, live: working, projects, undatable,
+  };
 }

--- a/src/components/ActivityRiver.tsx
+++ b/src/components/ActivityRiver.tsx
@@ -274,7 +274,10 @@ export function ActivityRiver({ items, runs, gates, logs, failedAt, landings, na
                   const x1 = Math.max(x(span.end), x0 + 2); // a point of activity stays visible
                   const body = span.live
                     ? 'var(--status-run-dim)'
-                    : span.outcome === 'fail' ? 'var(--status-fail-dim)' : 'var(--status-done)';
+                    : span.outcome === 'fail' ? 'var(--status-fail-dim)'
+                    // Cancelled ≠ failed (J5/A5): neutral ink, no fail dress.
+                    : span.outcome === 'cancelled' ? 'var(--ink-dim)'
+                    : 'var(--status-done)';
                   return (
                     <a key={span.runId} {...link(modePath(span.projectId, 'build', span.runId))}
                        data-testid="river-span" data-run-id={span.runId}

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -266,12 +266,26 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
           {liveChats.map((c) => {
             const streaming = c.lastFrameAt !== 0 && Date.now() - c.lastFrameAt < STREAMING_WINDOW_MS;
             return (
+              // J4/C6: a live row is a DOOR, not a plaque — clicking it (or
+              // Enter/Space with focus) opens the session at its real URL,
+              // `/chat/:id`, where the surface rejoins the warm seats. The End
+              // control stays its own gesture (stopPropagation).
               <div
                 key={c.chatId}
                 data-testid="live-chat-row"
                 data-chat-id={c.chatId}
                 data-streaming={streaming}
-                className="w-full flex items-center gap-3 rounded-2xl px-5 py-3"
+                role="button"
+                tabIndex={0}
+                title="Open this live session"
+                onClick={() => navigate(`/chat/${encodeURIComponent(c.chatId)}`)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    navigate(`/chat/${encodeURIComponent(c.chatId)}`);
+                  }
+                }}
+                className="w-full flex items-center gap-3 rounded-2xl px-5 py-3 cursor-pointer"
                 style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
               >
                 <span className="text-sm font-mono truncate" style={{ color: 'var(--ink-high)' }}>
@@ -299,7 +313,10 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
                   type="button"
                   data-testid="live-chat-end"
                   title="Disconnect this session's agents and end it"
-                  onClick={() => endLiveChat(c.chatId)}
+                  onClick={(e) => {
+                    e.stopPropagation(); // End is not Open
+                    endLiveChat(c.chatId);
+                  }}
                   className="text-[11px] px-2.5 py-1 rounded-lg shrink-0"
                   style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-overlay)' }}
                 >
@@ -311,10 +328,31 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
         </div>
       )}
 
-      {/* ── List / Empty state (untouched below the band, §4.3) ── */}
+      {/* ── List / Empty state (below the band, §4.3) ── */}
       <div className="px-8 pb-8 flex flex-col gap-2" data-testid="chats-list">
         {filtered.length === 0 ? (
+          // ONE truth per screen (J4/C6): "No chat sessions yet" may never sit
+          // beside a non-empty live band. With live sessions above, this rail
+          // says what it actually holds — recorded chat RUNS — and states the
+          // persistence boundary honestly (chat transcripts are not stored
+          // beyond the live session; there is no history wire to list here).
+          (liveChats?.length ?? 0) > 0 ? (
+            <div
+              data-testid="chats-empty-live"
+              className="rounded-2xl p-10 text-center"
+              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+            >
+              <p className="text-base font-mono font-semibold mb-3">
+                No recorded chat runs — your live sessions are above
+              </p>
+              <p className="text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
+                Open a live session to continue it. Chat transcripts aren’t stored
+                beyond the live session, so ended chats don’t appear here.
+              </p>
+            </div>
+          ) : (
           <div
+            data-testid="chats-empty"
             className="rounded-2xl p-10 text-center"
             style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
@@ -337,6 +375,7 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
               </button>
             </p>
           </div>
+          )
         ) : (
           filtered.map(v => (
             <button

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -216,11 +216,27 @@ interface Props {
    * OPEN — a user action — never on mount.
    */
   projectId?: string | null;
-  /** App-level route navigation — needed only by the "+ New project" hand-off. */
-  navigate?: (path: string) => void;
+  /** App-level route navigation — the "+ New project" hand-off and the J4
+   *  URL reflection (which replaces, so Back never walks through /chat/new). */
+  navigate?: (path: string, opts?: { replace?: boolean }) => void;
+  /**
+   * The chat session id the URL names (`/chat/:id`, J4/C6) — the surface
+   * REJOINS it if the daemon still holds it, and says honestly that it is
+   * gone if not. `null` on `/chat/new` and in the project shell.
+   */
+  routedChatId?: string | null;
+  /**
+   * When true (the flat `/chat/*` routes) the live session's id is reflected
+   * into the URL the moment it exists — mint, rejoin, or routed — so the
+   * session is findable again after navigating away (J4/C6). The project
+   * shell passes false: its chat lives at `/p/:pid/chat`.
+   */
+  reflectUrl?: boolean;
 }
 
-export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props): React.ReactElement {
+export function GroupChat({
+  repoId, onBack, projectId = null, navigate, routedChatId = null, reflectUrl = false,
+}: Props): React.ReactElement {
   const [chatId, setChatId] = useState<string | null>(null);
   const [seats, setSeats] = useState<Record<string, SeatState>>({});
   const [seatErrors, setSeatErrors] = useState<Record<string, string>>({});
@@ -240,6 +256,20 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
    * requests and gates nothing.
    */
   const [resolving, setResolving] = useState(false);
+  /**
+   * The client REJOINED a live session it did not open on this mount (J4/C6).
+   * The wire keeps no transcript (`GET /chats/:id` answers seats only), so a
+   * rejoined thread starts empty CLIENT-side — the boundary is stated in the
+   * thread, never a silent blank pretending nothing was said.
+   */
+  const [rejoined, setRejoined] = useState(false);
+  /**
+   * The URL named a session (`/chat/:id`) the daemon no longer holds (J4/C6):
+   * the pool reaped it or it was ended. Rendered as an honest boundary — the
+   * transcript is not persisted beyond the live session, so there is nothing
+   * to replay; a send starts a NEW session (and the URL follows it).
+   */
+  const [routedGone, setRoutedGone] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
@@ -346,6 +376,11 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   // daemon still holds it. This is deliberately agnostic to WHAT remounts us: any cause, including
   // a full page reload, lands on the same stored id.
   useEffect(() => {
+    // J4: `routedChatId` is a dep too, and its one same-mount transition is the
+    // URL reflection THIS component issued after minting or rejoining — the
+    // state already IS that chat's, and a reset here would wipe the live
+    // transcript mid-conversation. Skip exactly that case.
+    if (routedChatId !== null && routedChatId === chatIdRef.current) return;
     let cancelled = false;
 
     // `repoId` is a dep, so this effect also fires on a repo SWITCH with the component still
@@ -376,12 +411,16 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     // already treat it as not-ready and wait.
     setChatId(null);
     chatIdRef.current = null;
+    setRejoined(false);
+    setRoutedGone(false);
 
     // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
     // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
     // stored, this is first-run: NO probe, NO roster fetch, NO warming — zero requests (§2.4).
     // Read SYNCHRONOUSLY, and park the opt-ins while the probe runs (see `resolving`).
-    const stored = readStoredChatId(repoId);
+    // J4: a URL-routed id WINS over the per-repo stored id — the operator asked
+    // for THAT session by address; the stored id is only the tab's memory.
+    const stored = routedChatId ?? readStoredChatId(repoId);
     setResolving(stored !== null);
 
     void (async () => {
@@ -410,16 +449,25 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
       if (probe.seats.length > 0) {
         setChatId(stored);
         chatIdRef.current = stored;
+        // A routed rejoin becomes THIS tab's session for the repo too — /chats
+        // → row → send → navigate away → back must land on the same session.
+        writeStoredChatId(repoId, stored);
         // Warm seats only — the transcript is not persisted server-side, so a rejoined chat
         // starts with an empty log. The SESSIONS carry the conversation memory, which is the
         // expensive part; re-minting would have thrown that away as well as leaking it.
+        // J4/C6: that boundary is STATED in the thread (`rejoined`), never a
+        // silent blank pretending the conversation never happened.
         setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        setRejoined(true);
         setResolving(false);
         return;
       }
-      // Reclaimed → back to the calm first-run state, not a re-mint: warming is the
-      // user's call now, and the next opt-in mints fresh.
-      clearStoredChatId(repoId);
+      // Reclaimed → the id is dead. On `/chat/new` this lands on the calm
+      // first-run state; on a routed `/chat/:id` (J4) the page SAYS the session
+      // ended (`routedGone`) — the honest boundary, never a wordless empty.
+      // Either way warming stays the user's call and the next opt-in mints fresh.
+      if (routedChatId !== null) setRoutedGone(true);
+      if (readStoredChatId(repoId) === stored) clearStoredChatId(repoId);
       setResolving(false);
       // (On the cancelled path `resolving` is deliberately left alone: the next effect
       // run has already set its own value for the new repo.)
@@ -428,9 +476,19 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
     return () => {
       cancelled = true;
     };
-    // (The exhaustive-deps suppression that used to sit here is gone: the effect now closes over
-    // nothing but `repoId` and module-scope helpers, so the dep list is genuinely complete.)
-  }, [repoId]);
+    // (The exhaustive-deps suppression that used to sit here is gone: the effect closes over
+    // nothing but `repoId`/`routedChatId` and module-scope helpers — the list is complete.)
+  }, [repoId, routedChatId]);
+
+  // J4/C6 — the URL names the session the moment it exists. Mint, rejoin, or
+  // routed: on the flat chat routes the live id is REFLECTED into `/chat/:id`
+  // (replace, so Back never re-enters the transient /chat/new), making the
+  // session revisitable for its lifetime — from /chats, a bookmark, or Back.
+  useEffect(() => {
+    if (!reflectUrl || navigate === undefined || chatId === null) return;
+    if (routedChatId === chatId) return; // the URL already says so
+    navigate(`/chat/${encodeURIComponent(chatId)}`, { replace: true });
+  }, [reflectUrl, navigate, chatId, routedChatId]);
 
   // §7.9-1 (the seeding-order fix): a roster deposited AFTER this surface
   // seeded its chips from the cold-cache fallback re-seeds them — warm roster
@@ -874,7 +932,7 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
   // over a chat that may be about to pop back in would be a lie held for milliseconds.
   const firstRun =
     messages.length === 0 && Object.keys(seats).length === 0 && openError === null &&
-    sendFailed === null && !resolving;
+    sendFailed === null && !resolving && !routedGone;
   // The create-flow project field (§5.2) shows only while the chat is still being
   // CREATED (binding happens at open time) and only outside the project shell —
   // in the shell the context IS the project (§4.3) and rides `projectId` silently.
@@ -943,6 +1001,37 @@ export function GroupChat({ repoId, onBack, projectId = null, navigate }: Props)
       <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3">
         {openError !== null && (
           <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
+        )}
+        {/* J4/C6 — the honest boundary for a routed session that is gone: the
+            daemon holds sessions only while they live, and transcripts are not
+            persisted beyond that (the wire carries seats, never history). Say
+            it; never render a wordless empty that reads as "nothing was said". */}
+        {routedGone && chatId === null && (
+          <div
+            data-testid="chat-session-ended"
+            className="rounded-xl px-4 py-3 text-[12px] font-mono"
+            style={{ border: '1px dashed var(--surface-overlay)', color: 'var(--ink-muted)' }}
+          >
+            This chat session is no longer live on the daemon — it was ended or
+            reclaimed. Transcripts aren’t stored beyond the live session, so
+            there is nothing to replay here. Sending a message starts a new
+            session (this page’s address will follow it).
+          </div>
+        )}
+        {/* J4/C6 — the rejoin boundary: the warm session is back, but the wire
+            keeps no transcript, so what was said before this page opened is
+            not replayed. The agents still hold the conversation memory — the
+            thread continues; only the client-side log starts here. */}
+        {rejoined && (
+          <div
+            data-testid="chat-rejoined-note"
+            className="rounded-xl px-4 py-3 text-[12px] font-mono"
+            style={{ border: '1px dashed var(--surface-overlay)', color: 'var(--ink-muted)' }}
+          >
+            Rejoined the live session — its agents keep the conversation memory,
+            but earlier messages aren’t stored on the wire, so they can’t be
+            replayed here. New replies stream below.
+          </div>
         )}
         {firstRun && (
           // §2.4: the first-run state TEACHES — what Chat is, what typing does, and the

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -633,7 +633,10 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             navigate={navigate}
           >
             {chatRuns.length === 0
-              ? <EmptyRow label="No chat threads yet" href="/chats" navigate={navigate} />
+              // "Recorded" keeps this row's claim true beside a LIVE session
+              // (J4/C6 one-truth): the rail lists recorded chat runs only —
+              // live seats show on /chats, where this row points.
+              ? <EmptyRow label="No recorded chats yet" href="/chats" navigate={navigate} />
               : chatRuns.map((view) => (
                   <RunRow key={view.session.id} view={view} onOpen={() => navigate(runPath(view.session.id))} />
                 ))}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -90,7 +90,8 @@ export function headingForPath(pathname: string): PathKey | null {
   const [, first = '', second = ''] = pathname.split('/');
   if (first === 'projects' || first === 'p') return 'projects';
   if (first === 'make') return 'make';
-  if (first === 'chats' || (first === 'chat' && second === 'new')) return 'chat';
+  // `/chat/new` AND `/chat/:id` (J4/C6: a live session's real URL) are Chat's.
+  if (first === 'chats' || (first === 'chat' && second !== '')) return 'chat';
   if (first === 'repos' || first === 'repo-detail') return 'repos';
   if (SETTINGS_ROUTES.has(first)) return 'settings';
   return null;

--- a/src/components/NarrativeBand.tsx
+++ b/src/components/NarrativeBand.tsx
@@ -54,13 +54,22 @@ export function composeLede(c: LedeCounts): { quiet: boolean; segments: LedeSegm
   }
   const segments: LedeSegment[] = [{ text: 'While you were away: ', href: null }];
   if (c.finished > 0) {
-    const split = [
-      c.passed > 0 ? `${c.passed} passed` : null,
-      c.failed > 0 ? `${c.failed} failed` : null,
-    ].filter((s) => s !== null).join(', ');
     // Every all-runs number lands on /work — the ONE canonical runs surface
-    // (DES-UX-001 §7.4, slice Y; the bare /runs listing retired into a redirect).
-    segments.push({ text: `${plural(c.finished, 'run')} finished — ${split}`, href: '/work' });
+    // (DES-UX-001 §7.4, slice Y). Each OUTCOME number links to ITS filter
+    // (J5/A5: a count must be reproducible from a visible list — "1 failed"
+    // opens exactly the rows the Failed filter shows, cancelled ITS rows).
+    segments.push({ text: `${plural(c.finished, 'run')} finished`, href: '/work' });
+    segments.push({ text: ' — ', href: null });
+    const split: LedeSegment[] = [];
+    if (c.passed > 0) split.push({ text: `${c.passed} passed`, href: '/work?filter=completed' });
+    if (c.failed > 0) split.push({ text: `${c.failed} failed`, href: '/work?filter=failed' });
+    if (c.cancelled > 0) {
+      split.push({ text: `${c.cancelled} cancelled`, href: '/work?filter=cancelled' });
+    }
+    split.forEach((seg, i) => {
+      if (i > 0) segments.push({ text: ', ', href: null });
+      segments.push(seg);
+    });
   } else if (c.gates === 0) {
     // Nothing finished, nothing waiting — but something is moving: say that,
     // with the number still derived (EC29), never an empty "away:" stub.
@@ -93,10 +102,11 @@ export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now
   const landings = useDocThreadStore((s) => s.landings);
   const at = now ?? Date.now();
 
-  const lede = useMemo(
-    () => composeLede(ledeCounts(runs, attachedAt, logs, failedAt, items.length, at)),
+  const counts = useMemo(
+    () => ledeCounts(runs, attachedAt, logs, failedAt, items.length, at),
     [runs, attachedAt, logs, failedAt, items.length, at],
   );
+  const lede = useMemo(() => composeLede(counts), [counts]);
 
   // Observed spend — literally the same selector as the bottom bar and the
   // margin sparkline's endpoint (slice W: one selector per metric, §5.3).
@@ -153,6 +163,18 @@ export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now
         <span data-testid="lede-window" data-window="24h" style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0 }}>
           {windowWord('24h')}
         </span>
+        {counts.undatable > 0 && (
+          // EC39 (J5): the windowed fold EXCLUDES runs that carry no observed
+          // clock, and says so in the same breath — never a number a user
+          // cannot rebuild from the rows a list can show them.
+          <span
+            data-testid="lede-undatable"
+            data-undatable={counts.undatable}
+            style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0 }}
+          >
+            · excludes {counts.undatable} undated run{counts.undatable === 1 ? '' : 's'}
+          </span>
+        )}
         {spend !== null && (
           <>
             <a {...link('/make')} data-testid="lede-spend"

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -157,7 +157,7 @@ export function RunOutcomeBar({
           data-testid="outcome-unplaced-note"
           style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
         >
-          excludes {unplaced} undated run{unplaced === 1 ? '' : 's'}
+          excludes {unplaced} run{unplaced === 1 ? '' : 's'} with no clock in this window
         </p>
       )}
     </MetricTile>

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -13,7 +13,8 @@ export { outcomeOf } from '../board/metrics.js';
  *
  * SVG-first, no chart library (§2.3): 12 stacked bars, one per 2-hour window
  * over the last 24h, segments filled with the status tokens (`--status-run`
- * working / `--status-gate` waiting / `--status-fail` failed-or-cancelled /
+ * working / `--status-gate` waiting / `--status-fail` failed / `--ink-dim`
+ * cancelled — its own segment, never folded into failed (J5/A5) /
  * `--status-done` completed).
  *
  * WIRE HONESTY — the clock. §2.4 assumed a `created_at` on the session;
@@ -33,11 +34,14 @@ const W = 168;
 const H = 26;
 const COL_GAP = 2;
 
-/** Stack order bottom→top, with the fill token each segment means. */
+/** Stack order bottom→top, with the fill token each segment means. Cancelled
+ *  is its own segment in NEUTRAL ink (J5/A5: cancelled ≠ failed — it must not
+ *  wear the fail token, and it must not vanish into done). */
 const SEGMENTS: ReadonlyArray<{ key: Outcome; fill: string }> = [
   { key: 'run', fill: 'var(--status-run)' },
   { key: 'gate', fill: 'var(--status-gate)' },
   { key: 'fail', fill: 'var(--status-fail)' },
+  { key: 'cancelled', fill: 'var(--ink-dim)' },
   { key: 'done', fill: 'var(--status-done)' },
 ];
 
@@ -64,7 +68,10 @@ export function RunOutcomeBar({
   // bucket PLACEMENT (chart geometry) is derived here, on the same clock rule.
   const counts = useMemo(() => outcomeTotals24h(runs, attachedAt, at), [runs, attachedAt, at]);
   const { windows } = useMemo(() => {
-    const buckets = Array.from({ length: WINDOWS }, () => ({ run: 0, gate: 0, fail: 0, done: 0 }));
+    const buckets = Array.from(
+      { length: WINDOWS },
+      () => ({ run: 0, gate: 0, fail: 0, cancelled: 0, done: 0 }),
+    );
     const start = at - WINDOWS * WINDOW_MS;
     for (const v of runs) {
       if (v.session.archived_at != null) continue;
@@ -78,8 +85,11 @@ export function RunOutcomeBar({
   }, [runs, attachedAt, at]);
   const unplaced = counts.unplaced;
 
-  const inWindow = counts.run + counts.gate + counts.fail + counts.done;
-  const colMax = windows.reduce((m, w) => Math.max(m, w.run + w.gate + w.fail + w.done), 0);
+  const inWindow = counts.run + counts.gate + counts.fail + counts.cancelled + counts.done;
+  const colMax = windows.reduce(
+    (m, w) => Math.max(m, w.run + w.gate + w.fail + w.cancelled + w.done),
+    0,
+  );
   const colW = (W - COL_GAP * (WINDOWS - 1)) / WINDOWS;
 
   const value =
@@ -89,6 +99,7 @@ export function RunOutcomeBar({
           counts.run > 0 ? `${counts.run} working` : null,
           counts.gate > 0 ? `${counts.gate} gate` : null,
           counts.fail > 0 ? `${counts.fail} failed` : null,
+          counts.cancelled > 0 ? `${counts.cancelled} cancelled` : null,
           counts.done > 0 ? `${counts.done} done` : null,
         ].filter((s) => s !== null).join(' · ');
 
@@ -117,7 +128,7 @@ export function RunOutcomeBar({
           style={{ display: 'block' }}
         >
           {windows.map((w, i) => {
-            const total = w.run + w.gate + w.fail + w.done;
+            const total = w.run + w.gate + w.fail + w.cancelled + w.done;
             if (total === 0) return null;
             let y = H;
             return SEGMENTS.map(({ key, fill }) => {
@@ -137,6 +148,17 @@ export function RunOutcomeBar({
             });
           })}
         </svg>
+      )}
+      {unplaced > 0 && (
+        // EC39: the windowed count states its exclusions VISIBLY — runs with
+        // no clock in this window are not painted, and the label says so, so
+        // the number stays reproducible from the rows a user can see.
+        <p
+          data-testid="outcome-unplaced-note"
+          style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+        >
+          excludes {unplaced} undated run{unplaced === 1 ? '' : 's'}
+        </p>
       )}
     </MetricTile>
   );

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
+import { outcomeOf } from '../board/metrics.js';
 import { RunLink } from './RunLink.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
-type StatusTab = 'all' | 'active' | 'completed' | 'failed';
+type StatusTab = 'all' | 'active' | 'completed' | 'failed' | 'cancelled';
 
 interface Props {
   runs: SessionView[];
@@ -24,16 +25,23 @@ function routedFilter(search: string): StatusTab | null {
   return raw !== null && TABS.some((t) => t.id === raw) ? (raw as StatusTab) : null;
 }
 
+// The J5/A5 partition is THE shared one (src/board/metrics.ts `outcomeOf`):
+// cancelled ≠ failed, so the Failed filter lists exactly the set every failed
+// COUNT names — the landing's number is reproducible from these rows.
 const isTerminal = (s: string) => ['completed', 'failed', 'cancelled'].includes(s);
 const isActiveStatus = (s: string) => !isTerminal(s);
-const isCompletedStatus = (s: string) => s === 'completed';
-const isFailedStatus = (s: string) => s === 'failed' || s === 'cancelled';
+const isCompletedStatus = (s: string) => outcomeOf(s) === 'done';
+const isFailedStatus = (s: string) => outcomeOf(s) === 'fail';
+const isCancelledStatus = (s: string) => outcomeOf(s) === 'cancelled';
 
 const TABS: { id: StatusTab; label: string }[] = [
   { id: 'all', label: 'All' },
   { id: 'active', label: 'Active' },
   { id: 'completed', label: 'Completed' },
   { id: 'failed', label: 'Failed' },
+  // Cancelled runs get their OWN filter — they left the Failed set (J5/A5)
+  // and every terminal row must still be reachable through some filter.
+  { id: 'cancelled', label: 'Cancelled' },
 ];
 
 export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' }: Props): React.ReactElement {
@@ -122,22 +130,25 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
     return { total, active, successRate, topWorkflow };
   }, [windowedRuns]);
 
-  const counts: Record<StatusTab, number> = {
-    all: searched.length,
-    active: searched.filter(v => isActiveStatus(v.session.status)).length,
-    completed: searched.filter(v => isCompletedStatus(v.session.status)).length,
-    failed: searched.filter(v => isFailedStatus(v.session.status)).length,
-  };
-
   const activeGroup = searched.filter(v => isActiveStatus(v.session.status));
   const completedGroup = searched.filter(v => isCompletedStatus(v.session.status));
   const failedGroup = searched.filter(v => isFailedStatus(v.session.status));
+  const cancelledGroup = searched.filter(v => isCancelledStatus(v.session.status));
+
+  const counts: Record<StatusTab, number> = {
+    all: searched.length,
+    active: activeGroup.length,
+    completed: completedGroup.length,
+    failed: failedGroup.length,
+    cancelled: cancelledGroup.length,
+  };
 
   const filtered =
     tab === 'all' ? searched
     : tab === 'active' ? activeGroup
     : tab === 'completed' ? completedGroup
-    : failedGroup;
+    : tab === 'failed' ? failedGroup
+    : cancelledGroup;
 
   return (
     <div className="flex flex-col h-full" style={{ color: 'var(--ink-high)' }}>
@@ -288,6 +299,14 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
               <>
                 <GroupLabel>Failed</GroupLabel>
                 {failedGroup.map(v => (
+                  <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                ))}
+              </>
+            )}
+            {cancelledGroup.length > 0 && (
+              <>
+                <GroupLabel>Cancelled</GroupLabel>
+                {cancelledGroup.map(v => (
                   <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
                 ))}
               </>

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -353,12 +353,12 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
                 ))}
               </>
             )}
-            {searched.length === 0 && <EmptyState query={query} />}
+            {searched.length === 0 && <EmptyState query={query} hidden={hiddenByRange} />}
           </>
         ) : (
           <>
             {filtered.length === 0 ? (
-              <EmptyState query={query} tab={tab} />
+              <EmptyState query={query} tab={tab} hidden={hiddenByRange} />
             ) : (
               filtered.map(v => (
                 <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
@@ -414,9 +414,13 @@ function GroupLabel({ children, pulse }: { children: React.ReactNode; pulse?: bo
   );
 }
 
-function EmptyState({ query, tab }: { query: string; tab?: StatusTab }): React.ReactElement {
+function EmptyState({ query, tab, hidden = 0 }: { query: string; tab?: StatusTab; hidden?: number }): React.ReactElement {
+  // ONE truth per screen: "No <tab> runs yet." may not sit under a note saying
+  // N exist outside the range window — when rows are hidden, say WHERE they are.
   const msg = query
     ? `No runs match "${query}".`
+    : hidden > 0
+    ? `No${tab ? ` ${tab}` : ''} runs in this range view — ${hidden} exist${hidden === 1 ? 's' : ''} outside it.`
     : tab
     ? `No ${tab} runs yet.`
     : 'No work sessions yet.';

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -150,6 +150,21 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
     : tab === 'failed' ? failedGroup
     : cancelledGroup;
 
+  // EC39, the J5/A5 follow-through: the positional range window can hide the
+  // very rows a landing count NAMES (live: the lede's "3 cancelled" linked to
+  // a 30d view holding zero cancelled rows — a count with no visible list).
+  // When the window excludes rows of the ACTIVE filter, the exclusion is
+  // STATED, never silent. Search is the user's own narrowing and says so in
+  // its empty state already, so the note counts against the unsearched window.
+  const inTabGroup = (v: SessionView): boolean =>
+    tab === 'all' ? true
+    : tab === 'active' ? isActiveStatus(v.session.status)
+    : tab === 'completed' ? isCompletedStatus(v.session.status)
+    : tab === 'failed' ? isFailedStatus(v.session.status)
+    : isCancelledStatus(v.session.status);
+  const windowedTabCount = windowedRuns.filter(inTabGroup).length;
+  const hiddenByRange = allWorkRuns.filter(inTabGroup).length - windowedTabCount;
+
   return (
     <div className="flex flex-col h-full" style={{ color: 'var(--ink-high)' }}>
       {/* Header */}
@@ -277,6 +292,33 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
         aria-labelledby={`work-tab-${tab}`}
         className="flex-1 overflow-y-auto px-5 pb-8 flex flex-col"
       >
+        {hiddenByRange > 0 && (
+          <p
+            data-testid="work-range-hidden-note"
+            data-hidden={hiddenByRange}
+            className="px-3 pb-2 text-[11px] font-mono"
+            style={{ color: 'var(--ink-muted)', margin: 0 }}
+          >
+            {hiddenByRange} more{tab === 'all' ? '' : ` ${tab}`} run{hiddenByRange === 1 ? '' : 's'} sit
+            {hiddenByRange === 1 ? 's' : ''} outside this {range} view
+            {range !== '90d' ? (
+              <>
+                {' — '}
+                <button
+                  type="button"
+                  data-testid="work-range-widen"
+                  onClick={() => setRange('90d')}
+                  className="underline"
+                  style={{ color: 'var(--ink-muted)', background: 'none', border: 'none', padding: 0, font: 'inherit', cursor: 'pointer' }}
+                >
+                  widen to 90d
+                </button>
+              </>
+            ) : (
+              ' (the view is positional — newest first)'
+            )}
+          </p>
+        )}
         {tab === 'all' ? (
           <>
             {activeGroup.length > 0 && (

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -40,6 +40,9 @@ interface LegacyRoute {
   projectId: string | null;
   mode: Mode | null;
   showLaunch: boolean;
+  /** True on the chat-surface routes (`/chat/new`, `/chat/:id`) — these are
+   *  NOT the legacy bare-`/runs` listing and must never redirect to /work. */
+  chatMode: boolean;
 }
 
 /**
@@ -62,10 +65,11 @@ interface LegacyRoute {
  * guessed project binding.
  */
 export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void {
-  const { panel, runId, projectId, mode, showLaunch } = route;
+  const { panel, runId, projectId, mode, showLaunch, chatMode } = route;
 
   useEffect(() => {
     if (mode !== null) return; // already in the shell
+    if (chatMode) return; // `/chat/*` is the chat surface, not a legacy run route
 
     if (projectId !== null) {
       // Only the LEGACY `/projects/:id` panel redirects — onto the dashboard
@@ -92,5 +96,5 @@ export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void 
         /* projects surface unreachable — the legacy run view stays, which is the honest fallback */
       });
     return () => { cancelled = true; };
-  }, [panel, runId, projectId, mode, showLaunch, navigate]);
+  }, [panel, runId, projectId, mode, showLaunch, chatMode, navigate]);
 }

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -148,6 +148,14 @@ function parse(pathname: string): Route {
   if (first === 'chat' && second === 'new') {
     return route({ panel: 'runs', showLaunch: true, chatMode: true });
   }
+  // `/chat/:id` — a live chat SESSION's real URL (J4/C6: an opened chat is
+  // findable again). The id is the pool session's chatId, carried in
+  // `artifactId` (it is NOT a run — `runId` stays null so no run-selected
+  // machinery fires against it). GroupChat rejoins the warm session, or says
+  // honestly that it is gone.
+  if (first === 'chat' && second) {
+    return route({ panel: 'runs', chatMode: true, artifactId: safeDecode(second) });
+  }
   if (first === 'projects' && second) {
     return route({ panel: 'project-detail', projectId: safeDecode(second) });
   }

--- a/tests/ChatsPage.live.test.tsx
+++ b/tests/ChatsPage.live.test.tsx
@@ -31,8 +31,8 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
 
 const { ChatsPage } = await import('../src/components/ChatsPage.js');
 
-function page(): ReturnType<typeof render> {
-  return render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
+function page(navigate: (path: string) => void = () => {}): ReturnType<typeof render> {
+  return render(<ChatsPage runs={[]} onSelect={() => {}} navigate={navigate} />);
 }
 
 beforeEach(() => {
@@ -89,5 +89,40 @@ describe('the live-session band (§7.9-5)', () => {
       emit!({ type: 'chatClosed', chat: 'warm-chat-1', reason: 'closed elsewhere' });
     });
     await waitFor(() => expect(screen.queryByTestId('live-chat-row')).toBeNull());
+  });
+
+  it('a live row is a door (J4/C6): clicking it opens the session at /chat/:id', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    page(navigate);
+    await user.click(await screen.findByTestId('live-chat-row'));
+    expect(navigate).toHaveBeenCalledWith('/chat/warm-chat-1');
+  });
+
+  it('End is its own gesture — it never also opens the session', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    page(navigate);
+    await screen.findByTestId('live-chat-row');
+    await user.click(screen.getByTestId('live-chat-end'));
+    expect(closeChat).toHaveBeenCalledWith('warm-chat-1');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('one truth per screen (J4/C6): "No chat sessions yet" never renders beside a live band', async () => {
+    page(); // runs=[] → the run list below is empty; one live session is warm
+    await screen.findByTestId('live-chat-row');
+    expect(screen.queryByText('No chat sessions yet')).toBeNull();
+    const empty = screen.getByTestId('chats-empty-live');
+    // The honest boundary: transcripts are not stored beyond the live session.
+    expect(empty.textContent).toContain('aren’t stored beyond the live session');
+  });
+
+  it('with no live band, the plain empty state stands alone', async () => {
+    listChats.mockResolvedValue({ chats: [] });
+    page();
+    await waitFor(() => expect(listChats).toHaveBeenCalledTimes(1));
+    expect(await screen.findByTestId('chats-empty')).toHaveTextContent('No chat sessions yet');
+    expect(screen.queryByTestId('chats-empty-live')).toBeNull();
   });
 });

--- a/tests/GroupChat.rejoin.test.tsx
+++ b/tests/GroupChat.rejoin.test.tsx
@@ -318,3 +318,81 @@ describe('GroupChat — chat reuse (FINDING-027)', () => {
     expect(sessionStorage.getItem('wicked.chat.r1')).toBeNull();
   });
 });
+
+describe('GroupChat — the routed session URL (J4/C6)', () => {
+  it('a routed id the daemon still holds is rejoined — with the honest boundary note, never a silent empty', async () => {
+    getChat.mockResolvedValue({ chatId: 'routed-1', seats: ['claude'] });
+    render(<GroupChat repoId={null} onBack={() => undefined} routedChatId="routed-1" reflectUrl />);
+    await waitFor(() => expect(getChat).toHaveBeenCalledWith('routed-1'));
+    await waitFor(() => expect(screen.getByTitle('ready')).toHaveTextContent('claude'));
+    // The wire keeps seats, not history — the boundary is STATED in the thread.
+    expect(screen.getByTestId('chat-rejoined-note').textContent).toContain('can’t be replayed');
+    // The routed session becomes this tab's session for the repo scope.
+    expect(sessionStorage.getItem('wicked.chat._')).toBe('routed-1');
+    expect(openChat).not.toHaveBeenCalled();
+  });
+
+  it('the routed id wins over the tab-stored id — the URL is the operator\'s ask', async () => {
+    sessionStorage.setItem('wicked.chat._', 'stored-other');
+    getChat.mockResolvedValue({ chatId: 'routed-1', seats: ['claude'] });
+    render(<GroupChat repoId={null} onBack={() => undefined} routedChatId="routed-1" />);
+    await waitFor(() => expect(getChat).toHaveBeenCalledWith('routed-1'));
+    expect(getChat).not.toHaveBeenCalledWith('stored-other');
+  });
+
+  it('a routed id the daemon no longer holds says so — the ended boundary, not first-run teaching', async () => {
+    getChat.mockResolvedValue({ chatId: 'gone-1', seats: [] });
+    render(<GroupChat repoId={null} onBack={() => undefined} routedChatId="gone-1" />);
+    const ended = await screen.findByTestId('chat-session-ended');
+    expect(ended.textContent).toContain('aren’t stored beyond the live session');
+    expect(screen.queryByTestId('chat-firstrun')).toBeNull();
+    expect(openChat, 'a dead routed id must not auto-mint').not.toHaveBeenCalled();
+  });
+
+  it('a send from the ended boundary starts a NEW session and the URL follows it (replace)', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    getChat.mockResolvedValue({ chatId: 'gone-1', seats: [] });
+    render(
+      <GroupChat repoId={null} onBack={() => undefined} routedChatId="gone-1" reflectUrl navigate={navigate} />,
+    );
+    await screen.findByTestId('chat-session-ended');
+    await user.type(screen.getByRole('textbox'), 'start over');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const mintedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    expect(mintedId).not.toBe('gone-1');
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith(`/chat/${mintedId}`, { replace: true }));
+    // The ended boundary leaves the screen once a live session exists.
+    expect(screen.queryByTestId('chat-session-ended')).toBeNull();
+  });
+
+  it('minting on /chat/new reflects the id into /chat/:id the moment the session exists', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    render(<GroupChat repoId={null} onBack={() => undefined} reflectUrl navigate={navigate} />);
+    await armViaFirstSend(user);
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const mintedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith(`/chat/${mintedId}`, { replace: true }));
+  });
+
+  it('the reflection navigation does not reset the live transcript (routedChatId → own id)', async () => {
+    const user = userEvent.setup();
+    const view = render(<GroupChat repoId={null} onBack={() => undefined} reflectUrl />);
+    await armViaFirstSend(user);
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const mintedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    // The App re-renders the SAME mount with the reflected URL: routedChatId = own id.
+    view.rerender(
+      <GroupChat repoId={null} onBack={() => undefined} routedChatId={mintedId} reflectUrl />,
+    );
+    // No re-probe, no second open, and the sent bubble survives — the guard
+    // skips the self-reflection instead of wiping the live transcript.
+    expect(getChat).not.toHaveBeenCalled();
+    expect(openChat).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('user-bubble')).toHaveTextContent('warm us up');
+  });
+});

--- a/tests/NarrativeBand.test.tsx
+++ b/tests/NarrativeBand.test.tsx
@@ -19,8 +19,10 @@ const NOW = 1_700_000_000_000;
 const HOUR = 3_600_000;
 
 const text = (c: Partial<LedeCounts>): string =>
-  composeLede({ finished: 0, passed: 0, failed: 0, gates: 0, live: 0, projects: 5, ...c })
-    .segments.map((s) => s.text).join('');
+  composeLede({
+    finished: 0, passed: 0, failed: 0, cancelled: 0, gates: 0, live: 0,
+    projects: 5, undatable: 0, ...c,
+  }).segments.map((s) => s.text).join('');
 
 describe('composeLede — §7.3 grammar, every drop-out case', () => {
   it('the full sentence: finished with both outcomes, and gates', () => {
@@ -66,8 +68,20 @@ describe('composeLede — §7.3 grammar, every drop-out case', () => {
     expect(text({ live: 1 })).toBe('While you were away: nothing finished — 1 run still moving.');
   });
 
+  it('cancelled is its own clause — never folded into failed (J5/A5)', () => {
+    expect(text({ finished: 3, passed: 1, failed: 1, cancelled: 1, gates: 0 })).toBe(
+      'While you were away: 3 runs finished — 1 passed, 1 failed, 1 cancelled.',
+    );
+    expect(text({ finished: 2, cancelled: 2 })).toBe(
+      'While you were away: 2 runs finished — 2 cancelled.',
+    );
+  });
+
   it('the all-quiet system reads the quiet phrase — no zero-count segment renders', () => {
-    const quiet = composeLede({ finished: 0, passed: 0, failed: 0, gates: 0, live: 0, projects: 28 });
+    const quiet = composeLede({
+      finished: 0, passed: 0, failed: 0, cancelled: 0, gates: 0, live: 0,
+      projects: 28, undatable: 0,
+    });
     expect(quiet.quiet).toBe(true);
     expect(quiet.segments.map((s) => s.text).join('')).toBe(
       'All quiet. 28 projects, nothing running, nothing waiting.',
@@ -75,10 +89,19 @@ describe('composeLede — §7.3 grammar, every drop-out case', () => {
     expect(text({})).not.toContain('0 ');
   });
 
-  it('each numeric segment names a real destination (§7.3 links)', () => {
-    const full = composeLede({ finished: 4, passed: 3, failed: 1, gates: 2, live: 0, projects: 5 });
+  it('each numeric segment names a real destination (§7.3 links) — every outcome number opens ITS filter (J5)', () => {
+    const full = composeLede({
+      finished: 4, passed: 2, failed: 1, cancelled: 1, gates: 2, live: 0,
+      projects: 5, undatable: 0,
+    });
     const hrefs = full.segments.filter((s) => s.href !== null).map((s) => s.href);
-    expect(hrefs).toEqual(['/work', '#needs-you']);
+    expect(hrefs).toEqual([
+      '/work',
+      '/work?filter=completed',
+      '/work?filter=failed',
+      '/work?filter=cancelled',
+      '#needs-you',
+    ]);
   });
 });
 
@@ -99,7 +122,10 @@ describe('ledeCounts — honest clocks only (EC29: no invented clock)', () => {
       { 'r-in': NOW - 5 * HOUR, 'r-out': NOW - 30 * HOUR, 'r-archived': NOW - HOUR },
       {}, {}, 7, NOW,
     );
-    expect(c).toEqual({ finished: 1, passed: 1, failed: 0, gates: 1, live: 1, projects: 7 });
+    expect(c).toEqual({
+      finished: 1, passed: 1, failed: 0, cancelled: 0, gates: 1, live: 1,
+      projects: 7, undatable: 1, // r-clockless: excluded AND counted (EC39)
+    });
   });
 
   it('the failure tail and arrival-stamped frames extend a run into the window', () => {
@@ -153,7 +179,8 @@ describe('<NarrativeBand> — composition on screen', () => {
       'While you were away: 1 run finished — 1 passed — and 1 gate is waiting on you.',
     );
     const links = [...lede.querySelectorAll('a[data-testid="lede-segment"]')];
-    expect(links.map((a) => a.getAttribute('href'))).toEqual(['/work', '#needs-you']);
+    expect(links.map((a) => a.getAttribute('href')))
+      .toEqual(['/work', '/work?filter=completed', '#needs-you']);
     // §8.5: the two surviving slice-E tiles live on as margin notes.
     const margin = screen.getByTestId('river-margin');
     expect(margin.querySelector('[data-testid="run-outcome-bar"]')).not.toBeNull();

--- a/tests/WorkPage.filter.test.tsx
+++ b/tests/WorkPage.filter.test.tsx
@@ -97,6 +97,9 @@ describe('WorkPage — range-hidden rows are stated, never silent (EC39)', () =>
     const note = screen.getByTestId('work-range-hidden-note');
     expect(note).toHaveAttribute('data-hidden', '1');
     expect(note.textContent).toMatch(/1 more cancelled run sits outside this 30d view/);
+    // The empty state tells the SAME truth — never "No cancelled runs yet."
+    // one line under a note saying they exist.
+    expect(screen.getByText(/No cancelled runs in this range view — 1 exists outside it\./)).toBeInTheDocument();
     // Widen → the row appears and the note goes away (90d covers all 32).
     await userEvent.click(screen.getByTestId('work-range-widen'));
     expect(screen.getByText(/called off/)).toBeInTheDocument();

--- a/tests/WorkPage.filter.test.tsx
+++ b/tests/WorkPage.filter.test.tsx
@@ -75,3 +75,38 @@ describe('WorkPage — §7.4 context-sensitive entry (slice Y)', () => {
     expect(screen.getByRole('tablist')).toHaveAttribute('data-filter', 'active');
   });
 });
+
+// EC39 follow-through (fix slice J4/J5 verification finding): the positional
+// range window (useTimeRange, 30d → first 30 rows) can hide the very rows a
+// landing count links to — live, the lede's "3 cancelled" landed on a 30d
+// /work view holding ZERO cancelled rows. The exclusion must be STATED.
+describe('WorkPage — range-hidden rows are stated, never silent (EC39)', () => {
+  // 31 completed rows first (fills the 30d positional window), then the
+  // cancelled row — outside the window on the cancelled tab.
+  const MANY = [
+    ...Array.from({ length: 31 }, (_, i) =>
+      makeView({ id: `r-c${i}`, workflow_id: 'feature', problem: `done ${i}`, status: 'completed' })),
+    makeView({ id: 'r-cxl', workflow_id: 'feature', problem: 'called off', status: 'cancelled' }),
+  ];
+
+  it('states the hidden count on a filter whose rows the window excludes, and widens on demand', async () => {
+    render(
+      <WorkPage runs={MANY} selectedRunId={null} onSelect={() => {}} navigate={() => {}} search="?filter=cancelled" />,
+    );
+    // The 30d window (first 30 rows) holds no cancelled run — the note says so.
+    const note = screen.getByTestId('work-range-hidden-note');
+    expect(note).toHaveAttribute('data-hidden', '1');
+    expect(note.textContent).toMatch(/1 more cancelled run sits outside this 30d view/);
+    // Widen → the row appears and the note goes away (90d covers all 32).
+    await userEvent.click(screen.getByTestId('work-range-widen'));
+    expect(screen.getByText(/called off/)).toBeInTheDocument();
+    expect(screen.queryByTestId('work-range-hidden-note')).toBeNull();
+  });
+
+  it('renders no note when the window hides nothing', () => {
+    render(
+      <WorkPage runs={RUNS} selectedRunId={null} onSelect={() => {}} navigate={() => {}} search="?filter=failed" />,
+    );
+    expect(screen.queryByTestId('work-range-hidden-note')).toBeNull();
+  });
+});

--- a/tests/legacyRedirect.test.ts
+++ b/tests/legacyRedirect.test.ts
@@ -26,8 +26,8 @@ function member(projectId: string, kind: string, ref: string): ProjectMember {
 
 /** Route shape for a legacy path; `mode: null` is what makes it legacy. */
 const legacy = {
-  runs: (runId: string) => ({ panel: 'runs', runId, projectId: null, mode: null, showLaunch: false }),
-  projects: (projectId: string) => ({ panel: 'project-detail', runId: null, projectId, mode: null, showLaunch: false }),
+  runs: (runId: string) => ({ panel: 'runs', runId, projectId: null, mode: null, showLaunch: false, chatMode: false }),
+  projects: (projectId: string) => ({ panel: 'project-detail', runId: null, projectId, mode: null, showLaunch: false, chatMode: false }),
 };
 
 beforeEach(() => {
@@ -113,7 +113,7 @@ describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () =>
   it('a bare /p/:projectId is NOT redirected — it IS the dashboard (DES-FEEDBACK-001 §4.1)', () => {
     const navigate = vi.fn();
     renderHook(() => useLegacyRedirect(
-      { panel: 'runs', runId: null, projectId: 'proj-1', mode: null, showLaunch: false }, navigate));
+      { panel: 'runs', runId: null, projectId: 'proj-1', mode: null, showLaunch: false, chatMode: false }, navigate));
     expect(navigate).not.toHaveBeenCalled();
     expect(listProjects).not.toHaveBeenCalled();
   });
@@ -121,11 +121,11 @@ describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () =>
   it('never redirects a route that is already in the shell, or the launch form', () => {
     const navigate = vi.fn();
     renderHook(() => useLegacyRedirect(
-      { panel: 'runs', runId: 'run-9', projectId: 'proj-1', mode: 'build', showLaunch: false }, navigate));
+      { panel: 'runs', runId: 'run-9', projectId: 'proj-1', mode: 'build', showLaunch: false, chatMode: false }, navigate));
     renderHook(() => useLegacyRedirect(
-      { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: true }, navigate));
+      { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: true, chatMode: false }, navigate));
     renderHook(() => useLegacyRedirect(
-      { panel: 'work', runId: null, projectId: null, mode: null, showLaunch: false }, navigate));
+      { panel: 'work', runId: null, projectId: null, mode: null, showLaunch: false, chatMode: false }, navigate));
 
     expect(navigate).not.toHaveBeenCalled();
     expect(listProjects).not.toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe('useLegacyRedirect (DES-MERGE-001 §1.5 — no bookmark breaks)', () =>
 });
 
 describe('slice Y (DES-UX-001 §7.4): the bare /runs listing retires into /work', () => {
-  const bare = { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: false };
+  const bare = { panel: 'runs', runId: null, projectId: null, mode: null, showLaunch: false, chatMode: false };
 
   it('/runs → /work, replacing the history entry, with no membership lookup', () => {
     window.history.replaceState(null, '', '/runs');

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -81,8 +81,20 @@ describe('outcomeTotals24h / failedCount24h — window "24h" on the attach clock
 
   it('buckets on the honest clock; clockless/outside runs are unplaced', () => {
     expect(outcomeTotals24h(W2, attached, NOW)).toEqual({
-      run: 1, gate: 1, fail: 1, done: 1, unplaced: 2,
+      run: 1, gate: 1, fail: 1, cancelled: 0, done: 1, unplaced: 2,
     });
+  });
+
+  it('cancelled is its own bucket — never folded into fail (J5/A5)', () => {
+    const runs = [
+      makeView({ id: 'r-cx', status: 'cancelled' }),
+      makeView({ id: 'r-fx', status: 'failed' }),
+    ];
+    const clocks = { 'r-cx': NOW - HOUR, 'r-fx': NOW - 2 * HOUR };
+    expect(outcomeTotals24h(runs, clocks, NOW)).toEqual({
+      run: 0, gate: 0, fail: 1, cancelled: 1, done: 0, unplaced: 0,
+    });
+    expect(failedCount24h(runs, clocks, NOW)).toBe(1);
   });
 
   it('failedCount24h vs failedCountAll: two labeled truths, not a contradiction', () => {
@@ -90,11 +102,11 @@ describe('outcomeTotals24h / failedCount24h — window "24h" on the attach clock
     expect(failedCountAll(W2)).toBe(2);
   });
 
-  it('outcomeOf maps every status', () => {
+  it('outcomeOf maps every status — ONE partition, cancelled ≠ failed', () => {
     expect(outcomeOf('executing')).toBe('run');
     expect(outcomeOf('awaiting_human')).toBe('gate');
     expect(outcomeOf('failed')).toBe('fail');
-    expect(outcomeOf('cancelled')).toBe('fail');
+    expect(outcomeOf('cancelled')).toBe('cancelled');
     expect(outcomeOf('completed')).toBe('done');
   });
 });
@@ -162,7 +174,25 @@ describe('ledeCounts — gates/live are runStats\' own numbers (§5.1 offender p
     expect(c.finished).toBe(1);
     expect(c.failed).toBe(1);
     expect(c.passed).toBe(0);
+    expect(c.cancelled).toBe(0);
     expect(c.projects).toBe(3);
+    // Clockless terminal runs (r-fail-old, r-done) are excluded AND counted,
+    // so the label can state the exclusion (EC39 — never a silent drop).
+    expect(c.undatable).toBe(2);
+  });
+
+  it('a cancelled run finishes as cancelled — never as failed, never as passed', () => {
+    const runs = [
+      makeView({ id: 'r-cx', status: 'cancelled' }),
+      makeView({ id: 'r-fx', status: 'failed' }),
+      makeView({ id: 'r-dx', status: 'completed' }),
+    ];
+    const clocks = { 'r-cx': NOW - HOUR, 'r-fx': NOW - HOUR, 'r-dx': NOW - HOUR };
+    const c = ledeCounts(runs, clocks, {}, {}, 1, NOW);
+    expect(c.finished).toBe(3);
+    expect(c.passed).toBe(1);
+    expect(c.failed).toBe(1);
+    expect(c.cancelled).toBe(1);
   });
 
   it('the shared 24h span is the one constant', () => {

--- a/tests/metricsBar.test.tsx
+++ b/tests/metricsBar.test.tsx
@@ -80,12 +80,48 @@ describe('RunOutcomeBar (§2.1 — "Is the system healthy right now?")', () => {
     expect(tile.textContent).toContain('No runs attached in the last 24h');
   });
 
-  it('maps statuses to outcome classes (cancelled counts as failed)', () => {
+  it('maps statuses to outcome classes (cancelled is its OWN class — J5/A5)', () => {
     expect(outcomeOf('executing')).toBe('run');
     expect(outcomeOf('awaiting_human')).toBe('gate');
     expect(outcomeOf('failed')).toBe('fail');
-    expect(outcomeOf('cancelled')).toBe('fail');
+    expect(outcomeOf('cancelled')).toBe('cancelled');
     expect(outcomeOf('completed')).toBe('done');
+  });
+
+  it('a cancelled run wears its own neutral segment, never the fail token', () => {
+    const withCancelled = [
+      makeView({ id: 'r-x', status: 'failed' }),
+      makeView({ id: 'r-y', status: 'cancelled' }),
+    ];
+    render(
+      <RunOutcomeBar
+        runs={withCancelled}
+        attachedAt={{ 'r-x': NOW - HOUR, 'r-y': NOW - 2 * HOUR }}
+        now={NOW}
+      />,
+    );
+    const tile = screen.getByTestId('run-outcome-bar');
+    expect(tile.getAttribute('data-total')).toBe('2');
+    const fills = [...tile.querySelectorAll('rect')].map((r) => r.getAttribute('fill'));
+    expect(fills).toContain('var(--status-fail)');
+    expect(fills).toContain('var(--ink-dim)');
+    expect(tile.textContent).toContain('1 failed');
+    expect(tile.textContent).toContain('1 cancelled');
+  });
+
+  it('states its exclusions: undated runs are named beside the number (EC39)', () => {
+    render(
+      <RunOutcomeBar
+        runs={[
+          makeView({ id: 'r-in', status: 'failed' }),
+          makeView({ id: 'r-noclock', status: 'failed' }),
+        ]}
+        attachedAt={{ 'r-in': NOW - HOUR }}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByTestId('outcome-unplaced-note').textContent)
+      .toBe('excludes 1 undated run');
   });
 });
 

--- a/tests/metricsBar.test.tsx
+++ b/tests/metricsBar.test.tsx
@@ -121,7 +121,7 @@ describe('RunOutcomeBar (§2.1 — "Is the system healthy right now?")', () => {
       />,
     );
     expect(screen.getByTestId('outcome-unplaced-note').textContent)
-      .toBe('excludes 1 undated run');
+      .toBe('excludes 1 run with no clock in this window');
   });
 });
 

--- a/tests/useRoute.modes.test.ts
+++ b/tests/useRoute.modes.test.ts
@@ -65,6 +65,11 @@ describe('useRoute — the existing panel routes keep working', () => {
     expect(routeAt('/runs/run-1').current).toMatchObject({ panel: 'runs', runId: 'run-1' });
     expect(routeAt('/runs/new').current).toMatchObject({ panel: 'runs', showLaunch: true });
     expect(routeAt('/chat/new').current).toMatchObject({ showLaunch: true, chatMode: true });
+    // J4/C6: /chat/:id is a live SESSION's address — chat surface, never the
+    // launch form, and never a runId (a chat is not a run).
+    expect(routeAt('/chat/abc-123').current).toMatchObject({
+      panel: 'runs', chatMode: true, artifactId: 'abc-123', runId: null, showLaunch: false,
+    });
     expect(routeAt('/work').current.panel).toBe('work');
     expect(routeAt('/repos/new').current).toMatchObject({ panel: 'repos', showRegisterRepo: true });
     expect(routeAt('/repo-detail/repo-1').current).toMatchObject({ panel: 'repo-detail', repoId: 'repo-1' });


### PR DESCRIPTION
Fixes two blockers from BRIEF-UX-001's six-journey cold re-review.

**J4/C6 — chat findability**: an opened chat gets a real URL the moment its session exists, revisitable within the session lifetime; /chats live rows click through to it; the empty-state copy never renders beside a non-empty live band; honest boundary copy where the wire genuinely lacks history.

**J5/A5 — one definition of failed**: a single outcome partition in `src/board/metrics.ts` (cancelled ≠ failed) used by every consumer; the landing's failed count reconciles with /work's Failed rows for the same window; undatable rows handled per EC39's honest-qualifier grammar — no number a user cannot reproduce from a visible list.

Verified: unit suite green; slice rig ×2; regressions ux_sliceAB (11 steps), ux_sliceW, feedback3_sliceQ, studio_standalone (real daemon); live read-only reconciliation check; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
