### PR TITLE
DES-UX-002 slice BA: portfolio nerve center — active card enrichment

### DIFF
--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -2108,6 +2108,13 @@ try:
         page.wait_for_function(
             """() => getComputedStyle(document.querySelector('[data-testid="version-strip"]'))
                  .opacity === '0'""", timeout=10000)
+        # Round-3 J3 re-scope (#108): hit targets retire on transitionEND (a
+        # mid-fade click must reach the strip, not the sensor below), so
+        # pointer-events flips to none a beat AFTER opacity settles — wait for
+        # that second settling stage instead of racing it.
+        page.wait_for_function(
+            """() => getComputedStyle(document.querySelector('[data-testid="version-strip"]'))
+                 .pointerEvents === 'none'""", timeout=10000)
         strip_hidden_css = page.evaluate(
             """() => { const s = getComputedStyle(document.querySelector('[data-testid="version-strip"]'));
                        return { opacity: s.opacity, pointerEvents: s.pointerEvents }; }""")

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -1650,7 +1650,9 @@ try:
             selected_at_head == ["false", "false", "true"],
             head_src is not None and head_src.endswith("/doc/3"),
             v1_scroll_disabled,
-            "scroll to" in v1_scroll_title and "merge" in v1_scroll_title,
+            # Slice-T re-scope (DES-UX-001 §6.3): the null-anchor tooltip now
+            # names the transcript-anchor gap, not the pre-T "merge" copy.
+            "scroll to" in v1_scroll_title and "version anchors" in v1_scroll_title,
             v3_scroll_enabled,
             v1_src == expected_v1_src,
             v1_query == "v=1",

--- a/e2e/ux2_sliceBA_test.py
+++ b/e2e/ux2_sliceBA_test.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+ux2_sliceBA_test.py — the DES-UX-002 slice-BA gate: the portfolio nerve
+center's active-card enrichment (§1 — brief DoD conditions 1 and 6: "see live
+evidence accumulating without entering the run"; "the nerve center shows
+gate-approaching and quiet accumulation"). Runs against the shared frozen-NOW0
+W2 fixture (uxfix_fixture.py) with `nerve` switched on: r-upload (executing)
+carries the §1.5 five-unit plan — 2 done, 1 distributed, 2 pending.
+
+The §1.5 DOM ACs, verbatim mapping:
+
+  1. the ACTIVE card renders `[data-testid="phase-strip"]` with 5 nodes; the
+     active node carries `data-active="true"`; the 2 done nodes carry
+     `data-complete="true"` (EC46);
+  2. a `gateEscalated` fixture event renders `[data-testid="gate-approaching"]`
+     with `data-criterion` populated BEFORE the gate posts; NO Approve/Reject
+     buttons visible in the pre-gate state (EC47) — and the preview RETIRES
+     when `awaitingHuman` posts the gate;
+  3. `[data-testid="active-unit-description"]` renders the current unit's
+     description truncated to 60 chars and MOVES on a live `unitDispatched`
+     frame (injected over the same /ws the app already holds);
+  4. the live-feed block for the same project renders
+     `[data-testid="feed-phase-line"]` spelling `phase n/N · stage-name`,
+     which moves with the dispatch too;
+  5. request-tap: the card enrichment fires ZERO new HTTP requests — the
+     `unitDispatched` and `gateEscalated` frames repaint the board from the
+     /ws relay + the already-fetched SessionView alone.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-BA-phase-strip.png       the enriched ACTIVE card: strip + description
+  ux-BA-feed-phase.png        the sidebar block after the live dispatch moved it
+  ux-BA-gate-approaching.png  the pre-gate posture: amber ring, criterion, no buttons
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/
+when the source changed. Env knobs: FEEDBACK_PORT (default 4407),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    NERVE_UPLOAD_UNITS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4407"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+CARD = '[data-testid="project-card"][data-project-id="upload-endpoint"]'
+FEED = '[data-testid="live-feed-block-upload-endpoint"]'
+
+# The gate criterion the daemon escalates with (wire field: `condition` — the
+# slice-BB verified spelling). >40 chars on purpose: the feed line's §1.3
+# truncation needs a real overflow.
+CRITERION = ("the rate-limit middleware keeps every existing upload test green "
+             "and enforces the burst budget")
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture with the nerve plan ON ────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, nerve=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN,
+                                     "plan_units": len(NERVE_UPLOAD_UNITS)}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The request tap (AC 5): every API request the page fires, by path.
+    api_requests: list[str] = []
+    page.on("request", lambda req: api_requests.append(urlparse(req.url).path)
+            if "/api/v1/" in req.url else None)
+
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator(CARD).wait_for(timeout=30000)
+
+    # ── Scene 1 (AC 1 / EC46): the strip — 5 nodes, 2 complete, 1 active ────────
+    page.locator(f'{CARD} [data-testid="phase-strip"]').wait_for(timeout=15000)
+    strip = page.evaluate(
+        """(card) => {
+          const root = document.querySelector(card);
+          const nodes = [...root.querySelectorAll('[data-testid="phase-node"]')];
+          const desc = root.querySelector('[data-testid="active-unit-description"]');
+          return {
+            variant: root.dataset.variant,
+            nodeCount: nodes.length,
+            stages: nodes.map((n) => n.dataset.stage),
+            complete: nodes.filter((n) => n.dataset.complete === 'true').length,
+            activeIx: nodes.findIndex((n) => n.dataset.active === 'true'),
+            overflow: !!root.querySelector('[data-testid="phase-strip-overflow"]'),
+            descText: desc?.textContent ?? null,
+            descTitle: desc?.getAttribute('title') ?? null,
+            descRunId: desc?.dataset.runId ?? null,
+          };
+        }""", CARD)
+    check("phase_strip_five_nodes",
+          strip["variant"] == "active"
+          and strip["nodeCount"] == 5
+          and strip["stages"] == ["recon", "build", "review", "build", "test"]
+          and strip["complete"] == 2
+          and strip["activeIx"] == 2
+          and not strip["overflow"],
+          **strip)
+
+    # ── Scene 2 (AC 3, truncation half): 60 chars, honest ellipsis, full text
+    #    on the tooltip ─────────────────────────────────────────────────────────
+    full_desc = NERVE_UPLOAD_UNITS[2]["description"]
+    check("description_truncated_60",
+          strip["descRunId"] == "r-upload"
+          and strip["descTitle"] == full_desc
+          and len(full_desc) > 60
+          and strip["descText"] is not None
+          and len(strip["descText"]) == 60
+          and strip["descText"].endswith("…")
+          and strip["descText"].startswith(full_desc[:40]),
+          desc_len=len(strip["descText"] or ""), title_len=len(full_desc))
+
+    # ── Scene 3 (AC 4): the sidebar block's phase line ───────────────────────────
+    feed = page.evaluate(
+        """(sel) => {
+          const block = document.querySelector(sel);
+          return {
+            phaseLine: block?.querySelector('[data-testid="feed-phase-line"]')?.textContent ?? null,
+            unitDesc: block?.querySelector('[data-testid="feed-unit-description"]')?.textContent ?? null,
+          };
+        }""", FEED)
+    check("feed_phase_line",
+          feed["phaseLine"] == "phase 3/5 · review"
+          and feed["unitDesc"] is not None
+          and feed["unitDesc"].startswith("review the rate-limit middleware"),
+          **feed)
+    page.screenshot(path=str(VSHOTS / "ux-BA-phase-strip.png"))
+
+    # ── Scene 4 (AC 3 live half + AC 5): a unitDispatched frame moves the
+    #    description AND the strip AND the feed line — with ZERO new HTTP ─────────
+    page.wait_for_timeout(1500)  # let the boot-time fetch storm fully settle
+    reads_before = len(api_requests)
+    set_fixture(ORIGIN, extra_frames=[
+        {"type": "unitDispatched", "session": "r-upload", "ord": 3, "attempt": 0},
+    ])
+    t0 = time.monotonic()
+    page.wait_for_function(
+        """(card) => document.querySelector(card + ' [data-testid="active-unit-description"]')
+             ?.textContent === 'apply the review fixes to the middleware chain'""",
+        arg=CARD, timeout=10000)
+    moved_ms = int((time.monotonic() - t0) * 1000)
+    after = page.evaluate(
+        """([card, feedSel]) => {
+          const nodes = [...document.querySelector(card)
+            .querySelectorAll('[data-testid="phase-node"]')];
+          return {
+            activeIx: nodes.findIndex((n) => n.dataset.active === 'true'),
+            feedPhase: document.querySelector(feedSel + ' [data-testid="feed-phase-line"]')
+              ?.textContent ?? null,
+            feedDesc: document.querySelector(feedSel + ' [data-testid="feed-unit-description"]')
+              ?.textContent ?? null,
+          };
+        }""", [CARD, FEED])
+    page.wait_for_timeout(800)  # a late fetch would land here
+    check("dispatch_moves_the_board",
+          after["activeIx"] == 3
+          and after["feedPhase"] == "phase 4/5 · build"
+          and after["feedDesc"] == "apply the review fixes to the middleware chain",
+          moved_ms=moved_ms, **after)
+    check("dispatch_zero_new_requests",
+          len(api_requests) == reads_before,
+          reads_before=reads_before, reads_after=len(api_requests),
+          tail=api_requests[reads_before:])
+    page.screenshot(path=str(VSHOTS / "ux-BA-feed-phase.png"))
+
+    # ── Scene 5 (AC 2 / EC47 + AC 5): gateEscalated → the APPROACHING posture,
+    #    criterion named, NO Approve/Reject, zero new HTTP ───────────────────────
+    reads_before = len(api_requests)
+    set_fixture(ORIGIN, extra_frames=[
+        {"type": "gateEscalated", "session": "r-upload", "ord": 3,
+         "condition": CRITERION,
+         "verdictSummary": "agent judge: fail — the burst budget is not enforced"},
+    ])
+    page.locator(f'{CARD} [data-testid="gate-approaching"]').wait_for(timeout=10000)
+    page.wait_for_timeout(800)  # a late fetch would land here
+    approaching = page.evaluate(
+        """([card, feedSel]) => {
+          const root = document.querySelector(card);
+          const chip = root.querySelector('[data-testid="gate-approaching"]');
+          const feedGate = document.querySelector(
+            feedSel + ' [data-testid="feed-gate-approaching"]');
+          return {
+            criterion: chip?.dataset.criterion ?? null,
+            runId: chip?.dataset.runId ?? null,
+            text: chip?.textContent ?? '',
+            approveVisible: !!root.querySelector('[data-testid="gate-approve-r-upload"]'),
+            rejectVisible: !!root.querySelector('[data-testid="gate-reject-r-upload"]'),
+            feedGateText: feedGate?.textContent ?? null,
+            feedGateTitle: feedGate?.getAttribute('title') ?? null,
+          };
+        }""", [CARD, FEED])
+    check("gate_approaching_pre_gate",
+          approaching["criterion"] == CRITERION
+          and approaching["runId"] == "r-upload"
+          and "gate approaching" in approaching["text"]
+          and not approaching["approveVisible"]
+          and not approaching["rejectVisible"],
+          **{k: v for k, v in approaching.items() if not k.startswith("feed")})
+    # The feed's amber line: truncated to 40 chars, full criterion on the tooltip.
+    check("feed_gate_approaching",
+          approaching["feedGateText"] is not None
+          and approaching["feedGateText"].startswith("⏳ gate: ")
+          and len(approaching["feedGateText"]) <= len("⏳ gate: ") + 40
+          and approaching["feedGateText"].endswith("…")
+          and approaching["feedGateTitle"] == CRITERION,
+          feedGateText=approaching["feedGateText"])
+    check("escalation_zero_new_requests",
+          len(api_requests) == reads_before,
+          reads_before=reads_before, reads_after=len(api_requests),
+          tail=api_requests[reads_before:])
+    page.screenshot(path=str(VSHOTS / "ux-BA-gate-approaching.png"))
+
+    # ── Scene 6 (AC 2, the posture switch): awaitingHuman posts the gate — the
+    #    preview retires (the full pill is the standing GateChip contract, owned
+    #    by the run status on the wire; the preview must never outlive the post) ─
+    set_fixture(ORIGIN, extra_gates=[
+        {"session": "r-upload", "ord": 3, "prompt": "Approve the middleware review?"},
+    ])
+    page.wait_for_function(
+        """(card) => !document.querySelector(card + ' [data-testid="gate-approaching"]')""",
+        arg=CARD, timeout=10000)
+    check("approaching_retires_on_post", True)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1418,8 +1418,7 @@ def assemble_runs() -> list:
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
     if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
