### PR TITLE
Doc surface: operator feedback round — tabbed right panel, slim band, growing composer, Versions tab

### DIFF
--- a/e2e/ux2_docfb_test.py
+++ b/e2e/ux2_docfb_test.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+ux2_docfb_test.py — the doc-feedback-round gate: OPERATOR FEEDBACK on the
+Document surface, each verbatim bullet mapped to an AC and proven in a real
+browser against the shared W2 fixture (uxfix_fixture.py). No crew daemon.
+
+The operator's words, verbatim, and the AC each one becomes:
+
+  1. "export should move under chat box in right panel"
+       AC1: the ExportMenu renders INSIDE the panel's Chat tab, geometrically
+       BELOW the composer (measured rects, not inferred), and the slice-X
+       point-of-action contract rides along at the NEW click site unchanged:
+       export-pending on the clicked control, export-ready as a REAL anchor
+       whose same-origin href serves attachment-framed bytes, the thread
+       message remaining. The strip carries NO export control in either spot.
+  2. "Compare & Theme should become tabs on chat panel to right"
+       AC2: the right panel is a tabbed column — Chat | Compare | Theme |
+       Versions, in that order. The Compare tab wears the slice-K controls
+       (same testids; toggling renders the two compare-pane iframes on the
+       CANVAS — the lens stays the canvas owner's); the Theme tab hosts the
+       doc-scoped learn form INLINE (same testids, same EC37 lifecycle:
+       inflight → done), with NO themes-open trigger anywhere on the surface.
+  3. "The banner at bottom should only be versions, but get rid of the
+     'Threads X' and make the right chat column have it's own expand/collapse"
+       AC3a: the band is the SLIM variant — version pills only: no Fork /
+       In-thread chiclets, no spine caption, no [Themes]/[Export] toolbar, no
+       thread-toggle, no compare cluster, and no 'Thread'-labeled control.
+       AC3b: the panel owns its OWN expand/collapse — panel-collapse shrinks
+       it to the rail (canvas measurably reflows wider), panel-expand and the
+       rail's tab buttons bring it back (a rail tab lands STRAIGHT on its tab).
+  4. "remove the 'fork' and 'in thread' chiclets and reduce the overall height
+     of the band"
+       AC4: the band's height is MEASURED ≤ SLIM_BAND_MAX_PX (the old full
+       band stacked version+stamp+two-action-row entries inside 10px padding —
+       ~80px+; the slim row is a single pill line inside 4px padding). The
+       §0-protected gestures SURVIVE in the Versions tab: Fork forks (the
+       service's answer navigates to the new version), In-thread flips the
+       panel to Chat and focuses the producing message.
+  5. "chatbox should expand when typing (to like a max of 5 lines, the scroll
+     with more content (can't stay one line)"
+       AC5: driven by KEYBOARD TYPING (Shift+Enter for the newlines — plain
+       Enter submits): 1 line stays 1 line high; 3 lines grow the textarea to
+       3 lines; 7 lines cap it at 5 lines (COMPOSER_MAX_LINES × 24px) with
+       overflow-y auto actually scrolling (scrollHeight > clientHeight);
+       clearing shrinks it back to one line.
+  6. "additional version tab with details on each version, it can use the git
+     history"
+       AC6: the Versions tab renders one detail row per REAL manifest entry
+       (GET /d/:doc/api/versions — versions.json verbatim), newest first,
+       showing version, lineage (parent), timestamp and the html_file record
+       — cross-checked against the SAME wire fetched independently by this
+       rig. The document workspace keeps NO git wire (verified against
+       wicked-interactive server.js: loadManifest reads versions.json and
+       nothing else), so the tab SAYS the manifest is the history — the
+       honesty line is pinned verbatim-ish, and nothing on the tab dresses
+       up as a commit.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into
+e2e/shots/vision/:
+  ux2-docfb-panel.png      the tabbed panel on Chat: export under the chatbox,
+                           the slim band beneath the canvas
+  ux2-docfb-versions.png   the Versions tab: detail rows + the honesty line
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4410),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+    wake_strip,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4410"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+DOC_URL = f"{ORIGIN}/p/scratch/document"
+BRIEF = "Make me a deck for the Q3 review"
+STEER = "Tighten the headline on slide one"
+
+# AC4's measured bound: the slim band is one pill row (text-xs line ≈ 19px +
+# 2px pill borders) inside 4px vertical padding + the 2px accent rule — ~33px
+# rendered. 44px is the bound with rendering slack; the OLD band could not get
+# under ~80px (version + stamp + action row stacked in a 10px-padded entry).
+SLIM_BAND_MAX_PX = 44
+
+# The composer's growth constants — DocumentThread.tsx COMPOSER_MAX_LINES /
+# COMPOSER_LINE_PX, pinned here so a drive-by change re-answers the operator.
+LINE_PX = 24
+MAX_LINES = 5
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as res:
+        return json.loads(res.read())
+
+
+# ── 1. The same-origin build + the shared W2 fixture (default switches) ────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    console_errors: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # ── Scene 0: the journey — create v1, steer v2 (the slice-6 W3 shape) ──────
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+
+    # ── AC5 FIRST (a pristine composer): growth 1 → 3 → cap-at-5 → scroll ──────
+    composer = page.locator('[data-testid="doc-composer"]')
+    composer.click()
+    page.keyboard.type("line one")
+    one = page.evaluate(
+        """() => { const el = document.querySelector('[data-testid="doc-composer"]');
+                   return { h: el.clientHeight, overflow: getComputedStyle(el).overflowY }; }""")
+    for line in ["line two", "line three"]:
+        page.keyboard.press("Shift+Enter")
+        page.keyboard.type(line)
+    three = page.evaluate(
+        """() => { const el = document.querySelector('[data-testid="doc-composer"]');
+                   return { h: el.clientHeight, overflow: getComputedStyle(el).overflowY }; }""")
+    for line in ["line four", "line five", "line six", "line seven"]:
+        page.keyboard.press("Shift+Enter")
+        page.keyboard.type(line)
+    seven = page.evaluate(
+        """() => { const el = document.querySelector('[data-testid="doc-composer"]');
+                   return { h: el.clientHeight, scrollH: el.scrollHeight,
+                            overflow: getComputedStyle(el).overflowY,
+                            maxLines: el.getAttribute('data-max-lines') }; }""")
+    composer.fill("")
+    cleared = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-composer"]').clientHeight""")
+    check("AC5_composer_grows_then_scrolls",
+          # 1 line: one line high (± the sub-pixel slack), no scrollbar.
+          abs(one["h"] - LINE_PX) <= 2 and one["overflow"] == "hidden"
+          # 3 lines: grew to exactly 3 lines — expansion, not a jump to max.
+          and abs(three["h"] - 3 * LINE_PX) <= 2 and three["overflow"] == "hidden"
+          # 7 lines: capped at 5 lines and genuinely scrolling past the cap.
+          and abs(seven["h"] - MAX_LINES * LINE_PX) <= 2
+          and seven["overflow"] == "auto" and seven["scrollH"] > seven["h"]
+          and seven["maxLines"] == str(MAX_LINES)
+          # cleared: back to one line — growth is content-driven both ways.
+          and abs(cleared - LINE_PX) <= 2,
+          one_line=one, three_lines=three, seven_lines=seven, cleared_h=cleared)
+
+    # Create v1, then steer v2 — the versions the tabs act on.
+    composer.fill(BRIEF)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
+    v1_msg_id = page.evaluate(
+        """() => document.querySelector('[data-testid="doc-message"]')
+                  ?.getAttribute('data-message-id')""")
+    composer.fill(STEER)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+
+    doc_id = urlparse(page.url).path.rsplit("/", 1)[-1]
+    manifest = get_json(f"{ORIGIN}/api/v1/projects/scratch/interactive/d/{doc_id}/api/versions")
+
+    # ── AC2 (structure): the tabbed column — Chat | Compare | Theme | Versions ─
+    tabs = page.evaluate(
+        """() => {
+             const panel = document.querySelector('[data-testid="doc-panel"]');
+             const tabs = Array.from(document.querySelectorAll('[data-testid="panel-tab"]'));
+             return {
+               panelUp: !!panel,
+               activeTab: panel?.getAttribute('data-tab'),
+               order: tabs.map(t => t.getAttribute('data-tab')),
+               labels: tabs.map(t => (t.textContent || '').trim()),
+               collapseInPanel: !!panel?.querySelector('[data-testid="panel-collapse"]'),
+               threadInChatBody: !!document.querySelector(
+                 '[data-testid="panel-body"][data-tab="chat"] [data-testid="thread"]'),
+             };
+           }""")
+    check("AC2_tab_structure",
+          tabs["panelUp"] and tabs["activeTab"] == "chat"
+          and tabs["order"] == ["chat", "compare", "theme", "versions"]
+          and tabs["labels"] == ["Chat", "Compare", "Theme", "Versions"]
+          and tabs["collapseInPanel"] and tabs["threadInChatBody"], **tabs)
+
+    # ── AC1: export UNDER the chat box, in the right panel — measured ───────────
+    under = page.evaluate(
+        """() => {
+             const chatBody = document.querySelector('[data-testid="panel-body"][data-tab="chat"]');
+             const exportBox = chatBody?.querySelector('[data-testid="chat-export"]');
+             const menu = exportBox?.querySelector('[data-testid="export-menu"]');
+             const composer = chatBody?.querySelector('[data-testid="doc-composer"]');
+             const er = exportBox?.getBoundingClientRect(), cr = composer?.getBoundingClientRect();
+             const strip = document.querySelector('[data-testid="version-strip"]');
+             return {
+               exportInChatTab: !!menu,
+               belowComposer: !!er && !!cr && er.top >= cr.bottom - 2,
+               stripHasNoExport: !!strip && !strip.querySelector('[data-testid="export-menu"]')
+                 && !strip.querySelector('[data-testid="export-format"]'),
+             };
+           }""")
+    check("AC1_export_under_chatbox",
+          under["exportInChatTab"] and under["belowComposer"] and under["stripHasNoExport"],
+          **under)
+
+    page.screenshot(path=str(VSHOTS / "ux2-docfb-panel.png"))
+
+    # AC1 (behavior): the slice-X point-of-action contract at the NEW click site.
+    set_fixture(ORIGIN, export_delay_ms=1500)
+    page.locator('[data-testid="chat-export"] [data-testid="export-format"][data-format="html"]').click()
+    page.locator('[data-testid="export-pending"]').wait_for(timeout=5000)
+    pending = page.evaluate(
+        """() => {
+             const pend = document.querySelector('[data-testid="export-pending"]');
+             const host = pend?.closest('[data-testid="export-format"]');
+             const inChat = !!pend?.closest('[data-testid="chat-export"]');
+             const others = Array.from(
+               document.querySelectorAll('[data-testid="export-format"]'))
+               .filter(b => b.getAttribute('data-format') !== 'html');
+             return { onClickedControl: host?.getAttribute('data-format') === 'html',
+                      answersUnderChatbox: inChat,
+                      siblingsHeld: others.length > 0 && others.every(b => b.disabled) };
+           }""")
+    ready = page.locator('[data-testid="export-ready"][data-format="html"]')
+    ready.wait_for(timeout=15000)
+    facts = page.evaluate(
+        """() => {
+             const a = document.querySelector('[data-testid="export-ready"]');
+             const inThread = Array.from(
+               document.querySelectorAll('[data-testid="doc-agent"]'))
+               .some(m => /export ready/i.test(m.textContent || '')
+                          && !!m.querySelector('[data-testid="doc-artifact-download"]'));
+             return { tag: a?.tagName ?? null, href: a?.getAttribute('href') ?? null,
+                      file: a?.getAttribute('download') ?? null,
+                      sameOrigin: (a?.href ?? '').startsWith(location.origin),
+                      inChatExport: !!a?.closest('[data-testid="chat-export"]'),
+                      threadMessageRemains: inThread };
+           }""")
+    dl = page.request.get(f"{ORIGIN}{facts['href']}" if (facts["href"] or "").startswith("/")
+                          else (facts["href"] or ""))
+    check("AC1_export_answers_at_new_click_site",
+          pending["onClickedControl"] and pending["answersUnderChatbox"]
+          and pending["siblingsHeld"]
+          and facts["tag"] == "A" and facts["sameOrigin"] and facts["inChatExport"]
+          and facts["file"] == f"{doc_id}_v2.html"  # per-version: v2 is addressed
+          and facts["threadMessageRemains"]
+          and dl.status == 200
+          and "attachment" in (dl.headers.get("content-disposition") or "")
+          and len(dl.body()) > 0,
+          **pending, **facts, dl_status=dl.status)
+    set_fixture(ORIGIN, export_delay_ms=0)
+
+    # ── AC3a + AC4 (band): versions only, measured height ───────────────────────
+    wake_strip(page)
+    band = page.evaluate(
+        """() => {
+             const strip = document.querySelector('[data-testid="version-strip"]');
+             const r = strip?.getBoundingClientRect();
+             const q = (sel) => strip ? strip.querySelectorAll(sel).length : -1;
+             return {
+               variant: strip?.getAttribute('data-variant'),
+               height: r ? r.height : null,
+               pills: q('[data-testid="version-entry"]'),
+               forkChiclets: q('[data-testid="version-fork"]'),
+               inThreadChiclets: q('[data-testid="version-scroll"]'),
+               caption: q('[data-testid="version-spine-caption"]'),
+               themes: q('[data-testid="themes-open"]'),
+               exports: q('[data-testid="export-menu"]'),
+               compare: q('[data-testid="version-compare-toggle"]'),
+               threadToggle: q('[data-testid="thread-toggle"]'),
+               threadsLabel: /Thread/.test(strip?.textContent || ''),
+             };
+           }""")
+    check("AC3a_AC4_band_is_versions_only_and_short",
+          band["variant"] == "slim"
+          and band["pills"] == 2
+          and band["forkChiclets"] == 0 and band["inThreadChiclets"] == 0
+          and band["caption"] == 0 and band["themes"] == 0 and band["exports"] == 0
+          and band["compare"] == 0 and band["threadToggle"] == 0
+          and not band["threadsLabel"]
+          and band["height"] is not None and band["height"] <= SLIM_BAND_MAX_PX,
+          **band, max_px=SLIM_BAND_MAX_PX)
+
+    # ── AC3b: the panel's OWN expand/collapse — the canvas measurably reflows ──
+    canvas_w_open = page.evaluate(
+        """() => document.querySelector('[data-testid="document-canvas"]')
+                  .getBoundingClientRect().width""")
+    page.locator('[data-testid="panel-collapse"]').click()
+    page.locator('[data-testid="doc-panel-rail"]').wait_for(timeout=15000)
+    collapsed = page.evaluate(
+        """() => ({
+             panelGone: !document.querySelector('[data-testid="doc-panel"]'),
+             railTabs: Array.from(document.querySelectorAll('[data-testid="panel-rail-tab"]'))
+               .map(t => t.getAttribute('data-tab')),
+             canvasW: document.querySelector('[data-testid="document-canvas"]')
+               .getBoundingClientRect().width,
+           })""")
+    # Expand STRAIGHT onto a tab from the rail — the versions tab, for AC6.
+    page.locator('[data-testid="panel-rail-tab"][data-tab="versions"]').click()
+    page.locator('[data-testid="doc-panel"][data-tab="versions"]').wait_for(timeout=15000)
+    check("AC3b_panel_owns_expand_collapse",
+          collapsed["panelGone"]
+          and collapsed["railTabs"] == ["chat", "compare", "theme", "versions"]
+          and collapsed["canvasW"] > canvas_w_open + 100,
+          **collapsed, canvas_w_open=canvas_w_open)
+
+    # ── AC6: the Versions tab — detail rows off the REAL manifest, honest copy ──
+    page.locator('[data-testid="version-detail"]').first.wait_for(timeout=15000)
+    detail = page.evaluate(
+        """() => {
+             const note = document.querySelector('[data-testid="versions-history-note"]');
+             const rows = Array.from(document.querySelectorAll('[data-testid="version-detail"]'));
+             const body = document.querySelector('[data-testid="panel-body"][data-tab="versions"]');
+             return {
+               note: note?.textContent || '',
+               rows: rows.map(r => ({
+                 version: r.getAttribute('data-version'),
+                 parent: r.getAttribute('data-parent'),
+                 selected: r.getAttribute('data-selected'),
+                 stamp: r.querySelector('[data-testid="version-detail-stamp"]')?.textContent || '',
+                 lineage: r.querySelector('[data-testid="version-detail-lineage"]')?.textContent || '',
+                 files: r.querySelector('[data-testid="version-detail-files"]')?.textContent || '',
+               })),
+               noCommitDress: !/\\bcommit\\b/i.test(body?.textContent || ''),
+             };
+           }""")
+    wire = sorted(manifest["versions"], key=lambda e: -e["version"])
+    rows_match = (
+        len(detail["rows"]) == len(wire)
+        and all(
+            r["version"] == str(e["version"])
+            and r["parent"] == ("" if e["parent"] is None else str(e["parent"]))
+            and e["html_file"] in r["files"]
+            and r["stamp"].strip() != ""
+            for r, e in zip(detail["rows"], wire))
+    )
+    check("AC6_versions_tab_from_real_manifest",
+          rows_match
+          # The honesty line: the operator asked for git history; the workspace
+          # has no git wire, and the tab says the manifest IS the history.
+          and "keeps no" in detail["note"] and "git log" in detail["note"]
+          and "manifest is the history" in detail["note"]
+          and detail["noCommitDress"]
+          and detail["rows"][0]["selected"] == "true"  # newest first; v2 shown
+          and "root" in detail["rows"][-1]["lineage"],
+          wire_versions=[e["version"] for e in wire], **detail)
+
+    page.screenshot(path=str(VSHOTS / "ux2-docfb-versions.png"))
+
+    # ── AC4 (gestures survive): Fork from the tab is the REAL service fork ─────
+    page.locator('[data-testid="version-detail"][data-version="1"] [data-testid="version-fork"]').click()
+    page.locator('[data-testid="version-entry"][data-version="3"]').wait_for(timeout=30000)
+    page.locator('[data-testid="version-detail"][data-version="3"]').wait_for(timeout=30000)
+    forked = page.evaluate(
+        """() => ({
+             url: location.pathname + location.search,
+             lineage: document.querySelector(
+               '[data-testid="version-detail"][data-version="3"] '
+               + '[data-testid="version-detail-lineage"]')?.textContent || '',
+             pills: document.querySelectorAll(
+               '[data-testid="version-strip"] [data-testid="version-entry"]').length,
+           })""")
+    check("AC4_fork_survives_in_versions_tab",
+          forked["url"].endswith("?v=3")
+          and "branched from v1" in forked["lineage"]
+          and forked["pills"] == 3,
+          **forked)
+
+    # ── AC4 (gestures survive): In-thread flips the panel to Chat and focuses ──
+    page.locator('[data-testid="version-detail"][data-version="1"] [data-testid="version-scroll"]').click()
+    page.locator('[data-testid="doc-panel"][data-tab="chat"]').wait_for(timeout=15000)
+    page.wait_for_function(
+        """(id) => document.activeElement?.getAttribute('data-message-id') === id""",
+        arg=v1_msg_id, timeout=15000)
+    check("AC4_in_thread_flips_to_chat_and_focuses", True, focused=v1_msg_id)
+
+    # ── AC2 (behavior): the Compare tab drives the canvas lens ─────────────────
+    page.locator('[data-testid="panel-tab"][data-tab="compare"]').click()
+    page.locator('[data-testid="compare-explainer"]').wait_for(timeout=15000)
+    page.locator('[data-testid="version-compare-toggle"]').click()
+    page.locator('[data-testid="compare-panes"]').wait_for(timeout=15000)
+    cmp = page.evaluate(
+        """() => {
+             const panes = Array.from(document.querySelectorAll('[data-testid="compare-pane"]'));
+             const inCanvas = panes.every(p =>
+               !!p.closest('[data-testid="document-canvas"]'));
+             return {
+               versions: panes.map(p => p.getAttribute('data-version')),
+               panesOnCanvas: inCanvas,
+               controlsInPanel: !!document.querySelector(
+                 '[data-testid="panel-body"][data-tab="compare"] [data-testid="compare-controls"]'),
+             };
+           }""")
+    page.locator('[data-testid="compare-exit"]').click()
+    page.locator('[data-testid="compare-panes"]').wait_for(state="detached", timeout=15000)
+    check("AC2_compare_tab_drives_canvas_lens",
+          # v3 is selected; its lineage parent v1 is the default comparand.
+          cmp["versions"] == ["3", "1"] and cmp["panesOnCanvas"] and cmp["controlsInPanel"],
+          **cmp)
+
+    # ── AC2 (behavior): the Theme tab hosts the inline learn form, EC37 intact ─
+    page.locator('[data-testid="panel-tab"][data-tab="theme"]').click()
+    page.locator('[data-testid="panel-body"][data-tab="theme"] [data-testid="themes-panel"]') \
+        .wait_for(timeout=15000)
+    no_trigger = page.evaluate(
+        """() => document.querySelectorAll('[data-testid="themes-open"]').length""")
+    page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
+    page.locator('[data-testid="themes-submit"]').click()
+    page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
+    page.locator('[data-testid="learn-done"]').wait_for(timeout=90000)
+    check("AC2_theme_tab_inline_learn_lifecycle", no_trigger == 0,
+          themes_open_triggers=no_trigger)
+
+    # Console hygiene: nothing unexpected (the learned-theme 404s before a learn
+    # ripens are the readback's real contract, logged by the browser as resource
+    # errors).
+    unexpected = [e for e in console_errors
+                  if "404" not in e and "Failed to load resource" not in e]
+    check("console_hygiene", unexpected == [], errors=unexpected)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["shots"] = ["ux2-docfb-panel.png", "ux2-docfb-versions.png"]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_sliceT_test.py
+++ b/e2e/ux_sliceT_test.py
@@ -25,8 +25,13 @@ The §6.1 / §6.3 DOM ACs, verbatim mapping:
      ONE `GET /d/:doc/api/conversation` on doc open — the one sanctioned mount
      fetch this slice adds; the other doc-open reads stay the standing manifest
      + rendered-doc pair), the version markers are back from the session-storage
