### PR TITLE
test: do not return a FontFaceSet across the Playwright boundary

### DIFF
--- a/site/tests/e2e/font-wait-hygiene.spec.ts
+++ b/site/tests/e2e/font-wait-hygiene.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { basename, dirname, join } from 'node:path';
+
+/**
+ * A font wait must not hand its result back across the CDP boundary.
+ *
+ * WHAT WAS WRONG. Four specs in this suite waited for webfonts like this:
+ *
+ *     await page.evaluate(() => document.fonts.ready);
+ *
+ * The arrow has an expression body, so it RETURNS the promise. Playwright awaits it in the page
+ * and then serializes whatever it settled to — a `FontFaceSet`, which has no serializable form.
+ * Measured against this site it does not throw; it round-trips a lossy `{}` (the second test
+ * below pins that). That is the bad kind of bug: nothing fails, so nothing tells you the suite
+ * is leaning on serializer behaviour nobody promised. These are the specs that guard the hero
+ * fitting a laptop viewport, and a font wait that throws or returns early takes out the guard
+ * rather than the thing it guards.
+ *
+ * The correct form awaits INSIDE the page and returns undefined:
+ *
+ *     await page.evaluate(async () => { await document.fonts.ready; });
+ *
+ * Reference fix: wicked-garden site/tests/e2e/band-fits.spec.ts, commit 52446c5b.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** This file quotes the anti-pattern as live code in the second test, so it cannot scan itself. */
+const SELF = basename(fileURLToPath(import.meta.url));
+
+/** An evaluate callback that hands `document.fonts.ready` back to the runner: either an
+ *  expression-bodied arrow (`=> document.fonts.ready`) or an explicit `return`. The fixed form,
+ *  `async () => { await document.fonts.ready; }`, matches neither. */
+const RETURNS_FONT_SET = /(?:=>\s*|\breturn\s+)document\s*\.\s*fonts\s*\.\s*ready/;
+
+test('no spec returns document.fonts.ready out of page.evaluate', () => {
+  const files = readdirSync(HERE)
+    .filter((f) => f.endsWith('.ts') && f !== SELF)
+    .sort();
+  // A scan that silently found nothing to read would pass forever. Prove it read the suite.
+  expect(files.length, 'the font-wait scan found no spec files to read').toBeGreaterThan(5);
+
+  const offenders: string[] = [];
+  for (const name of files) {
+    readFileSync(join(HERE, name), 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        if (/^\s*(\*|\/\/)/.test(line)) return; // prose, not code
+        if (RETURNS_FONT_SET.test(line)) offenders.push(`${name}:${i + 1}: ${line.trim()}`);
+      });
+  }
+
+  expect(
+    offenders,
+    'these return a FontFaceSet across the CDP boundary — await it inside the page instead:\n' +
+      '  await page.evaluate(async () => { await document.fonts.ready; });\n' +
+      offenders.map((o) => `  ${o}`).join('\n'),
+  ).toEqual([]);
+});
+
+test('the two forms differ: one leaks a value, the corrected one returns undefined', async ({ page }) => {
+  await page.goto('/');
+
+  // The corrected form: nothing crosses the boundary.
+  const clean = await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  expect(clean, 'the corrected font wait should resolve to undefined').toBeUndefined();
+
+  // The defective form, kept here as the executable record of what it does. It resolves to the
+  // FontFaceSet, so Playwright has to serialize it; today that yields a lossy `{}` rather than
+  // throwing. Either way it is not the clean `undefined` above — which is the whole point.
+  let leaked: unknown;
+  let threw = false;
+  try {
+    leaked = await page.evaluate(() => document.fonts.ready);
+  } catch {
+    threw = true;
+  }
+  expect(
+    threw || leaked !== undefined,
+    'returning document.fonts.ready is supposed to put a non-serializable FontFaceSet on the wire; ' +
+      'if that has become a clean no-op, this guard has stopped guarding anything',
+  ).toBe(true);
+});

--- a/site/tests/e2e/font-wait-hygiene.spec.ts
+++ b/site/tests/e2e/font-wait-hygiene.spec.ts
@@ -29,26 +29,73 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 /** This file quotes the anti-pattern as live code in the second test, so it cannot scan itself. */
 const SELF = basename(fileURLToPath(import.meta.url));
 
