### PR TITLE
Round-3 fix: continue-send honesty — no fork-per-send, live first-generation, reload-surviving send state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ e2e/shots/
 # Scratch the run harness and the e2e gate write inside the checkout, never source.
 tmp/
 __pycache__/
+dist-realhost/

--- a/e2e/ux_fixJ33_test.py
+++ b/e2e/ux_fixJ33_test.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+ux_fixJ33_test.py — the round-3 J3 blocker gate (round-2 cold-review findings
+1-4), driven against the shared W2 fixture extended with the REAL bridge's
+generation shape (doc_v0: create seeds a v0 "Building…" placeholder, the first
+draft lands LATER as v1) and the UNBOUND-doc frame reality (doc_unbound: doc
+frames carry NO project_id — exactly what an Unfiled doc's frames look like,
+whose silent dropping was round 2's dead-canvas repro on the live stack).
+
+The four ACs, verbatim mapping to the round-2 findings:
+
+  1. NO FABRICATED VERSIONS: a plain terminal-state send fires NO POST /api/fork
+     (pre-fix: every send minted a byte-identical version before any work). The
+     revised version arrives from the ANSWERER, tags the send via the wire's own
+     version.created, no continuation divider ever renders, and the manifest
+     grows by exactly one version per ask.
+  2. LIVE FIRST GENERATION: with the page OPEN on the v0 placeholder, the
+     answerer landing v1 swaps the canvas to v1 WITHOUT a reload — the frames
+     of an Unfiled (project-unbound) doc reach the canvas.
+  3. EXPORT ANSWERS SOMEWHERE, ALWAYS (drawer CLOSED): an export whose pending
+     answer is re-addressed by a mid-flight landing (the head advances, the
+     strip follows) stays visible at the click site, labeled with ITS version;
+     the strip stays clickable while it is still visibly fading (pointer-events
+     retire only after the fade), and a press on the hidden sensor band summons
+     the strip instead of dying silently.
+  4. SEND-STATE SURVIVES RELOAD: a send that was PENDING at reload comes back
+     pending with its ORIGINAL clock (an already-stalled send re-renders the
+     honest timeout + a WORKING retry, not a plain accepted message); a REFUSED
+     send — which the announce history has no line for — comes back wearing its
+     failure and a WORKING retry. Export entries survive in the transcript.
+
+Captures (§12.0 contract: 1440x900, dsf 1) into e2e/shots/vision/:
+  ux-fixJ33-live-first-gen.png    the canvas at v1 with no reload, marker landed
+  ux-fixJ33-stalled-after-reload.png  the restored stalled send + retry
+  ux-fixJ33-export-relabel.png    the v-labeled READY answer after re-addressing
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4403), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4403"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+# The Unfiled mount — the round-2 repro ran here: unbound docs, unstamped frames.
+PID = "default"
+DOC = "fixj33-live"
+KEY = f"{PID}:{DOC}"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def fixture_get(path: str):
+    with urllib.request.urlopen(f"{ORIGIN}{path}", timeout=10) as res:
+        return json.loads(res.read())
+
+
+def post_chat(text: str) -> None:
+    """An ask landing from OUTSIDE this page (another client) — the churn source."""
+    req = urllib.request.Request(
+        f"{ORIGIN}/api/v1/projects/{PID}/interactive/api/events", method="POST",
+        data=json.dumps({"event_type": "wicked.interactive.chat.posted",
+                         "payload": {"role": "user", "text": text, "document_id": DOC}}).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        res.read()
+
+
+# ── The same-origin build + the shared W2 fixture, in the honest bridge shape ──
+dist = ensure_build(lambda step, why: check(step, False, error=why))
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, doc_v0=True, doc_unbound=True, doc_run_ms=2500)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    fork_posts: list[str] = []
+    page.on("request", lambda r: fork_posts.append(r.url)
+            if r.method == "POST" and r.url.endswith("/api/fork") else None)
+
+    # ── Scene A (AC 2 + AC 1): create → v0 placeholder → v1 lands LIVE ──────────
+    page.goto(f"{ORIGIN}/p/{PID}/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-composer"]').fill(f'make a "{DOC}" deck for the launch review')
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-canvas"][data-version="0"]').wait_for(timeout=30000)
+    create_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"]')?.getAttribute('data-message-id')""")
+    # The v0 the canvas frames IS the placeholder — the real create shape.
+    v0_html = urllib.request.urlopen(
+        f"{ORIGIN}/api/v1/projects/{PID}/interactive/d/{DOC}/doc/0", timeout=10).read().decode()
+    check("A1_create_frames_the_v0_placeholder",
+          "Building" in v0_html and bool(create_id)
+          and page.locator('[data-testid="thread-generating"]').count() == 1,
+          message_id=create_id)
+
+    # The answerer lands v1 (2.5s): the OPEN page must swap — no reload anywhere.
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=20000)
+    page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+    landed = page.evaluate(
+        """(createId) => ({
+             markerV1CausedByCreate: document.querySelector(
+               `[data-testid="version-marker"][data-version="1"]`)?.getAttribute('data-caused-by') === createId,
+             generatingChipGone: !document.querySelector('[data-testid="thread-generating"]'),
+             composerState: document.querySelector('[data-testid="thread"]')?.getAttribute('data-composer-state'),
+           })""", create_id)
+    check("A2_first_generation_swaps_the_open_canvas_live",
+          landed["markerV1CausedByCreate"] and landed["generatingChipGone"]
+          and landed["composerState"] == "terminal" and fork_posts == [],
+          forks_fired=len(fork_posts), **landed)
+    page.screenshot(path=str(VSHOTS / "ux-fixJ33-live-first-gen.png"))
+
+    # ── Scene B (AC 1): a plain continue-send never forks ───────────────────────
+    versions_before = fixture_get(f"/api/v1/projects/{PID}/interactive/d/{DOC}/api/versions")
+    page.locator('[data-testid="doc-composer"]').fill("tighten the headline")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
+    b_id = page.evaluate(
+        """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                   return m[m.length - 1]?.getAttribute('data-message-id'); }""")
+    # The wire's own v2 answers the ask — and tags it; nothing was minted client-side.
+    page.locator(f'[data-testid="version-marker"][data-caused-by="{b_id}"]').wait_for(timeout=20000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=20000)
+    versions_after = fixture_get(f"/api/v1/projects/{PID}/interactive/d/{DOC}/api/versions")
+    plain = page.evaluate(
+        """(bId) => ({
+             markerVersion: document.querySelector(
+               `[data-testid="version-marker"][data-caused-by="${bId}"]`)?.getAttribute('data-version'),
+             divider: !!document.querySelector('[data-testid="version-divider"]'),
+           })""", b_id)
+    check("B_plain_send_no_fork_no_divider_one_new_version",
+          fork_posts == [] and plain["markerVersion"] == "2" and not plain["divider"]
+          and len(versions_after["versions"]) == len(versions_before["versions"]) + 1,
+          forks_fired=len(fork_posts),
+          versions_before=len(versions_before["versions"]),
+          versions_after=len(versions_after["versions"]), **plain)
+
+    # ── Scene C (AC 4): send-state survives the reload ──────────────────────────
+    # C1: a send the bridge ACKS and never answers (the silent no-answerer).
+    set_fixture(ORIGIN, doc_silent=True)
+    page.locator('[data-testid="doc-composer"]').fill("add a roadmap slide")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
+    # The reload happens AFTER the honesty budget would have expired: rewind the
+    # persisted clock instead of sleeping 90s — the assertion is that hydrate
+    # RESUMES the original clock (already stalled ⇒ visibly stalled), never re-arms.
+    rewound = page.evaluate(
+        """(key) => {
+             const k = `wk-thread-sends:${key}`;
+             const raw = sessionStorage.getItem(k);
+             if (!raw) return null;
+             const sends = JSON.parse(raw).map((s) => ({ ...s, sentAt: s.sentAt - 95000 }));
+             sessionStorage.setItem(k, JSON.stringify(sends));
+             return sends;
+           }""", KEY)
+    check("C1_pending_send_persisted", bool(rewound) and rewound[0]["state"] == "pending",
+          persisted=rewound)
+
+    page.reload(wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    # The restored send is STALLED, visibly — honest copy + a retry — never a
+    # plain accepted message, and never a fresh "being worked now" claim.
+    page.locator('[data-testid="thread-generating-timeout"]').wait_for(timeout=15000)
+    stalled = page.evaluate(
+        """() => ({
+             retry: !!document.querySelector('[data-testid="thread-generating-retry"]'),
+             freshGenerating: !!document.querySelector('[data-testid="thread-generating"]'),
+             steeringStalled: !!document.querySelector('[data-testid="steering-stalled"]'),
+             textBack: Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
+               .some((m) => (m.textContent || '').includes('add a roadmap slide')),
+           })""")
+    check("C2_stalled_send_restored_stalled_with_retry",
+          stalled["retry"] and not stalled["freshGenerating"]
+          and stalled["steeringStalled"] and stalled["textBack"], **stalled)
+    page.screenshot(path=str(VSHOTS / "ux-fixJ33-stalled-after-reload.png"))
+
+    # The restored retry WORKS: with the bridge answering again, the same send
+    # lands its version and the timeout retires into the real anchor.
+    set_fixture(ORIGIN, doc_silent=False, doc_run_ms=1500)
+    page.locator('[data-testid="thread-generating-retry"]').click()
+    page.locator('[data-testid="version-marker"][data-version="3"]').wait_for(timeout=20000)
+    revived = page.evaluate(
+        """() => ({
+             timedOut: !!document.querySelector('[data-testid="thread-generating-timeout"]'),
+             markerOnRoadmap: (() => {
+               const mk = document.querySelector('[data-testid="version-marker"][data-version="3"]');
+               const cause = mk?.getAttribute('data-caused-by');
+               const msg = document.querySelector(`[data-testid="doc-message"][data-message-id="${cause}"]`);
+               return !!msg && (msg.textContent || '').includes('add a roadmap slide');
+             })(),
+           })""")
+    check("C3_restored_retry_is_live_and_anchors",
+          not revived["timedOut"] and revived["markerOnRoadmap"], **revived)
+
+    # C4: a REFUSED send (the bridge never accepted it — no wire line exists).
+    set_fixture(ORIGIN, send_fail=True)
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
+    page.locator('[data-testid="doc-composer"]').fill("add a pricing slide")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-send-failed"]').wait_for(timeout=15000)
+    set_fixture(ORIGIN, send_fail=False)
+
+    page.reload(wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread-send-failed"]').wait_for(timeout=15000)
+    refused = page.evaluate(
+        """() => {
+             const msgs = Array.from(document.querySelectorAll('[data-testid="doc-message"]'));
+             const pricing = msgs.find((m) => (m.textContent || '').includes('add a pricing slide'));
+             return {
+               refusedTextBack: !!pricing,
+               retry: !!document.querySelector('[data-testid="thread-send-retry"]'),
+             };
+           }""")
+    check("C5_refused_send_restored_failed_with_retry",
+          refused["refusedTextBack"] and refused["retry"], **refused)
+    # …and ITS retry works too: the re-armed send is accepted and lands v4.
+    page.locator('[data-testid="thread-send-retry"]').click()
+    page.locator('[data-testid="version-marker"][data-version="4"]').wait_for(timeout=20000)
+    check("C6_refused_retry_lands", True)
+
+    # ── Scene D (AC 3): the export answers with the drawer CLOSED, through churn ─
+    set_fixture(ORIGIN, export_delay_ms=4000, doc_run_ms=1500)
+    page.goto(f"{ORIGIN}/p/{PID}/document/{DOC}", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"][data-version="4"]').wait_for(timeout=30000)
+    check("D1_drawer_closed_by_default",
+          page.locator('[data-testid="thread-drawer"]').count() == 0)
+
+    wake_strip(page)
+    page.locator('[data-testid="export-format"][data-format="html"]').click()  # exports v4
+    post_chat("one more tweak from another client")  # lands v5 in 1.5s — the churn
+    # Mid-flight, PAST the landing: the strip has re-addressed to v5, and the
+    # pending answer is STILL VISIBLE at the click site (pre-fix: wiped here).
+    page.locator('[data-testid="export-menu"][data-version="5"]').wait_for(timeout=15000)
+    mid = page.evaluate(
+        """() => ({
+             pending: !!document.querySelector('[data-testid="export-pending"]'),
+             ready: !!document.querySelector('[data-testid="export-ready"]'),
+             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
+           })""")
+    check("D2_pending_answer_survives_the_readdressing",
+          (mid["pending"] or mid["ready"]) and mid["stripHidden"] == "false", **mid)
+
+    # The READY answer lands labeled with ITS version (v4) under the v5 label row.
+    ready = page.locator('[data-testid="export-ready"][data-version="4"]')
+    ready.wait_for(timeout=15000)
+    page.wait_for_timeout(3600)  # a full idle budget with the mouse parked: still up
+    answered = page.evaluate(
+        """() => ({
+             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
+             label: document.querySelector('[data-testid="export-ready"]')?.textContent ?? '',
+             href: document.querySelector('[data-testid="export-ready"]')?.getAttribute('href'),
+             menuVersion: document.querySelector('[data-testid="export-menu"]')?.getAttribute('data-version'),
+           })""")
+    check("D3_ready_answer_visible_v_labeled_strip_held",
+          answered["stripHidden"] == "false" and "v4" in answered["label"]
+          and bool(answered["href"]) and answered["menuVersion"] == "5",
+          **answered)
+    page.screenshot(path=str(VSHOTS / "ux-fixJ33-export-relabel.png"))
+
+    # The affordance is REAL (attachment bytes), and ACTING on it retires it.
+    dl = page.request.get(answered["href"] if str(answered["href"]).startswith("http")
+                          else f"{ORIGIN}{answered['href']}")
+    check("D4_ready_href_serves_bytes",
+          dl.status == 200 and "attachment" in (dl.headers.get("content-disposition") or "")
+          and len(dl.body()) > 0,
+          status=dl.status)
+    ready.click()
+    page.locator('[data-testid="export-ready"]').wait_for(state="detached", timeout=10000)
+
+    # D5: the fading strip keeps its hit targets until the fade FINISHES, and a
+    # press on the hidden sensor band summons the strip instead of dying.
+    page.mouse.move(700, 300)  # park away from the strip; let the idle budget run
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden') === 'true'""",
+        timeout=10000)
+    grace = page.evaluate(
+        """() => getComputedStyle(document.querySelector('[data-testid="version-strip"]')).pointerEvents""")
+    page.wait_for_timeout(600)  # past STRIP_FADE_GRACE_MS
+    after_grace = page.evaluate(
+        """() => ({
+             pe: getComputedStyle(document.querySelector('[data-testid="version-strip"]')).pointerEvents,
+             sensor: !!document.querySelector('[data-testid="strip-sensor"]'),
+           })""")
+    page.evaluate(
+        """() => {
+             const sensor = document.querySelector('[data-testid="strip-sensor"]');
+             sensor.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+           }""")
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden') === 'false'""",
+        timeout=5000)
+    check("D5_fade_grace_and_sensor_press_summons_the_strip",
+          grace == "auto" and after_grace["pe"] == "none" and after_grace["sensor"],
+          pointer_events_during_fade=grace, **after_grace)
+
+    # ── Scene E (minor): the export entry survives in the transcript ────────────
+    set_fixture(ORIGIN, export_delay_ms=0, doc_run_ms=0)
+    page.reload(wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="doc-artifact-download"]').wait_for(timeout=15000)
+    entry = page.evaluate(
+        """() => ({
+             href: document.querySelector('[data-testid="doc-artifact-download"]')?.getAttribute('href'),
+             text: document.querySelector('[data-testid="doc-artifact-download"]')?.closest('[data-testid="doc-agent"]')?.textContent ?? '',
+           })""")
+    check("E_export_entry_restored_in_the_transcript",
+          bool(entry["href"]) and "export ready" in entry["text"], **entry)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["shots"] = ["ux-fixJ33-live-first-gen.png", "ux-fixJ33-stalled-after-reload.png",
+                   "ux-fixJ33-export-relabel.png"]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_fixJ33_test.py
+++ b/e2e/ux_fixJ33_test.py
@@ -177,15 +177,27 @@ with sync_playwright() as p:
     # RESUMES the original clock (already stalled ⇒ visibly stalled), never re-arms.
     rewound = page.evaluate(
         """(key) => {
-             const k = `wk-thread-sends:${key}`;
-             const raw = sessionStorage.getItem(k);
-             if (!raw) return null;
-             const sends = JSON.parse(raw).map((s) => ({ ...s, sentAt: s.sentAt - 95000 }));
-             sessionStorage.setItem(k, JSON.stringify(sends));
-             return sends;
+             const raw = sessionStorage.getItem(`wk-thread-sends:${key}`);
+             return raw === null ? null : JSON.parse(raw);
            }""", KEY)
     check("C1_pending_send_persisted", bool(rewound) and rewound[0]["state"] == "pending",
           persisted=rewound)
+    # The rewind itself rides an init script so it executes on the NEXT document
+    # BEFORE any app code — a live-tab rewrite here can lose a race with the
+    # store's own persist (any late frame re-derives the snapshot and restores
+    # the fresh clock; the cold-run flake). One-shot: later reloads must see the
+    # app's own writes, so the marker retires the rewind after this reload.
+    page.add_init_script(f"""
+        (() => {{
+          if (sessionStorage.getItem('fixj33-rewound') !== null) return;
+          const k = 'wk-thread-sends:{KEY}';
+          const raw = sessionStorage.getItem(k);
+          if (raw === null) return;
+          sessionStorage.setItem('fixj33-rewound', '1');
+          sessionStorage.setItem(k, JSON.stringify(
+            JSON.parse(raw).map((s) => ({{ ...s, sentAt: s.sentAt - 95000 }}))));
+        }})();
+    """)
 
     page.reload(wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)

--- a/e2e/ux_fixJ3J1_test.py
+++ b/e2e/ux_fixJ3J1_test.py
@@ -169,10 +169,15 @@ with sync_playwright() as p:
           revived["causedBy"] == msg_id and not revived["timedOut"] and not revived["generating"],
           expected_cause=msg_id, **revived)
 
