### PR TITLE
Build runs open a PR by default, with a settings toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import type { CoreEvent, RepoEntry } from './api/types.js';
 import { api } from './api/client.js';
 import { useAppearanceStore } from './theming/appearance.js';
 import { useNotifPrefsStore } from './store/notifPrefs.js';
+import { useComposerPrefsStore } from './store/composerPrefs.js';
 import { notifyGateIfUnfocused } from './board/desktopNotify.js';
 
 /** Frames that change run-list / unit state → trigger a `GET /runs` reconcile. */
@@ -125,6 +126,10 @@ export function App(): React.ReactElement {
     // once at startup; the defaults (Off) stand if the surface is absent.
     // Never touches the Notification API (EC25: no prompt on load).
     void useNotifPrefsStore.getState().load();
+    // studio#123: `studio.composer` rides the same settings store — read once
+    // at startup; the default (open a PR when a build run finishes) stands if
+    // the surface, or the key, is absent.
+    void useComposerPrefsStore.getState().load();
   }, []);
 
   // Pre-merge bookmarks (`/runs/:id`, `/projects/:id`) redirect into the shell (§1.5).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -544,6 +544,16 @@ export const api = {
       body: JSON.stringify({ 'studio.notifications': prefs }),
     }),
 
+  /** studio#123: `studio.composer` rides the SAME settings store, same
+   *  namespaced-key contract as `studio.appearance`. The returned merged blob
+   *  is the read-back the store checks — an unfixed daemon (wicked-crew#323)
+   *  answers 200 with the key silently absent. */
+  putComposerSettings: (prefs: import('../store/composerPrefs.js').StudioComposerPrefs) =>
+    apiFetch<{ settings: Record<string, unknown> }>('/settings', {
+      method: 'PUT',
+      body: JSON.stringify({ 'studio.composer': prefs }),
+    }),
+
   // ── Projects (DES-PROJECT-001) ───────────────────────────────────────────────
 
   /** All projects; `status=active` (default) or `archived` filters. Includes the synthesized "Unfiled" default. */

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
 import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
+import { useComposerPrefsStore } from '../store/composerPrefs.js';
 import { useGateStore } from '../store/gates.js';
 import { anyModalOpen, useLayerStore } from '../store/layers.js';
 import { useProvenanceStore } from '../store/provenance.js';
@@ -13,7 +14,7 @@ import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
-import type { RunMode } from './runMode.js';
+import { runKindOf, SYSTEM_WORKFLOW_IDS, type RunMode } from './runMode.js';
 
 interface Props {
   /** If set, we're in "run selected" mode — steer if gated, inject if executing, placeholder otherwise. */
@@ -105,9 +106,6 @@ function ActivePill({
 
 
 
-// Defense-in-depth denylist: catches system workflows that predate the is_system flag.
-const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
-
 export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOverride, mode, injectTarget, onClearInjectTarget, navigate, lockedProjectId = null }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
 
@@ -175,6 +173,11 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     prefill !== null ? prefillGate.beforeOrd : COMPOSER_DEFAULT_GATE_POSTURE.beforeOrd,
   );
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
+
+  // Delivery (studio#123): the composer carries no default of its own — the
+  // persisted `studio.composer` preference decides, and it ships ON. The two
+  // guards below are what keeps an ON default from producing a body crew 400s.
+  const deliverPr = useComposerPrefsStore((s) => s.prefs.deliverPr);
 
   // ── Preflight (DES-UX-001 §7.8, EC43, slice AC) ────────────────────────────
   // A code-shaped intent with no repo attached warns-and-blocks: zero POST
@@ -432,6 +435,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     if (firstRepo) body.repoRef = firstRepo;
     const wf = workflowOverride?.trim() || workflow;
     if (wf) body.workflow = wf;
+    // Delivery (crew#293, studio#123): `deliver: 'pr'` appends the daemon's
+    // hardened deliver phase — push the branch, open the PR; merge stays human.
+    // BUILD-kind runs only, and only with both guards met: `deliver` without
+    // `workflow` is a 400 (api-types index.d.ts:955-956), and the deliver
+    // script pushes to a remote, which is the attached repo. Either one missing
+    // and the run launches WITHOUT the key — never a body crew rejects. The
+    // same verdict is on screen before the operator sends (`deliverNotice`).
+    if (deliverPr && runKindOf(wf) === 'build' && firstRepo) body.deliver = 'pr';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -677,6 +688,37 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     (s) => selectedClis.has(s.key) && s.signed_in === false,
   );
 
