### PR TITLE
DES-UX-002 slice BE: durable guidance adoption + navigation wiring

### DIFF
--- a/e2e/ux2_sliceBD_test.py
+++ b/e2e/ux2_sliceBD_test.py
@@ -31,8 +31,10 @@ The §4.5 DOM ACs, as re-scoped:
      with the typed text as its value, auto-expanded to the draft's line count;
      ZERO /api/v1 requests fire between the annotation save and gate arrival
      (request-tap) — the draft is client state, no invented wire;
-  3. the session-scope label renders `[data-testid="annotation-scope-label"]`
-     with the exact honest copy (EC52) — present until CREW-UX-4 lands;
+  3. (RE-SCOPED by slice BE — CREW-UX-7/crew#312 landed, so the whole-widget
+     session-scope label RETIRED with the gap it named): the EC52 label now
+     names ONLY the unsaved edit — ABSENT on the freshly-opened widget,
+     present with the honest-split copy once text is typed and unsaved;
   4. Alt+1 within the steer textarea inserts `Focus: ` at the cursor
      (keyboard event assert); Alt+2 `Skip: `; Alt+3 `Context: `;
   5. the '?' overlay lists the Focus:/Skip:/Context: steer prefixes under the
@@ -82,8 +84,10 @@ DRAFT = ("keep the burst budget tests green\n"
          "prefer the token-bucket middleware\n"
          "do not touch the upload handler itself")
 
-# EC52's honest copy — must match src/store/annotations.ts SCOPE_LABEL verbatim.
-SCOPE_COPY = "saved for this browser session only — durable annotations land with CREW-UX-4."
+# EC52's honest copy after slice BE — must match src/store/annotations.ts
+# DRAFT_SCOPE_LABEL verbatim (the durable endpoint landed: only the UNSAVED
+# edit is still session-scoped, and the label says exactly that).
+SCOPE_COPY = "unsaved edit — this browser session only until you save guidance."
 
 report: dict = {"ok": False, "steps": {}}
 