-     stopgap, the strip's "In thread" is enabled and scrolls, and the stopgap
-     note is ABSENT (nothing is missing).
+     stopgap, "In thread" is enabled and scrolls, and the stopgap note is
+     ABSENT (nothing is missing).
+
+     DOC-FEEDBACK RE-SCOPE: the thread opens via the right panel's own rail
+     (the strip's thread-toggle retired with the slim band), and the In-thread
+     gesture lives in the panel's Versions tab per-version rows — clicking it
+     flips the panel to Chat first, so the focus assertion is awaited.
   4. §6.3 fresh-session reload (cleared session storage + bridge restart): the
      text is STILL back from the wire — never an empty state — while the
      version-anchor gap (the only thing the wire lacks) is stated by
@@ -55,7 +60,6 @@ from uxfix_fixture import (
     ensure_build,
     set_fixture,
     start_server,
-    wake_strip,
 )
 
 FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4383"))
@@ -281,9 +285,10 @@ with sync_playwright() as p:
           conv_reads == [conv_path] and unsanctioned == [],
           conversation_reads=conv_reads, unsanctioned=unsanctioned, mount_gets=mount_gets)
 
-    # Open the drawer (closed by default on a doc route) and assert the thread.
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    # Open the panel onto Chat (doc-feedback re-scope: the thread is no longer
+    # a strip-toggled drawer — the right panel collapses to its own rail on a
+    # doc route, and a rail tab expands it straight onto its tab).
+    page.locator('[data-testid="panel-rail-tab"][data-tab="chat"]').click()
     page.locator('[data-testid="thread"]').wait_for(timeout=30000)
     same_session = page.evaluate(
         """(brief) => {
@@ -309,20 +314,30 @@ with sync_playwright() as p:
           and same_session["stopgapAbsent"],
           **same_session)
 
-    # §6.3: the strip's "In thread" is ENABLED for the reloaded session's v1 and
-    # actually scrolls — the anchor survived the reload.
-    wake_strip(page)
-    v1_scroll = page.locator('[data-testid="version-entry"][data-version="1"] [data-testid="version-scroll"]')
-    v1_enabled = v1_scroll.is_enabled()
-    v1_scroll.click()
-    landed_on_msg = page.evaluate(
-        """() => {
-             const el = document.activeElement;
-             return el?.getAttribute('data-testid') === 'doc-message'
-               ? el.getAttribute('data-message-id') : null;
-           }""")
+    # §6.3: "In thread" is ENABLED for the reloaded session's v1 and actually
+    # scrolls — the anchor survived the reload. Doc-feedback re-scope: the
+    # In-thread gesture moved off the band into the panel's VERSIONS TAB
+    # (per-version detail rows); clicking it flips the panel to Chat first —
+    # the thread lives there — and focuses the producing message on the next
+    # frame, so the focus is awaited, not read synchronously.
     v1_cause = page.locator('[data-testid="version-marker"][data-version="1"]') \
         .get_attribute("data-caused-by")
+    page.locator('[data-testid="panel-tab"][data-tab="versions"]').click()
+    v1_scroll = page.locator(
+        '[data-testid="version-detail"][data-version="1"] [data-testid="version-scroll"]')
+    v1_scroll.wait_for(timeout=30000)
+    v1_enabled = v1_scroll.is_enabled()
+    v1_scroll.click()
+    page.locator('[data-testid="doc-panel"][data-tab="chat"]').wait_for(timeout=15000)
+    try:
+        page.wait_for_function(
+            """(id) => document.activeElement?.getAttribute('data-testid') === 'doc-message'
+                       && document.activeElement?.getAttribute('data-message-id') === id""",
+            arg=v1_cause, timeout=15000)
+        landed_on_msg = v1_cause
+    except Exception:
+        landed_on_msg = page.evaluate(
+            """() => document.activeElement?.getAttribute('data-message-id') ?? null""")
     check("T11_in_thread_enabled_and_scrolls_after_reload",
           v1_enabled and landed_on_msg == v1_cause,
           enabled=v1_enabled, focused=landed_on_msg, expected=v1_cause)
@@ -334,8 +349,8 @@ with sync_playwright() as p:
     page.reload(wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)  # re-add: styles die with the reload
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    # Doc-feedback re-scope: rail tab instead of the retired strip toggle.
+    page.locator('[data-testid="panel-rail-tab"][data-tab="chat"]').click()
     page.locator('[data-testid="thread"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread-stopgap"]').wait_for(timeout=30000)
 
@@ -345,28 +360,38 @@ with sync_playwright() as p:
              const texts = Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
                .map((m) => m.textContent || '');
              const stopgap = document.querySelector('[data-testid="thread-stopgap"]')?.textContent || '';
-             const scrolls = Array.from(document.querySelectorAll('[data-testid="version-scroll"]'));
              return {
                textBack: texts.some((t) => t.includes(brief)) && texts.some((t) => t.includes(steer)),
                narrationBack: !!document.querySelector('[data-testid="doc-narration"]'),
                noMarkerFaked: !document.querySelector('[data-testid="version-marker"]'),
                noEmptyState: !!texts.length,
                stopgap,
-               inThreadAllDisabled: scrolls.length > 0 && scrolls.every((b) => b.disabled),
-               disabledReasonHonest: (scrolls[0]?.title || '').includes('version anchors'),
              };
            }""", [BRIEF, STEER])
     stopgap_ok = all(phrase in fresh["stopgap"] for phrase in STOPGAP_MUST_SAY)
     conv_reads = [g for g in interactive_gets if g.endswith("/api/conversation")]
+
+    page.screenshot(path=str(VSHOTS / "ux-T-thread-reload.png"))
+
+    # The In-thread affordances live in the panel's Versions tab now (doc-
+    # feedback re-scope) — open it to read their disabled-with-reason state.
+    page.locator('[data-testid="panel-tab"][data-tab="versions"]').click()
+    page.locator('[data-testid="version-detail"]').first.wait_for(timeout=30000)
+    scroll_state = page.evaluate(
+        """() => {
+             const scrolls = Array.from(document.querySelectorAll('[data-testid="version-scroll"]'));
+             return {
+               inThreadAllDisabled: scrolls.length > 0 && scrolls.every((b) => b.disabled),
+               disabledReasonHonest: (scrolls[0]?.title || '').includes('version anchors'),
+             };
+           }""")
     check("T12_fresh_session_text_back_stopgap_on_anchor_gap_only",
           fresh["textBack"] and fresh["narrationBack"] and fresh["noMarkerFaked"]
           and fresh["noEmptyState"] and stopgap_ok
-          and fresh["inThreadAllDisabled"] and fresh["disabledReasonHonest"]
+          and scroll_state["inThreadAllDisabled"] and scroll_state["disabledReasonHonest"]
           and conv_reads == [conv_path],
-          stopgap_copy_ok=stopgap_ok, conversation_reads=conv_reads,
+          stopgap_copy_ok=stopgap_ok, conversation_reads=conv_reads, **scroll_state,
           **{k: v for k, v in fresh.items() if k != "stopgap"})
-
-    page.screenshot(path=str(VSHOTS / "ux-T-thread-reload.png"))
 
     # Console hygiene: the deliberate 500 refusal logs one resource error; nothing
     # else may.

--- a/e2e/ux_sliceX_test.py
+++ b/e2e/ux_sliceX_test.py
@@ -9,6 +9,14 @@ progress, timeout, or error").
 EC37, mechanically enforced: the control you clicked answers — pending,
 ready, or failed — WHERE you clicked it.
 
+DOC-FEEDBACK RE-SCOPE (operator round on the doc surface): the click sites
+MOVED — export now renders under the chatbox in the right panel's Chat tab,
+and the Themes popover became the panel's Theme tab (inline form, no
+trigger button). Same testids, same EC37 lifecycle, new geometry; every
+scene below drives the same contract at the new sites. The in-flight pulse
+that lived on the [Themes] trigger is asserted on the form's own submit
+button now.
+
 The §7.2 DOM ACs, verbatim mapping:
 
   1. clicking an export format renders `[data-testid="export-pending"]` on
@@ -39,10 +47,10 @@ The §7.2 DOM ACs, verbatim mapping:
 
 Captures (§12.0 contract: 1440x900, device_scale_factor=1) into
 e2e/shots/vision/:
-  ux-X-export-ready.png   the version strip: the clicked HTML control now IS
-                          the download (accent anchor), the thread's export
-                          message beside it.
-  ux-X-learn-timeout.png  the Themes popover: the honest timeout copy + Retry
+  ux-X-export-ready.png   the export box under the chatbox: the clicked HTML
+                          control now IS the download (accent anchor), the
+                          thread's export message above it.
+  ux-X-learn-timeout.png  the Theme tab: the honest timeout copy + Retry
                           after the bounded wait on a silent bridge.
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
@@ -64,7 +72,6 @@ from uxfix_fixture import (
     ensure_build,
     set_fixture,
     start_server,
-    wake_strip,
 )
 
 FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4388"))
@@ -124,15 +131,17 @@ with sync_playwright() as p:
         page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
 
     # ── Scene 1 (AC 1): export answers PENDING then READY at the click site ────
+    # Doc-feedback re-scope: the export controls moved UNDER THE CHATBOX in the
+    # right panel's Chat tab (operator: "export should move under chat box in
+    # right panel") — same testids, same EC37 contract, new click site. The
+    # panel is collapsed to its rail by default on a doc route; its own rail
+    # tab expands it straight onto Chat (the thread + the export box together —
+    # the strip carries no thread-toggle and no export any more).
     set_fixture(ORIGIN, export_delay_ms=1500)
     goto_doc()
-    wake_strip(page)
-    # §7.3: the thread is a DRAWER, closed by default when a doc is open — WHY the
-    # click site must answer (EC37). Open it so AC 1's "the thread message remains"
-    # is checked against a visible transcript (and the shot shows both truths).
-    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="panel-rail-tab"][data-tab="chat"]').click()
     page.locator('[data-testid="thread"]').wait_for(timeout=15000)
-    wake_strip(page)
+    page.locator('[data-testid="chat-export"]').wait_for(timeout=15000)
     html_btn = page.locator('[data-testid="export-format"][data-format="html"]')
     html_btn.wait_for(timeout=15000)
     html_btn.click()