-    # ── Scene 2 (AC 2): no premature anchors on the continue path ──────────────
+    # ── Scene 2 (AC 2): no premature anchors — re-scoped to the round-3 contract:
+    # a PLAIN continue-send never forks (no divider, ever); the deferred divider
+    # is the explicit BRANCH gesture's anchor (sending from an older ?v=N). ─────
     created = api_create_doc("anchor-truth", "the anchor-truth brief")
     DOC2 = created["name"]
     set_fixture(ORIGIN, doc_run_ms=2500)
+    fork_posts: list[str] = []
+    page.on("request", lambda r: fork_posts.append(r.url)
+            if r.method == "POST" and r.url.endswith("/api/fork") else None)
     page.goto(f"{ORIGIN}/p/{PID}/document/{DOC2}", wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
@@ -187,8 +192,8 @@ with sync_playwright() as p:
     cont_id = page.evaluate(
         """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
                    return m[m.length - 1]?.getAttribute('data-message-id'); }""")
-    # The fork has acked (the send chip is up) but nothing has LANDED: no divider,
-    # no version chip on the continuation message — anchors wait for the wire.
+    # The send has acked but nothing has LANDED: no version chip yet — and no fork
+    # was fired, so no divider will EVER render for this plain send.
     page.wait_for_timeout(900)  # inside the 2.5s scheduled landing
     premature = page.evaluate(
         """(contId) => ({
@@ -197,26 +202,68 @@ with sync_playwright() as p:
                `[data-testid="version-marker"][data-caused-by="${contId}"]`),
            })""", cont_id)
     check("no_anchor_before_the_version_arrives",
-          not premature["divider"] and not premature["chipOnSend"], **premature)
+          not premature["divider"] and not premature["chipOnSend"],
+          forks_fired=len(fork_posts), **premature)
 
-    # The version.created arrival materializes the divider ABOVE its message.
+    # The ANSWERER's version.created is what tags the plain send — v2, from the
+    # service, with NO fork fired and NO continuation divider.
+    page.locator(f'[data-testid="version-marker"][data-caused-by="{cont_id}"]').wait_for(timeout=15000)
+    plain = page.evaluate(
+        """(contId) => ({
+             markerVersion: document.querySelector(
+               `[data-testid="version-marker"][data-caused-by="${contId}"]`)?.getAttribute('data-version'),
+             divider: !!document.querySelector('[data-testid="version-divider"]'),
+           })""", cont_id)
+    check("plain_send_answered_by_the_wire_no_fork_no_divider",
+          plain["markerVersion"] == "2" and not plain["divider"] and fork_posts == [],
+          forks_fired=len(fork_posts), **plain)
+
+    # The BRANCH gesture: send from the explicitly selected OLDER v1 — the one
+    # case fork survives, and the divider stays the deferred wire-proof anchor.
+    page.goto(f"{ORIGIN}/p/{PID}/document/{DOC2}?v=1", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+    wake_strip(page)
+    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
+    page.locator('[data-testid="doc-composer"]').fill("branch: keep the original intro")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
+    branch_id = page.evaluate(
+        """() => { const m = document.querySelectorAll('[data-testid="doc-message"]');
+                   return m[m.length - 1]?.getAttribute('data-message-id'); }""")
+    # The fork has acked (v3 committed) but nothing has LANDED: the divider is
+    # only REGISTERED — no anchor renders before the wire's proof.
+    page.wait_for_timeout(900)
+    branch_premature = page.evaluate(
+        """(bid) => ({
+             divider: !!document.querySelector('[data-testid="version-divider"]'),
+             chipOnSend: !!document.querySelector(
+               `[data-testid="version-marker"][data-caused-by="${bid}"]`),
+           })""", branch_id)
+    check("branch_divider_deferred_until_the_wire_proves_it",
+          len(fork_posts) == 1
+          and not branch_premature["divider"] and not branch_premature["chipOnSend"],
+          forks_fired=len(fork_posts), **branch_premature)
+
+    # The landing materializes the divider ABOVE its message.
     page.locator('[data-testid="version-divider"]').wait_for(timeout=15000)
     anchored = page.evaluate(
-        """(contId) => {
+        """(bid) => {
              const divider = document.querySelector('[data-testid="version-divider"]');
              const next = divider?.nextElementSibling;
              return {
                dividerVersion: divider?.getAttribute('data-version'),
                dividerText: divider?.textContent ?? '',
                aboveItsMessage: !!next?.querySelector(
-                 `[data-testid="doc-message"][data-message-id="${contId}"]`),
+                 `[data-testid="doc-message"][data-message-id="${bid}"]`),
                chipOnSend: !!document.querySelector(
-                 `[data-testid="version-marker"][data-caused-by="${contId}"]`),
+                 `[data-testid="version-marker"][data-caused-by="${bid}"]`),
              };
-           }""", cont_id)
+           }""", branch_id)
     check("divider_anchors_on_arrival_above_its_message",
-          anchored["dividerVersion"] == "2"
-          and "continues as v2" in anchored["dividerText"]
+          anchored["dividerVersion"] == "3"
+          and "continues as v3" in anchored["dividerText"]
           and anchored["aboveItsMessage"] and anchored["chipOnSend"],
           **anchored)
     set_fixture(ORIGIN, doc_run_ms=0)

--- a/e2e/ux_fixJ3J1_test.py
+++ b/e2e/ux_fixJ3J1_test.py
@@ -153,20 +153,22 @@ with sync_playwright() as p:
 
     # The retry is LIVE: with the bridge speaking again, the same send lands its
     # version — the pill retires into the real anchor (§3.3: a failure state
-    # always carries its own fix).
+    # always carries its own fix). (Round-3 fixture honesty: the retry's answer is
+    # the ANSWERER minting a NEW version — head+1 — never a version re-announced
+    # for the send itself, so the anchor is whatever version the wire lands.)
     set_fixture(ORIGIN, doc_silent=False)
     page.locator('[data-testid="thread-generating-retry"]').click()
     page.locator('[data-testid="thread-generating"]').wait_for(timeout=15000)
-    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
+    page.locator(f'[data-testid="version-marker"][data-caused-by="{msg_id}"]').wait_for(timeout=30000)
     revived = page.evaluate(
-        """() => ({
-             causedBy: document.querySelector('[data-testid="version-marker"][data-version="1"]')
-               ?.getAttribute('data-caused-by'),
+        """(msgId) => ({
+             markerVersion: document.querySelector(
+               `[data-testid="version-marker"][data-caused-by="${msgId}"]`)?.getAttribute('data-version'),
              timedOut: !!document.querySelector('[data-testid="thread-generating-timeout"]'),
              generating: !!document.querySelector('[data-testid="thread-generating"]'),
-           })""")
+           })""", msg_id)
     check("timeout_retry_is_live_and_anchors",
-          revived["causedBy"] == msg_id and not revived["timedOut"] and not revived["generating"],
+          bool(revived["markerVersion"]) and not revived["timedOut"] and not revived["generating"],
           expected_cause=msg_id, **revived)
 
     # ── Scene 2 (AC 2): no premature anchors — re-scoped to the round-3 contract:

--- a/e2e/ux_sliceT_test.py
+++ b/e2e/ux_sliceT_test.py
@@ -68,11 +68,12 @@ STEER = "Tighten the headline on slide one"
 FAILING = "Add a closing slide with the roadmap"
 
 # §6.3's stopgap copy — the promise with a pointer, scoped to the anchor gap.
+# Round-3 copy pass: operator language — the spec ref (BRIDGE-UX-1 §8.4.1) no
+# longer leaks into product copy; the promise names the service capability.
 STOPGAP_MUST_SAY = [
     "restored from the document’s transcript",
     "what this session observed",
-    "return when the transcript carries version anchors",
-    "BRIDGE-UX-1",
+    "return once the document service records which message produced each version",
 ]
 
 report: dict = {"ok": False, "steps": {}}

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -320,6 +320,20 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # GENERATING_SILENCE_BUDGET_MS timeout is what stands between the user
          # and an eternal "being worked now".
          "doc_silent": False,
+         # Round-3 J3: mirror the REAL bridge's create shape (generation.js) —
+         # a kind:"source" create seeds a PLACEHOLDER v0 ("Building {name}…",
+         # head 0) and answers 200 {name, head: 0, generating: true}; the first
+         # draft lands LATER as v1 (kind "generated") when the answerer emits
+         # draft.completed — doc_run_ms is how long that answerer takes.
+         # Switch-gated (default False) so standing rigs keep the historical
+         # v1-at-create shape; the round-3 rig runs the real v0→v1 journey.
+         "doc_v0": False,
+         # Round-3 J3: mirror the UNBOUND-doc reality (serviceEmit stamps
+         # project_id only on docs bound to a crew project): when True, doc
+         # frames ride the relay WITHOUT project_id — exactly what an Unfiled
+         # doc's frames look like on the real stack. Default False: standing
+         # rigs keep the stamped frames their projects legitimately have.
+         "doc_unbound": False,
          # Slice U (DES-UX-001 §6.2, §8.4.1 probe 3): when True, POST
          # /api/docs answers the bridge's REAL refused-bind shape — a loud
          # 502 {"error": "crew daemon unreachable at …"} with NOTHING created