@@ -173,16 +177,23 @@ with sync_playwright() as p:
         }""", arg=CARD, timeout=5000)
     check("chip_click_opens_and_focuses", True)
 
-    # ── Scene 2 (AC 3 / EC52): the honest scope label, exact copy ──────────────
+    # ── Scene 2 (AC 3 / EC52, slice-BE re-scope): a freshly-opened widget has
+    #    NOTHING session-scoped — the label must be absent (durability holds) ───
+    check("scope_label_absent_before_edit",
+          page.evaluate(
+              """(card) => !document.querySelector(
+                   card + ' [data-testid="annotation-scope-label"]')""",
+              CARD))
+
+    # ── Scene 3 (AC 2, the save half): type the draft; the label now names the
+    #    UNSAVED edit (exact honest-split copy); the window between the draft
+    #    landing and gate arrival fires ZERO /api/v1 requests ───────────────────
+    page.locator(INPUT).fill(DRAFT)
     scope = page.evaluate(
         """(card) => document.querySelector(
              card + ' [data-testid="annotation-scope-label"]')?.textContent ?? null""",
         CARD)
     check("scope_label_exact_honest_copy", scope == SCOPE_COPY, label=scope)
-
-    # ── Scene 3 (AC 2, the save half): type the draft; the window between save
-    #    and gate arrival fires ZERO /api/v1 requests ───────────────────────────
-    page.locator(INPUT).fill(DRAFT)
     page.wait_for_timeout(1500)  # let any (illegal) debounced write surface
     reads_before = len(api_requests)
     page.wait_for_timeout(1000)

--- a/e2e/ux2_sliceBE_test.py
+++ b/e2e/ux2_sliceBE_test.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+ux2_sliceBE_test.py — the DES-UX-002 slice-BE gate (§8.1, the FINAL slice):
+CREW-UX-7 adoption + navigation wiring.
+
+CONTEXT CORRECTION applied throughout: the endpoint the doc specs as
+"CREW-UX-4" (§7.2) LANDED as CREW-UX-7 (crew#312, live on the daemon):
+`PUT /api/v1/runs/:id/guidance {text}` upserts ('' clears, 404 unknown, 8KB
+cap named in a 400, response {runId, guidance}); the run DTOs carry
+`guidance?: string` ABSENT-when-never-set (api-types 0.9.0 — unpublished on
+npm, so the studio types the fields locally; src/api/guidance.ts). And per
+slice BD's measurement finding (gateEscalated barely exists on real runs),
+the ANY-TIME annotation widget — not the approaching chip — is the operative
+entry point this slice wires.
+
+The ACs:
+
+  1. WIRE SHAPE — the fixture mirrors the real wire: the seeded run's DTO
+     carries `guidance`; every unseeded run's session has NO `guidance` key
+     (absent-when-never-set, confirmed against the live daemon 2026-08-24);
+     PUT round-trip: unknown run → 404 "Run not found"; >8192 bytes → a 400
+     NAMING the cap; set → echoed on GET; '' → cleared (key drops).
+  2. DURABLE PRE-POPULATION — the board widget mounts OPEN with the DTO's
+     durable note; NO scope label (nothing is session-scoped); save disarmed.
+  3. LABEL HONESTY (EC52 honest split) — an edit raises the label with the
+     exact unsaved-edit copy; the durable state never carries it.
+  4. SAVE ACTION (EC37) — "save guidance" PUTs {text} once, feedback lands at
+     the point of action ("saved — survives this session"), the label retires.
+  5. MULTI-SESSION SURVIVAL (the point) — a full reload (fresh stores = a new
+     session as far as client state goes) pre-populates from the DTO again.
+  6. ROUTES (§5.2/§5.3) — /p/:id/chronicle is a REAL route rendering the
+     chronicle; the Runs|Chronicle toggle NAVIGATES (URL flips both ways,
+     Back restores); /runs/:id still defaults to the timeline lens (BB pin).
+  7. KEYS (§5.4, the one registry) — `u`/`t` switch the run detail's lenses;
+     `n` focuses the selected board card's annotation widget; the '?' overlay
+     documents all three from the registry itself; board Enter on a card with
+     a MOVING run opens that run (the §5.3 timeline entry point).
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  ux-BE-durable-guidance.png   the board widget: durable note + saved feedback
+  ux-BE-nav-chrome.png         the /p/:id/chronicle route: shell + toggle + chronicle
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 (ensure_build CACHES — delete a stale dist-sameorigin/
+when the source changed). Env knobs: FEEDBACK_PORT (default 4412),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4412"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+CARD = '[data-testid="project-card"][data-project-id="upload-endpoint"]'
+WIDGET = f'{CARD} [data-testid="pre-gate-annotate"]'
+INPUT = f'{CARD} [data-testid="pre-gate-annotate-input"]'
+
+DURABLE = ("rate-limit by API key, not by IP\n"
+           "keep the burst budget tests green")
+EDIT_LINE = "\nprefer the token-bucket middleware"
+
+# EC52's honest-split copy — must match src/store/annotations.ts
+# DRAFT_SCOPE_LABEL verbatim.
+SCOPE_COPY = "unsaved edit — this browser session only until you save guidance."
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def api_get_runs() -> list:
+    with urllib.request.urlopen(f"{ORIGIN}/api/v1/runs", timeout=10) as res:
+        return json.loads(res.read())["runs"]
+
+
+def put_guidance(rid: str, text: str):
+    req = urllib.request.Request(
+        f"{ORIGIN}/api/v1/runs/{rid}/guidance", method="PUT",
+        data=json.dumps({"text": text}).encode(),
+        headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as res:
+            return res.status, json.loads(res.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+# ── 1. Build + fixture: nerve plan on, ONE durable note seeded ─────────────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, nerve=True, guidance={"r-upload": DURABLE})
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+# ── AC 1a: the DTO echo — present where set, ABSENT where never set ────────────
+runs = {r["session"]["id"]: r["session"] for r in api_get_runs()}
+check("dto_absent_when_never_set",
+      runs["r-upload"].get("guidance") == DURABLE
+      and "guidance" not in runs["r-auth"]
+      and "guidance" not in runs["r-q3"],
+      upload=runs["r-upload"].get("guidance"),
+      auth_has_key="guidance" in runs["r-auth"])
+
+# ── AC 1b: the PUT contract round-trip, mirrored verbatim (on r-api) ───────────
+code, body = put_guidance("r-nope", "x")
+check("put_unknown_run_404", code == 404 and body.get("error") == "Run not found",
+      code=code, body=body)
+code, body = put_guidance("r-api", "x" * 8193)
+check("put_cap_named_400", code == 400 and "8192-byte cap" in body.get("error", ""),
+      code=code)
+code, body = put_guidance("r-api", "focus the migration on the auth tables")
+check("put_upsert_echoes", code == 200
+      and body == {"runId": "r-api", "guidance": "focus the migration on the auth tables"},
+      body=body)
+check("put_lands_on_dto",
+      {r["session"]["id"]: r["session"] for r in api_get_runs()}["r-api"].get("guidance")
+      == "focus the migration on the auth tables")
+code, body = put_guidance("r-api", "")
+check("put_empty_clears", code == 200 and body == {"runId": "r-api", "guidance": ""}
+      and "guidance" not in {r["session"]["id"]: r["session"] for r in api_get_runs()}["r-api"],
+      body=body)
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # The PUT tap (AC 4): every guidance write the page fires, with its body.
+    guidance_puts: list = []
+    page.on("request", lambda r: guidance_puts.append(r.post_data)
+            if r.method == "PUT" and r.url.endswith("/runs/r-upload/guidance") else None)
+
+    def load_board() -> None:
+        page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+        page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+        page.add_style_tag(content=HIDE_GATE_TOASTS)
+        page.locator(CARD).wait_for(timeout=30000)
+
+    load_board()
+
+    # ── AC 2: durable pre-population — open, populated, unlabelled, disarmed ───
+    page.locator(WIDGET).wait_for(timeout=15000)
+    pre = page.evaluate(
+        """(card) => {
+          const root = document.querySelector(card);
+          const w = root.querySelector('[data-testid="pre-gate-annotate"]');
+          const input = root.querySelector('[data-testid="pre-gate-annotate-input"]');
+          return {
+            open: w?.dataset.open ?? null,
+            value: input?.value ?? null,
+            label: !!root.querySelector('[data-testid="annotation-scope-label"]'),
+            saveDisabled: root.querySelector('[data-testid="save-guidance"]')?.disabled ?? null,
+          };
+        }""", CARD)
+    check("durable_prepopulates_widget",
+          pre["open"] == "true" and pre["value"] == DURABLE
+          and not pre["label"] and pre["saveDisabled"] is True,
+          **pre)
+
+    # ── AC 3: an edit raises the EC52 honest-split label, exact copy ───────────
+    page.locator(INPUT).fill(DURABLE + EDIT_LINE)
+    label = page.evaluate(
+        """(card) => document.querySelector(
+             card + ' [data-testid="annotation-scope-label"]')?.textContent ?? null""",
+        CARD)
+    check("unsaved_edit_labelled", label == SCOPE_COPY, label=label)
+
+    # ── AC 4: the save gesture — ONE PUT {text}, point-of-action feedback,
+    #    label retires where durability now holds ────────────────────────────────
+    page.locator(f'{CARD} [data-testid="save-guidance"]').click()
+    page.wait_for_function(
+        """(card) => document.querySelector(
+             card + ' [data-testid="guidance-save-state"]')?.dataset.phase === 'saved'""",
+        arg=CARD, timeout=10000)
+    feedback = page.evaluate(
+        """(card) => {
+          const root = document.querySelector(card);
+          return {
+            text: root.querySelector('[data-testid="guidance-save-state"]')?.textContent ?? null,
+            label: !!root.querySelector('[data-testid="annotation-scope-label"]'),
+            saveDisabled: root.querySelector('[data-testid="save-guidance"]')?.disabled ?? null,
+          };
+        }""", CARD)
+    posts = [json.loads(b) for b in guidance_puts]
+    check("save_puts_once_with_text",
+          posts == [{"text": DURABLE + EDIT_LINE}], posts=posts)
+    check("save_feedback_at_point_of_action",
+          feedback["text"] == "saved — survives this session"
+          and not feedback["label"] and feedback["saveDisabled"] is True,
+          **feedback)
+    page.locator(WIDGET).scroll_into_view_if_needed()
+    page.wait_for_timeout(300)
+    page.screenshot(path=str(VSHOTS / "ux-BE-durable-guidance.png"))
+
+    # ── AC 5: multi-session survival — a fresh load pre-populates the SAVED
+    #    text from the DTO alone (client stores start empty) ────────────────────
+    load_board()
+    page.locator(WIDGET).wait_for(timeout=15000)
+    survived = page.evaluate(
+        """(card) => {
+          const root = document.querySelector(card);
+          return {
+            value: root.querySelector('[data-testid="pre-gate-annotate-input"]')?.value ?? null,
+            label: !!root.querySelector('[data-testid="annotation-scope-label"]'),
+          };
+        }""", CARD)
+    check("guidance_survives_sessions",
+          survived["value"] == DURABLE + EDIT_LINE and not survived["label"],
+          **survived)
+
+    # ── AC 7a: `n` — select the widget's card with j, then n focuses the note ──
+    selected = None
+    for _ in range(20):
+        page.keyboard.press("j")
+        selected = page.evaluate(
+            "() => document.querySelector('[data-kbd-selected]')?.dataset.projectId ?? null")
+        if selected == "upload-endpoint":
+            break
+    check("triage_reaches_widget_card", selected == "upload-endpoint", selected=selected)
+    page.keyboard.press("n")
+    page.wait_for_function(
+        """(card) => document.activeElement === document.querySelector(
+             card + ' [data-testid="pre-gate-annotate-input"]')""",
+        arg=CARD, timeout=5000)
+    check("n_focuses_annotation_widget", True)
+    # The overlay documents it from the registry — folded to ONE row (EC42).
+    page.evaluate("() => document.activeElement?.blur?.()")
+    page.keyboard.press("?")
+    page.locator('[data-testid="shortcut-overlay"]').wait_for(timeout=5000)
+    gates_text = page.evaluate(
+        """() => document.querySelector('[data-testid="shortcut-group-gates"]')
+             ?.textContent ?? ''""")
+    check("overlay_lists_n_once",
+          gates_text.count("Compose a steer note on the selected card") == 1,
+          gates=gates_text[:200])
+    page.keyboard.press("Escape")
+
+    # ── AC 7b: board Enter on the MOVING-run card opens that run (§5.3) — the
+    #    legacy /runs/:id redirect may then rewrite it into the shell ───────────
+    page.keyboard.press("Escape")  # clear the triage cursor, then re-walk from the top
+    for _ in range(20):
+        page.keyboard.press("j")
+        if page.evaluate(
+                "() => document.querySelector('[data-kbd-selected]')?.dataset.projectId ?? null") \
+                == "upload-endpoint":
+            break
+    page.keyboard.press("Enter")
+    page.wait_for_function(
+        """() => ['/runs/r-upload/timeline', '/runs/r-upload',
+                  '/p/upload-endpoint/build/r-upload'].includes(window.location.pathname)""",
+        timeout=15000)
+    check("card_enter_opens_moving_run", True,
+          landed=page.evaluate("() => window.location.pathname"))
+
+    # ── AC 6 + 7c: run-detail lenses — timeline default (BB pin), u/t keys,
+    #    overlay documentation ──────────────────────────────────────────────────
+    page.goto(f"{ORIGIN}/runs/r-auth", wait_until="domcontentloaded")
+    page.locator('[data-testid="tab-timeline"]').wait_for(timeout=30000)
+    check("timeline_stays_default",
+          page.evaluate("""() => document.querySelector('[data-testid="tab-timeline"]')
+                              ?.getAttribute('aria-selected') === 'true'"""))
+    page.keyboard.press("u")
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="tab-unit-list"]')
+             ?.getAttribute('aria-selected') === 'true'""", timeout=5000)
+    page.keyboard.press("t")
+    page.wait_for_function(
+        """() => document.querySelector('[data-testid="tab-timeline"]')
+             ?.getAttribute('aria-selected') === 'true'""", timeout=5000)
+    check("t_u_switch_lenses", True)
+    page.keyboard.press("?")
+    page.locator('[data-testid="shortcut-overlay"]').wait_for(timeout=5000)
+    panels_text = page.evaluate(
+        """() => document.querySelector('[data-testid="shortcut-group-panels"]')
+             ?.textContent ?? ''""")
+    check("overlay_lists_t_u",
+          "Run detail: show the evidence timeline" in panels_text
+          and "Run detail: show the unit list" in panels_text,
+          panels=panels_text[:300])
+    page.keyboard.press("Escape")
+
+    # ── AC 6: /p/:id/chronicle is a REAL route; the toggle NAVIGATES ───────────
+    set_fixture(ORIGIN, chronicle=True, project_dto=True)
+    page.goto(f"{ORIGIN}/p/auth-refactor/chronicle", wait_until="domcontentloaded")
+    page.locator('[data-testid="work-chronicle"]').wait_for(timeout=30000)
+    chron = page.evaluate(
+        """() => ({
+          path: window.location.pathname,
+          chronicleSelected: document.querySelector('[data-testid="build-view-chronicle"]')
+            ?.getAttribute('aria-selected') === 'true',
+          modeTab: document.querySelector('[data-testid="mode-switcher"] [aria-selected="true"]')
+            ?.dataset.mode ?? null,
+        })""")
+    check("chronicle_route_renders",
+          chron["path"] == "/p/auth-refactor/chronicle"
+          and chron["chronicleSelected"] and chron["modeTab"] == "build",
+          **chron)
+    page.screenshot(path=str(VSHOTS / "ux-BE-nav-chrome.png"))
+    # The toggle re-points: each segment is a NAVIGATION, so Back restores.
+    page.locator('[data-testid="build-view-runs"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/auth-refactor/build'", timeout=10000)
+    check("toggle_runs_navigates",
+          page.evaluate(
+              "() => !document.querySelector('[data-testid=\"work-chronicle\"]')"))
+    page.locator('[data-testid="build-view-chronicle"]').click()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/auth-refactor/chronicle'", timeout=10000)
+    page.locator('[data-testid="work-chronicle"]').wait_for(timeout=10000)
+    page.go_back()
+    page.wait_for_function(
+        "() => window.location.pathname === '/p/auth-refactor/build'", timeout=10000)
+    check("toggle_chronicle_navigates_and_back_restores", True)
+
+    browser.close()
+
+# Reset the mutable switches for any rig that shares this port later.
+set_fixture(ORIGIN, guidance={}, chronicle=False, project_dto=False, nerve=False)
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -418,6 +418,13 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # gate.decided entries and honours `?action=`. Default False: no
          # standing rig's corpus changes.
          "chronicle": False,
+         # Slice BE (DES-UX-002 §8.1): the CREW-UX-7 durable-guidance store
+         # (crew#312 — the doc's "CREW-UX-4", renamed) — {run_id: note}. A rig
+         # seeds it over /__fixture; PUT /api/v1/runs/:id/guidance upserts it
+         # exactly as the daemon does ('' clears; 8KB named 400; 404 unknown;
+         # echo {runId, guidance}); the run DTOs echo `guidance` ONLY for ids
+         # present here — the wire's absent-when-never-set contract.
+         "guidance": {},
          }
 state_lock = threading.Lock()
 
