### PR TITLE
Nerve center: a project with running work is WORKING, never QUIET

### DIFF
--- a/e2e/feedback_sliceE_test.py
+++ b/e2e/feedback_sliceE_test.py
@@ -110,7 +110,9 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 VSHOTS.mkdir(parents=True, exist_ok=True)
 console_errors: list[str] = []
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 
 with sync_playwright() as p:
     browser = p.chromium.launch()

--- a/e2e/ux2_fixC6_test.py
+++ b/e2e/ux2_fixC6_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+ux2_fixC6_test.py — the BRIEF-UX-002 final-gate C6 MAJOR pin: the home board's
+WORKING band derives from run DTO STATUS, never from a decaying clock.
+
+The live-observed failure (rereview5): with 2 runs actively EXECUTING, the
+board's active card rendered in exactly ONE 25s sample, then decayed back to
+QUIET ("Nothing needs you right now", chip "·15h") for ~5 of 6 minutes — while
+the same page's footer said "2 working" and the rail streamed the run's phases.
+Root cause: the band hung off the decayed attention score, whose `running`
+clock ladder bottomed out at a 15h-stale project clock when no live frame had
+arrived yet. Two conflations rode along: the no-gate WORKING card rendered
+under the "NEEDS YOU" header, and the quiet chip stamped live work "·15h".
+
+This rig runs the shared W2 fixture under the `c6_stale` switch — the exact
+reproduction posture: r-upload EXECUTING while every clock the board can read
+for upload-endpoint (project.updated_at, the attach clock) is 15 HOURS stale
+and the /ws narration for it is MUTED. The only working evidence the board
+holds is the run DTO status — which is precisely what the fix derives from.
+
+The ACs, DOM-verbatim:
+
+  1. WORKING, not QUIET, on a cold load: the upload-endpoint card renders
+     data-band="working" (ACTIVE variant) inside its OWN
+     `[data-testid="band-working"]` section headed "Working" — NEVER under
+     the NEEDS YOU header, and NO quiet-chip for it anywhere (the "·15h"
+     stale-freshness chip cannot exist because the project never lands in
+     QUIET while a run is non-terminal);
+  2. NEEDS YOU stays gates + fresh failures ONLY: q3-review-deck + api-migration
+     (waiting gates) and auth-refactor (13-min-old failure) — upload-endpoint
+     is not among them;
+  3. survives a reload: a second cold load lands the card in WORKING again
+     (the C6 bug fired on exactly this path — no frames yet, stale clocks);
+  4. survives a 60s soak sampled every ~20s (the live decay was caught in a
+     25s sample; TICK_MS=60s guarantees at least one decay-clock recompute
+     inside the window): data-band === "working" at every sample, and the
+     board NEVER shows "Nothing needs you right now" as the only content;
+  5. a gate posting for the working run MOVES it to NEEDS YOU (live
+     awaitingHuman frame + status flip): band-working empties, the card
+     re-renders data-band="needs-you";
+  6. idle stays QUIET throughout: the 20 quiet clones never enter WORKING
+     (band-working data-count is exactly 1 before the gate posts), and the
+     quiet band keeps its population.
+
+Captures (§12.0 contract: 1440x900, dsf=1) into e2e/shots/vision/:
+  ux-C6-working-band.png   cold load: WORKING band between NEEDS YOU and QUIET
+  ux-C6-soak.png           after the 60s soak: the card has NOT decayed
+  ux-C6-gate-posted.png    the gate posted: the card now under NEEDS YOU
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1. Env knobs: FEEDBACK_PORT (default 4413),
+SKIP_STUDIO_BUILD. Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4413"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+CARD = '[data-testid="project-card"][data-project-id="upload-endpoint"]'
+WORKING_BAND = '[data-testid="band-working"]'
+NEEDS_BAND = '[data-testid="band-needs-you"]'
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def board_state(page) -> dict:
+    """One DOM read: everything the ACs assert about the three bands."""
+    return page.evaluate(
+        """() => {
+          const board = document.querySelector('[data-testid="project-board"]');
+          const card = document.querySelector(
+            '[data-testid="project-card"][data-project-id="upload-endpoint"]');
+          const workingBand = document.querySelector('[data-testid="band-working"]');
+          const needsCards = [...document.querySelectorAll(
+            '[data-testid="band-needs-you"] [data-testid="project-card"]')]
+            .map((c) => c.dataset.projectId);
+          const workingCards = [...document.querySelectorAll(
+            '[data-testid="band-working"] [data-testid="project-card"]')]
+            .map((c) => c.dataset.projectId);
+          const quietChipIds = [...document.querySelectorAll(
+            '[data-testid="quiet-chip"]')].map((c) => c.dataset.projectId);
+          const workingLabel = workingBand
+            ? workingBand.querySelector('p')?.textContent ?? null : null;
+          return {
+            working: Number(board?.dataset.working ?? -1),
+            needsYou: Number(board?.dataset.needsYou ?? -1),
+            quiet: Number(board?.dataset.quiet ?? -1),
+            cardBand: card?.dataset.band ?? null,
+            cardVariant: card?.dataset.variant ?? null,
+            cardInWorking: workingCards.includes('upload-endpoint'),
+            cardInNeeds: needsCards.includes('upload-endpoint'),
+            needsCards,
+            workingCards,
+            workingLabel,
+            uploadQuietChip: quietChipIds.includes('upload-endpoint'),
+            quietChipCount: quietChipIds.length,
+            allQuietLine: !!document.querySelector('[data-testid="board-all-quiet"]'),
+            cardText: card?.textContent ?? '',
+          };
+        }""")
+
+
+def assert_working(step: str, s: dict) -> None:
+    """The AC-1/AC-2 invariant, applied at every sample point."""
+    check(step,
+          s["cardBand"] == "working"
+          and s["cardVariant"] == "active"
+          and s["cardInWorking"]
+          and not s["cardInNeeds"]
+          and s["working"] == 1
+          and s["workingLabel"] == "Working"
+          and not s["uploadQuietChip"]
+          and "15h" not in s["cardText"]
+          # NEEDS YOU is gates + the fresh failure, never the executing run.
+          and set(s["needsCards"]) == {"q3-review-deck", "api-migration", "auth-refactor"},
+          **{k: v for k, v in s.items() if k != "cardText"})
+
+
+# ── 1. The same-origin build + the stale-clock reproduction switched ON ───────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, c6_stale=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # ── Scene 1 (AC 1 + 2): cold load — WORKING off the DTO status alone ───────
+    page.goto(f"{ORIGIN}/", wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator(f"{WORKING_BAND} {CARD}").wait_for(timeout=30000)
+    s1 = board_state(page)
+    assert_working("cold_load_working", s1)
+    # AC 6 half: the calm majority is untouched — quiet population intact.
+    check("idle_stays_quiet", s1["quiet"] >= 20 and s1["quietChipCount"] > 0,
+          quiet=s1["quiet"], chips=s1["quietChipCount"])
+    page.screenshot(path=str(VSHOTS / "ux-C6-working-band.png"))
+
+    # ── Scene 2 (AC 3): a reload lands in WORKING again — the exact C6 path
+    #    (fresh page, zero frames, every clock stale) ─────────────────────────────
+    page.reload(wait_until="domcontentloaded")
+    page.locator('[data-testid="project-board"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator(f"{WORKING_BAND} {CARD}").wait_for(timeout=30000)
+    assert_working("reload_still_working", board_state(page))
+
+    # ── Scene 3 (AC 4): the 60s soak, sampled inside the observed decay window —
+    #    TICK_MS=60s guarantees at least one decay-clock recompute in-window ─────
+    samples: list[dict] = []
+    t0 = time.monotonic()
+    for wait_s in (20, 20, 25):  # samples at ~20s / ~40s / ~65s
+        page.wait_for_timeout(wait_s * 1000)
+        s = board_state(page)
+        samples.append({"t_s": round(time.monotonic() - t0),
+                        "band": s["cardBand"], "working": s["working"],
+                        "allQuietLine": s["allQuietLine"]})
+        assert_working(f"soak_sample_{samples[-1]['t_s']}s", s)
+    report["steps"]["soak_no_decay"] = {"ok": True, "samples": samples}
+    page.screenshot(path=str(VSHOTS / "ux-C6-soak.png"))
+
+    # ── Scene 4 (AC 5): the gate posts for the working run — it MOVES to
+    #    NEEDS YOU (live awaitingHuman frame + the status flip on the wires) ─────
+    set_fixture(ORIGIN, gate_now=["r-upload"], extra_gates=[
+        {"session": "r-upload", "ord": 0,
+         "prompt": "Approve the rate-limit middleware?"},
+    ])
+    page.wait_for_function(
+        """(card) => document.querySelector(card)?.dataset.band === 'needs-you'""",
+        arg=CARD, timeout=15000)
+    s4 = board_state(page)
+    check("gate_moves_to_needs_you",
+          s4["cardInNeeds"]
+          and not s4["cardInWorking"]
+          and s4["working"] == 0
+          and "upload-endpoint" in s4["needsCards"]
+          and not s4["uploadQuietChip"],
+          **{k: v for k, v in s4.items() if k != "cardText"})
+    page.screenshot(path=str(VSHOTS / "ux-C6-gate-posted.png"))
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -298,6 +298,16 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # (the units + output wires). Default False: sliceR's tail keeps its
          # historical 4-event shape.
          "timeline": False,
+         # C6 fix (BRIEF-UX-002 final gate): the stale-clock reproduction —
+         # EVERY clock the board could read for upload-endpoint goes 15h stale
+         # (project.updated_at, the r-upload attach clock) AND the /ws
+         # narration for r-upload goes silent, exactly the live-observed
+         # posture (2 executing runs, chip "·15h", zero fresh frames). The run
+         # DTO status stays `executing` — the ONE truth the C6 fix derives the
+         # band from. Pre-fix code decays this project into QUIET; fixed code
+         # keeps it WORKING forever. Default False: standing rigs keep the
+         # fresh clocks + narration they assert.
+         "c6_stale": False,
          # Slice BA (DES-UX-002 §1): the nerve-center plan corpus — r-upload's
          # SessionView carries the §1.5 five-unit plan (2 done, 1 distributed,
          # 2 pending; the return-to-build leg IS the 5th strip node — StageKind
@@ -1868,10 +1878,17 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # One burn frame per tick until the slice-E drip drains.
                 if newest and burn_drip:
                     self.wfile.write(ws_frame(burn_drip.pop(0)))
-                self.wfile.write(ws_frame({
-                    "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
-                    "text": NARRATION + "\n",
-                }))
+                # C6 fix: under the stale-clock reproduction r-upload streams
+                # NOTHING — the run executes with zero fresh frames, so the
+                # only working-band evidence the board holds is the DTO status.
+                # Read per-tick so a rig can flip it without reconnecting.
+                with state_lock:
+                    c6_mute = state["c6_stale"]
+                if not c6_mute:
+                    self.wfile.write(ws_frame({
+                        "type": "unitOutputDelta", "session": "r-upload", "ord": 0,
+                        "text": NARRATION + "\n",
+                    }))
                 self.wfile.flush()
                 time.sleep(1.0)
         except OSError:
@@ -1952,10 +1969,16 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/projects":
             with state_lock:
                 batch_on = state["batch_gates"]
+                c6_on = state["c6_stale"]
                 # Slice X2: this-lifetime created projects ride the list too.
                 created = json.loads(json.dumps(created_projects))
-            self._json(200, {"projects": PROJECTS
-                             + (BATCH_PROJECTS if batch_on else []) + created})
+            rows = PROJECTS + (BATCH_PROJECTS if batch_on else []) + created
+            # C6 fix: the stale-clock reproduction — upload-endpoint's project
+            # clock reads 15 HOURS old while its run executes NOW.
+            if c6_on:
+                rows = [{**p, "updated_at": NOW0 - 15 * HOUR}
+                        if p["id"] == "upload-endpoint" else p for p in rows]
+            self._json(200, {"projects": rows})
             return True
         if path == "/api/v1/repos":
             with state_lock:
@@ -2054,6 +2077,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                 kinds[REPO_ID] = "crew.repo"
             # Slice Q: the 24h-spread clocks override the W2 defaults (river on).
             clocks = {**ATTACHED_AT, **(RIVER_ATTACHED_AT if river_on else {})}
+            # C6 fix: the attach clock — the running signal's floor — goes just
+            # as stale as everything else; only the DTO status stays honest.
+            with state_lock:
+                if state["c6_stale"]:
+                    clocks = {**clocks, "r-upload": NOW0 - 15 * HOUR}
             self._json(200, {"members": [
                 {"id": f"{pid}:{kinds.get(ref, 'crew.run')}:{ref}", "project_id": pid,
                  "member_kind": kinds.get(ref, "crew.run"), "member_ref": ref, "meta": None,

--- a/e2e/uxfix_slice2_test.py
+++ b/e2e/uxfix_slice2_test.py
@@ -77,7 +77,9 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 
 SHOTS.mkdir(parents=True, exist_ok=True)
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 # The §1 spine, verbatim from MODE_SPECS — labels and first-run sublabels.
 MODE_LABELS = ["Chat", "Build", "Document", "Video"]
 MODE_KEYS = ["chat", "build", "document", "video"]

--- a/e2e/uxfix_slice3_test.py
+++ b/e2e/uxfix_slice3_test.py
@@ -85,7 +85,12 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 
 SHOTS.mkdir(parents=True, exist_ok=True)
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): the BOARD's NEEDS YOU band is gates + fresh failures only —
+# upload-endpoint (executing, no gate) renders in WORKING. The RAIL stays the
+# score-ordered top of ALL items (its §3.3 contract is unchanged), so its
+# leading rows still include the live run after the three that need a human.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
+RAIL_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
 # Retired vocabulary that must not survive inside the rail (AC 1). "Chats" and
 # "Work" are checked against the RAIL's text only — the board legitimately
 # renders run problems containing the word "work" in prose.
@@ -133,7 +138,7 @@ with sync_playwright() as p:
                '[data-testid="rail-heading-projects"] [data-testid="rail-project"]'))
                .map(r => r.dataset.projectId);
              return JSON.stringify(ids.slice(0, 4)) === JSON.stringify(expected); }""",
-        EXPECTED_ORDER,
+        RAIL_ORDER,
     )
     rail_rows = page.evaluate(
         """() => Array.from(document.querySelectorAll(

--- a/e2e/vision_slice1_test.py
+++ b/e2e/vision_slice1_test.py
@@ -109,7 +109,9 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 
 SHOTS.mkdir(parents=True, exist_ok=True)
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 console_errors: list[str] = []
 
 with sync_playwright() as p:

--- a/e2e/vision_slice2_test.py
+++ b/e2e/vision_slice2_test.py
@@ -71,7 +71,9 @@ FRESH_LINE = "Applying the token bucket to PUT /upload"
 SLICE_FILES = ["HomeBoard.tsx", "LiveFeed.tsx", "ProjectCard.tsx",
                "GateChip.tsx", "useBoardHeadline.ts"]
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 
 report: dict = {"ok": False, "steps": {}}
 

--- a/e2e/vision_slice6_test.py
+++ b/e2e/vision_slice6_test.py
@@ -105,7 +105,9 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 
 VSHOTS.mkdir(parents=True, exist_ok=True)
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 console_errors: list[str] = []
 
 with sync_playwright() as p:

--- a/e2e/vision_slice7_test.py
+++ b/e2e/vision_slice7_test.py
@@ -136,7 +136,9 @@ from playwright.sync_api import sync_playwright  # noqa: E402 (import after serv
 
 VSHOTS.mkdir(parents=True, exist_ok=True)
 
-EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor", "upload-endpoint"]
+# C6 (BRIEF-UX-002): upload-endpoint (executing, no gate) now renders in the
+# WORKING band — NEEDS YOU is gates + fresh failures only.
+EXPECTED_ORDER = ["q3-review-deck", "api-migration", "auth-refactor"]
 console_errors: list[str] = []
 
 with sync_playwright() as p:

--- a/src/board/boardAttention.ts
+++ b/src/board/boardAttention.ts
@@ -87,11 +87,42 @@ export function topSignal(
   return signal === null ? { score: 0, signal: null } : { score, signal };
 }
 
-export type Band = 'needs-you' | 'quiet';
+export type Band = 'needs-you' | 'working' | 'quiet';
 
-/** Which band a score renders in. Exactly the threshold is still NEEDS YOU. */
+/** Which band a score renders in. Exactly the threshold is still NEEDS YOU.
+ *  Score-only — the C6 fix demoted it from the board's band verdict (that is
+ *  `bandFor`, which reads run STATUS first); it survives for score→band
+ *  labelling where no run status exists. */
 export function bandOf(score: number): Band {
   return score >= TRIAGE_THRESHOLD ? 'needs-you' : 'quiet';
+}
+
+/**
+ * The board's band verdict (BRIEF-UX-002 C6 fix). Bands are DERIVED FROM RUN
+ * STATUS first and decay second — the C6 finding was a project with two
+ * EXECUTING runs reading "Nothing needs you right now" because its band hung
+ * off a decaying live-frame clock instead of the run DTO the board already held.
+ *
+ *   NEEDS YOU — a human is the blocker: a waiting gate (never decays), or a
+ *               failure fresh enough to still demand triage (the F3 decay).
+ *   WORKING   — work is accumulating fine WITHOUT needing anyone: any
+ *               non-terminal run (`hasActiveRun`, read off DTO statuses — a
+ *               project with one is NEVER quiet, no matter what any clock
+ *               says), or live doc activity fresh enough to score.
+ *   QUIET     — genuinely nothing moving and nothing demanding.
+ *
+ * Pure in all arguments including `now`, like everything else in this file.
+ */
+export function bandFor(signals: Signal[], hasActiveRun: boolean, now: number): Band {
+  if (signals.some((s) => s.kind === 'gate')) return 'needs-you';
+  if (signals.some((s) => s.kind === 'failing' && scoreOf(s, now) >= TRIAGE_THRESHOLD)) {
+    return 'needs-you';
+  }
+  if (hasActiveRun) return 'working';
+  if (signals.some((s) => s.kind === 'running' && scoreOf(s, now) >= TRIAGE_THRESHOLD)) {
+    return 'working';
+  }
+  return 'quiet';
 }
 
 /** Score desc → newest signal first → name asc — the parent's deterministic tail,

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -17,13 +17,17 @@ import { ProjectSparkline } from './ProjectSparkline.js';
  * The orchestrator home board (DES-MERGE-001 §1.2/§1.4; bands per DES-UXFIX-001
  * §2.1.4, slice 1) — the route `/`.
  *
- * A wall of what is happening across many unrelated projects at once, in TWO
- * bands read off each project's decayed attention score (§2.1.3):
+ * A wall of what is happening across many unrelated projects at once, in THREE
+ * bands (BRIEF-UX-002 C6: bands derive from run STATUS first, decay second —
+ * `bandFor` in boardAttention.ts):
  *
- *   NEEDS YOU — score at or above the triage threshold, score-ordered. Full
- *   cards. This is what a returning operator scans first.
+ *   NEEDS YOU — a human is the blocker: waiting gates, fresh failures.
+ *   Score-ordered full cards. This is what a returning operator scans first.
+ *   WORKING — runs accumulating fine without needing anyone (any non-terminal
+ *   run puts its project here — never in QUIET, however stale the clocks).
+ *   Full ACTIVE cards under their own honest header.
  *   QUIET (N) — the calm majority, collapsed to a header + a preview strip of
- *   one-line chips; expandable into a second windowed grid of full cards.
+ *   one-line chips; expandable into a third windowed grid of full cards.
  *
  * "Many projects at once is the default case" (§1.4), so both grids are
  * WINDOWED against the ONE shared scroller (`boardWindow.ts`): cards are a
@@ -153,6 +157,11 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   }, []);
 
   const needsYou = items.filter((i) => i.band === 'needs-you');
+  // C6 (BRIEF-UX-002): accumulating-without-gates is its OWN band — WORKING is
+  // named honestly, never conflated with NEEDS YOU (gates + fresh failures) and
+  // never allowed to decay into QUIET while a run is non-terminal (bandFor
+  // derives it from the DTO statuses the board already holds).
+  const working = items.filter((i) => i.band === 'working');
   const quiet = items.filter((i) => i.band === 'quiet');
 
   // ── Slice H (DES-FEEDBACK-002 §2): the keyboard triage cursor ──────────────
@@ -195,9 +204,14 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
   // header-height error is smaller than the overscan row that absorbs it.
   const needsTop = BAND_H;
   const needsH = needsYou.length === 0 ? BAND_H : Math.ceil(needsYou.length / columns) * activeRowH;
-  const quietGridTop = needsTop + needsH + BAND_H;
+  // The WORKING band sits between NEEDS YOU and QUIET; absent entirely when
+  // nothing is accumulating (the empty-state budget applies to bands too).
+  const workingTop = needsTop + needsH + BAND_H;
+  const workingH = working.length === 0 ? 0 : Math.ceil(working.length / columns) * activeRowH;
+  const quietGridTop = workingTop + (working.length === 0 ? 0 : workingH + BAND_H);
 
   const needsWin = windowRows(needsYou.length, columns, activeRowH, scrollTop, viewH, needsTop);
+  const workingWin = windowRows(working.length, columns, activeRowH, scrollTop, viewH, workingTop);
   const quietWin = quietOpen
     ? windowRows(quiet.length, columns, quietRowH, scrollTop, viewH, quietGridTop)
     : null;
@@ -206,6 +220,9 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
     (needsWin.lastRow < needsWin.firstRow
       ? 0
       : Math.min(needsYou.length, (needsWin.lastRow + 1) * columns) - needsWin.firstRow * columns) +
+    (workingWin.lastRow < workingWin.firstRow
+      ? 0
+      : Math.min(working.length, (workingWin.lastRow + 1) * columns) - workingWin.firstRow * columns) +
     (quietWin === null || quietWin.lastRow < quietWin.firstRow
       ? 0
       : Math.min(quiet.length, (quietWin.lastRow + 1) * columns) - quietWin.firstRow * columns);
@@ -276,6 +293,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
         data-testid="project-board"
         data-total={items.length}
         data-needs-you={needsYou.length}
+        data-working={working.length}
         data-quiet={quiet.length}
         data-rendered={mounted}
         style={{ flex: 1, overflowY: 'auto', padding: '0 var(--space-6) var(--space-6)' }}
@@ -334,6 +352,25 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                 j/k select · a approve · r reject · ↵ open
               </p>
             )}
+          </section>
+        )}
+
+        {/* C6: the WORKING band — runs accumulating fine, no gate posted. Full
+            ACTIVE cards (the slice-BA anatomy: live lines, phase strip, chips),
+            always expanded — but under its OWN honest header, never under
+            "Needs you", and never decaying into QUIET while a run is live.
+            Blue names the band because blue MEANS "work is moving" (§2.6). */}
+        {working.length > 0 && (
+          <section data-testid="band-working" data-count={working.length} style={{ marginTop: '18px' }}>
+            <p style={{ ...CSS.bandLabel, color: 'var(--status-run)' }}>Working</p>
+            <BandGrid
+              items={working}
+              columns={columns}
+              rowH={activeRowH}
+              firstRow={workingWin.firstRow}
+              lastRow={workingWin.lastRow}
+              navigate={navigate}
+            />
           </section>
         )}
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -24,7 +24,8 @@ import { STATUS_STYLE } from './RunCard.js';
  * One orchestrator-board card, in TWO variants chosen by the decayed attention
  * band (DES-UXFIX-001 §2.1.1, slice 2):
  *
- *   ACTIVE (band `needs-you`) — rich: header + attention pill, live headline,
+ *   ACTIVE (bands `needs-you` and `working` — C6: any non-quiet band) — rich:
+ *   header + attention pill, live headline,
  *   answerable run/gate chips, doc tiles. A region with no content is OMITTED,
  *   never filled with a "nothing" line — the empty-state budget (§2.1.2, F1).
  *   QUIET (band `quiet`) — calm, not empty: ONE line of absence

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -110,10 +110,13 @@ export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attent
  *   gate    → the gate store's `receivedAt` (server ISO on reconcile, arrival live)
  *   failing → the run's durable-log tail `ts` (backfilled once per run id, capped)
  *   running → the newest structured frame the runtime store has logged for the run,
- *             else the run's membership `attached_at` (the C6 fix: a fresh page
- *             load has no frames yet, and the PROJECT clock — which anything on
- *             the project moves — read hours stale while the run was executing
- *             NOW; the run's own attach clock is the more honest floor), or a
+ *             else the FRESHER of the run's membership `attached_at` and the
+ *             project clock (the C6 fix: a fresh page load has no frames yet;
+ *             either clock alone can read hours stale while the run executes
+ *             NOW — the C6 posture was a 15h-stale project clock, while the
+ *             standing W2 corpus has the attach clock as the stale one — so a
+ *             frameless live run is ordered by the freshest evidence held, and
+ *             the BAND never hangs off this clock at all), or a
  *             relayed interactive `status.posted` (a document being edited NOW
  *             is live work — it is what puts the doc-activity line on an ACTIVE
  *             card now that a quiet card renders no activity at all, slice 2)
@@ -145,7 +148,7 @@ function signalsOf(
     } else if (status === 'failed') {
       signals.push({ kind: 'failing', at: failedAt[id] ?? fallback, runId: id });
     } else if (ACTIVE.has(status)) {
-      signals.push({ kind: 'running', at: logTail(id) ?? attachedAt[id] ?? fallback, runId: id });
+      signals.push({ kind: 'running', at: logTail(id) ?? Math.max(attachedAt[id] ?? 0, fallback), runId: id });
     }
   }
   if (docs.length > 0) {

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -3,7 +3,7 @@ import { api } from '../api/client.js';
 import { listDocs, type DocSummary } from '../api/interactive.js';
 import type { Project, ProjectMember, SessionView } from '../api/types.js';
 import {
-  bandOf,
+  bandFor,
   compareScored,
   topSignal,
   type Band,
@@ -110,11 +110,19 @@ export function deriveAttention(runs: SessionView[], docs: DocSummary[]): Attent
  *   gate    → the gate store's `receivedAt` (server ISO on reconcile, arrival live)
  *   failing → the run's durable-log tail `ts` (backfilled once per run id, capped)
  *   running → the newest structured frame the runtime store has logged for the run,
- *             or a relayed interactive `status.posted` (a document being edited NOW
+ *             else the run's membership `attached_at` (the C6 fix: a fresh page
+ *             load has no frames yet, and the PROJECT clock — which anything on
+ *             the project moves — read hours stale while the run was executing
+ *             NOW; the run's own attach clock is the more honest floor), or a
+ *             relayed interactive `status.posted` (a document being edited NOW
  *             is live work — it is what puts the doc-activity line on an ACTIVE
  *             card now that a quiet card renders no activity at all, slice 2)
  *   drafts  → the newest doc's `updated_at`
  *   any     → `project.updated_at`
+ *
+ * Note (C6): the running clock no longer decides whether a live project leaves
+ * the working band — `bandFor` reads the DTO statuses directly — it only orders
+ * and labels. A decayed clock can demote a card WITHIN a band, never to QUIET.
  */
 function signalsOf(
   project: Project,
@@ -124,6 +132,7 @@ function signalsOf(
   logTail: (runId: string) => number | undefined,
   failedAt: Record<string, number>,
   activityAt: number | undefined,
+  attachedAt: Record<string, number>,
 ): Signal[] {
   const fallback = project.updated_at;
   const signals: Signal[] = [];
@@ -136,7 +145,7 @@ function signalsOf(
     } else if (status === 'failed') {
       signals.push({ kind: 'failing', at: failedAt[id] ?? fallback, runId: id });
     } else if (ACTIVE.has(status)) {
-      signals.push({ kind: 'running', at: logTail(id) ?? fallback, runId: id });
+      signals.push({ kind: 'running', at: logTail(id) ?? attachedAt[id] ?? fallback, runId: id });
     }
   }
   if (docs.length > 0) {
@@ -379,14 +388,19 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
         .map((project): BoardProject => {
           const b = bindings[project.id] ?? EMPTY;
           const mine = runs.filter((v) => belongsTo(v, project.id, b.runIds));
-          const { score, signal } = topSignal(
-            signalsOf(project, mine, b.docs, gates, logTail, failedAt, docActivity[project.id]?.at),
-            now,
+          const signals = signalsOf(
+            project, mine, b.docs, gates, logTail, failedAt,
+            docActivity[project.id]?.at, b.attachedAt,
           );
+          const { score, signal } = topSignal(signals, now);
+          // C6: the band verdict reads the run DTO statuses the board ALREADY
+          // holds — a project with any non-terminal run is never QUIET, no
+          // matter how stale the clocks are. Decay orders; status bands.
+          const hasActiveRun = mine.some((v) => ACTIVE.has(v.session.status));
           return {
             project, repo: b.repo, runs: mine, docs: b.docs, attachedAt: b.attachedAt,
             attention: deriveAttention(mine, b.docs),
-            score, band: bandOf(score), signal,
+            score, band: bandFor(signals, hasActiveRun, now), signal,
           };
         })
         .sort((a, b) =>

--- a/tests/HomeBoard.bands.test.tsx
+++ b/tests/HomeBoard.bands.test.tsx
@@ -104,6 +104,11 @@ const needsYouIds = (): (string | null)[] =>
   [...screen.getByTestId('band-needs-you').querySelectorAll('[data-testid="project-card"]')]
     .map((c) => c.getAttribute('data-project-id'));
 
+/** C6: the WORKING band — absent from the DOM entirely when nothing is moving. */
+const workingIds = (): (string | null)[] =>
+  [...(screen.queryByTestId('band-working')?.querySelectorAll('[data-testid="project-card"]') ?? [])]
+    .map((c) => c.getAttribute('data-project-id'));
+
 async function board(runs: SessionView[], expectedTotal = projects.length): Promise<void> {
   render(<HomeBoard runs={runs} navigate={() => {}} />);
   await vi.waitFor(() => {
@@ -136,7 +141,8 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
       ).toBeTruthy();
     });
     expect(needsYouIds()).not.toContain('legacy-spike');
-    expect(needsYouIds()).toContain('upload-endpoint');
+    // C6: a live run is WORKING — its own honest band, not NEEDS YOU (no gate).
+    expect(workingIds()).toContain('upload-endpoint');
 
     // Its card (mounted once QUIET expands) carries the decay verdict.
     fireEvent.click(screen.getByTestId('band-quiet-toggle'));
@@ -146,7 +152,7 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
     expect(legacy).toHaveAttribute('data-signal', 'failing');
   });
 
-  it('orders NEEDS YOU by decayed score: gates, then the fresh failure, then the live run', async () => {
+  it('orders NEEDS YOU by decayed score (gates, then the fresh failure); the live run is WORKING', async () => {
     const runs = seedW2(Date.now());
     await board(runs);
 
@@ -155,16 +161,25 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
         'q3-review-deck',   // gate, 30s — no decay
         'api-migration',    // gate, 2m — no decay, older than q3
         'auth-refactor',    // failing, 12m — ≈67.6, still urgent
-        'upload-endpoint',  // running now — 40
       ]);
+      // C6: the executing run is accumulating fine — WORKING, not NEEDS YOU.
+      expect(workingIds()).toEqual(['upload-endpoint']);
     });
-    // The band boundary, off the DOM: nothing below the threshold leads, nothing
-    // above it hides (slice-1 AC / §5.5 assertion 6).
+    // The band boundary, off the DOM (C6 re-pin of the slice-1 AC): NEEDS YOU
+    // holds exactly the gate/fresh-failure cards; WORKING holds live runs
+    // regardless of score; nothing urgent hides in QUIET.
     const cards = [...document.querySelectorAll('[data-testid="project-card"]')];
     for (const c of cards) {
+      const band = c.getAttribute('data-band');
+      const signal = c.getAttribute('data-signal');
       const score = Number(c.getAttribute('data-score'));
-      const inBand = c.closest('[data-testid="band-needs-you"]') !== null;
-      expect(inBand).toBe(score >= 20);
+      const inNeeds = c.closest('[data-testid="band-needs-you"]') !== null;
+      const inWorking = c.closest('[data-testid="band-working"]') !== null;
+      expect(inNeeds).toBe(band === 'needs-you');
+      expect(inWorking).toBe(band === 'working');
+      if (band === 'needs-you') {
+        expect(signal === 'gate' || (signal === 'failing' && score >= 20)).toBe(true);
+      }
     }
   });
 
@@ -280,7 +295,7 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
     expect(screen.getByTestId('unfiled-run')).toHaveAttribute('data-run-id', 'r-orphan');
   });
 
-  it('the 60s tick demotes a running project silent for a half-life — no new data needed', async () => {
+  it('the 60s tick can NEVER demote an executing run out of WORKING — the C6 fix', async () => {
     vi.useFakeTimers();
     try {
       const t0 = Date.now();
@@ -291,14 +306,23 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
       );
       // Flush the project + binding loads (microtask chains, no timers involved).
       for (let i = 0; i < 6; i++) await act(async () => { await Promise.resolve(); });
-      expect(needsYouIds()).toEqual(['silent']);
-
-      // 31 minutes of narration silence: one half-life past 40 → ~19.5, under the
-      // threshold. The tick alone must carry the card out of the live band (D7).
-      await act(async () => { vi.advanceTimersByTime(31 * MIN); });
+      // No gate anywhere: nothing NEEDS the user — but the run is WORKING.
       expect(needsYouIds()).toEqual([]);
-      expect(screen.getByTestId('quiet-chip')).toHaveAttribute('data-project-id', 'silent');
-      expect(screen.getByTestId('board-all-quiet')).toBeTruthy();
+      expect(workingIds()).toEqual(['silent']);
+
+      // C6 (BRIEF-UX-002): 31 minutes of narration silence decays the SCORE past
+      // the old threshold — but the band derives from the run DTO's status, so
+      // an executing run's project must STAY in WORKING, never fall to QUIET.
+      // (This test previously pinned the opposite — the exact live-observed bug:
+      // 2 executing runs, board saying "Nothing needs you right now", chip ·15h.)
+      await act(async () => { vi.advanceTimersByTime(31 * MIN); });
+      expect(workingIds()).toEqual(['silent']);
+      expect(screen.queryByTestId('quiet-chip')).toBeNull();
+
+      // …and hours of silence still cannot: WORKING ends when the STATUS does.
+      await act(async () => { vi.advanceTimersByTime(6 * 60 * MIN); });
+      expect(workingIds()).toEqual(['silent']);
+      expect(screen.queryByTestId('quiet-chip')).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/tests/HomeBoard.test.tsx
+++ b/tests/HomeBoard.test.tsx
@@ -92,12 +92,17 @@ describe('HomeBoard — the orchestrator board', () => {
       makeView({ id: 'run-gate', status: 'awaiting_human' }),
     ]);
 
-    // Slice 1 bands: the projects that need a human are CARDS inside NEEDS YOU,
-    // score-ordered; the quiet one is a one-line preview chip, not a card.
+    // Slice 1 bands, re-pinned by C6: the project that needs a HUMAN (the gate)
+    // is a card inside NEEDS YOU; the executing one is a card inside WORKING —
+    // its own honest band; the quiet one is a one-line preview chip, not a card.
     await vi.waitFor(() => {
-      const band = screen.getByTestId('band-needs-you');
-      const cards = within(band).getAllByTestId('project-card');
-      expect(cards.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-gate', 'p-run']);
+      const needs = within(screen.getByTestId('band-needs-you')).getAllByTestId('project-card');
+      expect(needs.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-gate']);
+      const workingBand = screen.getByTestId('band-working');
+      const workingCards = within(workingBand).getAllByTestId('project-card');
+      expect(workingCards.map((c) => c.getAttribute('data-project-id'))).toEqual(['p-run']);
+      expect(workingCards[0]).toHaveAttribute('data-band', 'working');
+      expect(workingCards[0]).toHaveAttribute('data-variant', 'active');
     });
     expect(screen.getByTestId('quiet-chip')).toHaveAttribute('data-project-id', 'p-quiet');
     // AC: the first card IS the gate-waiting one, and says so.

--- a/tests/boardAttention.test.ts
+++ b/tests/boardAttention.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  bandFor,
   bandOf,
   compareScored,
   scoreOf,
@@ -81,6 +82,43 @@ describe('bandOf', () => {
   it('exactly the threshold is still needs-you', () => {
     expect(bandOf(TRIAGE_THRESHOLD)).toBe('needs-you');
     expect(bandOf(TRIAGE_THRESHOLD - 0.001)).toBe('quiet');
+  });
+});
+
+describe('bandFor — the C6 status-first band verdict', () => {
+  it('a project with ANY non-terminal run is NEVER quiet — however stale every clock is', () => {
+    // The live-observed C6 bug: an executing run whose only clock was 15h old
+    // scored ~0 and the project read "quiet" while the footer said "working".
+    const stale: Signal[] = [{ kind: 'running', at: at(15 * HOUR), runId: 'r1' }];
+    expect(bandFor(stale, true, NOW)).toBe('working');
+    // Even with NO running signal at all (a fresh reload before any frame),
+    // the DTO status alone holds the band.
+    expect(bandFor([], true, NOW)).toBe('working');
+  });
+
+  it('a gate puts the project in NEEDS YOU — above working, regardless of age', () => {
+    const s: Signal[] = [
+      { kind: 'gate', at: at(8 * DAY), runId: 'rg' },
+      { kind: 'running', at: at(0), runId: 'rr' },
+    ];
+    expect(bandFor(s, true, NOW)).toBe('needs-you');
+  });
+
+  it('a fresh failure is NEEDS YOU; an 8-day-old one is not (F3 decay preserved)', () => {
+    expect(bandFor([sig('failing', 12 * MIN)], false, NOW)).toBe('needs-you');
+    expect(bandFor([sig('failing', 8 * DAY)], false, NOW)).toBe('quiet');
+    // …and a stale failure beside a live run leaves the project WORKING.
+    expect(bandFor([sig('failing', 8 * DAY)], true, NOW)).toBe('working');
+  });
+
+  it('fresh doc activity (a running signal without an active run) is WORKING, not NEEDS YOU', () => {
+    expect(bandFor([sig('running', 0)], false, NOW)).toBe('working');
+    expect(bandFor([sig('running', 31 * MIN)], false, NOW)).toBe('quiet');
+  });
+
+  it('drafts never leave QUIET (D2), and no signals at all is QUIET', () => {
+    expect(bandFor([sig('drafts', 0)], false, NOW)).toBe('quiet');
+    expect(bandFor([], false, NOW)).toBe('quiet');
   });
 });
 


### PR DESCRIPTION
Fixes the C6 MAJOR from BRIEF-UX-002's final gate: **the nerve center filed an actively-working project under QUIET** ("Nothing needs you right now · 15h") for ~5 of 6 observed minutes while two runs executed — the WORKING card rendered once, then decayed, contradicting the same page's "2 working" footer.

- `bandFor()` derives the band from run DTO statuses: any non-terminal run ⇒ WORKING, never QUIET, no matter what any clock says; gates + fresh failures alone are NEEDS YOU (the accumulating-fine vs needs-attention split condition 6 demands).
- A third windowed **WORKING** band renders under its own honest header between NEEDS YOU and QUIET.
- Frameless running signals clock at the freshest evidence held, so the stale "·15h" chip can't appear on a live project. This also cures the reload-mid-run demotion found during the C2 re-run (a fresh session now sees WORKING from the DTO alone).

Verified: new rig with a 15h-stale-clocks fixture — WORKING across cold load, reload, and a 60s soak; gate moves the card to NEEDS YOU; 20 idle clones stay QUIET; the rig fails against pre-fix main (mutation check). 1588/1588 unit tests ×2; regressions BA/W/E + uxfix_slice2/3 + vision_slice2/6/7 (band-split re-scopes as dedicated commits). Known pre-existing debt untouched: uxfix_slice5 scene B still pins the retired flat /runs (fails identically on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
