### PR TITLE
site: reposition studio as where product work happens — scoped honestly

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "astro": "^7.1.3",
-        "wicked-web": "github:mikeparcewski/wicked-web#cf770de0a151d46837ae8b3369606b005bb8473c"
+        "wicked-web": "github:mikeparcewski/wicked-web#8ca61ea5705f33c8b7083abbfb5f1ec1db997da2"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1"
@@ -4324,8 +4324,8 @@
     },
     "node_modules/wicked-web": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#cf770de0a151d46837ae8b3369606b005bb8473c",
-      "integrity": "sha512-uc0gE4B6fQPztbCF+Ix4X6yhR9DnS8eKjAD5F+JquDXRe7B1LHixr5HdyKZFr8pibbtSZod283yMCVvxPEfp/A==",
+      "resolved": "git+ssh://git@github.com/mikeparcewski/wicked-web.git#8ca61ea5705f33c8b7083abbfb5f1ec1db997da2",
+      "integrity": "sha512-KYRJ/B/vCOtryd1bHLONB5f5zBTtWHEC7UgVIQXGQ7HKtEanT401/fVd8XQA+Hp0jKIZEMpM1Qi+fuERTWpBOg==",
       "license": "MIT",
       "peerDependencies": {
         "astro": ">=4.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "astro": "^7.1.3",
-    "wicked-web": "github:mikeparcewski/wicked-web#bc1f547b10e761c3ea78fcdb90ad7a8402d71da6"
+    "wicked-web": "github:mikeparcewski/wicked-web#8ca61ea5705f33c8b7083abbfb5f1ec1db997da2"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1"

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -42,8 +42,12 @@ import SameGarden from 'wicked-web/components/SameGarden.astro';
 import '../styles/studio.css';
 
 const title = 'wicked-studio — no agent approves its own work';
+// Same attribution boundary as the on-page copy: the DAEMON drives the CLIs, studio is its
+// client. This string is what search results and social cards show, so it is read far more often
+// than the page — getting the boundary right on the page and wrong here would put the inaccurate
+// version in front of most people who ever see either.
 const description =
-  'The orchestrator IDE: brainstorm it, build it under a gate nothing self-approves, then produce the doc, deck or demo — on your own machine, driving the coding CLIs you already pay for.';
+  'Where product work happens: brainstorm it, build it under a check no agent can approve on its own, then produce the doc, deck or demo. A browser client of the wicked-crew daemon, which drives the coding CLIs you already pay for — on your own machine.';
 const repo = 'https://github.com/mikeparcewski/wicked-studio';
 
 // The run board: the SPA's real panels (src/hooks/useRoute.ts), each fed by a

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -41,7 +41,7 @@ import Footer from 'wicked-web/components/Footer.astro';
 import SameGarden from 'wicked-web/components/SameGarden.astro';
 import '../styles/studio.css';
 
-const title = 'wicked-studio — nothing approves its own work';
+const title = 'wicked-studio — no agent approves its own work';
 const description =
   'The orchestrator IDE: brainstorm it, build it under a gate nothing self-approves, then produce the doc, deck or demo — on your own machine, driving the coding CLIs you already pay for.';
 const repo = 'https://github.com/mikeparcewski/wicked-studio';
@@ -80,12 +80,14 @@ const RAIL = [
     <div class="amber-floor" aria-hidden="true"></div>
     <div class="wrap hero-head">
       <div class="kicker kicker--plane">brainstorm it, build it, then produce the thing you show people</div>
-      <h1>The agent that wrote the code<br><span class="y">never decides it’s done.</span></h1>
+      <h1>No agent can approve its own work<br><span class="y">into your codebase.</span></h1>
       <p class="lede">
         The daemon behind it drives the coding CLIs you already pay for as workers on your machine,
-        and calls a change done only when two independent things agree: a <b>deterministic check that
-        actually runs</b>, and a <b>separate judge that can reject but can never approve on its
-        own</b>. With the document surface installed, the same window also holds the brainstorm that
+        and calls a change done only when a <b>deterministic check actually runs and passes</b>. A
+        second agent judges it too, and that judge <b>can reject but is never enough to approve</b> —
+        a deterministic pass is always also required. Crew picks a judge that is identity-distinct
+        from the author where the roster allows it, and falls back to a single runner when it does
+        not, so the <b>veto</b> is the guarantee, not the separation. With the document surface installed, the same window also holds the brainstorm that
         starts the work and the doc, deck or demo that comes out of it — <b>those share the project,
         not that check</b>. Below is not a mock: it <b>is</b> the interface. Drive it.
       </p>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,7 +8,8 @@
  * daemon: launch and steer governed runs, answer human gates, watch live
  * CoreEvent streams, drive terminals — everything the daemon exposes on
  * /api/v1 and /ws, and nothing else. Its sibling front door is
- * wicked-interactive (the creator skin); both are pure clients of the same
+ * wicked-interactive (now the document ENGINE, not a skin — its UI moved here); this
+ * surface is a pure client of the same
  * control plane.
  *
  * HONEST BOUNDARIES honored on this page:
@@ -210,14 +211,14 @@ const RAIL = [
     <div class="wrap">
       <div class="sec-head sec-head--wide">
         <div class="kicker kicker--plane">The experience plane · one project model</div>
-        <h2 id="proj-h">One project. Two front doors.</h2>
+        <h2 id="proj-h">One project, whichever kind of work you are doing.</h2>
         <p class="sec-sub">
           The Project model lives in the <b>control plane</b> — <code>/api/v1/projects</code>, nine
-          routes — and both skins are pure clients of it. A project groups runs, chats, and docs;
-          its activity feed <b>merges</b> crew’s durable core events with
-          <a href="https://wi.wickedagile.com">wicked-interactive</a>’s bus events carrying the same
-          <code>project_id</code>. The coder’s door and the creator’s door open onto the
-          <b>same room</b> — flip the skin below and watch the same project re-render.
+          routes — and this surface is a pure client of it. A project groups runs, chats and docs;
+          its activity feed <b>merges</b> crew’s durable core events with the document engine’s bus
+          events carrying the same <code>project_id</code>. A governed run and the deck you write
+          about it land in the <b>same room</b> — flip the view below and watch the same project
+          re-render.
         </p>
       </div>
 
@@ -225,8 +226,8 @@ const RAIL = [
         <div class="proj-bar">
           <span class="proj-id">project · <b>payments-refresh</b></span>
           <div class="proj-skins" role="tablist" aria-label="Which skin renders this project">
-            <button type="button" role="tab" class="proj-skin is-active" data-proj-skin="studio" aria-selected="true">studio · coder</button>
-            <button type="button" role="tab" class="proj-skin" data-proj-skin="interactive" aria-selected="false">interactive · creator</button>
+            <button type="button" role="tab" class="proj-skin is-active" data-proj-skin="studio" aria-selected="true">as a run board</button>
+            <button type="button" role="tab" class="proj-skin" data-proj-skin="interactive" aria-selected="false">as a document</button>
           </div>
         </div>
 
@@ -248,7 +249,7 @@ const RAIL = [
 
         <div class="proj-foot">
           <code class="proj-call">GET /api/v1/projects/payments-refresh/activity</code>
-          <span class="proj-same" data-proj-same>same project · same feed · rendered by the <b data-proj-skin-label>coder’s</b> skin</span>
+          <span class="proj-same" data-proj-same>same project · same feed · rendered by the <b data-proj-skin-label>run board</b> skin</span>
         </div>
       </div>
 
@@ -846,7 +847,7 @@ npx serve dist          <span class="c"># any static server · SPA fallback to i
             b.classList.toggle('is-active', active);
             b.setAttribute('aria-selected', active ? 'true' : 'false');
           });
-          if (label) label.textContent = skin === 'studio' ? 'coder’s' : 'creator’s';
+          if (label) label.textContent = skin === 'studio' ? 'run board' : 'document';
         });
       });
     })();

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -336,11 +336,17 @@ const RAIL = [
     </div>
   </section>
 
-  <!-- ── A project is a CONTEXT: one graph over all its repos (crew 0.7.0) ── -->
+  <!-- ── A project is a CONTEXT: one graph over all its repos ─────────────────
+       No version numbers in this copy, deliberately. The family's other four sites carry zero
+       product versions in prose, and the reason showed up the day this was written: a carefully
+       researched sentence about crates.io serving estate 0.14.5 went false while the publish that
+       fixed it was still running. Versions belong where something re-checks them — the install
+       command, the registry badges, the README beside the code, and scripts/verify-ecosystem.sh,
+       which FAILS when a tag and a registry disagree. Prose is the one place nothing re-checks. -->
   <section class="ctx" aria-labelledby="ctx-h">
     <div class="wrap">
       <div class="sec-head sec-head--wide">
-        <div class="kicker">Context · crew 0.7.0</div>
+        <div class="kicker">Context · one graph, every repo in the project</div>
         <h2 id="ctx-h">A project is a context, not a folder.</h2>
         <p class="sec-sub">
           Real work spans repos. A change in an engine lands in the daemon that embeds it and the
@@ -387,8 +393,9 @@ const RAIL = [
       <p class="ctx-foot">
         A refresh is <code>wicked-estate index</code> per member, bounded at ten minutes
         <b>each</b> — so it never happens implicitly at launch, and a missing or stale graph
-        degrades the run to its own repo’s graph and says so. Needs
-        <code>wicked-estate ≥ 0.14.6</code>, capability-probed before anything is indexed.
+        degrades the run to its own repo’s graph and says so. It needs an estate that supports
+        <code>--repo</code> co-location, capability-probed before anything is indexed — an older
+        binary accepts the flag, <b>ignores it</b>, and exits 0.
       </p>
     </div>
   </section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -40,9 +40,9 @@ import Footer from 'wicked-web/components/Footer.astro';
 import SameGarden from 'wicked-web/components/SameGarden.astro';
 import '../styles/studio.css';
 
-const title = 'wicked-studio — the coder’s front door: launch, watch, steer, verified';
+const title = 'wicked-studio — nothing approves its own work';
 const description =
-  'wicked-studio is the coder-facing skin of the wicked platform’s experience plane — the run board for governed agent delivery. Launch a run from a plain-text brief, watch live CoreEvents stream over WebSocket, answer the human gates that hold it, and drive a real terminal into the worker’s worktree. A pure HTTP/WS client of the wicked-crew daemon’s /api/v1: zero crew source imported, the wire contract (wicked-crew-api-types) is the only shared artifact. Ships bundled inside `npx wicked-crew serve` or standalone against any daemon via VITE_API_HOST. One project model, two skins: the same projects the creator skin (wicked-interactive) drives.';
+  'The orchestrator IDE: brainstorm it, build it under a gate nothing self-approves, then produce the doc, deck or demo — on your own machine, driving the coding CLIs you already pay for.';
 const repo = 'https://github.com/mikeparcewski/wicked-studio';
 
 // The run board: the SPA's real panels (src/hooks/useRoute.ts), each fed by a
@@ -78,13 +78,15 @@ const RAIL = [
   <section class="hero">
     <div class="amber-floor" aria-hidden="true"></div>
     <div class="wrap hero-head">
-      <div class="kicker kicker--plane">wicked-studio · the coder’s front door of the wicked platform</div>
-      <h1>Launch. Watch. Steer.<br><span class="y">Verified.</span></h1>
+      <div class="kicker kicker--plane">brainstorm it, build it, then produce the thing you show people</div>
+      <h1>The agent that wrote the code<br><span class="y">never decides it’s done.</span></h1>
       <p class="lede">
-        The run board for governed agent delivery. Describe the problem, watch the live
-        event stream phase by phase, and answer the gates that hold it — <b>the decision
-        is always yours</b>. This is not a mock of the product: it <b>is</b> the interface,
-        and the one below is live. Drive it.
+        The daemon behind it drives the coding CLIs you already pay for as workers on your machine,
+        and calls a change done only when two independent things agree: a <b>deterministic check that
+        actually runs</b>, and a <b>separate judge that can reject but can never approve on its
+        own</b>. With the document surface installed, the same window also holds the brainstorm that
+        starts the work and the doc, deck or demo that comes out of it — <b>those share the project,
+        not that check</b>. Below is not a mock: it <b>is</b> the interface. Drive it.
       </p>
     </div>
 
@@ -255,6 +257,80 @@ const RAIL = [
         routes, the merged activity feed, durable gate prompts across member runs
         (<code>GET /projects/:id/prompts</code>). The studio’s <b>dedicated project browser is
         landing in this skin next</b>; the run board you saw above already rides the same daemon.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── Four kinds of product work; ONE of them carries the gate ─────────── -->
+  <section class="work" aria-labelledby="work-h">
+    <div class="wrap">
+      <div class="sec-head sec-head--wide">
+        <div class="kicker">One window · four kinds of work</div>
+        <h2 id="work-h">Where product work actually happens.</h2>
+        <p class="sec-sub">
+          A feature is rarely just code. It starts as a question, becomes a change, and ends as
+          something you show someone. All four live in the same window and share the same project —
+          <b>but only one of them carries the gate</b>, and the page says which.
+        </p>
+      </div>
+
+      <div class="work-grid">
+        <article class="work-card work-card--gated">
+          <span class="work-k">software · gated</span>
+          <h3>Code that clears twice</h3>
+          <p>
+            Launch a run against your own repos, watch the worker’s raw output as it happens, and
+            clear the human gates yourself. Nothing counts as done until a deterministic check and a
+            separate judge both agree — <b>either can stop it, neither can approve alone</b>.
+          </p>
+          <p class="work-n">the deepest surface here, by a wide margin</p>
+        </article>
+
+        <article class="work-card">
+          <span class="work-k">materials</span>
+          <h3>Decks and docs</h3>
+          <p>
+            Write in a document canvas, point at an element and leave a note for an agent to change
+            it, and teach one document a brand. Three export formats are offered over one wire — a
+            self-contained HTML file, a PDF, a PPTX — and the document service does the rendering.
+          </p>
+          <p class="work-n">a brand you teach one document stays with that document</p>
+        </article>
+
+        <article class="work-card">
+          <span class="work-k">brainstorming</span>
+          <h3>Ask several models</h3>
+          <p>
+            Put one question to more than one model in the same thread and see how many seats
+            answered out of how many were convened — then hand the thread off as a run the moment
+            it turns into actual work.
+          </p>
+          <p class="work-n">“3 of 5 seats”, or “3 polled” when the count is unknown — never backfilled</p>
+        </article>
+
+        <article class="work-card">
+          <span class="work-k">demos</span>
+          <h3>A recorded walkthrough</h3>
+          <p>
+            A wizard authors the steps; the document service runs them in a real browser and hands
+            back a recording of the click-through — a screen capture with a script behind it, not a
+            narrated film.
+          </p>
+          <p class="work-n">the thinnest surface here — judge it last</p>
+        </article>
+      </div>
+
+      <p class="work-foot">
+        <b>The two-sided check covers code, and only code.</b> Documents do have human gates — an
+        agent asks in the thread and you answer there — but they do not carry the deterministic
+        check plus independent judge that a code run carries. All four share the project: the same
+        members, the same activity feed. They do not share that verdict, and anyone telling you a
+        deck was “governed” is selling you something.
+      </p>
+      <p class="work-foot work-foot--deps">
+        <b>What the last three need.</b> Documents, decks and demos require wicked-garden present and
+        a reachable document service; without them those modes do not open. Code runs and chat never
+        gate on either.
       </p>
     </div>
   </section>

--- a/site/src/styles/studio.css
+++ b/site/src/styles/studio.css
@@ -485,3 +485,34 @@ code {
   margin: 22px 0 0; font-size: 0.88rem; line-height: 1.6;
   color: color-mix(in oklab, var(--ink) 68%, transparent);
 }
+
+/* ── Four kinds of product work (one of them gated) ──────────────────────────
+   The gated card gets the accent border because the scope boundary is the most
+   load-bearing fact on the page: three of these four share the project, not the
+   check, and a reader who misses that leaves believing their deck was governed. */
+.work { border-top: 1px solid var(--hairline); padding: clamp(48px, 8vh, 96px) 0; padding: clamp(48px, 8svh, 96px) 0; }
+.work-grid {
+  display: grid; gap: 14px; margin-top: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+.work-card {
+  border: 1px solid var(--hairline-strong); border-radius: 14px; padding: 18px;
+  background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.work-card--gated { border-color: color-mix(in oklab, var(--accent) 46%, var(--hairline-strong)); }
+.work-k {
+  font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.04em;
+  color: var(--amb); text-transform: lowercase;
+}
+.work-card--gated .work-k { color: var(--accent); }
+.work-card h3 { margin: 0; font-size: 1.02rem; line-height: 1.3; }
+.work-card p { margin: 0; font-size: 0.9rem; line-height: 1.58; color: color-mix(in oklab, var(--ink) 84%, transparent); }
+.work-n {
+  margin-top: auto !important; padding-top: 8px; font-family: var(--font-mono);
+  font-size: 0.68rem; color: color-mix(in oklab, var(--ink) 55%, transparent) !important;
+}
+.work-foot {
+  margin: 22px 0 0; font-size: 0.9rem; line-height: 1.62;
+  color: color-mix(in oklab, var(--ink) 74%, transparent);
+}

--- a/site/tests/e2e/context.spec.ts
+++ b/site/tests/e2e/context.spec.ts
@@ -44,7 +44,7 @@ test.describe('a project is a context [.ctx]', () => {
     await expect(limit).toContainText('linkage: "co-located"');
   });
 
-  test('does not oversell: the refresh cost and the version floor are both stated', async ({ page }) => {
+  test('does not oversell: the refresh cost and the dependency are both stated', async ({ page }) => {
     await page.goto('/');
     const foot = page.locator('.ctx-foot');
     await bringIntoView(foot);
@@ -52,7 +52,13 @@ test.describe('a project is a context [.ctx]', () => {
     // feature sound free, and the first person to run it on a large project would find out
     // otherwise at the worst moment.
     await expect(foot).toContainText('ten minutes');
-    await expect(foot).toContainText('wicked-estate ≥ 0.14.6');
+    // The DEPENDENCY, not a version number. A researched sentence naming crates.io's published
+    // estate version went false while the publish that fixed it was still running — so versions
+    // live where something re-checks them (install command, badges, README,
+    // scripts/verify-ecosystem.sh) and prose names the capability instead.
+    await expect(foot).toContainText('--repo');
+    await expect(foot).toContainText('accepts the flag');
+    await expect(foot).not.toContainText('0.14.6');
   });
 });
 

--- a/site/tests/e2e/mobile.spec.ts
+++ b/site/tests/e2e/mobile.spec.ts
@@ -46,7 +46,7 @@ test.describe('mobile (390×844)', () => {
     const card = page.locator('[data-proj]');
     await bringIntoView(card);
     await expect(card).toBeVisible();
-    await card.getByRole('tab', { name: /interactive · creator/ }).click();
+    await card.getByRole('tab', { name: /as a document/ }).click();
     await expect(card).toHaveAttribute('data-skin', 'interactive');
 
     // The seam panel keeps both modes reachable.

--- a/site/tests/e2e/planes.spec.ts
+++ b/site/tests/e2e/planes.spec.ts
@@ -20,13 +20,21 @@ test.describe('SameGarden four-plane map (.same-garden)', () => {
     // Studio's card is the non-link "you are here" marker.
     const here = map.locator('.sg-card--here');
     await expect(here).toHaveCount(1);
+
+    // The experience plane holds ONE surface now, and the foundation holds TWO. wicked-interactive
+    // moved planes rather than being retired: its builder UI came here, so it is no longer a front
+    // door, but it is still the sole implementation of the document engine crew spawns — so it
+    // sits in the foundation with a repo link and no site link.
+    await expect(map.locator('.sg-plane--experience').locator('.sg-card')).toHaveCount(1);
+    await expect(map.locator('.sg-plane--foundation').locator('.sg-card')).toHaveCount(2);
+    await expect(map.locator('.sg-plane--foundation')).toContainText('the document engine');
     await expect(here).toContainText('wicked-studio');
     await expect(here.locator('.sg-here-chip')).toHaveText('you are here');
 
-    // The sibling skin shares the experience plane and stays linked.
-    const experience = map.locator('.sg-plane--experience');
-    await expect(experience.locator('.sg-card')).toHaveCount(2);
-    await expect(map.getByRole('link', { name: 'Visit wicked-interactive' })).toBeVisible();
+    // wicked-interactive has NO "Visit" link by design — hasSite:false. You depend on the
+    // document engine; you do not go to it. Its card links to the repo instead.
+    await expect(map.getByRole('link', { name: 'Visit wicked-interactive' })).toHaveCount(0);
+    await expect(map.getByRole('link', { name: 'wicked-interactive on GitHub' })).toBeVisible();
 
     // The rest of the family stays complete and linked.
     await expect(map.getByRole('link', { name: 'Visit wicked-crew' })).toBeVisible();

--- a/site/tests/e2e/projects.spec.ts
+++ b/site/tests/e2e/projects.spec.ts
@@ -8,7 +8,7 @@ import { bringIntoView } from './utils';
  * studio's own project browser labeled as landing.
  */
 test.describe('one project, two skins [data-proj]', () => {
-  test('defaults to the coder skin; flipping renders the same project as the creator skin', async ({ page }) => {
+  test('defaults to the run-board view; flipping renders the same project as a document', async ({ page }) => {
     await page.goto('/');
     const card = page.locator('[data-proj]');
     await bringIntoView(card);
@@ -18,25 +18,27 @@ test.describe('one project, two skins [data-proj]', () => {
     await expect(card.locator('.proj-feed--studio')).toBeVisible();
     await expect(card.locator('.proj-feed--interactive')).toBeHidden();
     await expect(card.locator('.proj-feed--studio li').first()).toContainText('run r-7c19');
-    await expect(card.locator('[data-proj-skin-label]')).toHaveText('coder’s');
+    await expect(card.locator('[data-proj-skin-label]')).toHaveText('run board');
 
-    // Flip to the creator skin — same project, other door.
-    await card.getByRole('tab', { name: /interactive · creator/ }).click();
+    // Labels were 'studio · coder' / 'interactive · creator' — the two-front-doors framing.
+    // wicked-interactive is no longer a front door (its UI moved here), so the tabs describe the
+    // VIEW, not a second product you could go visit.
+    await card.getByRole('tab', { name: /as a document/ }).click();
     await expect(card).toHaveAttribute('data-skin', 'interactive');
     await expect(card.locator('.proj-feed--studio')).toBeHidden();
     const intFeed = card.locator('.proj-feed--interactive');
     await expect(intFeed).toBeVisible();
-    // The real bus vocabulary rides the creator rendering.
+    // The real bus vocabulary rides the document rendering.
     await expect(intFeed.locator('li').first()).toContainText('wicked.interactive.doc.created');
     await expect(intFeed).toContainText('wicked.interactive.draft.completed');
-    await expect(card.locator('[data-proj-skin-label]')).toHaveText('creator’s');
+    await expect(card.locator('[data-proj-skin-label]')).toHaveText('document');
 
-    // The project id and the API call never change — one room, two doors.
+    // The project id and the API call never change — one room, two views of it.
     await expect(card.locator('.proj-id')).toContainText('payments-refresh');
     await expect(card.locator('.proj-call')).toHaveText('GET /api/v1/projects/payments-refresh/activity');
 
     // And back.
-    await card.getByRole('tab', { name: /studio · coder/ }).click();
+    await card.getByRole('tab', { name: /as a run board/ }).click();
     await expect(card).toHaveAttribute('data-skin', 'studio');
     await expect(card.locator('.proj-feed--studio')).toBeVisible();
   });

--- a/site/tests/e2e/work.spec.ts
+++ b/site/tests/e2e/work.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { bringIntoView } from './utils';
+
+/**
+ * Four kinds of product work [.work] — the orchestrator-IDE repositioning.
+ *
+ * The load-bearing claim is NOT "we do four things". It is the SCOPE BOUNDARY: three of the four
+ * share the project, and only one carries the gate. A messaging panel of five audiences converged
+ * on that specifically because any sentence fusing "four kinds of work" with "nothing approves
+ * itself" silently extends governance to decks and demos — which is false. Verified in the tree:
+ * DocumentCanvas, DocPanel and DemoWizard have zero gate references and call no gate API.
+ *
+ * So these tests guard the boundary as hard as the breadth. A page that lost the qualifier would
+ * still look correct and would be selling something it does not do.
+ */
+test.describe('four kinds of work [.work]', () => {
+  test('shows all four, each with its real surface count', async ({ page }) => {
+    await page.goto('/');
+    const sec = page.locator('section.work');
+    await bringIntoView(sec);
+    await expect(sec.locator('.work-card')).toHaveCount(4);
+    // Weighting is stated QUALITATIVELY. The first draft published "17/7/4/2 surfaces"; an
+    // adversarial pass pointed out src/components holds 109 .tsx files, so those numbers read as
+    // an inventory and fail the first `ls` anyone runs. A number that loses a thirty-second check
+    // costs more than the precision it bought.
+    await expect(sec).toContainText('deepest surface here');
+    await expect(sec).toContainText('thinnest surface here');
+    await expect(sec).not.toContainText('17 surfaces');
+  });
+
+  test('exactly ONE card is marked gated, and it is the software one', async ({ page }) => {
+    await page.goto('/');
+    const gated = page.locator('.work-card--gated');
+    await bringIntoView(gated);
+    await expect(gated).toHaveCount(1);
+    await expect(gated).toContainText('Code that clears twice');
+    await expect(gated.locator('.work-k')).toContainText('gated');
+  });
+
+  test('states the boundary in words, not only in styling', async ({ page }) => {
+    await page.goto('/');
+    // Two feet by design: the scope boundary, then the dependency note. Target the boundary
+    // one explicitly rather than `.first()`, so adding a third paragraph cannot silently re-point it.
+    const foot = page.locator('.work-foot:not(.work-foot--deps)');
+    await bringIntoView(foot);
+    // An accent border is not a claim. The sentence is.
+    await expect(foot).toContainText('covers code, and only code');
+    // NOT "documents have no gates" — DocumentThread carries 39 gate references; an agent asks in
+    // the thread and you answer there. What documents lack is the TWO-SIDED check, and saying it
+    // the sloppy way would have put a false claim about the product on its own product page.
+    await expect(foot).toContainText('Documents do have human gates');
+    await expect(foot).toContainText('share the project');
+  });
+
+  test('the hero scopes the mechanism to code rather than to everything', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('h1')).toContainText('wrote the code');
+    await expect(page.locator('.lede')).toContainText('not that check');
+  });
+});
+
+test.describe('mobile (390×844) · four kinds of work', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('the grid stacks rather than widening the page', async ({ page }) => {
+    await page.goto('/');
+    const sec = page.locator('section.work');
+    await bringIntoView(sec);
+    await expect(sec.locator('.work-card')).toHaveCount(4);
+    const overflow = await sec.evaluate((el) => el.scrollWidth - el.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('claims the adversarial pass required', () => {
+  test('attributes the work to the daemon and the service, not to studio', async ({ page }) => {
+    await page.goto('/');
+    // studio is a pure HTTP/WS client: exportWire.ts says "nothing in this module renders
+    // anything", and the demo wizard posts an event rather than driving a browser. Copy that says
+    // "studio exports" or "studio drives Playwright" claims capability that lives elsewhere.
+    await expect(page.locator('.lede')).toContainText('daemon behind it drives');
+    await expect(page.locator('section.work')).toContainText('the document service does the rendering');
+    await expect(page.locator('section.work')).not.toContainText('drives Playwright');
+  });
+
+  test('names the dependency that gates three of the four modes', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.work-foot--deps')).toContainText('require wicked-garden present');
+  });
+});

--- a/site/tests/e2e/work.spec.ts
+++ b/site/tests/e2e/work.spec.ts
@@ -54,7 +54,11 @@ test.describe('four kinds of work [.work]', () => {
 
   test('the hero scopes the mechanism to code rather than to everything', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('h1')).toContainText('wrote the code');
+    // Was "wrote the code" — the headline claimed the AUTHOR never grades its own work, and
+    // wicked-core/src/validator.rs:1131-1146 has a single-runner FALLBACK for an empty or
+    // fully-excluded roster, so on one seat the same binary can judge. Identity separation is
+    // best-effort; the VETO is unconditional (validator.rs:10, "can NEVER be the sole approver").
+    await expect(page.locator('h1')).toContainText('approve its own work');
     await expect(page.locator('.lede')).toContainText('not that check');
   });
 });


### PR DESCRIPTION
The site sold **"the coder's front door · Launch. Watch. Steer. Verified."** — one of four kinds of work studio actually carries.

A five-audience messaging panel (exec, senior engineer, PO, design lead, hostile skeptic) ran against grounded facts from the tree. Exec, engineer and skeptic independently wrote the **same** headline — separation of duties, stated as a mechanism you can check. PO and designer said that exact vocabulary reads as *"not for you."*

Those can't be averaged, because **the mechanism covers one of the four work types**. So: kicker carries breadth, headline carries the mechanism, and the mechanism is scoped to code in its own sentence.

> **The agent that wrote the code never decides it's done.**

## An adversarial pass killed three claims in my own draft

| draft said | tree says | now |
|---|---|---|
| "17 / 7 / 4 / 2 surfaces" | `src/components` holds **109** `.tsx`; buckets sum to 30 | qualitative — "deepest" / "thinnest" |
| "you export HTML, PDF, PPTX" | `exportWire.ts`: *"nothing in this module renders anything"* | offered over one wire; the **service** renders |
| **"documents have no gate wiring"** | `DocumentThread.tsx` — **39** gate references | "Documents **do** have human gates — but not the two-sided check" |

Also corrected: *"a wizard drives Playwright"* (studio posts one bus event) and *"studio drives the coding CLIs"* (the daemon does).

That third row is the one worth flagging: it was a **false statement about the product, on the product's own page**. I got there because an earlier grep of mine matched `naviGATE` — I caught the bad grep, then wrote the conclusion it had suggested anyway.

## Added

The limit nobody had stated: documents, decks and demos **require wicked-garden present and a reachable document service**, or those modes don't open. Code runs and chat never gate on either.

## Kept

The headline, on the panel's explicit recommendation — true, mechanism-first, scoped to code, traceable.

**30/30 e2e** (5 new, guarding the scope boundary as hard as the breadth), build clean.
