### PR TITLE
Round-3 fix: chat cold-start roster truth + draft survival + session URL

### DIFF
--- a/e2e/ux_fixJ42_test.py
+++ b/e2e/ux_fixJ42_test.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+ux_fixJ42_test.py — the BRIEF-UX-001 ROUND-2 fix gate (J4 findings 1–4).
+
+Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py), whose
+POST /chats now enforces the REAL daemon's roster contract unconditionally:
+any cli not in ROSTER answers the core's own per-seat rejection
+("no ACP config for '<key>'" — wicked-core acp_runner.rs). The class this
+round-2 review caught — the fallback trio riding the wire and every cold
+profile's first send failing — can never pass this rig by fixture leniency.
+
+Scenes (each on a FRESH browser context — zero storage, the cold profile):
+
+  1. COLD PROFILE (finding 1 + 3): /chat/new mounts with the fallback chips
+     as PLACEHOLDERS (data-source="fallback", zero chat-surface requests);
+     the FIRST SEND fetches the roster on the gesture (exactly one GET
+     /roster), opens with the ROSTER's seats — the strict fixture accepts
+     them, the send succeeds, a reply lands — the URL flips to /chat/:id
+     (J4: the session is findable), the rail lists the live session and
+     never says "no chats", and /chats' Active-now headline counts the
+     live row (finding 4a: no "0 of 0" beside a live session).
+  2. ROSTER UNREACHABLE (finding 1): with GET /roster answering 500, a
+     pristine first send FAILS INLINE — zero POST /chats (the trio never
+     ships), the draft survives in the composer, the failure renders with
+     a working Retry; after the roster recovers, Retry sends the ROSTER's
+     seats and exactly one user bubble renders (no duplicate).
+  3. OPEN-FAILURE RECOVERY (finding 2 + 3): every seat rejected at open →
+     the failure renders as a retryable row beside the banner, the draft
+     survives; remove one chip, un-reject, Retry → the send succeeds into
+     the SAME chat id, the stale banner clears, and the removed seat's
+     red chip is pruned (no stale failed chips beside a live conversation).
+  4. PICKER VOCABULARY (finding 4b): the [+ Add] menu carries each seat's
+     display name and OBSERVED health (data-health; absent on the wire →
+     "unknown", never a fabricated "active").
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-J42-cold-first-send.png   the cold profile's first send answered, URL
+                               flipped, live session on the rail
+  ux-J42-roster-down.png       the inline roster-unreachable failure with
+                               the draft intact and Retry offered
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4404),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ROSTER,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4404"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+ROSTER_KEYS = [s["key"] for s in ROSTER]
+FALLBACK = ["writer", "reviewer", "planner"]
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. Build + the shared fixture (strict roster contract is ALWAYS on) ───────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+
+def tap(page) -> list:
+    net: list = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if not path.startswith("/api/"):
+            return
+        body = None
+        if req.post_data:
+            try:
+                body = json.loads(req.post_data)
+            except ValueError:
+                body = None
+        net.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return net
+
+
+def is_chat_surface(path: str) -> bool:
+    return path.startswith("/api/v1/chats") or path == "/api/v1/roster"
+
+
+CENSUS = """() => {
+  const bar = document.querySelector('[data-testid="agent-chips-bar"]');
+  const chips = [...document.querySelectorAll('[data-testid="seat-chip"]')];
+  return {
+    pathname: location.pathname,
+    chipsBar: bar ? { count: bar.dataset.count, source: bar.dataset.source } : null,
+    seatChips: Object.fromEntries(chips.map((c) => [c.dataset.agent, c.dataset.state])),
+    composer: document.querySelector('textarea')?.value ?? null,
+    sendDisabled: [...document.querySelectorAll('button')].find((b) => b.textContent === 'Send')?.disabled ?? null,
+    openError: document.body.innerText.includes('Could not open chat'),
+    sendFailed: document.querySelector('[data-testid="chat-send-failed"]')?.textContent ?? null,
+    userBubbles: [...document.querySelectorAll('[data-testid="user-bubble"]')].map((u) => u.textContent),
+    replies: [...document.querySelectorAll('[data-testid="seat-bubble"][data-pending="false"]')].length,
+    railLiveChats: [...document.querySelectorAll('[data-testid="rail-live-chat"]')]
+      .map((r) => r.dataset.chatId),
+    railEmptyLabel: document.body.innerText.includes('No recorded chats yet'),
+  };
+}"""
+
+MSG_COLD = "cold profile: compare the auth options"
+MSG_DOWN = "roster is down: still want to chat"
+MSG_REJ = "every seat rejected: recover me"
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+
+    # ── Scene 1: the COLD PROFILE first send succeeds (findings 1 + 3 + 4a) ───
+    set_fixture(ORIGIN, chat_replies=True)
+    ctx1 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx1.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net = tap(page)
+    page.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.locator('[data-testid="agent-chips-bar"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    storage = page.evaluate("() => sessionStorage.length + localStorage.length")
+    mount = page.evaluate(CENSUS)
+    mount_chat = [(m, q) for (m, q, _b) in net if is_chat_surface(q)]
+    check("cold_mount_placeholders_zero_requests",
+          storage == 0
+          and mount["chipsBar"] is not None
+          and mount["chipsBar"]["source"] == "fallback"
+          and mount["chipsBar"]["count"] == str(len(FALLBACK))
+          and len(mount_chat) == 0,
+          storage_entries=storage, chips_bar=mount["chipsBar"], mount_chat_requests=mount_chat)
+
+    page.locator("textarea").fill(MSG_COLD)
+    page.keyboard.press("Enter")
+    # The daemon ACCEPTS (strict contract): composer clears, replies land.
+    page.wait_for_function(
+        """() => document.querySelector('textarea')?.value === ''
+             && document.querySelectorAll('[data-testid="seat-bubble"][data-pending="false"]').length > 0""",
+        timeout=30000)
+    sent = page.evaluate(CENSUS)
+    roster_gets = [(m, q) for (m, q, _b) in net if q == "/api/v1/roster"]
+    opens = [(m, q, b) for (m, q, b) in net if m == "POST" and q == "/api/v1/chats"]
+    chat_id = (opens[0][2] or {}).get("chatId") if opens else None
+    check("cold_first_send_roster_first_and_accepted",
+          len(roster_gets) == 1
+          and len(opens) == 1
+          and (opens[0][2] or {}).get("clis") == ROSTER_KEYS
+          and not sent["openError"]
+          and sent["sendFailed"] is None
+          and sent["userBubbles"] == [MSG_COLD]
+          and sent["replies"] > 0,
+          roster_gets=len(roster_gets), open_body=opens[0][2] if opens else None,
+          census=sent)
+
+    # Finding 3: the URL flipped to the session's real address…
+    check("cold_url_flips_to_session",
+          chat_id is not None and sent["pathname"] == f"/chat/{chat_id}",
+          pathname=sent["pathname"], chat_id=chat_id)
+    # …and the rail lists the live session — never "no chats" beside it.
+    check("rail_lists_live_session",
+          chat_id in sent["railLiveChats"] and not sent["railEmptyLabel"],
+          rail_live=sent["railLiveChats"], empty_label=sent["railEmptyLabel"])
+
+    page.screenshot(path=str(VSHOTS / "ux-J42-cold-first-send.png"))
+
+    # Finding 4a: /chats' Active-now headline counts the live row it shows.
+    page.goto(f"{ORIGIN}/chats", wait_until="domcontentloaded")
+    page.locator('[data-testid="chats-dashboard-tiles"]').wait_for(timeout=30000)
+    page.locator('[data-testid="live-chat-row"]').wait_for(timeout=30000)
+    tile = page.evaluate(
+        """() => {
+          const t = document.querySelector('[data-testid="chats-active-tile"]');
+          return { count: t?.dataset.count, live: t?.dataset.live, text: t?.textContent ?? '' };
+        }""")
+    check("active_now_counts_the_live_row",
+          tile["live"] == "1" and int(tile["count"] or 0) >= 1
+          and "live session" in tile["text"] and " in 30d" in tile["text"],
+          **tile)
+    ctx1.close()
+
+    # ── Scene 2: roster unreachable — NOTHING ships; Retry recovers (finding 1) ─
+    set_fixture(ORIGIN, chat_replies=False, roster_fail=True)
+    ctx2 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page2 = ctx2.new_page()
+    page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net2 = tap(page2)
+    page2.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    page2.locator("textarea").fill(MSG_DOWN)
+    page2.keyboard.press("Enter")
+    page2.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)
+    down = page2.evaluate(CENSUS)
+    down_opens = [(m, q) for (m, q, _b) in net2 if m == "POST" and q == "/api/v1/chats"]
+    down_sends = [(m, q) for (m, q, _b) in net2 if m == "POST" and "/messages" in q]
+    check("roster_down_nothing_ships_draft_survives",
+          len(down_opens) == 0 and len(down_sends) == 0
+          and "roster" in (down["sendFailed"] or "")
+          and down["composer"] == MSG_DOWN
+          and down["userBubbles"] == []
+          and down["sendDisabled"] is False
+          and down["pathname"] == "/chat/new",
+          opens=down_opens, sends=down_sends, census=down)
+
+    page2.screenshot(path=str(VSHOTS / "ux-J42-roster-down.png"))
+
+    # The roster recovers → Retry sends the ROSTER's seats, exactly once.
+    set_fixture(ORIGIN, roster_fail=False)
+    page2.locator('[data-testid="chat-send-retry"]').click()
+    page2.wait_for_function(
+        f"""() => [...document.querySelectorAll('[data-testid="user-bubble"]')]
+                  .filter((u) => u.textContent === {json.dumps(MSG_DOWN)}).length === 1
+               && !document.querySelector('[data-testid="chat-send-failed"]')
+               && document.querySelector('textarea')?.value === ''""",
+        timeout=30000)
+    retry_opens = [(m, q, b) for (m, q, b) in net2 if m == "POST" and q == "/api/v1/chats"]
+    check("roster_recovers_retry_sends_roster_once",
+          len(retry_opens) == 1 and (retry_opens[0][2] or {}).get("clis") == ROSTER_KEYS,
+          open_body=retry_opens[0][2] if retry_opens else None)
+    ctx2.close()
+
+    # ── Scene 3: all seats rejected → recover; stale banner + chips clear ─────
+    set_fixture(ORIGIN, chat_reject_seats=ROSTER_KEYS)
+    ctx3 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page3 = ctx3.new_page()
+    page3.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net3 = tap(page3)
+    page3.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page3.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page3.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    page3.locator("textarea").fill(MSG_REJ)
+    page3.keyboard.press("Enter")
+    page3.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)
+    rej = page3.evaluate(CENSUS)
+    rej_sends = [(m, q) for (m, q, _b) in net3 if m == "POST" and "/messages" in q]
+    check("all_rejected_is_retryable_with_guidance",
+          rej["openError"]  # the banner names the rejected chips (§6.2 guidance)
+          and rej["sendFailed"] is not None
+          and rej["composer"] == MSG_REJ
+          and rej["userBubbles"] == []
+          and len(rej_sends) == 0
+          and all(st == "failed" for st in rej["seatChips"].values())
+          and set(rej["seatChips"]) == set(ROSTER_KEYS),
+          census=rej, sends=rej_sends)
+
+    # Remove one chip; the retried open must not name it — and its stale red
+    # seat chip must be PRUNED once the send succeeds (finding 3).
+    removed = ROSTER_KEYS[-1]
+    page3.locator(f'[data-testid="agent-chip"][data-agent="{removed}"] button').click()
+    set_fixture(ORIGIN, chat_reject_seats=[])
+    page3.locator('[data-testid="chat-send-retry"]').click()
+    # Wait for the ACCEPTED send (composer clears only then, §7.9-2), the
+    # single user bubble, and the pruned stale chip — not just the optimistic
+    # start of the retry (which also renders a bubble while the arm is still
+    # in flight).
+    page3.wait_for_function(
+        f"""() => [...document.querySelectorAll('[data-testid="user-bubble"]')]
+                  .filter((u) => u.textContent === {json.dumps(MSG_REJ)}).length === 1
+               && !document.querySelector('[data-testid="chat-send-failed"]')
+               && document.querySelector('textarea')?.value === ''
+               && !document.querySelector('[data-testid="seat-chip"][data-agent="{removed}"]')""",
+        timeout=30000)
+    recovered = page3.evaluate(CENSUS)
+    opens3 = [(m, q, b) for (m, q, b) in net3 if m == "POST" and q == "/api/v1/chats"]
+    kept = [k for k in ROSTER_KEYS if k != removed]
+    check("recovery_same_chat_banner_and_stale_chips_clear",
+          len(opens3) == 2
+          and (opens3[0][2] or {}).get("chatId") == (opens3[1][2] or {}).get("chatId")
+          and (opens3[1][2] or {}).get("clis") == kept
+          and not recovered["openError"]
+          and recovered["sendFailed"] is None
+          and removed not in recovered["seatChips"]  # the stale red chip is gone
+          and all(recovered["seatChips"].get(k) == "working" for k in kept),
+          open_bodies=[b for (_m, _q, b) in opens3], census=recovered)
+
+    # ── Scene 4: the picker's roster vocabulary (finding 4b) ──────────────────
+    # A fresh chat surface (same context, new page — the picker is pre-send UI).
+    page4 = ctx3.new_page()
+    page4.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    # This tab already stored scene 3's chat id — but the picker renders on the
+    # chips bar regardless once the rejoin probe resolves; wait for the bar.
+    page4.locator('[data-testid="agent-chips-bar"], [data-testid="seat-chip"]').first.wait_for(timeout=30000)
+    if page4.locator('[data-testid="add-agent"]').count() == 0:
+        # Rejoined the warm chat (no chips bar) — end it to get the create flow.
+        page4.locator('[data-testid="chat-close"]').click()
+        page4.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+        page4.locator('[data-testid="add-agent"]').wait_for(timeout=30000)
+    page4.locator('[data-testid="add-agent"]').click()
+    page4.locator('[data-testid="agent-picker-option"]').first.wait_for(timeout=30000)
+    picker = page4.evaluate(
+        """() => [...document.querySelectorAll('[data-testid="agent-picker-option"]')]
+                 .map((o) => ({ key: o.dataset.agentKey, health: o.dataset.health,
+                                title: o.title, text: o.textContent }))""")
+    by_key = {o["key"]: o for o in picker}
+    check("picker_display_names_and_health",
+          [o["key"] for o in picker] == ROSTER_KEYS
+          # Fixture wire truth: claude/agy active, codex inactive, pi carries
+          # NO health (a pre-crew#274 daemon) and must read unknown — never a
+          # fabricated "active".
+          and by_key["claude"]["health"] == "active"
+          and by_key["codex"]["health"] == "inactive"
+          and by_key["pi"]["health"] == "unknown"
+          and by_key["codex"]["title"] == "codex — inactive"
+          and all((o["text"] or "").strip() != "" for o in picker),
+          picker=picker)
+    ctx3.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [str(VSHOTS / "ux-J42-cold-first-send.png"),
+                         str(VSHOTS / "ux-J42-roster-down.png")]
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/ux_sliceAB_test.py
+++ b/e2e/ux_sliceAB_test.py
@@ -9,11 +9,14 @@ open-time failed-with-reason seat, §7.9-4).
 The §7.9 DOM ACs, verbatim mapping:
 
   1. roster-true chips (§7.9-1, re-scoped per §11.2 to roster-first with the
-     cold-cache fallback): a fresh /chat/new mounts with the FALLBACK trio and
-     ZERO chat-surface requests (`data-source="fallback"` — the §2.4 budget
-     holds); the FIRST SEND fetches the roster ON THE GESTURE (exactly one
-     GET /roster) and opens with the ROSTER's seats — the daemon accepts them,
-     no rejected-chip error renders, and ≥1 reply frame lands after flush;
+     cold-cache fallback; round-2 J4 finding 1 tightened it further — the
+     fallback trio is a PLACEHOLDER that never ships, and the roster-down
+     branch is pinned by ux_fixJ42): a fresh /chat/new mounts with the
+     FALLBACK trio and ZERO chat-surface requests (`data-source="fallback"` —
+     the §2.4 budget holds); the FIRST SEND fetches the roster ON THE GESTURE
+     (exactly one GET /roster) and opens with the ROSTER's seats — the daemon
+     accepts them, no rejected-chip error renders, and ≥1 reply frame lands
+     after flush;
   2. a fixture-failed send (chat_send_fail) leaves the composer text INTACT,
      retracts the optimistic bubbles, and renders inline retry (§7.9-2);
      retry after the failure clears resends exactly the failed text;

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -147,8 +147,20 @@ Mutable switches (flipped over POST /__fixture between page loads):
   chat_reject_seats — slice AB (DES-UX-001 §7.9-4): cliKeys POST /chats
                     answers ok:false + a per-seat error (open-time
                     failed-with-reason). Default [].
