### PR TITLE
fix: clarify unresolved caveat and coverage empty states post-migration

### DIFF
--- a/src/components/CoverageView.tsx
+++ b/src/components/CoverageView.tsx
@@ -385,7 +385,7 @@ export function CoverageView(): React.ReactElement {
         <p className="text-xs" style={{ color: 'var(--ink-dim)' }}>
           No coverage data — run{' '}
           <code className="font-mono" style={{ color: 'var(--ink-muted)' }}>wicked-core rules ingest</code>{' '}
-          to populate.
+          to populate. After a graph re-index (migration), re-run the annotation workflow to restore coverage.
         </p>
       )}
 

--- a/src/components/RepoGraphModal.tsx
+++ b/src/components/RepoGraphModal.tsx
@@ -150,7 +150,11 @@ function NodeDetailPanel({
               blast radius · {blast.dependents.length} dependents
             </span>
             {blast.unresolved > 0 && (
-              <span className="text-[10px] font-mono" style={{ color: T.deny }}>
+              <span
+                className="text-[10px] font-mono"
+                style={{ color: T.deny }}
+                title="References no resolver could bind — repeat call sites of resolved relationships are not counted; 0 is normal for fully-resolved symbols"
+              >
                 +{blast.unresolved} unresolved call(s) — impact may be larger
               </span>
             )}
@@ -765,7 +769,7 @@ export function RepoGraphModal({ repo, onClose, onSelectRun, initialFocus }: Pro
                     </div>
                   ) : (
                     <p className="text-[11px] font-mono" style={{ color: T.faint }}>
-                      No coverage data — run onboarding first.
+                      No coverage data — run onboarding first, or re-run the annotation workflow below after a graph re-index.
                     </p>
                   )}
                   <button


### PR DESCRIPTION
Consumer-side copy for the upcoming wicked-estate scheme-2/accounting release (cross-repo impact review action #9).

- Tooltip on the blast-radius unresolved caveat: under the new definition, unresolved counts only references no resolver could bind — repeat call sites of resolved relationships are not counted, and 0 is normal for fully-resolved symbols.
- Coverage/Domain empty states point at the "Run annotation workflow" affordance (annotations keyed to pre-migration symbol ids are regenerated by that workflow).

Copy-only; no runtime change. typecheck/lint clean, 1,835 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)