-            or chronicle_on:
-    if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on or nerve_on:
+            or chronicle_on or nerve_on:
         runs = json.loads(json.dumps(runs))
         for r in runs:
             # Slice BA: r-upload's §1.5 five-unit plan; unit_ix follows the

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -294,6 +294,13 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # (the units + output wires). Default False: sliceR's tail keeps its
          # historical 4-event shape.
          "timeline": False,
+         # Slice BA (DES-UX-002 §1): the nerve-center plan corpus — r-upload's
+         # SessionView carries the §1.5 five-unit plan (2 done, 1 distributed,
+         # 2 pending; the return-to-build leg IS the 5th strip node — StageKind
+         # has only 4 spellings on the wire) and unit_ix moves to the
+         # distributed review. Default False: no standing rig's r-upload
+         # grows units.
+         "nerve": False,
          # Slice V (DES-UX-001 §3/§4): the provenance + retry corpus.
          #   provenance — GET /audit?runId= gains REAL AuditEntry rows for
          #                r-auth and r-retry (actor{id,kind,trust} + the
@@ -1066,6 +1073,34 @@ TIMELINE_AUTH_EVENTS = [
 # real fetch (the zero-request-hang regression trap, §1.3-4b).
 FORENSICS_DIFF_HANG_SECONDS = 30
 
+# ── Slice BA (DES-UX-002 §1): the nerve-center plan corpus, behind `nerve` ────
+#
+# r-upload's plan grows to §1.5's shape: 5 ordered units, 2 done, 1 active
+# (distributed), 2 pending. Every field is the REAL WorkUnit DTO; the stages
+# are the wire's own 4 StageKind spellings, so the 5th strip node is the
+# return-to-build leg after review — a distinct leg of the plan, not an
+# invented stage. u2's description exceeds 60 chars on purpose: the §1.5
+# truncation AC needs a real overflow to prove the honest ellipsis.
+
+
+def _nerve_unit(ord_: int, desc: str, stage: str, status: str) -> dict:
+    return {"id": f"r-upload:u{ord_}", "session_id": "r-upload", "ord": ord_,
+            "description": desc, "stage": stage,
+            "assigned_cli": "claude" if status != "pending" else None,
+            "assigned_invocation": None, "council_task_ref": None, "routing": None,
+            "denial_reason": None, "phase_ref": None, "conformance_ref": None,
+            "phase_status": None, "collection_scope": None, "status": status}
+
+
+NERVE_UPLOAD_UNITS = [
+    _nerve_unit(0, "survey the upload endpoint's rate-limit surface", "recon", "done"),
+    _nerve_unit(1, "wire the token-bucket middleware into /upload", "build", "done"),
+    _nerve_unit(2, "review the rate-limit middleware against the acceptance criteria list",
+                "review", "distributed"),
+    _nerve_unit(3, "apply the review fixes to the middleware chain", "build", "pending"),
+    _nerve_unit(4, "run the rate-limit acceptance suite end to end", "test", "pending"),
+]
+
 # ── The vision-slice-4 Video surface (DES-VISION-001 §5.6): one recorded demo ──
 #
 # The interactive bridge, reduced to what Video mode reads through crew's proxy:
@@ -1377,14 +1412,21 @@ def assemble_runs() -> list:
         provenance_on = state["provenance"]
         project_dto_on = state["project_dto"]
         chronicle_on = state["chronicle"]
+        nerve_on = state["nerve"]
         # Slice S (DES-UX-001 §2.3): the null-claim run + this-lifetime launches
         # join BOTH wires (list + detail) so the DTO echo decorates identically.
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
     if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
             or chronicle_on:
+    if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on or nerve_on:
         runs = json.loads(json.dumps(runs))
         for r in runs:
+            # Slice BA: r-upload's §1.5 five-unit plan; unit_ix follows the
+            # distributed review (the unit the run is genuinely ON).
+            if nerve_on and r["session"]["id"] == "r-upload":
+                r["units"] = json.loads(json.dumps(NERVE_UPLOAD_UNITS))
+                r["session"]["unit_ix"] = 2
             # Slice V: the CREW-UX-2 DTO echo for the lineage pair — the retry
             # prefill's project binding reads it (`project_id`, api-types 0.8.0).
             if provenance_on and r["session"]["id"] in ("r-auth", "r-retry"):

--- a/e2e/vision_slice2_test.py
+++ b/e2e/vision_slice2_test.py
@@ -246,11 +246,41 @@ with sync_playwright() as p:
                      c.querySelectorAll('[data-testid="quiet-summary"]').length === 1); }""")
     preserved["quietBudgetOneLine"] = budget_ok
     preserved_ok = all(preserved.values())
+
+    # ── Slice BA re-scope (DES-UX-002 §8.3): the first ACTIVE card with a
+    #    moving run now carries the phase strip + current-unit description
+    #    (EC46) — this rig OWNS that anatomy on the default W2 board, so a
+    #    future slice removing it fails here, not only in the BA rig. At rest
+    #    nothing is escalated: gate-approaching must be ABSENT board-wide, and
+    #    quiet cards never grow a strip (their budget stays one line, above).
+    ba = page.evaluate(
+        """() => { const up = document.querySelector(
+                     '[data-testid="project-card"][data-project-id="upload-endpoint"]');
+                   return {
+                     strip: !!up?.querySelector('[data-testid="phase-strip"]'),
+                     stripNodes: up?.querySelectorAll('[data-testid="phase-node"]').length ?? 0,
+                     unitDesc: up?.querySelector('[data-testid="active-unit-description"]')
+                       ?.textContent ?? null,
+                     feedPhase: document.querySelector(
+                       '[data-testid="live-feed-block-upload-endpoint"] '
+                       + '[data-testid="feed-phase-line"]')?.textContent ?? null,
+                     approachingAnywhere: !!document.querySelector(
+                       '[data-testid="gate-approaching"]'),
+                     quietStrips: document.querySelectorAll(
+                       '[data-testid="project-card"][data-variant="quiet"] '
+                       + '[data-testid="phase-strip"]').length,
+                   }; }""")
+    ba_ok = (
+        ba["strip"] and ba["stripNodes"] == 1  # W2's r-upload plan is 1 unit
+        and ba["unitDesc"] == "add rate-limiting to the upload endpoint"
+        and ba["feedPhase"] == "phase 1/1 · build"
+        and not ba["approachingAnywhere"] and ba["quietStrips"] == 0)
     browser.close()
 
 report["steps"]["dom_acs"] = {
     "ok": all([order_ok, narration_ok, fonts_ok, feed_ok, membership_ok, feed_updated,
-               ec15_card_bg, bar_gate_ok, bar_fail_ok, ec12_ok, ec13_ok, preserved_ok]),
+               ec15_card_bg, bar_gate_ok, bar_fail_ok, ec12_ok, ec13_ok, preserved_ok,
+               ba_ok]),
     "board_settled_w2_order": order_ok,
     "live_narration_streamed": narration_ok,
     "web_fonts_loaded": fonts_ok,
@@ -265,6 +295,7 @@ report["steps"]["dom_acs"] = {
     "ec12_accent_not_a_status_color": ec12_ok,
     "ec13_mono_narration_sans_labels": ec13_ok,
     "uxfix_preserved": preserved,
+    "slice_ba_card_enrichment": {**ba, "ok": ba_ok},
     "console_errors": console_errors[:10],
     "screenshots": [str(VSHOTS / n) for n in
                     ("vision-2-home-live-feed.png", "vision-2-active-card.png")],

--- a/src/board/phaseProgress.ts
+++ b/src/board/phaseProgress.ts
@@ -1,0 +1,120 @@
+import type { SessionView, WorkUnit } from '../api/types.js';
+import type { LoggedEvent } from '../store/runtime.js';
+
+/**
+ * The phase-progress derivation (DES-UX-002 §1.2, slice BA) — pure functions,
+ * no React, no clock, so the strip's verdicts are pinnable in unit tests.
+ *
+ * Everything here is a CLIENT derivation over data the studio already holds:
+ * the run's ordered `units` (on every `SessionView` the board fetched) and the
+ * run's live event log (the shared runtime store, fed by the one `/ws`
+ * subscription). Zero new requests — §1.5's request-tap AC.
+ */
+
+/** Statuses in which a run is moving under its own power — the runs whose
+ *  cards carry the phase strip (§1.3 "cards with an active run"). One spelling,
+ *  shared with the live feed's block-eligibility rule. */
+export const MOVING: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
+
+/** One stage node on the strip: a consecutive run of same-stage units. */
+export interface PhaseNode {
+  stage: string;
+  /** The ords of the units this node spans, in plan order. */
+  ords: number[];
+  state: 'complete' | 'active' | 'future';
+}
+
+/** §1.3's truncation: cap a description for a one-line surface, honestly elided. */
+export function truncate(text: string, cap: number): string {
+  return text.length > cap ? `${text.slice(0, cap - 1)}…` : text;
+}
+
+/** The newest `unitDispatched` ord in a run's live log, or undefined. */
+function dispatchedOrd(log: LoggedEvent[] | undefined): number | undefined {
+  if (log === undefined) return undefined;
+  for (let i = log.length - 1; i >= 0; i--) {
+    const entry = log[i];
+    if (entry !== undefined && entry.type === 'unitDispatched' && typeof entry.ord === 'number') {
+      return entry.ord;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The unit the run is on — §1.2's CLIENT derivation, with the live wire on top:
+ *
+ *   1. the newest `unitDispatched` in the run's event log names the current
+ *      unit (the event IS the dispatch — this is what makes the description
+ *      line move within a frame of the frame, no refetch);
+ *   2. otherwise the lowest-ord `distributed` unit;
+ *   3. otherwise the lowest-ord `pending` unit after the last `done`.
+ *
+ * A dispatch whose unit the (possibly fresher) unit list already shows as
+ * terminal is stale, not current — rule 1 yields to the list.
+ */
+export function currentUnitOf(
+  units: readonly WorkUnit[],
+  log?: LoggedEvent[],
+): WorkUnit | undefined {
+  const ordered = [...units].sort((a, b) => a.ord - b.ord);
+  const live = dispatchedOrd(log);
+  if (live !== undefined) {
+    const unit = ordered.find((u) => u.ord === live);
+    if (unit !== undefined && unit.status !== 'done' && unit.status !== 'rejected') return unit;
+  }
+  const distributed = ordered.find((u) => u.status === 'distributed');
+  if (distributed !== undefined) return distributed;
+  let lastDone = -1;
+  for (const u of ordered) if (u.status === 'done') lastDone = u.ord;
+  return ordered.find((u) => u.status === 'pending' && u.ord > lastDone)
+    ?? ordered.find((u) => u.status === 'pending');
+}
+
+/**
+ * The strip's nodes: the plan's units in `ord` order, grouped into consecutive
+ * same-stage runs (§1.3 "one per distinct stage value in the run's unit plan" —
+ * a plan that returns to `build` after `review` earns a second build node,
+ * because that IS a distinct leg of the plan). A node is `complete` when every
+ * unit it spans is done, `active` when it holds the current unit, `future`
+ * otherwise.
+ */
+export function phaseNodesOf(
+  units: readonly WorkUnit[],
+  currentOrd: number | undefined,
+): PhaseNode[] {
+  const ordered = [...units].sort((a, b) => a.ord - b.ord);
+  const groups: { stage: string; units: WorkUnit[] }[] = [];
+  for (const unit of ordered) {
+    const last = groups[groups.length - 1];
+    if (last !== undefined && last.stage === unit.stage) last.units.push(unit);
+    else groups.push({ stage: unit.stage, units: [unit] });
+  }
+  return groups.map((g) => ({
+    stage: g.stage,
+    ords: g.units.map((u) => u.ord),
+    state:
+      currentOrd !== undefined && g.units.some((u) => u.ord === currentOrd)
+        ? 'active'
+        : g.units.every((u) => u.status === 'done')
+          ? 'complete'
+          : 'future',
+  }));
+}
+
+/**
+ * The sidebar's phase line (§1.3): `phase n/N · stage-name`, off the active
+ * node — or null when no node is active (no plan yet, or a terminal run),
+ * so the block never states a position it does not hold.
+ */
+export function phaseLineOf(nodes: readonly PhaseNode[]): string | null {
+  const active = nodes.findIndex((n) => n.state === 'active');
+  if (active === -1) return null;
+  const node = nodes[active];
+  return node === undefined ? null : `phase ${active + 1}/${nodes.length} · ${node.stage}`;
+}
+
+/** The leading moving run of a card/block — the one whose plan the strip shows. */
+export function leadMovingRun(runs: readonly SessionView[]): SessionView | undefined {
+  return runs.find((v) => MOVING.has(v.session.status));
+}

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,4 +1,4 @@
-import type { SessionView } from '../api/types.js';
+import type { SessionView, WorkUnit } from '../api/types.js';
 import { currentUnitOf, MOVING, phaseLineOf, phaseNodesOf, truncate } from '../board/phaseProgress.js';
 import { activeUnit, lastMeaningfulLines, useRunHeadline } from '../hooks/useBoardHeadline.js';
 import type { BoardProject } from '../hooks/useBoardModel.js';
@@ -71,14 +71,24 @@ type PathLink = (path: string) => { href: string; onClick: (e: React.MouseEvent)
  * deep-linkable. The operator sees a run narrating and CAN click the words.
  * No underline at rest (mono narration must not read as prose links); hover
  * lifts the ink and fades in the ↗ at line-end (`.wk-feed-link`, global.css).
+ *
+ * Slice BA (DES-UX-002 §1.3): when the block's phase line + current-unit
+ * description are rendering above (`fallback: false`, the lead run with a
+ * plan), the description line REPLACES the raw narration fallback — nothing
+ * streamed means no line here, never the same unit description twice.
  */
-function RunLines({ view, max, link }: { view: SessionView; max: number; link: Link }): React.ReactElement {
+function RunLines({ view, max, link, fallback = true }: {
+  view: SessionView;
+  max: number;
+  link: Link;
+  fallback?: boolean;
+}): React.ReactElement {
   const runId = view.session.id;
   const ord = activeUnit(view)?.ord ?? 0;
   const text = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
   const headline = useRunHeadline(view);
   const lines = lastMeaningfulLines(text, max);
-  const shown = lines.length > 0 ? lines : [headline];
+  const shown = lines.length > 0 ? lines : fallback ? [headline] : [];
   return (
     <>
       {shown.map((line) => (
@@ -108,19 +118,19 @@ function RunLines({ view, max, link }: { view: SessionView; max: number; link: L
  * accumulating evidence below the triage threshold is still legible from the
  * periphery (the brief's "quiet accumulation" condition).
  */
-function FeedPhase({ view }: { view: SessionView }): React.ReactElement | null {
-  const log = useRuntimeStore((s) => s.logs[view.session.id]);
-  const unit = currentUnitOf(view.units, log);
-  const line = phaseLineOf(phaseNodesOf(view.units, unit?.ord));
-  if (line === null || unit === undefined) return null;
+function FeedPhase({ runId, unit, line }: {
+  runId: string;
+  unit: WorkUnit;
+  line: string;
+}): React.ReactElement {
   return (
     <>
-      <p data-testid="feed-phase-line" data-run-id={view.session.id} style={{ ...CSS.line, color: 'var(--ink-muted)' }}>
+      <p data-testid="feed-phase-line" data-run-id={runId} style={{ ...CSS.line, color: 'var(--ink-muted)' }}>
         {line}
       </p>
       <p
         data-testid="feed-unit-description"
-        data-run-id={view.session.id}
+        data-run-id={runId}
         title={unit.description}
         style={{ ...CSS.line, color: 'var(--ink-body)' }}
       >
@@ -133,6 +143,13 @@ function FeedPhase({ view }: { view: SessionView }): React.ReactElement | null {
 function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate }): React.ReactElement {
   const { project, runs, signal } = item;
   const moving = runs.filter((v) => MOVING.has(v.session.status));
+  // Slice BA (§1.3): the lead run's current unit + phase line, derived once at
+  // the block level so the narration fallback below KNOWS the description line
+  // is carrying its duty (`fallback: false`) — the two never render as twins.
+  const lead = moving[0];
+  const leadLog = useRuntimeStore((s) => (lead === undefined ? undefined : s.logs[lead.session.id]));
+  const leadUnit = lead === undefined ? undefined : currentUnitOf(lead.units, leadLog);
+  const leadLine = lead === undefined ? null : phaseLineOf(phaseNodesOf(lead.units, leadUnit?.ord));
   // Slice BA (§1.3): an escalated-but-not-posted gate on any of this project's
   // runs — the amber approaching line, same store fold the card chip reads.
   const near = useGateStore((s) => {
@@ -167,9 +184,19 @@ function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate 
         <a {...pathLink(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
       </p>
       {/* Slice BA (§1.3): phase n/N · stage + the current unit, off the lead run. */}
-      {moving[0] !== undefined && <FeedPhase view={moving[0]} />}
+      {lead !== undefined && leadUnit !== undefined && leadLine !== null && (
+        <FeedPhase runId={lead.session.id} unit={leadUnit} line={leadLine} />
+      )}
       {moving.slice(0, MAX_RUNS).map((v, i) => (
-        <RunLines key={v.session.id} view={v} max={i === 0 ? MAX_LINES : 1} link={runLink} />
+        <RunLines
+          key={v.session.id}
+          view={v}
+          max={i === 0 ? MAX_LINES : 1}
+          link={runLink}
+          // The lead run's generic fallback is REPLACED by the description
+          // line above whenever that line is rendering (§1.3).
+          fallback={!(i === 0 && leadUnit !== undefined && leadLine !== null)}
+        />
       ))}
       {near !== undefined && (
         <p

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,7 +1,9 @@
 import type { SessionView } from '../api/types.js';
+import { currentUnitOf, MOVING, phaseLineOf, phaseNodesOf, truncate } from '../board/phaseProgress.js';
 import { activeUnit, lastMeaningfulLines, useRunHeadline } from '../hooks/useBoardHeadline.js';
 import type { BoardProject } from '../hooks/useBoardModel.js';
 import { modePath, type Navigate } from '../hooks/useRoute.js';
+import { useGateStore } from '../store/gates.js';
 import { outputKey, useRuntimeStore } from '../store/runtime.js';
 import { ago, SIGNAL_BAR } from './ProjectCard.js';
 
@@ -24,9 +26,6 @@ import { ago, SIGNAL_BAR } from './ProjectCard.js';
  * line fades in at the top of its block (`--dur-fast`), a new block fades in
  * (`--dur-base`), nothing loops (see `.wk-feed-*` in global.css).
  */
-
-/** Statuses in which a run is moving under its own power — what earns a block. */
-const MOVING: ReadonlySet<string> = new Set(['planning', 'distributing', 'executing']);
 
 /** Runs narrating per block, and lines for the lead run — the block never exceeds
  *  3 lines (§1.3): 2 from the newest run, 1 from the next; extras are silence. */
@@ -101,9 +100,48 @@ function RunLines({ view, max, link }: { view: SessionView; max: number; link: L
   );
 }
 
+/**
+ * The block's phase line + current-unit description (DES-UX-002 §1.3, slice
+ * BA): `phase n/N · stage-name` derived from the lead moving run's unit plan
+ * (§1.2's CLIENT derivation, live `unitDispatched` on top), and beneath it the
+ * unit's own description — the block names WHERE the work is, so a project
+ * accumulating evidence below the triage threshold is still legible from the
+ * periphery (the brief's "quiet accumulation" condition).
+ */
+function FeedPhase({ view }: { view: SessionView }): React.ReactElement | null {
+  const log = useRuntimeStore((s) => s.logs[view.session.id]);
+  const unit = currentUnitOf(view.units, log);
+  const line = phaseLineOf(phaseNodesOf(view.units, unit?.ord));
+  if (line === null || unit === undefined) return null;
+  return (
+    <>
+      <p data-testid="feed-phase-line" data-run-id={view.session.id} style={{ ...CSS.line, color: 'var(--ink-muted)' }}>
+        {line}
+      </p>
+      <p
+        data-testid="feed-unit-description"
+        data-run-id={view.session.id}
+        title={unit.description}
+        style={{ ...CSS.line, color: 'var(--ink-body)' }}
+      >
+        {truncate(unit.description, 60)}
+      </p>
+    </>
+  );
+}
+
 function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate }): React.ReactElement {
   const { project, runs, signal } = item;
   const moving = runs.filter((v) => MOVING.has(v.session.status));
+  // Slice BA (§1.3): an escalated-but-not-posted gate on any of this project's
+  // runs — the amber approaching line, same store fold the card chip reads.
+  const near = useGateStore((s) => {
+    for (const v of runs) {
+      const g = s.approaching[v.session.id];
+      if (g !== undefined) return g;
+    }
+    return undefined;
+  });
   const failing = signal !== null && signal.kind === 'failing'
     ? runs.find((v) => v.session.status === 'failed')
     : undefined;
@@ -128,9 +166,21 @@ function FeedBlock({ item, navigate }: { item: BoardProject; navigate: Navigate 
         {/* The block header keeps its project-level link — two altitudes, both real. */}
         <a {...pathLink(modePath(project.id, 'build'))} style={CSS.name}>{project.name}</a>
       </p>
+      {/* Slice BA (§1.3): phase n/N · stage + the current unit, off the lead run. */}
+      {moving[0] !== undefined && <FeedPhase view={moving[0]} />}
       {moving.slice(0, MAX_RUNS).map((v, i) => (
         <RunLines key={v.session.id} view={v} max={i === 0 ? MAX_LINES : 1} link={runLink} />
       ))}
+      {near !== undefined && (
+        <p
+          data-testid="feed-gate-approaching"
+          data-run-id={near.runId}
+          title={near.condition}
+          style={{ ...CSS.line, color: 'var(--status-gate)' }}
+        >
+          ⏳ gate: {truncate(near.condition, 40)}
+        </p>
+      )}
       {failing !== undefined && signal !== null && (
         // §10.1: the whole failure line is now the run link (anchors don't
         // nest); `[open run]` stays as the visible affordance inside it.

--- a/src/components/PhaseStrip.tsx
+++ b/src/components/PhaseStrip.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import type { SessionView, WorkUnit } from '../api/types.js';
+import { currentUnitOf, phaseNodesOf, type PhaseNode } from '../board/phaseProgress.js';
+import { useRuntimeStore } from '../store/runtime.js';
+
+/**
+ * The phase progress strip (DES-UX-002 §1.3, slice BA): a horizontal row of
+ * stage nodes, one per consecutive same-stage leg of the run's unit plan.
+ * The active node glows `--status-run-dim`, completed nodes are
+ * `--status-done`, future nodes `--ink-dim`; the 2px gaps between nodes are
+ * the card's own surface (§1.4's gap-fill) — no new semantic tokens.
+ *
+ * Overflow past 5 nodes collapses to an honest mono label rather than
+ * squeezing the strip — the count is stated, never silently dropped.
+ */
+
+/** Nodes shown before the strip collapses the tail into a count (§1.3). */
+const MAX_NODES = 5;
+
+const NODE_BG: Record<PhaseNode['state'], string> = {
+  active: 'var(--status-run-dim)',
+  complete: 'var(--status-done)',
+  future: 'var(--ink-dim)',
+};
+
+/**
+ * The current unit of a run, live: the shared runtime log's newest
+ * `unitDispatched` wins (so the strip and the description line move within a
+ * frame of the frame's fold — no refetch), degrading to the unit list's own
+ * statuses (§1.2's CLIENT derivation).
+ */
+export function useCurrentUnit(view: SessionView): WorkUnit | undefined {
+  const log = useRuntimeStore((s) => s.logs[view.session.id]);
+  return useMemo(() => currentUnitOf(view.units, log), [view, log]);
+}
+
+export function PhaseStrip({ units, currentOrd }: {
+  units: readonly WorkUnit[];
+  /** The current unit's ord — `undefined` marks no node active. */
+  currentOrd: number | undefined;
+}): React.ReactElement | null {
+  const nodes = phaseNodesOf(units, currentOrd);
+  if (nodes.length === 0) return null;
+  const shown = nodes.slice(0, MAX_NODES);
+  const hidden = nodes.length - shown.length;
+  return (
+    <div
+      data-testid="phase-strip"
+      data-nodes={nodes.length}
+      style={{ display: 'flex', alignItems: 'center', gap: '2px', marginTop: '8px' }}
+    >
+      {shown.map((node, i) => (
+        <span
+          key={`${node.stage}:${node.ords[0] ?? i}`}
+          data-testid="phase-node"
+          data-stage={node.stage}
+          {...(node.state === 'active' ? { 'data-active': 'true' } : {})}
+          {...(node.state === 'complete' ? { 'data-complete': 'true' } : {})}
+          title={node.stage}
+          style={{
+            width: '8px', height: '8px', borderRadius: 'var(--radius-full)', flexShrink: 0,
+            background: NODE_BG[node.state],
+            // The §1.3 glow — same token as the fill, halo only, no new color.
+            boxShadow: node.state === 'active' ? '0 0 4px 1px var(--status-run-dim)' : 'none',
+          }}
+        />
+      ))}
+      {hidden > 0 && (
+        <span
+          data-testid="phase-strip-overflow"
+          style={{
+            fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+            color: 'var(--ink-dim)', marginLeft: '4px',
+          }}
+        >
+          · {hidden} remaining
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,6 +1,8 @@
+import { Fragment } from 'react';
 import type { SessionView } from '../api/types.js';
 import type { SignalKind } from '../board/boardAttention.js';
-import { isLive, useRunHeadline } from '../hooks/useBoardHeadline.js';
+import { leadMovingRun, truncate } from '../board/phaseProgress.js';
+import { isLive, useRunHeadline, useRunNarration } from '../hooks/useBoardHeadline.js';
 import { modePath, MODES, projectPath, type Navigate } from '../hooks/useRoute.js';
 import type { Attention, BoardProject } from '../hooks/useBoardModel.js';
 import { useGateStore } from '../store/gates.js';
@@ -9,6 +11,7 @@ import { BatchSelectBox } from './BatchGateBar.js';
 import { ExportMenu } from './ExportMenu.js';
 import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
+import { PhaseStrip, useCurrentUnit } from './PhaseStrip.js';
 import { ProjectSparkline } from './ProjectSparkline.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
@@ -48,8 +51,10 @@ import { STATUS_STYLE } from './RunCard.js';
  *  treats this as a `maxHeight`, so a light card is short, not hollow — the
  *  SLOT stays fixed for the windowing math, the pixels do not. (Vision slice 2:
  *  +6px over the pre-token slot — `--space-4` padding is 16px, was 14px, and the
- *  2px status bar rides inside the border-box.) */
-export const ACTIVE_CARD_H = 336;
+ *  2px status bar rides inside the border-box. Slice BA: +24px for the phase
+ *  strip + current-unit description an active-run card now carries, DES-UX-002
+ *  §1.3.) */
+export const ACTIVE_CARD_H = 360;
 
 /** QUIET-card slot height in px — one summary line plus the action row, with
  *  room for the first-run 2×2 sublabelled grid (§2.2) in the same slot. Also a
@@ -251,19 +256,60 @@ function DocTile({ projectId, name, kind, head, when }: {
  * One run's newest narration line (§1.4 live activity, derived per §3.4(b)). One
  * line, ellipsised, never scrolling — the card is scanned, not watched; the thread
  * is where a user goes to watch.
+ *
+ * Slice BA (DES-UX-002 §1.3): on the card's LEADING moving run the phase strip +
+ * current-unit description below now carry rule 3's duty, so `narrationOnly`
+ * renders the line only when something genuinely streamed (rules 1–2) — never
+ * the generic `<phase> — <unit title>` fallback twice on one card.
  */
-function LiveLine({ view }: { view: SessionView }): React.ReactElement {
+function LiveLine({ view, narrationOnly = false }: {
+  view: SessionView;
+  narrationOnly?: boolean;
+}): React.ReactElement | null {
   const headline = useRunHeadline(view);
+  const narration = useRunNarration(view);
+  const line = narrationOnly ? narration : headline;
+  if (line === null) return null;
   return (
     <p
       data-testid="live-line"
       data-run-id={view.session.id}
-      title={headline}
+      title={line}
       style={CSS.line}
     >
       <span aria-hidden style={CSS.pulse} />
-      {headline}
+      {line}
     </p>
+  );
+}
+
+/**
+ * The active-run plan region (DES-UX-002 §1.3, slice BA): the phase progress
+ * strip over the run's unit plan, and beneath it the current unit's
+ * description — the card says WHERE the run is, from data the board already
+ * holds (`SessionView.units` + the shared runtime log; zero new requests).
+ */
+function ActivePlan({ view }: { view: SessionView }): React.ReactElement | null {
+  const unit = useCurrentUnit(view);
+  if (view.units.length === 0) return null;
+  return (
+    <div data-testid="active-plan" data-run-id={view.session.id}>
+      <PhaseStrip units={view.units} currentOrd={unit?.ord} />
+      {unit !== undefined && (
+        <p
+          data-testid="active-unit-description"
+          data-run-id={view.session.id}
+          title={unit.description}
+          style={{
+            margin: '4px 0 0', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+            color: 'var(--ink-muted)', overflow: 'hidden', textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {truncate(unit.description, 60)}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -284,9 +330,14 @@ export function ProjectCard({
 }: Props): React.ReactElement {
   const { project, repo, runs, docs, attention, band, score, signal } = item;
   const gates = useGateStore((s) => s.gates);
+  // Slice BA (DES-UX-002 §1.3): escalated-but-not-yet-posted gates — the
+  // approaching preview chip renders from this, the same store fold as gates.
+  const approaching = useGateStore((s) => s.approaching);
   // Relayed interactive status for THIS project — one line, plus the tile date it implies.
   const activity = useRuntimeStore((s) => s.docActivity[project.id]);
   const live = runs.filter(isLive);
+  // The leading MOVING run — whose plan the phase strip + description show (§1.3).
+  const lead = leadMovingRun(runs);
   // Slice L (§9.2): the card's batch-selectable gate is its LEADING waiting
   // run — the same run the triage cursor's `x` toggles (TriageItem.runId).
   const leadingWaiting = runs.find((v) => v.session.status === 'awaiting_human')?.session.id;
@@ -436,7 +487,9 @@ export function ProjectCard({
       {(live.length > 0 || activity !== undefined) && (
         <div data-testid="live-activity" style={{ marginTop: '10px' }}>
           {live.slice(0, MAX_LINES).map((v) => (
-            <LiveLine key={v.session.id} view={v} />
+            // The lead moving run narrates only what genuinely streamed —
+            // the strip + description below replace its generic fallback (§1.3).
+            <LiveLine key={v.session.id} view={v} narrationOnly={v === lead} />
           ))}
           {activity !== undefined && (
             <p data-testid="doc-activity" title={activity.message} style={CSS.line}>
@@ -452,6 +505,9 @@ export function ProjectCard({
               {live.length - MAX_LINES} more running
             </span>
           )}
+          {/* Slice BA (§1.3): the phase strip + current-unit description —
+              below the narration, above the gate chip. */}
+          {lead !== undefined && <ActivePlan view={lead} />}
         </div>
       )}
 
@@ -474,11 +530,13 @@ export function ProjectCard({
                 />
               );
             }
+            const near = approaching[session.id];
             return (
               // A waiting gate is ANSWERABLE, not a badge (§1.4) — so the row is a row:
               // the run link, and beside it a chip carrying its own controls. Nesting
               // buttons inside the link would be neither valid nor operable.
-              <div key={session.id} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <Fragment key={session.id}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                 {/* Slice L (§9.2): the selection slot — checkbox for a simple
                     gate, the ↗ needs-the-thread marker for a complex one;
                     renders only once ≥1 gate is selected anywhere. */}
@@ -512,6 +570,34 @@ export function ProjectCard({
                   <GateChip runId={session.id} projectId={project.id} gate={gate} navigate={navigate} />
                 )}
               </div>
+              {/* Slice BA (DES-UX-002 §1.3, EC47): the gate-APPROACHING posture —
+                  `gateEscalated` fired, the gate is not yet posted. An amber ring
+                  and the criterion preview, deliberately with NO Approve/Reject:
+                  this is a signal to compose pre-gate guidance, not an action
+                  surface. It retires the moment `awaitingHuman` posts the gate,
+                  where the full pill (GateChip, above) takes over. */}
+              {!waiting && near !== undefined && (
+                <div
+                  data-testid="gate-approaching"
+                  data-run-id={session.id}
+                  data-criterion={near.condition}
+                  title={near.condition}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '6px',
+                    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+                    border: '1px solid var(--status-gate)', background: 'var(--status-gate-dim)',
+                    borderRadius: 'var(--radius-sm)', padding: '3px 7px',
+                    overflow: 'hidden', whiteSpace: 'nowrap',
+                  }}
+                >
+                  <span aria-hidden style={{ color: 'var(--status-gate)', flexShrink: 0 }}>⏳</span>
+                  <span style={{ color: 'var(--status-gate)', flexShrink: 0 }}>gate approaching</span>
+                  <span style={{ color: 'var(--ink-muted)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {near.condition}
+                  </span>
+                </div>
+              )}
+              </Fragment>
             );
           })}
           {runs.length > MAX_CHIPS && (

--- a/src/hooks/useBoardHeadline.ts
+++ b/src/hooks/useBoardHeadline.ts
@@ -107,13 +107,27 @@ export interface HeadlineInput {
 export function deriveHeadline({ view, text, log, deltaSeq }: HeadlineInput): string {
   const unit = activeUnit(view);
   const phase = unit?.stage ?? view.session.status;
-  const structured = [...(log ?? [])].reverse().find((e) => STRUCTURED.has(e.type));
+  return (
+    deriveNarration({ view, text, log, deltaSeq }) ??
+    `${phase} — ${clamp((unit?.description ?? view.session.problem).trim())}`
+  );
+}
+
+/**
+ * Rules 1–2 only: the line is real narration (a structured status or streamed
+ * output), or `null` when only rule 3's generic fallback would remain. Slice BA
+ * (DES-UX-002 §1.3) is the consumer: on a card with an active run the phase
+ * strip + current-unit description REPLACE the generic narration line, so the
+ * card's live line renders only what actually streamed — never the same unit
+ * description twice.
+ */
+export function deriveNarration({ view, text, log, deltaSeq }: HeadlineInput): string | null {
+  const unit = activeUnit(view);
+  const phase = unit?.stage ?? view.session.status;
   const what =
-    (structured !== undefined && structured.seq > deltaSeq ? structured.detail || null : null) ??
-    lastMeaningfulLine(text) ??
-    unit?.description ??
-    view.session.problem;
-  return `${phase} — ${clamp(what.trim())}`;
+    (log ?? []).slice().reverse().find((e) => STRUCTURED.has(e.type) && e.seq > deltaSeq)?.detail ||
+    lastMeaningfulLine(text);
+  return what == null || what === '' ? null : `${phase} — ${clamp(what.trim())}`;
 }
 
 /**
@@ -128,4 +142,17 @@ export function useRunHeadline(view: SessionView): string {
   const log = useRuntimeStore((s) => s.logs[runId]);
   const deltaSeq = useRuntimeStore((s) => s.deltaSeq[runId] ?? -1);
   return deriveHeadline({ view, text, log, deltaSeq });
+}
+
+/**
+ * The live narration for one run, or `null` when nothing has genuinely
+ * streamed (rules 1–2 empty) — same store, same slices as `useRunHeadline`.
+ */
+export function useRunNarration(view: SessionView): string | null {
+  const runId = view.session.id;
+  const ord = activeUnit(view)?.ord ?? 0;
+  const text = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
+  const log = useRuntimeStore((s) => s.logs[runId]);
+  const deltaSeq = useRuntimeStore((s) => s.deltaSeq[runId] ?? -1);
+  return deriveNarration({ view, text, log, deltaSeq });
 }

--- a/src/store/gates.ts
+++ b/src/store/gates.ts
@@ -59,9 +59,33 @@ export function isSimpleGate(gate: OpenGate | undefined): boolean {
   return (gate.choices ?? ['approve', 'reject']).length <= 2;
 }
 
+/**
+ * A gate the daemon has ESCALATED but not yet posted (DES-UX-002 §1.3, slice
+ * BA): `gateEscalated` fires before the operator is pinged, so this record IS
+ * the "gate approaching" signal — the card's preview chip and the feed's amber
+ * line render from it. Event-sourced only (session-scoped: a reload before the
+ * gate posts simply loses the preview — the gate itself is never at risk).
+ */
+export interface ApproachingGate {
+  runId: string;
+  ord: number;
+  /** The gate's criterion — the wire spells the field `condition`. */
+  condition: string;
+  receivedAt: number;
+}
+
+/** Frames on which an approaching-gate preview retires: the gate posted
+ *  (`awaitingHuman`), resolved without a human (`gateDecided`), or the run
+ *  moved past it. */
+const APPROACH_CLEARS: ReadonlySet<string> = new Set([
+  'awaitingHuman', 'gateDecided', 'resumed', 'sessionCompleted', 'runCancelled', 'sessionFailed',
+]);
+
 interface GateStore {
   /** Open gates keyed by run id. */
   gates: Record<string, OpenGate>;
+  /** Escalated-but-not-yet-posted gates keyed by run id (§1.3's preview). */
+  approaching: Record<string, ApproachingGate>;
   /** Upsert a gate (from a live event or a `GET /runs/:id/gate` reconcile). */
   setGate: (gate: OpenGate) => void;
   /** Drop a run's gate. */
@@ -74,6 +98,7 @@ interface GateStore {
 
 export const useGateStore = create<GateStore>((set) => ({
   gates: {},
+  approaching: {},
 
   setGate: (gate) => set((s) => ({ gates: { ...s.gates, [gate.runId]: gate } })),
 
@@ -89,11 +114,30 @@ export const useGateStore = create<GateStore>((set) => ({
     const session = typeof event.session === 'string' ? event.session : undefined;
     if (session === undefined) return;
     set((s) => {
+      // The approaching preview folds FIRST (slice BA): it opens on
+      // `gateEscalated` and retires on any frame that supersedes it —
+      // `awaitingHuman` below both retires the preview AND opens the gate,
+      // which is exactly the §1.3 approaching → awaiting posture switch.
+      let approaching = s.approaching;
+      if (
+        event.type === 'gateEscalated' &&
+        typeof event.ord === 'number' &&
+        typeof event.condition === 'string'
+      ) {
+        approaching = {
+          ...approaching,
+          [session]: { runId: session, ord: event.ord, condition: event.condition, receivedAt: Date.now() },
+        };
+      } else if (APPROACH_CLEARS.has(event.type) && session in approaching) {
+        approaching = { ...approaching };
+        delete approaching[session];
+      }
       switch (event.type) {
         case 'awaitingHuman': {
           if (typeof event.ord === 'number' && typeof event.prompt === 'string') {
             const choices = choicesOf(event as unknown as Record<string, unknown>);
             return {
+              approaching,
               gates: {
                 ...s.gates,
                 [session]: {
@@ -108,19 +152,19 @@ export const useGateStore = create<GateStore>((set) => ({
               },
             };
           }
-          return s;
+          return approaching === s.approaching ? s : { approaching };
         }
         case 'resumed':
         case 'sessionCompleted':
         case 'runCancelled':
         case 'sessionFailed': {
-          if (!(session in s.gates)) return s;
+          if (!(session in s.gates)) return approaching === s.approaching ? s : { approaching };
           const next = { ...s.gates };
           delete next[session];
-          return { gates: next };
+          return { approaching, gates: next };
         }
         default:
-          return s;
+          return approaching === s.approaching ? s : { approaching };
       }
     });
   },

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -96,11 +96,15 @@ describe('HomeBoard — live activity (slice 6)', () => {
     members = { 'p-a': [member('p-a', 'run-a')], 'p-b': [member('p-b', 'run-b')] };
     await board([running('run-a'), running('run-b')]);
 
-    // Before: both cards state their subject from phase + title (§3.4(b) rule 3) —
-    // no card is ever blank, and neither says "Working…".
-    const before = within(card('p-a')).getByTestId('live-line').textContent;
-    expect(before).toBe('build — wire the board');
-    expect(within(card('p-b')).getByTestId('live-line')).toHaveTextContent('build — wire the board');
+    // Before: both cards state their subject — since slice BA (DES-UX-002 §1.3)
+    // an active-run card's subject is the current unit DESCRIPTION line (the
+    // plan region), which replaces the generic `phase — title` narration
+    // fallback; the live line renders only what genuinely streamed. No card is
+    // ever blank, and neither says "Working…".
+    const before = within(card('p-a')).getByTestId('active-unit-description').textContent;
+    expect(before).toBe('wire the board');
+    expect(within(card('p-a')).queryByTestId('live-line')).toBeNull();
+    expect(within(card('p-b')).getByTestId('active-unit-description')).toHaveTextContent('wire the board');
 
     push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Writing the acceptance criteria for AC-3\n' } as CoreEvent);
 
@@ -110,8 +114,10 @@ describe('HomeBoard — live activity (slice 6)', () => {
       expect(within(card('p-b')).getByTestId('live-line'))
         .toHaveTextContent('build — Writing the acceptance criteria for AC-3');
     });
-    // The AC's other half: the card the user was NOT looking at is unchanged.
-    expect(within(card('p-a')).getByTestId('live-line').textContent).toBe(before);
+    // The AC's other half: the card the user was NOT looking at is unchanged —
+    // still the plan-region subject, still no streamed line.
+    expect(within(card('p-a')).getByTestId('active-unit-description').textContent).toBe(before);
+    expect(within(card('p-a')).queryByTestId('live-line')).toBeNull();
   });
 
   it('keeps streaming: the newest line replaces the previous one, no scroll, no dump', async () => {
@@ -226,6 +232,9 @@ describe('HomeBoard — live activity (slice 6)', () => {
     rerender(<HomeBoard runs={[running('run-new')]} navigate={() => {}} />);
 
     await vi.waitFor(() => expect(within(card('p-a')).getByTestId('run-chip')).toHaveAttribute('data-run-id', 'run-new'));
-    expect(within(card('p-a')).getByTestId('live-line')).toHaveTextContent('build — wire the board');
+    // Slice BA: the launched run's subject is the plan region's description
+    // line (nothing has streamed yet — no generic narration fallback).
+    expect(within(card('p-a')).getByTestId('active-unit-description')).toHaveTextContent('wire the board');
+    expect(within(card('p-a')).getByTestId('phase-strip')).toBeInTheDocument();
   });
 });

--- a/tests/LiveFeed.test.tsx
+++ b/tests/LiveFeed.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, screen, within } from '@testing-library/react';
 import type { CoreEvent, Project, ProjectMember, SessionStatus, SessionView } from '../src/api/types.js';
+import { useGateStore } from '../src/store/gates.js';
 import { useRuntimeStore } from '../src/store/runtime.js';
 import { makeUnit, makeView } from './factories.js';
 
@@ -75,6 +76,7 @@ describe('LiveFeed — the home route heartbeat (vision slice 2)', () => {
   beforeEach(() => {
     projects = [];
     members = {};
+    useGateStore.setState({ gates: {}, approaching: {} });
     useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
   });
 
@@ -86,9 +88,13 @@ describe('LiveFeed — the home route heartbeat (vision slice 2)', () => {
     await vi.waitFor(() => {
       expect(screen.getByTestId('live-feed')).toHaveAttribute('data-blocks', '2');
     });
-    // Before any output: the block narrates the run's truthful headline (rule 3).
-    expect(within(block('p-b') as HTMLElement).getByTestId('feed-line'))
-      .toHaveTextContent('build — wire the board');
+    // Before any output: the block states its subject from the plan — the
+    // §1.3 phase line + the current unit's description (slice BA), which
+    // REPLACE the old raw `phase — title` narration fallback.
+    const b = block('p-b') as HTMLElement;
+    expect(within(b).getByTestId('feed-phase-line')).toHaveTextContent('phase 1/1 · build');
+    expect(within(b).getByTestId('feed-unit-description')).toHaveTextContent('wire the board');
+    expect(within(b).queryByTestId('feed-line')).toBeNull();
 
     push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Writing AC-3 for the checkout flow\n' } as CoreEvent);
 
@@ -160,6 +166,58 @@ describe('LiveFeed — the home route heartbeat (vision slice 2)', () => {
     expect(failLine).toHaveAttribute('href', '/p/p-fresh/build/run-f');
     expect(within(failLine).getByTestId('feed-open-run')).toBeInTheDocument();
     expect(block('p-stale')).toBeNull();
+  });
+
+  it('the block carries phase n/N · stage + the current unit for the LEAD run (slice BA, §1.3)', async () => {
+    projects = [project('p-b', { updated_at: Date.now() })];
+    members = { 'p-b': [member('p-b', 'run-b')] };
+    const view = makeView({ id: 'run-b', status: 'executing', unit_ix: 1 }, [
+      makeUnit({ id: 'run-b:u0', session_id: 'run-b', ord: 0, stage: 'recon', status: 'done', description: 'survey' }),
+      makeUnit({ id: 'run-b:u1', session_id: 'run-b', ord: 1, stage: 'build', status: 'distributed', description: 'wire the endpoint' }),
+      makeUnit({ id: 'run-b:u2', session_id: 'run-b', ord: 2, stage: 'test', status: 'pending', description: 'run the suite' }),
+    ]);
+    await board([view]);
+
+    const b = block('p-b') as HTMLElement;
+    expect(within(b).getByTestId('feed-phase-line')).toHaveTextContent('phase 2/3 · build');
+    expect(within(b).getByTestId('feed-unit-description')).toHaveTextContent('wire the endpoint');
+
+    // A live dispatch moves the line — same store fold, no navigation, no fetch.
+    push({ type: 'unitDispatched', session: 'run-b', ord: 2, attempt: 0 } as CoreEvent);
+    await vi.waitFor(() => {
+      expect(within(block('p-b') as HTMLElement).getByTestId('feed-phase-line'))
+        .toHaveTextContent('phase 3/3 · test');
+    });
+    expect(within(block('p-b') as HTMLElement).getByTestId('feed-unit-description'))
+      .toHaveTextContent('run the suite');
+  });
+
+  it('an approaching gate paints the amber criterion line; it retires when the gate posts (EC47)', async () => {
+    projects = [project('p-b', { updated_at: Date.now() })];
+    members = { 'p-b': [member('p-b', 'run-b')] };
+    await board([running('run-b')]);
+
+    act(() => {
+      useGateStore.getState().ingest({
+        type: 'gateEscalated', session: 'run-b', ord: 0,
+        condition: 'All acceptance criteria demonstrably verified with evidence attached',
+      } as CoreEvent);
+    });
+    const line = await vi.waitFor(() =>
+      within(block('p-b') as HTMLElement).getByTestId('feed-gate-approaching'));
+    // Truncated to 40 chars (§1.3), amber mono, full criterion on the tooltip.
+    expect(line).toHaveTextContent('gate:');
+    expect(line.title).toBe('All acceptance criteria demonstrably verified with evidence attached');
+    expect(line.style.color).toBe('var(--status-gate)');
+
+    act(() => {
+      useGateStore.getState().ingest({
+        type: 'awaitingHuman', session: 'run-b', ord: 0, prompt: 'Approve?',
+      } as CoreEvent);
+    });
+    await vi.waitFor(() => {
+      expect(within(block('p-b') as HTMLElement).queryByTestId('feed-gate-approaching')).toBeNull();
+    });
   });
 
   it('every narration line is a real link to its run — href ends with data-run-id (§10.1, slice J)', async () => {

--- a/tests/ProjectCard.variants.test.tsx
+++ b/tests/ProjectCard.variants.test.tsx
@@ -181,12 +181,21 @@ describe('the ACTIVE variant — rich, but an empty region is OMITTED (§2.1.1)'
     const pill = within(card()).getByTestId('attention-pill');
     expect(pill).toHaveAttribute('data-kind', 'running');
     expect(pill).toHaveTextContent('working');
-    expect(within(card()).getByTestId('live-line')).toBeInTheDocument();
+    // Slice BA (DES-UX-002 §1.3): with nothing streamed, the active card's
+    // subject is the plan region — strip + unit description, not the old
+    // generic narration fallback.
+    expect(within(card()).getByTestId('phase-strip')).toBeInTheDocument();
+    expect(within(card()).getByTestId('active-unit-description')).toBeInTheDocument();
   });
 });
 
 describe('the vision-slice-2 card language (DES-VISION-001 §5.1)', () => {
   it('the card is token-built: --surface-card ground, --shadow-card, mono narration (EC13/EC15)', () => {
+    // Slice BA: the live line renders only what genuinely STREAMED — seed the
+    // run's delta buffer so the narration pin below has a real line to style.
+    useRuntimeStore.getState().ingest({
+      type: 'unitOutputDelta', session: 'r-live', ord: 0, text: 'Writing the token-bucket middleware\n',
+    } as never);
     render(
       <ProjectCard
         item={item('upload-endpoint', {
@@ -201,6 +210,7 @@ describe('the vision-slice-2 card language (DES-VISION-001 §5.1)', () => {
     expect(card().style.boxShadow).toBe('var(--shadow-card)');
     // Narration is DATA — the mono face at body ink (§1.5 rule 3).
     const line = within(card()).getByTestId('live-line');
+    expect(line).toHaveTextContent('Writing the token-bucket middleware');
     expect(line.style.fontFamily).toBe('var(--font-mono)');
     expect(line.style.color).toBe('var(--ink-body)');
   });

--- a/tests/gates.store.test.ts
+++ b/tests/gates.store.test.ts
@@ -32,7 +32,7 @@ describe('simple vs. complex gates (§7.11 — ≤2 choices and no free text)', 
   });
 });
 
-const reset = (): void => useGateStore.setState({ gates: {} });
+const reset = (): void => useGateStore.setState({ gates: {}, approaching: {} });
 
 describe('gate cache (§3.3 — event-sourced, self-healing, keyed by run id)', () => {
   beforeEach(reset);
@@ -80,6 +80,55 @@ describe('gate cache (§3.3 — event-sourced, self-healing, keyed by run id)', 
   it('leaves `choices` absent for the plain workflow gate the daemon sends today', () => {
     useGateStore.getState().ingest({ type: 'awaitingHuman', session: 'run-1', ord: 0, prompt: 'Proceed?' } as CoreEvent);
     expect(useGateStore.getState().gates['run-1']).not.toHaveProperty('choices');
+  });
+
+  it('gateEscalated opens the APPROACHING preview — the wire spells the field `condition` (slice BA)', () => {
+    useGateStore.getState().ingest({
+      type: 'gateEscalated', session: 'run-1', ord: 2,
+      condition: 'All acceptance criteria demonstrably verified',
+    } as CoreEvent);
+    expect(useGateStore.getState().approaching['run-1']).toMatchObject({
+      runId: 'run-1', ord: 2, condition: 'All acceptance criteria demonstrably verified',
+    });
+    // The gate itself has NOT posted — the preview is not an open gate.
+    expect(useGateStore.getState().gates['run-1']).toBeUndefined();
+  });
+
+  it('a gateEscalated missing ord or condition is dropped, never a half-record', () => {
+    useGateStore.getState().ingest({ type: 'gateEscalated', session: 'run-1', ord: 2 } as CoreEvent);
+    useGateStore.getState().ingest({ type: 'gateEscalated', session: 'run-1', condition: 'x' } as CoreEvent);
+    expect(useGateStore.getState().approaching['run-1']).toBeUndefined();
+  });
+
+  it('awaitingHuman retires the preview AND opens the gate — the §1.3 posture switch', () => {
+    useGateStore.getState().ingest({
+      type: 'gateEscalated', session: 'run-1', ord: 2, condition: 'criterion',
+    } as CoreEvent);
+    useGateStore.getState().ingest({
+      type: 'awaitingHuman', session: 'run-1', ord: 2, prompt: 'Proceed?',
+    } as CoreEvent);
+    expect(useGateStore.getState().approaching['run-1']).toBeUndefined();
+    expect(useGateStore.getState().gates['run-1']).toMatchObject({ runId: 'run-1', ord: 2 });
+  });
+
+  it.each(['gateDecided', 'resumed', 'sessionCompleted', 'runCancelled', 'sessionFailed'])(
+    'the preview retires on a %s frame — a superseded signal never lingers',
+    (type) => {
+      useGateStore.getState().ingest({
+        type: 'gateEscalated', session: 'run-1', ord: 0, condition: 'criterion',
+      } as CoreEvent);
+      useGateStore.getState().ingest({ type, session: 'run-1' } as CoreEvent);
+      expect(useGateStore.getState().approaching['run-1']).toBeUndefined();
+    },
+  );
+
+  it('an unrelated run-scoped frame leaves the store untouched (same state identity)', () => {
+    useGateStore.getState().ingest({
+      type: 'gateEscalated', session: 'run-1', ord: 0, condition: 'criterion',
+    } as CoreEvent);
+    const before = useGateStore.getState();
+    useGateStore.getState().ingest({ type: 'unitDispatched', session: 'run-1', ord: 1 } as CoreEvent);
+    expect(useGateStore.getState()).toBe(before);
   });
 
   it('reconcile keeps only still-awaiting runs (self-healing)', () => {

--- a/tests/nerveCenter.test.tsx
+++ b/tests/nerveCenter.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, render, screen, within } from '@testing-library/react';
+import { PhaseStrip } from '../src/components/PhaseStrip.js';
+import { ProjectCard } from '../src/components/ProjectCard.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import type { BoardProject } from '../src/hooks/useBoardModel.js';
+import type { CoreEvent, Project, WorkUnit } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The slice-BA DOM contracts (DES-UX-002 §1.3/§1.5) that need no browser:
+ * the phase strip's node grammar, the ACTIVE card's active-plan region
+ * (strip + 60-char unit description, moving on a live `unitDispatched`),
+ * and the gate-APPROACHING posture (EC47) — criterion preview, NO
+ * Approve/Reject, retiring into the full chip when the gate posts.
+ */
+
+/** The §1.5 fixture plan: 5 ordered units — 2 done, 1 active, 2 pending. */
+const PLAN: WorkUnit[] = [
+  makeUnit({ id: 'r-live:u0', session_id: 'r-live', ord: 0, stage: 'recon', status: 'done', description: 'survey the surface' }),
+  makeUnit({ id: 'r-live:u1', session_id: 'r-live', ord: 1, stage: 'build', status: 'done', description: 'wire the endpoint' }),
+  makeUnit({ id: 'r-live:u2', session_id: 'r-live', ord: 2, stage: 'review', status: 'distributed', description: 'review the middleware refactor against the acceptance criteria list' }),
+  makeUnit({ id: 'r-live:u3', session_id: 'r-live', ord: 3, stage: 'build', status: 'pending', description: 'apply the review fixes' }),
+  makeUnit({ id: 'r-live:u4', session_id: 'r-live', ord: 4, stage: 'test', status: 'pending', description: 'run the acceptance suite' }),
+];
+
+const THREE_DAYS = 3 * 86_400_000;
+
+function project(id: string): Project {
+  return {
+    id, name: id, description: null, status: 'active', scope: `project:${id}`,
+    created_at: Date.now() - THREE_DAYS, updated_at: Date.now() - THREE_DAYS,
+  };
+}
+
+function item(id: string, over: Partial<BoardProject> = {}): BoardProject {
+  return {
+    project: project(id), repo: null, runs: [], docs: [], attachedAt: {},
+    attention: 'quiet', score: 0, band: 'quiet', signal: null,
+    ...over,
+  };
+}
+
+const activeItem = (units: WorkUnit[] = PLAN): BoardProject =>
+  item('upload-endpoint', {
+    runs: [makeView({ id: 'r-live', status: 'executing', unit_ix: 2 }, units)],
+    attention: 'running', band: 'needs-you', score: 40,
+    signal: { kind: 'running', at: Date.now(), runId: 'r-live' },
+  });
+
+const ingest = (event: CoreEvent): void => {
+  act(() => {
+    useGateStore.getState().ingest(event);
+    useRuntimeStore.getState().ingest(event);
+  });
+};
+
+beforeEach(() => {
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
+});
+afterEach(cleanup);
+
+describe('PhaseStrip — the §1.3 node grammar', () => {
+  it('renders one node per consecutive same-stage leg with the §1.5 data marks', () => {
+    render(<PhaseStrip units={PLAN} currentOrd={2} />);
+    const nodes = screen.getAllByTestId('phase-node');
+    expect(nodes).toHaveLength(5);
+    expect(nodes.map((n) => n.dataset.stage)).toEqual(['recon', 'build', 'review', 'build', 'test']);
+    expect(nodes.filter((n) => n.dataset.complete === 'true')).toHaveLength(2);
+    expect(nodes[2]).toHaveAttribute('data-active', 'true');
+    // §1.4 tokens: done / active-dim / future ink, never literals.
+    expect(nodes[0]?.style.background).toBe('var(--status-done)');
+    expect(nodes[2]?.style.background).toBe('var(--status-run-dim)');
+    expect(nodes[3]?.style.background).toBe('var(--ink-dim)');
+  });
+
+  it('collapses past 5 nodes into an honest remaining count, never a squeeze', () => {
+    const long = Array.from({ length: 8 }, (_, i) =>
+      makeUnit({
+        id: `r:u${i}`, ord: i, status: 'pending',
+        stage: (['recon', 'build', 'review', 'test'] as const)[i % 4] ?? 'build',
+      }));
+    render(<PhaseStrip units={long} currentOrd={0} />);
+    expect(screen.getAllByTestId('phase-node')).toHaveLength(5);
+    expect(screen.getByTestId('phase-strip-overflow')).toHaveTextContent('3 remaining');
+    expect(screen.getByTestId('phase-strip')).toHaveAttribute('data-nodes', '8');
+  });
+
+  it('renders nothing for a planless run — no empty furniture', () => {
+    render(<PhaseStrip units={[]} currentOrd={undefined} />);
+    expect(screen.queryByTestId('phase-strip')).toBeNull();
+  });
+});
+
+describe('the ACTIVE card active-plan region (§1.3, §1.5)', () => {
+  it('renders the strip and the current unit description, capped at 60 chars', () => {
+    render(<ProjectCard item={activeItem()} navigate={() => {}} />);
+    const plan = screen.getByTestId('active-plan');
+    expect(plan).toHaveAttribute('data-run-id', 'r-live');
+    expect(within(plan).getByTestId('phase-strip')).toBeInTheDocument();
+    const desc = within(plan).getByTestId('active-unit-description');
+    expect(desc.textContent?.length).toBeLessThanOrEqual(60);
+    expect(desc.textContent?.startsWith('review the middleware refactor')).toBe(true);
+    expect(desc.textContent?.endsWith('…')).toBe(true);
+    // The full description survives on the tooltip.
+    expect(desc).toHaveAttribute('title', PLAN[2]?.description);
+    // Mono, muted — §1.3's spelling.
+    expect(desc.style.fontFamily).toBe('var(--font-mono)');
+    expect(desc.style.color).toBe('var(--ink-muted)');
+  });
+
+  it('a unitDispatched frame moves the description to the dispatched unit', () => {
+    render(<ProjectCard item={activeItem()} navigate={() => {}} />);
+    ingest({ type: 'unitDispatched', session: 'r-live', ord: 3, attempt: 0 } as CoreEvent);
+    expect(screen.getByTestId('active-unit-description')).toHaveTextContent('apply the review fixes');
+    const nodes = screen.getAllByTestId('phase-node');
+    expect(nodes[3]).toHaveAttribute('data-active', 'true');
+    expect(nodes[2]).not.toHaveAttribute('data-active');
+  });
+
+  it('the generic narration fallback does NOT render beside the plan region — one duty, one line', () => {
+    render(<ProjectCard item={activeItem()} navigate={() => {}} />);
+    // Nothing streamed: the description line carries the subject; no live-line.
+    expect(screen.queryByTestId('live-line')).toBeNull();
+    // Something genuinely streams for the CURRENT unit: the live line returns.
+    ingest({ type: 'unitOutputDelta', session: 'r-live', ord: 2, text: 'Checking the token-refresh path\n' } as CoreEvent);
+    expect(screen.getByTestId('live-line')).toHaveTextContent('Checking the token-refresh path');
+  });
+
+  it('a card with no moving run keeps the pre-BA model — no strip, no description', () => {
+    render(
+      <ProjectCard
+        item={item('q3-review-deck', {
+          runs: [makeView({ id: 'r-gate', status: 'awaiting_human' }, [makeUnit({ id: 'r-gate:u0', session_id: 'r-gate' })])],
+          attention: 'gate', band: 'needs-you', score: 100,
+          signal: { kind: 'gate', at: Date.now(), runId: 'r-gate' },
+        })}
+        navigate={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('active-plan')).toBeNull();
+  });
+});
+
+describe('the gate-APPROACHING posture (§1.3, EC47)', () => {
+  const CRITERION = 'All acceptance criteria demonstrably verified with evidence';
+
+  it('gateEscalated renders the preview chip — criterion named, NO Approve/Reject', () => {
+    render(<ProjectCard item={activeItem()} navigate={() => {}} />);
+    ingest({ type: 'gateEscalated', session: 'r-live', ord: 2, condition: CRITERION } as CoreEvent);
+    const chip = screen.getByTestId('gate-approaching');
+    expect(chip).toHaveAttribute('data-criterion', CRITERION);
+    expect(chip).toHaveAttribute('data-run-id', 'r-live');
+    expect(chip).toHaveTextContent('gate approaching');
+    // This is a signal to compose guidance, not an action surface.
+    expect(screen.queryByTestId('gate-approve-r-live')).toBeNull();
+    expect(screen.queryByTestId('gate-reject-r-live')).toBeNull();
+    // §1.4: the gate chip vocabulary — amber on the dim gate surface.
+    expect(chip.style.background).toBe('var(--status-gate-dim)');
+  });
+
+  it('the preview retires into the FULL chip when the gate posts (awaitingHuman)', () => {
+    render(<ProjectCard item={activeItem()} navigate={() => {}} />);
+    ingest({ type: 'gateEscalated', session: 'r-live', ord: 2, condition: CRITERION } as CoreEvent);
+    ingest({ type: 'awaitingHuman', session: 'r-live', ord: 2, prompt: 'Approve the review?' } as CoreEvent);
+    expect(screen.queryByTestId('gate-approaching')).toBeNull();
+  });
+});

--- a/tests/phaseProgress.test.ts
+++ b/tests/phaseProgress.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  currentUnitOf,
+  leadMovingRun,
+  phaseLineOf,
+  phaseNodesOf,
+  truncate,
+} from '../src/board/phaseProgress.js';
+import type { LoggedEvent } from '../src/store/runtime.js';
+import type { WorkUnit } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The slice-BA CLIENT derivation (DES-UX-002 §1.2): phase progress over the
+ * unit plan the board already holds, with the live `unitDispatched` wire on
+ * top. Pure functions — every verdict here is pinned with no React and no
+ * clock.
+ */
+
+/** The §1.5 fixture plan: 5 ordered units, 2 done, 1 active, 2 pending —
+ *  5 nodes because a return-to-build leg IS a distinct leg of the plan
+ *  (StageKind has only 4 values; the wire cannot spell 5 distinct stages). */
+const PLAN: WorkUnit[] = [
+  makeUnit({ id: 'r:u0', ord: 0, stage: 'recon', status: 'done', description: 'survey the surface' }),
+  makeUnit({ id: 'r:u1', ord: 1, stage: 'build', status: 'done', description: 'wire the endpoint' }),
+  makeUnit({ id: 'r:u2', ord: 2, stage: 'review', status: 'distributed', description: 'review the middleware refactor' }),
+  makeUnit({ id: 'r:u3', ord: 3, stage: 'build', status: 'pending', description: 'apply the review fixes' }),
+  makeUnit({ id: 'r:u4', ord: 4, stage: 'test', status: 'pending', description: 'run the acceptance suite' }),
+];
+
+const logged = (type: string, ord: number, seq = 1): LoggedEvent => ({ seq, type, ord, ts: 0, detail: '' });
+
+describe('truncate — the §1.3 one-line cap, honestly elided', () => {
+  it('passes a short description through untouched', () => {
+    expect(truncate('wire the board', 60)).toBe('wire the board');
+  });
+
+  it('caps at the limit INCLUDING the ellipsis — never cap+1 chars', () => {
+    const long = 'x'.repeat(80);
+    expect(truncate(long, 60)).toHaveLength(60);
+    expect(truncate(long, 60).endsWith('…')).toBe(true);
+  });
+});
+
+describe('currentUnitOf — §1.2 rule order (live dispatch → distributed → pending-after-done)', () => {
+  it('no log: the distributed unit is the current one', () => {
+    expect(currentUnitOf(PLAN)?.ord).toBe(2);
+  });
+
+  it('the newest unitDispatched in the live log wins over the (stale) unit list', () => {
+    const log = [logged('unitDispatched', 2, 1), logged('unitDispatched', 3, 2)];
+    expect(currentUnitOf(PLAN, log)?.ord).toBe(3);
+  });
+
+  it('a dispatch whose unit the fresher list already shows terminal yields to the list', () => {
+    const log = [logged('unitDispatched', 1, 1)]; // u1 is done — stale frame
+    expect(currentUnitOf(PLAN, log)?.ord).toBe(2);
+  });
+
+  it('non-dispatch frames in the log are not position claims', () => {
+    const log = [logged('unitOutputCaptured', 4, 1)];
+    expect(currentUnitOf(PLAN, log)?.ord).toBe(2);
+  });
+
+  it('no distributed unit: the lowest-ord pending after the last done', () => {
+    const plan = [
+      makeUnit({ id: 'r:u0', ord: 0, stage: 'recon', status: 'done' }),
+      makeUnit({ id: 'r:u1', ord: 1, stage: 'build', status: 'pending' }),
+      makeUnit({ id: 'r:u2', ord: 2, stage: 'test', status: 'pending' }),
+    ];
+    expect(currentUnitOf(plan)?.ord).toBe(1);
+  });
+
+  it('an all-done plan has NO current unit — the strip never states a false position', () => {
+    const plan = PLAN.map((u) => ({ ...u, status: 'done' as const }));
+    expect(currentUnitOf(plan)).toBeUndefined();
+  });
+
+  it('an empty plan has no current unit', () => {
+    expect(currentUnitOf([])).toBeUndefined();
+  });
+});
+
+describe('phaseNodesOf — consecutive same-stage legs, §1.3 grouping', () => {
+  it('the §1.5 fixture plan yields 5 nodes: 2 complete, 1 active, 2 future', () => {
+    const nodes = phaseNodesOf(PLAN, 2);
+    expect(nodes.map((n) => n.stage)).toEqual(['recon', 'build', 'review', 'build', 'test']);
+    expect(nodes.map((n) => n.state)).toEqual(['complete', 'complete', 'active', 'future', 'future']);
+  });
+
+  it('consecutive same-stage units fold into ONE node spanning their ords', () => {
+    const plan = [
+      makeUnit({ id: 'r:u0', ord: 0, stage: 'recon', status: 'done' }),
+      makeUnit({ id: 'r:u1', ord: 1, stage: 'build', status: 'done' }),
+      makeUnit({ id: 'r:u2', ord: 2, stage: 'build', status: 'distributed' }),
+    ];
+    const nodes = phaseNodesOf(plan, 2);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[1]?.ords).toEqual([1, 2]);
+    // The leg holding the current unit is ACTIVE even though a sibling is done.
+    expect(nodes[1]?.state).toBe('active');
+  });
+
+  it('no current ord: nodes are complete or future, none active', () => {
+    const nodes = phaseNodesOf(PLAN, undefined);
+    expect(nodes.some((n) => n.state === 'active')).toBe(false);
+    expect(nodes[0]?.state).toBe('complete');
+    expect(nodes[2]?.state).toBe('future'); // distributed ≠ every-unit-done
+  });
+
+  it('units arrive unsorted: nodes group in ord order regardless', () => {
+    const nodes = phaseNodesOf([...PLAN].reverse(), 2);
+    expect(nodes.map((n) => n.stage)).toEqual(['recon', 'build', 'review', 'build', 'test']);
+  });
+});
+
+describe('phaseLineOf — the sidebar line, never a position it does not hold', () => {
+  it('spells phase n/N · stage-name off the active node', () => {
+    expect(phaseLineOf(phaseNodesOf(PLAN, 2))).toBe('phase 3/5 · review');
+  });
+
+  it('is null with no active node (no plan, or a terminal run)', () => {
+    expect(phaseLineOf(phaseNodesOf(PLAN, undefined))).toBeNull();
+    expect(phaseLineOf([])).toBeNull();
+  });
+});
+
+describe('leadMovingRun — whose plan the card strip shows', () => {
+  it('picks the first run moving under its own power; terminal and gated runs never lead', () => {
+    const gated = makeView({ id: 'r-gate', status: 'awaiting_human' });
+    const done = makeView({ id: 'r-done', status: 'completed' });
+    const live = makeView({ id: 'r-live', status: 'executing' });
+    expect(leadMovingRun([gated, done, live])?.session.id).toBe('r-live');
+    expect(leadMovingRun([gated, done])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements **DES-UX-002 §1 (slice BA)** — the portfolio nerve center's active-card enrichment (EC46, EC47).

- `phaseProgress.ts`: pure client derivation of the run's phase legs from real units/events; `PhaseStrip` with done/active/pending nodes (>5 collapses honestly).
- ACTIVE project cards gain the phase strip + current-unit description (fixes the observed hole: a project with two working runs filed under QUIET with "Nothing needs you right now" — recorded live during this campaign).
- **EC47**: a gate-approaching chip renders from `gateEscalated`'s real `condition` field with a criterion preview — no Approve/Reject on the preview; it retires on awaitingHuman/decision/terminal.
- LiveFeed lines upgrade to "phase n/N · stage" + description, replacing the raw narration fallback.

Verified: 1511/1511 unit tests post-rebase; slice rig (every §1.5 AC incl. request-taps proving zero new HTTP on dispatch/escalation) ×2; 11 regression rigs incl. studio_standalone 22/22 against a real spawned daemon; adversarial verifier approved with a negative check vs main. 312 LOC (~320 budget). Two pre-existing stale pins in studio_standalone re-scoped in dedicated commits (red on main before this branch). Post-rebase fixture header reconcile as a dedicated commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
