### PR TITLE
release: 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json`, three lines.

Ships #128 (delivery: the worktree is a fact) and the denylist close.

Cut as a PR rather than a push to main because the repo's branch guard requires it, and the release workflow validates `tag == package.json.version`, so the manifest has to be on main before `v0.4.0` is tagged.

**Why this release matters beyond studio:** wicked-crew bundles studio's `dist` as its default local skin via a `^0.2.0` devDependency pin. A caret on `0.x` pins the *minor*, so crew has been shipping studio **0.2.0** — the delivery-visibility work reached npm but never reached `npx wicked-crew serve`. Crew's pin gets bumped to `^0.4.0` next, before crew's own release.