### PR TITLE
Delivery visibility: what a run produced, where the operator already is

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,3 +13,29 @@
  */
 
 export type * from 'wicked-crew-api-types';
+
+import type { AgentSession } from 'wicked-crew-api-types';
+
+/**
+ * `AgentSession.delivery` — the server-carried PR reference (CREW-UX-8,
+ * wicked-crew#321), declared HERE and nowhere else because studio's installed
+ * `wicked-crew-api-types` is STALE at 0.8.0 and the field ships in a later
+ * version. This is the ONE hand-written shape in this module, and it is a
+ * temporary one: **delete both declarations below and read `delivery` straight
+ * off `AgentSession`** the moment studio bumps to the api-types version that
+ * carries it.
+ *
+ * Read it as `session.delivery?.url` (see `src/components/delivery.ts`): the
+ * field is absent on every daemon shipping today, so the surface falls back to
+ * the single per-run transcript fetch and lights up — link on the project rows,
+ * zero fetches in the right panel — the day the server starts sending it, with
+ * no adoption work here. `kind` is the whole concession to a future second kind
+ * of deliverable, and it is free.
+ */
+export interface SessionDelivery {
+  kind: 'pull_request';
+  url: string;
+}
+
+/** `AgentSession` as the post-#321 daemon sends it. See {@link SessionDelivery}. */
+export type SessionWithDelivery = AgentSession & { delivery?: SessionDelivery | null };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,9 +12,10 @@
  * (DES-STUDIO-001 §5.1); no `any` at the boundary.
  */
 
+import type { AgentSession } from 'wicked-crew-api-types';
+
 export type * from 'wicked-crew-api-types';
 
-import type { AgentSession } from 'wicked-crew-api-types';
 
 /**
  * `AgentSession.delivery` — the server-carried PR reference (CREW-UX-8,

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -24,6 +24,7 @@ import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { chroniclePath, modePath } from '../hooks/useRoute.js';
 import { useTimeRange } from '../hooks/useTimeRange.js';
+import { DeliveryChip } from './RunDelivery.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 import { WorkChronicle } from './WorkChronicle.js';
 
@@ -628,6 +629,10 @@ function RunRow({ view, failReason, onSelect }: RunRowProps): React.ReactElement
       >
         {intent}
       </span>
+      {/* studio#122: the same delivery chip the project rows carry — what the
+          run PRODUCED, next to what it is doing. Pure DTO, zero requests; a run
+          with no deliver phase renders nothing rather than an "unknown" badge. */}
+      <DeliveryChip view={view} />
       {/* Status word + phase detail: data, so mono; the detail dims (§5.4). */}
       <span style={{ fontSize: 'var(--text-xs)', color: m.color, ...mono, flexShrink: 0, transition: 'color var(--dur-base)' }}>
         {m.status}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -10,11 +10,12 @@ import { useProvenanceStore } from '../store/provenance.js';
 import { clearRetryPrefill, confirmModeOf, peekRetryPrefill, type RetryPrefill } from '../store/retryPrefill.js';
 import { clearSteerPrefill, peekSteerPrefill } from '../store/steerPrefill.js';
 import { setCachedRoster } from '../store/rosterCache.js';
+import { isSystemWorkflowIn, setCachedWorkflows } from '../store/workflowCache.js';
 import { ContextPopover } from './ContextPopover.js';
 import type { ConfirmMode } from './ContextPopover.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
-import { runKindOf, SYSTEM_WORKFLOW_IDS, type RunKind, type RunMode } from './runMode.js';
+import { deliverKindOf, SYSTEM_WORKFLOW_IDS, type RunKind, type RunMode } from './runMode.js';
 
 interface Props {
   /** If set, we're in "run selected" mode — steer if gated, inject if executing, placeholder otherwise. */
@@ -154,23 +155,23 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const [roster, setRoster] = useState<RosterSeat[]>([]);
   const [workflows, setWorkflows] = useState<WorkflowDef[]>([]);
   /**
-   * The run kind for delivery, off the AUTHORITATIVE signal where we have one.
-   * `runKindOf` matches a hardcoded denylist, which by its own comment only
-   * "catches system workflows that predate the is_system flag" — a system
-   * workflow shipped under a new id is invisible to it. The selector below
-   * already reads `is_system` off the fetched defs, and the launch form can be
-   * seeded from a RETRY PREFILL (`prefill.workflowId`, ~:153) that never passed
-   * through that selector, so the denylist alone can classify a genuinely
-   * system workflow as build work and let it carry `deliver`.
+   * The run kind for delivery, off the AUTHORITATIVE signal where we have one:
+   * a hardcoded denylist only "catches system workflows that predate the
+   * is_system flag", and a system workflow shipped under a new id is invisible
+   * to it — the launch form can be seeded from a RETRY PREFILL
+   * (`prefill.workflowId`, ~:153) that never passed through the `is_system`-
+   * reading selector below.
    *
-   * Deliberately one-directional: a positively-known `is_system` DEMOTES to
-   * 'system', but a missing def (workflows still loading, or the fetch failed)
-   * never promotes — it falls back to the denylist verdict. So this can only
-   * ever withhold delivery, never add it.
+   * The RULE now lives in `runMode.deliverKindOf` — the single definition the
+   * delivery surfaces classify with too (studio#122 D-1: this callback used to
+   * carry its own copy, `canDeliver` carried another, and the two disagreed
+   * about `collab` and every `interactive-*`). This is the LOOKUP and nothing
+   * else. Its one-directional guarantee is unchanged and now stated there: a
+   * positively-known `is_system` DEMOTES to 'system', a missing def (workflows
+   * still loading, or the fetch failed) never promotes.
    */
-  const deliverKindOf = useCallback(
-    (id: string): RunKind =>
-      workflows.find((w) => w.id === id)?.is_system === true ? 'system' : runKindOf(id),
+  const deliverKind = useCallback(
+    (id: string): RunKind => deliverKindOf(id, (wf) => isSystemWorkflowIn(workflows, wf)),
     [workflows],
   );
 
@@ -289,7 +290,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       .catch(() => {});
     api
       .listWorkflows()
-      .then(({ workflows: wfs }) => setWorkflows(wfs))
+      .then(({ workflows: wfs }) => {
+        // Deposit for the app (studio#122 D-1), exactly as the roster fetch
+        // above does: the delivery surfaces need `is_system` and have no fetch
+        // of their own, and the composer's answer is the same list. Whichever
+        // side asks first, the session pays for ONE `GET /workflows`.
+        setCachedWorkflows(wfs);
+        setWorkflows(wfs);
+      })
       .catch(() => {});
     // `prefill` is lazy-initialized state: stable for the component's lifetime,
     // so this still runs exactly once per mount.
@@ -463,7 +471,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // script pushes to a remote, which is the attached repo. Either one missing
     // and the run launches WITHOUT the key — never a body crew rejects. The
     // same verdict is on screen before the operator sends (`deliverNotice`).
-    if (deliverPr && deliverKindOf(wf) === 'build' && firstRepo) body.deliver = 'pr';
+    if (deliverPr && deliverKind(wf) === 'build' && firstRepo) body.deliver = 'pr';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -719,7 +727,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   const deliverWorkflow = workflowOverride?.trim() || workflow;
   const deliverNotice: { state: string; text: string } | null = ((): { state: string; text: string } | null => {
     if (!deliverPr) return null;
-    switch (deliverKindOf(deliverWorkflow)) {
+    switch (deliverKind(deliverWorkflow)) {
       case 'system':
         return null;
       case 'freeform':

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -17,6 +17,8 @@ import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { deliverySummary } from './delivery.js';
+import { DeliveryChip } from './RunDelivery.js';
 import { RunSparkline } from './RunSparkline.js';
 import { STATUS_STYLE } from './RunCard.js';
 
@@ -90,6 +92,12 @@ const CSS = {
   },
   empty: { fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', margin: 0 },
   overflow: { fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '6px 0 0' },
+  // studio#122: the delivery census, directly under the RUNS head. Data, so mono
+  // and dim — the tile's own count stays the headline.
+  deliverySummary: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-dim)', margin: '-6px 0 10px',
+  },
 } as const satisfies Record<string, React.CSSProperties>;
 
 /** The per-run attention signal — the home board's model (§2.1.3) scoped to one run. */
@@ -335,6 +343,16 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
             Runs ({myRuns.length > MAX_ROWS ? `${MAX_ROWS} of ${myRuns.length}` : myRuns.length}){' '}
             <span data-testid="dashboard-runs-window" style={WINDOW_LABEL_STYLE}>all</span>
           </p>
+          {/* ── studio#122: what these runs PRODUCED, counted over ALL of them,
+              never the MAX_ROWS window — 665a9aeb (the run that read as the most
+              productive in the project and delivered nothing) is not in the
+              visible six, and a census that could not see it would be exactly
+              the lie this slice exists to remove. Pure DTO: zero requests. ── */}
+          {myRuns.length > 0 && (
+            <p data-testid="dashboard-delivery-summary" style={CSS.deliverySummary}>
+              {deliverySummary(myRuns.map(({ view }) => view))}
+            </p>
+          )}
           {myRuns.length === 0 ? (
             <p style={CSS.empty}>No runs yet — Build starts one.</p>
           ) : (
@@ -360,6 +378,9 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
                       }}
                     />
                     <span style={CSS.rowText}>{session.problem}</span>
+                    {/* studio#122: what the run produced, beside what it is
+                        doing — DTO-derived, so the row costs no request. */}
+                    <DeliveryChip view={view} />
                     <span style={{ flexShrink: 0, color: style?.color ?? 'var(--ink-dim)' }}>
                       {style?.label ?? session.status}
                     </span>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -18,6 +18,7 @@ import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
 import { deliverySummary } from './delivery.js';
+import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import { DeliveryChip } from './RunDelivery.js';
 import { RunSparkline } from './RunSparkline.js';
 import { STATUS_STYLE } from './RunCard.js';
@@ -212,7 +213,18 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   // studio#122: the delivery census, over every run in the project (not the
   // MAX_ROWS window) and over deliverable runs only (not the chats). `''` when
   // there is nothing to census — see the render guard below.
-  const deliveryCensus = useMemo(() => deliverySummary(myRuns.map(({ view }) => view)), [myRuns]);
+  //
+  // The `is_system` lookup is the app's ONE `GET /workflows`, shared and cached
+  // (D-1): the denylist alone knows five of the daemon's eleven system
+  // workflows, so an interactive doc or video thread was counted under "no
+  // deliver phase" — a number about chats dressed as a delivery finding, which
+  // is the exact D5 complaint. O(1) per app, never O(runs): the rows below read
+  // no defs at all.
+  const isSystemWorkflow = useIsSystemWorkflow();
+  const deliveryCensus = useMemo(
+    () => deliverySummary(myRuns.map(({ view }) => view), isSystemWorkflow),
+    [myRuns, isSystemWorkflow],
+  );
 
   const openRuns = myRuns.filter(({ view }) => !['completed', 'cancelled', 'failed'].includes(view.session.status));
   const waiting = myRuns.filter(({ view }) => view.session.status === 'awaiting_human');

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -209,6 +209,11 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
       ));
   }, [runs, memberKinds, attachedAt, gates, fallbackAt, projectId]);
 
+  // studio#122: the delivery census, over every run in the project (not the
+  // MAX_ROWS window) and over deliverable runs only (not the chats). `''` when
+  // there is nothing to census — see the render guard below.
+  const deliveryCensus = useMemo(() => deliverySummary(myRuns.map(({ view }) => view)), [myRuns]);
+
   const openRuns = myRuns.filter(({ view }) => !['completed', 'cancelled', 'failed'].includes(view.session.status));
   const waiting = myRuns.filter(({ view }) => view.session.status === 'awaiting_human');
 
@@ -347,10 +352,14 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
               never the MAX_ROWS window — 665a9aeb (the run that read as the most
               productive in the project and delivered nothing) is not in the
               visible six, and a census that could not see it would be exactly
