### PR TITLE
DES-UX-002 slice BC: work chronicle

### DIFF
--- a/e2e/ux2_sliceBC_test.py
+++ b/e2e/ux2_sliceBC_test.py
@@ -213,10 +213,19 @@ with sync_playwright() as p:
     # AC 2: attempt 2's "view timeline" navigates to run B's evidence timeline.
     page.locator(f'{chain_sel} [data-testid="attempt-row"][data-attempt="2"] '
                  '[data-testid="view-timeline"]').click()
+    # The link's own spelling is §5.2's `/runs/:id/timeline`; the app's
+    # legacy-redirect then re-homes a FILED run into its project shell
+    # (`/p/auth-refactor/build/r-retry`, DES-MERGE-001 §1.5) — the race
+    # between the two spellings is the app's, so the rig accepts either and
+    # pins the SURFACE: run B open, evidence timeline visible (slice BB's
+    # terminal-run default tab).
     page.wait_for_function(
-        """() => window.location.pathname === '/runs/r-retry/timeline'""", timeout=10000)
-    page.locator('[data-testid="thread"]').wait_for(timeout=15000)
-    check("view_timeline_navigates", True,
+        """() => window.location.pathname === '/runs/r-retry/timeline'
+              || window.location.pathname === '/p/auth-refactor/build/r-retry'""",
+        timeout=10000)
+    page.locator('[data-testid="timeline"]').wait_for(timeout=15000)
+    check("view_timeline_navigates",
+          "r-retry" in page.evaluate("() => window.location.pathname"),
           pathname=page.evaluate("() => window.location.pathname"))
 
     # ── Scene 4 (AC 3, EC53): the honest empty state — no completed run ─────────

