### PR TITLE
site: version stamp v0.4.1 + build-time injection (DT-7)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,6 +1,16 @@
 import { defineConfig } from 'astro/config';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+
+// The install CTA's version stamp is injected at build time from the repo's
+// own package.json (the published `wicked-studio` npm manifest), so the stamp
+// can never re-stale the way a hardcoded string does (it sat at v0.1.0, then
+// v0.4.0, while npm moved on). Deliberately NOT an npm-registry fetch: that
+// would make the build non-hermetic. The release train keeps package.json in
+// sync with npm, so stamp == npm at every deploy from main. (DT-7)
+const studioPkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'),
+);
 
 // Shared chrome lives in the `wicked-web` package. Develop against the local
 // source when it sits beside this repo (../../wicked-web from this site dir),
@@ -25,5 +35,8 @@ export default defineConfig({
   // review and invisible to layout measurement. A few KB of retained whitespace is cheaper than
   // shipping mashed sentences. Pinned by tests/e2e/prose.spec.ts.
   compressHTML: false,
-  vite: { resolve: { alias } },
+  vite: {
+    resolve: { alias },
+    define: { __WICKED_STUDIO_VERSION__: JSON.stringify(studioPkg.version) },
+  },
 });

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="astro/client" />
+
+/**
+ * Build-time constant injected by astro.config.mjs (vite define) from the
+ * repo's package.json — the published `wicked-studio` npm manifest. Keeps the
+ * site's install-CTA version stamp true by construction (DT-7).
+ */
+declare const __WICKED_STUDIO_VERSION__: string;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -78,6 +78,10 @@ const RAIL = [
   { id: 'Term',        line: 'A real PTY into the worker’s worktree — raw bytes over /ws/terminals/:id.' },
   { id: 'Cov',         line: 'Repo-scoped coverage, one click from the run that changed it.' },
 ];
+
+// Injected at build time from the repo's package.json via astro.config.mjs
+// (vite define). Never hardcode a version in this file — it re-stales. (DT-7)
+const studioVersion = __WICKED_STUDIO_VERSION__;
 ---
 
 <Base title={title} description={description} favicon="/favicon.svg">
@@ -492,7 +496,7 @@ wsBase()  → ws://127.0.0.1:7701                  <span class="c"># same contra
                 onclick="navigator.clipboard&&navigator.clipboard.writeText('npx wicked-crew serve').then(()=>{this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1400);})">Copy</button>
             </div>
             <pre class="install__code"><code>npx wicked-crew serve   <span class="c"># daemon + this studio · one port · same origin</span></code></pre>
-            <p class="install__note">Node ≥ 22. The daemon serves the studio at its own origin — open the printed URL and launch a run. <span class="install__ver">wicked-studio npm v0.4.0</span></p>
+            <p class="install__note">Node ≥ 22. The daemon serves the studio at its own origin — open the printed URL and launch a run. <span class="install__ver">wicked-studio npm v{studioVersion}</span></p>
           </div>
 
           <div class="install-or" aria-hidden="true"><span>or run the skin standalone</span></div>


### PR DESCRIPTION
Stamp injected from package.json at build; site builds green.

Part of the triple-recon execution program (recon-2026-08/TASK-PLAN.md v1.0, wave 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)