@@ -186,8 +195,9 @@ with sync_playwright() as p:
     page.screenshot(path=str(VSHOTS / "ux-X-export-ready.png"))
 
     # ── Scene 2 (AC 2): a refused export answers FAILED at the click site ──────
+    # (No wake needed: the click site lives in the panel now, which never
+    # auto-hides — only the version band does.)
     set_fixture(ORIGIN, export_delay_ms=0, export_pptx_missing=True)
-    wake_strip(page)
     page.locator('[data-testid="export-format"][data-format="pptx"]').click()
     hint = page.locator('[data-testid="export-hint"]')
     hint.wait_for(timeout=15000)
@@ -205,9 +215,14 @@ with sync_playwright() as p:
     set_fixture(ORIGIN, export_pptx_missing=False)
 
     # ── Scene 3 (AC 3): learn answers IN-FLIGHT (staged) then DONE ─────────────
+    # Doc-feedback re-scope: the Themes popover became the panel's THEME TAB
+    # (operator: "Compare & Theme should become tabs on chat panel to right") —
+    # the inline host renders the SAME learn form (same testids, same EC37
+    # lifecycle) with no [Themes] trigger button; the tab is how it opens. The
+    # in-flight state that used to pulse on the trigger now shows on the form's
+    # own submit button ("Learning…") — asserted per scene below.
     set_fixture(ORIGIN, learn_delay_s=4)  # long enough to witness the stage line
-    wake_strip(page)
-    page.locator('[data-testid="themes-open"]').click()
+    page.locator('[data-testid="panel-tab"][data-tab="theme"]').click()
     page.locator('[data-testid="themes-panel"]').wait_for(timeout=15000)
     page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
     page.locator('[data-testid="themes-submit"]').click()
@@ -222,12 +237,12 @@ with sync_playwright() as p:
     inflight = page.evaluate(
         """() => ({
              stage: document.querySelector('[data-testid="learn-stage"]')?.textContent ?? null,
-             trigger: document.querySelector('[data-testid="themes-open"]')?.textContent ?? null,
+             submitLabel: document.querySelector('[data-testid="themes-submit"]')?.textContent ?? null,
              inputHeld: !!document.querySelector('[data-testid="themes-input"]')?.disabled,
            })""")
     check("learn_inflight_stages_bridge_frame",
           "Grabbing the page" in (inflight["stage"] or "")
-          and "Themes…" in (inflight["trigger"] or "")
+          and "Learning…" in (inflight["submitLabel"] or "")
           and inflight["inputHeld"], **inflight)
 
     # DONE: the readback ripening is the one completion truth; the popover says so.
@@ -237,7 +252,7 @@ with sync_playwright() as p:
     # ── Scene 4 (AC 4): a learn the bridge REFUSES answers with ITS sentence ───
     # §8.4.1 probe 4 (re-verified at slice time): one doc-scoped status.posted
     # {state:"error"} — surfaced verbatim, never re-worded into the timeout copy.
-    wake_strip(page)  # §7.3 auto-hide owns the strip; clicks need it awake
+    # (No wake: the form lives in the panel's Theme tab, which never auto-hides.)
     page.locator('[data-testid="themes-input"]').fill("http://169.254.169.254/")
     page.locator('[data-testid="themes-submit"]').click()
     err = page.locator('[data-testid="learn-error"]')
@@ -257,7 +272,6 @@ with sync_playwright() as p:
     # readback. The client's bounded poll (~66s hard cap, the REAL schedule) is
     # the only thing standing between the user and eternal narration.
     set_fixture(ORIGIN, learn_silent=True, reset_learn=True)
-    wake_strip(page)
     page.locator('[data-testid="themes-input"]').fill("https://slow.example/never")
     page.locator('[data-testid="themes-submit"]').click()
     page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
@@ -265,26 +279,20 @@ with sync_playwright() as p:
 
     # Within the budget: the poll caps at ~66s — 100s here is the rig's margin,
     # not the promise. Past the cap there must be NO unresolved in-flight state.
+    # (The panel never auto-hides, so no strip wake/fade dance before capture.)
     timeout_el = page.locator('[data-testid="learn-timeout"]')
     timeout_el.wait_for(timeout=100000)
-    wake_strip(page)  # the long wait dimmed the strip — wake it for the capture
-    # …and let the strip's opacity transition FINISH: data-hidden flips at the
-    # start of the fade-in, and a capture mid-fade ghosts the popover.
-    page.wait_for_function(
-        """() => getComputedStyle(
-                 document.querySelector('[data-testid="version-strip"]')).opacity === '1'""",
-        timeout=10000)
     silence = page.evaluate(
         """() => ({
              copy: document.querySelector('[data-testid="learn-timeout"]')?.textContent ?? '',
              retry: !!document.querySelector('[data-testid="learn-retry"]'),
              stillInflight: !!document.querySelector('[data-testid="learn-inflight"]'),
-             triggerSettled: (document.querySelector('[data-testid="themes-open"]')
-                              ?.textContent ?? '').trim() === 'Themes',
+             submitSettled: (document.querySelector('[data-testid="themes-submit"]')
+                             ?.textContent ?? '').startsWith('Learn from this'),
            })""")
     check("silence_resolves_to_honest_timeout",
           TIMEOUT_COPY in silence["copy"] and silence["retry"]
-          and not silence["stillInflight"] and silence["triggerSettled"],
+          and not silence["stillInflight"] and silence["submitSettled"],
           **silence)
 
     page.screenshot(path=str(VSHOTS / "ux-X-learn-timeout.png"))
@@ -292,7 +300,6 @@ with sync_playwright() as p:
     # The retry is LIVE: with the bridge speaking again, the same control lands
     # the learn — the §3.3 rule that a failure state always carries its own fix.
     set_fixture(ORIGIN, learn_silent=False, reset_learn=True, learn_delay_s=0.75)
-    wake_strip(page)
     page.locator('[data-testid="learn-retry"]').click()
     page.locator('[data-testid="learn-inflight"]').wait_for(timeout=10000)
     page.locator('[data-testid="learn-done"]').wait_for(timeout=90000)

--- a/e2e/uxfix_slice6_test.py
+++ b/e2e/uxfix_slice6_test.py
@@ -16,14 +16,19 @@ project: create a deck from a brief, watch v1 land, continue with a change,
 watch v2 land — then walk the relationship in both directions.
 
 What it asserts (design §4.3, the slice-6 DOM AC — the GEOMETRY half re-scoped
-by DES-FEEDBACK-001 §7.3, which made Document mode canvas-first):
-  1. The spine (§2.6 rules 1+2, as §7.3 re-drew them): the version strip floats
-     INSIDE the canvas container over its bottom edge (measured from
-     getBoundingClientRect, not inferred), the canvas and the OPEN thread
-     drawer are non-overlapping siblings in one row, the caption still names
-     what selecting does, and there is no dead middle column between the panes.
-     (The thread is open throughout this journey: it starts on the picker,
-     whose empty state points at it, and the drawer state survives the
+by DES-FEEDBACK-001 §7.3, which made Document mode canvas-first, and AGAIN by
+the doc-feedback round, which replaced the thread drawer with the tabbed right
+PANEL and slimmed the band to version pills only):
+  1. The spine (§2.6 rules 1+2, as re-drawn): the version strip — the SLIM
+     band now — floats INSIDE the canvas container over its bottom edge
+     (measured from getBoundingClientRect, not inferred), the canvas and the
+     OPEN right panel (whose Chat tab holds the thread) are non-overlapping
+     siblings in one row, and there is no dead middle column between the
+     panes. The spine caption retired with the slim band; Themes and Export
+     moved into the panel (the Theme tab; the chat-export box), and the strip
+     carries NEITHER any more.
+     (The panel is open throughout this journey: it starts on the picker,
+     whose empty state points at the thread, and the panel state survives the
      navigation the composer makes.)
   2. Thread tags: each message that produced a version carries
      data-testid="version-marker" with its data-version, reading
@@ -33,13 +38,14 @@ by DES-FEEDBACK-001 §7.3, which made Document mode canvas-first):
      canvas to that version AND scrolls/focuses the thread message whose id
      the manifest's meta.sourceMessageId names — the id the CLIENT minted at
      submit, echoed back through the fixture's manifest.
-  4. Themes (V19, corrected by issue #65): data-testid="themes-open" reads
-     "Themes", sits on the strip beside Export, and opening it reveals the
-     one-line explanation ("Borrow a look from a site, PDF, or image.") plus
-     the REAL capability — learn a look for THIS document. Submitting a URL
-     rides the corrected wire (POST /api/events, theme.requested) and lands as
-     a thread message; there is NO theme list, NO picking, NO composer chip.
-     NO data-testid and NO copy reading "theme library" anywhere.
+  4. Themes (V19, corrected by issue #65; re-homed by the doc-feedback round):
+     the control is the panel's Theme TAB (the [Themes] strip trigger retired
+     with the slim band), and opening it reveals the one-line explanation
+     ("Borrow a look from a site, PDF, or image.") plus the REAL capability —
+     learn a look for THIS document. Submitting a URL rides the corrected wire
+     (POST /api/events, theme.requested) and lands as a thread message; there
+     is NO theme list, NO picking, NO composer chip. NO data-testid and NO
+     copy reading "theme library" anywhere.
 
 Captures (§4.0 contract: 1440x900 viewport, device_scale_factor=1, waits on
 data-testid, never a sleep) into e2e/shots/uxfix/ — gitignored evidence:
@@ -169,41 +175,49 @@ with sync_playwright() as p:
         "ok": no_divider == 0, "dividers": no_divider,
     }
 
-    # AC 1 — the spine, in the §7.3 canvas-first geometry: the strip floats INSIDE
-    # the canvas container over its bottom edge; the canvas and the OPEN thread
-    # drawer are non-overlapping siblings in one row (no dead middle column).
+    # AC 1 — the spine, in the §7.3 canvas-first geometry, RE-SCOPED by the
+    # doc-feedback round: the strip (now the SLIM band — version pills only)
+    # still floats INSIDE the canvas container over its bottom edge; the canvas
+    # and the OPEN right PANEL (which replaced the thread drawer on the doc
+    # surface — its Chat tab holds the thread) are non-overlapping siblings in
+    # one row (no dead middle column). Themes and Export left the strip for the
+    # panel: the Theme tab and the chat-export box under the composer.
     wake_strip(page)  # the strip auto-hides after 3s idle — measure it awake
     spine = page.evaluate(
         """() => {
              const strip = document.querySelector('[data-testid="version-strip"]');
              const container = document.querySelector('[data-testid="document-canvas"]');
              const canvas = document.querySelector('[data-testid="doc-canvas"]');
-             const drawer = document.querySelector('[data-testid="thread-drawer"]');
+             const panel = document.querySelector('[data-testid="doc-panel"]');
              const thread = document.querySelector('[data-testid="thread"]');
-             const caption = document.querySelector('[data-testid="version-spine-caption"]');
-             const themes = document.querySelector('[data-testid="version-strip"] [data-testid="themes-open"]');
-             const exportMenu = document.querySelector('[data-testid="version-strip"] [data-testid="export-menu"]');
+             const themeTab = document.querySelector('[data-testid="panel-tab"][data-tab="theme"]');
+             const exportBox = panel?.querySelector('[data-testid="chat-export"] [data-testid="export-menu"]');
              const sr = strip?.getBoundingClientRect(), cr = container?.getBoundingClientRect();
-             const kr = canvas?.getBoundingClientRect(), dr = drawer?.getBoundingClientRect();
+             const kr = canvas?.getBoundingClientRect(), pr = panel?.getBoundingClientRect();
              return {
+               stripVariant: strip?.getAttribute('data-variant'),
                stripInsideCanvasContainer: !!container && container.contains(strip),
                stripOverBottomEdge: !!sr && !!cr && Math.abs(sr.bottom - cr.bottom) < 3
                  && sr.left >= cr.left - 1 && sr.right <= cr.right + 1,
-               drawerHoldsThread: !!drawer && drawer.contains(thread),
-               canvasBesideDrawer: !!kr && !!dr && kr.right <= dr.left + 1
-                 && dr.right - dr.left > 300,
-               captionText: caption ? caption.textContent : null,
-               themesOnStrip: !!themes, exportOnStrip: !!exportMenu,
+               panelHoldsThread: !!panel && panel.contains(thread),
+               canvasBesidePanel: !!kr && !!pr && kr.right <= pr.left + 1
+                 && pr.right - pr.left > 300,
+               noCaption: !document.querySelector('[data-testid="version-spine-caption"]'),
+               themesOffStrip: !!strip && !strip.querySelector('[data-testid="themes-open"]'),
+               exportOffStrip: !!strip && !strip.querySelector('[data-testid="export-menu"]'),
+               themeTabUp: !!themeTab, exportUnderChatbox: !!exportBox,
                entries: document.querySelectorAll('[data-testid="version-entry"]').length,
              };
            }"""
     )
     report["steps"]["slice6_spine"] = {
         "ok": all([
+            spine["stripVariant"] == "slim",
             spine["stripInsideCanvasContainer"], spine["stripOverBottomEdge"],
-            spine["drawerHoldsThread"], spine["canvasBesideDrawer"],
-            spine["themesOnStrip"], spine["exportOnStrip"],
-            "scrolls the thread" in (spine["captionText"] or ""),
+            spine["panelHoldsThread"], spine["canvasBesidePanel"],
+            spine["noCaption"],
+            spine["themesOffStrip"], spine["exportOffStrip"],
+            spine["themeTabUp"], spine["exportUnderChatbox"],
             spine["entries"] == 2,
         ]),
         **spine,
@@ -230,15 +244,19 @@ with sync_playwright() as p:
     }
 
     # AC 4 (half) — no spelling of "theme library" anywhere on the surface.
+    # Doc-feedback re-scope: the [Themes] strip trigger retired — the control
+    # is the panel's Theme TAB now, labeled "Theme" (PANEL_TABS), same ban on
+    # the invented "theme library" spelling.
     v19 = page.evaluate(
         """() => ({
              libraryTestids: document.querySelectorAll('[data-testid*="theme-library"]').length,
              libraryCopy: document.body.innerText.toLowerCase().includes('theme library'),
-             themesLabel: document.querySelector('[data-testid="themes-open"]')?.textContent.trim(),
+             themesLabel: document.querySelector('[data-testid="panel-tab"][data-tab="theme"]')
+               ?.textContent.trim(),
            })"""
     )
     report["steps"]["slice6_v19_rename"] = {
-        "ok": v19["libraryTestids"] == 0 and not v19["libraryCopy"] and v19["themesLabel"] == "Themes",
+        "ok": v19["libraryTestids"] == 0 and not v19["libraryCopy"] and v19["themesLabel"] == "Theme",
         **v19,
     }
 
@@ -262,22 +280,30 @@ with sync_playwright() as p:
              v1Selected: document.querySelector('[data-testid="version-entry"][data-version="1"]')
                ?.getAttribute('data-selected'),
              focusedMessageId: document.activeElement?.getAttribute('data-message-id') || null,