--- a/e2e/ux2_sliceBC_test.py
+++ b/e2e/ux2_sliceBC_test.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+ux2_sliceBC_test.py — the DES-UX-002 slice-BC gate: the work chronicle (§3).
+
+Runs against the shared W2 fixture with the `chronicle` + `project_dto`
+corpora on (real wire shapes only): auth-refactor's membership carries a
+3-LINK retry chain (r-auth failed → r-retry failed, attempt 1 → r-retry2
+completed, attempt 2 — `retry_of` is the api-types 0.8.0 DTO echo) plus a
+standalone in-progress episode (r-hooks), the audit trail serves REAL
+gate.decided entries (routes.ts:983 detail {approve, amend?, status}) and
+honours `?action=`, and r-unfiled rides the run list as the UNFILED episode
+that must never leak into a project's chronicle.
+
+The §3.5 DOM ACs, mapped (the fixture's chain is the AC's A→B pair EXTENDED
+to three links per the slice brief, so the pinned "attempt 2" sub-row is
+r-retry — the middle attempt):
+
+  1. grouping (EC50): the chronicle renders exactly 2 chain cards for the 4
+     scoped runs — one 3-attempt episode (header names `3 attempts`), one
+     solo card; retry siblings are SUB-ROWS, never peer rows; sub-rows list
+     attempts 1..3 in order (r-auth, r-retry, r-retry2);
+  2. `[data-testid="attempt-row"][data-attempt="2"]`'s
+     `[data-testid="view-timeline"]` navigates to run B's (r-retry's)
+     evidence timeline route;
+  3. the current-state strip renders the last completed run's criterion
+     phrase (off r-retry2's durable gateEvaluated tail) + `3 phases`; on a
+     project with NO completed run (upload-endpoint) it renders the EXACT
+     no-run copy (EC53 — never a fabricated state);
+  4. the guidance panel is gesture-gated: ZERO /audit requests on chronicle
+     mount; the explicit open fires EXACTLY ONE GET /audit?action=gate.decided
+     (request-tap), and the rows are the project's amendments only — the
+     foreign-project amend and the no-amend reject are filtered client-side;
+  5. "use in next run" opens the composer with the amendment text in
+     `[data-testid="steer-prefill"]`; the launch POST carries the fold
+     (problem + the labelled Operator guidance paragraph).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-BC-chronicle.png       the chronicle: state strip, 2 episode cards,
+                            gesture-gated guidance panel
+  ux-BC-chain-expanded.png  the 3-attempt episode expanded into sub-rows
+  ux-BC-guidance-panel.png  the guidance summary opened, amendments listed
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 (ensure_build CACHES — delete a stale dist-sameorigin/
+when the source changed). Env knobs: FEEDBACK_PORT (default 4408),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4408"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+PROJECT = "auth-refactor"
+BUILD_TAB = f"/p/{PROJECT}/build"
+CRITERION = "auth middleware refactor passes the full test suite"
+AMEND_AUTH = "focus on the middleware tests, skip the docs pass"
+AMEND_TIP = "keep the session-token API unchanged; refactor only the middleware layer"
+AMEND_FOREIGN = "rate-limit by API key, not by IP"
+NO_RUN_COPY = ("No completed run yet — this project's first successful build "
+               "will appear here.")
+LAUNCH_INTENT = "tighten the retry backoff for auth"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, chronicle corpus ON ──────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, chronicle=True, project_dto=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The request tap: every audit read (with its query), every per-run events
+    # read, every launch POST body.
+    audit_reads: list[dict] = []
+    event_reads: list[str] = []
+    launch_posts: list[dict] = []
+
+    def on_request(req):
+        u = urlparse(req.url)
+        if req.method == "GET" and u.path == "/api/v1/audit":
+            q = parse_qs(u.query)
+            audit_reads.append({"action": (q.get("action") or [""])[0],
+                                "runId": (q.get("runId") or [""])[0]})
+        elif req.method == "GET" and u.path.startswith("/api/v1/runs/") \
+                and u.path.endswith("/events"):
+            event_reads.append(u.path.split("/")[4])
+        elif req.method == "POST" and u.path == "/api/v1/runs":
+            try:
+                launch_posts.append(json.loads(req.post_data or "{}"))
+            except ValueError:
+                launch_posts.append({"unparseable": req.post_data})
+
+    page.on("request", on_request)
+
+    def goto(path: str) -> None:
+        page.goto(f"{ORIGIN}{path}", wait_until="domcontentloaded")
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    def open_chronicle() -> None:
+        page.locator('[data-testid="build-dashboard"]').wait_for(timeout=30000)
+        page.locator('[data-testid="build-view-chronicle"]').click()
+        page.locator('[data-testid="work-chronicle"]').wait_for(timeout=15000)
+
+    # ── Scene 1 (AC 1, EC50): grouping — 2 chain cards for 4 scoped runs ────────
+    goto(BUILD_TAB)
+    open_chronicle()
+    page.wait_for_function(
+        """() => document.querySelectorAll('[data-testid="episode-chain"]').length === 2""",
+        timeout=15000)
+    cards = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="episode-chain"]'))
+                 .map(c => ({ attempts: c.dataset.attempts, status: c.dataset.chainStatus,
+                              expanded: c.dataset.expanded,
+                              header: c.querySelector('[data-testid="chain-header"]')
+                                ?.innerText.replace(/\\s+/g, ' ') ?? '' }))""")
+    chain = next((c for c in cards if c["attempts"] == "3"), None)
+    solo = next((c for c in cards if c["attempts"] == "1"), None)
+    check("chain_grouping_ec50",
+          len(cards) == 2 and chain is not None and solo is not None
+          # the resolved 3-link chain: completed (r-retry2 completed ⇒ any-completed),
+          # quiet posture (ships collapsed); header names the attempt count.
+          and chain["status"] == "completed" and chain["expanded"] == "false"
+          and "3 attempts" in chain["header"]
+          and "refactor the auth middleware" in chain["header"]
+          # the in-progress solo episode ships expanded.
+          and solo["status"] == "executing" and solo["expanded"] == "true"
+          and "add pre-commit hooks" in solo["header"],
+          cards=cards)
+
+    # The unfiled episode (r-unfiled, project_id: null) never leaks into a
+    # project's chronicle; the retry siblings never render as peer cards.
+    leak = page.evaluate(
+        """() => (document.querySelector('[data-testid="work-chronicle"]')
+                  ?.innerText ?? '').includes('poke at the flaky CI job')""")
+    check("unfiled_episode_never_leaks", not leak)
+
+    # ── Scene 2 (AC 3): the current-state strip — criterion phrase + phases ─────
+    page.wait_for_function(
+        """() => (document.querySelector('[data-testid="chronicle-state"]')
+                  ?.innerText ?? '').includes('passed:')""",
+        timeout=15000)
+    strip = page.evaluate(
+        """() => ({ empty: document.querySelector('[data-testid="chronicle-state"]')
+                      ?.dataset.empty ?? null,
+                    text: document.querySelector('[data-testid="chronicle-state"]')
+                      ?.innerText.replace(/\\s+/g, ' ') ?? '' })""")
+    check("state_strip_criterion",
+          strip["empty"] == "false"
+          and "Last completed run:" in strip["text"]
+          and "3 phases" in strip["text"]
+          and CRITERION in strip["text"]
+          and "wf-w2" in strip["text"]
+          # the derivation read the TIP run's durable tail — the sanctioned read.
+          and event_reads.count("r-retry2") >= 1,
+          **strip, event_reads=event_reads)
+
+    # AC 4's first half: the guidance panel fired ZERO audit reads on mount.
+    check("guidance_gesture_gated_mount", len(audit_reads) == 0, audit_reads=audit_reads)
+    page.screenshot(path=str(VSHOTS / "ux-BC-chronicle.png"))
+
+    # ── Scene 3 (AC 1 sub-rows + AC 2): expand the chain, walk the attempts ─────
+    chain_sel = '[data-testid="episode-chain"][data-attempts="3"]'
+    page.locator(f'{chain_sel} [data-testid="chain-header"]').click()
+    page.locator(f'{chain_sel} [data-testid="attempt-row"]').first.wait_for(timeout=10000)
+    rows = page.evaluate(
+        f"""() => Array.from(document.querySelectorAll(
+                    '{chain_sel} [data-testid="attempt-row"]'))
+                  .map(r => ({{ attempt: r.dataset.attempt, run: r.dataset.runId,
+                                text: r.innerText.replace(/\\s+/g, ' ') }}))""")
+    check("attempt_subrows_in_order",
+          [r["attempt"] for r in rows] == ["1", "2", "3"]
+          and [r["run"] for r in rows] == ["r-auth", "r-retry", "r-retry2"]
+          and "failed" in rows[0]["text"] and "failed" in rows[1]["text"]
+          and "done" in rows[2]["text"],
+          rows=rows)
+    page.screenshot(path=str(VSHOTS / "ux-BC-chain-expanded.png"))
+
+    # AC 2: attempt 2's "view timeline" navigates to run B's evidence timeline.
+    page.locator(f'{chain_sel} [data-testid="attempt-row"][data-attempt="2"] '
+                 '[data-testid="view-timeline"]').click()
+    page.wait_for_function(
+        """() => window.location.pathname === '/runs/r-retry/timeline'""", timeout=10000)
+    page.locator('[data-testid="thread"]').wait_for(timeout=15000)
+    check("view_timeline_navigates", True,
+          pathname=page.evaluate("() => window.location.pathname"))
+
+    # ── Scene 4 (AC 3, EC53): the honest empty state — no completed run ─────────
+    goto("/p/upload-endpoint/build")
+    open_chronicle()
+    empty = page.evaluate(
+        """() => ({ empty: document.querySelector('[data-testid="chronicle-state"]')
+                      ?.dataset.empty ?? null,
+                    text: document.querySelector('[data-testid="chronicle-state"]')
+                      ?.innerText.trim() ?? '' })""")
+    check("state_strip_honest_empty",
+          empty["empty"] == "true" and empty["text"] == NO_RUN_COPY, **empty)
+
+    # ── Scene 5 (AC 4): the gesture-gated audit fan-out + the scope filter ──────
+    goto(BUILD_TAB)
+    open_chronicle()
+    # Scene 3's run-detail visit legitimately read `?runId=r-retry` (the
+    # What/Where provenance line, slice V) — the guidance panel's OWN request
+    # signature is `?action=gate.decided`, and there must be NONE before the
+    # explicit open gesture.
+    def gate_reads() -> list:
+        return [a for a in audit_reads if a["action"] == "gate.decided"]
+
+    check("zero_guidance_reads_before_open", len(gate_reads()) == 0,
+          audit_reads=audit_reads)
+    page.locator('[data-testid="guidance-open"]').click()
+    page.locator('[data-testid="guidance-row"]').first.wait_for(timeout=10000)
+    rows = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="guidance-row"]'))
+                 .map(r => r.innerText.replace(/\\s+/g, ' '))""")
+    check("guidance_one_request_scoped_rows",
+          gate_reads() == [{"action": "gate.decided", "runId": ""}]
+          and len(rows) == 2
+          and AMEND_TIP in rows[0] and "approved" in rows[0]
+          and AMEND_AUTH in rows[1] and "approved" in rows[1]
+          # the foreign-project amend and the no-amend reject never render.
+          and all(AMEND_FOREIGN not in t for t in rows)
+          and all("rejected" not in t for t in rows),
+          audit_reads=audit_reads, rows=rows)
+    page.screenshot(path=str(VSHOTS / "ux-BC-guidance-panel.png"))
+
+    # ── Scene 6 (AC 5): "use in next run" — the composer steer prefill ──────────
+    page.locator('[data-testid="guidance-row"]').nth(1) \
+        .locator('[data-testid="guidance-use"]').click()
+    page.wait_for_function(
+        f"""() => window.location.pathname === '{BUILD_TAB}/new'""", timeout=10000)
+    page.locator('[data-testid="steer-prefill"]').wait_for(timeout=10000)
+    prefill = page.evaluate(
+        """() => ({ steer: document.querySelector('[data-testid="steer-prefill"]')?.value ?? null,
+                    bound: document.querySelector('[data-testid="launch-project-row"]')
+                      ?.innerText ?? '' })""")
+    check("steer_prefill_populated",
+          prefill["steer"] == AMEND_AUTH and PROJECT in prefill["bound"], **prefill)
+
+    # The launch folds the guidance into the problem body, visibly labelled —
+    # LaunchRunBody carries no guidance key until CREW-UX-4 (§7.2).
+    page.locator('[data-testid="launch-problem"]').fill(LAUNCH_INTENT)
+    page.locator('[data-testid="launch-submit"]').click()
+    page.wait_for_function(
+        f"""() => window.location.pathname.startsWith('{BUILD_TAB}/r-launched-')""",
+        timeout=15000)
+    check("launch_carries_guidance_fold",
+          len(launch_posts) == 1
+          and launch_posts[0].get("problem")
+              == f"{LAUNCH_INTENT}\n\nOperator guidance: {AMEND_AUTH}"
+          and launch_posts[0].get("projectId") == PROJECT,
+          posts=launch_posts)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -394,6 +394,12 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # roster-unreachable branch. A pristine first send must fail INLINE
          # (draft kept, retry) with ZERO wire calls; the trio never ships.
          "roster_fail": False,
+         # Slice BC (DES-UX-002 §3): the chronicle corpus — r-retry2 + r-hooks
+         # join the list, r-retry restates failed/attempt-1 (the 3-link chain),
+         # auth-refactor's members wire carries the chain, /audit grows real
+         # gate.decided entries and honours `?action=`. Default False: no
+         # standing rig's corpus changes.
+         "chronicle": False,
          }
 state_lock = threading.Lock()
 
@@ -549,6 +555,80 @@ AUDIT_ENTRIES = {
                  "runId": "r-retry",
                  "detail": {"workflow": "wf-w2", "retryOf": "r-auth"}}],
 }
