### PR TITLE
Doc canvas: restore block-level click-to-edit (bridge injection + real feedback wire)

### DIFF
--- a/e2e/feedback2_sliceK_test.py
+++ b/e2e/feedback2_sliceK_test.py
@@ -30,16 +30,21 @@ DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar
    3. Toggling fires ZERO /api requests (C1), keeps the composer's focus and
       draft, and Enter still sends from columns mode.
 
-  Version compare (§7.5):
-   4. On the 3-version doc, [data-testid="version-compare-toggle"] enters
-      compare: two [data-testid="compare-pane"] iframes, src ending /doc/3 and
-      /doc/2 (the lineage parent); the pane pair spans >80% viewport width
-      (EC18-as-region); the URL keeps ?v=3 throughout.
+  Version compare (§7.5, re-scoped to the #115 anatomy — tabbed right panel +
+  slim band: the compare cluster lives in the panel's Compare tab, the strip is
+  version pills only, and the thread drawer is the panel's always-on Chat tab):
+   4. On the 3-version doc — after selecting v3 on the slim band (landings
+      follow the head WITHOUT minting a route; ?v=N is the pill's §7.6
+      cross-link) — [data-testid="version-compare-toggle"] in the Compare tab
+      enters compare: two [data-testid="compare-pane"] iframes, src ending
+      /doc/3 and /doc/2 (the lineage parent); the pane pair spans >80% of the
+      CANVAS REGION (EC18-as-region — the permanent panel is a flex sibling);
+      the URL keeps ?v=3 throughout.
    5. The vs: dropdown lists every OTHER version; picking v1 re-points ONLY the
       right pane. Overlay stacks the two frames with the opacity slider.
-   6. The slice-F strip machinery survives compare: the strip auto-hides after
-      idle WITH TWO IFRAMES PRESENT and wakes on bottom proximity; the thread
-      drawer still opens/closes.
+   6. The slice-F strip machinery survives compare: the slim band auto-hides
+      after idle WITH TWO IFRAMES PRESENT and wakes on bottom proximity; the
+      panel's Chat tab still shows the thread over the pane pair.
    7. Exits: Escape returns to the solo canvas at the selected version; a strip
       selection while comparing re-points the LEFT pane only; ✕ exits. Entering
       compare adds no history entry.
@@ -47,7 +52,7 @@ DES-FEEDBACK-003 §8.6 — the canvas REGION, panes included, ends above the bar
 
 Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
   feedback2-K-chat-columns.png    4-seat rounds side by side, one empty cell
-  feedback2-K-compare-split.png   v3 ↔ v2 split with the strip toolbar cluster
+  feedback2-K-compare-split.png   v3 ↔ v2 split with the panel's compare cluster
   feedback2-K-compare-overlay.png overlay mode, slider at 50
 
 Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
@@ -227,17 +232,19 @@ with sync_playwright() as p:
     page.keyboard.press("Enter")
     page.locator('[data-testid="doc-canvas"][data-version="3"]').wait_for(timeout=30000)
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=30000)
-    if "?v=3" not in page.url:
-        fail("K3_journey", f"expected the route at ?v=3 after the third landing, got {page.url}")
-
-    # Close the drawer: EC18 measures the canvas-first posture (drawer closed by
-    # default; this journey opened it on the picker and it survived — by design).
+    # Re-scoped to the #115 anatomy: a LANDING follows the head without minting a
+    # route — the URL stays the doc's base address; `?v=N` is the pill's §7.6
+    # cross-link, a gesture the user makes. Make it: select v3 on the slim band.
+    if "?v=" in page.url:
+        fail("K3_journey", f"expected the base doc route after landings (head-follow), got {page.url}")
     wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
-    page.locator('[data-testid="thread-drawer"]').wait_for(state="detached", timeout=30000)
+    page.locator('[data-testid="version-entry"][data-version="3"] [data-testid="version-select"]').click()
+    page.wait_for_function("() => location.search.includes('v=3')", timeout=15000)
 
-    # Enter compare from the strip toolbar (§7.2).
-    wake_strip(page)
+    # Enter compare from the panel's Compare tab (§7.2 as re-homed by #115: the
+    # strip is the slim band — versions only — and the compare cluster lives in
+    # the tabbed right panel, which is on screen throughout; no drawer exists).
+    page.locator('[data-testid="panel-tab"][data-tab="compare"]').click()
     history_before = page.evaluate("() => history.length")
     page.locator('[data-testid="version-compare-toggle"]').click()
     page.locator('[data-testid="compare-pane"]').first.wait_for(timeout=30000)
@@ -247,22 +254,28 @@ with sync_playwright() as p:
              const rects = panes.map(p => p.getBoundingClientRect());
              const left = Math.min(...rects.map(r => r.left));
              const right = Math.max(...rects.map(r => r.right));
+             // EC18-as-region, re-scoped by #115: the permanent tabbed panel is a
+             // flex SIBLING of the canvas region, so the pane pair is measured
+             // against the canvas region it owns — not the whole viewport.
+             const region = document.querySelector('[data-testid="document-canvas"]')
+               .getBoundingClientRect();
              return {
                count: panes.length,
                srcs: panes.map(p => new URL(p.src).pathname),
-               pairWidthFrac: (right - left) / window.innerWidth,
+               pairWidthFrac: (right - left) / region.width,
                soloGone: !document.querySelector('[data-testid="doc-canvas"]'),
                cluster: document.querySelector('[data-testid="compare-controls"]')?.textContent || '',
-               parentLabel: [...document.querySelectorAll('span')]
-                 .some(s => (s.textContent || '').trim() === 'v2 (parent)'),
                url: location.search,
              };
            }""")
+    # (The old strip cluster's literal "v2 (parent)" span retired with the strip
+    # toolbar; the LINEAGE-PARENT default is still what the src assertion proves —
+    # v3's comparand came up as /doc/2 with nobody picking it.)
     step("K3_compare_split",
          split["count"] == 2
          and split["srcs"][0].endswith("/doc/3") and split["srcs"][1].endswith("/doc/2")
          and split["pairWidthFrac"] > 0.8 and split["soloGone"]
-         and "Comparing v3 ↔ v2" in split["cluster"] and split["parentLabel"]
+         and "Comparing v3 ↔ v2" in split["cluster"]
          and "v=3" in split["url"],
          **split)
     # No history entry was added by entering compare (a lens, not an address).
@@ -333,15 +346,15 @@ with sync_playwright() as p:
     wake_strip(page)  # asserts data-hidden flips back to 'false'
     step("K6_strip_hides_and_wakes_in_compare", two_iframes == 2, iframes=two_iframes)
 
-    # …and the thread drawer still opens/closes over the pane pair.
-    page.locator('[data-testid="thread-toggle"]').click()
-    page.locator('[data-testid="thread-drawer"]').wait_for(timeout=30000)
+    # …and the panel's CHAT tab (the drawer's #115 successor) still shows the
+    # thread over the pane pair — switching tabs must not tear down compare.
+    page.locator('[data-testid="panel-tab"][data-tab="chat"]').click()
+    page.locator('[data-testid="panel-body"][data-tab="chat"] [data-testid="thread"]').wait_for(timeout=30000)
     drawer_panes = page.evaluate(
         "() => document.querySelectorAll('[data-testid=\"compare-pane\"]').length")
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
-    page.locator('[data-testid="thread-drawer"]').wait_for(state="detached", timeout=30000)
-    step("K6_drawer_works_in_compare", drawer_panes == 2, panes_while_open=drawer_panes)
+    page.locator('[data-testid="panel-tab"][data-tab="compare"]').click()
+    page.locator('[data-testid="compare-controls"]').wait_for(timeout=30000)
+    step("K6_panel_chat_works_in_compare", drawer_panes == 2, panes_while_open=drawer_panes)
 
     # AC 7 exits. Escape → solo canvas at the selected version.
     page.keyboard.press("Escape")
@@ -383,7 +396,8 @@ with sync_playwright() as p:
     page.keyboard.press("Enter")
     page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
     page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
-    wake_strip(page)
+    # #115: the toggle lives in the panel's Compare tab now.
+    page.locator('[data-testid="panel-tab"][data-tab="compare"]').click()
     v1only = page.evaluate(
         """() => {
              const t = document.querySelector('[data-testid="version-compare-toggle"]');

--- a/e2e/interactive_wire_contract_test.py
+++ b/e2e/interactive_wire_contract_test.py
@@ -219,11 +219,15 @@ try:
         # The CORRECTED record wire (§7.4): requestRecord speaks demo.requested.
         ("requestRecord",     "POST", "/api/events",
          {"event_type": "wicked.interactive.demo.requested", "payload": {"document_id": DEMO}}),
-        # The batch contract step feedback rides (§7.4 "what is kept").
+        # The batch contract step feedback rides (§7.4 "what is kept"). docfb2:
+        # items are ADR-0002 schema items — the shape writeFeedback serializes and
+        # applyFeedbackItems consumes ({selector, type, …}), which the client now sends.
         ("feedback_batch",    "POST", "/api/events",
          {"event_type": "wicked.interactive.feedback.submitted",
           "payload": {"document_id": DEMO, "version": head, "target": "demo_step",
-                      "source_message_id": "m2", "items": [{"wid": "step-0", "comment": "x"}]}}),
+                      "source_message_id": "m2",
+                      "items": [{"selector": "step-0", "type": "structural-change",
+                                 "instruction": "x"}]}}),
         # The CORRECTED theme wire (issue #65): requestThemeLearn speaks
         # theme.requested — doc-scoped, url OR path, exactly what
         # materializeThemeRequested reads. Both source kinds must be routable.

--- a/e2e/studio_standalone_test.py
+++ b/e2e/studio_standalone_test.py
@@ -1425,9 +1425,11 @@ try:
                     rows = doc_versions.get(name)
                     if steps is not None and rows:
                         for item in payload.get("items") or []:
-                            at = re.match(r"^step-(\d+)$", str(item.get("wid") or ""))
+                            # docfb2: items arrive schema-shaped — the step anchor is
+                            # the item's `selector`, the ask its `instruction`.
+                            at = re.match(r"^step-(\d+)$", str(item.get("selector") or ""))
                             if at and int(at.group(1)) < len(steps):