-/** An evaluate callback that hands `document.fonts.ready` back to the runner: either an
- *  expression-bodied arrow (`=> document.fonts.ready`) or an explicit `return`. The fixed form,
- *  `async () => { await document.fonts.ready; }`, matches neither. */
-const RETURNS_FONT_SET = /(?:=>\s*|\breturn\s+)document\s*\.\s*fonts\s*\.\s*ready/;
+/**
+ * Blank out comments and string/template literals, preserving length and newlines so byte
+ * offsets still map to the right line. Without this the scan reports prose: a line inside a
+ * block comment quoting the bad form, or a string constant containing the phrase, both read as
+ * code to a bare regex. Copilot flagged exactly that on this file.
+ */
+function codeOnly(src: string): string {
+  const out = src.split('');
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) if (out[k] !== '\n') out[k] = ' ';
+  };
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === '//') {
+      const end = src.indexOf('\n', i);
+      blank(i, end === -1 ? src.length : end);
+      i = end === -1 ? src.length : end;
+    } else if (two === '/*') {
+      const end = src.indexOf('*/', i + 2);
+      blank(i, end === -1 ? src.length : end + 2);
+      i = end === -1 ? src.length : end + 2;
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const quote = src[i];
+      let k = i + 1;
+      while (k < src.length && src[k] !== quote) k += src[k] === '\\' ? 2 : 1;
+      blank(i, k + 1);
+      i = k + 1;
+    } else {
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * An evaluate callback that hands `document.fonts.ready` back to the runner: either an
+ * expression-bodied arrow (`=> document.fonts.ready`) or an explicit `return`. The fixed form,
+ * `async () => { await document.fonts.ready; }`, matches neither — the `await` sits between.
+ *
+ * Applied to the WHOLE file rather than line by line, because the line-based version missed the
+ * multi-line spelling entirely:
+ *
+ *     await page.evaluate(() =>
+ *       document.fonts.ready
+ *     );
+ *
+ * which is the same defect in a plausible reformatting of a long line.
+ */
+const RETURNS_FONT_SET = /(?:=>|\breturn\b)\s*document\s*\.\s*fonts\s*\.\s*ready/g;
 
 test('no spec returns document.fonts.ready out of page.evaluate', () => {
   const files = readdirSync(HERE)
     .filter((f) => f.endsWith('.ts') && f !== SELF)
     .sort();
-  // A scan that silently found nothing to read would pass forever. Prove it read the suite.
-  expect(files.length, 'the font-wait scan found no spec files to read').toBeGreaterThan(5);
+  // A scan that silently found nothing to read would pass forever. Prove it read something —
+  // but do not couple to today's suite size, or trimming the suite reds CI for no reason.
+  expect(files.length, 'the font-wait scan found no spec files to read').toBeGreaterThan(0);
 
   const offenders: string[] = [];
   for (const name of files) {
-    readFileSync(join(HERE, name), 'utf8')
-      .split('\n')
-      .forEach((line, i) => {
-        if (/^\s*(\*|\/\/)/.test(line)) return; // prose, not code
-        if (RETURNS_FONT_SET.test(line)) offenders.push(`${name}:${i + 1}: ${line.trim()}`);
-      });
+    const raw = readFileSync(join(HERE, name), 'utf8');
+    const scanned = codeOnly(raw);
+    for (const m of scanned.matchAll(RETURNS_FONT_SET)) {
+      const line = scanned.slice(0, m.index).split('\n').length;
+      offenders.push(`${name}:${line}: ${raw.split('\n')[line - 1].trim()}`);
+    }
   }
 
   expect(
@@ -57,6 +104,25 @@ test('no spec returns document.fonts.ready out of page.evaluate', () => {
       '  await page.evaluate(async () => { await document.fonts.ready; });\n' +
       offenders.map((o) => `  ${o}`).join('\n'),
   ).toEqual([]);
+});
+
+test('the scan reads code, not prose, and catches the multi-line spelling', () => {
+  // Both directions, on synthetic input, so the guard's own accuracy is pinned rather than
+  // assumed. These are the three cases review found it got wrong.
+  const scan = (src: string) => [...codeOnly(src).matchAll(RETURNS_FONT_SET)].length;
+
+  // FALSE POSITIVES it used to produce — all prose, none are code.
+  expect(scan('/* await page.evaluate(() => document.fonts.ready); */'), 'block comment').toBe(0);
+  expect(scan('const s = "() => document.fonts.ready";'), 'string literal').toBe(0);
+  expect(scan('foo(); // () => document.fonts.ready'), 'trailing comment').toBe(0);
+
+  // FALSE NEGATIVE it used to miss — real code, split across lines.
+  expect(scan('await page.evaluate(() =>\n  document.fonts.ready\n);'), 'multi-line').toBe(1);
+
+  // Still catches the single-line forms, and still allows the corrected one.
+  expect(scan('await page.evaluate(() => document.fonts.ready);'), 'arrow').toBe(1);
+  expect(scan('await page.evaluate(() => { return document.fonts.ready; });'), 'return').toBe(1);
+  expect(scan('await page.evaluate(async () => { await document.fonts.ready; });'), 'fixed').toBe(0);
 });
 
 test('the two forms differ: one leaks a value, the corrected one returns undefined', async ({ page }) => {

--- a/site/tests/e2e/hero-fits.spec.ts
+++ b/site/tests/e2e/hero-fits.spec.ts
@@ -47,7 +47,7 @@ for (const vp of [LAPTOP, LAPTOP_TALL]) {
 
     test('the hero fits the viewport before and after the gate raises', async ({ page }) => {
       await page.goto('/');
-      await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(async () => { await document.fonts.ready; });
       const heroH = () =>
         page.evaluate(() => Math.round(document.querySelector('.hero')!.getBoundingClientRect().height));
 
@@ -62,7 +62,7 @@ for (const vp of [LAPTOP, LAPTOP_TALL]) {
 
     test('the steering decision is on screen without scrolling', async ({ page }) => {
       await page.goto('/');
-      await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(async () => { await document.fonts.ready; });
       await gateRaised(page);
 
       // The page has not been scrolled, so every one of these must sit inside the window.
@@ -96,7 +96,7 @@ for (const vp of [LAPTOP, LAPTOP_TALL]) {
       // macOS. A hero tuned to exactly the usable height passed locally and failed on CI with
       // ".hero is 642px in 636px of usable height". Measure the CONTENT and require slack.
       await page.goto('/');
-      await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(async () => { await document.fonts.ready; });
 
       const { content, usable } = await page.evaluate((vh) => {
         const hero = document.querySelector('.hero') as HTMLElement;
@@ -134,7 +134,7 @@ for (const vp of [LAPTOP, LAPTOP_TALL]) {
       // Shared chrome (wicked-web SameGarden). It rendered 1115px before the band was rebuilt;
       // a site that has not re-pinned the chrome commit will fail here.
       await page.goto('/');
-      await page.evaluate(() => document.fonts.ready);
+      await page.evaluate(async () => { await document.fonts.ready; });
       const h = await page.evaluate(() =>
         Math.round(document.querySelector('.same-garden')!.getBoundingClientRect().height),
       );


### PR DESCRIPTION
Closes #135.

## What was wrong

`site/tests/e2e/hero-fits.spec.ts` waited for webfonts as:

```js
await page.evaluate(() => document.fonts.ready);
```

The arrow has an expression body, so it **returns** the promise. Playwright awaits it in the page and then serializes what it settled to — a `FontFaceSet`, which has no serializable form.

**Four call sites, not three.** The issue counts lines 50, 65, and 99; line 137 (`the platform band fits the viewport`) has it too.

## Why fix a latent bug

I reproduced the defective form against this site before changing anything. It does *not* throw — it waits correctly and round-trips a lossy `{}`:

```
DEFECTIVE typeof: object   value: {}   error: <none>
FIXED     typeof: undefined value: undefined
DEFECTIVE waited(ms): 1201  promise had settled: true
```

So the issue's read is right: latent, not breaking. That is the reason to fix it rather than leave it. These four call sites are the specs that guard the hero fitting a laptop viewport. A font wait that throws or returns early takes out the *guard* rather than the thing it guards — and it would do so by leaning on serializer behaviour nobody promised.

All four now await inside the page and return `undefined`, matching the reference fix in wicked-garden `site/tests/e2e/band-fits.spec.ts` (`52446c5b`) from garden#1076. I introduced the pattern here first, in #134, and did not carry the fix back.

## The guard

New `site/tests/e2e/font-wait-hygiene.spec.ts` — because a source-shape defect that never fails at runtime will come back. Two parts:

**1. Static scan** of every `.ts` in `tests/e2e` for an evaluate callback that hands `document.fonts.ready` to the runner (expression-bodied arrow *or* explicit `return`). Against the unfixed file it fails, naming all four lines:

```
Error: these return a FontFaceSet across the CDP boundary — await it inside the page instead:
  await page.evaluate(async () => { await document.fonts.ready; });
  hero-fits.spec.ts:50: await page.evaluate(() => document.fonts.ready);
  hero-fits.spec.ts:65: await page.evaluate(() => document.fonts.ready);
  hero-fits.spec.ts:99: await page.evaluate(() => document.fonts.ready);
  hero-fits.spec.ts:137: await page.evaluate(() => document.fonts.ready);
```

It passes against the fix. It asserts it found files to read, so an empty directory cannot make it pass vacuously, and it skips its own file (test 2 quotes the anti-pattern as live code). Regex checked both directions — flags the arrow form, the `return` form, and a whitespace-spaced variant; allows the corrected form.

**2. Runtime test** pinning that the two forms actually differ: the corrected form resolves to `undefined`; the defective one either throws or leaks a value. If returning a `FontFaceSet` ever becomes a clean no-op, part 1 is guarding nothing and this says so.

The scan lives in the Playwright suite rather than as a lint rule because `site/` has no eslint config and root vitest explicitly excludes `site/**`. The Site E2E workflow runs `npm run test:e2e` over the whole directory, so it is covered in CI.

## Verification

- Guard fails against the original defect (message quoted above), passes against the fix.
- Full site suite: **47/47 pass** at `E2E_PORT=4711`, on a clean build (`rm -rf dist node_modules/.astro`).
- Diff is test-only — no site source or rendered output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)