### PR TITLE
Board attention bands: one source of truth for the copy

### DIFF
--- a/src/board/bandCopy.ts
+++ b/src/board/bandCopy.ts
@@ -1,0 +1,24 @@
+import type { Band } from './boardAttention.js';
+
+const COPY: Record<Band, { label: string; hint: string }> = {
+  'needs-you': {
+    label: 'Needs you',
+    hint: 'A gate is open or a recent run failed — your attention is required.',
+  },
+  working: {
+    label: 'Working',
+    hint: 'A run is active and progressing without your input.',
+  },
+  quiet: {
+    label: 'Quiet',
+    hint: 'No active runs or open gates — this project is idle.',
+  },
+};
+
+export function bandLabel(band: Band): string {
+  return COPY[band].label;
+}
+
+export function bandHint(band: Band): string {
+  return COPY[band].hint;
+}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -4,6 +4,7 @@ import { windowRows } from '../board/boardWindow.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { leadMovingRun } from '../board/phaseProgress.js';
+import { bandHint, bandLabel } from '../board/bandCopy.js';
 import { modePath, projectPath, runTimelinePath } from '../hooks/useRoute.js';
 import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
@@ -322,7 +323,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
           <section data-testid="band-needs-you" data-count={needsYou.length}>
             {/* Amber names the band because amber MEANS "you are the blocker"
                 (§2.6) — a status color, not the accent (§1.5 rule 2). */}
-            <p style={{ ...CSS.bandLabel, color: 'var(--status-gate)' }}>Needs you</p>
+            <p style={{ ...CSS.bandLabel, color: 'var(--status-gate)' }} title={bandHint('needs-you')}>{bandLabel('needs-you')}</p>
             {needsYou.length === 0 ? (
               // The all-quiet state (§3.1): calm is one line, not a wall of absence.
               <p data-testid="board-all-quiet" style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '0 0 6px' }}>
@@ -362,7 +363,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
             Blue names the band because blue MEANS "work is moving" (§2.6). */}
         {working.length > 0 && (
           <section data-testid="band-working" data-count={working.length} style={{ marginTop: '18px' }}>
-            <p style={{ ...CSS.bandLabel, color: 'var(--status-run)' }}>Working</p>
+            <p style={{ ...CSS.bandLabel, color: 'var(--status-run)' }} title={bandHint('working')}>{bandLabel('working')}</p>
             <BandGrid
               items={working}
               columns={columns}
@@ -382,7 +383,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
             style={{ marginTop: '18px' }}
           >
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
-              <p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }}>Quiet ({quiet.length})</p>
+              <p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }} title={bandHint('quiet')}>{bandLabel('quiet')} ({quiet.length})</p>
               <button
                 type="button"
                 data-testid="band-quiet-toggle"

--- a/tests/bandCopy.test.ts
+++ b/tests/bandCopy.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { bandHint, bandLabel } from '../src/board/bandCopy.js';
 
 describe('bandLabel', () => {
@@ -18,5 +20,39 @@ describe('bandHint', () => {
     ['quiet',     'No active runs or open gates — this project is idle.'],
   ] as const)('returns a hint for %s', (band, expected) => {
     expect(bandHint(band)).toBe(expected);
+  });
+});
+
+/**
+ * The module only earns its place if the board USES it. As opened, this slice added the copy and
+ * left `HomeBoard.tsx` holding the same three strings inline — a second source of truth, which is
+ * worse than no module at all: the next person changes one and the other silently disagrees.
+ *
+ * Asserted against the SOURCE because the alternative (rendering HomeBoard) needs the whole run
+ * store; the property that matters is "the literals are gone from the component", and that reads
+ * directly.
+ */
+describe('the board consumes this module rather than repeating it', () => {
+  const src = readFileSync(
+    join(import.meta.dirname, '..', 'src', 'components', 'HomeBoard.tsx'),
+    'utf8',
+  );
+  // Comments legitimately mention the band names (e.g. a note about `Quiet (9)`), so only JSX
+  // TEXT counts — `>Needs you<` is a rendered literal, a mention in prose is not.
+  const jsxText = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it.each([
+    ['needs-you', 'Needs you'],
+    ['working', 'Working'],
+    ['quiet', 'Quiet'],
+  ] as const)('renders the %s label from bandLabel(), not a literal', (band, literal) => {
+    expect(jsxText).toContain(`bandLabel('${band}')`);
+    expect(jsxText).not.toContain(`>${literal}<`);
+  });
+
+  it('gives every hint a consumer — three strings that render nowhere are not copy, they are dead weight', () => {
+    for (const band of ['needs-you', 'working', 'quiet'] as const) {
+      expect(jsxText).toContain(`bandHint('${band}')`);
+    }
   });
 });

--- a/tests/bandCopy.test.ts
+++ b/tests/bandCopy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { bandHint, bandLabel } from '../src/board/bandCopy.js';
+
+describe('bandLabel', () => {
+  it.each([
+    ['needs-you', 'Needs you'],
+    ['working',   'Working'],
+    ['quiet',     'Quiet'],
+  ] as const)('returns the operator label for %s', (band, expected) => {
+    expect(bandLabel(band)).toBe(expected);
+  });
+});
+
+describe('bandHint', () => {
+  it.each([
+    ['needs-you', 'A gate is open or a recent run failed — your attention is required.'],
+    ['working',   'A run is active and progressing without your input.'],
+    ['quiet',     'No active runs or open gates — this project is idle.'],
+  ] as const)('returns a hint for %s', (band, expected) => {
+    expect(bandHint(band)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Governed-run deliverable from run `5c5e08b7-9e06-43cc-9b15-300bfc599e21`, reviewed and completed.

## What the run produced, and what it missed

It added `src/board/bandCopy.ts` (label + hint per attention band) and unit tests — then stopped. `HomeBoard.tsx` still held all three strings inline:

```tsx
<p style={{ ...CSS.bandLabel, color: 'var(--status-gate)' }}>Needs you</p>
<p style={{ ...CSS.bandLabel, color: 'var(--status-run)' }}>Working</p>
<p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }}>Quiet ({quiet.length})</p>
```

So merging as-opened would have shipped **a module with no consumer** and **two sources of truth** for operator-facing copy — worse than not merging it, because the next person edits one and the other silently disagrees. The three *hints* were worse: they existed only in the new file and rendered nowhere at all.

The apparent consumers were a name collision — `CSS.bandLabel` is a style object, not the function.

## Completed here

- all three headings render `bandLabel(band)`; the literals are gone
- each carries `bandHint(band)` as `title`, giving the hints a real consumer and explaining a band on hover instead of asking the operator to infer it
- rebased onto `main` (it was 6 commits behind)

## The guard

A test pins the wiring **both ways** — the label must come from `bandLabel(...)` *and* the literal must be absent from the JSX. It strips comments from the component source first, because the band names legitimately appear in prose there (`a "Quiet (9)" head over six chips`); matching those would have let the guard pass on a mention while the render regressed.

**1833/1833** studio tests, tsc + lint clean.