+  // Delivery verdict, said out loud BEFORE the send (studio#123): with the
+  // preference ON the operator must be able to READ — not hover — whether this
+  // launch will open a PR, and when it will not, which guard stopped it. The
+  // three states mirror the `submit` condition exactly, off the same inputs, so
+  // the line can never disagree with the body that goes on the wire. Silent
+  // when the preference is off (the setting is the answer) and on the chat
+  // surface (a system workflow has nothing to deliver).
+  const deliverWorkflow = workflowOverride?.trim() || workflow;
+  const deliverNotice: { state: string; text: string } | null = ((): { state: string; text: string } | null => {
+    if (!deliverPr) return null;
+    switch (runKindOf(deliverWorkflow)) {
+      case 'system':
+        return null;
+      case 'freeform':
+        return {
+          state: 'no-workflow',
+          text: 'No PR when this finishes — a run needs a workflow to deliver one. Pick one in launch options.',
+        };
+      case 'build':
+        return repoRefs.length > 0
+          ? {
+              state: 'on',
+              text: 'When this finishes it pushes its branch and opens a PR. Merging stays yours.',
+            }
+          : {
+              state: 'no-repo',
+              text: 'No PR when this finishes — delivery pushes to a repository, and none is attached.',
+            };
+    }
+  })();
+
   // Determine whether CLIs differ from the defaults that loaded from the roster
   const defaultCliSet = new Set(
     roster.filter((s) => s.enabled_for_council).map((s) => s.key),
@@ -913,6 +955,22 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             Launch anyway
           </button>
         </div>
+      )}
+
+      {/* ── Delivery verdict (studio#123) — visible text, never a tooltip: the
+          operator reads whether a PR is coming, or which guard stopped it,
+          before sending. `--ink-muted` when delivery is on (a statement of
+          fact), `--status-gate` when a guard withheld it (something to act
+          on) — the composer's own warn dress, one notch below the fail red. ── */}
+      {deliverNotice !== null && (
+        <p
+          data-testid="deliver-notice"
+          data-deliver-state={deliverNotice.state}
+          className="text-xs px-1 font-mono"
+          style={{ color: deliverNotice.state === 'on' ? 'var(--ink-muted)' : 'var(--status-gate)' }}
+        >
+          {deliverNotice.text}
+        </p>
       )}
 
       {/* ── Guidance steer field (DES-UX-002 §3.3, slice BC) — rendered only

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
@@ -14,7 +14,7 @@ import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
-import { runKindOf, SYSTEM_WORKFLOW_IDS, type RunMode } from './runMode.js';
+import { runKindOf, SYSTEM_WORKFLOW_IDS, type RunKind, type RunMode } from './runMode.js';
 
 interface Props {
   /** If set, we're in "run selected" mode — steer if gated, inject if executing, placeholder otherwise. */
@@ -153,6 +153,27 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const [workflow, setWorkflow] = useState(prefill?.workflowId ?? '');
   const [roster, setRoster] = useState<RosterSeat[]>([]);
   const [workflows, setWorkflows] = useState<WorkflowDef[]>([]);
+  /**
+   * The run kind for delivery, off the AUTHORITATIVE signal where we have one.
+   * `runKindOf` matches a hardcoded denylist, which by its own comment only
+   * "catches system workflows that predate the is_system flag" — a system
+   * workflow shipped under a new id is invisible to it. The selector below
+   * already reads `is_system` off the fetched defs, and the launch form can be
+   * seeded from a RETRY PREFILL (`prefill.workflowId`, ~:153) that never passed
+   * through that selector, so the denylist alone can classify a genuinely
+   * system workflow as build work and let it carry `deliver`.
+   *
+   * Deliberately one-directional: a positively-known `is_system` DEMOTES to
+   * 'system', but a missing def (workflows still loading, or the fetch failed)
+   * never promotes — it falls back to the denylist verdict. So this can only
+   * ever withhold delivery, never add it.
+   */
+  const deliverKindOf = useCallback(
+    (id: string): RunKind =>
+      workflows.find((w) => w.id === id)?.is_system === true ? 'system' : runKindOf(id),
+    [workflows],
+  );
+
   const selectableWorkflows = useMemo(
     () => workflows.filter((w) => !w.is_system && !SYSTEM_WORKFLOW_IDS.has(w.id)),
     [workflows],
@@ -442,7 +463,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // script pushes to a remote, which is the attached repo. Either one missing
     // and the run launches WITHOUT the key — never a body crew rejects. The
     // same verdict is on screen before the operator sends (`deliverNotice`).
-    if (deliverPr && runKindOf(wf) === 'build' && firstRepo) body.deliver = 'pr';
+    if (deliverPr && deliverKindOf(wf) === 'build' && firstRepo) body.deliver = 'pr';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -698,7 +719,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const deliverWorkflow = workflowOverride?.trim() || workflow;
   const deliverNotice: { state: string; text: string } | null = ((): { state: string; text: string } | null => {
     if (!deliverPr) return null;
-    switch (runKindOf(deliverWorkflow)) {
+    switch (deliverKindOf(deliverWorkflow)) {
       case 'system':
         return null;
       case 'freeform':
@@ -707,7 +728,12 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           text: 'No PR when this finishes — a run needs a workflow to deliver one. Pick one in launch options.',
         };
       case 'build':
-        return repoRefs.length > 0
+        // The SAME truthiness the submit site guards on (`const firstRepo =
+        // repoRefs[0]`), not `repoRefs.length > 0` — otherwise a falsy first
+        // entry renders "a PR is coming" over a body that carries no
+        // `deliver`, and the notice's whole contract is that it cannot
+        // disagree with the wire.
+        return repoRefs[0]
           ? {
               state: 'on',
               text: 'When this finishes it pushes its branch and opens a PR. Merging stays yours.',

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { RosterSeat, SystemSettings as Settings } from '../api/types.js';
+import { useComposerPrefsStore } from '../store/composerPrefs.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 import { Modal } from './Modal.js';
 import { NotificationSettings } from './NotificationSettings.js';
@@ -66,6 +67,12 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
   const [signInSeat, setSignInSeat] = useState<RosterSeat | null>(null);
   /** Daemon 400 from a save whose patch included worker_config_root — rendered inline at the field. */
   const [workerRootError, setWorkerRootError] = useState<string | null>(null);
+
+  // Runs (studio#123): `studio.composer` on the crew settings wire — the
+  // `useNotifPrefsStore` pattern, self-saving, outside the `dirty` patch.
+  const deliverPr = useComposerPrefsStore((s) => s.prefs.deliverPr);
+  const composerPersist = useComposerPrefsStore((s) => s.persist);
+  const updateComposerPrefs = useComposerPrefsStore((s) => s.update);
 
   useEffect(() => {
     api.getSettings()
@@ -192,6 +199,53 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
           crew-persisted (`studio.notifications`), permission asked only on
           the toggle's own gesture (EC25). */}
       <NotificationSettings />
+
+      {/* ── Runs (studio#123) ─────────────────────────────────────────────────
+          Crew-persisted under `studio.composer`, like Notifications above —
+          it saves itself (debounced), so the Save button below governs only
+          the daemon tunables, never this row. */}
+      <section
+        data-testid="runs-settings"
+        className="rounded-xl px-5 mb-6"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+      >
+        <h2
+          className="text-xs font-semibold uppercase tracking-wide pt-4 pb-2 font-mono"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Runs
+        </h2>
+
+        <SettingRow
+          label="Open a PR when a build run finishes"
+          description="On a finished build run the daemon pushes the run's branch, rebases it onto the default branch, and opens a pull request. Merging stays human — nothing lands without you. Runs with no workflow or no attached repository launch without delivery; the composer says so before you send."
+        >
+          <div className="flex flex-col items-end gap-1">
+            <input
+              type="checkbox"
+              aria-label="Open a PR when a build run finishes"
+              data-testid="deliver-pr-toggle"
+              checked={deliverPr}
+              onChange={(e) => updateComposerPrefs({ deliverPr: e.target.checked })}
+              className="w-3.5 h-3.5 shrink-0"
+              style={{ accentColor: 'var(--accent)' }}
+            />
+            {/* wicked-crew#323: an unfixed daemon answers 200 and drops
+                `studio.*` keys. The read-back is the only proof the write
+                landed, so an unverified write says so rather than sitting
+                there looking saved. */}
+            {composerPersist === 'dropped' && (
+              <p
+                className="text-xs text-right"
+                style={{ color: 'var(--status-gate)' }}
+                data-testid="deliver-pr-unsaved"
+              >
+                Not stored by this daemon — applies to this session only.
+              </p>
+            )}
+          </div>
+        </SettingRow>
+      </section>
 
       <section
         className="rounded-xl px-5 mb-6"

--- a/src/components/runMode.ts
+++ b/src/components/runMode.ts
@@ -6,3 +6,28 @@ export const MODE_LABELS: Record<RunMode, string> = {
   balanced:   'Balanced',
   autonomous: 'Autonomous',
 };
+
+// Defense-in-depth denylist: catches system workflows that predate the is_system flag.
+export const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
+
+/**
+ * What KIND of run a launch body describes, read off its effective workflow —
+ * the seam the composer already uses to tell its surfaces apart (ChatPanel's
+ * chat surface launches with `workflowOverride: 'chat'`; the Build surface
+ * passes none and the operator picks one).
+ *
+ *   'build'    — a real workflow: governed code work, the only kind that can
+ *                deliver a PR (studio#123).
+ *   'system'   — chat and the other machine-owned workflows, which the launch
+ *                form hides from its selector; delivery is meaningless there.
+ *   'freeform' — no workflow at all (free-text single-unit mode). `deliver`
+ *                without `workflow` is a 400 (api-types index.d.ts:955-956),
+ *                so this kind can never carry one.
+ */
+export type RunKind = 'build' | 'system' | 'freeform';
+
+export function runKindOf(workflowId: string | null | undefined): RunKind {
+  const wf = workflowId?.trim() ?? '';
+  if (wf === '') return 'freeform';
+  return SYSTEM_WORKFLOW_IDS.has(wf) ? 'system' : 'build';
+}

--- a/src/store/composerPrefs.ts
+++ b/src/store/composerPrefs.ts
@@ -1,0 +1,114 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+
+/**
+ * Composer preferences (studio#123): whether a finished BUILD run opens a pull
+ * request — `deliver: 'pr'` on the launch body (crew#293,
+ * `wicked-crew-api-types/index.d.ts:950`). Persisted in crew's settings store
+ * under the namespaced key `studio.composer` — the `useNotifPrefsStore` pattern
+ * verbatim: load-once at startup, optimistic update, debounced fire-and-forget
+ * persist with one silent retry.
+ *
+ * The one difference from its siblings is the default's direction. This one
+ * ships ON (the operator's decision on #123), so ABSENCE and a stored `false`
+ * must stay distinguishable: `sanitizeComposerPrefs` reads only a strict
+ * `false` as off, and never `??`/`||` over the raw value (both would read a
+ * stored `false` as "unset" or leave it, respectively, and only one of those
+ * is right by accident).
+ *
+ * The persist ALSO reports whether it landed. wicked-crew#323: `PUT /settings`
+ * on an unfixed daemon filters through a closed allowlist and drops `studio.*`
+ * keys while returning 200, so a fire-and-forget write there is silently lost.
+ * The response is the merged settings blob, so the key's presence in it is the
+ * only honest proof — `persist` carries that verdict to the settings surface,
+ * which says so rather than rendering a saved state nobody verified. One PUT,
+ * one retry, then a verdict: never a spin.
+ */
+
+/** The `studio.composer` wire object — what crew persists verbatim.
+ *  Shaped to grow (a future per-workflow delivery map) without migration. */
+export interface StudioComposerPrefs {
+  /** Open a PR when a build run finishes (`deliver: 'pr'`). Default ON. */
+  deliverPr: boolean;
+}
+
+export const COMPOSER_PREFS_KEY = 'studio.composer';
+
+/** #123's operator decision: ON — a build run delivers unless told otherwise. */
+export const DEFAULT_COMPOSER_PREFS: StudioComposerPrefs = { deliverPr: true };
+
+/** Whether the last persist was OBSERVED to land in crew's settings blob. */
+export type PersistState = 'unknown' | 'ok' | 'dropped';
+
+const PERSIST_DEBOUNCE_MS = 400;
+const RETRY_MS = 2000;
+
+/** Never trust the stored shape (§3.3 rule — an external store). Only a strict
+ *  `false` turns the toggle off; absent, null, and garbage all mean "unset",
+ *  which is the default (ON) — the `??` trap, spelled out. */
+export function sanitizeComposerPrefs(raw: unknown): StudioComposerPrefs {
+  const o = (raw !== null && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  return {
+    deliverPr: o.deliverPr === false ? false : DEFAULT_COMPOSER_PREFS.deliverPr,
+  };
+}
+
+interface ComposerPrefsStore {
+  prefs: StudioComposerPrefs;
+  /** True once the startup GET settled (either way). */
+  loaded: boolean;
+  /** 'unknown' until a PUT has answered; 'dropped' when the merged response
+   *  came back without our key, or when both attempts failed outright. */
+  persist: PersistState;
+  /** Startup read (App.tsx): GET the settings store, take `studio.composer`.
+   *  A daemon without a settings surface fails silently — the default stands. */
+  load: () => Promise<void>;
+  /** Optimistic partial update: apply NOW, persist after the debounce. */
+  update: (patch: Partial<StudioComposerPrefs>) => void;
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useComposerPrefsStore = create<ComposerPrefsStore>((set, get) => ({
+  prefs: DEFAULT_COMPOSER_PREFS,
+  loaded: false,
+  persist: 'unknown',
+
+  load: async () => {
+    try {
+      const { settings } = await api.getAppearanceSettings();
+      const stored = (settings as Record<string, unknown>)[COMPOSER_PREFS_KEY];
+      set({ prefs: sanitizeComposerPrefs(stored), loaded: true });
+    } catch {
+      set({ loaded: true }); // no settings surface — the default (ON) stands
+    }
+  },
+
+  update: (patch) => {
+    const prefs = { ...get().prefs, ...patch };
+    set({ prefs, persist: 'unknown' });
+    if (persistTimer !== null) clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      // Fire-and-forget with ONE silent retry; the retry re-reads the store so
+      // a newer edit is never clobbered by a stale snapshot (the sibling
+      // stores' rule). The read-back verdict is the only non-silent part.
+      void attempt(get, set).catch(() => {
+        setTimeout(() => {
+          void attempt(get, set).catch(() => set({ persist: 'dropped' }));
+        }, RETRY_MS);
+      });
+    }, PERSIST_DEBOUNCE_MS);
+  },
+}));
+
+/** One PUT plus the read-back check (wicked-crew#323). Rejects on transport
+ *  failure so the caller can run its single retry. */
+async function attempt(
+  get: () => ComposerPrefsStore,
+  set: (partial: Partial<ComposerPrefsStore>) => void,
+): Promise<void> {
+  const { settings } = await api.putComposerSettings(get().prefs);
+  const echoed = (settings as Record<string, unknown>)[COMPOSER_PREFS_KEY];
+  set({ persist: echoed === undefined ? 'dropped' : 'ok' });
+}

--- a/tests/ChatInput.deliver.test.tsx
+++ b/tests/ChatInput.deliver.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import * as client from '../src/api/client.js';
+import type { LaunchRunBody } from '../src/api/types.js';
+import { DEFAULT_COMPOSER_PREFS, useComposerPrefsStore } from '../src/store/composerPrefs.js';
+
+/**
+ * studio#123 — the composer reaches for `deliver: 'pr'` (crew#293,
+ * api-types index.d.ts:950), from the persisted `studio.composer` preference
+ * rather than a hardcoded composer default:
+ *   - a BUILD-kind run with a workflow AND a repo bound carries the key;
+ *   - either guard unmet ⇒ the run still LAUNCHES, without the key — crew 400s
+ *     on `deliver` without `workflow` (index.d.ts:955-956), and the deliver
+ *     phase pushes to a remote it would not have;
+ *   - the preference off ⇒ never sent;
+ *   - and in every case the verdict is VISIBLE text above the composer before
+ *     the operator sends, never a tooltip.
+ */
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({
+    repos: [{ id: 'studio-api', name: 'studio-api', root_path: '/tmp/studio-api' } as never],
+  });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({
+    workflows: [{ id: 'feature', is_system: false, phases: [] }],
+  });
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  // The default-ON preference, as a fresh install loads it (no stored key).
+  useComposerPrefsStore.setState({
+    prefs: DEFAULT_COMPOSER_PREFS, loaded: true, persist: 'unknown',
+  });
+  localStorage.clear();
+});
+
+/** Bind workflow and/or repo through the launch options drawer — the controls
+ *  the operator actually uses, not a prefill shortcut. */
+async function bind(
+  user: ReturnType<typeof userEvent.setup>,
+  opts: { workflow?: string; repo?: string },
+): Promise<void> {
+  await user.click(screen.getByRole('button', { name: /open launch options/i }));
+  if (opts.workflow !== undefined) {
+    await waitFor(() => expect(screen.getByTestId('launch-workflow')).toBeInTheDocument());
+    await user.selectOptions(screen.getByTestId('launch-workflow'), opts.workflow);
+  }
+  if (opts.repo !== undefined) {
+    await user.click(screen.getByTestId(`launch-repo-${opts.repo}`));
+  }
+  await user.click(screen.getByRole('button', { name: /open launch options/i }));
+}
+
+async function send(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.type(screen.getByTestId('launch-problem'), text);
+  await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+  await user.click(screen.getByTestId('launch-submit'));
+}
+
+function sentBody(): LaunchRunBody {
+  return vi.mocked(client.api.launchRun).mock.calls[0]![0];
+}
+
+describe('ChatInput delivery (#123)', () => {
+  it('a build run with workflow + repo bound sends deliver: pr, and says so first', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+
+    // Visible before the send — the operator reads that a PR is coming.
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverState).toBe('on');
+    expect(notice.textContent).toMatch(/opens a PR/i);
+    expect(notice.textContent).toMatch(/Merging stays yours/i);
+
+    await send(user, 'add the delivery toggle');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.deliver).toBe('pr');
+    expect(body.workflow).toBe('feature');
+    expect(body.repoRef).toBe('studio-api');
+  });
+
+  it('GUARD — no workflow: launches WITHOUT deliver (crew would 400), and names the guard', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { repo: 'studio-api' });
+
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverState).toBe('no-workflow');
+    expect(notice.textContent).toMatch(/needs a workflow/i);
+
+    // A non-code-shaped intent, so the §7.8 preflight is not what stops us here.
+    await send(user, 'summarise the roster');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect('deliver' in body, 'no workflow = no deliver key at all').toBe(false);
+    expect('workflow' in body).toBe(false);
+  });
+
+  it('GUARD — no repo: launches WITHOUT deliver (nothing to push to), and names the guard', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature' });
+
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverState).toBe('no-repo');
+    expect(notice.textContent).toMatch(/none is attached/i);
+
+    // A workflow with no repo is code-shaped: §7.8 warn-and-blocks first, and
+    // the override is the launch. Either way the body must carry no deliver.
+    await send(user, 'add the delivery toggle');
+    expect(client.api.launchRun).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId('preflight-override'));
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect('deliver' in body, 'no repoRef = no deliver key at all').toBe(false);
+    expect(body.workflow).toBe('feature');
+  });
+
+  it('the preference OFF sends no deliver key and renders no notice', async () => {
+    useComposerPrefsStore.setState({ prefs: { deliverPr: false } });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+
+    expect(screen.queryByTestId('deliver-notice')).toBeNull();
+
+    await send(user, 'add the delivery toggle');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    expect('deliver' in sentBody(), 'preference off = no deliver key at all').toBe(false);
+  });
+
+  it('the chat surface (workflowOverride: chat) never delivers and stays silent', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} workflowOverride="chat" />,
+    );
+    await bind(user, { repo: 'studio-api' });
+
+    // A system workflow has nothing to deliver — no notice, no key.
+    expect(screen.queryByTestId('deliver-notice')).toBeNull();
+
+    await send(user, 'what changed in the api last week');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.workflow).toBe('chat');
+    expect('deliver' in body, 'chat is not build work').toBe(false);
+  });
+});

