### PR TITLE
interactive: pin the missing doc/demo delete wire instead of inventing one (#119)

### DIFF
--- a/e2e/interactive_wire_contract_test.py
+++ b/e2e/interactive_wire_contract_test.py
@@ -130,7 +130,11 @@ import re  # noqa: E402 (grouped with its one use, harness style)
 BANNED_SPELLINGS = re.compile(
     r"getDemoSpec|getLatestRecording|api/demo/(spec|recordings|record)\b"
     r"|api/themes|api/theme/learn\b|listThemes|getTheme\b|learnTheme\b"
-    r"|(delete|remove|purge|destroy)(Doc|Docs|Demo|Demos|Document)"
+    # Keep this verb list IDENTICAL to UNMAKE in tests/interactive.client.test.ts. They guard the
+    # same absence from two sides, and when they drifted apart (this list was missing archive,
+    # discard, retire and unmake) a wrapper could clear one while the other banned the event it
+    # emits. If you add a verb, add it in both places.
+    r"|(delete|remove|purge|destroy|archive|discard|retire|unmake)(Doc|Docs|Demo|Demos|Document)"
     r"|wicked\.interactive\.doc\.(deleted|removed|retired|archived)")
 spelled: list[str] = []
 for f in sorted((REPO / "src").rglob("*")):

--- a/e2e/interactive_wire_contract_test.py
+++ b/e2e/interactive_wire_contract_test.py
@@ -36,6 +36,13 @@ file — the wire studio's restored brand-learn flow polls. The remaining
 known-invented wire OUTSIDE scope (sources attach: slice 19) is still probed as
 ADVISORY — reported, not fatal.
 
+studio#119 adds section 8, the same pin turned on a wire that has never existed
+in EITHER shape: the doc registry serves create + read only — no delete route
+(every spelling is Express's route-missing 404) and no delete bus command (the
+`docs` subdomain owns only `doc.created`). It is FATAL in the "absent" direction
+for the same reason section 4 is: studio must not grow a delete affordance for a
+wire nobody serves, and the day the bridge does serve one, this is what says so.
+
 BRIDGE-UX-1 (DES-UX-001 §8.4): section 7 grows the FATAL probes for the four
 bridge-contract questions DES-UX-001 is gated on — mid-run sends (queue or
 drop, B1), the thread-history read (B3), unfiled-doc hosting (B2), and per-seat
@@ -116,9 +123,15 @@ import re  # noqa: E402 (grouped with its one use, harness style)
 # that helper now speaks the corrected event wire; `api/theme/learn\b` does not match
 # `api/theme/learned` — the REAL interactive#181 readback route getLearnedTheme
 # builds, whose existence is asserted as a FATAL positive step below.)
+# studio#119 adds the delete spellings PRE-EMPTIVELY — the one entry here that bans a
+# wire nobody has invented yet, because the ask is live and the wire is absent in both
+# shapes (section 8). The vitest guard covers the client module's exports; this covers
+# the rest of src/, where a component could build the URL inline and skip it.
 BANNED_SPELLINGS = re.compile(
     r"getDemoSpec|getLatestRecording|api/demo/(spec|recordings|record)\b"
-    r"|api/themes|api/theme/learn\b|listThemes|getTheme\b|learnTheme\b")
+    r"|api/themes|api/theme/learn\b|listThemes|getTheme\b|learnTheme\b"
+    r"|(delete|remove|purge|destroy)(Doc|Docs|Demo|Demos|Document)"
+    r"|wicked\.interactive\.doc\.(deleted|removed|retired|archived)")
 spelled: list[str] = []
 for f in sorted((REPO / "src").rglob("*")):
     if f.suffix not in (".ts", ".tsx"):
@@ -129,8 +142,8 @@ for f in sorted((REPO / "src").rglob("*")):
 report["steps"]["client_never_spells_invented_wire"] = {"ok": spelled == [], "hits": spelled}
 if spelled:
     fail("client_grep_verdict",
-         "src/ still spells an invented demo wire — remove it before contract-checking: "
-         + "; ".join(spelled[:5]))
+         "src/ spells a wire the bridge does not serve — land it upstream (and move the "
+         "matching pin below) before contract-checking: " + "; ".join(spelled[:5]))
 
 # ── 1. The real bridge, on a temp root ─────────────────────────────────────────
 cli = WI_DIR / "bin" / "wicked-interactive.js"
@@ -587,6 +600,80 @@ try:
                      "entry_keys": sorted({k for e in entries for k in e})},
         "survives_restart": {"ok": survives_restart, "texts": landed_after},
         "doc_remounted_after_restart": remounted,