@@ -1431,14 +1438,21 @@ def assemble_runs() -> list:
         chronicle_on = state["chronicle"]
         nerve_on = state["nerve"]
         gate_now = list(state["gate_now"])
+        guidance = dict(state["guidance"])
         # Slice S (DES-UX-001 §2.3): the null-claim run + this-lifetime launches
         # join BOTH wires (list + detail) so the DTO echo decorates identically.
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
     if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
-            or chronicle_on or nerve_on or gate_now:
+            or chronicle_on or nerve_on or gate_now or guidance:
         runs = json.loads(json.dumps(runs))
         for r in runs:
+            # Slice BE (CREW-UX-7, crew#312): the DTO echoes the durable note
+            # ONLY when one is set — ABSENT (never null/'') otherwise, the
+            # api-types 0.9.0 contract the studio's absent-when-never reads.
+            note = guidance.get(r["session"]["id"])
+            if note:
+                r["session"]["guidance"] = note
             # Slice BA: r-upload's §1.5 five-unit plan; unit_ix follows the
             # distributed review (the unit the run is genuinely ON).
             if nerve_on and r["session"]["id"] == "r-upload":
@@ -2923,6 +2937,29 @@ class W2Handler(SimpleHTTPRequestHandler):
                     settings_store.update(body)
                 snapshot = json.loads(json.dumps(settings_store))
             return self._json(200, {"settings": snapshot})
+        # Slice BE: PUT /runs/:id/guidance — the CREW-UX-7 upsert (crew#312),
+        # mirrored verbatim: strict {text} body; the 8KB cap answers a 400
+        # NAMING the limit (the daemon's exact sentence); an unknown run is the
+        # daemon's 404; '' clears (the DTO drops the field); echo what stored.
+        m = re.match(r"^/api/v1/runs/([^/]+)/guidance$", path)
+        if m:
+            rid = urllib.parse.unquote(m.group(1))
+            text = body.get("text") if isinstance(body, dict) else None
+            if not isinstance(text, str) or set(body) != {"text"}:
+                return self._json(400, {"error": "Invalid request body"})
+            if len(text.encode("utf-8")) > 8192:
+                return self._json(400, {"error": (
+                    "guidance exceeds the 8192-byte cap — a note this size belongs "
+                    "in the problem statement or a linked doc")})
+            known = {r["session"]["id"] for r in assemble_runs()}
+            if rid not in known:
+                return self._json(404, {"error": "Run not found"})
+            with state_lock:
+                if text == "":
+                    state["guidance"].pop(rid, None)
+                else:
+                    state["guidance"][rid] = text
+            return self._json(200, {"runId": rid, "guidance": text})
         return self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
 
     def do_DELETE(self):  # noqa: N802 (stdlib naming)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
 const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, navigate, search, pathname } = useRoute();
+  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, chronicleView, navigate, search, pathname } = useRoute();
   const { runs, refresh, loaded: runsLoaded } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestAnnotation = useAnnotationStore((s) => s.ingest);
@@ -274,6 +274,9 @@ export function App(): React.ReactElement {
         onRejectGate={onDashboardRejectGate}
         navigate={navigate}
         projectId={projectId}
+        // Slice BE (DES-UX-002 §5.2): the Runs|Chronicle view is ROUTE state —
+        // `/p/:id/chronicle` — so the chronicle is deep-linkable and Back works.
+        chronicleView={chronicleView}
       />
     </div>
   );

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -21,8 +21,10 @@ import type {
 } from './types.js';
 
 import { ApiError, apiStatus } from './errors.js';
+import type { GuidanceUpdate } from './guidance.js';
 
 export type * from './types.js';
+export { sessionGuidance, type GuidanceUpdate } from './guidance.js';
 export { ApiError, apiStatus, apiWire, isRouteAbsent, translateWireError } from './errors.js';
 
 /**
@@ -187,6 +189,18 @@ export const api = {
   /** Cancel a running or paused run (the distinct third action, §11.1). */
   cancelRun: (id: string) =>
     apiFetch<{ status: string }>(`/runs/${encodeURIComponent(id)}/cancel`, { method: 'POST' }),
+
+  /**
+   * Upsert the run's ONE durable operator guidance note (CREW-UX-7, crew#312 —
+   * DES-UX-002 §7.2's "CREW-UX-4", renamed; see api/guidance.ts). `''` clears;
+   * 404 unknown run; a named 400 past the 8KB cap. Slice BE's write side of
+   * the durable annotation layer — the read side is the DTO's `guidance` echo.
+   */
+  putGuidance: (id: string, text: string) =>
+    apiFetch<GuidanceUpdate>(`/runs/${encodeURIComponent(id)}/guidance`, {
+      method: 'PUT',
+      body: JSON.stringify({ text }),
+    }),
 
   /** Advance a run: confirm-gate if paused, else resume from the cursor (§11.8). */
   resumeRun: (id: string) =>

--- a/src/api/guidance.ts
+++ b/src/api/guidance.ts
@@ -1,0 +1,36 @@
+import type { AgentSession } from './types.js';
+
+/**
+ * CREW-UX-7 — durable operator guidance (DES-UX-002 §7.2; the doc specs it as
+ * "CREW-UX-4", it LANDED as CREW-UX-7 in crew#312 because crew#308 had already
+ * spent that id). The daemon contract, live since crew#312:
+ *
+ *   - `PUT /runs/:id/guidance` `{text}` upserts the ONE operator note on the
+ *     run; `text: ''` CLEARS it; unknown run → 404; >8192 bytes → a named 400.
+ *     Response: `{runId, guidance}`.
+ *   - `GET /runs` + `GET /runs/:id` DTOs carry `guidance?: string` — ABSENT
+ *     (never null/'') when no note is set, so `'guidance' in session` and
+ *     `!== undefined` agree, and a pre-0.9.0 daemon reads as "no note".
+ *
+ * TYPED LOCALLY, not via a dep bump: the fields ship in wicked-crew-api-types
+ * 0.9.0, which exists only in the crew repo's workspace — npm has 0.8.0, the
+ * version this package pins (`^0.8.0`). Faking a bump would break `npm ci`;
+ * when 0.9.0 publishes, these locals collapse into the package types.
+ */
+
+/** Response of `PUT /runs/:id/guidance` (crew#312; api-types 0.9.0 GuidanceUpdate). */
+export interface GuidanceUpdate {
+  runId: string;
+  /** What was stored — `''` after a clear. */
+  guidance: string;
+}
+
+/**
+ * The run DTO's durable guidance note (api-types 0.9.0 `AgentSession.guidance`),
+ * read off the 0.8.0-typed session without a cast leaking anywhere else:
+ * `undefined` = no note (never set, cleared, or a pre-0.9.0 daemon).
+ */
+export function sessionGuidance(session: AgentSession): string | undefined {
+  const raw = (session as AgentSession & { guidance?: unknown }).guidance;
+  return typeof raw === 'string' ? raw : undefined;
+}

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -22,6 +22,7 @@ import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
 import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
