### PR TITLE
site: a project is a context — the multi-repo graph the site never mentioned

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -259,6 +259,63 @@ const RAIL = [
     </div>
   </section>
 
+  <!-- ── A project is a CONTEXT: one graph over all its repos (crew 0.7.0) ── -->
+  <section class="ctx" aria-labelledby="ctx-h">
+    <div class="wrap">
+      <div class="sec-head sec-head--wide">
+        <div class="kicker">Context · crew 0.7.0</div>
+        <h2 id="ctx-h">A project is a context, not a folder.</h2>
+        <p class="sec-sub">
+          Real work spans repos. A change in an engine lands in the daemon that embeds it and the
+          console that renders it — and an agent that can only see one of them answers
+          <b>“not found”</b> about the other two, confidently, because a per-repo graph has no way
+          to know it was asked about something outside itself. Attach repos to a project and crew
+          builds <b>one co-located code graph</b> over all of them
+          (<code>POST /api/v1/projects/:id/graph/refresh</code>). Runs filed into that project are
+          <b>bound to it</b>.
+        </p>
+      </div>
+
+      <div class="ctx-grid">
+        <div class="ctx-card">
+          <span class="ctx-k">one query · three repos</span>
+          <p class="ctx-p">
+            <code>register</code> across a project holding studio + crew + core returns
+            <b>8 hits</b> — 4 in <code>wicked-core</code>, 3 in <code>wicked-crew</code>, 1 in
+            <code>wicked-studio</code> — each attributed to the repo it came from, spanning
+            <b>Rust and TypeScript</b> in one answer. Blast radius works the same way.
+          </p>
+        </div>
+        <div class="ctx-card">
+          <span class="ctx-k">the run says what it saw</span>
+          <p class="ctx-p">
+            The binding decision is recorded on <b>both</b> outcomes. “This run sees the project”
+            and “this run sees one repo, <b>because X</b>” are equally facts about what the run
+            could observe — and the second is the one you need when a worker reports that a sibling
+            repo does not exist.
+          </p>
+        </div>
+        <div class="ctx-card ctx-card--limit">
+          <span class="ctx-k">the limit, stated on the wire</span>
+          <p class="ctx-p">
+            <b>Co-located is not linked.</b> Each repo is indexed under its own label and edges do
+            <b>not</b> resolve across repos — <code>studio → api-types → crew</code> does not
+            traverse. What you get is per-repo results gathered into one answer with the repo named
+            on every hit. Every response carries <code>linkage: "co-located"</code> and a note
+            saying so, so a consumer cannot mistake it for a cross-repo trace.
+          </p>
+        </div>
+      </div>
+
+      <p class="ctx-foot">
+        A refresh is <code>wicked-estate index</code> per member, bounded at ten minutes
+        <b>each</b> — so it never happens implicitly at launch, and a missing or stale graph
+        degrades the run to its own repo’s graph and says so. Needs
+        <code>wicked-estate ≥ 0.14.6</code>, capability-probed before anything is indexed.
+      </p>
+    </div>
+  </section>
+
   <!-- ── The client seam — a pure client, nothing privileged ─────────────── -->
   <section class="pair" id="client" aria-labelledby="pair-h">
     <div class="wrap">

--- a/site/src/styles/studio.css
+++ b/site/src/styles/studio.css
@@ -456,7 +456,15 @@ code {
    of the page rather than an appendix. Three cards, the last one carrying the
    LIMIT — given the accent border because "co-located is not linked" is the
    sentence a reader most needs to leave with, not a footnote. */
-.ctx { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.ctx {
+  border-top: 1px solid var(--hairline);
+  /* vh first, svh second: a browser without `svh` drops the SECOND declaration and keeps the
+     first, where a bare `svh` shorthand would be dropped entirely and collapse the band's
+     vertical rhythm. The rest of this file still uses `svh` bare (7 sites) — same latent issue,
+     tracked separately rather than swept into a docs PR. */
+  padding: clamp(48px, 8vh, 96px) 0;
+  padding: clamp(48px, 8svh, 96px) 0;
+}
 .ctx-grid {
   display: grid; gap: 14px; margin-top: 28px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/site/src/styles/studio.css
+++ b/site/src/styles/studio.css
@@ -450,3 +450,30 @@ code {
   .btn-primary:hover, .cl-go:hover, .board-item:hover, .gh-pill:hover { transform: none; }
   html { scroll-behavior: auto; }
 }
+
+/* ── A project is a context: one graph over all its repos (crew 0.7.0) ───────
+   Same hairline-separated band as .proj / .pair, so the section reads as part
+   of the page rather than an appendix. Three cards, the last one carrying the
+   LIMIT — given the accent border because "co-located is not linked" is the
+   sentence a reader most needs to leave with, not a footnote. */
+.ctx { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.ctx-grid {
+  display: grid; gap: 14px; margin-top: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.ctx-card {
+  border: 1px solid var(--hairline-strong); border-radius: 14px; padding: 18px 18px 16px;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
+}
+.ctx-card--limit { border-color: color-mix(in oklab, var(--accent) 42%, var(--hairline-strong)); }
+.ctx-k {
+  display: block; font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.04em;
+  text-transform: lowercase; color: var(--amb); margin-bottom: 8px;
+}
+.ctx-card--limit .ctx-k { color: var(--accent); }
+.ctx-p { margin: 0; font-size: 0.94rem; line-height: 1.62; color: color-mix(in oklab, var(--ink) 86%, transparent); }
+.ctx-p code, .ctx-foot code { font-family: var(--font-mono); font-size: 0.86em; }
+.ctx-foot {
+  margin: 22px 0 0; font-size: 0.88rem; line-height: 1.6;
+  color: color-mix(in oklab, var(--ink) 68%, transparent);
+}

--- a/site/tests/e2e/context.spec.ts
+++ b/site/tests/e2e/context.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * A project is a context [.ctx] — the multi-repo code graph (crew 0.7.0).
+ *
+ * The claim the section exists to make is NOT "we federate your repos". It is the pair: one query
+ * reaches every member repo, AND edges do not resolve across them. A site that shipped only the
+ * first half would be selling a cross-repo dependency trace, which this is not — so the limit is
+ * asserted here as hard as the capability, and it is asserted as VISIBLE TEXT rather than as
+ * markup that happens to exist.
+ */
+test.describe('a project is a context [.ctx]', () => {
+  test('states the capability and names the repos a single query reaches', async ({ page }) => {
+    await page.goto('/');
+    const sec = page.locator('section.ctx');
+    await bringIntoView(sec);
+    await expect(sec).toBeVisible();
+
+    await expect(sec.locator('h2')).toContainText('context');
+    // The concrete result, not an adjective: one query, three repos, attributed.
+    const cards = sec.locator('.ctx-card');
+    await expect(cards).toHaveCount(3);
+    await expect(cards.first()).toContainText('wicked-core');
+    await expect(cards.first()).toContainText('wicked-crew');
+    await expect(cards.first()).toContainText('wicked-studio');
+    await expect(cards.first()).toContainText('Rust and TypeScript');
+  });
+
+  test('ships the LIMIT as prominently as the capability — co-located is not linked', async ({ page }) => {
+    await page.goto('/');
+    const limit = page.locator('.ctx-card--limit');
+    await bringIntoView(limit);
+    await expect(limit).toBeVisible();
+
+    // The exact sentence a reader must leave with, and the wire field that proves it is not
+    // marketing: a consumer can check `linkage` at runtime.
+    await expect(limit).toContainText('Co-located is not linked');
+    await expect(limit).toContainText('do');
+    await expect(limit).toContainText('not');
+    await expect(limit).toContainText('linkage');
+    await expect(limit).toContainText('co-located');
+  });
+
+  test('does not oversell: the refresh cost and the version floor are both stated', async ({ page }) => {
+    await page.goto('/');
+    const foot = page.locator('.ctx-foot');
+    await bringIntoView(foot);
+    // Ten minutes PER MEMBER is why a refresh is never implicit — omitting it would make the
+    // feature sound free, and the first person to run it on a large project would find out
+    // otherwise at the worst moment.
+    await expect(foot).toContainText('ten minutes');
+    await expect(foot).toContainText('wicked-estate ≥ 0.14.6');
+  });
+});
+
+test.describe('mobile (390×844) · the context section', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('renders on a phone with all three cards and no sideways scroll', async ({ page }) => {
+    await page.goto('/');
+    const sec = page.locator('section.ctx');
+    await bringIntoView(sec);
+    await expect(sec).toBeVisible();
+    await expect(sec.locator('.ctx-card')).toHaveCount(3);
+
+    // The grid is auto-fit; on a 390px viewport it must stack rather than overflow. The page-wide
+    // overflow test covers the document — this pins the SECTION, so a later change here cannot
+    // widen the page and be blamed on something else.
+    const overflow = await sec.evaluate(
+      (el) => el.scrollWidth - el.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/site/tests/e2e/context.spec.ts
+++ b/site/tests/e2e/context.spec.ts
@@ -33,13 +33,15 @@ test.describe('a project is a context [.ctx]', () => {
     await bringIntoView(limit);
     await expect(limit).toBeVisible();
 
-    // The exact sentence a reader must leave with, and the wire field that proves it is not
-    // marketing: a consumer can check `linkage` at runtime.
+    // WHOLE phrases, never fragments. The first cut asserted `'do'` and `'not'` separately, which
+    // matched "does" and "cannot" — so the pair passed even with the limitation deleted. A guard
+    // that reports success while asserting nothing is exactly the failure this section warns about.
     await expect(limit).toContainText('Co-located is not linked');
-    await expect(limit).toContainText('do');
-    await expect(limit).toContainText('not');
-    await expect(limit).toContainText('linkage');
-    await expect(limit).toContainText('co-located');
+    await expect(limit).toContainText('resolve across repos');
+    // The concrete non-example, and the wire field a consumer can check at runtime.
+    await expect(limit).toContainText('studio → api-types → crew');
+    await expect(limit).toContainText('does not');
+    await expect(limit).toContainText('linkage: "co-located"');
   });
 
   test('does not oversell: the refresh cost and the version floor are both stated', async ({ page }) => {


### PR DESCRIPTION
crew 0.7.0 shipped **one co-located code graph over every repo a project owns**, and the product site had *zero* mentions of it — not "project graph", not "co-located", not "multi-repo", not "blast radius". A visitor had no way to learn the capability exists.

## Written around the pair, not the headline

The claim is **not** "we federate your repos." It's that one query reaches every member repo **and** edges do not resolve across them. A site shipping only the first half would be selling a cross-repo dependency trace, which this is not — so the limit card gets the accent border and names `linkage: "co-located"`, the field a consumer can actually check at runtime.

Three cards: what one query returns, what the run records either way, and the limit.

## The numbers are measured, not illustrative

`register` across a real project holding studio + crew + core returns **8 hits** — 4 in `wicked-core`, 3 in `wicked-crew`, 1 in `wicked-studio` — spanning **Rust and TypeScript** in one answer. Those came from an actual co-located graph (11,045 nodes / 22,881 edges / 826 files), not from prose.

The refresh cost is stated too: **ten minutes per member**, which is why it's never implicit. Omitting it would make the feature sound free, and the first person to run it on a large project would find out otherwise at the worst possible moment.

## Verification

- **23/23 e2e** (19 existing + 4 new), site builds clean
- one of the new tests runs at **390px**: the auto-fit grid must stack, not widen the page — asserted on the section itself so a later change here can't widen the document and be blamed elsewhere
- rendered HTML checked for all seven load-bearing phrases, not just "the build passed"

Shared skin untouched — still `wicked-web` Base/Topbar/Footer/SameGarden.