+    }
+
+    # ── 8. The doc registry is CREATE + READ only (studio#119) — FATAL ─────────
+    # studio#119 asks for a delete affordance for docs/demos. This section is the
+    # answer, PINNED against the real bridge rather than asserted in prose: there is
+    # no wire to hang one on, so studio (a pure client) cannot grow the button.
+    #
+    # Both escape hatches are checked, because the record (§7.4) and theme (issue #65)
+    # wires each answered "no HTTP route" by turning out to be a UI-emittable bus
+    # COMMAND — the shape an invented `deleteDoc` would most plausibly be waved
+    # through as:
+    #   a. every plausible HTTP spelling is Express's route-missing 404, and the
+    #      "Cannot <METHOD> …" body is the proof it is route-missing rather than a
+    #      service refusal (which would be JSON, as GET /d/:doc/api/theme/learned is);
+    #   b. the bus has no unmake verb in the `docs` subdomain at all — the ownership
+    #      table (src/service/events.js) holds only doc.created — so both candidate
+    #      spellings are rejected `400 unknown event type`, one step BEFORE the
+    #      403 uiEmittable check an existing-but-service-owned type would hit;
+    #   c. the doc is still listed afterwards — no probe accidentally deleted it,
+    #      which is what makes (a) and (b) a real absence rather than a lucky 404.
+    #
+    # When this section FAILS, the bridge grew the wire: adopt it in
+    # src/api/interactive.ts, drop the CI guard in tests/interactive.client.test.ts,
+    # and move this pin — all in the same change. Cleanup is not done at the bridge
+    # alone: crew keeps a per-document replay-dedup row in
+    # ~/.wicked-crew/interactive-draft-ledger.json (keyed by document id for the draft
+    # leg), so a delete that leaves the row behind means a doc re-created under the
+    # same name never gets its first draft again.
+    DELETE_SPELLINGS = [
+        ("DELETE", f"/api/docs/{DEMO}"),
+        ("DELETE", f"/d/{DEMO}"),
+        ("DELETE", f"/d/{DEMO}/api/doc"),
+        ("DELETE", f"/d/{DEMO}/api/versions"),
+        ("POST",   f"/api/docs/{DEMO}/delete"),
+    ]
+    delete_rows = []
+    delete_absent = True
+    for method, path in DELETE_SPELLINGS:
+        status, text, _ = http(method, f"{base}{path}", {} if method == "POST" else None)
+        ok = status == 404 and f"Cannot {method} " in text
+        delete_absent = delete_absent and ok
+        delete_rows.append({
+            "method": method, "path": path, "status": status, "ok": ok,
+            **({} if ok else {"body": text[:200],
+                              "error": "the bridge now answers here — adopt the wire in "
+                                       "src/api/interactive.ts, drop the CI guard in "
+                                       "tests/interactive.client.test.ts, and move this pin"}),
+        })
+    bus_rows = []
+    bus_absent = True
+    for verb in ("deleted", "removed", "retired", "archived"):
+        status, text, _ = http("POST", f"{base}/api/events", {
+            "event_type": f"wicked.interactive.doc.{verb}",
+            "payload": {"document_id": DEMO}})
+        ok = status == 400 and "unknown event type" in text
+        bus_absent = bus_absent and ok
+        bus_rows.append({"event_type": f"wicked.interactive.doc.{verb}",
+                         "status": status, "ok": ok,
+                         **({} if ok else {"body": text[:200]})})
+    s_list3, t_list3, _ = http("GET", f"{base}/api/docs")
+    survives = s_list3 == 200 and any(d.get("name") == DEMO for d in json.loads(t_list3))
+    report["steps"]["doc_delete_wire_absent"] = {
+        "ok": delete_absent and bus_absent and survives,
+        "verdict": "studio#119 = NO delete wire EXISTS: not an HTTP route (every spelling is "
+                   "Express's route-missing 404) and not a bus command (the docs subdomain "
+                   "owns only doc.created, so every unmake verb is `unknown event type`). "
+                   "Crew's proxy is not the blocker — registerInteractiveProxy mounts "
+                   "scope.all(…) and forwards any method verbatim. The UI has no delete "
+                   "affordance BECAUSE the wire has none; it must land in wicked-interactive "
+                   "(route + doc.* unmake event) and wicked-crew (drop the doc's "
+                   "interactive-draft-ledger.json row) before studio grows the button.",
+        "http_spellings": delete_rows,
+        "bus_spellings": bus_rows,
+        "doc_survives_every_probe": survives,
     }
 
     # ── Advisory: invented wires OUTSIDE this scope (on the record, not fatal) ──

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -278,6 +278,43 @@ export function createDoc(projectId: string, body: CreateDocBody): Promise<Creat
   return iFetch<CreateDocResult>(`${interactiveBase(projectId)}/api/docs`, jsonPost(body));
 }
 