+
+# ── Slice BC (DES-UX-002 §3): the chronicle corpus, behind `chronicle` ────────
+#
+# Extends the slice-V lineage pair to a REAL 3-link chain (r-auth failed →
+# r-retry, restated failed + attempt 1 under this corpus → r-retry2 completed,
+# attempt 2) plus a standalone in-progress episode (r-hooks) in the SAME
+# project — so the chronicle's EC50 grouping (retry siblings are sub-rows of
+# one episode, never peer rows) and the mixed-card scene both have true
+# records. The unfiled episode stays r-unfiled (`project_dto` on): a null
+# project claim that must never leak into a project's chronicle.
+RETRY_RUN2 = session("r-retry2", "completed", "refactor the auth middleware",
+                     "refactor the auth middleware")
+RETRY_RUN2["session"]["retry_of"] = "r-retry"
+RETRY_RUN2["session"]["attempt"] = 2
+# Three DONE units across three stages — the current-state strip's honest
+# "3 phases" count (§3.3) reads exactly these.
+RETRY_RUN2["units"] = [
+    {**RETRY_RUN2["units"][0], "id": f"r-retry2:u{i}", "ord": i, "stage": stage,
+     "description": desc, "status": "done"}
+    for i, (stage, desc) in enumerate([
+        ("recon", "survey the middleware call sites"),
+        ("build", "refactor the auth middleware"),
+        ("review", "review the refactor against the test suite"),
+    ])
+]
+CHRONICLE_SOLO = session("r-hooks", "executing", "add pre-commit hooks to the repo",
+                         "add pre-commit hooks to the repo")
+CHRONICLE_RUNS = [RETRY_RUN2, CHRONICLE_SOLO]
+CHRONICLE_MEMBER_REFS = ["r-retry", "r-retry2", "r-hooks"]
+ATTACHED_AT["r-retry"] = NOW0 - 5 * MIN
+ATTACHED_AT["r-retry2"] = NOW0 - 3 * MIN
+ATTACHED_AT["r-hooks"] = NOW0 - 90 * SEC
+
+# The chain tip's durable trail: sessionStarted → workflowSelected (EVT-001,
+# camelCase per event_to_json) → a PASSED gateEvaluated (the full B1 shape,
+# `combined: true`) → sessionCompleted. The current-state strip derives its
+# criterion phrase + workflow from exactly this tail.
+CHRONICLE_TIP_CRITERION = "auth middleware refactor passes the full test suite"
+CHRONICLE_EVENTS = {
+    "r-retry2": [
+        {"type": "sessionStarted", "session": "r-retry2", "ts": NOW0 - 3 * MIN},
+        {"type": "workflowSelected", "session": "r-retry2", "workflowId": "wf-w2",
+         "unitCount": 3, "ts": NOW0 - 3 * MIN + 2 * SEC},
+        {"type": "gateEvaluated", "session": "r-retry2", "ord": 2,
+         "criterion": CHRONICLE_TIP_CRITERION, "hasDeterministicFloor": True,
+         "deterministicPass": True, "agentVerdict": None, "agentReasoning": None,
+         "evaluatorPass": True, "evaluatorPolicies": ["qe-default"],
+         "denialReason": None, "combined": True, "ts": NOW0 - 2 * MIN - 10 * SEC},
+        {"type": "sessionCompleted", "session": "r-retry2", "ts": NOW0 - 2 * MIN},
+    ],
+}
+
+# GET /audit?action=gate.decided — the REAL entry shape routes.ts:983 writes:
+# detail {approve, amend?, status}. One amend per lineage decision, one plain
+# reject (no amend — a decision, not guidance) and one FOREIGN-project amend
+# (r-upload, filed under upload-endpoint) the client's scope filter must drop.
+GATE_DECIDED_ENTRIES = [
+    {"ts": NOW0 - 2 * MIN, "action": "gate.decided", "actor": AUDIT_ACTOR,
+     "runId": "r-retry2",
+     "detail": {"approve": True,
+                "amend": "keep the session-token API unchanged; refactor only the middleware layer",
+                "status": "resumed"}},
+    {"ts": NOW0 - 4 * MIN, "action": "gate.decided", "actor": AUDIT_ACTOR,
+     "runId": "r-retry", "detail": {"approve": False, "status": "cancelled"}},
+    {"ts": NOW0 - 12 * MIN, "action": "gate.decided", "actor": AUDIT_ACTOR,
+     "runId": "r-auth",
+     "detail": {"approve": True,
+                "amend": "focus on the middleware tests, skip the docs pass",
+                "status": "resumed"}},
+    {"ts": NOW0 - HOUR, "action": "gate.decided", "actor": AUDIT_ACTOR,
+     "runId": "r-upload",
+     "detail": {"approve": True, "amend": "rate-limit by API key, not by IP",
+                "status": "resumed"}},
+]
 
 # ── Slice S (DES-UX-001 §2.3): the CREW-UX-2 project_id corpus, behind
 #    `project_dto` ──────────────────────────────────────────────────────────────
@@ -1288,23 +1368,36 @@ def assemble_runs() -> list:
                 + ([LONG_RUN] if state["long_prompt"] else []) \
                 + ([CHAT_LIVE, CHAT_GATED] if state["chat_runs"] else []) \
                 + (BATCH_RUNS if state["batch_gates"] else []) \
-                + ([RETRY_RUN] if state["provenance"] else []) \
+                + ([RETRY_RUN] if state["provenance"] or state["chronicle"] else []) \
+                + (CHRONICLE_RUNS if state["chronicle"] else []) \
                 + (J5_RUNS if state["j5_runs"] else [])
         viewer_on = state["viewer"]
         repo_refs_on = state["repo_refs"]
         forensics_on = state["forensics"]
         provenance_on = state["provenance"]
         project_dto_on = state["project_dto"]
+        chronicle_on = state["chronicle"]
         # Slice S (DES-UX-001 §2.3): the null-claim run + this-lifetime launches
         # join BOTH wires (list + detail) so the DTO echo decorates identically.
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
-    if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on:
+    if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
+            or chronicle_on:
         runs = json.loads(json.dumps(runs))
         for r in runs:
             # Slice V: the CREW-UX-2 DTO echo for the lineage pair — the retry
             # prefill's project binding reads it (`project_id`, api-types 0.8.0).
             if provenance_on and r["session"]["id"] in ("r-auth", "r-retry"):
+                r["session"]["project_id"] = "auth-refactor"
+            # Slice BC (DES-UX-002 §3): under the chronicle corpus r-retry is
+            # the chain's FAILED middle attempt (attempt 1 — retried again as
+            # r-retry2), and the whole chain + the solo episode claim their
+            # project on the DTO (the CREW-UX-2 echo the scope filter reads).
+            if chronicle_on and r["session"]["id"] == "r-retry":
+                r["session"]["status"] = "failed"
+                r["session"]["attempt"] = 1
+            if chronicle_on and r["session"]["id"] in (
+                    "r-auth", "r-retry", "r-retry2", "r-hooks"):
                 r["session"]["project_id"] = "auth-refactor"
             # Slice I: the live run gains a workdir (the diff route's
             # 409 gate reads it; AgentSession carries it on the wire).
@@ -1744,9 +1837,23 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/audit":
             q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
             run_id = (q.get("runId") or [""])[0]
+            action = (q.get("action") or [""])[0]
             with state_lock:
                 provenance_on = state["provenance"]
+                chronicle_on = state["chronicle"]
             entries = AUDIT_ENTRIES.get(run_id, []) if provenance_on else []
+            # Slice BC: with the chronicle corpus on, the trail serves the FULL
+            # pool (the real route is one append-only log) and honours the
+            # `?action=` filter routes.ts:292 accepts alongside `?runId=`.
+            if chronicle_on:
+                pool = [e for v in AUDIT_ENTRIES.values() for e in v] \
+                    + GATE_DECIDED_ENTRIES
+                if run_id:
+                    pool = [e for e in pool if e.get("runId") == run_id]
+                entries = pool
+            if action:
+                entries = [e for e in entries if e.get("action") == action]
+            entries = sorted(entries, key=lambda e: -e.get("ts", 0))
             self._json(200, {"entries": entries})
             return True
         # Slice I: the crew#305 file/diff routes (real contract, switch-gated).
@@ -1832,10 +1939,15 @@ class W2Handler(SimpleHTTPRequestHandler):
                 repo_member_on = state["repo_member"]
                 batch_on = state["batch_gates"]
                 j5_on = state["j5_runs"]
