### PR TITLE
EC44: chips are truth — roster-resolved, capability-aware, send == display

### DIFF
--- a/e2e/feedback2_sliceK_test.py
+++ b/e2e/feedback2_sliceK_test.py
@@ -20,7 +20,8 @@ DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar
       the toggle appears; columns mode renders [data-testid="chat-round"] with
       a [data-testid="chat-round-grid"] of data-columns="4" — since DES-UX-001
       slice AB (§7.9-1, the §11.2 re-scope) the first pristine cold-cache send
-      is ROSTER-FIRST: it warms the fixture's four roster seats, not the
+      is ROSTER-TRUE (EC44 round-3 re-scope): it warms the CHAT-CAPABLE
+      seats the chips display (claude + pi), not the
       fallback trio.
    2. The same seat's cells share a column index across rounds; a seat that
       died between rounds (real chatSessionFailed) renders
@@ -117,6 +118,9 @@ with sync_playwright() as p:
     # ══ Scene 1 — chat columns (§6.5) ═══════════════════════════════════════════
     page.goto(CHAT_URL, wait_until="domcontentloaded")
     page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    # EC44: wait for the chips to RESOLVE (Send is disabled while the roster
+    # is unknown — typing earlier would no-op).
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     # AC: no toggle before anything replied (a single/zero-seat chat has nothing
@@ -124,22 +128,23 @@ with sync_playwright() as p:
     step("K1_toggle_absent_firstrun",
          page.locator('[data-testid="chat-layout-toggle"]').count() == 0)
 
-    # Round 1: the first send is roster-first (slice AB §7.9-1) — it warms the
-    # fixture's four roster seats; the fixture fans out one REAL chatReply per
-    # seat, then kills the last-warmed seat (chatSessionFailed → 'pi').
+    # Round 1: the first send is roster-TRUE (EC44) — it warms exactly the
+    # chat-capable chips (claude + pi); the fixture fans out one REAL
+    # chatReply per seat, then kills the last-warmed seat
+    # (chatSessionFailed → 'pi').
     composer = page.locator("textarea.wk-composer")
     composer.fill("How should we refactor the fetch layer?")
     page.keyboard.press("Enter")
     page.wait_for_function(
         """() => [...document.querySelectorAll('[data-testid="doc-canvas"], p, div')]
                  .filter(el => el.childElementCount === 0 && (el.textContent || '').includes('(round 1)'))
-                 .length >= 3""",
+                 .length >= 2""",
         timeout=30000)
     # The dying seat's chip goes failed BEFORE round 2 (its title carries the reason).
     page.locator('[title="session exited unexpectedly (fixture)"]').wait_for(timeout=30000)
     step("K1_round1_replies", True)
 
-    # The toggle appeared (3 distinct replying seats). Type a draft, then switch
+    # The toggle appeared (2 distinct replying seats). Type a draft, then switch
     # layouts — the composer must keep focus AND the draft (§6.5), and the
     # toggle must fire ZERO requests (C1).
     page.locator('[data-testid="chat-layout-toggle"]').wait_for(timeout=30000)
@@ -165,7 +170,7 @@ with sync_playwright() as p:
              };
            }""")
     step("K1_columns_grid",
-         grid1["columns"] == "4" and grid1["rounds"] == 1 and len(grid1["agents"]) == 4,
+         grid1["columns"] == "2" and grid1["rounds"] == 1 and len(grid1["agents"]) == 2,
          **grid1)
     step("K1_toggle_zero_requests_keeps_draft",
          api_requests == before_toggle
@@ -173,14 +178,14 @@ with sync_playwright() as p:
          new_requests=[r for r in api_requests if r not in before_toggle])
 
     # Round 2, sent FROM columns mode (Enter still sends — the toggle never
