### PR TITLE
campaigns: read-only scoreboard — ladder, verdict chips, cost, delivery rollup (TH-14)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CenterDashboard } from './components/CenterDashboard.js';
 import { CommandPalette, paletteShortcutEntries } from './components/CommandPalette.js';
+import { CampaignScoreboard } from './components/CampaignScoreboard.js';
+import { CampaignsPage } from './components/CampaignsPage.js';
 import { ChatsPage } from './components/ChatsPage.js';
 import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
@@ -36,6 +38,7 @@ import { useLegacyRedirect } from './hooks/useLegacyRedirect.js';
 import { modePath, routedVersion, useRoute, type Mode } from './hooks/useRoute.js';
 import { useRuns } from './hooks/useRuns.js';
 import { useAnnotationStore } from './store/annotations.js';
+import { useCampaignsStore } from './store/campaigns.js';
 import { useGateStore } from './store/gates.js';
 import { useElicitationStore } from './store/elicitations.js';
 import { useLiveChatsStore } from './store/liveChats.js';
@@ -70,9 +73,10 @@ const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
 const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, chronicleView, navigate, search, pathname } = useRoute();
+  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, chronicleView, campaignId, navigate, search, pathname } = useRoute();
   const { runs, refresh, loaded: runsLoaded } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
+  const ingestCampaign = useCampaignsStore((s) => s.ingest);
   const ingestAnnotation = useAnnotationStore((s) => s.ingest);
   const ingestElicitation = useElicitationStore((s) => s.ingest);
   const ingestNotif = useNotificationStore((s) => s.ingest);
@@ -107,12 +111,15 @@ export function App(): React.ReactElement {
       // J4 round 2: chat frames announce/retire live sessions for the rail's
       // Chat accordion — evidence this subscription already carries, no fetch.
       ingestLiveChat(event);
+      // TH-14: fold core's Campaign* frames (a cheap prefix miss for everything else) so the
+      // campaign scoreboard's node status is live the moment the daemon relays them (TH-9).
+      ingestCampaign(event);
       // Slice L (DES-FEEDBACK-002 §8.2): the desktop layer folds off the SAME
       // subscription — hidden-tab-only, opt-in, permission-gated, never prompts.
       notifyGateIfUnfocused(event);
       if (LIFECYCLE_EVENTS.has(event.type)) refresh();
     },
-    [ingestGate, ingestAnnotation, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, ingestLiveChat, refresh],
+    [ingestGate, ingestCampaign, ingestAnnotation, ingestElicitation, ingestNotif, ingestRuntime, ingestRunEvent, ingestDocThread, ingestLiveChat, refresh],
   );
 
   useEventStream(handleEvent);
@@ -515,6 +522,22 @@ export function App(): React.ReactElement {
       return (
         <div className="flex-1 overflow-y-auto" data-testid="make-dashboard">
           <MakeDashboard runs={runs} navigate={navigate} runPath={runPath} />
+        </div>
+      );
+    }
+    // `/campaigns` + `/campaigns/:id` — the read-only campaign surface (TH-14, extends
+    // studio#27): the escape-hatch list and the sibling-run scoreboard.
+    if (panel === 'campaigns') {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <CampaignsPage navigate={navigate} />
+        </div>
+      );
+    }
+    if (panel === 'campaign-detail' && campaignId) {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <CampaignScoreboard campaignId={campaignId} runs={runs} navigate={navigate} />
         </div>
       );
     }

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -1,0 +1,142 @@
+/**
+ * The campaign wire (DES-CAMPAIGN-001 §1.4/§4.1 + TH-14) — types and calls for the
+ * read-only campaign surface: `GET /campaigns` and `GET /campaigns/:id`.
+ *
+ * ── INTEGRATION POINT (TH-9 / crew#342, marked per the TH-14 lane) ──────────────────────────
+ * These shapes are hand-mirrored from the MERGED design contract in
+ * `.product/DES-CAMPAIGN-001.md` §1.4 (b)–(d) because the crew slice that serves them
+ * (crew#342 slice 1: api-types Campaign contract + store + read routes) is being built in a
+ * parallel lane and studio's installed `wicked-crew-api-types` predates it. Like
+ * `SessionDelivery` in `./types.ts`, every declaration here is TEMPORARY: **delete this
+ * block and re-export from `wicked-crew-api-types`** the moment studio bumps to the
+ * api-types version that carries the Campaign contract. Field names, spellings and null
+ * conventions below are the design's, verbatim — a served payload that disagrees is a
+ * contract bug, not an adoption gap.
+ *
+ * The support probe (§1.5) is the adoption seam: an older daemon has no `/campaigns` route,
+ * so `404` means "this daemon predates campaigns" and the surface says so honestly —
+ * `200 []` is the "no campaigns yet" answer, never a 404.
+ */
+
+import { apiFetch } from './client.js';
+import type { SessionStatus } from './types.js';
+
+/** The campaign — the launch-time label that groups the sibling runs of one effort (§1.4b). */
+export interface Campaign {
+  /** The label itself; minted by first use, never by a create call. */
+  id: string;
+  /** Operator-set display title; `null` ⇒ surfaces render the id. */
+  title: string | null;
+  /**
+   * Operator-declared total run count (>= 1), or `null` when undeclared — the DENOMINATOR of
+   * "n of m landed". §3.3: a surface must SAY which denominator it is using (the "so far"
+   * suffix), never render the two identically.
+   */
+  expected: number | null;
+  /** Unix millis — the first launch that used this label. */
+  created_at: number;
+  /** Unix millis — the newest launch filed here, or the newest metadata write. */
+  updated_at: number;
+  [k: string]: unknown;
+}
+
+/**
+ * Run counts over the campaign's FULL filed set, INCLUDING archived runs — computed
+ * server-side (§4.2: the client's run list is archive-filtered, so a client-derived
+ * denominator shrinks when the operator archives a landed run — remembering what the run
+ * list forgets is the campaign's entire job).
+ */
+export interface CampaignCounts {
+  filed: number;
+  landed: number;
+  failed: number;
+  cancelled: number;
+  /** `planning | distributing | executing`. */
+  running: number;
+  awaitingHuman: number;
+  /** Any status the daemon could not classify — never folded into another bucket. */
+  other: number;
+  /** How many of `filed` are archived — reported so a surface can explain a gap it cannot show. */
+  archived: number;
+}
+
+/** A landed run's pull request (§4.3) — the URL verbatim as the deliver phase printed it. */
+export interface CampaignPr {
+  runId: string;
+  url: string;
+}
+
+/** One row of `GET /campaigns` (§1.4c). */
+export interface CampaignSummary {
+  campaign: Campaign;
+  /** Every run filed under this label, newest launch first. INCLUDES archived runs (§4.2). */
+  runIds: string[];
+  /** The projects those runs are filed into, deduped, first-seen order (§3.4). */
+  projectIds: string[];
+  counts: CampaignCounts;
+  /** Landed runs that opened a PR, newest first; capped server-side. */
+  prs: CampaignPr[];
+  prsTruncated: boolean;
+}
+
+/** One run's place in a campaign (§1.4d). Status is a SNAPSHOT — live status stays the run list's job. */
+export interface CampaignRun {
+  runId: string;
+  /** The run's status at read time; `null` when the engine no longer holds the run. */
+  status: SessionStatus | null;
+  /** The project this run is filed into, or `null` for an unfiled run. */
+  projectId: string | null;
+  problem: string;
+  /** Unix millis — when the label was attached. */
+  filed_at: number;
+  /** The PR this run opened, when it opened one. */
+  prUrl?: string;
+  /** True when the run is archived and therefore absent from the default `GET /runs` list. */
+  archived: boolean;
+  /**
+   * INTEGRATION POINT (TH-20 / test-R22, NOT in DES-CAMPAIGN-001 §1.4): per-node cost, once
+   * campaign budget governance folds token/cost accounting into the evidence manifest and
+   * crew serves it here. Absent on every daemon shipping today — the scoreboard's cost
+   * column renders an honest "—" until the producer exists.
+   */
+  cost?: number;
+}
+
+/** `GET /campaigns/:id` — the summary plus the per-run roll-up the list route is too hot to carry. */
+export interface CampaignDetail {
+  campaign: Campaign;
+  runs: CampaignRun[];
+  counts: CampaignCounts;
+}
+
+/**
+ * The acceptance gate's resolution for one run — the `gate` half of crew's
+ * `GET /runs/:id/acceptance` (a shipping route today; crew-internal `AcceptanceView`, so only
+ * the fields the verdict chip reads are typed here). Deny-dominates: `satisfied` is `true`
+ * only for a clean PASS or when nothing was required; `reason` is always populated.
+ */
+export interface RunAcceptance {
+  runId: string;
+  gate: {
+    required: boolean;
+    satisfied: boolean;
+    verdict: string | null;
+    reason: string;
+  };
+  [k: string]: unknown;
+}
+
+/** `GET /campaigns` — always 200 with `[]` on an empty store; 404 = daemon predates campaigns (§1.5). */
+export function listCampaigns(): Promise<{ campaigns: CampaignSummary[] }> {
+  return apiFetch<{ campaigns: CampaignSummary[] }>('/campaigns');
+}
+
+/** `GET /campaigns/:id` — 404 on an unknown label. */
+export function getCampaign(id: string): Promise<CampaignDetail> {
+  return apiFetch<CampaignDetail>(`/campaigns/${encodeURIComponent(id)}`);
+}
+
+/** `GET /runs/:id/acceptance` — always 200 for a known run ("no ledger" is an answer, not an error). */
+export function getRunAcceptance(runId: string): Promise<RunAcceptance> {
+  return apiFetch<RunAcceptance>(`/runs/${encodeURIComponent(runId)}/acceptance`);
+}

