### PR TITLE
test(doc-canvas): fix the LANDED-version flake — it read the DOM in the frame's swap gap

### DIFF
--- a/tests/DocumentCanvas.test.tsx
+++ b/tests/DocumentCanvas.test.tsx
@@ -497,15 +497,28 @@ describe('DocumentCanvas — canvas-first: right panel + slim strip (doc-feedbac
     stubFetch({ '/api/versions': { get body() { reads += 1; return reads === 1 ? MANIFEST : grown; } } });
     render(<DocumentCanvas projectId={PROJECT} docId={DOC} navigate={() => {}} />);
 
-    await screen.findByTestId('doc-canvas');
+    expect(await screen.findByTestId('doc-canvas')).toHaveAttribute('data-version', '3');
     expect(screen.getAllByTestId('version-entry')).toHaveLength(3);
+    // "No reload" is a claim about THIS node — the canvas surface itself. Hold its
+    // identity now so the assertion below can be about the surface surviving the
+    // re-read rather than about whichever iframe is mounted at the instant we look.
+    const surface = screen.getByTestId('document-canvas');
 
     // The stream lands v4 (the docThread store's `landed` fact — same trigger
     // VideoStoryboard re-reads on). The strip must advance without a remount.
     act(() => { useDocThreadStore.setState({ landed: { [threadKey(PROJECT, DOC)]: 4 } }); });
 
     await waitFor(() => expect(screen.getAllByTestId('version-entry')).toHaveLength(4));
-    // …and the strip never blinked: the canvas stayed mounted through the re-read.
-    expect(screen.getByTestId('doc-canvas')).toBeInTheDocument();
+    // The frame follows the strip, one async hop behind it: advancing the shown
+    // version RE-INSTRUMENTS the frame (DocFrame re-reads the version's HTML before
+    // re-creating the iframe), so between the manifest landing and that read the
+    // iframe is legitimately absent — the named loading state covers it. Wait for
+    // the frame the landing produced instead of reading the DOM inside that gap;
+    // reading it there is what made this case fail on CI and pass locally (#136),
+    // because the stub answers in a microtask that a loaded runner reorders.
+    await waitFor(() => expect(screen.getByTestId('doc-canvas')).toHaveAttribute('data-version', '4'));
+    // …and the strip never blinked: the SAME canvas surface carried the re-read
+    // from end to end — a reload would have replaced this node.
+    expect(screen.getByTestId('document-canvas')).toBe(surface);
   });
 });


### PR DESCRIPTION
Fixes #136.

## What was wrong

The flaky case is `AC (§2.6 rule 3): a LANDED version re-reads the manifest — the strip advances, no reload`. On [run 32996651176](https://github.com/mikeparcewski/wicked-studio/actions/runs/32996651176) it failed a merge gate on a site-only PR and passed on rerun:

```
TestingLibraryElementError: Unable to find an element by: [data-testid="doc-canvas"]
```

The race is an **unawaited effect**, not a timer and not a fake-timer boundary.

Landing v4 advances the manifest → advances `resolvedShown` 3 → 4 → re-runs `DocFrame`'s instrumentation effect, which clears `instrumented` (unmounting the iframe), re-reads the new version's HTML, and only then re-creates the frame. The iframe is therefore **legitimately absent** while that read is in flight; the named loading overlay covers the gap. The CI DOM dump shows exactly that state — `document-canvas` present, `doc-canvas-loading` over it, the strip already advanced to four entries.

The test awaited condition A (the strip has four entries) and then read condition B (the iframe) **synchronously**. A fetch separates them. Locally the stub answers in a microtask, so the frame is back inside the single `setTimeout(0)` drain RTL performs after `waitFor` resolves; on a loaded runner React's scheduler work slips past that 1 ms timer and the read lands inside the gap.

## The change (test only — the canvas behaves correctly)

Assert what the AC actually claims, on conditions the test waits for:

- `waitFor` the frame the landing **produced** (`data-version` = `4`) instead of any frame being mounted. This also proves the canvas followed the head, which the old assertion never checked.
- Pin "no reload" **structurally**: the `document-canvas` node captured before the landing must be the same node after it.

No sleep, no retry, no timeout bump.

## Proof, both directions

Deferring the stub's unrouted replies by 5 ms — the ordering a loaded runner produces — makes the flake deterministic.

| Variant (under the 5 ms ordering) | Result |
|---|---|
| Old assertion | ❌ `Unable to find an element by: [data-testid="doc-canvas"]` — the CI message verbatim, same DOM |
| New assertion | ✅ 27/27 |

And the new assertions still fail on real regressions:

| Mutation to `DocumentCanvas.tsx` | Failure |
|---|---|
| drop `landed` from the manifest re-read deps | `expected [ … ] to have a length of 4 but got 3` |
| drop `resolvedShown` from the instrumentation effect (frame stops following the head) | `Unable to find an element by: [data-testid="doc-canvas"]` (now a true 1 s timeout, not an instant read) |
| re-key the canvas container per head (a "reload") | `expected <div …> to be <div …> // Object.is equality` |

## Verification

- `npm test` — **181 test files passed**
- `tests/DocumentCanvas.test.tsx` — 27/27, run 8× consecutively, all green
- `npm run lint`, `npm run typecheck` — clean

The `Not implemented: HTMLCanvasElement.prototype.getContext` noise the issue asked about is unrelated: `tests/setup.ts` installs a canvas stub, and the message is jsdom's own probe *inside that guard* deciding whether the stub is needed. It fires on green runs too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)