-             inThreadEnabled: Array.from(document.querySelectorAll('[data-testid="version-scroll"]'))
-               .every(b => !b.disabled),
            })"""
     )
+    page.screenshot(path=str(SHOTS / "uxfix-6-version-crosslink.png"))
+    # Doc-feedback re-scope: the In-thread affordances moved off the band into
+    # the panel's Versions tab — open it to read them, then return to Chat (the
+    # thread must be visible for the thread→strip direction below).
+    page.locator('[data-testid="panel-tab"][data-tab="versions"]').click()
+    page.locator('[data-testid="version-detail"]').first.wait_for(timeout=30000)
+    in_thread_enabled = page.evaluate(
+        """() => { const b = Array.from(document.querySelectorAll('[data-testid="version-scroll"]'));
+                   return b.length > 0 && b.every(x => !x.disabled); }""")
+    page.locator('[data-testid="panel-tab"][data-tab="chat"]').click()
     report["steps"]["slice6_strip_to_thread"] = {
         "ok": all([
             strip_to_thread["url"].endswith("?v=1"),
             strip_to_thread["canvasVersion"] == "1",
             strip_to_thread["v1Selected"] == "true",
             v1_msg_id is not None and strip_to_thread["focusedMessageId"] == v1_msg_id,
-            strip_to_thread["inThreadEnabled"],
+            in_thread_enabled,
         ]),
         "v1_message_id": v1_msg_id,
+        "inThreadEnabled": in_thread_enabled,
         **strip_to_thread,
     }
-    page.screenshot(path=str(SHOTS / "uxfix-6-version-crosslink.png"))
 
     # thread → strip: clicking a tag navigates to ITS version; the strip follows.
     page.locator('[data-testid="version-marker"][data-version="2"]').click()
@@ -290,10 +316,11 @@ with sync_playwright() as p:
     }
 
     # ── Scene D: Themes explains itself and offers the REAL capability (#65) ──────
-    # No list, no picking: the popover is the doc-scoped learn form, and a submit
-    # rides the corrected wire — theme.requested over POST /api/events.
-    wake_strip(page)
-    page.locator('[data-testid="themes-open"]').click()
+    # No list, no picking: the doc-scoped learn form (the SAME testids the popover
+    # carried), hosted inline by the panel's Theme tab since the doc-feedback
+    # round; a submit rides the corrected wire — theme.requested over POST
+    # /api/events.
+    page.locator('[data-testid="panel-tab"][data-tab="theme"]').click()
     page.locator('[data-testid="themes-panel"]').wait_for(timeout=30000)
     page.locator('[data-testid="themes-input"]').wait_for(timeout=30000)
     themes = page.evaluate(
@@ -317,16 +344,20 @@ with sync_playwright() as p:
     VSHOTS.mkdir(parents=True, exist_ok=True)
     page.screenshot(path=str(VSHOTS / "theme-wire-fix-themes-menu.png"))
 
-    wake_strip(page)  # the panel rides the strip — keep it awake for the submit
+    # (No wake: the form rides the panel now, which never auto-hides.)
     page.locator('[data-testid="themes-input"]').fill("https://acme.example/brand")
     page.locator('[data-testid="themes-submit"]').click()
     # DES-UX-001 §7.2 (slice X, EC37) SUPERSEDES the close-on-submit here: the popover
     # now STAYS OPEN and answers — in-flight, then done when the readback ripens. The
     # submission is still a MESSAGE (§2.3): the ask lands in the thread verbatim.
     page.locator('[data-testid="learn-inflight"]').wait_for(timeout=30000)
+    # The ask lands in the thread, which lives in the KEPT-MOUNTED Chat tab body
+    # (display:none while the Theme tab shows) — assert its DOM presence
+    # (state="attached"), not visibility; the Chat tab's visible transcript is
+    # covered by the scenes that run on it.
     page.locator('[data-testid="doc-message"]',
                  has_text="Learn a theme from https://acme.example/brand") \
-        .first.wait_for(timeout=30000)
+        .first.wait_for(state="attached", timeout=30000)
     learned = page.evaluate(
         """() => ({
              askInThread: Array.from(document.querySelectorAll('[data-testid="doc-message"]'))
@@ -340,11 +371,11 @@ with sync_playwright() as p:
     # its own status line, arriving over the bus — never an HTTP 4xx on the ack. The
     # fixture emits exactly the frame materializeThemeRequested writes. The panel is
     # still open (slice X) — editing the input starts the fresh ask.
-    wake_strip(page)
     page.locator('[data-testid="themes-input"]').fill("http://169.254.169.254/")
     page.locator('[data-testid="themes-submit"]').click()
+    # Same kept-mounted-but-hidden thread: presence, not visibility.
     page.locator('[data-testid="doc-narration"]', has_text="Couldn't grab that URL") \
-        .first.wait_for(timeout=30000)
+        .first.wait_for(state="attached", timeout=30000)
     refusal = page.evaluate(
         """() => {
              const lines = Array.from(document.querySelectorAll('[data-testid="doc-narration"]'))

--- a/e2e/vision_slice4_test.py
+++ b/e2e/vision_slice4_test.py
@@ -437,9 +437,12 @@ with sync_playwright() as p:
     )
     page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
 
-    # Themes: the popover opens WITH its explanation (the §6.3 AC's testid).
-    wake_strip(page)
-    page.locator('[data-testid="themes-open"]').click()
+    # Themes: the explanation opens WITH the form (the §6.3 AC's testid).
+    # Doc-feedback re-scope: the [Themes] strip popover became the right
+    # panel's Theme TAB (inline host, same testids, same token dress) — open
+    # the tab instead of the retired trigger, and return to Chat for the
+    # capture (the tab has no Escape-close; the panel simply shows another tab).
+    page.locator('[data-testid="panel-tab"][data-tab="theme"]').click()
     page.locator('[data-testid="themes-panel"]').wait_for(timeout=30000)
     themes = page.evaluate(
         """() => { const ex = document.querySelector('[data-testid="themes-explanation"]');
@@ -448,9 +451,7 @@ with sync_playwright() as p:
                font: ex ? getComputedStyle(ex).fontFamily : null,
                size: ex ? getComputedStyle(ex).fontSize : null,
              }; }""")
-    page.keyboard.press("Escape")
-    wake_strip(page)
-    page.locator('[data-testid="themes-open"]').click()  # toggle shut for the capture
+    page.locator('[data-testid="panel-tab"][data-tab="chat"]').click()  # back for the capture
 
     # Back to v2 for the named capture (the slice entry: v2 selected, tags visible).
     page.locator('[data-testid="version-marker"][data-version="2"]').click()

--- a/src/components/DocPanel.tsx
+++ b/src/components/DocPanel.tsx
@@ -259,7 +259,12 @@ function lineageOf(entry: VersionEntry): string {
     : `continues v${entry.parent}`;
 }
 
-function VersionsTab({ doc }: { doc: DocPanelDoc }): React.ReactElement {
+function VersionsTab({ doc, onShowChat }: {
+  doc: DocPanelDoc;
+  /** Switch the panel to the Chat tab — the In-thread action's whole point is
+   *  the thread, and a scroll inside a hidden tab would be a silent no-op. */
+  onShowChat: () => void;
+}): React.ReactElement {
   const { projectId, docId, manifest, selected, navigate, onForked } = doc;
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -380,7 +385,14 @@ function VersionsTab({ doc }: { doc: DocPanelDoc }): React.ReactElement {
               <button
                 type="button"
                 data-testid="version-scroll"
-                onClick={() => { if (anchor !== null) scrollThreadToMessage(anchor); }}
+                onClick={() => {
+                  if (anchor === null) return;
+                  onShowChat();
+                  // The thread lives in the Chat tab's kept-mounted body, which is
+                  // display:none right now — scroll on the frame AFTER React commits
+                  // the tab switch, when the thread has geometry again.
+                  requestAnimationFrame(() => { scrollThreadToMessage(anchor); });
+                }}
                 disabled={anchor === null}
                 title={anchor === null
                   ? NO_ANCHOR_TITLE
@@ -552,7 +564,7 @@ export function DocPanel({
       {doc !== null && tab === 'versions' && (
         <div data-testid="panel-body" data-tab="versions" className="flex flex-col"
              style={{ flex: 1, minHeight: 0 }}>
-          <VersionsTab doc={doc} />
+          <VersionsTab doc={doc} onShowChat={() => onTab('chat')} />
         </div>
       )}
 

--- a/src/components/DocPanel.tsx
+++ b/src/components/DocPanel.tsx
@@ -1,0 +1,571 @@
+import { useMemo, useState } from 'react';
+import { postFork } from '../api/interactive.js';
+import type { ForkResult, VersionEntry, VersionManifest } from '../api/interactive.js';
+import { versionPath, type Navigate } from '../hooks/useRoute.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../store/docThread.js';
+import { ExportMenu } from './ExportMenu.js';
+import { ThemesMenu } from './ThemesMenu.js';
+import { scrollThreadToMessage } from './threadAnchor.js';
+import { anchorOf, anchorsFrom, forkedFrom, NO_ANCHOR_TITLE } from './VersionStrip.js';
+
+// The Document surface's RIGHT PANEL (operator feedback, doc-feedback round) —
+// one tabbed column that owns everything the bottom band used to carry besides
+// the versions themselves. The operator's words, verbatim, each a requirement:
+//
+//   - "export should move under chat box in right panel"            → Chat tab,
+//     the ExportMenu (slice-X point-of-action states intact, same testids)
+//     rendered DIRECTLY UNDER the thread's composer;
+//   - "Compare & Theme should become tabs on chat panel to right"   → the
+//     Compare tab wears the slice-K lens controls (the panes stay the canvas
+//     owner's), the Theme tab hosts the doc-scoped learn form inline;
+//   - "make the right chat column have it's own expand/collapse"    → the
+//     panel collapses to a RAIL (its own affordance — no strip toggle), and
+//     the rail's tab buttons expand it straight onto a tab;
+//   - the fork and in-thread gestures the band dropped SURVIVE HERE, in the
+//     Versions tab's per-version actions (§0: a protected gesture moves, it
+//     never silently dies).
+//
+// The Versions tab is built on REAL wire data only: the version manifest
+// (`GET /d/:doc/api/versions` — versions.json verbatim: version, parent,
+// feedback_file, html_file, created_at, meta.sourceMessageId when the bridge
+// wrote one) plus the session's own thread anchors. The document workspace has
+// NO git-history wire (verified against wicked-interactive server.js — the
+// manifest loader reads versions.json and nothing else), so the tab SAYS the
+// manifest is the history rather than dressing it up as commits.
+
+const S = {
+  bar:    'var(--surface-rail)',
+  base:   'var(--surface-base)',
+  border: 'var(--surface-raised)',
+  ink:    'var(--ink-high)',
+  body:   'var(--ink-body)',
+  muted:  'var(--ink-muted)',
+  faint:  'var(--ink-dim)',
+  accent: 'var(--accent)',
+  selected: 'var(--accent-subtle)',
+  danger: 'var(--status-fail)',
+};
+
+export type DocPanelTab = 'chat' | 'compare' | 'theme' | 'versions';
+
+export const PANEL_TABS: { id: DocPanelTab; label: string; icon: string; title: string }[] = [
+  { id: 'chat',     label: 'Chat',     icon: '💬', title: 'The conversation about this artifact' },
+  { id: 'compare',  label: 'Compare',  icon: '⇆',  title: 'Put two versions side by side' },
+  { id: 'theme',    label: 'Theme',    icon: '◩',  title: 'Borrow a look from a site, PDF, or image' },
+  { id: 'versions', label: 'Versions', icon: '⑂',  title: 'Every version, with its lineage and actions' },
+];
+
+/**
+ * The compare lens control surface (DES-FEEDBACK-002 §7, slice K — RE-HOMED
+ * from the version strip by the doc-feedback round). The panel only WEARS the
+ * state — the panes (and the state itself) are the canvas owner's
+ * (DocumentCanvas), because comparing is a lens on the canvas, not an address
+ * (§7.2: the left pane stays the `?v=N` navigation; the comparand is ephemeral
+ * UI state).
+ */
+export interface CompareControl {
+  /** Comparing right now. */
+  active: boolean;
+  /** The right pane's version (null only while inactive). */
+  comparand: number | null;
+  /** §7.5/§7.6 disabled-with-reason: non-null renders the toggle disabled with
+   *  the reason as its title ("only one version exists" on a v1-only doc). */
+  disabledReason: string | null;
+  /** The `[▣ overlay]` sub-toggle inside compare (§7.2). */
+  overlay: boolean;
+  onToggle: () => void;
+  onComparand: (version: number) => void;
+  onOverlay: (on: boolean) => void;
+  onExit: () => void;
+}
+
+/** Everything the doc-scoped tabs need. Null on the picker and while the
+ *  manifest has not loaded — those tabs disable with a stated reason. */
+export interface DocPanelDoc {
+  projectId: string;
+  docId: string;
+  manifest: VersionManifest;
+  /** The version the route resolved to — what Export addresses and Compare's
+   *  left pane shows. */
+  selected: number;
+  navigate: Navigate;
+  /** The service's fork result; the owner re-reads the manifest and routes to it. */
+  onForked: (result: ForkResult) => void;
+  compare: CompareControl;
+}
+
+export interface DocPanelProps {
+  open: boolean;
+  tab: DocPanelTab;
+  /** Expand the panel — straight onto `tab` when the rail button names one. */
+  onExpand: (tab?: DocPanelTab) => void;
+  onCollapse: () => void;
+  onTab: (tab: DocPanelTab) => void;
+  doc: DocPanelDoc | null;
+  /** The thread pane (DocumentThread) — the Chat tab's body. */
+  children?: React.ReactNode;
+}
+
+const NO_DOC_REASON = 'Open a document first — this tab acts on one document.';
+
+/** Oldest → newest for pickers; the detail list flips it (newest first). */
+function byVersion(a: VersionEntry, b: VersionEntry): number {
+  return a.version - b.version;
+}
+
+/** Full locale stamp for the detail rows; an unparseable stamp stays raw. */
+function fullStamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+const NO_MSGS: DocMsg[] = [];
+
+const TAB_BTN: React.CSSProperties = {
+  background: 'transparent', border: 'none', borderBottom: '2px solid transparent',
+  color: S.muted, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-xs)', fontWeight: 600, lineHeight: 1.6, padding: '6px 9px',
+};
+
+const ACTION: React.CSSProperties = {
+  background: 'transparent', border: `1px solid ${S.border}`, borderRadius: 'var(--radius-sm)',
+  color: S.muted, cursor: 'pointer', fontSize: 'var(--text-2xs)',
+  fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
+};
+
+/** §6.4 segmented dress (compare cluster, carried over from the strip). */
+const SEGMENT: React.CSSProperties = {
+  background: 'transparent', border: 'none', borderRadius: 'var(--radius-md)',
+  color: S.muted, cursor: 'pointer', fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-2xs)', lineHeight: 1.6, padding: '1px 7px',
+};
+
+// ── The Compare tab (slice K's controls, re-homed) ───────────────────────────
+
+function CompareTab({ doc }: { doc: DocPanelDoc }): React.ReactElement {
+  const c = doc.compare;
+  return (
+    <div className="flex flex-col gap-2" style={{ padding: '10px 12px' }}>
+      <p
+        data-testid="compare-explainer"
+        style={{ color: S.body, fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)',
+                 lineHeight: 1.4, margin: 0 }}
+      >
+        Put two versions of this document side by side on the canvas — or stack
+        them with adjustable opacity to spot layout shifts.
+      </p>
+      {!c.active && (
+        <button
+          type="button"
+          data-testid="version-compare-toggle"
+          disabled={c.disabledReason !== null}
+          onClick={c.onToggle}
+          title={c.disabledReason
+            ?? `Compare v${doc.selected} with another version side by side`}
+          style={{
+            ...ACTION, alignSelf: 'flex-start',
+            cursor: c.disabledReason !== null ? 'not-allowed' : 'pointer',
+            opacity: c.disabledReason !== null ? 0.4 : 1,
+            padding: '4px 10px',
+          }}
+        >
+          ⇆ Compare
+        </button>
+      )}
+      {c.active && c.comparand !== null && (
+        <div
+          data-testid="compare-controls"
+          className="flex flex-col gap-1.5"
+          style={{ border: `1px solid ${S.border}`, borderRadius: 'var(--radius-md)',
+                   padding: '8px 10px' }}
+        >
+          <span style={{ color: S.ink, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)' }}>
+            ⇆ Comparing v{doc.selected} ↔ v{c.comparand}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              data-testid="compare-overlay-toggle"
+              aria-pressed={c.overlay}
+              onClick={() => c.onOverlay(!c.overlay)}
+              title={c.overlay
+                ? 'Back to the side-by-side split'
+                : 'Stack the two versions with adjustable opacity — spot layout shifts'}
+              style={{
+                ...SEGMENT,
+                background: c.overlay ? 'var(--surface-raised)' : 'transparent',
+                border: `1px solid ${S.border}`,
+                color: c.overlay ? S.ink : S.muted,
+              }}
+            >
+              ▣ overlay
+            </button>
+            <label style={{
+              alignItems: 'center', color: S.faint, display: 'inline-flex', gap: '4px',
+              fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)',
+            }}>
+              vs:
+              <select
+                data-testid="compare-vs"
+                value={c.comparand}
+                onChange={(e) => c.onComparand(Number(e.target.value))}
+                title="Pick which version the right pane shows"
+                style={{
+                  background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
+                  borderRadius: 'var(--radius-sm)', color: S.ink,
+                  fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)', padding: '0 2px',
+                }}
+              >
+                {[...doc.manifest.versions].sort(byVersion)
+                  .filter((e) => e.version !== doc.selected)
+                  .map((e) => (
+                    <option key={e.version} value={e.version}>v{e.version}</option>
+                  ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              data-testid="compare-exit"
+              onClick={c.onExit}
+              title="Exit compare — back to the solo canvas (Escape works too)"
+              style={{ ...SEGMENT, border: `1px solid ${S.border}`, padding: '1px 6px' }}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── The Versions tab — per-version detail off the manifest, plus the moved
+//    fork / in-thread gestures ────────────────────────────────────────────────
+
+/** The tab's honesty line, pinned by the rig: the operator asked for git
+ *  history; the workspace has none on any wire, and the manifest IS the record. */
+export const VERSIONS_HISTORY_NOTE =
+  'From the document’s own version manifest — the document workspace keeps no '
+  + 'git log, so this manifest is the history: number, lineage, timestamp, and '
+  + 'the files each revision was built from.';
+
+function lineageOf(entry: VersionEntry): string {
+  if (entry.parent === null) return 'root — the first version';
+  return forkedFrom(entry) !== null
+    ? `branched from v${entry.parent}`
+    : `continues v${entry.parent}`;
+}
+
+function VersionsTab({ doc }: { doc: DocPanelDoc }): React.ReactElement {
+  const { projectId, docId, manifest, selected, navigate, onForked } = doc;
+  const [forking, setForking] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // The same session-observed anchors the band's chiclet used (§7.6): the
+  // manifest's meta first, the thread's own tagged messages otherwise.
+  const msgs = useDocThreadStore((s) => s.messages[threadKey(projectId, docId)] ?? NO_MSGS);
+  const anchorsByVersion = useMemo(() => anchorsFrom(msgs), [msgs]);
+
+  async function fork(entry: VersionEntry): Promise<void> {
+    setForking(entry.version);
+    setError(null);
+    try {
+      const result = await postFork(projectId, docId, entry.version);
+      onForked(result);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setForking(null);
+    }
+  }
+
+  function show(entry: VersionEntry): void {
+    navigate(versionPath(projectId, docId, entry.version));
+    const anchor = anchorOf(entry, anchorsByVersion);
+    if (anchor !== null) scrollThreadToMessage(anchor);
+  }
+
+  return (
+    <div className="flex flex-col gap-2 overflow-y-auto" style={{ padding: '10px 12px' }}>
+      <p
+        data-testid="versions-history-note"
+        style={{ color: S.faint, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-sans)',
+                 lineHeight: 1.4, margin: 0 }}
+      >
+        {VERSIONS_HISTORY_NOTE}
+      </p>
+      {error !== null && (
+        <span
+          data-testid="version-fork-error"
+          style={{ color: S.danger, fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)' }}
+        >
+          Fork failed: {error} — the document is unchanged; try again.
+        </span>
+      )}
+      {[...manifest.versions].sort(byVersion).reverse().map((entry) => {
+        const isSelected = entry.version === selected;
+        const anchor = anchorOf(entry, anchorsByVersion);
+        return (
+          <div
+            key={entry.version}
+            data-testid="version-detail"
+            data-version={entry.version}
+            data-parent={entry.parent === null ? '' : entry.parent}
+            data-selected={isSelected ? 'true' : 'false'}
+            className="flex flex-col gap-1"
+            style={{
+              background: isSelected ? S.selected : 'transparent',
+              border: `1px solid ${isSelected ? S.accent : S.border}`,
+              borderRadius: 'var(--radius-md)', padding: '8px 10px',
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <span style={{
+                color: isSelected ? S.ink : S.muted, fontSize: 'var(--text-xs)',
+                fontWeight: 600, fontFamily: 'var(--font-mono)',
+              }}>
+                v{entry.version}
+              </span>
+              <span data-testid="version-detail-stamp" style={{
+                color: S.muted, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+              }}>
+                {fullStamp(entry.created_at)}
+              </span>
+              {isSelected && (
+                <span style={{ color: S.accent, fontSize: 'var(--text-2xs)',
+                               fontFamily: 'var(--font-mono)' }}>
+                  ● shown
+                </span>
+              )}
+            </div>
+            <span data-testid="version-detail-lineage" style={{
+              color: S.muted, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+            }}>
+              {lineageOf(entry)}
+            </span>
+            {/* The manifest's file record, verbatim fields: the rendered HTML and —
+                when the revision came from a feedback pass — its feedback file. */}
+            <span data-testid="version-detail-files" style={{
+              color: S.faint, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+            }}>
+              {entry.html_file}
+              {entry.feedback_file !== null ? ` · feedback: ${entry.feedback_file}` : ''}
+            </span>
+            <div className="flex gap-1.5">
+              <button
+                type="button"
+                data-testid="version-detail-show"
+                onClick={() => show(entry)}
+                disabled={isSelected}
+                title={isSelected
+                  ? `v${entry.version} is on the canvas now`
+                  : `Show version ${entry.version} on the canvas`}
+                style={{ ...ACTION, opacity: isSelected ? 0.4 : 1,
+                         cursor: isSelected ? 'default' : 'pointer' }}
+              >
+                Show
+              </button>
+              <button
+                type="button"
+                data-testid="version-fork"
+                onClick={() => void fork(entry)}
+                disabled={forking !== null}
+                title={`Fork a new version from v${entry.version} — the original stays untouched`}
+                style={{ ...ACTION, opacity: forking !== null ? 0.5 : 1 }}
+              >
+                {forking === entry.version ? 'Forking…' : 'Fork'}
+              </button>
+              <button
+                type="button"
+                data-testid="version-scroll"
+                onClick={() => { if (anchor !== null) scrollThreadToMessage(anchor); }}
+                disabled={anchor === null}
+                title={anchor === null
+                  ? NO_ANCHOR_TITLE
+                  : 'Scroll the thread to the message that produced this version'}
+                style={{ ...ACTION, cursor: anchor === null ? 'not-allowed' : 'pointer',
+                         opacity: anchor === null ? 0.4 : 1 }}
+              >
+                In thread
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── The panel ─────────────────────────────────────────────────────────────────
+
+export function DocPanel({
+  open, tab, onExpand, onCollapse, onTab, doc, children,
+}: DocPanelProps): React.ReactElement {
+  // Collapsed: the RAIL — the panel's own expand affordance, always on screen
+  // (the strip carries no toggle any more). Each tab button expands straight
+  // onto its tab; doc-scoped tabs are disabled with the stated reason.
+  if (!open) {
+    return (
+      <div
+        data-testid="doc-panel-rail"
+        className="flex flex-col items-center gap-1"
+        style={{ background: S.bar, borderLeft: `1px solid ${S.border}`,
+                 flexShrink: 0, padding: '8px 0', width: '38px' }}
+      >
+        <button
+          type="button"
+          data-testid="panel-expand"
+          aria-label="Expand the panel"
+          title="Expand the panel"
+          onClick={() => onExpand()}
+          style={{ background: 'transparent', border: `1px solid ${S.border}`,
+                   borderRadius: 'var(--radius-sm)', color: S.ink, cursor: 'pointer',
+                   fontSize: 'var(--text-xs)', lineHeight: 1.4, padding: '2px 7px' }}
+        >
+          ◀
+        </button>
+        {PANEL_TABS.map((t) => {
+          const needsDoc = t.id !== 'chat' && doc === null;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              data-testid="panel-rail-tab"
+              data-tab={t.id}
+              disabled={needsDoc}
+              title={needsDoc ? NO_DOC_REASON : t.title}
+              onClick={() => onExpand(t.id)}
+              style={{ background: 'transparent', border: 'none', color: S.muted,
+                       cursor: needsDoc ? 'not-allowed' : 'pointer',
+                       fontSize: 'var(--text-sm)', opacity: needsDoc ? 0.35 : 1,
+                       padding: '5px 0' }}
+            >
+              {t.icon}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="doc-panel"
+      data-tab={tab}
+      className="flex flex-col"
+      style={{ background: S.base, borderLeft: `1px solid ${S.border}`, flexShrink: 0,
+               minHeight: 0, overflow: 'hidden', width: 'min(440px, 40vw)' }}
+    >
+      <div
+        role="tablist"
+        className="flex items-center"
+        style={{ background: S.bar, borderBottom: `1px solid ${S.border}`, flexShrink: 0 }}
+      >
+        {PANEL_TABS.map((t) => {
+          const needsDoc = t.id !== 'chat' && doc === null;
+          const active = t.id === tab;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              data-testid="panel-tab"
+              data-tab={t.id}
+              data-active={active ? 'true' : 'false'}
+              aria-selected={active}
+              disabled={needsDoc}
+              title={needsDoc ? NO_DOC_REASON : t.title}
+              onClick={() => onTab(t.id)}
+              style={{
+                ...TAB_BTN,
+                borderBottomColor: active ? S.accent : 'transparent',
+                color: active ? S.ink : S.muted,
+                cursor: needsDoc ? 'not-allowed' : 'pointer',
+                opacity: needsDoc ? 0.35 : 1,
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+        <span style={{ flex: 1 }} />
+        <button
+          type="button"
+          data-testid="panel-collapse"
+          aria-label="Collapse the panel"
+          title="Collapse the panel"
+          onClick={onCollapse}
+          style={{ background: 'transparent', border: 'none', color: S.muted,
+                   cursor: 'pointer', fontSize: 'var(--text-xs)', padding: '4px 10px' }}
+        >
+          ▶
+        </button>
+      </div>
+
+      {/* The CHAT tab stays MOUNTED whichever tab shows — the composer's draft,
+          the send FIFO chips and the export answers under the chatbox must
+          survive a tab switch (slice-T / slice-X state lives here). */}
+      <div
+        data-testid="panel-body"
+        data-tab="chat"
+        className="flex flex-col"
+        style={{ display: tab === 'chat' ? 'flex' : 'none', flex: 1, minHeight: 0 }}
+      >
+        {children}
+        {/* Operator feedback, verbatim requirement: "export should move under
+            chat box in right panel". The slice-X point-of-action contract rides
+            along unchanged (same testids: export-format / export-pending /
+            export-ready / export-hint) — the click site simply lives here now. */}
+        {doc !== null && (
+          <div
+            data-testid="chat-export"
+            style={{ background: S.bar, borderTop: `1px solid ${S.border}`,
+                     flexShrink: 0, padding: '8px 14px' }}
+          >
+            <ExportMenu projectId={doc.projectId} docId={doc.docId} version={doc.selected} />
+          </div>
+        )}
+      </div>
+
+      {/* THEME stays mounted too once a doc exists: a learn in flight keeps
+          answering (EC37) across tab switches instead of losing its poll. */}
+      {doc !== null && (
+        <div
+          data-testid="panel-body"
+          data-tab="theme"
+          className="flex-col overflow-y-auto"
+          style={{ display: tab === 'theme' ? 'flex' : 'none', flex: 1, minHeight: 0 }}
+        >
+          <ThemesMenu projectId={doc.projectId} docId={doc.docId} inline />
+        </div>
+      )}
+
+      {doc !== null && tab === 'compare' && (
+        <div data-testid="panel-body" data-tab="compare" className="flex flex-col"
+             style={{ flex: 1, minHeight: 0 }}>
+          <CompareTab doc={doc} />
+        </div>
+      )}
+
+      {doc !== null && tab === 'versions' && (
+        <div data-testid="panel-body" data-tab="versions" className="flex flex-col"
+             style={{ flex: 1, minHeight: 0 }}>
+          <VersionsTab doc={doc} />
+        </div>
+      )}
+
+      {/* A doc-scoped tab with no doc behind it (the manifest failed mid-session):
+          the tab says why it is empty instead of rendering a blank (§1.4). */}
+      {doc === null && tab !== 'chat' && (
+        <div data-testid="panel-body" data-tab={tab} style={{ flex: 1, padding: '10px 12px' }}>
+          <p data-testid="panel-needs-doc" style={{ color: S.muted, margin: 0,
+             fontSize: 'var(--text-sm)', fontFamily: 'var(--font-sans)' }}>
+            {NO_DOC_REASON}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -7,8 +7,9 @@ import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { threadKey, useDocThreadStore } from '../store/docThread.js';
+import { DocPanel, type DocPanelTab } from './DocPanel.js';
 import { FeedbackOverlay } from './FeedbackOverlay.js';
-import { StripSensor, ThreadDrawer, ThreadToggle, useStripAutoHide } from './ThreadDrawer.js';
+import { StripSensor, useStripAutoHide } from './ThreadDrawer.js';
 import { Failed, Loading, PANEL, S, useLoad } from './SurfaceState.js';
 import { VersionStrip } from './VersionStrip.js';
 
@@ -171,11 +172,21 @@ function PaneHeader({ label, accent }: { label: string; accent: boolean }): Reac
   );
 }
 
+/** The right panel's lifted state — owned by DocumentCanvas so it survives
+ *  picker→doc navigation AND a DocFrame remount on doc change. */
+interface PanelState {
+  open: boolean;
+  tab: DocPanelTab;
+  onExpand: (tab?: DocPanelTab) => void;
+  onCollapse: () => void;
+  onTab: (tab: DocPanelTab) => void;
+}
+
 function DocFrame({
-  projectId, docId, version, navigate, threadOpen, onToggleThread, children,
+  projectId, docId, version, navigate, panel, children,
 }: {
   projectId: string; docId: string; version: number | null; navigate: Navigate;
-  threadOpen: boolean; onToggleThread: () => void;
+  panel: PanelState;
   children?: React.ReactNode;
 }): React.ReactElement {
   // §2.6 rule 3: a landing version re-reads the manifest, so the strip advances and the
@@ -206,9 +217,10 @@ function DocFrame({
   // race left a stale "Loading" overlay over an already-loaded frame.
   const resolvedShown = manifest === null ? null : resolveVersion(manifest, version);
   useEffect(() => { setLoaded(false); }, [projectId, docId, resolvedShown]);
-  // §7.3's strip presence: visible now, gone after 3s of idleness, back on proximity.
-  // `hold` (J3): a strip control holding an un-acted answer pins it visible.
-  const { hidden, wake, hold } = useStripAutoHide();
+  // §7.3's strip presence: visible now, gone after 3s of idleness, back on
+  // proximity. (The J3 `hold` retired WITH the strip's export control: the
+  // export answers moved under the chatbox, a site auto-hide never touches.)
+  const { hidden, wake } = useStripAutoHide();
 
   // ── Compare state (DES-FEEDBACK-002 §7, slice K) — the lens, not an address ──
   // `cmp` is the comparand version; null = solo canvas. The overlay refinement
@@ -257,15 +269,11 @@ function DocFrame({
           {failure
             ? <Failed surface="doc" subject={subject} failure={failure} onRetry={retry} />
             : <Loading surface="doc" subject={subject} />}
-          {/* No manifest means no strip, so the toggle floats — the conversation must
-              stay reachable even (especially) while the bridge is down (§1.2). */}
-          {threadOpen ? null : (
-            <div style={{ position: 'absolute', right: '14px', top: '14px' }}>
-              <ThreadToggle open={false} onToggle={onToggleThread} />
-            </div>
-          )}
         </div>
-        <ThreadDrawer open={threadOpen} onClose={onToggleThread}>{children}</ThreadDrawer>
+        {/* The panel (its collapsed rail included) is ALWAYS on screen, so the
+            conversation stays reachable even — especially — while the bridge is
+            down (§1.2). Doc-scoped tabs disable themselves without a manifest. */}
+        <DocPanel {...panel} doc={null}>{children}</DocPanel>
       </div>
     );
   }
@@ -451,6 +459,9 @@ function DocFrame({
       {/* pointerEvents none on the WRAPPER: the strip re-enables itself while visible;
           while dimmed the box must not shadow the z-1 sensor, or nothing can wake it. */}
       <div style={{ bottom: 0, left: 0, pointerEvents: 'none', position: 'absolute', right: 0, zIndex: 3 }}>
+        {/* Operator feedback (doc-feedback round): the band is VERSIONS ONLY —
+            the slim variant. No fork / in-thread chiclets (they live in the
+            panel's Versions tab), no toolbar, no toggle, visibly shorter. */}
         <VersionStrip
           projectId={projectId}
           docId={docId}
@@ -458,14 +469,27 @@ function DocFrame({
           selected={shown}
           navigate={navigate}
           onForked={onForked}
+          variant="slim"
           dimmed={hidden}
           onWake={wake}
-          onHold={hold}
-          trailing={<ThreadToggle open={threadOpen} onToggle={onToggleThread} />}
-          // §7 (slice K): the strip WEARS the compare state this frame owns. The
-          // strip's auto-hide/wake and the thread drawer are untouched by compare
-          // — the panes live inside the same canvas container the sensor guards.
-          compare={{
+        />
+      </div>
+      </div>
+      {/* The right panel (operator feedback): one tabbed column — Chat | Compare |
+          Theme | Versions — with its OWN expand/collapse (the rail). A flex
+          sibling, so opening it reflows the canvas rather than covering it. */}
+      <DocPanel
+        {...panel}
+        doc={{
+          projectId,
+          docId,
+          manifest,
+          selected: shown,
+          navigate,
+          onForked,
+          // §7 (slice K): the PANEL wears the compare state this frame owns —
+          // the panes live inside the same canvas container the sensor guards.
+          compare: {
             active: comparing,
             comparand,
             disabledReason: compareDisabledReason,
@@ -478,14 +502,11 @@ function DocFrame({
             onComparand: setCmp,
             onOverlay: setOverlayOn,
             onExit: exitCompare,
-          }}
-        />
-      </div>
-      </div>
-      {/* §7.3: the thread is a DRAWER — a flex sibling, so opening it reflows the
-          canvas rather than covering it. Closed by default: the canvas is full-width
-          on first visit, and the conversation is one click away, never lost. */}
-      <ThreadDrawer open={threadOpen} onClose={onToggleThread}>{children}</ThreadDrawer>
+          },
+        }}
+      >
+        {children}
+      </DocPanel>
     </div>
   );
 }
@@ -537,31 +558,37 @@ export function DocumentCanvas({
     return () => { cancelled = true; };
   }, [projectId, docId]);
 
-  // §7.3: the drawer's state lives on the Document surface. Default CLOSED when a doc
-  // is open (the canvas is full-width on first visit); default OPEN on the picker,
-  // whose empty state points at the thread — a pointer at a hidden pane would be a
-  // dead end. The state survives picker→doc navigation, so a conversation that just
-  // created a document stays on screen while its first version lands (W3).
-  const [threadOpen, setThreadOpen] = useState(docId === null);
-  const toggleThread = (): void => { setThreadOpen((v) => !v); };
+  // The right panel's state lives on the Document surface (operator feedback:
+  // the column owns its OWN expand/collapse). Default OPEN on the picker, whose
+  // empty state points at the thread — a pointer at a hidden pane would be a
+  // dead end; default COLLAPSED (the rail) with a doc open, so the canvas is
+  // full-width on first visit. The state survives picker→doc navigation, so a
+  // conversation that just created a document stays on screen while its first
+  // version lands (W3).
+  const [panelOpen, setPanelOpen] = useState(docId === null);
+  const [panelTab, setPanelTab] = useState<DocPanelTab>('chat');
+  const panel: PanelState = {
+    open: panelOpen,
+    tab: panelTab,
+    onExpand: (tab?: DocPanelTab): void => {
+      setPanelOpen(true);
+      if (tab !== undefined) setPanelTab(tab);
+    },
+    onCollapse: (): void => { setPanelOpen(false); },
+    onTab: setPanelTab,
+  };
   return (
     <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
       {docId === null
         ? (
           // No doc means no versions, so there is no spine row — the picker's empty
-          // state points at the thread instead (§2.6 rule 5, W3 step 2).
+          // state points at the thread instead (§2.6 rule 5, W3 step 2). Doc-scoped
+          // tabs disable themselves (there is no document to compare/theme/list).
           <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
             <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
               <DocPicker projectId={projectId} navigate={navigate} />
-              {/* The picker has no strip to host the toggle, so a closed drawer gets
-                  its reopen affordance here — same testid, never both mounted. */}
-              {threadOpen ? null : (
-                <div style={{ position: 'absolute', right: '14px', top: '14px' }}>
-                  <ThreadToggle open={false} onToggle={toggleThread} />
-                </div>
-              )}
             </div>
-            <ThreadDrawer open={threadOpen} onClose={toggleThread}>{children}</ThreadDrawer>
+            <DocPanel {...panel} doc={null}>{children}</DocPanel>
           </div>
         )
         : (
@@ -571,8 +598,7 @@ export function DocumentCanvas({
             docId={docId}
             version={version}
             navigate={navigate}
-            threadOpen={threadOpen}
-            onToggleThread={toggleThread}
+            panel={panel}
           >
             {children}
           </DocFrame>

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -77,6 +77,29 @@ export type SendState = 'generating' | 'queued' | 'failed' | 'stalled';
 export const GENERATING_TIMEOUT_COPY =
   'no worker has picked this up — the generation service may be down';
 
+// ── Composer growth (operator feedback, doc-surface round: "chatbox should
+// expand when typing (to like a max of 5 lines, the[n] scroll with more
+// content (can't stay one line)") ─────────────────────────────────────────────
+//
+// The textarea auto-grows with its content from one line up to COMPOSER_MAX_LINES,
+// then becomes its own scroll region. Growth is measured from scrollHeight on
+// every text change — never a rows= guess, which counts newlines but not wraps.
+
+/** The growth cap, in lines. Beyond it the composer scrolls (never grows). */
+export const COMPOSER_MAX_LINES = 5;
+/** One composer line in px — the `leading-6` line height the textarea wears. */
+export const COMPOSER_LINE_PX = 24;
+
+/** Resize `el` to fit its content, clamped to the 5-line cap; overflow scrolls. */
+export function growComposer(el: HTMLTextAreaElement): void {
+  // Collapse first so scrollHeight reports the CONTENT height, not the old box.
+  el.style.height = 'auto';
+  const max = COMPOSER_MAX_LINES * COMPOSER_LINE_PX;
+  const fit = Math.max(el.scrollHeight, COMPOSER_LINE_PX);
+  el.style.height = `${Math.min(fit, max)}px`;
+  el.style.overflowY = fit > max ? 'auto' : 'hidden';
+}
+
 function Bubble({
   msg, projectId, docId, onShowVersion, sendState, onRetrySend,
 }: {
@@ -505,6 +528,13 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   // different case.
   const [wizard, setWizard] = useState<{ seed: string; msgId: string } | null>(null);
   const bottom = useRef<HTMLDivElement>(null);
+  // The growing composer (operator feedback): re-measured on every text change —
+  // including the programmatic clears a submit makes — so it always fits what it
+  // actually holds, 1 line minimum, 5 lines maximum, scrolling past that.
+  const composerEl = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (composerEl.current !== null) growComposer(composerEl.current);
+  }, [text]);
 
   useEffect(() => { bottom.current?.scrollIntoView({ block: 'end' }); }, [messages.length]);
 
@@ -862,9 +892,14 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                       border: '1px solid var(--surface-overlay)',
                       borderRadius: 'var(--radius-xl)' }}>
           <textarea
+            ref={composerEl}
             data-testid="doc-composer"
+            data-max-lines={COMPOSER_MAX_LINES}
             className="flex-1 resize-none text-sm outline-none border-0 bg-transparent leading-6"
-            style={{ color: S.ink, fontFamily: 'var(--font-sans)', minHeight: '28px' }}
+            // Grows with its content (growComposer) from one line to the 5-line
+            // cap, then scrolls — the height itself is set imperatively so it can
+            // be measured, not guessed from newline counts.
+            style={{ color: S.ink, fontFamily: 'var(--font-sans)', minHeight: `${COMPOSER_LINE_PX}px` }}
             placeholder={prompt}
             value={text}
             rows={1}

--- a/src/components/ThemesMenu.tsx
+++ b/src/components/ThemesMenu.tsx
@@ -84,9 +84,18 @@ type LearnPhase =
 export interface ThemesMenuProps {
   projectId: string;
   docId: string;
+  /**
+   * Inline host (operator feedback, doc-surface round): the Document surface's
+   * right panel hosts the learn form as its THEME TAB — always visible while
+   * the tab is, no trigger button, no popover positioning. Everything inside
+   * (testids, the learn lifecycle, the honest timeout) is the same surface;
+   * only where it sits changed. Default false: Video mode's strip keeps the
+   * [Themes] popover verbatim.
+   */
+  inline?: boolean;
 }
 
-export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactElement {
+export function ThemesMenu({ projectId, docId, inline = false }: ThemesMenuProps): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [kind, setKind] = useState<LearnKind>('url');
   const [value, setValue] = useState('');
@@ -161,29 +170,37 @@ export function ThemesMenu({ projectId, docId }: ThemesMenuProps): React.ReactEl
   }
 
   return (
-    <div style={{ alignSelf: 'center', flexShrink: 0, position: 'relative' }}>
-      <button
-        type="button"
-        data-testid="themes-open"
-        aria-expanded={open}
-        onClick={() => setOpen(!open)}
-        title={`${THEMES_EXPLAINER} ${THEMES_STICKS}`}
-        style={{ ...BUTTON, ...(busy ? { color: S.accent } : {}) }}
-      >
-        {/* The in-flight state survives a closed popover — the control still answers. */}
-        {busy ? <span className="animate-pulse">Themes…</span> : 'Themes'}
-      </button>
+    <div style={inline
+      ? { display: 'flex', flexDirection: 'column', minHeight: 0 }
+      : { alignSelf: 'center', flexShrink: 0, position: 'relative' }}
+    >
+      {!inline && (
+        <button
+          type="button"
+          data-testid="themes-open"
+          aria-expanded={open}
+          onClick={() => setOpen(!open)}
+          title={`${THEMES_EXPLAINER} ${THEMES_STICKS}`}
+          style={{ ...BUTTON, ...(busy ? { color: S.accent } : {}) }}
+        >
+          {/* The in-flight state survives a closed popover — the control still answers. */}
+          {busy ? <span className="animate-pulse">Themes…</span> : 'Themes'}
+        </button>
+      )}
 
-      {open && (
+      {(inline || open) && (
         <div
           data-testid="themes-panel"
           className="flex flex-col gap-1.5"
-          style={{
-            background: S.card, border: '1px solid var(--surface-overlay)',
-            borderRadius: 'var(--radius-lg)', boxShadow: 'var(--shadow-overlay)',
-            bottom: 'calc(100% + 6px)', padding: '8px 10px',
-            position: 'absolute', right: 0, width: '260px', zIndex: 30,
-          }}
+          style={inline
+            // The tab host owns the box — the form flows in it, no overlay dress.
+            ? { padding: '10px 12px' }
+            : {
+                background: S.card, border: '1px solid var(--surface-overlay)',
+                borderRadius: 'var(--radius-lg)', boxShadow: 'var(--shadow-overlay)',
+                bottom: 'calc(100% + 6px)', padding: '8px 10px',
+                position: 'absolute', right: 0, width: '260px', zIndex: 30,
+              }}
         >
           {/* §5.5: the one-line explanation opens WITH the popover, in
               --font-sans --ink-body --text-sm — prose, never tooltip-only. */}

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -72,7 +72,7 @@ function byVersion(a: VersionEntry, b: VersionEntry): number {
  * A BRANCH is a version whose parent is not the one immediately before it — the
  * lineage the linear strip cannot show positionally, so it is named instead.
  */
-function forkedFrom(entry: VersionEntry): number | null {
+export function forkedFrom(entry: VersionEntry): number | null {
   return entry.parent !== null && entry.parent !== entry.version - 1 ? entry.parent : null;
 }
 
@@ -85,12 +85,12 @@ function forkedFrom(entry: VersionEntry): number | null {
  * stopgap after a reload. `meta` stays the first look for any bridge that does echo
  * it; the store map is what actually answers today.
  */
-function anchorOf(entry: VersionEntry, byVersion: Map<number, string>): string | null {
+export function anchorOf(entry: VersionEntry, byVersion: Map<number, string>): string | null {
   return entry.meta?.sourceMessageId ?? byVersion.get(entry.version) ?? null;
 }
 
 /** version → the id of the user message tagged with it, from one thread's transcript. */
-function anchorsFrom(msgs: DocMsg[]): Map<number, string> {
+export function anchorsFrom(msgs: DocMsg[]): Map<number, string> {
   const map = new Map<number, string>();
   for (const m of msgs) {
     if (m.kind === 'user' && m.version !== undefined) map.set(m.version, m.id);
@@ -148,6 +148,22 @@ export interface VersionStripProps {
   navigate: Navigate;
   /** The service's fork result; the owner re-reads the manifest and routes to it. */
   onForked: (result: ForkResult) => void;
+  /**
+   * The band's dress (operator feedback, doc-surface round: "The banner at
+   * bottom should only be versions … remove the 'fork' and 'in thread'
+   * chiclets and reduce the overall height of the band").
+   *
+   * - 'full' (default): the historical band — multi-row entries with Fork /
+   *   In-thread actions, the spine caption, and the [Themes] [Export] toolbar.
+   *   Video mode still wears this.
+   * - 'slim': VERSION PILLS ONLY, one row, visibly shorter. No chiclets, no
+   *   caption, no toolbar, and `compare`/`trailing` are never rendered — those
+   *   affordances live in the Document surface's right panel now (DocPanel).
+   *   Selecting a pill keeps the §7.6 cross-link (navigate + scroll the thread
+   *   to the producing message); the fork gesture SURVIVES in the panel's
+   *   Versions tab (§0: a protected gesture moves, it never silently dies).
+   */
+  variant?: 'full' | 'slim';
   /** Which mode route a selection navigates (DES-FEEDBACK-001 §7.4): Video reuses
    *  the strip verbatim, so the ONLY thing that differs is the path it builds. */
   mode?: 'document' | 'video';
@@ -174,7 +190,7 @@ export const STRIP_FADE_GRACE_MS = 320;
 
 export function VersionStrip({
   projectId, docId, manifest, selected, navigate, onForked,
-  mode = 'document', dimmed = false, onWake, onHold, trailing, compare,
+  variant = 'full', mode = 'document', dimmed = false, onWake, onHold, trailing, compare,
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -211,6 +227,91 @@ export function VersionStrip({
     } finally {
       setForking(null);
     }
+  }
+
+  // ── The slim band (operator feedback): version pills ONLY, one short row ────
+  if (variant === 'slim') {
+    return (
+      <div
+        data-testid="version-strip"
+        data-variant="slim"
+        data-hidden={dimmed ? 'true' : 'false'}
+        onMouseMove={onWake}
+        onPointerDown={onWake}
+        style={{
+          alignItems: 'center', background: S.bar,
+          borderTop: '2px solid var(--accent-subtle)',
+          display: 'flex', flexShrink: 0, gap: '8px', padding: '4px 10px',
+          opacity: dimmed ? 0 : 1,
+          pointerEvents: dimmed && inert ? 'none' : 'auto',
+          transition: 'opacity var(--dur-base)',
+        }}
+      >
+        <span style={{
+          color: S.faint, flexShrink: 0, fontSize: 'var(--text-2xs)', fontWeight: 600,
+          fontFamily: 'var(--font-mono)', letterSpacing: '0.06em', textTransform: 'uppercase',
+        }}>
+          Versions
+        </span>
+        <div style={{ alignItems: 'center', display: 'flex', flex: 1, gap: '6px',
+                      minWidth: 0, overflowX: 'auto' }}>
+          {[...manifest.versions].sort(byVersion).map((entry) => {
+            const isSelected = entry.version === selected;
+            const branchOf = forkedFrom(entry);
+            return (
+              <div
+                key={entry.version}
+                data-testid="version-entry"
+                data-version={entry.version}
+                data-parent={entry.parent === null ? '' : entry.parent}
+                data-selected={isSelected ? 'true' : 'false'}
+                style={{
+                  background: isSelected ? S.selected : 'transparent',
+                  border: `1px solid ${isSelected ? S.accent : S.border}`,
+                  borderRadius: 'var(--radius-full)', display: 'inline-flex',
+                  flexShrink: 0, padding: '1px 8px',
+                }}
+              >
+                <button
+                  type="button"
+                  data-testid="version-select"
+                  aria-current={isSelected ? 'true' : undefined}
+                  onClick={() => select(entry)}
+                  title={branchOf === null
+                    ? `Show version ${entry.version}`
+                    : `Show version ${entry.version} — continues from v${branchOf}`}
+                  style={{
+                    alignItems: 'center', background: 'transparent', border: 'none',
+                    color: isSelected ? S.ink : S.muted, cursor: 'pointer',
+                    display: 'inline-flex', gap: '5px', padding: 0,
+                  }}
+                >
+                  {isSelected && (
+                    <span
+                      data-testid="version-active-dot"
+                      style={{
+                        background: S.accent, borderRadius: 'var(--radius-full)',
+                        display: 'inline-block', flexShrink: 0, height: '6px', width: '6px',
+                      }}
+                    />
+                  )}
+                  <span style={{
+                    fontSize: 'var(--text-xs)', fontWeight: 600, fontFamily: 'var(--font-mono)',
+                  }}>
+                    v{entry.version}
+                  </span>
+                  <span data-testid="version-stamp" style={{
+                    color: S.muted, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                  }}>
+                    {stamp(entry.created_at)}
+                  </span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/VersionStrip.tsx
+++ b/src/components/VersionStrip.tsx
@@ -48,7 +48,7 @@ const S = {
 /** §7.6: no anchor known ⇒ nothing to scroll to, and the reason is the tooltip.
  *  DES-UX-001 §6.3: the transcript read carries no version anchors (BRIDGE-UX-1
  *  §8.4.1), so anchors survive only for what this session observed. */
-const NO_ANCHOR_TITLE =
+export const NO_ANCHOR_TITLE =
   'The message that produced this version is not known to this session, so there is '
   + 'nothing to scroll to. The document service does not yet record version anchors '
   + 'in the transcript — they survive for what this session observed; older documents '
@@ -106,39 +106,6 @@ const ACTION: React.CSSProperties = {
   fontFamily: 'var(--font-sans)', lineHeight: 1.6, padding: '1px 6px',
 };
 
-/**
- * The compare lens (DES-FEEDBACK-002 §7, slice K): the strip's toolbar carries the
- * `[⇆ Compare]` toggle and, while comparing, the `v(N) ↔ v(M) · overlay · vs: · ✕`
- * cluster. The strip only WEARS the state — the panes (and the state itself) are
- * the canvas owner's (DocumentCanvas), because comparing is a lens on the canvas,
- * not an address (§7.2: the left pane stays the `?v=N` navigation; the comparand
- * is ephemeral UI state). Video mode never passes this prop, so the storyboard's
- * strip is untouched.
- */
-export interface CompareControl {
-  /** Comparing right now. */
-  active: boolean;
-  /** The right pane's version (null only while inactive). */
-  comparand: number | null;
-  /** §7.5/§7.6 disabled-with-reason: non-null renders the toggle disabled with
-   *  the reason as its title ("only one version exists" on a v1-only doc). */
-  disabledReason: string | null;
-  /** The `[▣ overlay]` sub-toggle inside compare (§7.2). */
-  overlay: boolean;
-  onToggle: () => void;
-  onComparand: (version: number) => void;
-  onOverlay: (on: boolean) => void;
-  onExit: () => void;
-}
-
-/** §6.4 segmented dress (shared by §7.4): active = --surface-raised + --ink-high,
- *  inactive = --ink-muted; --radius-md. */
-const SEGMENT: React.CSSProperties = {
-  background: 'transparent', border: 'none', borderRadius: 'var(--radius-md)',
-  color: S.muted, cursor: 'pointer', fontFamily: 'var(--font-sans)',
-  fontSize: 'var(--text-2xs)', lineHeight: 1.6, padding: '1px 7px',
-};
-
 export interface VersionStripProps {
   projectId: string;
   docId: string;
@@ -175,11 +142,10 @@ export interface VersionStripProps {
   /** §7.2 (the J3 closed-drawer pin): a strip control holding an unanswered/
    *  un-acted answer pins the strip visible — see `useStripAutoHide().hold`. */
   onHold?: ((held: boolean) => void) | undefined;
-  /** The canvas-first chrome's extra control — the thread-drawer toggle (§7.3). */
+  /** The canvas-first chrome's extra control — the thread-drawer toggle (§7.3).
+   *  Full variant only (Video); the Document surface's panel owns its own
+   *  expand/collapse now, so its slim band carries no toggle. */
   trailing?: React.ReactNode;
-  /** DES-FEEDBACK-002 §7 (slice K): the compare toggle/cluster. Absent = no
-   *  compare affordance (Video mode reuses the strip without one). */
-  compare?: CompareControl;
 }
 
 /** How long the strip stays CLICKABLE after auto-hide dims it — the fade itself
@@ -190,7 +156,7 @@ export const STRIP_FADE_GRACE_MS = 320;
 
 export function VersionStrip({
   projectId, docId, manifest, selected, navigate, onForked,
-  variant = 'full', mode = 'document', dimmed = false, onWake, onHold, trailing, compare,
+  variant = 'full', mode = 'document', dimmed = false, onWake, onHold, trailing,
 }: VersionStripProps): React.ReactElement {
   const [forking, setForking] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -467,93 +433,9 @@ export function VersionStrip({
         selecting a version scrolls the thread to the message that made it ▸
       </span>
 
-      {/* DES-FEEDBACK-002 §7.2 (slice K): the compare toggle rides the toolbar
-          beside [Themes] [Export]. Inactive: one button (disabled with a stated
-          reason on a v1-only doc — §7.6's rule). Active: the comparing cluster —
-          what is compared, the overlay sub-toggle, the `vs:` comparand picker
-          (every OTHER version), and the ✕ exit. */}
-      {compare !== undefined && !compare.active && (
-        <button
-          type="button"
-          data-testid="version-compare-toggle"
-          disabled={compare.disabledReason !== null}
-          onClick={compare.onToggle}
-          title={compare.disabledReason
-            ?? `Compare v${selected} with another version side by side`}
-          style={{
-            ...ACTION,
-            alignSelf: 'center', flexShrink: 0,
-            cursor: compare.disabledReason !== null ? 'not-allowed' : 'pointer',
-            opacity: compare.disabledReason !== null ? 0.4 : 1,
-          }}
-        >
-          ⇆ Compare
-        </button>
-      )}
-      {compare !== undefined && compare.active && compare.comparand !== null && (
-        <span
-          data-testid="compare-controls"
-          style={{
-            alignItems: 'center', alignSelf: 'center',
-            border: `1px solid ${S.border}`, borderRadius: 'var(--radius-md)',
-            display: 'inline-flex', flexShrink: 0, gap: '6px', padding: '1px 6px',
-          }}
-        >
-          <span style={{
-            color: S.ink, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)',
-          }}>
-            ⇆ Comparing v{selected} ↔ v{compare.comparand}
-          </span>
-          <button
-            type="button"
-            data-testid="compare-overlay-toggle"
-            aria-pressed={compare.overlay}
-            onClick={() => compare.onOverlay(!compare.overlay)}
-            title={compare.overlay
-              ? 'Back to the side-by-side split'
-              : 'Stack the two versions with adjustable opacity — spot layout shifts'}
-            style={{
-              ...SEGMENT,
-              background: compare.overlay ? 'var(--surface-raised)' : 'transparent',
-              color: compare.overlay ? S.ink : S.muted,
-            }}
-          >
-            ▣ overlay
-          </button>
-          <label style={{
-            alignItems: 'center', color: S.faint, display: 'inline-flex', gap: '4px',
-            fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)',
-          }}>
-            vs:
-            <select
-              data-testid="compare-vs"
-              value={compare.comparand}
-              onChange={(e) => compare.onComparand(Number(e.target.value))}
-              title="Pick which version the right pane shows"
-              style={{
-                background: 'var(--surface-raised)', border: `1px solid ${S.border}`,
-                borderRadius: 'var(--radius-sm)', color: S.ink,
-                fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)', padding: '0 2px',
-              }}
-            >
-              {[...manifest.versions].sort(byVersion)
-                .filter((e) => e.version !== selected)
-                .map((e) => (
-                  <option key={e.version} value={e.version}>v{e.version}</option>
-                ))}
-            </select>
-          </label>
-          <button
-            type="button"
-            data-testid="compare-exit"
-            onClick={compare.onExit}
-            title="Exit compare — back to the solo canvas (Escape works too)"
-            style={{ ...SEGMENT, padding: '1px 4px' }}
-          >
-            ✕
-          </button>
-        </span>
-      )}
+      {/* NOTE (doc-feedback round): the slice-K compare toggle/cluster used to ride
+          this toolbar. Compare moved to the Document panel's Compare tab (DocPanel)
+          — the strip never wears it now, in either variant. */}
 
       {/* The canvas toolbar (§2.6 rule 4): [Themes] [Export], acting on the document. */}
       <ThemesMenu projectId={projectId} docId={docId} />

--- a/tests/DocPanel.versions.test.tsx
+++ b/tests/DocPanel.versions.test.tsx
@@ -87,6 +87,27 @@ describe('DocPanel — the Versions tab', () => {
     }
   });
 
+  it('In-thread with a real anchor flips the panel to the Chat tab — the thread is THERE, and a scroll inside a hidden tab would be a silent no-op', async () => {
+    const onTab = vi.fn();
+    const d = doc({
+      manifest: {
+        head: 2,
+        versions: [entry(1), entry(2, { meta: { sourceMessageId: 'm-42' } })],
+      },
+      selected: 1,
+    });
+    render(
+      <DocPanel open tab="versions" onExpand={() => {}} onCollapse={() => {}} onTab={onTab} doc={d}>
+        <div data-testid="fake-thread" />
+      </DocPanel>,
+    );
+    const anchored = screen.getAllByTestId('version-scroll')
+      .find((b) => !(b as HTMLButtonElement).disabled)!;
+    expect(anchored).toBeDefined();
+    await userEvent.click(anchored);
+    expect(onTab).toHaveBeenCalledWith('chat');
+  });
+
   it('Show navigates to ?v=N and the selected row says it is on the canvas', async () => {
     const d = doc();
     mount(d);

--- a/tests/DocPanel.versions.test.tsx
+++ b/tests/DocPanel.versions.test.tsx
@@ -1,0 +1,116 @@
+// The right panel's VERSIONS TAB (doc-feedback round): per-version detail built
+// on REAL wire data only — the versions.json manifest (version, parent,
+// feedback_file, html_file, created_at, meta) plus session-observed thread
+// anchors. The operator asked for git history; the document workspace has no
+// git wire, so the tab SAYS the manifest is the history — never fabricated
+// commits.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocPanel, VERSIONS_HISTORY_NOTE } from '../src/components/DocPanel.js';
+import type { DocPanelDoc } from '../src/components/DocPanel.js';
+import type { VersionEntry, VersionManifest } from '../src/api/interactive.js';
+
+const postFork = vi.hoisted(() => vi.fn());
+vi.mock('../src/api/interactive.js', async (orig) => ({
+  ...(await orig<typeof import('../src/api/interactive.js')>()),
+  postFork,
+}));
+
+function entry(version: number, over: Partial<VersionEntry> = {}): VersionEntry {
+  return {
+    version, parent: version - 1 || null, feedback_file: null,
+    html_file: `_v${version}.html`, created_at: `2026-08-1${version}T09:00:00Z`, ...over,
+  };
+}
+
+const MANIFEST: VersionManifest = {
+  head: 3,
+  versions: [entry(1), entry(2, { feedback_file: '_v2.md' }), entry(3, { parent: 1 })],
+};
+
+function doc(over: Partial<DocPanelDoc> = {}): DocPanelDoc {
+  return {
+    projectId: 'p1', docId: 'q3-report', manifest: MANIFEST, selected: 3,
+    navigate: vi.fn(), onForked: vi.fn(),
+    compare: { active: false, comparand: null, disabledReason: null, overlay: false,
+               onToggle: vi.fn(), onComparand: vi.fn(), onOverlay: vi.fn(), onExit: vi.fn() },
+    ...over,
+  };
+}
+
+function mount(d: DocPanelDoc = doc()): void {
+  render(
+    <DocPanel open tab="versions" onExpand={() => {}} onCollapse={() => {}} onTab={() => {}} doc={d}>
+      <div data-testid="fake-thread" />
+    </DocPanel>,
+  );
+}
+
+afterEach(() => { cleanup(); postFork.mockReset(); });
+
+describe('DocPanel — the Versions tab', () => {
+  it('states honestly that the manifest IS the history (no git log exists on any wire)', () => {
+    mount();
+    const note = screen.getByTestId('versions-history-note');
+    expect(note).toHaveTextContent(/keeps no\s+git log/i);
+    expect(note).toHaveTextContent(/this manifest is the history/i);
+    expect(note.textContent).toBe(VERSIONS_HISTORY_NOTE);
+  });
+
+  it('renders one detail row per manifest version, NEWEST first, from real fields only', () => {
+    mount();
+    const rows = screen.getAllByTestId('version-detail');
+    expect(rows.map((r) => r.getAttribute('data-version'))).toEqual(['3', '2', '1']);
+    // Lineage: v3 branched (parent 1 ≠ 2), v2 continues, v1 is the root.
+    expect(screen.getAllByTestId('version-detail-lineage').map((l) => l.textContent))
+      .toEqual(['branched from v1', 'continues v1', 'root — the first version']);
+    // The manifest's file record, verbatim: html_file always, feedback when present.
+    const files = screen.getAllByTestId('version-detail-files').map((f) => f.textContent);
+    expect(files[0]).toBe('_v3.html');
+    expect(files[1]).toBe('_v2.html · feedback: _v2.md');
+    // Nothing pretends to be a commit: no hash-like dress anywhere in the tab.
+    expect(document.body.textContent).not.toMatch(/\bcommit\b/i);
+  });
+
+  it('the moved gestures: Fork calls the service; In-thread disables with the stated reason', async () => {
+    postFork.mockResolvedValue({ version: 4, parent: 1 });
+    const d = doc();
+    mount(d);
+    const rows = screen.getAllByTestId('version-detail');
+    await userEvent.click(rows[2]!.querySelector('[data-testid="version-fork"]') as HTMLElement);
+    expect(postFork).toHaveBeenCalledWith('p1', 'q3-report', 1);
+    // No anchors in this session and none in meta → disabled, with the reason.
+    for (const b of screen.getAllByTestId('version-scroll')) {
+      expect(b).toBeDisabled();
+      expect(b.getAttribute('title') ?? '').toMatch(/does not yet record version anchors/i);
+    }
+  });
+
+  it('Show navigates to ?v=N and the selected row says it is on the canvas', async () => {
+    const d = doc();
+    mount(d);
+    const rows = screen.getAllByTestId('version-detail');
+    expect(rows[0]!.getAttribute('data-selected')).toBe('true');
+    expect((rows[0]!.querySelector('[data-testid="version-detail-show"]') as HTMLButtonElement).disabled)
+      .toBe(true);
+    await userEvent.click(rows[2]!.querySelector('[data-testid="version-detail-show"]') as HTMLElement);
+    expect(d.navigate).toHaveBeenCalledWith('/p/p1/document/q3-report?v=1');
+  });
+});
+
+describe('DocPanel — doc-less honesty', () => {
+  it('doc-scoped tabs disable with a stated reason when no document is open', () => {
+    render(
+      <DocPanel open tab="chat" onExpand={() => {}} onCollapse={() => {}} onTab={() => {}} doc={null}>
+        <div data-testid="fake-thread" />
+      </DocPanel>,
+    );
+    for (const t of ['compare', 'theme', 'versions']) {
+      const tab = document.querySelector(`[data-testid="panel-tab"][data-tab="${t}"]`)!;
+      expect((tab as HTMLButtonElement).disabled).toBe(true);
+      expect(tab.getAttribute('title')).toMatch(/open a document first/i);
+    }
+    expect(screen.queryByTestId('chat-export')).toBeNull();
+  });
+});

--- a/tests/DocumentCanvas.compare.test.tsx
+++ b/tests/DocumentCanvas.compare.test.tsx
@@ -93,6 +93,11 @@ async function mountDoc(manifest: VersionManifest, version: number | null = null
   const navigate = vi.fn();
   render(<DocumentCanvas projectId={PROJECT} docId={DOC} version={version} navigate={navigate} />);
   await screen.findByTestId('doc-canvas');
+  // RE-SCOPED (doc-feedback round): the compare controls moved off the band
+  // into the right panel's COMPARE TAB — the rail button opens straight onto it.
+  await userEvent.click(document.querySelector(
+    '[data-testid="panel-rail-tab"][data-tab="compare"]') as HTMLElement);
+  expect(screen.getByTestId('doc-panel').getAttribute('data-tab')).toBe('compare');
   return navigate;
 }
 

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -176,7 +176,10 @@ describe('DocumentCanvas — the routed version drives the frame (§4.2, slice 9
     expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=1`);
   });
 
-  it('a fork re-reads the manifest and routes to the version the SERVICE reported', async () => {
+  it('a fork (now in the panel’s Versions tab) re-reads the manifest and routes to the version the SERVICE reported', async () => {
+    // RE-SCOPED (doc-feedback round): the band's Fork chiclet is gone — the
+    // fork gesture LIVES in the right panel's Versions tab (§0: protected
+    // gestures move, they never silently die).
     const forked = {
       head: 4,
       versions: [...MANIFEST.versions, {
@@ -193,12 +196,21 @@ describe('DocumentCanvas — the routed version drives the frame (§4.2, slice 9
     render(<DocumentCanvas projectId={PROJECT} docId={DOC} version={null} navigate={navigate} />);
 
     await screen.findByTestId('doc-canvas');
-    await userEvent.click(screen.getAllByTestId('version-fork')[0]!);
+    // The rail's Versions button expands the panel straight onto the tab.
+    await userEvent.click(screen.getByTestId('doc-panel-rail')
+      .querySelector('[data-testid="panel-rail-tab"][data-tab="versions"]') as HTMLElement);
+    // Detail rows are NEWEST FIRST; v1's row is the last. Fork from v1.
+    const rows = screen.getAllByTestId('version-detail');
+    expect(rows.map((r) => r.getAttribute('data-version'))).toEqual(['3', '2', '1']);
+    await userEvent.click(rows[2]!.querySelector('[data-testid="version-fork"]') as HTMLElement);
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DOC}?v=4`));
     // The manifest is re-read rather than patched locally (§4.2: the service is authority).
     await waitFor(() => expect(screen.getAllByTestId('version-entry')).toHaveLength(4));
-    expect(screen.getByTestId('version-lineage')).toHaveTextContent('continues from v1');
+    // The band pill names the branch in its title; the DETAIL row states it.
+    await waitFor(() => expect(
+      screen.getAllByTestId('version-detail-lineage').map((l) => l.textContent),
+    ).toContain('branched from v1'));
   });
 });
 
@@ -313,16 +325,17 @@ describe('DocumentCanvas — the picker (§6.3: no :docId in the route)', () => 
   });
 });
 
-// ── DES-UXFIX-001 §2.6 (slice 6): the three-pane spine ───────────────────────
+// ── DES-UXFIX-001 §2.6 (slice 6) → RE-SCOPED by the doc-feedback round: the
+//    right panel replaced the drawer, the band is versions-only ───────────────
 
-describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK-001 §7.3)', () => {
+describe('DocumentCanvas — canvas-first: right panel + slim strip (doc-feedback round)', () => {
   const thread = <aside data-testid="fake-thread">the thread pane</aside>;
 
   beforeEach(() => {
     useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {} });
   });
 
-  it('AC: with a doc open the thread drawer is CLOSED by default and the strip lives INSIDE the canvas container', async () => {
+  it('AC: with a doc open the panel is COLLAPSED to its rail by default and the strip lives INSIDE the canvas container', async () => {
     stubFetch({ '/api/versions': { body: MANIFEST } });
     render(
       <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
@@ -331,9 +344,12 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
     );
 
     await screen.findByTestId('doc-canvas');
-    // §7.3: the canvas owns the viewport — no thread column on first visit.
-    expect(screen.queryByTestId('thread-drawer')).toBeNull();
+    // The canvas owns the viewport — the panel is a RAIL on first visit, and
+    // the rail is the panel's OWN expand affordance (no strip toggle).
+    expect(screen.queryByTestId('doc-panel')).toBeNull();
     expect(screen.queryByTestId('fake-thread')).toBeNull();
+    expect(screen.getByTestId('doc-panel-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('panel-expand')).toBeInTheDocument();
     // The strip floats over the canvas's bottom edge, inside its container.
     const container = screen.getByTestId('document-canvas');
     const strip = screen.getByTestId('version-strip');
@@ -341,7 +357,7 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
     expect(container.contains(screen.getByTestId('doc-canvas'))).toBe(true);
   });
 
-  it('AC: the strip toggle opens the drawer (canvas reflows to a flex sibling) and closes it again', async () => {
+  it('AC: the panel expands from its OWN rail (canvas reflows to a flex sibling) and collapses again', async () => {
     stubFetch({ '/api/versions': { body: MANIFEST } });
     render(
       <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
@@ -350,33 +366,61 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
     );
     await screen.findByTestId('doc-canvas');
 
-    await userEvent.click(screen.getByTestId('thread-toggle'));
-    const drawer = screen.getByTestId('thread-drawer');
-    expect(drawer).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('panel-expand'));
+    const panel = screen.getByTestId('doc-panel');
+    expect(panel).toBeInTheDocument();
+    expect(panel.getAttribute('data-tab')).toBe('chat');
     expect(screen.getByTestId('fake-thread')).toBeInTheDocument();
     // A flex SIBLING of the canvas container — reflow, not overlay (§7.3).
     const container = screen.getByTestId('document-canvas');
-    expect(drawer.parentElement).toBe(container.parentElement);
-    expect(drawer.style.width).toBe('min(440px, 40vw)');
+    expect(panel.parentElement).toBe(container.parentElement);
+    expect(panel.style.width).toBe('min(440px, 40vw)');
 
-    await userEvent.click(screen.getByTestId('thread-close'));
-    expect(screen.queryByTestId('thread-drawer')).toBeNull();
+    await userEvent.click(screen.getByTestId('panel-collapse'));
+    expect(screen.queryByTestId('doc-panel')).toBeNull();
+    expect(screen.getByTestId('doc-panel-rail')).toBeInTheDocument();
   });
 
-  it('the strip says what selecting does, and carries [Themes] [Export] + the thread toggle', async () => {
+  it('the band is VERSIONS ONLY: no chiclets, no toolbar, no toggle, no caption — pills with stamps', async () => {
     stubFetch({ '/api/versions': { body: MANIFEST } });
     render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
 
     await screen.findByTestId('doc-canvas');
     const strip = screen.getByTestId('version-strip');
-    expect(strip.querySelector('[data-testid="version-spine-caption"]'))
-      .toHaveTextContent(/selecting a version scrolls the thread/i);
-    expect(strip.querySelector('[data-testid="themes-open"]')).toHaveTextContent('Themes');
-    expect(strip.querySelector('[data-testid="export-menu"]')).not.toBeNull();
-    expect(strip.querySelector('[data-testid="thread-toggle"]')).not.toBeNull();
+    expect(strip.getAttribute('data-variant')).toBe('slim');
+    // The operator's list, verbatim: no Threads/toggle, no fork, no in-thread.
+    expect(strip.querySelector('[data-testid="thread-toggle"]')).toBeNull();
+    expect(strip.querySelector('[data-testid="version-fork"]')).toBeNull();
+    expect(strip.querySelector('[data-testid="version-scroll"]')).toBeNull();
+    expect(strip.querySelector('[data-testid="version-spine-caption"]')).toBeNull();
+    expect(strip.querySelector('[data-testid="themes-open"]')).toBeNull();
+    expect(strip.querySelector('[data-testid="export-menu"]')).toBeNull();
+    // What remains: one pill per version, each with its number and stamp.
+    expect(strip.querySelectorAll('[data-testid="version-entry"]')).toHaveLength(3);
+    expect(strip.querySelectorAll('[data-testid="version-stamp"]')).toHaveLength(3);
   });
 
-  it('the conversation stays REACHABLE while loading and on failure: the floating toggle opens it (§1.2)', async () => {
+  it('export lives UNDER THE CHATBOX in the Chat tab (the moved slice-X click site)', async () => {
+    stubFetch({ '/api/versions': { body: MANIFEST } });
+    render(
+      <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
+        {thread}
+      </DocumentCanvas>,
+    );
+    await screen.findByTestId('doc-canvas');
+    await userEvent.click(screen.getByTestId('panel-expand'));
+
+    const chatBody = document.querySelector('[data-testid="panel-body"][data-tab="chat"]')!;
+    const exportBlock = screen.getByTestId('chat-export');
+    expect(chatBody.contains(exportBlock)).toBe(true);
+    // The chat body's order: the thread first, the export block after it.
+    expect(exportBlock.previousSibling).toBe(screen.getByTestId('fake-thread'));
+    // The same slice-X control, addressing the shown version.
+    expect(exportBlock.querySelector('[data-testid="export-menu"]'))
+      .toHaveAttribute('data-version', '3');
+  });
+
+  it('the conversation stays REACHABLE while loading and on failure: the rail expands it (§1.2)', async () => {
     stubFetch({ '/api/versions': { status: 500, body: { error: 'versions.json is corrupt' } } });
     render(
       <DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}}>
@@ -386,11 +430,15 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
 
     await screen.findByTestId('doc-canvas-error');
     expect(screen.queryByTestId('version-strip')).toBeNull();          // no manifest, no strip
-    await userEvent.click(screen.getByTestId('thread-toggle'));        // …but the thread is one click away
+    await userEvent.click(screen.getByTestId('panel-expand'));         // …but the thread is one click away
     expect(screen.getByTestId('fake-thread')).toBeInTheDocument();
+    // Doc-scoped tabs are honest about needing a manifest: disabled with a reason.
+    const compareTab = document.querySelector('[data-testid="panel-tab"][data-tab="compare"]')!;
+    expect((compareTab as HTMLButtonElement).disabled).toBe(true);
+    expect(compareTab.getAttribute('title')).toMatch(/open a document/i);
   });
 
-  it('the doc-less picker keeps the thread OPEN beside it (its empty state points there), with no strip', async () => {
+  it('the doc-less picker keeps the panel OPEN on Chat beside it (its empty state points there), with no strip', async () => {
     stubFetch({ '/api/docs': { body: [] } });
     render(
       <DocumentCanvas projectId={PROJECT} docId={null} navigate={() => {}}>
@@ -399,9 +447,12 @@ describe('DocumentCanvas — canvas-first: drawer + floating strip (DES-FEEDBACK
     );
 
     await screen.findByTestId('doc-picker-empty');
-    expect(screen.getByTestId('thread-drawer')).toBeInTheDocument();
+    const panel = screen.getByTestId('doc-panel');
+    expect(panel.getAttribute('data-tab')).toBe('chat');
     expect(screen.getByTestId('fake-thread')).toBeInTheDocument();
     expect(screen.queryByTestId('version-strip')).toBeNull();
+    // Nothing to export on the picker — the block waits for a document.
+    expect(screen.queryByTestId('chat-export')).toBeNull();
   });
 
   it('§7.3 auto-hide: the strip retires after 3s idle and the bottom sensor wakes it', async () => {

--- a/tests/composerGrow.test.tsx
+++ b/tests/composerGrow.test.tsx
@@ -1,0 +1,71 @@
+// The growing doc composer (operator feedback, doc-surface round): the chat box
+// expands with its content from ONE line to a FIVE-line cap, then scrolls —
+// "can't stay one line". growComposer is the one measuring function; the
+// DocumentThread textarea re-runs it on every text change.
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+import {
+  COMPOSER_LINE_PX, COMPOSER_MAX_LINES, DocumentThread, growComposer,
+} from '../src/components/DocumentThread.js';
+
+/** A textarea whose scrollHeight is scriptable — jsdom does no layout. */
+function fakeArea(scrollHeight: number): HTMLTextAreaElement {
+  const el = document.createElement('textarea');
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  return el;
+}
+
+afterEach(cleanup);
+
+describe('growComposer — 1 line minimum, 5 lines maximum, scroll past that', () => {
+  it('one line of content keeps a one-line box, no scrollbar', () => {
+    const el = fakeArea(COMPOSER_LINE_PX);
+    growComposer(el);
+    expect(el.style.height).toBe(`${COMPOSER_LINE_PX}px`);
+    expect(el.style.overflowY).toBe('hidden');
+  });
+
+  it('grows to fit content between the bounds (3 lines → 3 lines tall)', () => {
+    const el = fakeArea(3 * COMPOSER_LINE_PX);
+    growComposer(el);
+    expect(el.style.height).toBe(`${3 * COMPOSER_LINE_PX}px`);
+    expect(el.style.overflowY).toBe('hidden');
+  });
+
+  it('clamps at COMPOSER_MAX_LINES and switches to its own scroll', () => {
+    const el = fakeArea(9 * COMPOSER_LINE_PX);
+    growComposer(el);
+    expect(el.style.height).toBe(`${COMPOSER_MAX_LINES * COMPOSER_LINE_PX}px`);
+    expect(el.style.overflowY).toBe('auto');
+  });
+
+  it('a jsdom-style zero scrollHeight still floors at one line — never a 0px box', () => {
+    const el = fakeArea(0);
+    growComposer(el);
+    expect(el.style.height).toBe(`${COMPOSER_LINE_PX}px`);
+  });
+
+  it('the cap is the operator’s number: five lines', () => {
+    expect(COMPOSER_MAX_LINES).toBe(5);
+  });
+});
+
+describe('DocumentThread — the composer wears the growth wiring', () => {
+  it('re-measures on every change (height set from scrollHeight, capped)', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('no wire in this test'))));
+    render(
+      <DocumentThread projectId="p1" docId={null} selectedVersion={null} navigate={() => {}} />,
+    );
+    const area = screen.getByTestId('doc-composer') as HTMLTextAreaElement;
+    expect(area.getAttribute('data-max-lines')).toBe(String(COMPOSER_MAX_LINES));
+    // Simulate real layout: content is 7 lines tall.
+    Object.defineProperty(area, 'scrollHeight', {
+      configurable: true, get: () => 7 * COMPOSER_LINE_PX,
+    });
+    fireEvent.change(area, { target: { value: 'a\nb\nc\nd\ne\nf\ng' } });
+    expect(area.style.height).toBe(`${COMPOSER_MAX_LINES * COMPOSER_LINE_PX}px`);
+    expect(area.style.overflowY).toBe('auto');
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
Operator-feedback round on the document surface — all six points, verbatim requirements:

- **Export lives under the chat box** in the right panel's Chat tab (slice-X point-of-action states intact at the new site).
- **Compare & Theme are tabs** on the right column (Chat | Compare | Theme | Versions), and the column has its **own expand/collapse** (canvas reflows >100px wider when collapsed).
- **The bottom band is versions only**: no "Threads ✕", no Fork/In-thread chiclets — measured **30.5px vs 93.5px** on main. The §0-protected fork and in-thread gestures survive in the Versions tab (verifier drove both).
- **The chatbox auto-grows** 1→5 lines then scrolls (real keyboard-typing assertion; clears back to one line).
- **Versions tab** with per-version details from the real manifest wire — no git wire exists for doc workspaces (verified against the bridge source), and the tab says so honestly instead of fabricating commits.

Verified: 1545/1545 unit tests; new gate rig green ×2 mapping each bullet to an AC; re-scoped ux_sliceT/X, uxfix_slice6, vision_slice4 as dedicated line-justified commits; adversarial verifier measured the band live against a main build and cross-checked the Versions rows against an independently fetched manifest. Known follow-ups: feedback2_sliceK, ux_fixJ33/J3J1, studio_standalone still pin the retired anatomy (re-scope owed at next touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