-              the lie this slice exists to remove. Pure DTO: zero requests. ── */}
-          {myRuns.length > 0 && (
+              the lie this slice exists to remove. Pure DTO: zero requests.
+
+              `deliverySummary` counts DELIVERABLE runs only, so a project whose
+              runs are all chats has nothing to census and gets no line rather
+              than an empty paragraph — the `!== ''` guard, not `length > 0`. ── */}
+          {deliveryCensus !== '' && (
             <p data-testid="dashboard-delivery-summary" style={CSS.deliverySummary}>
-              {deliverySummary(myRuns.map(({ view }) => view))}
+              {deliveryCensus}
             </p>
           )}
           {myRuns.length === 0 ? (

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -218,8 +218,12 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   // (D-1): the denylist alone knows five of the daemon's eleven system
   // workflows, so an interactive doc or video thread was counted under "no
   // deliver phase" — a number about chats dressed as a delivery finding, which
-  // is the exact D5 complaint. O(1) per app, never O(runs): the rows below read
-  // no defs at all.
+  // is the exact D5 complaint. The "no deliver phase" bucket now counts only
+  // runs a def in hand says could have delivered: a materialised `wf-<runId>`
+  // workflow — 86 of the 129 live runs — is unclassifiable forever, and this
+  // project's line read "8 no deliver phase" over eight document threads.
+  // O(1) per app, never O(runs): the cache is module state, so the row chips
+  // share this same one request rather than adding any of their own.
   const isSystemWorkflow = useIsSystemWorkflow();
   const deliveryCensus = useMemo(
     () => deliverySummary(myRuns.map(({ view }) => view), isSystemWorkflow),

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -533,12 +533,21 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
       : 'whatwhere';
 
   function toggleAccordion(id: AccordionId): void {
-    // Compare against the EFFECTIVE open section, not the raw state (Copilot on #125). After a
-    // run switch drops the open section, `openAccordion` still names the vanished id while the
-    // rail RENDERS `openId` — so clicking the visibly-open What/Where compared 'delivery' with
-    // 'whatwhere', re-opened what was already open, and did nothing until a second click.
-    // Deliberately not a functional update: the correct input is what the operator can SEE.
-    setOpenAccordion(openId === id ? null : id);
+    // Functional update, and heal INSIDE it (Copilot on #125, twice).
+    //
+    // First round: comparing the raw `openAccordion` was wrong — after a run switch drops the
+    // open section it still names the vanished id while the rail RENDERS the healed one, so
+    // clicking the visibly-open What/Where compared 'delivery' with 'whatwhere' and did nothing
+    // until a second click.
+    //
+    // Second round: reading the derived `openId` from the closure fixed that but reintroduced a
+    // stale read — two clicks inside one render batch both see the first render's value, so the
+    // second is swallowed. Taking `prev` from the updater and applying the SAME healing rule to
+    // it gets both: fresh state, and the section the operator can actually see.
+    setOpenAccordion((prev) => {
+      const effective = prev === null || sections.some((s) => s.id === prev) ? prev : 'whatwhere';
+      return effective === id ? null : id;
+    });
   }
 
   if (collapsed) {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -7,7 +7,7 @@ import type { RunModel } from '../hooks/useRunModel.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { LiveNarration } from './ChatPanel.js';
-import { isChatRun } from './ChatsPage.js';
+import { canDeliver } from './delivery.js';
 import { Burn } from './Burn.js';
 import { FileViewer } from './FileViewer.js';
 import { CoverageView } from './CoverageView.js';
@@ -39,10 +39,15 @@ type AccordionId =
   | 'delivery';
 
 /**
- * The rail's sections (studio#122 revised EC54): NINE, with `delivery` the
- * ninth. Delivery is a section like every other — not a pinned band above the
- * list, not a tablist — because "delivery isn't a top level class, it goes in
- * the right chat panel as a tab" (operator decision 2026-08-24), and the rail's
+ * The rail's sections. The contract is **nine on a run that can deliver, eight
+ * on every run that cannot** — chat threads, the other system workflows, and
+ * freeform runs, per `canDeliver`. There is no fixed count of nine: `delivery`
+ * is the conditional ninth, and a surface that says otherwise is describing
+ * build runs only.
+ *
+ * Delivery is a section like every other — not a pinned band above the list,
+ * not a tablist — because "delivery isn't a top level class, it goes in the
+ * right chat panel as a tab" (operator decision 2026-08-24), and the rail's
  * one-open-at-a-time `openAccordion` IS that tab behaviour. `whatwhere` keeps
  * the default open slot; the at-a-glance signal the band would have bought back
  * lives on the Delivery header's {@link DeliveryBadge} instead, which is legible
@@ -489,13 +494,14 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
     ? new Set(model.units.flatMap((u) => u.filesRead)).size
     : null;
 
-  // studio#122 EC57: a chat thread has no deliver phase and never will, so it
-  // gets no Delivery section at all — silence, not a section that says "none"
-  // on every chat. The predicate is studio's own (`isChatRun`, the one every
-  // surface routes by); nothing in the DELIVERY derivation reads
-  // `session.workflow_id` (EC61) — this is a visibility gate, not a wire read.
+  // studio#122 EC57: a run that cannot deliver gets no Delivery section at all —
+  // silence, not a section that says "none" on every chat. `canDeliver` is the
+  // SAME predicate the project census filters by (D5), so the rail and the
+  // census can never disagree about what a deliverable run is. Nothing in the
+  // delivery DERIVATION reads `session.workflow_id` (EC61) — this is a
+  // visibility gate, not a wire read.
   const sections = useMemo(
-    () => (isChatRun(view) ? ACCORDIONS.filter((a) => a.id !== 'delivery') : ACCORDIONS),
+    () => (canDeliver(view) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),
     [view],
   );
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -7,6 +7,7 @@ import type { RunModel } from '../hooks/useRunModel.js';
 import { useProvenanceStore } from '../store/provenance.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { LiveNarration } from './ChatPanel.js';
+import { isChatRun } from './ChatsPage.js';
 import { Burn } from './Burn.js';
 import { FileViewer } from './FileViewer.js';
 import { CoverageView } from './CoverageView.js';
@@ -14,6 +15,7 @@ import { DataUsed } from './DataUsed.js';
 import { DecisionsLedger } from './DecisionsLedger.js';
 import { GovernanceAudit } from './GovernanceAudit.js';
 import { Modal } from './Modal.js';
+import { DeliveryBadge, RunDelivery } from './RunDelivery.js';
 import { SteeringTimeline } from './SteeringTimeline.js';
 import { Terminal } from './Terminal.js';
 import { WhatWhere } from './WhatWhere.js';
@@ -33,8 +35,24 @@ type AccordionId =
   | 'steering'
   | 'whatwhere'
   | 'assumptions'
-  | 'files';
+  | 'files'
+  | 'delivery';
 
+/**
+ * The rail's sections (studio#122 revised EC54): NINE, with `delivery` the
+ * ninth. Delivery is a section like every other — not a pinned band above the
+ * list, not a tablist — because "delivery isn't a top level class, it goes in
+ * the right chat panel as a tab" (operator decision 2026-08-24), and the rail's
+ * one-open-at-a-time `openAccordion` IS that tab behaviour. `whatwhere` keeps
+ * the default open slot; the at-a-glance signal the band would have bought back
+ * lives on the Delivery header's {@link DeliveryBadge} instead, which is legible
+ * with no gesture.
+ *
+ * `files` reads "Files referenced" for the reason the caption in
+ * {@link FilesPanel} spells out: the panel counts what the agents TOUCHED, which
+ * is not a changeset and never was (run 665a9aeb reported 13 under
+ * "MODIFIED / CREATED" while its deliver phase pushed an empty branch).
+ */
 const ACCORDIONS: { id: AccordionId; label: string }[] = [
   { id: 'whatwhere', label: 'What / Where' },
   { id: 'decisions', label: 'Decisions' },
@@ -43,7 +61,8 @@ const ACCORDIONS: { id: AccordionId; label: string }[] = [
   { id: 'data', label: 'Data' },
   { id: 'steering', label: 'Steering' },
   { id: 'assumptions', label: 'Assumptions' },
-  { id: 'files', label: 'Files' },
+  { id: 'files', label: 'Files referenced' },
+  { id: 'delivery', label: 'Delivery' },
 ];
 
 /**
@@ -349,6 +368,17 @@ function FilesPanel({ model }: { model: RunModel }): React.ReactElement {
 
   return (
     <div className="flex flex-col gap-4">
+      {/* studio#122: what this panel actually counts, said before the counts are
+          read. The rows come from each unit's `filesRead` set — every file the
+          agents opened in the worktree, with "MODIFIED / CREATED" inferred from
+          governance hook fires — so the number is a measure of ATTENTION, not of
+          delivered change. Run 665a9aeb reported 13 files here while its deliver
+          phase pushed a branch with zero commits; the Delivery section below
+          carries the outcome claim, and this one stops making it. */}
+      <p data-testid="files-scope-note" className="text-[10px] font-mono leading-snug" style={{ color: 'var(--ink-dim)' }}>
+        files the agents read or wrote in the worktree — not a delivered changeset
+      </p>
+
       {/* Panel header: the whole-run diff affordance (§3.4) */}
       <div className="flex items-center gap-2">
         <button
@@ -459,6 +489,16 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
     ? new Set(model.units.flatMap((u) => u.filesRead)).size
     : null;
 
+  // studio#122 EC57: a chat thread has no deliver phase and never will, so it
+  // gets no Delivery section at all — silence, not a section that says "none"
+  // on every chat. The predicate is studio's own (`isChatRun`, the one every
+  // surface routes by); nothing in the DELIVERY derivation reads
+  // `session.workflow_id` (EC61) — this is a visibility gate, not a wire read.
+  const sections = useMemo(
+    () => (isChatRun(view) ? ACCORDIONS.filter((a) => a.id !== 'delivery') : ACCORDIONS),
+    [view],
+  );
+
   function toggleAccordion(id: AccordionId): void {
     setOpenAccordion((prev) => (prev === id ? null : id));
   }
@@ -555,7 +595,7 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
 
       {/* Accordion sections */}
       <div className="flex-1 overflow-y-auto">
-        {ACCORDIONS.map(({ id, label }) => (
+        {sections.map(({ id, label }) => (
           <div key={id} style={{ borderBottom: '1px solid var(--surface-raised)' }}>
             <button
               type="button"
@@ -576,12 +616,26 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                     {fileCount}
                   </span>
                 )}
+                {/* studio#122 revised EC54: the state on the HEADER, so "did this
+                    run open a PR" is answerable without opening anything. Same
+                    badge shape as the file count beside it; derived from `view`
+                    alone, so it paints before (and without) the run model. */}
+                {id === 'delivery' && <DeliveryBadge view={view} />}
               </div>
               <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
                 {openAccordion === id ? '▲' : '▼'}
               </span>
             </button>
-            {openAccordion === id && model && (
+            {/* Delivery derives from the `view` prop alone (zero events, zero
+                model), so it never waits on the snapshot the other bodies need
+                — a run that opened a PR says so on the first paint of the
+                section, not after the re-hydrate lands. */}
+            {openAccordion === id && id === 'delivery' && (
+              <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
+                <RunDelivery view={view} />
+              </div>
+            )}
+            {openAccordion === id && id !== 'delivery' && model && (
               <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
                 {id === 'decisions' && <DecisionsLedger model={model} />}
                 {id === 'governance' && <GovernanceAudit model={model} />}
@@ -600,7 +654,7 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                 {id === 'files' && <FilesPanel model={model} />}
               </div>
             )}
-            {openAccordion === id && !model && (
+            {openAccordion === id && id !== 'delivery' && !model && (
               <div className="px-4 py-3">
                 <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>Loading…</p>
               </div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -5,6 +5,7 @@ import type { SessionView } from '../api/types.js';
 import { useRunModel } from '../hooks/useRunModel.js';
 import type { RunModel } from '../hooks/useRunModel.js';
 import { useProvenanceStore } from '../store/provenance.js';
+import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { LiveNarration } from './ChatPanel.js';
 import { canDeliver } from './delivery.js';
@@ -496,13 +497,17 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
 
   // studio#122 EC57: a run that cannot deliver gets no Delivery section at all —
   // silence, not a section that says "none" on every chat. `canDeliver` is the
-  // SAME predicate the project census filters by (D5), so the rail and the
-  // census can never disagree about what a deliverable run is. Nothing in the
-  // delivery DERIVATION reads `session.workflow_id` (EC61) — this is a
-  // visibility gate, not a wire read.
+  // SAME predicate the project census filters by (D5) AND the same one the
+  // COMPOSER classifies with (D-1), so the rail, the census and the launch form
+  // can never disagree about what a deliverable run is. The lookup is the
+  // authoritative `is_system` flag off the app's one `GET /workflows` — the
+  // five-id denylist alone left `collab` and every `interactive-*` looking like
+  // build work here. Nothing in the delivery DERIVATION reads
+  // `session.workflow_id` (EC61) — this is a visibility gate, not a wire read.
+  const isSystemWorkflow = useIsSystemWorkflow();
   const sections = useMemo(
-    () => (canDeliver(view) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),
-    [view],
+    () => (canDeliver(view, isSystemWorkflow) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),
+    [view, isSystemWorkflow],
   );
 
   function toggleAccordion(id: AccordionId): void {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -517,6 +517,21 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
     [view, isSystemWorkflow],
   );
 
+  /**
+   * The EFFECTIVE open section (Copilot on #125). `openAccordion` is mount-scoped state and the
+   * panel does not remount between runs, so opening `delivery` on a deliverable run and then
+   * selecting a run that cannot deliver leaves the id pointing at a section `sections` no longer
+   * contains — and the rail renders with nothing open, silently losing What/Where's default.
+   *
+   * Healed by derivation rather than an effect: an effect would paint the broken frame first and
+   * then correct it. `null` is passed through untouched because it is a REAL state — the operator
+   * collapsed everything — and must not be confused with a stale id.
+   */
+  const openId: AccordionId | null =
+    openAccordion === null || sections.some((s) => s.id === openAccordion)
+      ? openAccordion
+      : 'whatwhere';
+
   function toggleAccordion(id: AccordionId): void {
     setOpenAccordion((prev) => (prev === id ? null : id));
   }
@@ -619,10 +634,10 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
               type="button"
               onClick={() => toggleAccordion(id)}
               className="w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors"
-              style={{ color: openAccordion === id ? 'var(--ink-high)' : 'var(--ink-muted)' }}
+              style={{ color: openId === id ? 'var(--ink-high)' : 'var(--ink-muted)' }}
               onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; }}
               onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-              aria-expanded={openAccordion === id}
+              aria-expanded={openId === id}
             >
               <div className="flex items-center gap-1.5">
                 <span className="text-xs font-medium font-mono">{label}</span>
@@ -641,19 +656,19 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                 {id === 'delivery' && <DeliveryBadge view={view} />}
               </div>
               <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>
-                {openAccordion === id ? '▲' : '▼'}
+                {openId === id ? '▲' : '▼'}
               </span>
             </button>
             {/* Delivery derives from the `view` prop alone (zero events, zero
                 model), so it never waits on the snapshot the other bodies need
                 — a run that opened a PR says so on the first paint of the
                 section, not after the re-hydrate lands. */}
-            {openAccordion === id && id === 'delivery' && (
+            {openId === id && id === 'delivery' && (
               <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
                 <RunDelivery view={view} />
               </div>
             )}
-            {openAccordion === id && id !== 'delivery' && model && (
+            {openId === id && id !== 'delivery' && model && (
               <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
                 {id === 'decisions' && <DecisionsLedger model={model} />}
                 {id === 'governance' && <GovernanceAudit model={model} />}
@@ -672,7 +687,7 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                 {id === 'files' && <FilesPanel model={model} />}
               </div>
             )}
-            {openAccordion === id && id !== 'delivery' && !model && (
+            {openId === id && id !== 'delivery' && !model && (
               <div className="px-4 py-3">
                 <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>Loading…</p>
               </div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -497,13 +497,20 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
 
   // studio#122 EC57: a run that cannot deliver gets no Delivery section at all —
   // silence, not a section that says "none" on every chat. `canDeliver` is the
-  // SAME predicate the project census filters by (D5) AND the same one the
-  // COMPOSER classifies with (D-1), so the rail, the census and the launch form
-  // can never disagree about what a deliverable run is. The lookup is the
-  // authoritative `is_system` flag off the app's one `GET /workflows` — the
-  // five-id denylist alone left `collab` and every `interactive-*` looking like
-  // build work here. Nothing in the delivery DERIVATION reads
-  // `session.workflow_id` (EC61) — this is a visibility gate, not a wire read.
+  // SAME predicate the project census filters by (D5), the row chips gate on
+  // (D2) AND the one the COMPOSER classifies with (D-1), so the rail, the rows,
+  // the census and the launch form can never disagree about what a deliverable
+  // run is. The lookup is the authoritative `is_system` flag off the app's one
+  // `GET /workflows`.
+  //
+  // A run with a deliver PHASE keeps this section whatever its workflow id says
+  // — 5c5e08b7 opened a real PR under a materialised `wf-<runId>` def. A run
+  // WITHOUT one gets it only once a def in hand says the workflow is ordinary:
+  // "this run has no deliver phase" is a claim about a classification, and 86 of
+  // the 129 live runs carry an id no catalog serves, so `undefined` is the
+  // permanent answer for them and the sentence would be unevidenced. Nothing in
+  // the delivery DERIVATION reads `session.workflow_id` (EC61) — the
+  // classification half is a visibility gate, not a wire read.
   const isSystemWorkflow = useIsSystemWorkflow();
   const sections = useMemo(
     () => (canDeliver(view, isSystemWorkflow) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -533,7 +533,12 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
       : 'whatwhere';
 
   function toggleAccordion(id: AccordionId): void {
-    setOpenAccordion((prev) => (prev === id ? null : id));
+    // Compare against the EFFECTIVE open section, not the raw state (Copilot on #125). After a
+    // run switch drops the open section, `openAccordion` still names the vanished id while the
+    // rail RENDERS `openId` — so clicking the visibly-open What/Where compared 'delivery' with
+    // 'whatwhere', re-opened what was already open, and did nothing until a second click.
+    // Deliberately not a functional update: the correct input is what the operator can SEE.
+    setOpenAccordion(openId === id ? null : id);
   }
 
   if (collapsed) {

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -224,7 +224,7 @@ export function RunDelivery({ view }: Props): React.ReactElement {
           data-testid="run-delivery-link"
           href={href}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="font-mono break-all transition-opacity hover:opacity-70"
           style={{ color: 'var(--accent)' }}
         >

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -219,9 +219,22 @@ export function RunDelivery({ view }: Props): React.ReactElement {
 
   return (
     <div data-testid="run-delivery" data-state={claim} className="flex flex-col gap-1.5 text-[11px]">
-      <p style={{ color: claim === 'pr-open' ? 'var(--ink-muted)' : DELIVERY_COLOR[claim] }}>
-        {HEADLINE[claim]}
-      </p>
+      {/*
+        * The `'none'` headline is a CLASSIFICATION claim ("this run has no deliver phase"), so it
+        * needs the same `is_system === false` licence the remedy does. The rail already withholds
+        * the whole section unlicensed, which is why this is unreachable today — but the invariant
+        * lived only in the caller (Copilot on #125), and this component is exported. Enforcing it
+        * here too means a future call site cannot reintroduce the claim by accident.
+        *
+        * Only the SENTENCE is gated, not the section: the worktree line below is a DTO fact
+        * (`session.workdir`) that holds whatever produced the run, and withholding facts along
+        * with claims is the separate bug tracked in #126.
+        */}
+      {(claim !== 'none' || remedyLicensed) && (
+        <p style={{ color: claim === 'pr-open' ? 'var(--ink-muted)' : DELIVERY_COLOR[claim] }}>
+          {HEADLINE[claim]}
+        </p>
+      )}
 
       {claim === 'pr-open' && href !== null && (
         <a

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { SessionView } from '../api/types.js';
 import { useDeliveryStore } from '../store/delivery.js';
+import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import {
   DELIVERY_COLOR,
   DELIVERY_LABEL,
@@ -131,7 +132,31 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
  *    rejected unit has no stored transcript by design, and re-wording a gate's
  *    own message is how a surface starts lying.
  *  - `none` — deliverable runs only (the caller gates the rest out): names the
- *    worktree the work is sitting in, and the launch option that would deliver it.
+ *    worktree the work is sitting in, and — only when the workflow is
+ *    POSITIVELY known deliverable — the launch option that would deliver it.
+ *
+ * ── THE COLD-CACHE INVARIANT (D-1) ───────────────────────────────────────────
+ * **The "launch with deliver: pr" remedy never renders for a run studio cannot
+ * prove is deliverable — the loading window included.**
+ *
+ * `canDeliver` gates this component in, and before the workflow defs land it can
+ * only consult the five-id denylist, which does not know `collab` or any of the
+ * five `interactive-*` — the document and video seams. So for one paint the rail
+ * would offer a remedy studio's OWN composer refuses (its `deliverKindOf` reads
+ * `is_system` and demotes exactly those to 'system'). The suppression is on the
+ * REMEDY LINE, not the section, and that is the deliberate half:
+ *
+ *  - Every OTHER claim in this body — delivered / pr-open / nothing-to-deliver /
+ *    failed — is derived from the run's own units and is true no matter what
+ *    kind of workflow produced them. Hiding the section would withhold facts to
+ *    avoid a suggestion.
+ *  - The remedy is the ONLY thing here that can be false, because it is the only
+ *    thing that speaks about a FUTURE launch. Withholding it costs the operator
+ *    a sentence they can get from the composer; printing it wrongly tells them
+ *    to do something the composer will not do.
+ *
+ * Erring toward saying less. The line appears the moment the defs land — and for
+ * a system workflow the whole section correctly disappears instead.
  */
 export function RunDelivery({ view }: Props): React.ReactElement {
   const runId = view.session.id;
@@ -154,6 +179,13 @@ export function RunDelivery({ view }: Props): React.ReactElement {
   }, [runId, unitKey]);
 
   const workdir = view.session.workdir;
+
+  // The remedy's licence: `is_system === false` — a def IN HAND that carries no
+  // flag (the daemon omits `is_system` on ordinary workflows). `undefined` — the
+  // defs have not loaded, the fetch degraded, or this id is not in the list — is
+  // NOT a licence. See the cold-cache invariant above.
+  const isSystemWorkflow = useIsSystemWorkflow();
+  const remedyLicensed = isSystemWorkflow(view.session.workflow_id?.trim() ?? '') === false;
 
   return (
     <div data-testid="run-delivery" data-state={claim} className="flex flex-col gap-1.5 text-[11px]">
@@ -209,12 +241,14 @@ export function RunDelivery({ view }: Props): React.ReactElement {
         </>
       )}
 
-      {claim === 'none' && (
+      {claim === 'none' && ((workdir !== undefined && workdir !== null) || remedyLicensed) && (
         <p className="font-mono" style={{ color: 'var(--ink-dim)' }}
           {...(workdir !== undefined && workdir !== null ? { title: workdir } : {})}
         >
           {workdir !== undefined && workdir !== null
-            ? `the work is in ${compactPath(workdir)} — launch with deliver: pr to open a PR from it`
+            ? remedyLicensed
+              ? `the work is in ${compactPath(workdir)} — launch with deliver: pr to open a PR from it`
+              : `the work is in ${compactPath(workdir)}`
             : 'launch with deliver: pr to have the run open a PR from its worktree'}
         </p>
       )}

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -121,7 +121,11 @@ export function DeliveryChip({ view }: Props): React.ReactElement | null {
  */
 export const HEADLINE: Record<DeliveryClaim, string> = {
   'none':               'This run has no deliver phase.',
-  'in-flight':          'The deliver phase has not finished — no PR exists yet.',
+  // NOT "no PR exists yet" (Copilot on #125). The deliver script pushes the branch, THEN runs
+  // `gh pr create`, THEN echoes the url — a unit that is still `pending`/`distributed` can be at
+  // any point in that sequence, so a PR may already be open. Asserting its non-existence is the
+  // same unevidenced claim as asserting its existence, pointed the other way.
+  'in-flight':          'The deliver phase is still running — what it produced is not known yet.',
   // The 665a9aeb wording. Approved is not the same as produced, and this line
   // is the whole difference said out loud.
   'delivered':          'The deliver phase ran and crew approved it. That alone is not a PR.',

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -1,0 +1,173 @@
+import { useEffect } from 'react';
+import type { SessionView } from '../api/types.js';
+import { useDeliveryStore } from '../store/delivery.js';
+import { DELIVERY_COLOR, DELIVERY_LABEL, deliveryOf, type DeliveryState } from './delivery.js';
+import { compactPath } from './WhatWhere.js';
+
+/**
+ * The Delivery views (wicked-studio#122, slice DA) — what a run PRODUCED, in the
+ * three places an operator looks for it. Every one of them derives from
+ * {@link deliveryOf}, so none of them can disagree, and only the rail body ever
+ * fetches (once, for a run that actually delivered).
+ *
+ * Copy rule, load-bearing: the deliver phase opens a PR and STOPS. Nothing here
+ * says "shipped" and nothing says "merged" — merge stays human.
+ */
+
+interface Props {
+  view: SessionView;
+}
+
+/**
+ * The rail header's state badge — the at-a-glance signal the operator decision
+ * bought back when the pinned band was reverted (revised EC54): Delivery is the
+ * ninth accordion, so its body costs a click, but its STATE is legible on the
+ * header without one. Same shape as the Files count badge it sits beside.
+ *
+ * `'none'` renders nothing: a run with no deliver phase has no state worth a
+ * chip, and silence beats an "unknown" badge.
+ */
+export function DeliveryBadge({ view }: Props): React.ReactElement | null {
+  const { state } = deliveryOf(view);
+  if (state === 'none') return null;
+  return (
+    <span
+      data-testid="run-delivery-badge"
+      data-state={state}
+      className="text-[9px] font-mono px-1 py-0.5 rounded"
+      style={{ background: 'var(--surface-raised)', color: DELIVERY_COLOR[state] }}
+    >
+      {DELIVERY_LABEL[state]}
+    </span>
+  );
+}
+
+/**
+ * The list-row chip (project dashboard rows, build run rows). Pure DTO — a list
+ * surface fires ZERO requests, which is why the chip is a word and not a link
+ * until `session.delivery` (CREW-UX-8) makes the url free.
+ *
+ * Rendered only for a RESOLVED delivery fact. `'none'` is silence (EC57), and so
+ * is `'in-flight'`: the row already carries the run's status pill, and a
+ * cancelled run's deliver unit stays `pending` forever — a second motion word
+ * there would claim progress that stopped.
+ */
+export function DeliveryChip({ view }: Props): React.ReactElement | null {
+  const { state } = deliveryOf(view);
+  if (state === 'none' || state === 'in-flight') return null;
+  return (
+    <span
+      data-testid="run-delivery-chip"
+      data-state={state}
+      style={{
+        flexShrink: 0,
+        fontSize: 'var(--text-2xs)',
+        fontFamily: 'var(--font-mono)',
+        color: DELIVERY_COLOR[state],
+      }}
+    >
+      {DELIVERY_LABEL[state]}
+    </span>
+  );
+}
+
+/** The rail body's one-line lead, per state. */
+const HEADLINE: Record<DeliveryState, string> = {
+  'none':               'This run has no deliver phase.',
+  'in-flight':          'The deliver phase has not finished — no PR exists yet.',
+  'delivered':          'PR open — merge stays human.',
+  'nothing-to-deliver': 'Delivered nothing. Crew refused the push:',
+  'failed':             'Delivery failed. Crew recorded:',
+};
+
+/**
+ * The Delivery accordion body. States, and what each one costs:
+ *
+ *  - `delivered` — the PR as a real external anchor. The url comes free from
+ *    `session.delivery` when the daemon carries it (crew#321); otherwise ONE
+ *    `GET /runs/:id/units/:unitKey/output`, fired here and only here, gated on
+ *    the operator opening this section. A delivered run whose transcript holds
+ *    no url says exactly that — never a silently linkless "Delivered" (EC59).
+ *  - `nothing-to-deliver` / `failed` — `denial_reason` VERBATIM. Zero fetches: a
+ *    rejected unit has no stored transcript by design, and re-wording a gate's
+ *    own message is how a surface starts lying.
+ *  - `none` — build runs only (the caller gates chat runs out): names the
+ *    worktree the work is sitting in, and the launch option that would deliver it.
+ */
+export function RunDelivery({ view }: Props): React.ReactElement {
+  const runId = view.session.id;
+  const { state, unitId, reason, url } = deliveryOf(view);
+  const fetched = useDeliveryStore((s) => s.byRun[runId]);
+
+  // The ONE per-run fetch, and only when there is something to point at: a
+  // delivered run whose url the daemon does not already carry.
+  const needsFetch = state === 'delivered' && url === null && unitId !== null;
+  useEffect(() => {
+    if (needsFetch) useDeliveryStore.getState().load(runId, unitId as string);
+  }, [needsFetch, runId, unitId]);
+
+  const href = url ?? fetched?.url ?? null;
+  const workdir = view.session.workdir;
+
+  return (
+    <div data-testid="run-delivery" data-state={state} className="flex flex-col gap-1.5 text-[11px]">
+      <p style={{ color: state === 'delivered' ? 'var(--ink-muted)' : DELIVERY_COLOR[state] }}>
+        {HEADLINE[state]}
+      </p>
+
+      {state === 'delivered' && href !== null && (
+        <a
+          data-testid="run-delivery-link"
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono break-all transition-opacity hover:opacity-70"
+          style={{ color: 'var(--accent)' }}
+        >
+          {href} <span aria-hidden>↗</span>
+        </a>
+      )}
+      {state === 'delivered' && href === null && fetched === undefined && (
+        <p className="font-mono" style={{ color: 'var(--ink-dim)' }}>
+          reading the deliver phase transcript for the PR link…
+        </p>
+      )}
+      {state === 'delivered' && href === null && fetched !== undefined && (
+        // The 665a9aeb case, said out loud: crew approved the phase and the
+        // transcript carries no PR url (its overlay pushed an empty branch and
+        // reported success — crew#317). `unavailable` is the daemon's OWN words
+        // when it has any; otherwise the absence itself is the finding.
+        <p data-testid="run-delivery-nolink" className="font-mono" style={{ color: 'var(--status-fail)' }}>
+          {fetched.unavailable ?? 'the deliver phase recorded no PR link — nothing can be pointed at'}
+        </p>
+      )}
+
+      {(state === 'nothing-to-deliver' || state === 'failed') && (
+        <>
+          <p
+            data-testid="run-delivery-reason"
+            className="font-mono break-words whitespace-pre-wrap"
+            style={{ color: 'var(--status-fail)' }}
+          >
+            {reason ?? 'crew recorded no reason'}
+          </p>
+          {workdir !== undefined && workdir !== null && (
+            <p className="font-mono" style={{ color: 'var(--ink-dim)' }} title={workdir}>
+              the work is in {compactPath(workdir)}
+            </p>
+          )}
+        </>
+      )}
+
+      {state === 'none' && (
+        <p className="font-mono" style={{ color: 'var(--ink-dim)' }}
+          {...(workdir !== undefined && workdir !== null ? { title: workdir } : {})}
+        >
+          {workdir !== undefined && workdir !== null
+            ? `the work is in ${compactPath(workdir)} — launch with deliver: pr to open a PR from it`
+            : 'launch with deliver: pr to have the run open a PR from its worktree'}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -78,7 +78,7 @@ export function DeliveryBadge({ view }: Props): React.ReactElement | null {
  * cancelled run's deliver unit stays `pending` forever — a second motion word
  * there would claim progress that stopped.
  *
- * D2: it gates on {@link canDeliver} FIRST, the same predicate the rail's
+ * D2: it gates on {@link canDeliver} — the same predicate the rail's
  * section and the census gate on, so a row can never chip a run whose Delivery
  * section studio itself withholds. The objection to this was cost — that a
  * per-row `is_system` read would break the O(1) request budget — and it is
@@ -91,8 +91,11 @@ export function DeliveryBadge({ view }: Props): React.ReactElement | null {
  */
 export function DeliveryChip({ view }: Props): React.ReactElement | null {
   const isSystemWorkflow = useIsSystemWorkflow();
-  const { claim } = resolveDelivery(deliveryOf(view));
+  // The gate runs before anything is derived (Copilot on #125): the comment said "FIRST" while
+  // `claim` was resolved above it. Harmless as written — the gate still governed the return —
+  // but a doc that misdescribes evaluation order is what a later edit trusts.
   if (!canDeliver(view, isSystemWorkflow)) return null;
+  const { claim } = resolveDelivery(deliveryOf(view));
   if (claim === 'none' || claim === 'in-flight') return null;
   return (
     <span

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -95,8 +95,16 @@ export function DeliveryChip({ view }: Props): React.ReactElement | null {
   );
 }
 
-/** The rail body's one-line lead, per claim. */
-const HEADLINE: Record<DeliveryClaim, string> = {
+/**
+ * The rail body's one-line lead, per claim.
+ *
+ * EXPORTED so the same structural guard that pins {@link DELIVERY_LABEL} can be
+ * pointed at it: the badge word was tested and this sentence was not, so
+ * `'delivered'` could be edited back to "PR open — merge stays human." — the
+ * exact claim this slice was re-cut to remove — with the whole suite still
+ * green. Only `'pr-open'` may assert an open PR.
+ */
+export const HEADLINE: Record<DeliveryClaim, string> = {
   'none':               'This run has no deliver phase.',
   'in-flight':          'The deliver phase has not finished — no PR exists yet.',
   // The 665a9aeb wording. Approved is not the same as produced, and this line

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -100,11 +100,13 @@ export function RunDelivery({ view }: Props): React.ReactElement {
   const fetched = useDeliveryStore((s) => s.byRun[runId]);
 
   // The ONE per-run fetch, and only when there is something to point at: a
-  // delivered run whose url the daemon does not already carry.
-  const needsFetch = state === 'delivered' && url === null && unitId !== null;
+  // delivered run whose url the daemon does not already carry. `unitKey` is the
+  // deliver unit's FULL id — the output route's most-specific pass matches
+  // `u.id === unitKey`, so an overlay-named phase needs no key guessing (EC61).
+  const unitKey = state === 'delivered' && url === null ? unitId : null;
   useEffect(() => {
-    if (needsFetch) useDeliveryStore.getState().load(runId, unitId as string);
-  }, [needsFetch, runId, unitId]);
+    if (unitKey !== null) useDeliveryStore.getState().load(runId, unitKey);
+  }, [runId, unitKey]);
 
   const href = url ?? fetched?.url ?? null;
   const workdir = view.session.workdir;

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -121,11 +121,17 @@ export function DeliveryChip({ view }: Props): React.ReactElement | null {
  */
 export const HEADLINE: Record<DeliveryClaim, string> = {
   'none':               'This run has no deliver phase.',
-  // NOT "no PR exists yet" (Copilot on #125). The deliver script pushes the branch, THEN runs
+  // NOT "no PR exists yet", and NOT "is still running" (Copilot on #125, twice). The first
+  // asserted a PR's non-existence; the SECOND asserted execution — and this module says in four
+  // places that a cancelled run's deliver unit is `pending` FOREVER (10 of the live corpus's 12
+  // `distributed` units sit in terminal sessions). `pending` means UNRESOLVED, never RUNNING.
+  // The wording now matches the state's own definition and claims nothing further.
+  //
+  // The original note still holds: the deliver script pushes the branch, THEN runs
   // `gh pr create`, THEN echoes the url — a unit that is still `pending`/`distributed` can be at
   // any point in that sequence, so a PR may already be open. Asserting its non-existence is the
   // same unevidenced claim as asserting its existence, pointed the other way.
-  'in-flight':          'The deliver phase is still running — what it produced is not known yet.',
+  'in-flight':          'The deliver phase has not resolved — what it produced is not recorded.',
   // The 665a9aeb wording. Approved is not the same as produced, and this line
   // is the whole difference said out loud.
   'delivered':          'The deliver phase ran and crew approved it. That alone is not a PR.',

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -5,6 +5,7 @@ import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import {
   DELIVERY_COLOR,
   DELIVERY_LABEL,
+  canDeliver,
   deliveryOf,
   resolveDelivery,
   type DeliveryClaim,
@@ -76,9 +77,22 @@ export function DeliveryBadge({ view }: Props): React.ReactElement | null {
  * is `'in-flight'`: the row already carries the run's status pill, and a
  * cancelled run's deliver unit stays `pending` forever — a second motion word
  * there would claim progress that stopped.
+ *
+ * D2: it gates on {@link canDeliver} FIRST, the same predicate the rail's
+ * section and the census gate on, so a row can never chip a run whose Delivery
+ * section studio itself withholds. The objection to this was cost — that a
+ * per-row `is_system` read would break the O(1) request budget — and it is
+ * false: `useIsSystemWorkflow` reads MODULE state behind at most one
+ * `GET /workflows` per session, so 120 rows fire one request between them and
+ * ZERO per row (pinned in `tests/delivery.workflowBudget.test.tsx`). Today the
+ * gate is also implied — every chipped claim has a deliver unit, which
+ * `canDeliver` licenses outright — and that is precisely why it is written down:
+ * an implied invariant is one a later edit to either side silently breaks.
  */
 export function DeliveryChip({ view }: Props): React.ReactElement | null {
+  const isSystemWorkflow = useIsSystemWorkflow();
   const { claim } = resolveDelivery(deliveryOf(view));
+  if (!canDeliver(view, isSystemWorkflow)) return null;
   if (claim === 'none' || claim === 'in-flight') return null;
   return (
     <span
@@ -131,32 +145,42 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
  *  - `nothing-to-deliver` / `failed` — `denial_reason` VERBATIM. Zero fetches: a
  *    rejected unit has no stored transcript by design, and re-wording a gate's
  *    own message is how a surface starts lying.
- *  - `none` — deliverable runs only (the caller gates the rest out): names the
- *    worktree the work is sitting in, and — only when the workflow is
- *    POSITIVELY known deliverable — the launch option that would deliver it.
+ *  - `none` — positively-classified deliverable runs only (`canDeliver` gates
+ *    the rest out, defs in hand): names the worktree the work is sitting in and
+ *    the launch option that would deliver it.
  *
  * ── THE COLD-CACHE INVARIANT (D-1) ───────────────────────────────────────────
- * **The "launch with deliver: pr" remedy never renders for a run studio cannot
- * prove is deliverable — the loading window included.**
+ * **Nothing studio cannot prove is deliverable gets a "no deliver phase"
+ * sentence or a "launch with deliver: pr" remedy — the loading window, and the
+ * permanently-unclassifiable run, included.**
  *
- * `canDeliver` gates this component in, and before the workflow defs land it can
- * only consult the five-id denylist, which does not know `collab` or any of the
- * five `interactive-*` — the document and video seams. So for one paint the rail
- * would offer a remedy studio's OWN composer refuses (its `deliverKindOf` reads
- * `is_system` and demotes exactly those to 'system'). The suppression is on the
- * REMEDY LINE, not the section, and that is the deliberate half:
+ * The first cut suppressed the REMEDY LINE and kept the section, on the argument
+ * that the rest of the body is derived from the run's own units and is true
+ * whatever composed them. That argument holds for every claim EXCEPT `'none'`,
+ * which is not a fact about units at all — it is a claim about a classification
+ * studio may not have. And that is the case the live corpus is made of: 86 of
+ * 129 runs carry a materialised `wf-<runId>` id that `GET /workflows` never
+ * serves, so the lookup answers `undefined` for them forever, not just for a
+ * paint. Thirty interactive document threads therefore rendered a Delivery
+ * section whose entire body read "This run has no deliver phase."
  *
- *  - Every OTHER claim in this body — delivered / pr-open / nothing-to-deliver /
- *    failed — is derived from the run's own units and is true no matter what
- *    kind of workflow produced them. Hiding the section would withhold facts to
- *    avoid a suggestion.
- *  - The remedy is the ONLY thing here that can be false, because it is the only
- *    thing that speaks about a FUTURE launch. Withholding it costs the operator
- *    a sentence they can get from the composer; printing it wrongly tells them
- *    to do something the composer will not do.
+ * So `canDeliver` now withholds the SECTION on the `'none'` arm under the same
+ * `is_system === false` licence this line has always used, and the two halves
+ * are one rule:
  *
- * Erring toward saying less. The line appears the moment the defs land — and for
- * a system workflow the whole section correctly disappears instead.
+ *  - a run WITH a deliver phase keeps its section unconditionally — 5c5e08b7's
+ *    own workflow id is materialised, and gating that arm would hide a real PR;
+ *  - a run WITHOUT one gets a section only once a def in hand says the workflow
+ *    is ordinary. `undefined` is not a licence.
+ *
+ * Erring toward saying less: withholding costs the operator a sentence they can
+ * get from the composer; printing it wrongly tells them a run failed to do
+ * something it was never asked to do. The section and the line appear together
+ * the moment the defs land — and for a system workflow neither ever does.
+ *
+ * The licence is re-checked HERE as well as in the caller because this component
+ * is exported and rendered directly by tests and by any future surface: one
+ * rule, held on both sides of the seam, never a second rule.
  */
 export function RunDelivery({ view }: Props): React.ReactElement {
   const runId = view.session.id;
@@ -180,10 +204,12 @@ export function RunDelivery({ view }: Props): React.ReactElement {
 
   const workdir = view.session.workdir;
 
-  // The remedy's licence: `is_system === false` — a def IN HAND that carries no
-  // flag (the daemon omits `is_system` on ordinary workflows). `undefined` — the
-  // defs have not loaded, the fetch degraded, or this id is not in the list — is
-  // NOT a licence. See the cold-cache invariant above.
+  // The licence — for the remedy line, and (in the caller) for the whole `'none'`
+  // arm this body would otherwise open with "This run has no deliver phase":
+  // `is_system === false`, a def IN HAND that carries no flag (the daemon omits
+  // `is_system` on ordinary workflows). `undefined` — the defs have not loaded,
+  // the fetch degraded, or the id is a materialised `wf-<runId>` that no catalog
+  // will ever carry — is NOT a licence. See the cold-cache invariant above.
   const isSystemWorkflow = useIsSystemWorkflow();
   const remedyLicensed = isSystemWorkflow(view.session.workflow_id?.trim() ?? '') === false;
 

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -1,17 +1,28 @@
 import { useEffect } from 'react';
 import type { SessionView } from '../api/types.js';
 import { useDeliveryStore } from '../store/delivery.js';
-import { DELIVERY_COLOR, DELIVERY_LABEL, deliveryOf, type DeliveryState } from './delivery.js';
+import {
+  DELIVERY_COLOR,
+  DELIVERY_LABEL,
+  deliveryOf,
+  resolveDelivery,
+  type DeliveryClaim,
+} from './delivery.js';
 import { compactPath } from './WhatWhere.js';
 
 /**
  * The Delivery views (wicked-studio#122, slice DA) — what a run PRODUCED, in the
- * three places an operator looks for it. Every one of them derives from
- * {@link deliveryOf}, so none of them can disagree, and only the rail body ever
- * fetches (once, for a run that actually delivered).
+ * three places an operator looks for it. Every one of them goes through
+ * {@link deliveryOf} and then {@link resolveDelivery}, so none of them can
+ * disagree, and only the rail body ever fetches (once, for a run whose phase
+ * completed and whose url the wire does not already carry).
  *
- * Copy rule, load-bearing: the deliver phase opens a PR and STOPS. Nothing here
- * says "shipped" and nothing says "merged" — merge stays human.
+ * Copy rules, both load-bearing:
+ *  - **"A PR is open" needs a url in hand.** `status === 'done'` buys the
+ *    phase-only wording ("deliver ran") and nothing more; the PR claim, the
+ *    accent and the link arrive together with the url or not at all.
+ *  - The deliver phase opens a PR and STOPS. Nothing here says "shipped" and
+ *    nothing says "merged" — merge stays human.
  */
 
 interface Props {
@@ -19,33 +30,46 @@ interface Props {
 }
 
 /**
- * The rail header's state badge — the at-a-glance signal the operator decision
+ * The rail header's claim badge — the at-a-glance signal the operator decision
  * bought back when the pinned band was reverted (revised EC54): Delivery is the
- * ninth accordion, so its body costs a click, but its STATE is legible on the
+ * last accordion, so its body costs a click, but its state is legible on the
  * header without one. Same shape as the Files count badge it sits beside.
+ *
+ * It reads the SAME resolved truth its body renders, store included (D1). The
+ * first cut derived from `deliveryOf(view)` alone and ignored the store, so with
+ * the section open on run 665a9aeb the header said "PR open" in `--accent` while
+ * the body directly beneath it said no PR link was recorded. A badge that can
+ * contradict its own body is worse than no badge.
  *
  * `'none'` renders nothing: a run with no deliver phase has no state worth a
  * chip, and silence beats an "unknown" badge.
  */
 export function DeliveryBadge({ view }: Props): React.ReactElement | null {
-  const { state } = deliveryOf(view);
-  if (state === 'none') return null;
+  const fetched = useDeliveryStore((s) => s.byRun[view.session.id]);
+  const { claim } = resolveDelivery(deliveryOf(view), fetched?.url ?? null);
+  if (claim === 'none') return null;
   return (
     <span
       data-testid="run-delivery-badge"
-      data-state={state}
+      data-state={claim}
       className="text-[9px] font-mono px-1 py-0.5 rounded"
-      style={{ background: 'var(--surface-raised)', color: DELIVERY_COLOR[state] }}
+      style={{ background: 'var(--surface-raised)', color: DELIVERY_COLOR[claim] }}
     >
-      {DELIVERY_LABEL[state]}
+      {DELIVERY_LABEL[claim]}
     </span>
   );
 }
 
 /**
  * The list-row chip (project dashboard rows, build run rows). Pure DTO — a list
- * surface fires ZERO requests, which is why the chip is a word and not a link
- * until `session.delivery` (CREW-UX-8) makes the url free.
+ * surface fires ZERO requests and reads no store, so the only url it can ever
+ * hold is the wire-carried `session.delivery.url` (CREW-UX-8 / crew#321). Until
+ * that field ships, every chip on every list is the phase-only word; it never
+ * says "PR open" on the strength of `done` alone.
+ *
+ * The chip stays a `<span>` even when a url IS in hand, because both callers
+ * render the row as an `<a>` and a nested anchor is invalid HTML. The link lives
+ * in the rail body, which is where the operator went to get it.
  *
  * Rendered only for a RESOLVED delivery fact. `'none'` is silence (EC57), and so
  * is `'in-flight'`: the row already carries the run's status pill, and a
@@ -53,71 +77,83 @@ export function DeliveryBadge({ view }: Props): React.ReactElement | null {
  * there would claim progress that stopped.
  */
 export function DeliveryChip({ view }: Props): React.ReactElement | null {
-  const { state } = deliveryOf(view);
-  if (state === 'none' || state === 'in-flight') return null;
+  const { claim } = resolveDelivery(deliveryOf(view));
+  if (claim === 'none' || claim === 'in-flight') return null;
   return (
     <span
       data-testid="run-delivery-chip"
-      data-state={state}
+      data-state={claim}
       style={{
         flexShrink: 0,
         fontSize: 'var(--text-2xs)',
         fontFamily: 'var(--font-mono)',
-        color: DELIVERY_COLOR[state],
+        color: DELIVERY_COLOR[claim],
       }}
     >
-      {DELIVERY_LABEL[state]}
+      {DELIVERY_LABEL[claim]}
     </span>
   );
 }
 
-/** The rail body's one-line lead, per state. */
-const HEADLINE: Record<DeliveryState, string> = {
+/** The rail body's one-line lead, per claim. */
+const HEADLINE: Record<DeliveryClaim, string> = {
   'none':               'This run has no deliver phase.',
   'in-flight':          'The deliver phase has not finished — no PR exists yet.',
-  'delivered':          'PR open — merge stays human.',
+  // The 665a9aeb wording. Approved is not the same as produced, and this line
+  // is the whole difference said out loud.
+  'delivered':          'The deliver phase ran and crew approved it. That alone is not a PR.',
+  'pr-open':            'PR open — merge stays human.',
   'nothing-to-deliver': 'Delivered nothing. Crew refused the push:',
   'failed':             'Delivery failed. Crew recorded:',
 };
 
 /**
- * The Delivery accordion body. States, and what each one costs:
+ * The Delivery accordion body. Claims, and what each one costs:
  *
- *  - `delivered` — the PR as a real external anchor. The url comes free from
- *    `session.delivery` when the daemon carries it (crew#321); otherwise ONE
+ *  - `pr-open` — the PR as a real external anchor. The url comes free from
+ *    `session.delivery` when the daemon carries it (crew#321); otherwise it is
+ *    what the one transcript read below recovered.
+ *  - `delivered` — the phase completed and no url is in hand. ONE
  *    `GET /runs/:id/units/:unitKey/output`, fired here and only here, gated on
- *    the operator opening this section. A delivered run whose transcript holds
- *    no url says exactly that — never a silently linkless "Delivered" (EC59).
+ *    the operator opening this section. If the read comes back without a url the
+ *    body says so plainly and the headline never upgrades — the 665a9aeb case,
+ *    which is a `done` unit with a `null` denial_reason and a transcript holding
+ *    one `/pull/new/` form and no numbered PR (EC59).
  *  - `nothing-to-deliver` / `failed` — `denial_reason` VERBATIM. Zero fetches: a
  *    rejected unit has no stored transcript by design, and re-wording a gate's
  *    own message is how a surface starts lying.
- *  - `none` — build runs only (the caller gates chat runs out): names the
+ *  - `none` — deliverable runs only (the caller gates the rest out): names the
  *    worktree the work is sitting in, and the launch option that would deliver it.
  */
 export function RunDelivery({ view }: Props): React.ReactElement {
   const runId = view.session.id;
-  const { state, unitId, reason, url } = deliveryOf(view);
   const fetched = useDeliveryStore((s) => s.byRun[runId]);
+  const { state, claim, unitId, reason, href } = resolveDelivery(
+    deliveryOf(view),
+    fetched?.url ?? null,
+  );
 
-  // The ONE per-run fetch, and only when there is something to point at: a
-  // delivered run whose url the daemon does not already carry. `unitKey` is the
-  // deliver unit's FULL id — the output route's most-specific pass matches
+  // The ONE per-run fetch, and only when there may be something to point at: an
+  // approved deliver phase whose url the daemon does not already carry. `unitKey`
+  // is the deliver unit's FULL id — the output route's most-specific pass matches
   // `u.id === unitKey`, so an overlay-named phase needs no key guessing (EC61).
-  const unitKey = state === 'delivered' && url === null ? unitId : null;
+  // Keyed off `state`, not `claim`: once the read lands `claim` may flip to
+  // `pr-open`, and gating on that would make the effect re-evaluate its own
+  // result. `load` is idempotent per run either way.
+  const unitKey = state === 'delivered' && href === null ? unitId : null;
   useEffect(() => {
     if (unitKey !== null) useDeliveryStore.getState().load(runId, unitKey);
   }, [runId, unitKey]);
 
-  const href = url ?? fetched?.url ?? null;
   const workdir = view.session.workdir;
 
   return (
-    <div data-testid="run-delivery" data-state={state} className="flex flex-col gap-1.5 text-[11px]">
-      <p style={{ color: state === 'delivered' ? 'var(--ink-muted)' : DELIVERY_COLOR[state] }}>
-        {HEADLINE[state]}
+    <div data-testid="run-delivery" data-state={claim} className="flex flex-col gap-1.5 text-[11px]">
+      <p style={{ color: claim === 'pr-open' ? 'var(--ink-muted)' : DELIVERY_COLOR[claim] }}>
+        {HEADLINE[claim]}
       </p>
 
-      {state === 'delivered' && href !== null && (
+      {claim === 'pr-open' && href !== null && (
         <a
           data-testid="run-delivery-link"
           href={href}
@@ -129,28 +165,32 @@ export function RunDelivery({ view }: Props): React.ReactElement {
           {href} <span aria-hidden>↗</span>
         </a>
       )}
-      {state === 'delivered' && href === null && fetched === undefined && (
+      {claim === 'delivered' && fetched === undefined && (
         <p className="font-mono" style={{ color: 'var(--ink-dim)' }}>
           reading the deliver phase transcript for the PR link…
         </p>
       )}
-      {state === 'delivered' && href === null && fetched !== undefined && (
+      {claim === 'delivered' && fetched !== undefined && (
         // The 665a9aeb case, said out loud: crew approved the phase and the
         // transcript carries no PR url (its overlay pushed an empty branch and
         // reported success — crew#317). `unavailable` is the daemon's OWN words
-        // when it has any; otherwise the absence itself is the finding.
-        <p data-testid="run-delivery-nolink" className="font-mono" style={{ color: 'var(--status-fail)' }}>
+        // when it has any; otherwise the absence itself is the finding. Muted,
+        // not `--status-fail`: an approved phase that produced no PR is a gap in
+        // the EVIDENCE, not a run that failed.
+        <p data-testid="run-delivery-nolink" className="font-mono" style={{ color: 'var(--ink-muted)' }}>
           {fetched.unavailable ?? 'the deliver phase recorded no PR link — nothing can be pointed at'}
         </p>
       )}
 
-      {(state === 'nothing-to-deliver' || state === 'failed') && (
+      {(claim === 'nothing-to-deliver' || claim === 'failed') && (
         <>
           <p
             data-testid="run-delivery-reason"
             className="font-mono break-words whitespace-pre-wrap"
             style={{ color: 'var(--status-fail)' }}
           >
+            {/* `reason` is already empty-normalized to `null` by the derivation,
+                so `??` cannot paint a blank paragraph here. */}
             {reason ?? 'crew recorded no reason'}
           </p>
           {workdir !== undefined && workdir !== null && (
@@ -161,7 +201,7 @@ export function RunDelivery({ view }: Props): React.ReactElement {
         </>
       )}
 
-      {state === 'none' && (
+      {claim === 'none' && (
         <p className="font-mono" style={{ color: 'var(--ink-dim)' }}
           {...(workdir !== undefined && workdir !== null ? { title: workdir } : {})}
         >

--- a/src/components/WorkflowViewer.tsx
+++ b/src/components/WorkflowViewer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { GateSpec, PhaseDef, PhaseExecutor, WorkflowDef } from '../api/types.js';
+import { setCachedWorkflows } from '../store/workflowCache.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -597,6 +598,10 @@ export function WorkflowViewer(): React.ReactElement {
     setError(null);
     try {
       const { workflows: wfs } = await api.listWorkflows();
+      // Deposit for the app (studio#122 D-1): this surface RE-loads after every
+      // create/delete, so the shared `is_system` cache the delivery surfaces
+      // read stays current with the edits made here — and costs no extra GET.
+      setCachedWorkflows(wfs);
       setWorkflows(wfs);
       if (wfs.length > 0 && !selectedRef.current) setSelected(wfs[0]?.id ?? null);
     } catch (e) { setError(e instanceof Error ? e.message : String(e)); }

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -234,8 +234,13 @@ export function resolveDelivery(d: Delivery, readUrl: string | null = null): Res
   // empty string: the claim would become `pr-open` in `--accent` over an
   // `href=""` link that points at the app itself. The ONE invariant this module
   // exists to hold is re-checked here rather than trusted from upstream.
+  // Re-check the SHAPE, not just emptiness (Copilot on #125). The note above was right about
+  // why — this function is exported and takes a hand-built `Delivery` — and then stopped at one
+  // member of the class: `resolveDelivery({state:'delivered', url:'javascript:alert(1)'})`
+  // returned `pr-open` with that href. This is the single choke point every surface's PR claim
+  // passes through, so it validates rather than trusts, for both sources.
   const candidate = d.url ?? readUrl;
-  const href = candidate === null || candidate === '' ? null : candidate;
+  const href = candidate !== null && isPrUrl(candidate) ? candidate : null;
   return { ...d, claim: href === null ? 'delivered' : 'pr-open', href };
 }
 

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -111,7 +111,42 @@ const NOTHING_TO_DELIVER = /nothing to deliver/i;
  */
 export function prUrlFrom(text: string): string | null {
   const matches = text.match(/https:\/\/\S+\/pull\/\d+/g);
-  return matches === null ? null : (matches[matches.length - 1] ?? null);
+  const last = matches === null ? null : (matches[matches.length - 1] ?? null);
+  return last === null ? null : (isPrUrl(last) ? last : null);
+}
+
+/**
+ * The ONE shape a PR url may have, for BOTH sources (Copilot on #125).
+ *
+ * The transcript path was validated by the extracting regex; the wire-carried
+ * `session.delivery.url` (wicked-crew#321) was trusted as "any non-empty string" —
+ * and it is rendered straight into an external `<a href>` AND decides the `pr-open`
+ * claim. A malformed or hostile value (`javascript:…`, an attacker-controlled host,
+ * a `/pull/new/` form) would have become a clickable link labelled "PR open".
+ *
+ * Latent today — no shipping daemon sends the field — which is exactly why it had to
+ * be fixed now: this module is written to light up the moment the server starts
+ * sending it, with no further change here.
+ *
+ * Anchored at both ends: scheme must be `https:`, path must END in `/pull/<digits>`,
+ * so `/pull/new/<branch>` (the create-PR form the operator hit first in the raw
+ * transcript) can never satisfy it.
+ */
+export function isPrUrl(candidate: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return false;
+  }
+  // `https:` only — this becomes an external `<a href>`, so `javascript:` and `data:` must not
+  // survive. Shape is checked on `pathname`, so a query or fragment cannot smuggle the digits
+  // (`…/pull/new/branch?x=/pull/9` has pathname `/pull/new/branch` and is refused).
+  //
+  // Deliberately NOT host-restricted: crew re-derives this url from the run's own git remote
+  // (deliver.ts), GitHub Enterprise is a real deployment, and an allowlist here would be a second,
+  // weaker copy of a decision that belongs server-side. This validates SHAPE, not provenance.
+  return parsed.protocol === 'https:' && /\/pull\/\d+$/.test(parsed.pathname);
 }
 
 /**
@@ -158,7 +193,10 @@ export function deliveryOf(view: SessionView): Delivery {
   // `session.delivery` is declared in ../api/types.js, not in the installed
   // api-types — the cast is the honest spelling until studio bumps (see there).
   const declared = (view.session as SessionWithDelivery).delivery;
-  const url = typeof declared?.url === 'string' && declared.url !== '' ? declared.url : null;
+  // Same gate as the transcript path — a wire-carried url is not more trustworthy
+  // for being wire-carried (Copilot on #125). Non-conforming ⇒ no url ⇒ no PR claim.
+  const url =
+    typeof declared?.url === 'string' && isPrUrl(declared.url) ? declared.url : null;
 
   return { state, unitId: unit.id, reason, url };
 }

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -168,14 +168,30 @@ export function isPrUrl(candidate: string): boolean {
  * contains the string anywhere — `grep -rn 'gh pr create' docs/`, `echo "run gh
  * pr create yourself"`, a heredoc of instructions — and any one of those would
  * have masqueraded as the run's deliver phase and inherited its whole claim.
- * The invocation is anchored instead: `gh` must start the string or follow a
- * shell command separator (`;`, `&&`, `||`, a pipe, a newline, a subshell open).
- * Quoted mentions are preceded by a quote, so they cannot match.
  *
- * Verified against the two real deliver commands on the live daemon: both run it
- * after `;`/newline (`… git push -u origin "$B"; gh pr create --head "$B" --fill`).
+ * A BARE `(` is not an invocation position; `$(` is (Copilot on #125).
+ *
+ * Including a plain `(` in the separator class let `grep -rn "(gh pr create)" .`
+ * match — a false POSITIVE that asserts a Delivery section on a unit that never
+ * delivered, which is the one thing this module must not do. The old comment
+ * claimed quoted mentions could not match, and that was simply wrong: the quote
+ * sits before the `(`, not before the `gh`.
+ *
+ * But `(` could not just be dropped — `URL=$(gh pr create --fill)` is a command
+ * substitution and a real invocation, and the live daemon runs that shape. So
+ * the substitution opener is admitted and the bare paren is not.
+ *
+ * `;`, `&&`, `||`, a pipe, a newline and start-of-string remain, with `^`
+ * multiline so a script's later lines count. A regex cannot truly separate an
+ * invocation from a mention in shell, so the residue errs toward silence: a bare
+ * subshell `( gh pr create )` is refused, and a miss degrades to `'none'` —
+ * silent, where a false positive is not.
+ *
+ * Checked against the LIVE corpus, not a fixture: all 31 units whose command
+ * mentions `gh pr create` still resolve.
  */
-const INVOKES_GH_PR_CREATE = /(?:^|[;&|(\n])\s*(?:sudo\s+|env\s+\S+=\S+\s+)*gh\s+pr\s+create\b/;
+const INVOKES_GH_PR_CREATE =
+  /(?:^|[;&|\n]|\$\()\s*(?:sudo\s+|env\s+\S+=\S+\s+)*gh\s+pr\s+create\b/m;
 
 /**
  * This run's deliver unit, or `null`. The id suffix is the primary key; the

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -151,6 +151,13 @@ export function isPrUrl(candidate: string): boolean {
   // rendered as "PR open" with a link to a create-PR form. That form is the exact trap the
   // operator hit first in the raw transcript, so it is refused by name rather than by shape.
   if (parsed.pathname.includes('/pull/new/')) return false;
+  // No query, no fragment (Copilot on #125). EC55 pins the rendered href as
+  // `^https://\S+/pull/\d+$`, and a url ending `…/pull/121?diff=split` satisfies the pathname
+  // test while violating that contract — the validator would admit a link the slice's own
+  // acceptance criterion rejects. Nothing upstream produces one either: crew greps
+  // `https://[^[:space:]]+/pull/[0-9]+`, which stops at the digits. Refusing is honest;
+  // silently stripping would alter what crew actually reported.
+  if (parsed.search !== '' || parsed.hash !== '') return false;
   return parsed.protocol === 'https:' && /\/pull\/\d+$/.test(parsed.pathname);
 }
 

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -1,5 +1,5 @@
 import type { SessionView, SessionWithDelivery, WorkUnit } from '../api/types.js';
-import { runKindOf } from './runMode.js';
+import { deliverKindOf, type IsSystemWorkflow } from './runMode.js';
 
 /**
  * Delivery — the one derivation every surface reads (wicked-studio#122, slice DA).
@@ -241,19 +241,28 @@ export const DELIVERY_COLOR: Record<DeliveryClaim, string> = {
  * project read "3 delivered · 30 no deliver phase" — a number about chats,
  * dressed as a delivery finding).
  *
- * It reuses studio#124's `runKindOf` rather than re-deriving a chat test: that
- * helper is already the composer's own answer to "may this run carry
- * `deliver: 'pr'`", and only `'build'` may. `'system'` (chat, onboarding,
- * survey-repo, …) is machine-owned work the launch form hides; `'freeform'`
- * carries no workflow at all and `deliver` without `workflow` is a 400
- * (api-types index.d.ts:955-956). Neither can ever produce a PR, so neither
+ * It calls studio#124's `deliverKindOf` — literally the same function the
+ * COMPOSER classifies with, not a second copy of the rule (D-1: the composer
+ * read `is_system` and this predicate read a five-id denylist, so `collab` and
+ * every `interactive-*` were 'system' there and 'build' here). Only `'build'`
+ * may deliver. `'system'` is machine-owned work the launch form hides;
+ * `'freeform'` carries no workflow at all and `deliver` without `workflow` is a
+ * 400 (api-types index.d.ts:955-956). Neither can ever produce a PR, so neither
  * gets a Delivery surface or a line in the census.
+ *
+ * @param isSystemWorkflow the AUTHORITATIVE `is_system` lookup, three-valued —
+ *   see {@link IsSystemWorkflow}. This module stays PURE and table-testable: it
+ *   imports no store and fires no fetch, so the caller (which has React) passes
+ *   `store/workflowCache.useIsSystemWorkflow()`. Omitted, the derivation falls
+ *   back to the denylist, which can only ever over-report deliverability — so a
+ *   caller that renders a REMEDY must additionally require a positively-known
+ *   def before saying it out loud (see `RunDelivery`).
  *
  * This is a VISIBILITY gate, not a wire read: {@link deliveryOf} stays
  * indifferent to `session.workflow_id` (EC61).
  */
-export function canDeliver(view: SessionView): boolean {
-  return runKindOf(view.session.workflow_id) === 'build';
+export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflow): boolean {
+  return deliverKindOf(view.session.workflow_id, isSystemWorkflow) === 'build';
 }
 
 /**
@@ -262,17 +271,23 @@ export function canDeliver(view: SessionView): boolean {
  * delivering nothing, is not in the visible six).
  *
  * Chats and the other non-deliverable kinds are filtered out entirely, per
- * {@link canDeliver}. Wording tracks {@link DELIVERY_LABEL} exactly: the
+ * {@link canDeliver} — pass the SAME `isSystemWorkflow` lookup the rail uses, or
+ * the six ids the denylist misses (`collab`, the five `interactive-*`) come back
+ * as "no deliver phase" and the D5 complaint is recreated for the document and
+ * video threads. Wording tracks {@link DELIVERY_LABEL} exactly: the
  * `in-flight` bucket says "deliver pending", never "still to deliver" — the
  * label refuses forward-looking words because a cancelled run's unit stays
  * `pending` forever, and the census may not smuggle them back in (D3).
  */
-export function deliverySummary(views: readonly SessionView[]): string {
+export function deliverySummary(
+  views: readonly SessionView[],
+  isSystemWorkflow?: IsSystemWorkflow,
+): string {
   const counts: Record<DeliveryClaim, number> = {
     'none': 0, 'in-flight': 0, 'delivered': 0, 'pr-open': 0, 'nothing-to-deliver': 0, 'failed': 0,
   };
   for (const v of views) {
-    if (!canDeliver(v)) continue;
+    if (!canDeliver(v, isSystemWorkflow)) continue;
     // No `readUrl`: the census is a list surface and fires zero requests, so the
     // only url it can ever see is the wire-carried one (crew#321).
     counts[resolveDelivery(deliveryOf(v)).claim] += 1;

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -361,6 +361,12 @@ export const DELIVERY_COLOR: Record<DeliveryClaim, string> = {
 export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflow): boolean {
   if (deliveryOf(view).state !== 'none') return true;
   const wf = view.session.workflow_id?.trim() ?? '';
+  // The lookup is deliberately called TWICE — once inside `deliverKindOf`, once for the licence.
+  // Collapsing it into a closure over one memoized answer was tried (Copilot on #125 raised the
+  // repeat) and REVERTED: `tests/deliverKind.shared.test.tsx` pins that `canDeliver` hands
+  // `deliverKindOf` the very lookup it received, which is the guard stopping this slice and the
+  // composer from re-forking the rule — the defect that took a whole round to find. Weakening a
+  // structural invariant to save a map lookup on an array of at most 17 defs is the wrong trade.
   return deliverKindOf(wf, isSystemWorkflow) === 'build' && isSystemWorkflow?.(wf) === false;
 }
 

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -146,6 +146,11 @@ export function isPrUrl(candidate: string): boolean {
   // Deliberately NOT host-restricted: crew re-derives this url from the run's own git remote
   // (deliver.ts), GitHub Enterprise is a real deployment, and an allowlist here would be a second,
   // weaker copy of a decision that belongs server-side. This validates SHAPE, not provenance.
+  // `/pull/new/` is REJECTED outright, not merely out-shaped (Copilot on #125). The end-anchored
+  // test alone lets a crafted path through — `…/pull/new/pull/5` ends in `/pull/5` and would be
+  // rendered as "PR open" with a link to a create-PR form. That form is the exact trap the
+  // operator hit first in the raw transcript, so it is refused by name rather than by shape.
+  if (parsed.pathname.includes('/pull/new/')) return false;
   return parsed.protocol === 'https:' && /\/pull\/\d+$/.test(parsed.pathname);
 }
 

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -184,7 +184,15 @@ export interface ResolvedDelivery extends Delivery {
  */
 export function resolveDelivery(d: Delivery, readUrl: string | null = null): ResolvedDelivery {
   if (d.state !== 'delivered') return { ...d, claim: d.state, href: null };
-  const href = d.url ?? readUrl;
+  // Empty is absent — the third member of the same class already normalized at
+  // `Delivery.reason` and in `store/delivery.ts`. `deliveryOf` maps an empty
+  // `session.delivery.url` to `null` at the derivation, but this function is
+  // exported and takes a hand-built `Delivery`, and `'' ?? readUrl` keeps the
+  // empty string: the claim would become `pr-open` in `--accent` over an
+  // `href=""` link that points at the app itself. The ONE invariant this module
+  // exists to hold is re-checked here rather than trusted from upstream.
+  const candidate = d.url ?? readUrl;
+  const href = candidate === null || candidate === '' ? null : candidate;
   return { ...d, claim: href === null ? 'delivered' : 'pr-open', href };
 }
 

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -1,0 +1,146 @@
+import type { SessionView, SessionWithDelivery, WorkUnit } from '../api/types.js';
+
+/**
+ * Delivery — the one derivation every surface reads (wicked-studio#122, slice DA).
+ *
+ * A run that opened a PR never said so anywhere in studio: the URL existed only
+ * as raw `git push` console text ~4500px down the Units tab, under a LARGER and
+ * WRONG `…/pull/new/…` create-PR link. This module is the whole answer, and it
+ * is deliberately pure — no React, no fetch — so the project page, the build run
+ * list and the run's right panel all derive the same fact from the DTO they
+ * already hold. **Zero requests on any list surface** is the standing rule; the
+ * one sanctioned per-run fetch lives in `src/store/delivery.ts` and fires only
+ * for a run that actually delivered.
+ *
+ * Wire truth this rests on (verified against api-types 0.8.0 + the live daemon):
+ *  - `WorkUnit` has NO `output` member at all — transcripts are a separate GET,
+ *    and inlining them into `GET /runs` would make the list endpoint O(all
+ *    transcript bytes). Nothing here reads a transcript.
+ *  - `units[].denial_reason` already carries crew#318's message on the LIST
+ *    wire, so "why did it deliver nothing" costs nothing.
+ *  - The deliver unit is found by its id suffix, never by `session.workflow_id`
+ *    (EC61): the composed `<base>-deliver-<runId>` id exists only when crew
+ *    composes the phase, and run 5c5e08b7 delivered through a `feature-pr`
+ *    OVERLAY whose workflow id is plain. `tool_cmd` is the overlay's fallback.
+ */
+
+/**
+ * What this run's delivery is, as five mutually exclusive facts.
+ *
+ *  - `delivered` — the deliver phase was APPROVED (`done`). It is not "shipped"
+ *    and it is not "merged": the phase opens a PR and stops, by design.
+ *  - `nothing-to-deliver` — denied because the run committed nothing (crew#318).
+ *  - `failed` — denied for any other reason; the reason is rendered verbatim.
+ *  - `in-flight` — the deliver phase has not resolved (`pending`/`distributed`).
+ *  - `none` — this run has no deliver phase at all.
+ */
+export type DeliveryState = 'none' | 'in-flight' | 'delivered' | 'nothing-to-deliver' | 'failed';
+
+export interface Delivery {
+  state: DeliveryState;
+  /**
+   * The deliver unit's FULL id, which is also the `unitKey` the output route
+   * resolves (its most-specific pass matches `u.id === unitKey` — so an
+   * overlay-named phase needs no key guessing, EC61). `null` when `state` is
+   * `'none'`.
+   */
+  unitId: string | null;
+  /** `denial_reason` VERBATIM off the list wire — never re-worded, never synthesized. */
+  reason: string | null;
+  /**
+   * The PR url when the SERVER carries it (`session.delivery`, wicked-crew#321).
+   * `null` on today's daemon, which is what the one per-run transcript fetch is
+   * for; when crew ships the field this goes non-null and the fetch stops firing.
+   */
+  url: string | null;
+}
+
+/** crew#318's refusal, matched ONLY to classify — the message itself renders verbatim. */
+const NOTHING_TO_DELIVER = /nothing to deliver/i;
+
+/**
+ * The PR url in a deliver transcript — crew's own grep, mirrored
+ * (`packages/crew/src/core/deliver.ts:162`: `grep -Eo
+ * 'https://[^[:space:]]+/pull/[0-9]+' | tail -1`).
+ *
+ * Requiring the DIGITS is the entire point: `https://…/pull/new/wicked/<run>`
+ * — the create-PR form git prints on every push — appears FIRST and reads like
+ * the answer. It is a trap, and this regex cannot match it. The LAST match wins,
+ * same as crew's `tail -1`.
+ */
+export function prUrlFrom(text: string): string | null {
+  const matches = text.match(/https:\/\/\S+\/pull\/\d+/g);
+  return matches === null ? null : (matches[matches.length - 1] ?? null);
+}
+
+/**
+ * This run's deliver unit, or `null`. The id suffix is the primary key; the
+ * `tool_cmd` probe is the fallback for an operator overlay that named its phase
+ * something else (`tool_cmd` is optional on the wire, so a miss degrades to
+ * `'none'` — silent, never wrong).
+ */
+export function deliverUnit(view: SessionView): WorkUnit | null {
+  const byId = view.units.find((u) => u.id.endsWith(':deliver'));
+  if (byId !== undefined) return byId;
+  return view.units.find((u) => (u.tool_cmd ?? []).join(' ').includes('gh pr create')) ?? null;
+}
+
+/** The whole derivation, from the DTO the caller already holds. Never fetches. */
+export function deliveryOf(view: SessionView): Delivery {
+  const unit = deliverUnit(view);
+  if (unit === null) return { state: 'none', unitId: null, reason: null, url: null };
+
+  const reason = unit.denial_reason;
+  const state: DeliveryState =
+    unit.status === 'done' ? 'delivered'
+    : unit.status === 'rejected'
+      ? (reason !== null && NOTHING_TO_DELIVER.test(reason) ? 'nothing-to-deliver' : 'failed')
+      : 'in-flight';
+
+  // `session.delivery` is declared in ../api/types.js, not in the installed
+  // api-types — the cast is the honest spelling until studio bumps (see there).
+  const declared = (view.session as SessionWithDelivery).delivery;
+  const url = typeof declared?.url === 'string' && declared.url !== '' ? declared.url : null;
+
+  return { state, unitId: unit.id, reason, url };
+}
+
+/** The badge/chip word per state — `'none'` has nothing to say and says nothing. */
+export const DELIVERY_LABEL: Record<DeliveryState, string> = {
+  'none':               '',
+  // Never "in flight": a cancelled run's deliver unit is `pending` forever, and
+  // the word would claim motion that stopped. "pending" is true either way.
+  'in-flight':          'pending',
+  'delivered':          'PR open',
+  'nothing-to-deliver': 'nothing delivered',
+  'failed':             'deliver failed',
+};
+
+/** Token per state — failure is `--status-fail`, delivery is the accent, never green-as-shipped. */
+export const DELIVERY_COLOR: Record<DeliveryState, string> = {
+  'none':               'var(--ink-dim)',
+  'in-flight':          'var(--ink-muted)',
+  'delivered':          'var(--accent)',
+  'nothing-to-deliver': 'var(--status-fail)',
+  'failed':             'var(--status-fail)',
+};
+
+/**
+ * The project-page summary over ALL runs (never the MAX_ROWS window — run
+ * 665a9aeb, the one that delivered nothing while reading as the most productive
+ * run in the project, is not in the visible six).
+ */
+export function deliverySummary(views: readonly SessionView[]): string {
+  const counts: Record<DeliveryState, number> = {
+    'none': 0, 'in-flight': 0, 'delivered': 0, 'nothing-to-deliver': 0, 'failed': 0,
+  };
+  for (const v of views) counts[deliveryOf(v).state] += 1;
+
+  const parts: string[] = [];
+  if (counts['delivered'] > 0) parts.push(`${counts['delivered']} delivered`);
+  if (counts['nothing-to-deliver'] > 0) parts.push(`${counts['nothing-to-deliver']} delivered nothing`);
+  if (counts['failed'] > 0) parts.push(`${counts['failed']} failed to deliver`);
+  if (counts['in-flight'] > 0) parts.push(`${counts['in-flight']} still to deliver`);
+  if (counts['none'] > 0) parts.push(`${counts['none']} no deliver phase`);
+  return parts.join(' · ');
+}

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -1,4 +1,5 @@
 import type { SessionView, SessionWithDelivery, WorkUnit } from '../api/types.js';
+import { runKindOf } from './runMode.js';
 
 /**
  * Delivery — the one derivation every surface reads (wicked-studio#122, slice DA).
@@ -11,6 +12,24 @@ import type { SessionView, SessionWithDelivery, WorkUnit } from '../api/types.js
  * already hold. **Zero requests on any list surface** is the standing rule; the
  * one sanctioned per-run fetch lives in `src/store/delivery.ts` and fires only
  * for a run that actually delivered.
+ *
+ * ── THE RULE THIS MODULE ENFORCES ────────────────────────────────────────────
+ * **Claiming "a PR is open" requires a URL IN HAND. `status === 'done'` alone
+ * supports only "the deliver phase ran."**
+ *
+ * `done` means crew APPROVED the deliver phase, and that is all it means. Only a
+ * post-crew#318 daemon fails the phase when there was nothing to deliver, so an
+ * older run can be `done` having pushed a branch and opened no PR at all — run
+ * 665a9aeb is exactly that: deliver unit `done`, `denial_reason: null`, and a
+ * 677-byte transcript with ZERO `/pull/\d+` matches and one `/pull/new/` form.
+ * The first cut of this slice rendered "PR open" for precisely the run whose
+ * false productivity signal it was written to remove.
+ *
+ * So the derivation stops at {@link DeliveryState} (the PHASE fact, free off the
+ * list wire) and the CLAIM is a second, url-aware step — {@link resolveDelivery}
+ * — which every rendering surface goes through. Nothing may read
+ * `DELIVERY_LABEL` off a bare `DeliveryState`; the map is keyed by
+ * {@link DeliveryClaim} so that spelling does not typecheck.
  *
  * Wire truth this rests on (verified against api-types 0.8.0 + the live daemon):
  *  - `WorkUnit` has NO `output` member at all — transcripts are a separate GET,
@@ -25,16 +44,31 @@ import type { SessionView, SessionWithDelivery, WorkUnit } from '../api/types.js
  */
 
 /**
- * What this run's delivery is, as five mutually exclusive facts.
+ * What this run's deliver PHASE is, as five mutually exclusive facts. This is
+ * the phase, never the artifact — see {@link DeliveryClaim} for what a surface
+ * is allowed to say out loud.
  *
- *  - `delivered` — the deliver phase was APPROVED (`done`). It is not "shipped"
- *    and it is not "merged": the phase opens a PR and stops, by design.
+ *  - `delivered` — the deliver phase was APPROVED (`done`). It is not "a PR",
+ *    it is not "shipped" and it is not "merged".
  *  - `nothing-to-deliver` — denied because the run committed nothing (crew#318).
  *  - `failed` — denied for any other reason; the reason is rendered verbatim.
  *  - `in-flight` — the deliver phase has not resolved (`pending`/`distributed`).
  *  - `none` — this run has no deliver phase at all.
  */
 export type DeliveryState = 'none' | 'in-flight' | 'delivered' | 'nothing-to-deliver' | 'failed';
+
+/**
+ * What a surface may SAY — {@link DeliveryState} with `delivered` split by the
+ * only thing that licenses the PR claim: whether a url is in hand.
+ *
+ *  - `pr-open` — a url is in hand (`session.delivery.url` off the wire, or the
+ *    one transcript read the rail body makes). This alone earns the PR claim,
+ *    the accent token and a link.
+ *  - `delivered` — the phase was approved and NO url is known here. Every
+ *    zero-fetch list surface lives in this arm, and so does a detail view whose
+ *    read came back without a url. The wording describes the phase.
+ */
+export type DeliveryClaim = DeliveryState | 'pr-open';
 
 export interface Delivery {
   state: DeliveryState;
@@ -45,7 +79,14 @@ export interface Delivery {
    * `'none'`.
    */
   unitId: string | null;
-  /** `denial_reason` VERBATIM off the list wire — never re-worded, never synthesized. */
+  /**
+   * `denial_reason` VERBATIM off the list wire — never re-worded, never
+   * synthesized. An EMPTY string normalizes to `null` here (the same
+   * absent-and-empty-are-one-thing class of bug already fixed in
+   * `store/delivery.ts`): `reason ?? '…'` keeps `''` and the panel paints a
+   * blank red paragraph where crew's message belongs. One normalization, at
+   * the derivation, so no surface has to remember.
+   */
   reason: string | null;
   /**
    * The PR url when the SERVER carries it (`session.delivery`, wicked-crew#321).
@@ -74,6 +115,22 @@ export function prUrlFrom(text: string): string | null {
 }
 
 /**
+ * `gh pr create` INVOKED, not merely mentioned.
+ *
+ * A bare `.includes('gh pr create')` matched any unit whose joined command
+ * contains the string anywhere — `grep -rn 'gh pr create' docs/`, `echo "run gh
+ * pr create yourself"`, a heredoc of instructions — and any one of those would
+ * have masqueraded as the run's deliver phase and inherited its whole claim.
+ * The invocation is anchored instead: `gh` must start the string or follow a
+ * shell command separator (`;`, `&&`, `||`, a pipe, a newline, a subshell open).
+ * Quoted mentions are preceded by a quote, so they cannot match.
+ *
+ * Verified against the two real deliver commands on the live daemon: both run it
+ * after `;`/newline (`… git push -u origin "$B"; gh pr create --head "$B" --fill`).
+ */
+const INVOKES_GH_PR_CREATE = /(?:^|[;&|(\n])\s*(?:sudo\s+|env\s+\S+=\S+\s+)*gh\s+pr\s+create\b/;
+
+/**
  * This run's deliver unit, or `null`. The id suffix is the primary key; the
  * `tool_cmd` probe is the fallback for an operator overlay that named its phase
  * something else (`tool_cmd` is optional on the wire, so a miss degrades to
@@ -82,7 +139,7 @@ export function prUrlFrom(text: string): string | null {
 export function deliverUnit(view: SessionView): WorkUnit | null {
   const byId = view.units.find((u) => u.id.endsWith(':deliver'));
   if (byId !== undefined) return byId;
-  return view.units.find((u) => (u.tool_cmd ?? []).join(' ').includes('gh pr create')) ?? null;
+  return view.units.find((u) => INVOKES_GH_PR_CREATE.test((u.tool_cmd ?? []).join(' '))) ?? null;
 }
 
 /** The whole derivation, from the DTO the caller already holds. Never fetches. */
@@ -90,7 +147,8 @@ export function deliveryOf(view: SessionView): Delivery {
   const unit = deliverUnit(view);
   if (unit === null) return { state: 'none', unitId: null, reason: null, url: null };
 
-  const reason = unit.denial_reason;
+  // Absent and empty are the same "crew recorded nothing" — see `Delivery.reason`.
+  const reason = unit.denial_reason === '' ? null : unit.denial_reason;
   const state: DeliveryState =
     unit.status === 'done' ? 'delivered'
     : unit.status === 'rejected'
@@ -105,42 +163,119 @@ export function deliveryOf(view: SessionView): Delivery {
   return { state, unitId: unit.id, reason, url };
 }
 
-/** The badge/chip word per state — `'none'` has nothing to say and says nothing. */
-export const DELIVERY_LABEL: Record<DeliveryState, string> = {
+/** A {@link Delivery} plus the claim it licenses and the url that licensed it. */
+export interface ResolvedDelivery extends Delivery {
+  /** What the surface may say. See {@link DeliveryClaim}. */
+  claim: DeliveryClaim;
+  /** The PR url in hand, wire-carried or read — `null` unless `claim` is `'pr-open'`. */
+  href: string | null;
+}
+
+/**
+ * The claim step. **Every rendering surface goes through this**, so the badge on
+ * a section header and the body inside it cannot say different things (D1: the
+ * badge derived from `deliveryOf` alone and painted "PR open" in `--accent`
+ * while the body it sat on said no PR link was recorded).
+ *
+ * @param d        the phase fact, from {@link deliveryOf}.
+ * @param readUrl  a url recovered by the ONE sanctioned per-run transcript read
+ *                 (`store/delivery.ts`). Omit it — as every zero-fetch list
+ *                 surface does — and the delivered arm stays phase-only.
+ */
+export function resolveDelivery(d: Delivery, readUrl: string | null = null): ResolvedDelivery {
+  if (d.state !== 'delivered') return { ...d, claim: d.state, href: null };
+  const href = d.url ?? readUrl;
+  return { ...d, claim: href === null ? 'delivered' : 'pr-open', href };
+}
+
+/**
+ * The badge/chip word per CLAIM — `'none'` has nothing to say and says nothing.
+ *
+ * `'delivered'` is the honest half of the split: crew approved the phase and no
+ * url is in hand, so the word names the PHASE and stops. It must not read as a
+ * failure either — a pre-crew#318 run whose deliver phase completed is not a
+ * failure, it is simply not evidence of a PR — which is why it stays neutral in
+ * {@link DELIVERY_COLOR} rather than borrowing `--status-fail`.
+ */
+export const DELIVERY_LABEL: Record<DeliveryClaim, string> = {
   'none':               '',
   // Never "in flight": a cancelled run's deliver unit is `pending` forever, and
-  // the word would claim motion that stopped. "pending" is true either way.
+  // the word would claim motion that stopped. "pending" is true either way. All
+  // 12 `distributed` deliver units in the live corpus sit in terminal sessions
+  // (10 cancelled, 2 failed) — not one of them is going to move again.
   'in-flight':          'pending',
-  'delivered':          'PR open',
+  'delivered':          'deliver ran',
+  'pr-open':            'PR open',
   'nothing-to-deliver': 'nothing delivered',
   'failed':             'deliver failed',
 };
 
-/** Token per state — failure is `--status-fail`, delivery is the accent, never green-as-shipped. */
-export const DELIVERY_COLOR: Record<DeliveryState, string> = {
+/**
+ * Token per claim — failure is `--status-fail`, an actual PR is the accent,
+ * never green-as-shipped. The phase-only `'delivered'` is deliberately MUTED:
+ * accent would read as the PR claim the wording just declined to make, and
+ * `--status-fail` would call a completed phase a failure.
+ */
+export const DELIVERY_COLOR: Record<DeliveryClaim, string> = {
   'none':               'var(--ink-dim)',
   'in-flight':          'var(--ink-muted)',
-  'delivered':          'var(--accent)',
+  'delivered':          'var(--ink-muted)',
+  'pr-open':            'var(--accent)',
   'nothing-to-deliver': 'var(--status-fail)',
   'failed':             'var(--status-fail)',
 };
 
 /**
- * The project-page summary over ALL runs (never the MAX_ROWS window — run
- * 665a9aeb, the one that delivered nothing while reading as the most productive
- * run in the project, is not in the visible six).
+ * Can this run deliver at all? The ONE predicate behind both the rail's Delivery
+ * section and the project census, so the two surfaces cannot disagree about what
+ * a deliverable run is (D5: the rail hid Delivery from chat threads while the
+ * census counted every one of them under "no deliver phase", and a chat-heavy
+ * project read "3 delivered · 30 no deliver phase" — a number about chats,
+ * dressed as a delivery finding).
+ *
+ * It reuses studio#124's `runKindOf` rather than re-deriving a chat test: that
+ * helper is already the composer's own answer to "may this run carry
+ * `deliver: 'pr'`", and only `'build'` may. `'system'` (chat, onboarding,
+ * survey-repo, …) is machine-owned work the launch form hides; `'freeform'`
+ * carries no workflow at all and `deliver` without `workflow` is a 400
+ * (api-types index.d.ts:955-956). Neither can ever produce a PR, so neither
+ * gets a Delivery surface or a line in the census.
+ *
+ * This is a VISIBILITY gate, not a wire read: {@link deliveryOf} stays
+ * indifferent to `session.workflow_id` (EC61).
+ */
+export function canDeliver(view: SessionView): boolean {
+  return runKindOf(view.session.workflow_id) === 'build';
+}
+
+/**
+ * The project-page census over ALL deliverable runs (never the MAX_ROWS window —
+ * run 665a9aeb, the one that read as the most productive in the project while
+ * delivering nothing, is not in the visible six).
+ *
+ * Chats and the other non-deliverable kinds are filtered out entirely, per
+ * {@link canDeliver}. Wording tracks {@link DELIVERY_LABEL} exactly: the
+ * `in-flight` bucket says "deliver pending", never "still to deliver" — the
+ * label refuses forward-looking words because a cancelled run's unit stays
+ * `pending` forever, and the census may not smuggle them back in (D3).
  */
 export function deliverySummary(views: readonly SessionView[]): string {
-  const counts: Record<DeliveryState, number> = {
-    'none': 0, 'in-flight': 0, 'delivered': 0, 'nothing-to-deliver': 0, 'failed': 0,
+  const counts: Record<DeliveryClaim, number> = {
+    'none': 0, 'in-flight': 0, 'delivered': 0, 'pr-open': 0, 'nothing-to-deliver': 0, 'failed': 0,
   };
-  for (const v of views) counts[deliveryOf(v).state] += 1;
+  for (const v of views) {
+    if (!canDeliver(v)) continue;
+    // No `readUrl`: the census is a list surface and fires zero requests, so the
+    // only url it can ever see is the wire-carried one (crew#321).
+    counts[resolveDelivery(deliveryOf(v)).claim] += 1;
+  }
 
   const parts: string[] = [];
-  if (counts['delivered'] > 0) parts.push(`${counts['delivered']} delivered`);
+  if (counts['pr-open'] > 0) parts.push(`${counts['pr-open']} PR open`);
+  if (counts['delivered'] > 0) parts.push(`${counts['delivered']} ran deliver`);
   if (counts['nothing-to-deliver'] > 0) parts.push(`${counts['nothing-to-deliver']} delivered nothing`);
   if (counts['failed'] > 0) parts.push(`${counts['failed']} failed to deliver`);
-  if (counts['in-flight'] > 0) parts.push(`${counts['in-flight']} still to deliver`);
+  if (counts['in-flight'] > 0) parts.push(`${counts['in-flight']} deliver pending`);
   if (counts['none'] > 0) parts.push(`${counts['none']} no deliver phase`);
   return parts.join(' · ');
 }

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -241,28 +241,56 @@ export const DELIVERY_COLOR: Record<DeliveryClaim, string> = {
  * project read "3 delivered · 30 no deliver phase" — a number about chats,
  * dressed as a delivery finding).
  *
- * It calls studio#124's `deliverKindOf` — literally the same function the
- * COMPOSER classifies with, not a second copy of the rule (D-1: the composer
- * read `is_system` and this predicate read a five-id denylist, so `collab` and
- * every `interactive-*` were 'system' there and 'build' here). Only `'build'`
- * may deliver. `'system'` is machine-owned work the launch form hides;
- * `'freeform'` carries no workflow at all and `deliver` without `workflow` is a
- * 400 (api-types index.d.ts:955-956). Neither can ever produce a PR, so neither
- * gets a Delivery surface or a line in the census.
+ * ── EVIDENCE FIRST, CLASSIFICATION SECOND ────────────────────────────────────
+ * **A run that HAS a deliver phase is deliverable — it demonstrably delivered,
+ * whatever its workflow id says. A run that has NONE is deliverable only when
+ * its workflow is POSITIVELY KNOWN not to be a system workflow.**
+ *
+ * The two arms are asymmetric on purpose, because the two claims cost different
+ * things:
+ *
+ *  - The delivering arms (delivered / pr-open / nothing-to-deliver / failed /
+ *    in-flight) are read off the run's OWN units and are true no matter what
+ *    composed them. Gating them on the catalog would hide a REAL PR: run
+ *    5c5e08b7 opened one, and its `workflow_id` is `wf-5c5e08b7-…`, a
+ *    materialised per-run def that `GET /workflows` does not serve. So this arm
+ *    ignores the lookup entirely.
+ *  - `'none'` is a CLAIM ABOUT A CLASSIFICATION — "this run has no deliver
+ *    phase" is only worth saying about a run that could have had one. On the
+ *    live corpus 86 of 129 runs carry a materialised `wf-<runId>`, which is in
+ *    no catalog, so the lookup answers `undefined` for them PERMANENTLY. The
+ *    denylist then called every one of them build work and 30 interactive
+ *    document threads grew a Delivery section reading "This run has no deliver
+ *    phase", with a project whose census line said, in full, "8 no deliver
+ *    phase" — a number about documents, dressed as a delivery finding. That is
+ *    D5 again, and the first `is_system` fix did not touch it because it never
+ *    reaches a def at all.
+ *
+ * So the `'none'` arm takes the SAME licence the remedy line has always taken:
+ * `is_system === false` — a def IN HAND that carries no flag. `undefined` is not
+ * a licence. Never assert what the wire cannot evidence; where studio cannot
+ * classify the run, it says nothing rather than a sentence about documents.
+ *
+ * {@link deliverKindOf} still fronts it — literally the same function the
+ * COMPOSER classifies with, not a second copy of the rule (D-1) — so a
+ * denylisted id stays 'system' even if a def turns up without the flag, and
+ * `'freeform'` (no workflow at all; `deliver` without `workflow` is a 400,
+ * api-types index.d.ts:955-956) stays out.
  *
  * @param isSystemWorkflow the AUTHORITATIVE `is_system` lookup, three-valued —
  *   see {@link IsSystemWorkflow}. This module stays PURE and table-testable: it
  *   imports no store and fires no fetch, so the caller (which has React) passes
- *   `store/workflowCache.useIsSystemWorkflow()`. Omitted, the derivation falls
- *   back to the denylist, which can only ever over-report deliverability — so a
- *   caller that renders a REMEDY must additionally require a positively-known
- *   def before saying it out loud (see `RunDelivery`).
+ *   `store/workflowCache.useIsSystemWorkflow()`. Omitted — or answering
+ *   `undefined`, which is the same thing — no run without a deliver phase is
+ *   deliverable. The predicate can only ever WITHHOLD, never invent.
  *
- * This is a VISIBILITY gate, not a wire read: {@link deliveryOf} stays
- * indifferent to `session.workflow_id` (EC61).
+ * The classification half is a VISIBILITY gate, not a wire read: {@link
+ * deliveryOf} stays indifferent to `session.workflow_id` (EC61).
  */
 export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflow): boolean {
-  return deliverKindOf(view.session.workflow_id, isSystemWorkflow) === 'build';
+  if (deliveryOf(view).state !== 'none') return true;
+  const wf = view.session.workflow_id?.trim() ?? '';
+  return deliverKindOf(wf, isSystemWorkflow) === 'build' && isSystemWorkflow?.(wf) === false;
 }
 
 /**
@@ -274,7 +302,14 @@ export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflo
  * {@link canDeliver} — pass the SAME `isSystemWorkflow` lookup the rail uses, or
  * the six ids the denylist misses (`collab`, the five `interactive-*`) come back
  * as "no deliver phase" and the D5 complaint is recreated for the document and
- * video threads. Wording tracks {@link DELIVERY_LABEL} exactly: the
+ * video threads.
+ *
+ * The "no deliver phase" bucket is the one that can lie, and it is the one
+ * {@link canDeliver} now withholds: a run studio cannot positively classify is
+ * not counted at all, so the bucket only ever counts runs that could have
+ * delivered and didn't. The delivering buckets count every run that has a
+ * deliver phase, catalog or not — a materialised `wf-<runId>` def hides nothing.
+ * Wording tracks {@link DELIVERY_LABEL} exactly: the
  * `in-flight` bucket says "deliver pending", never "still to deliver" — the
  * label refuses forward-looking words because a cancelled run's unit stays
  * `pending` forever, and the census may not smuggle them back in (D3).

--- a/src/components/runMode.ts
+++ b/src/components/runMode.ts
@@ -7,7 +7,17 @@ export const MODE_LABELS: Record<RunMode, string> = {
   autonomous: 'Autonomous',
 };
 
-// Defense-in-depth denylist: catches system workflows that predate the is_system flag.
+/**
+ * Defense-in-depth denylist: catches system workflows that predate the
+ * `is_system` flag, and covers the window before the defs have loaded.
+ *
+ * It is a FALLBACK and nothing more — never the answer when a def is in hand.
+ * The live daemon serves ELEVEN system workflows and this list names five, so
+ * on its own it classifies `collab` and every `interactive-*` (the document and
+ * video seams) as build work. That was studio#122 D-1: the rail offered
+ * "launch with deliver: pr" on an interactive thread, a remedy the composer —
+ * which reads `is_system` — refuses. Use {@link deliverKindOf}, not this set.
+ */
 export const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
 
 /**
@@ -30,4 +40,45 @@ export function runKindOf(workflowId: string | null | undefined): RunKind {
   const wf = workflowId?.trim() ?? '';
   if (wf === '') return 'freeform';
   return SYSTEM_WORKFLOW_IDS.has(wf) ? 'system' : 'build';
+}
+
+/**
+ * `is_system` for one workflow id, three-valued: `true`/`false` when the def is
+ * known, `undefined` when it is not (defs still loading, fetch degraded, or the
+ * id is absent from the list). `store/workflowCache.isSystemWorkflowIn` is the
+ * implementation every surface actually passes.
+ */
+export type IsSystemWorkflow = (id: string) => boolean | undefined;
+
+/**
+ * **THE run-kind predicate — the ONE definition, for every surface.**
+ *
+ * There were two, and they disagreed (studio#122 D-1). The composer carried its
+ * own copy that read `is_system` off the fetched defs; `canDeliver` called
+ * `runKindOf`, which knows only the five-id denylist. So a run on `collab` or
+ * any `interactive-*` classified 'build' on the delivery surfaces and 'system'
+ * in the composer, and the rail told the operator to "launch with deliver: pr"
+ * on a workflow the composer would refuse to launch that way. Both slices call
+ * THIS function now, so they cannot re-fork.
+ *
+ * The layering:
+ *  - `''`/absent ⇒ 'freeform'. `deliver` without `workflow` is a 400
+ *    (api-types index.d.ts:955-956), so it can never carry one.
+ *  - a positively-known `is_system: true` ⇒ 'system'. The flag ALWAYS wins.
+ *  - anything else ⇒ {@link runKindOf}, the denylist, as honest
+ *    defense-in-depth for pre-flag workflows.
+ *
+ * Deliberately ONE-DIRECTIONAL (studio#124's rule, preserved verbatim): a
+ * positively-known flag DEMOTES to 'system', but a missing or unknown def NEVER
+ * promotes to 'build' — it falls back to the denylist verdict. This function can
+ * only ever withhold delivery, never add it.
+ */
+export function deliverKindOf(
+  workflowId: string | null | undefined,
+  isSystemWorkflow?: IsSystemWorkflow,
+): RunKind {
+  const wf = workflowId?.trim() ?? '';
+  const fallback = runKindOf(wf);
+  if (fallback !== 'build') return fallback;
+  return isSystemWorkflow?.(wf) === true ? 'system' : 'build';
 }

--- a/src/store/delivery.ts
+++ b/src/store/delivery.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+import { prUrlFrom } from '../components/delivery.js';
+
+/**
+ * The delivered run's PR url — the ONE sanctioned per-run fetch (studio#122, EC59).
+ *
+ * `WorkUnit` carries no transcript (deliberately: `GET /runs` assembles every
+ * run's detail, so inlining output would make the list endpoint O(all transcript
+ * bytes)), so the url a delivered run printed lives behind
+ * `GET /runs/:id/units/:unitKey/output` — the call studio already has
+ * (`api.getUnitOutput`). This store holds one resolved {@link DeliveryUrl} per
+ * run id, on exactly the posture `store/provenance.ts` set:
+ *
+ *  - ONE fetch per delivered run, cached per run id, in-flight-deduped.
+ *  - A failed fetch caches the degraded answer too: revisits never re-fire.
+ *  - LIST SURFACES NEVER CALL THIS. The project page and the build run list are
+ *    DTO-derived and fire zero requests — an N-run fan-out is exactly what
+ *    CREW-UX-8 (`session.delivery`) exists to make unnecessary, and when that
+ *    field lands `load` is never reached at all.
+ *
+ * Call it ONLY for `state === 'delivered'`. A `rejected` deliver unit has NO
+ * stored transcript BY DESIGN — deny-dominates writes no `work_output` past a
+ * deny — so fetching for a failure asks a question the wire already answered
+ * with `denial_reason`.
+ */
+export interface DeliveryUrl {
+  /** The PR url from the transcript, or `null` when it carries none. */
+  url: string | null;
+  /**
+   * The daemon's OWN reason the transcript is absent (`outputUnavailable`), or a
+   * client-side "unreachable" note. `null` when the read succeeded — in which
+   * case a `null` url is itself the honest answer: the deliver phase reported
+   * done and printed no PR url (run 665a9aeb, the empty-branch push crew#317
+   * describes). Never rendered as a link, never rendered as "Delivered" alone.
+   */
+  unavailable: string | null;
+}
+
+interface DeliveryStore {
+  /** Resolved url per run id. An ABSENT key = not read yet (never "no url"). */
+  byRun: Record<string, DeliveryUrl>;
+  /** The one output fetch per delivered run; cached + in-flight-deduped. */
+  load: (runId: string, unitKey: string) => void;
+}
+
+/** In-flight guard so a re-render during the fetch never doubles it. */
+const inflight = new Set<string>();
+
+export const useDeliveryStore = create<DeliveryStore>((set, get) => ({
+  byRun: {},
+
+  load: (runId, unitKey) => {
+    if (get().byRun[runId] !== undefined || inflight.has(runId)) return;
+    inflight.add(runId);
+    api
+      .getUnitOutput(runId, unitKey)
+      .then(({ output, outputUnavailable }) => {
+        set((s) => ({
+          byRun: {
+            ...s.byRun,
+            [runId]: {
+              url: output === null ? null : prUrlFrom(output),
+              unavailable: outputUnavailable ?? null,
+            },
+          },
+        }));
+      })
+      .catch(() => {
+        // Daemon unreachable / route absent — the degraded answer is cached too,
+        // so the one-fetch-per-run budget holds on revisit (ConnectionStatus owns
+        // reporting the outage; this line just stays honest about the link).
+        set((s) => ({
+          byRun: {
+            ...s.byRun,
+            [runId]: { url: null, unavailable: 'the deliver phase transcript could not be read' },
+          },
+        }));
+      })
+      .finally(() => {
+        inflight.delete(runId);
+      });
+  },
+}));

--- a/src/store/delivery.ts
+++ b/src/store/delivery.ts
@@ -61,7 +61,12 @@ export const useDeliveryStore = create<DeliveryStore>((set, get) => ({
             ...s.byRun,
             [runId]: {
               url: output === null ? null : prUrlFrom(output),
-              unavailable: outputUnavailable ?? null,
+              // `??` alone would keep an EMPTY `outputUnavailable` and the panel
+              // would render a blank line where the daemon's reason belongs —
+              // absent and empty are the same "nothing to say" here, and the
+              // caller's own sentence is the honest fallback for both.
+              unavailable:
+                outputUnavailable !== undefined && outputUnavailable !== '' ? outputUnavailable : null,
             },
           },
         }));

--- a/src/store/workflowCache.ts
+++ b/src/store/workflowCache.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { api } from '../api/client.js';
+import type { WorkflowDef } from '../api/types.js';
+
+/**
+ * The workflow-def cache — `is_system` for the whole app, at O(1) requests
+ * (wicked-studio#122 D-1).
+ *
+ * `is_system` is the AUTHORITATIVE answer to "may this run deliver a PR", and
+ * before this module only the composer had it: `runMode.SYSTEM_WORKFLOW_IDS`
+ * listed five ids while the live daemon serves ELEVEN system workflows, so
+ * `collab` and all five `interactive-*` (the document and video seams — the
+ * most-used non-build flows) classified as build work everywhere the composer
+ * was not. The rail then offered "launch with deliver: pr" on an interactive
+ * thread — a remedy studio's OWN composer refuses — and the project census
+ * counted those threads under "no deliver phase".
+ *
+ * Shape, deliberately the two house patterns already in this directory rather
+ * than a third invention:
+ *  - `rosterCache.ts` — plain module state plus deposit/subscribe, so every
+ *    surface that ALREADY fetches this list (the composer, `WorkflowViewer`)
+ *    warms it for the surfaces that only need to read it, and a React reader
+ *    re-renders when the deposit lands.
+ *  - `repoCache.ts` / `store/delivery.ts` — fetch-once, in-flight-deduped, and
+ *    the DEGRADED answer is cached too, so an older daemon with no `/workflows`
+ *    surface is asked exactly once and then left alone.
+ *
+ * **The budget is the point: at most ONE `GET /workflows` per session, however
+ * many surfaces ask and however many runs they render.** A list surface
+ * rendering 120 rows fires one request, not 120 — the guards below are module
+ * state, not component state, and the per-row chips read no defs at all.
+ */
+
+/** The defs the app has fetched, or `null` when none have landed. */
+let cached: WorkflowDef[] | null = null;
+/** The one in-flight GET, shared by every cold caller. */
+let inFlight: Promise<void> | null = null;
+/**
+ * Has the app already asked? Set by a deposit AND by a failure, so a daemon
+ * that has no `/workflows` route is asked once per session and never again
+ * (the same "cache the degraded answer" posture as `store/delivery.ts`).
+ */
+let attempted = false;
+const listeners = new Set<() => void>();
+
+/** The cached defs, or `null` when nothing has been deposited yet. */
+export function getCachedWorkflows(): WorkflowDef[] | null {
+  return cached;
+}
+
+/** Deposit a freshly fetched list for later synchronous reads. */
+export function setCachedWorkflows(defs: WorkflowDef[]): void {
+  cached = defs;
+  attempted = true;
+  for (const fn of [...listeners]) fn();
+}
+
+/**
+ * Deposit notification, for `useSyncExternalStore`. The callback takes no
+ * argument (unlike `rosterCache`'s) because every reader here re-reads through
+ * {@link getCachedWorkflows}, whose identity is the snapshot.
+ */
+export function subscribeWorkflows(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/**
+ * The app-level fetch: at most once per session, whoever calls it.
+ *
+ * Degrades SILENTLY and permanently — a rejected promise (daemon unreachable,
+ * route absent) and a throwing call site (an `api` surface that has no
+ * `listWorkflows` at all) both land on `attempted = true` with the cache still
+ * `null`, which every consumer reads as "not known", never as "not a system
+ * workflow". Withholding is always the safe direction here.
+ */
+export function fetchWorkflowsCached(): void {
+  if (attempted || inFlight !== null) return;
+  try {
+    inFlight = api
+      .listWorkflows()
+      .then(({ workflows }) => {
+        setCachedWorkflows(workflows);
+      })
+      .catch(() => {
+        attempted = true;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  } catch {
+    attempted = true;
+  }
+}
+
+/**
+ * `is_system` for one workflow id, as a THREE-valued answer:
+ *
+ *  - `true`  — the def is known and flagged. The only value that may demote a
+ *              run out of 'build' (see `runMode.deliverKindOf`).
+ *  - `false` — the def is known and carries no flag. The daemon OMITS
+ *              `is_system` on ordinary workflows (verified on the live wire:
+ *              `feature`, `bug`, `migration`, `domain-extraction`,
+ *              `feature-pr`, `qe-accept-functional` have no such key), so
+ *              presence in the list — not the flag's value — is what makes
+ *              this a positive "deliverable" answer.
+ *  - `undefined` — nothing is known: the defs have not loaded, the fetch
+ *              degraded, or this id is not in the list at all.
+ */
+export function isSystemWorkflowIn(
+  defs: readonly WorkflowDef[] | null,
+  id: string,
+): boolean | undefined {
+  const def = defs?.find((w) => w.id === id);
+  return def === undefined ? undefined : def.is_system === true;
+}
+
+/** The cached defs, subscribed — and the one fetch, if nobody has made it. */
+export function useWorkflowDefs(): WorkflowDef[] | null {
+  useEffect(() => {
+    fetchWorkflowsCached();
+  }, []);
+  return useSyncExternalStore(subscribeWorkflows, getCachedWorkflows);
+}
+
+/**
+ * The lookup every delivery surface passes to `canDeliver` / `deliverySummary`
+ * / `deliverKindOf`. Stable per deposit, so a `useMemo` keyed on it recomputes
+ * exactly once when the defs land.
+ */
+export function useIsSystemWorkflow(): (id: string) => boolean | undefined {
+  const defs = useWorkflowDefs();
+  return useCallback((id: string) => isSystemWorkflowIn(defs, id), [defs]);
+}
+
+/** Test hook: return to the cold-start state. */
+export function clearCachedWorkflows(): void {
+  cached = null;
+  inFlight = null;
+  attempted = false;
+  listeners.clear();
+}

--- a/src/store/workflowCache.ts
+++ b/src/store/workflowCache.ts
@@ -41,6 +41,14 @@ let inFlight: Promise<void> | null = null;
  * (the same "cache the degraded answer" posture as `store/delivery.ts`).
  */
 let attempted = false;
+/**
+ * How many deposits have landed. Read before a fetch starts and re-read when it resolves, so an
+ * in-flight response cannot clobber a deposit that arrived while it was on the wire
+ * (Copilot on #125): the composer and `WorkflowViewer` fetch this list themselves and deposit it,
+ * and the app-level fetch may have STARTED earlier, so its answer can be the older one.
+ * Silently regressing `is_system` would re-open the exact classification hole this module closed.
+ */
+let deposits = 0;
 const listeners = new Set<() => void>();
 
 /** The cached defs, or `null` when nothing has been deposited yet. */
@@ -52,6 +60,7 @@ export function getCachedWorkflows(): WorkflowDef[] | null {
 export function setCachedWorkflows(defs: WorkflowDef[]): void {
   cached = defs;
   attempted = true;
+  deposits += 1;
   for (const fn of [...listeners]) fn();
 }
 
@@ -78,10 +87,14 @@ export function subscribeWorkflows(fn: () => void): () => void {
  */
 export function fetchWorkflowsCached(): void {
   if (attempted || inFlight !== null) return;
+  const depositsAtStart = deposits;
   try {
     inFlight = api
       .listWorkflows()
       .then(({ workflows }) => {
+        // A deposit landed while this was in flight — it is at least as fresh as this
+        // response and possibly newer, so leave it alone.
+        if (deposits !== depositsAtStart) return;
         setCachedWorkflows(workflows);
       })
       .catch(() => {
@@ -140,5 +153,6 @@ export function clearCachedWorkflows(): void {
   cached = null;
   inFlight = null;
   attempted = false;
+  deposits = 0;
   listeners.clear();
 }

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { RightPanel } from '../src/components/RightPanel.js';
 import * as client from '../src/api/client.js';
 import { useRunEventStore } from '../src/store/events.js';
@@ -405,6 +405,24 @@ describe('the rail heals a stale open section (Copilot on #125)', () => {
     fireEvent.click(screen.getByRole('button', { name: /What \/ Where/ }));
     await waitFor(() => {
       expect(document.querySelectorAll('[aria-expanded="true"]').length).toBe(0);
+    });
+  });
+
+  it('two rapid clicks toggle twice — no swallowed second click', async () => {
+    // A non-functional update read `openId` from the closure, so both clicks in one batch saw
+    // the first render's value and the second was lost (Copilot on #125, round two).
+    render(<RightPanel view={run('r-rapid', 'done')} />);
+    const header = screen.getByRole('button', { name: /What \/ Where/ });
+    // BOTH clicks inside ONE act() so React batches them — `fireEvent` on its own flushes
+    // between calls, which is why a naive two-click test cannot see this bug at all.
+    act(() => {
+      header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await waitFor(() => {
+      const open = document.querySelectorAll('[aria-expanded="true"]');
+      expect(open.length).toBe(1);
+      expect(open[0]?.textContent).toContain('What / Where');
     });
   });
 

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -391,6 +391,23 @@ describe('the rail heals a stale open section (Copilot on #125)', () => {
     expect(expanded[0]?.textContent).toContain('What / Where');
   });
 
+  it('the healed section collapses on the FIRST click, not the second', async () => {
+    // The toggle compared the RAW `openAccordion` while the rail rendered the healed `openId`,
+    // so after a run switch the visibly-open section needed two clicks to close (Copilot on #125).
+    const { rerender } = render(<RightPanel view={run('r-tog-yes', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    await screen.findByTestId('run-delivery');
+
+    rerender(<RightPanel view={makeView({ id: 'r-tog-no', workflow_id: 'chat' }, [])} />);
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Delivery/ })).toBeNull());
+
+    // What / Where is the section now showing. ONE click must close it.
+    fireEvent.click(screen.getByRole('button', { name: /What \/ Where/ }));
+    await waitFor(() => {
+      expect(document.querySelectorAll('[aria-expanded="true"]').length).toBe(0);
+    });
+  });
+
   it('a deliberately collapsed rail STAYS collapsed — null is a real state, not a stale id', async () => {
     render(<RightPanel view={run('r-stale-null', 'done')} />);
     fireEvent.click(screen.getByRole('button', { name: /What \/ Where/ }));

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -166,13 +166,17 @@ describe('the rail keeps its shape (revised EC54)', () => {
     expect(body.style.color).not.toBe('var(--status-fail)');
   });
 
-  it('EC57: a run with no deliver phase carries no badge — silence, not "unknown"', () => {
+  it('EC57: a run with no deliver phase carries no badge — silence, not "unknown"', async () => {
     const view = makeView({ id: 'r-none', workflow_id: 'feature', workdir: '/w/tree' }, [
       makeUnit({ id: 'r-none:build', session_id: 'r-none', ord: 0, status: 'done' }),
     ]);
     render(<RightPanel view={view} />);
 
-    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+    // The section itself waits for the def that proves `feature` deliverable —
+    // `tests/delivery.coldCache.test.tsx` owns that half. Once it is here, the
+    // header carries no badge: a run with no deliver phase has no state worth a
+    // chip, and silence beats an "unknown" one.
+    expect(await screen.findByRole('button', { name: /Delivery/ })).toBeInTheDocument();
     expect(screen.queryByTestId('run-delivery-badge')).not.toBeInTheDocument();
   });
 
@@ -325,13 +329,15 @@ describe('a run that delivered NOTHING (EC56)', () => {
       makeUnit({ id: 'r-nodeliver:build', session_id: 'r-nodeliver', ord: 0, status: 'done' }),
     ]);
     render(<RightPanel view={view} />);
-    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    // The SECTION waits for the defs, not just the remedy line (D-1's cold-cache
+    // invariant, tightened): "this run has no deliver phase" is a claim about a
+    // classification, so `feature` gets it only once the daemon's own flag
+    // confirms the workflow is ordinary. `tests/delivery.coldCache.test.tsx`
+    // owns the withheld half.
+    fireEvent.click(await screen.findByRole('button', { name: /Delivery/ }));
 
     const body = await screen.findByTestId('run-delivery');
     expect(body).toHaveAttribute('data-state', 'none');
-    // The remedy waits for the DEFS (D-1's cold-cache invariant): `feature` is
-    // deliverable, but studio says so only once the daemon's own flag confirms
-    // it. `tests/delivery.coldCache.test.tsx` owns the withheld half.
     await waitFor(() => expect(body).toHaveTextContent('deliver: pr'));
     expect(getUnitOutput).not.toHaveBeenCalled();
   });

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -178,6 +178,18 @@ describe('opening Delivery for a run that DID open a PR (EC55, EC59)', () => {
     expect(screen.queryByTestId('run-delivery-link')).not.toBeInTheDocument();
   });
 
+  it('an EMPTY `outputUnavailable` falls back to studio\'s sentence, never a blank line', async () => {
+    // `outputUnavailable ?? null` kept the empty string and the panel painted an
+    // empty red paragraph where the reason belongs — absent and empty both mean
+    // "the daemon said nothing", so both take the fallback.
+    getUnitOutput.mockResolvedValue({ output: null, outputUnavailable: '' });
+    render(<RightPanel view={run('r-blank', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect((await screen.findByTestId('run-delivery-nolink')).textContent)
+      .toStrictEqual('the deliver phase recorded no PR link — nothing can be pointed at');
+  });
+
   it('EC59: `outputUnavailable` renders the DAEMON\'s words, never an indefinite Loading…', async () => {
     getUnitOutput.mockResolvedValue({
       output: null,

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -7,6 +7,7 @@ import { useDeliveryStore } from '../src/store/delivery.js';
 import { useProvenanceStore } from '../src/store/provenance.js';
 import { makeUnit, makeView } from './factories.js';
 import {
+  EMPTY_PUSH_OUTPUT,
   NO_URL_REASON,
   NOTHING_REASON,
   REAL_DELIVER_OUTPUT,
@@ -17,9 +18,12 @@ import type { SessionView, UnitStatus } from '../src/api/types.js';
 /**
  * The Delivery rail section (wicked-studio#122, slice DA) under the OPERATOR's
  * amended spec (2026-08-24): "delivery isn't a top level class, it goes in the
- * right chat panel as a tab". So — a ninth accordion governed by the same
- * `openAccordion`, never a pinned band and never a tablist conversion; the
+ * right chat panel as a tab". So — a conditional last accordion governed by the
+ * same `openAccordion`, never a pinned band and never a tablist conversion; the
  * at-a-glance signal lives on the header badge instead (revised EC54).
+ *
+ * The section count is NINE on a run that can deliver and EIGHT on one that
+ * cannot. There is no fixed nine.
  */
 
 let getUnitOutput: ReturnType<typeof vi.fn>;
@@ -53,14 +57,25 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('the rail keeps its shape (revised EC54)', () => {
-  it('has exactly 9 sections and still opens on What / Where', () => {
-    render(<RightPanel view={run('r-shape', 'done')} />);
+  const sectionCount = (): number =>
+    screen.getAllByRole('button', { expanded: false })
+      .concat(screen.getAllByRole('button', { expanded: true })).length;
 
-    const headers = screen.getAllByRole('button', { expanded: false })
-      .concat(screen.getAllByRole('button', { expanded: true }));
-    expect(headers).toHaveLength(9);
+  it('the real contract: NINE sections on a build run, EIGHT on a chat thread', () => {
+    // "Exactly nine" was never the contract — Delivery is the CONDITIONAL ninth,
+    // and hiding it on threads that can never deliver is the product decision
+    // (the operator put delivery in the right panel as a tab; a chat thread has
+    // no deliver phase and never will). Both halves are pinned here so neither
+    // can drift into a fixed count.
+    render(<RightPanel view={run('r-shape', 'done')} />);
+    expect(sectionCount()).toBe(9);
     expect(screen.getByRole('button', { name: /What \/ Where/ })).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByRole('button', { name: /Delivery/ })).toHaveAttribute('aria-expanded', 'false');
+    cleanup();
+
+    render(<RightPanel view={makeView({ id: 'r-shape-chat', workflow_id: 'chat' }, [])} />);
+    expect(sectionCount()).toBe(8);
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
   });
 
   it('renders no delivery element outside the rail, and no band above it', () => {
@@ -78,9 +93,11 @@ describe('the rail keeps its shape (revised EC54)', () => {
     expect(container.querySelector('[role="tablist"]')).toBeNull();
   });
 
-  it('the badge states the outcome WITHOUT any gesture', () => {
+  it('the badge states the outcome WITHOUT any gesture — and never claims a PR unread', () => {
     const cases: { status: UnitStatus; denial: string | null; state: string; label: string }[] = [
-      { status: 'done', denial: null, state: 'delivered', label: 'PR open' },
+      // `done` with no url in hand is the PHASE, not the artifact (D2). This is
+      // the 665a9aeb row: the first cut said "PR open" here.
+      { status: 'done', denial: null, state: 'delivered', label: 'deliver ran' },
       { status: 'rejected', denial: NOTHING_REASON, state: 'nothing-to-deliver', label: 'nothing delivered' },
       { status: 'rejected', denial: NO_URL_REASON, state: 'failed', label: 'deliver failed' },
       { status: 'pending', denial: null, state: 'in-flight', label: 'pending' },
@@ -90,8 +107,44 @@ describe('the rail keeps its shape (revised EC54)', () => {
       const badge = screen.getByTestId('run-delivery-badge');
       expect(badge).toHaveAttribute('data-state', c.state);
       expect(badge).toHaveTextContent(c.label);
+      expect(badge.textContent).not.toMatch(/\bPR\b/);
       cleanup();
     }
+  });
+
+  it('the badge upgrades to the PR claim ONLY once a url is in hand', async () => {
+    render(<RightPanel view={run('r-badge-up', 'done')} />);
+    const badge = () => screen.getByTestId('run-delivery-badge');
+    expect(badge()).toHaveAttribute('data-state', 'delivered');
+    expect(badge()).toHaveTextContent('deliver ran');
+
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    await screen.findByTestId('run-delivery-link');
+
+    expect(badge()).toHaveAttribute('data-state', 'pr-open');
+    expect(badge()).toHaveTextContent('PR open');
+  });
+
+  it('D1: the badge cannot contradict its own body — the 665a9aeb shape, both halves', async () => {
+    // The REAL wire shape: deliver unit `done`, `denial_reason: null`, and the
+    // real 677-byte transcript, which carries one `/pull/new/` form and zero
+    // numbered PRs. The first cut painted "PR open" in `--accent` on the header
+    // while the body underneath said no PR link was recorded.
+    getUnitOutput.mockResolvedValue({ output: EMPTY_PUSH_OUTPUT });
+    render(<RightPanel view={run('r-665a9aeb', 'done')} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    const body = await screen.findByTestId('run-delivery-nolink');
+
+    const badge = screen.getByTestId('run-delivery-badge');
+    expect(badge).toHaveAttribute('data-state', 'delivered');
+    expect(badge).toHaveTextContent('deliver ran');
+    // Body and badge agree, and neither claims an artifact.
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'delivered');
+    expect(body).toHaveTextContent('the deliver phase recorded no PR link — nothing can be pointed at');
+    expect(screen.queryByTestId('run-delivery-link')).not.toBeInTheDocument();
+    // And the badge is not painted as the PR accent nor as a failure.
+    expect(badge.style.color).toBe('var(--ink-muted)');
   });
 
   it('EC57: a run with no deliver phase carries no badge — silence, not "unknown"', () => {
@@ -127,7 +180,8 @@ describe('opening Delivery for a run that DID open a PR (EC55, EC59)', () => {
     expect(link.getAttribute('href')).toMatch(/^https:\/\/\S+\/pull\/\d+$/);
     expect(getUnitOutput).toHaveBeenCalledTimes(1);
     expect(getUnitOutput).toHaveBeenCalledWith('r-pr', 'r-pr:deliver');
-    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'delivered');
+    // The url is in hand, so — and only so — the claim becomes the artifact.
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'pr-open');
   });
 
   it('EC55 negative pin: no href anywhere in the panel contains /pull/new/', async () => {
@@ -235,6 +289,16 @@ describe('a run that delivered NOTHING (EC56)', () => {
     expect((await screen.findByTestId('run-delivery-reason')).textContent)
       .toStrictEqual('crew recorded no reason');
     expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+
+  it('an EMPTY denial_reason takes the same fallback, never a blank paragraph', async () => {
+    // `reason ?? '…'` keeps `''` — the same absent-vs-empty bug already fixed in
+    // `store/delivery.ts`, one field over. Normalized at the derivation now.
+    render(<RightPanel view={run('r-blank-reason', 'rejected', '')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect((await screen.findByTestId('run-delivery-reason')).textContent)
+      .toStrictEqual('crew recorded no reason');
   });
 
   it('a run with no deliver phase names the worktree and the remedy, and reads nothing', async () => {

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -362,3 +362,34 @@ describe('EC60: the Files panel stops presenting attention as outcome', () => {
     expect(screen.getByTestId('run-delivery-badge')).toHaveAttribute('data-state', 'nothing-to-deliver');
   });
 });
+
+describe('the rail heals a stale open section (Copilot on #125)', () => {
+  it('falls back to What / Where when the open section disappears with the run', async () => {
+    // `openAccordion` is mount-scoped and RightPanel does not remount between runs. Open
+    // Delivery on a run that CAN deliver, then hand the SAME mounted panel a run that cannot:
+    // the id is now absent from `sections`, and the rail must not render with nothing open.
+    const deliverable = run('r-stale-yes', 'done');
+    const notDeliverable = makeView({ id: 'r-stale-no', workflow_id: 'chat' }, []);
+
+    const { rerender } = render(<RightPanel view={deliverable} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    await screen.findByTestId('run-delivery');
+
+    rerender(<RightPanel view={notDeliverable} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Delivery/ })).toBeNull();
+    });
+    const expanded = document.querySelectorAll('[aria-expanded="true"]');
+    expect(expanded.length).toBe(1);
+    expect(expanded[0]?.textContent).toContain('What / Where');
+  });
+
+  it('a deliberately collapsed rail STAYS collapsed — null is a real state, not a stale id', async () => {
+    render(<RightPanel view={run('r-stale-null', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /What \/ Where/ }));
+    await waitFor(() => {
+      expect(document.querySelectorAll('[aria-expanded="true"]').length).toBe(0);
+    });
+  });
+});

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -201,6 +201,12 @@ describe('opening Delivery for a run that DID open a PR (EC55, EC59)', () => {
     const link = await screen.findByTestId('run-delivery-link');
     expect(link).toHaveAttribute('href', REAL_PR_URL);
     expect(link.getAttribute('href')).toMatch(/^https:\/\/\S+\/pull\/\d+$/);
+    // The link opens a third-party origin, so pin BOTH tokens (Copilot on #125). Modern
+    // browsers imply `noopener` for `target="_blank"`, but the repo's own external links
+    // (Markdown.tsx, RepoDetailPage.tsx) state it explicitly and this must not be the
+    // one that drifts.
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     expect(getUnitOutput).toHaveBeenCalledTimes(1);
     expect(getUnitOutput).toHaveBeenCalledWith('r-pr', 'r-pr:deliver');
     // The url is in hand, so — and only so — the claim becomes the artifact.

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { RightPanel } from '../src/components/RightPanel.js';
 import * as client from '../src/api/client.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { useDeliveryStore } from '../src/store/delivery.js';
 import { useProvenanceStore } from '../src/store/provenance.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
 import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS } from './fixtures/workflows.js';
 import {
   EMPTY_PUSH_OUTPUT,
   NO_URL_REASON,
@@ -45,6 +47,11 @@ beforeEach(() => {
   useRunEventStore.setState({ byRun: {} });
   useDeliveryStore.setState({ byRun: {} });
   useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+  // The app's ONE workflow-defs read (studio#122 D-1). The rail's visibility
+  // gate and its remedy line both consult `is_system` now, so the panel is
+  // rendered here against the REAL daemon table, cold cache each time.
+  clearCachedWorkflows();
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
   vi.spyOn(client.api, 'getAudit').mockResolvedValue({ entries: [] });
   vi.spyOn(client.api, 'getRun').mockImplementation((id: string) =>
     Promise.resolve({ run: run(id, 'done') }),
@@ -322,7 +329,10 @@ describe('a run that delivered NOTHING (EC56)', () => {
 
     const body = await screen.findByTestId('run-delivery');
     expect(body).toHaveAttribute('data-state', 'none');
-    expect(body).toHaveTextContent('deliver: pr');
+    // The remedy waits for the DEFS (D-1's cold-cache invariant): `feature` is
+    // deliverable, but studio says so only once the daemon's own flag confirms
+    // it. `tests/delivery.coldCache.test.tsx` owns the withheld half.
+    await waitFor(() => expect(body).toHaveTextContent('deliver: pr'));
     expect(getUnitOutput).not.toHaveBeenCalled();
   });
 });

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { RightPanel } from '../src/components/RightPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useDeliveryStore } from '../src/store/delivery.js';
+import { useProvenanceStore } from '../src/store/provenance.js';
+import { makeUnit, makeView } from './factories.js';
+import {
+  NO_URL_REASON,
+  NOTHING_REASON,
+  REAL_DELIVER_OUTPUT,
+  REAL_PR_URL,
+} from './fixtures/deliverOutput.js';
+import type { SessionView, UnitStatus } from '../src/api/types.js';
+
+/**
+ * The Delivery rail section (wicked-studio#122, slice DA) under the OPERATOR's
+ * amended spec (2026-08-24): "delivery isn't a top level class, it goes in the
+ * right chat panel as a tab". So — a ninth accordion governed by the same
+ * `openAccordion`, never a pinned band and never a tablist conversion; the
+ * at-a-glance signal lives on the header badge instead (revised EC54).
+ */
+
+let getUnitOutput: ReturnType<typeof vi.fn>;
+
+/** A build run with a deliver phase in the given state. Distinct ids per test:
+ *  the delivery + provenance caches are per-run-id and outlive a render. */
+function run(id: string, status: UnitStatus, denial: string | null = null): SessionView {
+  return makeView(
+    { id, workflow_id: 'feature', status: 'completed', problem: 'wire the thing', workdir: '/w/tree' },
+    [
+      makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status, denial_reason: denial }),
+    ],
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  useDeliveryStore.setState({ byRun: {} });
+  useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+  vi.spyOn(client.api, 'getAudit').mockResolvedValue({ entries: [] });
+  vi.spyOn(client.api, 'getRun').mockImplementation((id: string) =>
+    Promise.resolve({ run: run(id, 'done') }),
+  );
+  getUnitOutput = vi.fn().mockResolvedValue({ output: REAL_DELIVER_OUTPUT });
+  vi.spyOn(client.api, 'getUnitOutput').mockImplementation(
+    getUnitOutput as unknown as typeof client.api.getUnitOutput,
+  );
+});
+afterEach(cleanup);
+
+describe('the rail keeps its shape (revised EC54)', () => {
+  it('has exactly 9 sections and still opens on What / Where', () => {
+    render(<RightPanel view={run('r-shape', 'done')} />);
+
+    const headers = screen.getAllByRole('button', { expanded: false })
+      .concat(screen.getAllByRole('button', { expanded: true }));
+    expect(headers).toHaveLength(9);
+    expect(screen.getByRole('button', { name: /What \/ Where/ })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: /Delivery/ })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders no delivery element outside the rail, and no band above it', () => {
+    const { container } = render(<RightPanel view={run('r-band', 'done')} />);
+
+    // The badge is the ONLY delivery element before a gesture; the body is not
+    // in the document at all until the section is opened.
+    expect(screen.getByTestId('run-delivery-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('run-delivery')).not.toBeInTheDocument();
+
+    // …and it lives INSIDE the Delivery header button, not in a band of its own.
+    const header = screen.getByRole('button', { name: /Delivery/ });
+    expect(header).toContainElement(screen.getByTestId('run-delivery-badge'));
+    // The rail is still an accordion list, never a tablist (the DocPanel strip).
+    expect(container.querySelector('[role="tablist"]')).toBeNull();
+  });
+
+  it('the badge states the outcome WITHOUT any gesture', () => {
+    const cases: { status: UnitStatus; denial: string | null; state: string; label: string }[] = [
+      { status: 'done', denial: null, state: 'delivered', label: 'PR open' },
+      { status: 'rejected', denial: NOTHING_REASON, state: 'nothing-to-deliver', label: 'nothing delivered' },
+      { status: 'rejected', denial: NO_URL_REASON, state: 'failed', label: 'deliver failed' },
+      { status: 'pending', denial: null, state: 'in-flight', label: 'pending' },
+    ];
+    for (const [i, c] of cases.entries()) {
+      render(<RightPanel view={run(`r-badge-${i}`, c.status, c.denial)} />);
+      const badge = screen.getByTestId('run-delivery-badge');
+      expect(badge).toHaveAttribute('data-state', c.state);
+      expect(badge).toHaveTextContent(c.label);
+      cleanup();
+    }
+  });
+
+  it('EC57: a run with no deliver phase carries no badge — silence, not "unknown"', () => {
+    const view = makeView({ id: 'r-none', workflow_id: 'feature', workdir: '/w/tree' }, [
+      makeUnit({ id: 'r-none:build', session_id: 'r-none', ord: 0, status: 'done' }),
+    ]);
+    render(<RightPanel view={view} />);
+
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+    expect(screen.queryByTestId('run-delivery-badge')).not.toBeInTheDocument();
+  });
+
+  it('EC57: a CHAT thread gets no Delivery section at all', () => {
+    const view = makeView({ id: 'r-chat', workflow_id: 'chat' }, []);
+    render(<RightPanel view={view} />);
+
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('run-delivery-badge')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /What \/ Where|Decisions|Governance|Burn|Data|Steering|Assumptions|Files referenced/ }))
+      .toHaveLength(8);
+  });
+});
+
+describe('opening Delivery for a run that DID open a PR (EC55, EC59)', () => {
+  it('fires ONE output read, keyed by the deliver unit\'s FULL id, and links the numbered PR', async () => {
+    render(<RightPanel view={run('r-pr', 'done')} />);
+    expect(getUnitOutput).not.toHaveBeenCalled(); // gesture-gated
+
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    const link = await screen.findByTestId('run-delivery-link');
+    expect(link).toHaveAttribute('href', REAL_PR_URL);
+    expect(link.getAttribute('href')).toMatch(/^https:\/\/\S+\/pull\/\d+$/);
+    expect(getUnitOutput).toHaveBeenCalledTimes(1);
+    expect(getUnitOutput).toHaveBeenCalledWith('r-pr', 'r-pr:deliver');
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'delivered');
+  });
+
+  it('EC55 negative pin: no href anywhere in the panel contains /pull/new/', async () => {
+    const { container } = render(<RightPanel view={run('r-trap', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    await screen.findByTestId('run-delivery-link');
+
+    const hrefs = [...container.querySelectorAll('[href]')].map((e) => e.getAttribute('href') ?? '');
+    expect(hrefs.some((h) => h.includes('/pull/new/'))).toBe(false);
+    expect(hrefs).toContain(REAL_PR_URL);
+  });
+
+  it('EC61: an OVERLAY-named deliver unit resolves by tool_cmd and reads its own id', async () => {
+    const view = makeView({ id: 'r-ovl', workflow_id: 'feature-pr', status: 'completed', workdir: '/w/tree' }, [
+      makeUnit({ id: 'r-ovl:build', session_id: 'r-ovl', ord: 0, status: 'done' }),
+      makeUnit({
+        id: 'r-ovl:open-the-pr', session_id: 'r-ovl', ord: 1, status: 'done',
+        tool_cmd: ['bash', '-lc', 'git push …\ngh pr create --head "$B" --fill'],
+      }),
+    ]);
+    render(<RightPanel view={view} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect(await screen.findByTestId('run-delivery-link')).toHaveAttribute('href', REAL_PR_URL);
+    expect(getUnitOutput).toHaveBeenCalledWith('r-ovl', 'r-ovl:open-the-pr');
+  });
+
+  it('re-opening the section re-reads nothing — the budget is one per run', async () => {
+    render(<RightPanel view={run('r-once', 'done')} />);
+    const header = screen.getByRole('button', { name: /Delivery/ });
+
+    fireEvent.click(header);
+    await screen.findByTestId('run-delivery-link');
+    fireEvent.click(header); // collapse
+    fireEvent.click(header); // and open again
+    await screen.findByTestId('run-delivery-link');
+
+    expect(getUnitOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it('EC59: a delivered run whose transcript carries no url says so — never a linkless "Delivered"', async () => {
+    getUnitOutput.mockResolvedValue({ output: 'Everything up-to-date\n' });
+    render(<RightPanel view={run('r-nolink', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect(await screen.findByTestId('run-delivery-nolink'))
+      .toHaveTextContent('the deliver phase recorded no PR link — nothing can be pointed at');
+    expect(screen.queryByTestId('run-delivery-link')).not.toBeInTheDocument();
+  });
+
+  it('EC59: `outputUnavailable` renders the DAEMON\'s words, never an indefinite Loading…', async () => {
+    getUnitOutput.mockResolvedValue({
+      output: null,
+      outputUnavailable: 'the unit was denied — deny-dominates stores no output past a deny',
+    });
+    render(<RightPanel view={run('r-unavail', 'done')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect(await screen.findByTestId('run-delivery-nolink')).toHaveTextContent(
+      'the unit was denied — deny-dominates stores no output past a deny',
+    );
+  });
+});
+
+describe('a run that delivered NOTHING (EC56)', () => {
+  it('renders denial_reason by STRING EQUALITY and fires ZERO output reads', async () => {
+    render(<RightPanel view={run('r-empty', 'rejected', NOTHING_REASON)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    const reason = await screen.findByTestId('run-delivery-reason');
+    // Equality, not phrase-matching: a message crew truncates must degrade, not
+    // be re-worded into something studio made up (crew#322).
+    expect(reason.textContent).toStrictEqual(NOTHING_REASON);
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'nothing-to-deliver');
+    // A rejected unit has NO stored transcript by design — asking is the bug.
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+
+  it('a deliver failure for any other reason is `failed`, same verbatim rule, same zero reads', async () => {
+    render(<RightPanel view={run('r-fail', 'rejected', NO_URL_REASON)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    const reason = await screen.findByTestId('run-delivery-reason');
+    expect(reason.textContent).toStrictEqual(NO_URL_REASON);
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'failed');
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+
+  it('a null denial_reason says crew recorded none, and synthesizes nothing', async () => {
+    render(<RightPanel view={run('r-silent', 'rejected', null)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    expect((await screen.findByTestId('run-delivery-reason')).textContent)
+      .toStrictEqual('crew recorded no reason');
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+
+  it('a run with no deliver phase names the worktree and the remedy, and reads nothing', async () => {
+    const view = makeView({ id: 'r-nodeliver', workflow_id: 'feature', workdir: '/w/tree' }, [
+      makeUnit({ id: 'r-nodeliver:build', session_id: 'r-nodeliver', ord: 0, status: 'done' }),
+    ]);
+    render(<RightPanel view={view} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    const body = await screen.findByTestId('run-delivery');
+    expect(body).toHaveAttribute('data-state', 'none');
+    expect(body).toHaveTextContent('deliver: pr');
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe('EC60: the Files panel stops presenting attention as outcome', () => {
+  it('is labelled "Files referenced" and captions what it actually counts', async () => {
+    const id = 'r-files';
+    useRunEventStore.getState().hydrate(id, [
+      { type: 'dataUsed', session: id, ord: 0, files: ['/w/tree/a.ts', '/w/tree/b.ts'] },
+    ]);
+    render(<RightPanel view={run(id, 'rejected', NOTHING_REASON)} />);
+
+    expect(screen.getByRole('button', { name: /Files referenced/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Files referenced/ }));
+    expect(await screen.findByTestId('files-scope-note')).toHaveTextContent(
+      'files the agents read or wrote in the worktree — not a delivered changeset',
+    );
+    // The 665a9aeb shape: a file count beside a delivery that produced nothing.
+    // The count no longer claims to be the run's outcome — the caption disclaims
+    // it, and the Delivery badge carries the outcome instead.
+    expect(screen.getByTestId('run-delivery-badge')).toHaveAttribute('data-state', 'nothing-to-deliver');
+  });
+});

--- a/tests/RightPanel.delivery.test.tsx
+++ b/tests/RightPanel.delivery.test.tsx
@@ -140,11 +140,23 @@ describe('the rail keeps its shape (revised EC54)', () => {
     expect(badge).toHaveAttribute('data-state', 'delivered');
     expect(badge).toHaveTextContent('deliver ran');
     // Body and badge agree, and neither claims an artifact.
-    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'delivered');
+    const panel = screen.getByTestId('run-delivery');
+    expect(panel).toHaveAttribute('data-state', 'delivered');
     expect(body).toHaveTextContent('the deliver phase recorded no PR link — nothing can be pointed at');
     expect(screen.queryByTestId('run-delivery-link')).not.toBeInTheDocument();
     // And the badge is not painted as the PR accent nor as a failure.
     expect(badge.style.color).toBe('var(--ink-muted)');
+
+    // The HEADLINE is the loudest sentence in the section and was the one the
+    // first cut got wrong; pin the rendered words, not just the badge's.
+    expect(panel).toHaveTextContent('The deliver phase ran and crew approved it. That alone is not a PR.');
+    expect(panel.textContent ?? '').not.toMatch(/\bPR open\b/i);
+
+    // …and the "no link" line is MUTED, not `--status-fail`: an approved phase
+    // that produced no PR is missing evidence, not a run that failed. The
+    // colour is the claim as much as the words are.
+    expect(body.style.color).toBe('var(--ink-muted)');
+    expect(body.style.color).not.toBe('var(--status-fail)');
   });
 
   it('EC57: a run with no deliver phase carries no badge — silence, not "unknown"', () => {

--- a/tests/deliverKind.shared.test.tsx
+++ b/tests/deliverKind.shared.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * The structural guard (wicked-studio#122 D-1): **the composer and the delivery
+ * surfaces classify a run through the SAME function.**
+ *
+ * They did not. #124's `deliverKindOf` lived inside `ChatInput` as a
+ * `useCallback` and read `is_system`; #122's `canDeliver` called `runKindOf`
+ * and read a five-id denylist. Nothing pinned them together, so they drifted:
+ * `collab` and every `interactive-*` were 'system' to the composer and 'build'
+ * to the rail, and studio told operators to launch a delivery the composer
+ * would have refused.
+ *
+ * The guard is a WRAPPED module export, not an assertion about source text: the
+ * real `runMode.deliverKindOf` is replaced by a spy that still does the real
+ * work, and BOTH call sites are then observed going through it. A future edit
+ * that re-forks either side — a local copy of the rule in `ChatInput`, a
+ * `runKindOf` call back in `canDeliver` — drops that side's count to zero and
+ * fails here.
+ */
+vi.mock('../src/components/runMode.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/components/runMode.js')>();
+  return { ...actual, deliverKindOf: vi.fn(actual.deliverKindOf) };
+});
+
+import { api } from '../src/api/client.js';
+import { ChatInput } from '../src/components/ChatInput.js';
+import { canDeliver, deliverySummary } from '../src/components/delivery.js';
+import { deliverKindOf } from '../src/components/runMode.js';
+import { DEFAULT_COMPOSER_PREFS, useComposerPrefsStore } from '../src/store/composerPrefs.js';
+import { clearRetryPrefill } from '../src/store/retryPrefill.js';
+import { clearCachedWorkflows, isSystemWorkflowIn } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS } from './fixtures/workflows.js';
+
+const spy = vi.mocked(deliverKindOf);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  clearCachedWorkflows();
+  clearRetryPrefill();
+  vi.spyOn(api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  });
+  vi.spyOn(api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+  vi.spyOn(api, 'listProjects').mockResolvedValue({ projects: [] });
+  useComposerPrefsStore.setState({ prefs: DEFAULT_COMPOSER_PREFS, loaded: true, persist: 'unknown' });
+  spy.mockClear();
+});
+afterEach(cleanup);
+
+const view = (workflow_id: string) => {
+  const v = makeView({ id: 'run-1' }, [makeUnit({ id: 'run-1:build', status: 'done' })]);
+  return { ...v, session: { ...v.session, workflow_id } as typeof v.session };
+};
+
+describe('one predicate, both slices', () => {
+  it('the COMPOSER classifies through runMode.deliverKindOf', async () => {
+    render(<ChatInput onLaunched={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('launch-problem')).toBeInTheDocument());
+
+    expect(spy, 'ChatInput no longer calls the shared predicate').toHaveBeenCalled();
+    // Second argument is the LOOKUP — the composer supplies `is_system`, it does
+    // not re-implement the rule.
+    expect(spy.mock.calls.every(([, lookup]) => typeof lookup === 'function')).toBe(true);
+  });
+
+  it('the DELIVERY SURFACES classify through runMode.deliverKindOf', () => {
+    canDeliver(view('interactive-draft'));
+    expect(spy, 'canDeliver no longer calls the shared predicate').toHaveBeenCalledWith(
+      'interactive-draft', undefined,
+    );
+
+    spy.mockClear();
+    const lookup = (id: string): boolean | undefined => isSystemWorkflowIn(LIVE_WORKFLOWS, id);
+    deliverySummary([view('feature')], lookup);
+    expect(spy).toHaveBeenCalledWith('feature', lookup);
+  });
+
+  it('and they agree over the whole live workflow table', () => {
+    // The behavioural half of the same claim: whatever the shared predicate
+    // says, `canDeliver` says — no id where one is 'build' and the other isn't.
+    const lookup = (id: string): boolean | undefined => isSystemWorkflowIn(LIVE_WORKFLOWS, id);
+    for (const w of LIVE_WORKFLOWS) {
+      expect(canDeliver(view(w.id), lookup)).toBe(deliverKindOf(w.id, lookup) === 'build');
+    }
+  });
+});

--- a/tests/deliverKind.test.ts
+++ b/tests/deliverKind.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as client from '../src/api/client.js';
+import { canDeliver, deliverySummary } from '../src/components/delivery.js';
+import { deliverKindOf, runKindOf, SYSTEM_WORKFLOW_IDS, type RunKind } from '../src/components/runMode.js';
+import {
+  clearCachedWorkflows,
+  fetchWorkflowsCached,
+  getCachedWorkflows,
+  isSystemWorkflowIn,
+  setCachedWorkflows,
+  subscribeWorkflows,
+} from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { BUILD_IDS, DENYLIST_BLIND_SPOT, LIVE_WORKFLOWS, SYSTEM_IDS } from './fixtures/workflows.js';
+
+/**
+ * `deliverKindOf` — the ONE run-kind predicate (wicked-studio#122 D-1).
+ *
+ * The defect, in one line: `SYSTEM_WORKFLOW_IDS` names FIVE of the daemon's
+ * ELEVEN system workflows, so `canDeliver` classified `collab` and all five
+ * `interactive-*` — the document and video seams — as build work, and the rail
+ * offered them a remedy ("launch with deliver: pr") that studio's own composer
+ * refuses. This table is the whole live `GET /workflows` payload, so a
+ * workflow the daemon flags can never again be build work to one half of the app.
+ */
+
+/** The authoritative lookup, as the app's workflow cache serves it. */
+const KNOWN = (id: string): boolean | undefined => isSystemWorkflowIn(LIVE_WORKFLOWS, id);
+
+const viewOf = (workflow_id: string | null) => {
+  const v = makeView({ id: 'run-1' }, [makeUnit({ id: 'run-1:build', status: 'done' })]);
+  return { ...v, session: { ...v.session, workflow_id } as typeof v.session };
+};
+
+describe('the ELEVEN real is_system ids all classify system', () => {
+  for (const id of SYSTEM_IDS) {
+    it(`${id} → system, and cannot deliver`, () => {
+      expect(deliverKindOf(id, KNOWN)).toBe<RunKind>('system');
+      expect(canDeliver(viewOf(id), KNOWN)).toBe(false);
+    });
+  }
+
+  it('the six the denylist never knew: build BEFORE the fix, system after', () => {
+    for (const id of DENYLIST_BLIND_SPOT) {
+      // The defect, pinned: the denylist alone — which is exactly what
+      // `canDeliver` used to consult — calls every one of these build work.
+      expect(SYSTEM_WORKFLOW_IDS.has(id), `${id} is not on the denylist`).toBe(false);
+      expect(runKindOf(id)).toBe<RunKind>('build');
+      // The fix: the daemon's own flag wins.
+      expect(deliverKindOf(id, KNOWN), `${id} must be system`).toBe<RunKind>('system');
+    }
+    expect(DENYLIST_BLIND_SPOT).toHaveLength(6);
+  });
+});
+
+describe('the six NON-system ids stay build', () => {
+  for (const id of BUILD_IDS) {
+    it(`${id} → build, and can deliver`, () => {
+      // These defs carry NO `is_system` key at all on the live wire — presence
+      // in the list, not the flag's value, is the positive answer.
+      expect(LIVE_WORKFLOWS.find((w) => w.id === id)?.is_system).toBeUndefined();
+      expect(KNOWN(id)).toBe(false);
+      expect(deliverKindOf(id, KNOWN)).toBe<RunKind>('build');
+      expect(canDeliver(viewOf(id), KNOWN)).toBe(true);
+    });
+  }
+});
+
+describe('the denylist survives as a FALLBACK, and the rule stays one-directional', () => {
+  it('with NO lookup, every id falls back to the denylist verdict verbatim', () => {
+    for (const id of [...SYSTEM_IDS, ...BUILD_IDS]) {
+      expect(deliverKindOf(id)).toBe(runKindOf(id));
+    }
+  });
+
+  it('an unknown def never PROMOTES a denylisted id to build', () => {
+    // The one-directional guarantee studio#124 wrote and this refactor inherits:
+    // the flag may only ever withhold delivery. A def that is absent, or that
+    // positively says `is_system: false`, cannot overturn the denylist.
+    expect(deliverKindOf('chat', () => undefined)).toBe<RunKind>('system');
+    expect(deliverKindOf('chat', () => false)).toBe<RunKind>('system');
+    expect(deliverKindOf('memories', () => false)).toBe<RunKind>('system');
+  });
+
+  it('an unknown def leaves a pre-flag workflow deliverable — degrading, not guessing', () => {
+    expect(deliverKindOf('some-workflow-shipped-tomorrow', () => undefined)).toBe<RunKind>('build');
+    expect(deliverKindOf('some-workflow-shipped-tomorrow', KNOWN)).toBe<RunKind>('build');
+  });
+
+  it('no workflow at all is freeform, lookup or not — deliver without workflow is a 400', () => {
+    for (const id of ['', '   ', null, undefined]) {
+      expect(deliverKindOf(id, KNOWN)).toBe<RunKind>('freeform');
+      expect(deliverKindOf(id, () => false)).toBe<RunKind>('freeform');
+    }
+    expect(canDeliver(viewOf(null), KNOWN)).toBe(false);
+  });
+});
+
+describe('the census stops counting document and video threads (D5, re-opened by D-1)', () => {
+  /** A run on `id` whose deliver phase never existed. */
+  const plain = (id: string, workflow_id: string) =>
+    makeView({ id, workflow_id }, [makeUnit({ id: `${id}:build`, session_id: id, status: 'done' })]);
+  /** A build run that ran its deliver phase. */
+  const delivered = (id: string) =>
+    makeView({ id, workflow_id: 'feature' }, [
+      makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status: 'done' }),
+    ]);
+
+  const runs = [
+    delivered('r-1'), delivered('r-2'),
+    ...DENYLIST_BLIND_SPOT.map((wf, i) => plain(`i-${i}`, wf)),
+  ];
+
+  it('without the lookup the six read as "no deliver phase" — the reported symptom', () => {
+    expect(deliverySummary(runs)).toBe('2 ran deliver · 6 no deliver phase');
+  });
+
+  it('with the lookup they are out of the census entirely', () => {
+    expect(deliverySummary(runs, KNOWN)).toBe('2 ran deliver');
+  });
+});
+
+describe('the shared workflow cache: ONE GET for the app, degrading silently', () => {
+  beforeEach(() => {
+    clearCachedWorkflows();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    clearCachedWorkflows();
+  });
+
+  it('N callers, ONE request — in-flight-deduped, then served from cache', async () => {
+    let resolve!: (v: { workflows: typeof LIVE_WORKFLOWS }) => void;
+    const spy = vi.spyOn(client.api, 'listWorkflows').mockReturnValue(
+      new Promise((r) => { resolve = r; }),
+    );
+
+    for (let i = 0; i < 50; i += 1) fetchWorkflowsCached();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(getCachedWorkflows()).toBeNull();
+
+    resolve({ workflows: LIVE_WORKFLOWS });
+    await vi.waitFor(() => expect(getCachedWorkflows()).toHaveLength(17));
+
+    for (let i = 0; i < 50; i += 1) fetchWorkflowsCached();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed fetch caches the degraded answer — asked once per session, never retried', async () => {
+    const spy = vi.spyOn(client.api, 'listWorkflows').mockRejectedValue(new Error('route absent'));
+    fetchWorkflowsCached();
+    await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+    fetchWorkflowsCached();
+    fetchWorkflowsCached();
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Still UNKNOWN, never "not a system workflow" — the safe direction.
+    expect(getCachedWorkflows()).toBeNull();
+    expect(isSystemWorkflowIn(getCachedWorkflows(), 'interactive-draft')).toBeUndefined();
+  });
+
+  it('an api surface with no listWorkflows at all does not throw into the render', () => {
+    vi.spyOn(client.api, 'listWorkflows').mockImplementation(() => {
+      throw new TypeError('api.listWorkflows is not a function');
+    });
+    expect(() => fetchWorkflowsCached()).not.toThrow();
+    expect(getCachedWorkflows()).toBeNull();
+  });
+
+  it('a deposit from a surface that already fetched satisfies the app', () => {
+    const spy = vi.spyOn(client.api, 'listWorkflows');
+    const seen: number[] = [];
+    const unsub = subscribeWorkflows(() => seen.push(getCachedWorkflows()?.length ?? 0));
+
+    setCachedWorkflows(LIVE_WORKFLOWS);
+    expect(seen).toStrictEqual([17]);
+
+    fetchWorkflowsCached();
+    expect(spy).not.toHaveBeenCalled();
+    unsub();
+  });
+});

--- a/tests/deliverKind.test.ts
+++ b/tests/deliverKind.test.ts
@@ -112,12 +112,19 @@ describe('the census stops counting document and video threads (D5, re-opened by
     ...DENYLIST_BLIND_SPOT.map((wf, i) => plain(`i-${i}`, wf)),
   ];
 
-  it('without the lookup the six read as "no deliver phase" — the reported symptom', () => {
-    expect(deliverySummary(runs)).toBe('2 ran deliver · 6 no deliver phase');
-  });
-
   it('with the lookup they are out of the census entirely', () => {
     expect(deliverySummary(runs, KNOWN)).toBe('2 ran deliver');
+  });
+
+  it('and without it they are out for the OTHER reason — nothing proves they could deliver', () => {
+    // The reported symptom was "2 ran deliver · 6 no deliver phase": the six
+    // read as build work because the denylist does not know them. The flag is
+    // one half of the answer and the licence is the other — the "no deliver
+    // phase" bucket counts a run only when a def IN HAND says the workflow is
+    // ordinary, so an unproven id is never counted whichever way it would have
+    // classified. The delivering runs need no licence: they have a deliver unit.
+    expect(deliverySummary(runs)).toBe('2 ran deliver');
+    for (const id of DENYLIST_BLIND_SPOT) expect(runKindOf(id)).toBe<RunKind>('build');
   });
 });
 

--- a/tests/delivery.chipGate.test.tsx
+++ b/tests/delivery.chipGate.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * D2, held STRUCTURALLY: **`DeliveryChip` decides through `canDeliver` — the
+ * same predicate the rail's section and the project census gate on.**
+ *
+ * The sibling assertion in `delivery.materialised.test.tsx` ("if a row is
+ * chipped, `canDeliver` is true for it") cannot fail, and a mutation run proved
+ * it: delete the gate from `DeliveryChip` and every delivery test still passes.
+ * That is not the test being weak — it is the invariant being UNREACHABLE
+ * today, by construction. `canDeliver` returns true for any run whose deliver
+ * state is not `'none'`, and the chip already returns null on the `'none'` and
+ * `'in-flight'` claims, so the two conditions can never disagree while
+ * `canDeliver` leads with the evidence arm.
+ *
+ * So the thing worth pinning is not an outcome (there is none to observe) but
+ * the WIRING: that the row consults the shared predicate at all, and obeys it
+ * when it says no. Both are checked here against a wrapped module export — the
+ * pattern `deliverKind.shared.test.tsx` already uses for the composer/rail
+ * seam — so a later edit that drops the gate, or re-forks the rule into a
+ * row-local copy, fails HERE instead of silently.
+ */
+vi.mock('../src/components/delivery.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/components/delivery.js')>();
+  return { ...actual, canDeliver: vi.fn(actual.canDeliver) };
+});
+
+import * as client from '../src/api/client.js';
+import { DeliveryChip } from '../src/components/RunDelivery.js';
+import { canDeliver } from '../src/components/delivery.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { LIVE_RUN_IDS, LIVE_WORKFLOWS, materialised } from './fixtures/workflows.js';
+import type { SessionView } from '../src/api/types.js';
+
+const gate = vi.mocked(canDeliver);
+
+/** The live PR run's shape: materialised def, deliver unit `done`. */
+function delivering(id: string = LIVE_RUN_IDS.prOpened): SessionView {
+  return makeView(
+    { id, workflow_id: materialised(id), status: 'completed', workdir: '/w/tree' },
+    [
+      makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status: 'done' }),
+    ],
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  clearCachedWorkflows();
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+  gate.mockClear();
+});
+afterEach(cleanup);
+
+describe('D2: the row chips only what the shared predicate licenses', () => {
+  it('the chip DECIDES through canDeliver, with the row\'s own view', () => {
+    const view = delivering();
+    render(<DeliveryChip view={view} />);
+
+    expect(screen.getByTestId('run-delivery-chip')).toHaveTextContent('deliver ran');
+    expect(gate).toHaveBeenCalled();
+    expect(gate.mock.calls.some(([v]) => v === view)).toBe(true);
+  });
+
+  it('and OBEYS it: a withheld run is not chipped, whatever its own units say', () => {
+    // The unreachable half, forced: the predicate says no about a run that
+    // demonstrably delivered. The chip must stay silent — a row may never
+    // announce an outcome for a run whose Delivery section studio withholds.
+    gate.mockReturnValue(false);
+    render(<DeliveryChip view={delivering()} />);
+    expect(screen.queryByTestId('run-delivery-chip')).toBeNull();
+  });
+
+  it('costs no request of its own — the defs read is module state, shared', async () => {
+    render(
+      <>
+        {Array.from({ length: 40 }, (_, i) => (
+          <DeliveryChip key={i} view={delivering(`chip-budget-${i}`)} />
+        ))}
+      </>,
+    );
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalledTimes(1));
+    expect(client.api.listWorkflows).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByTestId('run-delivery-chip')).toHaveLength(40);
+  });
+});

--- a/tests/delivery.coldCache.test.tsx
+++ b/tests/delivery.coldCache.test.tsx
@@ -7,28 +7,29 @@ import { useRunEventStore } from '../src/store/events.js';
 import { useProvenanceStore } from '../src/store/provenance.js';
 import { clearCachedWorkflows } from '../src/store/workflowCache.js';
 import { makeUnit, makeView } from './factories.js';
-import { DENYLIST_BLIND_SPOT, LIVE_WORKFLOWS } from './fixtures/workflows.js';
+import { DENYLIST_BLIND_SPOT, LIVE_WORKFLOWS, materialised } from './fixtures/workflows.js';
 import type { SessionView, WorkflowDef } from '../src/api/types.js';
 
 /**
- * THE COLD-CACHE INVARIANT (wicked-studio#122 D-1).
+ * THE COLD-CACHE INVARIANT (wicked-studio#122 D-1, tightened after the live
+ * measurement).
  *
- * **studio never renders the "launch with deliver: pr" remedy for a run whose
- * workflow is `is_system` — INCLUDING before the workflow defs have loaded.**
+ * **studio says nothing about the delivery of a run it cannot prove is
+ * deliverable — no section, no "no deliver phase" sentence, no "launch with
+ * deliver: pr" remedy — before the defs land AND after.**
  *
- * The loading window is the whole difficulty. `canDeliver` gates the Delivery
- * section in, and with a cold cache all it can consult is the five-id denylist,
- * which does not know `collab` or any `interactive-*`. So for one paint an
- * interactive doc thread looks like build work — and the remedy it would print
- * is a suggestion the composer refuses (`deliverKindOf` demotes exactly those
- * to 'system' and strips `deliver` off the launch body).
+ * The first cut suppressed only the REMEDY LINE, on the argument that the rest
+ * of the body is derived from the run's own units and true whatever composed
+ * them. That holds for every claim except `'none'`, which is not a fact about
+ * units at all: "this run has no deliver phase" is a claim about a
+ * classification. Measured against the live daemon, that was the whole corpus —
+ * 86 of 129 runs carry a materialised `wf-<runId>` def `GET /workflows` never
+ * serves, so `undefined` is their permanent answer, and 30 interactive document
+ * threads rendered a Delivery section whose entire body was that sentence.
  *
- * The chosen suppression is the REMEDY LINE, not the section: every other line
- * in that body is derived from the run's own units and is true whatever
- * workflow produced them, while the remedy is the only sentence that speaks
- * about a FUTURE launch and therefore the only one that can be false. Saying
- * less costs the operator a sentence; saying it wrongly sends them at a button
- * that will not do it.
+ * So the licence is the same on both: `is_system === false`, a def IN HAND. The
+ * exception, pinned below, is a run that HAS a deliver phase — evidence beats
+ * classification, and 5c5e08b7 opened a real PR under a materialised def.
  */
 
 let getUnitOutput: ReturnType<typeof vi.fn>;
@@ -39,6 +40,15 @@ function noDeliverRun(id: string, workflow_id: string): SessionView {
   return makeView({ id, workflow_id, status: 'completed', problem: 'author the deck', workdir: '/w/tree' }, [
     makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
   ]);
+}
+
+/** The same run, WITH a deliver phase crew approved. */
+function deliveredRun(id: string, workflow_id: string): SessionView {
+  const v = noDeliverRun(id, workflow_id);
+  return {
+    ...v,
+    units: [...v.units, makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status: 'done' })],
+  };
 }
 
 beforeEach(() => {
@@ -62,67 +72,94 @@ beforeEach(() => {
 });
 afterEach(() => { cleanup(); clearCachedWorkflows(); });
 
-describe('before the defs load', () => {
+describe('before the defs load, a run with no deliver phase gets no section at all', () => {
   for (const wf of DENYLIST_BLIND_SPOT) {
-    it(`${wf}: the section may show, the "deliver: pr" remedy may NOT`, async () => {
+    it(`${wf}: no Delivery header, no body, no remedy`, () => {
       render(<RightPanel view={noDeliverRun(`r-${wf}`, wf)} />);
-      // The denylist cannot rule this workflow out yet, so the section is here —
-      // that is the exact window the defect lived in.
-      fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
-
-      const body = await screen.findByTestId('run-delivery');
-      expect(body).toHaveAttribute('data-state', 'none');
-      expect(body.textContent, 'a remedy the composer refuses').not.toContain('deliver: pr');
-      // What it still says is TRUE and useful: the phase fact, and where the work is.
-      expect(body).toHaveTextContent('This run has no deliver phase.');
-      expect(body).toHaveTextContent('the work is in');
+      // This is the window the defect lived in: the denylist cannot rule these
+      // out, so the section used to render and say "This run has no deliver
+      // phase." about a document thread.
+      expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('run-delivery')).not.toBeInTheDocument();
+      expect(document.body.textContent).not.toContain('This run has no deliver phase.');
+      expect(document.body.textContent).not.toContain('deliver: pr');
       expect(getUnitOutput).not.toHaveBeenCalled();
     });
   }
 
-  it('a run with no workdir either says nothing at all beyond the phase fact', async () => {
-    const view = makeView({ id: 'r-bare', workflow_id: 'interactive-demo', workdir: null }, [
-      makeUnit({ id: 'r-bare:build', session_id: 'r-bare', ord: 0, status: 'done' }),
-    ]);
-    render(<RightPanel view={view} />);
-    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
-
-    const body = await screen.findByTestId('run-delivery');
-    expect(body.textContent?.trim()).toStrictEqual('This run has no deliver phase.');
+  it('an ORDINARY workflow is withheld from too — a def in hand is the only licence', () => {
+    // Erring toward saying less: `feature` IS deliverable, but nothing has
+    // proved it yet. The section arrives with the defs, one tick later.
+    render(<RightPanel view={noDeliverRun('r-feature', 'feature')} />);
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
   });
 
-  it('an ORDINARY workflow is withheld from too — a def in hand is the only licence', async () => {
-    // Erring toward saying less: `feature` IS deliverable, but nothing has
-    // proved it yet. The line arrives with the defs, one tick later.
-    render(<RightPanel view={noDeliverRun('r-feature', 'feature')} />);
-    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
-    expect((await screen.findByTestId('run-delivery')).textContent).not.toContain('deliver: pr');
+  it('and a MATERIALISED def is withheld forever — it is in no catalog to arrive in', async () => {
+    const id = 'r-materialised';
+    render(<RightPanel view={noDeliverRun(id, materialised(id))} />);
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('a run that HAS a deliver phase is never withheld — evidence beats classification', () => {
+  it('a materialised def keeps its section with the cache stone cold', () => {
+    const id = '5c5e08b7-9e06-43cc-9b15-300bfc599e21';
+    render(<RightPanel view={deliveredRun(id, materialised(id))} />);
+
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+    expect(screen.getByTestId('run-delivery-badge')).toHaveTextContent('deliver ran');
+  });
+
+  it('so does an is_system workflow that somehow ran one', async () => {
+    render(<RightPanel view={deliveredRun('r-sys-delivered', 'interactive-draft')} />);
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    // The flag demotes the CLASSIFICATION, not the unit that already ran.
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
   });
 });
 
 describe('once the defs land', () => {
-  it('the interactive thread loses its Delivery section entirely', async () => {
+  it('the interactive thread still has no Delivery section', async () => {
     render(<RightPanel view={noDeliverRun('r-draft', 'interactive-draft')} />);
-    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
-
     resolveWorkflows({ workflows: LIVE_WORKFLOWS });
 
-    await waitFor(() =>
-      expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
   });
 
-  it('the ordinary workflow gets its remedy back', async () => {
+  it('the ordinary workflow gets its section, its phase fact and its remedy', async () => {
     render(<RightPanel view={noDeliverRun('r-feature-2', 'feature')} />);
-    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
-    await screen.findByTestId('run-delivery');
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
 
     resolveWorkflows({ workflows: LIVE_WORKFLOWS });
 
-    await waitFor(() =>
-      expect(screen.getByTestId('run-delivery')).toHaveTextContent(
-        'the work is in /w/tree — launch with deliver: pr to open a PR from it',
-      ),
+    const header = await screen.findByRole('button', { name: /Delivery/ });
+    fireEvent.click(header);
+    const body = await screen.findByTestId('run-delivery');
+    expect(body).toHaveAttribute('data-state', 'none');
+    expect(body).toHaveTextContent('This run has no deliver phase.');
+    expect(body).toHaveTextContent('the work is in /w/tree — launch with deliver: pr to open a PR from it');
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+
+  it('a run with no workdir says the phase fact and the remedy, and nothing else', async () => {
+    const view = makeView({ id: 'r-bare', workflow_id: 'bug', workdir: null }, [
+      makeUnit({ id: 'r-bare:build', session_id: 'r-bare', ord: 0, status: 'done' }),
+    ]);
+    render(<RightPanel view={view} />);
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Delivery/ }));
+    const body = await screen.findByTestId('run-delivery');
+    expect(body.textContent?.trim()).toStrictEqual(
+      'This run has no deliver phase.launch with deliver: pr to have the run open a PR from its worktree',
     );
   });
 });

--- a/tests/delivery.coldCache.test.tsx
+++ b/tests/delivery.coldCache.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as client from '../src/api/client.js';
 import { RightPanel } from '../src/components/RightPanel.js';
+import { RunDelivery } from '../src/components/RunDelivery.js';
 import { useDeliveryStore } from '../src/store/delivery.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { useProvenanceStore } from '../src/store/provenance.js';
@@ -161,5 +162,31 @@ describe('once the defs land', () => {
     expect(body.textContent?.trim()).toStrictEqual(
       'This run has no deliver phase.launch with deliver: pr to have the run open a PR from its worktree',
     );
+  });
+});
+
+describe('RunDelivery enforces the licence itself, not just via the rail (Copilot on #125)', () => {
+  it('rendered DIRECTLY for an unclassifiable run, it withholds the "no deliver phase" claim', async () => {
+    // The rail would filter this section out entirely; the component is exported, so it must not
+    // depend on that. A materialised `wf-<runId>` id is never in the catalog, so the licence is
+    // permanently `undefined` — not `false`.
+    clearCachedWorkflows();
+    vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+    const view = makeView(
+      { id: 'r-direct', workflow_id: 'wf-r-direct', workdir: '/w/tree' },
+      [],
+    );
+    render(<RunDelivery view={view} />);
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    expect(screen.queryByText(/no deliver phase/i)).toBeNull();
+    expect(screen.queryByText(/deliver: pr/i)).toBeNull();
+  });
+
+  it('but a positively-classified feature run rendered directly DOES state it', async () => {
+    clearCachedWorkflows();
+    vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+    const view = makeView({ id: 'r-direct-ok', workflow_id: 'feature', workdir: '/w/tree' }, []);
+    render(<RunDelivery view={view} />);
+    await waitFor(() => expect(screen.queryByText(/no deliver phase/i)).not.toBeNull());
   });
 });

--- a/tests/delivery.coldCache.test.tsx
+++ b/tests/delivery.coldCache.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as client from '../src/api/client.js';
+import { RightPanel } from '../src/components/RightPanel.js';
+import { useDeliveryStore } from '../src/store/delivery.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useProvenanceStore } from '../src/store/provenance.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { DENYLIST_BLIND_SPOT, LIVE_WORKFLOWS } from './fixtures/workflows.js';
+import type { SessionView, WorkflowDef } from '../src/api/types.js';
+
+/**
+ * THE COLD-CACHE INVARIANT (wicked-studio#122 D-1).
+ *
+ * **studio never renders the "launch with deliver: pr" remedy for a run whose
+ * workflow is `is_system` — INCLUDING before the workflow defs have loaded.**
+ *
+ * The loading window is the whole difficulty. `canDeliver` gates the Delivery
+ * section in, and with a cold cache all it can consult is the five-id denylist,
+ * which does not know `collab` or any `interactive-*`. So for one paint an
+ * interactive doc thread looks like build work — and the remedy it would print
+ * is a suggestion the composer refuses (`deliverKindOf` demotes exactly those
+ * to 'system' and strips `deliver` off the launch body).
+ *
+ * The chosen suppression is the REMEDY LINE, not the section: every other line
+ * in that body is derived from the run's own units and is true whatever
+ * workflow produced them, while the remedy is the only sentence that speaks
+ * about a FUTURE launch and therefore the only one that can be false. Saying
+ * less costs the operator a sentence; saying it wrongly sends them at a button
+ * that will not do it.
+ */
+
+let getUnitOutput: ReturnType<typeof vi.fn>;
+let resolveWorkflows: (v: { workflows: WorkflowDef[] }) => void;
+
+/** A run on `workflow_id` with a build unit and no deliver phase. */
+function noDeliverRun(id: string, workflow_id: string): SessionView {
+  return makeView({ id, workflow_id, status: 'completed', problem: 'author the deck', workdir: '/w/tree' }, [
+    makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+  ]);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  clearCachedWorkflows();
+  useRunEventStore.setState({ byRun: {} });
+  useDeliveryStore.setState({ byRun: {} });
+  useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+  vi.spyOn(client.api, 'getAudit').mockResolvedValue({ entries: [] });
+  vi.spyOn(client.api, 'getRun').mockImplementation((id: string) =>
+    Promise.resolve({ run: noDeliverRun(id, 'interactive-draft') }),
+  );
+  getUnitOutput = vi.fn();
+  vi.spyOn(client.api, 'getUnitOutput').mockImplementation(
+    getUnitOutput as unknown as typeof client.api.getUnitOutput,
+  );
+  // The defs are IN FLIGHT for the whole render, until a test resolves them.
+  vi.spyOn(client.api, 'listWorkflows').mockReturnValue(
+    new Promise((r) => { resolveWorkflows = r; }),
+  );
+});
+afterEach(() => { cleanup(); clearCachedWorkflows(); });
+
+describe('before the defs load', () => {
+  for (const wf of DENYLIST_BLIND_SPOT) {
+    it(`${wf}: the section may show, the "deliver: pr" remedy may NOT`, async () => {
+      render(<RightPanel view={noDeliverRun(`r-${wf}`, wf)} />);
+      // The denylist cannot rule this workflow out yet, so the section is here —
+      // that is the exact window the defect lived in.
+      fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+      const body = await screen.findByTestId('run-delivery');
+      expect(body).toHaveAttribute('data-state', 'none');
+      expect(body.textContent, 'a remedy the composer refuses').not.toContain('deliver: pr');
+      // What it still says is TRUE and useful: the phase fact, and where the work is.
+      expect(body).toHaveTextContent('This run has no deliver phase.');
+      expect(body).toHaveTextContent('the work is in');
+      expect(getUnitOutput).not.toHaveBeenCalled();
+    });
+  }
+
+  it('a run with no workdir either says nothing at all beyond the phase fact', async () => {
+    const view = makeView({ id: 'r-bare', workflow_id: 'interactive-demo', workdir: null }, [
+      makeUnit({ id: 'r-bare:build', session_id: 'r-bare', ord: 0, status: 'done' }),
+    ]);
+    render(<RightPanel view={view} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+
+    const body = await screen.findByTestId('run-delivery');
+    expect(body.textContent?.trim()).toStrictEqual('This run has no deliver phase.');
+  });
+
+  it('an ORDINARY workflow is withheld from too — a def in hand is the only licence', async () => {
+    // Erring toward saying less: `feature` IS deliverable, but nothing has
+    // proved it yet. The line arrives with the defs, one tick later.
+    render(<RightPanel view={noDeliverRun('r-feature', 'feature')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    expect((await screen.findByTestId('run-delivery')).textContent).not.toContain('deliver: pr');
+  });
+});
+
+describe('once the defs land', () => {
+  it('the interactive thread loses its Delivery section entirely', async () => {
+    render(<RightPanel view={noDeliverRun('r-draft', 'interactive-draft')} />);
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument(),
+    );
+  });
+
+  it('the ordinary workflow gets its remedy back', async () => {
+    render(<RightPanel view={noDeliverRun('r-feature-2', 'feature')} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delivery/ }));
+    await screen.findByTestId('run-delivery');
+
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('run-delivery')).toHaveTextContent(
+        'the work is in /w/tree — launch with deliver: pr to open a PR from it',
+      ),
+    );
+  });
+});

--- a/tests/delivery.materialised.test.tsx
+++ b/tests/delivery.materialised.test.tsx
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import * as client from '../src/api/client.js';
+import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
+import { RightPanel } from '../src/components/RightPanel.js';
+import { canDeliver, deliverySummary } from '../src/components/delivery.js';
+import { useDeliveryStore } from '../src/store/delivery.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useProjectsStore } from '../src/store/projects.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useProvenanceStore } from '../src/store/provenance.js';
+import { clearCachedWorkflows, isSystemWorkflowIn } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import {
+  DOC_THREAD_RUN_IDS,
+  LIVE_RUN_IDS,
+  LIVE_WORKFLOWS,
+  materialised,
+} from './fixtures/workflows.js';
+import { NOTHING_REASON, REAL_DELIVER_OUTPUT, REAL_PR_URL } from './fixtures/deliverOutput.js';
+import type { Project, SessionView, UnitStatus } from '../src/api/types.js';
+
+/**
+ * THE MATERIALISED PER-RUN DEF (wicked-studio#122, D5 re-opened).
+ *
+ * The first `is_system` fix was measured against the live corpus and moved
+ * NOTHING: byte-identical census output warm, cold, and with no lookup at all.
+ * The reason is in `fixtures/workflows.ts` — **86 of the 129 live runs carry
+ * `workflow_id: "wf-<their own runId>"`, a def `GET /workflows` never serves**,
+ * so the lookup answers `undefined` for them permanently, `deliverKindOf` falls
+ * through to the five-id denylist, and every one of them classified 'build'.
+ * Thirty interactive document threads therefore rendered a Delivery section
+ * whose whole body read "This run has no deliver phase.", and one project's
+ * census line read, in full, `8 no deliver phase`.
+ *
+ * The rule, and every case in this file:
+ *
+ *  - a run WITH a deliver unit is shown and counted **whatever its workflow id
+ *    is** — 5c5e08b7 opened a real PR under a materialised def, and gating that
+ *    arm on the catalog would hide it;
+ *  - a run WITHOUT one is shown and counted only when a def IN HAND says the
+ *    workflow is ordinary (`is_system === false`) — the same licence the remedy
+ *    line has always required. `undefined` is not a licence.
+ *
+ * Fixtures here are the REAL ids off the daemon, never synthetic
+ * `feature`/`chat` ones: synthetic ids are exactly what let the last round ship
+ * a zero-delta fix with a green suite.
+ */
+
+const KNOWN = (id: string): boolean | undefined => isSystemWorkflowIn(LIVE_WORKFLOWS, id);
+const NOW = Date.now();
+
+const listDocs = vi.fn();
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (...a: unknown[]) => listDocs(...a),
+}));
+
+/** A run on a MATERIALISED def whose deliver phase is in the given state. */
+function delivering(id: string, status: UnitStatus, denial: string | null = null): SessionView {
+  return makeView(
+    {
+      id, workflow_id: materialised(id), status: 'completed',
+      problem: `problem of ${id}`, workdir: '/w/tree', project_id: 'proj-1',
+    },
+    [
+      makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status, denial_reason: denial }),
+    ],
+  );
+}
+
+/**
+ * A wicked-interactive DOCUMENT thread, as the wire carries them: a materialised
+ * def, `:outline`/`:draft` units, no deliver phase anywhere.
+ */
+function docThread(id: string): SessionView {
+  return makeView(
+    {
+      id, workflow_id: materialised(id), status: 'completed', workdir: '/w/tree',
+      problem: `Produce the first draft of the wicked-interactive document "${id}"`,
+      project_id: 'proj-1',
+    },
+    [
+      makeUnit({ id: `${id}:outline`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:draft`, session_id: id, ord: 1, status: 'done' }),
+    ],
+  );
+}
+
+/** A CATALOG build run with no deliver phase — the arm that keeps its section. */
+function catalogPlain(id: string, workflow_id = 'feature'): SessionView {
+  return makeView(
+    { id, workflow_id, status: 'completed', problem: `problem of ${id}`, workdir: '/w/tree', project_id: 'proj-1' },
+    [makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' })],
+  );
+}
+
+describe('the predicate, over the real corpus shapes', () => {
+  it('a materialised def is unknown to the catalog — permanently, not while loading', () => {
+    expect(LIVE_WORKFLOWS.some((w) => w.id === materialised(LIVE_RUN_IDS.prOpened))).toBe(false);
+    expect(KNOWN(materialised(LIVE_RUN_IDS.prOpened))).toBeUndefined();
+    // 86 of 129 live runs are this shape. It is the corpus, not an edge case.
+    expect(materialised(LIVE_RUN_IDS.prOpened)).toBe(`wf-${LIVE_RUN_IDS.prOpened}`);
+  });
+
+  const states: { name: string; status: UnitStatus; denial: string | null }[] = [
+    { name: 'delivered', status: 'done', denial: null },
+    { name: 'nothing-to-deliver', status: 'rejected', denial: NOTHING_REASON },
+    { name: 'failed', status: 'rejected', denial: 'the push was refused' },
+    { name: 'in-flight (pending)', status: 'pending', denial: null },
+    { name: 'in-flight (distributed)', status: 'distributed', denial: null },
+  ];
+  for (const s of states) {
+    it(`a materialised run WITH a deliver unit (${s.name}) stays deliverable — lookup or not`, () => {
+      const view = delivering(LIVE_RUN_IDS.prOpened, s.status, s.denial);
+      expect(canDeliver(view, KNOWN), 'warm cache').toBe(true);
+      expect(canDeliver(view, () => undefined), 'cold cache').toBe(true);
+      expect(canDeliver(view), 'no lookup at all').toBe(true);
+    });
+  }
+
+  it('a materialised run with NO deliver unit is withheld in every cache state', () => {
+    const view = docThread(DOC_THREAD_RUN_IDS[0]);
+    expect(canDeliver(view, KNOWN), 'warm cache — still unknown, because it is not a catalog def').toBe(false);
+    expect(canDeliver(view, () => undefined)).toBe(false);
+    expect(canDeliver(view)).toBe(false);
+  });
+
+  it('a CATALOG non-system workflow with no deliver unit keeps its section', () => {
+    expect(KNOWN('feature')).toBe(false);
+    expect(canDeliver(catalogPlain('r-feature'), KNOWN)).toBe(true);
+    // …but only with the def in hand. Before it lands, studio cannot say so.
+    expect(canDeliver(catalogPlain('r-feature'), () => undefined)).toBe(false);
+  });
+
+  it('a CATALOG is_system workflow with no deliver unit is withheld, as before', () => {
+    expect(KNOWN('interactive-draft')).toBe(true);
+    expect(canDeliver(catalogPlain('r-draft', 'interactive-draft'), KNOWN)).toBe(false);
+  });
+
+  it('THE CENSUS: the eight document threads stop being a delivery finding', () => {
+    const threads = DOC_THREAD_RUN_IDS.map(docThread);
+    expect(threads).toHaveLength(8);
+    // The live line, verbatim, before: a count of documents in a delivery census.
+    expect(deliverySummary(threads, KNOWN)).toBe('');
+    expect(deliverySummary(threads)).toBe('');
+  });
+
+  it('…while the runs that DID deliver are all still counted', () => {
+    const line = deliverySummary(
+      [
+        delivering(LIVE_RUN_IDS.prOpened, 'done'),
+        delivering(LIVE_RUN_IDS.deliverRan, 'done'),
+        delivering('r-pending', 'pending'),
+        ...DOC_THREAD_RUN_IDS.map(docThread),
+      ],
+      KNOWN,
+    );
+    expect(line).toBe('2 ran deliver · 1 deliver pending');
+    expect(line).not.toContain('no deliver phase');
+  });
+});
+
+describe('the rail (RightPanel)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearCachedWorkflows();
+    useRunEventStore.setState({ byRun: {} });
+    useDeliveryStore.setState({ byRun: {} });
+    useProvenanceStore.setState({ byRun: {}, launchedHere: {} });
+    vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+    vi.spyOn(client.api, 'getAudit').mockResolvedValue({ entries: [] });
+    vi.spyOn(client.api, 'getRun').mockImplementation((id: string) =>
+      Promise.resolve({ run: docThread(id) }),
+    );
+    vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: REAL_DELIVER_OUTPUT });
+  });
+  afterEach(() => { cleanup(); clearCachedWorkflows(); });
+
+  it('a document thread gets NO Delivery section — not before the defs land, not after', async () => {
+    render(<RightPanel view={docThread(DOC_THREAD_RUN_IDS[0])} />);
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+
+    // The defs land and change nothing: this id is in no catalog, ever.
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('run-delivery')).not.toBeInTheDocument();
+    // The sentence that used to be there, about a run studio cannot classify.
+    expect(document.body.textContent).not.toContain('This run has no deliver phase.');
+  });
+
+  it('5c5e08b7 — a materialised def that opened a REAL PR — keeps its section and its link', async () => {
+    render(<RightPanel view={delivering(LIVE_RUN_IDS.prOpened, 'done')} />);
+
+    // Present from the first paint: the deliver unit is the licence, not a def.
+    const header = screen.getByRole('button', { name: /Delivery/ });
+    expect(screen.getByTestId('run-delivery-badge')).toHaveTextContent('deliver ran');
+
+    fireEvent.click(header);
+    const link = await screen.findByTestId('run-delivery-link');
+    expect(link).toHaveAttribute('href', REAL_PR_URL);
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'pr-open');
+  });
+
+  it('665a9aeb still reads "deliver ran" — the phase, on a def no catalog carries', () => {
+    render(<RightPanel view={delivering(LIVE_RUN_IDS.deliverRan, 'done')} />);
+
+    const badge = screen.getByTestId('run-delivery-badge');
+    expect(badge).toHaveAttribute('data-state', 'delivered');
+    expect(badge).toHaveTextContent('deliver ran');
+    expect(badge.textContent).not.toMatch(/\bPR\b/);
+  });
+
+  it('every delivering state keeps its section on a materialised def', () => {
+    for (const [i, s] of ([
+      ['done', null], ['rejected', NOTHING_REASON], ['rejected', 'the push was refused'],
+      ['pending', null], ['distributed', null],
+    ] as [UnitStatus, string | null][]).entries()) {
+      render(<RightPanel view={delivering(`r-state-${i}`, s[0], s[1])} />);
+      expect(screen.getByRole('button', { name: /Delivery/ }), `state ${s[0]}`).toBeInTheDocument();
+      cleanup();
+    }
+  });
+
+  it('a CATALOG feature run gets its section back once the defs land, remedy included', async () => {
+    render(<RightPanel view={catalogPlain('r-feature-late')} />);
+    // Cold: nothing is proven, so nothing is claimed — including the section.
+    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+
+    const header = await screen.findByRole('button', { name: /Delivery/ });
+    fireEvent.click(header);
+    const body = await screen.findByTestId('run-delivery');
+    expect(body).toHaveAttribute('data-state', 'none');
+    expect(body).toHaveTextContent('This run has no deliver phase.');
+    expect(body).toHaveTextContent('launch with deliver: pr');
+  });
+});
+
+describe('the project census surface', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearCachedWorkflows();
+    listDocs.mockReset().mockResolvedValue([]);
+    vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+    vi.spyOn(client.api, 'listProjectMembers').mockResolvedValue({ members: [] });
+    vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
+    vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+    useGateStore.setState({ gates: {} });
+    useRunEventStore.setState({ byRun: {} });
+    useProjectsStore.setState({
+      projects: [{
+        id: 'proj-1', name: 'The proof project', description: null, status: 'active',
+        scope: 'project:proj-1', created_at: NOW - 1000, updated_at: NOW - 100,
+      } as Project],
+      loading: false,
+      error: null,
+    });
+  });
+  afterEach(() => { cleanup(); clearCachedWorkflows(); });
+
+  it('proj_178674023693500000: eight document threads, and NO census line at all', async () => {
+    render(
+      <ProjectDashboard projectId="proj-1" runs={DOC_THREAD_RUN_IDS.map(docThread)} navigate={() => {}} />,
+    );
+
+    await screen.findByTestId('dashboard-runs');
+    expect(screen.getAllByTestId('dashboard-run').length).toBeGreaterThan(0);
+    // Was: "8 no deliver phase" — the D5 complaint at 100% of the line.
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    expect(screen.queryByTestId('dashboard-delivery-summary')).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('no deliver phase');
+  });
+
+  it('a mixed project still censuses everything that has a deliver phase', async () => {
+    render(
+      <ProjectDashboard
+        projectId="proj-1"
+        runs={[
+          delivering(LIVE_RUN_IDS.prOpened, 'done'),
+          delivering(LIVE_RUN_IDS.deliverRan, 'done'),
+          delivering('r-inflight', 'pending'),
+          ...DOC_THREAD_RUN_IDS.map(docThread),
+        ]}
+        navigate={() => {}}
+      />,
+    );
+
+    const summary = await screen.findByTestId('dashboard-delivery-summary');
+    expect(summary.textContent).toStrictEqual('2 ran deliver · 1 deliver pending');
+  });
+
+  it('D2: a row chips only what the rail would open — and reads no defs of its own', async () => {
+    const runs = [
+      delivering('r-chip-done', 'done'),
+      delivering('r-chip-empty', 'rejected', NOTHING_REASON),
+      delivering('r-chip-pending', 'pending'),
+      ...DOC_THREAD_RUN_IDS.slice(0, 3).map(docThread),
+    ];
+    render(<ProjectDashboard projectId="proj-1" runs={runs} navigate={() => {}} />);
+
+    const rows = await screen.findAllByTestId('dashboard-run');
+    for (const row of rows) {
+      const id = row.getAttribute('data-run-id') ?? '';
+      const view = runs.find((v) => v.session.id === id) as SessionView;
+      const chip = within(row).queryByTestId('run-delivery-chip');
+      // The invariant: nothing may be chipped that the section itself withholds.
+      if (chip !== null) expect(canDeliver(view, KNOWN), `${id} chipped`).toBe(true);
+    }
+    // …and the whole surface still costs ONE /workflows, zero per row.
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalledTimes(1));
+    expect(client.api.listWorkflows).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/delivery.surfaces.test.tsx
+++ b/tests/delivery.surfaces.test.tsx
@@ -116,6 +116,28 @@ describe('the project page (EC57, EC58)', () => {
     expect(within(plainRow as HTMLElement).queryByTestId('run-delivery-chip')).toBeNull();
   });
 
+  it('an UNRESOLVED deliver phase gets no row chip — the status pill already owns motion', async () => {
+    // Verification gap closed: `DeliveryChip` returns null for `in-flight` by
+    // deliberate design (a cancelled run's deliver unit stays `pending` forever,
+    // so a second motion word on the row would claim progress that stopped) and
+    // nothing pinned it — dropping the `in-flight` arm left every test green.
+    render(
+      <ProjectDashboard
+        projectId="proj-1"
+        runs={[run('r-pending', 'pending'), run('r-dist', 'distributed'), run('r-pr-1', 'done')]}
+        navigate={() => {}}
+      />,
+    );
+
+    const rows = await screen.findAllByTestId('dashboard-run');
+    const chipOf = (id: string): string | null | undefined =>
+      within(rows.find((r) => r.getAttribute('data-run-id') === id) as HTMLElement)
+        .queryByTestId('run-delivery-chip')?.getAttribute('data-state');
+    expect(chipOf('r-pending')).toBeUndefined();
+    expect(chipOf('r-dist')).toBeUndefined();
+    expect(chipOf('r-pr-1')).toBe('delivered');
+  });
+
   it('the RUNS-tile census counts ALL runs, not the MAX_ROWS window', async () => {
     render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
 
@@ -180,6 +202,12 @@ describe('the Build run list (EC57, EC58)', () => {
     expect(stateOf('r-empty-1')).toBe('nothing-to-deliver');
     // No deliver phase → no chip (the status pill already says what it is doing).
     expect(stateOf('r-plain-0')).toBeUndefined();
+  });
+
+  it('an UNRESOLVED deliver phase gets no chip here either', () => {
+    build([run('r-pending', 'pending'), run('r-dist', 'distributed')]);
+
+    expect(screen.queryByTestId('run-delivery-chip')).toBeNull();
   });
 
   it('EC58: the list fires ZERO per-run output reads', () => {

--- a/tests/delivery.surfaces.test.tsx
+++ b/tests/delivery.surfaces.test.tsx
@@ -68,6 +68,14 @@ function plain(id: string): SessionView {
   );
 }
 
+/** A CHAT thread filed into `proj-1` — a run that can never deliver (D5). */
+function chat(id: string): SessionView {
+  return makeView(
+    { id, workflow_id: 'chat', status: 'completed', problem: `chat ${id}`, project_id: 'proj-1' },
+    [],
+  );
+}
+
 /**
  * Nineteen runs: 3 delivered, 2 delivered nothing, 14 with no deliver phase —
  * deliberately more than the tile's MAX_ROWS of 6, and with the interesting ones
@@ -109,6 +117,8 @@ describe('the project page (EC57, EC58)', () => {
     for (const row of chipped) {
       const chip = within(row).getByTestId('run-delivery-chip');
       expect(['delivered', 'nothing-to-deliver', 'failed']).toContain(chip.getAttribute('data-state'));
+      // D2: a list surface holds no url, so no chip on it may claim a PR.
+      expect(chip.textContent).not.toMatch(/\bPR\b/);
     }
     // Rows for runs with no deliver phase carry no chip — silence, never "unknown".
     const plainRow = rows.find((r) => r.getAttribute('data-run-id')?.startsWith('r-plain-'));
@@ -142,9 +152,42 @@ describe('the project page (EC57, EC58)', () => {
     render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
 
     const summary = await screen.findByTestId('dashboard-delivery-summary');
-    // 19 runs; 6 rows rendered. The census sees all nineteen.
-    expect(summary).toHaveTextContent('3 delivered · 2 delivered nothing · 14 no deliver phase');
+    // 19 runs; 6 rows rendered. The census sees all nineteen — and says "ran
+    // deliver", never "delivered": zero fetches means zero urls in hand.
+    expect(summary.textContent)
+      .toStrictEqual('3 ran deliver · 2 delivered nothing · 14 no deliver phase');
+    expect(summary.textContent).not.toMatch(/\bPR\b/);
     expect(screen.getAllByTestId('dashboard-run')).toHaveLength(6);
+  });
+
+  it('D5: chat threads are OUT of the census — the rail hides Delivery from them', async () => {
+    // The reported symptom, exactly: a chat-heavy project read
+    // "3 delivered · 30 no deliver phase", a count of conversations dressed up
+    // as a delivery finding. The rail already refused to show Delivery on those
+    // threads; now both surfaces agree on what a deliverable run is.
+    const runs = [
+      run('r-pr-1', 'done'), run('r-pr-2', 'done'), run('r-pr-3', 'done'),
+      ...Array.from({ length: 30 }, (_, i) => chat(`c-${i}`)),
+    ];
+    render(<ProjectDashboard projectId="proj-1" runs={runs} navigate={() => {}} />);
+
+    const summary = await screen.findByTestId('dashboard-delivery-summary');
+    expect(summary.textContent).toStrictEqual('3 ran deliver');
+    expect(summary.textContent).not.toContain('no deliver phase');
+  });
+
+  it('a project of ONLY chats shows no census line at all, not an empty one', async () => {
+    render(
+      <ProjectDashboard
+        projectId="proj-1"
+        runs={Array.from({ length: 5 }, (_, i) => chat(`c-${i}`))}
+        navigate={() => {}}
+      />,
+    );
+
+    await screen.findByTestId('dashboard-runs');
+    expect(screen.getAllByTestId('dashboard-run').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('dashboard-delivery-summary')).not.toBeInTheDocument();
   });
 
   it('a project with no runs shows no census line rather than "0 delivered"', async () => {
@@ -194,14 +237,31 @@ describe('the Build run list (EC57, EC58)', () => {
     build([run('r-pr-1', 'done'), run('r-empty-1', 'rejected', NOTHING_REASON), plain('r-plain-0')]);
 
     const rows = screen.getAllByTestId('build-run-row');
-    const stateOf = (id: string): string | null | undefined => {
+    const chipOf = (id: string): HTMLElement | null => {
       const row = rows.find((r) => r.getAttribute('title')?.includes(id));
-      return within(row as HTMLElement).queryByTestId('run-delivery-chip')?.getAttribute('data-state');
+      return within(row as HTMLElement).queryByTestId('run-delivery-chip');
     };
-    expect(stateOf('r-pr-1')).toBe('delivered');
-    expect(stateOf('r-empty-1')).toBe('nothing-to-deliver');
+    expect(chipOf('r-pr-1')?.getAttribute('data-state')).toBe('delivered');
+    expect(chipOf('r-empty-1')?.getAttribute('data-state')).toBe('nothing-to-deliver');
     // No deliver phase → no chip (the status pill already says what it is doing).
-    expect(stateOf('r-plain-0')).toBeUndefined();
+    expect(chipOf('r-plain-0')).toBeNull();
+  });
+
+  it('D2: an approved deliver phase reads as the PHASE here — never "PR open"', () => {
+    // The 665a9aeb wire shape on a zero-fetch surface: `done`, `denial_reason`
+    // null, and no url anywhere on the DTO. The first cut rendered "PR open" for
+    // exactly this run — the false productivity signal the slice exists to kill.
+    build([run('r-665a9aeb', 'done')]);
+
+    const chip = screen.getByTestId('run-delivery-chip');
+    expect(chip).toHaveAttribute('data-state', 'delivered');
+    expect(chip.textContent).toStrictEqual('deliver ran');
+    expect(chip.textContent).not.toMatch(/\bPR\b/);
+    // Nothing was read to reach that word, and nothing on the row links a PR.
+    expect(getUnitOutput).not.toHaveBeenCalled();
+    const row = screen.getByTestId('build-run-row');
+    const hrefs = [...row.querySelectorAll('[href]')].map((e) => e.getAttribute('href') ?? '');
+    expect(hrefs.filter((h) => h.includes('/pull/'))).toEqual([]);
   });
 
   it('an UNRESOLVED deliver phase gets no chip here either', () => {

--- a/tests/delivery.surfaces.test.tsx
+++ b/tests/delivery.surfaces.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
+import { CenterDashboard } from '../src/components/CenterDashboard.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useProjectsStore } from '../src/store/projects.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeUnit, makeView } from './factories.js';
+import { NOTHING_REASON } from './fixtures/deliverOutput.js';
+import type { Project, SessionView, UnitStatus } from '../src/api/types.js';
+
+/**
+ * The two LIST surfaces (wicked-studio#122, slice DA, EC57/EC58): the project
+ * page's run rows + RUNS-tile census, and Build's run list.
+ *
+ * The budget is the point. Both surfaces are DTO-derived and fire ZERO per-run
+ * requests — an N-run fan-out to `/runs/:id/units/:key/output` is exactly what
+ * CREW-UX-8 (`session.delivery`) exists to make unnecessary, and it is the one
+ * thing this slice is not allowed to do. `getUnitOutput` sits in both mocks so a
+ * regression that reaches for it fails here rather than in production.
+ */
+
+const listProjectMembers = vi.fn();
+const getUnitOutput = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects: [] }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    confirmGate: () => Promise.resolve({}),
+    injectMessage: () => Promise.resolve({}),
+    getUnitOutput: (...a: unknown[]) => getUnitOutput(...a),
+  },
+}));
+
+const listDocs = vi.fn();
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (...a: unknown[]) => listDocs(...a),
+}));
+
+const NOW = Date.now();
+
+function project(id: string): Project {
+  return {
+    id, name: `The ${id} project`, description: null, status: 'active',
+    scope: `project:${id}`, created_at: NOW - 1000, updated_at: NOW - 100,
+  };
+}
+
+/** A build run filed into `proj-1` whose deliver phase is in the given state. */
+function run(id: string, status: UnitStatus, denial: string | null = null): SessionView {
+  return makeView(
+    { id, workflow_id: 'feature', status: 'completed', problem: `problem of ${id}`, project_id: 'proj-1' },
+    [
+      makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' }),
+      makeUnit({ id: `${id}:deliver`, session_id: id, ord: 1, status, denial_reason: denial }),
+    ],
+  );
+}
+
+/** A build run with no deliver phase at all. */
+function plain(id: string): SessionView {
+  return makeView(
+    { id, workflow_id: 'feature', status: 'completed', problem: `problem of ${id}`, project_id: 'proj-1' },
+    [makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' })],
+  );
+}
+
+/**
+ * Nineteen runs: 3 delivered, 2 delivered nothing, 14 with no deliver phase —
+ * deliberately more than the tile's MAX_ROWS of 6, and with the interesting ones
+ * pushed OUT of the visible window (the 665a9aeb shape: the run that read as the
+ * most productive in the project is not in the visible six).
+ */
+function corpus(): SessionView[] {
+  return [
+    ...Array.from({ length: 14 }, (_, i) => plain(`r-plain-${i}`)),
+    run('r-pr-1', 'done'), run('r-pr-2', 'done'), run('r-pr-3', 'done'),
+    run('r-empty-1', 'rejected', NOTHING_REASON), run('r-empty-2', 'rejected', NOTHING_REASON),
+  ];
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  listProjectMembers.mockReset().mockResolvedValue({ members: [] });
+  listDocs.mockReset().mockResolvedValue([]);
+  getUnitOutput.mockReset();
+  useGateStore.setState({ gates: {} });
+  useRunEventStore.setState({ byRun: {} });
+  useProjectsStore.setState({ projects: [project('proj-1')], loading: false, error: null });
+  // The evidence bundle is a bare `fetch`, not an `api` method (client.ts:103) —
+  // EC58 names it, so the budget is asserted at the transport.
+  fetchSpy = vi.fn().mockRejectedValue(new Error('no request should reach the wire'));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+describe('the project page (EC57, EC58)', () => {
+  it('chips each run row with what it produced, and stays silent for runs that have no deliver phase', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+
+    const rows = await screen.findAllByTestId('dashboard-run');
+    expect(rows).toHaveLength(6); // MAX_ROWS
+
+    const chipped = rows.filter((r) => within(r).queryByTestId('run-delivery-chip') !== null);
+    for (const row of chipped) {
+      const chip = within(row).getByTestId('run-delivery-chip');
+      expect(['delivered', 'nothing-to-deliver', 'failed']).toContain(chip.getAttribute('data-state'));
+    }
+    // Rows for runs with no deliver phase carry no chip — silence, never "unknown".
+    const plainRow = rows.find((r) => r.getAttribute('data-run-id')?.startsWith('r-plain-'));
+    expect(plainRow).toBeDefined();
+    expect(within(plainRow as HTMLElement).queryByTestId('run-delivery-chip')).toBeNull();
+  });
+
+  it('the RUNS-tile census counts ALL runs, not the MAX_ROWS window', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+
+    const summary = await screen.findByTestId('dashboard-delivery-summary');
+    // 19 runs; 6 rows rendered. The census sees all nineteen.
+    expect(summary).toHaveTextContent('3 delivered · 2 delivered nothing · 14 no deliver phase');
+    expect(screen.getAllByTestId('dashboard-run')).toHaveLength(6);
+  });
+
+  it('a project with no runs shows no census line rather than "0 delivered"', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    await screen.findByTestId('dashboard-runs');
+    expect(screen.queryByTestId('dashboard-delivery-summary')).not.toBeInTheDocument();
+  });
+
+  it('EC58: rendering the page fires ZERO /units/*/output and ZERO /evidence requests', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+    await screen.findByTestId('dashboard-delivery-summary');
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
+
+    expect(getUnitOutput).not.toHaveBeenCalled();
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.filter((u) => u.includes('/output') || u.includes('/evidence'))).toEqual([]);
+  });
+
+  it('no delivery TILE is added — the 2×2 grid keeps its four sections', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+    await screen.findByTestId('dashboard-runs');
+
+    expect(screen.getByTestId('dashboard-runs')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-docs')).toBeInTheDocument();
+    expect(screen.queryByTestId('dashboard-delivery')).not.toBeInTheDocument();
+    // The census lives INSIDE the runs tile, not in a tile of its own.
+    expect(screen.getByTestId('dashboard-runs'))
+      .toContainElement(screen.getByTestId('dashboard-delivery-summary'));
+  });
+});
+
+describe('the Build run list (EC57, EC58)', () => {
+  function build(runs: SessionView[]): void {
+    render(
+      <CenterDashboard
+        runs={runs}
+        onSelectRun={vi.fn()}
+        onApproveGate={vi.fn()}
+        onRejectGate={vi.fn()}
+        navigate={vi.fn()}
+      />,
+    );
+  }
+
+  it('carries the SAME chip as the project rows, per state', () => {
+    build([run('r-pr-1', 'done'), run('r-empty-1', 'rejected', NOTHING_REASON), plain('r-plain-0')]);
+
+    const rows = screen.getAllByTestId('build-run-row');
+    const stateOf = (id: string): string | null | undefined => {
+      const row = rows.find((r) => r.getAttribute('title')?.includes(id));
+      return within(row as HTMLElement).queryByTestId('run-delivery-chip')?.getAttribute('data-state');
+    };
+    expect(stateOf('r-pr-1')).toBe('delivered');
+    expect(stateOf('r-empty-1')).toBe('nothing-to-deliver');
+    // No deliver phase → no chip (the status pill already says what it is doing).
+    expect(stateOf('r-plain-0')).toBeUndefined();
+  });
+
+  it('EC58: the list fires ZERO per-run output reads', () => {
+    build(corpus());
+
+    expect(screen.getAllByTestId('build-run-row').length).toBeGreaterThan(0);
+    expect(getUnitOutput).not.toHaveBeenCalled();
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.filter((u) => u.includes('/output') || u.includes('/evidence'))).toEqual([]);
+  });
+});

--- a/tests/delivery.surfaces.test.tsx
+++ b/tests/delivery.surfaces.test.tsx
@@ -5,8 +5,10 @@ import { CenterDashboard } from '../src/components/CenterDashboard.js';
 import { useGateStore } from '../src/store/gates.js';
 import { useProjectsStore } from '../src/store/projects.js';
 import { useRunEventStore } from '../src/store/events.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
 import { makeUnit, makeView } from './factories.js';
 import { NOTHING_REASON } from './fixtures/deliverOutput.js';
+import { LIVE_WORKFLOWS } from './fixtures/workflows.js';
 import type { Project, SessionView, UnitStatus } from '../src/api/types.js';
 
 /**
@@ -25,6 +27,10 @@ const getUnitOutput = vi.fn();
 
 vi.mock('../src/api/client.js', () => ({
   api: {
+    // The app's ONE workflow-defs read. Both surfaces gate on `is_system` now
+    // (the census bucket AND the row chips, D2), so the mock serves the real
+    // daemon table rather than leaving every id unknown.
+    listWorkflows: () => Promise.resolve({ workflows: LIVE_WORKFLOWS }),
     listProjects: () => Promise.resolve({ projects: [] }),
     listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
     listRepos: () => Promise.resolve({ repos: [] }),
@@ -99,12 +105,13 @@ beforeEach(() => {
   useGateStore.setState({ gates: {} });
   useRunEventStore.setState({ byRun: {} });
   useProjectsStore.setState({ projects: [project('proj-1')], loading: false, error: null });
+  clearCachedWorkflows();
   // The evidence bundle is a bare `fetch`, not an `api` method (client.ts:103) —
   // EC58 names it, so the budget is asserted at the transport.
   fetchSpy = vi.fn().mockRejectedValue(new Error('no request should reach the wire'));
   vi.stubGlobal('fetch', fetchSpy);
 });
-afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); clearCachedWorkflows(); });
 
 describe('the project page (EC57, EC58)', () => {
   it('chips each run row with what it produced, and stays silent for runs that have no deliver phase', async () => {
@@ -154,8 +161,14 @@ describe('the project page (EC57, EC58)', () => {
     const summary = await screen.findByTestId('dashboard-delivery-summary');
     // 19 runs; 6 rows rendered. The census sees all nineteen — and says "ran
     // deliver", never "delivered": zero fetches means zero urls in hand.
-    expect(summary.textContent)
-      .toStrictEqual('3 ran deliver · 2 delivered nothing · 14 no deliver phase');
+    // The fourteen land in "no deliver phase" only because the defs prove
+    // `feature` is an ordinary workflow — the bucket is a claim about a
+    // classification, so it waits for one. (`delivery.materialised.test.tsx`
+    // owns the other side: a run whose def no catalog carries is never counted.)
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-delivery-summary').textContent)
+        .toStrictEqual('3 ran deliver · 2 delivered nothing · 14 no deliver phase'),
+    );
     expect(summary.textContent).not.toMatch(/\bPR\b/);
     expect(screen.getAllByTestId('dashboard-run')).toHaveLength(6);
   });

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -10,6 +10,7 @@ import {
   resolveDelivery,
   type DeliveryState,
 } from '../src/components/delivery.js';
+import { HEADLINE } from '../src/components/RunDelivery.js';
 import { makeUnit, makeView } from './factories.js';
 import {
   EMPTY_PUSH_OUTPUT,
@@ -287,6 +288,24 @@ describe('resolveDelivery — the PR claim needs a URL IN HAND (D1/D2)', () => {
     expect(r.href).toBe('https://x/pull/9');
   });
 
+  it('an EMPTY url is an ABSENT url — at the derivation AND at the claim', () => {
+    // Third member of the same absent-vs-empty class as `denial_reason` and
+    // `outputUnavailable`. Un-normalized, `'' ?? readUrl` keeps the empty
+    // string, `href === null` is false, and the surface paints "PR open" in
+    // `--accent` over an `href=""` that points back at studio. Both layers are
+    // pinned: the wire read, and `resolveDelivery`'s own re-check (it is
+    // exported and takes a hand-built `Delivery`).
+    const view = composed('done');
+    const session = { ...view.session, delivery: { kind: 'pull_request', url: '' } };
+    expect(deliveryOf({ ...view, session: session as typeof view.session }).url).toBeNull();
+
+    const hand = { state: 'delivered' as const, unitId: 'r:deliver', reason: null, url: '' };
+    expect(resolveDelivery(hand).claim).toBe('delivered');
+    expect(resolveDelivery(hand).href).toBeNull();
+    expect(resolveDelivery({ ...hand, url: null }, '').claim).toBe('delivered');
+    expect(resolveDelivery({ ...hand, url: null }, '').href).toBeNull();
+  });
+
   it('a read url can never upgrade a state that was not approved', () => {
     const states: DeliveryState[] = ['none', 'in-flight', 'nothing-to-deliver', 'failed'];
     const views = [
@@ -316,6 +335,31 @@ describe('DELIVERY_LABEL', () => {
       .filter(([, w]) => /\bPR\b/i.test(w))
       .map(([k]) => k);
     expect(mentions).toStrictEqual(['pr-open']);
+  });
+});
+
+describe('HEADLINE — the rail body says what the badge says', () => {
+  // The badge WORD carried a structural guard and this sentence did not, so
+  // `HEADLINE['delivered']` could be edited back to "PR open — merge stays
+  // human." (the review's own example of the lie) with the suite still green.
+  it('exactly ONE headline asserts an open PR, and it is the url-bearing claim', () => {
+    const asserts = Object.entries(HEADLINE)
+      .filter(([, s]) => /\bPR open\b/i.test(s))
+      .map(([k]) => k);
+    expect(asserts).toStrictEqual(['pr-open']);
+  });
+
+  it('the phase-only headline names the PHASE and denies the artifact', () => {
+    const line = HEADLINE['delivered'];
+    expect(line).toContain('deliver phase');
+    expect(line).toMatch(/not a PR/i);
+    expect(line).not.toMatch(/\bPR open\b/i);
+  });
+
+  it('no headline says shipped or merged-without-a-human', () => {
+    const words = Object.values(HEADLINE).join(' ').toLowerCase();
+    expect(words).not.toContain('shipped');
+    expect(words).not.toContain('merged');
   });
 });
 

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -600,3 +600,36 @@ describe('isPrUrl agrees with the href shape EC55 pins', () => {
     }
   });
 });
+
+describe('the deliver-unit fallback errs toward silence (Copilot on #125)', () => {
+  const unitWith = (cmd: string[]) =>
+    makeView({ id: 'r-fb', workflow_id: 'feature' }, [
+      makeUnit({ id: 'r-fb:build', status: 'done', tool_cmd: cmd }),
+    ]);
+
+  it('a quoted MENTION is never mistaken for the deliver phase', () => {
+    // The separator form matched `grep -rn "(gh pr create)" .` because `(` counted as an
+    // invocation separator regardless of the quote before it — a false positive that would
+    // assert a Delivery section on a unit that never delivered.
+    for (const cmd of [
+      ['grep', '-rn', '"(gh pr create)"', '.'],
+      ['bash', '-lc', 'echo (gh pr create)'],
+      ['bash', '-lc', 'echo "run gh pr create yourself"'],
+      ['sed', '-i', 's/gh pr create/…/', 'x.sh'],
+    ]) {
+      expect(deliverUnit(unitWith(cmd))).toBeNull();
+    }
+  });
+
+  it('a real invocation at a line start is still found', () => {
+    const u = deliverUnit(unitWith(['bash', '-lc', 'git push -u origin "$B"\ngh pr create --fill']));
+    expect(u).not.toBeNull();
+  });
+
+  it('the id suffix remains the PRIMARY key — the fallback is only for overlays', () => {
+    const v = makeView({ id: 'r-pri', workflow_id: 'feature' }, [
+      makeUnit({ id: 'r-pri:deliver', status: 'done' }),
+    ]);
+    expect(deliverUnit(v)?.id).toBe('r-pri:deliver');
+  });
+});

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -519,6 +519,8 @@ describe('isPrUrl — one gate for BOTH url sources (Copilot on #125)', () => {
     'https://github.com/o/r/pull/new/wicked/branch',       // the create-PR form
     'https://github.com/o/r/pull/new/pull/5',              // crafted: ends /pull/5 but IS a form
     'https://github.com/o/r/compare/pull/new/x/pull/9',    // …and buried mid-path
+    'https://github.com/o/r/pull/121?diff=split',          // query breaks the pinned href shape
+    'https://github.com/o/r/pull/121#discussion_r1',       // …so does a fragment
     'https://github.com/o/r/pull/',
     'https://github.com/o/r/pull/abc',
     'not a url at all',
@@ -579,5 +581,22 @@ describe('resolveDelivery validates its own input (Copilot on #125)', () => {
     const d = { state: 'delivered' as const, unitId: 'u', reason: null, url: null };
     expect(resolveDelivery(d, 'javascript:alert(1)').claim).toBe('delivered');
     expect(resolveDelivery(d, 'https://github.com/o/r/pull/9').claim).toBe('pr-open');
+  });
+});
+
+describe('isPrUrl agrees with the href shape EC55 pins', () => {
+  it('every url it accepts satisfies the acceptance criterion', () => {
+    // The validator and the AC must not disagree: anything isPrUrl admits gets rendered as the
+    // external link, and EC55 asserts that href matches this exact shape.
+    const EC55 = /^https:\/\/\S+\/pull\/\d+$/;
+    const accepted = [
+      'https://github.com/mikeparcewski/wicked-studio/pull/121',
+      'https://x/pull/9',
+      'https://ghe.internal.example/o/r/pull/7',
+    ];
+    for (const u of accepted) {
+      expect(isPrUrl(u)).toBe(true);
+      expect(EC55.test(u)).toBe(true);
+    }
   });
 });

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DELIVERY_COLOR,
   DELIVERY_LABEL,
+  canDeliver,
   deliverUnit,
   deliveryOf,
   deliverySummary,
   prUrlFrom,
+  resolveDelivery,
   type DeliveryState,
 } from '../src/components/delivery.js';
 import { makeUnit, makeView } from './factories.js';
 import {
+  EMPTY_PUSH_OUTPUT,
   NO_URL_REASON,
   NOTHING_REASON,
   REAL_DELIVER_OUTPUT,
@@ -55,6 +59,11 @@ describe('prUrlFrom — crew\'s own grep, mirrored (deliver.ts:162)', () => {
     {
       name: 'a create-PR form ALONE resolves to nothing (the digits are the whole gate)',
       text: 'remote:      https://github.com/o/r/pull/new/wicked/665a9aeb-285d-407b\n',
+      want: null,
+    },
+    {
+      name: 'the REAL 665a9aeb transcript — an approved phase that opened no PR',
+      text: EMPTY_PUSH_OUTPUT,
       want: null,
     },
     {
@@ -185,11 +194,112 @@ describe('deliveryOf — five mutually exclusive states, zero fetches', () => {
     expect(deliveryOf(view).state).toBe('none');
   });
 
+  it('a unit that only MENTIONS `gh pr create` is not the deliver phase', () => {
+    // The fallback used a bare `.includes()`, so any Tool phase carrying the
+    // string anywhere in its joined command inherited the whole delivery claim.
+    const mentions = [
+      ['bash', '-lc', "grep -rn 'gh pr create' docs/"],
+      ['bash', '-lc', 'echo "run gh pr create yourself when the review lands"'],
+      ['bash', '-lc', "sed -i 's/gh pr create/gh pr view/' scripts/deliver.sh"],
+      ['rg', '--fixed-strings', 'gh pr create'],
+    ];
+    for (const tool_cmd of mentions) {
+      const view = makeView({ id: 'run-1' }, [
+        makeUnit({ id: 'run-1:tool', ord: 0, status: 'done', tool_cmd }),
+      ]);
+      expect(deliverUnit(view), tool_cmd.join(' ')).toBeNull();
+      expect(deliveryOf(view).state).toBe('none');
+    }
+  });
+
+  it('…but a real INVOCATION still resolves, in every shape the live daemon runs', () => {
+    // Both strings are the live daemon's own deliver commands, joined.
+    const invocations = [
+      ['gh', 'pr', 'create', '--head', 'B', '--fill'],
+      ['bash', '-lc', 'git push -u origin "$B"; gh pr create --head "$B" --fill 2>&1 | tail -1'],
+      ['bash', '-lc', 'set -euo pipefail\ngit push …\ngh pr create --head "$B" --fill'],
+      ['bash', '-lc', 'git push && gh pr create --fill'],
+      ['bash', '-lc', 'URL=$(gh pr create --fill)'],
+    ];
+    for (const tool_cmd of invocations) {
+      const view = makeView({ id: 'run-1' }, [
+        makeUnit({ id: 'run-1:tool', ord: 0, status: 'done', tool_cmd }),
+      ]);
+      expect(deliverUnit(view)?.id, tool_cmd.join(' ')).toBe('run-1:tool');
+    }
+  });
+
+  it('an EMPTY denial_reason normalizes to null — `?? "…"` may not paint a blank line', () => {
+    // The same absent-and-empty class of bug already fixed in `store/delivery.ts`.
+    const d = deliveryOf(composed('rejected', ''));
+    expect(d.state).toBe('failed');
+    expect(d.reason).toBeNull();
+  });
+
   it('reads the server-carried url when the daemon carries one (crew#321)', () => {
     const view = composed('done');
     const session = { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } };
     expect(deliveryOf({ ...view, session: session as typeof view.session }).url)
       .toBe('https://x/pull/9');
+  });
+});
+
+describe('resolveDelivery — the PR claim needs a URL IN HAND (D1/D2)', () => {
+  /** The REAL 665a9aeb shape: `done`, `denial_reason: null`, no url anywhere. */
+  const realShape = composed('done');
+
+  it('the 665a9aeb shape claims the PHASE, never the artifact — with no read', () => {
+    const r = resolveDelivery(deliveryOf(realShape));
+    expect(r.state).toBe('delivered'); // the phase WAS approved…
+    expect(r.claim).toBe('delivered'); // …and that alone claims nothing
+    expect(r.href).toBeNull();
+    expect(DELIVERY_LABEL[r.claim]).toBe('deliver ran');
+    expect(DELIVERY_LABEL[r.claim]).not.toContain('PR');
+  });
+
+  it('the 665a9aeb shape STILL claims the phase after its transcript is read', () => {
+    // `prUrlFrom` over the real 677-byte transcript is the read's whole result.
+    const readUrl = prUrlFrom(EMPTY_PUSH_OUTPUT);
+    expect(readUrl).toBeNull();
+
+    const r = resolveDelivery(deliveryOf(realShape), readUrl);
+    expect(r.claim).toBe('delivered');
+    expect(r.href).toBeNull();
+    expect(DELIVERY_COLOR[r.claim]).not.toBe('var(--accent)');
+    // …and it is not painted as a failure either: an approved phase that
+    // produced no PR is missing evidence, not a run that failed.
+    expect(DELIVERY_COLOR[r.claim]).not.toBe('var(--status-fail)');
+  });
+
+  it('a url from the ONE transcript read earns `pr-open`, the accent and the href', () => {
+    const r = resolveDelivery(deliveryOf(composed('done')), prUrlFrom(REAL_DELIVER_OUTPUT));
+    expect(r.claim).toBe('pr-open');
+    expect(r.href).toBe(REAL_PR_URL);
+    expect(DELIVERY_LABEL[r.claim]).toBe('PR open');
+    expect(DELIVERY_COLOR[r.claim]).toBe('var(--accent)');
+  });
+
+  it('a WIRE-carried url earns it with no read at all (crew#321)', () => {
+    const view = composed('done');
+    const session = { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } };
+    const r = resolveDelivery(deliveryOf({ ...view, session: session as typeof view.session }));
+    expect(r.claim).toBe('pr-open');
+    expect(r.href).toBe('https://x/pull/9');
+  });
+
+  it('a read url can never upgrade a state that was not approved', () => {
+    const states: DeliveryState[] = ['none', 'in-flight', 'nothing-to-deliver', 'failed'];
+    const views = [
+      makeView({ id: 'run-1' }, [] as WorkUnit[]),
+      composed('pending'),
+      composed('rejected', NOTHING_REASON),
+      composed('rejected', NO_URL_REASON),
+    ];
+    for (const [i, v] of views.entries()) {
+      const r = resolveDelivery(deliveryOf(v), REAL_PR_URL);
+      expect(r.claim).toBe(states[i]);
+      expect(r.href).toBeNull();
+    }
   });
 });
 
@@ -200,24 +310,79 @@ describe('DELIVERY_LABEL', () => {
     expect(words).not.toContain('shipped');
     expect(words).not.toContain('merged');
   });
+
+  it('exactly ONE claim may mention a PR, and it is the one that holds a url', () => {
+    const mentions = Object.entries(DELIVERY_LABEL)
+      .filter(([, w]) => /\bPR\b/i.test(w))
+      .map(([k]) => k);
+    expect(mentions).toStrictEqual(['pr-open']);
+  });
 });
 
-describe('deliverySummary — the census over ALL runs', () => {
-  it('counts every state, in the brief\'s own order', () => {
+describe('deliverySummary — the census over ALL DELIVERABLE runs', () => {
+  it('counts every claim, in the brief\'s own order', () => {
     const views = [
       composed('done'), composed('done'), composed('done'),
       composed('rejected', NOTHING_REASON), composed('rejected', NOTHING_REASON),
-      ...Array.from({ length: 11 }, () => makeView({ id: 'r' }, [] as WorkUnit[])),
+      ...Array.from({ length: 11 }, () => makeView({ id: 'r', workflow_id: 'feature' }, [] as WorkUnit[])),
     ];
-    expect(deliverySummary(views)).toBe('3 delivered · 2 delivered nothing · 11 no deliver phase');
+    // "3 delivered" was the lie: three approved phases, zero known PRs.
+    expect(deliverySummary(views)).toBe('3 ran deliver · 2 delivered nothing · 11 no deliver phase');
   });
 
-  it('names failures and in-flight deliveries too, and omits empty buckets', () => {
-    expect(deliverySummary([composed('rejected', NO_URL_REASON), composed('pending')]))
-      .toBe('1 failed to deliver · 1 still to deliver');
+  it('D3: the in-flight bucket matches its own label — no forward-looking wording', () => {
+    const line = deliverySummary([composed('rejected', NO_URL_REASON), composed('pending')]);
+    expect(line).toBe('1 failed to deliver · 1 deliver pending');
+    // The label refuses "still"/"to deliver" because a cancelled run's unit
+    // stays `pending` forever; the census may not smuggle them back in.
+    expect(line).not.toContain('still');
+    expect(DELIVERY_LABEL['in-flight']).toBe('pending');
+  });
+
+  it('D5: chats are not counted — the rail hides Delivery from them, so does the census', () => {
+    const chats = Array.from({ length: 30 }, () =>
+      makeView({ id: 'c', workflow_id: 'chat' }, [] as WorkUnit[]));
+    const freeform = makeView({ id: 'f', workflow_id: '' }, [] as WorkUnit[]);
+    const system = makeView({ id: 's', workflow_id: 'onboarding' }, [] as WorkUnit[]);
+
+    // The exact reported symptom: "3 delivered · 30 no deliver phase".
+    expect(deliverySummary([composed('done'), composed('done'), composed('done'), ...chats]))
+      .toBe('3 ran deliver');
+    expect(deliverySummary([...chats, freeform, system])).toBe('');
   });
 
   it('an empty project says nothing rather than "0 delivered"', () => {
     expect(deliverySummary([])).toBe('');
   });
+
+  it('a wire-carried url is counted as an open PR, separately from the phase', () => {
+    const view = composed('done');
+    const withUrl = {
+      ...view,
+      session: { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } } as typeof view.session,
+    };
+    expect(deliverySummary([withUrl, composed('done')])).toBe('1 PR open · 1 ran deliver');
+  });
+});
+
+describe('canDeliver — the ONE predicate both surfaces gate on (D5)', () => {
+  const cases: { workflow_id: string | null; want: boolean }[] = [
+    { workflow_id: 'feature', want: true },
+    { workflow_id: 'feature-pr', want: true },
+    { workflow_id: 'wf-665a9aeb-285d-407b-b869-813b67e50973', want: true },
+    { workflow_id: 'chat', want: false },
+    { workflow_id: 'onboarding', want: false },
+    { workflow_id: 'survey-repo', want: false },
+    { workflow_id: 'memories', want: false },
+    { workflow_id: '', want: false },
+    { workflow_id: null, want: false },
+  ];
+
+  for (const { workflow_id, want } of cases) {
+    it(`${JSON.stringify(workflow_id)} → ${want ? 'deliverable' : 'not deliverable'}`, () => {
+      const view = makeView({ id: 'run-1' }, [] as WorkUnit[]);
+      const session = { ...view.session, workflow_id } as typeof view.session;
+      expect(canDeliver({ ...view, session })).toBe(want);
+    });
+  }
 });

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -517,6 +517,8 @@ describe('isPrUrl — one gate for BOTH url sources (Copilot on #125)', () => {
     'http://github.com/o/r/pull/1',                        // not https
     'https://e.test/o/r/pull/new/b?x=/pull/9',             // digits smuggled in the QUERY
     'https://github.com/o/r/pull/new/wicked/branch',       // the create-PR form
+    'https://github.com/o/r/pull/new/pull/5',              // crafted: ends /pull/5 but IS a form
+    'https://github.com/o/r/compare/pull/new/x/pull/9',    // …and buried mid-path
     'https://github.com/o/r/pull/',
     'https://github.com/o/r/pull/abc',
     'not a url at all',

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -351,6 +351,18 @@ describe('HEADLINE — the rail body says what the badge says', () => {
     expect(asserts).toStrictEqual(['pr-open']);
   });
 
+  it('NO headline asserts a PR exists or does not exist, except the url-bearing one', () => {
+    // The guard above pinned the POSITIVE lie ("PR open") because that is the one round 3
+    // found. It said nothing about the negative — and `in-flight` shipped "no PR exists yet",
+    // which the wire cannot evidence either: the deliver script creates the PR partway through
+    // the phase, so a still-running unit may already have one. Same rule, both directions.
+    const EXISTENCE = /\b(no PR|PR exists|PR was (?:not )?(?:created|opened)|there is no PR|without a PR)\b/i;
+    const offenders = Object.entries(HEADLINE)
+      .filter(([k, sentence]) => k !== 'pr-open' && EXISTENCE.test(sentence))
+      .map(([k]) => k);
+    expect(offenders).toStrictEqual([]);
+  });
+
   it('the phase-only headline names the PHASE and denies the artifact', () => {
     const line = HEADLINE['delivered'];
     expect(line).toContain('deliver phase');

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -11,7 +11,9 @@ import {
   type DeliveryState,
 } from '../src/components/delivery.js';
 import { HEADLINE } from '../src/components/RunDelivery.js';
+import { isSystemWorkflowIn } from '../src/store/workflowCache.js';
 import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS, materialised } from './fixtures/workflows.js';
 import {
   EMPTY_PUSH_OUTPUT,
   NO_URL_REASON,
@@ -363,6 +365,9 @@ describe('HEADLINE — the rail body says what the badge says', () => {
   });
 });
 
+/** The authoritative lookup, as the app's workflow cache serves it. */
+const KNOWN = (id: string): boolean | undefined => isSystemWorkflowIn(LIVE_WORKFLOWS, id);
+
 describe('deliverySummary — the census over ALL DELIVERABLE runs', () => {
   it('counts every claim, in the brief\'s own order', () => {
     const views = [
@@ -371,7 +376,11 @@ describe('deliverySummary — the census over ALL DELIVERABLE runs', () => {
       ...Array.from({ length: 11 }, () => makeView({ id: 'r', workflow_id: 'feature' }, [] as WorkUnit[])),
     ];
     // "3 delivered" was the lie: three approved phases, zero known PRs.
-    expect(deliverySummary(views)).toBe('3 ran deliver · 2 delivered nothing · 11 no deliver phase');
+    // The lookup is what licenses the "no deliver phase" bucket at all: eleven
+    // `feature` runs are countable because a def in hand says `feature` is an
+    // ordinary workflow. The three delivering runs need no such licence — they
+    // have a deliver unit, and their `wf-run-1` def is in no catalog.
+    expect(deliverySummary(views, KNOWN)).toBe('3 ran deliver · 2 delivered nothing · 11 no deliver phase');
   });
 
   it('D3: the in-flight bucket matches its own label — no forward-looking wording', () => {
@@ -409,24 +418,69 @@ describe('deliverySummary — the census over ALL DELIVERABLE runs', () => {
   });
 });
 
-describe('canDeliver — the ONE predicate both surfaces gate on (D5)', () => {
-  const cases: { workflow_id: string | null; want: boolean }[] = [
-    { workflow_id: 'feature', want: true },
-    { workflow_id: 'feature-pr', want: true },
-    { workflow_id: 'wf-665a9aeb-285d-407b-b869-813b67e50973', want: true },
-    { workflow_id: 'chat', want: false },
-    { workflow_id: 'onboarding', want: false },
-    { workflow_id: 'survey-repo', want: false },
-    { workflow_id: 'memories', want: false },
-    { workflow_id: '', want: false },
-    { workflow_id: null, want: false },
-  ];
+describe('canDeliver — the ONE predicate every surface gates on (D5)', () => {
+  /** A run on `workflow_id` with NO deliver phase — the arm that needs a licence. */
+  const plainOn = (workflow_id: string | null): SessionView => {
+    const view = makeView({ id: 'run-1' }, [makeUnit({ id: 'run-1:build', status: 'done' })]);
+    return { ...view, session: { ...view.session, workflow_id } as typeof view.session };
+  };
 
-  for (const { workflow_id, want } of cases) {
-    it(`${JSON.stringify(workflow_id)} → ${want ? 'deliverable' : 'not deliverable'}`, () => {
-      const view = makeView({ id: 'run-1' }, [] as WorkUnit[]);
-      const session = { ...view.session, workflow_id } as typeof view.session;
-      expect(canDeliver({ ...view, session })).toBe(want);
+  describe('NO deliver phase: only a def in hand licenses the claim', () => {
+    const cases: { workflow_id: string | null; want: boolean; why: string }[] = [
+      { workflow_id: 'feature', want: true, why: 'in the catalog, no is_system flag' },
+      { workflow_id: 'feature-pr', want: true, why: 'in the catalog, no is_system flag' },
+      // THE CHANGE. 86 of the 129 live runs carry a materialised `wf-<runId>`
+      // def that `GET /workflows` does not serve, so the lookup answers
+      // `undefined` for them forever. Saying "this run has no deliver phase"
+      // about a run studio cannot classify is asserting past the wire — and it
+      // put a Delivery section on 30 interactive document threads.
+      { workflow_id: materialised('665a9aeb-285d-407b-b869-813b67e50973'), want: false, why: 'materialised: in no catalog, ever' },
+      { workflow_id: 'a-workflow-shipped-tomorrow', want: false, why: 'unknown id, nothing proves it' },
+      { workflow_id: 'chat', want: false, why: 'is_system' },
+      { workflow_id: 'onboarding', want: false, why: 'is_system' },
+      { workflow_id: 'interactive-draft', want: false, why: 'is_system (the denylist never knew it)' },
+      { workflow_id: 'survey-repo', want: false, why: 'is_system' },
+      { workflow_id: 'memories', want: false, why: 'is_system' },
+      { workflow_id: '', want: false, why: 'freeform — deliver without workflow is a 400' },
+      { workflow_id: null, want: false, why: 'freeform' },
+    ];
+
+    for (const { workflow_id, want, why } of cases) {
+      it(`${JSON.stringify(workflow_id)} → ${want ? 'deliverable' : 'withheld'} (${why})`, () => {
+        expect(canDeliver(plainOn(workflow_id), KNOWN)).toBe(want);
+      });
+    }
+
+    it('with NO lookup nothing is deliverable — the predicate withholds, never invents', () => {
+      for (const { workflow_id } of cases) {
+        expect(canDeliver(plainOn(workflow_id)), `${workflow_id} with a cold cache`).toBe(false);
+      }
     });
-  }
+  });
+
+  describe('a deliver phase IN HAND licenses itself, whatever the workflow id', () => {
+    // 5c5e08b7 opened a real PR and its `workflow_id` is `wf-5c5e08b7-…`.
+    // Gating this arm on the catalog would hide a PR the operator has.
+    const statuses: UnitStatus[] = ['done', 'rejected', 'pending', 'distributed'];
+    for (const status of statuses) {
+      it(`${status} on a materialised def is shown and counted, warm cache or cold`, () => {
+        const view = composed(status, status === 'rejected' ? NOTHING_REASON : null);
+        expect(view.session.workflow_id, 'the fixture is a materialised def').toBe('wf-run-1');
+        expect(KNOWN('wf-run-1'), 'which the catalog does not carry').toBeUndefined();
+        expect(canDeliver(view, KNOWN)).toBe(true);
+        expect(canDeliver(view)).toBe(true);
+      });
+    }
+
+    it('an OVERLAY-named deliver unit counts too — resolution is by unit, not by id', () => {
+      expect(canDeliver(overlay('done'), KNOWN)).toBe(true);
+      expect(canDeliver(overlay('done'))).toBe(true);
+    });
+
+    it('…and a deliver phase on a SYSTEM workflow is still evidence, not a guess', () => {
+      const view = composed('done');
+      const session = { ...view.session, workflow_id: 'interactive-draft' } as typeof view.session;
+      expect(canDeliver({ ...view, session }, KNOWN)).toBe(true);
+    });
+  });
 });

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DELIVERY_LABEL,
+  deliverUnit,
+  deliveryOf,
+  deliverySummary,
+  prUrlFrom,
+  type DeliveryState,
+} from '../src/components/delivery.js';
+import { makeUnit, makeView } from './factories.js';
+import {
+  NO_URL_REASON,
+  NOTHING_REASON,
+  REAL_DELIVER_OUTPUT,
+  REAL_PR_URL,
+} from './fixtures/deliverOutput.js';
+import type { SessionView, UnitStatus, WorkUnit } from '../src/api/types.js';
+
+/**
+ * The delivery derivation (wicked-studio#122, slice DA) — the one pure fact
+ * every surface reads. Table-driven, because the whole value of the module is
+ * that the project page, the build list and the right panel CANNOT disagree.
+ */
+
+/** A run whose deliver phase is the COMPOSED one (`<runId>:deliver`). */
+function composed(status: UnitStatus, denial: string | null = null): SessionView {
+  return makeView({ id: 'run-1', workflow_id: 'wf-run-1' }, [
+    makeUnit({ id: 'run-1:build', ord: 0, status: 'done' }),
+    makeUnit({ id: 'run-1:deliver', ord: 1, status, denial_reason: denial }),
+  ]);
+}
+
+/**
+ * A run whose deliver phase came from an OVERLAY that named it something else —
+ * run 5c5e08b7's shape (a `feature-pr` overlay carrying its own deliver phase,
+ * so nothing about its ids or its `workflow_id` says "deliver").
+ */
+function overlay(status: UnitStatus, denial: string | null = null): SessionView {
+  return makeView({ id: 'run-1', workflow_id: 'feature-pr' }, [
+    makeUnit({ id: 'run-1:build', ord: 0, status: 'done' }),
+    makeUnit({
+      id: 'run-1:open-the-pr', ord: 1, status, denial_reason: denial,
+      tool_cmd: ['bash', '-lc', 'set -euo pipefail\ngit push …\ngh pr create --head "$B" --fill'],
+    }),
+  ]);
+}
+
+describe('prUrlFrom — crew\'s own grep, mirrored (deliver.ts:162)', () => {
+  const cases: { name: string; text: string; want: string | null }[] = [
+    {
+      name: 'the real 5c5e08b7 transcript: the NUMBERED PR, never the pull/new form',
+      text: REAL_DELIVER_OUTPUT,
+      want: REAL_PR_URL,
+    },
+    {
+      name: 'a create-PR form ALONE resolves to nothing (the digits are the whole gate)',
+      text: 'remote:      https://github.com/o/r/pull/new/wicked/665a9aeb-285d-407b\n',
+      want: null,
+    },
+    {
+      name: 'the LAST numbered match wins, same as crew\'s `tail -1`',
+      text: 'https://github.com/o/r/pull/7\nsuperseded by\nhttps://github.com/o/r/pull/121',
+      want: 'https://github.com/o/r/pull/121',
+    },
+    {
+      name: 'a fragment does not bleed into the href',
+      text: 'https://github.com/o/r/pull/121#issuecomment-99',
+      want: 'https://github.com/o/r/pull/121',
+    },
+    {
+      name: 'trailing prose punctuation is not part of the url',
+      text: 'opened https://github.com/o/r/pull/121.',
+      want: 'https://github.com/o/r/pull/121',
+    },
+    { name: 'an empty transcript', text: '', want: null },
+    { name: 'a transcript with no url at all', text: 'Everything up-to-date\n', want: null },
+  ];
+
+  for (const { name, text, want } of cases) {
+    it(name, () => {
+      expect(prUrlFrom(text)).toBe(want);
+    });
+  }
+
+  it('EC55: whatever it returns satisfies the href shape the surface promises', () => {
+    const url = prUrlFrom(REAL_DELIVER_OUTPUT);
+    expect(url).not.toBeNull();
+    expect(url).toMatch(/^https:\/\/\S+\/pull\/\d+$/);
+    expect(url).not.toContain('/pull/new/');
+  });
+});
+
+describe('deliveryOf — five mutually exclusive states, zero fetches', () => {
+  const cases: {
+    name: string;
+    view: SessionView;
+    state: DeliveryState;
+    unitId: string | null;
+    reason: string | null;
+  }[] = [
+    {
+      name: 'no deliver phase at all',
+      view: makeView({ id: 'run-1' }, [makeUnit({ id: 'run-1:build', status: 'done' })]),
+      state: 'none', unitId: null, reason: null,
+    },
+    {
+      name: 'a run with no units at all',
+      view: makeView({ id: 'run-1' }, []),
+      state: 'none', unitId: null, reason: null,
+    },
+    {
+      name: 'the composed deliver unit is done → delivered',
+      view: composed('done'), state: 'delivered', unitId: 'run-1:deliver', reason: null,
+    },
+    {
+      name: 'rejected with crew#318\'s refusal → nothing-to-deliver',
+      view: composed('rejected', NOTHING_REASON),
+      state: 'nothing-to-deliver', unitId: 'run-1:deliver', reason: NOTHING_REASON,
+    },
+    {
+      name: 'rejected for any OTHER reason → failed',
+      view: composed('rejected', NO_URL_REASON),
+      state: 'failed', unitId: 'run-1:deliver', reason: NO_URL_REASON,
+    },
+    {
+      name: 'rejected with NO recorded reason → failed, and nothing is synthesized',
+      view: composed('rejected', null), state: 'failed', unitId: 'run-1:deliver', reason: null,
+    },
+    {
+      name: 'pending → in-flight',
+      view: composed('pending'), state: 'in-flight', unitId: 'run-1:deliver', reason: null,
+    },
+    {
+      name: 'distributed → in-flight',
+      view: composed('distributed'), state: 'in-flight', unitId: 'run-1:deliver', reason: null,
+    },
+    {
+      name: 'EC61: an OVERLAY-named deliver unit resolves via tool_cmd, by its FULL id',
+      view: overlay('done'), state: 'delivered', unitId: 'run-1:open-the-pr', reason: null,
+    },
+    {
+      name: 'EC61: an overlay-named unit that was rejected still reads its denial_reason',
+      view: overlay('rejected', NOTHING_REASON),
+      state: 'nothing-to-deliver', unitId: 'run-1:open-the-pr', reason: NOTHING_REASON,
+    },
+  ];
+
+  for (const { name, view, state, unitId, reason } of cases) {
+    it(name, () => {
+      const d = deliveryOf(view);
+      expect(d.state).toBe(state);
+      expect(d.unitId).toBe(unitId);
+      // The reason is the wire's bytes, asserted by EQUALITY — never a phrase match.
+      expect(d.reason).toStrictEqual(reason);
+      // Nothing here has a server-carried url yet (crew#321 is unshipped).
+      expect(d.url).toBeNull();
+    });
+  }
+
+  it('EC61: the derivation is INDIFFERENT to session.workflow_id', () => {
+    const ids = ['chat', 'feature', 'feature-pr', 'wf-run-1', '', 'deliver'];
+    const results = ids.map((workflow_id) =>
+      deliveryOf(makeView({ id: 'run-1', workflow_id }, [
+        makeUnit({ id: 'run-1:deliver', ord: 0, status: 'done' }),
+      ])),
+    );
+    for (const r of results) expect(r).toStrictEqual(results[0]);
+    expect(results[0]?.state).toBe('delivered');
+  });
+
+  it('the id suffix beats the tool_cmd probe when a run somehow carries both', () => {
+    const view = makeView({ id: 'run-1' }, [
+      makeUnit({ id: 'run-1:open-the-pr', ord: 0, status: 'rejected', tool_cmd: ['gh pr create'] }),
+      makeUnit({ id: 'run-1:deliver', ord: 1, status: 'done' }),
+    ]);
+    expect(deliverUnit(view)?.id).toBe('run-1:deliver');
+    expect(deliveryOf(view).state).toBe('delivered');
+  });
+
+  it('a tool unit that is NOT a deliver phase does not masquerade as one', () => {
+    const view = makeView({ id: 'run-1' }, [
+      makeUnit({ id: 'run-1:test', ord: 0, status: 'done', tool_cmd: ['bash', '-lc', 'npm test'] }),
+    ]);
+    expect(deliverUnit(view)).toBeNull();
+    expect(deliveryOf(view).state).toBe('none');
+  });
+
+  it('reads the server-carried url when the daemon carries one (crew#321)', () => {
+    const view = composed('done');
+    const session = { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } };
+    expect(deliveryOf({ ...view, session: session as typeof view.session }).url)
+      .toBe('https://x/pull/9');
+  });
+});
+
+describe('DELIVERY_LABEL', () => {
+  it('says nothing for a run with no deliver phase, and never says "shipped"/"merged"', () => {
+    expect(DELIVERY_LABEL['none']).toBe('');
+    const words = Object.values(DELIVERY_LABEL).join(' ').toLowerCase();
+    expect(words).not.toContain('shipped');
+    expect(words).not.toContain('merged');
+  });
+});
+
+describe('deliverySummary — the census over ALL runs', () => {
+  it('counts every state, in the brief\'s own order', () => {
+    const views = [
+      composed('done'), composed('done'), composed('done'),
+      composed('rejected', NOTHING_REASON), composed('rejected', NOTHING_REASON),
+      ...Array.from({ length: 11 }, () => makeView({ id: 'r' }, [] as WorkUnit[])),
+    ];
+    expect(deliverySummary(views)).toBe('3 delivered · 2 delivered nothing · 11 no deliver phase');
+  });
+
+  it('names failures and in-flight deliveries too, and omits empty buckets', () => {
+    expect(deliverySummary([composed('rejected', NO_URL_REASON), composed('pending')]))
+      .toBe('1 failed to deliver · 1 still to deliver');
+  });
+
+  it('an empty project says nothing rather than "0 delivered"', () => {
+    expect(deliverySummary([])).toBe('');
+  });
+});

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -6,6 +6,7 @@ import {
   deliverUnit,
   deliveryOf,
   deliverySummary,
+  isPrUrl,
   prUrlFrom,
   resolveDelivery,
   type DeliveryState,
@@ -494,5 +495,52 @@ describe('canDeliver — the ONE predicate every surface gates on (D5)', () => {
       const session = { ...view.session, workflow_id: 'interactive-draft' } as typeof view.session;
       expect(canDeliver({ ...view, session }, KNOWN)).toBe(true);
     });
+  });
+});
+
+describe('isPrUrl — one gate for BOTH url sources (Copilot on #125)', () => {
+  const HOSTILE = [
+    'javascript:alert(1)',                                 // would execute in an <a href>
+    'data:text/html,<script>alert(1)</script>',
+    'http://github.com/o/r/pull/1',                        // not https
+    'https://e.test/o/r/pull/new/b?x=/pull/9',             // digits smuggled in the QUERY
+    'https://github.com/o/r/pull/new/wicked/branch',       // the create-PR form
+    'https://github.com/o/r/pull/',
+    'https://github.com/o/r/pull/abc',
+    'not a url at all',
+    '',
+    '   ',
+  ];
+  it.each(HOSTILE)('refuses %j', (bad) => {
+    expect(isPrUrl(bad)).toBe(false);
+  });
+
+  it('accepts a real PR url, and a bare-host one', () => {
+    expect(isPrUrl('https://github.com/mikeparcewski/wicked-studio/pull/121')).toBe(true);
+    expect(isPrUrl('https://x/pull/9')).toBe(true);
+  });
+
+  it('validates SHAPE, not provenance — a foreign https host of the right shape passes', () => {
+    // Stated so nobody mistakes this for a trust boundary: crew re-derives the url from the
+    // run's own git remote and GitHub Enterprise is a real deployment, so an allowlist here
+    // would be a second, weaker copy of a server-side decision.
+    expect(isPrUrl('https://ghe.internal.example/o/r/pull/7')).toBe(true);
+  });
+
+  it('a WIRE-carried url gets the same gate as a transcript-derived one', () => {
+    // The whole point: `session.delivery.url` is not more trustworthy for arriving on the wire.
+    for (const bad of HOSTILE) {
+      const view = makeView({ id: 'r-wire', workflow_id: 'feature' }, [
+        makeUnit({ id: 'r-wire:deliver', status: 'done', tool_cmd: ['bash', '-lc', 'gh pr create'] }),
+      ]);
+      (view.session as unknown as { delivery: { kind: string; url: string } }).delivery = {
+        kind: 'pull_request',
+        url: bad,
+      };
+      const d = deliveryOf(view);
+      expect(d.url).toBeNull();
+      // …and with no url in hand the claim can never be the artifact.
+      expect(resolveDelivery(d).claim).not.toBe('pr-open');
+    }
   });
 });

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -364,6 +364,18 @@ describe('HEADLINE — the rail body says what the badge says', () => {
     expect(offenders).toStrictEqual([]);
   });
 
+  it('NO headline asserts a phase is EXECUTING — `pending` means unresolved, not running', () => {
+    // The second own-goal (Copilot on #125): the fix for "no PR exists yet" replaced it with
+    // "is still running", which this module elsewhere states is false — a cancelled run's
+    // deliver unit stays `pending` forever, and 10 of the live corpus's 12 `distributed` units
+    // sit in terminal sessions. We know a unit has not RESOLVED; we do not know it is RUNNING.
+    const MOTION = /\b(still running|in progress|currently running|executing|underway|in flight)\b/i;
+    const offenders = Object.entries(HEADLINE)
+      .filter(([, sentence]) => MOTION.test(sentence))
+      .map(([k]) => k);
+    expect(offenders).toStrictEqual([]);
+  });
+
   it('the phase-only headline names the PHASE and denies the artifact', () => {
     const line = HEADLINE['delivered'];
     expect(line).toContain('deliver phase');

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -558,3 +558,26 @@ describe('isPrUrl — one gate for BOTH url sources (Copilot on #125)', () => {
     }
   });
 });
+
+describe('resolveDelivery validates its own input (Copilot on #125)', () => {
+  it('a hand-built Delivery cannot smuggle a bad url into the PR claim', () => {
+    // The function is exported, so `deliveryOf`'s validation is not on this path.
+    for (const bad of [
+      'javascript:alert(1)',
+      'https://github.com/o/r/pull/new/pull/5',
+      'not-a-url',
+      'http://github.com/o/r/pull/1',
+      '',
+    ]) {
+      const r = resolveDelivery({ state: 'delivered', unitId: 'u', reason: null, url: bad });
+      expect(r.href).toBeNull();
+      expect(r.claim).toBe('delivered');
+    }
+  });
+
+  it('…and the transcript-read url gets the same gate', () => {
+    const d = { state: 'delivered' as const, unitId: 'u', reason: null, url: null };
+    expect(resolveDelivery(d, 'javascript:alert(1)').claim).toBe('delivered');
+    expect(resolveDelivery(d, 'https://github.com/o/r/pull/9').claim).toBe('pr-open');
+  });
+});

--- a/tests/delivery.workflowBudget.test.tsx
+++ b/tests/delivery.workflowBudget.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
+import { CenterDashboard } from '../src/components/CenterDashboard.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useProjectsStore } from '../src/store/projects.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS, SYSTEM_IDS } from './fixtures/workflows.js';
+import type { Project, SessionView } from '../src/api/types.js';
+
+/**
+ * THE REQUEST BUDGET (wicked-studio#122 D-1), load-bearing.
+ *
+ * `is_system` is app-level reference data, so reading it must cost the app ONE
+ * request — never one per run. A list surface rendering 120 rows fires at most
+ * a single `GET /workflows` and ZERO per-row requests; the row chips read no
+ * defs at all, and a second list surface mounting after it fires none, because
+ * the cache is module state, not component state.
+ *
+ * Everything is counted at the client boundary — one `vi.fn` per api method,
+ * plus a global `fetch` counter for the raw-transport call `client.ts:103`
+ * makes (EC58's budget was asserted there, and this file keeps that).
+ */
+
+/** One counter per api method — `vi.hoisted` so the mock factory can see it. */
+const calls = vi.hoisted(() => ({
+  listWorkflows: vi.fn(),
+  listProjectMembers: vi.fn(),
+  listProjects: vi.fn(),
+  listRepos: vi.fn(),
+  getUnitOutput: vi.fn(),
+  getRun: vi.fn(),
+  getAudit: vi.fn(),
+  confirmGate: vi.fn(),
+  injectMessage: vi.fn(),
+}));
+
+vi.mock('../src/api/client.js', () => ({ api: calls }));
+
+const listDocs = vi.fn();
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (...a: unknown[]) => listDocs(...a),
+}));
+
+const NOW = Date.now();
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+function project(id: string): Project {
+  return {
+    id, name: `The ${id} project`, description: null, status: 'active',
+    scope: `project:${id}`, created_at: NOW - 1000, updated_at: NOW - 100,
+  };
+}
+
+/**
+ * 120 runs: 60 build runs that ran a deliver phase, and 60 spread across every
+ * one of the eleven real system workflows — the ids the denylist could not see.
+ */
+function corpus(): SessionView[] {
+  const build = Array.from({ length: 60 }, (_, i) =>
+    makeView(
+      { id: `b-${i}`, workflow_id: 'feature', status: 'completed', problem: `build ${i}`, project_id: 'proj-1' },
+      [
+        makeUnit({ id: `b-${i}:build`, session_id: `b-${i}`, ord: 0, status: 'done' }),
+        makeUnit({ id: `b-${i}:deliver`, session_id: `b-${i}`, ord: 1, status: 'done' }),
+      ],
+    ),
+  );
+  const system = Array.from({ length: 60 }, (_, i) =>
+    makeView(
+      {
+        id: `s-${i}`, workflow_id: SYSTEM_IDS[i % SYSTEM_IDS.length] as string,
+        status: 'completed', problem: `system ${i}`, project_id: 'proj-1',
+      },
+      [makeUnit({ id: `s-${i}:build`, session_id: `s-${i}`, ord: 0, status: 'done' })],
+    ),
+  );
+  return [...build, ...system];
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(calls)) fn.mockReset();
+  calls.listWorkflows.mockResolvedValue({ workflows: LIVE_WORKFLOWS });
+  calls.listProjectMembers.mockResolvedValue({ members: [] });
+  calls.listProjects.mockResolvedValue({ projects: [] });
+  calls.listRepos.mockResolvedValue({ repos: [] });
+  calls.getAudit.mockResolvedValue({ entries: [] });
+  calls.confirmGate.mockResolvedValue({});
+  calls.injectMessage.mockResolvedValue({});
+  listDocs.mockReset().mockResolvedValue([]);
+  clearCachedWorkflows();
+  useGateStore.setState({ gates: {} });
+  useRunEventStore.setState({ byRun: {} });
+  useProjectsStore.setState({ projects: [project('proj-1')], loading: false, error: null });
+  fetchSpy = vi.fn().mockRejectedValue(new Error('no raw request should reach the wire'));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); clearCachedWorkflows(); });
+
+describe('120 runs, ONE workflows request', () => {
+  it('the project page: 1 × /workflows, 0 per run', async () => {
+    const runs = corpus();
+    render(<ProjectDashboard projectId="proj-1" runs={runs} navigate={() => {}} />);
+    await screen.findByTestId('dashboard-delivery-summary');
+
+    expect(runs).toHaveLength(120);
+    expect(calls.listWorkflows, 'ONE /workflows for the whole surface').toHaveBeenCalledTimes(1);
+    expect(calls.getUnitOutput, 'zero per-run transcript reads').toHaveBeenCalledTimes(0);
+    expect(calls.getRun, 'zero per-run detail reads').toHaveBeenCalledTimes(0);
+    expect(calls.getAudit).toHaveBeenCalledTimes(0);
+    expect(fetchSpy, 'zero raw-transport requests').toHaveBeenCalledTimes(0);
+  });
+
+  it('and the census is now about DELIVERABLE runs only', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+    // 60 build runs delivered; the 60 system runs — chats, collab, and the five
+    // interactive-* seams — are out entirely, not counted as "no deliver phase".
+    const summary = await screen.findByTestId('dashboard-delivery-summary');
+    expect(summary.textContent).toStrictEqual('60 ran deliver');
+  });
+
+  it('a SECOND list surface mounting after it fires none — the cache is app-level', async () => {
+    render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
+    await screen.findByTestId('dashboard-delivery-summary');
+    expect(calls.listWorkflows).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    render(
+      <CenterDashboard
+        runs={corpus()}
+        onSelectRun={() => {}}
+        navigate={() => {}}
+        onApproveGate={() => {}}
+        onRejectGate={() => {}}
+      />,
+    );
+    await screen.findAllByTestId('run-delivery-chip');
+
+    expect(calls.listWorkflows, 'the second surface re-asked').toHaveBeenCalledTimes(1);
+    expect(calls.getUnitOutput).toHaveBeenCalledTimes(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/tests/delivery.workflowBudget.test.tsx
+++ b/tests/delivery.workflowBudget.test.tsx
@@ -15,9 +15,14 @@ import type { Project, SessionView } from '../src/api/types.js';
  *
  * `is_system` is app-level reference data, so reading it must cost the app ONE
  * request — never one per run. A list surface rendering 120 rows fires at most
- * a single `GET /workflows` and ZERO per-row requests; the row chips read no
- * defs at all, and a second list surface mounting after it fires none, because
- * the cache is module state, not component state.
+ * a single `GET /workflows` and ZERO per-row requests; the row chips READ the
+ * defs (D2 — a row may not chip what the rail's section would withhold) but
+ * read them out of MODULE state, and a second list surface mounting after it
+ * fires none, because the cache is not component state.
+ *
+ * That is the measured answer to the objection against fixing D2 — "a per-row
+ * `is_system` read would break the O(1) budget". It does not: 120 chips share
+ * one request between them, and the surface that mounts second shares it too.
  *
  * Everything is counted at the client boundary — one `vi.fn` per api method,
  * plus a global `fetch` counter for the raw-transport call `client.ts:103`
@@ -120,6 +125,32 @@ describe('120 runs, ONE workflows request', () => {
     // interactive-* seams — are out entirely, not counted as "no deliver phase".
     const summary = await screen.findByTestId('dashboard-delivery-summary');
     expect(summary.textContent).toStrictEqual('60 ran deliver');
+  });
+
+  it('D2: the Build list ALONE — 120 gated chips, still ONE request and none per row', async () => {
+    // The cost objection to gating the chip, measured on a COLD cache: every
+    // chip calls `useIsSystemWorkflow`, and between them they fire one request.
+    const runs = corpus();
+    render(
+      <CenterDashboard
+        runs={runs}
+        onSelectRun={() => {}}
+        navigate={() => {}}
+        onApproveGate={() => {}}
+        onRejectGate={() => {}}
+      />,
+    );
+    const chips = await screen.findAllByTestId('run-delivery-chip');
+
+    expect(runs).toHaveLength(120);
+    // Every rendered row is a gated chip's worth of lookups; only the build runs
+    // chip (the system ones have no deliver phase and stay silent).
+    expect(chips.length).toBeGreaterThan(0);
+    expect(chips.length).toBeLessThanOrEqual(screen.getAllByTestId('build-run-row').length);
+    expect(calls.listWorkflows, 'one request for 120 rows').toHaveBeenCalledTimes(1);
+    expect(calls.getUnitOutput, 'zero per-row reads').toHaveBeenCalledTimes(0);
+    expect(calls.getRun).toHaveBeenCalledTimes(0);
+    expect(fetchSpy, 'zero raw-transport requests').toHaveBeenCalledTimes(0);
   });
 
   it('a SECOND list surface mounting after it fires none — the cache is app-level', async () => {

--- a/tests/fixtures/deliverOutput.ts
+++ b/tests/fixtures/deliverOutput.ts
@@ -16,6 +16,11 @@ export const REAL_DELIVER_OUTPUT = [
   "branch 'wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21' set up to track 'origin/wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21'.",
   'https://github.com/mikeparcewski/wicked-studio/pull/121',
   'https://github.com/mikeparcewski/wicked-studio/pull/121',
+  // The daemon's trailing newline. Without it this fixture is 724 bytes and the
+  // "725 bytes, VERBATIM" above is false — small, but a fixture that claims to
+  // be the wire has to BE the wire (re-verified byte-for-byte against
+  // `GET /runs/5c5e08b7…/units/5c5e08b7…:deliver/output`).
+  '',
 ].join('\n');
 
 /** The PR the transcript above actually opened. */

--- a/tests/fixtures/deliverOutput.ts
+++ b/tests/fixtures/deliverOutput.ts
@@ -21,6 +21,34 @@ export const REAL_DELIVER_OUTPUT = [
 /** The PR the transcript above actually opened. */
 export const REAL_PR_URL = 'https://github.com/mikeparcewski/wicked-studio/pull/121';
 
+/**
+ * The deliver transcript of run **665a9aeb** — copied VERBATIM off the live
+ * daemon (`GET /runs/665a9aeb…/units/665a9aeb…:deliver/output`, 677 bytes,
+ * `outputUnavailable` absent), and the whole reason this slice was re-cut.
+ *
+ * The unit's status is `done` and its `denial_reason` is `null`, so the list
+ * wire says the deliver phase was APPROVED — and the transcript below contains
+ * ZERO `/pull/\d+` matches and exactly one `/pull/new/` form. Crew pushed a
+ * branch with no commits ahead of `origin/main` and opened no PR. Only a
+ * post-crew#318 daemon fails the phase in this situation; 17 of the live
+ * corpus's deliver units are `done` and some of them look exactly like this.
+ *
+ * Every surface must be provable against this shape: `done` buys the phase-only
+ * wording, never the PR claim.
+ */
+export const EMPTY_PUSH_OUTPUT = [
+  "branch 'wicked/665a9aeb-285d-407b-b869-813b67e50973' set up to track 'origin/wicked/665a9aeb-285d-407b-b869-813b67e50973'.",
+  'could not compute title or body defaults: could not find any commits between origin/main and wicked/665a9aeb-285d-407b-b869-813b67e50973',
+  '',
+  'remote: ',
+  "remote: Create a pull request for 'wicked/665a9aeb-285d-407b-b869-813b67e50973' on GitHub by visiting:        ",
+  'remote:      https://github.com/mikeparcewski/wicked-studio/pull/new/wicked/665a9aeb-285d-407b-b869-813b67e50973        ',
+  'remote: ',
+  'To https://github.com/mikeparcewski/wicked-studio.git',
+  ' * [new branch]      wicked/665a9aeb-285d-407b-b869-813b67e50973 -> wicked/665a9aeb-285d-407b-b869-813b67e50973',
+  '',
+].join('\n');
+
 /** crew#318's refusal, verbatim from `packages/crew/src/core/deliver.ts:142`. */
 export const NOTHING_REASON =
   'deliver: nothing to deliver — the run produced no committed change '

--- a/tests/fixtures/deliverOutput.ts
+++ b/tests/fixtures/deliverOutput.ts
@@ -1,0 +1,32 @@
+/**
+ * The deliver transcript of run 5c5e08b7 — copied VERBATIM off the live daemon
+ * (`GET /runs/5c5e08b7…/units/5c5e08b7…:deliver/output`, 725 bytes), so the
+ * `pull/new/` negative is tested in its natural habitat rather than a synthetic
+ * one: the create-PR form git prints on every push appears FIRST, is longer, and
+ * looks exactly like the answer. Studio must return PR 121 and only PR 121.
+ */
+export const REAL_DELIVER_OUTPUT = [
+  'Current branch wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21 is up to date.',
+  'remote: ',
+  "remote: Create a pull request for 'wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21' on GitHub by visiting:        ",
+  'remote:      https://github.com/mikeparcewski/wicked-studio/pull/new/wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21        ',
+  'remote: ',
+  'To https://github.com/mikeparcewski/wicked-studio.git',
+  ' * [new branch]      wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21 -> wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21',
+  "branch 'wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21' set up to track 'origin/wicked/5c5e08b7-9e06-43cc-9b15-300bfc599e21'.",
+  'https://github.com/mikeparcewski/wicked-studio/pull/121',
+  'https://github.com/mikeparcewski/wicked-studio/pull/121',
+].join('\n');
+
+/** The PR the transcript above actually opened. */
+export const REAL_PR_URL = 'https://github.com/mikeparcewski/wicked-studio/pull/121';
+
+/** crew#318's refusal, verbatim from `packages/crew/src/core/deliver.ts:142`. */
+export const NOTHING_REASON =
+  'deliver: nothing to deliver — the run produced no committed change '
+  + '(wicked/665a9aeb is not ahead of origin/main); nothing was pushed';
+
+/** crew's other loud deliver failure (`deliver.ts:163`). */
+export const NO_URL_REASON =
+  'deliver: gh pr create exited 0 but produced no PR URL for wicked/abc '
+  + '— refusing to report a delivery nothing can be pointed at';

--- a/tests/fixtures/workflows.ts
+++ b/tests/fixtures/workflows.ts
@@ -52,3 +52,46 @@ export const LIVE_WORKFLOWS: WorkflowDef[] = [
   ...SYSTEM_IDS.map((id) => ({ id, is_system: true, phases: [] })),
   ...BUILD_IDS.map((id) => ({ id, phases: [] })),
 ];
+
+/**
+ * ── THE MATERIALISED PER-RUN DEF — the corpus's actual majority ──────────────
+ *
+ * crew materialises a def for most runs, so `session.workflow_id` is `wf-<the
+ * run's OWN id>`: **86 of the 129 runs on the live daemon (127.0.0.1:7701,
+ * 2026-08-24) carry one.** Those ids are not among the 17 defs `GET /workflows`
+ * serves, and `GET /workflows/wf-…` 404s, so {@link isSystemWorkflowIn} answers
+ * `undefined` for them PERMANENTLY — cold cache, warm cache, forever. They are
+ * not a loading window; they are the steady state.
+ *
+ * Every fixture in the first `is_system` round was synthetic (`feature`,
+ * `chat`, `interactive-draft`), so the whole suite was green over a change that
+ * measurably moved nothing: 86 of 120 runs never reach a def at all, fall
+ * through to the five-id denylist, and classify 'build' in every cache state.
+ * These ids exist so that cannot happen twice.
+ */
+export const materialised = (runId: string): string => `wf-${runId}`;
+
+/** Two REAL run ids, both materialised, both with a composed `:deliver` unit. */
+export const LIVE_RUN_IDS = {
+  /** Opened a real numbered PR. Gating its section on the catalog would hide it. */
+  prOpened: '5c5e08b7-9e06-43cc-9b15-300bfc599e21',
+  /** deliver `done`, `denial_reason` null, transcript with no numbered PR. */
+  deliverRan: '665a9aeb-285d-407b-b869-813b67e50973',
+} as const;
+
+/**
+ * The EIGHT runs of live project `proj_178674023693500000` — wicked-interactive
+ * document threads (`:outline`/`:draft`/`:edit` units, no deliver phase, every
+ * workflow id materialised). Its census line read, in full, `8 no deliver
+ * phase`: a number about documents, dressed as a delivery finding.
+ */
+export const DOC_THREAD_RUN_IDS = [
+  '4f6ca6a6-96ba-4074-8baa-ab6e31309cd2',
+  '9cc8df93-80d0-420b-bcf2-3798cdebf522',
+  '3ce95a58-7a9f-4668-afe6-7f8e1692e839',
+  'e4a5e0b9-f1a4-4511-a1dd-58fa5b20ed42',
+  'df1559ff-da71-4f0a-9d91-8e42948c6185',
+  '7b8807c1-ea75-406d-9dbf-e2cb2c8c9607',
+  '537edead-4eba-4171-96a5-de56b05d708f',
+  '61027a00-d73a-4315-9329-166b1c7f1bae',
+] as const;

--- a/tests/fixtures/workflows.ts
+++ b/tests/fixtures/workflows.ts
@@ -1,0 +1,54 @@
+import type { WorkflowDef } from '../../src/api/types.js';
+
+/**
+ * `GET /api/v1/workflows` as the LIVE daemon serves it (127.0.0.1:7701,
+ * 2026-08-24) — 17 defs, ELEVEN of them `is_system: true`.
+ *
+ * Copied verbatim in shape, including the thing that makes the flag awkward:
+ * **`is_system` is OMITTED on ordinary workflows**, never sent as `false`. So
+ * "the def is present" — not the flag's value — is what licenses a positive
+ * deliverable answer, and `isSystemWorkflowIn` is written that way.
+ *
+ * `SYSTEM_WORKFLOW_IDS`, the pre-D-1 denylist, named five of the eleven. The six
+ * it missed are `collab` and the five `interactive-*` — the document and video
+ * seams, i.e. the most-used non-build flows in the product.
+ */
+export const SYSTEM_IDS = [
+  'chat',
+  'collab',
+  'domain-graph-slice',
+  'interactive-chat',
+  'interactive-demo',
+  'interactive-demo-reauthor',
+  'interactive-draft',
+  'interactive-edit',
+  'memories',
+  'onboarding',
+  'survey-repo',
+] as const;
+
+/** The six the denylist never knew about — the whole point of D-1. */
+export const DENYLIST_BLIND_SPOT = [
+  'collab',
+  'interactive-chat',
+  'interactive-demo',
+  'interactive-demo-reauthor',
+  'interactive-draft',
+  'interactive-edit',
+] as const;
+
+/** The six ordinary workflows. None of them carries an `is_system` key. */
+export const BUILD_IDS = [
+  'bug',
+  'domain-extraction',
+  'feature',
+  'feature-pr',
+  'migration',
+  'qe-accept-functional',
+] as const;
+
+/** The whole wire payload, flag-omission included. */
+export const LIVE_WORKFLOWS: WorkflowDef[] = [
+  ...SYSTEM_IDS.map((id) => ({ id, is_system: true, phases: [] })),
+  ...BUILD_IDS.map((id) => ({ id, phases: [] })),
+];

--- a/tests/workflowCache.race.test.ts
+++ b/tests/workflowCache.race.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../src/api/client.js';
+import {
+  clearCachedWorkflows,
+  fetchWorkflowsCached,
+  getCachedWorkflows,
+  setCachedWorkflows,
+} from '../src/store/workflowCache.js';
+import type { WorkflowDef } from '../src/api/types.js';
+
+const def = (id: string, isSystem?: boolean): WorkflowDef =>
+  ({ id, ...(isSystem === undefined ? {} : { is_system: isSystem }) }) as WorkflowDef;
+
+afterEach(() => {
+  clearCachedWorkflows();
+  vi.restoreAllMocks();
+});
+
+describe('an in-flight fetch never clobbers a deposit that landed while it was on the wire', () => {
+  it('the deposit wins (Copilot on #125)', async () => {
+    // The app-level fetch may have STARTED first and still answer LAST: the composer and
+    // WorkflowViewer fetch this list themselves and deposit it. Letting the older response win
+    // silently regresses `is_system` — re-opening the classification hole this module closed.
+    let release!: (v: { workflows: WorkflowDef[] }) => void;
+    vi.spyOn(api, 'listWorkflows').mockReturnValue(
+      new Promise((res) => {
+        release = res;
+      }) as ReturnType<typeof api.listWorkflows>,
+    );
+
+    fetchWorkflowsCached(); // starts, does not resolve
+
+    // A fresher list arrives from a surface that fetched it itself.
+    setCachedWorkflows([def('interactive-draft', true)]);
+    expect(getCachedWorkflows()).toHaveLength(1);
+
+    // The older in-flight answer now lands.
+    release({ workflows: [def('feature'), def('bug')] });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const now = getCachedWorkflows();
+    expect(now).toHaveLength(1);
+    expect(now?.[0]?.id).toBe('interactive-draft');
+    expect(now?.[0]?.is_system).toBe(true);
+  });
+
+  it('with NO competing deposit, the fetched list is stored as before', async () => {
+    vi.spyOn(api, 'listWorkflows').mockResolvedValue({ workflows: [def('feature')] } as never);
+    fetchWorkflowsCached();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(getCachedWorkflows()?.[0]?.id).toBe('feature');
+  });
+});


### PR DESCRIPTION
Closes #122.

Makes a run's delivery visible where the operator already is — the build right panel and the project page — under one rule: **never assert what the wire cannot evidence.**

## The problem, measured

Run `5c5e08b7` opened a real PR and studio showed it nowhere. Finding it cost 2 clicks and ~4400px of scroll into raw `git push` console text, where the **first and larger** link is `…/pull/new/wicked/<branch>` — a create-PR form that looks like the answer. Meanwhile `665a9aeb`, which pushed an empty branch and opened nothing, rendered as *more* productive: "Files 13 / MODIFIED / CREATED" against the real PR's "Files 5 / REFERENCED", both headed "Completed" with seven green chips.

## What ships

A `Delivery` section in the right panel's rail (the ninth entry, sharing the rail's one-open-at-a-time switching — **not** a pinned band, per the operator's call), with a state badge on the header so the state reads without opening it. Delivery chips on the project-page and Build-list rows, plus a project-wide census in the RUNS tile head. The Files accordion is relabelled "Files referenced" with a scope caption, because it was making the claim Delivery should own.

Every list surface spends **zero** requests. The right panel spends at most one, only for a delivered run, only on open.

## Three rounds of review changed the design. Each was a real defect.

**1 — `done` is a phase, not a PR.** The first cut claimed "PR open" from `unit.status === 'done'`. That is false for pre-crew#318 runs: `665a9aeb`'s deliver unit is `done` with `denial_reason: null` and a 677-byte transcript containing zero `/pull/\d+`. It pushed a branch and stopped. The slice would have reproduced, on a new surface, the exact false-productivity signal it was written to remove. Now the PR claim requires a **URL in hand**; `done` alone renders "deliver ran".

**2 — two predicates disagreed.** #122 classified runs off a five-id denylist while #124's composer consulted the daemon's `is_system` flag. Six `is_system` workflows are missing from that denylist — `collab` and all five `interactive-*` — so document and demo threads were offered a "launch with `deliver: pr`" remedy the composer then refuses. Both now call one exported predicate, pinned by a structural test.

**3 — that fix changed nothing on real data.** 86 of 129 live runs (67%) carry a materialised `wf-<runId>` workflow id that is **not in `GET /workflows`**, so `is_system` can never answer for them. Measured delta was zero. The fix: `'none'` is not a fact about units, it is a claim about a classification, so it takes the same positive-knowledge licence the remedy already had.

## Measured delta (verification pulled the live daemon independently, 129 runs)

| | before | after |
|---|---|---|
| Delivery sections rendered (warm) | 110 | **55** |
| cold cache / no lookup | 110 / 110 | **31 / 31** |
| sections with no deliver unit | 79 | **24** |
| runs reclassified | — | **55 of 129** |

Census lines that were describing documents as delivery findings:

- `proj_178674023693500000` — 8 runs, all document threads: `"8 no deliver phase"` → **no line at all**
- unfiled: `"… · 50 no deliver phase"` → `"… · 24 no deliver phase"`; the 24 survivors are all catalog `feature` runs — genuinely "could have delivered, didn't"

Anchors hold in warm, cold and failed-cache states: `5c5e08b7` keeps its section and its `/pull/121` link; `665a9aeb` still reads "deliver ran" with badge and body agreeing.

## Verification

179 files / **1787 tests** green; lint, typecheck and production build clean. Reviewers mutation-tested each round and killed every mutant — including one that revealed the round-3 test suite could not detect its own fix being reverted, and one where the body's headline (the loudest sentence in the section) could be reverted to "PR open" with the whole suite green.

Fixtures are built from **real daemon ids and real transcripts**, not synthetic ones — round 3 passed on synthetic fixtures precisely because they lacked materialised ids.

## Two disclosed design notes, deliberately not fixed here

- **A `feature` run with no deliver phase now has no Delivery surface while `/workflows` is slow, and none if it is down** (24 live runs; also a one-tick pop-in on cold load). The worktree path is a fact its own DTO carries and it is currently withheld alongside the claim. The split — render the section with the worktree line whenever `workdir` is known, gate only the "no deliver phase" sentence and remedy — is a design change, filed as a follow-up.
- `DeliveryChip`'s `canDeliver` gate is currently **unreachable by construction** (a chipped row always has a deliver unit). It is kept as a structural invariant with a test that pins it honestly; it is not claimed as a behavioural change.

Related: wicked-crew#321 would put the PR URL on the list wire, at which point the chips become real links and the right panel's one fetch drops to zero. This slice already reads `session.delivery?.url` when present, so it upgrades with no follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