+                    NOTE (fix J4 round 2): independent of this switch, POST
+                    /chats now mirrors the REAL daemon's roster contract —
+                    any cli NOT in ROSTER is rejected per-seat with the
+                    core's own sentence ("no ACP config for '<key>'",
+                    wicked-core acp_runner chat_ensure). The accept-anything
+                    fixture is what let the fallback-trio-on-the-wire class
+                    pass the rigs while the real daemon rejected every cold
+                    profile's first send.
   chat_send_fail  — slice AB (§7.9-2): POST /chats/<id>/messages answers a
                     500 {error} — the draft-surviving failure. Default False.
+  roster_fail     — fix J4 round 2 (§7.9-1): GET /api/v1/roster answers a
+                    500 {error} — the roster-unreachable branch, where a
+                    pristine first send must FAIL INLINE with nothing on the
+                    wire (the trio never ships). Default False.
   chat_deltas     — slice AB (§7.9-3): sends BUFFER interleaved chatDelta
                     chunks + a chatReply per live seat; POST /__fixture
                     {"chat_flush": true} broadcasts the buffered rounds in
@@ -347,6 +359,10 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #                       open turn 2 BEFORE turn 1's chunks arrive (the
          #                       §7.9-3 splice corpus).
          "chat_reject_seats": [], "chat_send_fail": False, "chat_deltas": False,
