### PR TITLE
fix: saveable rule template, truthful version row, CLAUDE.md stub (AW-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# wicked-studio
+
+The coder-facing skin of the wicked experience plane: a Vite/React SPA that is a
+**pure HTTP/WS client** of the wicked-crew daemon — launch/steer governed runs,
+answer HITL gates, browse projects/evidence/coverage, watch live CoreEvents.
+
+## Wire contract (the one hard rule)
+
+- Studio speaks ONLY crew's published surface: HTTP `/api/v1` + WS `/ws`.
+- The only thing shared with crew is the published wire-contract package
+  **`wicked-crew-api-types`** (`src/api/types.ts` re-exports it). Zero crew
+  source imports — if a type is missing, it lands in the contract package first.
+- crew bundles this repo's built `dist/` as its default local skin
+  (`build:with-studio`); a studio release means bumping crew's devDep pin too.
+
+## Where things live
+
+- `src/api/` — HTTP client + wire types; `src/components/` — the UI.
+- `.product/` — design docs (DES-*, BRIEF-*): read before reshaping a surface.
+- `tests/` — vitest (jsdom): `npm test`; typecheck with `npm run typecheck`.
+- `e2e/` — Python E2E suites driven against a live daemon.
+- `site/` — the marketing site: its own app/deps, excluded from vitest.
+- `wicked-worktrees/` — gitignored checkouts created by governed runs inside
+  this repo; never edit or clean them by hand.
+
+Ecosystem-wide context and the PR merge protocol: `../CLAUDE.md` at the
+wicked workspace root (when working inside the multi-repo checkout).

--- a/src/components/RuleManager.tsx
+++ b/src/components/RuleManager.tsx
@@ -9,14 +9,24 @@ const SEVERITY_COLOR: Record<string, string> = {
   info: 'var(--ink-muted)',
 };
 
-const RULE_TEMPLATE: ConformanceRule = {
-  id: '',
+/**
+ * Seed JSON for the "+ New rule" editor. Every field must pass the engine's
+ * fail-closed write invariants (`wicked-governance::ConformanceRule::validate`),
+ * or the template can never save as-is:
+ * - INV-C1: id matches `^(PAT|POL)-[0-9]{3,6}$` with the prefix agreeing with
+ *   `rule_type` (PAT ⇔ pattern) — `PAT-100` is a valid placeholder to edit.
+ * - INV-C4: `provenance.source_kinds` values come from the shared wire enum
+ *   `code-body | type-def | comment | doc` ('policy' is NOT in it).
+ * Exported so the template's validity contract stays pinned by test.
+ */
+export const RULE_TEMPLATE: ConformanceRule = {
+  id: 'PAT-100',
   rule_type: 'pattern',
   statement: '',
   severity: 'warn',
   confidence: 0.9,
   targets: {},
-  provenance: { source: 'manual', source_kinds: ['policy'] },
+  provenance: { source: 'manual', source_kinds: ['code-body'] },
 };
 
 function RuleRow({

--- a/src/components/SettingsRailSection.tsx
+++ b/src/components/SettingsRailSection.tsx
@@ -1,3 +1,5 @@
+import { version } from '../../package.json';
+
 /**
  * The Settings shortcut rows (DES-FEEDBACK-001 §1.2/§4.4, slice A — re-homed by
  * DES-FEEDBACK-003 §3.1, slice M): Settings is a PRIMARY heading in the rail's
@@ -41,12 +43,14 @@ export function SettingsShortcutRows({ navigate }: Props): React.ReactElement {
           {item.label}
         </button>
       ))}
-      {/* The quiet version row the retired dropdown carried — moved, not dropped. */}
+      {/* The quiet version row the retired dropdown carried — moved, not dropped.
+          Read from package.json at build time so it can never go stale again
+          (it sat hardcoded at "v0.3.2" while the app shipped 0.4.0). */}
       <p
         className="px-6 pt-1.5 pb-0.5 text-[10px] font-mono select-none"
         style={{ color: 'var(--ink-dim)', margin: 0 }}
       >
-        v0.3.2
+        {`v${version}`}
       </p>
     </div>
   );

--- a/tests/RuleManager.template.test.ts
+++ b/tests/RuleManager.template.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { RULE_TEMPLATE } from '../src/components/RuleManager.js';
+
+/**
+ * The "+ New rule" seed JSON must SAVE as-is: the daemon forwards it to the
+ * engine's fail-closed write boundary (`wicked-governance::ConformanceRule::
+ * validate`, wicked-core/crates/wicked-governance/src/conformance.rs), which
+ * rejects out-of-contract rules. The template shipped for a while with
+ * `id: ''` (fails INV-C1) and `source_kinds: ['policy']` (fails INV-C4 —
+ * 'policy' is not in the wire enum), so every save from the pristine template
+ * errored. These tests mirror the engine's invariants so the template can
+ * never regress to un-saveable again.
+ */
+
+/** The shared `provenance.source_kinds` wire enum (conformance.rs VALID_SOURCE_KINDS). */
+const VALID_SOURCE_KINDS = ['code-body', 'type-def', 'comment', 'doc'];
+
+describe('RULE_TEMPLATE engine-invariant conformance', () => {
+  it('INV-C1: id matches `^(PAT|POL)-[0-9]{3,6}$` with the prefix agreeing with rule_type', () => {
+    expect(RULE_TEMPLATE.id).toMatch(/^(PAT|POL)-[0-9]{3,6}$/);
+    const prefix = RULE_TEMPLATE.rule_type === 'pattern' ? 'PAT-' : 'POL-';
+    expect(RULE_TEMPLATE.id.startsWith(prefix)).toBe(true);
+  });
+
+  it('INV-C2: confidence is a number in [0,1]', () => {
+    expect(RULE_TEMPLATE.confidence).toBeGreaterThanOrEqual(0);
+    expect(RULE_TEMPLATE.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('INV-C4: every provenance.source_kinds value is in the shared wire enum', () => {
+    expect(RULE_TEMPLATE.provenance.source_kinds.length).toBeGreaterThan(0);
+    for (const sk of RULE_TEMPLATE.provenance.source_kinds) {
+      expect(VALID_SOURCE_KINDS).toContain(sk);
+    }
+  });
+
+  it('round-trips through the editor: JSON.parse(JSON.stringify(template)) preserves the contract fields', () => {
+    // The editor serialises the template into a textarea and parses it back
+    // before POSTing — the contract-bearing fields must survive that trip.
+    const parsed = JSON.parse(JSON.stringify(RULE_TEMPLATE, null, 2));
+    expect(parsed.id).toBe(RULE_TEMPLATE.id);
+    expect(parsed.rule_type).toBe(RULE_TEMPLATE.rule_type);
+    expect(parsed.provenance.source_kinds).toEqual(RULE_TEMPLATE.provenance.source_kinds);
+  });
+});

--- a/tests/SettingsRailSection.test.tsx
+++ b/tests/SettingsRailSection.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { SETTINGS_ITEMS, SettingsShortcutRows } from '../src/components/SettingsRailSection.js';
+import { version as pkgVersion } from '../package.json';
 
 /**
  * The Settings shortcut rows (slice A, re-homed by DES-FEEDBACK-003 §3.1
@@ -26,7 +27,10 @@ describe('SettingsShortcutRows', () => {
       expect(screen.getByRole('menuitem', { name: item.label })).toBeInTheDocument();
     }
     // The quiet version row rode along from the dropdown — moved, not dropped.
+    // It must MATCH package.json (not a hardcoded literal): the row sat stale
+    // at "v0.3.2" while the app shipped 0.4.0.
     expect(screen.getByText(/^v\d+\.\d+\.\d+$/)).toBeInTheDocument();
+    expect(screen.getByText(`v${pkgVersion}`)).toBeInTheDocument();
   });
 
   it('each entry is a navigate() shortcut — never a parallel settings surface', () => {


### PR DESCRIPTION
Fixes campaign finding #2 / arch-R11: RULE_TEMPLATE failed the backend's own INV-C1/C4 validation (template could never save); SettingsRailSection hardcoded v0.3.2 — now dynamic; adds the root CLAUDE.md pointer stub.

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)