@@ -1309,11 +1323,19 @@ def queue_interactive(event_type: str, payload: dict) -> None:
     # Slice T: doc-scoped narration is ALSO appended to the durable announce
     # history — the same dual-write the real bridge does (SSE relay + JSONL),
     # so GET /d/:doc/api/conversation reads back what the stream said.
+    # (Logged BEFORE the unbound strip below: the disk knows the doc's home
+    # even when the frame does not carry it — same as the real bridge.)
     if event_type == "wicked.interactive.status.posted":
         pid, doc = payload.get("project_id"), payload.get("document_id")
         text = payload.get("message")
         if pid and doc and text:
             log_conversation(pid, doc, "agent", str(text), payload.get("state"))
+    # Round-3 J3 (`doc_unbound`): an UNBOUND doc's frames carry no project_id on
+    # the real relay (serviceEmit stamps only bound docs) — mirror that shape.
+    with state_lock:
+        unbound = state["doc_unbound"]
+    if unbound and payload.get("document_id"):
+        payload = {k: v for k, v in payload.items() if k != "project_id"}
     with ws_lock:
         ws_queue.append({"type": "interactiveEvent",
                          "event": {"event_type": event_type, "payload": payload}})
@@ -1393,7 +1415,18 @@ def doc_versions(pid: str, doc: str) -> list:
 
 def doc_html(doc: str, version: int) -> str:
     """The rendered document at one version — a light deck slide, so the canvas reads
-    as a document against the app chrome and the v1→v2 headline change is visible."""
+    as a document against the app chrome and the v1→v2 headline change is visible.
+    v0 is the REAL bridge's generation placeholder (generation.js), verbatim in
+    spirit: 'Building {name}…' + the updates-automatically promise — what the
+    canvas shows between create and the answerer's first draft (doc_v0)."""
+    if version == 0:
+        title = doc.replace("-", " ")
+        return (f"<!doctype html><html><head><meta charset=\"utf-8\"><title>{doc} v0</title>"
+                "</head><body><section>"
+                f"<h1>Building {title}…</h1>"
+                "<p class=\"lead\">Reading your brief and drafting your document. "
+                "This view updates automatically the moment the first draft is ready.</p>"
+                "</section></body></html>")
     headline = HEADLINES.get(version, TIGHT_HEADLINE)
     return f"""<!doctype html><html><head><meta charset="utf-8"><title>{doc} v{version}</title>
 <style>body{{margin:0;font-family:Georgia,serif;background:#f4f1ea;color:#1b1b1b;
@@ -2049,27 +2082,42 @@ class W2Handler(SimpleHTTPRequestHandler):
             # no `meta.sourceMessageId` ever reaches the manifest (the interactive.ts
             # claim was aspirational). The client's anchor is client-side; the
             # fixture must not serve a correlation the wire does not carry.
-            with docs_lock:
-                docs_created.setdefault(pid, {})[doc] = [
-                    {"version": 1, "parent": None, "feedback_file": None,
-                     "html_file": "v1.html", "created_at": iso(NOW0)}]
+            with state_lock:
+                silent_doc = bool(state["doc_silent"])
+                run_ms = int(state["doc_run_ms"])
+                v0_mirror = bool(state["doc_v0"])
+            if v0_mirror:
+                # Round-3 J3: the REAL create shape (generation.js) — a v0
+                # "Building…" placeholder is what exists at ack time; the first
+                # draft lands LATER as v1 when the answerer's draft.completed
+                # materializes (schedule_doc_run below, doc_run_ms later).
+                with docs_lock:
+                    docs_created.setdefault(pid, {})[doc] = [
+                        {"version": 0, "parent": None, "feedback_file": None,
+                         "html_file": "_v0.html", "created_at": iso(NOW0)}]
+            else:
+                with docs_lock:
+                    docs_created.setdefault(pid, {})[doc] = [
+                        {"version": 1, "parent": None, "feedback_file": None,
+                         "html_file": "v1.html", "created_at": iso(NOW0)}]
             brief = str(body.get("brief") or "")
             if brief:
                 # The brief IS the doc's first user line in the announce history
                 # (the create message the reload scene must get back, §6.3).
                 log_conversation(pid, doc, "user", brief)
-            with state_lock:
-                silent_doc = bool(state["doc_silent"])
+            head0 = 0 if v0_mirror else 1
             if silent_doc:
                 # J3 no-answerer shape: the ack is real, the bus never speaks.
-                self._json(201, {"name": doc, "head": 1, "generating": True, "project_id": pid})
+                self._json(201, {"name": doc, "head": head0, "generating": True, "project_id": pid})
                 return True
             queue_interactive("wicked.interactive.status.posted", {
                 "project_id": pid, "document_id": doc, "state": "working",
                 "message": "Planning the deck — outline first, then the slides."})
-            with state_lock:
-                run_ms = int(state["doc_run_ms"])
-            if run_ms > 0:
+            if v0_mirror:
+                # The answerer lands the FIRST DRAFT as v1 (head 0 → 1), exactly
+                # the real materializeDraft → version.created "generated" path.
+                schedule_doc_run(pid, doc, run_ms / 1000.0)
+            elif run_ms > 0:
                 # Slice T: v1 is committed now but LANDS (the frame) after the
                 # run — long enough for the rig to witness thread-generating.
                 schedule_doc_run(pid, doc, run_ms / 1000.0, fixed_version=1)
@@ -2077,7 +2125,7 @@ class W2Handler(SimpleHTTPRequestHandler):
                 queue_interactive("wicked.interactive.version.created", {
                     "project_id": pid, "document_id": doc,
                     "version": 1, "parent": None, "kind": "generated"})
-            self._json(201, {"name": doc, "head": 1, "generating": True, "project_id": pid})
+            self._json(201, {"name": doc, "head": head0, "generating": True, "project_id": pid})
             return True
         # POST /api/v1/projects/<pid>/interactive/d/<doc>/api/fork — branch (§7.10).
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/api/fork$", path)
@@ -2208,17 +2256,31 @@ class W2Handler(SimpleHTTPRequestHandler):
                     # doc_run_ms after the previous landing (§8.4.1 queue truth).
                     schedule_doc_run(pid, doc, run_ms / 1000.0)
                 else:
-                    # Historical instant path, unchanged for every standing rig:
-                    # re-announce the head as the regenerated version.
-                    versions = doc_versions(pid, doc)
-                    head = max((e["version"] for e in versions), default=1)
+                    # Round-3 J3 honesty: NO version is minted for the send by
+                    # the client — the ANSWERER lands one. The instant path is
+                    # the answerer taking ~0s: it appends head+1 to a created
+                    # doc's manifest and announces THAT (mirroring the real
+                    # regenerate → version.created "generated"). Static registry
+                    # docs (the notes seeds) cannot grow, so they keep the
+                    # historical head re-announce.
+                    with docs_lock:
+                        created_versions = docs_created.get(pid, {}).get(doc)
+                        if created_versions is not None:
+                            v = max(e["version"] for e in created_versions) + 1
+                            created_versions.append(
+                                {"version": v, "parent": v - 1, "feedback_file": None,
+                                 "html_file": f"v{v}.html", "created_at": iso(NOW0 + v * SEC)})
+                            parent = v - 1
+                        else:
+                            versions = doc_versions(pid, doc)
+                            v = max((e["version"] for e in versions), default=1)
+                            parent = v - 1 if v > 1 else None
                     queue_interactive("wicked.interactive.status.posted", {
                         "project_id": pid, "document_id": doc, "state": "working",
                         "message": "Tightening the headline and rebalancing the slide."})
                     queue_interactive("wicked.interactive.version.created", {
                         "project_id": pid, "document_id": doc,
-                        "version": head, "parent": head - 1 if head > 1 else None,
-                        "kind": "generated"})
+                        "version": v, "parent": parent, "kind": "generated"})
             self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
             return True
         return False

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -151,15 +151,23 @@ with sync_playwright() as p:
     page.locator('[data-testid="version-entry"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
 
-    # ── Scene B: continue — one composer action, v2 lands, everything advances ────
+    # ── Scene B: continue — ONE plain send, the ANSWERER lands v2, everything ─────
+    # advances (round-3 J3 re-scope: a plain continue-send no longer forks — the
+    # revised version arrives from the service, and NO continuation divider renders;
+    # the divider is the explicit-branch gesture's anchor, which this journey never
+    # makes).
     page.locator('[data-testid="doc-composer"]').fill("Tighten this headline")
     page.keyboard.press("Enter")
-    page.locator('[data-testid="version-divider"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=30000)
     page.locator('[data-testid="version-entry"][data-version="2"][data-selected="true"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
     # The canvas is LOADED (its named loading state has retired) before any capture.
     page.locator('[data-testid="doc-canvas-loading"]').wait_for(state="detached", timeout=30000)
+    no_divider = page.evaluate(
+        "() => document.querySelectorAll('[data-testid=\"version-divider\"]').length")
+    report["steps"]["slice6_plain_send_no_divider"] = {
+        "ok": no_divider == 0, "dividers": no_divider,
+    }
 
     # AC 1 — the spine, in the §7.3 canvas-first geometry: the strip floats INSIDE
     # the canvas container over its bottom edge; the canvas and the OPEN thread
@@ -373,16 +381,16 @@ with sync_playwright() as p:
         "spa_requests_to_the_target": ssrf_outbound,
     }
 
-    # ── The wire, as the tap saw it: create carried the anchor; fork carried the
-    # second anchor and branched from v1; the steer rode the inject event. ────────
+    # ── The wire, as the tap saw it (round-3 J3 re-scope): create carried the
+    # anchor; the continue rode the inject event ALONE — NO fork on a plain send
+    # (the pre-fix fork-per-send minted a byte-identical version before any work). ─
     creates = [b for (_m, q, b) in net if q.endswith("/interactive/api/docs")]
     forks = [b for (_m, q, b) in net if q.endswith("/api/fork")]
     events = [b for (_m, q, b) in net if q.endswith("/api/events")]
     report["steps"]["slice6_wire"] = {
         "ok": all([
             len(creates) == 1, bool((creates[0] or {}).get("source_message_id")),
-            len(forks) == 1, (forks[0] or {}).get("from") == 1,
-            bool((forks[0] or {}).get("source_message_id")),
+            len(forks) == 0,
             any((e or {}).get("event_type") == "wicked.interactive.chat.posted" for e in events),
         ]),
         "create_bodies": creates, "fork_bodies": forks, "event_types":

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getConversation, getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
-import { readAnchors } from '../interactive/threadStopgap.js';
+import { readAnchors, readExports, readSendStates } from '../interactive/threadStopgap.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive.js';
@@ -522,10 +522,17 @@ export function DocumentCanvas({
     let cancelled = false;
     getConversation(projectId, docId)
       .then((entries) => {
-        if (!cancelled) useDocThreadStore.getState().hydrate(key, entries, readAnchors(key));
+        if (!cancelled) {
+          // Anchors, unresolved sends and export entries all ride the same
+          // session stopgap (round-3 J3 finding 4 + the export-persistence minor).
+          useDocThreadStore.getState().hydrate(
+            key, entries, readAnchors(key), readSendStates(key), readExports(key));
+        }
       })
       .catch(() => {
-        if (!cancelled) useDocThreadStore.getState().hydrate(key, [], []);
+        if (!cancelled) {
+          useDocThreadStore.getState().hydrate(key, [], [], readSendStates(key), readExports(key));
+        }
       });
     return () => { cancelled = true; };
   }, [projectId, docId]);

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -199,7 +199,13 @@ function DocFrame({
   // guarantees a wid survives WITHIN a document's lineage, not that rects do).
   const [frameEl, setFrameEl] = useState<HTMLIFrameElement | null>(null);
   const [loadNonce, setLoadNonce] = useState(0);
-  useEffect(() => { setLoaded(false); }, [projectId, docId, version]);
+  // The RESOLVED version, computed before the hooks so the loading overlay is
+  // keyed to what the frame actually shows. Keying on the routed `version` prop
+  // missed every head-follow swap (routed null, head advanced on a landing): the
+  // remounted iframe painted blank with no named loading state — and the reverse
+  // race left a stale "Loading" overlay over an already-loaded frame.
+  const resolvedShown = manifest === null ? null : resolveVersion(manifest, version);
+  useEffect(() => { setLoaded(false); }, [projectId, docId, resolvedShown]);
   // §7.3's strip presence: visible now, gone after 3s of idleness, back on proximity.
   // `hold` (J3): a strip control holding an un-acted answer pins it visible.
   const { hidden, wake, hold } = useStripAutoHide();

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -726,8 +726,8 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                        margin: 0, fontFamily: 'var(--font-sans)' }}
             >
               Thread restored from the document’s transcript. Version markers show what
-              this session observed — markers from before this session return when the
-              transcript carries version anchors (BRIDGE-UX-1 §8.4.1).
+              this session observed — markers from before this session return once the
+              document service records which message produced each version.
             </p>
           )}
         {messages.length === 0 && (

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -508,6 +508,23 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
 
   useEffect(() => { bottom.current?.scrollIntoView({ block: 'end' }); }, [messages.length]);
 
+  // Page teardown flag: a reload/navigation ABORTS every in-flight send fetch,
+  // and that rejection is not a refusal — the bridge usually took the message
+  // (its line is on the wire). Marking it refused here would PERSIST a fabricated
+  // failure into the stopgap for the next load to restore. `pageshow` re-arms
+  // after a bfcache resurrection, where this document lives on.
+  const unloading = useRef(false);
+  useEffect(() => {
+    const hide = (): void => { unloading.current = true; };
+    const show = (): void => { unloading.current = false; };
+    window.addEventListener('pagehide', hide);
+    window.addEventListener('pageshow', show);
+    return () => {
+      window.removeEventListener('pagehide', hide);
+      window.removeEventListener('pageshow', show);
+    };
+  }, []);
+
   const gate = state === 'gated'
     ? [...messages].reverse().find((m): m is Extract<DocMsg, { kind: 'gate' }> => m.kind === 'gate') ?? null
     : null;
@@ -628,6 +645,10 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
    *  persist its text for the failure to survive a reload (round-3 finding 4). */
   function failVisibly(msgId: string): void {
     if (key === null) return;
+    // A rejection during page teardown is the ABORT of the unload, not the
+    // bridge refusing: leave the send exactly as persisted (pending, its own
+    // clock) — the next load's hydrate restores its honest unresolved state.
+    if (unloading.current) return;
     const store = useDocThreadStore.getState();
     store.markSendFailed(key, msgId, true);
     if ((useDocThreadStore.getState().pending[key] ?? []).length === 0

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -21,8 +21,14 @@ import { GENERATING_SILENCE_BUDGET_MS, nextMsgId, threadKey, useDocThreadStore, 
 //              the doc's generation run opens with this message as its first line.
 //   generating → STEER: `wicked.interactive.chat.posted` injects into the live agent.
 //   gated      → ANSWER: the question is answerable in the transcript, where it was asked.
-//   terminal   → CONTINUE: fork + inject as ONE atomic composer action (§7.10). The thread
-//              renders the linked run as a continuation — a version divider, no new header.
+//   terminal   → CONTINUE (§7.10, round-3 contract): a PLAIN send — nothing selected, or
+//              the head selected — is the ask alone (`chat.posted`); the REVISED version
+//              arrives when the answerer lands one, and only then is anything tagged.
+//              The client never mints a version for a plain send: the pre-fix fork-per-send
+//              committed a byte-identical copy before any work existed (the round-2 J3
+//              fabricated-versions finding). Fork survives ONLY for the genuine branch
+//              gesture — sending from an explicitly selected OLDER version — and even
+//              there the "continues as vN" divider stays the deferred wire-proof anchor.
 //
 // There is no dead composer state and no synthetic liveness: no whimsy filler (filtered in
 // the store, §3.2), no `status.requested` heartbeat (never emitted at all).
@@ -547,20 +553,42 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         return;
       }
 
-      // 4 — CONTINUE (§7.10). Fork + inject is ONE composer action: the branch lands, the
-      // divider marks it, and the same message steers the run that continues from it. The
-      // seam is hidden in the UI; underneath it is still two governed runs (§2.4).
+      // 4 — CONTINUE (§7.10, round-3 contract). A PLAIN send (no version selected, or
+      // the head selected) never forks: the ask rides `chat.posted` alone, and the
+      // revised version arrives when the answerer lands one — the round-2 J3 pin
+      // (fork-per-send minted a byte-identical version before any work existed).
+      // Fork remains ONLY the genuine branch gesture: sending from an explicitly
+      // selected OLDER version.
       if (state === 'terminal') {
-        const from = selectedVersion ?? (await getVersions(projectId, docId)).head;
-        const forked = await postFork(projectId, docId, from, msgId);
+        const head = selectedVersion === null
+          ? null
+          : (await getVersions(projectId, docId)).head;
+        const branching = selectedVersion !== null && selectedVersion !== head;
+        if (!branching) {
+          store.addUserMsg(key, msgId, body);
+          store.setGenState(key, 'generating');
+          // §6.1 (EC36): once the message is ON the thread, a refused send fails
+          // THERE — the failed chip with its retry, never a silent transcript row.
+          try {
+            await injectDocMessage(projectId, docId, body, msgId);
+          } catch {
+            failVisibly(msgId);
+          }
+          setText('');
+          // A head-pinned route (?v=head) un-pins so the canvas follows the version
+          // the answer lands; a bare route already follows the head.
+          if (selectedVersion !== null) navigate(versionPath(projectId, docId, null));
+          return;
+        }
+        // The BRANCH gesture: fork from the older selected version, then steer the
+        // run that continues from it — still one composer action (§2.4 underneath).
+        const forked = await postFork(projectId, docId, selectedVersion, msgId);
         // §7.10 + the J3 bookkeeping pin: the "continues as vN" divider is an
         // ANCHOR, so it renders only when the wire shows vN exists — registered
         // here, inserted above this message by the version.created arrival.
         store.expectDivider(key, msgId, forked.version);
         store.addUserMsg(key, msgId, body);
         store.setGenState(key, 'generating');
-        // §6.1 (EC36): once the message is ON the thread, a refused send fails
-        // THERE — the failed chip with its retry, never a silent transcript row.
         try {
           await injectDocMessage(projectId, docId, body, msgId);
         } catch {

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -623,11 +623,13 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   }
 
   /** §6.1's visible failure: the message stays on the thread wearing the failed
-   *  chip; the working state retires when nothing else is pending behind it. */
+   *  chip; the working state retires when nothing else is pending behind it.
+   *  `refused: true` — the bridge never accepted the send, so the stopgap must
+   *  persist its text for the failure to survive a reload (round-3 finding 4). */
   function failVisibly(msgId: string): void {
     if (key === null) return;
     const store = useDocThreadStore.getState();
-    store.markSendFailed(key, msgId);
+    store.markSendFailed(key, msgId, true);
     if ((useDocThreadStore.getState().pending[key] ?? []).length === 0
         && useDocThreadStore.getState().genState[key] === 'generating') {
       store.setGenState(key, 'terminal');

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { interactiveUrl } from '../api/interactive.js';
 import type { ExportFormat } from '../api/interactive.js';
 import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
+import { exportKey, NO_ANSWERS, useExportAnswers } from '../store/exportAnswers.js';
+import type { ExportAnswer } from '../store/exportAnswers.js';
 
 // The export control (DES-MERGE-001 §4.4, §6.4 slice 15) — ONE component in both places
 // the design puts it: per-version on the document's version strip, and as a quick action
@@ -16,6 +18,11 @@ import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
 // the control), READY (the control itself becomes the download affordance), or FAILED
 // (the reason, adjacent, with the retriable row above it) — where the click happened,
 // never only in a thread that may be off screen.
+//
+// Round-3 J3: the answers live in the exportAnswers STORE, not component state — a
+// landing that advances the addressed version (the route follows the head), a strip
+// re-render, or a selection move must never wipe an un-acted answer. An answer for
+// another version of the same doc stays visible here, labeled with ITS version.
 
 // DES-VISION-001 §2.11: semantic tokens only. The RUNNING format speaks the
 // brand accent (an affordance state); the hint below is an actionable install
@@ -47,9 +54,6 @@ const READY: React.CSSProperties = {
   textDecoration: 'none',
 };
 
-/** What the click site holds once its export finished: the artifact itself. */
-interface ReadyArtifact { format: ExportFormat; href: string; file: string }
-
 export interface ExportMenuProps {
   projectId: string;
   docId: string;
@@ -59,7 +63,7 @@ export interface ExportMenuProps {
   compact?: boolean;
   /**
    * §7.2, the J3 closed-drawer pin: told `true` while this control owes (or is
-   * showing) an answer — an export in flight, a READY download not yet retired,
+   * showing) an answer — an export in flight, a READY download not yet acted on,
    * a FAILED hint. The strip host pins itself visible on it: auto-hide fading the
    * click site's answer out from under a closed drawer IS the "clicked, nothing
    * visibly happened" failure. Optional — the board tile has no auto-hide to pin.
@@ -68,17 +72,21 @@ export interface ExportMenuProps {
 }
 
 export function ExportMenu({ projectId, docId, version, compact = false, onHold }: ExportMenuProps): React.ReactElement {
-  const [busy, setBusy] = useState<ExportFormat | null>(null);
-  const [ready, setReady] = useState<ReadyArtifact | null>(null);
-  const [hint, setHint] = useState<string | null>(null);
+  const key = exportKey(projectId, docId);
+  const answers = useExportAnswers((s) => s.answers[key] ?? NO_ANSWERS);
 
-  // §7.2: the click site answers for THIS version. A new selection retires the
-  // previous answer — a v3 artifact link must not sit under an "Export v4" label.
-  useEffect(() => { setReady(null); setHint(null); }, [docId, version]);
+  const pending = answers.find((a) => a.state === 'pending');
+  const readyHere = answers.find((a) => a.state === 'ready' && a.version === version);
+  const failedHere = answers.filter((a) => a.state === 'failed' && a.version === version);
+  // Round-3 J3: un-acted answers for OTHER versions of this doc stay at the click
+  // site, labeled with their own version — never wiped by a selection move or a
+  // head-follow landing, and never mislabeled as the addressed version.
+  const readyElsewhere = answers.filter((a) => a.state === 'ready' && a.version !== version);
+  const failedElsewhere = answers.filter((a) => a.state === 'failed' && a.version !== version);
 
   // The J3 hold: pending, ready and failed are all states the user has not acted
-  // on yet — each keeps the click site on screen until it is consumed or retired.
-  const answering = busy !== null || ready !== null || hint !== null;
+  // on yet — each keeps the click site on screen until it is consumed or replaced.
+  const answering = answers.length > 0;
   useEffect(() => {
     if (!answering || onHold === undefined) return;
     onHold(true);
@@ -86,21 +94,42 @@ export function ExportMenu({ projectId, docId, version, compact = false, onHold 
   }, [answering, onHold]);
 
   function run(format: ExportFormat): void {
-    setBusy(format);
-    setReady(null);
-    setHint(null);
+    const store = useExportAnswers.getState();
+    store.begin(key, version, format);
+    // The continuation writes to the module-level store, so the answer lands even
+    // if this click site unmounted meanwhile (round-3 J3: churn-proof answers).
     void runExport({ projectId, docId, version, format })
       .then((outcome) => {
-        if (outcome.ok) {
-          // READY at the click site: the service's `download` is bridge-root-relative;
-          // resolved through the proxy it stays on the one origin (§5.3).
-          setReady({ format, href: interactiveUrl(projectId, outcome.result.download),
-                     file: outcome.file });
-        } else {
-          setHint(outcome.hint);
-        }
-      })
-      .finally(() => setBusy(null));
+        useExportAnswers.getState().settle(key, outcome.ok
+          ? { state: 'ready', version, format,
+              // READY at the click site: the service's `download` is bridge-root-relative;
+              // resolved through the proxy it stays on the one origin (§5.3).
+              href: interactiveUrl(projectId, outcome.result.download), file: outcome.file }
+          : { state: 'failed', version, format, hint: outcome.hint });
+      });
+  }
+
+  /** The READY anchor — the artifact IS the affordance now (§7.2). Acting on it
+   *  (the download click) consumes the answer, which releases the strip hold. */
+  function readyAnchor(a: Extract<ExportAnswer, { state: 'ready' }>, labelVersion: boolean): React.ReactElement {
+    const label = labelVersion
+      ? (compact ? `${a.format} v${a.version} ↓` : `${a.format.toUpperCase()} v${a.version} ↓`)
+      : (compact ? `${a.format} ↓` : `${a.format.toUpperCase()} ↓`);
+    return (
+      <a
+        key={`${a.format}-${a.version}`}
+        data-testid="export-ready"
+        data-format={a.format}
+        data-version={String(a.version)}
+        href={a.href}
+        download={a.file}
+        onClick={() => useExportAnswers.getState().consume(key, a.version, a.format)}
+        title={`${a.format.toUpperCase()} of v${a.version} ready — download ${a.file}`}
+        style={{ ...(compact ? COMPACT : BUTTON), ...READY }}
+      >
+        {label}
+      </a>
+    );
   }
 
   return (
@@ -113,7 +142,7 @@ export function ExportMenu({ projectId, docId, version, compact = false, onHold 
       style={{ alignSelf: 'center', display: 'flex', flexDirection: 'column',
                flexShrink: 0, gap: '2px', maxWidth: '220px', minWidth: 0 }}
     >
-      <div style={{ alignItems: 'center', display: 'flex', gap: compact ? '7px' : '5px' }}>
+      <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: compact ? '7px' : '5px' }}>
         {!compact && (
           <span style={{ color: S.faint, fontSize: 'var(--text-2xs)', letterSpacing: '0.06em',
                          fontFamily: 'var(--font-mono)', textTransform: 'uppercase' }}>
@@ -124,51 +153,58 @@ export function ExportMenu({ projectId, docId, version, compact = false, onHold 
           // §7.2 READY: the control that was clicked IS the download now — a real
           // anchor with the artifact's name, at the click site. The thread message
           // remains; this is the click site answering (EC37).
-          ready !== null && ready.format === format ? (
-            <a
-              key={format}
-              data-testid="export-ready"
-              data-format={format}
-              href={ready.href}
-              download={ready.file}
-              title={`${format.toUpperCase()} ready — download ${ready.file}`}
-              style={{ ...(compact ? COMPACT : BUTTON), ...READY }}
-            >
-              {compact ? `${format} ↓` : `${format.toUpperCase()} ↓`}
-            </a>
+          readyHere !== undefined && readyHere.format === format ? (
+            readyAnchor(readyHere as Extract<ExportAnswer, { state: 'ready' }>, false)
           ) : (
             <button
               key={format}
               type="button"
               data-testid="export-format"
               data-format={format}
-              disabled={busy !== null}
+              disabled={pending !== undefined}
               onClick={() => run(format)}
               title={`Export “${docId}” v${version} as ${format.toUpperCase()} — it lands in the thread as a download`}
               style={{ ...(compact ? COMPACT : BUTTON),
-                       color: busy === format ? S.accent : S.muted,
-                       opacity: busy !== null && busy !== format ? 0.4 : 1 }}
+                       color: pending !== undefined && pending.format === format
+                              && pending.version === version ? S.accent : S.muted,
+                       opacity: pending !== undefined
+                         && (pending.format !== format || pending.version !== version) ? 0.4 : 1 }}
             >
               {/* §7.2 PENDING: the spinner lives ON the clicked control. */}
-              {busy === format
+              {pending !== undefined && pending.format === format && pending.version === version
                 ? <span data-testid="export-pending" className="animate-pulse">{format}…</span>
                 : compact ? format : format.toUpperCase()}
             </button>
           )
         ))}
+        {/* Round-3 J3: answers the user has not acted on, for other versions of THIS
+            doc — visible at the click site, wearing their own version. */}
+        {readyElsewhere.map((a) => readyAnchor(a as Extract<ExportAnswer, { state: 'ready' }>, true))}
+        {pending !== undefined && pending.version !== version && (
+          <span data-testid="export-pending" data-version={String(pending.version)}
+                className="animate-pulse"
+                style={{ color: S.accent, fontSize: compact ? '9px' : 'var(--text-2xs)',
+                         fontFamily: compact ? 'var(--font-mono)' : 'var(--font-sans)' }}>
+            {pending.format} v{pending.version}…
+          </span>
+        )}
       </div>
       {/* §7.2 FAILED, §3.3: the reason is stated and the control that retries it is the
           row above — adjacent, not a toast that takes the fix away with it when it fades. */}
-      {hint !== null && (
+      {[...failedHere, ...failedElsewhere].map((a) => (
         <span
+          key={`hint-${a.format}-${a.version}`}
           data-testid="export-hint"
-          title={hint}
+          data-version={String(a.version)}
+          title={a.state === 'failed' ? a.hint : undefined}
           style={{ color: S.hint, fontSize: '9px', fontFamily: 'var(--font-mono)',
                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
-          {hint}
+          {a.state === 'failed'
+            ? (a.version === version ? a.hint : `v${a.version}: ${a.hint}`)
+            : null}
         </span>
-      )}
+      ))}
     </div>
   );
 }

--- a/src/components/ThreadDrawer.tsx
+++ b/src/components/ThreadDrawer.tsx
@@ -72,6 +72,12 @@ export function StripSensor({ hidden, wake }: { hidden: boolean; wake: () => voi
     <div
       data-testid="strip-sensor"
       onMouseMove={wake}
+      // Round-3 J3 (the pointer-interception minor): the sensor sits over the
+      // iframe, so a CLICK that lands on it would otherwise die silently — the
+      // exact "clicked, nothing visibly happened" failure. A pointerdown is an
+      // interaction like any other: it wakes the strip, so the click visibly
+      // summons the control the user was reaching for.
+      onPointerDown={wake}
       style={{
         bottom: 0, height: `${STRIP_SENSOR_PX}px`, left: 0, position: 'absolute',
         right: 0, zIndex: 1,

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { postFork } from '../api/interactive.js';
 import type { ForkResult, VersionEntry, VersionManifest } from '../api/interactive.js';
 import { versionPath, type Navigate } from '../hooks/useRoute.js';
@@ -166,12 +166,26 @@ export interface VersionStripProps {
   compare?: CompareControl;
 }
 
+/** How long the strip stays CLICKABLE after auto-hide dims it — the fade itself
+ *  (--dur-base, 220ms) plus a beat. Round-3 J3: while the strip is still visibly
+ *  fading, its controls look present; retiring their hit targets at t=0 sent the
+ *  click through to the sensor beneath, where it died silently. */
+export const STRIP_FADE_GRACE_MS = 320;
+
 export function VersionStrip({
   projectId, docId, manifest, selected, navigate, onForked,
   mode = 'document', dimmed = false, onWake, onHold, trailing, compare,
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Inert only once the fade has FINISHED: a mid-fade strip is still visible, so
+  // it keeps its hit targets (and a click on it wakes it) for the grace window.
+  const [inert, setInert] = useState(false);
+  useEffect(() => {
+    if (!dimmed) { setInert(false); return; }
+    const timer = setTimeout(() => { setInert(true); }, STRIP_FADE_GRACE_MS);
+    return () => { clearTimeout(timer); };
+  }, [dimmed]);
   // The thread's own version→message tags (§6.1/§6.3): the anchor source that is
   // actually on the wire's side of truth — see anchorOf.
   const msgs = useDocThreadStore((s) => s.messages[threadKey(projectId, docId)] ?? NO_MSGS);
@@ -204,6 +218,9 @@ export function VersionStrip({
       data-testid="version-strip"
       data-hidden={dimmed ? 'true' : 'false'}
       onMouseMove={onWake}
+      // Round-3 J3: a press on a fading (still-clickable) strip is an interaction —
+      // it wakes the strip, so the control under the finger is fully present again.
+      onPointerDown={onWake}
       // The spine's drawn connection (DES-UXFIX-001 §2.6) now speaks the brand
       // accent's subtle tier — connective tissue, not a status signal (§2.5).
       // DES-FEEDBACK-001 §7.3: when dimmed, the strip retires visually AND as a
@@ -213,7 +230,9 @@ export function VersionStrip({
         borderTop: '2px solid var(--accent-subtle)',
         display: 'flex', flexShrink: 0, gap: '8px', padding: '10px 12px',
         opacity: dimmed ? 0 : 1,
-        pointerEvents: dimmed ? 'none' : 'auto',
+        // Hit targets retire only when the strip has actually FADED (round-3 J3):
+        // pointerEvents none at dim-time sent mid-fade clicks to the sensor below.
+        pointerEvents: dimmed && inert ? 'none' : 'auto',
         transition: 'opacity var(--dur-base)',
       }}
     >

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -50,8 +50,8 @@ const S = {
  *  §8.4.1), so anchors survive only for what this session observed. */
 const NO_ANCHOR_TITLE =
   'The message that produced this version is not known to this session, so there is '
-  + 'nothing to scroll to. The transcript carries no version anchors (BRIDGE-UX-1) — '
-  + 'they survive for what this session observed; documents created before the merge '
+  + 'nothing to scroll to. The document service does not yet record version anchors '
+  + 'in the transcript — they survive for what this session observed; older documents '
   + 'have no anchor.';
 
 /** Compact, locale-formatted; an unparseable stamp falls back to what the manifest said. */

--- a/src/interactive/threadStopgap.ts
+++ b/src/interactive/threadStopgap.ts
@@ -61,3 +61,109 @@ export function recordAnchor(threadKey: string, ord: number, version: number): v
     // Full or refused storage: the anchor is simply not restorable next reload.
   }
 }
+
+// ── Send states (round-3 J3, finding 4) ───────────────────────────────────────
+//
+// A send that has not RESOLVED is state the wire does not carry: the conversation
+// read returns accepted user lines with no notion of "answered", "failed" or
+// "stalled", so a reload used to re-render every unresolved send as a plain
+// accepted message — the failure (and its retry) silently vanished. The stopgap
+// persists each thread's unresolved sends the same way it persists anchors:
+// session-scoped, addressed by ACCEPTED-user-line ordinal.
+//
+//   - `state:"pending"`  an accepted send still awaiting its landing. `sentAt`
+//     rides along so the §6.1 honesty budget RESUMES across the reload instead
+//     of re-arming (a send that was already stalled stays visibly stalled).
+//   - `state:"failed"` with no `text`: an accepted send whose run died (the
+//     status-error backlog kill) — the wire holds its line; the flag re-attaches.
+//   - `state:"failed"` WITH `text`: a REFUSED send — the bridge never accepted
+//     it, so the wire has no line to attach to. `ord` is the accepted ordinal it
+//     follows (0 = before any), and `text` lets the reload re-render the message
+//     itself, wearing its failure and its retry.
+
+export interface StoredSendState {
+  /** For accepted sends: their 1-based ordinal among accepted user lines.
+   *  For refused sends: the accepted ordinal they FOLLOW (0 = the thread start). */
+  ord: number;
+  state: 'pending' | 'failed';
+  sentAt: number;
+  /** Present only on refused sends — the wire has no copy of the message. */
+  text?: string;
+}
+
+function sendsKey(threadKey: string): string {
+  return `wk-thread-sends:${threadKey}`;
+}
+
+/** The unresolved sends this session (and its reloads) still owes answers for. */
+export function readSendStates(threadKey: string): StoredSendState[] {
+  const storage = safeStorage();
+  if (storage === null) return [];
+  try {
+    const raw = storage.getItem(sendsKey(threadKey));
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is StoredSendState =>
+      typeof s === 'object' && s !== null
+      && Number.isInteger((s as StoredSendState).ord)
+      && ((s as StoredSendState).state === 'pending' || (s as StoredSendState).state === 'failed')
+      && typeof (s as StoredSendState).sentAt === 'number');
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the thread's unresolved-send snapshot wholesale — the writer derives
+ *  it from the live projection after every mutation, so replace-all is the only
+ *  write that cannot drift. */
+export function writeSendStates(threadKey: string, states: StoredSendState[]): void {
+  const storage = safeStorage();
+  if (storage === null) return;
+  try {
+    if (states.length === 0) storage.removeItem(sendsKey(threadKey));
+    else storage.setItem(sendsKey(threadKey), JSON.stringify(states));
+  } catch {
+    // Full or refused storage: the send states simply do not survive the reload.
+  }
+}
+
+// ── Export entries (round-3 minor: the transcript's downloads survive reload) ──
+//
+// An export lands in the thread as an agent message carrying its download
+// (§4.4), but the announce history carries no exports — so a reload dropped
+// them. Session-scoped, deduplicated on href; restored at the transcript tail.
+
+export interface StoredExport { text: string; href: string; file?: string }
+
+function exportsKey(threadKey: string): string {
+  return `wk-thread-exports:${threadKey}`;
+}
+
+export function readExports(threadKey: string): StoredExport[] {
+  const storage = safeStorage();
+  if (storage === null) return [];
+  try {
+    const raw = storage.getItem(exportsKey(threadKey));
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((e): e is StoredExport =>
+      typeof e === 'object' && e !== null
+      && typeof (e as StoredExport).text === 'string'
+      && typeof (e as StoredExport).href === 'string');
+  } catch {
+    return [];
+  }
+}
+
+export function recordExport(threadKey: string, entry: StoredExport): void {
+  const storage = safeStorage();
+  if (storage === null) return;
+  try {
+    const kept = readExports(threadKey).filter((e) => e.href !== entry.href);
+    storage.setItem(exportsKey(threadKey), JSON.stringify([...kept, entry]));
+  } catch {
+    // Full or refused storage: the export message is simply not restorable.
+  }
+}

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -12,7 +12,10 @@
 
 import { create } from 'zustand';
 import { isFiller } from './narration.js';
-import { recordAnchor, type StoredAnchor } from '../interactive/threadStopgap.js';
+import {
+  recordAnchor, recordExport, writeSendStates,
+  type StoredAnchor, type StoredExport, type StoredSendState,
+} from '../interactive/threadStopgap.js';
 import { UNFILED_MOUNT } from '../api/interactive.js';
 import type { ConversationEntry, ExportFormat } from '../api/interactive.js';
 import type { CoreEvent } from '../api/types.js';
@@ -53,9 +56,12 @@ export type DocMsg =
   // `sentAt` is the send's own clock (§6.1 honesty budget): stamped when the
   // message is enqueued and re-stamped by a retry, it is half of what decides
   // when the generating chip must stop claiming "being worked now".
+  // `refused` narrows `failed` (round-3 J3): the bridge never ACCEPTED this send,
+  // so the wire's announce history holds no line for it — the send-state stopgap
+  // must persist its text itself for the failure to survive a reload.
   | { kind: 'user';      id: string; text: string; version?: number;
-      items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; restored?: boolean;
-      sentAt?: number }
+      items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; refused?: boolean;
+      restored?: boolean; sentAt?: number }
   | { kind: 'narration'; id: string; text: string }
   // `href` + `file` make an agent message DOWNLOADABLE (§4.4): an export is an ordinary
   // message from the service, carrying its artifact — never a toast, never a second origin.
@@ -195,8 +201,10 @@ interface DocThreadStore {
   /** Flag/clear §7.7's "not recorded in the run" chip on one already-rendered message. */
   markNotRecorded: (key: string, id: string, notRecorded: boolean) => void;
   /** §6.1's visible failure: the send was refused — drop it from the pending queue
-   *  and mark the message failed, so it renders `thread-send-failed` with a retry. */
-  markSendFailed: (key: string, id: string) => void;
+   *  and mark the message failed, so it renders `thread-send-failed` with a retry.
+   *  `refused` says the bridge never ACCEPTED it (an HTTP refusal): the wire holds
+   *  no line for it, so the send-state stopgap persists its text itself. */
+  markSendFailed: (key: string, id: string, refused?: boolean) => void;
   /** Re-arm a failed send: clear the flag and re-enqueue at the TAIL — a retry is a
    *  new send in queue order, never a jump back to its original position. */
   retrySend: (key: string, id: string) => void;
@@ -208,8 +216,16 @@ interface DocThreadStore {
    * ordinal (the only correlation the wire supports). Applies only while the
    * projection is empty; a thread with live messages keeps them and just marks
    * itself hydrated, so the read never doubles what this session already saw.
+   *
+   * Round-3 J3 (finding 4): `sends` re-attaches the unresolved-send states the
+   * wire cannot carry — pending sends re-enter the FIFO with their ORIGINAL
+   * sentAt (the honesty budget resumes, it never re-arms), failed accepted sends
+   * re-wear their failure + retry, and REFUSED sends (no wire line) are
+   * re-rendered from their persisted text. `exports` restores the transcript's
+   * downloadable export entries the announce history has no record of.
    */
-  hydrate: (key: string, entries: ConversationEntry[], anchors: StoredAnchor[]) => void;
+  hydrate: (key: string, entries: ConversationEntry[], anchors: StoredAnchor[],
+            sends?: StoredSendState[], exports?: StoredExport[]) => void;
   /** Append a client-authored informative line (§3.3) — an action the user took. */
   addNarration: (key: string, text: string) => void;
   /**
@@ -241,6 +257,32 @@ function append(messages: Record<string, DocMsg[]>, key: string, msg: DocMsg): R
   return { ...messages, [key]: [...(messages[key] ?? []), msg] };
 }
 
+/**
+ * Round-3 J3 (finding 4): derive one thread's unresolved-send snapshot from the
+ * live projection and persist it (session storage) — called after every mutation
+ * that can change it, so the write cannot drift from the truth on screen.
+ * Ordinals count ACCEPTED user lines only (the wire's own addressing); a REFUSED
+ * send carries its text, because the announce history has no line for it.
+ */
+function persistSendStates(key: string): void {
+  const s = useDocThreadStore.getState();
+  const msgs = s.messages[key] ?? [];
+  const pending = new Set(s.pending[key] ?? []);
+  const out: StoredSendState[] = [];
+  let ord = 0; // accepted-user-line ordinal, the wire's addressing
+  for (const m of msgs) {
+    if (m.kind !== 'user') continue;
+    if (m.refused === true) {
+      out.push({ ord, state: 'failed', sentAt: m.sentAt ?? 0, text: m.text });
+      continue;
+    }
+    ord += 1;
+    if (m.failed === true) out.push({ ord, state: 'failed', sentAt: m.sentAt ?? 0 });
+    else if (pending.has(m.id)) out.push({ ord, state: 'pending', sentAt: m.sentAt ?? 0 });
+  }
+  writeSendStates(key, out);
+}
+
 export const useDocThreadStore = create<DocThreadStore>((set) => ({
   messages: {},
   genState: {},
@@ -263,6 +305,8 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
     // session-storage stopgap (§6.3) records it OUTSIDE the state update.
     let taggedOrd: number | null = null;
     let taggedVersion = 0;
+    // The EXPORTED branch's stopgap record, surfaced the same way.
+    let exportEntry: StoredExport | null = null;
 
     set((s) => {
       const messages = s.messages;
@@ -356,10 +400,13 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         if (href !== null && (messages[key] ?? []).some(
           (m) => m.kind === 'agent' && m.href === href,
         )) return s;
+        const text = `${format.toUpperCase()} export ready — ${file}`;
+        // Round-3 minor: the announce history carries no exports, so the entry is
+        // ALSO recorded in the session stopgap — the reload restores the download.
+        if (href !== null) exportEntry = { text, href, file };
         return {
           messages: append(messages, key, {
-            kind: 'agent', id: nextMsgId(), author: 'export',
-            text: `${format.toUpperCase()} export ready — ${file}`,
+            kind: 'agent', id: nextMsgId(), author: 'export', text,
             ...(href === null ? {} : { href, file }),
           }),
         };
@@ -445,65 +492,122 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
       return s;
     });
     if (taggedOrd !== null) recordAnchor(key, taggedOrd, taggedVersion);
+    if (exportEntry !== null) recordExport(key, exportEntry);
+    // Any frame can resolve or fail sends (a landing consumes the head anchor, a
+    // status error kills the backlog) — re-derive the persisted snapshot either way.
+    persistSendStates(key);
   },
 
-  addUserMsg: (key, id, text, items) =>
+  addUserMsg: (key, id, text, items) => {
     set((s) => ({
       messages: append(s.messages, key,
         { kind: 'user', id, text, sentAt: Date.now(), ...(items ? { items } : {}) }),
       pending: { ...s.pending, [key]: [...(s.pending[key] ?? []), id] },
-    })),
+    }));
+    persistSendStates(key);
+  },
 
-  markSendFailed: (key, id) =>
+  markSendFailed: (key, id, refused = false) => {
     set((s) => ({
       messages: {
         ...s.messages,
         [key]: (s.messages[key] ?? []).map((m) =>
-          m.kind === 'user' && m.id === id ? { ...m, failed: true } : m),
+          m.kind === 'user' && m.id === id
+            ? { ...m, failed: true, ...(refused ? { refused: true } : {}) }
+            : m),
       },
       pending: { ...s.pending, [key]: (s.pending[key] ?? []).filter((p) => p !== id) },
-    })),
+    }));
+    persistSendStates(key);
+  },
 
-  retrySend: (key, id) =>
+  retrySend: (key, id) => {
     set((s) => ({
       messages: {
         ...s.messages,
         [key]: (s.messages[key] ?? []).map((m) =>
           // A retry is a NEW send, so its §6.1 honesty-budget clock restarts too.
-          m.kind === 'user' && m.id === id ? { ...m, failed: false, sentAt: Date.now() } : m),
+          // A refused send being re-armed sheds the refused mark: if THIS attempt
+          // is accepted, the wire will hold its line like any other send's.
+          m.kind === 'user' && m.id === id
+            ? { ...m, failed: false, refused: false, sentAt: Date.now() }
+            : m),
       },
       pending: { ...s.pending, [key]: [...(s.pending[key] ?? []).filter((p) => p !== id), id] },
-    })),
+    }));
+    persistSendStates(key);
+  },
 
-  hydrate: (key, entries, anchors) =>
+  hydrate: (key, entries, anchors, sends = [], exports = []) =>
     set((s) => {
       // Once per thread per session, and never over a live projection: the read
       // restores what the wire holds, it must not double what this tab saw.
       if (s.hydrated[key] === true) return s;
       if ((s.messages[key] ?? []).length > 0) return { hydrated: { ...s.hydrated, [key]: true } };
       const byOrd = new Map(anchors.map((a) => [a.ord, a.version]));
+      // Round-3 J3: the persisted unresolved sends, by accepted-user ordinal.
+      const sendByOrd = new Map(sends.filter((x) => x.text === undefined).map((x) => [x.ord, x]));
+      const refusedAfter = new Map<number, StoredSendState[]>();
+      for (const x of sends) {
+        if (x.text === undefined) continue;
+        refusedAfter.set(x.ord, [...(refusedAfter.get(x.ord) ?? []), x]);
+      }
       const restored: DocMsg[] = [];
+      const pendingRestored: { ord: number; id: string }[] = [];
+      const pushRefused = (afterOrd: number): void => {
+        for (const x of refusedAfter.get(afterOrd) ?? []) {
+          // A REFUSED send has no wire line — its persisted text re-renders it,
+          // wearing the failure and its retry (never a plain accepted message).
+          restored.push({
+            kind: 'user', id: nextMsgId(), text: x.text as string, restored: true,
+            failed: true, refused: true, sentAt: x.sentAt,
+          });
+        }
+      };
       let ord = 0;
+      pushRefused(0);
       for (const e of entries) {
         const text = typeof e.text === 'string' ? e.text.trim() : '';
         if (text === '') continue;
         if (e.role === 'user') {
           ord += 1;
           const version = byOrd.get(ord);
+          const sendState = sendByOrd.get(ord);
+          const id = nextMsgId();
           restored.push({
-            kind: 'user', id: nextMsgId(), text, restored: true,
+            kind: 'user', id, text, restored: true,
             ...(version === undefined ? {} : { version }),
+            // A still-unresolved send keeps its ORIGINAL clock: the honesty
+            // budget resumes across the reload instead of re-arming (a send
+            // that was already stalled comes back visibly stalled).
+            ...(sendState === undefined ? {} : { sentAt: sendState.sentAt }),
+            ...(sendState?.state === 'failed' ? { failed: true } : {}),
           });
+          if (sendState?.state === 'pending') pendingRestored.push({ ord, id });
+          pushRefused(ord);
         } else if (!isFiller(text)) {
           // Agent narration (including error states) at the same seam live frames
           // cross: filler is dropped here too — one rule, both sources (§3.2).
           restored.push({ kind: 'narration', id: nextMsgId(), text });
         }
       }
+      // Round-3 minor: the transcript's export downloads, restored at the tail —
+      // the announce history holds no exports, so the stopgap is their record.
+      for (const x of exports) {
+        restored.push({ kind: 'agent', id: nextMsgId(), author: 'export',
+                        text: x.text, href: x.href, ...(x.file === undefined ? {} : { file: x.file }) });
+      }
       if (restored.length === 0) return { hydrated: { ...s.hydrated, [key]: true } };
+      const pendingIds = pendingRestored.sort((a, b) => a.ord - b.ord).map((x) => x.id);
       return {
         messages: { ...s.messages, [key]: restored },
         hydrated: { ...s.hydrated, [key]: true },
+        ...(pendingIds.length === 0 ? {} : {
+          pending: { ...s.pending, [key]: pendingIds },
+          // Sends are still in flight, so the thread IS generating — restored
+          // exactly as unresolved, never quietly demoted to terminal.
+          genState: { ...s.genState, [key]: 'generating' as GenState },
+        }),
       };
     }),
 

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -458,11 +458,13 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
             };
         if (anchorId !== undefined && generated) {
           // The session-storage stopgap's address (§6.3): the tagged message's
-          // 1-based ordinal among USER messages — the only spelling that survives
-          // a reload, because message ids are minted per session.
+          // 1-based ordinal among ACCEPTED user messages — the only spelling that
+          // survives a reload, because message ids are minted per session. A
+          // REFUSED send has no wire line, so it does not count (round-3 J3:
+          // the wire's ordinals are the address space, not the projection's).
           let ord = 0;
           for (const m of thread) {
-            if (m.kind === 'user') ord += 1;
+            if (m.kind === 'user' && m.refused !== true) ord += 1;
             if (m.kind === 'user' && m.id === anchorId) { taggedOrd = ord; break; }
           }
           taggedVersion = version;

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -13,6 +13,7 @@
 import { create } from 'zustand';
 import { isFiller } from './narration.js';
 import { recordAnchor, type StoredAnchor } from '../interactive/threadStopgap.js';
+import { UNFILED_MOUNT } from '../api/interactive.js';
 import type { ConversationEntry, ExportFormat } from '../api/interactive.js';
 import type { CoreEvent } from '../api/types.js';
 
@@ -98,7 +99,16 @@ function pick(bag: Record<string, unknown>, ...keys: string[]): string | null {
 
 interface Frame { key: string; type: string; payload: Record<string, unknown> }
 
-/** A relayed interactive frame, reduced to `(thread key, event type, payload)`. */
+/** A relayed interactive frame, reduced to `(thread key, event type, payload)`.
+ *
+ *  Project resolution (the round-2 first-generation fix): the bridge stamps
+ *  `project_id` on every payload of a doc BOUND to a crew project (serviceEmit
+ *  derives it from the binding breadcrumb), and stamps NOTHING for an unbound
+ *  doc — which the studio serves through the Unfiled (`default`) mount. So a
+ *  doc-naming frame with no project is not ambiguous, it is the Unfiled mount's:
+ *  dropping it (the pre-fix behavior) left every Unfiled doc's thread deaf —
+ *  the canvas kept the v0 "Building…" placeholder after v1 landed, the
+ *  generating chip never resolved, and the manifest never re-read. */
 function frameOf(event: CoreEvent): Frame | null {
   if (event.type !== 'interactiveEvent') return null;
   const ev = event.event as Record<string, unknown> | undefined;
@@ -106,8 +116,10 @@ function frameOf(event: CoreEvent): Frame | null {
   const type = pick(ev, 'event_type', 'type');
   const payload = (typeof ev.payload === 'object' && ev.payload !== null ? ev.payload : ev) as Record<string, unknown>;
   const docId = pick(payload, 'document_id', 'doc_id', 'document');
-  const projectId = pick(payload, 'project_id', 'project') ?? pick(ev, 'project_id', 'project');
-  if (type === null || docId === null || projectId === null) return null;
+  if (type === null || docId === null) return null;
+  const projectId = pick(payload, 'project_id', 'project')
+    ?? pick(ev, 'project_id', 'project')
+    ?? UNFILED_MOUNT;
   return { key: threadKey(projectId, docId), type, payload };
 }
 

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -623,14 +623,21 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
   addNarration: (key, text) =>
     set((s) => ({ messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text }) })),
 
-  addAgentMsg: (key, author, text, artifact) =>
+  addAgentMsg: (key, author, text, artifact) => {
     set((s) => ({
       messages: append(s.messages, key, {
         kind: 'agent', id: nextMsgId(), author, text,
         ...(artifact === undefined ? {} : { href: artifact.href }),
         ...(artifact?.file === undefined ? {} : { file: artifact.file }),
       }),
-    })),
+    }));
+    // Round-3 minor: a downloadable artifact message (an export) is state the
+    // announce history does not carry — record it so the reload restores it.
+    if (artifact !== undefined) {
+      recordExport(key, { text, href: artifact.href,
+                          ...(artifact.file === undefined ? {} : { file: artifact.file }) });
+    }
+  },
 
   addActionable: (key, text, hint, retry) =>
     set((s) => ({

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -554,6 +554,27 @@ export const useDocThreadStore = create<DocThreadStore>((set) => ({
         if (x.text === undefined) continue;
         refusedAfter.set(x.ord, [...(refusedAfter.get(x.ord) ?? []), x]);
       }
+      // The wire OUTRANKS a refusal mark: a "refused" send whose exact text IS
+      // the next accepted line was accepted after all — the failure was the lost
+      // RESPONSE (a reload tearing down the in-flight fetch, a network blip),
+      // never the send. Restoring the stale copy would duplicate the message
+      // wearing a fabricated failure; the truth is an accepted send still
+      // awaiting its answer, so it re-enters as PENDING on its original clock.
+      {
+        let o = 0;
+        for (const e of entries) {
+          const t = typeof e.text === 'string' ? e.text.trim() : '';
+          if (t === '' || e.role !== 'user') continue;
+          o += 1;
+          const queued = refusedAfter.get(o - 1) ?? [];
+          const match = queued.find((x) => (x.text as string).trim() === t);
+          if (match === undefined) continue;
+          if (!sendByOrd.has(o)) {
+            sendByOrd.set(o, { ord: o, state: 'pending', sentAt: match.sentAt });
+          }
+          queued.splice(queued.indexOf(match), 1);
+        }
+      }
       const restored: DocMsg[] = [];
       const pendingRestored: { ord: number; id: string }[] = [];
       const pushRefused = (afterOrd: number): void => {

--- a/src/store/exportAnswers.ts
+++ b/src/store/exportAnswers.ts
@@ -1,0 +1,81 @@
+// The click site's export answers, held OUTSIDE the component (round-3 J3).
+//
+// DES-UX-001 §7.2 (B5/EC37) makes the clicked control answer PENDING → READY/FAILED
+// at the click site. Round 2 found the answer could still end up NOWHERE with the
+// thread drawer closed: the answer lived in ExportMenu's local state, keyed to the
+// CURRENTLY addressed version — so a landing that advanced the head (the route
+// follows the head), a strip re-render, or any selection change wiped the un-acted
+// answer out from under the user, and the only other copy sat in a closed drawer.
+//
+// The store fixes both failure shapes at once:
+//   - the answer survives the component's own churn (remounts, selection moves,
+//     head-follow landings) because it is not component state;
+//   - an un-acted answer for ANOTHER version of the same doc stays VISIBLE at the
+//     click site, labeled with its own version — which also keeps the original
+//     §7.2 rule honest (a v3 artifact never sits under a bare "Export v4" label;
+//     it sits beside it saying v3).
+//
+// An answer retires only when the user ACTS on it: downloading a READY artifact
+// consumes it; re-running the same version+format replaces a FAILED hint. Session-
+// transient by design — the durable record is the thread transcript (§4.4).
+
+import { create } from 'zustand';
+import type { ExportFormat } from '../api/interactive.js';
+
+export type ExportAnswer =
+  | { state: 'pending'; version: number; format: ExportFormat }
+  | { state: 'ready'; version: number; format: ExportFormat; href: string; file: string }
+  | { state: 'failed'; version: number; format: ExportFormat; hint: string };
+
+/** One click site's identity: the doc, on its project mount. */
+export function exportKey(projectId: string, docId: string): string {
+  return `${projectId}:${docId}`;
+}
+
+interface ExportAnswersStore {
+  /** Per exportKey: every un-acted answer, at most one per (version, format). */
+  answers: Record<string, ExportAnswer[]>;
+  /** A run begins: PENDING replaces any previous answer for the same version+format. */
+  begin: (key: string, version: number, format: ExportFormat) => void;
+  /** The run resolved: the pending entry becomes READY or FAILED. */
+  settle: (key: string, answer: ExportAnswer) => void;
+  /** The user acted on the answer (downloaded / dismissed): it retires. */
+  consume: (key: string, version: number, format: ExportFormat) => void;
+  /** Test seam. */
+  clear: () => void;
+}
+
+function without(list: ExportAnswer[], version: number, format: ExportFormat): ExportAnswer[] {
+  return list.filter((a) => a.version !== version || a.format !== format);
+}
+
+export const useExportAnswers = create<ExportAnswersStore>((set) => ({
+  answers: {},
+
+  begin: (key, version, format) =>
+    set((s) => ({
+      answers: {
+        ...s.answers,
+        [key]: [...without(s.answers[key] ?? [], version, format),
+                { state: 'pending', version, format }],
+      },
+    })),
+
+  settle: (key, answer) =>
+    set((s) => ({
+      answers: {
+        ...s.answers,
+        [key]: [...without(s.answers[key] ?? [], answer.version, answer.format), answer],
+      },
+    })),
+
+  consume: (key, version, format) =>
+    set((s) => ({
+      answers: { ...s.answers, [key]: without(s.answers[key] ?? [], version, format) },
+    })),
+
+  clear: () => set({ answers: {} }),
+}));
+
+/** Stable empty list so selectors never mint a fresh array per render. */
+export const NO_ANSWERS: ExportAnswer[] = [];

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -416,6 +416,11 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
       act(() => { vi.advanceTimersByTime(3100); });
       expect(strip).toHaveAttribute('data-hidden', 'true');
       expect(strip.style.opacity).toBe('0');
+      // Round-3 J3: hit targets survive the visible fade — pointer events
+      // retire only after STRIP_FADE_GRACE_MS, so a mid-fade click still
+      // lands on the control instead of falling through to the sensor.
+      expect(strip.style.pointerEvents).toBe('auto');
+      act(() => { vi.advanceTimersByTime(400); }); // past the fade grace
       expect(strip.style.pointerEvents).toBe('none');
 
       const sensor = screen.getByTestId('strip-sensor');

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -2,8 +2,9 @@
 //
 // What Enter does is a pure function of the generation's state, so each test drives the
 // composer in one state and asserts the WIRE it chose. The §7.10 case is the load-bearing
-// one: editing a complete version is fork + inject as a SINGLE composer action, rendered
-// as a continuation — a version divider, no new thread header.
+// one (round-3 contract): a PLAIN continue-send is the ask alone — the client never mints
+// a version for it; fork survives only for the genuine branch gesture (sending from an
+// explicitly selected OLDER version), rendered as a continuation with a deferred divider.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -169,33 +170,32 @@ describe('state 3 — gated: the gate is answerable in the thread', () => {
   });
 });
 
-describe('state 4 — terminal: fork + inject is ONE atomic action (§7.10)', () => {
-  it('forks from the shown version, injects with the same message, renders a continuation', async () => {
-    mount(DOC, 3);
+describe('state 4 — terminal: a PLAIN send never forks (§7.10, round-3 contract)', () => {
+  it('with no routed version: inject only — no fork, no minted version, no divider', async () => {
+    mount(DOC, null);
     expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'terminal');
 
     await send('make the closing slide stronger');
 
     await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
-    // ONE composer action → one fork, one inject, both carrying the same anchor id.
     const anchorId = screen.getByTestId('doc-message').getAttribute('data-message-id');
-    expect(postFork).toHaveBeenCalledTimes(1);
-    expect(postFork).toHaveBeenCalledWith(PROJECT, DOC, 3, anchorId);
+    // The round-2 J3 pin: NO fork on a plain send — the pre-fix path minted a
+    // byte-identical version before any work existed.
+    expect(postFork).not.toHaveBeenCalled();
     expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      event_type: 'wicked.interactive.chat.posted',
       payload: expect.objectContaining({
         text: 'make the closing slide stronger', document_id: DOC, source_message_id: anchorId,
       }),
     }));
-
-    // The J3 bookkeeping pin: "continues as v4" is an ANCHOR — it must NOT
-    // render before the thread observed v4 on the wire. Right after the fork
-    // acks, the divider is only REGISTERED, never shown.
+    // No divider, ever, for a plain send — a continuation divider is a branch anchor.
     expect(screen.queryByTestId('version-divider')).toBeNull();
-    expect((useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind))
-      .toEqual(['user']);
+    // Nothing landed yet, so the route stays put: the bare route already follows the head.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
 
-    // The version.created arrival is what materializes it — a CONTINUATION:
-    // a version divider above its message, and no new thread header.
+    // The REAL revised version arriving is what tags the send — the wire's proof,
+    // never the client's own mint.
     act(() => {
       useDocThreadStore.getState().ingest({
         type: 'interactiveEvent',
@@ -205,32 +205,60 @@ describe('state 4 — terminal: fork + inject is ONE atomic action (§7.10)', ()
         },
       } as never);
     });
+    expect(screen.getByTestId('version-marker')).toHaveAttribute('data-caused-by', anchorId);
+    expect(screen.queryByTestId('version-divider')).toBeNull();
+  });
+
+  it('with the HEAD selected: still a plain send — no fork; the route un-pins to follow the head', async () => {
+    mount(DOC, 3); // head is 3 (getVersions mock)
+    await send('tighten the intro');
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(getVersions).toHaveBeenCalledWith(PROJECT, DOC);
+    expect(postFork).not.toHaveBeenCalled();
+    // ?v=3 pinned the head; the send un-pins so the canvas follows the landing.
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}`);
+  });
+
+  it('from an explicitly selected OLDER version: the genuine branch gesture forks, with the deferred divider', async () => {
+    mount(DOC, 2); // older than the head (3) — the one case fork survives
+    await send('branch: keep the old chart');
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    const anchorId = screen.getByTestId('doc-message').getAttribute('data-message-id');
+    expect(postFork).toHaveBeenCalledTimes(1);
+    expect(postFork).toHaveBeenCalledWith(PROJECT, DOC, 2, anchorId);
+
+    // The J3 bookkeeping pin holds on the branch too: "continues as v4" is an
+    // ANCHOR — registered on the fork ack, rendered only on the wire's proof.
+    expect(screen.queryByTestId('version-divider')).toBeNull();
+    expect((useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind))
+      .toEqual(['user']);
+
+    act(() => {
+      useDocThreadStore.getState().ingest({
+        type: 'interactiveEvent',
+        event: {
+          event_type: 'wicked.interactive.version.created',
+          payload: { project_id: PROJECT, document_id: DOC, version: 4, parent: 2, kind: 'generated' },
+        },
+      } as never);
+    });
     const divider = screen.getByTestId('version-divider');
     expect(divider).toHaveAttribute('data-version', '4');
     expect(divider).toHaveTextContent('continues as v4');
     expect(screen.queryByTestId('thread-header')).toBeNull();
-    expect(screen.getAllByTestId('thread')).toHaveLength(1);
 
-    // The divider precedes the message it continues into, and the landing
-    // consumed both the anchor and the expectation.
+    // The divider precedes the message it continues into.
     const order = (useDocThreadStore.getState().messages[KEY] ?? []).map((m) => m.kind);
     expect(order).toEqual(['divider', 'user']);
     expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=4`);
   });
 
-  it('the composer is live (generating) after the fork, before anything lands', async () => {
-    mount(DOC, 3);
+  it('the composer is live (generating) after a plain send, before anything lands', async () => {
+    mount(DOC, null);
     await send('make the closing slide stronger');
     await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
     expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
-  });
-
-  it('with no routed version it forks from the manifest head, never from v1', async () => {
-    mount(DOC, null);
-    await send('tighten the intro');
-    await waitFor(() => expect(postFork).toHaveBeenCalledTimes(1));
-    expect(getVersions).toHaveBeenCalledWith(PROJECT, DOC);
-    expect(postFork).toHaveBeenCalledWith(PROJECT, DOC, 3, expect.any(String));
   });
 });
 

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -360,3 +360,37 @@ describe('the ▤ v<N> landed tag — the thread half of the doc↔canvas↔thre
     expect(screen.queryByTestId('version-marker')).toBeNull();
   });
 });
+
+describe('teardown honesty — an unload-aborted send is NOT a refusal', () => {
+  it('a rejection landing after pagehide leaves the send pending (no fabricated refusal persisted)', async () => {
+    mount(DOC, null);
+    let reject!: (e: Error) => void;
+    postEvent.mockImplementationOnce(() => new Promise((_, rej) => { reject = rej; }));
+
+    await send('add a roadmap slide');
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    expect(useDocThreadStore.getState().pending[KEY]).toHaveLength(1);
+
+    // The reload begins: pagehide fires FIRST, then the browser aborts the fetch.
+    window.dispatchEvent(new Event('pagehide'));
+    await act(async () => { reject(new TypeError('Failed to fetch')); });
+
+    // The send keeps its honest unresolved state — pending, unfailed — so the
+    // stopgap the next load hydrates from still holds `pending` + the clock.
+    const msg = thread().find((m) => m.kind === 'user' && m.text === 'add a roadmap slide');
+    expect(msg).toMatchObject({ kind: 'user' });
+    expect((msg as Extract<DocMsg, { kind: 'user' }>).failed).not.toBe(true);
+    expect(useDocThreadStore.getState().pending[KEY]).toHaveLength(1);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+
+    // pageshow re-arms the guard (a bfcache resurrection lives on): a LIVE
+    // rejection after it fails visibly again.
+    window.dispatchEvent(new Event('pageshow'));
+    postEvent.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await send('one more ask');
+    await waitFor(() => {
+      const failed = thread().find((m) => m.kind === 'user' && m.text === 'one more ask');
+      expect((failed as Extract<DocMsg, { kind: 'user' }>).failed).toBe(true);
+    });
+  });
+});

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -10,6 +10,7 @@ import { ProjectCard } from '../src/components/ProjectCard.js';
 import { VersionStrip } from '../src/components/VersionStrip.js';
 import type { BoardProject } from '../src/hooks/useBoardModel.js';
 import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+import { useExportAnswers } from '../src/store/exportAnswers.js';
 
 const postExport = vi.fn();
 const postFork = vi.fn();
@@ -97,6 +98,7 @@ async function press(format: string, scope?: HTMLElement): Promise<void> {
 beforeEach(() => {
   vi.clearAllMocks();
   useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
+  useExportAnswers.getState().clear();
   postExport.mockResolvedValue(reply('roadmap_v3.pdf'));
 });
 afterEach(cleanup);
@@ -151,7 +153,7 @@ describe('the version strip exports the SELECTED version (§4.4, §4.2)', () => 
     expect(screen.getAllByTestId('export-format')).toHaveLength(2);
   });
 
-  it('§7.2: a new version selection retires the previous READY answer', async () => {
+  it('round-3 J3: a new version selection KEEPS the un-acted READY answer, wearing its own version', async () => {
     const { rerender } = render(
       <VersionStrip projectId={PROJECT} docId={DOC} manifest={MANIFEST}
                     selected={3} navigate={() => {}} onForked={() => {}} />,
@@ -163,9 +165,18 @@ describe('the version strip exports the SELECTED version (§4.4, §4.2)', () => 
       <VersionStrip projectId={PROJECT} docId={DOC} manifest={MANIFEST}
                     selected={2} navigate={() => {}} onForked={() => {}} />,
     );
-    // A v3 artifact link must not sit under an "Export v2" label.
-    expect(screen.queryByTestId('export-ready')).toBeNull();
+    // The round-2 finding: selection moves (incl. head-follow landings) wiped the
+    // un-acted answer — with the drawer closed it then lived NOWHERE. It stays at
+    // the click site now, labeled with ITS version, so the old §7.2 mislabel rule
+    // still holds: a v3 artifact never sits under a bare "Export v2" label.
+    const ready = screen.getByTestId('export-ready');
+    expect(ready).toHaveAttribute('data-version', '3');
+    expect(ready).toHaveTextContent('v3');
+    // All three formats are offered for the NEWLY addressed version beside it.
     expect(screen.getAllByTestId('export-format')).toHaveLength(3);
+    // Acting on the answer (the download click) is what retires it.
+    await userEvent.setup().click(ready);
+    expect(screen.queryByTestId('export-ready')).toBeNull();
   });
 });
 

--- a/tests/VersionStrip.test.tsx
+++ b/tests/VersionStrip.test.tsx
@@ -151,7 +151,9 @@ describe('VersionStrip — the version → message cross-link (§7.6)', () => {
     for (const button of screen.getAllByTestId('version-scroll')) {
       expect(button).toBeDisabled();
       expect(button.getAttribute('title') ?? '').toMatch(/no source message|nothing to scroll to/i);
-      expect(button.getAttribute('title') ?? '').toMatch(/before the merge/i);
+      // Round-3 copy pass: operator language — the reason names the service
+      // capability, no spec refs, no merge-history jargon.
+      expect(button.getAttribute('title') ?? '').toMatch(/does not yet record version anchors/i);
     }
   });
 

--- a/tests/VideoStoryboard.test.tsx
+++ b/tests/VideoStoryboard.test.tsx
@@ -185,6 +185,11 @@ describe('version strip auto-hide', () => {
       act(() => { vi.advanceTimersByTime(3100); });
       expect(strip).toHaveAttribute('data-hidden', 'true');
       expect(strip.style.opacity).toBe('0');
+      // Round-3 J3: hit targets survive the visible fade — pointer events
+      // retire only after STRIP_FADE_GRACE_MS, so a mid-fade click still
+      // lands on the control instead of falling through to the sensor.
+      expect(strip.style.pointerEvents).toBe('auto');
+      act(() => { vi.advanceTimersByTime(400); }); // past the fade grace
       expect(strip.style.pointerEvents).toBe('none');
 
       // Proximity: the sensor exists only while hidden, and a mousemove wakes.

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -399,3 +399,80 @@ describe('unbound-doc frames (the round-2 first-generation fix)', () => {
     expect(Object.keys(useDocThreadStore.getState().landed).sort()).toEqual(before);
   });
 });
+
+// ── Round-3 J3 finding 4: unresolved sends survive the reload ─────────────────
+
+describe('send-state persistence (round-3 finding 4)', () => {
+  beforeEach(() => { window.sessionStorage.clear(); });
+
+  it('an accepted-but-unanswered send persists as pending and resumes on hydrate — with its ORIGINAL clock', async () => {
+    const { readSendStates } = await import('../src/interactive/threadStopgap.js');
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dmsg-p1', 'make me a deck');
+    const persisted = readSendStates(KEY);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({ ord: 1, state: 'pending' });
+    const sentAt = persisted[0]!.sentAt;
+    expect(sentAt).toBeGreaterThan(0);
+
+    // A fresh session (new store keys) hydrates the wire's text + the stopgap's sends.
+    useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
+    useDocThreadStore.getState().hydrate(
+      KEY, [{ role: 'user', text: 'make me a deck', ts: 't1' }], [], persisted, []);
+    const msgs = messages();
+    expect(msgs[0]).toMatchObject({ kind: 'user', restored: true, sentAt });
+    expect(useDocThreadStore.getState().pending[KEY]).toHaveLength(1);
+    // Unresolved sends mean the thread is still GENERATING — never quietly terminal.
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('a landing consumes the persisted pending record', () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dmsg-p2', 'make me a deck');
+    ingest(frame('wicked.interactive.version.created', { version: 1, parent: null, kind: 'generated' }));
+    return import('../src/interactive/threadStopgap.js').then(({ readSendStates }) => {
+      expect(readSendStates(KEY)).toHaveLength(0);
+    });
+  });
+
+  it('a REFUSED send persists its TEXT and re-renders failed (with retry) after hydrate', async () => {
+    const { readSendStates } = await import('../src/interactive/threadStopgap.js');
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'dmsg-ok', 'the brief');           // accepted, then answered
+    ingest(frame('wicked.interactive.version.created', { version: 1, parent: null, kind: 'generated' }));
+    store.addUserMsg(KEY, 'dmsg-ref', 'add a closing slide'); // refused by the bridge
+    store.markSendFailed(KEY, 'dmsg-ref', true);
+    const persisted = readSendStates(KEY);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({ ord: 1, state: 'failed', text: 'add a closing slide' });
+
+    // The wire holds only the ACCEPTED line; the refused one re-renders from the stopgap.
+    useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
+    useDocThreadStore.getState().hydrate(
+      KEY, [{ role: 'user', text: 'the brief', ts: 't1' }], [{ ord: 1, version: 1 }], persisted, []);
+    const users = messages().filter((m): m is Extract<DocMsg, { kind: 'user' }> => m.kind === 'user');
+    expect(users).toHaveLength(2);
+    expect(users[0]).toMatchObject({ text: 'the brief', version: 1 });
+    expect(users[1]).toMatchObject({ text: 'add a closing slide', failed: true });
+    // Nothing pending — a refused send is failed, not in flight.
+    expect(useDocThreadStore.getState().pending[KEY] ?? []).toHaveLength(0);
+  });
+
+  it('an export entry persists and is restored at the transcript tail', () => {
+    ingest(frame('wicked.interactive.export.generated', {
+      format: 'pdf', file: 'deck_v1.pdf', download: '/d/launch-deck/api/export/file/deck_v1.pdf',
+    }));
+    return import('../src/interactive/threadStopgap.js').then(({ readExports }) => {
+      const stored = readExports(KEY);
+      expect(stored).toHaveLength(1);
+      useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {} });
+      useDocThreadStore.getState().hydrate(
+        KEY, [{ role: 'user', text: 'the brief', ts: 't1' }], [], [], stored);
+      const tail = messages()[messages().length - 1];
+      expect(tail).toMatchObject({
+        kind: 'agent', author: 'export',
+        href: '/d/launch-deck/api/export/file/deck_v1.pdf', file: 'deck_v1.pdf',
+      });
+    });
+  });
+});

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -367,3 +367,35 @@ describe('the signal clock (§6.1 honesty budget)', () => {
     expect(retried !== undefined && retried.kind === 'user' && typeof retried.sentAt).toBe('number');
   });
 });
+
+// ── Round-3 J3: unbound-doc frames key to the Unfiled mount ───────────────────
+
+describe('unbound-doc frames (the round-2 first-generation fix)', () => {
+  it('a doc-naming frame with NO project keys to the Unfiled (default) mount, never dropped', () => {
+    const key = threadKey('default', DOC);
+    ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.version.created',
+        // The real bridge stamps project_id ONLY on bound docs (serviceEmit);
+        // an Unfiled doc's payloads carry none — pre-fix these were dropped,
+        // leaving the open canvas on the v0 placeholder after v1 landed.
+        payload: { document_id: DOC, version: 1, parent: 0, kind: 'generated' },
+      },
+    } as unknown as CoreEvent);
+    expect(useDocThreadStore.getState().landed[key]).toBe(1);
+    expect(useDocThreadStore.getState().lastSignalAt[key]).toBeGreaterThan(0);
+  });
+
+  it('a frame naming no document is still dropped — the fallback never invents a doc', () => {
+    const before = Object.keys(useDocThreadStore.getState().landed).sort();
+    ingest({
+      type: 'interactiveEvent',
+      event: {
+        event_type: 'wicked.interactive.version.created',
+        payload: { version: 1, kind: 'generated' },
+      },
+    } as unknown as CoreEvent);
+    expect(Object.keys(useDocThreadStore.getState().landed).sort()).toEqual(before);
+  });
+});

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -458,6 +458,26 @@ describe('send-state persistence (round-3 finding 4)', () => {
     expect(useDocThreadStore.getState().pending[KEY] ?? []).toHaveLength(0);
   });
 
+  it('the wire outranks a stale refusal: a "refused" send the wire ACCEPTED restores as ONE pending message', () => {
+    // The reload-teardown shape: the in-flight fetch was aborted by the unload,
+    // the catch persisted a refusal — but the bridge took the message (its line
+    // is on the wire). Hydrate must not render a duplicated, fabricated failure:
+    // the send restores from the wire line, PENDING, on its original clock.
+    const stale = [{ ord: 1, state: 'failed' as const, sentAt: 12345, text: 'add a roadmap slide' }];
+    useDocThreadStore.getState().hydrate(
+      KEY,
+      [{ role: 'user', text: 'the brief', ts: 't1' },
+       { role: 'user', text: 'add a roadmap slide', ts: 't2' }],
+      [{ ord: 1, version: 1 }], stale, []);
+    const users = messages().filter((m): m is Extract<DocMsg, { kind: 'user' }> => m.kind === 'user');
+    expect(users).toHaveLength(2); // no duplicate refused copy
+    expect(users[1]).toMatchObject({ text: 'add a roadmap slide', sentAt: 12345 });
+    expect(users[1]?.failed).not.toBe(true);
+    // Accepted and still unanswered ⇒ pending, and the thread is generating.
+    expect(useDocThreadStore.getState().pending[KEY] ?? []).toHaveLength(1);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
   it('an export entry persists and is restored at the transcript tail', () => {
     ingest(frame('wicked.interactive.export.generated', {
       format: 'pdf', file: 'deck_v1.pdf', download: '/d/launch-deck/api/export/file/deck_v1.pdf',

--- a/tests/stripHold.test.tsx
+++ b/tests/stripHold.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render, renderHook, screen } from '@testing-library/react';
 import { ExportMenu } from '../src/components/ExportMenu.js';
 import { STRIP_IDLE_MS, useStripAutoHide } from '../src/components/ThreadDrawer.js';
+import { useExportAnswers } from '../src/store/exportAnswers.js';
 
 const postExport = vi.fn();
 
@@ -26,6 +27,7 @@ vi.mock('../src/api/interactive.js', () => ({
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  useExportAnswers.getState().clear();
 });
 
 afterEach(() => {
@@ -61,7 +63,7 @@ describe('useStripAutoHide — the hold contract', () => {
 });
 
 describe('ExportMenu — holds its host while it owes (or shows) an answer', () => {
-  it('holds through pending AND the un-acted READY answer; a version change releases', async () => {
+  it('holds through pending, the un-acted READY answer, and a version change; ACTING releases', async () => {
     const onHold = vi.fn();
     let resolveExport: (v: unknown) => void = () => {};
     postExport.mockImplementation(() => new Promise((res) => { resolveExport = res; }));
@@ -83,8 +85,17 @@ describe('ExportMenu — holds its host while it owes (or shows) an answer', () 
     const calls = onHold.mock.calls.map((c) => c[0]);
     expect(calls.filter((v) => v === true).length - calls.filter((v) => v === false).length).toBe(1);
 
-    // Addressing another version retires the answer — the hold releases with it.
+    // Round-3 J3: addressing another version must NOT release the hold — the round-2
+    // finding was exactly this wipe (a head-follow landing re-addressed the menu and
+    // the un-acted answer, the only visible copy with the drawer closed, vanished).
     rerender(<ExportMenu projectId="p1" docId="roadmap" version={2} onHold={onHold} />);
+    const ready = screen.getByTestId('export-ready');
+    expect(ready).toHaveAttribute('data-version', '3');
+    const mid = onHold.mock.calls.map((c) => c[0]);
+    expect(mid.filter((v) => v === true).length - mid.filter((v) => v === false).length).toBe(1);
+
+    // ACTING on the answer (the download click) is what releases the hold.
+    act(() => { ready.click(); });
     const after = onHold.mock.calls.map((c) => c[0]);
     expect(after.filter((v) => v === true).length).toBe(after.filter((v) => v === false).length);
   });


### PR DESCRIPTION
Round-3 fix for BRIEF-UX-001's J3 (studio side; the platform side landed as CREW-UX-4/5 — creation and iteration are now both governed and proven live).

- **No fork-per-send**: a plain continue-send no longer mints a version — the ask goes over the wire and the real revised version arrives from the governed answerer; `postFork` survives only for an explicit branch from an older selected version (divider still wire-deferred). This kills round-2's "fabricated versions byte-identical to v1".
- **First-generation live update**: unfiled-doc frames reach the canvas — the open v0 placeholder swaps to v1 without reload.
- **Export with the drawer closed** always answers at the click site; the answer persists through strip churn/fading; the sensor band summons the strip instead of eating clicks.
- **Send-state survives reload**: stalled/refused sends restore with their failure state and a working retry on the original clock. The gate run exposed a real extra bug — reload aborting an in-flight send persisted a fabricated refusal — fixed (pagehide guard + wire-outranks-refusal hydrate reconciliation).
- Minors: export transcript persistence, spec-refs removed from product copy, and the fixture now mirrors the real bridge (no client-minted versions) so this class can't pass a rig again.

Verified: 1453/1453 unit tests post-rebase; slice rig 15 checks (6 consecutive passes incl. cold build); regressions ux_sliceT (fork-pinned scenes re-scoped to the no-fork contract), ux_fixJ3J1, ux_fixJ42, uxfix_slice6; adversarial verifier approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