+         # Fix J4 round 2 (§7.9-1): GET /roster answers 500 — the
+         # roster-unreachable branch. A pristine first send must fail INLINE
+         # (draft kept, retry) with ZERO wire calls; the trio never ships.
+         "roster_fail": False,
          }
 state_lock = threading.Lock()
 
@@ -1636,7 +1652,13 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"contributors": REPO_CONTRIBUTORS})
             return True
         if path == "/api/v1/roster":
-            self._json(200, {"roster": ROSTER})
+            # Fix J4 round 2: the roster-unreachable branch, switch-gated.
+            with state_lock:
+                roster_down = state["roster_fail"]
+            if roster_down:
+                self._json(500, {"error": "roster unavailable (fixture)"})
+            else:
+                self._json(200, {"roster": ROSTER})
             return True
         # Slice J (§5.2): the decisions corpus — read on the search GESTURE only.
         if path == "/api/v1/governance/claims":
@@ -2336,27 +2358,41 @@ class W2Handler(SimpleHTTPRequestHandler):
                 return self._json(409, {"error": "not awaiting a human gate"})
             return self._json(200, {"status": "resumed"})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
-        # roster when `clis` is omitted, matching the daemon), every seat ok, instantly.
+        # roster when `clis` is omitted, matching the daemon), instantly.
+        # Fix J4 round 2 — the STRICT roster contract, always on: the real
+        # daemon warms a seat via wicked-core's chat_ensure, which answers
+        # "no ACP config for '<key>'" for any cli its roster does not carry
+        # (acp_runner.rs). The old accept-anything behavior is exactly what
+        # let a fallback-trio open pass the rigs while every REAL cold
+        # profile's first send failed — that class can never pass here again.
         if path == "/api/v1/chats":
             clis = body.get("clis") or [s["key"] for s in ROSTER]
             chat_id = body.get("chatId") or "fixture-chat"
+            known = {s["key"] for s in ROSTER}
             # Slice AB (§7.9-4): seats named by `chat_reject_seats` answer the
             # daemon's real per-seat shape — ok:false with an error the chip
             # must wear as failed-with-reason. Only accepted seats warm.
             with state_lock:
                 reject = set(state["chat_reject_seats"])
+
+            def seat(k: str) -> dict:
+                if k not in known:
+                    return {"cliKey": k, "ok": False, "error": f"no ACP config for '{k}'"}
+                if k in reject:
+                    return {"cliKey": k, "ok": False, "error": f"unknown agent '{k}'"}
+                return {"cliKey": k, "ok": True}
+
+            seats = [seat(k) for k in clis]
             with chat_state_lock:
-                chat_warm_seats[chat_id] = [k for k in clis if k not in reject]
-                chat_dead_seats.setdefault(chat_id, set())
-                chat_send_count.setdefault(chat_id, 0)
-            return self._json(201, {
-                "chatId": chat_id,
-                "seats": [
-                    {"cliKey": k, "ok": True} if k not in reject
-                    else {"cliKey": k, "ok": False, "error": f"unknown agent '{k}'"}
-                    for k in clis
-                ],
-            })
+                warmed = [s["cliKey"] for s in seats if s["ok"]]
+                if warmed or chat_id in chat_warm_seats:
+                    chat_warm_seats.setdefault(chat_id, [])
+                    for k in warmed:
+                        if k not in chat_warm_seats[chat_id]:
+                            chat_warm_seats[chat_id].append(k)
+                    chat_dead_seats.setdefault(chat_id, set())
+                    chat_send_count.setdefault(chat_id, 0)
+            return self._json(201, {"chatId": chat_id, "seats": seats})
         # POST /api/v1/chats/<id>/messages — accept the fan-out; replies would
         # stream over /ws, which this fixture leaves to the narration loop —
         # UNLESS the slice-K `chat_replies` switch is on: then each send queues

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -44,8 +44,9 @@ What it asserts (design §4.3 as amended by DES-FEEDBACK-001 §6/§8.3):
   4. Typing is the warm opt-in: in a FRESH tab (own sessionStorage), typing a
      message and pressing Enter is ROSTER-FIRST (slice AB §7.9-1): one GET
      /roster rides the send gesture, then exactly ONE POST /api/v1/chats whose