--- a/tests/ChatInput.deliver.test.tsx
+++ b/tests/ChatInput.deliver.test.tsx
@@ -5,6 +5,7 @@ import { ChatInput } from '../src/components/ChatInput.js';
 import * as client from '../src/api/client.js';
 import type { LaunchRunBody } from '../src/api/types.js';
 import { DEFAULT_COMPOSER_PREFS, useComposerPrefsStore } from '../src/store/composerPrefs.js';
+import { clearRetryPrefill, setRetryPrefill } from '../src/store/retryPrefill.js';
 
 /**
  * studio#123 — the composer reaches for `deliver: 'pr'` (crew#293,
@@ -37,6 +38,7 @@ beforeEach(() => {
     prefs: DEFAULT_COMPOSER_PREFS, loaded: true, persist: 'unknown',
   });
   localStorage.clear();
+  clearRetryPrefill();
 });
 
 /** Bind workflow and/or repo through the launch options drawer — the controls
@@ -134,6 +136,34 @@ describe('ChatInput delivery (#123)', () => {
     await send(user, 'add the delivery toggle');
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
     expect('deliver' in sentBody(), 'preference off = no deliver key at all').toBe(false);
+  });
+
+  it('a retry prefill of an is_system workflow NOT on the denylist never delivers', async () => {
+    // The denylist only "catches system workflows that predate the is_system
+    // flag". A daemon shipping a system workflow under a NEW id is invisible to
+    // it, and the retry prefill seeds `workflow` directly — bypassing the
+    // selector that DOES read is_system. The authoritative flag must win.
+    vi.mocked(client.api.listWorkflows).mockResolvedValue({
+      workflows: [
+        { id: 'feature', is_system: false, phases: [] },
+        { id: 'estate-reindex', is_system: true, phases: [] },
+      ],
+    });
+    setRetryPrefill({
+      retryOf: 'r-old', problem: 'redo it', clis: ['claude'], workflowId: 'estate-reindex',
+      repoRef: 'studio-api', entityMode: 'shared', humanConfirm: 'none', projectId: null,
+    });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+
+    // A system workflow has nothing to deliver — no notice, and no key.
+    await waitFor(() => expect(screen.queryByTestId('deliver-notice')).toBeNull());
+    await send(user, ' now');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.workflow).toBe('estate-reindex');
+    expect('deliver' in body, 'is_system:true is not build work').toBe(false);
   });
 
   it('the chat surface (workflowOverride: chat) never delivers and stays silent', async () => {

--- a/tests/SystemSettings.runs.test.tsx
+++ b/tests/SystemSettings.runs.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SystemSettings } from '../src/components/SystemSettings.js';
+import * as client from '../src/api/client.js';
+import { DEFAULT_COMPOSER_PREFS, useComposerPrefsStore } from '../src/store/composerPrefs.js';
+
+/**
+ * studio#123 — the Runs section of /system: one row, "Open a PR when a build
+ * run finishes", default ON, persisted as `studio.composer` on the crew
+ * settings wire (the `studio.notifications` contract). It saves itself, so the
+ * page's Save button — which patches the daemon's own tunables — never touches
+ * it, and a daemon that silently drops the key (wicked-crew#323) is reported
+ * rather than rendered as saved.
+ *
+ * Fake timers + `act` around the 400ms debounce: the store's persist pattern,
+ * tested the way BrandLearn tests the appearance store's.
+ */
+
+// Terminal drags in xterm.js; this suite never opens it, but SystemSettings
+// imports it at module level, so stub it out of the graph.
+vi.mock('../src/components/Terminal.js', () => ({ Terminal: () => <div data-testid="mock-terminal" /> }));
+
+/** Let the mount's getSettings/getRoster promises land before asserting. */
+async function settleMount(): Promise<void> {
+  await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+}
+
+/** Flip the toggle and let the debounce + the PUT (+ its read-back) settle. */
+async function flipAndSettle(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('deliver-pr-toggle'));
+    await vi.advanceTimersByTimeAsync(400);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getSettings').mockResolvedValue({ settings: { graphNodeLimit: 150 } });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'putComposerSettings').mockImplementation((prefs) =>
+    Promise.resolve({ settings: { graphNodeLimit: 150, 'studio.composer': prefs } }),
+  );
+  useComposerPrefsStore.setState({
+    prefs: DEFAULT_COMPOSER_PREFS, loaded: true, persist: 'unknown',
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('SystemSettings — Runs (#123)', () => {
+  it('renders the Runs section with the toggle ON by default and an honest description', async () => {
+    render(<SystemSettings />);
+    await settleMount();
+
+    const section = screen.getByTestId('runs-settings');
+    expect(section).toHaveTextContent('Runs');
+    expect(section).toHaveTextContent('Open a PR when a build run finishes');
+    // Honest about what it does: pushes a branch, opens a PR, merge stays human.
+    expect(section.textContent).toMatch(/pushes the run's branch/i);
+    expect(section.textContent).toMatch(/opens a pull request/i);
+    expect(section.textContent).toMatch(/Merging stays human/i);
+
+    // Default ON — the fresh-install state, with nothing ever persisted.
+    expect(screen.getByTestId('deliver-pr-toggle')).toBeChecked();
+    expect(client.api.putComposerSettings).not.toHaveBeenCalled();
+  });
+
+  it('turning it off persists studio.composer with deliverPr: false', async () => {
+    render(<SystemSettings />);
+    await settleMount();
+    await flipAndSettle();
+
+    expect(screen.getByTestId('deliver-pr-toggle')).not.toBeChecked();
+    // A stored false is a real false, not an unset key that re-defaults to ON.
+    expect(client.api.putComposerSettings).toHaveBeenCalledExactlyOnceWith({ deliverPr: false });
+    // The key read back out of the merged response — verified, not assumed.
+    expect(useComposerPrefsStore.getState().persist).toBe('ok');
+    expect(screen.queryByTestId('deliver-pr-unsaved')).toBeNull();
+  });
+
+  it('an unfixed daemon that drops the key (crew#323) says so instead of looking saved', async () => {
+    // Pre-#323 PUT /settings: closed allowlist, silent discard, 200 with the
+    // blob untouched. The read-back is the only proof, so the row reports it.
+    vi.mocked(client.api.putComposerSettings).mockResolvedValue({
+      settings: { graphNodeLimit: 150, workerStallMinutes: 10 },
+    });
+    render(<SystemSettings />);
+    await settleMount();
+    await flipAndSettle();
+
+    expect(screen.getByTestId('deliver-pr-unsaved')).toHaveTextContent('applies to this session only');
+    // The optimistic value still stands for this session — no silent revert,
+    // and the write is not retried forever: one PUT answered the question.
+    expect(screen.getByTestId('deliver-pr-toggle')).not.toBeChecked();
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(client.api.putComposerSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('the row is outside the daemon settings patch — Save stays disabled', async () => {
+    const updated = vi.spyOn(client.api, 'updateSettings');
+    render(<SystemSettings />);
+    await settleMount();
+    await flipAndSettle();
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(updated).not.toHaveBeenCalled();
+  });
+});

--- a/tests/composerPrefs.store.test.ts
+++ b/tests/composerPrefs.store.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The composer-prefs store (studio#123): the `useNotifPrefsStore` shape on the
+ * `studio.composer` key — load-once, optimistic update, 400ms-debounced
+ * fire-and-forget persist with one silent retry.
+ *
+ * The one thing it does NOT share with its siblings is the direction of the
+ * default. `deliverPr` ships ON, so ABSENCE and a stored `false` must never
+ * collapse into each other (the `??` trap), and a write that crew silently
+ * dropped (wicked-crew#323) must be reported, not rendered as saved.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getAppearanceSettings: vi.fn(),
+    putComposerSettings: vi.fn(),
+  },
+}));
+
+const { api } = await import('../src/api/client.js');
+const {
+  COMPOSER_PREFS_KEY, DEFAULT_COMPOSER_PREFS, sanitizeComposerPrefs, useComposerPrefsStore,
+} = await import('../src/store/composerPrefs.js');
+
+const getSettings = vi.mocked(api.getAppearanceSettings);
+const putComposer = vi.mocked(api.putComposerSettings);
+
+/** The fixed daemon (wicked-crew#323): a partial PUT merges and echoes back. */
+function echoingDaemon(): void {
+  putComposer.mockImplementation((prefs) =>
+    Promise.resolve({ settings: { graphNodeLimit: 150, [COMPOSER_PREFS_KEY]: prefs } }),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getSettings.mockReset().mockResolvedValue({ settings: {} });
+  putComposer.mockReset();
+  echoingDaemon();
+  useComposerPrefsStore.setState({
+    prefs: DEFAULT_COMPOSER_PREFS, loaded: false, persist: 'unknown',
+  });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('sanitizeComposerPrefs (the ?? trap)', () => {
+  it('defaults ON when the value is ABSENT — the fresh-install case', () => {
+    expect(DEFAULT_COMPOSER_PREFS.deliverPr).toBe(true);
+    expect(sanitizeComposerPrefs(undefined)).toEqual({ deliverPr: true });
+    expect(sanitizeComposerPrefs({})).toEqual({ deliverPr: true });
+    expect(sanitizeComposerPrefs(null)).toEqual({ deliverPr: true });
+    expect(sanitizeComposerPrefs('nonsense')).toEqual({ deliverPr: true });
+  });
+
+  it('a stored false stays false — absence and false are distinguishable', () => {
+    expect(sanitizeComposerPrefs({ deliverPr: false })).toEqual({ deliverPr: false });
+    expect(sanitizeComposerPrefs({ deliverPr: true })).toEqual({ deliverPr: true });
+  });
+});
+
+describe('load (startup read)', () => {
+  it('a settings blob WITHOUT the key yields the default (ON)', async () => {
+    getSettings.mockResolvedValue({ settings: { graphNodeLimit: 150 } });
+    await useComposerPrefsStore.getState().load();
+    expect(useComposerPrefsStore.getState().prefs).toEqual({ deliverPr: true });
+    expect(useComposerPrefsStore.getState().loaded).toBe(true);
+    expect(putComposer).not.toHaveBeenCalled();
+  });
+
+  it('a stored false survives the round trip — never re-defaulted to ON', async () => {
+    getSettings.mockResolvedValue({ settings: { [COMPOSER_PREFS_KEY]: { deliverPr: false } } });
+    await useComposerPrefsStore.getState().load();
+    expect(useComposerPrefsStore.getState().prefs).toEqual({ deliverPr: false });
+  });
+
+  it('a daemon without a settings surface fails silently — the default stands', async () => {
+    getSettings.mockRejectedValue(new Error('API 404: nope'));
+    await useComposerPrefsStore.getState().load();
+    expect(useComposerPrefsStore.getState().prefs).toEqual(DEFAULT_COMPOSER_PREFS);
+    expect(useComposerPrefsStore.getState().loaded).toBe(true);
+  });
+});
+
+describe('update (optimistic + debounced persist)', () => {
+  it('applies now, PUTs the studio.composer key once after the debounce', async () => {
+    useComposerPrefsStore.getState().update({ deliverPr: false });
+    expect(useComposerPrefsStore.getState().prefs).toEqual({ deliverPr: false });
+    expect(putComposer).not.toHaveBeenCalled(); // still inside the debounce
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putComposer).toHaveBeenCalledTimes(1);
+    expect(putComposer).toHaveBeenCalledWith({ deliverPr: false });
+    expect(useComposerPrefsStore.getState().persist).toBe('ok');
+  });
+
+  it('retries ONCE, silently, re-reading the store (never a stale snapshot)', async () => {
+    putComposer.mockRejectedValueOnce(new Error('API 500'));
+    useComposerPrefsStore.getState().update({ deliverPr: false });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putComposer).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(putComposer).toHaveBeenCalledTimes(2);
+    expect(putComposer.mock.calls.at(-1)?.[0]).toEqual({ deliverPr: false });
+    expect(useComposerPrefsStore.getState().persist).toBe('ok');
+  });
+
+  it('an UNFIXED daemon (crew#323) 200s without the key — reported dropped, not saved', async () => {
+    // The pre-#323 route: closed allowlist, silent discard, 200 with the
+    // untouched blob. The read-back is the only way to know.
+    putComposer.mockResolvedValue({ settings: { graphNodeLimit: 150, workerStallMinutes: 10 } });
+    useComposerPrefsStore.getState().update({ deliverPr: false });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(putComposer).toHaveBeenCalledTimes(1);
+    expect(useComposerPrefsStore.getState().persist).toBe('dropped');
+    // The optimistic value still stands for this session — no silent revert,
+    // and no spin: exactly one PUT answered the question.
+    expect(useComposerPrefsStore.getState().prefs).toEqual({ deliverPr: false });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(putComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it('both attempts failing lands on dropped — never a saved state nobody saw', async () => {
+    putComposer.mockRejectedValue(new Error('API 500'));
+    useComposerPrefsStore.getState().update({ deliverPr: false });
+    await vi.advanceTimersByTimeAsync(400 + 2000);
+    expect(putComposer).toHaveBeenCalledTimes(2);
+    expect(useComposerPrefsStore.getState().persist).toBe('dropped');
+  });
+});

--- a/tests/composerPrefs.wire.test.ts
+++ b/tests/composerPrefs.wire.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The `studio.composer` WIRE, driven through the REAL client against a stubbed
+ * `fetch` — not a mocked `api` module. Every other suite in this slice mocks
+ * `putComposerSettings` wholesale, which means the one string that actually
+ * decides whether the preference persists (the namespaced key in the PUT body)
+ * is asserted nowhere: a typo there would leave all of them green while the
+ * setting silently never stored, and the store's read-back would blame the
+ * DAEMON ("Not stored by this daemon") for a studio bug.
+ *
+ * The key literal lives in two places by the codebase's own convention — the
+ * client's body and `COMPOSER_PREFS_KEY`, which the store's read-back compares
+ * against — so this test pins that they agree.
+ */
+import { api, apiBase } from '../src/api/client.js';
+import { COMPOSER_PREFS_KEY } from '../src/store/composerPrefs.js';
+
+interface Call { url: string; init: RequestInit | undefined }
+
+function stubFetch(body: unknown): Call[] {
+  const calls: Call[] = [];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve({
+      ok: true, status: 200, statusText: '200',
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    });
+  }));
+  return calls;
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_API_HOST', '');
+  Object.defineProperty(window, 'location', {
+    value: new URL('http://127.0.0.1:7701/'), writable: true, configurable: true,
+  });
+});
+afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+describe('putComposerSettings (the studio.composer wire)', () => {
+  it('PUTs /settings with the studio.composer key — the exact string the store reads back', async () => {
+    const calls = stubFetch({ settings: { [COMPOSER_PREFS_KEY]: { deliverPr: false } } });
+    await api.putComposerSettings({ deliverPr: false });
+
+    expect(calls).toHaveLength(1);
+    const { url, init } = calls[0]!;
+    expect(url).toBe(`${apiBase()}/settings`);
+    expect(init?.method).toBe('PUT');
+    // The whole contract: ONE namespaced key, spelled exactly as the store's
+    // read-back looks for it, carrying the prefs verbatim.
+    expect(JSON.parse(init?.body as string)).toEqual({ 'studio.composer': { deliverPr: false } });
+    expect(Object.keys(JSON.parse(init?.body as string))).toEqual([COMPOSER_PREFS_KEY]);
+  });
+
+  it('a stored false travels as false — never dropped from the body', async () => {
+    const calls = stubFetch({ settings: {} });
+    await api.putComposerSettings({ deliverPr: false });
+    const sent = JSON.parse(calls[0]!.init?.body as string) as Record<string, { deliverPr: boolean }>;
+    expect(sent[COMPOSER_PREFS_KEY]!.deliverPr).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #123.

## The gap

`ChatInput.tsx` built `LaunchRunBody` with problem, seats, entity mode, confirm mode, repo, workflow, project and retry lineage — and never set `deliver`. Zero occurrences of the string in the file. `LaunchRunBody.deliver?: 'pr'` has been on the wire since crew#293, so the capability shipped in crew and the composer simply never reached for it.

Consequence: **no run launched from studio could ever deliver.** The delivery-visibility surface in #122 would render "no deliver phase" for every run an operator starts from the UI, forever.

## What this does

Per the operator's decision on the issue, the default lives in settings and is **on**:

- A **Runs** section in `SystemSettings.tsx`, following that file's existing card-section pattern, with one row: *"Open a PR when a build run finishes"*, default **true**.
- Persistence via a new `studio.composer` key through `PUT /settings`, the same namespaced-key contract `studio.appearance` and `studio.notifications` use.
- `ChatInput` reads the setting and sets `body.deliver = 'pr'` for build-kind runs.
- **Guards**, which matter more with the default on: crew 400s on `deliver` without `workflow`, and the deliver script needs a git remote, so it needs a bound `repoRef`. When either is missing the run still launches — without `deliver` — rather than sending a body that fails. The composer says so in visible text, not a tooltip, so an operator can see *before* sending that no PR will be opened.

## Prerequisite, now met

Specifying this surfaced wicked-crew#323: `PUT /settings` filtered through a closed three-key allowlist and silently discarded everything else at 200, so `studio.appearance` and `studio.notifications` had never persisted. A `studio.composer` key would have been dropped identically — and with the default **on**, the failure mode was not a lost preference but a real side effect: turn delivery off, reload, the preference silently reverts, and the next build run pushes a branch and opens a PR against the operator's expressed wish.

That is fixed and merged (wicked-crew#324). **Note for deployment:** the behaviour needs a daemon carrying that fix. Against an older daemon the store degrades honestly — the row reports that the daemon did not store the preference rather than showing a saved state it cannot verify.

## Review found three defects, all fixed

- **Run-kind classification was keyable past.** `runKindOf` classified purely off a hardcoded `SYSTEM_WORKFLOW_IDS` denylist whose own comment concedes it only catches system workflows predating the `is_system` flag. Verified reachable: `ChatInput.tsx:153` seeds `workflow` from a retry prefill, which never passes through the selector that reads `is_system` — so retrying a run that used an `is_system: true` workflow shipped under a new id classified as build work and sent `deliver: 'pr'` on it. Now `deliverKindOf` consults the positively-known `is_system` from the already-fetched workflow list, and is deliberately one-directional: a missing def never *promotes* to build, so the change can only ever withhold delivery, never add it.
- **The notice could contradict the wire.** It guarded on `repoRefs.length > 0` while the submit site guards on `repoRefs[0]`, so a falsy first entry rendered "this pushes its branch and opens a PR" above a body carrying no `deliver`. Both now use the same truthiness, and both go through `deliverKindOf`, so they cannot diverge.
- **The one string deciding persistence was asserted nowhere.** Every suite mocked `putComposerSettings` wholesale, so the `'studio.composer'` literal was untested — a typo there keeps all suites green while the setting silently never stores, and the read-back would blame the *daemon* for a studio bug. New `composerPrefs.wire.test.ts` drives the real client against a stubbed fetch and pins the request body to exactly `{ 'studio.composer': { deliverPr: false } }`.

## Verification

170 test files / **1625 tests green**, eslint clean, tsc clean, production build clean.

The new suites were mutation-tested: 19/19 mutations killed after review's additions, including the three above. Coverage pins the cases that matter — default-true when the key is absent, an explicit `false` surviving as `false` (the `??`-vs-`||` trap), `deliver: 'pr'` sent for a build run with repo and workflow bound, no `deliver` key when either guard is unmet, and the visible guard text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
