### PR TITLE
Delivery: the worktree is a fact, so stop gating it on the workflow catalog

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -8,7 +8,7 @@ import { useProvenanceStore } from '../store/provenance.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import { AssumptionsPanel } from './AssumptionsPanel.js';
 import { LiveNarration } from './ChatPanel.js';
-import { canDeliver } from './delivery.js';
+import { hasDeliverySection } from './delivery.js';
 import { Burn } from './Burn.js';
 import { FileViewer } from './FileViewer.js';
 import { CoverageView } from './CoverageView.js';
@@ -505,15 +505,21 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
   //
   // A run with a deliver PHASE keeps this section whatever its workflow id says
   // — 5c5e08b7 opened a real PR under a materialised `wf-<runId>` def. A run
-  // WITHOUT one gets it only once a def in hand says the workflow is ordinary:
-  // "this run has no deliver phase" is a claim about a classification, and 86 of
-  // the 129 live runs carry an id no catalog serves, so `undefined` is the
-  // permanent answer for them and the sentence would be unevidenced. Nothing in
-  // the delivery DERIVATION reads `session.workflow_id` (EC61) — the
-  // classification half is a visibility gate, not a wire read.
+  // WITHOUT one keeps it when its `workdir` is known: that path is a DTO fact,
+  // not a classification, so no `GET /workflows` answer is needed to show it and
+  // none can take it away (studio#126). The CLAIM built on top of it — "this run
+  // has no deliver phase", and the `deliver: pr` remedy — stays gated inside
+  // {@link RunDelivery} on `is_system === false`, because 86 of the 129 live runs
+  // carry an id no catalog serves and `undefined` is their permanent answer.
+  //
+  // `hasDeliverySection`, not `canDeliver`: the census and the row chips keep the
+  // narrower predicate on purpose (widening them would recreate a "24 no deliver
+  // phase" census line about runs studio cannot classify). Nothing in the
+  // delivery DERIVATION reads `session.workflow_id` (EC61) — the classification
+  // half is a visibility gate, not a wire read.
   const isSystemWorkflow = useIsSystemWorkflow();
   const sections = useMemo(
-    () => (canDeliver(view, isSystemWorkflow) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),
+    () => (hasDeliverySection(view, isSystemWorkflow) ? ACCORDIONS : ACCORDIONS.filter((a) => a.id !== 'delivery')),
     [view, isSystemWorkflow],
   );
 

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -177,23 +177,35 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
  * paint. Thirty interactive document threads therefore rendered a Delivery
  * section whose entire body read "This run has no deliver phase."
  *