-     `clis` is the ROSTER (the fallback trio ships only when the roster is
-     unreachable) — then POSTs the message to /chats/<id>/messages; the user
+     `clis` is the ROSTER (round-2 re-scope, J4 finding 1: the fallback trio
+     NEVER ships — an unreachable roster fails the send inline instead, pinned
+     by ux_fixJ42) — then POSTs the message to /chats/<id>/messages; the user
      bubble renders and the chips bar retires (the header's warm seat chips
      are the truth now).
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { modePath, routedVersion, useRoute, type Mode } from './hooks/useRoute.j
 import { useRuns } from './hooks/useRuns.js';
 import { useGateStore } from './store/gates.js';
 import { useElicitationStore } from './store/elicitations.js';
+import { useLiveChatsStore } from './store/liveChats.js';
 import { useNotificationStore } from './store/notifications.js';
 import { useRuntimeStore } from './store/runtime.js';
 import { useRunEventStore } from './store/events.js';
@@ -75,6 +76,7 @@ export function App(): React.ReactElement {
   const ingestRuntime = useRuntimeStore((s) => s.ingest);
   const ingestRunEvent = useRunEventStore((s) => s.ingest);
   const ingestDocThread = useDocThreadStore((s) => s.ingest);
+  const ingestLiveChat = useLiveChatsStore((s) => s.ingest);
 
   // Dashboard gate callbacks — the CenterDashboard handles the API call + store
   // clearing itself; these callbacks exist for any post-confirmation side-effects
@@ -97,12 +99,15 @@ export function App(): React.ReactElement {
       // Relayed interactive frames feed BOTH altitudes off the one subscription (§3.4):
       // the runtime store's board headline above, the doc transcript here.
       ingestDocThread(event);
+      // J4 round 2: chat frames announce/retire live sessions for the rail's
+      // Chat accordion — evidence this subscription already carries, no fetch.
+      ingestLiveChat(event);
       // Slice L (DES-FEEDBACK-002 §8.2): the desktop layer folds off the SAME
       // subscription — hidden-tab-only, opt-in, permission-gated, never prompts.
       notifyGateIfUnfocused(event);
       if (LIFECYCLE_EVENTS.has(event.type)) refresh();
     },
-    [ingestGate, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, refresh],
+    [ingestGate, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, ingestLiveChat, refresh],
   );
 
   useEventStream(handleEvent);

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -174,6 +174,10 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
 
   const active = useMemo(() => chats.filter(v => !terminal(v.session.status)), [chats]);
 
+  /** Live pool sessions visible on this screen — the Active-now headline
+   *  counts them too (round 2, J4 minor / EC39: the number matches the page). */
+  const liveCount = liveChats?.length ?? 0;
+
   // Gates from chats (§4.3 row 3): the gate store filtered to THIS partition —
   // "Did a conversation stall on me?" is asked of every chat, not just the
   // range-filtered slice, so the filter is the partition predicate alone.
@@ -233,14 +237,25 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
             testId="chats-active-tile"
             question="How many threads are warm?"
             title="Active now"
-            value={`${active.length} of ${chats.length}`}
-            data={{ 'data-count': active.length }}
+            // Round 2, J4 minor / EC39: the headline counts what THIS SCREEN
+            // shows — live pool sessions (the band below) plus non-terminal
+            // chat runs in the selected range — and labels each part, so
+            // "0 of 0" can never sit beside a visible live row.
+            value={
+              liveCount > 0
+                ? `${liveCount} live session${liveCount === 1 ? '' : 's'} · ${active.length} chat run${active.length === 1 ? '' : 's'} in ${range}`
+                : `${active.length} of ${chats.length} chat runs in ${range}`
+            }
+            data={{ 'data-count': active.length + liveCount, 'data-live': liveCount }}
           >
             <p
               className="text-lg font-semibold leading-none"
-              style={{ margin: 0, color: active.length > 0 ? 'var(--status-run)' : 'var(--ink-dim)' }}
+              style={{
+                margin: 0,
+                color: active.length + liveCount > 0 ? 'var(--status-run)' : 'var(--ink-dim)',
+              }}
             >