-                                steps[int(at.group(1))]["title"] = str(item.get("comment") or "")
+                                steps[int(at.group(1))]["title"] = str(item.get("instruction") or "")
                         created = max(r["version"] for r in rows) + 1
                         rows.append({"version": created, "parent": created - 1,
                                      "feedback_file": f"feedback-v{created}.json",
@@ -2017,8 +2019,13 @@ try:
             messages_added == 1,
             FB_ONE in batch_text, FB_TWO in batch_text,
             len(feedback_events) == 2,  # the batch of two, then the unrecordable one
-            [i.get("wid") for i in (batch_event.get("items") or [])] == ["h1", "p1"],
-            [i.get("comment") for i in (batch_event.get("items") or [])] == [FB_ONE, FB_TWO],
+            # docfb2: items ride the ADR-0002 schema shape ({selector, type, …}) —
+            # what the real materializeFeedback loop consumes. The old {wid, comment}
+            # spelling was rejected per item as selector-not-found by the real bridge.
+            [i.get("selector") for i in (batch_event.get("items") or [])] == ["h1", "p1"],
+            [i.get("type") for i in (batch_event.get("items") or [])]
+            == ["structural-change", "structural-change"],
+            [i.get("instruction") for i in (batch_event.get("items") or [])] == [FB_ONE, FB_TWO],
             batch_event.get("version") == 2,
             len(batch_injects) == 1,
             # The deep-link brought the element back over the protocol.

--- a/e2e/ux2_docfb2_test.py
+++ b/e2e/ux2_docfb2_test.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+ux2_docfb2_test.py — the click-to-edit RESTORE gate (operator finding: "can't
+click and edit like the original wicked-interactive"), proven in a real browser
+against the shared W2 fixture (uxfix_fixture.py). No crew daemon.
+
+The diagnosis this rig pins (src/interactive/instrumented.ts carries the full
+story): the production instrument-bridge injector promised by doc-fixture.html's
+contract comment half-shipped — interactive's instrument.js injects data-wid
+ANCHORS but no repo anywhere served the bridge SCRIPT, so studio's sandboxed
+frame never answered the overlay's handshake and "Comment" rendered permanently
+disabled. The restore: studio fetches the version HTML, injects the bridge
+itself, renders via srcdoc (same sandbox, opaque origin), and the bridge
+restores the ORIGINAL grammar — click a block, get the card.
+
+The ACs:
+
+  1. HANDSHAKE FROM INJECTION, HONESTLY: the wire's own /doc/1 HTML carries NO
+     bridge (asserted against the fixture bytes), yet the overlay reaches
+     data-ready="true" — readiness can only have come from studio's injected
+     bridge. The frame renders via srcdoc with sandbox="allow-scripts" and the
+     src attribute still names the version address.
+  2. CLICK-TO-EDIT, NO MODE TOGGLE (the original grammar): hovering the
+     headline INSIDE the frame highlights it; clicking it opens the targeted
+     card at that wid — with the comment mode toggle still OFF and no hit
+     layer mounted. A composite block (click the footer → nearest ancestor
+     slide-1) gets a card WITHOUT the Change-text pair (the destructive-
+     replace rule).
+  3. THE DETERMINISTIC EDIT RIDES THE REAL WIRE: Change text seeds the block's
+     EXACT current text; the submitted POST body is the ADR-0002 schema —
+     feedback.submitted with items [{selector, type:"content-edit", value,
+     before}] — one event, one inject.
+  4. THE EDIT LANDS AS A NEW VERSION: the fixture materializes (the real
+     materializeFeedback shape) — version.created {kind:"deterministic"} — the
+     canvas swaps to v2 whose h1 IS the typed text, the composer returns
+     terminal (the landing consumed the anchor), and the THREAD records the
+     batch: one user message wearing the item deep-link and the v2 marker.
+  5. STRUCTURAL COMMENTS STAY HONEST: a This-block comment submits as
+     structural-change and the thread STAYS generating — the agent owes the
+     version, and nothing pretends otherwise.
+
+Captures (§12.0 contract: 1440x900, dsf 1) into e2e/shots/vision/:
+  ux2-docfb2-card.png     the card open on the clicked headline, mode pair up
+  ux2-docfb2-landed.png   v2 landed: edited canvas + the batch in the thread
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4411), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from urllib.parse import urlparse
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4411"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+DOC_URL = f"{ORIGIN}/p/scratch/document"
+BRIEF = "Make me a deck for the Q3 review"
+NEW_HEADLINE = "Q3: the quarter we shipped everything"
+STRUCTURAL_ASK = "make this whole slide darker"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def get_text(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=10) as res:
+        return res.read().decode("utf-8", "replace")
+
+
+# ── 1. The same-origin build + the shared W2 fixture (default switches) ────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    console_errors: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+
+    # ── Scene 0: create v1 — the document the loop edits ───────────────────────
+    page.goto(DOC_URL, wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    composer = page.locator('[data-testid="doc-composer"]')
+    composer.fill(BRIEF)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="version-marker"][data-version="1"]').wait_for(timeout=30000)
+    page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
+    doc_id = urlparse(page.url).path.rsplit("/", 1)[-1]
+
+    # ── AC1: readiness CAME FROM the injection — the wire html has no bridge ───
+    wire_html = get_text(
+        f"{ORIGIN}/api/v1/projects/scratch/interactive/d/{doc_id}/doc/1")
+    page.locator('[data-testid="feedback-overlay"][data-ready="true"]').wait_for(timeout=30000)
+    frame_facts = page.evaluate(
+        """() => {
+             const f = document.querySelector('[data-testid="doc-canvas"]');
+             return {
+               sandbox: f?.getAttribute('sandbox'),
+               srcNamesVersion: /\\/doc\\/1$/.test(f?.getAttribute('src') || ''),
+               srcdocInjected: (f?.getAttribute('srcdoc') || '').includes('request-inventory'),
+               toggleEnabled: !document.querySelector('[data-testid="feedback-toggle"]')?.disabled,
+             };
+           }""")
+    check("AC1_handshake_from_injection",
+          "request-inventory" not in wire_html          # the wire serves NO bridge…
+          and 'data-wid="headline"' in wire_html        # …but the anchors are there
+          and frame_facts["srcdocInjected"]             # studio injected its own
+          and frame_facts["sandbox"] == "allow-scripts"
+          and frame_facts["srcNamesVersion"]
+          and frame_facts["toggleEnabled"],
+          **frame_facts)
+
+    # ── AC2: the original grammar — hover highlights, click opens the card ─────
+    doc_frame = page.frame_locator('[data-testid="doc-canvas"]')
+    doc_frame.locator('[data-wid="headline"]').hover()
+    page.locator('[data-testid="feedback-hover"][data-wid="headline"]').wait_for(timeout=10000)
+    doc_frame.locator('[data-wid="headline"]').click()
+    card = page.locator('[data-testid="feedback-comment"]')
+    card.wait_for(timeout=10000)
+    direct = page.evaluate(
+        """() => ({
+             cardWid: document.querySelector('[data-testid="feedback-comment"]')
+               ?.getAttribute('data-wid'),
+             hitLayer: !!document.querySelector('[data-testid="feedback-hitlayer"]'),
+             toggleActive: document.querySelector('[data-testid="feedback-toggle"]')
+               ?.getAttribute('data-active'),
+             modePair: !!document.querySelector('[data-testid="feedback-mode"]'),
+           })""")
+    check("AC2_click_to_edit_no_toggle",
+          direct["cardWid"] == "headline"
+          and not direct["hitLayer"]           # no mode was entered…
+          and direct["toggleActive"] == "false"
+          and direct["modePair"],              # …and the leaf block offers both modes
+          **direct)
+    page.screenshot(path=str(VSHOTS / "ux2-docfb2-card.png"))
+
+    # A COMPOSITE block (the slide container, reached via its un-anchored footer)
+    # gets a card WITHOUT the Change-text pair.
+    page.locator('[data-testid="feedback-comment-cancel"]').click()
+    doc_frame.locator("footer").click()
+    card.wait_for(timeout=10000)
+    composite = page.evaluate(
+        """() => ({
+             cardWid: document.querySelector('[data-testid="feedback-comment"]')
+               ?.getAttribute('data-wid'),
+             modePair: !!document.querySelector('[data-testid="feedback-mode"]'),
+           })""")
+    check("AC2_composite_hides_change_text",
+          composite["cardWid"] == "slide-1" and not composite["modePair"], **composite)
+    page.locator('[data-testid="feedback-comment-cancel"]').click()
+
+    # ── AC3: Change text — seeded with the EXACT current text, schema on the wire ─
+    v1_headline = doc_frame.locator('[data-wid="headline"]').inner_text().strip()
+    doc_frame.locator('[data-wid="headline"]').click()
+    card.wait_for(timeout=10000)
+    page.locator('[data-testid="feedback-mode-change-text"]').click()
+    seeded = page.locator('[data-testid="feedback-comment-input"]').input_value()
+    page.locator('[data-testid="feedback-comment-input"]').fill(NEW_HEADLINE)
+    page.locator('[data-testid="feedback-comment-add"]').click()
+    page.locator('[data-testid="feedback-pin"][data-wid="headline"]').wait_for(timeout=10000)
+
+    with page.expect_request(
+        lambda r: r.method == "POST" and r.url.endswith("/interactive/api/events")
+        and "feedback.submitted" in (r.post_data or ""),
+        timeout=15000,
+    ) as req_info:
+        page.locator('[data-testid="feedback-submit"]').click()
+    batch_body = json.loads(req_info.value.post_data or "{}")
+    payload = batch_body.get("payload") or {}
+    items = payload.get("items") or []
+    check("AC3_schema_item_on_the_real_wire",
+          seeded == v1_headline
+          and batch_body.get("event_type") == "wicked.interactive.feedback.submitted"
+          and payload.get("document_id") == doc_id
+          and payload.get("version") == 1
+          and bool(payload.get("source_message_id"))
+          and items == [{"selector": "headline", "type": "content-edit",
+                         "value": NEW_HEADLINE, "before": v1_headline}],
+          seeded=seeded, wire_body=batch_body)
+
+    # ── AC4: the deterministic edit LANDS — canvas, composer, thread ───────────
+    page.locator('[data-testid="doc-canvas"][data-version="2"]').wait_for(timeout=30000)
+    page.frame_locator('[data-testid="doc-canvas"]') \
+        .locator('[data-wid="headline"]').wait_for(timeout=30000)
+    v2_headline = page.frame_locator('[data-testid="doc-canvas"]') \
+        .locator('[data-wid="headline"]').inner_text().strip()
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
+    page.locator('[data-testid="version-marker"][data-version="2"]').wait_for(timeout=15000)
+    thread_facts = page.evaluate(
+        """() => {
+             const msgs = Array.from(document.querySelectorAll('[data-testid="doc-message"]'));
+             const batch = msgs.find(m => m.getAttribute('data-items') === '1');
+             return {
+               batchRecorded: !!batch,
+               itemLink: !!batch?.querySelector(
+                 '[data-testid="feedback-item-link"][data-wid="headline"]'),
+               textCarriesEdit: (batch?.textContent || '').includes('[headline]'),
+               generatingChips: document.querySelectorAll(
+                 '[data-testid="thread-generating"]').length,
+             };
+           }""")
+    manifest = json.loads(get_text(
+        f"{ORIGIN}/api/v1/projects/scratch/interactive/d/{doc_id}/api/versions"))
+    v2 = next((e for e in manifest["versions"] if e["version"] == 2), None)
+    check("AC4_deterministic_edit_lands_as_v2",
+          v2_headline == NEW_HEADLINE
+          and v2 is not None and v2["parent"] == 1
+          and bool(v2.get("feedback_file"))     # the manifest records the batch
+          and thread_facts["batchRecorded"] and thread_facts["itemLink"]
+          and thread_facts["textCarriesEdit"]
+          and thread_facts["generatingChips"] == 0,   # the landing consumed the anchor
+          v2_headline=v2_headline, manifest_v2=v2, **thread_facts)
+    page.screenshot(path=str(VSHOTS / "ux2-docfb2-landed.png"))
+
+    # ── AC5: a structural comment stays honestly UNANSWERED ────────────────────
+    doc_frame2 = page.frame_locator('[data-testid="doc-canvas"]')
+    doc_frame2.locator('[data-wid="headline"]').click()
+    card.wait_for(timeout=10000)
+    page.locator('[data-testid="feedback-comment-input"]').fill(STRUCTURAL_ASK)
+    page.locator('[data-testid="feedback-comment-add"]').click()
+    with page.expect_request(
+        lambda r: r.method == "POST" and r.url.endswith("/interactive/api/events")
+        and "feedback.submitted" in (r.post_data or ""),
+        timeout=15000,
+    ) as req2_info:
+        page.locator('[data-testid="feedback-submit"]').click()
+    body2 = json.loads(req2_info.value.post_data or "{}")
+    items2 = (body2.get("payload") or {}).get("items") or []
+    page.locator('[data-testid="thread"][data-composer-state="generating"]').wait_for(timeout=15000)
+    check("AC5_structural_comment_stays_generating",
+          len(items2) == 1
+          and items2[0].get("selector") == "headline"
+          and items2[0].get("type") == "structural-change"
+          and items2[0].get("instruction") == STRUCTURAL_ASK,
+          wire_body=body2)
+
+    # ── The mode toggle SURVIVES beside the direct grammar ─────────────────────
+    page.locator('[data-testid="feedback-toggle"]').click()
+    page.locator('[data-testid="feedback-hitlayer"]').wait_for(timeout=10000)
+    page.locator('[data-testid="feedback-toggle"]').click()
+    page.locator('[data-testid="feedback-hitlayer"]').wait_for(state="detached", timeout=10000)
+    report["steps"]["comment_mode_survives"] = {"ok": True}
+
+    # Console hygiene (the sibling rig's contract): nothing unexpected.
+    unexpected = [e for e in console_errors
+                  if "404" not in e and "Failed to load resource" not in e]
+    check("console_hygiene", unexpected == [], errors=unexpected)
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+report["shots"] = ["ux2-docfb2-card.png", "ux2-docfb2-landed.png"]
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/ux_fixJ33_test.py
+++ b/e2e/ux_fixJ33_test.py
@@ -17,12 +17,17 @@ The four ACs, verbatim mapping to the round-2 findings:
   2. LIVE FIRST GENERATION: with the page OPEN on the v0 placeholder, the
      answerer landing v1 swaps the canvas to v1 WITHOUT a reload — the frames
      of an Unfiled (project-unbound) doc reach the canvas.
-  3. EXPORT ANSWERS SOMEWHERE, ALWAYS (drawer CLOSED): an export whose pending
-     answer is re-addressed by a mid-flight landing (the head advances, the
-     strip follows) stays visible at the click site, labeled with ITS version;
-     the strip stays clickable while it is still visibly fading (pointer-events
-     retire only after the fade), and a press on the hidden sensor band summons
-     the strip instead of dying silently.
+  3. EXPORT ANSWERS SOMEWHERE, ALWAYS (re-scoped to the #115 anatomy: the
+     export click site moved off the strip into the tabbed panel's Chat tab,
+     under the chatbox — the doc address starts with the panel collapsed to
+     its rail, the drawer's successor to "closed by default"): an export whose
+     pending answer is re-addressed by a mid-flight landing (the head advances,
+     the menu follows) stays visible at the click site, labeled with ITS
+     version, a full idle budget later — no auto-hide touches the panel. The
+     slim band keeps the fade machinery: the strip stays clickable while it is
+     still visibly fading (pointer-events retire only after the fade), and a
+     press on the hidden sensor band summons the strip instead of dying
+     silently.
   4. SEND-STATE SURVIVES RELOAD: a send that was PENDING at reload comes back
      pending with its ORIGINAL clock (an already-stalled send re-renders the
      honest timeout + a WORKING retry, not a plain accepted message); a REFUSED
@@ -202,8 +207,9 @@ with sync_playwright() as p:
     page.reload(wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    # #115: the drawer became the tabbed right panel; on a doc address it starts
+    # collapsed to the rail — expand it (Chat is the default tab, the thread).
+    page.locator('[data-testid="panel-expand"]').click()
     # The restored send is STALLED, visibly — honest copy + a retry — never a
     # plain accepted message, and never a fresh "being worked now" claim.
     page.locator('[data-testid="thread-generating-timeout"]').wait_for(timeout=15000)
@@ -249,8 +255,7 @@ with sync_playwright() as p:
     page.reload(wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="panel-expand"]').click()  # #115: rail → Chat tab
     page.locator('[data-testid="thread-send-failed"]').wait_for(timeout=15000)
     refused = page.evaluate(
         """() => {
@@ -268,42 +273,56 @@ with sync_playwright() as p:
     page.locator('[data-testid="version-marker"][data-version="4"]').wait_for(timeout=20000)
     check("C6_refused_retry_lands", True)
 
-    # ── Scene D (AC 3): the export answers with the drawer CLOSED, through churn ─
+    # ── Scene D (AC 3): the export answers SOMEWHERE, ALWAYS, through churn ─────
+    # Re-scoped to the #115 anatomy: the export click site moved off the strip
+    # into the panel's Chat tab, UNDER the chatbox — a site no auto-hide touches
+    # (the J3 strip `hold` retired with the move). The AC's spirit is unchanged:
+    # the answer stays visible at the click site, labeled with ITS version,
+    # through a mid-flight re-addressing.
     set_fixture(ORIGIN, export_delay_ms=4000, doc_run_ms=1500)
     page.goto(f"{ORIGIN}/p/{PID}/document/{DOC}", wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"][data-version="4"]').wait_for(timeout=30000)
-    check("D1_drawer_closed_by_default",
-          page.locator('[data-testid="thread-drawer"]').count() == 0)
+    # Canvas-first posture (#115): a doc address starts with the panel collapsed
+    # to its rail — the drawer's successor to "closed by default".
+    check("D1_panel_rail_by_default",
+          page.locator('[data-testid="doc-panel-rail"]').count() == 1
+          and page.locator('[data-testid="doc-panel"]').count() == 0)
 
-    wake_strip(page)
+    page.locator('[data-testid="panel-expand"]').click()  # the export lives in Chat
+    page.locator('[data-testid="chat-export"]').wait_for(timeout=15000)
     page.locator('[data-testid="export-format"][data-format="html"]').click()  # exports v4
     post_chat("one more tweak from another client")  # lands v5 in 1.5s — the churn
-    # Mid-flight, PAST the landing: the strip has re-addressed to v5, and the
+    # Mid-flight, PAST the landing: the menu has re-addressed to v5, and the
     # pending answer is STILL VISIBLE at the click site (pre-fix: wiped here).
     page.locator('[data-testid="export-menu"][data-version="5"]').wait_for(timeout=15000)
     mid = page.evaluate(
         """() => ({
              pending: !!document.querySelector('[data-testid="export-pending"]'),
              ready: !!document.querySelector('[data-testid="export-ready"]'),
-             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
            })""")
     check("D2_pending_answer_survives_the_readdressing",
-          (mid["pending"] or mid["ready"]) and mid["stripHidden"] == "false", **mid)
+          mid["pending"] or mid["ready"], **mid)
 
-    # The READY answer lands labeled with ITS version (v4) under the v5 label row.
+    # The READY answer lands labeled with ITS version (v4) under the v5 label row —
+    # and a full idle budget later it is STILL at the click site: the panel is
+    # not the strip; nothing fades it.
     ready = page.locator('[data-testid="export-ready"][data-version="4"]')
     ready.wait_for(timeout=15000)
     page.wait_for_timeout(3600)  # a full idle budget with the mouse parked: still up
     answered = page.evaluate(
-        """() => ({
-             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
-             label: document.querySelector('[data-testid="export-ready"]')?.textContent ?? '',
-             href: document.querySelector('[data-testid="export-ready"]')?.getAttribute('href'),
-             menuVersion: document.querySelector('[data-testid="export-menu"]')?.getAttribute('data-version'),
-           })""")
-    check("D3_ready_answer_visible_v_labeled_strip_held",
-          answered["stripHidden"] == "false" and "v4" in answered["label"]
+        """() => {
+             const r = document.querySelector('[data-testid="export-ready"]');
+             return {
+               visible: !!r && r.offsetParent !== null,
+               inPanel: !!r && !!r.closest('[data-testid="chat-export"]'),
+               label: r?.textContent ?? '',
+               href: r?.getAttribute('href'),
+               menuVersion: document.querySelector('[data-testid="export-menu"]')?.getAttribute('data-version'),
+             };
+           }""")
+    check("D3_ready_answer_visible_v_labeled_at_the_click_site",
+          answered["visible"] and answered["inPanel"] and "v4" in answered["label"]
           and bool(answered["href"]) and answered["menuVersion"] == "5",
           **answered)
     page.screenshot(path=str(VSHOTS / "ux-fixJ33-export-relabel.png"))
@@ -320,6 +339,9 @@ with sync_playwright() as p:
 
     # D5: the fading strip keeps its hit targets until the fade FINISHES, and a
     # press on the hidden sensor band summons the strip instead of dying.
+    # (#115: no export holds the strip any more, so RAISE it first — the fade
+    # must be caught in progress, not sampled hours after it finished.)
+    wake_strip(page)
     page.mouse.move(700, 300)  # park away from the strip; let the idle budget run
     page.wait_for_function(
         """() => document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden') === 'true'""",
@@ -349,8 +371,7 @@ with sync_playwright() as p:
     page.reload(wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="panel-expand"]').click()  # #115: rail → Chat tab
     page.locator('[data-testid="doc-artifact-download"]').wait_for(timeout=15000)
     entry = page.evaluate(
         """() => ({

--- a/e2e/ux_fixJ3J1_test.py
+++ b/e2e/ux_fixJ3J1_test.py
@@ -20,10 +20,13 @@ The four ACs, verbatim mapping:
      NO `continues as vN` divider and NO new version chip render before the
      thread OBSERVES a `version.created` arrival — the anchor lands only with
      the wire's proof, positioned immediately above its continuation message.
-  3. J3 closed-drawer export: with the thread drawer CLOSED, the export click
-     site keeps its answer VISIBLE — the strip must not auto-hide while the
-     export is pending or its READY answer sits un-acted (pre-fix: the whole
-     strip faded to opacity 0 three seconds after the click; zero response).
+  3. J3 export answers at the click site (re-scoped to the #115 anatomy: the
+     export control moved off the strip into the tabbed panel's Chat tab,
+     under the chatbox; a doc address starts with the panel collapsed to its
+     rail — the drawer's successor to "closed by default"): the pending and
+     READY answers stay VISIBLE at the click site past the idle budget — the
+     slim band may fade; the panel never does (pre-fix: the whole strip faded
+     to opacity 0 three seconds after the click; zero response).
   4. J1 governance non-contradiction: on the r-auth-class run (halt banner +
      Decisions DENY, EMPTY /governance/claims), the Governance panel must NOT
      say "No governance claims recorded for this run" — it states which wire
@@ -54,7 +57,6 @@ from uxfix_fixture import (
     ensure_build,
     set_fixture,
     start_server,
-    wake_strip,
 )
 
 FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4401"))
@@ -183,8 +185,9 @@ with sync_playwright() as p:
     page.goto(f"{ORIGIN}/p/{PID}/document/{DOC2}", wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    # #115: the drawer became the tabbed panel — rail by default on a doc
+    # address; expand to the Chat tab (the thread).
+    page.locator('[data-testid="panel-expand"]').click()
     # A reloaded doc with nothing in flight is TERMINAL — the continue path.
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
 
@@ -225,8 +228,7 @@ with sync_playwright() as p:
     page.goto(f"{ORIGIN}/p/{PID}/document/{DOC2}?v=1", wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"][data-version="1"]').wait_for(timeout=30000)
-    wake_strip(page)
-    page.locator('[data-testid="thread-toggle"]').click()
+    page.locator('[data-testid="panel-expand"]').click()  # #115: rail → Chat tab
     page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=15000)
     page.locator('[data-testid="doc-composer"]').fill("branch: keep the original intro")
     page.keyboard.press("Enter")
@@ -270,44 +272,58 @@ with sync_playwright() as p:
           **anchored)
     set_fixture(ORIGIN, doc_run_ms=0)
 
-    # ── Scene 3 (AC 3): the export answers with the drawer CLOSED ──────────────
+    # ── Scene 3 (AC 3): the export answers at the click site, ALWAYS ───────────
+    # Re-scoped to the #115 anatomy: the export control moved off the strip into
+    # the panel's Chat tab, under the chatbox — a site no auto-hide reaches (the
+    # strip `hold` retired with the move). The AC's spirit is unchanged: past
+    # the idle budget the click site is still answering, visibly.
     created = api_create_doc("closed-drawer-export", "the closed-drawer brief")
     DOC3 = created["name"]
     set_fixture(ORIGIN, export_delay_ms=4500)
     page.goto(f"{ORIGIN}/p/{PID}/document/{DOC3}", wait_until="domcontentloaded")
     page.add_style_tag(content=HIDE_GATE_TOASTS)
     page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
-    drawer_closed = page.evaluate(
-        "() => !document.querySelector('[data-testid=\"thread-drawer\"]')")
-    check("drawer_is_closed_by_default", drawer_closed)
+    # Canvas-first posture: a doc address starts with the panel collapsed to its
+    # rail — the drawer's successor to "closed by default".
+    check("panel_rail_by_default",
+          page.locator('[data-testid="doc-panel-rail"]').count() == 1
+          and page.locator('[data-testid="doc-panel"]').count() == 0)
 
-    wake_strip(page)
+    page.locator('[data-testid="panel-expand"]').click()  # the export lives in Chat
+    page.locator('[data-testid="chat-export"]').wait_for(timeout=15000)
     page.locator('[data-testid="export-format"][data-format="html"]').click()
     # Do NOT move the mouse again: pre-fix, the strip auto-hid 3s from now and
     # took the pending answer with it. Past the idle budget the click site must
-    # still be answering, visibly.
+    # still be answering, visibly — the slim band may fade; the panel never does.
     page.wait_for_timeout(3600)
     mid = page.evaluate(
-        """() => ({
-             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
-             pending: !!document.querySelector('[data-testid="export-pending"]'),
-           })""")
+        """() => {
+             const pend = document.querySelector('[data-testid="export-pending"]');
+             return {
+               pending: !!pend,
+               visible: !!pend && pend.offsetParent !== null,
+               inPanel: !!pend && !!pend.closest('[data-testid="chat-export"]'),
+             };
+           }""")
     check("pending_answer_survives_the_idle_budget",
-          mid["stripHidden"] == "false" and mid["pending"], **mid)
+          mid["pending"] and mid["visible"] and mid["inPanel"], **mid)
 
     ready = page.locator('[data-testid="export-ready"][data-format="html"]')
     ready.wait_for(timeout=15000)
     page.wait_for_timeout(3600)  # past another idle budget with the mouse still parked
     landed = page.evaluate(
-        """() => ({
-             stripHidden: document.querySelector('[data-testid="version-strip"]')?.getAttribute('data-hidden'),
-             opacity: getComputedStyle(document.querySelector('[data-testid="version-strip"]')).opacity,
-             readyHref: document.querySelector('[data-testid="export-ready"]')?.getAttribute('href'),
-             drawerStillClosed: !document.querySelector('[data-testid="thread-drawer"]'),
-           })""")
-    check("ready_answer_holds_the_strip_visible_drawer_closed",
-          landed["stripHidden"] == "false" and landed["opacity"] == "1"
-          and bool(landed["readyHref"]) and landed["drawerStillClosed"],
+        """() => {
+             const r = document.querySelector('[data-testid="export-ready"]');
+             return {
+               readyVisible: !!r && r.offsetParent !== null,
+               inPanel: !!r && !!r.closest('[data-testid="chat-export"]'),
+               readyHref: r?.getAttribute('href'),
+               panelStillUp: !!document.querySelector('[data-testid="doc-panel"]'),
+             };
+           }""")
+    check("ready_answer_visible_at_the_click_site_past_the_budget",
+          landed["readyVisible"] and landed["inPanel"]
+          and bool(landed["readyHref"]) and landed["panelStillUp"],
           **landed)
 
     # The affordance is REAL: its href serves the artifact bytes, attachment-framed.

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1508,6 +1508,17 @@ docs_lock = threading.Lock()
 # pid -> docId -> [version entries, manifest-shaped]. Grown by create/fork below.
 docs_created: dict = {}
 
+# ── docfb2: materialized feedback (the REAL materializeFeedback shape) ────────
+# A feedback.submitted batch's content-edits are applied DETERMINISTICALLY to the
+# head HTML and land as a new version (kind "deterministic"), mirroring
+# wicked-interactive handlers.js materializeFeedback → applyFeedbackItems. The
+# landed HTML lives here, keyed by version; the doc GET route serves it verbatim.
+doc_html_overrides: dict = {}  # (pid, doc, version) -> html
+# The batch's write 2 is a chat.posted inject carrying the SAME source_message_id.
+# The real answerer does not regenerate on it (the batch already landed its own
+# version), so the fixture must not mint a steer version for that inject either.
+feedback_msg_ids: dict = {}    # (pid, doc) -> {source_message_id, …}
+
 # ── Slice K (DES-FEEDBACK-002 §6): per-chat reply bookkeeping ─────────────────
 # Which seats each fixture chat warmed, which have since failed, and how many
 # sends it has taken — so the switch-gated reply drip fans out to exactly the
@@ -2343,9 +2354,14 @@ class W2Handler(SimpleHTTPRequestHandler):
         # storyboard() lands them.
         m = re.match(r"^/api/v1/projects/([^/]+)/interactive/d/([^/]+)/doc/(\d+)$", path)
         if m:
-            doc = urllib.parse.unquote(m.group(2))
-            html = (storyboard_doc_html(int(m.group(3))) if doc == DEMO_NAME
-                    else doc_html(doc, int(m.group(3))))
+            pid, doc = (urllib.parse.unquote(g) for g in (m.group(1), m.group(2)))
+            v = int(m.group(3))
+            # docfb2: a version a feedback batch materialized serves ITS html.
+            with docs_lock:
+                override = doc_html_overrides.get((pid, doc, v))
+            html = (override if override is not None
+                    else storyboard_doc_html(v) if doc == DEMO_NAME
+                    else doc_html(doc, v))
             body = html.encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -2527,6 +2543,67 @@ class W2Handler(SimpleHTTPRequestHandler):
                         learned_themes[(pid, doc)] = int(time.time() * 1000) + delay_ms
                 self._json(200, {"ok": True, "event_id": "evt-fixture", "correlation_id": "c-fixture"})
                 return True
+            # ── docfb2: the REAL materializeFeedback shape (handlers.js) ─────────
+            # Deterministic content-edits are applied to the head HTML NOW and land
+            # as version.created {kind:"deterministic"}; the structural remainder is
+            # handed off inline on feedback.processed. Items are ADR-0002 schema
+            # items ({selector, type, value|instruction, before}).
+            if body.get("event_type") == "wicked.interactive.feedback.submitted" and doc:
+                items = payload.get("items") or []
+                src_msg = str(payload.get("source_message_id") or "")
+                applied: list = []
+                rejected: list = []
+                structural: list = []
+                landed_v = None
+                with docs_lock:
+                    versions = docs_created.get(pid, {}).get(doc)
+                    if versions is not None:
+                        head = max(e["version"] for e in versions)
+                        html = doc_html_overrides.get((pid, doc, head)) or doc_html(doc, head)
+                        for item in items:
+                            sel = str(item.get("selector") or "")
+                            typ = str(item.get("type") or "")
+                            if typ == "content-edit":
+                                pat = re.compile(
+                                    r'(data-wid="' + re.escape(sel) + r'"[^>]*>)([^<]*)')
+                                if sel and pat.search(html):
+                                    new_text = str(item.get("value") or "")
+                                    html = pat.sub(
+                                        lambda mm: mm.group(1) + new_text, html, count=1)
+                                    applied.append(sel)
+                                else:
+                                    rejected.append({"selector": sel,
+                                                     "reason": "selector-not-found"})
+                            elif typ == "structural-change":
+                                structural.append({"selector": sel, "type": typ,
+                                                   "instruction": str(item.get("instruction") or "")})
+                            else:
+                                rejected.append({"selector": sel,
+                                                 "reason": f"unsupported-type:{typ}"})
+                        if applied:
+                            landed_v = head + 1
+                            versions.append({"version": landed_v, "parent": head,
+                                             "feedback_file": f"_v{landed_v}.md",
+                                             "html_file": f"_v{landed_v}.html",
+                                             "created_at": iso(NOW0 + landed_v * SEC)})
+                            doc_html_overrides[(pid, doc, landed_v)] = html
+                        if src_msg:
+                            feedback_msg_ids.setdefault((pid, doc), set()).add(src_msg)
+                if versions is not None:
+                    if landed_v is not None:
+                        queue_interactive("wicked.interactive.version.created", {
+                            "project_id": pid, "document_id": doc,
+                            "version": landed_v, "parent": landed_v - 1,
+                            "kind": "deterministic", "html_file": f"_v{landed_v}.html"})
+                    queue_interactive("wicked.interactive.feedback.processed", {
+                        "project_id": pid, "document_id": doc,
+                        "version": landed_v if landed_v is not None else head,
+                        "applied": applied, "rejected": rejected, "stale": [],
+                        "awaiting_structural": len(structural),
+                        "structural_items": structural})
+                self._json(200, {"ok": True, "event_id": "evt-fixture",
+                                 "correlation_id": "c-fixture"})
+                return True
             if body.get("event_type") == "wicked.interactive.chat.posted" and doc:
                 # Slice T (§6.1): a refused send is a LOUD 500 — the client's
                 # visible-failure branch. Real shape: the bridge reports {error}.
@@ -2541,6 +2618,16 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # order (BRIDGE-UX-1 probe 1: the bus is the queue) …
                 if payload.get("role") == "user" and payload.get("text"):
                     log_conversation(pid, doc, "user", str(payload.get("text")))
+                # docfb2: the feedback batch's write 2 (the inject) carries the same
+                # source_message_id the batch event carried. The batch already landed
+                # its own version, so the answerer does NOT regenerate on the inject —
+                # it lands in the transcript and nothing else.
+                with docs_lock:
+                    fb_ids = feedback_msg_ids.get((pid, doc), set())
+                if str(payload.get("source_message_id") or "") in fb_ids:
+                    self._json(200, {"ok": True, "event_id": "evt-fixture",
+                                     "correlation_id": "c-fixture"})
+                    return True
                 if silent_doc:
                     # J3 no-answerer shape: 200 {ok}, landed durably — and then
                     # NOTHING answers it (no status frame, no landing, ever).

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -7,6 +7,7 @@ import type { DocSummary, ForkResult, VersionManifest } from '../api/interactive
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import { threadKey, useDocThreadStore } from '../store/docThread.js';
+import { hasInstrumentBridge, instrumentDocHtml } from '../interactive/instrumented.js';
 import { DocPanel, type DocPanelTab } from './DocPanel.js';
 import { FeedbackOverlay } from './FeedbackOverlay.js';
 import { StripSensor, useStripAutoHide } from './ThreadDrawer.js';
@@ -217,6 +218,39 @@ function DocFrame({
   // race left a stale "Loading" overlay over an already-loaded frame.
   const resolvedShown = manifest === null ? null : resolveVersion(manifest, version);
   useEffect(() => { setLoaded(false); }, [projectId, docId, resolvedShown]);
+  // ── The docfb2 restore: give bridge-less documents an instrument bridge ──────
+  // The promised production injector half-shipped (see instrumented.ts): every real
+  // document carries data-wid anchors but NO bridge script, so the overlay's
+  // handshake starved and point-and-comment rendered permanently disabled. The
+  // frame's HTML is fetched (same origin, same bytes the iframe was about to load),
+  // and a document that does not already answer the protocol is rendered via
+  // `srcdoc` with the bridge appended — still `sandbox="allow-scripts"`, still an
+  // opaque origin. A document that brought its own bridge keeps the plain `src`
+  // path untouched, and a failed fetch degrades to it too (the overlay then
+  // disables with its reason, exactly the pre-restore posture).
+  const [instrumented, setInstrumented] =
+    useState<{ version: number; srcDoc: string | null } | null>(null);
+  useEffect(() => {
+    if (resolvedShown === null) return undefined;
+    let cancelled = false;
+    setInstrumented(null);
+    const url = interactiveDocUrl(projectId, docId, resolvedShown);
+    fetch(url)
+      .then((res) => (res.ok ? res.text() : Promise.reject(new Error(String(res.status)))))
+      .then((html) => {
+        if (cancelled) return;
+        setInstrumented({
+          version: resolvedShown,
+          srcDoc: hasInstrumentBridge(html)
+            ? null
+            : instrumentDocHtml(html, new URL(url, window.location.href).href),
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setInstrumented({ version: resolvedShown, srcDoc: null });
+      });
+    return () => { cancelled = true; };
+  }, [projectId, docId, resolvedShown]);
   // §7.3's strip presence: visible now, gone after 3s of idleness, back on
   // proximity. (The J3 `hold` retired WITH the strip's export control: the
   // export answers moved under the chatbox, a site auto-hide never touches.)
@@ -417,26 +451,34 @@ function DocFrame({
         </div>
       ) : (
         <>
+          {instrumented !== null && instrumented.version === shown && (
           <iframe
             // Keyed on the VERSION so a swap REPLACES the element instead of mutating its
             // src. Mutating it navigates the frame, and a frame navigation lands in the
             // joint session history — so Back undid the frame's move rather than the route's
             // (§4.2: the version lives in the URL, and Back must rewind it in one press).
-            // A freshly created frame's first load replaces its own entry instead.
+            // A freshly created frame's first load replaces its own entry instead — true
+            // for the srcdoc path too, because the srcdoc is set at CREATION, never mutated.
             key={shown}
             ref={setFrameEl}
             data-testid="doc-canvas"
             data-doc-id={docId}
             data-version={shown}
+            // `src` is ALWAYS the version's address (what the tests and the copy-link
+            // gestures read); when the fetched HTML needed the injected bridge, `srcDoc`
+            // carries the same bytes plus the bridge, and the browser renders THAT.
             src={src}
+            {...(instrumented.srcDoc === null ? {} : { srcDoc: instrumented.srcDoc })}
             title={`Document ${docId}, version ${shown}`}
             onLoad={() => { setLoaded(true); setLoadNonce((n) => n + 1); }}
             // §5.5, §7.3: `allow-scripts` because documents ARE interactive HTML, and NOTHING
             // else. `allow-same-origin` is not "not yet" here — it is gone, and the overlay
-            // below is what made removing it possible. Pinned by a regression test.
+            // below is what made removing it possible. Pinned by a regression test. The
+            // srcdoc path keeps the SAME sandbox: an opaque origin either way.
             sandbox="allow-scripts"
             style={{ border: 'none', display: 'block', height: '100%', width: '100%' }}
           />
+          )}
           {/* The frame is in the DOM while it loads, so the named status sits over it. */}
           {loaded ? null : (
             <div style={{ background: 'var(--surface-base)', inset: 0, position: 'absolute' }}>

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { hitTest, overlayBox, type OverlayBox, type ScrollState } from '../interactive/anchoring.js';
 import {
   REQUEST_INVENTORY, makeScrollToWid, parseInbound,
-  type OverlayToBridgeMsg, type WidRect,
+  type OverlayToBridgeMsg, type WidBlock, type WidRect,
 } from '../interactive/instrument-protocol.js';
 import { submitFeedbackBatch } from '../interactive/feedbackBatch.js';
 import { registerWidScroller } from '../interactive/widScroller.js';
@@ -47,7 +47,16 @@ const DEGRADED_TITLE =
   'Comments need the document’s preview to finish loading — reopen the document '
   + 'or regenerate this version. It still renders, versions and exports normally.';
 
-interface Inventory { widMap: Record<string, WidRect>; measured: ScrollState }
+interface Inventory {
+  widMap: Record<string, WidRect>;
+  measured: ScrollState;
+  /** Per-block text + compositeness — sent by the injected bridge (instrumented.ts),
+   *  absent from the hand-written fixture bridges. Empty when absent: the Change-text
+   *  mode simply does not offer itself without a `before` snapshot to seed and guard. */
+  blocks: Record<string, WidBlock>;
+}
+
+type DraftMode = 'comment' | 'change-text';
 
 export interface FeedbackOverlayProps {
   /** The framed document. Null until React attaches the ref. */
@@ -68,7 +77,7 @@ export function FeedbackOverlay({
   const [timedOut, setTimedOut] = useState(false);
   const [active, setActive] = useState(false);
   const [hover, setHover] = useState<string | null>(null);
-  const [draft, setDraft] = useState<{ wid: string; text: string } | null>(null);
+  const [draft, setDraft] = useState<{ wid: string; text: string; mode: DraftMode } | null>(null);
   const [items, setItems] = useState<FeedbackItem[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,10 +103,20 @@ export function FeedbackOverlay({
       if (msg === null) return;
       if (msg.type === 'wid-inventory') {
         const at = { scrollX: msg.scrollX, scrollY: msg.scrollY };
-        setInventory({ widMap: msg.widMap, measured: at });
+        setInventory({ widMap: msg.widMap, measured: at, blocks: msg.blocks ?? {} });
         setScroll(at);
       } else if (msg.type === 'scroll-state') {
         setScroll({ scrollX: msg.scrollX, scrollY: msg.scrollY });
+      } else if (msg.type === 'wid-click') {
+        // The ORIGINAL interaction grammar (the docfb2 restore): the injected bridge
+        // preempted a click on an instrumented block inside the document and reports
+        // it — the targeted card opens directly, no mode toggle first.
+        setHover(null);
+        setDraft({ wid: msg.wid, text: '', mode: 'comment' });
+      } else if (msg.type === 'wid-hover') {
+        // The original hover highlight, reported from inside the frame. The overlay's
+        // own hit layer (comment mode) drives the same state from the parent side.
+        setHover(msg.wid);
       }
     }
 
@@ -128,9 +147,29 @@ export function FeedbackOverlay({
   const widAt = (e: React.MouseEvent<HTMLDivElement>): string | null =>
     inventory === null ? null : hitTest(inventory.widMap, inventory.measured, scroll, pointIn(e));
 
+  // The clicked block's facts — undefined for bridges that predate `blocks`, and for
+  // COMPOSITE blocks the Change-text mode hides itself (the original InlineComment
+  // rule: a destructive innerText replace would flatten the nested anchors).
+  const draftBlock = draft === null ? undefined : inventory?.blocks[draft.wid];
+  const changeTextAllowed = draftBlock !== undefined && !draftBlock.composite;
+
+  function switchMode(mode: DraftMode): void {
+    if (draft === null || mode === draft.mode) return;
+    // The original's seeding: exact-text mode starts from the current text (the
+    // `before` snapshot); comment modes start blank.
+    const seed = mode === 'change-text' ? (draftBlock?.text ?? '') : '';
+    setDraft({ wid: draft.wid, text: seed, mode });
+  }
+
   function commit(): void {
     if (draft === null || draft.text.trim() === '') return;
-    setItems((prev) => [...prev, { wid: draft.wid, text: draft.text.trim() }]);
+    const before = inventory?.blocks[draft.wid]?.text;
+    setItems((prev) => [...prev, {
+      wid: draft.wid,
+      text: draft.text.trim(),
+      mode: draft.mode,
+      ...(before === undefined ? {} : { before }),
+    }]);
     setDraft(null);
   }
 
@@ -168,7 +207,7 @@ export function FeedbackOverlay({
           onMouseLeave={() => setHover(null)}
           onClick={(e) => {
             const wid = widAt(e);
-            if (wid !== null) { setDraft({ wid, text: '' }); setHover(null); }
+            if (wid !== null) { setDraft({ wid, text: '', mode: 'comment' }); setHover(null); }
           }}
         />
       )}
@@ -220,13 +259,39 @@ export function FeedbackOverlay({
           <span style={{ color: S.muted, fontFamily: 'monospace', fontSize: '10px' }}>
             {draft.wid}
           </span>
+          {/* The original InlineComment's mode pair (the docfb2 restore): a comment the
+              agent interprets vs the EXACT new text, applied deterministically. Offered
+              only when the bridge reported the block's text (the seed + `before` guard)
+              and the block is not a composite. */}
+          {changeTextAllowed && (
+            <div data-testid="feedback-mode" style={{ display: 'flex', gap: '4px' }}>
+              {([['comment', 'This block'], ['change-text', 'Change text']] as const)
+                .map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    data-testid={`feedback-mode-${mode}`}
+                    data-on={String(draft.mode === mode)}
+                    onClick={() => switchMode(mode)}
+                    style={{
+                      ...btn, fontSize: '10px', padding: '2px 8px',
+                      background: draft.mode === mode ? S.accent : 'transparent',
+                      border: `1px solid ${draft.mode === mode ? S.accent : S.border}`,
+                      color: draft.mode === mode ? 'var(--accent-fg)' : S.muted,
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+            </div>
+          )}
           <textarea
             data-testid="feedback-comment-input"
             autoFocus
             rows={3}
             value={draft.text}
-            placeholder="What should change here?"
-            onChange={(e) => setDraft({ wid: draft.wid, text: e.target.value })}
+            placeholder={draft.mode === 'change-text' ? 'Exact new text…' : 'What should change here?'}
+            onChange={(e) => setDraft({ ...draft, text: e.target.value })}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); }
               if (e.key === 'Escape') setDraft(null);

--- a/src/interactive/feedbackBatch.ts
+++ b/src/interactive/feedbackBatch.ts
@@ -19,6 +19,37 @@ import { nextMsgId, threadKey, useDocThreadStore, type FeedbackItem } from '../s
 export const FEEDBACK_EVENT = 'wicked.interactive.feedback.submitted';
 
 /**
+ * One item as the SERVICE consumes it — the ADR-0002 schema `materializeFeedback` →
+ * `applyFeedbackItems` reads: `{selector, type, …}` with per-type operation fields
+ * (content-edit → value; structural-change → instruction), `before` as the staleness
+ * guard. The docfb2 diagnosis: the batch used to ride `{wid, comment}`, a shape the
+ * real regenerate loop rejects per item as "selector-not-found" (`item.selector` is
+ * undefined) — so even a delivered batch could never land an edit. The client keeps
+ * its own `FeedbackItem` spelling and translates HERE, at the one wire crossing.
+ */
+export interface WireFeedbackItem {
+  selector: string;
+  type: 'content-edit' | 'structural-change';
+  value?: string;
+  instruction?: string;
+  before?: string;
+}
+
+/** Client item → schema item. 'change-text' is the deterministic content-edit (the
+ *  typed text IS the new text); everything else asks the agent (structural-change). */
+export function toWireItem(item: FeedbackItem): WireFeedbackItem {
+  return item.mode === 'change-text'
+    ? {
+        selector: item.wid, type: 'content-edit', value: item.text,
+        ...(item.before === undefined ? {} : { before: item.before }),
+      }
+    : {
+        selector: item.wid, type: 'structural-change', instruction: item.text,
+        ...(item.before === undefined ? {} : { before: item.before }),
+      };
+}
+
+/**
  * The batch, as the one line of conversation it is. The `[wid]` tag is not decoration:
  * it is the same anchor the item's deep-link resolves through, so the message a human
  * reads and the target the agent edits are provably the same element.
@@ -67,12 +98,20 @@ export async function submitFeedbackBatch(
       version,
       source_message_id: msgId,
       ...(target === undefined ? {} : { target }),
-      items: items.map((item) => ({ wid: item.wid, comment: item.text })),
+      // The ADR-0002 schema shape (see `toWireItem`) — what the real
+      // materializeFeedback loop consumes, not the client's own spelling.
+      items: items.map(toWireItem),
     },
   });
 
   const store = useDocThreadStore.getState();
   store.addUserMsg(key, msgId, text, items);
+  // The batch is a SEND awaiting its landing, exactly like a composer steer — the
+  // service is already materializing it (write 1 succeeded). A deterministic batch
+  // lands `version.created {kind:"deterministic"}` moments later, which consumes the
+  // anchor and turns this terminal; a structural batch stays working until the
+  // agent's follow-on version (docfb2 — before this the batch never even pended).
+  store.setGenState(key, 'generating');
   try {
     await injectDocMessage(projectId, docId, text, msgId);
     return { msgId, text, recorded: true };

--- a/src/interactive/instrument-protocol.ts
+++ b/src/interactive/instrument-protocol.ts
@@ -26,12 +26,22 @@ export interface WidRect {
 
 // ── Bridge → Overlay (inbound; MUST validate before use) ─────────────────────
 
+/** One block's non-geometric facts, carried with the inventory when the bridge can
+ *  compute them. `text` is the element's normalized innerText — the seed for the
+ *  deterministic Change-text mode (interactive's `describe()` `before` snapshot);
+ *  `composite` marks an element that nests other instrumented blocks, for which a
+ *  destructive text replace would flatten the subtree (InlineComment hides the mode). */
+export interface WidBlock { text: string; composite: boolean }
+
 /** Full inventory: all [data-wid] rects plus current frame scroll. Posted in
- *  response to `request-inventory` and whenever the inventory changes substantially. */
+ *  response to `request-inventory` and whenever the inventory changes substantially.
+ *  `blocks` is OPTIONAL: the client-injected bridge (instrumented.ts) always sends it;
+ *  the hand-written fixture bridges predate the field and stay valid v1 senders. */
 export interface WidInventoryMsg {
   v: 1; type: 'wid-inventory';
   widMap: Record<string, WidRect>;
   scrollX: number; scrollY: number;
+  blocks?: Record<string, WidBlock>;
 }
 
 /** Posted by the bridge on every frame scroll event so the overlay can recompute
@@ -46,7 +56,18 @@ export interface ScrollAckMsg {
   v: 1; type: 'scroll-ack'; wid: string;
 }
 
-export type BridgeToOverlayMsg = WidInventoryMsg | ScrollStateMsg | ScrollAckMsg;
+/** The frame's own click landed on an instrumented block — the ORIGINAL interaction
+ *  grammar (wicked-interactive App.jsx: `nearestReviewable` walk-up, `preventDefault`,
+ *  select). The bridge preempts the click inside the document; the overlay opens the
+ *  targeted feedback card without any mode toggle. */
+export interface WidClickMsg { v: 1; type: 'wid-click'; wid: string }
+
+/** The frame's pointer moved onto a block (`wid`) or off every block (`null`) —
+ *  the original hover-highlight, reported from inside the document. */
+export interface WidHoverMsg { v: 1; type: 'wid-hover'; wid: string | null }
+
+export type BridgeToOverlayMsg =
+  | WidInventoryMsg | ScrollStateMsg | ScrollAckMsg | WidClickMsg | WidHoverMsg;
 
 // ── Overlay → Bridge (outbound; authored here, sent via postMessage) ──────────
 
@@ -62,6 +83,12 @@ export type OverlayToBridgeMsg = RequestInventoryMsg | ScrollToWidMsg;
 
 function isFiniteNum(x: unknown): x is number {
   return typeof x === 'number' && isFinite(x);
+}
+
+function isWidBlock(x: unknown): x is WidBlock {
+  if (typeof x !== 'object' || x === null) return false;
+  const b = x as Record<string, unknown>;
+  return typeof b['text'] === 'string' && typeof b['composite'] === 'boolean';
 }
 
 function isWidRect(x: unknown): x is WidRect {
@@ -100,7 +127,17 @@ export function parseInbound(data: unknown): BridgeToOverlayMsg | null {
       if (!isWidRect(rect)) return null;
       widMap[wid] = rect;
     }
-    return { v: 1, type: 'wid-inventory', widMap, scrollX, scrollY };
+    // `blocks` is optional (older bridges never send it) — but when present it must
+    // be well-formed in full, by the same partial-trust-is-worse rule as the widMap.
+    const rawBlocks = d['blocks'];
+    if (rawBlocks === undefined) return { v: 1, type: 'wid-inventory', widMap, scrollX, scrollY };
+    if (typeof rawBlocks !== 'object' || rawBlocks === null) return null;
+    const blocks: Record<string, WidBlock> = {};
+    for (const [wid, block] of Object.entries(rawBlocks as Record<string, unknown>)) {
+      if (!isWidBlock(block)) return null;
+      blocks[wid] = { text: block.text, composite: block.composite };
+    }
+    return { v: 1, type: 'wid-inventory', widMap, scrollX, scrollY, blocks };
   }
 
   if (type === 'scroll-state') {
@@ -114,6 +151,18 @@ export function parseInbound(data: unknown): BridgeToOverlayMsg | null {
     const wid = d['wid'];
     if (typeof wid !== 'string' || wid === '') return null;
     return { v: 1, type: 'scroll-ack', wid };
+  }
+
+  if (type === 'wid-click') {
+    const wid = d['wid'];
+    if (typeof wid !== 'string' || wid === '') return null;
+    return { v: 1, type: 'wid-click', wid };
+  }
+
+  if (type === 'wid-hover') {
+    const wid = d['wid'];
+    if (wid !== null && (typeof wid !== 'string' || wid === '')) return null;
+    return { v: 1, type: 'wid-hover', wid };
   }
 
   return null;

--- a/src/interactive/instrumented.ts
+++ b/src/interactive/instrumented.ts
@@ -1,0 +1,139 @@
+// The CLIENT-INJECTED instrument bridge (the docfb2 restore).
+//
+// DIAGNOSIS this module answers: studio's half of the point-and-comment loop
+// (FeedbackOverlay + instrument-protocol) was built and proven against a HAND-WRITTEN
+// fixture bridge (`e2e/fixtures/doc-fixture.html`), whose header promised that "in
+// production core/instrument.js (wicked-interactive, the sibling slice) injects the
+// data-wid anchors AND the bridge script". The sibling slice half-shipped: interactive's
+// `instrument.js` injects the `data-wid` ANCHORS into every landed version, but no
+// bridge script exists anywhere in wicked-interactive — its own retired SPA never
+// needed one, because it framed documents SAME-ORIGIN and read `contentDocument`
+// directly (App.jsx `onIframeLoad`). Studio's frame is `sandbox="allow-scripts"` with
+// an opaque origin BY DESIGN (§5.5), so against every real document the overlay's four
+// asks went unanswered, the 3s give-up fired, and "Comment" rendered permanently
+// disabled — the operator's "can't click and edit like the original".
+//
+// THE RESTORE: studio fetches the version HTML it was going to frame anyway (same
+// origin, same bytes, through crew's proxy), appends this bridge script, and renders
+// the result via `srcdoc` — still `sandbox="allow-scripts"`, still an opaque origin,
+// still nothing readable back. A document that already carries a bridge (the fixture
+// contract, or a future server-side injector) is framed by `src` untouched: the
+// served bridge stays authoritative.
+//
+// The script mirrors doc-fixture.html's bridge and RESTORES the original interaction
+// grammar on top of it (wicked-interactive App.jsx + selection.js):
+//   · hover walks up to the nearest [data-wid] and reports it (`wid-hover`);
+//   · click on an instrumented block is PREEMPTED (preventDefault, exactly the
+//     original's move) and reported (`wid-click`) — click-to-edit, no mode toggle;
+//   · the inventory carries per-block `text` (the Change-text seed / `before`
+//     snapshot) and `composite` (nested anchors — text replace hidden, as the
+//     original InlineComment hides it).
+
+/** Marker every bridge answers to — presence in served HTML means "already bridged". */
+const BRIDGE_MARK = 'request-inventory';
+
+/**
+ * True when the served HTML already speaks the instrument protocol — the fixture
+ * contract, or a future interactive-side injector. String detection is deliberate:
+ * the alternative (inject always, guard at runtime) would race two bridges' answers.
+ */
+export function hasInstrumentBridge(html: string): boolean {
+  return html.includes(BRIDGE_MARK);
+}
+
+// The bridge, as an inline classic script (no modules inside srcdoc). Kept ES5-flat so
+// it runs in anything an agent-authored document runs in. NOTE: must never contain the
+// literal close-script sequence.
+const BRIDGE_SOURCE = `
+(function () {
+  if (window.__wickedInstrumentBridge) return;
+  window.__wickedInstrumentBridge = 1;
+  function nearest(node) {
+    var el = node;
+    while (el) {
+      if (el.getAttribute && el.getAttribute('data-wid')) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+  function inventory() {
+    var widMap = {};
+    var blocks = {};
+    var nodes = document.querySelectorAll('[data-wid]');
+    for (var i = 0; i < nodes.length; i++) {
+      var el = nodes[i];
+      var wid = el.getAttribute('data-wid');
+      var r = el.getBoundingClientRect();
+      widMap[wid] = { x: r.x, y: r.y, width: r.width, height: r.height,
+                      top: r.top, left: r.left, right: r.right, bottom: r.bottom };
+      var text = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+      blocks[wid] = { text: text.length > 400 ? text.slice(0, 400) : text,
+                      composite: el.querySelector('[data-wid]') !== null };
+    }
+    return { v: 1, type: 'wid-inventory', widMap: widMap, blocks: blocks,
+             scrollX: window.scrollX, scrollY: window.scrollY };
+  }
+  function post(msg) { parent.postMessage(msg, '*'); }
+  window.addEventListener('message', function (e) {
+    var m = e.data;
+    if (!m || m.v !== 1) return;
+    if (m.type === 'request-inventory') {
+      post(inventory());
+    } else if (m.type === 'scroll-to-wid' && typeof m.wid === 'string') {
+      var el = document.querySelector('[data-wid="' + m.wid.replace(/["\\\\]/g, '') + '"]');
+      if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center' });
+      post({ v: 1, type: 'scroll-ack', wid: m.wid });
+    }
+  });
+  document.addEventListener('scroll', function (e) {
+    if (e.target === document || e.target === document.documentElement || e.target === document.body) {
+      post({ v: 1, type: 'scroll-state', scrollX: window.scrollX, scrollY: window.scrollY });
+    } else {
+      post(inventory());
+    }
+  }, { passive: true, capture: true });
+  window.addEventListener('resize', function () { post(inventory()); });
+  document.addEventListener('click', function (e) {
+    var el = nearest(e.target);
+    if (!el) return;
+    e.preventDefault();
+    post({ v: 1, type: 'wid-click', wid: el.getAttribute('data-wid') });
+  });
+  var lastHover = null;
+  document.addEventListener('mousemove', function (e) {
+    var el = nearest(e.target);
+    var wid = el ? el.getAttribute('data-wid') : null;
+    if (wid !== lastHover) {
+      lastHover = wid;
+      post({ v: 1, type: 'wid-hover', wid: wid });
+    }
+  });
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { post(inventory()); });
+  } else {
+    post(inventory());
+  }
+})();
+`;
+
+/**
+ * Instrument one served document for the sandboxed frame:
+ *   · a `<base href>` pinning relative URLs to the document's own proxy address —
+ *     srcdoc documents inherit the PARENT page's base, which would re-root every
+ *     relative asset onto the SPA route; skipped when the document brought its own;
+ *   · the bridge script, appended at the end of `<body>` so the inventory it
+ *     volunteers measures the parsed document.
+ */
+export function instrumentDocHtml(html: string, baseHref: string): string {
+  let out = html;
+  if (!/<base[\s>]/i.test(out)) {
+    const baseTag = `<base href="${baseHref.replace(/"/g, '&quot;')}">`;
+    out = /<head[^>]*>/i.test(out)
+      ? out.replace(/<head[^>]*>/i, (m) => `${m}${baseTag}`)
+      : `${baseTag}${out}`;
+  }
+  const scriptTag = `<script>${BRIDGE_SOURCE}<\/script>`;
+  return /<\/body>/i.test(out)
+    ? out.replace(/<\/body>/i, () => `${scriptTag}</body>`)
+    : `${out}${scriptTag}`;
+}

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -27,7 +27,17 @@ import type { CoreEvent } from '../api/types.js';
  * is the document's own stable anchor (INV-1), which is what makes the item deep-linkable
  * back to its element for as long as the element exists.
  */
-export interface FeedbackItem { wid: string; text: string }
+/** One targeted-feedback item, client-side. `mode` is the original InlineComment's
+ *  split: 'comment' asks the agent (structural-change on the wire), 'change-text'
+ *  is the deterministic edit (content-edit — the typed text IS the new text, applied
+ *  by the service without a model). `before` snapshots the block's text at click
+ *  time, the staleness guard the schema has always carried (ADR-0002). */
+export interface FeedbackItem {
+  wid: string;
+  text: string;
+  mode?: 'comment' | 'change-text';
+  before?: string;
+}
 
 /** What a failed export offers to run again — the same format, at the same version. */
 export interface ExportRetry { format: ExportFormat; version: number }
@@ -91,8 +101,12 @@ const VERSION  = 'wicked.interactive.version.created';
 const EXPORTED = 'wicked.interactive.export.generated';
 
 /** Version kinds a GENERATION produces. A `fork` is a lineage move the user made, not
- *  the agent finishing — it neither ends the working state nor consumes the anchor. */
-const GENERATED: ReadonlySet<string> = new Set(['generated', 'structural', 'demo']);
+ *  the agent finishing — it neither ends the working state nor consumes the anchor.
+ *  `deterministic` is materializeFeedback's model-free landing (a content-edit batch
+ *  applied instantly): it ANSWERS the batch message exactly as a generated version
+ *  answers a steer, so it consumes the anchor and ends the working state too — without
+ *  it the feedback batch's thread entry span "generating" forever (the docfb2 find). */
+const GENERATED: ReadonlySet<string> = new Set(['generated', 'structural', 'demo', 'deterministic']);
 
 /** First non-empty string among the candidate keys of an untyped bag. */
 function pick(bag: Record<string, unknown>, ...keys: string[]): string | null {

--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -263,7 +263,9 @@ describe('DocumentCanvas — bridge_unavailable (§7.12, §3.3)', () => {
 
     await userEvent.click(await screen.findByTestId('doc-canvas-retry'));
     expect(await screen.findByTestId('doc-canvas')).toBeInTheDocument();
-    expect(attempt).toBe(2);
+    // Load 1 failed, load 2 (the retry) answered the manifest — and the healthy
+    // frame's own HTML read (the docfb2 instrument fetch) is load 3.
+    expect(attempt).toBe(3);
   });
 });
 

--- a/tests/FeedbackOverlay.test.tsx
+++ b/tests/FeedbackOverlay.test.tsx
@@ -223,9 +223,11 @@ describe('FeedbackOverlay — batching and submit (§4.3, §7.7)', () => {
     expect(user).toHaveLength(1);
     expect(user[0]!.text).toContain('make this title punchier');
     expect(user[0]!.text).toContain('cut this in half');
+    // The fixture bridge sends no `blocks`, so items carry no `before` snapshot and
+    // the card stays in comment mode (Change-text never offers itself without a seed).
     expect(user[0]!.kind === 'user' && user[0]!.items).toEqual([
-      { wid: 'h1', text: 'make this title punchier' },
-      { wid: 'p1', text: 'cut this in half' },
+      { wid: 'h1', text: 'make this title punchier', mode: 'comment' },
+      { wid: 'p1', text: 'cut this in half', mode: 'comment' },
     ]);
     expect(injectDocMessage).toHaveBeenCalledTimes(1);
   });
@@ -273,5 +275,97 @@ describe('FeedbackOverlay — deep-linking back to the element (§4.3)', () => {
   it('a deep-link with no overlay mounted no-ops rather than throwing', () => {
     cleanup();
     expect(() => scrollToWid('h1')).not.toThrow();
+  });
+});
+
+// ── The docfb2 restore: the ORIGINAL interaction grammar, over the protocol ──
+// wicked-interactive's retired SPA selected on a direct click and highlighted on
+// hover (App.jsx onIframeLoad). Studio cannot reach into the sandboxed frame, so
+// the INJECTED bridge (instrumented.ts) preempts the click inside the document
+// and reports it — these tests drive that wire.
+
+const BLOCKS = {
+  section: { text: 'Q3 grew in every segment', composite: true },
+  h1:      { text: 'Q3 in review',             composite: false },
+  p1:      { text: 'Pipeline grew in every segment', composite: false },
+};
+
+describe('FeedbackOverlay — click-to-edit without a mode toggle (docfb2)', () => {
+  it('AC: a wid-click from the frame opens the targeted card directly — no toggle first', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, blocks: BLOCKS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+    expect(screen.getByTestId('feedback-toggle').getAttribute('data-active')).toBe('false');
+
+    act(() => { bridge.clickWid('h1'); });
+
+    const card = await screen.findByTestId('feedback-comment');
+    expect(card.getAttribute('data-wid')).toBe('h1');
+    // Still NOT in comment mode: the direct grammar needs no hit layer.
+    expect(screen.queryByTestId('feedback-hitlayer')).toBeNull();
+  });
+
+  it('a wid-hover from the frame highlights the block, and null clears it', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, blocks: BLOCKS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    act(() => { bridge.hoverWid('p1'); });
+    expect((await screen.findByTestId('feedback-hover')).getAttribute('data-wid')).toBe('p1');
+
+    act(() => { bridge.hoverWid(null); });
+    await waitFor(() => expect(screen.queryByTestId('feedback-hover')).toBeNull());
+  });
+});
+
+describe('FeedbackOverlay — the Change-text mode (docfb2, the original InlineComment pair)', () => {
+  it('AC: Change text seeds the EXACT current text and the item rides as a deterministic edit', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, blocks: BLOCKS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    act(() => { bridge.clickWid('h1'); });
+    await screen.findByTestId('feedback-comment');
+    await userEvent.click(screen.getByTestId('feedback-mode-change-text'));
+
+    // Seeded with the block's own text — the original's `before` snapshot.
+    const input = screen.getByTestId('feedback-comment-input');
+    expect(input).toHaveValue('Q3 in review');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Q3: the year we shipped');
+    await userEvent.click(screen.getByTestId('feedback-comment-add'));
+    await userEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => expect(postEvent).toHaveBeenCalledTimes(1));
+    // The wire carries the ADR-0002 schema item: deterministic content-edit with
+    // the before guard — what materializeFeedback applies WITHOUT a model.
+    expect(postEvent).toHaveBeenCalledWith(PROJECT, expect.objectContaining({
+      payload: expect.objectContaining({
+        items: [{
+          selector: 'h1', type: 'content-edit',
+          value: 'Q3: the year we shipped', before: 'Q3 in review',
+        }],
+      }),
+    }));
+  });
+
+  it('a COMPOSITE block hides Change text (the destructive-replace rule)', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS, blocks: BLOCKS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    act(() => { bridge.clickWid('section'); });
+    await screen.findByTestId('feedback-comment');
+    expect(screen.queryByTestId('feedback-mode')).toBeNull();
+  });
+
+  it('a bridge without `blocks` (the fixture contract) never offers the mode pair', async () => {
+    const bridge = makeFixtureBridge({ widMap: WIDS });
+    mount(bridge);
+    await waitFor(() => expect(screen.getByTestId('feedback-toggle')).toBeEnabled());
+
+    act(() => { bridge.clickWid('h1'); });
+    await screen.findByTestId('feedback-comment');
+    expect(screen.queryByTestId('feedback-mode')).toBeNull();
   });
 });

--- a/tests/demoWire.test.ts
+++ b/tests/demoWire.test.ts
@@ -182,10 +182,12 @@ describe('commenting on a step asks for the SPEC to be re-authored', () => {
       version: 2,
       // What makes this a spec diff rather than an HTML fragment edit — and therefore
       // what keeps the re-record deterministic instead of a fresh take (ADR-0018).
+      // Items ride the ADR-0002 schema shape (docfb2): a step comment is an
+      // instruction for the agent — structural-change on the step's anchor.
       target: 'demo_step',
       items: [
-        { wid: 'step-1', comment: 'add TWO hoodies, not one' },
-        { wid: 'step-3', comment: 'pause on the receipt' },
+        { selector: 'step-1', type: 'structural-change', instruction: 'add TWO hoodies, not one' },
+        { selector: 'step-3', type: 'structural-change', instruction: 'pause on the receipt' },
       ],
     });
     expect(stepWid(1)).toBe('step-1');

--- a/tests/docThread.store.test.ts
+++ b/tests/docThread.store.test.ts
@@ -87,6 +87,21 @@ describe('composer state mapping (§2.2)', () => {
     expect(state()).toBe('terminal');
   });
 
+  // The docfb2 restore: materializeFeedback's model-free landing (`kind:
+  // "deterministic"`) ANSWERS the feedback batch — it consumes the pending anchor
+  // and ends the working state, exactly as a generated version answers a steer.
+  // Before the fix the batch's message span "generating" forever.
+  it('a DETERMINISTIC landing (a content-edit batch) answers the batch message', () => {
+    const id = nextMsgId();
+    useDocThreadStore.getState().addUserMsg(KEY, id, 'Feedback on 1 place…',
+      [{ wid: 'headline', text: 'Q3: shipped', mode: 'change-text', before: 'Q3 review' }]);
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    ingest(frame('wicked.interactive.version.created', { version: 2, parent: 1, kind: 'deterministic' }));
+    expect(messages()[0]).toMatchObject({ kind: 'user', id, version: 2 });
+    expect(state()).toBe('terminal');
+    expect(useDocThreadStore.getState().pending[KEY]).toEqual([]);
+  });
+
   it('ignores frames that are not relayed interactive events, and unkeyable ones', () => {
     ingest({ type: 'unitOutputDelta', session: 's1', ord: 0, text: 'hi' } as unknown as CoreEvent);
     ingest({

--- a/tests/feedbackBatch.test.ts
+++ b/tests/feedbackBatch.test.ts
@@ -73,9 +73,12 @@ describe('submitFeedbackBatch — §7.7: the client authors BOTH writes', () => 
       payload: expect.objectContaining({
         document_id: DOC,
         version: 3,
+        // The ADR-0002 schema shape — what the real materializeFeedback loop consumes.
+        // The pre-docfb2 `{wid, comment}` spelling was rejected per item by the real
+        // regenerate loop as "selector-not-found" (item.selector was undefined).
         items: [
-          { wid: 'slide-2-heading-1', comment: 'make this title punchier' },
-          { wid: 'slide-4-body-2',    comment: 'cut this paragraph in half' },
+          { selector: 'slide-2-heading-1', type: 'structural-change', instruction: 'make this title punchier' },
+          { selector: 'slide-4-body-2',    type: 'structural-change', instruction: 'cut this paragraph in half' },
         ],
       }),
     }));

--- a/tests/fixtures/fixtureBridge.ts
+++ b/tests/fixtures/fixtureBridge.ts
@@ -10,13 +10,16 @@
 // What this deliberately does NOT do is bypass the protocol. Every byte the overlay
 // consumes in these tests went through `postMessage` shape and `parseInbound`.
 
-import type { WidRect } from '../../src/interactive/instrument-protocol.js';
+import type { WidBlock, WidRect } from '../../src/interactive/instrument-protocol.js';
 
 export interface FixtureBridgeOptions {
   /** Rects the fixture reports, as measured at `scrollY`. */
   widMap: Record<string, WidRect>;
   scrollX?: number;
   scrollY?: number;
+  /** Per-block text/composite — the INJECTED bridge's extra field (docfb2). Absent
+   *  models the hand-written fixture bridges, which never send it. */
+  blocks?: Record<string, WidBlock>;
   /** A frame that never answers — the graceful-degradation path (§7.12-shaped). */
   silent?: boolean;
 }
@@ -28,6 +31,10 @@ export interface FixtureBridge {
   sent: unknown[];
   /** Push a scroll the way a real document would, without a new inventory. */
   scrollTo: (scrollX: number, scrollY: number) => void;
+  /** The injected bridge preempted a click on a block INSIDE the frame (docfb2). */
+  clickWid: (wid: string) => void;
+  /** The frame's pointer moved onto a block, or off every block (null). */
+  hoverWid: (wid: string | null) => void;
   /** Post a raw payload the overlay must survive — malformed, stale, or hostile. */
   postRaw: (data: unknown) => void;
   dispose: () => void;
@@ -42,7 +49,7 @@ export function rect(left: number, top: number, width: number, height: number): 
 }
 
 export function makeFixtureBridge(opts: FixtureBridgeOptions): FixtureBridge {
-  const { widMap, scrollX = 0, scrollY = 0, silent = false } = opts;
+  const { widMap, scrollX = 0, scrollY = 0, blocks, silent = false } = opts;
   const sent: unknown[] = [];
 
   // Identity is what the overlay checks (a sandboxed frame's origin is the string
@@ -67,7 +74,10 @@ export function makeFixtureBridge(opts: FixtureBridgeOptions): FixtureBridge {
     const msg = data as { v?: number; type?: string; wid?: string };
     if (msg?.v !== 1) return;
     if (msg.type === 'request-inventory') {
-      deliver({ v: 1, type: 'wid-inventory', widMap, scrollX, scrollY });
+      deliver({
+        v: 1, type: 'wid-inventory', widMap, scrollX, scrollY,
+        ...(blocks === undefined ? {} : { blocks }),
+      });
     } else if (msg.type === 'scroll-to-wid') {
       deliver({ v: 1, type: 'scroll-ack', wid: msg.wid });
     }
@@ -77,6 +87,8 @@ export function makeFixtureBridge(opts: FixtureBridgeOptions): FixtureBridge {
     frame,
     sent,
     scrollTo: (x, y) => deliver({ v: 1, type: 'scroll-state', scrollX: x, scrollY: y }),
+    clickWid: (wid) => deliver({ v: 1, type: 'wid-click', wid }),
+    hoverWid: (wid) => deliver({ v: 1, type: 'wid-hover', wid }),
     postRaw: deliver,
     dispose: () => { sent.length = 0; },
   };

--- a/tests/instrumentProtocol.test.ts
+++ b/tests/instrumentProtocol.test.ts
@@ -35,6 +35,25 @@ describe('parseInbound — well-formed v1 frames', () => {
     expect(parseInbound({ v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 }))
       .toEqual({ v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0 });
   });
+
+  it('accepts an inventory carrying `blocks` (the injected bridge) and one without (fixture bridges)', () => {
+    const blocks = { h1: { text: 'Q3 review', composite: false } };
+    expect(parseInbound({
+      v: 1, type: 'wid-inventory', widMap: { h1: RECT }, scrollX: 0, scrollY: 0, blocks,
+    })).toEqual({
+      v: 1, type: 'wid-inventory', widMap: { h1: RECT }, scrollX: 0, scrollY: 0, blocks,
+    });
+  });
+
+  it('accepts wid-click and wid-hover — the original click-to-edit grammar, reported by the frame', () => {
+    expect(parseInbound({ v: 1, type: 'wid-click', wid: 'headline' }))
+      .toEqual({ v: 1, type: 'wid-click', wid: 'headline' });
+    expect(parseInbound({ v: 1, type: 'wid-hover', wid: 'headline' }))
+      .toEqual({ v: 1, type: 'wid-hover', wid: 'headline' });
+    // Hover OFF every block is `null` — a real state, not a malformed frame.
+    expect(parseInbound({ v: 1, type: 'wid-hover', wid: null }))
+      .toEqual({ v: 1, type: 'wid-hover', wid: null });
+  });
 });
 
 describe('parseInbound — malformed inbound messages are DROPPED', () => {
@@ -57,6 +76,16 @@ describe('parseInbound — malformed inbound messages are DROPPED', () => {
     ['ack with no wid',         { v: 1, type: 'scroll-ack' }],
     ['ack with an empty wid',   { v: 1, type: 'scroll-ack', wid: '' }],
     ['ack with a non-string',   { v: 1, type: 'scroll-ack', wid: { toString: () => 'h1' } }],
+    ['click with no wid',       { v: 1, type: 'wid-click' }],
+    ['click with an empty wid', { v: 1, type: 'wid-click', wid: '' }],
+    ['click with a null wid',   { v: 1, type: 'wid-click', wid: null }],
+    ['hover with no wid key',   { v: 1, type: 'wid-hover' }],
+    ['hover with an empty wid', { v: 1, type: 'wid-hover', wid: '' }],
+    ['blocks not an object',    { v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0, blocks: 'h1' }],
+    ['a block missing text',    { v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0,
+                                  blocks: { h1: { composite: false } } }],
+    ['a block with a non-bool', { v: 1, type: 'wid-inventory', widMap: {}, scrollX: 0, scrollY: 0,
+                                  blocks: { h1: { text: 'x', composite: 'no' } } }],
   ];
   it.each(junk)('drops %s', (_label, data) => {
     expect(parseInbound(data)).toBeNull();

--- a/tests/instrumented.test.ts
+++ b/tests/instrumented.test.ts
@@ -1,0 +1,62 @@
+// The client-injected instrument bridge (the docfb2 restore) — the injector's
+// contract. The bridge SCRIPT itself is proven in a real browser by
+// e2e/ux2_docfb2_test.py (jsdom lays nothing out, so rect and click assertions
+// would be vacuous here); what a unit can pin is the string surgery: where the
+// script lands, when it is withheld, and what the <base> repair does.
+import { describe, expect, it } from 'vitest';
+import { hasInstrumentBridge, instrumentDocHtml } from '../src/interactive/instrumented.js';
+
+const BASE = 'http://127.0.0.1:7788/api/v1/projects/p1/interactive/d/q3/doc/2';
+
+const PLAIN = '<!doctype html><html><head><title>t</title></head>'
+  + '<body><h1 data-wid="headline">Q3</h1></body></html>';
+
+describe('hasInstrumentBridge', () => {
+  it('detects a document that already answers the protocol (the fixture contract)', () => {
+    expect(hasInstrumentBridge('<script>on("request-inventory")</script>')).toBe(true);
+  });
+
+  it('a real interactive-served document (data-wid anchors, NO bridge) needs injection', () => {
+    // The half-shipped sibling slice: instrument.js injects anchors, never a bridge.
+    expect(hasInstrumentBridge(PLAIN)).toBe(false);
+  });
+});
+
+describe('instrumentDocHtml', () => {
+  it('appends the bridge inside <body> and the result self-reports as bridged', () => {
+    const out = instrumentDocHtml(PLAIN, BASE);
+    expect(hasInstrumentBridge(out)).toBe(true);
+    // Inside the body, so the volunteered first inventory measures parsed content.
+    expect(out).toMatch(/wid-inventory[\s\S]*<\/body>/);
+    // The document's own content is untouched.
+    expect(out).toContain('<h1 data-wid="headline">Q3</h1>');
+  });
+
+  it('pins relative URLs with a <base href> at the document\'s own proxy address', () => {
+    const out = instrumentDocHtml(PLAIN, BASE);
+    expect(out).toContain(`<head><base href="${BASE}">`);
+  });
+
+  it('respects a document that brought its own <base>', () => {
+    const based = PLAIN.replace('<head>', '<head><base href="https://example.test/x/">');
+    const out = instrumentDocHtml(based, BASE);
+    expect(out).toContain('<base href="https://example.test/x/">');
+    expect(out).not.toContain(BASE);
+  });
+
+  it('survives fragment documents with no <head> or <body> at all', () => {
+    const out = instrumentDocHtml('<h1 data-wid="h">x</h1>', BASE);
+    expect(out.startsWith(`<base href="${BASE}">`)).toBe(true);
+    expect(hasInstrumentBridge(out)).toBe(true);
+  });
+
+  it('restores the ORIGINAL grammar: the script preempts block clicks and reports them', () => {
+    const out = instrumentDocHtml(PLAIN, BASE);
+    // The grammar's wire words, present in the injected script: click-to-edit
+    // (wid-click), hover highlight (wid-hover), and the Change-text seed (blocks).
+    expect(out).toContain('wid-click');
+    expect(out).toContain('wid-hover');
+    expect(out).toContain('preventDefault');
+    expect(out).toContain('composite');
+  });
+});


### PR DESCRIPTION
Restores block-level click-to-edit on the document canvas (operator: "can't click and edit like the original wicked-interactive").

**Root cause — the feature never worked against real documents**: FeedbackOverlay + instrument-protocol were proven against a hand-written fixture bridge that was never shipped — wicked-interactive's `instrument.js` injects only the `data-wid` anchors (its retired SPA read `contentDocument` same-origin and needed no bridge), so studio's sandboxed iframe handshake starved on every real doc and the affordance rendered permanently disabled. Behind that: the batch wire spelling `{wid, comment}` would be rejected per-item by the real `materializeFeedback` (ADR-0002 wants `{selector, type, value|instruction, before}`), and `kind:'deterministic'` landings never consumed their thread anchor.

**The restore**: studio fetches the version HTML and injects its own bridge (srcdoc, same sandbox; auto-yields if the service ever ships one) — hover walks to the nearest anchored block, click opens the targeted card (This block / Change text seeded with the block's text), submit posts the real ADR-0002 item shape, deterministic edits land and consume. Fitted into #115's tabbed panel; works expanded and rail-collapsed.

Verified: 1568/1568 unit tests; the new gate rig ×2 with an honest fixture that materializes real batches; #115's six ACs + ux_sliceT regressions; the three stale doc rigs (#115's known debt) proven stale on a main-tip baseline then re-scoped in dedicated commits, all green; adversarial verifier drove the full loop with raw mouse events and cross-checked the wire contract against wicked-interactive's source; negative check confirms the dead-end on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