-    # intercepts composer keys): two live seats reply; the dead seat's column
-    # renders the dimmed EMPTY cell, and column indexes hold across rounds.
+    # intercepts composer keys): the surviving seat replies; the dead seat's
+    # column renders the dimmed EMPTY cell, and column indexes hold.
     composer.fill("Which part ships first?")
     page.keyboard.press("Enter")
     page.wait_for_function(
         """() => [...document.querySelectorAll('div,p')]
                  .filter(el => el.childElementCount === 0 && (el.textContent || '').includes('(round 2)'))
-                 .length >= 2""",
+                 .length >= 1""",
         timeout=30000)
     rounds = page.evaluate(
         """() => {
@@ -197,7 +202,7 @@ with sync_playwright() as p:
              };
            }""")
     step("K2_empty_cell_stable_columns",
-         rounds["count"] == 2 and rounds["columns"] == ["4", "4"]
+         rounds["count"] == 2 and rounds["columns"] == ["2", "2"]
          and rounds["agents"][0] == rounds["agents"][1]
          and rounds["emptyAgents"] == ["pi"] and rounds["emptyInSecond"]
          and rounds["noHorizPageScroll"],

--- a/e2e/feedback_sliceC_test.py
+++ b/e2e/feedback_sliceC_test.py
@@ -58,8 +58,9 @@ CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
 # EC44: the cold route resolves the roster on mount; the default chips are
-# the CHAT-CAPABLE subset (acp object or absent key — pi's arm; explicit
-# null = incapable, offered only in the labeled picker).
+# the CHAT-CAPABLE subset (acp objects on claude/pi; round 4: an absent
+# key beside a speaking roster = "no config" — incapable seats are offered
+# only in the labeled picker).
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
 CAPABLE = ["claude", "pi"]
 

--- a/e2e/feedback_sliceC_test.py
+++ b/e2e/feedback_sliceC_test.py
@@ -4,29 +4,24 @@ feedback_sliceC_test.py — the DES-FEEDBACK-001 slice-C gate: Chat default
 agent chips (§6, §8.3 slice C), against the shared frozen-NOW0 W2 fixture
 (uxfix_fixture.py).
 
-The slice DOM ACs, verbatim from §8.3:
+The slice DOM ACs (§8.3), as RE-SCOPED TWICE — by DES-UX-001 slice AB
+(§11.2, roster-first) and by BRIEF-UX-001 C6/EC44 (round 3: chips are truth —
+the fallback trio is GONE; no chip is painted until the roster is known):
 
-  1. `[data-testid="agent-chip"]` elements are present on first render without
-     any network request having fired;
-  2. the `data-count` attribute on `[data-testid="agent-chips-bar"]` equals 3;
+  1. `[data-testid="agent-chip"]` elements resolve on this cold route from the
+     surface's ONE named mount request (GET /roster) — roster-true, never a
+     fabricated trio (`data-source="roster"`);
+  2. the `data-count` attribute equals the CHAT-CAPABLE seat count;
   3. clicking a chip's ✕ removes it (count decrements);
-  4. `[data-testid="add-agent"]` button opens the roster picker;
+  4. `[data-testid="add-agent"]` button opens the roster picker (from the
+     now-warm cache — no second fetch);
   5. zero `openChat` requests fire on mount (verified by `page.on('request')`).
 
-RE-SCOPED by DES-UX-001 slice AB (§11.2): chip seeding is ROSTER-FIRST with
-the cold-cache fallback — this route fetches no roster before Chat mounts, so
-what this rig pins IS the cold-cache fallback arm (the trio, zero requests,
-`data-source="fallback"` on the chips bar). The roster-first arm — a warm
-cache seeding the chips, the first send fetching the roster on its own
-gesture — is pinned by ux_sliceAB_test.py and the GroupChat unit suites.
-
-"Without any network request" is measured as the slice-B rig measured it: the
-app-shell rail fires its own requests identically on main (projects, runs —
-they are not this slice's), so the tap records EVERY /api/v1/* request and the
-assertion is on the DELTA the chat surface could add — the chat-surface set
-(`/api/v1/chats*`, `/api/v1/roster`) must be EMPTY on mount (§6.1: chips render
-from the cache/fallback, the binding UXFIX §2.4 constraint). The rail's own
-requests are reported informationally, never asserted against.
+The mount-network assertion is the same DELTA discipline as before: the tap
+records EVERY /api/v1/* request; the chat-surface set on mount must be
+EXACTLY the one named GET /roster (EC44's carve-out from the §2.4 budget) and
+zero /chats requests. The rail's own requests are reported informationally,
+never asserted against.
 
 Plus the §8.3 preservation list this rig can see: the chat first-run teaching
 state (EC7 — the surface teaches itself; pinned in depth by uxfix_slice4) and
@@ -34,7 +29,7 @@ EC13 (chip text reads in the SANS — asserted via computed style, with the
 token anatomy: --radius-full resolves to 9999px, --text-xs to 11px).
 
 Captures (§8.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
-  feedback-C-chat-chips.png          Chat first-run, 3 default chips, no thread
+  feedback-C-chat-chips.png          Chat first-run, capable default chips, no thread
   feedback-C-chat-chips-removed.png  one chip removed, 2 remaining
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
@@ -62,10 +57,11 @@ ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 CHAT_URL = f"{ORIGIN}/p/q3-review-deck/chat"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
-# §6.2's hardcoded fallback trio — what renders here: nothing on this route
-# fetches a roster before Chat mounts, so the cache is cold by construction.
-FALLBACK = ["writer", "reviewer", "planner"]
+# EC44: the cold route resolves the roster on mount; the default chips are
+# the CHAT-CAPABLE subset (acp object or absent key — pi's arm; explicit
+# null = incapable, offered only in the labeled picker).
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
+CAPABLE = ["claude", "pi"]
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -125,6 +121,9 @@ with sync_playwright() as p:
     page.goto(CHAT_URL, wait_until="domcontentloaded")
     page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
     page.locator('[data-testid="agent-chips-bar"]').wait_for(timeout=30000)
+    # EC44: the chips RESOLVE (the honest resolving row first, then roster-true
+    # chips) — wait for the resolved state before the census.
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     fonts_ok = page.evaluate("() => document.fonts.status") is not None  # settle probe below
@@ -175,7 +174,7 @@ with sync_playwright() as p:
     page.screenshot(path=str(VSHOTS / "feedback-C-chat-chips.png"))
 
     # ── AC 3: ✕ removes — count decrements, chip gone ──────────────────────────
-    page.locator('[data-testid="agent-chip"][data-agent="writer"] button').click()
+    page.locator('[data-testid="agent-chip"][data-agent="claude"] button').click()
     removed = page.evaluate(
         """() => ({
              barCount: document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null,
@@ -212,9 +211,9 @@ with sync_playwright() as p:
 report["steps"]["chips_first_render"] = {
     "ok": all([
         fonts_ok,
-        first_render["barCount"] == "3",
-        first_render["barSource"] == "fallback",  # slice AB §7.9-1's honesty attr
-        first_render["chipKeys"] == FALLBACK,
+        first_render["barCount"] == str(len(CAPABLE)),
+        first_render["barSource"] == "roster",  # EC44's honesty attr: chips are seats
+        first_render["chipKeys"] == CAPABLE,
         # §6.3 anatomy in tokens: --radius-full → 9999px, --text-xs → 11px,
         # EC13: the chip label reads in the SANS (Inter stack), 3px 8px 3px 6px.
         first_render["chipRadius"] == "9999px",
@@ -231,13 +230,14 @@ report["steps"]["chips_first_render"] = {
     "screenshot": str(VSHOTS / "feedback-C-chat-chips.png"),
 }
 report["steps"]["mount_network_delta"] = {
-    "ok": len(mount_chat_surface) == 0 and len(open_posts_on_mount) == 0,
+    # EC44: exactly the ONE named roster resolve — and nothing chat-shaped.
+    "ok": mount_chat_surface == [("GET", "/api/v1/roster")] and len(open_posts_on_mount) == 0,
     "chat_surface_requests_on_mount": mount_chat_surface,
     "openChat_posts_on_mount": len(open_posts_on_mount),
     "rail_owned_requests_ignored": mount_rail,
 }
 report["steps"]["chip_remove"] = {
-    "ok": removed["barCount"] == "2" and removed["chipKeys"] == ["reviewer", "planner"],
+    "ok": removed["barCount"] == "1" and removed["chipKeys"] == ["pi"],
     **removed,
     "screenshot": str(VSHOTS / "feedback-C-chat-chips-removed.png"),
 }
@@ -245,8 +245,9 @@ report["steps"]["add_agent_picker"] = {
     "ok": all([
         picker_options_ok,
         picker == ROSTER_KEYS,
-        # The roster fetch rode the CLICK: zero before, exactly one after.
-        roster_gets_before == 0,
+        # The mount already resolved the roster (EC44's one named request);
+        # the picker reads the warm cache — the click adds NO fetch.
+        roster_gets_before == 1,
         roster_gets_after == 1,
     ]),
     "picker_options": picker,

--- a/e2e/ux_fixJ42_test.py
+++ b/e2e/ux_fixJ42_test.py
@@ -9,22 +9,31 @@ any cli not in ROSTER answers the core's own per-seat rejection
 round-2 review caught — the fallback trio riding the wire and every cold
 profile's first send failing — can never pass this rig by fixture leniency.
 
+ROUND-3 RE-SCOPE (BRIEF-UX-001 C6/EC44 — chips are truth): the fallback-
+trio-as-placeholder arm this rig used to pin is GONE (that placeholder was
+the round-3 defect: chips painted that the send did not connect). The scenes
+below now pin the same J4 outcomes through the EC44 contract: cold mount
+resolves the roster with its ONE named request, the chips are the CHAT-
+CAPABLE seats, and every send connects exactly the displayed chips. The
+dedicated EC44 gate (paint witness, capability labels) is ux_fixJ43_test.py.
+
 Scenes (each on a FRESH browser context — zero storage, the cold profile):
 
-  1. COLD PROFILE (finding 1 + 3): /chat/new mounts with the fallback chips
-     as PLACEHOLDERS (data-source="fallback", zero chat-surface requests);
-     the FIRST SEND fetches the roster on the gesture (exactly one GET
-     /roster), opens with the ROSTER's seats — the strict fixture accepts
-     them, the send succeeds, a reply lands — the URL flips to /chat/:id
+  1. COLD PROFILE (finding 1 + 3): /chat/new mounts with NO chat request but
+     the ONE named GET /roster (EC44); the chips resolve roster-true
+     (data-source="roster", the chat-capable seats); the FIRST SEND opens
+     with EXACTLY the displayed chips — the strict fixture accepts them,
+     the send succeeds, a reply lands — the URL flips to /chat/:id
      (J4: the session is findable), the rail lists the live session and
      never says "no chats", and /chats' Active-now headline counts the
      live row (finding 4a: no "0 of 0" beside a live session).
-  2. ROSTER UNREACHABLE (finding 1): with GET /roster answering 500, a
-     pristine first send FAILS INLINE — zero POST /chats (the trio never
-     ships), the draft survives in the composer, the failure renders with
-     a working Retry; after the roster recovers, Retry sends the ROSTER's
-     seats and exactly one user bubble renders (no duplicate).
-  3. OPEN-FAILURE RECOVERY (finding 2 + 3): every seat rejected at open →
+  2. ROSTER UNREACHABLE (finding 1, re-dressed by EC44): with GET /roster
+     answering 500, the MOUNT resolve fails — the bar says so with a
+     working Retry, NO chip is painted, Send stays disabled, and nothing
+     ships (zero POST /chats); after the roster recovers, Retry resolves
+     the chips and the send connects the capable seats, exactly one user
+     bubble (no duplicate).
+  3. OPEN-FAILURE RECOVERY (finding 2 + 3): every (capable) seat rejected at open →
      the failure renders as a retryable row beside the banner, the draft
      survives; remove one chip, un-reject, Retry → the send succeeds into
      the SAME chat id, the stale banner clears, and the removed seat's
@@ -50,6 +59,7 @@ import sys
 from urllib.parse import urlparse
 
 from uxfix_fixture import (
+    CHAT_CAPABLE_KEYS,
     HIDE_GATE_TOASTS,
     REPO,
     ROSTER,
@@ -63,7 +73,7 @@ ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
 ROSTER_KEYS = [s["key"] for s in ROSTER]
-FALLBACK = ["writer", "reviewer", "planner"]
+CAPABLE = CHAT_CAPABLE_KEYS  # the EC44 default chip set — what a cold send connects
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -150,17 +160,20 @@ with sync_playwright() as p:
     page.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
     page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
     page.locator('[data-testid="agent-chips-bar"]').wait_for(timeout=30000)
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     storage = page.evaluate("() => sessionStorage.length + localStorage.length")
     mount = page.evaluate(CENSUS)
     mount_chat = [(m, q) for (m, q, _b) in net if is_chat_surface(q)]
-    check("cold_mount_placeholders_zero_requests",
+    # EC44: the ONE named mount request (GET /roster) resolves the chips
+    # roster-true; nothing chat-shaped fires and nothing warms.
+    check("cold_mount_resolves_roster_true_chips",
           storage == 0
           and mount["chipsBar"] is not None
-          and mount["chipsBar"]["source"] == "fallback"
-          and mount["chipsBar"]["count"] == str(len(FALLBACK))
-          and len(mount_chat) == 0,
+          and mount["chipsBar"]["source"] == "roster"
+          and mount["chipsBar"]["count"] == str(len(CAPABLE))
+          and mount_chat == [("GET", "/api/v1/roster")],
           storage_entries=storage, chips_bar=mount["chipsBar"], mount_chat_requests=mount_chat)
 
     page.locator("textarea").fill(MSG_COLD)
@@ -177,7 +190,7 @@ with sync_playwright() as p:
     check("cold_first_send_roster_first_and_accepted",
           len(roster_gets) == 1
           and len(opens) == 1
-          and (opens[0][2] or {}).get("clis") == ROSTER_KEYS
+          and (opens[0][2] or {}).get("clis") == CAPABLE
           and not sent["openError"]
           and sent["sendFailed"] is None
           and sent["userBubbles"] == [MSG_COLD]
@@ -221,26 +234,34 @@ with sync_playwright() as p:
     page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
+    # EC44: the failed MOUNT resolve renders as the bar's unresolved row —
+    # no chip is painted, Send stays disabled, and Enter ships NOTHING.
+    page2.locator('[data-testid="agent-chips-unresolved"]').wait_for(timeout=30000)
     page2.locator("textarea").fill(MSG_DOWN)
     page2.keyboard.press("Enter")
-    page2.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)
     down = page2.evaluate(CENSUS)
     down_opens = [(m, q) for (m, q, _b) in net2 if m == "POST" and q == "/api/v1/chats"]
     down_sends = [(m, q) for (m, q, _b) in net2 if m == "POST" and "/messages" in q]
+    down_chips = page2.evaluate(
+        """() => [...document.querySelectorAll('[data-testid=\"agent-chip\"]')].length""")
     check("roster_down_nothing_ships_draft_survives",
           len(down_opens) == 0 and len(down_sends) == 0
-          and "roster" in (down["sendFailed"] or "")
+          and down_chips == 0
           and down["composer"] == MSG_DOWN
           and down["userBubbles"] == []
-          and down["sendDisabled"] is False
+          and down["sendDisabled"] is True
           and down["pathname"] == "/chat/new",
-          opens=down_opens, sends=down_sends, census=down)
+          opens=down_opens, sends=down_sends, chips=down_chips, census=down)
 
     page2.screenshot(path=str(VSHOTS / "ux-J42-roster-down.png"))
 
-    # The roster recovers → Retry sends the ROSTER's seats, exactly once.
+    # The roster recovers → the bar's Retry resolves the chips, and the send
+    # connects EXACTLY the displayed (capable) seats, exactly once.
     set_fixture(ORIGIN, roster_fail=False)
-    page2.locator('[data-testid="chat-send-retry"]').click()
+    page2.locator('[data-testid="agent-chips-retry"]').click()
+    page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
+    page2.locator("textarea").click()
+    page2.keyboard.press("Enter")
     page2.wait_for_function(
         f"""() => [...document.querySelectorAll('[data-testid="user-bubble"]')]
                   .filter((u) => u.textContent === {json.dumps(MSG_DOWN)}).length === 1
@@ -248,8 +269,8 @@ with sync_playwright() as p:
                && document.querySelector('textarea')?.value === ''""",
         timeout=30000)
     retry_opens = [(m, q, b) for (m, q, b) in net2 if m == "POST" and q == "/api/v1/chats"]
-    check("roster_recovers_retry_sends_roster_once",
-          len(retry_opens) == 1 and (retry_opens[0][2] or {}).get("clis") == ROSTER_KEYS,
+    check("roster_recovers_retry_sends_capable_once",
+          len(retry_opens) == 1 and (retry_opens[0][2] or {}).get("clis") == CAPABLE,
           open_body=retry_opens[0][2] if retry_opens else None)
     ctx2.close()
 
@@ -261,6 +282,7 @@ with sync_playwright() as p:
     net3 = tap(page3)
     page3.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
     page3.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page3.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page3.add_style_tag(content=HIDE_GATE_TOASTS)
 
     page3.locator("textarea").fill(MSG_REJ)
@@ -275,12 +297,12 @@ with sync_playwright() as p:
           and rej["userBubbles"] == []
           and len(rej_sends) == 0
           and all(st == "failed" for st in rej["seatChips"].values())
-          and set(rej["seatChips"]) == set(ROSTER_KEYS),
+          and set(rej["seatChips"]) == set(CAPABLE),
           census=rej, sends=rej_sends)
 
     # Remove one chip; the retried open must not name it — and its stale red
     # seat chip must be PRUNED once the send succeeds (finding 3).
-    removed = ROSTER_KEYS[-1]
+    removed = CAPABLE[-1]
     page3.locator(f'[data-testid="agent-chip"][data-agent="{removed}"] button').click()
     set_fixture(ORIGIN, chat_reject_seats=[])
     page3.locator('[data-testid="chat-send-retry"]').click()
@@ -297,7 +319,7 @@ with sync_playwright() as p:
         timeout=30000)
     recovered = page3.evaluate(CENSUS)
     opens3 = [(m, q, b) for (m, q, b) in net3 if m == "POST" and q == "/api/v1/chats"]
-    kept = [k for k in ROSTER_KEYS if k != removed]
+    kept = [k for k in CAPABLE if k != removed]
     check("recovery_same_chat_banner_and_stale_chips_clear",
           len(opens3) == 2
           and (opens3[0][2] or {}).get("chatId") == (opens3[1][2] or {}).get("chatId")
@@ -335,7 +357,7 @@ with sync_playwright() as p:
           and by_key["claude"]["health"] == "active"
           and by_key["codex"]["health"] == "inactive"
           and by_key["pi"]["health"] == "unknown"
-          and by_key["codex"]["title"] == "codex — inactive"
+          and by_key["codex"]["title"] == "codex — inactive — no chat (ACP) config — can’t join a chat"
           and all((o["text"] or "").strip() != "" for o in picker),
           picker=picker)
     ctx3.close()

--- a/e2e/ux_fixJ43_test.py
+++ b/e2e/ux_fixJ43_test.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+ux_fixJ43_test.py — the BRIEF-UX-001 ROUND-3 fix gate (C6/EC44: chips are truth).
+
+The round-3 cold review (real daemon, fresh profile) caught the new-chat
+composer painting the writer/reviewer/planner FALLBACK TRIO as if they were
+seats on cold render, '+ Add' silently swapping them for the CLI roster, and
+the SEND connecting the whole roster regardless of the 3 chips displayed —
+plus 4 of 6 roster seats carrying no ACP config, so every cold chat opened
+with 4 red "no ACP config" seats. The EC44 contract this rig gates:
+
+  what the chips SHOW at send time == what the send CONNECTS.
+
+Runs against the shared fixture (uxfix_fixture.py), whose roster now mirrors
+the REAL daemon's capability wire: each seat carries the `acp` marker (object
+= chat-capable, EXPLICIT null = not, ABSENT = additive/no-claim = capable),
+and POST /chats rejects acp-null seats per-seat with the core's own
+"no ACP config for '<key>'" (wicked-core acp_runner chat_ensure) — a UI that
+silently fans out to incapable seats cannot pass by fixture leniency.
+
+Scenes (each on a FRESH browser context — zero storage, the cold profile):
+
+  1. COLD TRUTH: /chat/new mounts with NO painted chip — a MutationObserver
+     (installed pre-navigation) proves the resolving row rendered and that
+     writer/reviewer/planner (and the incapable codex/agy) were NEVER painted
+     as chips; the surface makes its ONE named mount request (GET /roster);
+     the chips resolve to the CHAT-CAPABLE seats (claude + pi — pi via the
+     ABSENT-key arm); [+ Add] labels the incapable seats ("no chat config",
+     data-chat-capable="false"); the SEND's POST /chats body names EXACTLY
+     the displayed chips (request-tapped), the send succeeds, replies land,
+     and NO seat chip is red — the no-4-red-seats-by-default acceptance.
+  2. WARM CHIPS: a fresh context resolves once on /chat/new (1 GET /roster),
+     navigates away and back — the cached roster renders the chips
+     IMMEDIATELY (no resolving flash, no second fetch).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-J43-cold-truth.png   the cold first send answered — roster-true chips
+                          became exactly-these warm seats, none red
+  ux-J43-warm-chips.png   the warm return: chips immediate from cache
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4405),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    CHAT_CAPABLE_KEYS,
+    HIDE_GATE_TOASTS,
+    REPO,
+    ROSTER,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4405"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+ROSTER_KEYS = [s["key"] for s in ROSTER]
+INCAPABLE = [k for k in ROSTER_KEYS if k not in CHAT_CAPABLE_KEYS]
+GHOSTS = ["writer", "reviewer", "planner"]  # the trio that must NEVER paint
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. Build + the shared fixture ─────────────────────────────────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN,
+                                     "capable": CHAT_CAPABLE_KEYS, "incapable": INCAPABLE}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+console_errors: list[str] = []
+
+# The paint witness: mutation RECORDS (not a post-hoc DOM scan), so a chip or
+# resolving row that rendered and was replaced before any query still counts.
+PAINT_OBSERVER = """
+(() => {
+  window.__paint = { agents: [], resolving: false, sources: [] };
+  const note = (el) => {
+    if (!el || el.nodeType !== 1) return;
+    const all = [el, ...(el.querySelectorAll ? el.querySelectorAll('[data-testid]') : [])];
+    for (const n of all) {
+      const t = n.dataset ? n.dataset.testid : null;
+      if (t === 'agent-chip' && n.dataset.agent && !window.__paint.agents.includes(n.dataset.agent)) {
+        window.__paint.agents.push(n.dataset.agent);
+      }
+      if (t === 'agent-chips-resolving') window.__paint.resolving = true;
+      if (t === 'agent-chips-bar' && n.dataset.source
+          && !window.__paint.sources.includes(n.dataset.source)) {
+        window.__paint.sources.push(n.dataset.source);
+      }
+    }
+  };
+  const obs = new MutationObserver((muts) => {
+    for (const m of muts) {
+      for (const n of m.addedNodes) note(n);
+      if (m.type === 'attributes') note(m.target);
+    }
+  });
+  // (init scripts run before <html> exists — observe the document node itself)
+  obs.observe(document, { childList: true, subtree: true,
+                          attributes: true, attributeFilter: ['data-source', 'data-agent'] });
+})();
+"""
+
+CENSUS = """() => {
+  const bar = document.querySelector('[data-testid="agent-chips-bar"]');
+  return {
+    pathname: location.pathname,
+    chipsBar: bar ? { count: bar.dataset.count, source: bar.dataset.source } : null,
+    chips: [...document.querySelectorAll('[data-testid="agent-chip"]')].map((c) => c.dataset.agent),
+    seatChips: Object.fromEntries(
+      [...document.querySelectorAll('[data-testid="seat-chip"]')]
+        .map((c) => [c.dataset.agent, c.dataset.state])),
+    seatReasons: Object.fromEntries(
+      [...document.querySelectorAll('[data-testid="seat-chip"]')]
+        .map((c) => [c.dataset.agent, c.title ?? ''])),
+    composer: document.querySelector('textarea')?.value ?? null,
+    sendFailed: document.querySelector('[data-testid="chat-send-failed"]')?.textContent ?? null,
+    openError: document.body.innerText.includes('Could not open chat'),
+    userBubbles: [...document.querySelectorAll('[data-testid="user-bubble"]')].map((u) => u.textContent),
+    replies: [...document.querySelectorAll('[data-testid="seat-bubble"][data-pending="false"]')].length,
+    painted: window.__paint ?? null,
+  };
+}"""
+
+
+def tap(page) -> list:
+    net: list = []
+
+    def on_request(req):
+        path = urlparse(req.url).path
+        if not path.startswith("/api/"):
+            return
+        body = None
+        if req.post_data:
+            try:
+                body = json.loads(req.post_data)
+            except ValueError:
+                body = None
+        net.append((req.method, path, body))
+
+    page.on("request", on_request)
+    return net
+
+
+MSG_COLD = "cold truth: what do these chips connect"
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+
+    # ── Scene 1: COLD TRUTH — resolving → roster-true chips → exact-audience send ──
+    set_fixture(ORIGIN, chat_replies=True)
+    ctx1 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    ctx1.add_init_script(PAINT_OBSERVER)
+    page = ctx1.new_page()
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net = tap(page)
+    page.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    storage = page.evaluate("() => sessionStorage.length + localStorage.length")
+    mount = page.evaluate(CENSUS)
+    painted = mount["painted"] or {}
+    roster_gets = [(m, q) for (m, q, _b) in net if q == "/api/v1/roster"]
+    mount_opens = [(m, q) for (m, q, _b) in net if q.startswith("/api/v1/chats")]
+
+    # The cold render was HONEST: the resolving row painted first, the trio
+    # (and the incapable seats) were never painted as chips, and the chips
+    # that stand are the chat-capable roster seats.
+    check("cold_render_never_paints_ghost_chips",
+          storage == 0
+          and painted.get("resolving") is True
+          and all(g not in painted.get("agents", []) for g in GHOSTS + INCAPABLE)
+          and painted.get("agents") == CHAT_CAPABLE_KEYS
+          and "resolving" in painted.get("sources", [])
+          and mount["chips"] == CHAT_CAPABLE_KEYS
+          and mount["chipsBar"] == {"count": str(len(CHAT_CAPABLE_KEYS)), "source": "roster"},
+          storage_entries=storage, painted=painted, census_chips=mount["chips"],
+          chips_bar=mount["chipsBar"])
+
+    # The ONE named mount request — GET /roster, and nothing chat-shaped else.
+    check("cold_mount_one_named_roster_request",
+          len(roster_gets) == 1 and len(mount_opens) == 0,
+          roster_gets=len(roster_gets), chat_requests=mount_opens)
+
+    # [+ Add] disproves the silent-swap: every roster seat is offered, and the
+    # incapable ones are LABELED — capability is a disclosed distinction.
+    page.locator('[data-testid="add-agent"]').click()
+    page.locator('[data-testid="agent-picker-option"]').first.wait_for(timeout=30000)
+    picker = page.evaluate(
+        """() => [...document.querySelectorAll('[data-testid="agent-picker-option"]')]
+                 .map((o) => ({ key: o.dataset.agentKey, capable: o.dataset.chatCapable,
+                                labeled: !!o.querySelector('[data-testid="agent-picker-nochat"]') }))""")
+    by_key = {o["key"]: o for o in picker}
+    check("picker_labels_capability",
+          [o["key"] for o in picker] == ROSTER_KEYS
+          and all(by_key[k]["capable"] == "true" and not by_key[k]["labeled"] for k in CHAT_CAPABLE_KEYS)
+          and all(by_key[k]["capable"] == "false" and by_key[k]["labeled"] for k in INCAPABLE),
+          picker=picker)
+    page.locator("textarea").click()  # outside-click closes the picker
+
+    # The SEND connects EXACTLY the displayed chips (request-tapped body) and
+    # no seat comes up red — the no-4-red-seats-by-default acceptance.
+    displayed = page.evaluate(
+        """() => [...document.querySelectorAll('[data-testid="agent-chip"]')].map((c) => c.dataset.agent)""")
+    page.locator("textarea").fill(MSG_COLD)
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        """() => document.querySelector('textarea')?.value === ''
+             && document.querySelectorAll('[data-testid="seat-bubble"][data-pending="false"]').length > 0""",
+        timeout=30000)
+    sent = page.evaluate(CENSUS)
+    opens = [(m, q, b) for (m, q, b) in net if m == "POST" and q == "/api/v1/chats"]
+    sends = [(m, q) for (m, q, _b) in net if m == "POST" and "/messages" in q]
+    roster_gets_after = [(m, q) for (m, q, _b) in net if q == "/api/v1/roster"]
+    check("send_connects_exactly_the_displayed_chips",
+          len(opens) == 1
+          and (opens[0][2] or {}).get("clis") == displayed
+          and displayed == CHAT_CAPABLE_KEYS
+          and len(sends) == 1
+          and len(roster_gets_after) == 1  # no send-time re-fetch or swap
+          and sent["userBubbles"] == [MSG_COLD]
+          and sent["replies"] > 0
+          and not sent["openError"]
+          and sent["sendFailed"] is None,
+          displayed=displayed, open_body=opens[0][2] if opens else None,
+          sends=len(sends), roster_gets=len(roster_gets_after), census=sent)
+    # No ACP-config red seats by default: only capable seats have chips at
+    # all, and none wears the core's "no ACP config" rejection. (The fixture's
+    # slice-K reply drip DELIBERATELY kills the last-warmed seat after round 1
+    # with "session exited unexpectedly" — a mid-stream death, allowed here;
+    # the round-3 defect was OPEN-time "failed — no ACP config" seats.)
+    check("no_acp_red_seats_by_default",
+          set(sent["seatChips"]) == set(CHAT_CAPABLE_KEYS)
+          and all("no ACP config" not in (sent["seatReasons"].get(k) or "")
+                  for k in sent["seatChips"]),
+          seat_chips=sent["seatChips"], seat_reasons=sent["seatReasons"])
+
+    page.screenshot(path=str(VSHOTS / "ux-J43-cold-truth.png"))
+    ctx1.close()
+
+    # ── Scene 2: WARM CHIPS — the cached roster renders immediately ───────────
+    ctx2 = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    ctx2.add_init_script(PAINT_OBSERVER)
+    page2 = ctx2.new_page()
+    page2.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    net2 = tap(page2)
+    page2.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
+    page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
+    page2.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # Reset the paint witness, then SPA-navigate away and back (no reload —
+    # the module-scope cache survives; a reload would be the cold arm again).
+    page2.evaluate("() => { window.__paint = { agents: [], resolving: false, sources: [] }; }")
+    page2.evaluate("""() => { history.pushState(null, '', '/chats');
+                              window.dispatchEvent(new PopStateEvent('popstate')); }""")
+    page2.get_by_text("New Chat", exact=True).first.wait_for(timeout=30000)
+    page2.evaluate("""() => { history.pushState(null, '', '/chat/new');
+                              window.dispatchEvent(new PopStateEvent('popstate')); }""")
+    page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
+
+    warm = page2.evaluate(CENSUS)
+    warm_painted = warm["painted"] or {}
+    warm_roster_gets = [(m, q) for (m, q, _b) in net2 if q == "/api/v1/roster"]
+    check("warm_return_chips_immediate_from_cache",
+          warm["chips"] == CHAT_CAPABLE_KEYS
+          and warm["chipsBar"] == {"count": str(len(CHAT_CAPABLE_KEYS)), "source": "roster"}
+          and warm_painted.get("resolving") is False  # no resolving flash on the warm arm
+          and len(warm_roster_gets) == 1,  # the first visit's resolve; the return added none
+          census_chips=warm["chips"], chips_bar=warm["chipsBar"],
+          painted=warm_painted, roster_gets=len(warm_roster_gets))
+
+    page2.screenshot(path=str(VSHOTS / "ux-J43-warm-chips.png"))
+    ctx2.close()
+    browser.close()
+
+report["console_errors"] = console_errors[:10]
+report["screenshots"] = [str(VSHOTS / "ux-J43-cold-truth.png"),
+                         str(VSHOTS / "ux-J43-warm-chips.png")]
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/ux_fixJ43_test.py
+++ b/e2e/ux_fixJ43_test.py
@@ -12,11 +12,14 @@ with 4 red "no ACP config" seats. The EC44 contract this rig gates:
   what the chips SHOW at send time == what the send CONNECTS.
 
 Runs against the shared fixture (uxfix_fixture.py), whose roster now mirrors
-the REAL daemon's capability wire: each seat carries the `acp` marker (object
-= chat-capable, EXPLICIT null = not, ABSENT = additive/no-claim = capable),
-and POST /chats rejects acp-null seats per-seat with the core's own
-"no ACP config for '<key>'" (wicked-core acp_runner chat_ensure) — a UI that
-silently fans out to incapable seats cannot pass by fixture leniency.
+the REAL daemon's capability wire (round-4 corrected): `acp` is an object on
+chat-capable seats and ABSENT on the rest — the engine's skip_serializing_if
+never writes a null, so beside a roster that speaks the field, absence IS
+"no config" (only a roster with no acp key anywhere reads all-capable — a
+daemon predating the field). The fixture keeps one explicit-null belt seat
+(agy), and POST /chats rejects BOTH incapable spellings per-seat with the
+core's own "no ACP config for '<key>'" (wicked-core acp_runner chat_ensure)
+— a UI that silently fans out to incapable seats cannot pass by leniency.
 
 Scenes (each on a FRESH browser context — zero storage, the cold profile):
 
@@ -24,8 +27,9 @@ Scenes (each on a FRESH browser context — zero storage, the cold profile):
      (installed pre-navigation) proves the resolving row rendered and that
      writer/reviewer/planner (and the incapable codex/agy) were NEVER painted
      as chips; the surface makes its ONE named mount request (GET /roster);
-     the chips resolve to the CHAT-CAPABLE seats (claude + pi — pi via the
-     ABSENT-key arm); [+ Add] labels the incapable seats ("no chat config",
+     the chips resolve to the CHAT-CAPABLE seats (claude + pi, the two
+     acp-object seats, as on the live wire); [+ Add] labels the incapable
+     seats ("no chat config",
      data-chat-capable="false"); the SEND's POST /chats body names EXACTLY
      the displayed chips (request-tapped), the send succeeds, replies land,
      and NO seat chip is red — the no-4-red-seats-by-default acceptance.

--- a/e2e/ux_fixJ4J5_test.py
+++ b/e2e/ux_fixJ4J5_test.py
@@ -264,6 +264,9 @@ with sync_playwright() as p:
     net2 = tap(page2)
     page2.goto(f"{ORIGIN}/chat/new", wait_until="domcontentloaded")
     page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    # EC44 (round 3): the chips RESOLVE before the send — Send is disabled
+    # while the roster is unknown, so wait for the resolved chips first.
+    page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
     page2.locator("textarea").fill(MSG1)

--- a/e2e/ux_sliceAB_test.py
+++ b/e2e/ux_sliceAB_test.py
@@ -4,10 +4,11 @@ ux_sliceAB_test.py — the DES-UX-001 slice-AB gate: chat repair (§7.9, EC44, C
 Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the
 slice-AB corpus: `chat_deltas` (buffered interleaved chunk rounds + a flush
 control — the §7.9-3 splice corpus). The open-time failed-with-reason seat
-(§7.9-4) is now the fixture's OWN capability rejection: codex carries
-acp=null on the roster wire, so explicitly adding it fails the open with the
-core's genuine "no ACP config for 'codex'" (round-3 re-scope — no
-chat_reject_seats switch needed for this scene).
+(§7.9-4) is now the fixture's OWN capability rejection: codex's roster
+entry OMITS the acp key (the engine's real "no config" spelling —
+skip_serializing_if never writes null), so explicitly adding it fails the
+open with the core's genuine "no ACP config for 'codex'" (round-3 re-scope,
+round-4 wire correction — no chat_reject_seats switch needed).
 
 The §7.9 DOM ACs, verbatim mapping:
 
@@ -70,11 +71,12 @@ ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
 # The fixture's roster (uxfix_fixture.ROSTER keys); the chat-capable subset
-# is the EC44 default chip set. codex (acp=null) is the open-time
-# failed-with-reason seat once explicitly added.
+# is the EC44 default chip set. codex (acp key ABSENT — the real wire
+# spelling of "no config") is the open-time failed-with-reason seat once
+# explicitly added.
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
 CAPABLE = ["claude", "pi"]
-REJECTED = "codex"  # acp=null on the wire — the open answers "no ACP config"
+REJECTED = "codex"  # no acp on the wire — the open answers "no ACP config"
 WARM = CAPABLE
 
 MSG1 = "compare the auth options"

--- a/e2e/ux_sliceAB_test.py
+++ b/e2e/ux_sliceAB_test.py
@@ -3,20 +3,22 @@
 ux_sliceAB_test.py — the DES-UX-001 slice-AB gate: chat repair (§7.9, EC44, C6).
 Runs against the shared frozen-NOW0 W2 fixture (uxfix_fixture.py) with the
 slice-AB corpus: `chat_deltas` (buffered interleaved chunk rounds + a flush
-control — the §7.9-3 splice corpus) and `chat_reject_seats=["codex"]` (the
-open-time failed-with-reason seat, §7.9-4).
+control — the §7.9-3 splice corpus). The open-time failed-with-reason seat
+(§7.9-4) is now the fixture's OWN capability rejection: codex carries
+acp=null on the roster wire, so explicitly adding it fails the open with the
+core's genuine "no ACP config for 'codex'" (round-3 re-scope — no
+chat_reject_seats switch needed for this scene).
 
 The §7.9 DOM ACs, verbatim mapping:
 