--- a/src/components/CampaignScoreboard.tsx
+++ b/src/components/CampaignScoreboard.tsx
@@ -1,0 +1,448 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getCampaign, type CampaignDetail, type CampaignRun } from '../api/campaigns.js';
+import { downloadRunEvidence } from '../api/client.js';
+import { apiStatus } from '../api/errors.js';
+import type { SessionView } from '../api/types.js';
+import { useAcceptanceStore } from '../store/acceptance.js';
+import { useCampaignsStore, type CampaignNodeLive } from '../store/campaigns.js';
+import { deliveryOf, isPrUrl, resolveDelivery, DELIVERY_LABEL } from './delivery.js';
+import { STATUS_STYLE } from './RunCard.js';
+import { runShortId } from './runIdentity.js';
+
+/**
+ * The campaign scoreboard (TH-14, extends wicked-studio#27) — READ-ONLY: one surface that
+ * groups a campaign's sibling runs. The ladder is one row per filed run (DES-CAMPAIGN-001
+ * §4.4's table, deliberately not a graph — there is no edge data in this model to draw);
+ * node status goes live off core's Campaign* `/ws` frames the moment the daemon relays them
+ * (TH-9 — see `store/campaigns.ts` for the fold and the frame shapes), and falls back to the
+ * live run list, then to the detail snapshot, in that order.
+ *
+ * ── THE WIRE RULES THIS SURFACE HOLDS ────────────────────────────────────────────────────────
+ *  - The delivery rollup ("K of N siblings delivered") reads `session.delivery` off the run
+ *    LIST wire (CREW-UX-8, crew#321) plus the server-resolved `prUrl` snapshot the detail
+ *    payload carries (§4.3) — NEVER a per-run transcript fetch. Zero requests beyond the one
+ *    `GET /campaigns/:id`.
+ *  - Verdict chips are a per-run acceptance read (`GET /runs/:id/acceptance`) behind ONE
+ *    explicit gesture (the MakeDashboard fan-out precedent): zero requests on render,
+ *    exactly N on click, cached per run id forever after (`store/acceptance.ts`).
+ *  - Evidence links download through the existing `GET /runs/:id/evidence` — on click only.
+ *  - The cost column is an honest "—" until TH-20 folds per-node cost into the wire (the
+ *    integration point is typed on `CampaignRun.cost`); flake/coverage trends need the
+ *    TH-6 per-scenario flake history, which has no studio-reachable wire yet — named here so
+ *    it is a known gap, not an invisible one.
+ */
+
+const terminal = (s: string | null): boolean =>
+  s !== null && ['completed', 'failed', 'cancelled'].includes(s);
+
+/** The node-frame status words, rendered with the closest run-status token. */
+const NODE_STATUS_STYLE: Record<string, { label: string; color: string }> = {
+  ready:          { label: 'Ready',          color: 'var(--ink-muted)' },
+  started:        { label: 'Executing',      color: 'var(--status-run)' },
+  awaiting_human: { label: 'Awaiting human', color: 'var(--status-gate)' },
+  completed:      { label: 'Completed',      color: 'var(--status-done)' },
+  failed:         { label: 'Failed',         color: 'var(--status-fail)' },
+  blocked:        { label: 'Blocked',        color: 'var(--status-fail)' },
+};
+
+const CELL: React.CSSProperties = { padding: '8px 10px', verticalAlign: 'top' };
+const HEAD: React.CSSProperties = {
+  ...CELL,
+  textAlign: 'left',
+  color: 'var(--ink-dim)',
+  fontSize: 'var(--text-xs)',
+  fontWeight: 500,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+};
+
+function Chip({ label, color, testid, title, extra }: {
+  label: string;
+  color: string;
+  testid: string;
+  title?: string | undefined;
+  extra?: Record<string, string> | undefined;
+}): React.ReactElement {
+  return (
+    <span
+      data-testid={testid}
+      title={title}
+      {...extra}
+      style={{
+        display: 'inline-block',
+        padding: '1px 8px',
+        borderRadius: '999px',
+        fontSize: 'var(--text-xs)',
+        color,
+        border: `1px solid ${color}`,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
+ * One sibling's row-level facts, joined zero-fetch: live view (run list) over snapshot
+ * (detail), Campaign* node fold over both for the status chip.
+ */
+function rowStatus(
+  row: CampaignRun,
+  view: SessionView | undefined,
+  node: CampaignNodeLive | undefined,
+): { label: string; color: string; source: 'frame' | 'live' | 'snapshot' | 'gone' } {
+  if (node !== undefined) {
+    const s = NODE_STATUS_STYLE[node.status] ?? { label: node.status, color: 'var(--ink-dim)' };
+    return { ...s, source: 'frame' };
+  }
+  const status = view?.session.status ?? row.status;
+  if (status === null) return { label: 'No longer held', color: 'var(--ink-dim)', source: 'gone' };
+  const s = STATUS_STYLE[status] ?? { label: status, color: 'var(--ink-dim)' };
+  return { ...s, source: view !== undefined ? 'live' : 'snapshot' };
+}
+
+interface Props {
+  campaignId: string;
+  /** The board's live run list — sibling rows render live status/delivery from it, zero-fetch. */
+  runs: SessionView[];
+  navigate: (path: string) => void;
+}
+
+export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React.ReactElement {
+  const [detail, setDetail] = useState<CampaignDetail | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [failed, setFailed] = useState<string | null>(null);
+  const live = useCampaignsStore((s) => s.live[campaignId]);
+  const verdicts = useAcceptanceStore((s) => s.byRun);
+  const loadVerdict = useAcceptanceStore((s) => s.load);
+  const [verdictsRequested, setVerdictsRequested] = useState(false);
+
+  // The one fetch this surface makes on its own: the campaign's per-run roll-up. Re-read when
+  // a Campaign* frame for THIS campaign lands (`live` identity changes) — new nodes mean new
+  // filed runs the snapshot does not hold yet. The run list itself arrives via props.
+  useEffect(() => {
+    let cancelled = false;
+    setNotFound(false);
+    setFailed(null);
+    getCampaign(campaignId)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (apiStatus(e) === 404) setNotFound(true);
+        else setFailed(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [campaignId, live]);
+
+  const runsById = useMemo(() => {
+    const m = new Map<string, SessionView>();
+    for (const v of runs) m.set(v.session.id, v);
+    return m;
+  }, [runs]);
+
+  /** Campaign* node fold joined by the runId the started/awaitingHuman frames carry. */
+  const nodeByRun = useMemo(() => {
+    const m = new Map<string, CampaignNodeLive>();
+    for (const id of live?.nodeOrder ?? []) {
+      const n = live?.nodes[id];
+      if (n?.runId != null) m.set(n.runId, n);
+    }
+    return m;
+  }, [live]);
+
+  if (notFound) {
+    return (
+      <div data-testid="campaign-notfound" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
+        <p style={{ marginBottom: '12px' }}>
+          No campaign is filed under <b style={{ color: 'var(--ink-high)' }}>{campaignId}</b> on
+          this daemon — a campaign is minted by its first filed run, so this label either never
+          launched one or lives on another daemon.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/campaigns')}
+          style={{ color: 'var(--status-run)', textDecoration: 'underline' }}
+        >
+          All campaigns
+        </button>
+      </div>
+    );
+  }
+  if (failed !== null) {
+    return (
+      <div data-testid="campaign-load-failed" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
+        {failed}
+      </div>
+    );
+  }
+  if (detail === null) {
+    return (
+      <div data-testid="campaign-loading" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
+        Loading campaign {campaignId}…
+      </div>
+    );
+  }
+
+  const { campaign, counts } = detail;
+  // §3.3 denominator honesty: `expected` set ⇒ a real denominator; unset ⇒ "so far" — two
+  // DIFFERENT strings, never rendered identically, because one of them can grow.
+  const progress =
+    campaign.expected !== null
+      ? `${counts.landed} of ${campaign.expected} landed`
+      : `${counts.landed} of ${counts.filed} landed so far`;
+
+  // The delivery rollup, strictly off wire-carried facts (never a transcript fetch): a
+  // sibling counts as delivered when its live DTO's deliver phase is approved (state
+  // 'delivered' — `session.delivery` is what upgrades the CLAIM to a linkable pr-open), or —
+  // for a run the list no longer shows (archived/gone) — when the detail snapshot carries the
+  // server-resolved prUrl (§4.3).
+  const deliveredCount = detail.runs.filter((row) => {
+    const view = runsById.get(row.runId);
+    if (view !== undefined) return deliveryOf(view).state === 'delivered';
+    return typeof row.prUrl === 'string' && isPrUrl(row.prUrl);
+  }).length;
+
+  const seg = [
+    { n: counts.landed, color: 'var(--status-done)' },
+    { n: counts.failed, color: 'var(--status-fail)' },
+    { n: counts.awaitingHuman, color: 'var(--status-gate)' },
+    { n: counts.running, color: 'var(--status-run)' },
+    { n: counts.cancelled + counts.other, color: 'var(--ink-dim)' },
+  ];
+  const segTotal = Math.max(
+    1,
+    campaign.expected ?? counts.filed,
+    seg.reduce((a, s) => a + s.n, 0),
+  );
+
+  return (
+    <div data-testid="campaign-scoreboard" style={{ padding: '24px', maxWidth: '1100px' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', flexWrap: 'wrap' }}>
+        <h1 style={{ fontSize: 'var(--text-xl)', color: 'var(--ink-high)', fontWeight: 600 }}>
+          {campaign.title ?? campaign.id}
+        </h1>
+        {campaign.title !== null && (
+          <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-sm)' }}>{campaign.id}</span>
+        )}
+        {live?.status != null && (
+          <Chip
+            testid="campaign-live-status"
+            label={live.status}
+            color={
+              live.status === 'completed' ? 'var(--status-done)'
+              : live.status === 'paused' ? 'var(--status-gate)'
+              : 'var(--status-fail)'
+            }
+          />
+        )}
+      </div>
+
+      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
+        <span data-testid="campaign-progress" style={{ color: 'var(--ink-high)', fontSize: 'var(--text-sm)' }}>
+          {progress}
+          {counts.archived > 0 && (
+            <span style={{ color: 'var(--ink-dim)' }}> ({counts.archived} archived)</span>
+          )}
+        </span>
+        <span data-testid="campaign-delivery-rollup" style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>
+          {deliveredCount} of {detail.runs.length} siblings delivered
+        </span>
+      </div>
+
+      <div
+        aria-hidden
+        style={{ marginTop: '8px', display: 'flex', height: '6px', borderRadius: '3px', overflow: 'hidden', background: 'var(--surface-raised)', maxWidth: '520px' }}
+      >
+        {seg.filter((s) => s.n > 0).map((s, i) => (
+          <div key={i} style={{ width: `${(s.n / segTotal) * 100}%`, background: s.color }} />
+        ))}
+      </div>
+
+      <div style={{ marginTop: '20px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <h2 style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-muted)', fontWeight: 500 }}>
+          Sibling runs
+        </h2>
+        {!verdictsRequested ? (
+          // Verdicts are a per-run read the list wire deliberately does not carry — loaded
+          // behind ONE explicit gesture (zero fetches on render, exactly N on click).
+          <button
+            type="button"
+            data-testid="campaign-load-verdicts"
+            onClick={() => {
+              setVerdictsRequested(true);
+              for (const row of detail.runs) if (terminal(runsById.get(row.runId)?.session.status ?? row.status)) loadVerdict(row.runId);
+            }}
+            style={{ color: 'var(--status-run)', fontSize: 'var(--text-xs)', textDecoration: 'underline' }}
+          >
+            Load verdicts
+          </button>
+        ) : null}
+      </div>
+
+      <div style={{ overflowX: 'auto' }}>
+        <table data-testid="campaign-ladder" style={{ marginTop: '8px', borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--surface-raised)' }}>
+              <th style={HEAD}>Run</th>
+              <th style={HEAD}>Status</th>
+              <th style={HEAD}>Verdict</th>
+              <th style={HEAD}>Delivery</th>
+              <th style={HEAD}>Evidence</th>
+              <th style={HEAD} title="Per-node cost lands with campaign budget governance (TH-20); no daemon serves it yet">
+                Cost
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {detail.runs.map((row) => {
+              const view = runsById.get(row.runId);
+              const node = nodeByRun.get(row.runId);
+              const status = rowStatus(row, view, node);
+              // Delivery, zero-fetch: the DTO derivation (which reads the wire-carried
+              // `session.delivery`) with the detail's server-resolved prUrl as the read-back
+              // source — `resolveDelivery` re-validates the shape of both.
+              const d = view !== undefined
+                ? resolveDelivery(deliveryOf(view), row.prUrl ?? null)
+                : null;
+              const href = d?.href ?? null;
+              // The snapshot-only arm (archived / no longer listed) goes through the SAME
+              // shape gate as every other PR claim (delivery.ts's one invariant).
+              const snapshotHref =
+                view === undefined && typeof row.prUrl === 'string' && isPrUrl(row.prUrl)
+                  ? row.prUrl
+                  : null;
+              const verdict = verdicts[row.runId];
+              return (
+                <tr
+                  key={row.runId}
+                  data-testid="campaign-ladder-row"
+                  data-run-id={row.runId}
+                  style={{ borderBottom: '1px solid var(--surface-raised)' }}
+                >
+                  <td style={CELL}>
+                    <button
+                      type="button"
+                      data-testid="campaign-run-link"
+                      onClick={() => navigate(`/runs/${encodeURIComponent(row.runId)}`)}
+                      style={{ color: 'var(--ink-high)', textAlign: 'left' }}
+                      title={row.runId}
+                    >
+                      <span style={{ color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', marginRight: '8px' }}>
+                        {runShortId(row.runId)}
+                      </span>
+                      {row.problem}
+                    </button>
+                    {row.archived && (
+                      <span style={{ marginLeft: '8px', color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}>
+                        archived
+                      </span>
+                    )}
+                  </td>
+                  <td style={CELL}>
+                    <Chip
+                      testid="campaign-node-status"
+                      label={status.label}
+                      color={status.color}
+                      extra={{ 'data-status-source': status.source }}
+                      title={
+                        node?.prompt != null ? node.prompt
+                        : status.source === 'snapshot' ? 'status at last read — the run is not in the live list'
+                        : undefined
+                      }
+                    />
+                  </td>
+                  <td style={CELL}>
+                    {verdict === undefined ? (
+                      <span style={{ color: 'var(--ink-dim)' }}>—</span>
+                    ) : verdict.gate === null ? (
+                      <Chip testid="campaign-verdict-chip" label="unreadable" color="var(--ink-dim)" title={verdict.unavailable ?? undefined} extra={{ 'data-satisfied': 'unknown' }} />
+                    ) : (
+                      <Chip
+                        testid="campaign-verdict-chip"
+                        label={
+                          !verdict.gate.satisfied ? (verdict.gate.verdict ?? 'deny')
+                          : verdict.gate.required ? (verdict.gate.verdict ?? 'pass')
+                          : 'no requirement'
+                        }
+                        color={
+                          !verdict.gate.satisfied ? 'var(--status-fail)'
+                          : verdict.gate.required ? 'var(--status-done)'
+                          : 'var(--ink-dim)'
+                        }
+                        title={verdict.gate.reason}
+                        extra={{ 'data-satisfied': String(verdict.gate.satisfied) }}
+                      />
+                    )}
+                  </td>
+                  <td style={CELL} data-testid="campaign-run-delivery">
+                    {href !== null || snapshotHref !== null ? (
+                      <a
+                        href={(href ?? snapshotHref)!}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{ color: 'var(--status-run)', textDecoration: 'underline' }}
+                      >
+                        {DELIVERY_LABEL['pr-open']}
+                      </a>
+                    ) : (
+                      <span style={{ color: d !== null && d.claim === 'failed' ? 'var(--status-fail)' : 'var(--ink-dim)' }} title={d?.reason ?? undefined}>
+                        {d !== null && DELIVERY_LABEL[d.claim] !== '' ? DELIVERY_LABEL[d.claim] : '—'}
+                      </span>
+                    )}
+                  </td>
+                  <td style={CELL}>
+                    <button
+                      type="button"
+                      data-testid="campaign-evidence-link"
+                      onClick={() => void downloadRunEvidence(row.runId)}
+                      style={{ color: 'var(--status-run)', fontSize: 'var(--text-xs)', textDecoration: 'underline' }}
+                    >
+                      download
+                    </button>
+                  </td>
+                  <td style={CELL} data-testid="campaign-cost-cell">
+                    {typeof row.cost === 'number' ? (
+                      <span style={{ color: 'var(--ink-high)' }}>${row.cost.toFixed(2)}</span>
+                    ) : (
+                      <span style={{ color: 'var(--ink-dim)' }}>—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Ladder rungs the frames announced but no filed run answers yet (a node whose run has
+          not been dispatched, or whose filing the snapshot has not caught up with). */}
+      {(live?.nodeOrder ?? []).filter((id) => {
+        const n = live?.nodes[id];
+        return n !== undefined && (n.runId === null || !detail.runs.some((r) => r.runId === n.runId));
+      }).length > 0 && (
+        <div style={{ marginTop: '12px' }} data-testid="campaign-pending-nodes">
+          {(live?.nodeOrder ?? [])
+            .filter((id) => {
+              const n = live?.nodes[id];
+              return n !== undefined && (n.runId === null || !detail.runs.some((r) => r.runId === n.runId));
+            })
+            .map((id) => {
+              const n = live!.nodes[id]!;
+              const s = NODE_STATUS_STYLE[n.status] ?? { label: n.status, color: 'var(--ink-dim)' };
+              return (
+                <div key={id} data-testid="campaign-pending-node" style={{ display: 'flex', gap: '10px', alignItems: 'center', padding: '4px 0' }}>
+                  <Chip testid="campaign-node-status" label={s.label} color={s.color} extra={{ 'data-status-source': 'frame' }} title={n.prompt ?? undefined} />
+                  <span style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>{id}</span>
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect } from 'react';
+import { useCampaignsStore } from '../store/campaigns.js';
+
+/**
+ * `/campaigns` — every campaign, active and finished, newest-updated first (DES-CAMPAIGN-001
+ * §3.5's escape hatch, exactly as `/runs` is for the board). Read-only (TH-14): each row is
+ * the campaign's progress readout and a link into its scoreboard; zero requests beyond the
+ * store's one `GET /campaigns`.
+ *
+ * The §1.5 probe renders in three honest states — probing / supported / unsupported — never a
+ * boolean, so "not probed yet" cannot read as "not supported". Unsupported names the fact
+ * (this daemon predates campaigns), not an error.
+ */
+
+interface Props {
+  navigate: (path: string) => void;
+}
+
+export function CampaignsPage({ navigate }: Props): React.ReactElement {
+  const support = useCampaignsStore((s) => s.support);
+  const summaries = useCampaignsStore((s) => s.summaries);
+  const refresh = useCampaignsStore((s) => s.refresh);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (support === 'unknown') {
+    return (
+      <div data-testid="campaigns-probing" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
+        Checking this daemon for campaigns…
+      </div>
+    );
+  }
+  if (support === 'unsupported') {
+    return (
+      <div data-testid="campaigns-unsupported" style={{ padding: '32px', color: 'var(--ink-muted)', maxWidth: '640px' }}>
+        This daemon has no campaign surface — `GET /campaigns` is not served, which means the
+        connected wicked-crew predates campaign grouping. Upgrade the daemon to group a
+        multi-run effort's sibling runs here.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="campaigns-page" style={{ padding: '24px', maxWidth: '900px' }}>
+      <h1 style={{ fontSize: 'var(--text-xl)', color: 'var(--ink-high)', fontWeight: 600 }}>
+        Campaigns
+      </h1>
+      {summaries.length === 0 ? (
+        <p data-testid="campaigns-empty" style={{ marginTop: '16px', color: 'var(--ink-muted)' }}>
+          No campaigns yet. A campaign is minted by its first filed run — launch a run with a
+          campaign label and it appears here.
+        </p>
+      ) : (
+        <div style={{ marginTop: '16px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {summaries.map((s) => {
+            // §3.3 denominator honesty, same two strings as the scoreboard header.
+            const progress =
+              s.campaign.expected !== null
+                ? `${s.counts.landed} of ${s.campaign.expected} landed`
+                : `${s.counts.landed} of ${s.counts.filed} landed so far`;
+            const attention =
+              s.counts.awaitingHuman > 0 ? { word: `${s.counts.awaitingHuman} waiting on you`, color: 'var(--status-gate)' }
+              : s.counts.failed > 0 ? { word: `${s.counts.failed} failed`, color: 'var(--status-fail)' }
+              : s.counts.running > 0 ? { word: `${s.counts.running} running`, color: 'var(--status-run)' }
+              : null;
+            return (
+              <button
+                key={s.campaign.id}
+                type="button"
+                data-testid="campaign-row"
+                data-campaign-id={s.campaign.id}
+                onClick={() => navigate(`/campaigns/${encodeURIComponent(s.campaign.id)}`)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: '14px',
+                  padding: '12px 14px',
+                  textAlign: 'left',
+                  background: 'var(--surface-card)',
+                  border: '1px solid var(--surface-raised)',
+                  borderRadius: 'var(--radius-lg)',
+                }}
+              >
+                <span style={{ color: 'var(--ink-high)', fontWeight: 500 }}>
+                  {s.campaign.title ?? s.campaign.id}
+                </span>
+                <span style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>{progress}</span>
+                {attention !== null && (
+                  <span style={{ color: attention.color, fontSize: 'var(--text-sm)' }}>{attention.word}</span>
+                )}
+                {s.projectIds.length > 0 && (
+                  <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)', marginLeft: 'auto' }}>
+                    {s.projectIds.length === 1 ? '1 project' : `${s.projectIds.length} projects`}
+                    {s.prs.length > 0 && ` · ${s.prs.length}${s.prsTruncated ? '+' : ''} PR${s.prs.length === 1 && !s.prsTruncated ? '' : 's'}`}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -3,9 +3,9 @@ import { useCallback, useEffect, useState } from 'react';
 // `make` is the round-4 primary-path dashboard route (DES-FEEDBACK-003 §2.1) —
 // a CLIENT route (a new panel id in this union), not a wire. Slice M registers
 // it with a placeholder surface; the real dashboard is slice O (§4.2).
-export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make';
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'campaigns' | 'campaign-detail';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make', 'campaigns'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not
@@ -44,6 +44,8 @@ interface Route {
    *  VIEW of the project's build work, §3's adopted additive position), so
    *  this flag — not a fifth Mode — is what selects the view. */
   chronicleView: boolean;
+  /** Non-null only on `/campaigns/:id` (DES-CAMPAIGN-001 §3.5 / TH-14) — the campaign label. */
+  campaignId: string | null;
 }
 
 /** Route options a caller can override; everything else takes its inert default. */
@@ -58,6 +60,7 @@ const INERT: Route = {
   mode: null,
   artifactId: null,
   chronicleView: false,
+  campaignId: null,
 };
 
 function route(over: Partial<Route>): Route {
@@ -164,6 +167,11 @@ function parse(pathname: string): Route {
       runId: mode === 'build' || mode === 'chat' ? artifactId : null,
       chatMode: mode === 'chat',
     });
+  }
+  // `/campaigns/:id` — one campaign's scoreboard (DES-CAMPAIGN-001 §3.5 / TH-14); the bare
+  // `/campaigns` list resolves through the PANELS catch-all below, same as `/repos`.
+  if (first === 'campaigns' && second) {
+    return route({ panel: 'campaign-detail', campaignId: safeDecode(second) });
   }
   if (first === 'repo-detail' && second) {
     return route({ panel: 'repo-detail', repoId: safeDecode(second) });

--- a/src/store/acceptance.ts
+++ b/src/store/acceptance.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { getRunAcceptance, type RunAcceptance } from '../api/campaigns.js';
+
+/**
+ * Per-run acceptance verdicts (TH-14's verdict chips) — `GET /runs/:id/acceptance`, crew's
+ * deny-dominates gate over the QE ledger, on the posture `store/delivery.ts` set:
+ *
+ *  - ONE fetch per run, cached per run id, in-flight-deduped. A failed fetch caches the
+ *    degraded answer too, so revisits never re-fire.
+ *  - NEVER called on render. The scoreboard loads verdicts behind ONE explicit operator
+ *    gesture (the MakeDashboard fan-out precedent: zero requests on render, exactly N on
+ *    click) — the wire law forbids an implicit N-fetch fan-out, and acceptance is a per-run
+ *    read the list wire deliberately does not carry.
+ */
+export interface RunVerdict {
+  /** The gate's answer, or `null` when the read failed (rendered as "unreadable", never as a verdict). */
+  gate: RunAcceptance['gate'] | null;
+  unavailable: string | null;
+}
+
+interface AcceptanceStore {
+  /** Resolved verdict per run id. An ABSENT key = not read yet (never "no verdict"). */
+  byRun: Record<string, RunVerdict>;
+  /** The one acceptance fetch per run; cached + deduped. Fire only from an explicit gesture. */
+  load: (runId: string) => void;
+}
+
+const inflight = new Set<string>();
+
+export const useAcceptanceStore = create<AcceptanceStore>((set, get) => ({
+  byRun: {},
+
+  load: (runId) => {
+    if (get().byRun[runId] !== undefined || inflight.has(runId)) return;
+    inflight.add(runId);
+    getRunAcceptance(runId)
+      .then((view) => {
+        set((s) => ({ byRun: { ...s.byRun, [runId]: { gate: view.gate ?? null, unavailable: null } } }));
+      })
+      .catch(() => {
+        set((s) => ({
+          byRun: {
+            ...s.byRun,
+            [runId]: { gate: null, unavailable: 'the acceptance gate could not be read' },
+          },
+        }));
+      })
+      .finally(() => {
+        inflight.delete(runId);
+      });
+  },
+}));

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -1,0 +1,154 @@
+import { create } from 'zustand';
+import { listCampaigns, type CampaignSummary } from '../api/campaigns.js';
+import type { CoreEvent } from '../api/types.js';
+
+/**
+ * The campaign store (DES-CAMPAIGN-001 §1.5/§2.4 + TH-14): the support probe, the campaign
+ * list, and the LIVE fold of core's Campaign* `/ws` frames.
+ *
+ * Three states for support, never a boolean, so "not probed yet" cannot render as "not
+ * supported" (§1.5): `200` on `GET /campaigns` ⇒ supported (`[]` is the "no campaigns yet"
+ * answer); `404` ⇒ this daemon predates campaigns; any other failure ⇒ unsupported, said
+ * once, honestly.
+ *
+ * ── The Campaign* frame fold (TH-9 integration point) ───────────────────────────────────────
+ * wicked-core already serializes eleven Campaign* CoreEvents (campaignLaunched,
+ * campaignNodeReady|Started|AwaitingHuman|Completed|Failed|Blocked, campaignPaused|
+ * Completed|Failed|Cancelled — `crates/wicked-core-ts/src/lib.rs` event_to_json, camelCase
+ * tagged JSON); the crew daemon's `/ws` fan-out forwards frames VERBATIM, and studio's
+ * `useEventStream` passes unknown variants through by design. TH-9 (extends crew#342) is the
+ * lane that makes the daemon EMIT them; this fold is written against core's serialized shape
+ * — `{ type, campaign, node?, runId?, prompt? }` — so the scoreboard's node status goes live
+ * the moment those frames flow, with no change here. Until then the fold simply never fires
+ * and status comes from the run list + detail snapshot.
+ *
+ * The fold is deliberately NOT a cache of the campaign store's join (§2.4's rule): it holds
+ * only what frames carry — per-node live status — and the REST payloads stay the system of
+ * record for membership and counts.
+ */
+
+export type CampaignSupport = 'unknown' | 'supported' | 'unsupported';
+
+/** A campaign node's live status, exactly as the frame stream last reported it. */
+export type CampaignNodeStatus =
+  | 'ready'
+  | 'started'
+  | 'awaiting_human'
+  | 'completed'
+  | 'failed'
+  | 'blocked';
+
+export interface CampaignNodeLive {
+  status: CampaignNodeStatus;
+  /** The governed run dispatched for this node — carried by started/awaitingHuman frames. */
+  runId: string | null;
+  /** The pending HITL prompt when status is `awaiting_human`. */
+  prompt: string | null;
+}
+
+/** A campaign's terminal/paused state off the campaign-level frames; `null` = launched/running. */
+export type CampaignLiveStatus = 'paused' | 'completed' | 'failed' | 'cancelled' | null;
+
+export interface CampaignLive {
+  status: CampaignLiveStatus;
+  /** Node id → live status, in first-seen order (`nodeOrder` preserves the ladder). */
+  nodes: Record<string, CampaignNodeLive>;
+  nodeOrder: string[];
+}
+
+/** The Campaign* frame shapes core-ts serializes (camelCase tagged JSON). */
+const NODE_STATUS_BY_TYPE: Record<string, CampaignNodeStatus> = {
+  campaignNodeReady: 'ready',
+  campaignNodeStarted: 'started',
+  campaignNodeAwaitingHuman: 'awaiting_human',
+  campaignNodeCompleted: 'completed',
+  campaignNodeFailed: 'failed',
+  campaignNodeBlocked: 'blocked',
+};
+
+const CAMPAIGN_STATUS_BY_TYPE: Record<string, CampaignLiveStatus> = {
+  campaignPaused: 'paused',
+  campaignCompleted: 'completed',
+  campaignFailed: 'failed',
+  campaignCancelled: 'cancelled',
+};
+
+interface CampaignsStore {
+  support: CampaignSupport;
+  /** `GET /campaigns` rows, server-ordered (newest-updated first). */
+  summaries: CampaignSummary[];
+  /** Live frame fold, keyed by campaign id. */
+  live: Record<string, CampaignLive>;
+  /** Probe + (re)fetch the list. Sets `support` from the answer (§1.5). */
+  refresh: () => Promise<void>;
+  /** Fold one `/ws` frame; non-campaign frames are a cheap string-prefix miss. */
+  ingest: (event: CoreEvent) => void;
+}
+
+/** In-flight guard so a burst of refresh calls costs one fetch. */
+let inflight: Promise<void> | null = null;
+
+export const useCampaignsStore = create<CampaignsStore>((set) => ({
+  support: 'unknown',
+  summaries: [],
+  live: {},
+
+  refresh: () => {
+    if (inflight !== null) return inflight;
+    inflight = listCampaigns()
+      .then(({ campaigns }) => {
+        set({ support: 'supported', summaries: campaigns });
+      })
+      .catch(() => {
+        // 404 = the route does not exist on this daemon (§1.5's whole discriminator);
+        // anything else (network, 500) also reads as unsupported — said once, not spun on.
+        set({ support: 'unsupported', summaries: [] });
+      })
+      .finally(() => {
+        inflight = null;
+      });
+    return inflight;
+  },
+
+  ingest: (event) => {
+    if (!event.type.startsWith('campaign')) return;
+    const frame = event as unknown as Record<string, unknown>;
+    const campaign = typeof frame['campaign'] === 'string' ? frame['campaign'] : null;
+    if (campaign === null) return;
+
+    const nodeStatus = NODE_STATUS_BY_TYPE[event.type];
+    const campaignStatus = CAMPAIGN_STATUS_BY_TYPE[event.type];
+    const isLaunch = event.type === 'campaignLaunched';
+    if (nodeStatus === undefined && campaignStatus === undefined && !isLaunch) return;
+
+    set((s) => {
+      const prev: CampaignLive = s.live[campaign] ?? { status: null, nodes: {}, nodeOrder: [] };
+      // A (re)launch resets the fold — a resumed campaign replays its truth in new frames.
+      if (isLaunch) {
+        return { live: { ...s.live, [campaign]: { status: null, nodes: {}, nodeOrder: [] } } };
+      }
+      if (campaignStatus !== undefined) {
+        return { live: { ...s.live, [campaign]: { ...prev, status: campaignStatus } } };
+      }
+      // Node frame: `node` names the ladder rung; started/awaitingHuman also carry `runId`.
+      const node = typeof frame['node'] === 'string' ? frame['node'] : null;
+      if (node === null) return s;
+      const existing = prev.nodes[node];
+      const runId = typeof frame['runId'] === 'string' ? frame['runId'] : (existing?.runId ?? null);
+      const prompt =
+        nodeStatus === 'awaiting_human' && typeof frame['prompt'] === 'string'
+          ? frame['prompt']
+          : null;
+      return {
+        live: {
+          ...s.live,
+          [campaign]: {
+            ...prev,
+            nodes: { ...prev.nodes, [node]: { status: nodeStatus!, runId, prompt } },
+            nodeOrder: existing !== undefined ? prev.nodeOrder : [...prev.nodeOrder, node],
+          },
+        },
+      };
+    });
+  },
+}));

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.1",
   "counts": {
     "files": 95,
-    "occurrences": 668,
-    "static": 565,
+    "occurrences": 676,
+    "static": 572,
     "dynamic": 38,
     "computed": 5
   },
@@ -21,6 +21,12 @@
       "testId": "accent-reset",
       "files": [
         "src/components/AppearanceSettings.tsx"
+      ]
+    },
+    {
+      "testId": "acceptance-gate-line",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
       ]
     },
     {
@@ -702,6 +708,18 @@
       ]
     },
     {
+      "testId": "conformance-claim",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
+      "testId": "conformance-rule-citation",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
       "testId": "connection-dot",
       "files": [
         "src/components/AppChrome.tsx"
@@ -1326,6 +1344,24 @@
       ]
     },
     {
+      "testId": "governance-claims-unavailable",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
+      "testId": "governance-coverage-boundary",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
+      "testId": "governance-enforcement",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
       "testId": "governance-run-decision",
       "files": [
         "src/components/GovernanceAudit.tsx"
@@ -1333,6 +1369,12 @@
     },
     {
       "testId": "governance-run-record",
+      "files": [
+        "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
+      "testId": "governance-unenforced-unit",
       "files": [
         "src/components/GovernanceAudit.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,23 +10,17 @@
   "version": 1,
   "studioVersion": "0.4.1",
   "counts": {
-    "files": 93,
-    "occurrences": 655,
-    "static": 552,
+    "files": 95,
+    "occurrences": 668,
+    "static": 565,
     "dynamic": 38,
-    "computed": 4
+    "computed": 5
   },
   "static": [
     {
       "testId": "accent-reset",
       "files": [
         "src/components/AppearanceSettings.tsx"
-      ]
-    },
-    {
-      "testId": "acceptance-gate-line",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
       ]
     },
     {
@@ -374,6 +368,126 @@
       ]
     },
     {
+      "testId": "campaign-cost-cell",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-delivery-rollup",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-evidence-link",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-ladder",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-ladder-row",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-load-failed",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-load-verdicts",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-loading",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-notfound",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-pending-node",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-pending-nodes",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-progress",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-row",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-run-delivery",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-run-link",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-scoreboard",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-empty",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-page",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-probing",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-unsupported",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
       "testId": "chain-header",
       "files": [
         "src/components/WorkChronicle.tsx"
@@ -585,18 +699,6 @@
       "testId": "compare-vs",
       "files": [
         "src/components/DocPanel.tsx"
-      ]
-    },
-    {
-      "testId": "conformance-claim",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
-      "testId": "conformance-rule-citation",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
       ]
     },
     {
@@ -1224,24 +1326,6 @@
       ]
     },
     {
-      "testId": "governance-claims-unavailable",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
-      "testId": "governance-coverage-boundary",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
-      "testId": "governance-enforcement",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
       "testId": "governance-run-decision",
       "files": [
         "src/components/GovernanceAudit.tsx"
@@ -1249,12 +1333,6 @@
     },
     {
       "testId": "governance-run-record",
-      "files": [
-        "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
-      "testId": "governance-unenforced-unit",
       "files": [
         "src/components/GovernanceAudit.tsx"
       ]
@@ -3605,6 +3683,12 @@
         "src/components/ProvenanceLine.tsx",
         "src/components/RunSparkline.tsx",
         "src/components/RunsBottomPanel.tsx"
+      ]
+    },
+    {
+      "expression": "testid",
+      "files": [
+        "src/components/CampaignScoreboard.tsx"
       ]
     },
     {

--- a/tests/CampaignScoreboard.test.tsx
+++ b/tests/CampaignScoreboard.test.tsx
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { CoreEvent, SessionView } from '../src/api/types.js';
+import type { SessionWithDelivery } from '../src/api/types.js';
+import type { CampaignDetail } from '../src/api/campaigns.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The campaign scoreboard (TH-14, extends studio#27) — ONE surface groups a campaign's
+ * sibling runs, demo-able entirely off mocked wire payloads + mocked Campaign* frames.
+ * Pinned here:
+ *   - the ladder is one row per filed sibling, joined live to the run list;
+ *   - the delivery rollup reads `session.delivery` (crew#321) / the detail's server-resolved
+ *     prUrl — NEVER a per-run transcript fetch (asserted: zero network calls on render);
+ *   - node status flips LIVE off Campaign* frames (data-status-source="frame");
+ *   - verdict chips load behind ONE explicit gesture, terminal rows only;
+ *   - §3.3 denominator honesty ("of N landed" vs "of N landed so far" — two strings);
+ *   - the cost column is an honest "—" until TH-20's wire exists;
+ *   - an unknown campaign states the fact and offers /campaigns, never a spinner.
+ */
+
+const getCampaign = vi.fn();
+const getRunAcceptance = vi.fn();
+
+vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/campaigns.js')>()),
+  getCampaign: (id: string) => getCampaign(id) as Promise<unknown>,
+  getRunAcceptance: (id: string) => getRunAcceptance(id) as Promise<unknown>,
+}));
+
+const { CampaignScoreboard } = await import('../src/components/CampaignScoreboard.js');
+const { useCampaignsStore } = await import('../src/store/campaigns.js');
+const { useAcceptanceStore } = await import('../src/store/acceptance.js');
+const { ApiError } = await import('../src/api/errors.js');
+
+const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
+  ({ type, ...fields }) as CoreEvent;
+
+function detail(over: Partial<CampaignDetail['campaign']> = {}, runs: CampaignDetail['runs'] = []): CampaignDetail {
+  return {
+    campaign: { id: 'DES-X', title: null, expected: null, created_at: 1, updated_at: 2, ...over },
+    runs,
+    counts: {
+      filed: runs.length,
+      landed: runs.filter((r) => r.status === 'completed').length,
+      failed: 0,
+      cancelled: 0,
+      running: 0,
+      awaitingHuman: 0,
+      other: 0,
+      archived: runs.filter((r) => r.archived).length,
+    },
+  };
+}
+
+const row = (
+  runId: string,
+  over: Partial<CampaignDetail['runs'][number]> = {},
+): CampaignDetail['runs'][number] => ({
+  runId,
+  status: 'completed',
+  projectId: null,
+  problem: `problem of ${runId}`,
+  filed_at: 10,
+  archived: false,
+  ...over,
+});
+
+/** A sibling that DELIVERED: approved deliver unit + the wire-carried session.delivery. */
+function deliveredView(id: string, url: string): SessionView {
+  const v = makeView({ id, status: 'completed' }, [
+    makeUnit({ id: `wf-${id}:deliver`, session_id: id, status: 'done' }),
+  ]);
+  (v.session as SessionWithDelivery).delivery = { kind: 'pull_request', url };
+  return v;
+}
+
+const fetchSpy = vi.fn(() => Promise.reject(new Error('network use is banned on this surface')));
+
+beforeEach(() => {
+  getCampaign.mockReset();
+  getRunAcceptance.mockReset();
+  fetchSpy.mockClear();
+  vi.stubGlobal('fetch', fetchSpy);
+  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+  useAcceptanceStore.setState({ byRun: {} });
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function board(runs: SessionView[], navigate: (p: string) => void = () => {}) {
+  return render(<CampaignScoreboard campaignId="DES-X" runs={runs} navigate={navigate} />);
+}
+
+describe('one surface groups the sibling runs', () => {
+  it('renders one ladder row per filed sibling — live, archived and gone alike', async () => {
+    getCampaign.mockResolvedValue(
+      detail({ expected: 3 }, [
+        row('r1'),
+        row('r2', { status: 'executing' }),
+        row('r3', { archived: true, prUrl: 'https://github.com/o/x/pull/7' }),
+      ]),
+    );
+    board([deliveredView('r1', 'https://github.com/o/x/pull/5'), makeView({ id: 'r2', status: 'executing' })]);
+
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    const rows = screen.getAllByTestId('campaign-ladder-row').map((r) => r.getAttribute('data-run-id'));
+    expect(rows).toEqual(['r1', 'r2', 'r3']);
+    // The archived sibling is stated, never dropped (§4.2's whole argument).
+    expect(screen.getByText('archived')).toBeInTheDocument();
+  });
+
+  it('the delivery rollup reads session.delivery + the snapshot prUrl — ZERO fetches', async () => {
+    getCampaign.mockResolvedValue(
+      detail({ expected: 3 }, [
+        row('r1'),
+        row('r2', { status: 'executing' }),
+        row('r3', { archived: true, prUrl: 'https://github.com/o/x/pull/7' }),
+      ]),
+    );
+    board([deliveredView('r1', 'https://github.com/o/x/pull/5'), makeView({ id: 'r2', status: 'executing' })]);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('campaign-delivery-rollup').textContent).toBe('2 of 3 siblings delivered'),
+    );
+    // The AC's hard rule: the rollup NEVER costs a transcript fetch — no network at all
+    // beyond the mocked GET /campaigns/:id this surface owns.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getRunAcceptance).not.toHaveBeenCalled();
+    // The wire-carried url renders as the linkable PR claim on the delivered row.
+    const links = screen.getAllByRole('link');
+    expect(links.map((l) => l.getAttribute('href'))).toContain('https://github.com/o/x/pull/5');
+    // The archived row's server-resolved snapshot url is linkable too (§4.3).
+    expect(links.map((l) => l.getAttribute('href'))).toContain('https://github.com/o/x/pull/7');
+  });
+
+  it('§3.3 denominator honesty: expected set vs unset are two DIFFERENT strings', async () => {
+    getCampaign.mockResolvedValue(detail({ expected: 18 }, [row('r1')]));
+    board([]);
+    await waitFor(() =>
+      expect(screen.getByTestId('campaign-progress').textContent).toContain('1 of 18 landed'),
+    );
+    expect(screen.getByTestId('campaign-progress').textContent).not.toContain('so far');
+    cleanup();
+
+    getCampaign.mockResolvedValue(detail({ expected: null }, [row('r1')]));
+    board([]);
+    await waitFor(() =>
+      expect(screen.getByTestId('campaign-progress').textContent).toContain('1 of 1 landed so far'),
+    );
+  });
+});
+
+describe('node status from Campaign* WS frames (mocked — the TH-9 wire shape)', () => {
+  it('a campaignNodeStarted frame flips the joined row to frame-sourced Executing, live', async () => {
+    getCampaign.mockResolvedValue(detail({}, [row('r1', { status: 'planning' })]));
+    board([makeView({ id: 'r1', status: 'planning' })]);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+
+    act(() => {
+      useCampaignsStore
+        .getState()
+        .ingest(frame('campaignNodeStarted', { campaign: 'DES-X', node: 'n-r1', runId: 'r1' }));
+    });
+
+    await waitFor(() => {
+      const chip = screen
+        .getAllByTestId('campaign-node-status')
+        .find((c) => c.closest('[data-run-id]')?.getAttribute('data-run-id') === 'r1');
+      expect(chip?.getAttribute('data-status-source')).toBe('frame');
+      expect(chip?.textContent).toBe('Executing');
+    });
+  });
+
+  it('an awaitingHuman frame carries its prompt onto the chip; nodes with no filed run render as pending rungs', async () => {
+    getCampaign.mockResolvedValue(detail({}, [row('r1', { status: 'executing' })]));
+    board([makeView({ id: 'r1', status: 'executing' })]);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+
+    act(() => {
+      useCampaignsStore.getState().ingest(
+        frame('campaignNodeAwaitingHuman', { campaign: 'DES-X', node: 'n-r1', runId: 'r1', prompt: 'approve AC-3?' }),
+      );
+      useCampaignsStore.getState().ingest(frame('campaignNodeReady', { campaign: 'DES-X', node: 'n-later' }));
+    });
+
+    await waitFor(() => {
+      const chip = screen
+        .getAllByTestId('campaign-node-status')
+        .find((c) => c.closest('[data-run-id]')?.getAttribute('data-run-id') === 'r1');
+      expect(chip?.textContent).toBe('Awaiting human');
+      expect(chip?.getAttribute('title')).toBe('approve AC-3?');
+    });
+    expect(screen.getByTestId('campaign-pending-nodes').textContent).toContain('n-later');
+  });
+
+  it('campaign-level frames render the live-status chip', async () => {
+    getCampaign.mockResolvedValue(detail({}, [row('r1')]));
+    board([]);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    act(() => {
+      useCampaignsStore.getState().ingest(frame('campaignPaused', { campaign: 'DES-X' }));
+    });
+    await waitFor(() => expect(screen.getByTestId('campaign-live-status').textContent).toBe('paused'));
+  });
+});
+
+describe('verdict chips — per-run acceptance behind ONE explicit gesture', () => {
+  it('zero acceptance reads on render; the gesture fires exactly one per TERMINAL sibling', async () => {
+    getCampaign.mockResolvedValue(
+      detail({}, [row('r1'), row('r2', { status: 'executing' }), row('r3', { status: 'failed' })]),
+    );
+    getRunAcceptance.mockImplementation((id: string) =>
+      Promise.resolve({
+        runId: id,
+        gate:
+          id === 'r1'
+            ? { required: true, satisfied: true, verdict: 'PASS', reason: 'ok' }
+            : { required: true, satisfied: false, verdict: null, reason: 'no QE ledger — missing ⇒ deny' },
+      }),
+    );
+    board([makeView({ id: 'r2', status: 'executing' })]);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    expect(getRunAcceptance).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('campaign-load-verdicts'));
+    await waitFor(() => expect(screen.getAllByTestId('campaign-verdict-chip')).toHaveLength(2));
+    // Exactly the terminal siblings — never the executing one.
+    expect(getRunAcceptance.mock.calls.map((c) => c[0]).sort()).toEqual(['r1', 'r3']);
+
+    const chips = screen.getAllByTestId('campaign-verdict-chip');
+    expect(chips.map((c) => c.getAttribute('data-satisfied')).sort()).toEqual(['false', 'true']);
+    // Deny-dominates renders the gate's own reason, not an invented word.
+    expect(chips.find((c) => c.getAttribute('data-satisfied') === 'false')?.getAttribute('title')).toContain(
+      'no QE ledger',
+    );
+  });
+});
+
+describe('honest degradation', () => {
+  it('an unknown campaign states the fact in words and offers /campaigns — never a spinner', async () => {
+    getCampaign.mockRejectedValue(new ApiError(404, 'Unknown campaign'));
+    const navigate = vi.fn();
+    board([], navigate);
+    await waitFor(() => expect(screen.getByTestId('campaign-notfound')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('All campaigns'));
+    expect(navigate).toHaveBeenCalledWith('/campaigns');
+  });
+
+  it('the cost column renders an honest "—" until TH-20 wires per-node cost', async () => {
+    getCampaign.mockResolvedValue(detail({}, [row('r1'), row('r2', { cost: 1.5 })]));
+    board([]);
+    await waitFor(() => expect(screen.getAllByTestId('campaign-cost-cell')).toHaveLength(2));
+    const cells = screen.getAllByTestId('campaign-cost-cell').map((c) => c.textContent);
+    expect(cells).toEqual(['—', '$1.50']);
+  });
+});

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { CampaignSummary } from '../src/api/campaigns.js';
+
+/**
+ * `/campaigns` (TH-14 / DES-CAMPAIGN-001 §3.5): the escape-hatch list over every campaign.
+ * Pinned: the §1.5 probe's three honest states (probing / supported / unsupported — never a
+ * boolean), the empty answer as words, the row's denominator honesty, and the row → scoreboard
+ * navigation.
+ */
+
+const listCampaigns = vi.fn();
+
+vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/campaigns.js')>()),
+  listCampaigns: () => listCampaigns() as Promise<unknown>,
+}));
+
+const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
+const { useCampaignsStore } = await import('../src/store/campaigns.js');
+const { ApiError } = await import('../src/api/errors.js');
+
+function summary(id: string, over: Partial<CampaignSummary['campaign']> = {}, counts: Partial<CampaignSummary['counts']> = {}): CampaignSummary {
+  return {
+    campaign: { id, title: null, expected: null, created_at: 1, updated_at: 2, ...over },
+    runIds: [],
+    projectIds: ['p1'],
+    counts: { filed: 0, landed: 0, failed: 0, cancelled: 0, running: 0, awaitingHuman: 0, other: 0, archived: 0, ...counts },
+    prs: [],
+    prsTruncated: false,
+  };
+}
+
+beforeEach(() => {
+  listCampaigns.mockReset();
+  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+});
+afterEach(() => cleanup());
+
+describe('the §1.5 probe states', () => {
+  it('404 renders the honest "daemon predates campaigns" copy — a fact, not an error', async () => {
+    listCampaigns.mockRejectedValue(new ApiError(404, 'Not Found'));
+    render(<CampaignsPage navigate={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('campaigns-unsupported')).toBeInTheDocument());
+    expect(screen.getByTestId('campaigns-unsupported').textContent).toContain('predates campaign grouping');
+  });
+
+  it('200 [] is the "no campaigns yet" answer, in words that name how one is minted', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [] });
+    render(<CampaignsPage navigate={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument());
+    expect(screen.getByTestId('campaigns-empty').textContent).toContain('minted by its first filed run');
+  });
+});
+
+describe('the list', () => {
+  it('rows carry the honest denominator and navigate into the scoreboard', async () => {
+    listCampaigns.mockResolvedValue({
+      campaigns: [
+        summary('DES-MERGE-001', { expected: 18 }, { filed: 17, landed: 15 }),
+        summary('estate-rollout', { expected: null }, { filed: 6, landed: 2, awaitingHuman: 1 }),
+      ],
+    });
+    const navigate = vi.fn();
+    render(<CampaignsPage navigate={navigate} />);
+    await waitFor(() => expect(screen.getAllByTestId('campaign-row')).toHaveLength(2));
+
+    const rows = screen.getAllByTestId('campaign-row');
+    // §3.3: a declared denominator has no "so far"; an undeclared one MUST say it.
+    expect(rows[0]!.textContent).toContain('15 of 18 landed');
+    expect(rows[0]!.textContent).not.toContain('so far');
+    expect(rows[1]!.textContent).toContain('2 of 6 landed so far');
+    expect(rows[1]!.textContent).toContain('1 waiting on you');
+
+    fireEvent.click(rows[0]!);
+    expect(navigate).toHaveBeenCalledWith('/campaigns/DES-MERGE-001');
+  });
+});

--- a/tests/campaigns.store.test.ts
+++ b/tests/campaigns.store.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+
+/**
+ * The campaign store (TH-14): the §1.5 support probe's three states and the Campaign* frame
+ * fold — written against core-ts's serialized shapes (camelCase tagged JSON, `event_to_json`:
+ * campaignLaunched / campaignNode{Ready,Started,AwaitingHuman,Completed,Failed,Blocked} /
+ * campaign{Paused,Completed,Failed,Cancelled}), the wire TH-9's daemon passthrough relays
+ * verbatim. Frames are MOCKED here — the fold must be demo-able with no daemon at all.
+ */
+
+const listCampaigns = vi.fn();
+
+vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/campaigns.js')>()),
+  listCampaigns: () => listCampaigns() as Promise<unknown>,
+}));
+
+const { useCampaignsStore } = await import('../src/store/campaigns.js');
+const { ApiError } = await import('../src/api/errors.js');
+
+const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
+  ({ type, ...fields }) as CoreEvent;
+
+beforeEach(() => {
+  listCampaigns.mockReset();
+  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('the §1.5 support probe — three states, never a boolean', () => {
+  it('starts unknown ("not probed yet" must never render as "not supported")', () => {
+    expect(useCampaignsStore.getState().support).toBe('unknown');
+  });
+
+  it('200 with [] is SUPPORTED — the "no campaigns yet" answer, never a 404', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [] });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().support).toBe('supported');
+    expect(useCampaignsStore.getState().summaries).toEqual([]);
+  });
+
+  it('404 = this daemon predates campaigns → unsupported', async () => {
+    listCampaigns.mockRejectedValue(new ApiError(404, 'Not Found'));
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().support).toBe('unsupported');
+  });
+});
+
+describe('the Campaign* frame fold', () => {
+  const ingest = (e: CoreEvent): void => useCampaignsStore.getState().ingest(e);
+
+  it('node frames build the ladder in first-seen order, newest status per node winning', () => {
+    ingest(frame('campaignNodeReady', { campaign: 'C1', node: 'n-api' }));
+    ingest(frame('campaignNodeReady', { campaign: 'C1', node: 'n-ui' }));
+    ingest(frame('campaignNodeStarted', { campaign: 'C1', node: 'n-api', runId: 'run-1' }));
+    ingest(frame('campaignNodeCompleted', { campaign: 'C1', node: 'n-api' }));
+
+    const live = useCampaignsStore.getState().live['C1']!;
+    expect(live.nodeOrder).toEqual(['n-api', 'n-ui']);
+    expect(live.nodes['n-api']).toEqual({ status: 'completed', runId: 'run-1', prompt: null });
+    expect(live.nodes['n-ui']).toEqual({ status: 'ready', runId: null, prompt: null });
+  });
+
+  it('the runId a started frame carried SURVIVES later frames for the node (the ladder join key)', () => {
+    ingest(frame('campaignNodeStarted', { campaign: 'C1', node: 'n1', runId: 'run-9' }));
+    ingest(frame('campaignNodeFailed', { campaign: 'C1', node: 'n1' }));
+    expect(useCampaignsStore.getState().live['C1']!.nodes['n1']!.runId).toBe('run-9');
+  });
+
+  it('awaitingHuman carries the prompt; a later status clears it', () => {
+    ingest(frame('campaignNodeAwaitingHuman', { campaign: 'C1', node: 'n1', runId: 'r', prompt: 'approve AC-3?' }));
+    expect(useCampaignsStore.getState().live['C1']!.nodes['n1']!.prompt).toBe('approve AC-3?');
+    ingest(frame('campaignNodeCompleted', { campaign: 'C1', node: 'n1' }));
+    expect(useCampaignsStore.getState().live['C1']!.nodes['n1']!.prompt).toBeNull();
+  });
+
+  it('campaign-level frames set the campaign status; blocked is a node fact, not a campaign one', () => {
+    ingest(frame('campaignNodeBlocked', { campaign: 'C1', node: 'n1' }));
+    expect(useCampaignsStore.getState().live['C1']!.status).toBeNull();
+    expect(useCampaignsStore.getState().live['C1']!.nodes['n1']!.status).toBe('blocked');
+    for (const [type, want] of [
+      ['campaignPaused', 'paused'],
+      ['campaignCompleted', 'completed'],
+      ['campaignFailed', 'failed'],
+      ['campaignCancelled', 'cancelled'],
+    ] as const) {
+      ingest(frame(type, { campaign: 'C1' }));
+      expect(useCampaignsStore.getState().live['C1']!.status).toBe(want);
+    }
+  });
+
+  it('campaignLaunched RESETS the fold — a resumed campaign replays its truth in new frames', () => {
+    ingest(frame('campaignNodeStarted', { campaign: 'C1', node: 'n1', runId: 'r1' }));
+    ingest(frame('campaignFailed', { campaign: 'C1' }));
+    ingest(frame('campaignLaunched', { campaign: 'C1' }));
+    expect(useCampaignsStore.getState().live['C1']).toEqual({ status: null, nodes: {}, nodeOrder: [] });
+  });
+
+  it('campaigns fold independently; non-campaign frames are a no-op', () => {
+    ingest(frame('campaignNodeStarted', { campaign: 'C1', node: 'n1', runId: 'r1' }));
+    ingest(frame('campaignNodeStarted', { campaign: 'C2', node: 'n1', runId: 'r2' }));
+    ingest(frame('sessionCompleted', { session: 'r1' }));
+    ingest(frame('unitOutputDelta', { session: 'r1', chunk: 'x' }));
+    const live = useCampaignsStore.getState().live;
+    expect(Object.keys(live).sort()).toEqual(['C1', 'C2']);
+    expect(live['C1']!.nodes['n1']!.runId).toBe('r1');
+    expect(live['C2']!.nodes['n1']!.runId).toBe('r2');
+  });
+});


### PR DESCRIPTION
Node status from Campaign* WS frames; sibling-run rollup reads session.delivery from the list wire (crew#321's field, implemented in the paired crew PR); flake/coverage trends honestly deferred until TH-6 history reaches a wire. Extends studio#27.

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)