+// ── The registry is CREATE + READ only (studio#119) ──────────────────────────
+//
+// There is deliberately no unmake wrapper below `createDoc`, and adding one would be
+// the slice-13/slice-16 mistake a third time: a wrapper for a route the bridge does
+// not serve, whose break only shows up in production. Verified against a REAL bridge
+// (`bin/wicked-interactive.js serve`, wicked-interactive @ 0.8.x) — every plausible
+// spelling is Express's route-missing 404, HTML, not a service answer:
+//
+//   DELETE /api/docs/:doc        → 404 "Cannot DELETE /api/docs/<doc>"
+//   DELETE /d/:doc               → 404 "Cannot DELETE /d/<doc>"
+//   DELETE /d/:doc/api/doc       → 404 "Cannot DELETE /d/<doc>/api/doc"
+//   POST   /api/docs/:doc/delete → 404 "Cannot POST /api/docs/<doc>/delete"
+//
+// …and the bus escape hatch is shut too. `requestRecord` and `requestThemeLearn` both
+// answer "no HTTP route" by speaking a UI-emittable COMMAND over `POST /api/events`;
+// there is no such command here. The bridge's ownership table (`src/service/events.js`)
+// has no unmake verb in the `docs` subdomain at all — only `wicked.interactive.doc.created`
+// — so the bus refuses both candidate spellings with `400 {"error":"unknown event type: …"}`.
+// `wicked.interactive.source.removed` is UI-emittable but detaches ONE source file from a
+// doc; it cannot retire the doc.
+//
+// Crew's proxy is NOT the blocker: `registerInteractiveProxy` mounts `scope.all(…)`, so it
+// already forwards any method verbatim. The moment the bridge serves the route, the wrapper
+// here is a two-line addition.
+//
+// Nor is the doc dir the whole of it: crew keeps a durable replay-dedup row per document in
+// `~/.wicked-crew/interactive-draft-ledger.json`, keyed by document id for the draft leg.
+// Removing a doc without dropping that row means a doc later re-created under the same name
+// never gets its first draft — which is exactly why today's cleanup is hand-editing that JSON
+// plus an `rm -rf` of the bridge's doc dir.
+//
+// So the UI has no affordance BECAUSE the wire has none, not because it was forgotten.
+// The guards that keep it honest: `tests/interactive.client.test.ts` fails in CI if this
+// module grows an unmake wrapper, and section 8 of `e2e/interactive_wire_contract_test.py`
+// pins the absence against the real bridge — it fails the moment the bridge grows the wire,
+// which is the signal to adopt it here and move the pin in the same change.
+
 /**
  * `POST /d/:docId/api/fork` — branch a new version off `version`. `sourceMessageId`
  * (§7.6) is the thread message the branch came from, carried for the manifest's

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -468,7 +468,12 @@ describe('no invented unmake wire (studio#119)', () => {
     const src = readFileSync(join(process.cwd(), 'src/api/interactive.ts'), 'utf8')
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .replace(/^[ \t]*\/\/.*$/gm, '');
-    expect(src).not.toMatch(/['"]DELETE['"]/);
+    // Match how a DELETE is actually BUILT, not every occurrence of the word. Banning the bare
+    // string meant this module could not legitimately mention DELETE for any other reason —
+    // including an allow-list, or another resource that does support it. The test name says
+    // "builds a DELETE against the doc registry", so assert on the construction.
+    expect(src, 'a fetch with method DELETE').not.toMatch(/method\s*:\s*['"]DELETE['"]/i);
+    expect(src, 'an http-client .delete( call').not.toMatch(/\.\s*delete\s*\(/);
     // …and no bus command invented to stand in for it.
     expect(src).not.toMatch(/wicked\.interactive\.doc\.(deleted|removed|retired|archived)/);
   });

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -445,7 +445,12 @@ describe('happy-path shapes', () => {
 describe('no invented unmake wire (studio#119)', () => {
   // Scoped to the doc/demo nouns on purpose: `wicked.interactive.source.removed` IS
   // UI-emittable, so a future `removeSource` is legitimate and must not trip this.
-  const UNMAKE = /^(delete|remove|destroy|purge|discard|archive)(Doc|Docs|Demo|Demos|Document)/i;
+  // `retire` and `unmake` belong here: the event guard below already covers
+  // `wicked.interactive.doc.retired`, so leaving them out of the EXPORT guard let the two
+  // disagree — a `retireDoc()` wrapper would have passed this while the event it emits was
+  // banned three lines down.
+  const UNMAKE =
+    /^(delete|remove|destroy|purge|discard|archive|retire|unmake)(Doc|Docs|Demo|Demos|Document)/i;
 
   it('the client module exports no doc/demo unmake wrapper', async () => {
     const mod = (await import('../src/api/interactive.js')) as Record<string, unknown>;

--- a/tests/interactive.client.test.ts
+++ b/tests/interactive.client.test.ts
@@ -8,6 +8,8 @@
 //   3. Happy path: each wrapper hits the right method/path/body and returns the
 //      declared shape, pinned against the bridge's real responses.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   BridgeUnavailableError,
   ServiceHintError,
@@ -422,5 +424,47 @@ describe('happy-path shapes', () => {
     // A dead bridge stays the typed 503, exactly as every other wrapper.
     stubFetch({ code: 'bridge_unavailable', hint: 'npm i -g wicked-interactive' }, 503);
     await expect(getLearnedTheme(PROJECT, DOC)).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+});
+
+// ── The registry is CREATE + READ only (studio#119) ──────────────────────────
+//
+// A delete affordance is missing from studio because the wire is missing from the
+// bridge, verified against a REAL one: every DELETE spelling is Express's
+// route-missing 404 ("Cannot DELETE /api/docs/<doc>"), and — unlike the record and
+// theme wires, which answered "no HTTP route" with a UI-emittable bus COMMAND —
+// there is no unmake verb in the bridge's `docs` subdomain either, so the bus
+// refuses with `400 unknown event type`.
+//
+// This is the CI-visible half of the guard: it fails on the PR that grows a wrapper
+// for a route nobody serves, which is the slice-13 (`getDemoSpec`,
+// `getLatestRecording`) and slice-16 (`learnTheme`, `listThemes`) break both times.
+// Its sibling — section 8 of e2e/interactive_wire_contract_test.py — fails from the
+// other side, the moment the bridge DOES grow the wire. Adopt the real route here
+// and move both guards in the same change; never one without the other.
+describe('no invented unmake wire (studio#119)', () => {
+  // Scoped to the doc/demo nouns on purpose: `wicked.interactive.source.removed` IS
+  // UI-emittable, so a future `removeSource` is legitimate and must not trip this.
+  const UNMAKE = /^(delete|remove|destroy|purge|discard|archive)(Doc|Docs|Demo|Demos|Document)/i;
+
+  it('the client module exports no doc/demo unmake wrapper', async () => {
+    const mod = (await import('../src/api/interactive.js')) as Record<string, unknown>;
+    const offenders = Object.keys(mod).filter((k) => UNMAKE.test(k));
+    expect(offenders, `src/api/interactive.ts exports ${offenders.join(', ')} — but the `
+      + 'wicked-interactive bridge serves no delete route and no delete bus command '
+      + '(studio#119). Land the wire upstream first, then move this guard and section 8 '
+      + 'of e2e/interactive_wire_contract_test.py together.').toEqual([]);
+  });
+
+  it('no wrapper in the module builds a DELETE against the doc registry', () => {
+    // The export name is the easy half to rename around; the request itself is not.
+    // Comments are stripped first so this file's own prose (and interactive.ts's
+    // NOTE block, which quotes the 404s verbatim) cannot satisfy or trip the check.
+    const src = readFileSync(join(process.cwd(), 'src/api/interactive.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+    expect(src).not.toMatch(/['"]DELETE['"]/);
+    // …and no bus command invented to stand in for it.
+    expect(src).not.toMatch(/wicked\.interactive\.doc\.(deleted|removed|retired|archived)/);
   });
 });


### PR DESCRIPTION
Closes nothing — #119 stays open, blocked upstream. Read the finding first; the code is small on purpose.

## #119 is not a missing button

It reads as "the UI forgot delete". It isn't. Probed against a **real** bridge (`bin/wicked-interactive.js serve`, wicked-interactive @ 0.8.x) after creating a demo, the doc registry serves CREATE + READ only — there is nothing for a button to call:

| probe | result |
|---|---|
| `DELETE /api/docs/<doc>` | `404 "Cannot DELETE /api/docs/<doc>"` |
| `DELETE /d/<doc>` | `404 "Cannot DELETE /d/<doc>"` |
| `DELETE /d/<doc>/api/doc` | `404 "Cannot DELETE /d/<doc>/api/doc"` |
| `DELETE /d/<doc>/api/versions` | `404 "Cannot DELETE /d/<doc>/api/versions"` |
| `POST /api/docs/<doc>/delete` | `404 "Cannot POST /api/docs/<doc>/delete"` |

Express's route-missing body, not a service refusal — and the doc is still in `GET /api/docs` after every probe, which is what makes this a real absence rather than a lucky 404.

The **bus escape hatch is shut too**, and that is the part worth pausing on: `requestRecord` (§7.4) and `requestThemeLearn` (#65) each answered "no HTTP route" by turning out to be a UI-emittable COMMAND over `POST /api/events`. An invented `deleteDoc` would most plausibly be waved through the same way. It cannot be — the bridge's ownership table (`src/service/events.js`) has no unmake verb in the `docs` subdomain at all, only `doc.created`, so every candidate spelling is refused `400 {"error":"unknown event type: …"}` one step *before* the `uiEmittable` check. `source.removed` is UI-emittable but detaches one source **file**; it cannot retire a doc.

Crew's proxy is **not** the blocker: `registerInteractiveProxy` mounts `scope.all(…)` and forwards any method verbatim. The day the bridge serves the route, the client wrapper is a two-line addition.

## So no UI ships here

Studio is a pure client. A button now means a wrapper for a route nobody serves — the slice-13 (`getDemoSpec`, `getLatestRecording`) and slice-16 (`learnTheme`, `listThemes`) break a third time, discovered in production. This PR ships the finding and the guards; the affordance is blocked on upstream work that is genuinely two-sided, now filed:

- **wicked-interactive#189** — an unmake route + a `docs`-subdomain unmake event, so removal is observable rather than a silent `rm -rf`.
- **wicked-crew#338** — drop the doc's rows from `~/.wicked-crew/interactive-draft-ledger.json`. The draft leg keys by **document id**, so a delete that leaves the row behind means a doc re-created under the same name never gets a first draft again. That is precisely why today's cleanup is hand-editing that JSON *plus* the `rm -rf`.

(Worth noting for whoever picks this up: unfiling the doc from its project via the existing `DELETE /projects/:id/members/:mid` is **not** a substitute. `listDocs()` is a directory scan of the bridge root with no project filter, so the doc stays in every picker.)

## The guards — they fail from opposite sides, on purpose

**`tests/interactive.client.test.ts`** (CI-visible). Fails on the PR that grows an unmake wrapper or builds a `DELETE` in `src/api/interactive.ts`. Verified by adding a `deleteDoc` speaking `DELETE /api/docs/:id`:

```
× no invented unmake wire (studio#119) > the client module exports no doc/demo unmake wrapper
  → src/api/interactive.ts exports deleteDoc — but the wicked-interactive bridge serves no
    delete route and no delete bus command (studio#119). Land the wire upstream first, then
    move this guard and section 8 of e2e/interactive_wire_contract_test.py together.
    expected [ 'deleteDoc' ] to deeply equal []
× no invented unmake wire (studio#119) > no wrapper in the module builds a DELETE against the doc registry
  → expected '…' not to match /['"]DELETE['"]/
```

Scoped to doc/demo nouns so a future (legitimate) `removeSource` does not trip it — `source.removed` really is UI-emittable.

**`e2e/interactive_wire_contract_test.py` section 8** (against the real bridge). Passes today; fails the moment the bridge grows the wire, which is the signal to adopt it. Verified by forking the bridge with a `DELETE /api/docs/:doc` route:

```
FAIL doc_delete_wire_absent
  DELETE /api/docs/contract-check-demo -> 200 {"ok":true,...}
  "the bridge now answers here — adopt the wire in src/api/interactive.ts, drop the CI guard
   in tests/interactive.client.test.ts, and move this pin"
contract_verdict: contract-check assertions did not all hold — see doc_delete_wire_absent
```

Section 0's `BANNED_SPELLINGS` also grows the delete spellings — the vitest guard covers the client module's exports, this covers the rest of `src/` where a component could build the URL inline and skip it.

`src/api/interactive.ts` gets the NOTE block explaining all of the above where the wrapper would go, in the same shape as the existing #65 / slice-13 notes.

## Verification

- `npm test` — 181 files / 1835 tests pass
- `npm run typecheck`, `npm run lint` — clean
- `WICKED_INTERACTIVE_DIR=… python3 e2e/interactive_wire_contract_test.py` — exit 0, all 12 steps PASS including the new `doc_delete_wire_absent`
- both guards demonstrated failing against their respective defects (quoted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)