+import { chroniclePath, modePath } from '../hooks/useRoute.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 import { WorkChronicle } from './WorkChronicle.js';
@@ -41,6 +42,12 @@ interface Props {
    * unbound `/runs/new`.
    */
   projectId?: string | null;
+  /**
+   * Slice BE (DES-UX-002 §5.2): true on `/p/:id/chronicle` — the chronicle
+   * view selected by ROUTE, not local state, so it is deep-linkable and the
+   * Back button restores the flat list. The toggle below navigates.
+   */
+  chronicleView?: boolean;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -777,6 +784,7 @@ export function CenterDashboard({
   onRejectGate,
   navigate,
   projectId = null,
+  chronicleView = false,
 }: Props): React.ReactElement {
   const byRun = useRunEventStore((s) => s.byRun);
   const gates = useGateStore((s) => s.gates);
@@ -806,10 +814,13 @@ export function CenterDashboard({
 
   // ── The work chronicle (DES-UX-002 §3, slice BC) — a second VIEW of the
   // project's build work, additive beside the flat list (§10's adopted
-  // position: additive tab; slice BE wires the §5.2 route + default). It
-  // reads the FULL scoped history — episode chains are the project's story,
-  // not a time-window slice — so its input skips the range filter.
-  const [view, setView] = useState<'runs' | 'chronicle'>('runs');
+  // position: additive tab — the flat list stays the default; re-defaulting
+  // remains the named open question). Slice BE wired the §5.2 route: the view
+  // IS the route (`/p/:id/chronicle` vs `/p/:id/build`), so the toggle
+  // navigates and the chronicle is deep-linkable. It reads the FULL scoped
+  // history — episode chains are the project's story, not a time-window
+  // slice — so its input skips the range filter.
+  const view: 'runs' | 'chronicle' = chronicleView ? 'chronicle' : 'runs';
   const chronicleRuns = useMemo(
     () => scopedRuns.filter((v) => !!v.session.workflow_id && v.session.workflow_id !== 'chat'),
     [scopedRuns],
@@ -988,8 +999,11 @@ export function CenterDashboard({
         </p>
 
         {/* ── The Runs | Chronicle view toggle (DES-UX-002 §3.3 + §5.3, slice
-               BC): project context only. The flat list stays the default — the
-               §10 open question's adopted additive position; BE may re-default. */}
+               BC): project context only. The flat list stays the default (the
+               §10 open question's adopted additive position). Slice BE
+               re-pointed the toggle at the §5.2 ROUTES: each segment is a
+               navigation, so the chronicle has a real URL and Back restores
+               the list. */}
         {projectId !== null && (
           <div role="tablist" aria-label="Build view" style={{ display: 'flex', gap: '4px', marginBottom: '20px' }}>
             {(['runs', 'chronicle'] as const).map((v) => (
@@ -999,7 +1013,11 @@ export function CenterDashboard({
                 role="tab"
                 aria-selected={view === v}
                 data-testid={`build-view-${v}`}
-                onClick={() => setView(v)}
+                onClick={() => {
+                  if (v !== view) {
+                    navigate(v === 'chronicle' ? chroniclePath(projectId) : modePath(projectId, 'build'));
+                  }
+                }}
                 style={{
                   background: view === v ? 'var(--surface-raised)' : 'transparent',
                   border: '1px solid var(--surface-raised)',

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { lostQuorum, quorumLabel } from './councilQuorum.js';
 import { api, downloadRunEvidence } from '../api/client.js';
 import { sessionGuidance } from '../api/guidance.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import type { SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
 import { executingOrd } from '../api/run-state.js';
 import { useGateStore } from '../store/gates.js';
@@ -863,6 +864,34 @@ function RunChat({
 
   const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'var(--ink-muted)' };
   const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
+
+  // DES-UX-002 §5.4 (slice BE): `t` / `u` switch the terminal run's two lenses
+  // — timeline / unit list — through the ONE shortcut registry (EC42: the '?'
+  // overlay documents them from the registration itself, exactly where they
+  // work). Guarded on the run being terminal: a live run has no tab row, so
+  // the keys yield silently there; the shared typing guard keeps letters as
+  // letters in the steer textarea.
+  const tabsLive = useRef(isTerminal);
+  tabsLive.current = isTerminal;
+  const tabEntries = useMemo<ShortcutEntry[]>(() => [
+    {
+      id: 'run-tab-timeline',
+      chord: { key: 't' },
+      group: 'panels',
+      description: 'Run detail: show the evidence timeline',
+      guard: () => tabsLive.current,
+      handler: (e) => { e.preventDefault(); setRunTab('timeline'); },
+    },
+    {
+      id: 'run-tab-units',
+      chord: { key: 'u' },
+      group: 'panels',
+      description: 'Run detail: show the unit list',
+      guard: () => tabsLive.current,
+      handler: (e) => { e.preventDefault(); setRunTab('units'); },
+    },
+  ], []);
+  useGlobalShortcuts(tabEntries);
   // Keep action + system events interleaved in arrival order (log is seq-ordered).
   const eventLog = log.filter((e) => SYSTEM_EVENT_TYPES.has(e.type) || ACTION_EVENT_TYPES.has(e.type));
   const dotColor = statusDotColor(session.status);

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { lostQuorum, quorumLabel } from './councilQuorum.js';
 import { api, downloadRunEvidence } from '../api/client.js';
+import { sessionGuidance } from '../api/guidance.js';
 import type { SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
 import { executingOrd } from '../api/run-state.js';
 import { useGateStore } from '../store/gates.js';
@@ -1205,6 +1206,7 @@ function RunChat({
               <div key={`gate-before-${unit.id}`} className="self-center w-full max-w-lg">
                 <SteeringGate
                   runId={session.id}
+                  guidance={sessionGuidance(session)}
                   {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
                   onResolved={onRefresh}
                 />
@@ -1255,6 +1257,7 @@ function RunChat({
           <div className="self-center w-full max-w-lg">
             <SteeringGate
               runId={session.id}
+              guidance={sessionGuidance(session)}
               {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
               onResolved={onRefresh}
             />

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -3,7 +3,8 @@ import type { SessionView } from '../api/types.js';
 import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
-import { modePath, projectPath } from '../hooks/useRoute.js';
+import { leadMovingRun } from '../board/phaseProgress.js';
+import { modePath, projectPath, runTimelinePath } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
 import { BatchGateBar } from './BatchGateBar.js';
@@ -163,12 +164,18 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     () =>
       needsYou.map((i) => {
         const waiting = i.runs.find((v) => v.session.status === 'awaiting_human');
+        // Slice BE (DES-UX-002 §5.3): while a run is MOVING on the card, the
+        // card's open target is that run's evidence — `/runs/:id/timeline` —
+        // instead of the project dashboard (the card's project NAME remains
+        // the shell link). A card with nothing moving keeps the dashboard.
+        const moving = leadMovingRun(i.runs);
         return {
           key: i.project.id,
           runId: waiting?.session.id ?? null,
           gate: waiting === undefined ? undefined : gates[waiting.session.id],
-          // Enter opens what clicking the card's name opens: the dashboard.
-          openPath: projectPath(i.project.id),
+          openPath: moving !== undefined
+            ? runTimelinePath(moving.session.id)
+            : projectPath(i.project.id),
           projectId: i.project.id,
         };
       }),

--- a/src/components/PreGateAnnotate.tsx
+++ b/src/components/PreGateAnnotate.tsx
@@ -104,10 +104,16 @@ export function PreGateAnnotate({ runId, guidance, openSignal = 0 }: Props): Rea
   }, [durable]);
 
   useEffect(() => {
-    if (openSignal > 0) {
-      wantFocus.current = true;
-      setOpen(true);
+    if (openSignal === 0) return;
+    // Already open (slice BE: a durable note mounts the widget open) — the
+    // entry point's job is FOCUS, and the open-state effect below will never
+    // re-run, so focus directly.
+    if (ref.current !== null) {
+      ref.current.focus();
+      return;
     }
+    wantFocus.current = true;
+    setOpen(true);
   }, [openSignal]);
 
   useEffect(() => {

--- a/src/components/PreGateAnnotate.tsx
+++ b/src/components/PreGateAnnotate.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
-import { SCOPE_LABEL, useAnnotationStore } from '../store/annotations.js';
+import { DRAFT_SCOPE_LABEL, useAnnotationStore } from '../store/annotations.js';
+import { durableGuidance, useGuidanceStore } from '../store/guidance.js';
 import { useSteerPrefixes } from '../hooks/useSteerPrefixes.js';
 
 /**
- * The pre-gate annotation widget (DES-UX-002 §4.3, slice BD): compose gate
- * guidance from the home board, BEFORE any gate exists. The draft lives in the
- * session-scoped client store (`annotations.ts` — wire verdict CLIENT, §4.2)
- * and pre-populates the gate card's steer textarea when a gate arrives (EC51).
+ * The pre-gate annotation widget (DES-UX-002 §4.3 slice BD; §8.1 slice BE):
+ * compose gate guidance from the home board, BEFORE any gate exists.
+ *
+ * Slice BE adopted the durable endpoint (CREW-UX-7, crew#312 — the doc's
+ * "CREW-UX-4"; api/guidance.ts): the widget now reads the run DTO's
+ * `guidance` field and pre-populates from it, the session draft layered ON
+ * TOP (the newer local edit wins); a gesture-gated "save guidance" PUTs the
+ * note so it survives tab close and reaches other sessions — multi-session
+ * survival is the point. Feedback is point-of-action (EC37): saving/saved/a
+ * named error beside the button. The old whole-widget session-scope label
+ * retired with the gap; what remains session-scoped is exactly the unsaved
+ * edit, and the EC52 label now names only that, only while one exists.
  *
  * COPY SHAPED TO THE MEASURED TRUTH (see annotations.ts): escalation-to-gate
  * windows on the live daemon are milliseconds, so this widget never pretends
@@ -15,7 +24,7 @@ import { useSteerPrefixes } from '../hooks/useSteerPrefixes.js';
  * (slice BA) is an entry point that opens it, not its lifetime.
  *
  * Tokens (§4.4): `--surface-raised` ground, `--ink-muted` placeholder,
- * `--ink-dim --text-2xs` session-scope label (EC52's honest copy, verbatim).
+ * `--ink-dim --text-2xs` scope label (EC52's honest-split copy).
  */
 
 const CSS = {
@@ -33,29 +42,66 @@ const CSS = {
     outline: 'none', padding: 0, fontSize: 'var(--text-xs)',
     fontFamily: 'var(--font-mono)', color: 'var(--ink-high)',
   },
+  footer: {
+    display: 'flex', alignItems: 'center', gap: '8px', marginTop: '4px',
+  },
   label: {
-    margin: '4px 0 0', fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    margin: 0, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
     color: 'var(--ink-dim)',
+  },
+  save: {
+    background: 'transparent', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--ink-muted)', cursor: 'pointer',
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', padding: '1px 8px',
   },
 } as const satisfies Record<string, React.CSSProperties>;
 
 interface Props {
   runId: string;
-  /** Bumped by an entry point (the gate-approaching chip) to open + focus. */
+  /** The run DTO's durable note (CREW-UX-7 echo) — ABSENT when never set. */
+  guidance?: string | undefined;
+  /** Bumped by an entry point (the gate-approaching chip, the board's `n`) to open + focus. */
   openSignal?: number;
 }
 
-export function PreGateAnnotate({ runId, openSignal = 0 }: Props): React.ReactElement {
-  const draft = useAnnotationStore((s) => s.drafts[runId]) ?? '';
+export function PreGateAnnotate({ runId, guidance, openSignal = 0 }: Props): React.ReactElement {
+  const draft = useAnnotationStore((s) => s.drafts[runId]);
   const setDraft = useAnnotationStore((s) => s.setDraft);
-  // A card with a standing draft mounts open — the note is live state, not a
-  // secret behind a click.
-  const [open, setOpen] = useState(draft !== '');
+  const mirror = useGuidanceStore((s) => s.saved);
+  const saveState = useGuidanceStore((s) => s.saveState[runId]);
+  const save = useGuidanceStore((s) => s.save);
+
+  // Pre-population order (slice BE): the DURABLE note first, the session
+  // draft ON TOP — the draft is the newer local edit when both exist.
+  const durable = durableGuidance(runId, guidance, mirror) ?? '';
+  // Local text is the render truth while mounted: the draft store cannot
+  // spell "emptied on top of a durable note" (empty deletes the draft), so
+  // the textarea owns its emptiness and a save of '' is the honest clear.
+  const [text, setText] = useState(() => draft ?? durable);
+  // An unsaved edit is what is still session-scoped — the EC52 label's whole
+  // subject after BE, and the save button's arming condition.
+  const dirty = text !== durable;
+  // A widget holding a live note mounts open — state, not a secret.
+  const [open, setOpen] = useState(text !== '');
   const ref = useRef<HTMLTextAreaElement>(null);
   // Focus intent, resolved AFTER the textarea commits (a rAF here would race
   // the mount — and the board's triage cursor refocuses the card on the very
   // click that opened us, so the focus must land after that, not before).
   const wantFocus = useRef(false);
+  // Whether the operator has edited THIS mount (a standing draft counts): an
+  // untouched widget adopts a durable note that arrives after mount (the DTO
+  // echo rides the next /runs poll), while a touched one is never stomped —
+  // including the deliberate emptied state on its way to a saved clear.
+  const touched = useRef(draft !== undefined);
+
+  useEffect(() => {
+    if (!touched.current && text !== durable) {
+      setText(durable);
+      if (durable !== '') setOpen(true);
+    }
+    // `text` is deliberately not a dep: this reacts to the DURABLE note moving.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [durable]);
 
   useEffect(() => {
     if (openSignal > 0) {
@@ -72,6 +118,14 @@ export function PreGateAnnotate({ runId, openSignal = 0 }: Props): React.ReactEl
   }, [open]);
 
   useSteerPrefixes(`annotate-${runId}`, ref);
+
+  const apply = (next: string): void => {
+    touched.current = true;
+    setText(next);
+    // The draft store keeps the newest edit across remounts (the board
+    // windows cards); an emptied widget withdraws the draft, as before.
+    setDraft(runId, next);
+  };
 
   if (!open) {
     return (
@@ -97,17 +151,59 @@ export function PreGateAnnotate({ runId, openSignal = 0 }: Props): React.ReactEl
       <textarea
         ref={ref}
         data-testid="pre-gate-annotate-input"
-        rows={Math.min(4, Math.max(3, draft.split('\n').length))}
+        rows={Math.min(4, Math.max(3, text.split('\n').length))}
         placeholder="Guidance for this run's next gate — pre-fills the steer box when a gate arrives"
         className="wk-annotate"
         style={CSS.textarea}
-        value={draft}
-        onChange={(e) => setDraft(runId, e.target.value)}
+        value={text}
+        onChange={(e) => apply(e.target.value)}
       />
-      {/* EC52: the honest scope label — retired when CREW-UX-4 lands (slice BE). */}
-      <p data-testid="annotation-scope-label" style={CSS.label}>
-        {SCOPE_LABEL}
-      </p>
+      <div style={CSS.footer}>
+        {/* Slice BE: the gesture-gated durable write (CREW-UX-7) — armed only
+            by an unsaved edit; '' rides too (the honest clear). */}
+        <button
+          type="button"
+          data-testid="save-guidance"
+          disabled={!dirty || saveState?.phase === 'saving'}
+          title="Save this note on the run — it survives this browser session and reaches other sessions"
+          style={{ ...CSS.save, opacity: dirty ? 1 : 0.5 }}
+          onClick={() => {
+            void save(runId, text).then(() => {
+              // On success the note is durable — the session draft has
+              // nothing left to hold (clearing it also retires the label).
+              if (useGuidanceStore.getState().saveState[runId]?.phase === 'saved') {
+                useAnnotationStore.getState().clearDraft(runId);
+              }
+            });
+          }}
+        >
+          save guidance
+        </button>
+        {/* EC37: point-of-action feedback, beside the gesture that fired. A
+            stale "saved" says nothing under a NEWER unsaved edit — the scope
+            label owns that state. */}
+        {saveState !== undefined && !(saveState.phase === 'saved' && dirty) && (
+          <span
+            data-testid="guidance-save-state"
+            data-phase={saveState.phase}
+            style={{
+              ...CSS.label,
+              color: saveState.phase === 'error' ? 'var(--status-fail)' : 'var(--ink-dim)',
+            }}
+          >
+            {saveState.phase === 'saving' && 'saving…'}
+            {saveState.phase === 'saved' && !dirty && 'saved — survives this session'}
+            {saveState.phase === 'error' && `save failed: ${saveState.detail}`}
+          </span>
+        )}
+        {/* EC52 after BE: the label names ONLY what is still session-scoped —
+            the unsaved edit — and retires where durability holds. */}
+        {dirty && (
+          <p data-testid="annotation-scope-label" style={CSS.label}>
+            {DRAFT_SCOPE_LABEL}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,5 +1,6 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useRef, useState } from 'react';
 import { sessionGuidance } from '../api/guidance.js';
+import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import type { SessionView } from '../api/types.js';
 import type { SignalKind } from '../board/boardAttention.js';
 import { leadMovingRun, truncate } from '../board/phaseProgress.js';
@@ -359,6 +360,23 @@ export function ProjectCard({
   ) ?? lead;
   // Bumped by the gate-approaching chip (an entry point): opens + focuses the widget.
   const [annotateSignal, setAnnotateSignal] = useState(0);
+
+  // DES-UX-002 §5.4 (slice BE): `n` opens the steer-note widget from the board,
+  // through the ONE registry. Registered per card and guard-scoped to the
+  // triage-SELECTED card that actually mounts a widget — dispatch walks the
+  // table until a guard holds, so every peer card yields silently, and the
+  // overlay folds the identical descriptions into one row.
+  const nState = useRef({ selected: kbdSelected, has: false });
+  nState.current = { selected: kbdSelected, has: annotateFor !== undefined };
+  const nEntries = useMemo<ShortcutEntry[]>(() => [{
+    id: `annotate-note-${project.id}`,
+    chord: { key: 'n' },
+    group: 'gates',
+    description: 'Compose a steer note on the selected card',
+    guard: () => nState.current.selected && nState.current.has,
+    handler: (e) => { e.preventDefault(); setAnnotateSignal((x) => x + 1); },
+  }], [project.id]);
+  useGlobalShortcuts(nEntries);
 
   /** Every affordance on the card is a real link — deep-linkable, middle-clickable. */
   const link: Link = (path) => ({

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState } from 'react';
+import { sessionGuidance } from '../api/guidance.js';
 import type { SessionView } from '../api/types.js';
 import type { SignalKind } from '../board/boardAttention.js';
 import { leadMovingRun, truncate } from '../board/phaseProgress.js';
@@ -634,7 +635,13 @@ export function ProjectCard({
           arrival pre-fills its steer textarea from this draft. */}
       {annotateFor !== undefined && (
         <div style={{ marginTop: '8px' }}>
-          <PreGateAnnotate runId={annotateFor.session.id} openSignal={annotateSignal} />
+          <PreGateAnnotate
+            runId={annotateFor.session.id}
+            // Slice BE: the durable note off the run DTO (CREW-UX-7 echo) —
+            // pre-populates first; the session draft layers on top.
+            guidance={sessionGuidance(annotateFor.session)}
+            openSignal={annotateSignal}
+          />
         </div>
       )}
 

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -4,6 +4,7 @@ import type { CoverageReport } from '../api/types.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useSteerPrefixes } from '../hooks/useSteerPrefixes.js';
 import { useAnnotationStore } from '../store/annotations.js';
+import { durableGuidance, useGuidanceStore } from '../store/guidance.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
 import { GATE_HASH } from './GateChip.js';
@@ -12,6 +13,9 @@ interface Props {
   runId: string;
   ord?: number;
   prompt?: string;
+  /** The run DTO's durable guidance note (CREW-UX-7, crew#312 — slice BE):
+   *  pre-populates the steer textarea FIRST; the session draft layers on top. */
+  guidance?: string | undefined;
   /** When present, fetches coverage stats for inline display at the gate card. */
   repoRef?: string;
   onResolved?: () => void;
@@ -34,15 +38,20 @@ function coverageLabel(r: CoverageReport): string {
   return `Coverage: ${pct} · ${r.behavior_bearing.toLocaleString()} nodes · ${r.unaccounted} unaccounted${resolvedPct}`;
 }
 
-export function SteeringGate({ runId, ord, prompt, repoRef, onResolved }: Props): React.ReactElement {
+export function SteeringGate({ runId, ord, prompt, guidance, repoRef, onResolved }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
   const recordSteering = useSteeringStore((s) => s.record);
   // Slice BD (DES-UX-002 §4.3, EC51): gate arrival pre-populates the steer
-  // textarea from whatever session-scoped draft exists for this run — the gate
-  // card MOUNTING is the arrival on this surface. No draft ⇒ blank, as today.
-  // The lazy initializer reads once; `prepopulated` is a mount-stable fact.
+  // textarea — the gate card MOUNTING is the arrival on this surface. Slice BE
+  // added the durable layer (CREW-UX-7): pre-population order is the run DTO's
+  // `guidance` note FIRST, the session-scoped draft ON TOP (the newer local
+  // edit wins). Neither ⇒ blank, as today. The lazy initializer reads once;
+  // `prepopulated` is a mount-stable fact.
   const [amend, setAmend] = useState(
-    () => useAnnotationStore.getState().drafts[runId] ?? '',
+    () =>
+      useAnnotationStore.getState().drafts[runId]
+      ?? durableGuidance(runId, guidance, useGuidanceStore.getState().saved)
+      ?? '',
   );
   const [prepopulated] = useState(amend !== '');
   const [loading, setLoading] = useState(false);

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -38,6 +38,12 @@ interface Route {
   mode: Mode | null;
   /** What the mode has open: run id (Build), thread id (Chat), doc id, demo id. */
   artifactId: string | null;
+  /** True on `/p/:projectId/chronicle` (DES-UX-002 §5.2, slice BE): the work
+   *  chronicle as a REAL route — deep-linkable, back-button-correct. It rides
+   *  the Build surface (mode resolves to 'build'; the chronicle is a second
+   *  VIEW of the project's build work, §3's adopted additive position), so
+   *  this flag — not a fifth Mode — is what selects the view. */
+  chronicleView: boolean;
 }
 
 /** Route options a caller can override; everything else takes its inert default. */
@@ -51,6 +57,7 @@ const INERT: Route = {
   projectId: null,
   mode: null,
   artifactId: null,
+  chronicleView: false,
 };
 
 function route(over: Partial<Route>): Route {
@@ -75,6 +82,22 @@ export function projectPath(projectId: string): string {
 export function modePath(projectId: string, mode: Mode, artifactId?: string | null): string {
   const base = `${projectPath(projectId)}/${mode}`;
   return artifactId ? `${base}/${encodeURIComponent(artifactId)}` : base;
+}
+
+/** The work chronicle's real route (DES-UX-002 §5.2, slice BE) — see `chronicleView`. */
+export function chroniclePath(projectId: string): string {
+  return `${projectPath(projectId)}/chronicle`;
+}
+
+/**
+ * A run's evidence-timeline address (DES-UX-002 §5.2, slice BE): `/runs/:id/
+ * timeline` — the §5.2 alias of `/runs/:id`, whose default layout the timeline
+ * already is (slice BB, terminal runs). The parser resolves both spellings to
+ * the run detail; entry points (the home board's ACTIVE card, §5.3) use this
+ * one so the intent is legible in the URL.
+ */
+export function runTimelinePath(runId: string): string {
+  return `/runs/${encodeURIComponent(runId)}/timeline`;
 }
 
 /**
@@ -116,6 +139,12 @@ function parse(pathname: string): Route {
   // The project+mode parse runs AHEAD of the panel parse (DES-MERGE-001 §1.5); the
   // `Panel` union below is untouched and still owns every side panel.
   if (first === 'p' && second) {
+    // `/p/:projectId/chronicle` (DES-UX-002 §5.2, slice BE): the chronicle's
+    // real route. It resolves to the Build surface with the chronicle VIEW
+    // selected — never an artifact named "chronicle".
+    if (third === 'chronicle') {
+      return route({ projectId: safeDecode(second), mode: 'build', chronicleView: true });
+    }
     const mode = asMode(third);
     const raw = mode !== null && fourth ? safeDecode(fourth) : null;
     // `/p/:projectId/:mode/new` is the project-scoped CREATE route (DES-FEEDBACK-001

--- a/src/store/annotations.ts
+++ b/src/store/annotations.ts
@@ -6,8 +6,9 @@ import type { CoreEvent } from '../api/types.js';
  * operator composes on the home board BEFORE a gate exists, keyed by run id.
  * Pure CLIENT state — §4.2's wire verdict: no new wire; a draft resolves into
  * the EXISTING `amend` field of `POST /runs/:id/gate` when the gate card
- * consumes it. Session-scoped and honestly labelled so (EC52,
- * {@link SCOPE_LABEL}); the durable endpoint is CREW-UX-4 / slice BE.
+ * consumes it. Session-scoped and honestly labelled so while an edit is
+ * unsaved (EC52, {@link DRAFT_SCOPE_LABEL}); the durable layer landed with
+ * slice BE (CREW-UX-7, crew#312 — store/guidance.ts).
  *
  * MEASURED DEVIATION from §4.3 (operator steer at the design run's gate,
  * 2026-08, applied here): the doc scoped the widget to the "gate approaching"
@@ -23,9 +24,16 @@ import type { CoreEvent } from '../api/types.js';
  * pre-populates from whatever draft exists (EC51).
  */
 
-/** EC52's honest scope copy, verbatim per §4.3 — retired when CREW-UX-4 lands. */
-export const SCOPE_LABEL =
-  'saved for this browser session only — durable annotations land with CREW-UX-4.';
+/**
+ * EC52's honest scope copy after slice BE — the honest SPLIT: the durable
+ * endpoint landed (CREW-UX-7, crew#312 — the doc's "CREW-UX-4"), so saved
+ * guidance survives sessions and the old whole-widget session-scope label
+ * RETIRED with the gap it described. What is STILL session-scoped is exactly
+ * the unsaved edit, so this label names only that, renders only while an
+ * unsaved edit exists, and disappears where durability holds.
+ */
+export const DRAFT_SCOPE_LABEL =
+  'unsaved edit — this browser session only until you save guidance.';
 
 /** Frames on which a run's draft is moot: the run can never gate again. A
  *  `resumed` does NOT clear — the next gate of the same run should still

--- a/src/store/guidance.ts
+++ b/src/store/guidance.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+
+/**
+ * The durable-guidance layer (DES-UX-002 §8.1 slice BE): CREW-UX-7 adoption
+ * (crew#312 — the doc's "CREW-UX-4", renamed; see api/guidance.ts). Two jobs:
+ *
+ * 1. `saved` — the client's mirror of the run's durable note between a
+ *    successful PUT and the next `/runs` refetch, so the widget shows the
+ *    saved truth immediately. `''` here means CLEARED (the DTO drops the
+ *    field after a clear, so the mirror must out-vote a stale DTO echo);
+ *    `undefined` means "no local write — trust the DTO".
+ * 2. `saveState` — per-run point-of-action feedback for the save gesture
+ *    (EC37): saving → saved / a named error, rendered beside the button that
+ *    fired it, never a global toast.
+ */
+
+export type SavePhase =
+  | { phase: 'saving' }
+  | { phase: 'saved'; at: number }
+  | { phase: 'error'; detail: string };
+
+interface GuidanceStore {
+  /** Durable-note mirror by run id — see the module doc for the '' contract. */
+  saved: Record<string, string>;
+  /** The save gesture's point-of-action state, by run id. */
+  saveState: Record<string, SavePhase>;
+  /** PUT the note (upsert; `''` clears). Resolves the stores; never throws. */
+  save: (runId: string, text: string) => Promise<void>;
+}
+
+export const useGuidanceStore = create<GuidanceStore>((set) => ({
+  saved: {},
+  saveState: {},
+
+  save: async (runId, text) => {
+    set((s) => ({ saveState: { ...s.saveState, [runId]: { phase: 'saving' } } }));
+    try {
+      // The daemon echoes what it stored ('' after a clear) — mirror THAT,
+      // not what we sent, so the mirror is the wire's word.
+      const { guidance } = await api.putGuidance(runId, text);
+      set((s) => ({
+        saved: { ...s.saved, [runId]: guidance },
+        saveState: { ...s.saveState, [runId]: { phase: 'saved', at: Date.now() } },
+      }));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      set((s) => ({ saveState: { ...s.saveState, [runId]: { phase: 'error', detail } } }));
+    }
+  },
+}));
+
+/**
+ * The run's durable note as this client currently knows it: the local mirror
+ * out-votes the DTO echo (it is newer), the DTO answers otherwise. `''` and
+ * `undefined` both mean "no note" to a reader; they differ only in provenance.
+ */
+export function durableGuidance(
+  runId: string,
+  dtoGuidance: string | undefined,
+  mirror: Record<string, string>,
+): string | undefined {
+  const local = mirror[runId];
+  return local !== undefined ? local : dtoGuidance;
+}

--- a/tests/PreGateAnnotate.test.tsx
+++ b/tests/PreGateAnnotate.test.tsx
@@ -1,21 +1,28 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PreGateAnnotate } from '../src/components/PreGateAnnotate.js';
-import { SCOPE_LABEL, useAnnotationStore } from '../src/store/annotations.js';
+import { DRAFT_SCOPE_LABEL, useAnnotationStore } from '../src/store/annotations.js';
+import { useGuidanceStore } from '../src/store/guidance.js';
+import * as client from '../src/api/client.js';
 
 /**
  * Slice BD (DES-UX-002 §4.3, EC51/EC52): the home-board pre-gate annotation
- * widget — collapsed affordance, typed text lands in the session draft store,
- * the honest scope label rides the open widget.
+ * widget — collapsed affordance, typed text lands in the session draft store.
+ * Slice BE (§8.1): the durable layer — the run DTO's `guidance` pre-populates
+ * first with the draft on top, "save guidance" PUTs through CREW-UX-7 with
+ * point-of-action feedback (EC37), and the EC52 label names ONLY the unsaved
+ * edit (the one thing still session-scoped), retiring where durability holds.
  */
 
-describe('PreGateAnnotate (slice BD)', () => {
+describe('PreGateAnnotate (slices BD + BE)', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     useAnnotationStore.setState({ drafts: {} });
+    useGuidanceStore.setState({ saved: {}, saveState: {} });
   });
 
-  it('collapsed affordance opens into the textarea + EC52 scope label', async () => {
+  it('collapsed affordance opens; the EC52 label rides ONLY an unsaved edit', async () => {
     const user = userEvent.setup();
     render(<PreGateAnnotate runId="r-1" />);
     const affordance = screen.getByTestId('pre-gate-annotate');
@@ -23,7 +30,10 @@ describe('PreGateAnnotate (slice BD)', () => {
     expect(screen.queryByTestId('annotation-scope-label')).toBeNull();
     await user.click(affordance);
     expect(screen.getByTestId('pre-gate-annotate')).toHaveAttribute('data-open', 'true');
-    expect(screen.getByTestId('annotation-scope-label')).toHaveTextContent(SCOPE_LABEL);
+    // Nothing typed yet ⇒ nothing is session-scoped ⇒ no label (honest split).
+    expect(screen.queryByTestId('annotation-scope-label')).toBeNull();
+    await user.type(screen.getByTestId('pre-gate-annotate-input'), 'x');
+    expect(screen.getByTestId('annotation-scope-label')).toHaveTextContent(DRAFT_SCOPE_LABEL);
   });
 
   it('typing saves the draft keyed by run id — no wire, just the store', async () => {
@@ -50,5 +60,56 @@ describe('PreGateAnnotate (slice BD)', () => {
     expect(screen.getByTestId('pre-gate-annotate')).toHaveAttribute('data-open', 'true');
     await new Promise((r) => requestAnimationFrame(() => r(null)));
     expect(document.activeElement).toBe(input);
+  });
+
+  // ── Slice BE: the durable layer ────────────────────────────────────────────
+
+  it('the run DTO durable note mounts open, pre-populated, with NO scope label', () => {
+    render(<PreGateAnnotate runId="r-1" guidance="rate-limit by API key" />);
+    expect(screen.getByTestId('pre-gate-annotate')).toHaveAttribute('data-open', 'true');
+    expect((screen.getByTestId('pre-gate-annotate-input') as HTMLTextAreaElement).value)
+      .toBe('rate-limit by API key');
+    // Durability holds ⇒ the session-scope label retired (EC52 honest split).
+    expect(screen.queryByTestId('annotation-scope-label')).toBeNull();
+  });
+
+  it('pre-population order: durable first, the session draft ON TOP', () => {
+    useAnnotationStore.getState().setDraft('r-1', 'the newer local edit');
+    render(<PreGateAnnotate runId="r-1" guidance="the older durable note" />);
+    expect((screen.getByTestId('pre-gate-annotate-input') as HTMLTextAreaElement).value)
+      .toBe('the newer local edit');
+    expect(screen.getByTestId('annotation-scope-label')).toHaveTextContent(DRAFT_SCOPE_LABEL);
+  });
+
+  it('save guidance PUTs the text, shows point-of-action feedback, retires the label', async () => {
+    const put = vi.spyOn(client.api, 'putGuidance').mockResolvedValue(
+      { runId: 'r-1', guidance: 'keep the tests green' } as never,
+    );
+    const user = userEvent.setup();
+    render(<PreGateAnnotate runId="r-1" />);
+    await user.click(screen.getByTestId('pre-gate-annotate'));
+    await user.type(screen.getByTestId('pre-gate-annotate-input'), 'keep the tests green');
+    expect(screen.getByTestId('save-guidance')).toBeEnabled();
+    await user.click(screen.getByTestId('save-guidance'));
+    expect(put).toHaveBeenCalledWith('r-1', 'keep the tests green');
+    await waitFor(() =>
+      expect(screen.getByTestId('guidance-save-state')).toHaveAttribute('data-phase', 'saved'));
+    // Saved ⇒ nothing session-scoped remains: the label retires, the draft clears.
+    expect(screen.queryByTestId('annotation-scope-label')).toBeNull();
+    expect(useAnnotationStore.getState().drafts['r-1']).toBeUndefined();
+  });
+
+  it('a failed save names the error at the point of action; the edit stays scoped', async () => {
+    vi.spyOn(client.api, 'putGuidance').mockRejectedValue(new Error('Run not found'));
+    const user = userEvent.setup();
+    render(<PreGateAnnotate runId="r-1" />);
+    await user.click(screen.getByTestId('pre-gate-annotate'));
+    await user.type(screen.getByTestId('pre-gate-annotate-input'), 'note');
+    await user.click(screen.getByTestId('save-guidance'));
+    await waitFor(() =>
+      expect(screen.getByTestId('guidance-save-state')).toHaveAttribute('data-phase', 'error'));
+    expect(screen.getByTestId('guidance-save-state').textContent).toContain('Run not found');
+    expect(screen.getByTestId('annotation-scope-label')).toHaveTextContent(DRAFT_SCOPE_LABEL);
+    expect(useAnnotationStore.getState().drafts['r-1']).toBe('note');
   });
 });

--- a/tests/PreGateAnnotate.test.tsx
+++ b/tests/PreGateAnnotate.test.tsx
@@ -62,6 +62,15 @@ describe('PreGateAnnotate (slices BD + BE)', () => {
     expect(document.activeElement).toBe(input);
   });
 
+  it('an openSignal bump on an ALREADY-open widget focuses it (the board `n` key)', async () => {
+    useAnnotationStore.getState().setDraft('r-1', 'standing note'); // mounts open
+    const { rerender } = render(<PreGateAnnotate runId="r-1" openSignal={0} />);
+    expect(screen.getByTestId('pre-gate-annotate')).toHaveAttribute('data-open', 'true');
+    rerender(<PreGateAnnotate runId="r-1" openSignal={1} />);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByTestId('pre-gate-annotate-input')));
+  });
+
   // ── Slice BE: the durable layer ────────────────────────────────────────────
 
   it('the run DTO durable note mounts open, pre-populated, with NO scope label', () => {

--- a/tests/SteeringGate.prepopulate.test.tsx
+++ b/tests/SteeringGate.prepopulate.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SteeringGate } from '../src/components/SteeringGate.js';
 import * as client from '../src/api/client.js';
 import { useAnnotationStore } from '../src/store/annotations.js';
+import { useGuidanceStore } from '../src/store/guidance.js';
 import { useGateStore } from '../src/store/gates.js';
 
 /**
@@ -17,6 +18,7 @@ describe('SteeringGate pre-population (slice BD)', () => {
     vi.restoreAllMocks();
     useGateStore.setState({ gates: {}, approaching: {} });
     useAnnotationStore.setState({ drafts: {} });
+    useGuidanceStore.setState({ saved: {}, saveState: {} });
     vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' } as never);
     vi.spyOn(client.api, 'cancelRun').mockResolvedValue({ status: 'cancelled' } as never);
   });
@@ -67,6 +69,29 @@ describe('SteeringGate pre-population (slice BD)', () => {
     render(<SteeringGate runId="r-1" ord={1} prompt="Proceed?" />);
     await user.type(screen.getByTestId('steering-amend'), 'newest');
     expect(useAnnotationStore.getState().drafts['r-1']).toBe('newest');
+  });
+
+  // ── Slice BE: the durable layer under the standing BD contract ────────────
+
+  it('the run DTO durable note pre-populates when no session draft exists', () => {
+    render(<SteeringGate runId="r-1" ord={1} prompt="Proceed?" guidance="rate-limit by API key" />);
+    const ta = screen.getByTestId('amend-prepopulated') as HTMLTextAreaElement;
+    expect(ta.value).toBe('rate-limit by API key');
+    expect(screen.getByTestId('steering-approve-steer')).toBeEnabled();
+  });
+
+  it('pre-population order: the session draft rides ON TOP of the durable note', () => {
+    useAnnotationStore.getState().setDraft('r-1', 'the newer local edit');
+    render(<SteeringGate runId="r-1" ord={1} prompt="Proceed?" guidance="the older durable note" />);
+    expect((screen.getByTestId('amend-prepopulated') as HTMLTextAreaElement).value)
+      .toBe('the newer local edit');
+  });
+
+  it('the save mirror out-votes a stale DTO echo (a cleared note stays cleared)', () => {
+    useGuidanceStore.setState({ saved: { 'r-1': '' }, saveState: {} });
+    render(<SteeringGate runId="r-1" ord={1} prompt="Proceed?" guidance="stale DTO echo" />);
+    expect((screen.getByTestId('steering-amend') as HTMLTextAreaElement).value).toBe('');
+    expect(screen.queryByTestId('amend-prepopulated')).toBeNull();
   });
 
   it('Alt+1 inside the steer textarea inserts "Focus: " at the cursor', async () => {

--- a/tests/annotations.store.test.ts
+++ b/tests/annotations.store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SCOPE_LABEL, useAnnotationStore } from '../src/store/annotations.js';
+import { DRAFT_SCOPE_LABEL, useAnnotationStore } from '../src/store/annotations.js';
 import type { CoreEvent } from '../src/api/types.js';
 
 /**
@@ -41,9 +41,12 @@ describe('annotation draft store (slice BD)', () => {
     expect(Object.keys(drafts)).toEqual(['r-live']);
   });
 
-  it('EC52: the honest scope label names the session scope and CREW-UX-4, verbatim §4.3', () => {
-    expect(SCOPE_LABEL).toBe(
-      'saved for this browser session only — durable annotations land with CREW-UX-4.',
+  it('EC52 after slice BE: the label names ONLY the unsaved edit (the honest split)', () => {
+    // CREW-UX-7 landed (crew#312 — the doc's "CREW-UX-4"), so the old
+    // whole-widget session-scope copy retired; what is still session-scoped
+    // is exactly the unsaved edit, and the copy says so — nothing more.
+    expect(DRAFT_SCOPE_LABEL).toBe(
+      'unsaved edit — this browser session only until you save guidance.',
     );
   });
 });

--- a/tests/guidance.store.test.ts
+++ b/tests/guidance.store.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { durableGuidance, useGuidanceStore } from '../src/store/guidance.js';
+import * as client from '../src/api/client.js';
+
+/**
+ * Slice BE (DES-UX-002 §8.1): the durable-guidance layer over CREW-UX-7
+ * (crew#312 — the doc's "CREW-UX-4"): the save gesture's PUT, the mirror that
+ * out-votes a stale DTO echo, and the point-of-action save state (EC37).
+ */
+
+describe('guidance store (slice BE)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGuidanceStore.setState({ saved: {}, saveState: {} });
+  });
+
+  it('save PUTs {text} and mirrors what the daemon ECHOED, not what was sent', async () => {
+    const put = vi.spyOn(client.api, 'putGuidance').mockResolvedValue(
+      { runId: 'r-1', guidance: 'stored form' } as never,
+    );
+    await useGuidanceStore.getState().save('r-1', 'sent form');
+    expect(put).toHaveBeenCalledWith('r-1', 'sent form');
+    expect(useGuidanceStore.getState().saved['r-1']).toBe('stored form');
+    expect(useGuidanceStore.getState().saveState['r-1']).toMatchObject({ phase: 'saved' });
+  });
+
+  it("'' clears: the mirror holds '' so a stale DTO echo cannot resurrect the note", async () => {
+    vi.spyOn(client.api, 'putGuidance').mockResolvedValue(
+      { runId: 'r-1', guidance: '' } as never,
+    );
+    await useGuidanceStore.getState().save('r-1', '');
+    expect(useGuidanceStore.getState().saved['r-1']).toBe('');
+    // The DTO still echoes the old note until the next refetch — mirror wins.
+    expect(durableGuidance('r-1', 'stale echo', useGuidanceStore.getState().saved)).toBe('');
+  });
+
+  it('a failed save lands as a NAMED error state and never throws', async () => {
+    vi.spyOn(client.api, 'putGuidance').mockRejectedValue(new Error('Run not found'));
+    await useGuidanceStore.getState().save('r-x', 'note');
+    expect(useGuidanceStore.getState().saveState['r-x']).toEqual(
+      { phase: 'error', detail: 'Run not found' },
+    );
+    expect(useGuidanceStore.getState().saved['r-x']).toBeUndefined();
+  });
+
+  it('durableGuidance: no local write ⇒ the DTO answers (absent-when-never included)', () => {
+    expect(durableGuidance('r-1', 'dto note', {})).toBe('dto note');
+    expect(durableGuidance('r-1', undefined, {})).toBeUndefined();
+  });
+});

--- a/tests/useRoute.modes.test.ts
+++ b/tests/useRoute.modes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
-import { MODES, modePath, projectPath, useRoute } from '../src/hooks/useRoute.js';
+import { chroniclePath, MODES, modePath, projectPath, runTimelinePath, useRoute } from '../src/hooks/useRoute.js';
 
 /** Render the hook against a given path — the parse reads `window.location` at mount. */
 function routeAt(path: string) {
@@ -54,6 +54,32 @@ describe('useRoute — project + mode routes (DES-MERGE-001 §1.5)', () => {
     const r = routeAt('/p/proj%20one/build/run%2F9');
     expect(r.current.projectId).toBe('proj one');
     expect(r.current.artifactId).toBe('run/9');
+  });
+});
+
+describe('useRoute — slice BE routes (DES-UX-002 §5.2)', () => {
+  it('/p/:id/chronicle is the chronicle VIEW on the Build surface — a real route', () => {
+    const r = routeAt('/p/proj-1/chronicle').current;
+    expect(r.projectId).toBe('proj-1');
+    expect(r.mode).toBe('build');
+    expect(r.chronicleView).toBe(true);
+    // Never an artifact named "chronicle": no run-selected machinery fires.
+    expect(r.artifactId).toBeNull();
+    expect(r.runId).toBeNull();
+  });
+
+  it('every other route spells chronicleView false', () => {
+    expect(routeAt('/p/proj-1/build').current.chronicleView).toBe(false);
+    expect(routeAt('/p/proj-1').current.chronicleView).toBe(false);
+    expect(routeAt('/').current.chronicleView).toBe(false);
+  });
+
+  it('chroniclePath/runTimelinePath spell the §5.2 addresses; the alias resolves', () => {
+    expect(chroniclePath('proj one')).toBe('/p/proj%20one/chronicle');
+    expect(runTimelinePath('run/9')).toBe('/runs/run%2F9/timeline');
+    // `/runs/:id/timeline` is the §5.2 alias of `/runs/:id` — same run detail,
+    // whose default layout the timeline already is (slice BB, terminal runs).
+    expect(routeAt('/runs/run-1/timeline').current).toMatchObject({ panel: 'runs', runId: 'run-1' });
   });
 });
 


### PR DESCRIPTION
Implements **DES-UX-002 §8.1 slice BE** — the reimagining's final slice: durable guidance adoption + navigation/keyboard wiring.

- **Durable guidance (CREW-UX-7 / crew#312 adopted)**: the annotation widget and steer textarea pre-populate durable-first-with-draft-on-top; a gesture-gated "save guidance" writes `PUT /runs/:id/guidance` with point-of-action feedback (EC37); the EC52 session-scope label retires to the honest split — it renders only while an unsaved edit exists. The 0.9.0 DTO fields are typed locally citing crew#312 (npm still serves 0.8.0 — no fake dep bump). **Live-verified round trip on the real daemon**: save → fresh browser session → pre-populated from the DTO → clear → no residue.
- **Routes (§5.2–5.3)**: `/p/:id/chronicle` is a real route (toggle navigates both ways, Back restores); `/runs/:id/timeline` aliased; board card open targets re-point a moving run to its timeline. Chronicle-as-default NOT flipped (§10 open question — additive stands).
- **Keyboard (§5.4)**: `t`/`u` (timeline/unit-list lenses) and `n` (focus the annotation widget) through the one registry, documented in the '?' overlay.

Verified: 1583/1583 unit tests; slice rig 22/22 ×3; regressions BD/BC/BB + feedback2_sliceH (one-Escape); adversarial verifier approved incl. the live daemon scenes and the absent-when-never audit (0/108 phantom keys). LOC 394 gross (~250 net) vs ~200 disclosed — the durable-mirror store is one contract, shipped whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