-              {active.length}
+              {active.length + liveCount}
             </p>
           </MetricTile>
           <GatesWaitingTile

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client.js';
 import type { Project, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
 import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
+import { useLiveChatsStore } from '../store/liveChats.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
 import { Markdown } from './Markdown.js';
 import { NewProjectModal } from './NewProjectModal.js';
@@ -458,6 +459,8 @@ export function GroupChat({
         // J4/C6: that boundary is STATED in the thread (`rejoined`), never a
         // silent blank pretending the conversation never happened.
         setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        // A rejoined session is live — make it findable on the rail (J4).
+        useLiveChatsStore.getState().upsert(stored, probe.seats);
         setRejoined(true);
         setResolving(false);
         return;
@@ -584,10 +587,14 @@ export function GroupChat({
    * fetch here any more: the selection IS the answer (§6.1). Reuses the live
    * chat id when there is one: `chat_open` ensures per seat, so warming MORE
    * seats into an existing chat reuses the warm ones and adds only the missing.
-   * Returns the seat keys that came up ready.
+   * Returns the seat keys that came up ready, plus WHY nothing did when nothing
+   * did — the caller renders that as a retryable failed send (§7.9-2).
    */
-  async function armChat(agents: string[]): Promise<string[]> {
+  async function armChat(agents: string[]): Promise<{ ready: string[]; failure: string | null }> {
     setArming(true);
+    // Each arm attempt is a fresh claim: a stale open-failure banner from the
+    // previous attempt must not sit beside this one's outcome (J4 finding 3).
+    setOpenError(null);
     try {
       // The chat id is minted CLIENT-side and set before the open call: seats warm
       // serially (~2-3s each), and their chatSessionReady events arrive BEFORE the
@@ -622,35 +629,60 @@ export function GroupChat({
         const { seats: opened } = await api.openChat(body);
         // A repo switch mid-arm resets `chatIdRef` (the mount effect) — re-check
         // after the await so nothing is attributed to a repo we already left.
-        if (chatIdRef.current !== id) return [];
+        if (chatIdRef.current !== id) return { ready: [], failure: null };
         const st: Record<string, SeatState> = {};
         const errs: Record<string, string> = {};
         for (const s of opened) {
           st[s.cliKey] = s.ok ? 'ready' : 'failed';
           if (!s.ok && s.error) errs[s.cliKey] = s.error;
         }
-        setSeats((prev) => ({ ...prev, ...st }));
-        setSeatErrors((prev) => ({ ...prev, ...errs }));
         const ready = opened.filter((s) => s.ok).map((s) => s.cliKey);
-        // §6.2 recoverable error: a default chip may name an agent the daemon no
-        // longer has (stale cache or a fallback name with no seat behind it).
-        // When NOTHING came up, say WHICH names were rejected — the chips bar is
-        // back on screen (no seat is ready), so the user can remove the stale
-        // chip and send again; the retry re-arms into the same chat id.
+        // J4 finding 3: once an open SUCCEEDS, red chips left over from an
+        // earlier rejected attempt (seats this open did not name again) are
+        // stale evidence — prune them along with their reasons. Seats this
+        // open DID answer keep the daemon's fresh verdict, ok or not.
+        setSeats((prev) => {
+          const next = { ...prev };
+          if (ready.length > 0) {
+            for (const [k, state] of Object.entries(prev)) {
+              if (state === 'failed' && !opened.some((s) => s.cliKey === k)) delete next[k];
+            }
+          }
+          return { ...next, ...st };
+        });
+        setSeatErrors((prev) => {
+          const next = { ...prev };
+          if (ready.length > 0) {
+            for (const k of Object.keys(prev)) {
+              if (!opened.some((s) => s.cliKey === k)) delete next[k];
+            }
+          }
+          return { ...next, ...errs };
+        });
+        // §6.2 recoverable error: a chip may name an agent the daemon no
+        // longer has (a stale cache, or an operator-typed name with no seat
+        // behind it). When NOTHING came up, say WHICH names were rejected —
+        // the chips bar is back on screen (no seat is ready), so the user can
+        // remove the stale chip and send again; the retry re-arms into the
+        // same chat id.
         if (ready.length === 0 && opened.length > 0) {
           const rejected = opened.map((s) => `"${s.cliKey}"`).join(', ');
-          setOpenError(
+          const failure =
             `The daemon rejected agent${opened.length > 1 ? 's' : ''} ${rejected} — ` +
-              `remove the stale chip${opened.length > 1 ? 's' : ''} (✕) and send again.`,
-          );
+            `remove the stale chip${opened.length > 1 ? 's' : ''} (✕) and send again.`;
+          setOpenError(failure);
+          return { ready, failure };
         }
-        return ready;
+        // The session is live — make it findable (J4: the rail's live row).
+        if (ready.length > 0) useLiveChatsStore.getState().upsert(id, ready);
+        return { ready, failure: null };
       } catch (e: unknown) {
         // The id stays stored on purpose: an open that failed at the HTTP layer may still have
         // warmed seats server-side, and dropping the id here would orphan exactly what
         // FINDING-027 exists to stop orphaning. The next mount re-checks it and clears it if dead.
-        if (chatIdRef.current === id) setOpenError(e instanceof Error ? e.message : String(e));
-        return [];
+        const failure = e instanceof Error ? e.message : String(e);
+        if (chatIdRef.current === id) setOpenError(failure);
+        return { ready: [], failure };
       }
     } finally {
       setArming(false);
@@ -675,23 +707,38 @@ export function GroupChat({
     sendingRef.current = true;
     setSendFailed(null);
     try {
-      // §7.9-1 roster-first: a first send from a PRISTINE fallback selection with a
-      // still-cold cache fetches the roster ON THIS GESTURE (never on mount — §2.4
-      // holds) so the send names seats the daemon accepts. The fallback trio goes
-      // to the daemon only when the roster is genuinely unreachable.
-      if (warm.length === 0 && chatIdRef.current === null && !chipsTouchedRef.current
-        && getCachedRoster() === null) {
-        try {
-          const { roster } = await api.getRoster();
-          setCachedRoster(roster);
-          if (roster.length > 0) {
-            const keys = roster.map((s) => s.key);
-            setSelectedAgents(keys);
-            selectedAgentsRef.current = keys;
+      // §7.9-1 (round 2, J4 finding 1): a PRISTINE selection must NEVER reach
+      // the daemon with non-roster seats. While nothing is warm, no chat exists
+      // and the operator has not edited the chips, the audience can only be the
+      // ROSTER's — a cold OR empty cache fetches it ON THIS GESTURE (never on
+      // mount — §2.4 holds). The fallback trio is a placeholder rendering, not
+      // an audience: when the roster is unreachable or empty, the send FAILS
+      // HONESTLY here (draft survives, inline retry) and NOTHING goes on the
+      // wire. An operator-edited selection is their explicit call and ships
+      // as-is — the daemon's per-seat answer is the recovery path for that.
+      if (warm.length === 0 && chatIdRef.current === null && !chipsTouchedRef.current) {
+        let roster = getCachedRoster();
+        if (roster === null || roster.length === 0) {
+          try {
+            const fetched = await api.getRoster();
+            setCachedRoster(fetched.roster);
+            roster = fetched.roster;
+          } catch (e: unknown) {
+            const why = e instanceof Error ? e.message : String(e);
+            setSendFailed({
+              text,
+              reason: `could not load the agent roster (${why}); the default chips are placeholders and are never sent unresolved`,
+            });
+            return;
           }
-        } catch {
-          /* roster unreachable — the trio is the honest audience (§7.9-1) */
         }
+        if (roster.length === 0) {
+          setSendFailed({ text, reason: 'the daemon returned an empty agent roster — there is no seat to warm' });
+          return;
+        }
+        const keys = roster.map((s) => s.key);
+        setSelectedAgents(keys);
+        selectedAgentsRef.current = keys;
       }
       const turn = turnRef.current + 1;
       turnRef.current = turn;
@@ -707,13 +754,15 @@ export function GroupChat({
         // the §6.2 chips (defaults + additions − removals). Also the retry path
         // after a rejected open (stale chip): the re-arm reuses the same chat id
         // with the corrected selection, so recovery is just "send again".
-        warm = await armChat(selectedAgentsRef.current);
-        if (warm.length === 0) {
-          // armChat surfaced WHY (openError / failed chips); the user bubble
-          // retracts and the draft survives — nothing was fanned out.
-          setMessages((prev) => prev.filter((m) => m.turn !== turn));
+        const armed = await armChat(selectedAgentsRef.current);
+        if (armed.ready.length === 0) {
+          // Nothing was fanned out: the optimistic bubble retracts and the
+          // failure renders as a retryable inline row (§7.9-2 — the same
+          // dress a refused fan-out wears), beside armChat's chip guidance.
+          failSend(armed.failure ?? 'no agent seat came up');
           return;
         }
+        warm = armed.ready;
       }
       const id = chatIdRef.current;
       if (id === null) return; // repo switched under the send
@@ -731,6 +780,9 @@ export function GroupChat({
         // Accepted — the draft leaves the composer only now (§7.9-2). A mid-flight
         // edit is the operator's newer draft and is left alone.
         setInput((cur) => (cur.trim() === text ? '' : cur));
+        // A send the daemon accepted retires any lingering open-failure banner
+        // (J4 finding 3): the conversation is live; stale guidance would lie.
+        setOpenError(null);
       } catch (e: unknown) {
         failSend(e instanceof Error ? e.message : String(e));
         // The message never reached the daemon: this turn's audience is not
@@ -785,6 +837,7 @@ export function GroupChat({
     // leave a "live" id pointing at a chat the UI has already walked away from.
     clearStoredChatId(repoId);
     if (chatId !== null) {
+      useLiveChatsStore.getState().remove(chatId);
       try {
         await api.closeChat(chatId);
       } catch {
@@ -1269,6 +1322,16 @@ export function GroupChat({
                   ) : (
                     pickerRoster.map((seat) => {
                       const included = selectedAgents.includes(seat.key);
+                      // J4 round-2 minor: the picker speaks the roster's own
+                      // vocabulary — the seat's DISPLAY NAME (the key stays the
+                      // data identity), plus its observed health when the wire
+                      // carries one (crew#274 — additive; absent reads as no
+                      // claim, never a fabricated "active").
+                      const name =
+                        typeof seat.display_name === 'string' && seat.display_name !== ''
+                          ? seat.display_name
+                          : seat.key;
+                      const health = seat.health?.status;
                       return (
                         <button
                           key={seat.key}
@@ -1278,15 +1341,29 @@ export function GroupChat({
                           disabled={included}
                           data-testid="agent-picker-option"
                           data-agent-key={seat.key}
+                          data-health={health ?? 'unknown'}
+                          title={health ? `${name} — ${health}` : name}
                           onClick={() => {
                             chipsTouchedRef.current = true; // §7.9-1: an edit pins the selection
                             setSelectedAgents((prev) => (prev.includes(seat.key) ? prev : [...prev, seat.key]));
                             setPickerOpen(false);
                           }}
-                          className="w-full text-left px-3 py-1.5 text-xs font-mono truncate transition-colors hover:bg-surface-card disabled:opacity-40"
+                          className="w-full text-left px-3 py-1.5 text-xs font-mono transition-colors hover:bg-surface-card disabled:opacity-40 flex items-center gap-1.5"
                           style={{ color: included ? 'var(--ink-dim)' : 'var(--ink-body)' }}
                         >
-                          {seat.key}
+                          {health !== undefined && (
+                            <span
+                              aria-hidden
+                              className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                              style={{
+                                background: health === 'active' ? 'var(--status-run)' : 'var(--status-fail)',
+                              }}
+                            />
+                          )}
+                          <span className="truncate">{name}</span>
+                          {name !== seat.key && (
+                            <span className="truncate" style={{ color: 'var(--ink-dim)' }}>{seat.key}</span>
+                          )}
                           {included ? ' ✓' : ''}
                         </button>
                       );

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -5,6 +5,7 @@ import { ambientProjectId, launchPath, registerRepoPath } from '../hooks/ambient
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
+import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
@@ -537,6 +538,14 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
 
   // The Make/Chat partition invariant (§3.3): every run under exactly ONE path.
   const chatRuns = orderRuns(runs.filter(isChatRun)).slice(0, CHATS_MAX);
+  // Live pool sessions this client knows about (J4 round 2): deposited by
+  // GroupChat's open/rejoin and by chat frames on the app's /ws fold — never
+  // a fetch (the rail's zero-request budget holds). The Chat accordion must
+  // not claim "no chats" while one of these is live.
+  const liveChatSessions = useLiveChatsStore((s) => s.sessions);
+  const liveChats = Object.values(liveChatSessions)
+    .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+    .slice(0, CHATS_MAX);
   const madeDocs = items
     .flatMap((item) => item.docs.map((doc) => ({ doc, projectId: item.project.id, projectName: item.project.name })))
     .sort((a, b) => (b.doc.updated_at ?? '').localeCompare(a.doc.updated_at ?? ''))
@@ -632,10 +641,39 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             onNew={() => navigate(launchPath(ambient, 'chat'))}
             navigate={navigate}
           >
-            {chatRuns.length === 0
+            {/* Live pool sessions first (J4 round 2): a warm conversation is
+                findable from the rail at its real URL — and the empty label
+                below may only render when there is truly NOTHING to show. */}
+            {liveChats.map((c) => (
+              <button
+                key={c.chatId}
+                type="button"
+                data-testid="rail-live-chat"
+                data-chat-id={c.chatId}
+                onClick={() => navigate(`/chat/${encodeURIComponent(c.chatId)}`)}
+                title={`Open live chat session ${c.chatId}`}
+                className="w-full text-left px-3 py-1.5 rounded-md transition-colors flex items-center gap-2"
+                style={{ background: 'transparent' }}
+                onMouseEnter={e => { e.currentTarget.style.background = S.hover; }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+              >
+                <span
+                  aria-hidden
+                  className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                  style={{ background: 'var(--status-run)' }}
+                />
+                <span className="truncate" style={{ fontSize: 'var(--text-xs)', color: S.ink, fontFamily: 'var(--font-mono)' }}>
+                  {c.seats.length > 0 ? c.seats.join(' · ') : c.chatId.slice(0, 8)}
+                </span>
+                <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: S.faint, fontFamily: 'var(--font-sans)' }}>
+                  live
+                </span>
+              </button>
+            ))}
+            {chatRuns.length === 0 && liveChats.length === 0
               // "Recorded" keeps this row's claim true beside a LIVE session
-              // (J4/C6 one-truth): the rail lists recorded chat runs only —
-              // live seats show on /chats, where this row points.
+              // (J4/C6 one-truth) — and with live rows above, the label never
+              // renders beside a live conversation at all (round 2, J4/3).
               ? <EmptyRow label="No recorded chats yet" href="/chats" navigate={navigate} />
               : chatRuns.map((view) => (
                   <RunRow key={view.session.id} view={view} onOpen={() => navigate(runPath(view.session.id))} />

--- a/src/store/liveChats.ts
+++ b/src/store/liveChats.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand';
+import type { CoreEvent } from '../api/types.js';
+
+/**
+ * Live chat sessions THIS CLIENT knows about (BRIEF-UX-001 round 2, J4):
+ * the sidebar's Chat accordion must never claim "no chats" beside a live
+ * conversation — but the rail's zero-request budget forbids it a GET /chats
+ * on mount. So the sessions the app already learned about for free are
+ * event-sourced here:
+ *
+ *   - GroupChat deposits the session it MINTS or REJOINS (it made those
+ *     wire calls anyway) and retracts on End;
+ *   - the app-level /ws fold deposits sessions announced by their own
+ *     frames (chatSessionReady / chatDelta / chatReply) and retracts on
+ *     chatClosed — the same evidence ChatsPage folds into its live band.
+ *
+ * This is deliberately NOT a mirror of the daemon's pool (that is GET
+ * /chats, read by /chats on navigation): a session another tab opened
+ * before this page loaded stays invisible here until a frame arrives.
+ * The rail therefore renders this store as "live now" evidence, never as
+ * the complete census — /chats remains the census surface.
+ */
+export interface LiveChatSession {
+  chatId: string;
+  /** Seats observed for this session, first-seen order. */
+  seats: string[];
+  /** When this client last saw evidence of the session (ms epoch). */
+  lastSeenAt: number;
+}
+
+interface LiveChatsState {
+  sessions: Record<string, LiveChatSession>;
+  /** Authoritative deposit — a session this client opened or rejoined. */
+  upsert: (chatId: string, seats: string[]) => void;
+  /** The session was ended (Close / End) or the daemon said chatClosed. */
+  remove: (chatId: string) => void;
+  /** Fold one /ws frame — chat frames announce and retire sessions. */
+  ingest: (event: CoreEvent) => void;
+}
+
+const CHAT_FRAME_TYPES = new Set(['chatSessionReady', 'chatDelta', 'chatReply']);
+
+export const useLiveChatsStore = create<LiveChatsState>((set) => ({
+  sessions: {},
+  upsert: (chatId, seats) =>
+    set((s) => {
+      const prev = s.sessions[chatId];
+      const merged = prev ? [...prev.seats] : [];
+      for (const k of seats) if (!merged.includes(k)) merged.push(k);
+      return {
+        sessions: {
+          ...s.sessions,
+          [chatId]: { chatId, seats: merged, lastSeenAt: Date.now() },
+        },
+      };
+    }),
+  remove: (chatId) =>
+    set((s) => {
+      if (!(chatId in s.sessions)) return s;
+      const next = { ...s.sessions };
+      delete next[chatId];
+      return { sessions: next };
+    }),
+  ingest: (event) =>
+    set((s) => {
+      const frame = event as { type: string; chat?: string; cliKey?: string };
+      if (typeof frame.chat !== 'string' || frame.chat === '') return s;
+      if (frame.type === 'chatClosed') {
+        if (!(frame.chat in s.sessions)) return s;
+        const next = { ...s.sessions };
+        delete next[frame.chat];
+        return { sessions: next };
+      }
+      if (!CHAT_FRAME_TYPES.has(frame.type)) return s;
+      const prev = s.sessions[frame.chat];
+      const seats = prev ? [...prev.seats] : [];
+      if (frame.cliKey && !seats.includes(frame.cliKey)) seats.push(frame.cliKey);
+      return {
+        sessions: {
+          ...s.sessions,
+          [frame.chat]: { chatId: frame.chat, seats, lastSeenAt: Date.now() },
+        },
+      };
+    }),
+}));

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -154,12 +154,17 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     ]);
   });
 
-  it('a stale default the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
+  it('a stale EDITED chip the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
+    // Round-2 re-scope (BRIEF-UX-001 J4 finding 1): this test previously drove
+    // the recovery path through the PRISTINE fallback trio reaching the daemon
+    // (roster unreachable) — a wire call the round-2 mandate forbids outright.
+    // The §6.2 recovery contract it pinned is unchanged and still pinned here,
+    // now driven through what can still legitimately carry a stale name to the
+    // daemon: an OPERATOR-EDITED selection (an edit pins the selection — the
+    // operator's explicit call ships as-is; the daemon's per-seat answer is
+    // the recovery path).
     const user = userEvent.setup();
-    // Slice AB (§7.9-1): the stale-trio-reaches-the-daemon case now REQUIRES
-    // an unreachable roster — a reachable one would have re-seeded the send.
-    getRoster.mockRejectedValue(new Error('daemon unreachable'));
-    // First open: every requested seat is rejected (stale fallback names).
+    // First open: every requested seat is rejected (stale names).
     openChat.mockImplementationOnce((body: { chatId: string; clis?: string[] }) =>
       Promise.resolve({
         chatId: body.chatId,
@@ -168,20 +173,25 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     );
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
+    // The edit PINS the selection (§7.9-1) — no roster re-seed rides the send.
+    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
     await user.type(screen.getByRole('textbox'), 'hello?');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(getRoster).not.toHaveBeenCalled(); // touched selection: the operator's call
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner']);
 
-    // The error NAMES the rejected agents (§6.2) …
+    // The error NAMES the rejected agents (§6.2) — on the banner AND the
+    // retryable failed-send row (§7.9-2 carries the same reason).
     await waitFor(() =>
-      expect(screen.getByText(/rejected agents "writer", "reviewer", "planner"/)).toBeInTheDocument(),
+      expect(screen.getAllByText(/rejected agents "reviewer", "planner"/).length).toBeGreaterThan(0),
     );
-    // … and the message did NOT go out.
+    // … the message did NOT go out, and the failure is a retryable row (§7.9-2).
     expect(sendChatMessage).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-send-failed')).toBeInTheDocument();
     // Recoverable: the chips bar is back (nothing warmed), removals still work.
     const bar = await screen.findByTestId('agent-chips-bar');
-    expect(bar).toHaveAttribute('data-count', '3');
-    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
+    expect(bar).toHaveAttribute('data-count', '2');
     await user.click(screen.getByRole('button', { name: 'Remove reviewer' }));
 
     // §7.9-2: the failed send's DRAFT survived in the composer — clear it for
@@ -196,5 +206,9 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     expect(second.chatId, 'recovery must not mint a second chat (FINDING-027)').toBe(first.chatId);
     expect(second.clis).toEqual(['planner']);
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(second.chatId, 'try again'));
+    // J4 finding 3: the successful send retires the stale open-failure banner
+    // and the previously-rejected seats' red chips (they are not in this open).
+    await waitFor(() => expect(screen.queryByText(/rejected agents/)).toBeNull());
+    expect(document.querySelector('[data-testid="seat-chip"][data-agent="reviewer"]')).toBeNull();
   });
 });

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -154,6 +154,35 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     ]);
   });
 
+  it('the picker speaks the roster: display names and observed health ride each option (J4 round 2, minor)', async () => {
+    const user = userEvent.setup();
+    getRoster.mockResolvedValueOnce({
+      roster: [
+        { key: 'claude', display_name: 'Claude Code', enabled_for_council: true,
+          health: { status: 'active', since: '2026-08-01T00:00:00Z' } },
+        { key: 'codex', display_name: 'Codex', enabled_for_council: true,
+          health: { status: 'inactive', message: 'quota exceeded', since: '2026-08-01T00:00:00Z' } },
+        // A daemon predating crew#274: no health claim — never fabricated.
+        { key: 'pi', display_name: 'pi', enabled_for_council: true },
+      ] as unknown as RosterSeat[],
+    });
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await user.click(screen.getByTestId('add-agent'));
+
+    const options = await screen.findAllByTestId('agent-picker-option');
+    const byKey = Object.fromEntries(options.map((o) => [o.dataset['agentKey'], o]));
+    expect(byKey['claude']).toHaveTextContent('Claude Code');
+    expect(byKey['claude']!.dataset['health']).toBe('active');
+    expect(byKey['codex']!.dataset['health']).toBe('inactive');
+    expect(byKey['codex']!.title).toBe('Codex — inactive');
+    // No health on the wire → no claim in the DOM.
+    expect(byKey['pi']!.dataset['health']).toBe('unknown');
+    expect(byKey['pi']!.querySelector('span[aria-hidden]')).toBeNull();
+    // The KEY stays the data identity the send uses.
+    await user.click(byKey['claude']!);
+    expect(chipKeys()).toContain('claude');
+  });
+
   it('a stale EDITED chip the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
     // Round-2 re-scope (BRIEF-UX-001 J4 finding 1): this test previously drove
     // the recovery path through the PRISTINE fallback trio reaching the daemon

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -121,18 +121,38 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + 
     await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
   });
 
-  it('the fallback trio reaches the daemon ONLY when the roster is unreachable (§7.9-1)', async () => {
+  it('the fallback trio NEVER reaches the daemon: an unreachable roster fails the send inline, and Retry recovers (§7.9-1 round 2)', async () => {
+    // Round-2 re-scope (BRIEF-UX-001 J4 finding 1): this test previously
+    // pinned "the trio is the honest audience when the roster is unreachable"
+    // — the exact branch the cold-profile review caught rejecting every new
+    // user's first send. The trio is a PLACEHOLDER rendering now: a pristine
+    // selection either resolves to the roster or the send fails honestly
+    // (draft kept, inline retry) with NOTHING on the wire.
     const user = userEvent.setup();
-    getRoster.mockRejectedValue(new Error('daemon unreachable'));
+    getRoster.mockRejectedValueOnce(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     await user.type(screen.getByRole('textbox'), 'make me a deck');
     await user.keyboard('{Enter}');
 
-    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const failure = await screen.findByTestId('chat-send-failed');
+    expect(failure).toHaveTextContent(/could not load the agent roster/);
     expect(getRoster).toHaveBeenCalledTimes(1);
-    // Cold cache AND unreachable roster: the trio is the honest audience.
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(FALLBACK);
+    // NOTHING reached the wire — no open, no fan-out, no phantom turn.
+    expect(openChat).not.toHaveBeenCalled();
+    expect(sendChatMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox')).toHaveValue('make me a deck');
+    expect(screen.queryByTestId('user-bubble')).toBeNull();
+
+    // The roster recovers → Retry sends to the ROSTER's seats, exactly once.
+    await user.click(screen.getByTestId('chat-send-retry'));
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(ROSTER.map((s) => s.key));
+    const chatId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(chatId, 'make me a deck'));
+    // No duplicate: the retried message renders exactly once.
+    await waitFor(() => expect(screen.getAllByTestId('user-bubble')).toHaveLength(1));
+    expect(screen.queryByTestId('chat-send-failed')).toBeNull();
   });
 
   it('[+ Add] opens the roster picker (fetch rides the user action) and the addition joins the send', async () => {

--- a/tests/liveChats.rail.test.tsx
+++ b/tests/liveChats.rail.test.tsx
@@ -14,8 +14,9 @@ import { act, cleanup, render, screen, fireEvent } from '@testing-library/react'
  *     sessions + non-terminal chat runs) and labels each part (EC39).
  */
 
+interface ChatRow { chatId: string; seats: string[]; idleSecs: number | null }
 const listRepos = vi.fn(() => Promise.resolve({ repos: [] }));
-const listChats = vi.fn(() => Promise.resolve({ chats: [] }));
+const listChats = vi.fn((): Promise<{ chats: ChatRow[] }> => Promise.resolve({ chats: [] }));
 
 vi.mock('../src/hooks/useBoardModel.js', () => ({
   useBoardModel: () => ({ items: [], unfiled: [], loading: false, error: null }),

--- a/tests/liveChats.rail.test.tsx
+++ b/tests/liveChats.rail.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, cleanup, render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * BRIEF-UX-001 round 2 (J4, findings 3+4a) — live sessions are visible where
+ * the user looks, without a single new fetch:
+ *
+ *   - the live-chats store event-sources sessions from deposits (GroupChat's
+ *     open/rejoin) and from chat frames on the app's one /ws fold, and retires
+ *     them on chatClosed / End;
+ *   - the rail's Chat accordion lists live sessions as real /chat/:id doors,
+ *     and its empty label NEVER renders beside a live conversation;
+ *   - /chats' "Active now" headline counts what the screen shows (live pool
+ *     sessions + non-terminal chat runs) and labels each part (EC39).
+ */
+
+const listRepos = vi.fn(() => Promise.resolve({ repos: [] }));
+const listChats = vi.fn(() => Promise.resolve({ chats: [] }));
+
+vi.mock('../src/hooks/useBoardModel.js', () => ({
+  useBoardModel: () => ({ items: [], unfiled: [], loading: false, error: null }),
+}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ status: 'ok', version: '0.2.0', ping: 'pong' }),
+    listRepos: () => listRepos(),
+    listChats: () => listChats(),
+    closeChat: () => Promise.resolve({ ok: true }),
+  },
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+const { ChatsPage } = await import('../src/components/ChatsPage.js');
+const { useLiveChatsStore } = await import('../src/store/liveChats.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+beforeEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  listRepos.mockClear();
+  listChats.mockClear();
+  clearRepoCache();
+  useLiveChatsStore.setState({ sessions: {} });
+});
+
+describe('the live-chats store (event-sourced, zero fetches)', () => {
+  it('deposits, frame announcements, and chatClosed retirement', () => {
+    const s = useLiveChatsStore.getState();
+    s.upsert('c1', ['claude', 'codex']);
+    s.ingest({ type: 'chatDelta', chat: 'c2', cliKey: 'agy', text: 'hi' } as never);
+    expect(Object.keys(useLiveChatsStore.getState().sessions).sort()).toEqual(['c1', 'c2']);
+    expect(useLiveChatsStore.getState().sessions['c2']!.seats).toEqual(['agy']);
+
+    // A later deposit MERGES seats, never duplicates.
+    useLiveChatsStore.getState().upsert('c1', ['codex', 'pi']);
+    expect(useLiveChatsStore.getState().sessions['c1']!.seats).toEqual(['claude', 'codex', 'pi']);
+
+    useLiveChatsStore.getState().ingest({ type: 'chatClosed', chat: 'c1' } as never);
+    expect(Object.keys(useLiveChatsStore.getState().sessions)).toEqual(['c2']);
+
+    // Non-chat frames and chat-less frames are ignored.
+    useLiveChatsStore.getState().ingest({ type: 'unitOutputDelta', session: 'r1' } as never);
+    useLiveChatsStore.getState().ingest({ type: 'chatReply', chat: '' } as never);
+    expect(Object.keys(useLiveChatsStore.getState().sessions)).toEqual(['c2']);
+  });
+});
+
+describe('the rail beside a live conversation (J4 finding 3)', () => {
+  it('lists the live session as a /chat/:id door and never claims "no chats"', () => {
+    useLiveChatsStore.getState().upsert('live-1', ['claude', 'agy']);
+    const navigate = vi.fn();
+    render(<LeftSidebar runs={[]} navigate={navigate} pathname="/chat/live-1" />);
+
+    const row = screen.getByTestId('rail-live-chat');
+    expect(row).toHaveAttribute('data-chat-id', 'live-1');
+    expect(row).toHaveTextContent('claude · agy');
+    expect(screen.queryByText('No recorded chats yet')).toBeNull();
+
+    fireEvent.click(row);
+    expect(navigate).toHaveBeenCalledWith('/chat/live-1');
+  });
+
+  it('with nothing live and nothing recorded, the empty label stays', () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/chats" />);
+    expect(screen.queryByTestId('rail-live-chat')).toBeNull();
+    expect(screen.getByText('No recorded chats yet')).toBeInTheDocument();
+  });
+
+  it('a chatClosed frame (or End) retires the row live', () => {
+    useLiveChatsStore.getState().upsert('live-2', ['codex']);
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/chat/live-2" />);
+    expect(screen.getByTestId('rail-live-chat')).toBeInTheDocument();
+    act(() => {
+      useLiveChatsStore.getState().ingest({ type: 'chatClosed', chat: 'live-2' } as never);
+    });
+    expect(screen.queryByTestId('rail-live-chat')).toBeNull();
+  });
+});
+
+describe('/chats "Active now" counts what the screen shows (J4 finding 4a, EC39)', () => {
+  it('a live pool session is IN the headline — never "0 of 0" beside a live row', async () => {
+    listChats.mockResolvedValueOnce({
+      chats: [{ chatId: 'live-9', seats: ['claude'], idleSecs: 4 }],
+    });
+    render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
+
+    // The live band lists the session the daemon holds…
+    await screen.findByTestId('live-chat-row');
+    // …and the headline counts it, labeled by part and window.
+    const tile = screen.getByTestId('chats-active-tile');
+    expect(tile).toHaveAttribute('data-count', '1');
+    expect(tile).toHaveAttribute('data-live', '1');
+    expect(tile).toHaveTextContent('1 live session · 0 chat runs in 30d');
+  });
+
+  it('with no live sessions the range-scoped count is labeled with its window', async () => {
+    render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
+    await screen.findByTestId('chats-active-tile');
+    expect(screen.getByTestId('chats-active-tile')).toHaveTextContent('0 of 0 chat runs in 30d');
+  });
+});


### PR DESCRIPTION
Round-3 fix for BRIEF-UX-001's J4 (chat first send + findability), driven by the round-2 cold review on the real daemon.

- **Cold-start CRITICAL**: a pristine selection can no longer reach the daemon with non-roster seats — the roster resolves on the first send gesture and the send fans to real seats; the placeholder trio never hits the wire. The shared fixture's `POST /chats` now mirrors the real daemon (rejects unknown clis with the real error shape) so this class can't pass a rig again.
- **Draft survival**: an open-failure restores the draft to the composer, styles the dead message as failed with a working retry, and never duplicates on retry; a stale failure banner clears once a send succeeds.
- **New-chat URL flip**: the session URL lands as soon as the daemon answers with the chatId (reopen-from-/chats already worked from #106); the sidebar reflects the live conversation.
- /chats "ACTIVE NOW" headline reconciled with the rows it sits above; roster entries in +Add carry display names/health.

Verified: cold-profile rig scene (fresh context, zero storage — first send succeeds against the now-strict fixture); live-daemon drive (fresh browser context, first send success, URL flip, reopen); regressions ux_sliceAB (re-scoped trio-tolerant scenes as dedicated commits), ux_fixJ4J5, feedback_sliceC, studio_standalone; 1444/1444 unit tests; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
