### PR TITLE
docs: installer mention + historical markers (DT-19+DT-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The connection surface is deliberately small (`src/api/client.ts`):
 The daemon's loopback CORS admits any `http://localhost:*` / `http://127.0.0.1:*` origin, so a
 standalone studio on its own port can drive a local daemon out of the box.
 
+## Install
+
+You rarely install studio directly: **`npx wicked-crew serve` ships this UI bundled**,
+same-origin on one port. Or use the family installer — [`npx wicked-installer`](https://www.npmjs.com/package/wicked-installer)
+installs/updates the whole wicked-\* family (wicked-crew, which serves this skin, included).
+For a studio you build and host yourself, see [Standalone build](#standalone-build).
+
 ## Develop
 
 ```sh


### PR DESCRIPTION
Installer mention + marker sweep for studio docs.

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)