### PR TITLE
release: 0.4.1 — truth pass, rule template fix, onboarding copy (XC-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.4.1] — 2026-08-29
+
+The truth-pass release: the docs and the site describe the product that shipped, and the
+governance rule template actually saves. This is the version wicked-crew 0.7.1 bundles as its
+default local skin.
+
 ### Changed
 
 - Board attention bands read their copy from one source of truth (#121).
@@ -138,7 +146,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.1.1...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.0",
-  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "version": "0.4.1",
+  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version-synced 0.4.1 with CHANGELOG covering DT-9 truth pass, C#5 onboarding copy, AW-1 template/version fixes, #140. npm publish follows merge (blocked on npm login — publish sequence documented in EXEC-LEDGER).

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)