-  1. roster-true chips (§7.9-1, re-scoped per §11.2 to roster-first with the
-     cold-cache fallback; round-2 J4 finding 1 tightened it further — the
-     fallback trio is a PLACEHOLDER that never ships, and the roster-down
-     branch is pinned by ux_fixJ42): a fresh /chat/new mounts with the
-     FALLBACK trio and ZERO chat-surface requests (`data-source="fallback"` —
-     the §2.4 budget holds); the FIRST SEND fetches the roster ON THE GESTURE
-     (exactly one GET /roster) and opens with the ROSTER's seats — the daemon
-     accepts them, no rejected-chip error renders, and ≥1 reply frame lands
-     after flush;
+  1. roster-true chips (§7.9-1, re-scoped AGAIN by round 3 — BRIEF-UX-001
+     C6/EC44, chips are truth; the fallback trio is GONE): a fresh /chat/new
+     resolves the roster with its ONE named mount request (GET /roster) and
+     paints the CHAT-CAPABLE chips (`data-source="roster"`); the operator
+     explicitly ADDS the incapable codex from the labeled picker; the FIRST
+     SEND opens with EXACTLY the displayed chips — the capable seats warm,
+     codex fails with the core's own "no ACP config" reason, and ≥1 reply
+     frame lands after flush;
   2. a fixture-failed send (chat_send_fail) leaves the composer text INTACT,
      retracts the optimistic bubbles, and renders inline retry (§7.9-2);
      retry after the failure clears resends exactly the failed text;
@@ -67,11 +69,13 @@ FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4398"))
 ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
 VSHOTS = REPO / "e2e" / "shots" / "vision"
 
-# The fixture's roster (uxfix_fixture.ROSTER keys) and the §6.2 fallback trio.
+# The fixture's roster (uxfix_fixture.ROSTER keys); the chat-capable subset
+# is the EC44 default chip set. codex (acp=null) is the open-time
+# failed-with-reason seat once explicitly added.
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
-FALLBACK = ["writer", "reviewer", "planner"]
-REJECTED = "codex"  # chat_reject_seats — the open-time failed-with-reason seat
-WARM = [k for k in ROSTER_KEYS if k != REJECTED]
+CAPABLE = ["claude", "pi"]
+REJECTED = "codex"  # acp=null on the wire — the open answers "no ACP config"
+WARM = CAPABLE
 
 MSG1 = "compare the auth options"
 MSG2 = "now sketch the migration plan"
@@ -109,7 +113,7 @@ def api_post(path: str, body: dict) -> dict:
 # ── 1. Build + the shared fixture with the slice-AB corpus ────────────────────
 dist = ensure_build(fail)
 start_server(FEEDBACK_PORT, dist)
-set_fixture(ORIGIN, chat_deltas=True, chat_reject_seats=[REJECTED])
+set_fixture(ORIGIN, chat_deltas=True)
 report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
 
 from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
@@ -176,17 +180,31 @@ with sync_playwright() as p:
 
     baseline_working = page.locator('[data-testid="runs-bottom-bar"]').get_attribute("data-working")
 
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     mount = page.evaluate(CHAT_CENSUS)
     mount_chat_requests = [(m, q) for (m, q, _b) in net if is_chat_surface(q)]
