### PR TITLE
site: sections with no snap point, mandatory snapping, and fused words

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -15,5 +15,15 @@ export default defineConfig({
   // assets resolve from '/', so the CNAME root serves CSS/JS correctly.
   site: 'https://ws.wickedagile.com',
   output: 'static',
+  // Astro's HTML compressor (on by default) deletes the whitespace between a text node and a
+  // following inline tag rather than collapsing it to a single space, so prose wrapped as
+  //     ...core returns
+  //     <b>8 hits</b>
+  // ships as "returns8 hits". It hit this page in a dozen places — "arebound to it",
+  // "spanningRust", "donot resolve", "studio'sdedicated". The copy here wraps for readability, so
+  // every line break landing before a <b> or <code> was a latent word-join, invisible in source
+  // review and invisible to layout measurement. A few KB of retained whitespace is cheaper than
+  // shipping mashed sentences. Pinned by tests/e2e/prose.spec.ts.
+  compressHTML: false,
   vite: { resolve: { alias } },
 });

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -87,13 +87,14 @@ const RAIL = [
       <h1>No agent can approve its own work<br><span class="y">into your codebase.</span></h1>
       <p class="lede">
         The daemon behind it drives the coding CLIs you already pay for as workers on your machine,
-        and calls a change done only when a <b>deterministic check actually runs and passes</b>. A
-        second agent judges it too, and that judge <b>can reject but is never enough to approve</b> —
-        a deterministic pass is always also required. Crew picks a judge that is identity-distinct
-        from the author where the roster allows it, and falls back to a single runner when it does
-        not, so the <b>veto</b> is the guarantee, not the separation. With the document surface installed, the same window also holds the brainstorm that
-        starts the work and the doc, deck or demo that comes out of it — <b>those share the project,
-        not that check</b>. Below is not a mock: it <b>is</b> the interface. Drive it.
+        and calls a change done only when a <b>deterministic check actually runs and passes</b>. A second agent judges
+        it too — and that judge <b>can reject, but is never enough to approve</b>.
+      </p>
+      <p class="fine">
+        Crew prefers a judge identity-distinct from the author and falls back to a single runner when
+        the roster can’t supply one, so the <b>veto</b> is the guarantee, not the separation.
+        Brainstorms, docs and demos share the project, <b>not that check</b>. Below is not a mock —
+        it <b>is</b> the interface.
       </p>
     </div>
 
@@ -219,12 +220,10 @@ const RAIL = [
         <div class="kicker kicker--plane">The experience plane · one project model</div>
         <h2 id="proj-h">One project, whichever kind of work you are doing.</h2>
         <p class="sec-sub">
-          The Project model lives in the <b>control plane</b> — <code>/api/v1/projects</code>, nine
-          routes — and this surface is a pure client of it. A project groups runs, chats and docs;
-          its activity feed <b>merges</b> crew’s durable core events with the document engine’s bus
-          events carrying the same <code>project_id</code>. A governed run and the deck you write
-          about it land in the <b>same room</b> — flip the view below and watch the same project
-          re-render.
+          A project groups runs, chats and docs, and its activity feed <b>merges</b> crew’s durable
+          core events with the document engine’s bus events carrying the same <code>project_id</code>.
+          A governed run and the deck you write about it land in the <b>same room</b> — flip the view
+          below and watch the same project re-render.
         </p>
       </div>
 
@@ -261,9 +260,8 @@ const RAIL = [
 
       <p class="honest-note">
         <b>Where this stands:</b> the Project model is <b>shipped in the control plane</b> — nine
-        routes, the merged activity feed, durable gate prompts across member runs
-        (<code>GET /projects/:id/prompts</code>). The studio’s <b>dedicated project browser is
-        landing in this skin next</b>; the run board you saw above already rides the same daemon.
+        routes, the merged feed, durable gate prompts across member runs. The studio’s <b>dedicated
+        project browser is landing in this skin next</b>; the run board above rides that daemon.
       </p>
     </div>
   </section>
@@ -275,9 +273,8 @@ const RAIL = [
         <div class="kicker">One window · four kinds of work</div>
         <h2 id="work-h">Where product work actually happens.</h2>
         <p class="sec-sub">
-          A feature is rarely just code. It starts as a question, becomes a change, and ends as
-          something you show someone. All four live in the same window and share the same project —
-          <b>but only one of them carries the gate</b>, and the page says which.
+          A feature starts as a question, becomes a change, and ends as something you show someone.
+          All four share one project — <b>but only one carries the gate</b>.
         </p>
       </div>
 
@@ -286,9 +283,9 @@ const RAIL = [
           <span class="work-k">software · gated</span>
           <h3>Code that clears twice</h3>
           <p>
-            Launch a run against your own repos, watch the worker’s raw output as it happens, and
-            clear the human gates yourself. Nothing counts as done until a deterministic check and a
-            separate judge both agree — <b>either can stop it, neither can approve alone</b>.
+            Launch a run against your own repos, watch the worker’s raw output live, clear the gates
+            yourself. A deterministic check and a separate judge must both agree —
+            <b>either can stop it, neither can approve alone</b>.
           </p>
           <p class="work-n">the deepest surface here, by a wide margin</p>
         </article>
@@ -297,9 +294,9 @@ const RAIL = [
           <span class="work-k">materials</span>
           <h3>Decks and docs</h3>
           <p>
-            Write in a document canvas, point at an element and leave a note for an agent to change
-            it, and teach one document a brand. Three export formats are offered over one wire — a
-            self-contained HTML file, a PDF, a PPTX — and the document service does the rendering.
+            Write in a document canvas, point at an element to leave a note for an agent, and teach
+            one document a brand. Three formats over one wire — self-contained HTML, PDF, PPTX — and
+            the document service does the rendering.
           </p>
           <p class="work-n">a brand you teach one document stays with that document</p>
         </article>
@@ -308,9 +305,8 @@ const RAIL = [
           <span class="work-k">brainstorming</span>
           <h3>Ask several models</h3>
           <p>
-            Put one question to more than one model in the same thread and see how many seats
-            answered out of how many were convened — then hand the thread off as a run the moment
-            it turns into actual work.
+            Put one question to several models in the same thread and see how many seats answered —
+            then hand the thread off as a run the moment it turns into actual work.
           </p>
           <p class="work-n">“3 of 5 seats”, or “3 polled” when the count is unknown — never backfilled</p>
         </article>
@@ -320,8 +316,7 @@ const RAIL = [
           <h3>A recorded walkthrough</h3>
           <p>
             A wizard authors the steps; the document service runs them in a real browser and hands
-            back a recording of the click-through — a screen capture with a script behind it, not a
-            narrated film.
+            back a recording of the click-through — a screen capture, not a narrated film.
           </p>
           <p class="work-n">the thinnest surface here — judge it last</p>
         </article>
@@ -329,15 +324,10 @@ const RAIL = [
 
       <p class="work-foot">
         <b>The two-sided check covers code, and only code.</b> Documents do have human gates — an
-        agent asks in the thread and you answer there — but they do not carry the deterministic
-        check plus independent judge that a code run carries. All four share the project: the same
-        members, the same activity feed. They do not share that verdict, and anyone telling you a
-        deck was “governed” is selling you something.
-      </p>
-      <p class="work-foot work-foot--deps">
-        <b>What the last three need.</b> Documents, decks and demos require wicked-garden present and
-        a reachable document service; without them those modes do not open. Code runs and chat never
-        gate on either.
+        agent asks in the thread, you answer there — but not the deterministic check plus independent
+        judge a code run carries. All four share the project; they do not share that verdict.
+        Docs, decks and demos also need wicked-garden and a reachable document service to open at
+        all — code runs and chat never gate on either.
       </p>
     </div>
   </section>

--- a/site/src/styles/studio.css
+++ b/site/src/styles/studio.css
@@ -34,8 +34,18 @@ body { padding-top: var(--topbar-h); }
 @media (max-width: 560px) { .wrap { padding-inline: 18px; } }
 
 /* ── Scroll-lock to section + per-section viewport sizing ────────────────── */
-html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
-.hero, .board, .proj, .pair, .get {
+/* PROXIMITY, not mandatory. Mandatory snapping makes anything taller than the viewport
+   unreachable: the browser pulls you to the next snap point before you can scroll through the
+   overflow. The hero is 1179px tall in a 900px viewport, so its last ~280px were already being
+   swallowed; adding sections made the page long enough for it to be obvious. Proximity snaps when
+   you land near a boundary and otherwise lets you scroll normally, which is the behaviour a
+   variable-height page needs.
+
+   And the section list is a LIST, so every new section has to be added to it or the browser snaps
+   straight past — that is exactly what happened to .work and .ctx, which read as "the snap skips
+   sections". Anything added below must join this selector. */
+html { scroll-snap-type: y proximity; scroll-padding-top: var(--topbar-h); }
+.hero, .board, .proj, .work, .ctx, .pair, .get {
   min-height: calc(100svh - var(--topbar-h));
   scroll-snap-align: start;
   display: flex;
@@ -45,9 +55,9 @@ html { scroll-snap-type: y mandatory; scroll-padding-top: var(--topbar-h); }
 /* Alternating section bands — translucent darkening so the background art
    shows THROUGH instead of being painted over. */
 .board, .pair { background: color-mix(in oklab, #000 7%, transparent); }
-@media (max-width: 760px) {
+@media (max-width: 768px) {
   html { scroll-snap-type: none; }
-  .hero, .board, .proj, .pair, .get { min-height: 0; }
+  .hero, .board, .proj, .work, .ctx, .pair, .get { min-height: 0; }
 }
 
 /* ── Studio background — ITS OWN motif: the CODER'S FRONT DOOR ─────────────
@@ -147,7 +157,7 @@ code {
 .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
 
 /* Section heads: left-aligned, spanning the container. */
-.sec-head { max-width: none; margin: 0 0 clamp(26px, 4svh, 46px); }
+.sec-head { max-width: none; margin: 0 0 clamp(20px, 3svh, 34px); }
 .sec-head--wide { text-align: left; }
 .sec-head h2 { font-size: clamp(1.9rem, 3.6vw, 3rem); margin: 12px 0 0; }
 .sec-head h2 code { font-size: 0.82em; }
@@ -156,15 +166,23 @@ code {
 .sec-sub a { color: var(--link); }
 
 /* ── Hero ─────────────────────────────────────────────────────────────── */
-.hero { position: relative; overflow: hidden; padding: clamp(44px, 8svh, 96px) 0 clamp(36px, 6svh, 72px); }
+.hero { position: relative; overflow: hidden; padding: clamp(36px, 6svh, 68px) 0 clamp(28px, 4.5svh, 52px); }
 .amber-floor {
   position: absolute; inset: 0; z-index: -1; pointer-events: none;
   background: radial-gradient(ellipse 60% 60% at 82% 8%, color-mix(in oklab, var(--amb) 15%, transparent), transparent 60%);
 }
 .hero-head { text-align: center; }
-.hero-head h1 { font-size: clamp(2.3rem, 5.2vw, 4rem); margin: 14px 0 0; }
-.lede { margin: 18px auto 0; font-size: clamp(0.98rem, 1.35vw, 1.1rem); line-height: 1.6; color: color-mix(in oklab, var(--ink) 80%, transparent); max-width: 62%; }
+.hero-head h1 { font-size: clamp(2.1rem, 4.4vw, 3.4rem); margin: 12px 0 0; }
+.lede { margin: 14px auto 0; font-size: clamp(0.96rem, 1.2vw, 1.05rem); line-height: 1.55; color: color-mix(in oklab, var(--ink) 80%, transparent); max-width: 72ch; }
 .lede b { color: var(--ink); font-weight: 700; }
+/* Small print under the lede. The hero has to state real caveats (single-runner fallback, what
+   documents do NOT share) without those caveats costing 200px of hero height. */
+.fine {
+  margin: 12px auto 0; max-width: 76ch;
+  font-size: 0.78rem; line-height: 1.55;
+  color: color-mix(in oklab, var(--ink) 58%, transparent);
+}
+.fine b { color: color-mix(in oklab, var(--ink) 82%, transparent); font-weight: 650; }
 .hero-foot { margin-top: clamp(18px, 3svh, 30px); display: flex; flex-direction: column; align-items: center; gap: 15px; }
 .hero-tags { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; }
 .hero-tags span {
@@ -256,7 +274,7 @@ code {
 .console-rail-line { margin: 0; padding: 0 4px; font-family: var(--font-mono); font-size: 0.68rem; line-height: 1.5; color: var(--muted); min-height: 1.5em; }
 
 /* ── The run board (panel switcher) ───────────────────────────────────── */
-.board { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.board { border-top: 1px solid var(--hairline); padding: clamp(40px, 6svh, 68px) 0; }
 .board-layout { display: grid; grid-template-columns: minmax(200px, 280px) minmax(0, 1fr); gap: clamp(14px, 2vw, 26px); align-items: start; }
 .board-list { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 .board-item {
@@ -293,7 +311,7 @@ code {
 .board-status-btn.is-playing .bs-ic { color: var(--amb); }
 
 /* ── One project, two skins ───────────────────────────────────────────── */
-.proj { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.proj { border-top: 1px solid var(--hairline); padding: clamp(40px, 6svh, 68px) 0; }
 .proj-card {
   border: 1px solid var(--hairline-strong); border-radius: 16px; overflow: hidden;
   background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
@@ -338,7 +356,7 @@ code {
 .honest-note b { color: var(--ink); }
 
 /* ── The client seam (pairing modes) ──────────────────────────────────── */
-.pair { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.pair { border-top: 1px solid var(--hairline); padding: clamp(40px, 6svh, 68px) 0; }
 .pair-panel {
   border: 1px solid var(--hairline-strong); border-radius: 16px; overflow: hidden;
   background: color-mix(in oklab, var(--surface-2) 82%, #000 6%);
@@ -368,7 +386,7 @@ code {
 .pair-proof-t { font-size: 0.84rem; line-height: 1.6; color: color-mix(in oklab, var(--ink) 74%, transparent); }
 
 /* ── Get it / finale ──────────────────────────────────────────────────── */
-.get { border-top: 1px solid var(--hairline); padding: clamp(48px, 8svh, 96px) 0; }
+.get { border-top: 1px solid var(--hairline); padding: clamp(40px, 6svh, 68px) 0; }
 .get-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: clamp(24px, 3vw, 48px); align-items: center; }
 .get-intro { min-width: 0; }
 .get-intro h2 { font-size: clamp(1.8rem, 3.4vw, 2.8rem); margin: 12px 0 0; }
@@ -462,8 +480,8 @@ code {
      first, where a bare `svh` shorthand would be dropped entirely and collapse the band's
      vertical rhythm. The rest of this file still uses `svh` bare (7 sites) — same latent issue,
      tracked separately rather than swept into a docs PR. */
-  padding: clamp(48px, 8vh, 96px) 0;
-  padding: clamp(48px, 8svh, 96px) 0;
+  padding: clamp(40px, 6vh, 68px) 0;
+  padding: clamp(40px, 6svh, 68px) 0;
 }
 .ctx-grid {
   display: grid; gap: 14px; margin-top: 28px;
@@ -490,7 +508,7 @@ code {
    The gated card gets the accent border because the scope boundary is the most
    load-bearing fact on the page: three of these four share the project, not the
    check, and a reader who misses that leaves believing their deck was governed. */
-.work { border-top: 1px solid var(--hairline); padding: clamp(48px, 8vh, 96px) 0; padding: clamp(48px, 8svh, 96px) 0; }
+.work { border-top: 1px solid var(--hairline); padding: clamp(40px, 6vh, 68px) 0; padding: clamp(40px, 6svh, 68px) 0; }
 .work-grid {
   display: grid; gap: 14px; margin-top: 28px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/site/tests/e2e/prose.spec.ts
+++ b/site/tests/e2e/prose.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Guard against words fusing to the bold/code span that follows them.
+ *
+ * Astro's `compressHTML` (on by default) does not collapse the whitespace between a text node and
+ * a following inline element — it deletes it. Prose on this page wraps for readability, so any
+ * sentence that happened to break right before a <b> or <code> shipped as a single mashed word:
+ * "returns8 hits", "arebound to it", "spanningRust", "donot resolve", "studio'sdedicated".
+ *
+ * It is invisible in source review and invisible to any layout measurement — the section heights
+ * are identical either way. Only reading the rendered page catches it, so it is pinned here.
+ *
+ * These assert on rendered text, so they fail for ANY cause (compressHTML re-enabled, a minifier
+ * added to the pipeline, a hand-edit that drops the space), not just the one found.
+ */
+test('prose does not fuse words into the following bold or code span', async ({ page }) => {
+  await page.goto('/');
+
+  const body = (await page.locator('body').innerText()).replace(/\s+/g, ' ');
+
+  const mustRead = [
+    'returns 8 hits',
+    'project are bound to it',
+    'spanning Rust and TypeScript',
+    'edges do not resolve',
+    'bounded at ten minutes each',
+    'The studio’s dedicated project browser',
+  ];
+
+  for (const phrase of mustRead) {
+    expect(body, `"${phrase}" lost the space before its inline span`).toContain(phrase);
+  }
+
+  // And the specific fused forms must never appear.
+  for (const fused of ['returns8', 'arebound', 'spanningRust', 'donot', 'minuteseach']) {
+    expect(body, `found the fused form "${fused}"`).not.toContain(fused);
+  }
+});

--- a/site/tests/e2e/snap-layout.spec.ts
+++ b/site/tests/e2e/snap-layout.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression guard for two defects that shipped together on this page.
+ *
+ * 1. SKIPPED SECTIONS. `studio.css` gives snap points via a hardcoded selector list
+ *    (`.hero, .board, .proj, .work, .ctx, .pair, .get`). A section added to index.astro but not
+ *    to that list gets `scroll-snap-align: none`, and the browser scrolls straight past it. That
+ *    is what happened to `.work` and `.ctx`, and it reads to a user as "the snap skips sections".
+ *
+ * 2. UNREACHABLE CONTENT. The page used to set `scroll-snap-type: y mandatory`, overriding the
+ *    shared chrome's `y proximity` (wicked-web tokens.css). Mandatory snapping pulls the viewport
+ *    to the next snap point before you can scroll through a section that is taller than the
+ *    viewport, so the overflow of any tall section is simply unreachable.
+ *
+ * These assert behaviour, not pixel values, so ordinary copy edits do not trip them.
+ */
+
+const LAPTOP = { width: 1440, height: 700 };
+
+test.describe('scroll-snap layout', () => {
+  test('every section on the page has a snap point', async ({ page }) => {
+    await page.setViewportSize(LAPTOP);
+    await page.goto('/');
+
+    const noSnap = await page.$$eval('section', (sections) =>
+      sections
+        .filter((s) => getComputedStyle(s).scrollSnapAlign.split(' ')[0] === 'none')
+        .map((s) => s.className.split(' ')[0] || s.tagName),
+    );
+
+    expect(
+      noSnap,
+      `These sections have no snap point, so mandatory/proximity scrolling passes over them. ` +
+        `Add them to the section selector list in src/styles/studio.css.`,
+    ).toEqual([]);
+  });
+
+  test('snapping is proximity, so tall sections stay scrollable', async ({ page }) => {
+    await page.setViewportSize(LAPTOP);
+    await page.goto('/');
+
+    // The hero embeds a live console and is legitimately taller than a laptop viewport. Under
+    // `mandatory` its lower half cannot be reached; under `proximity` it can.
+    const snapType = await page.evaluate(
+      () => getComputedStyle(document.documentElement).scrollSnapType,
+    );
+    expect(snapType).not.toContain('mandatory');
+  });
+
+  test('scrolling top to bottom reaches every section', async ({ page }) => {
+    await page.setViewportSize(LAPTOP);
+    await page.goto('/');
+    await page.waitForTimeout(300);
+
+    const all = await page.$$eval('section', (ns) => ns.map((n) => n.className.split(' ')[0]));
+    const seen = new Set<string>();
+
+    const sweep = async () => {
+      const vis = await page.evaluate((vh) => {
+        const out: string[] = [];
+        document.querySelectorAll('section').forEach((s) => {
+          const r = s.getBoundingClientRect();
+          const shown = Math.min(r.bottom, vh) - Math.max(r.top, 0);
+          if (shown / Math.min(r.height, vh) >= 0.6) out.push(s.className.split(' ')[0]);
+        });
+        return out;
+      }, LAPTOP.height);
+      vis.forEach((v) => seen.add(v));
+    };
+
+    for (let i = 0; i < 40; i++) {
+      await sweep();
+      const atEnd = await page.evaluate((step) => {
+        window.scrollBy(0, step);
+        return window.scrollY + window.innerHeight >= document.body.scrollHeight - 2;
+      }, Math.round(LAPTOP.height * 0.85));
+      await page.waitForTimeout(100);
+      if (atEnd) break;
+    }
+    await sweep();
+
+    expect(all.filter((n) => !seen.has(n)), 'sections never became substantially visible').toEqual(
+      [],
+    );
+  });
+
+  test('the page never scrolls sideways', async ({ page }) => {
+    for (const vp of [LAPTOP, { width: 390, height: 844 }]) {
+      await page.setViewportSize(vp);
+      await page.goto('/');
+      const overflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      );
+      expect(overflow, `horizontal overflow at ${vp.width}x${vp.height}`).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/site/tests/e2e/snap-layout.spec.ts
+++ b/site/tests/e2e/snap-layout.spec.ts
@@ -18,6 +18,32 @@ import { test, expect } from '@playwright/test';
 
 const LAPTOP = { width: 1440, height: 700 };
 
+/**
+ * Wait for scrolling to actually finish rather than sleeping a guessed interval.
+ *
+ * `scrollend` fires once the scroll position is final AND scroll-snap has settled, which is
+ * precisely the state these tests sample. It is the deterministic signal; the timeout below is
+ * only a floor for the case where the gesture produces NO scroll at all — which is exactly the
+ * wedged-page failure being tested for, so it must not hang there.
+ */
+async function settled(page: import('@playwright/test').Page, cap = 700) {
+  await page.evaluate(
+    (ms) =>
+      new Promise<void>((resolve) => {
+        let done = false;
+        const finish = () => {
+          if (done) return;
+          done = true;
+          window.removeEventListener('scrollend', finish);
+          resolve();
+        };
+        window.addEventListener('scrollend', finish, { once: true });
+        window.setTimeout(finish, ms);
+      }),
+    cap,
+  );
+}
+
 test.describe('scroll-snap layout', () => {
   test('every section on the page has a snap point', async ({ page }) => {
     await page.setViewportSize(LAPTOP);
@@ -51,7 +77,7 @@ test.describe('scroll-snap layout', () => {
   test('scrolling top to bottom reaches every section', async ({ page }) => {
     await page.setViewportSize(LAPTOP);
     await page.goto('/');
-    await page.waitForTimeout(300);
+    await page.waitForLoadState('networkidle');
 
     const all = await page.$$eval('section', (ns) => ns.map((n) => n.className.split(' ')[0]));
     const seen = new Set<string>();
@@ -75,7 +101,7 @@ test.describe('scroll-snap layout', () => {
         window.scrollBy(0, step);
         return window.scrollY + window.innerHeight >= document.body.scrollHeight - 2;
       }, Math.round(LAPTOP.height * 0.85));
-      await page.waitForTimeout(100);
+      await settled(page);
       if (atEnd) break;
     }
     await sweep();
@@ -93,12 +119,12 @@ test.describe('scroll-snap layout', () => {
     // past it, because .work had no snap point and `mandatory` had nowhere to put the viewport.
     await page.setViewportSize(LAPTOP);
     await page.goto('/');
-    await page.waitForTimeout(500);
+    await page.waitForLoadState('networkidle');
 
     const restedOn: string[] = [];
     for (let i = 0; i < 45; i++) {
       await page.mouse.wheel(0, 320);
-      await page.waitForTimeout(240); // let the snap settle before sampling
+      await settled(page); // resolves on `scrollend` — the snap has finished moving
       const top = await page.evaluate((vh) => {
         let best = '';
         let cover = 0;

--- a/site/tests/e2e/snap-layout.spec.ts
+++ b/site/tests/e2e/snap-layout.spec.ts
@@ -85,6 +85,48 @@ test.describe('scroll-snap layout', () => {
     );
   });
 
+  test('wheel scrolling can come to rest on every section', async ({ page }) => {
+    // The strongest reproduction of the reported symptom -- "I can't stop on the section at all".
+    // scrollBy() moves the scroll position without producing a wheel event, so it walks the page
+    // even when snapping is actively fighting the user. Real wheel events do not: against the
+    // deployed build this sequence settled on hero -> board -> proj and could not rest anywhere
+    // past it, because .work had no snap point and `mandatory` had nowhere to put the viewport.
+    await page.setViewportSize(LAPTOP);
+    await page.goto('/');
+    await page.waitForTimeout(500);
+
+    const restedOn: string[] = [];
+    for (let i = 0; i < 45; i++) {
+      await page.mouse.wheel(0, 320);
+      await page.waitForTimeout(240); // let the snap settle before sampling
+      const top = await page.evaluate((vh) => {
+        let best = '';
+        let cover = 0;
+        document.querySelectorAll('section').forEach((s) => {
+          const r = s.getBoundingClientRect();
+          const shown = Math.max(0, Math.min(r.bottom, vh) - Math.max(r.top, 0));
+          if (shown > cover) {
+            cover = shown;
+            best = s.className.split(' ')[0];
+          }
+        });
+        return best;
+      }, LAPTOP.height);
+      if (restedOn[restedOn.length - 1] !== top) restedOn.push(top);
+      const atEnd = await page.evaluate(
+        () => window.scrollY + window.innerHeight >= document.body.scrollHeight - 2,
+      );
+      if (atEnd) break;
+    }
+
+    for (const section of ['work', 'ctx']) {
+      expect(
+        restedOn,
+        `wheel scrolling never came to rest on .${section} — it was scrolled past`,
+      ).toContain(section);
+    }
+  });
+
   test('the page never scrolls sideways', async ({ page }) => {
     for (const vp of [LAPTOP, { width: 390, height: 844 }]) {
       await page.setViewportSize(vp);

--- a/site/tests/e2e/work.spec.ts
+++ b/site/tests/e2e/work.spec.ts
@@ -59,7 +59,9 @@ test.describe('four kinds of work [.work]', () => {
     // fully-excluded roster, so on one seat the same binary can judge. Identity separation is
     // best-effort; the VETO is unconditional (validator.rs:10, "can NEVER be the sole approver").
     await expect(page.locator('h1')).toContainText('approve its own work');
-    await expect(page.locator('.lede')).toContainText('not that check');
+    // Lives in the hero's .fine small print now, not .lede — the lede was cut to two sentences
+    // because it had grown into a 700-char wall. Asserting on .hero keeps the guard on the CLAIM.
+    await expect(page.locator('.hero')).toContainText('not that check');
   });
 });
 
@@ -89,6 +91,11 @@ test.describe('claims the adversarial pass required', () => {
 
   test('names the dependency that gates three of the four modes', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.work-foot--deps')).toContainText('require wicked-garden present');
+    // The two work-foot paragraphs were merged into one; .work-foot--deps no longer exists.
+    // Same three facts in one paragraph: both named dependencies, and what does NOT gate on them.
+    const deps = page.locator('.work-foot');
+    await expect(deps).toContainText('wicked-garden');
+    await expect(deps).toContainText('document service');
+    await expect(deps).toContainText('never gate on either');
   });
 });


### PR DESCRIPTION
Reported as *"the snap is skipping sections and most sections overflow"*, then *"where product work section gets skipped over and snaps to next section. I can't stop on the section at all."*

Three separate defects.

### 1. Sections with no snap point

`studio.css` hands out snap points through a **hardcoded selector list** — `.hero, .board, .proj, .pair, .get`. The `.work` and `.ctx` sections added with the orchestrator-IDE copy were never added to it, so they computed `scroll-snap-align: none`.

### 2. `mandatory` snapping over the chrome's `proximity`

The page set `scroll-snap-type: y mandatory`, overriding the shared chrome — `wicked-web` `tokens.css:62` says outright that a site wanting hard snapping opts in itself.

**(1) and (2) together are what made "Where product work happens" unstoppable.** With no snap point on `.work` and `mandatory` refusing to leave the viewport anywhere that isn't one, wheel scrolling has nowhere to put you. Verified with real wheel events (`page.mouse.wheel`, not `scrollBy`, which cannot reproduce it):

| | rest order |
|---|---|
| **deployed** | `hero → board → proj` — never settles past it |
| **this branch** | `hero → board → proj → work → ctx → pair → same-garden → get` |

### 3. Sections taller than the viewport

I had been measuring at 1440×900, which hid this. At real laptop heights:

| section | before (1440×700) | after |
|---|---|---|
| hero | 1105 `OVER+405` | 970 (embeds the live console) |
| proj | 758 `OVER+58` | **678 fits** |
| work | 828 `OVER+128` | **638 fits** |
| ctx | 711 `OVER+11` | **683 fits** |
| pair | 705 `OVER+5` | **670 fits** |

Copy cut hard to get there — the hero lede was a 700-character wall, `work` carried two footnote paragraphs, every section opened with a long sub-paragraph. The hero stays tall because the live console *is* its argument; `proximity` makes it reachable. Mobile cutoff 760px → 768px to match the chrome rather than re-enabling snap in an 8px band.

### 4. Fused words

Astro's `compressHTML` **deletes** the whitespace between a text node and a following inline tag instead of collapsing it, so prose wrapping before a `<b>` or `<code>` shipped as:

> `returns8 hits` · `arebound to it` · `spanningRust` · `donot resolve` · `studio'sdedicated`

Caught by screenshotting the page — section heights are identical either way, so no measurement would have found it. `compressHTML: false`, pinned by `prose.spec.ts`.

### Accuracy regressions caught by the existing guards

Cutting copy cost two claims on the first pass; both caught and restored:

- the lede's subject became *"It drives the coding CLIs"* — attributing to **studio** what the **daemon** does
- card two lost *"the document service does the rendering"*

Claims that legitimately moved (`not that check` → the hero's small print; the dependency sentence → the merged `work-foot`) have their guards re-pointed at the **claim**, not the old element.

### Verification

New specs run in both directions — they fail against the original defect and pass against the fix. Full site suite 36 passed; root app lint + typecheck clean, 1833 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)