### PR TITLE
docs: 0.4.0 truth pass — shipped shell present-tense, README feature set, onboarding copy (DT-9+C#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,146 @@
+# Changelog
+
+All notable changes to **wicked-studio** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(0.x: minor versions may contain breaking changes).
+
+Backfilled 2026-08-29 from the git history and the npm registry; release dates are the
+npm publish dates. Every version listed here exists on
+[npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
+
+## [Unreleased]
+
+### Changed
+
+- Board attention bands read their copy from one source of truth (#121).
+- Site: repositioned as "where product work happens", scoped honestly (#131); the
+  project-as-context story — the multi-repo graph — added (#130); hero, scroll-snap, and
+  fixed-topbar band fixes (#132, #133, #134).
+- Truth pass (docs-R9): the site's project-shell copy flipped to present tense — the dedicated
+  project browser is shipped, not "landing next" — and the editorial guard comment that enforced
+  the stale claim now enforces the shipped one; README rewritten to the 0.4.x surface; the
+  crew-daemon floor corrected to v0.7.0+ (verified against the wire: `PUT /runs/:id/guidance`
+  is 0.7.0-only); onboarding copy corrected from "index → annotate → domain" to the two units
+  crew actually runs (index → annotate).
+
+### Fixed
+
+- The governance rule template is saveable and the version row truthful (AW-1, #141).
+- Unresolved-reference caveat and coverage empty states clarified post-migration (#140).
+- Document/demo delete: pin the missing wire instead of inventing one (#138).
+- Test stability: no FontFaceSet across the Playwright boundary (#137); doc-canvas LANDED case
+  no longer reads the DOM in the frame's swap gap (#139).
+
+## [0.4.0] — 2026-08-25
+
+### Changed
+
+- Delivery: the worktree is a fact — the delivery panel no longer gates it on the workflow
+  catalog (#128).
+
+This is the version certified by the 21-scenario functional campaign (21/21 PASS,
+`estate-review/STUDIO-CAMPAIGN.md`): projects, repo intelligence (code graph, ego focus,
+blast radius, domain graph + coverage, requirements), governed runs with HITL gates,
+group chat, governed PTY terminals, workflow builder, governance surfaces, settings
+persistence, document/video modes, and deep links.
+
+## [0.3.0] — 2026-08-25
+
+The largest release to date (~77 commits): four design programs landed.
+
+### Added
+
+- **DES-UX-002 — the agentic terminal of the future**: portfolio nerve center with active-card
+  enrichment (#113, #118), run evidence timeline (#111), work chronicle (#112), the steering
+  annotation layer with durable pre-gate guidance notes riding crew's `PUT /runs/:id/guidance`
+  (#114, #117).
+- **DES-UX-001 — the trust spine**: one canonical runs surface (#95), run identity (#96),
+  provenance + retry (#91), failure forensics — failed runs answer "why did this fail" (#90),
+  thread truth (visible sends, anchored versions, reload survival) (#97), the Unfiled path
+  (#98), toast lifecycle (#99), live execution + bookmarkability (#101), export + theme-learn
+  feedback (#102), chat repair (#103), keyboard coherence + composer preflight (#104),
+  roster-resolved capability-aware seat chips (#109).
+- **DES-FEEDBACK-002/-003 — FDE ergonomics**: universal command palette + global shortcut
+  registry (#76), keyboard gate triage — j/k select, a approve, r reject-with-note (#77),
+  in-studio file & diff viewer (#79), five-path accordion rail (#80), fixed bottom runs panel
+  (#81), health rail-foot + `/make` dashboard (#82), `/projects` `/chats` `/repos` reporting
+  dashboards (#83), narrative landing with the 24h activity river (#84), header project pivot +
+  honest global search (#85), chat grid/columns + document version compare (#86), desktop gate
+  notifications + batch gate resolution (#87).
+- **DES-VISION-001 / DES-UXFIX-001 — the visual re-envision**: design-token foundation through
+  full token conversion (#56–#60), appearance settings — logo, accent, theme, live preview
+  (#61), brand-learn (#62, #75), Theme page (#64), attention decay + bands (#49), segmented
+  mode spine (#52).
+- Build runs open a PR by default, with a settings toggle (#124).
+- Delivery visibility: what a run produced, where the operator already is (#125).
+- Doc canvas block-level click-to-edit (#116) and the video surface restored on the real
+  record wire (#120).
+
+### Fixed
+
+- Theme client speaks the real bridge wire — invented routes removed, contract probes FATAL
+  (#73, #75).
+- Send-lifecycle honesty: no fork-per-send, live first generation, reload-surviving send state
+  (#108); chat cold-start roster truth (#107).
+- Copy triage: internal vocabulary out of the product (#47).
+
+## [0.2.0] — 2026-08-19
+
+The merged interactive layer: wicked-interactive's UI moved into this skin (DES-MERGE-001).
+
+### Added
+
+- Project routes + the four-mode switcher — chat / build / document / video (#29).
+- The orchestrator home board, static then live, with answerable gate chips (#30, #31, #32).
+- Typed studio client for crew's proxied interactive service (#28).
+- Document mode: canvas iframe (#33), version strip + fork (#34), the one conversation thread
+  (#35), point-and-comment on the sandboxed bridge (#37), exports as thread artifacts (#40),
+  learn-a-theme + sources attach (#41).
+- Video mode: storyboard + player against the proxied demo endpoints (#38), record and
+  re-record from the thread (#39).
+- Merged preflight / install gate (#42).
+- Live narration + unified launch/steer conversation on the run thread (#24, #25).
+- Seat sign-in terminals, worker config root, launch check in settings (#23); runtime
+  seat-health chips on the dashboard, launch roster, and chat composer (#18, #19, #20).
+
+### Removed
+
+- Unrouted legacy views (#22).
+
+## [0.1.1] — 2026-08-16
+
+### Added
+
+- Projects UI: list, detail, create, archive (DES-PROJECT-001, #13) — the first projects
+  surface in the skin.
+- Run view: outputs primary in the main panel + Files tab system-open (#17); Archived chip
+  for finished history (#14).
+- npm trusted-publisher release workflow (#16).
+- `.product` artifact set: REQ-001–005, DES-001, TEST-001, RAID, acceptance evidence (#4, #6).
+
+### Fixed
+
+- Gate toasts scoped to the currently viewed run; pointer-events on the notification container
+  (#9, studio#10).
+- Gate HITL card data + cache-read token visibility (#7).
+- `wicked-crew-api-types` pinned to the npm registry version (#5).
+
+## [0.1.0] — 2026-08-12
+
+### Added
+
+- Initial release as its own product: carved out of the wicked-crew monorepo
+  (`packages/studio`) with the package's full in-monorepo history preserved via
+  `git subtree split` (92 commits).
+- The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
+- `ws.wickedagile.com` — the product site, with its own e2e suite and Pages deploy (#1).
+- Wire contract consumed from npm: `wicked-crew-api-types` (#2).
+
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/mikeparcewski/wicked-studio/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
 
 ### Added
 
+- `ws.wickedagile.com` — the product site, with its own e2e suite and Pages deploy (#1).
+- Wire contract consumed from npm: `wicked-crew-api-types` (#2).
 - Projects UI: list, detail, create, archive (DES-PROJECT-001, #13) — the first projects
   surface in the skin.
 - Run view: outputs primary in the main panel + Files tab system-open (#17); Archived chip
@@ -135,8 +137,6 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   (`packages/studio`) with the package's full in-monorepo history preserved via
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
-- `ws.wickedagile.com` — the product site, with its own e2e suite and Pages deploy (#1).
-- Wire contract consumed from npm: `wicked-crew-api-types` (#2).
 
 [Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ on `/api/v1` and `/ws`, and nothing else.
 
 ## What the skin surfaces (0.4.x)
 
-Every capability below is a real `/api/v1` or `/ws` wire — no invented routes — and the full
-set was verified end-to-end by a 21-scenario functional campaign against an isolated daemon
-(21/21 PASS, evidence-graded).
+Every capability below is a real `/api/v1` or `/ws` wire — no invented routes — verified by a
+21-scenario functional campaign against an isolated daemon (21/21 PASS, evidence-graded;
+`estate-review/STUDIO-CAMPAIGN.md`). Legs the campaign could only prove over the wire rather
+than through the UI are marked as such below.
 
 - **Projects** — create/rename/archive/restore, attach and detach members (repos, runs, chats,
   docs), a merged activity feed with a prompt inbox, a per-project dashboard, and a four-mode
@@ -25,8 +26,9 @@ set was verified end-to-end by a 21-scenario functional campaign against an isol
 - **Governed runs** — the composer (Ask / Balanced / Autonomous, seat selection, repo binding,
   PR delivery), run list/detail/timeline with event backfill on reload, **HITL steering gates**
   (approve / approve-with-steer / reject, plus keyboard batch triage), elicitation prompts,
-  durable pre-gate guidance notes, and the lifecycle verbs: cancel, resume, inject a message,
-  archive/unarchive, retry lineage.
+  durable pre-gate guidance notes, and the lifecycle verbs the UI wires today: cancel, inject
+  a message, unarchive, retry lineage. (Resume and archive exist as typed client wires,
+  campaign-verified over the API — the UI affordances are a filed gap, not yet shipped.)
 - **Evidence** — per-unit transcripts, the worktree file & diff viewer, and one-click
   **evidence bundle download** for any run. The skin surfaces the gates; it never grades.
 - **Group chat** — fan one question out to your whole warm CLI roster and watch each seat

--- a/README.md
+++ b/README.md
@@ -1,12 +1,48 @@
 # wicked-studio
 
-> **v0.1.0** · [![CI](https://github.com/mikeparcewski/wicked-studio/actions/workflows/ci.yml/badge.svg)](https://github.com/mikeparcewski/wicked-studio/actions/workflows/ci.yml) · [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+> [![npm](https://img.shields.io/npm/v/wicked-studio)](https://www.npmjs.com/package/wicked-studio) · [![CI](https://github.com/mikeparcewski/wicked-studio/actions/workflows/ci.yml/badge.svg)](https://github.com/mikeparcewski/wicked-studio/actions/workflows/ci.yml) · [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 **The coder-facing skin of the wicked experience plane.** A React SPA that is a *pure HTTP/WS
 client* of the [wicked-crew](https://github.com/mikeparcewski/wicked-crew) daemon: launch and
 steer governed agent runs, answer human gates, watch live CoreEvent streams, browse projects,
-evidence, coverage, and the decisions ledger — everything the daemon exposes on `/api/v1` and
-`/ws`, and nothing else.
+repo intelligence, evidence, coverage, and the decisions ledger — everything the daemon exposes
+on `/api/v1` and `/ws`, and nothing else.
+
+## What the skin surfaces (0.4.x)
+
+Every capability below is a real `/api/v1` or `/ws` wire — no invented routes — and the full
+set was verified end-to-end by a 21-scenario functional campaign against an isolated daemon
+(21/21 PASS, evidence-graded).
+
+- **Projects** — create/rename/archive/restore, attach and detach members (repos, runs, chats,
+  docs), a merged activity feed with a prompt inbox, a per-project dashboard, and a four-mode
+  project shell (chat / build / document / video) with deep-linkable routes (`/p/:id/…`).
+- **Repo intelligence** — register a local path or clone from a URL; either launches a governed
+  onboarding run (`index` → `annotate`, two tool units) that builds the repo's code graph. Then:
+  graph view with ego-focus navigation, **blast radius** for any symbol, hotspots, the domain
+  graph + coverage view, and a requirements browser with operator overrides (PATCH
+  title/notes/status/risk).
+- **Governed runs** — the composer (Ask / Balanced / Autonomous, seat selection, repo binding,
+  PR delivery), run list/detail/timeline with event backfill on reload, **HITL steering gates**
+  (approve / approve-with-steer / reject, plus keyboard batch triage), elicitation prompts,
+  durable pre-gate guidance notes, and the lifecycle verbs: cancel, resume, inject a message,
+  archive/unarchive, retry lineage.
+- **Evidence** — per-unit transcripts, the worktree file & diff viewer, and one-click
+  **evidence bundle download** for any run. The skin surfaces the gates; it never grades.
+- **Group chat** — fan one question out to your whole warm CLI roster and watch each seat
+  answer side by side.
+- **Governed PTY terminals** — real terminals (xterm over `/ws/terminals/:id`), including the
+  seat sign-in flow from settings.
+- **Workflow builder** — inspect and create WorkflowDefs (phases, gates, validation) and their
+  inline tool scripts, then launch runs against them.
+- **Governance** — policies, conformance rules (with facet preview), the decisions/claims
+  ledger, and the audit view.
+- **Settings** — daemon settings plus `studio.*` namespaced keys: appearance/theme (including
+  brand-learn), notifications, composer preferences.
+- **Document & Video modes** — the merged creator surface, riding crew's proxied interactive
+  bridge under `/api/v1/projects/:id/interactive/*`.
+- **Command palette + deep links** — Cmd+K verbs (open terminal, answer prompts), bookmarkable
+  routes throughout, desktop gate notifications.
 
 ```
 ┌─────────────────────┐         HTTP /api/v1  +  WS /ws          ┌──────────────────────┐
@@ -89,7 +125,11 @@ the code as-is and preserved the package's full in-monorepo history via `git sub
 
 - Node.js ≥ 22.0.0
 - npm ≥ 10 (for workspaces and `prepare` hooks)
-- A running [wicked-crew](https://github.com/mikeparcewski/wicked-crew) daemon (v0.4.0+) for the SPA to connect to
+- A running [wicked-crew](https://github.com/mikeparcewski/wicked-crew) daemon (**v0.7.0+**) for
+  the SPA to connect to. The floor is real, not ceremonial: the UI calls routes that first
+  shipped in crew 0.7.0 — `PUT /runs/:id/guidance` (the durable pre-gate note) exists only
+  there, and the projects surface, `/audit`, and run archiving need ≥ 0.6.0 — so an older
+  daemon 404s on surfaces the skin treats as present.
 - A modern browser (Chrome, Edge, Firefox, Safari)
 - macOS, Linux, or Windows
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -26,9 +26,13 @@
  *    live daemon.
  *  - The Project model is SHIPPED in the control plane (/api/v1/projects,
  *    nine routes; a project's activity feed merges crew core events with
- *    wicked.interactive.* bus events carrying the same project_id). The
- *    studio's DEDICATED project browser is the next surface to land in this
- *    skin — say "landing in this skin", never "shipped here".
+ *    wicked.interactive.* bus events carrying the same project_id) — AND the
+ *    studio's DEDICATED project browser is SHIPPED IN THIS SKIN: project-shell
+ *    routing in App.tsx, /projects + /p/:id routes, ProjectsPage /
+ *    ProjectDetailPage / ProjectDashboard / ProjectShell, verified end-to-end
+ *    by the 0.4.0 functional campaign (21/21 scenarios,
+ *    estate-review/STUDIO-CAMPAIGN.md). Say "shipped", present tense —
+ *    never "landing next".
  *  - Governance vocabulary (deny-dominates, evaluator ≠ creator, gates) is
  *    crew's — studio SURFACES it, it does not own it. The skin never grades
  *    anything.
@@ -264,8 +268,9 @@ const RAIL = [
 
       <p class="honest-note">
         <b>Where this stands:</b> the Project model is <b>shipped in the control plane</b> — nine
-        routes, the merged feed, durable gate prompts across member runs. The studio’s <b>dedicated
-        project browser is landing in this skin next</b>; the run board above rides that daemon.
+        routes, the merged feed, durable gate prompts across member runs — and the studio’s
+        <b>dedicated project browser is shipped in this skin</b>: project pages, the per-project
+        dashboard, and the four-mode shell, all riding that daemon.
       </p>
     </div>
   </section>
@@ -487,7 +492,7 @@ wsBase()  → ws://127.0.0.1:7701                  <span class="c"># same contra
                 onclick="navigator.clipboard&&navigator.clipboard.writeText('npx wicked-crew serve').then(()=>{this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1400);})">Copy</button>
             </div>
             <pre class="install__code"><code>npx wicked-crew serve   <span class="c"># daemon + this studio · one port · same origin</span></code></pre>
-            <p class="install__note">Node ≥ 22. The daemon serves the studio at its own origin — open the printed URL and launch a run. <span class="install__ver">wicked-studio npm v0.1.0</span></p>
+            <p class="install__note">Node ≥ 22. The daemon serves the studio at its own origin — open the printed URL and launch a run. <span class="install__ver">wicked-studio npm v0.4.0</span></p>
           </div>
 
           <div class="install-or" aria-hidden="true"><span>or run the skin standalone</span></div>

--- a/site/tests/e2e/projects.spec.ts
+++ b/site/tests/e2e/projects.spec.ts
@@ -5,7 +5,8 @@ import { bringIntoView } from './utils';
  * One project, two skins [data-proj] — the experience-plane interchangeability
  * story. The same project (payments-refresh) re-renders under either skin;
  * the API call in the foot never changes, and the honest note keeps the
- * studio's own project browser labeled as landing.
+ * studio's own project browser labeled as shipped — present tense, since it
+ * is (project pages, dashboard, four-mode shell; 0.4.0 campaign-verified).
  */
 test.describe('one project, two skins [data-proj]', () => {
   test('defaults to the run-board view; flipping renders the same project as a document', async ({ page }) => {
@@ -43,11 +44,13 @@ test.describe('one project, two skins [data-proj]', () => {
     await expect(card.locator('.proj-feed--studio')).toBeVisible();
   });
 
-  test('the honest note ships: model shipped in the control plane, browser landing in the skin', async ({ page }) => {
+  test('the honest note ships: model shipped in the control plane, browser shipped in the skin', async ({ page }) => {
     await page.goto('/');
     const note = page.locator('.proj .honest-note');
     await bringIntoView(note);
     await expect(note).toContainText('shipped in the control plane');
-    await expect(note).toContainText('landing in this skin');
+    await expect(note).toContainText('shipped in this skin');
+    // The stale future-tense claim must never come back (docs-R9).
+    await expect(note).not.toContainText('landing in this skin');
   });
 });

--- a/site/tests/e2e/prose.spec.ts
+++ b/site/tests/e2e/prose.spec.ts
@@ -25,7 +25,9 @@ test('prose does not fuse words into the following bold or code span', async ({ 
     'spanning Rust and TypeScript',
     'edges do not resolve',
     'bounded at ten minutes each',
-    'The studio’s dedicated project browser',
+    // Lowercase since the docs-R9 truth pass: the phrase now sits mid-sentence
+    // ("… — and the studio’s dedicated project browser is shipped in this skin").
+    'the studio’s dedicated project browser',
   ];
 
   for (const phrase of mustRead) {

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -187,8 +187,8 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
                 className="text-[10px] font-mono"
                 style={{ color: 'var(--ink-dim)' }}
               >
-                re-indexes this repo as a governed run (index → annotate → domain) —
-                rewrites its code graph + domain model; typically minutes
+                re-indexes this repo as a governed run (index → annotate, two units) —
+                rewrites its code graph and cluster annotations; typically minutes
               </span>
               <button
                 type="button"

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -473,9 +473,12 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
             {/* §7.8 (slice AC, EC43): the named action previews what it does,
                 what it writes, and roughly how long it takes. */}
             <p data-testid="action-preview" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+              {/* The onboarding workflow is TWO tool units — index, then annotate (crew's
+                  BUILTIN_WORKFLOWS; the third `domain` phase was removed in FINDING-068 —
+                  domain extraction is a separate downstream workflow). Don't re-add it here. */}
               {sourceMode === 'remote'
-                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run — writes the repo's code graph + domain model; typically minutes.`
-                : "Runs the onboarding workflow (index → annotate → domain) as a governed run — writes the repo's code graph + domain model; typically minutes."}
+                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run — writes the repo's code graph and annotates its clusters; typically minutes.`
+                : "Runs the onboarding workflow (index → annotate) as a governed run — writes the repo's code graph and annotates its clusters; typically minutes."}
             </p>
 
             {registerError && (
@@ -555,8 +558,8 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                 No repositories
               </p>
               <p className="text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
-                Register a local git repo or clone a remote one. wicked-crew will index it,
-                annotate the domain model, and keep the knowledge graph up to date.
+                Register a local git repo or clone a remote one. wicked-crew will index it
+                into a code graph and annotate its clusters as a governed onboarding run.
               </p>
               <button
                 type="button"


### PR DESCRIPTION
Site marketed the shipped project shell in future tense (editorial guard comment updated too); README rewritten to the campaign-proven 0.4.0 surface; crew daemon floor verified-then-stated; onboarding copy fixed to the real two-unit run. Ships in studio 0.4.1 via the release train.

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)