- * So `canDeliver` now withholds the SECTION on the `'none'` arm under the same
- * `is_system === false` licence this line has always used, and the two halves
- * are one rule:
+ * So the CLAIM is gated on `is_system === false` — a def in hand. `undefined` is
+ * not a licence. Erring toward saying less: withholding costs the operator a
+ * sentence they can get from the composer; printing it wrongly tells them a run
+ * failed to do something it was never asked to do.
+ *
+ * ── AND THE FACT IS NOT (studio#126) ─────────────────────────────────────────
+ * The first cut of that gate took the WORKTREE PATH down with the sentence,
+ * because `canDeliver` withheld the whole section. But `session.workdir` is a
+ * DTO fact, not a classification: it is true whatever composed the run and needs
+ * no `GET /workflows` answer to know. For 24 live runs the effect was a section
+ * that popped in a tick after every navigation, and vanished outright whenever
+ * the workflow fetch failed — a daemon hiccup removing a surface that does not
+ * depend on the daemon's workflow list.
+ *
+ * The two halves are now one rule split at the right seam:
  *
  *  - a run WITH a deliver phase keeps its section unconditionally — 5c5e08b7's
  *    own workflow id is materialised, and gating that arm would hide a real PR;
- *  - a run WITHOUT one gets a section only once a def in hand says the workflow
- *    is ordinary. `undefined` is not a licence.
+ *  - a run WITHOUT one keeps its section, and its worktree line, whenever
+ *    `workdir` is known (`hasDeliverySection`);
+ *  - the "no deliver phase" SENTENCE and the `deliver: pr` remedy appear only
+ *    once a def in hand says the workflow is ordinary.
  *
- * Erring toward saying less: withholding costs the operator a sentence they can
- * get from the composer; printing it wrongly tells them a run failed to do
- * something it was never asked to do. The section and the line appear together
- * the moment the defs land — and for a system workflow neither ever does.
+ * An `is_system` run still renders nothing at all, warm or cold: `deliverKindOf`
+ * answers 'system' off the denylist without the catalog.
  *
- * The licence is re-checked HERE as well as in the caller because this component
- * is exported and rendered directly by tests and by any future surface: one
- * rule, held on both sides of the seam, never a second rule.
+ * The sentence licence is re-checked HERE as well as in the caller because this
+ * component is exported and rendered directly by tests and by any future
+ * surface: one rule, held on both sides of the seam, never a second rule.
  */
 export function RunDelivery({ view }: Props): React.ReactElement {
   const runId = view.session.id;

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -200,8 +200,12 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
  *  - the "no deliver phase" SENTENCE and the `deliver: pr` remedy appear only
  *    once a def in hand says the workflow is ordinary.
  *
- * An `is_system` run still renders nothing at all, warm or cold: `deliverKindOf`
- * answers 'system' off the denylist without the catalog.
+ * An `is_system` run WITHOUT a deliver phase still renders nothing at all, warm
+ * or cold: `deliverKindOf` answers 'system' off the denylist without the
+ * catalog. One WITH a deliver phase keeps its section like any other — the first
+ * bullet is unconditional, because a unit that actually ran is evidence and the
+ * classification does not get to overrule it (pinned by "so does an is_system
+ * workflow that somehow ran one").
  *
  * The sentence licence is re-checked HERE as well as in the caller because this
  * component is exported and rendered directly by tests and by any future

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -388,11 +388,24 @@ export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflo
  * ENTIRELY when `GET /workflows` failed — a daemon hiccup silently removing a
  * surface that does not depend on the daemon's workflow list at all.
  *
- * So the rail renders on the FACT and {@link RunDelivery} gates the SENTENCE:
- *  - a deliver phase in the units ⇒ section, unconditionally (`canDeliver`);
- *  - otherwise a known `workdir` on a workflow NOTHING HAS RULED OUT as system
- *    (`deliverKindOf(...) === 'build'`) ⇒ section, worktree line only, no
- *    classification claim and no remedy.
+ * So the rail renders on the FACT and {@link RunDelivery} gates the SENTENCE.
+ * THREE arms reach the section, and each is independently evidenced — no path
+ * renders on nothing:
+ *
+ *  1. a deliver phase in the units ⇒ the unit itself is the evidence
+ *     (`canDeliver`, unconditional — classification never overrules a unit that
+ *     actually ran);
+ *  2. `is_system === false` ⇒ a def IN HAND licenses the CLAIM, so the sentence
+ *     and the remedy are evidenced (`canDeliver`) — this arm needs no `workdir`,
+ *     and a licensed run without one has stated the phase fact and the remedy
+ *     since #125. Gating it on `workdir` would withhold something the wire DOES
+ *     evidence, which is this bug pointed the other way;
+ *  3. **new** — a known `workdir` on a workflow nothing has ruled out as system
+ *     (`deliverKindOf(...) === 'build'`) ⇒ the DTO fact is the evidence:
+ *     section, worktree line only, no classification claim and no remedy.
+ *
+ * Arm 3 is the flicker fix. "A run with no workdir renders nothing" is true only
+ * of a run that ALSO fails arms 1 and 2 — the document-thread case.
  *
  * That second arm is deliberately weaker than `canDeliver`'s licence, and the
  * difference is the point: it does NOT require `is_system === false`, so it also

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -407,14 +407,14 @@ export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflo
  * Arm 3 is the flicker fix. "A run with no workdir renders nothing" is true only
  * of a run that ALSO fails arms 1 and 2 — the document-thread case.
  *
- * That second arm is deliberately weaker than `canDeliver`'s licence, and the
- * difference is the point: it does NOT require `is_system === false`, so it also
- * covers the runs the catalog can never classify — a materialised `wf-<runId>`
- * id gets its worktree line and never gets the sentence. Requiring the licence
- * here would put those runs straight back into the flicker this fixes.
+ * Arm 3 is deliberately weaker than arm 2's licence, and the difference is the
+ * point: it does NOT require `is_system === false`, so it also covers the runs
+ * the catalog can never classify — a materialised `wf-<runId>` id gets its
+ * worktree line and never gets the sentence. Requiring the licence there would
+ * put those runs straight back into the flicker this fixes.
  *
- * What it does NOT widen: `deliverKindOf(...) !== 'build'` still returns false,
- * so a run on a KNOWN system workflow gets no section from this arm warm or cold
+ * What arm 3 does NOT widen: `deliverKindOf(...) !== 'build'` returns false, so
+ * a run on a KNOWN system workflow gets no section from it warm or cold
  * (the denylist answers without the catalog — such a run reaches the rail only
  * via `canDeliver`, by actually having a deliver phase), and a `'freeform'` run
  * — no workflow at all, which `deliver` cannot accompany — stays out. The

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -390,14 +390,22 @@ export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflo
  *
  * So the rail renders on the FACT and {@link RunDelivery} gates the SENTENCE:
  *  - a deliver phase in the units ⇒ section, unconditionally (`canDeliver`);
- *  - otherwise a known `workdir` on an ordinary workflow ⇒ section, worktree
- *    line only, no classification claim and no remedy.
+ *  - otherwise a known `workdir` on a workflow NOTHING HAS RULED OUT as system
+ *    (`deliverKindOf(...) === 'build'`) ⇒ section, worktree line only, no
+ *    classification claim and no remedy.
  *
- * What this does NOT widen: `deliverKindOf(...) !== 'build'` still returns false,
- * so an `is_system` run renders nothing warm OR cold (the denylist answers
- * without the catalog), and a `'freeform'` run — no workflow at all, which
- * `deliver` cannot accompany — stays out. The predicate reaches exactly the runs
- * whose section was flickering, and no others.
+ * That second arm is deliberately weaker than `canDeliver`'s licence, and the
+ * difference is the point: it does NOT require `is_system === false`, so it also
+ * covers the runs the catalog can never classify — a materialised `wf-<runId>`
+ * id gets its worktree line and never gets the sentence. Requiring the licence
+ * here would put those runs straight back into the flicker this fixes.
+ *
+ * What it does NOT widen: `deliverKindOf(...) !== 'build'` still returns false,
+ * so a run on a KNOWN system workflow gets no section from this arm warm or cold
+ * (the denylist answers without the catalog — such a run reaches the rail only
+ * via `canDeliver`, by actually having a deliver phase), and a `'freeform'` run
+ * — no workflow at all, which `deliver` cannot accompany — stays out. The
+ * predicate reaches exactly the runs whose section was flickering.
  *
  * The census and the chips deliberately keep using `canDeliver`: widening THEM
  * would put these 24 unclassifiable runs back into a "24 no deliver phase"

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -371,6 +371,50 @@ export function canDeliver(view: SessionView, isSystemWorkflow?: IsSystemWorkflo
 }
 
 /**
+ * Whether the RAIL shows a Delivery section — which is a strictly wider question
+ * than {@link canDeliver}, and the two must not be collapsed (studio#126).
+ *
+ * `canDeliver` licenses a CLAIM: "this run has no deliver phase", the census
+ * bucket, the row chip. It requires `is_system === false` — a def in hand —
+ * because 86 of 129 live runs carry a materialised `wf-<runId>` the catalog
+ * never serves, and asserting a classification about them is D5.
+ *
+ * But the `'none'` body also carries the WORKTREE PATH, and that is not a claim.
+ * `session.workdir` comes straight off the run's own DTO; it is true whatever
+ * composed the run, needs no lookup to know, and is the one thing an operator
+ * opening Delivery on an undelivered run actually wants — where is the work. The
+ * `canDeliver` gate withheld it along with the sentence, so for **24 live runs**
+ * the section vanished on a cold cache and popped in a tick later, and vanished
+ * ENTIRELY when `GET /workflows` failed — a daemon hiccup silently removing a
+ * surface that does not depend on the daemon's workflow list at all.
+ *
+ * So the rail renders on the FACT and {@link RunDelivery} gates the SENTENCE:
+ *  - a deliver phase in the units ⇒ section, unconditionally (`canDeliver`);
+ *  - otherwise a known `workdir` on an ordinary workflow ⇒ section, worktree
+ *    line only, no classification claim and no remedy.
+ *
+ * What this does NOT widen: `deliverKindOf(...) !== 'build'` still returns false,
+ * so an `is_system` run renders nothing warm OR cold (the denylist answers
+ * without the catalog), and a `'freeform'` run — no workflow at all, which
+ * `deliver` cannot accompany — stays out. The predicate reaches exactly the runs
+ * whose section was flickering, and no others.
+ *
+ * The census and the chips deliberately keep using `canDeliver`: widening THEM
+ * would put these 24 unclassifiable runs back into a "24 no deliver phase"
+ * census line, which is the precise unevidenced claim #125 removed.
+ */
+export function hasDeliverySection(
+  view: SessionView,
+  isSystemWorkflow?: IsSystemWorkflow,
+): boolean {
+  if (canDeliver(view, isSystemWorkflow)) return true;
+  const wf = view.session.workflow_id?.trim() ?? '';
+  if (deliverKindOf(wf, isSystemWorkflow) !== 'build') return false;
+  const workdir = view.session.workdir;
+  return typeof workdir === 'string' && workdir.trim() !== '';
+}
+
+/**
  * The project-page census over ALL deliverable runs (never the MAX_ROWS window —
  * run 665a9aeb, the one that read as the most productive in the project while
  * delivering nothing, is not in the visible six).

--- a/src/components/runMode.ts
+++ b/src/components/runMode.ts
@@ -12,13 +12,33 @@ export const MODE_LABELS: Record<RunMode, string> = {
  * `is_system` flag, and covers the window before the defs have loaded.
  *
  * It is a FALLBACK and nothing more — never the answer when a def is in hand.
- * The live daemon serves ELEVEN system workflows and this list names five, so
- * on its own it classifies `collab` and every `interactive-*` (the document and
- * video seams) as build work. That was studio#122 D-1: the rail offered
- * "launch with deliver: pr" on an interactive thread, a remedy the composer —
- * which reads `is_system` — refuses. Use {@link deliverKindOf}, not this set.
+ *
+ * It used to name FIVE of the daemon's eleven system workflows, leaving `collab`
+ * and every `interactive-*` (the document and video seams) classified as build
+ * work whenever the catalog was unavailable. That gap was studio#122 D-1: the
+ * rail offered "launch with deliver: pr" on an interactive thread, a remedy the
+ * composer — which reads `is_system` — refuses.
+ *
+ * studio#126 made closing it a correctness requirement rather than a nicety.
+ * Once the Delivery section renders on a DTO fact (a known `workdir`) instead of
+ * waiting for the catalog, "show a `feature` run's worktree while the defs load"
+ * and "never show an `interactive-draft` run a Delivery section, warm or cold"
+ * are the same cold-cache instant — and with the blind spot open, studio has
+ * nothing to tell the two apart by. So the list now names all eleven, verified
+ * against the live daemon's catalog (17 defs, 11 `is_system: true`, these
+ * exactly).
+ *
+ * Adding an id here can only ever WITHHOLD delivery, never invent it
+ * ({@link deliverKindOf} is one-directional), and every id is one of crew's own
+ * reserved workflow names — so the failure mode of a stale entry is a surface
+ * saying less, which is the direction this module always errs in.
  */
-export const SYSTEM_WORKFLOW_IDS = new Set(['chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories']);
+export const SYSTEM_WORKFLOW_IDS = new Set([
+  'chat', 'onboarding', 'survey-repo', 'domain-graph-slice', 'memories',
+  // The former blind spot — crew's document and video seams (crew's interactive/*-events.ts).
+  'collab', 'interactive-chat', 'interactive-demo', 'interactive-demo-reauthor',
+  'interactive-draft', 'interactive-edit',
+]);
 
 /**
  * What KIND of run a launch body describes, read off its effective workflow —

--- a/tests/deliverKind.test.ts
+++ b/tests/deliverKind.test.ts
@@ -40,16 +40,37 @@ describe('the ELEVEN real is_system ids all classify system', () => {
     });
   }
 
-  it('the six the denylist never knew: build BEFORE the fix, system after', () => {
+  /**
+   * The former blind spot, now closed (studio#126). These six were the daemon's
+   * system workflows the denylist did not name, so with the catalog unavailable
+   * studio classified `collab` and every `interactive-*` as build work — the
+   * flag was the ONLY thing ruling them out.
+   *
+   * #126 made that gap load-bearing: once the Delivery section renders on a DTO
+   * fact rather than waiting for the catalog, "show a `feature` run's worktree
+   * while the defs load" and "never show an `interactive-draft` run a section,
+   * warm or cold" are the same instant, and with the gap open there was nothing
+   * to tell the two apart by. So the list names all eleven now, and these six
+   * classify system with NO lookup at all.
+   */
+  it('the six the denylist never knew are on it now — system with no lookup', () => {
     for (const id of DENYLIST_BLIND_SPOT) {
-      // The defect, pinned: the denylist alone — which is exactly what
-      // `canDeliver` used to consult — calls every one of these build work.
-      expect(SYSTEM_WORKFLOW_IDS.has(id), `${id} is not on the denylist`).toBe(false);
-      expect(runKindOf(id)).toBe<RunKind>('build');
-      // The fix: the daemon's own flag wins.
+      expect(SYSTEM_WORKFLOW_IDS.has(id), `${id} must be on the denylist`).toBe(true);
+      expect(runKindOf(id), `${id} cold`).toBe<RunKind>('system');
+      // Cold, warm, and with a flag that agrees — every path says system.
+      expect(deliverKindOf(id, undefined), `${id} with no lookup`).toBe<RunKind>('system');
       expect(deliverKindOf(id, KNOWN), `${id} must be system`).toBe<RunKind>('system');
+      expect(canDeliver(viewOf(id), undefined), `${id} cannot deliver cold`).toBe(false);
     }
     expect(DENYLIST_BLIND_SPOT).toHaveLength(6);
+  });
+
+  /** The denylist is now exactly the daemon's system set — measured, not assumed. */
+  it('names all ELEVEN system workflows the live daemon serves', () => {
+    expect(SYSTEM_WORKFLOW_IDS.size).toBe(11);
+    for (const id of [...SYSTEM_IDS, ...DENYLIST_BLIND_SPOT]) {
+      expect(SYSTEM_WORKFLOW_IDS.has(id), `${id} missing from the denylist`).toBe(true);
+    }
   });
 });
 
@@ -124,7 +145,9 @@ describe('the census stops counting document and video threads (D5, re-opened by
     // ordinary, so an unproven id is never counted whichever way it would have
     // classified. The delivering runs need no licence: they have a deliver unit.
     expect(deliverySummary(runs)).toBe('2 ran deliver');
-    for (const id of DENYLIST_BLIND_SPOT) expect(runKindOf(id)).toBe<RunKind>('build');
+    // Since #126 the denylist rules them out on its own too, so the census is now
+    // right for BOTH reasons — unproven licence and a positive system verdict.
+    for (const id of DENYLIST_BLIND_SPOT) expect(runKindOf(id)).toBe<RunKind>('system');
   });
 });
 