+                chronicle_on = state["chronicle"]
             # Fix slice J4/J5: the dated cancelled pair is filed under
             # smoke-tests (real attach clocks); the undated pair stays unfiled.
             if j5_on and pid == "smoke-tests":
                 refs.extend(J5_MEMBER_REFS)
+            # Slice BC: the retry chain + the solo episode file under
+            # auth-refactor — the membership record the DTO echo mirrors.
+            if chronicle_on and pid == "auth-refactor":
+                refs.extend(CHRONICLE_MEMBER_REFS)
             # Slice L: the batch corpus projects' runs.
             if batch_on:
                 refs.extend(BATCH_MEMBERS.get(pid, []))
@@ -1938,6 +2050,12 @@ class W2Handler(SimpleHTTPRequestHandler):
             # the full recorded chronology, seq-ordered, deny verdict included.
             if timeline_on and rid == "r-auth":
                 events = list(TIMELINE_AUTH_EVENTS)
+            # Slice BC: the chain tip's durable tail — the current-state
+            # strip's criterion/workflow derivation reads exactly this.
+            with state_lock:
+                chronicle_on = state["chronicle"]
+            if chronicle_on and rid in CHRONICLE_EVENTS:
+                events = events + CHRONICLE_EVENTS[rid]
             self._json(200, {"events": events})
             return True
         # Slice R: the REAL unit-transcript wire (routes.ts crew — the studio's

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -154,6 +154,16 @@ export const api = {
   getAudit: (runId: string) =>
     apiFetch<AuditPage>(`/audit?runId=${encodeURIComponent(runId)}`),
 
+  /**
+   * The audit trail filtered by ACTION (`GET /audit?action=`, newest first —
+   * crew routes.ts:292 accepts `?runId=` / `?action=` / `?limit=`). The work
+   * chronicle's guidance summary reads `gate.decided` this way — ONE request,
+   * gesture-gated, filtered client-side to the project's runs (DES-UX-002
+   * §3.3; a `?projectId=` filter does not exist on this wire, §10).
+   */
+  getAuditByAction: (action: string) =>
+    apiFetch<AuditPage>(`/audit?action=${encodeURIComponent(action)}`),
+
   /** A run's durably-persisted event trail (`GET /runs/:id/events`). Used to backfill the event
    * store on a reload with no live `/ws` replay so Burn/insight panels are not empty (FINDING-013).
    * Rejects (503) when the engine build has no event-log binding — callers treat that as "no backfill". */

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -24,6 +24,7 @@ import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
+import { WorkChronicle } from './WorkChronicle.js';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -803,6 +804,17 @@ export function CenterDashboard({
 
   const filteredRuns = useMemo(() => filterByRange(scopedRuns), [scopedRuns, filterByRange]);
 
+  // ── The work chronicle (DES-UX-002 §3, slice BC) — a second VIEW of the
+  // project's build work, additive beside the flat list (§10's adopted
+  // position: additive tab; slice BE wires the §5.2 route + default). It
+  // reads the FULL scoped history — episode chains are the project's story,
+  // not a time-window slice — so its input skips the range filter.
+  const [view, setView] = useState<'runs' | 'chronicle'>('runs');
+  const chronicleRuns = useMemo(
+    () => scopedRuns.filter((v) => !!v.session.workflow_id && v.session.workflow_id !== 'chat'),
+    [scopedRuns],
+  );
+
   // ── Derived: active sessions only (feed + send panel scope) ──────────────
   const activeRuns = useMemo(
     () => filteredRuns.filter((v) => ACTIVE_STATUSES.has(v.session.status)),
@@ -974,6 +986,42 @@ export function CenterDashboard({
         >
           {BUILD_PURPOSE}
         </p>
+
+        {/* ── The Runs | Chronicle view toggle (DES-UX-002 §3.3 + §5.3, slice
+               BC): project context only. The flat list stays the default — the
+               §10 open question's adopted additive position; BE may re-default. */}
+        {projectId !== null && (
+          <div role="tablist" aria-label="Build view" style={{ display: 'flex', gap: '4px', marginBottom: '20px' }}>
+            {(['runs', 'chronicle'] as const).map((v) => (
+              <button
+                key={v}
+                type="button"
+                role="tab"
+                aria-selected={view === v}
+                data-testid={`build-view-${v}`}
+                onClick={() => setView(v)}
+                style={{
+                  background: view === v ? 'var(--surface-raised)' : 'transparent',
+                  border: '1px solid var(--surface-raised)',
+                  borderRadius: 'var(--radius-md)',
+                  color: view === v ? 'var(--ink-high)' : 'var(--ink-muted)',
+                  cursor: 'pointer',
+                  fontSize: 'var(--text-xs)',
+                  fontWeight: 600,
+                  ...sans,
+                  padding: '5px 12px',
+                }}
+              >
+                {v === 'runs' ? 'Runs' : 'Chronicle'}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {projectId !== null && view === 'chronicle' ? (
+          <WorkChronicle runs={chronicleRuns} projectId={projectId} navigate={navigate} />
+        ) : (
+        <>
 
         {/* ── 2. Gate inbox — only when gates are pending (§2.7 rule 5, W4) ───── */}
         {openGates.length > 0 && (
@@ -1181,6 +1229,9 @@ export function CenterDashboard({
         {/* ── 6. Send-to-agents — only while something is running (empty-state
                budget: an idle surface does not announce the absence). ────────── */}
         {activeRuns.length > 0 && <SendPanel activeRuns={activeRuns} />}
+
+        </>
+        )}
 
       </div>
     </div>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -7,6 +7,7 @@ import { useGateStore } from '../store/gates.js';
 import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { clearRetryPrefill, confirmModeOf, peekRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
+import { clearSteerPrefill, peekSteerPrefill } from '../store/steerPrefill.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
@@ -122,6 +123,17 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   }, [prefill]);
   /** Lineage claim carried to the launch (`retryOf`, CREW-UX-3) — clearable. */
   const [retryOf, setRetryOf] = useState<string | null>(prefill?.retryOf ?? null);
+
+  // Guidance-as-prefill (DES-UX-002 §3.3, slice BC): the chronicle's "use in
+  // next run" deposits a past gate amendment; the launch form shows it in an
+  // EDITABLE steer field and folds it into the problem body at launch — the
+  // wire has no launch-time guidance field (CREW-UX-4/slice BE is the durable
+  // one), so the fold is visible, labelled, and clearable, never silent.
+  const [steerSeed] = useState(() => (runId ? null : peekSteerPrefill()));
+  useEffect(() => {
+    if (steerSeed !== null) clearSteerPrefill();
+  }, [steerSeed]);
+  const [launchSteer, setLaunchSteer] = useState(steerSeed?.steer ?? '');
 
   // ── Steer mode state ───────────────────────────────────────────────────────
   const [steerText, setSteerText] = useState('');
@@ -399,7 +411,13 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // TODO: ingest attachedFiles via api.ingestKnowledge(title, chunks) before launching
     // (api.ingestKnowledge does not yet exist on the client surface)
 
-    const body: LaunchRunBody = { problem: problem.trim() };
+    // The steer prefill rides the problem body as a labelled trailing
+    // paragraph (see the steer field's own caption) — LaunchRunBody carries
+    // no guidance key until CREW-UX-4 lands (DES-UX-002 §7.2).
+    const guidance = launchSteer.trim();
+    const body: LaunchRunBody = {
+      problem: guidance.length > 0 ? `${problem.trim()}\n\nOperator guidance: ${guidance}` : problem.trim(),
+    };
     const seats = roster.filter((s) => selectedClis.has(s.key));
     if (seats.length > 0) body.clisJson = JSON.stringify(seats);
     body.entityMode = entityMode;
@@ -894,6 +912,32 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           >
             Launch anyway
           </button>
+        </div>
+      )}
+
+      {/* ── Guidance steer field (DES-UX-002 §3.3, slice BC) — rendered only
+             when the chronicle deposited a prefill; `--surface-raised` with the
+             `--accent-subtle` left border (operator-authored content, §3.4). ── */}
+      {steerSeed !== null && (
+        <div
+          style={{
+            background: 'var(--surface-raised)',
+            borderLeft: '3px solid var(--accent-subtle)',
+            borderRadius: 'var(--radius-md)',
+            padding: '8px 12px',
+          }}
+        >
+          <p style={{ margin: '0 0 4px', fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-sans)' }}>
+            Guidance for this run — sent with the launch prompt as an “Operator guidance” paragraph. Edit or clear it before sending.
+          </p>
+          <textarea
+            data-testid="steer-prefill"
+            className="w-full resize-none outline-none border-0 bg-transparent leading-5"
+            style={{ color: 'var(--ink-high)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)' }}
+            value={launchSteer}
+            onChange={(e) => setLaunchSteer(e.target.value)}
+            rows={2}
+          />
         </div>
       )}
 

--- a/src/components/WorkChronicle.tsx
+++ b/src/components/WorkChronicle.tsx
@@ -1,0 +1,397 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import type { AuditEntry, CoreEvent, SessionView } from '../api/types.js';
+import { launchPath } from '../hooks/ambientProject.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { useRunEventStore } from '../store/events.js';
+import { useMembershipStore } from '../store/membership.js';
+import { setSteerPrefill } from '../store/steerPrefill.js';
+import {
+  assembleChains, chainInProgress, chainStatus, completedPhases,
+  guidanceAmendments, lastCompletedRun, lastWorkflowSelected, passedCriterion,
+} from './chronicle.js';
+import { deriveRunClocks, durationWord, runShortId, runTitle } from './runIdentity.js';
+
+// DES-UX-002 §3.4 token usage, verbatim: episode chain card `--surface-card`
+// collapsed / `--surface-raised` expanded; chain status badge reuses the
+// `--status-*` tokens; amendment lines `--ink-muted --font-mono --text-xs`;
+// the guidance panel `--surface-raised` with an `--accent-subtle` left border
+// (operator-authored content). No new semantic tokens.
+const mono = { fontFamily: 'var(--font-mono)' } as const;
+const sans = { fontFamily: 'var(--font-sans)' } as const;
+
+/** The §2.6 status layer for the chain badge — never the accent. */
+const STATUS_TOKEN: Record<string, string> = {
+  completed: 'var(--status-done)',
+  failed: 'var(--status-fail)',
+  awaiting_human: 'var(--status-gate)',
+  planning: 'var(--status-run)',
+  distributing: 'var(--status-run)',
+  executing: 'var(--status-run)',
+};
+
+/** The badge's word is the user vocabulary (V3), matching `runRowModel`. */
+const STATUS_WORD: Record<string, string> = {
+  completed: 'done',
+  failed: 'failed',
+  awaiting_human: 'gate',
+  planning: 'planning',
+  distributing: 'working',
+  executing: 'working',
+};
+
+function shortDate(ms: number | undefined): string | null {
+  return ms === undefined ? null : new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function StatusBadge({ status }: { status: string }): React.ReactElement {
+  return (
+    <span
+      data-testid="chain-status"
+      style={{
+        color: STATUS_TOKEN[status] ?? 'var(--ink-dim)',
+        fontSize: 'var(--text-2xs)',
+        fontWeight: 600,
+        ...mono,
+        flexShrink: 0,
+      }}
+    >
+      {STATUS_WORD[status] ?? status}
+    </span>
+  );
+}
+
+interface Props {
+  /** The project's work runs, already scoped by the DTO claim (CenterDashboard). */
+  runs: SessionView[];
+  projectId: string;
+  navigate: Navigate;
+}
+
+/**
+ * The work chronicle (DES-UX-002 §3.3, slice BC): the project's runs grouped
+ * into episode chains by `retry_of` lineage (EC50 — retry siblings are
+ * sub-rows of ONE episode card, never peer rows), a current-state strip
+ * derived from the last completed run's evidence (EC53 — honest empty state),
+ * and the gesture-gated guidance summary of past gate amendments.
+ */
+export function WorkChronicle({ runs, projectId, navigate }: Props): React.ReactElement {
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const byRun = useRunEventStore((s) => s.byRun);
+  const hydrate = useRunEventStore((s) => s.hydrate);
+
+  // Chains, newest root first (chronological by chain root, §3.3) — clock-less
+  // roots keep list order below the dated ones.
+  const chains = useMemo(() => {
+    const assembled = assembleChains(runs);
+    return assembled
+      .map((chain, ix) => ({ chain, clock: attachedAt[chain[0]?.session.id ?? ''] ?? ix - assembled.length }))
+      .sort((a, b) => b.clock - a.clock)
+      .map((c) => c.chain);
+  }, [runs, attachedAt]);
+
+  // ── Current-state strip (§3.3, EC53) ────────────────────────────────────
+  const tip = useMemo(() => lastCompletedRun(runs, attachedAt), [runs, attachedAt]);
+  const tipId = tip?.session.id ?? null;
+  const tipEvents = tipId !== null ? byRun[tipId] : undefined;
+  // The strip's criterion/workflow derivation reads the tip run's durable
+  // trail. One fetch, only when the store holds no frames for it yet — the
+  // same FINDING-013 hydrate the run detail uses. (The guidance panel below
+  // is the gesture-gated fetch; THIS one is the strip's sanctioned read.)
+  const tipEmpty = tipEvents === undefined || tipEvents.length === 0;
+  useEffect(() => {
+    if (tipId === null || !tipEmpty) return;
+    let cancelled = false;
+    void api
+      .getRunEvents(tipId)
+      .then(({ events }) => { if (!cancelled) hydrate(tipId, events); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [tipId, tipEmpty, hydrate]);
+  const criterion = tipEvents !== undefined ? passedCriterion(tipEvents) : null;
+  const workflow = tipEvents !== undefined ? lastWorkflowSelected(tipEvents) : null;
+
+  // ── Guidance summary (§3.3) — gesture-gated: ZERO requests until opened ──
+  const [guidance, setGuidance] = useState<AuditEntry[] | null>(null);
+  const [guidanceOpen, setGuidanceOpen] = useState(false);
+  const [guidanceError, setGuidanceError] = useState(false);
+  const scopedIds = useMemo(() => new Set(runs.map((v) => v.session.id)), [runs]);
+
+  function openGuidance(): void {
+    setGuidanceOpen(true);
+    if (guidance !== null) return;
+    api
+      .getAuditByAction('gate.decided')
+      .then(({ entries }) => setGuidance(guidanceAmendments(entries, scopedIds)))
+      .catch(() => setGuidanceError(true));
+  }
+
+  function applyGuidance(entry: AuditEntry): void {
+    const amend = entry.detail?.['amend'];
+    if (typeof amend !== 'string') return;
+    setSteerPrefill({ steer: amend, projectId });
+    navigate(launchPath(projectId, 'build'));
+  }
+
+  const tipDate = shortDate(tipId !== null ? attachedAt[tipId] : undefined);
+
+  return (
+    <div data-testid="work-chronicle" style={{ ...sans, color: 'var(--ink-body)' }}>
+      {/* ── The current-state strip: the CLIENT's best synthesis of "what did
+             this project accomplish?" off the last completed run's evidence —
+             or the EXACT no-run copy, never a fabricated state (EC53). ────── */}
+      <div
+        data-testid="chronicle-state"
+        data-empty={tip === null ? 'true' : 'false'}
+        style={{
+          background: 'var(--surface-card)',
+          border: '1px solid var(--surface-raised)',
+          borderRadius: 'var(--radius-lg)',
+          padding: '12px 16px',
+          marginBottom: '16px',
+        }}
+      >
+        {tip === null ? (
+          <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--ink-muted)' }}>
+            No completed run yet — this project&apos;s first successful build will appear here.
+          </p>
+        ) : (
+          <>
+            <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--ink-high)' }}>
+              Last completed run: <span style={mono}>{runTitle(tip.session)}</span>
+              {` · ${completedPhases(tip)} phase${completedPhases(tip) === 1 ? '' : 's'}`}
+              {tipDate !== null ? ` · ${tipDate}` : ''}
+            </p>
+            {(criterion !== null || workflow !== null) && (
+              <p
+                data-testid="chronicle-state-evidence"
+                style={{ margin: '4px 0 0', fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', ...mono }}
+              >
+                {criterion !== null ? `passed: “${criterion}”` : ''}
+                {criterion !== null && workflow !== null ? ' · ' : ''}
+                {workflow !== null ? `workflow: ${workflow}` : ''}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── Episode chains, chronological by chain root (§3.3) ─────────────── */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+        {chains.map((chain) => (
+          <EpisodeCard key={chain[0]?.session.id} chain={chain} byRun={byRun} attachedAt={attachedAt} navigate={navigate} />
+        ))}
+      </div>
+      {chains.length === 0 && (
+        <p style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-muted)', margin: 0 }}>
+          No build runs in this project yet.
+        </p>
+      )}
+
+      {/* ── Pre-launch guidance summary (§3.3): the operator's last gate
+             amendments for THIS project — gesture-gated (the audit fetch fires
+             on the explicit open, never on mount). ─────────────────────────── */}
+      <div
+        data-testid="guidance-summary"
+        data-loaded={guidance !== null ? 'true' : 'false'}
+        style={{
+          background: 'var(--surface-raised)',
+          borderLeft: '3px solid var(--accent-subtle)',
+          borderRadius: 'var(--radius-md)',
+          padding: '12px 16px',
+          marginTop: '20px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <p style={{ margin: 0, fontSize: 'var(--text-xs)', fontWeight: 600, color: 'var(--ink-muted)', ...sans }}>
+            Past guidance
+          </p>
+          {!guidanceOpen && (
+            <button
+              type="button"
+              data-testid="guidance-open"
+              onClick={openGuidance}
+              style={{
+                background: 'transparent', border: '1px solid var(--surface-card)',
+                borderRadius: 'var(--radius-md)', color: 'var(--accent)', cursor: 'pointer',
+                fontSize: 'var(--text-xs)', ...sans, padding: '4px 10px',
+              }}
+            >
+              show past guidance
+            </button>
+          )}
+        </div>
+        {guidanceOpen && guidance === null && !guidanceError && (
+          <p style={{ margin: '8px 0 0', fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', ...mono }}>loading…</p>
+        )}
+        {guidanceError && (
+          <p style={{ margin: '8px 0 0', fontSize: 'var(--text-xs)', color: 'var(--status-fail)', ...mono }}>
+            could not read the audit trail — try again from the button above
+          </p>
+        )}
+        {guidance !== null && guidance.length === 0 && (
+          <p style={{ margin: '8px 0 0', fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', ...sans }}>
+            No gate amendments recorded for this project&apos;s runs yet.
+          </p>
+        )}
+        {guidance !== null && guidance.map((entry, ix) => {
+          const amend = String(entry.detail?.['amend'] ?? '');
+          const approved = entry.detail?.['approve'] === true;
+          return (
+            <div
+              key={`${entry.runId}-${entry.ts}-${ix}`}
+              data-testid="guidance-row"
+              style={{ display: 'flex', alignItems: 'baseline', gap: '8px', marginTop: '8px' }}
+            >
+              {/* Amendment line: `--ink-muted --font-mono --text-xs` (§3.4). The wire's
+                  detail carries approve/amend/status (routes.ts:983) — no phase/criterion
+                  rides a gate.decided entry, so the line names run · decision · text. */}
+              <span style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', ...mono, flex: 1, minWidth: 0 }}>
+                {runShortId(entry.runId ?? '')} · {approved ? 'approved' : 'rejected'} · “{amend}”
+              </span>
+              <button
+                type="button"
+                data-testid="guidance-use"
+                onClick={() => applyGuidance(entry)}
+                style={{
+                  background: 'transparent', border: '1px solid var(--surface-card)',
+                  borderRadius: 'var(--radius-md)', color: 'var(--accent)', cursor: 'pointer',
+                  fontSize: 'var(--text-2xs)', ...sans, padding: '2px 8px', flexShrink: 0,
+                }}
+              >
+                use in next run
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface CardProps {
+  chain: SessionView[];
+  byRun: Record<string, CoreEvent[]>;
+  attachedAt: Record<string, number>;
+  navigate: Navigate;
+}
+
+/**
+ * One episode chain card (§3.3): collapsed = one quiet ~48px row; expanded =
+ * the attempts as sub-rows in lineage order. In-progress chains ship expanded;
+ * resolved chains ship collapsed.
+ */
+function EpisodeCard({ chain, byRun, attachedAt, navigate }: CardProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(() => chainInProgress(chain));
+  const root = chain[0] as SessionView;
+  const latest = chain[chain.length - 1] as SessionView;
+  const status = chainStatus(chain);
+
+  // Header intent: the truncated problem (the chain shares one intent by
+  // construction — retries relaunch the same problem).
+  const intent = root.session.problem.length > 60 ? `${root.session.problem.slice(0, 60)}…` : root.session.problem;
+
+  // Total duration: the sum of the attempts' event-derived clocks, where the
+  // store holds them (zero new requests). Underivable attempts contribute
+  // nothing and the total renders only when SOMETHING is derivable — stated
+  // duration is always evidence-backed, never fabricated.
+  const totalMs = chain.reduce((sum, v) => {
+    const clocks = deriveRunClocks(byRun[v.session.id] ?? [], []);
+    return clocks.started !== null && clocks.ended !== null ? sum + (clocks.ended.ms - clocks.started.ms) : sum;
+  }, 0);
+
+  // Date range: first attempt's attach clock → latest attempt's (the one
+  // honest per-run clock, `runIdentity.ts`). Absent clocks are omitted.
+  const from = shortDate(attachedAt[root.session.id]);
+  const to = shortDate(attachedAt[latest.session.id]);
+  const range = from !== null && to !== null ? (from === to ? from : `${from} → ${to}`) : from ?? to;
+
+  return (
+    <div
+      data-testid="episode-chain"
+      data-chain-status={status}
+      data-attempts={chain.length}
+      data-expanded={expanded ? 'true' : 'false'}
+      style={{
+        // §3.4: `--surface-card` collapsed, `--surface-raised` when expanded.
+        background: expanded ? 'var(--surface-raised)' : 'var(--surface-card)',
+        border: '1px solid var(--surface-raised)',
+        borderRadius: 'var(--radius-lg)',
+      }}
+    >
+      <button
+        type="button"
+        data-testid="chain-header"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '10px', width: '100%',
+          minHeight: '48px', boxSizing: 'border-box', padding: '0 14px',
+          background: 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left',
+        }}
+      >
+        <span aria-hidden style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)', flexShrink: 0 }}>
+          {expanded ? '▾' : '▸'}
+        </span>
+        <span style={{ color: 'var(--ink-high)', fontSize: 'var(--text-sm)', ...sans, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {intent}
+        </span>
+        <StatusBadge status={status} />
+        <span style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-2xs)', ...mono, flexShrink: 0 }}>
+          {chain.length} attempt{chain.length === 1 ? '' : 's'}
+        </span>
+        {totalMs > 0 && (
+          <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)', ...mono, flexShrink: 0 }}>
+            {durationWord(totalMs)}
+          </span>
+        )}
+        {range != null && (
+          <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)', ...mono, flexShrink: 0 }}>
+            {range}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <div style={{ padding: '0 14px 10px 32px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          {chain.map((v, ix) => {
+            const clocks = deriveRunClocks(byRun[v.session.id] ?? [], []);
+            const dur = clocks.started !== null && clocks.ended !== null
+              ? durationWord(clocks.ended.ms - clocks.started.ms)
+              : null;
+            return (
+              <div
+                key={v.session.id}
+                data-testid="attempt-row"
+                data-attempt={ix + 1}
+                data-run-id={v.session.id}
+                style={{ display: 'flex', alignItems: 'center', gap: '10px', minHeight: '28px' }}
+              >
+                <span style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-xs)', ...mono, width: '84px', flexShrink: 0 }}>
+                  attempt #{ix + 1}
+                </span>
+                <StatusBadge status={v.session.status} />
+                {dur !== null && (
+                  <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)', ...mono, flexShrink: 0 }}>{dur}</span>
+                )}
+                <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-2xs)', ...mono, flexShrink: 0 }}>
+                  {runShortId(v.session.id)}
+                </span>
+                <span style={{ flex: 1 }} />
+                {/* §5.2: the run detail route — timeline-by-default once slice BB's
+                    layout lands; today the same path opens the run detail. */}
+                <a
+                  data-testid="view-timeline"
+                  href={`/runs/${encodeURIComponent(v.session.id)}/timeline`}
+                  onClick={(e) => { e.preventDefault(); navigate(`/runs/${encodeURIComponent(v.session.id)}/timeline`); }}
+                  style={{ color: 'var(--accent)', fontSize: 'var(--text-xs)', ...sans, textDecoration: 'none', flexShrink: 0 }}
+                >
+                  view timeline
+                </a>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chronicle.ts
+++ b/src/components/chronicle.ts
@@ -1,0 +1,151 @@
+import type { AuditEntry, CoreEvent, SessionView } from '../api/types.js';
+
+/**
+ * Chain assembly for the work chronicle (DES-UX-002 §3.2, slice BC — EC50):
+ * runs group into episode chains by following the `retry_of` DTO echo
+ * (api-types 0.8.0, CREW-UX-3 — the system-of-record lineage, never prompt
+ * equality). Pure and unit-tested; the component renders what this derives.
+ */
+
+/** Run-level statuses that mean "still moving" (CenterDashboard's set). */
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
+  'planning',
+  'distributing',
+  'executing',
+  'awaiting_human',
+]);
+
+/**
+ * Group a scoped run list into chains, O(n) over the list (§3.2's CLIENT
+ * verdict): a run with no `retry_of` — or whose `retry_of` names a run OUTSIDE
+ * the scope, the honest broken-lineage case — is a chain root; every run whose
+ * `retry_of` names a member joins its parent's chain. Each chain is in lineage
+ * order, root first; fan-out (two retries of one run) orders siblings by the
+ * DTO's `attempt`, then flattens depth-first. A `retry_of` cycle (impossible
+ * on the real wire — launch validates the target exists BEFORE the new id is
+ * minted — but cheap to guard) terminates via the seen-set.
+ */
+export function assembleChains(runs: readonly SessionView[]): SessionView[][] {
+  const byId = new Map(runs.map((v) => [v.session.id, v]));
+  const children = new Map<string, SessionView[]>();
+  const roots: SessionView[] = [];
+  for (const v of runs) {
+    const parent = v.session.retry_of;
+    if (parent !== undefined && byId.has(parent)) {
+      const siblings = children.get(parent) ?? [];
+      siblings.push(v);
+      children.set(parent, siblings);
+    } else {
+      roots.push(v);
+    }
+  }
+  const chains: SessionView[][] = [];
+  for (const root of roots) {
+    const chain: SessionView[] = [];
+    const stack: SessionView[] = [root];
+    const seen = new Set<string>();
+    while (stack.length > 0) {
+      const cur = stack.pop() as SessionView;
+      if (seen.has(cur.session.id)) continue;
+      seen.add(cur.session.id);
+      chain.push(cur);
+      const kids = (children.get(cur.session.id) ?? [])
+        .slice()
+        .sort((a, b) => a.session.attempt - b.session.attempt);
+      for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i] as SessionView);
+    }
+    chains.push(chain);
+  }
+  return chains;
+}
+
+/**
+ * §3.3's chain-status semantics, deny-of-ambiguity order: a still-moving
+ * latest attempt makes the chain live (its own status word, so a gate reads
+ * as a gate); else `completed` if ANY attempt completed (the episode
+ * resolved); else `failed` when every attempt failed; else the latest
+ * attempt's terminal status (cancelled chains say cancelled).
+ */
+export function chainStatus(chain: readonly SessionView[]): string {
+  const latest = chain[chain.length - 1];
+  if (latest === undefined) return 'unknown';
+  if (ACTIVE_STATUSES.has(latest.session.status)) return latest.session.status;
+  if (chain.some((v) => v.session.status === 'completed')) return 'completed';
+  if (chain.every((v) => v.session.status === 'failed')) return 'failed';
+  return latest.session.status;
+}
+
+/** Is any attempt of this chain still moving? (drives the default-expanded rule) */
+export function chainInProgress(chain: readonly SessionView[]): boolean {
+  return chain.some((v) => ACTIVE_STATUSES.has(v.session.status));
+}
+
+/**
+ * The most recent COMPLETED run of the scope — the current-state strip's
+ * subject (§3.3). "Most recent" by the membership attach clock (the one honest
+ * per-run clock, `runIdentity.ts`); clock-less completed runs lose to dated
+ * ones and fall back to list position. `null` = the strip's honest empty state
+ * (EC53 — never a fabricated state).
+ */
+export function lastCompletedRun(
+  runs: readonly SessionView[],
+  attachedAt: Readonly<Record<string, number>>,
+): SessionView | null {
+  let best: SessionView | null = null;
+  let bestClock = -Infinity;
+  runs.forEach((v, ix) => {
+    if (v.session.status !== 'completed') return;
+    const clock = attachedAt[v.session.id] ?? ix - runs.length; // undated: positional, below any real clock
+    if (clock >= bestClock) {
+      best = v;
+      bestClock = clock;
+    }
+  });
+  return best;
+}
+
+/** Completed phases of a run — its done units (the house "phase n/N" vocabulary). */
+export function completedPhases(v: SessionView): number {
+  return v.units.filter((u) => u.status === 'done').length;
+}
+
+/** The last `gateEvaluated` criterion that PASSED (`combined === true`), else null. */
+export function passedCriterion(events: readonly CoreEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    if (ev?.type === 'gateEvaluated' && ev.combined === true && typeof ev.criterion === 'string') {
+      return ev.criterion;
+    }
+  }
+  return null;
+}
+
+/** The last `workflowSelected` workflow id in the trail, else null. */
+export function lastWorkflowSelected(events: readonly CoreEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    if (ev?.type === 'workflowSelected' && typeof ev.workflowId === 'string') return ev.workflowId;
+  }
+  return null;
+}
+
+/**
+ * The guidance summary's rows (§3.3): `gate.decided` audit entries that carry
+ * a non-empty `amend` AND address a run in this project's scope — the wire has
+ * no `?projectId=` audit filter (§10), so the scope join is client-side over
+ * the run ids the chronicle already holds. Newest-first order is the wire's;
+ * capped at the last `max` amendments.
+ */
+export function guidanceAmendments(
+  entries: readonly AuditEntry[],
+  scopedRunIds: ReadonlySet<string>,
+  max = 5,
+): AuditEntry[] {
+  return entries
+    .filter((e) => {
+      if (typeof e.runId !== 'string' || !scopedRunIds.has(e.runId)) return false;
+      const amend = e.detail?.['amend'];
+      return typeof amend === 'string' && amend.trim().length > 0;
+    })
+    .slice(0, max);
+}

--- a/src/store/steerPrefill.ts
+++ b/src/store/steerPrefill.ts
@@ -1,0 +1,35 @@
+/**
+ * Guidance-as-prefill (DES-UX-002 §3.3, slice BC): the work chronicle's
+ * "use in next run" action deposits a past gate amendment here and navigates
+ * to the standard composer, which consumes it ONCE at mount and shows it in an
+ * editable steer field. The same consume-once discipline as the retry prefill
+ * (`retryPrefill.ts`) — peek in the lazy initializer (StrictMode double-invokes
+ * initializers in dev), clear in the commit effect.
+ *
+ * The wire has no steer/guidance field on `LaunchRunBody` (wire honesty:
+ * CREW-UX-4 is the durable-guidance endpoint, slice BE) — so at launch the
+ * composer folds the steer text into the `problem` body as a labelled trailing
+ * paragraph, visibly: the operator sees exactly the text that will ride.
+ */
+export interface SteerPrefill {
+  /** The amendment text to pre-populate in the composer's steer field. */
+  steer: string;
+  /** The project the guidance came from — the composer's pre-bind hint. */
+  projectId: string | null;
+}
+
+let pending: SteerPrefill | null = null;
+
+export function setSteerPrefill(prefill: SteerPrefill): void {
+  pending = prefill;
+}
+
+/** Read WITHOUT consuming — for lazy `useState` initializers (see module doc). */
+export function peekSteerPrefill(): SteerPrefill | null {
+  return pending;
+}
+
+/** The second half of peek-then-clear: drop the deposit once a mount took it. */
+export function clearSteerPrefill(): void {
+  pending = null;
+}

--- a/tests/chronicle.test.ts
+++ b/tests/chronicle.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { AuditEntry, SessionView } from '../src/api/types.js';
+import {
+  assembleChains, chainInProgress, chainStatus, completedPhases,
+  guidanceAmendments, lastCompletedRun, lastWorkflowSelected, passedCriterion,
+} from '../src/components/chronicle.js';
+
+/**
+ * The work chronicle's pure derivations (DES-UX-002 §3.2/§3.3, slice BC):
+ * chain assembly by `retry_of` (EC50), chain-status semantics, the
+ * current-state pick (EC53), and the guidance summary's scope+amend filter.
+ */
+
+function run(id: string, status: string, over: Partial<SessionView['session']> = {}): SessionView {
+  return {
+    session: {
+      id, workflow_id: 'wf-w2', problem: `problem of ${id}`, entity_mode: 'shared',
+      collection_scope: null, clis: ['claude'], status, human_confirm: 'none',
+      unit_ix: 0, attempt: 0, workdir: null, repo_ref: null, extra_write_roots: [],
+      archived_at: null, archive_note: null, ...over,
+    } as SessionView['session'],
+    units: [],
+  } as unknown as SessionView;
+}
+
+describe('assembleChains (§3.2 CLIENT chain assembly, EC50)', () => {
+  it('groups a lineage chain under ONE root and keeps standalone runs as their own chains', () => {
+    const a = run('r-a', 'failed');
+    const b = run('r-b', 'failed', { retry_of: 'r-a', attempt: 1 });
+    const c = run('r-c', 'completed', { retry_of: 'r-b', attempt: 2 });
+    const solo = run('r-solo', 'executing');
+    const chains = assembleChains([a, b, c, solo]);
+    expect(chains.map((ch) => ch.map((v) => v.session.id))).toEqual([
+      ['r-a', 'r-b', 'r-c'],
+      ['r-solo'],
+    ]);
+  });
+
+  it('a retry_of naming a run OUTSIDE the scope makes an honest root, never a dropped run', () => {
+    const orphan = run('r-x', 'completed', { retry_of: 'r-gone' });
+    expect(assembleChains([orphan])).toEqual([[orphan]]);
+  });
+
+  it('fan-out siblings order by the DTO attempt', () => {
+    const a = run('r-a', 'failed');
+    const late = run('r-late', 'completed', { retry_of: 'r-a', attempt: 2 });
+    const early = run('r-early', 'failed', { retry_of: 'r-a', attempt: 1 });
+    const [chain] = assembleChains([a, late, early]);
+    expect(chain?.map((v) => v.session.id)).toEqual(['r-a', 'r-early', 'r-late']);
+  });
+});
+
+describe('chainStatus (§3.3 semantics)', () => {
+  it('a moving latest attempt makes the chain live in its own word', () => {
+    expect(chainStatus([run('r-a', 'failed'), run('r-b', 'executing')])).toBe('executing');
+    expect(chainStatus([run('r-a', 'failed'), run('r-b', 'awaiting_human')])).toBe('awaiting_human');
+  });
+  it('completed if ANY attempt completed; failed only when ALL failed', () => {
+    expect(chainStatus([run('r-a', 'failed'), run('r-b', 'completed')])).toBe('completed');
+    expect(chainStatus([run('r-a', 'failed'), run('r-b', 'failed')])).toBe('failed');
+    expect(chainStatus([run('r-a', 'failed'), run('r-b', 'cancelled')])).toBe('cancelled');
+  });
+  it('chainInProgress drives the default-expanded rule', () => {
+    expect(chainInProgress([run('r-a', 'failed'), run('r-b', 'executing')])).toBe(true);
+    expect(chainInProgress([run('r-a', 'failed'), run('r-b', 'completed')])).toBe(false);
+  });
+});
+
+describe('the current-state pick (EC53)', () => {
+  it('picks the newest completed run by the attach clock; null with none (the honest empty state)', () => {
+    const old = run('r-old', 'completed');
+    const fresh = run('r-new', 'completed');
+    const live = run('r-live', 'executing');
+    expect(lastCompletedRun([old, fresh, live], { 'r-old': 100, 'r-new': 900 })).toBe(fresh);
+    expect(lastCompletedRun([live], {})).toBeNull();
+  });
+
+  it('completedPhases counts done units; criterion/workflow read the durable trail', () => {
+    const v = run('r-a', 'completed');
+    (v as { units: unknown[] }).units = [
+      { status: 'done' }, { status: 'done' }, { status: 'pending' },
+    ];
+    expect(completedPhases(v)).toBe(2);
+    const events = [
+      { type: 'workflowSelected', session: 'r-a', workflowId: 'wf-w2', unitCount: 3 },
+      { type: 'gateEvaluated', session: 'r-a', ord: 0, criterion: 'tests pass', combined: false },
+      { type: 'gateEvaluated', session: 'r-a', ord: 1, criterion: 'review clean', combined: true },
+    ];
+    expect(passedCriterion(events)).toBe('review clean');
+    expect(lastWorkflowSelected(events)).toBe('wf-w2');
+    expect(passedCriterion([])).toBeNull();
+  });
+});
+
+describe('guidanceAmendments (§3.3 scope + amend filter)', () => {
+  const entry = (runId: string, detail: Record<string, unknown>): AuditEntry =>
+    ({ ts: 1, action: 'gate.decided', actor: { id: 'mika', kind: 'human', trust: 'operator' }, runId, detail });
+
+  it('keeps only in-scope entries that CARRY a non-empty amend, capped at 5', () => {
+    const scope = new Set(['r-a', 'r-b']);
+    const rows = guidanceAmendments([
+      entry('r-a', { approve: true, amend: 'focus the tests' }),
+      entry('r-a', { approve: false }), // no amend — a plain decision, not guidance
+      entry('r-foreign', { approve: true, amend: 'not this project' }),
+      entry('r-b', { approve: true, amend: '   ' }), // blank amend
+      ...Array.from({ length: 7 }, (_, i) => entry('r-b', { approve: true, amend: `g${i}` })),
+    ], scope);
+    expect(rows).toHaveLength(5);
+    expect(rows[0]?.detail?.['amend']).toBe('focus the tests');
+    expect(rows.every((r) => r.runId !== 'r-foreign')).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-002 §3 (slice BC)** — the work chronicle (EC50, EC53).

- `chronicle.ts`: pure chain assembly by `retry_of` lineage — retry siblings render as sub-rows of ONE episode card, never peer rows (EC50); broken-lineage honest roots; cycle guard; chain-status derivation.
- `WorkChronicle`: episode cards with attempt sub-rows linking to each run's timeline; current-state strip deriving from the last durable event with the honest empty state (EC53); gesture-gated guidance panel (zero audit fetches on mount, one `GET /audit?action=gate.decided` on explicit open); "use in next run" folds the amendment into the composer as a visible, editable Operator-guidance paragraph (no invented wire field — CREW guidance endpoint comes with BE).
- Ships as an additive Runs|Chronicle toggle (flat list stays default); slice BE owns route/default wiring per §8.1.

Verified: 1475/1475 unit tests; slice rig 12/12 ×2 (every §3.5 AC incl. request taps and the unfiled-never-leaks assert); regressions ux_sliceS/V, feedback_sliceD, ux2_sliceBB; **live read-only render of the real 01222b4c→05510ebc retry chain as one 2-attempt episode**; adversarial verifier approved. LOC overrun disclosed (523 non-comment vs ~330; the guidance panel + steer prefill are cleanly partitionable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