-    check("mount_fallback_zero_requests",
+    # EC44: the ONE named mount request resolves the chips roster-true
+    # (capable seats only); nothing chat-shaped fires, nothing warms.
+    check("mount_resolves_roster_true_chips",
           mount["chipsBar"] is not None
-          and mount["chipsBar"]["source"] == "fallback"
-          and mount["chipsBar"]["count"] == str(len(FALLBACK))
-          and len(mount_chat_requests) == 0,
+          and mount["chipsBar"]["source"] == "roster"
+          and mount["chipsBar"]["count"] == str(len(CAPABLE))
+          and mount_chat_requests == [("GET", "/api/v1/roster")],
           chips_bar=mount["chipsBar"], mount_chat_requests=mount_chat_requests)
 
-    # AC 1 — the first send is roster-first: ONE /roster GET rides the gesture,
-    # the open names the roster's seats, and no rejected-chip error renders.
+    # The incapable seat joins by the operator's EXPLICIT pick from the
+    # labeled picker (EC44: disclosed, never a silent equal).
+    page.locator('[data-testid="add-agent"]').click()
+    codex_opt = page.locator(f'[data-testid="agent-picker-option"][data-agent-key="{REJECTED}"]')
+    codex_opt.wait_for(timeout=30000)
+    check("picker_disclosed_incapable_pick",
+          codex_opt.get_attribute("data-chat-capable") == "false"
+          and codex_opt.locator('[data-testid="agent-picker-nochat"]').count() == 1,
+          capable_attr=codex_opt.get_attribute("data-chat-capable"))
+    codex_opt.click()
+
+    # AC 1 — the send connects EXACTLY the displayed chips: the open names the
+    # capable defaults + the explicit addition; no gesture-time roster fetch.
     page.locator("textarea").fill(MSG1)
     page.keyboard.press("Enter")
     page.wait_for_function(
@@ -197,14 +215,14 @@ with sync_playwright() as p:
     opens = [(m, q, b) for (m, q, b) in net if m == "POST" and q == "/api/v1/chats"]
     sent1 = page.evaluate(CHAT_CENSUS)
     chat_id = (opens[0][2] or {}).get("chatId") if opens else None
-    check("roster_first_send",
-          len(roster_gets) == 1
+    check("send_connects_displayed_chips",
+          len(roster_gets) == 1  # the mount resolve; the gesture added none
           and len(opens) == 1
-          and (opens[0][2] or {}).get("clis") == ROSTER_KEYS
+          and (opens[0][2] or {}).get("clis") == CAPABLE + [REJECTED]
           and not sent1["openError"]
           and sent1["chips"].get(REJECTED) == "failed"
           and all(sent1["chips"].get(k) == "working" for k in WARM)
-          and f"unknown agent '{REJECTED}'" in (sent1["failedChipText"] or "")
+          and f"no ACP config for '{REJECTED}'" in (sent1["failedChipText"] or "")
           and sent1["composer"] == ""  # the ACCEPTED draft left the composer
           and chat_id is not None,
           roster_gets=len(roster_gets), open_body=opens[0][2] if opens else None,

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1100,21 +1100,34 @@ REPO_CONTRIBUTORS = [
 # since/lastErrorAt) and the `signed_in` heuristic. `pi` deliberately carries
 # NEITHER — the additive-wire case (a daemon predating crew#274) the slice-O
 # health registry must render as unknown, never as a fabricated "active".
+#
+# Fix J4 round 3 (EC44): each seat also mirrors the real roster's CHAT-
+# capability marker — `acp` is the engine's ACP config object on seats that
+# can hold a chat session and EXPLICIT null on seats that cannot (the live
+# daemon serves acp=null on 4 of its 6 seats; wicked-core's chat_ensure
+# answers "no ACP config for '<key>'" for those). `pi` carries NO acp key at
+# all — the additive-wire case again (a daemon predating the field), which
+# the client must read as capable, never as a fabricated incapability.
 CODEX_HEALTH_MESSAGE = ("quota exceeded: the monthly usage limit for this "
                         "seat has been reached upstream")
 ROSTER = [
     {"key": "claude", "display_name": "claude", "binary": "claude",
      "enabled_for_council": True, "signed_in": True,
+     "acp": {"binary": "claude-agent-acp", "start_args": [], "transport": "stdio"},
      "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
     {"key": "codex", "display_name": "codex", "binary": "codex",
-     "enabled_for_council": True, "signed_in": False,
+     "enabled_for_council": True, "signed_in": False, "acp": None,
      "health": {"status": "inactive", "message": CODEX_HEALTH_MESSAGE,
                 "since": iso(NOW0 - 2 * HOUR), "lastErrorAt": iso(NOW0 - 2 * HOUR)}},
     {"key": "agy", "display_name": "agy", "binary": "agy",
-     "enabled_for_council": True, "signed_in": True,
+     "enabled_for_council": True, "signed_in": True, "acp": None,
      "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
     {"key": "pi", "display_name": "pi", "binary": "pi", "enabled_for_council": True},
 ]
+
+# The chat-capable subset (EC44): explicit acp object OR an absent key (no
+# claim = capable); only EXPLICIT null is an incapability on the wire.
+CHAT_CAPABLE_KEYS = [s["key"] for s in ROSTER if s.get("acp", "absent") is not None]
 
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 NARRATION = "Writing the token-bucket middleware for /upload"
@@ -2439,6 +2452,12 @@ class W2Handler(SimpleHTTPRequestHandler):
 
             def seat(k: str) -> dict:
                 if k not in known:
+                    return {"cliKey": k, "ok": False, "error": f"no ACP config for '{k}'"}
+                # Fix J4 round 3 (EC44): the real chat_ensure also rejects a
+                # KNOWN seat whose roster entry carries acp=null — chat needs
+                # an ACP session config, and 4 of the live daemon's 6 seats
+                # have none. Absent key = no claim = accepted (older engine).
+                if k not in CHAT_CAPABLE_KEYS:
                     return {"cliKey": k, "ok": False, "error": f"no ACP config for '{k}'"}
                 if k in reject:
                     return {"cliKey": k, "ok": False, "error": f"unknown agent '{k}'"}

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1101,13 +1101,19 @@ REPO_CONTRIBUTORS = [
 # NEITHER — the additive-wire case (a daemon predating crew#274) the slice-O
 # health registry must render as unknown, never as a fabricated "active".
 #
-# Fix J4 round 3 (EC44): each seat also mirrors the real roster's CHAT-
+# Fix J4 round 3+4 (EC44): each seat also mirrors the real roster's CHAT-
 # capability marker — `acp` is the engine's ACP config object on seats that
-# can hold a chat session and EXPLICIT null on seats that cannot (the live
-# daemon serves acp=null on 4 of its 6 seats; wicked-core's chat_ensure
-# answers "no ACP config for '<key>'" for those). `pi` carries NO acp key at
-# all — the additive-wire case again (a daemon predating the field), which
-# the client must read as capable, never as a fabricated incapability.
+# can hold a chat session and ABSENT on seats that cannot: `AgenticCli.acp`
+# is `#[serde(skip_serializing_if = "Option::is_none")]` (wicked-council
+# types.rs, since the field's introduction), so the engine NEVER serializes
+# a null — absence is the wire's only spelling of "no config" (verified
+# against the live daemon round 4: acp objects on claude/pi, no key at all
+# on agy/codex/copilot/opencode; wicked-core's chat_ensure answers
+# "no ACP config for '<key>'" for those). Here `claude` and `pi` carry the
+# object (the live capable pair), `codex` carries NO key — the REAL
+# incapable spelling — and `agy` carries an explicit null: no current
+# engine emits it, but the client treats a null claim as "no config" too
+# (belt), and the fixture keeps that arm honest end-to-end.
 CODEX_HEALTH_MESSAGE = ("quota exceeded: the monthly usage limit for this "
                         "seat has been reached upstream")
 ROSTER = [
@@ -1116,18 +1122,26 @@ ROSTER = [
      "acp": {"binary": "claude-agent-acp", "start_args": [], "transport": "stdio"},
      "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
     {"key": "codex", "display_name": "codex", "binary": "codex",
-     "enabled_for_council": True, "signed_in": False, "acp": None,
+     "enabled_for_council": True, "signed_in": False,
      "health": {"status": "inactive", "message": CODEX_HEALTH_MESSAGE,
                 "since": iso(NOW0 - 2 * HOUR), "lastErrorAt": iso(NOW0 - 2 * HOUR)}},
     {"key": "agy", "display_name": "agy", "binary": "agy",
      "enabled_for_council": True, "signed_in": True, "acp": None,
      "health": {"status": "active", "since": iso(NOW0 - 2 * DAY)}},
-    {"key": "pi", "display_name": "pi", "binary": "pi", "enabled_for_council": True},
+    {"key": "pi", "display_name": "pi", "binary": "pi", "enabled_for_council": True,
+     "acp": {"binary": "pi-acp", "start_args": [], "transport": "stdio"}},
 ]
 
-# The chat-capable subset (EC44): explicit acp object OR an absent key (no
-# claim = capable); only EXPLICIT null is an incapability on the wire.
-CHAT_CAPABLE_KEYS = [s["key"] for s in ROSTER if s.get("acp", "absent") is not None]
+# The chat-capable subset (EC44, round-4 corrected polarity): an acp OBJECT
+# is capable; explicit null is not; an ABSENT key is "no config" whenever ANY
+# seat in the roster speaks the field (skip_serializing_if — the engine never
+# writes null), and "no claim = capable" only on a roster with no acp key
+# anywhere (a daemon predating the field).
+_SPEAKS_ACP = any("acp" in s for s in ROSTER)
+CHAT_CAPABLE_KEYS = [
+    s["key"] for s in ROSTER
+    if isinstance(s.get("acp"), dict) or ("acp" not in s and not _SPEAKS_ACP)
+]
 
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 NARRATION = "Writing the token-bucket middleware for /upload"
@@ -2453,10 +2467,12 @@ class W2Handler(SimpleHTTPRequestHandler):
             def seat(k: str) -> dict:
                 if k not in known:
                     return {"cliKey": k, "ok": False, "error": f"no ACP config for '{k}'"}
-                # Fix J4 round 3 (EC44): the real chat_ensure also rejects a
-                # KNOWN seat whose roster entry carries acp=null — chat needs
-                # an ACP session config, and 4 of the live daemon's 6 seats
-                # have none. Absent key = no claim = accepted (older engine).
+                # Fix J4 round 3+4 (EC44): the real chat_ensure also rejects
+                # a KNOWN seat with no ACP session config — 4 of the live
+                # daemon's 6 seats have none (their roster entries OMIT the
+                # acp key; skip_serializing_if). Both incapable spellings —
+                # codex's absent key and agy's explicit null — reject here,
+                # exactly as acp_config_for answers None for each.
                 if k not in CHAT_CAPABLE_KEYS:
                     return {"cliKey": k, "ok": False, "error": f"no ACP config for '{k}'"}
                 if k in reject:

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -95,9 +95,11 @@ ACCENT_PROBE_JS = """() => {
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
 # EC44 (round 3): the fallback trio is GONE — the cold route resolves the
 # roster with the surface's ONE named mount request, and the default chips
-# are the CHAT-CAPABLE seats (acp object, or the absent-key arm — pi).
+# are the CHAT-CAPABLE seats (acp objects on claude/pi — round 4: an
+# absent key beside a speaking roster is "no config", the engine never
+# writes null).
 CAPABLE = ["claude", "pi"]
-ADDED = "codex"  # acp=null — joins only by the operator's explicit labeled pick
+ADDED = "codex"  # no acp config — joins only by the operator's explicit labeled pick
 
 report: dict = {"ok": False, "steps": {}}
 

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -93,9 +93,11 @@ ACCENT_PROBE_JS = """() => {
   return v;
 }"""
 ROSTER_KEYS = ["claude", "codex", "agy", "pi"]
-# §6.2's hardcoded fallback trio — what the default chips render on this route
-# (nothing fetches the roster before Chat mounts, so the cache is cold).
-FALLBACK = ["writer", "reviewer", "planner"]
+# EC44 (round 3): the fallback trio is GONE — the cold route resolves the
+# roster with the surface's ONE named mount request, and the default chips
+# are the CHAT-CAPABLE seats (acp object, or the absent-key arm — pi).
+CAPABLE = ["claude", "pi"]
+ADDED = "codex"  # acp=null — joins only by the operator's explicit labeled pick
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -159,6 +161,9 @@ with sync_playwright() as p:
     page.goto(CHAT_URL, wait_until="domcontentloaded")
     page.locator('[data-testid="mode-switcher"]').wait_for(timeout=30000)
     page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    # EC44: the chips RESOLVE roster-true (never a fabricated trio) — wait for
+    # the resolved state before the census.
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     # AC 1 — the switcher is the spine (F8): filled active segment, glyph+label
@@ -215,9 +220,12 @@ with sync_playwright() as p:
         path=str(SHOTS / "uxfix-4-switcher.png"))
     page.screenshot(path=str(SHOTS / "uxfix-4-chat-firstrun.png"))
 
-    # AC 3 — [+ Add] is the roster opt-in now (§6.2): the picker's fetch rides
-    # the click (ONE GET /roster), the addition joins the selection, and the
-    # first send warms the whole selection into the four-seat strip.
+    # AC 3 (re-scoped by EC44) — [+ Add] opens the picker from the now-warm
+    # cache (the mount resolve already paid the one named fetch — the click
+    # adds NONE); every roster seat is offered, the incapable ones LABELED;
+    # an explicit pick of the acp-null seat joins the selection, and the send
+    # connects EXACTLY the displayed chips — the capable seats warm, the
+    # explicit incapable pick fails with the core's own reason.
     page.locator('[data-testid="add-agent"]').click()
     page.locator('[data-testid="agent-picker"]').wait_for(timeout=10000)
     page.wait_for_function(
@@ -225,11 +233,10 @@ with sync_playwright() as p:
         arg=len(ROSTER_KEYS), timeout=10000,
     )
     picker_roster_gets = len([1 for (m, q, _b) in net if q == "/api/v1/roster"])
-    # Slice AB (§7.9-1): the picker's deposit re-seeds the pristine selection to
-    # the ROSTER — claude is already included (offered disabled, ✓-marked).
+    page.locator(f'[data-testid="agent-picker-option"][data-agent-key="{ADDED}"]').click()
     page.wait_for_function(
         """n => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count === String(n)""",
-        arg=len(ROSTER_KEYS), timeout=10000,
+        arg=len(CAPABLE) + 1, timeout=10000,
     )
     added_count = page.evaluate(
         """() => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null""")
@@ -237,26 +244,28 @@ with sync_playwright() as p:
     page.locator("textarea").fill("warm the whole selection")
     page.keyboard.press("Enter")
     page.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
-    # Slice AB (§7.9-4/EC44): the fanned-out seats SAY working — no reply ever
-    # lands in this scene, and a chip claiming "ready" here would be the lie
-    # the old rig pinned by accident.
+    # Slice AB (§7.9-4/EC44): the fanned-out CAPABLE seats SAY working — no
+    # reply ever lands in this scene — and the explicit incapable pick wears
+    # failed-with-reason (the daemon's own open-time answer).
     page.wait_for_function(
         """n => document.querySelectorAll('[data-testid="seat-chip"][data-state="working"]').length === n""",
-        arg=len(ROSTER_KEYS), timeout=30000,
+        arg=len(CAPABLE), timeout=30000,
     )
     disclosed = page.evaluate(
         """keys => {
-             const chips = Array.from(document.querySelectorAll('[data-testid="seat-chip"]'))
-               .map(c => c.dataset.agent);
+             const els = Array.from(document.querySelectorAll('[data-testid="seat-chip"]'));
+             const chips = els.map(c => c.dataset.agent);
+             const states = Object.fromEntries(els.map(c => [c.dataset.agent, c.dataset.state]));
              return {
                chips,
+               states,
                allSeats: keys.every(k => chips.includes(k)),
                chipsBarRetired: !document.querySelector('[data-testid="agent-chips-bar"]'),
                closePresent: !!document.querySelector('[data-testid="chat-close"]'),
                firstrunGone: !document.querySelector('[data-testid="chat-firstrun"]'),
              };
            }""",
-        ROSTER_KEYS,
+        CAPABLE + [ADDED],
     )
     disclosed_opens = opens(net)
     page.screenshot(path=str(SHOTS / "uxfix-4-chat-multiagent.png"))
@@ -268,6 +277,7 @@ with sync_playwright() as p:
     net2 = tap(page2)
     page2.goto(CHAT_URL, wait_until="domcontentloaded")
     page2.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
     page2.locator("textarea").fill("make me a deck")
@@ -303,13 +313,14 @@ report["steps"]["slice4_chat_firstrun"] = {
         firstrun["teachText"] is not None,
         "Chat with an agent about this project." in (firstrun["teachText"] or ""),
         "just talk" in (firstrun["teachText"] or ""),
-        # §6.2: the default chips render immediately — the fallback trio, no fetch.
-        firstrun["chipsBarCount"] == str(len(FALLBACK)),
-        firstrun["chipKeys"] == FALLBACK,
+        # EC44: the chips resolve roster-true — the capable seats, seeded by
+        # the surface's ONE named mount request (never a fabricated trio).
+        firstrun["chipsBarCount"] == str(len(CAPABLE)),
+        firstrun["chipKeys"] == CAPABLE,
         firstrun["addAgent"],
         firstrun["closeAbsent"], firstrun["noWarmChips"],
         firstrun["noGroupChatCopy"], firstrun["composerFocused"],
-        mount_opens == 0, mount_roster == 0,
+        mount_opens == 0, mount_roster == 1,
     ]),
     **firstrun,
     "openChat_requests_on_mount": mount_opens,
@@ -317,13 +328,17 @@ report["steps"]["slice4_chat_firstrun"] = {
 }
 report["steps"]["slice4_add_agent_picker"] = {
     "ok": all([
-        # The picker's roster fetch rode the CLICK — exactly one, none on mount.
+        # The mount resolve was the one fetch; the picker click added NONE.
         picker_roster_gets == 1,
-        added_count == str(len(ROSTER_KEYS)),
+        added_count == str(len(CAPABLE) + 1),
         disclosed["allSeats"], disclosed["chipsBarRetired"], disclosed["closePresent"],
         disclosed["firstrunGone"],
         len(disclosed_opens) == 1,
-        (disclosed_opens[0] or {}).get("clis") == ROSTER_KEYS,
+        # EC44: the open names EXACTLY the displayed chips…
+        (disclosed_opens[0] or {}).get("clis") == CAPABLE + [ADDED],
+        # …the capable seats work; the explicit incapable pick failed honestly.
+        all(disclosed["states"].get(k) == "working" for k in CAPABLE),
+        disclosed["states"].get(ADDED) == "failed",
     ]),
     **disclosed,
     "roster_gets_after_picker_open": picker_roster_gets,
@@ -334,10 +349,10 @@ report["steps"]["slice4_add_agent_picker"] = {
 report["steps"]["slice4_first_send"] = {
     "ok": all([
         typed["userBubble"],
-        typed["workingChips"] == ROSTER_KEYS,
+        typed["workingChips"] == CAPABLE,
         typed["chipsBarRetired"],
         len(typed_opens) == 1,
-        (typed_opens[0] or {}).get("clis") == ROSTER_KEYS,
+        (typed_opens[0] or {}).get("clis") == CAPABLE,
         len(sent) == 1,
         (sent[0][2] or {}).get("text") == "make me a deck",
     ]),

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -14,13 +14,11 @@ same branch converts):
      that run is at `awaiting_human` (and, same mechanism: `--status-run`
      while executing, `--status-fail` when failed);
   3. the Chat mode first-run state shows the instruction text and NO openChat
-     request (`POST /api/v1/chats`) fires on mount. (RE-SCOPED to the
-     DES-FEEDBACK-001 §6 chips reality, which slice C shipped: the pre-slice-C
-     `add-agents` opt-in this AC originally pinned no longer exists — the
-     default agent chips render from `DEFAULT_CHAT_AGENTS` with a `✕` each,
-     and the `[+ Add]` affordance (`data-testid="add-agent"`, dashed border,
-     --ink-dim) opens the roster picker. Zero-requests-on-mount is UNCHANGED —
-     the chips render from the cached roster / fallback constant, §6.1.);
+     request (`POST /api/v1/chats`) fires on mount. (RE-SCOPED TWICE — slice C
+     chips, then BRIEF-UX-001 C6/EC44 round 3: the fallback constant is GONE;
+     the chips RESOLVE roster-true from the surface's one named mount GET
+     /roster and show the CHAT-CAPABLE seats with a `✕` each; `[+ Add]`
+     (dashed border, --ink-dim) opens the roster picker.);
   4. the version strip's active dot computed `background` resolves from
      `var(--accent)`; the Themes popover `data-testid="themes-explanation"`
      is non-empty. (The storyboard-chapter accent AC retired with the
@@ -162,6 +160,8 @@ with sync_playwright() as p:
     # ══ Scene 1 — Chat, first run (§5.3) ══════════════════════════════════════
     page.goto(f"{ORIGIN}/p/q3-review-deck/chat", wait_until="domcontentloaded")
     page.locator('[data-testid="chat-firstrun"]').wait_for(timeout=30000)
+    # EC44: the chips RESOLVE roster-true — census the resolved state.
+    page.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page.add_style_tag(content=HIDE_GATE_TOASTS)
 
     # §2.8 reconciled fonts: both faces load; the sans is Inter.
@@ -209,9 +209,9 @@ with sync_playwright() as p:
         (chat["instructionText"] or "").strip() != "",
         chat["instructionColor"] == pr["inkBody"],
         "Inter" in (chat["instructionFont"] or ""),
-        # §6.2: three default chips render immediately from the cache/fallback.
-        chat["chipsBarCount"] == "3",
-        chat["chipAgents"] == ["writer", "reviewer", "planner"],
+        # EC44: the default chips are the resolved CHAT-CAPABLE seats.
+        chat["chipsBarCount"] == "2",
+        chat["chipAgents"] == ["claude", "pi"],
         # EC13: chip text in the sans; §6.3 anatomy — [+ Add] dashed, --ink-dim.
         "Inter" in (chat["chipFont"] or ""),
         chat["chipColor"] == pr["inkBody"],

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -382,7 +382,8 @@ export function GroupChat({
   // session (a warm cache already seeded the chips synchronously above).
   useEffect(() => {
     if (getCachedRoster() === null) resolveRoster();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only by design (EC44's one named request)
+    // (mount-only by design — EC44's one named request; the helper closes
+    // over nothing reactive, so the empty dep list is complete.)
   }, []);
 
   /** Toggle the roster picker; on first open with a cold cache, fetch (a user action — §2.4-safe). */

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -40,17 +40,39 @@ import { ProjectSwitcher } from './ProjectSwitcher.js';
 /**
  * EC44 chat-capability: a seat can hold a chat session only when its roster
  * entry carries an ACP config — wicked-core's `chat_ensure` answers
- * "no ACP config for '<key>'" for any seat without one (acp_runner.rs), so
- * default-selecting such a seat guarantees a red failed chip on every cold
- * chat. The marker is the seat's `acp` field on the roster wire: an object
- * ({binary, start_args, transport}) when configured, EXPLICIT `null` when
- * not (the engine serializes the None). The field predates the shared
- * `RosterSeat` type and rides its index signature, so it is read
- * defensively: an ABSENT key (a daemon predating the field) is no claim and
- * reads as capable — never a fabricated incapability.
+ * "no ACP config for '<key>'" for any seat without one (acp_runner.rs:3095
+ * via `acp_config_for`), so default-selecting such a seat guarantees a red
+ * failed chip on every cold chat. The marker is the seat's `acp` field on
+ * the roster wire: an object ({binary, start_args, transport}) when
+ * configured, and ABSENT when not — the engine's `AgenticCli.acp` is
+ * `#[serde(skip_serializing_if = "Option::is_none")]` (wicked-council
+ * types.rs, since the field's introduction), so a `None` NEVER serializes;
+ * absence is the wire's only spelling of "no config" (verified against the
+ * live daemon round 4: acp objects on claude/pi, no key at all on the other
+ * four). The field predates the shared `RosterSeat` type and rides its
+ * index signature, so it is read defensively, ROSTER-aware:
+ *
+ *   - `acp` object            → capable (the engine will ensure a session);
+ *   - `acp: null`             → not capable (belt: no current engine emits
+ *                               it, but a null claim is still "no config");
+ *   - key ABSENT, and ANY seat in this roster carries the key
+ *                             → not capable — this daemon SPEAKS the field,
+ *                               so absence is its own "no config" (reading
+ *                               it as capable repaints the round-3 defect:
+ *                               4 red "no ACP config" seats on every cold
+ *                               send — caught live in round 4);
+ *   - key ABSENT everywhere   → capable — a daemon predating the field
+ *                               makes no claim, and fabricating
+ *                               incapability would empty every chat.
  */
-export function chatCapable(seat: RosterSeat): boolean {
-  return seat['acp'] !== null;
+export function rosterSpeaksAcp(roster: RosterSeat[]): boolean {
+  return roster.some((s) => s['acp'] !== undefined);
+}
+
+export function chatCapable(seat: RosterSeat, speaksAcp: boolean): boolean {
+  if (seat['acp'] === null) return false;
+  if (seat['acp'] !== undefined) return true;
+  return !speaksAcp;
 }
 
 /**
@@ -61,7 +83,8 @@ export function chatCapable(seat: RosterSeat): boolean {
  * request.
  */
 export function defaultSelection(roster: RosterSeat[]): string[] {
-  return roster.filter(chatCapable).map((s) => s.key);
+  const speaks = rosterSpeaksAcp(roster);
+  return roster.filter((s) => chatCapable(s, speaks)).map((s) => s.key);
 }
 
 /**
@@ -765,15 +788,18 @@ export function GroupChat({
       .filter(([, st]) => WARM_STATES.has(st))
       .map(([k]) => k);
     // EC44 — the chips are truth: the send's audience IS the selection on
-    // screen, nothing else. While no chat exists, an unresolved roster or an
+    // screen, nothing else. While nothing is warm, an unresolved roster or an
     // empty selection means nobody would receive this — the disabled Send
-    // already says so; this is the belt to that suspender (Enter races the
-    // resolve). The round-2 hidden fan-out that swapped a pristine selection
-    // for the full roster AT SEND TIME is gone: it repaired the send outcome
-    // by bypassing the display, which is the exact lie C6 names.
+    // already says so; this is the belt to that suspender (Enter bypasses the
+    // disabled button and races the resolve). It holds with OR without a chat
+    // id: a fully-failed open leaves a chat id behind, and letting an emptied
+    // selection through would arm with `clis` OMITTED — the daemon then warms
+    // its OWN default set, an audience no chip ever showed (round-4 catch).
+    // The round-2 hidden fan-out that swapped a pristine selection for the
+    // full roster AT SEND TIME is gone: it repaired the send outcome by
+    // bypassing the display, which is the exact lie C6 names.
     if (
       warm.length === 0 &&
-      chatIdRef.current === null &&
       (knownRoster === null || selectedAgentsRef.current.length === 0)
     ) return;
     sendingRef.current = true;
@@ -1341,7 +1367,7 @@ export function GroupChat({
                 className="inline-flex items-center"
                 style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)' }}
               >
-                {knownRoster.some(chatCapable)
+                {defaultSelection(knownRoster).length > 0
                   ? 'no agents selected — add one to send'
                   : 'no agent has a chat (ACP) config — add one anyway, or configure ACP'}
               </span>
@@ -1440,7 +1466,7 @@ export function GroupChat({
                       // config"), never as a silent equal; picking it is the
                       // operator's explicit call and the daemon's per-seat
                       // answer is the recovery path.
-                      const capable = chatCapable(seat);
+                      const capable = chatCapable(seat, rosterSpeaksAcp(pickerRoster));
                       const titleBits = [name];
                       if (health) titleBits.push(health);
                       if (!capable) titleBits.push('no chat (ACP) config — can’t join a chat');

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -19,36 +19,49 @@ import { ProjectSwitcher } from './ProjectSwitcher.js';
  *
  * NOTHING warms on mount (DES-UXFIX-001 §2.4, F6). First-run is a calm teaching
  * state: one line on what Chat is, a focused composer, and the DEFAULT agent
- * chips (DES-FEEDBACK-001 §6.2): the agents that WILL join, rendered
- * synchronously from the cached roster (never fetched on mount — §6.1's
- * reconciliation of "agents by default" with zero-requests-on-mount), each
- * removable for this run via its ✕, extendable via [+ Add] (the roster
- * picker — its fetch rides that user action). The first send warms exactly
- * the selected set. The warm-and-rejoin machinery (FINDING-027) is preserved
- * verbatim — it still runs on opt-in, not on mount: a stored chat the daemon
- * still holds is rejoined exactly as before, because warm seats someone paid
- * for must not be orphaned.
+ * chips (DES-FEEDBACK-001 §6.2 as re-scoped by BRIEF-UX-001 C6/EC44): the
+ * agents that WILL join. EC44 — the chips are TRUTH: what the bar shows at
+ * send time is exactly what the send connects, so a chip is never painted
+ * until the roster is KNOWN. A warm cache renders chips synchronously with
+ * zero requests; a cold cache renders an honest "resolving agents…" row and
+ * this surface makes its ONE named mount request — GET /api/v1/roster — to
+ * resolve it (the truthfulness requirement outranks the §2.4 zero-mount
+ * budget here, by explicit round-3 mandate; the request is named in the AC).
+ * There is NO hardcoded fallback set any more: the writer/reviewer/planner
+ * trio round 3 caught being painted as seats is gone. Each chip is removable
+ * for this run via its ✕, extendable via [+ Add] (the roster picker). The
+ * first send warms exactly the selected set — no hidden fan-out. The
+ * warm-and-rejoin machinery (FINDING-027) is preserved verbatim — it still
+ * runs on opt-in, not on mount: a stored chat the daemon still holds is
+ * rejoined exactly as before, because warm seats someone paid for must not
+ * be orphaned.
  */
 
 /**
- * The hardcoded fallback default set (§6.2) — used ONLY when the roster cache
- * is empty (nothing has fetched the roster yet this session). These are the
- * ONLY hardcoded agent names in the agent layer; everything else comes from
- * the roster cache or user action.
+ * EC44 chat-capability: a seat can hold a chat session only when its roster
+ * entry carries an ACP config — wicked-core's `chat_ensure` answers
+ * "no ACP config for '<key>'" for any seat without one (acp_runner.rs), so
+ * default-selecting such a seat guarantees a red failed chip on every cold
+ * chat. The marker is the seat's `acp` field on the roster wire: an object
+ * ({binary, start_args, transport}) when configured, EXPLICIT `null` when
+ * not (the engine serializes the None). The field predates the shared
+ * `RosterSeat` type and rides its index signature, so it is read
+ * defensively: an ABSENT key (a daemon predating the field) is no claim and
+ * reads as capable — never a fabricated incapability.
  */
-export const DEFAULT_CHAT_AGENTS = ['writer', 'reviewer', 'planner'];
+export function chatCapable(seat: RosterSeat): boolean {
+  return seat['acp'] !== null;
+}
 
 /**
- * The default chip selection for a chat being created (§6.2): the cached
- * roster when the app has one (fetched at startup by the launch form, or by
- * any other roster consumer), else the hardcoded fallback trio. Synchronous
- * by construction — reading it can never fire a request.
+ * The default chip selection for a chat being created: the CHAT-CAPABLE
+ * subset of the roster (EC44 — the seats that can actually join; the
+ * incapable ones are offered in [+ Add], labeled honestly, never silently
+ * default-selected into guaranteed failures). Pure derivation — never a
+ * request.
  */
-function defaultSelection(): string[] {
-  const cached = getCachedRoster();
-  return cached !== null && cached.length > 0
-    ? cached.map((s) => s.key)
-    : [...DEFAULT_CHAT_AGENTS];
+export function defaultSelection(roster: RosterSeat[]): string[] {
+  return roster.filter(chatCapable).map((s) => s.key);
 }
 
 /**
@@ -285,17 +298,25 @@ export function GroupChat({
     writeStoredLayout(next);
   }
 
-  // ── Default agent chips (DES-FEEDBACK-001 §6, slice C) ─────────────────────
-  // The agents that will join on the first send: defaults (cached roster or
-  // the fallback trio) + picker additions − ✕ removals. Per-run only, never
-  // persisted (§6.2). Initialized synchronously — zero requests (§6.1).
-  const [selectedAgents, setSelectedAgents] = useState<string[]>(defaultSelection);
+  // ── Default agent chips (DES-FEEDBACK-001 §6 / EC44 — chips are truth) ─────
+  // The agents that will join on the first send: the chat-capable roster
+  // defaults + picker additions − ✕ removals. Per-run only, never persisted
+  // (§6.2). `roster` is this surface's copy of the known roster: a warm cache
+  // seeds it (and the chips) synchronously; while it is null the bar renders
+  // the resolving state and NO chip is painted (EC44 — never a placeholder
+  // dressed as a seat).
+  const [knownRoster, setKnownRoster] = useState<RosterSeat[] | null>(getCachedRoster);
+  const [rosterError, setRosterError] = useState<string | null>(null);
+  const [selectedAgents, setSelectedAgents] = useState<string[]>(() => {
+    const cached = getCachedRoster();
+    return cached !== null ? defaultSelection(cached) : [];
+  });
   const selectedAgentsRef = useRef<string[]>(selectedAgents);
   selectedAgentsRef.current = selectedAgents;
   // §7.9-1: whether the operator has EDITED the selection (✕ / picker add).
-  // While untouched, a warm roster arriving later re-seeds the chips — the
-  // fallback trio only ever reaches the daemon when the cache stayed cold AND
-  // the roster proved unreachable at send time. An edit pins the selection.
+  // While untouched, a roster arriving later (this surface's own resolve, or
+  // another surface's deposit) re-seeds the chips to the chat-capable
+  // defaults. An edit pins the selection.
   const chipsTouchedRef = useRef(false);
   // §7.9-2: a failed send keeps its draft; the failure renders inline with retry.
   const [sendFailed, setSendFailed] = useState<{ text: string; reason: string } | null>(null);
@@ -328,6 +349,41 @@ export function GroupChat({
         projectsRequested.current = false; // transient — retry on the next open
       });
   }
+
+  /**
+   * Resolve the roster (EC44) — the ONE request this surface may make on
+   * mount, and only with a cold cache: GET /api/v1/roster (named in the AC;
+   * the truthfulness requirement outranks the §2.4 zero-mount budget for
+   * this surface, by round-3 mandate). The answer is DEPOSITED into the
+   * shared cache — the subscribe effect below hears it and seeds the chips —
+   * so every other §2.4 surface still pays nothing. Failure renders as the
+   * bar's honest failed-to-resolve state with a Retry (never a fabricated
+   * chip row).
+   */
+  const rosterResolveInFlight = useRef(false);
+  function resolveRoster(): void {
+    if (rosterResolveInFlight.current) return;
+    rosterResolveInFlight.current = true;
+    setRosterError(null);
+    api
+      .getRoster()
+      .then(({ roster }) => {
+        setCachedRoster(roster); // the subscribe effect seeds chips + knownRoster
+      })
+      .catch((e: unknown) => {
+        setRosterError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        rosterResolveInFlight.current = false;
+      });
+  }
+
+  // The mount-time resolve: fires ONLY while nothing has fetched a roster this
+  // session (a warm cache already seeded the chips synchronously above).
+  useEffect(() => {
+    if (getCachedRoster() === null) resolveRoster();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only by design (EC44's one named request)
+  }, []);
 
   /** Toggle the roster picker; on first open with a cold cache, fetch (a user action — §2.4-safe). */
   function togglePicker(): void {
@@ -396,8 +452,12 @@ export function GroupChat({
     // starts a new create flow, so the binding resets to Unfiled (§5.1).
     setSelectedProjectId(null);
     // So does the chip selection (§6.2: per-run, never persisted): the new
-    // repo's create flow starts from the defaults again.
-    setSelectedAgents(defaultSelection());
+    // repo's create flow starts from the chat-capable defaults again (EC44 —
+    // empty while the roster is still unresolved, never a fabricated chip).
+    {
+      const cached = getCachedRoster();
+      setSelectedAgents(cached !== null ? defaultSelection(cached) : []);
+    }
     chipsTouchedRef.current = false;
     setSendFailed(null);
     turnRef.current = 0;
@@ -493,16 +553,18 @@ export function GroupChat({
     navigate(`/chat/${encodeURIComponent(chatId)}`, { replace: true });
   }, [reflectUrl, navigate, chatId, routedChatId]);
 
-  // §7.9-1 (the seeding-order fix): a roster deposited AFTER this surface
-  // seeded its chips from the cold-cache fallback re-seeds them — warm roster
-  // beats the fallback trio — but only while the selection is still pristine
-  // (untouched, nothing warmed, no thread). Never a fetch: this only HEARS
-  // deposits other surfaces already paid for (§2.4's budget holds unchanged).
+  // §7.9-1 / EC44: any roster deposit — this surface's own resolve, or another
+  // surface's fetch landing first — becomes the known roster, and re-seeds a
+  // PRISTINE selection (untouched, nothing warmed) to the chat-capable
+  // defaults. An edit pins the selection; a live chat's audience is the warm
+  // seats, not the chips.
   useEffect(() => {
     return subscribeRoster((roster) => {
+      setKnownRoster(roster);
+      setPickerRoster(roster);
+      setRosterError(null);
       if (chipsTouchedRef.current || chatIdRef.current !== null) return;
-      if (roster.length === 0) return;
-      setSelectedAgents(roster.map((s) => s.key));
+      setSelectedAgents(defaultSelection(roster));
     });
   }, []);
 
@@ -701,45 +763,21 @@ export function GroupChat({
     let warm = Object.entries(seats)
       .filter(([, st]) => WARM_STATES.has(st))
       .map(([k]) => k);
-    // Nothing warm with nothing selected: nobody would receive this (§6.2's
-    // selection is the send's audience) — the disabled Send already says so.
-    if (warm.length === 0 && chatIdRef.current === null && selectedAgentsRef.current.length === 0) return;
+    // EC44 — the chips are truth: the send's audience IS the selection on
+    // screen, nothing else. While no chat exists, an unresolved roster or an
+    // empty selection means nobody would receive this — the disabled Send
+    // already says so; this is the belt to that suspender (Enter races the
+    // resolve). The round-2 hidden fan-out that swapped a pristine selection
+    // for the full roster AT SEND TIME is gone: it repaired the send outcome
+    // by bypassing the display, which is the exact lie C6 names.
+    if (
+      warm.length === 0 &&
+      chatIdRef.current === null &&
+      (knownRoster === null || selectedAgentsRef.current.length === 0)
+    ) return;
     sendingRef.current = true;
     setSendFailed(null);
     try {
-      // §7.9-1 (round 2, J4 finding 1): a PRISTINE selection must NEVER reach
-      // the daemon with non-roster seats. While nothing is warm, no chat exists
-      // and the operator has not edited the chips, the audience can only be the
-      // ROSTER's — a cold OR empty cache fetches it ON THIS GESTURE (never on
-      // mount — §2.4 holds). The fallback trio is a placeholder rendering, not
-      // an audience: when the roster is unreachable or empty, the send FAILS
-      // HONESTLY here (draft survives, inline retry) and NOTHING goes on the
-      // wire. An operator-edited selection is their explicit call and ships
-      // as-is — the daemon's per-seat answer is the recovery path for that.
-      if (warm.length === 0 && chatIdRef.current === null && !chipsTouchedRef.current) {
-        let roster = getCachedRoster();
-        if (roster === null || roster.length === 0) {
-          try {
-            const fetched = await api.getRoster();
-            setCachedRoster(fetched.roster);
-            roster = fetched.roster;
-          } catch (e: unknown) {
-            const why = e instanceof Error ? e.message : String(e);
-            setSendFailed({
-              text,
-              reason: `could not load the agent roster (${why}); the default chips are placeholders and are never sent unresolved`,
-            });
-            return;
-          }
-        }
-        if (roster.length === 0) {
-          setSendFailed({ text, reason: 'the daemon returned an empty agent roster — there is no seat to warm' });
-          return;
-        }
-        const keys = roster.map((s) => s.key);
-        setSelectedAgents(keys);
-        selectedAgentsRef.current = keys;
-      }
       const turn = turnRef.current + 1;
       turnRef.current = turn;
       setMessages((prev) => [...prev, { kind: 'user', text, turn }]);
@@ -1226,23 +1264,87 @@ export function GroupChat({
             onClose={() => setShowNewProject(false)}
           />
         )}
-        {/* §6.2/§6.3: the default agent chips — the agents that WILL join the
-            first send. Rendered from the cached roster / fallback constant,
-            never a fetch (§6.1). Each chip is an agent that IS included; the
-            ✕ removes it for THIS run only. [+ Add] is the separate affordance
-            (dashed vs solid, --ink-dim vs --ink-body) opening the roster
-            picker. Chip text reads in the SANS (EC13: labels in sans — these
-            are selection labels, not narration data). */}
+        {/* §6.2/§6.3 as re-scoped by EC44: the default agent chips — the
+            agents that WILL join the first send, and NOTHING before that is
+            known. While the roster is unresolved the bar renders an honest
+            resolving row (or the failed-to-resolve row with Retry) — never a
+            chip dressed as a seat. Once known, each chip is an agent that IS
+            included; the ✕ removes it for THIS run only. [+ Add] is the
+            separate affordance (dashed vs solid) opening the roster picker.
+            Chip text reads in the SANS (EC13: labels in sans — these are
+            selection labels, not narration data). */}
         {showChipsBar && (
           <div
             data-testid="agent-chips-bar"
-            data-count={selectedAgents.length}
-            // §7.9-1 honesty: where this seeding came from — the live roster
-            // cache, or the cold-cache fallback trio (roster-first, fallback
-            // only while nothing has fetched a roster this session).
-            data-source={(getCachedRoster()?.length ?? 0) > 0 ? 'roster' : 'fallback'}
+            data-count={knownRoster === null ? undefined : selectedAgents.length}
+            // EC44 honesty: 'roster' once the seats are known; 'resolving'
+            // while they are not (and no chip is painted in that state).
+            data-source={knownRoster !== null ? 'roster' : 'resolving'}
             className="flex items-center gap-1.5 flex-wrap pb-2"
           >
+            {knownRoster === null && rosterError === null && (
+              <span
+                data-testid="agent-chips-resolving"
+                className="inline-flex items-center gap-1.5 animate-pulse"
+                style={{
+                  border: '1px dashed var(--surface-overlay)',
+                  borderRadius: 'var(--radius-full)',
+                  color: 'var(--ink-dim)',
+                  fontSize: 'var(--text-xs)',
+                  fontFamily: 'var(--font-sans)',
+                  padding: '3px 10px',
+                }}
+              >
+                resolving agents…
+              </span>
+            )}
+            {knownRoster === null && rosterError !== null && (
+              <span
+                data-testid="agent-chips-unresolved"
+                className="inline-flex items-center gap-2"
+                style={{
+                  border: '1px dashed var(--status-fail-dim)',
+                  borderRadius: 'var(--radius-full)',
+                  color: 'var(--ink-dim)',
+                  fontSize: 'var(--text-xs)',
+                  fontFamily: 'var(--font-sans)',
+                  padding: '3px 10px',
+                }}
+                title={rosterError}
+              >
+                couldn’t load the agent roster
+                <button
+                  type="button"
+                  data-testid="agent-chips-retry"
+                  onClick={resolveRoster}
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--surface-overlay)',
+                    borderRadius: 'var(--radius-full)',
+                    color: 'var(--ink-body)',
+                    cursor: 'pointer',
+                    fontSize: 'var(--text-2xs)',
+                    padding: '1px 8px',
+                  }}
+                >
+                  Retry
+                </button>
+              </span>
+            )}
+            {knownRoster !== null && knownRoster.length > 0 && selectedAgents.length === 0 && (
+              // The honest empty-selection note: everything was removed, or no
+              // configured seat carries a chat (ACP) config — either way the
+              // send has no audience until [+ Add] gives it one.
+              <span
+                data-testid="agent-chips-empty-note"
+                className="inline-flex items-center"
+                style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)' }}
+              >
+                {knownRoster.some(chatCapable)
+                  ? 'no agents selected — add one to send'
+                  : 'no agent has a chat (ACP) config — add one anyway, or configure ACP'}
+              </span>
+            )}
             {selectedAgents.map((key) => (
               <span
                 key={key}
@@ -1332,6 +1434,15 @@ export function GroupChat({
                           ? seat.display_name
                           : seat.key;
                       const health = seat.health?.status;
+                      // EC44: capability is DISCLOSED, not enforced — a seat
+                      // with no ACP config is offered labeled ("no chat
+                      // config"), never as a silent equal; picking it is the
+                      // operator's explicit call and the daemon's per-seat
+                      // answer is the recovery path.
+                      const capable = chatCapable(seat);
+                      const titleBits = [name];
+                      if (health) titleBits.push(health);
+                      if (!capable) titleBits.push('no chat (ACP) config — can’t join a chat');
                       return (
                         <button
                           key={seat.key}
@@ -1342,7 +1453,8 @@ export function GroupChat({
                           data-testid="agent-picker-option"
                           data-agent-key={seat.key}
                           data-health={health ?? 'unknown'}
-                          title={health ? `${name} — ${health}` : name}
+                          data-chat-capable={capable}
+                          title={titleBits.join(' — ')}
                           onClick={() => {
                             chipsTouchedRef.current = true; // §7.9-1: an edit pins the selection
                             setSelectedAgents((prev) => (prev.includes(seat.key) ? prev : [...prev, seat.key]));
@@ -1363,6 +1475,15 @@ export function GroupChat({
                           <span className="truncate">{name}</span>
                           {name !== seat.key && (
                             <span className="truncate" style={{ color: 'var(--ink-dim)' }}>{seat.key}</span>
+                          )}
+                          {!capable && (
+                            <span
+                              data-testid="agent-picker-nochat"
+                              className="shrink-0"
+                              style={{ color: 'var(--ink-dim)', fontStyle: 'italic' }}
+                            >
+                              no chat config
+                            </span>
                           )}
                           {included ? ' ✓' : ''}
                         </button>
@@ -1402,9 +1523,14 @@ export function GroupChat({
             // Typing is how the selected agents warm — so text alone enables Send,
             // including the §6.2 retry after a rejected open (send re-arms). The
             // holds: `resolving` (the stored chat is still being probed — not
-            // first-run yet), `arming` (an open is in flight), and an EMPTY chip
-            // selection with nothing warm (nobody would receive the message).
-            disabled={input.trim() === '' || arming || resolving || (showChipsBar && selectedAgents.length === 0)}
+            // first-run yet), `arming` (an open is in flight), an UNRESOLVED
+            // roster (EC44: the chips are the audience, and there are no chips
+            // until the roster is known), and an EMPTY chip selection with
+            // nothing warm (nobody would receive the message).
+            disabled={
+              input.trim() === '' || arming || resolving ||
+              (showChipsBar && (knownRoster === null || selectedAgents.length === 0))
+            }
             className="px-4 text-sm font-semibold disabled:opacity-40"
             style={{ background: 'var(--accent)', color: 'var(--accent-fg)', borderRadius: 'var(--radius-xl)' }}
           >

--- a/src/store/rosterCache.ts
+++ b/src/store/rosterCache.ts
@@ -3,14 +3,15 @@ import type { RosterSeat } from '../api/types.js';
 /**
  * The agent-roster cache (DES-FEEDBACK-001 §6.1/§6.2, slice C).
  *
- * Chat's default agent chips must render on FIRST paint with zero network
- * requests (DES-UXFIX-001 §2.4 — the binding constraint). The roster they
- * render from is therefore never fetched on Chat's mount: this module holds
+ * Chat's default agent chips render on FIRST paint with zero network requests
+ * whenever a roster is already known (DES-UXFIX-001 §2.4): this module holds
  * the list the app has ALREADY fetched — every `api.getRoster()` call site
- * (the Build launch form on startup, Settings, Chat's [+ Add] picker — a
- * user action) deposits its answer here — and Chat reads it synchronously.
- * When nothing has been deposited yet, Chat falls back to the hardcoded
- * `DEFAULT_CHAT_AGENTS` constant (§6.2) rather than fetching.
+ * (the Build launch form on startup, Settings, Chat's [+ Add] picker, Chat's
+ * own cold-cache mount resolve — the EC44-named request) deposits its answer
+ * here — and Chat reads it synchronously. When nothing has been deposited
+ * yet, Chat renders an honest resolving state and resolves it (BRIEF-UX-001
+ * C6/EC44: the chips are truth — there is NO hardcoded fallback set any
+ * more, because a chip must never claim a seat the send won't connect).
  *
  * Plain module state, not a zustand store: no component re-renders when the
  * cache fills — it is read at decision points (chip initialization, picker
@@ -32,11 +33,11 @@ export function setCachedRoster(roster: RosterSeat[]): void {
 }
 
 /**
- * Warm-roster notification (DES-UX-001 §7.9-1): a surface whose defaults were
- * seeded while the cache was cold (the fallback trio) hears the deposit that
- * arrives later — e.g. the launch form's startup fetch landing after Chat
- * mounted — so a warm roster beats the fallback without any new fetch. The
- * subscription itself can never fire a request (§2.4 holds unchanged).
+ * Warm-roster notification (DES-UX-001 §7.9-1): a surface that mounted while
+ * the cache was cold (rendering its resolving state) hears the deposit that
+ * arrives later — its own resolve, or e.g. the launch form's startup fetch
+ * landing first — and seeds its chips from it. The subscription itself can
+ * never fire a request (§2.4 holds unchanged).
  */
 export function subscribeRoster(fn: (roster: RosterSeat[]) => void): () => void {
   listeners.add(fn);

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -1,26 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GroupChat, DEFAULT_CHAT_AGENTS } from '../src/components/GroupChat.js';
+import { GroupChat, chatCapable, defaultSelection } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
 import type { RosterSeat } from '../src/api/types.js';
 
 /**
- * DES-FEEDBACK-001 §6 (slice C) — Chat's default agent chips.
+ * BRIEF-UX-001 C6 / EC44 — the chips are TRUTH — as re-scoped in round 3.
  *
- * Operator: "Agents should be added by default and those chips should be
- * clickable to remove/add." Reconciled with the BINDING zero-requests-on-mount
- * constraint (DES-UXFIX-001 §2.4) by §6.1's one rule: chips render from the
- * CACHED roster (or the hardcoded fallback trio), never a fetch. These pin:
- *   - chips render on first paint with ZERO api calls (spy across the client);
- *   - a warm cache supplies the chip set; a cold cache falls back to
- *     DEFAULT_CHAT_AGENTS — the only hardcoded names in the agent layer;
- *   - ✕ removes for THIS run only: the count decrements and the send's clis
- *     excludes the removal;
- *   - [+ Add] opens the roster picker (its fetch rides the user action) and an
- *     added agent joins the send;
- *   - a stale default the daemon rejects surfaces a recoverable error NAMING
- *     it, and removing the chip + sending again recovers into the SAME chat id.
+ * The round-3 cold review (real daemon, fresh profile) caught the composer
+ * painting the writer/reviewer/planner fallback trio as if they were seats,
+ * '+ Add' silently swapping them for the CLI roster, and the send connecting
+ * the whole roster regardless of the 3 chips displayed. The contract now:
+ *   - COLD render never paints a chip until the roster is KNOWN: an honest
+ *     "resolving agents…" row renders instead, and the surface makes its ONE
+ *     named mount request (GET /api/v1/roster) to resolve it — warm cache
+ *     renders chips synchronously with zero requests;
+ *   - the DEFAULT selection is the CHAT-CAPABLE seats only: the roster seat's
+ *     `acp` field is the capability marker (object when configured, explicit
+ *     null when not — wicked-core's chat_ensure answers "no ACP config" for
+ *     null-acp seats). An ABSENT key (older daemon) reads as capable;
+ *   - [+ Add] offers incapable seats LABELED ("no chat config"), never as
+ *     silent equals — picking one is the operator's explicit call;
+ *   - the send body = exactly the selected chips. No hidden fan-out;
+ *   - ✕ removes for THIS run only; a stale edited chip's rejection is a
+ *     recoverable error naming it (unchanged from slice C).
  */
 
 const openChat = vi.fn();
@@ -46,12 +50,15 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
   useEventStream: () => undefined,
 }));
 
+/** The live daemon's wire shape in miniature: `acp` is an object on the
+ *  chat-capable seats and EXPLICIT null on the rest (GET /api/v1/roster). */
 const ROSTER = [
-  { key: 'claude', enabled_for_council: true },
-  { key: 'codex', enabled_for_council: true },
-  { key: 'agy', enabled_for_council: false },
-  { key: 'pi', enabled_for_council: false },
+  { key: 'claude', enabled_for_council: true, acp: { binary: 'claude-agent-acp', transport: 'stdio' } },
+  { key: 'codex', enabled_for_council: true, acp: null },
+  { key: 'agy', enabled_for_council: false, acp: null },
+  { key: 'pi', enabled_for_council: false, acp: { binary: 'pi-acp', transport: 'stdio' } },
 ] as unknown as RosterSeat[];
+const CAPABLE = ['claude', 'pi'];
 
 const ALL_SPIES = { openChat, getChat, closeChat, getRoster, sendChatMessage, listProjects };
 
@@ -73,100 +80,179 @@ function chipKeys(): (string | undefined)[] {
   return screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent']);
 }
 
-describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
-  it('renders chips on first paint with ZERO api calls — the §6.1 constraint, spy-proven', async () => {
-    render(<GroupChat repoId={null} onBack={() => undefined} />);
-
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute(
-      'data-count',
-      String(DEFAULT_CHAT_AGENTS.length),
-    );
-    expect(screen.getAllByTestId('agent-chip')).toHaveLength(3);
-
-    // Flush microtasks, then hold the line: not one call on ANY api surface.
-    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
-    for (const [name, spy] of Object.entries(ALL_SPIES)) {
-      expect(spy, `${name} must not fire on mount (§2.4/§6.1)`).not.toHaveBeenCalled();
-    }
+describe('chatCapable / defaultSelection — the EC44 capability rule', () => {
+  it('acp object = capable; explicit null = not; ABSENT key = capable (no fabricated incapability)', () => {
+    expect(chatCapable({ acp: { binary: 'x' } } as unknown as RosterSeat)).toBe(true);
+    expect(chatCapable({ acp: null } as unknown as RosterSeat)).toBe(false);
+    expect(chatCapable({ key: 'old-daemon' } as unknown as RosterSeat)).toBe(true);
   });
 
-  it('a warm cache supplies the chip set — still zero calls', async () => {
+  it('defaultSelection is the chat-capable subset — a marker-less roster keeps every seat', () => {
+    expect(defaultSelection(ROSTER)).toEqual(CAPABLE);
+    const unmarked = [{ key: 'a' }, { key: 'b' }] as unknown as RosterSeat[];
+    expect(defaultSelection(unmarked)).toEqual(['a', 'b']);
+  });
+});
+
+describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
+  it('COLD render: no chip is painted — the resolving row shows, ONE named roster request resolves it, then roster-true chips', async () => {
+    // Hold the resolve open so the pre-resolve state is assertable — the
+    // mocked promise would otherwise land inside the first `await`.
+    let release: (v: { roster: RosterSeat[] }) => void = () => undefined;
+    getRoster.mockImplementationOnce(
+      () => new Promise<{ roster: RosterSeat[] }>((res) => { release = res; }),
+    );
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    // Before the resolve lands: the honest resolving state, ZERO chips —
+    // never the writer/reviewer/planner trio dressed as seats.
+    expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
+    expect(screen.getByTestId('agent-chips-resolving')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-source', 'resolving');
+    for (const ghost of ['writer', 'reviewer', 'planner']) {
+      expect(document.querySelector(`[data-agent="${ghost}"]`), `${ghost} must never render`).toBeNull();
+    }
+    // Send is disabled while the audience is unknown — even with text typed.
+    const user = userEvent.setup();
+    await user.type(screen.getByRole('textbox'), 'early bird');
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    await user.keyboard('{Enter}'); // and the belt behind it ships nothing
+    expect(openChat).not.toHaveBeenCalled();
+
+    // The ONE named mount request (EC44's carve-out from the §2.4 budget).
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    const { act } = await import('@testing-library/react');
+    act(() => release({ roster: ROSTER }));
+    await waitFor(() => expect(chipKeys()).toEqual(CAPABLE));
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-source', 'roster');
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
+    expect(screen.queryByTestId('agent-chips-resolving')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled();
+    // Nothing else fired: no open, no probe, no fan-out.
+    expect(openChat).not.toHaveBeenCalled();
+    expect(getChat).not.toHaveBeenCalled();
+    expect(sendChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('WARM cache: chips render synchronously — roster-true, capability-filtered, zero requests', async () => {
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
-    expect(chipKeys()).toEqual(['claude', 'codex', 'agy', 'pi']);
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '4');
+    expect(chipKeys()).toEqual(CAPABLE);
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-source', 'roster');
     await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    for (const [name, spy] of Object.entries(ALL_SPIES)) {
+      expect(spy, `${name} must not fire on a warm-cache mount`).not.toHaveBeenCalled();
+    }
+  });
+
+  it('the send CONNECTS exactly the displayed chips — the round-2 hidden roster fan-out is gone', async () => {
+    const user = userEvent.setup();
+    setCachedRoster(ROSTER);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    const displayed = chipKeys();
+    await user.type(screen.getByRole('textbox'), 'hello seats');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(displayed);
+    // The PRISTINE selection did not trigger a roster re-fetch or a swap.
     expect(getRoster).not.toHaveBeenCalled();
   });
 
-  it('a cold cache falls back to DEFAULT_CHAT_AGENTS — the only hardcoded names', () => {
+  it('a FAILED resolve renders the unresolved row with Retry — nothing ships, and Retry recovers', async () => {
+    const user = userEvent.setup();
+    getRoster.mockRejectedValueOnce(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
-    expect(chipKeys()).toEqual([...DEFAULT_CHAT_AGENTS]);
+
+    const failedRow = await screen.findByTestId('agent-chips-unresolved');
+    expect(failedRow).toHaveTextContent(/couldn’t load the agent roster/);
+    expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
+    await user.type(screen.getByRole('textbox'), 'anyone there?');
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    await user.keyboard('{Enter}'); // the belt behind the disabled suspender
+    expect(openChat).not.toHaveBeenCalled();
+    expect(sendChatMessage).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('agent-chips-retry'));
+    await waitFor(() => expect(chipKeys()).toEqual(CAPABLE));
+    expect(getRoster).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled();
   });
 
   it('✕ removes for this run only: the count decrements and the send excludes the removal', async () => {
     const user = userEvent.setup();
+    setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
-    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
-    expect(chipKeys()).toEqual(['reviewer', 'planner']);
+    await user.click(screen.getByRole('button', { name: 'Remove claude' }));
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '1');
+    expect(chipKeys()).toEqual(['pi']);
 
-    await user.type(screen.getByRole('textbox'), 'no writer please');
+    await user.type(screen.getByRole('textbox'), 'no claude please');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner']);
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['pi']);
   });
 
-  it('[+ Add] opens the picker (fetch on the user action, cached after) and the addition joins the send', async () => {
+  it('[+ Add] labels the incapable seats ("no chat config") and an EXPLICIT pick joins the send', async () => {
     const user = userEvent.setup();
+    setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
-    // Slice AB (§7.9-1): an edit pins the selection first — otherwise the
-    // picker's own roster deposit would re-seed the pristine fallback trio
-    // to the full roster (the warm-roster-wins rule) before the click lands.
-    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
     await user.click(screen.getByTestId('add-agent'));
-    await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
     const options = await screen.findAllByTestId('agent-picker-option');
     expect(options.map((o) => o.dataset['agentKey'])).toEqual(['claude', 'codex', 'agy', 'pi']);
-
-    await user.click(options[1]!); // codex
-    expect(chipKeys()).toEqual(['reviewer', 'planner', 'codex']);
-
-    // Re-opening reads the now-warm cache — no second fetch.
-    await user.click(screen.getByTestId('add-agent'));
-    expect(getRoster).toHaveBeenCalledTimes(1);
-    // An already-included agent is offered disabled, not duplicated.
-    const codexRow = screen
-      .getAllByTestId('agent-picker-option')
-      .find((o) => o.dataset['agentKey'] === 'codex')!;
-    expect(codexRow).toBeDisabled();
+    const byKey = Object.fromEntries(options.map((o) => [o.dataset['agentKey'], o]));
+    // Capability is DISCLOSED, not hidden: the marker rides the DOM + a label.
+    expect(byKey['codex']!.dataset['chatCapable']).toBe('false');
+    expect(byKey['agy']!.dataset['chatCapable']).toBe('false');
+    expect(byKey['claude']!.dataset['chatCapable']).toBe('true');
+    expect(byKey['codex']!).toHaveTextContent('no chat config');
+    expect(byKey['claude']!).not.toHaveTextContent('no chat config');
+    // The capable defaults are already included (disabled, not duplicated)…
+    expect(byKey['claude']!).toBeDisabled();
+    // …and the incapable seat is still the operator's explicit call.
+    await user.click(byKey['codex']!);
+    expect(chipKeys()).toEqual([...CAPABLE, 'codex']);
 
     await user.type(screen.getByRole('textbox'), 'bring codex too');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([
-      'reviewer',
-      'planner',
-      'codex',
-    ]);
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual([...CAPABLE, 'codex']);
+  });
+
+  it('a roster with NO capable seat defaults to an EMPTY selection with the honest note — never 4 red seats', async () => {
+    setCachedRoster([
+      { key: 'codex', enabled_for_council: true, acp: null },
+      { key: 'agy', enabled_for_council: false, acp: null },
+    ] as unknown as RosterSeat[]);
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+
+    expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
+    expect(screen.getByTestId('agent-chips-empty-note')).toHaveTextContent(/no agent has a chat \(ACP\) config/);
+    await user.type(screen.getByRole('textbox'), 'hello?');
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    expect(openChat).not.toHaveBeenCalled();
   });
 
   it('the picker speaks the roster: display names and observed health ride each option (J4 round 2, minor)', async () => {
     const user = userEvent.setup();
-    getRoster.mockResolvedValueOnce({
+    getRoster.mockResolvedValue({
       roster: [
         { key: 'claude', display_name: 'Claude Code', enabled_for_council: true,
+          acp: { binary: 'claude-agent-acp' },
           health: { status: 'active', since: '2026-08-01T00:00:00Z' } },
-        { key: 'codex', display_name: 'Codex', enabled_for_council: true,
+        { key: 'codex', display_name: 'Codex', enabled_for_council: true, acp: null,
           health: { status: 'inactive', message: 'quota exceeded', since: '2026-08-01T00:00:00Z' } },
-        // A daemon predating crew#274: no health claim — never fabricated.
+        // A daemon predating crew#274/acp: no health claim, no capability claim.
         { key: 'pi', display_name: 'pi', enabled_for_council: true },
       ] as unknown as RosterSeat[],
     });
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await waitFor(() => expect(screen.getAllByTestId('agent-chip').length).toBeGreaterThan(0));
     await user.click(screen.getByTestId('add-agent'));
 
     const options = await screen.findAllByTestId('agent-picker-option');
@@ -174,26 +260,18 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     expect(byKey['claude']).toHaveTextContent('Claude Code');
     expect(byKey['claude']!.dataset['health']).toBe('active');
     expect(byKey['codex']!.dataset['health']).toBe('inactive');
-    expect(byKey['codex']!.title).toBe('Codex — inactive');
-    // No health on the wire → no claim in the DOM.
+    expect(byKey['codex']!.title).toBe('Codex — inactive — no chat (ACP) config — can’t join a chat');
+    // No health on the wire → no claim in the DOM; absent acp → capable.
     expect(byKey['pi']!.dataset['health']).toBe('unknown');
+    expect(byKey['pi']!.dataset['chatCapable']).toBe('true');
     expect(byKey['pi']!.querySelector('span[aria-hidden]')).toBeNull();
-    // The KEY stays the data identity the send uses.
-    await user.click(byKey['claude']!);
-    expect(chipKeys()).toContain('claude');
   });
 
   it('a stale EDITED chip the daemon rejects surfaces a recoverable error naming it; remove + resend recovers into the same chat', async () => {
-    // Round-2 re-scope (BRIEF-UX-001 J4 finding 1): this test previously drove
-    // the recovery path through the PRISTINE fallback trio reaching the daemon
-    // (roster unreachable) — a wire call the round-2 mandate forbids outright.
-    // The §6.2 recovery contract it pinned is unchanged and still pinned here,
-    // now driven through what can still legitimately carry a stale name to the
-    // daemon: an OPERATOR-EDITED selection (an edit pins the selection — the
-    // operator's explicit call ships as-is; the daemon's per-seat answer is
-    // the recovery path).
+    // The §6.2 recovery contract, unchanged from round 2: an operator-edited
+    // selection ships as-is, and the daemon's per-seat answer is the recovery.
     const user = userEvent.setup();
-    // First open: every requested seat is rejected (stale names).
+    setCachedRoster(ROSTER);
     openChat.mockImplementationOnce((body: { chatId: string; clis?: string[] }) =>
       Promise.resolve({
         chatId: body.chatId,
@@ -203,25 +281,28 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     // The edit PINS the selection (§7.9-1) — no roster re-seed rides the send.
-    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
+    await user.click(screen.getByRole('button', { name: 'Remove claude' }));
     await user.type(screen.getByRole('textbox'), 'hello?');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     expect(getRoster).not.toHaveBeenCalled(); // touched selection: the operator's call
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner']);
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['pi']);
 
-    // The error NAMES the rejected agents (§6.2) — on the banner AND the
+    // The error NAMES the rejected agent (§6.2) — on the banner AND the
     // retryable failed-send row (§7.9-2 carries the same reason).
     await waitFor(() =>
-      expect(screen.getAllByText(/rejected agents "reviewer", "planner"/).length).toBeGreaterThan(0),
+      expect(screen.getAllByText(/rejected agent "pi"/).length).toBeGreaterThan(0),
     );
-    // … the message did NOT go out, and the failure is a retryable row (§7.9-2).
     expect(sendChatMessage).not.toHaveBeenCalled();
     expect(screen.getByTestId('chat-send-failed')).toBeInTheDocument();
-    // Recoverable: the chips bar is back (nothing warmed), removals still work.
+    // Recoverable: the chips bar is back (nothing warmed); +Add still works.
     const bar = await screen.findByTestId('agent-chips-bar');
-    expect(bar).toHaveAttribute('data-count', '2');
-    await user.click(screen.getByRole('button', { name: 'Remove reviewer' }));
+    expect(bar).toHaveAttribute('data-count', '1');
+    await user.click(screen.getByRole('button', { name: 'Remove pi' }));
+    await user.click(screen.getByTestId('add-agent'));
+    const claudeOpt = (await screen.findAllByTestId('agent-picker-option'))
+      .find((o) => o.dataset['agentKey'] === 'claude')!;
+    await user.click(claudeOpt);
 
     // §7.9-2: the failed send's DRAFT survived in the composer — clear it for
     // the corrected resend (the retry re-arms the SAME chat id, then sends).
@@ -233,11 +314,11 @@ describe('GroupChat — default agent chips (DES-FEEDBACK-001 §6)', () => {
     const first = openChat.mock.calls[0]?.[0] as { chatId: string };
     const second = openChat.mock.calls[1]?.[0] as { chatId: string; clis?: string[] };
     expect(second.chatId, 'recovery must not mint a second chat (FINDING-027)').toBe(first.chatId);
-    expect(second.clis).toEqual(['planner']);
+    expect(second.clis).toEqual(['claude']);
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(second.chatId, 'try again'));
     // J4 finding 3: the successful send retires the stale open-failure banner
-    // and the previously-rejected seats' red chips (they are not in this open).
-    await waitFor(() => expect(screen.queryByText(/rejected agents/)).toBeNull());
-    expect(document.querySelector('[data-testid="seat-chip"][data-agent="reviewer"]')).toBeNull();
+    // and the previously-rejected seat's red chip (it is not in this open).
+    await waitFor(() => expect(screen.queryByText(/rejected agent/)).toBeNull());
+    expect(document.querySelector('[data-testid="seat-chip"][data-agent="pi"]')).toBeNull();
   });
 });

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GroupChat, chatCapable, defaultSelection } from '../src/components/GroupChat.js';
+import { GroupChat, chatCapable, defaultSelection, rosterSpeaksAcp } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
 import type { RosterSeat } from '../src/api/types.js';
 
@@ -17,9 +17,12 @@ import type { RosterSeat } from '../src/api/types.js';
  *     named mount request (GET /api/v1/roster) to resolve it — warm cache
  *     renders chips synchronously with zero requests;
  *   - the DEFAULT selection is the CHAT-CAPABLE seats only: the roster seat's
- *     `acp` field is the capability marker (object when configured, explicit
- *     null when not — wicked-core's chat_ensure answers "no ACP config" for
- *     null-acp seats). An ABSENT key (older daemon) reads as capable;
+ *     `acp` field is the capability marker — an object when configured, and
+ *     ABSENT when not (skip_serializing_if: the engine never writes null;
+ *     wicked-core's chat_ensure answers "no ACP config" for configless
+ *     seats). Round-4 polarity: an absent key is "no config" whenever ANY
+ *     seat in the roster speaks the field; only a roster with no acp key
+ *     anywhere (a daemon predating the field) reads all-capable;
  *   - [+ Add] offers incapable seats LABELED ("no chat config"), never as
  *     silent equals — picking one is the operator's explicit call;
  *   - the send body = exactly the selected chips. No hidden fan-out;
@@ -51,10 +54,12 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
 }));
 
 /** The live daemon's wire shape in miniature: `acp` is an object on the
- *  chat-capable seats and EXPLICIT null on the rest (GET /api/v1/roster). */
+ *  chat-capable seats and ABSENT on the rest (GET /api/v1/roster — the
+ *  engine's skip_serializing_if never writes a null; codex here is the real
+ *  absent-key spelling, agy the defensive explicit-null belt arm). */
 const ROSTER = [
   { key: 'claude', enabled_for_council: true, acp: { binary: 'claude-agent-acp', transport: 'stdio' } },
-  { key: 'codex', enabled_for_council: true, acp: null },
+  { key: 'codex', enabled_for_council: true },
   { key: 'agy', enabled_for_council: false, acp: null },
   { key: 'pi', enabled_for_council: false, acp: { binary: 'pi-acp', transport: 'stdio' } },
 ] as unknown as RosterSeat[];
@@ -80,17 +85,38 @@ function chipKeys(): (string | undefined)[] {
   return screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent']);
 }
 
-describe('chatCapable / defaultSelection — the EC44 capability rule', () => {
-  it('acp object = capable; explicit null = not; ABSENT key = capable (no fabricated incapability)', () => {
-    expect(chatCapable({ acp: { binary: 'x' } } as unknown as RosterSeat)).toBe(true);
-    expect(chatCapable({ acp: null } as unknown as RosterSeat)).toBe(false);
-    expect(chatCapable({ key: 'old-daemon' } as unknown as RosterSeat)).toBe(true);
+describe('chatCapable / defaultSelection — the EC44 capability rule (round-4 polarity)', () => {
+  it('acp object = capable; null = not; ABSENT = not-capable when the roster speaks acp, capable when none does', () => {
+    expect(chatCapable({ acp: { binary: 'x' } } as unknown as RosterSeat, true)).toBe(true);
+    expect(chatCapable({ acp: null } as unknown as RosterSeat, true)).toBe(false);
+    // The round-4 correction: skip_serializing_if means the engine spells
+    // "no config" by OMITTING the key — beside a speaking roster, absence is
+    // the incapability, and reading it as capable repaints the 4-red-seats
+    // cold send this whole fix exists to kill.
+    expect(chatCapable({ key: 'no-config' } as unknown as RosterSeat, true)).toBe(false);
+    expect(chatCapable({ key: 'old-daemon' } as unknown as RosterSeat, false)).toBe(true);
+    expect(rosterSpeaksAcp(ROSTER)).toBe(true);
+    expect(rosterSpeaksAcp([{ key: 'a' }, { key: 'b' }] as unknown as RosterSeat[])).toBe(false);
+    // Explicit null counts as speaking (a claim is a claim).
+    expect(rosterSpeaksAcp([{ key: 'a', acp: null }] as unknown as RosterSeat[])).toBe(true);
   });
 
   it('defaultSelection is the chat-capable subset — a marker-less roster keeps every seat', () => {
     expect(defaultSelection(ROSTER)).toEqual(CAPABLE);
     const unmarked = [{ key: 'a' }, { key: 'b' }] as unknown as RosterSeat[];
     expect(defaultSelection(unmarked)).toEqual(['a', 'b']);
+  });
+
+  it('the LIVE daemon wire verbatim (round 4): objects on claude/pi, key absent on the other four', () => {
+    const live = [
+      { key: 'claude', acp: { binary: 'claude-agent-acp', start_args: [], transport: 'stdio' } },
+      { key: 'agy' },
+      { key: 'codex' },
+      { key: 'pi', acp: { binary: 'pi-acp', start_args: [], transport: 'stdio' } },
+      { key: 'copilot' },
+      { key: 'opencode' },
+    ] as unknown as RosterSeat[];
+    expect(defaultSelection(live)).toEqual(['claude', 'pi']);
   });
 });
 
@@ -247,7 +273,8 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
           health: { status: 'active', since: '2026-08-01T00:00:00Z' } },
         { key: 'codex', display_name: 'Codex', enabled_for_council: true, acp: null,
           health: { status: 'inactive', message: 'quota exceeded', since: '2026-08-01T00:00:00Z' } },
-        // A daemon predating crew#274/acp: no health claim, no capability claim.
+        // A seat with no health claim whose acp key is ABSENT — beside a
+        // roster that speaks acp, absence IS "no config" (round 4).
         { key: 'pi', display_name: 'pi', enabled_for_council: true },
       ] as unknown as RosterSeat[],
     });
@@ -261,9 +288,12 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     expect(byKey['claude']!.dataset['health']).toBe('active');
     expect(byKey['codex']!.dataset['health']).toBe('inactive');
     expect(byKey['codex']!.title).toBe('Codex — inactive — no chat (ACP) config — can’t join a chat');
-    // No health on the wire → no claim in the DOM; absent acp → capable.
+    // No health on the wire → no claim in the DOM. The acp key is absent on
+    // a roster that SPEAKS acp (claude carries the object), so absence is
+    // "no config" — labeled, never a silent default (round-4 polarity).
     expect(byKey['pi']!.dataset['health']).toBe('unknown');
-    expect(byKey['pi']!.dataset['chatCapable']).toBe('true');
+    expect(byKey['pi']!.dataset['chatCapable']).toBe('false');
+    expect(byKey['pi']!).toHaveTextContent('no chat config');
     expect(byKey['pi']!.querySelector('span[aria-hidden]')).toBeNull();
   });
 

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
@@ -7,16 +7,19 @@ import type { RosterSeat } from '../src/api/types.js';
 
 /**
  * DES-UXFIX-001 slice 4 (§2.4, F6) — Chat's first-run moment teaches — as
- * re-scoped by DES-FEEDBACK-001 §6 (slice C).
+ * re-scoped by DES-FEEDBACK-001 §6 (slice C) and BRIEF-UX-001 C6/EC44
+ * (round 3: chips are truth).
  *
- * The audit finding, verbatim: entering a project dropped the user into a pre-armed
- * "Group chat" with six agent chips and an End-chat button before they'd typed anything.
- * The §2.4 redesign: NOTHING warms on mount; the empty state says what Chat is and what
- * typing does; the first send is the warm opt-in. Slice C's §6 compromise keeps every
- * bit of that and replaces the "Add agents" disclosure with DEFAULT chips: the agents
- * that WILL join render immediately from the roster CACHE (fallback trio when cold),
- * still zero requests on mount — the chips are selection UI, not warm seats. The e2e
- * rig re-proves these against a real build with a network tap.
+ * The audit finding, verbatim: entering a project dropped the user into a
+ * pre-armed "Group chat" with six agent chips and an End-chat button before
+ * they'd typed anything. The §2.4 redesign: NOTHING warms on mount; the empty
+ * state says what Chat is and what typing does; the first send is the warm
+ * opt-in. Round 3 closes the last lie in that story: the chips are the
+ * agents the send CONNECTS, so no chip is painted until the roster is known —
+ * a cold cache renders an honest resolving row and this surface makes its ONE
+ * named mount request (GET /api/v1/roster) to resolve it. There is no
+ * fallback trio and no send-time roster swap any more. Warming still waits
+ * for the first send; nothing else fires on mount.
  */
 
 const openChat = vi.fn();
@@ -40,14 +43,13 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
   useEventStream: () => undefined,
 }));
 
+/** Wire-true miniature: `acp` object = chat-capable, explicit null = not. */
 const ROSTER = [
-  { key: 'claude', enabled_for_council: true },
-  { key: 'codex', enabled_for_council: true },
-  { key: 'agy', enabled_for_council: false },
+  { key: 'claude', enabled_for_council: true, acp: { binary: 'claude-agent-acp' } },
+  { key: 'codex', enabled_for_council: true, acp: null },
+  { key: 'agy', enabled_for_council: false, acp: { binary: 'agy-acp' } },
 ] as unknown as RosterSeat[];
-
-/** §6.2's hardcoded fallback — what the chips show when the cache is cold. */
-const FALLBACK = ['writer', 'reviewer', 'planner'];
+const CAPABLE = ['claude', 'agy'];
 
 const chipAgents = (): (string | undefined)[] =>
   screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent']);
@@ -67,47 +69,53 @@ beforeEach(() => {
   );
   sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
-  clearCachedRoster(); // cold cache — the §6.2 fallback path unless a test seeds it
+  clearCachedRoster(); // cold cache — the resolving arm unless a test seeds it
 });
 
-describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + DES-FEEDBACK-001 §6)', () => {
-  it('mounts cold: zero requests, default chips from the fallback, no Close — the AC verbatim', async () => {
+describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', () => {
+  it('mounts cold: teaching state, NO painted chips (resolving row), the ONE named roster request, no Close — the AC verbatim', async () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     // The teaching state is on screen…
     const teach = screen.getByTestId('chat-firstrun');
     expect(teach).toHaveTextContent('Chat with an agent about this project.');
     expect(teach).toHaveTextContent(/No run, no gates — just talk/);
-    // …the §6.2 default chips render IMMEDIATELY (cold cache → the fallback trio)…
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '3');
-    expect(screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent'])).toEqual(FALLBACK);
-    expect(screen.getByTestId('add-agent')).toBeInTheDocument();
-    // …and the pre-armed ambush is still gone: no warm seats, no teardown, no "Group chat".
+    // …no chip is PAINTED before the roster is known (EC44): the resolving
+    // row renders instead, and the trio ghosts never do.
+    expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
+    expect(screen.getByTestId('agent-chips-resolving')).toBeInTheDocument();
+    for (const ghost of ['writer', 'reviewer', 'planner']) {
+      expect(document.querySelector(`[data-agent="${ghost}"]`)).toBeNull();
+    }
+    // …and the pre-armed ambush is still gone: no warm seats, no teardown.
     expect(screen.queryByTestId('chat-close')).toBeNull();
     expect(screen.queryByTitle('ready')).toBeNull();
     expect(screen.queryByText('Group chat')).toBeNull();
 
-    // Flush pending microtasks, then hold the line: nothing fired on mount —
-    // the chips came from the cache/fallback, never a fetch (§6.1).
-    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    // The ONE named mount request resolves the chips to the CAPABLE seats
+    // (AC: GET /api/v1/roster is the only request this mount makes — the
+    // EC44 carve-out from the §2.4 zero-mount budget, cold cache only).
+    await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
+    expect(getRoster).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('add-agent')).toBeInTheDocument();
     expect(openChat, 'no chat may open on mount').not.toHaveBeenCalled();
-    expect(getRoster, 'no roster fetch on mount — chips read the cache').not.toHaveBeenCalled();
     expect(getChat, 'nothing stored, so nothing to probe').not.toHaveBeenCalled();
+    expect(sendChatMessage).not.toHaveBeenCalled();
   });
 
-  it('the first send is roster-first (DES-UX-001 §7.9-1): a pristine cold-cache send fetches the roster ON THE GESTURE and warms ITS seats', async () => {
+  it('the first send warms EXACTLY the displayed chips — typing is the opt-in, no hidden fan-out', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
 
-    // Mount stayed request-free (pinned above); the SEND is the opt-in gesture
-    // the roster fetch rides, so the open names seats the daemon accepts.
     await user.type(screen.getByRole('textbox'), 'make me a deck');
     await user.keyboard('{Enter}');
 
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    // Exactly one roster GET total — the mount resolve; the send added none.
     expect(getRoster).toHaveBeenCalledTimes(1);
     const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
-    expect(body.clis).toEqual(ROSTER.map((s) => s.key));
+    expect(body.clis).toEqual(CAPABLE);
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, 'make me a deck'));
 
     // The message and the warm seats are on screen; the teaching state and the
@@ -115,87 +123,93 @@ describe('GroupChat — first-run teaches, nothing warms (DES-UXFIX-001 §2.4 + 
     // every fanned-out seat SAYS it is working until its reply lands (EC44).
     expect(screen.getByText('make me a deck')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-firstrun')).toBeNull();
-    await waitFor(() => expect(screen.getAllByTitle('working')).toHaveLength(ROSTER.length));
+    await waitFor(() => expect(screen.getAllByTitle('working')).toHaveLength(CAPABLE.length));
     expect(screen.queryByTestId('agent-chips-bar')).toBeNull();
     // Agents are warm now, so the teardown control may exist (V8).
     await waitFor(() => expect(screen.getByTestId('chat-close')).toBeInTheDocument());
   });
 
-  it('the fallback trio NEVER reaches the daemon: an unreachable roster fails the send inline, and Retry recovers (§7.9-1 round 2)', async () => {
-    // Round-2 re-scope (BRIEF-UX-001 J4 finding 1): this test previously
-    // pinned "the trio is the honest audience when the roster is unreachable"
-    // — the exact branch the cold-profile review caught rejecting every new
-    // user's first send. The trio is a PLACEHOLDER rendering now: a pristine
-    // selection either resolves to the roster or the send fails honestly
-    // (draft kept, inline retry) with NOTHING on the wire.
+  it('an unreachable roster NEVER fabricates chips or ships a send: the unresolved row + Retry recover (EC44)', async () => {
     const user = userEvent.setup();
     getRoster.mockRejectedValueOnce(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
-    await user.type(screen.getByRole('textbox'), 'make me a deck');
-    await user.keyboard('{Enter}');
+    const row = await screen.findByTestId('agent-chips-unresolved');
+    expect(row).toHaveTextContent(/couldn’t load the agent roster/);
+    expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
 
-    const failure = await screen.findByTestId('chat-send-failed');
-    expect(failure).toHaveTextContent(/could not load the agent roster/);
-    expect(getRoster).toHaveBeenCalledTimes(1);
-    // NOTHING reached the wire — no open, no fan-out, no phantom turn.
+    await user.type(screen.getByRole('textbox'), 'make me a deck');
+    // Send is DISABLED while the audience is unknown; Enter ships nothing.
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    await user.keyboard('{Enter}');
     expect(openChat).not.toHaveBeenCalled();
     expect(sendChatMessage).not.toHaveBeenCalled();
     expect(screen.getByRole('textbox')).toHaveValue('make me a deck');
     expect(screen.queryByTestId('user-bubble')).toBeNull();
 
-    // The roster recovers → Retry sends to the ROSTER's seats, exactly once.
-    await user.click(screen.getByTestId('chat-send-retry'));
+    // The roster recovers → Retry resolves, the chips are true, the draft is
+    // still in the composer, and the send connects the displayed seats.
+    await user.click(screen.getByTestId('agent-chips-retry'));
+    await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
+    await user.click(screen.getByRole('textbox')); // Retry took the focus
+    await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(ROSTER.map((s) => s.key));
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(CAPABLE);
     const chatId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(chatId, 'make me a deck'));
-    // No duplicate: the retried message renders exactly once.
     await waitFor(() => expect(screen.getAllByTestId('user-bubble')).toHaveLength(1));
-    expect(screen.queryByTestId('chat-send-failed')).toBeNull();
   });
 
-  it('[+ Add] opens the roster picker (fetch rides the user action) and the addition joins the send', async () => {
+  it('[+ Add] opens the roster picker and the addition joins the send', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
+    expect(getRoster).toHaveBeenCalledTimes(1); // the mount resolve
 
-    expect(getRoster).not.toHaveBeenCalled();
-    // An edit PINS the selection (§7.9-1): the roster deposit from the picker
+    // An edit PINS the selection (§7.9-1): the deposit from a later picker
     // open must not re-seed over the operator's removal.
-    await user.click(screen.getByRole('button', { name: 'Remove writer' }));
+    await user.click(screen.getByRole('button', { name: 'Remove claude' }));
     await user.click(screen.getByTestId('add-agent'));
-    // Opening the picker is a USER action — the one place the roster may be fetched here.
-    await waitFor(() => expect(getRoster).toHaveBeenCalledTimes(1));
+    // The picker reads the now-warm cache — no second fetch.
+    expect(getRoster).toHaveBeenCalledTimes(1);
     const options = await screen.findAllByTestId('agent-picker-option');
     expect(options.map((o) => o.dataset['agentKey'])).toEqual(ROSTER.map((s) => s.key));
+    // The incapable seat is offered LABELED, never as a silent equal (EC44).
+    const codex = options.find((o) => o.dataset['agentKey'] === 'codex')!;
+    expect(codex.dataset['chatCapable']).toBe('false');
+    expect(codex).toHaveTextContent('no chat config');
 
-    await user.click(options[0]!); // add claude
-    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '3');
+    await user.click(options[0]!); // re-add claude
+    expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
 
     await user.type(screen.getByRole('textbox'), 'all hands');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
-    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['reviewer', 'planner', 'claude']);
+    expect((openChat.mock.calls[0]?.[0] as { clis?: string[] }).clis).toEqual(['agy', 'claude']);
   });
 
-  it('a warm roster deposited AFTER mount re-seeds a PRISTINE selection — warm roster beats the fallback trio (§7.9-1)', async () => {
+  it('a roster deposited by ANOTHER surface before the resolve lands seeds a PRISTINE selection — no duplicate fetch consumed', async () => {
+    setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
-    expect(chipAgents()).toEqual(FALLBACK);
+    // Warm cache: chips render synchronously and the mount resolve is skipped.
+    expect(chipAgents()).toEqual(CAPABLE);
+    await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
+    expect(getRoster).not.toHaveBeenCalled();
 
-    // Another surface (the launch form's startup fetch) deposits the roster.
-    const { act } = await import('@testing-library/react');
-    act(() => setCachedRoster(ROSTER));
-    await waitFor(() => expect(chipAgents()).toEqual(ROSTER.map((s) => s.key)));
-    // Still zero requests from THIS surface — it only heard the deposit.
+    // A later deposit (another surface refetching) re-seeds while pristine.
+    act(() => setCachedRoster([ROSTER[0]!]));
+    await waitFor(() => expect(chipAgents()).toEqual(['claude']));
     expect(getRoster).not.toHaveBeenCalled();
   });
 
-  it('Send is enabled by text alone on first-run — typing is the opt-in', async () => {
+  it('Send is enabled by text alone once the roster is known — typing is the opt-in', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
 
     const send = screen.getByRole('button', { name: 'Send' });
     expect(send).toBeDisabled();
+    await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
+    expect(send).toBeDisabled(); // roster known, but no text yet
     await user.type(screen.getByRole('textbox'), 'hello');
     expect(send).toBeEnabled();
   });

--- a/tests/GroupChat.project.test.tsx
+++ b/tests/GroupChat.project.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
+import { setCachedRoster } from '../src/store/rosterCache.js';
+import type { RosterSeat } from '../src/api/types.js';
 
 /**
  * DES-FEEDBACK-001 slice B (§5.1/§5.2/§4.3) — the Chat create flow's project
@@ -66,6 +68,11 @@ beforeEach(() => {
   );
   sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
+  // EC44 re-scope: this suite's subject is the project binding, not chip
+  // seeding — a WARM roster cache keeps the mount request-free (the cold-cache
+  // arm, where the surface makes its one named roster resolve, is pinned in
+  // GroupChat.chips/firstrun).
+  setCachedRoster(ROSTER as unknown as RosterSeat[]);
 });
 
 describe('GroupChat — create-flow project binding (slice B)', () => {

--- a/tests/GroupChat.tokens.test.tsx
+++ b/tests/GroupChat.tokens.test.tsx
@@ -23,7 +23,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
-import { clearCachedRoster } from '../src/store/rosterCache.js';
+import { setCachedRoster } from '../src/store/rosterCache.js';
+import type { RosterSeat } from '../src/api/types.js';
 
 const openChat = vi.fn();
 const getChat = vi.fn();
@@ -64,7 +65,9 @@ beforeEach(() => {
   );
   sendChatMessage.mockResolvedValue({ seats: [] });
   sessionStorage.clear();
-  clearCachedRoster(); // chips render the §6.2 fallback trio
+  // EC44 re-scope: a WARM cache renders the chips synchronously — this suite
+  // pins their VISUAL anatomy, not the seeding (see GroupChat.chips/firstrun).
+  setCachedRoster(ROSTER as unknown as RosterSeat[]);
 });
 
 describe('GroupChat — the §5.3 visual language', () => {


### PR DESCRIPTION
The campaign's final blocker (BRIEF-UX-001 C6 / EC44): **the chips shown are now exactly the seats the send connects.**

- Cold render never paints the writer/reviewer/planner trio — an honest "resolving agents…" row, ONE named `GET /roster` on a cold cache (warm cache: zero requests, chips immediate), inline Retry on failure, Send disabled while the audience is unknown.
- Default selection = chat-capable seats only, derived from the roster's `acp` config with roster-aware polarity (the key is serde-omitted, not null, for incapable seats — absent beside a speaking roster = no config; absent everywhere = pre-field daemon = all capable). On this daemon a cold chat defaults to claude + pi; the other 4 appear in +Add labeled "no chat config", selectable as an explicit choice.
- The send body is composed from the rendered selection only — the round-2 send-time roster swap is deleted, and a hidden fan-out hole (emptied chips → clis-omitted POST warming daemon defaults) is closed.
- The fixture now mirrors the true wire shape (serde-omitted keys, per-seat "no ACP config" rejections).

Verified: 1458 unit tests; the new rig ×2 (mutation-record paint witness — the trio provably never paints; request-tapped POST == chips); 9 regression rigs; **live real-daemon cold-profile proof** by the adversarial verifier (who also caught and fixed the builder's wrong polarity by reproducing the defect live first). Negative check fails on main at the trio-paint assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