--- a/tests/delivery.coldCache.test.tsx
+++ b/tests/delivery.coldCache.test.tsx
@@ -88,21 +88,63 @@ describe('before the defs load, a run with no deliver phase gets no section at a
     });
   }
 
-  it('an ORDINARY workflow is withheld from too — a def in hand is the only licence', () => {
-    // Erring toward saying less: `feature` IS deliverable, but nothing has
-    // proved it yet. The section arrives with the defs, one tick later.
+  it('an ORDINARY workflow keeps its WORKTREE cold — the fact, never the claim (#126)', async () => {
+    // #125 withheld this section entirely until the defs landed, which took the
+    // worktree path down with the sentence. The path is `session.workdir`, a DTO
+    // fact needing no lookup — so the section renders NOW, carrying only that.
     render(<RightPanel view={noDeliverRun('r-feature', 'feature')} />);
-    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /Delivery/ }));
+    const body = await screen.findByTestId('run-delivery');
+
+    expect(body).toHaveTextContent('the work is in /w/tree');
+    // The two things that ARE claims stay withheld until a def proves the run ordinary.
+    expect(body).not.toHaveTextContent('This run has no deliver phase.');
+    expect(body).not.toHaveTextContent('deliver: pr');
   });
 
-  it('and a MATERIALISED def is withheld forever — it is in no catalog to arrive in', async () => {
+  it('and a MATERIALISED def gets the same — a worktree is true whatever composed it', async () => {
     const id = 'r-materialised';
     render(<RightPanel view={noDeliverRun(id, materialised(id))} />);
+    fireEvent.click(await screen.findByRole('button', { name: /Delivery/ }));
+    expect(await screen.findByTestId('run-delivery')).toHaveTextContent('the work is in /w/tree');
+
+    // The catalog will NEVER carry this id, so the claim never becomes licensed —
+    // unlike the `feature` run above, this one stays fact-only forever.
+    resolveWorkflows({ workflows: LIVE_WORKFLOWS });
+    await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
+    const body = screen.getByTestId('run-delivery');
+    expect(body).toHaveTextContent('the work is in /w/tree');
+    expect(body).not.toHaveTextContent('This run has no deliver phase.');
+    expect(body).not.toHaveTextContent('deliver: pr');
+  });
+
+  /**
+   * The self-limiting half of the fact-gate, and the reason widening it does not
+   * re-open D5. Interactive document threads carry materialised ids the catalog
+   * never serves — but they have NO worktree (`workdir: null`, verified across
+   * all three live DOC_THREAD_RUN_IDS), so there is no fact to show and they stay
+   * exactly as silent as #125 made them.
+   */
+  it('a run with NO workdir is still withheld entirely — no fact, no section', async () => {
+    const id = 'r-doc-thread';
+    const v = noDeliverRun(id, materialised(id));
+    render(<RightPanel view={{ ...v, session: { ...v.session, workdir: null } }} />);
     expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
 
     resolveWorkflows({ workflows: LIVE_WORKFLOWS });
     await waitFor(() => expect(client.api.listWorkflows).toHaveBeenCalled());
     expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('This run has no deliver phase.');
+  });
+
+  it('a FAILED /workflows fetch cannot remove the worktree either', async () => {
+    vi.spyOn(client.api, 'listWorkflows').mockRejectedValue(new Error('daemon hiccup'));
+    render(<RightPanel view={noDeliverRun('r-feature-fail', 'feature')} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Delivery/ }));
+    const body = await screen.findByTestId('run-delivery');
+    expect(body).toHaveTextContent('the work is in /w/tree');
+    expect(body).not.toHaveTextContent('This run has no deliver phase.');
   });
 });
 
@@ -137,7 +179,9 @@ describe('once the defs land', () => {
 
   it('the ordinary workflow gets its section, its phase fact and its remedy', async () => {
     render(<RightPanel view={noDeliverRun('r-feature-2', 'feature')} />);
-    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    // #126: the section is already here on the DTO fact — what ARRIVES with the defs is the
+    // claim and the remedy, asserted below. (Before #126 the whole section waited.)
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
 
     resolveWorkflows({ workflows: LIVE_WORKFLOWS });
 

--- a/tests/delivery.materialised.test.tsx
+++ b/tests/delivery.materialised.test.tsx
@@ -74,10 +74,22 @@ function delivering(id: string, status: UnitStatus, denial: string | null = null
  * A wicked-interactive DOCUMENT thread, as the wire carries them: a materialised
  * def, `:outline`/`:draft` units, no deliver phase anywhere.
  */
+/**
+ * A real interactive document thread: a materialised `wf-<runId>` id no catalog
+ * serves, and **no worktree**.
+ *
+ * `workdir: null` is not incidental — it is measured. All three
+ * `DOC_THREAD_RUN_IDS` report `workdir: null` on the live daemon, because a
+ * document thread writes into the interactive doc workspace, not a run
+ * worktree. The fixture said `/w/tree` until studio#126, which was the one field
+ * that had never mattered: with the Delivery section gated on a DTO fact, an
+ * imaginary worktree here would have modelled these runs as gaining a section
+ * that the real ones cannot.
+ */
 function docThread(id: string): SessionView {
   return makeView(
     {
-      id, workflow_id: materialised(id), status: 'completed', workdir: '/w/tree',
+      id, workflow_id: materialised(id), status: 'completed', workdir: null,
       problem: `Produce the first draft of the wicked-interactive document "${id}"`,
       project_id: 'proj-1',
     },
@@ -226,8 +238,10 @@ describe('the rail (RightPanel)', () => {
 
   it('a CATALOG feature run gets its section back once the defs land, remedy included', async () => {
     render(<RightPanel view={catalogPlain('r-feature-late')} />);
-    // Cold: nothing is proven, so nothing is claimed — including the section.
-    expect(screen.queryByRole('button', { name: /Delivery/ })).not.toBeInTheDocument();
+    // Cold: nothing is CLAIMED, but the section itself is already here on the run's
+    // own `workdir` (studio#126). What the defs add is the sentence and the remedy.
+    expect(screen.getByRole('button', { name: /Delivery/ })).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('This run has no deliver phase.');
 
     const header = await screen.findByRole('button', { name: /Delivery/ });
     fireEvent.click(header);


### PR DESCRIPTION
Closes #126.

#125 gated the "no deliver phase" **claim** on positive knowledge — right — but withheld the whole section to do it, taking the **worktree path** down with the sentence. That path is `session.workdir`, straight off the run's own DTO: true whatever composed the run, knowable with no lookup.

Measured on the live daemon: **24 runs** are in this class. The section popped in a tick after every navigation, and vanished outright when `GET /workflows` failed — a daemon hiccup removing a surface that doesn't depend on the daemon's workflow list.

## The split

| | gated on |
|---|---|
| the section + **worktree line** | `session.workdir` is known — a DTO fact (`hasDeliverySection`, new) |
| "This run has no deliver phase." | `is_system === false` (unchanged, inside `RunDelivery`) |
| `deliver: pr` remedy | `is_system === false` (unchanged) |

`canDeliver` is deliberately **not** widened. The census and row chips keep the narrower predicate — widening them would put unclassifiable runs back into a "N no deliver phase" census line, the exact D5 claim #125 removed.

## The denylist gap this exposed

Rendering on a fact instead of the catalog makes *"show a `feature` run's worktree while the defs load"* and *"never show an `interactive-draft` run a section, warm or cold"* the **same cold-cache instant**. The denylist named 5 of the daemon's 11 system workflows, so studio had nothing to tell them apart by — #126's acceptance criteria were unsatisfiable until it closed.

Measured (17 defs, 11 `is_system: true`) and closed: the denylist now names all eleven. Adding an id can only ever **withhold** delivery (`deliverKindOf` is one-directional), and each is one of crew's own reserved names.

## A fixture that misdescribed the runs it named

`docThread()` built the three real `DOC_THREAD_RUN_IDS` with `workdir: '/w/tree'`. All three report **`workdir: null`** live — a document thread writes into the interactive doc workspace, not a run worktree. That field had never mattered; under a fact-gate it would have modelled those runs as gaining a section the real ones cannot.

It's also what keeps EC57 self-limiting: **no worktree → no fact → no section**. Document threads stay silent for a structural reason, not a lucky one.

## Acceptance — asserted in the DOM

- [x] worktree line renders **warm**, **still-loading**, and **failed-fetch**
- [x] claim + remedy appear only when `isSystemWorkflow(id) === false`
- [x] an `is_system` run renders **no section at all**, any cache state
- [x] a run with **no workdir and no licence** renders nothing (a *licensed* run with no workdir still states the phase fact and the remedy — deliberate since #125, pinned by `delivery.coldCache.test.tsx:197`)
- [x] no new requests on any list surface

1823/1823 studio tests green (180 files), tsc + lint + build clean.