### PR TITLE
feat: the Architecture Wiki page — browse, health, kill switch, authoring guide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
 import { RuleManager } from './components/RuleManager.js';
+import { WikiPage } from './components/WikiPage.js';
 import { RunsBottomPanel, RUNS_BAR_PX } from './components/RunsBottomPanel.js';
 import { ChatPanel } from './components/ChatPanel.js';
 import { GroupChat } from './components/GroupChat.js';
@@ -463,6 +464,13 @@ export function App(): React.ReactElement {
       return (
         <div className="flex-1 overflow-y-auto p-6">
           <RuleManager />
+        </div>
+      );
+    }
+    if (panel === 'wiki') {
+      return (
+        <div className="flex-1 overflow-y-auto p-6">
+          <WikiPage />
         </div>
       );
     }

--- a/src/api/wiki.ts
+++ b/src/api/wiki.ts
@@ -1,0 +1,238 @@
+/**
+ * The architecture-wiki wire (AW-23 scoreboard + wiki meta + RuleSet grouping) — types and
+ * calls for the read side of the Architecture Wiki surface (`/wiki`).
+ *
+ * ── INTEGRATION POINT (wiki-management build, paired crew lane) ──────────────────────────────
+ * These shapes are hand-mirrored from the engine that PRODUCES them — wicked-core's
+ * `crates/wicked-governance/src/scoreboard.rs` (`Scoreboard`, AW-23), `ruleset.rs`
+ * (`RuleSetGrouping`, AW-13) and `provenance.rs` (the `<path>@<blob sha>#<RULE-ID>` ref
+ * format, AW-10) — because the crew slice that serves them (`/governance/wiki/*`, built in a
+ * parallel lane, presence-gated on core-ts methods like the campaigns routes) is not yet in
+ * studio's installed `wicked-crew-api-types`. Like `Campaign` in `./campaigns.ts`, every
+ * declaration here is TEMPORARY: **delete this block and re-export from
+ * `wicked-crew-api-types`** the moment studio bumps to the api-types version that carries the
+ * wiki contract. Field names and spellings are the engine's serde output, verbatim — a served
+ * payload that disagrees is a contract bug, not an adoption gap.
+ *
+ * The support probe is the adoption seam, and it is TWO-LAYERED here:
+ *  - a bare 404 (Fastify's unknown-route answer) means "this crew daemon predates the wiki
+ *    routes entirely";
+ *  - a 501 means "the crew daemon HAS the route but its embedded core-ts engine predates the
+ *    wiki scoreboard method" (the campaigns presence-gate pattern, answered honestly in-band).
+ * Both resolve to the same operator truth — this daemon cannot measure the wiki yet — and
+ * {@link isWikiUnsupported} folds them so every caller renders the honest state, never a raw
+ * refusal.
+ *
+ * The rules themselves ride the SHIPPING wire: `GET /governance/rules` (listConformanceRules)
+ * and the retire kill switch `DELETE /governance/rules/:id` (retireConformanceRule) — nothing
+ * here re-declares those.
+ */
+
+import { apiFetch } from './client.js';
+import { ApiError, isRouteAbsent } from './errors.js';
+
+// ── AW-23 scoreboard (scoreboard.rs `Scoreboard`, serde snake_case) ───────────────────────────
+
+/** Typing coverage — % of doctrine statements typed into enforcement classes (doc frontmatter). */
+export interface WikiTypingCoverage {
+  /** False when the daemon had no docs root to scan; `reason` says why, in-band. */
+  available: boolean;
+  reason?: string;
+  docs_scanned: number;
+  statements_total: number;
+  statements_typed: number;
+  /** Absent when there is nothing to divide by (serde skips `None`). */
+  percent?: number;
+  /** Statement count per enforcement class (`policy | validator | guidance`). */
+  by_class: Record<string, number>;
+  docs_untyped: string[];
+}
+
+/** Connection coverage — % of active rules whose `symbol_ref` resolves at the CURRENT epoch. */
+export interface WikiConnectionCoverage {
+  rules_with_ref: number;
+  refs_resolving: number;
+  refs_unresolvable: number;
+  percent?: number;
+  /** Rules carrying live `Governs` edges into code. */
+  rules_linked: number;
+}
+
+/** One rule's enforcement evidence — deny claims citing it + accumulated Governs evidence. */
+export interface WikiRuleEvidenceRow {
+  rule_id: string;
+  denial_claims: number;
+  governs_evidence: number;
+}
+
+/** Enforcement evidence — gate denials that CITE wiki rules (evidenced_by edges). */
+export interface WikiEnforcementEvidence {
+  denial_claims: number;
+  rules_evidenced: number;
+  evidenced_by_edges: number;
+  governs_evidence_total: number;
+  per_rule: WikiRuleEvidenceRow[];
+}
+
+/** Recall volume — documented UNAVAILABLE by the engine (nothing writes recall telemetry yet);
+ *  the struct exists so the report says so in-band instead of silently omitting the metric. */
+export interface WikiRecallVolume {
+  available: boolean;
+  reason: string;
+}
+
+/** The AW-23 population/connection scoreboard, verbatim as the engine serializes it. */
+export interface WikiScoreboard {
+  rules_total: number;
+  rules_active: number;
+  rules_retired: number;
+  typing: WikiTypingCoverage;
+  connection: WikiConnectionCoverage;
+  evidence: WikiEnforcementEvidence;
+  recall_volume: WikiRecallVolume;
+  [k: string]: unknown;
+}
+
+// ── Wiki meta (seededness) ─────────────────────────────────────────────────────────────────────
+
+/** Per-doc metadata the meta route may carry — the frontmatter `enforcement_class` lives on the
+ *  DOC, never on the rule node, so a rule's class renders only when this join is served. */
+export interface WikiDocMeta {
+  /** Root-relative doc path — joins against the parsed `provenance.ref` path. */
+  path: string;
+  /** `policy | validator | guidance`, or null/absent for an untyped doc. */
+  enforcement_class?: string | null;
+  [k: string]: unknown;
+}
+
+/** `GET /governance/wiki/meta` — is there a wiki here at all? */
+export interface WikiMeta {
+  /** False = no doctrine has ever been ingested into this store — the surface's EMPTY state. */
+  seeded: boolean;
+  rules_total?: number;
+  rulesets?: number;
+  docs?: WikiDocMeta[];
+  [k: string]: unknown;
+}
+
+// ── RuleSet grouping (ruleset.rs `RuleSetGrouping`) ───────────────────────────────────────────
+
+/** One doctrine domain's membership: the RuleSet parent plus the rule ids it contains. */
+export interface WikiRuleSet {
+  /** The doctrine domain — RuleSet node name (`plane-boundaries`, `storage-doctrine`, …). */
+  domain: string;
+  /** The `PAT-`/`POL-` ids of the rules this RuleSet contains. */
+  rule_ids: string[];
+  [k: string]: unknown;
+}
+
+// ── Calls ─────────────────────────────────────────────────────────────────────────────────────
+
+/** `GET /governance/wiki/scoreboard` — 501 = engine predates the scoreboard; bare 404 = crew
+ *  predates the wiki routes. Both are {@link isWikiUnsupported}, never an error card. */
+export function getWikiScoreboard(): Promise<{ scoreboard: WikiScoreboard }> {
+  return apiFetch<{ scoreboard: WikiScoreboard }>('/governance/wiki/scoreboard');
+}
+
+/** `GET /governance/wiki/meta` — `{ seeded: false }` is an ANSWER (the empty state), never a 404. */
+export function getWikiMeta(): Promise<{ meta: WikiMeta }> {
+  return apiFetch<{ meta: WikiMeta }>('/governance/wiki/meta');
+}
+
+/** `GET /governance/wiki/rulesets` — always 200 with `[]` on an ungrouped store. */
+export function listWikiRuleSets(): Promise<{ rulesets: WikiRuleSet[] }> {
+  return apiFetch<{ rulesets: WikiRuleSet[] }>('/governance/wiki/rulesets');
+}
+
+/**
+ * True when this daemon cannot serve the wiki read yet: a 501 (route present, engine method
+ * absent — the presence-gate's honest in-band answer) or Fastify's bare unknown-route 404
+ * (crew predates the wiki routes entirely). A NAMED 404 from a daemon WITH the route is a
+ * real answer and must surface as one.
+ */
+export function isWikiUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}
+
+// ── Provenance ref parsing (provenance.rs `parse_provenance_ref`, mirrored) ──────────────────
+
+/** A parsed `provenance.ref`. Every field but `path` is optional because every HISTORICAL ref
+ *  shape must keep parsing — a legacy `path#id` ref is drift residue, never a crash. */
+export interface ParsedProvenanceRef {
+  path: string;
+  /** The git blob sha the rule was ingested at, when the ref carries one. */
+  sha: string | null;
+  /** The `#`-anchor (the rule id within the doc), when present. */
+  anchor: string | null;
+}
+
+function isBlobSha(s: string): boolean {
+  return /^[0-9a-f]{40}$/.test(s);
+}
+
+/**
+ * Parse a provenance ref of any historical shape — `path@sha#id`, `path#id`, `path@sha`,
+ * bare `path`, free-form. The sha is recognized ONLY as a trailing `@<40 lowercase hex>`
+ * before the anchor — an `@` inside an ordinary path does not false-positive. Mirrors the
+ * engine's `parse_provenance_ref` exactly so studio and the drift CLI read one ref the
+ * same way.
+ */
+export function parseProvenanceRef(ref: string): ParsedProvenanceRef {
+  const hash = ref.indexOf('#');
+  const left = hash === -1 ? ref : ref.slice(0, hash);
+  const anchor = hash === -1 ? null : ref.slice(hash + 1);
+  const at = left.lastIndexOf('@');
+  if (at !== -1 && isBlobSha(left.slice(at + 1))) {
+    return { path: left.slice(0, at), sha: left.slice(at + 1), anchor };
+  }
+  return { path: left, sha: null, anchor };
+}
+
+// ── The populated-vs-decaying verdict ─────────────────────────────────────────────────────────
+
+/**
+ * The health header's one-word reading of the scoreboard. Derived HERE, in studio, from the
+ * AW-23 raw signals (the engine deliberately reports signals, not adjectives) — and always
+ * rendered BESIDE those raw numbers, never instead of them.
+ */
+export type WikiVerdict = 'empty' | 'populated' | 'decaying' | 'unproven';
+
+export const VERDICT_COPY: Record<WikiVerdict, string> = {
+  empty: 'No active rules — the wiki is not populated.',
+  decaying:
+    'Ingested once and drifting: unresolvable symbol refs or mostly-untyped doctrine. Re-run ingest/relink.',
+  populated: 'Typed, connected to code, and cited by enforcement — the wiki is alive.',
+  unproven:
+    'Rules exist but nothing proves they are wired: no live code links or enforcement evidence yet.',
+};
+
+/**
+ * The derivation, pinned by unit test:
+ * - `empty`    — no active rules.
+ * - `decaying` — a symbol ref no longer resolves at the current epoch (drift), or typing was
+ *                measured and under half the doctrine is typed. Decay signals DOMINATE.
+ * - `populated`— live `Governs` links into code AND enforcement evidence citing wiki rules
+ *                (denials or accumulated Governs evidence).
+ * - `unproven` — the honest middle: rules exist, nothing decayed, nothing proven.
+ */
+export function scoreboardVerdict(sb: WikiScoreboard): WikiVerdict {
+  if (sb.rules_active === 0) return 'empty';
+  const typingWeak =
+    sb.typing.available && sb.typing.statements_total > 0 && (sb.typing.percent ?? 0) < 50;
+  if (sb.connection.refs_unresolvable > 0 || typingWeak) return 'decaying';
+  const evidenced = sb.evidence.denial_claims > 0 || sb.evidence.governs_evidence_total > 0;
+  if (sb.connection.rules_linked > 0 && evidenced) return 'populated';
+  return 'unproven';
+}
+
+// ── The seed runbook (the empty state's way out) ─────────────────────────────────────────────
+
+/** Where the seed runbook + authoring contract live (AW-13). A repo path, not a wire. */
+export const SEED_RUNBOOK_PATH = 'wicked-core/crates/wicked-governance/seed/README.md';
+export const SEED_RUNBOOK_URL =
+  'https://github.com/mikeparcewski/wicked-core/blob/main/crates/wicked-governance/seed/README.md';
+
+/** The runbook's driver invocation, abbreviated to what identifies it (the README carries the
+ *  full flag list — every store it writes is scratch-only, never a daemon-held store). */
+export const SEED_COMMAND =
+  'python3 crates/wicked-governance/seed/seed_wiki.py --core-bin <wicked-core> --estate-bin <wicked-estate> --scratch <dir> …';

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -80,7 +80,7 @@ const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Re
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
 const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_SETTINGS];
 
-const SETTINGS_ROUTES = new Set(['system', 'theme', 'coverage', 'domain', 'workflows', 'policies', 'rules']);
+const SETTINGS_ROUTES = new Set(['system', 'theme', 'coverage', 'domain', 'workflows', 'policies', 'rules', 'wiki']);
 
 /**
  * The route→heading map (§3.2): which primary path owns a pathname. `/` and

--- a/src/components/SettingsRailSection.tsx
+++ b/src/components/SettingsRailSection.tsx
@@ -21,6 +21,7 @@ export const SETTINGS_ITEMS: { label: string; path: string }[] = [
   { label: 'Workflows', path: '/workflows' },
   { label: 'Policies', path: '/policies' },
   { label: 'Rules', path: '/rules' },
+  { label: 'Arch Wiki', path: '/wiki' },
   { label: 'System', path: '/system' },
 ];
 

--- a/src/components/WikiPage.tsx
+++ b/src/components/WikiPage.tsx
@@ -1,0 +1,805 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import type { ConformanceRule } from '../api/types.js';
+import {
+  getWikiMeta,
+  getWikiScoreboard,
+  isWikiUnsupported,
+  listWikiRuleSets,
+  parseProvenanceRef,
+  scoreboardVerdict,
+  SEED_COMMAND,
+  SEED_RUNBOOK_PATH,
+  SEED_RUNBOOK_URL,
+  VERDICT_COPY,
+  type WikiMeta,
+  type WikiRuleSet,
+  type WikiScoreboard,
+  type WikiVerdict,
+} from '../api/wiki.js';
+import { useModalEscape } from './Modal.js';
+
+/**
+ * The Architecture Wiki surface (`/wiki`) — THE page that makes the graph-backed wiki exist
+ * for humans. Everything else about the wiki is agent-facing (rules.recall / knowledge.recall
+ * over estate MCP, gate denials citing rules); without this page no operator knows it is
+ * there, so nothing keeps it alive.
+ *
+ * Four reads, every one with an honest degraded state (the campaigns adoption-seam pattern):
+ *  - `GET /governance/wiki/scoreboard` (AW-23) — the health header. 501/route-absent =
+ *    "this daemon's engine predates the wiki scoreboard", stated in-band, never an error card.
+ *  - `GET /governance/wiki/meta` — seededness. `seeded: false` = the EMPTY state with the
+ *    seed-runbook command shown; an unsupported meta route just means the page cannot tell,
+ *    so it falls through to the rules browser's own empty copy.
+ *  - `GET /governance/rules` — the SHIPPING rules wire; the browser filters client-side.
+ *  - `GET /governance/wiki/rulesets` — AW-13 grouping; unsupported = flat list, said plainly.
+ *
+ * The kill switch (retire) calls the SHIPPING `DELETE /governance/rules/:id` behind a
+ * typed-confirmation modal. The reason field is REQUIRED by the modal but the wire does not
+ * carry it — deliberately: git is the source of truth (no rules.write), so the reason's
+ * durable home is the doc PR that retires the doctrine; the modal echoes it back after the
+ * retire so the operator carries it there instead of losing it.
+ */
+
+// ── Shared bits ───────────────────────────────────────────────────────────────────────────────
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: 'var(--status-fail)',
+  error: 'var(--status-fail)',
+  warn: 'var(--status-gate)',
+  info: 'var(--ink-muted)',
+};
+
+const VERDICT_COLOR: Record<WikiVerdict, string> = {
+  empty: 'var(--ink-dim)',
+  decaying: 'var(--status-fail)',
+  populated: 'var(--status-done)',
+  unproven: 'var(--status-gate)',
+};
+
+function SeverityChip({ severity }: { severity: string }): React.ReactElement {
+  return (
+    <span
+      className="inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
+      style={{ background: 'var(--surface-raised)', color: SEVERITY_COLOR[severity] ?? 'var(--ink-muted)' }}
+    >
+      {severity}
+    </span>
+  );
+}
+
+/** One health-header stat: the number, its label, and the honest sub-line when it cannot be measured. */
+function Stat({ testid, label, value, sub }: {
+  testid: string;
+  label: string;
+  value: string;
+  sub?: string | undefined;
+}): React.ReactElement {
+  return (
+    <div
+      data-testid={testid}
+      className="flex flex-col gap-0.5 rounded p-3 min-w-[10rem]"
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+    >
+      <span className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>{label}</span>
+      <span className="text-lg font-semibold font-mono" style={{ color: 'var(--ink-high)' }}>{value}</span>
+      {sub !== undefined && (
+        <span className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>{sub}</span>
+      )}
+    </div>
+  );
+}
+
+const pct = (v: number | undefined): string => (v === undefined ? '—' : `${Math.round(v)}%`);
+
+// ── The health header (AW-23 scoreboard) ──────────────────────────────────────────────────────
+
+type ScoreboardState =
+  | { kind: 'loading' }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string }
+  | { kind: 'loaded'; scoreboard: WikiScoreboard };
+
+function HealthHeader({ state }: { state: ScoreboardState }): React.ReactElement {
+  if (state.kind === 'loading') {
+    return <p data-testid="wiki-health-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Measuring wiki health…</p>;
+  }
+  if (state.kind === 'unsupported') {
+    // The honest adoption state: the daemon is fine, it just predates the AW-23 scoreboard —
+    // say that, and say what the page still does (the rules wire below ships today).
+    return (
+      <p
+        data-testid="wiki-health-unsupported"
+        className="rounded px-3 py-2 text-xs"
+        style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+      >
+        This daemon&rsquo;s engine predates the wiki scoreboard — population and connection cannot be
+        measured here yet. The rules browser below still reads the live store.
+      </p>
+    );
+  }
+  if (state.kind === 'failed') {
+    return (
+      <p data-testid="wiki-health-error" className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+        {state.message}
+      </p>
+    );
+  }
+  const sb = state.scoreboard;
+  const verdict = scoreboardVerdict(sb);
+  return (
+    <div data-testid="wiki-health" className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span
+          data-testid="wiki-verdict"
+          data-verdict={verdict}
+          title={`${VERDICT_COPY[verdict]} (derived in studio from the raw AW-23 signals shown beside it)`}
+          className="inline-flex rounded-full px-2.5 py-0.5 text-[11px] font-semibold"
+          style={{ color: VERDICT_COLOR[verdict], border: `1px solid ${VERDICT_COLOR[verdict]}` }}
+        >
+          {verdict}
+        </span>
+        <span className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>{VERDICT_COPY[verdict]}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Stat
+          testid="wiki-stat-rules"
+          label="Rules"
+          value={`${sb.rules_active} active`}
+          sub={`${sb.rules_total} total · ${sb.rules_retired} retired`}
+        />
+        <Stat
+          testid="wiki-stat-typed"
+          label="Typed"
+          value={sb.typing.available ? pct(sb.typing.percent) : 'not measured'}
+          sub={
+            sb.typing.available
+              ? `${sb.typing.statements_typed} of ${sb.typing.statements_total} statements across ${sb.typing.docs_scanned} docs`
+              : sb.typing.reason ?? 'no docs root supplied to the daemon'
+          }
+        />
+        <Stat
+          testid="wiki-stat-resolving"
+          label="Refs resolving"
+          value={sb.connection.rules_with_ref === 0 ? 'no refs' : pct(sb.connection.percent)}
+          sub={`${sb.connection.refs_resolving} of ${sb.connection.rules_with_ref} symbol refs · ${sb.connection.rules_linked} rules linked to code`}
+        />
+        <Stat
+          testid="wiki-stat-denials"
+          label="Denials citing wiki"
+          value={String(sb.evidence.denial_claims)}
+          sub={`${sb.evidence.rules_evidenced} rules evidenced · ${sb.evidence.governs_evidence_total} governs-evidence total`}
+        />
+      </div>
+      {!sb.recall_volume.available && (
+        <p data-testid="wiki-recall-unavailable" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          Recall volume: {sb.recall_volume.reason}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── About this wiki ───────────────────────────────────────────────────────────────────────────
+
+function AboutPanel(): React.ReactElement {
+  return (
+    <div
+      data-testid="wiki-about"
+      className="flex flex-col gap-2 rounded p-3 text-[11px]"
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+    >
+      <p style={{ color: 'var(--ink-high)' }} className="font-semibold">How doctrine gets here</p>
+      <p>
+        <span className="font-mono">doc PR → rules ingest → fanout → relink</span> — a frontmattered
+        markdown doc merges to a repo, <span className="font-mono">wicked-core rules ingest</span> materializes
+        its rules (fail-closed), fanout writes every lane (rules, RuleSets, knowledge chunks), and{' '}
+        <span className="font-mono">rules relink</span> re-derives the Governs edges into the code the
+        rules govern. Re-running the pipeline is idempotent — drift self-heals on the next ingest.
+      </p>
+      <p style={{ color: 'var(--ink-high)' }} className="font-semibold">How agents consume it</p>
+      <p>
+        Over estate MCP: <span className="font-mono">rules.recall</span> answers &ldquo;which rules govern this
+        code?&rdquo; with provenance citations, and <span className="font-mono">
+        knowledge.recall {'{scope_prefix: "wiki:"}'}</span> returns the rationale chunks each carrying its
+        source URI. Gate denials cite rule ids, which lead back to the exact doc via the provenance ref.
+      </p>
+      <p style={{ color: 'var(--ink-high)' }} className="font-semibold">Authoring contract</p>
+      <p>
+        There is <strong>no rules.write</strong> — git is the source of truth. New or changed doctrine is a
+        doc PR that re-ingests; the retire button here is the emergency kill switch only (it withdraws a
+        rule from recall now — the doc PR that removes it is still yours to open). Seed runbook +
+        authoring contract:{' '}
+        <a
+          data-testid="wiki-runbook-link"
+          href={SEED_RUNBOOK_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+          style={{ color: 'var(--accent)' }}
+        >
+          {SEED_RUNBOOK_PATH}
+        </a>
+      </p>
+    </div>
+  );
+}
+
+// ── The retire kill switch ────────────────────────────────────────────────────────────────────
+
+function RetireModal({ rule, onClose, onRetired }: {
+  rule: ConformanceRule;
+  onClose: () => void;
+  onRetired: (reason: string) => void;
+}): React.ReactElement {
+  const [typed, setTyped] = useState('');
+  const [reason, setReason] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useModalEscape(onClose);
+
+  const armed = typed === rule.id && reason.trim() !== '' && !busy;
+
+  const confirm = async (): Promise<void> => {
+    if (!armed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await api.retireConformanceRule(rule.id);
+      onRetired(reason.trim());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
+      <div
+        data-testid="wiki-retire-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Retire ${rule.id}`}
+        className="flex w-[28rem] max-w-[92vw] flex-col gap-3 rounded-xl p-4 shadow-2xl"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--status-fail-dim)' }}
+      >
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--status-fail)' }}>
+          Retire {rule.id}
+        </h3>
+        <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Withdraws this rule from recall and every fan-out lane <em>now</em>. The record stays listed —
+          past decisions cite it. Git stays the source of truth: carry your reason into the doc PR that
+          retires the doctrine itself.
+        </p>
+        <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Type the rule id to confirm
+          <input
+            data-testid="wiki-retire-confirm-input"
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={rule.id}
+            spellCheck={false}
+            className="rounded px-2 py-1 font-mono text-[11px] focus:outline-none"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Reason (required)
+          <textarea
+            data-testid="wiki-retire-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Why this rule must stop enforcing now"
+            className="min-h-[3.5rem] resize-y rounded px-2 py-1 text-[11px] focus:outline-none"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+        </label>
+        {error !== null && (
+          <p data-testid="wiki-retire-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+            {error}
+          </p>
+        )}
+        <div className="flex items-center justify-end gap-2">
+          <button
+            data-testid="wiki-retire-cancel"
+            type="button"
+            onClick={onClose}
+            className="rounded px-3 py-1 text-[11px]"
+            style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="wiki-retire-confirm"
+            type="button"
+            disabled={!armed}
+            onClick={() => void confirm()}
+            className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+            style={{ background: 'var(--status-fail)', color: 'var(--surface-base)' }}
+          >
+            {busy ? 'Retiring…' : 'Retire rule'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Rule detail ───────────────────────────────────────────────────────────────────────────────
+
+function DetailRow({ label, testid, children }: {
+  label: string;
+  testid: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex gap-2 text-[11px]">
+      <span className="w-32 shrink-0 text-[10px] uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>{label}</span>
+      <span data-testid={testid} className="min-w-0 break-words" style={{ color: 'var(--ink-muted)' }}>{children}</span>
+    </div>
+  );
+}
+
+function RuleDetail({ rule, enforcementClass, evidence, onRetire }: {
+  rule: ConformanceRule;
+  /** From the meta docs join, when the daemon serves it — the class lives on the DOC. */
+  enforcementClass: string | null;
+  /** From the scoreboard's per-rule evidence join, when the scoreboard is served. */
+  evidence: { denial_claims: number; governs_evidence: number } | null;
+  onRetire: (rule: ConformanceRule) => void;
+}): React.ReactElement {
+  const ref = rule.provenance.ref;
+  const parsed = ref !== undefined && ref !== '' ? parseProvenanceRef(ref) : null;
+  return (
+    <div
+      data-testid="wiki-rule-detail"
+      className="flex flex-col gap-1.5 rounded p-3"
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+    >
+      <DetailRow label="Statement" testid="wiki-rule-statement">{rule.statement}</DetailRow>
+      <DetailRow label="Enforcement class" testid="wiki-rule-class">
+        {enforcementClass ?? (
+          <span title="the class lives in doc frontmatter; this daemon does not serve the per-doc join">—</span>
+        )}
+      </DetailRow>
+      <DetailRow label="Provenance" testid="wiki-rule-provenance">
+        {parsed === null ? (
+          <span title="this rule carries no provenance ref">—</span>
+        ) : parsed.sha === null ? (
+          <span className="font-mono" title="legacy ref without a blob digest — re-ingest to stamp one">
+            {parsed.path} <span style={{ color: 'var(--status-gate)' }}>(no digest — re-ingest)</span>
+          </span>
+        ) : (
+          <span className="font-mono">{parsed.path}@{parsed.sha.slice(0, 12)}</span>
+        )}
+      </DetailRow>
+      <DetailRow label="Wiki URI" testid="wiki-rule-wiki-uri">
+        {ref !== undefined && ref !== '' ? <span className="font-mono">{ref}</span> : '—'}
+      </DetailRow>
+      <DetailRow label="Evidence" testid="wiki-rule-evidence">
+        {evidence === null ? (
+          <span title="evidence counts ride the wiki scoreboard, which this daemon does not serve">—</span>
+        ) : (
+          `${evidence.denial_claims} denial claims · ${evidence.governs_evidence} governs evidence`
+        )}
+      </DetailRow>
+      {rule.symbol_ref !== undefined && (
+        <DetailRow label="Symbol ref" testid="wiki-rule-symbol-ref">
+          <span className="font-mono">{rule.symbol_ref}</span>
+        </DetailRow>
+      )}
+      <DetailRow label="Confidence" testid="wiki-rule-confidence">{rule.confidence}</DetailRow>
+      {rule.compliance !== undefined && (
+        <DetailRow label="Compliance" testid="wiki-rule-compliance">
+          <span className="font-mono">{rule.compliance.framework} / {rule.compliance.control_id}</span>
+        </DetailRow>
+      )}
+      <div className="flex justify-end pt-1">
+        {rule.retired === true ? (
+          <span data-testid="wiki-rule-retired-note" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            retired — withdrawn from recall; kept listed because past decisions cite it
+          </span>
+        ) : (
+          <button
+            data-testid="wiki-retire-open"
+            type="button"
+            onClick={() => onRetire(rule)}
+            className="rounded px-2 py-1 text-[10px] font-semibold"
+            style={{ color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
+          >
+            Retire…
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── The rules browser ─────────────────────────────────────────────────────────────────────────
+
+type StatusFacet = 'all' | 'active' | 'retired';
+
+interface Facets {
+  severity: string;
+  layer: string;
+  rule_type: string;
+  status: StatusFacet;
+}
+
+const FACETS_ALL: Facets = { severity: 'all', layer: 'all', rule_type: 'all', status: 'all' };
+
+/** Client-side facet filter over the shipping rules wire — pinned by unit test. */
+export function filterRules(rules: ConformanceRule[], f: Facets): ConformanceRule[] {
+  return rules.filter((r) => {
+    if (f.severity !== 'all' && r.severity !== f.severity) return false;
+    if (f.rule_type !== 'all' && r.rule_type !== f.rule_type) return false;
+    if (f.layer !== 'all' && (r.targets.layer ?? '') !== f.layer) return false;
+    const retired = r.retired === true;
+    if (f.status === 'active' && retired) return false;
+    if (f.status === 'retired' && !retired) return false;
+    return true;
+  });
+}
+
+function FacetSelect({ testid, label, value, options, onChange }: {
+  testid: string;
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
+}): React.ReactElement {
+  return (
+    <label className="flex items-center gap-1 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+      {label}
+      <select
+        data-testid={testid}
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded px-1.5 py-0.5 text-[10px] focus:outline-none"
+        style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+      >
+        <option value="all">all</option>
+        {options.map((o) => (
+          <option key={o} value={o}>{o}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function RuleRow({ rule, selected, onSelect }: {
+  rule: ConformanceRule;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}): React.ReactElement {
+  return (
+    <button
+      data-testid="wiki-rule-row"
+      data-rule-id={rule.id}
+      type="button"
+      aria-expanded={selected}
+      onClick={() => onSelect(rule.id)}
+      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[11px] hover:bg-surface-raised"
+      style={{
+        border: selected ? '1px solid var(--accent)' : '1px solid transparent',
+        color: 'var(--ink-muted)',
+      }}
+    >
+      <span className="w-20 shrink-0 font-mono" style={{ color: 'var(--ink-high)' }}>{rule.id}</span>
+      <SeverityChip severity={rule.severity} />
+      <span className="w-14 shrink-0 text-[10px]" style={{ color: 'var(--ink-dim)' }}>{rule.rule_type}</span>
+      <span className="min-w-0 flex-1 truncate">{rule.statement}</span>
+      {rule.targets.layer !== undefined && (
+        <span className="shrink-0 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{rule.targets.layer}</span>
+      )}
+      {rule.retired === true && (
+        <span
+          data-testid="wiki-rule-retired-chip"
+          className="shrink-0 rounded px-1.5 text-[9px] font-semibold uppercase"
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-dim)' }}
+        >
+          retired
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ── The page ──────────────────────────────────────────────────────────────────────────────────
+
+type RuleSetsState =
+  | { kind: 'loading' }
+  | { kind: 'unsupported' }
+  | { kind: 'loaded'; rulesets: WikiRuleSet[] };
+
+export function WikiPage(): React.ReactElement {
+  const [scoreboard, setScoreboard] = useState<ScoreboardState>({ kind: 'loading' });
+  const [meta, setMeta] = useState<WikiMeta | null>(null);
+  const [rules, setRules] = useState<ConformanceRule[]>([]);
+  const [rulesLoading, setRulesLoading] = useState(true);
+  const [rulesError, setRulesError] = useState<string | null>(null);
+  const [rulesets, setRulesets] = useState<RuleSetsState>({ kind: 'loading' });
+  const [facets, setFacets] = useState<Facets>(FACETS_ALL);
+  const [grouped, setGrouped] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [retiring, setRetiring] = useState<ConformanceRule | null>(null);
+  const [retiredNote, setRetiredNote] = useState<{ id: string; reason: string } | null>(null);
+  const [aboutOpen, setAboutOpen] = useState(false);
+
+  const loadRules = useCallback(async (): Promise<void> => {
+    setRulesLoading(true);
+    setRulesError(null);
+    try {
+      const { rules: rs } = await api.listConformanceRules();
+      setRules(rs);
+    } catch (e) {
+      setRulesError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRulesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRules();
+    void getWikiScoreboard()
+      .then(({ scoreboard: sb }) => setScoreboard({ kind: 'loaded', scoreboard: sb }))
+      .catch((e: unknown) => {
+        if (isWikiUnsupported(e)) setScoreboard({ kind: 'unsupported' });
+        else setScoreboard({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+      });
+    void getWikiMeta()
+      .then(({ meta: m }) => setMeta(m))
+      // An unsupported (or failed) meta route means the page cannot tell whether the store is
+      // seeded — it must NOT claim "unseeded", so meta stays null and the browser's own empty
+      // copy covers the zero-rules case.
+      .catch(() => setMeta(null));
+    void listWikiRuleSets()
+      .then(({ rulesets: rss }) => setRulesets({ kind: 'loaded', rulesets: rss }))
+      .catch(() => setRulesets({ kind: 'unsupported' }));
+  }, [loadRules]);
+
+  const layers = useMemo(
+    () => [...new Set(rules.map((r) => r.targets.layer).filter((l): l is string => l !== undefined && l !== ''))].sort(),
+    [rules],
+  );
+  const visible = useMemo(() => filterRules(rules, facets), [rules, facets]);
+  const selected = selectedId === null ? null : visible.find((r) => r.id === selectedId) ?? null;
+
+  /** enforcement_class join: rule → provenance path → meta.docs (the class lives on the DOC). */
+  const classByPath = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const d of meta?.docs ?? []) {
+      if (typeof d.enforcement_class === 'string' && d.enforcement_class !== '') m.set(d.path, d.enforcement_class);
+    }
+    return m;
+  }, [meta]);
+  const classOf = (r: ConformanceRule): string | null => {
+    const ref = r.provenance.ref;
+    if (ref === undefined || ref === '') return null;
+    return classByPath.get(parseProvenanceRef(ref).path) ?? null;
+  };
+
+  /** evidence_count join: the AW-23 per-rule evidence rows, when the scoreboard is served. */
+  const evidenceOf = (id: string): { denial_claims: number; governs_evidence: number } | null => {
+    if (scoreboard.kind !== 'loaded') return null;
+    const row = scoreboard.scoreboard.evidence.per_rule.find((r) => r.rule_id === id);
+    return row ?? { denial_claims: 0, governs_evidence: 0 };
+  };
+
+  const onRetired = (reason: string): void => {
+    const id = retiring?.id ?? '';
+    setRetiring(null);
+    setRetiredNote({ id, reason });
+    // Reload so the row shows the SERVER's state, never this surface's optimism.
+    void loadRules();
+  };
+
+  /** RuleSet grouping: domain → member rules (of the currently visible set), plus the ungrouped rest. */
+  const groups = useMemo(() => {
+    if (rulesets.kind !== 'loaded') return null;
+    const byId = new Map(visible.map((r) => [r.id, r]));
+    const claimed = new Set<string>();
+    const out: { domain: string; rules: ConformanceRule[] }[] = [];
+    for (const rs of rulesets.rulesets) {
+      const members = rs.rule_ids.flatMap((id) => {
+        const r = byId.get(id);
+        if (r === undefined) return [];
+        claimed.add(id);
+        return [r];
+      });
+      if (members.length > 0) out.push({ domain: rs.domain, rules: members });
+    }
+    const ungrouped = visible.filter((r) => !claimed.has(r.id));
+    if (ungrouped.length > 0) out.push({ domain: 'ungrouped', rules: ungrouped });
+    return out;
+  }, [rulesets, visible]);
+
+  const detailFor = (r: ConformanceRule): React.ReactElement => (
+    <RuleDetail rule={r} enforcementClass={classOf(r)} evidence={evidenceOf(r.id)} onRetire={setRetiring} />
+  );
+
+  const listBody = (): React.ReactElement => {
+    if (rulesLoading) {
+      return <p data-testid="wiki-rules-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading rules…</p>;
+    }
+    if (rulesError !== null) {
+      return (
+        <p data-testid="wiki-rules-error" className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+          {rulesError}
+        </p>
+      );
+    }
+    if (visible.length === 0) {
+      return (
+        <p data-testid="wiki-rules-empty" className="text-xs" style={{ color: 'var(--ink-dim)' }}>
+          {rules.length === 0 ? 'No rules in the store.' : 'No rules match these facets.'}
+        </p>
+      );
+    }
+    if (grouped && groups !== null) {
+      return (
+        <div className="flex flex-col gap-3">
+          {groups.map((g) => (
+            <div key={g.domain} data-testid="wiki-ruleset-group" data-domain={g.domain}>
+              <h3 className="pb-1 text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>
+                {g.domain} <span className="font-normal">({g.rules.length})</span>
+              </h3>
+              <div className="flex flex-col gap-0.5">
+                {g.rules.map((r) => (
+                  <div key={r.id}>
+                    <RuleRow rule={r} selected={selected?.id === r.id} onSelect={(id) => setSelectedId(id === selectedId ? null : id)} />
+                    {selected?.id === r.id && detailFor(r)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-col gap-0.5">
+        {visible.map((r) => (
+          <div key={r.id}>
+            <RuleRow rule={r} selected={selected?.id === r.id} onSelect={(id) => setSelectedId(id === selectedId ? null : id)} />
+            {selected?.id === r.id && detailFor(r)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // The EMPTY state is keyed on an EXPLICIT `seeded: false` from the meta route — a daemon that
+  // cannot answer must not be accused of an unseeded store.
+  if (meta !== null && meta.seeded === false) {
+    return (
+      <div data-testid="wiki-page" className="flex max-w-4xl flex-col gap-4">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Architecture Wiki</h2>
+        <div
+          data-testid="wiki-unseeded"
+          className="flex flex-col gap-2 rounded p-4"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+        >
+          <p className="text-xs font-semibold" style={{ color: 'var(--ink-high)' }}>
+            Wiki not seeded — run the seed runbook.
+          </p>
+          <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+            No doctrine has been ingested into this store yet. The seed corpus and the repeatable
+            driver live at{' '}
+            <a href={SEED_RUNBOOK_URL} target="_blank" rel="noreferrer" className="underline" style={{ color: 'var(--accent)' }}>
+              {SEED_RUNBOOK_PATH}
+            </a>:
+          </p>
+          <code
+            data-testid="wiki-seed-command"
+            className="overflow-x-auto whitespace-pre rounded px-2 py-1.5 font-mono text-[10px]"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          >
+            {SEED_COMMAND}
+          </code>
+        </div>
+        <AboutPanel />
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="wiki-page" className="flex max-w-5xl flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Architecture Wiki</h2>
+        <button
+          data-testid="wiki-about-toggle"
+          type="button"
+          aria-expanded={aboutOpen}
+          onClick={() => setAboutOpen((v) => !v)}
+          className="text-[10px] hover:underline"
+          style={{ color: 'var(--accent)' }}
+        >
+          {aboutOpen ? 'Hide' : 'About this wiki'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void loadRules()}
+          className="ml-auto text-[10px] hover:underline"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {aboutOpen && <AboutPanel />}
+
+      <HealthHeader state={scoreboard} />
+
+      {retiredNote !== null && (
+        <p
+          data-testid="wiki-retired-note"
+          className="rounded px-3 py-2 text-[11px]"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+        >
+          Retired <span className="font-mono">{retiredNote.id}</span> — withdrawn from recall. Carry your
+          reason into the doc PR that retires the doctrine: <em>&ldquo;{retiredNote.reason}&rdquo;</em>
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <FacetSelect
+          testid="wiki-filter-severity"
+          label="severity"
+          value={facets.severity}
+          options={['critical', 'error', 'warn', 'info']}
+          onChange={(v) => setFacets((f) => ({ ...f, severity: v }))}
+        />
+        <FacetSelect
+          testid="wiki-filter-layer"
+          label="layer"
+          value={facets.layer}
+          options={layers}
+          onChange={(v) => setFacets((f) => ({ ...f, layer: v }))}
+        />
+        <FacetSelect
+          testid="wiki-filter-type"
+          label="type"
+          value={facets.rule_type}
+          options={['pattern', 'policy']}
+          onChange={(v) => setFacets((f) => ({ ...f, rule_type: v }))}
+        />
+        <FacetSelect
+          testid="wiki-filter-status"
+          label="status"
+          value={facets.status}
+          options={['active', 'retired']}
+          onChange={(v) => setFacets((f) => ({ ...f, status: v as StatusFacet }))}
+        />
+        {rulesets.kind === 'loaded' ? (
+          <button
+            data-testid="wiki-group-toggle"
+            type="button"
+            aria-pressed={grouped}
+            onClick={() => setGrouped((v) => !v)}
+            className="ml-auto rounded px-2 py-0.5 text-[10px] font-semibold"
+            style={{
+              border: '1px solid var(--surface-raised)',
+              background: grouped ? 'var(--surface-raised)' : 'var(--surface-rail)',
+              color: 'var(--ink-high)',
+            }}
+          >
+            {grouped ? 'Flat list' : 'Group by RuleSet'}
+          </button>
+        ) : rulesets.kind === 'unsupported' ? (
+          <span data-testid="wiki-groups-unsupported" className="ml-auto text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            RuleSet grouping is not served by this daemon — flat list
+          </span>
+        ) : null}
+      </div>
+
+      {listBody()}
+
+      {retiring !== null && (
+        <RetireModal rule={retiring} onClose={() => setRetiring(null)} onRetired={onRetired} />
+      )}
+    </div>
+  );
+}

--- a/src/components/WikiPage.tsx
+++ b/src/components/WikiPage.tsx
@@ -550,7 +550,9 @@ export function WikiPage(): React.ReactElement {
         else setScoreboard({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
       });
     void getWikiMeta()
-      .then(({ meta: m }) => setMeta(m))
+      // `?? null`: a mis-shaped payload (no `meta` wrapper) must degrade exactly like an
+      // unanswerable meta route — it is a contract bug to report, never a page crash.
+      .then(({ meta: m }) => setMeta(m ?? null))
       // An unsupported (or failed) meta route means the page cannot tell whether the store is
       // seeded — it must NOT claim "unseeded", so meta stays null and the browser's own empty
       // copy covers the zero-rules case.

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -3,9 +3,9 @@ import { useCallback, useEffect, useState } from 'react';
 // `make` is the round-4 primary-path dashboard route (DES-FEEDBACK-003 §2.1) —
 // a CLIENT route (a new panel id in this union), not a wire. Slice M registers
 // it with a placeholder surface; the real dashboard is slice O (§4.2).
-export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'campaigns' | 'campaign-detail';
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'rules' | 'wiki' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'campaigns' | 'campaign-detail';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make', 'campaigns'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'rules', 'wiki', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make', 'campaigns'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.1",
   "counts": {
-    "files": 95,
-    "occurrences": 676,
-    "static": 572,
+    "files": 96,
+    "occurrences": 710,
+    "static": 602,
     "dynamic": 38,
     "computed": 5
   },
@@ -3357,6 +3357,186 @@
       ]
     },
     {
+      "testId": "wiki-about",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-about-toggle",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-group-toggle",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-groups-unsupported",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-health",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-health-error",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-health-loading",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-health-unsupported",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-page",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-recall-unavailable",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-cancel",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-confirm",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-confirm-input",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-error",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-modal",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-open",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retire-reason",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-retired-note",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rule-detail",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rule-retired-chip",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rule-retired-note",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rule-row",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rules-empty",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rules-error",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-rules-loading",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-ruleset-group",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-runbook-link",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-seed-command",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-unseeded",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
+      "testId": "wiki-verdict",
+      "files": [
+        "src/components/WikiPage.tsx"
+      ]
+    },
+    {
       "testId": "wizard-cancel",
       "files": [
         "src/components/DemoWizard.tsx"
@@ -3730,7 +3910,8 @@
     {
       "expression": "testid",
       "files": [
-        "src/components/CampaignScoreboard.tsx"
+        "src/components/CampaignScoreboard.tsx",
+        "src/components/WikiPage.tsx"
       ]
     },
     {

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -339,7 +339,8 @@ describe('accordion contents (§3.3)', () => {
 
     const settings = screen.getByTestId('rail-heading-settings');
     expect(settings.getAttribute('aria-expanded')).toBe('true');
-    expect(within(settings).getAllByRole('menuitem')).toHaveLength(7);
+    // 8 rows: Theme, Coverage, Domain, Workflows, Policies, Rules, Arch Wiki, System.
+    expect(within(settings).getAllByRole('menuitem')).toHaveLength(8);
     expect(within(settings).getByText(/^v\d+\.\d+\.\d+$/)).toBeInTheDocument();
   });
 });

--- a/tests/WikiPage.test.tsx
+++ b/tests/WikiPage.test.tsx
@@ -1,0 +1,406 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WikiPage, filterRules } from '../src/components/WikiPage.js';
+import { ApiError } from '../src/api/errors.js';
+import type { WikiMeta, WikiRuleSet, WikiScoreboard } from '../src/api/wiki.js';
+import type { ConformanceRule } from '../src/api/types.js';
+
+/**
+ * The Architecture Wiki surface (`/wiki`) — demo-able entirely off mocked wire payloads.
+ * Pinned here:
+ *  - the health header renders the AW-23 scoreboard's RAW signals plus studio's derived
+ *    populated-vs-decaying verdict chip beside them;
+ *  - a 501 (engine predates the scoreboard) is the HONEST adoption state, never an error card;
+ *  - `meta.seeded === false` is the EMPTY state with the seed-runbook command shown — and a
+ *    daemon that cannot answer meta is never accused of an unseeded store;
+ *  - the rules browser filters client-side on severity/layer/rule_type/status (incl. retired);
+ *  - rule detail joins enforcement class (meta docs), provenance path@sha + wiki URI
+ *    (provenance.ref), and evidence counts (scoreboard per_rule) — each with an honest "—"
+ *    when its producer is not served;
+ *  - the retire kill switch takes a TYPED confirmation (the exact rule id) AND a required
+ *    reason before the existing DELETE wire fires, reloads to show the server's state, and
+ *    surfaces a failed retire instead of pretending;
+ *  - RuleSet grouping groups by doctrine domain with an `ungrouped` bucket, and says plainly
+ *    when the daemon does not serve grouping.
+ */
+
+const listConformanceRules = vi.fn();
+const retireConformanceRule = vi.fn();
+const apiFetch = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listConformanceRules: (...a: unknown[]) => listConformanceRules(...a),
+    retireConformanceRule: (...a: unknown[]) => retireConformanceRule(...a),
+  },
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+const SHA = 'a'.repeat(40);
+
+function rule(over: Partial<ConformanceRule> = {}): ConformanceRule {
+  return {
+    id: 'PAT-001',
+    rule_type: 'pattern',
+    statement: 'Never use printf without %s',
+    severity: 'error',
+    confidence: 0.9,
+    targets: { layer: 'foundation' },
+    provenance: { source: 'markdown', ref: `docs/agent-behavior.md@${SHA}#PAT-001`, source_kinds: ['doc'] },
+    ...over,
+  };
+}
+
+function scoreboard(over: Partial<WikiScoreboard> = {}): WikiScoreboard {
+  return {
+    rules_total: 3,
+    rules_active: 2,
+    rules_retired: 1,
+    typing: {
+      available: true,
+      docs_scanned: 4,
+      statements_total: 20,
+      statements_typed: 18,
+      percent: 90,
+      by_class: { policy: 10, guidance: 8 },
+      docs_untyped: [],
+    },
+    connection: { rules_with_ref: 3, refs_resolving: 3, refs_unresolvable: 0, percent: 100, rules_linked: 3 },
+    evidence: {
+      denial_claims: 2,
+      rules_evidenced: 2,
+      evidenced_by_edges: 2,
+      governs_evidence_total: 5,
+      per_rule: [{ rule_id: 'PAT-001', denial_claims: 3, governs_evidence: 7 }],
+    },
+    recall_volume: { available: false, reason: 'nothing writes recall telemetry yet' },
+    ...over,
+  };
+}
+
+/** Wire the three wiki reads; each is a thunk so a case can reject one independently. */
+function wire(w: {
+  scoreboard?: () => Promise<{ scoreboard: WikiScoreboard }>;
+  meta?: () => Promise<{ meta: WikiMeta }>;
+  rulesets?: () => Promise<{ rulesets: WikiRuleSet[] }>;
+} = {}): void {
+  const routeAbsent = (): Promise<never> => Promise.reject(new ApiError(404, 'Not Found'));
+  apiFetch.mockImplementation((path: unknown) => {
+    if (path === '/governance/wiki/scoreboard') return (w.scoreboard ?? routeAbsent)();
+    if (path === '/governance/wiki/meta') return (w.meta ?? routeAbsent)();
+    if (path === '/governance/wiki/rulesets') return (w.rulesets ?? routeAbsent)();
+    return Promise.reject(new Error(`unexpected apiFetch path: ${String(path)}`));
+  });
+}
+
+beforeEach(() => {
+  listConformanceRules.mockReset();
+  retireConformanceRule.mockReset();
+  apiFetch.mockReset();
+});
+
+describe('WikiPage — health header', () => {
+  it('renders the scoreboard raw signals with the derived verdict chip beside them', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire({ scoreboard: () => Promise.resolve({ scoreboard: scoreboard() }) });
+    render(<WikiPage />);
+
+    const health = await screen.findByTestId('wiki-health');
+    expect(within(health).getByTestId('wiki-verdict')).toHaveAttribute('data-verdict', 'populated');
+    expect(within(health).getByTestId('wiki-stat-typed')).toHaveTextContent('90%');
+    expect(within(health).getByTestId('wiki-stat-resolving')).toHaveTextContent('100%');
+    expect(within(health).getByTestId('wiki-stat-denials')).toHaveTextContent('2');
+    expect(within(health).getByTestId('wiki-stat-rules')).toHaveTextContent('2 active');
+    // Recall volume is documented UNAVAILABLE by the engine — the header says so in-band.
+    expect(screen.getByTestId('wiki-recall-unavailable')).toHaveTextContent('nothing writes recall telemetry yet');
+  });
+
+  it('states the honest unmeasured typing reason when the daemon had no docs root', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    const sb = scoreboard();
+    sb.typing = { available: false, reason: 'no docs root supplied', docs_scanned: 0, statements_total: 0, statements_typed: 0, by_class: {}, docs_untyped: [] };
+    wire({ scoreboard: () => Promise.resolve({ scoreboard: sb }) });
+    render(<WikiPage />);
+
+    const typed = await screen.findByTestId('wiki-stat-typed');
+    expect(typed).toHaveTextContent('not measured');
+    expect(typed).toHaveTextContent('no docs root supplied');
+  });
+
+  it('a 501 renders the honest "engine predates the wiki scoreboard" state, never an error card', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire({ scoreboard: () => Promise.reject(new ApiError(501, 'core-ts engine predates wiki scoreboard')) });
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-health-unsupported')).toHaveTextContent(/predates the wiki scoreboard/);
+    expect(screen.queryByTestId('wiki-health-error')).toBeNull();
+    // The rules browser still works off the shipping wire.
+    expect(await screen.findByTestId('wiki-rule-row')).toBeInTheDocument();
+  });
+
+  it('a real scoreboard failure surfaces as one', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    wire({ scoreboard: () => Promise.reject(new ApiError(500, 'store locked')) });
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-health-error')).toHaveTextContent(/store locked/);
+  });
+});
+
+describe('WikiPage — seededness', () => {
+  it('meta seeded:false renders the EMPTY state with the seed-runbook command shown', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    wire({ meta: () => Promise.resolve({ meta: { seeded: false } }) });
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-unseeded')).toHaveTextContent(/Wiki not seeded — run the seed runbook/);
+    expect(screen.getByTestId('wiki-seed-command')).toHaveTextContent('seed_wiki.py');
+    // The empty state replaces the browser — no facets to fiddle with an empty store.
+    expect(screen.queryByTestId('wiki-filter-severity')).toBeNull();
+    // The About panel still explains the pipeline, so the way out is on the page.
+    expect(screen.getByTestId('wiki-about')).toBeInTheDocument();
+  });
+
+  it('a daemon that cannot answer meta is never accused of an unseeded store', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    wire(); // every wiki route absent
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-rules-empty')).toHaveTextContent('No rules in the store.');
+    expect(screen.queryByTestId('wiki-unseeded')).toBeNull();
+  });
+});
+
+describe('WikiPage — rules browser facets', () => {
+  const corpus = [
+    rule(),
+    rule({ id: 'POL-100', rule_type: 'policy', severity: 'critical', statement: 'One writer per store', targets: { layer: 'surface' } }),
+    rule({ id: 'PAT-002', severity: 'warn', statement: 'Old habit', retired: true }),
+  ];
+
+  it('shows everything by default (status facet = all), retired chip included', async () => {
+    listConformanceRules.mockResolvedValue({ rules: corpus });
+    wire();
+    render(<WikiPage />);
+
+    expect(await screen.findAllByTestId('wiki-rule-row')).toHaveLength(3);
+    expect(screen.getByTestId('wiki-rule-retired-chip')).toBeInTheDocument();
+  });
+
+  it('filters by severity, layer, type, and status incl. retired', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: corpus });
+    wire();
+    render(<WikiPage />);
+    await screen.findAllByTestId('wiki-rule-row');
+
+    await user.selectOptions(screen.getByTestId('wiki-filter-severity'), 'critical');
+    let rows = screen.getAllByTestId('wiki-rule-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute('data-rule-id', 'POL-100');
+
+    await user.selectOptions(screen.getByTestId('wiki-filter-severity'), 'all');
+    await user.selectOptions(screen.getByTestId('wiki-filter-status'), 'retired');
+    rows = screen.getAllByTestId('wiki-rule-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute('data-rule-id', 'PAT-002');
+
+    await user.selectOptions(screen.getByTestId('wiki-filter-status'), 'active');
+    await user.selectOptions(screen.getByTestId('wiki-filter-layer'), 'surface');
+    rows = screen.getAllByTestId('wiki-rule-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute('data-rule-id', 'POL-100');
+
+    await user.selectOptions(screen.getByTestId('wiki-filter-layer'), 'all');
+    await user.selectOptions(screen.getByTestId('wiki-filter-status'), 'all');
+    await user.selectOptions(screen.getByTestId('wiki-filter-type'), 'pattern');
+    expect(screen.getAllByTestId('wiki-rule-row')).toHaveLength(2);
+  });
+
+  it('says which kind of empty it is when facets match nothing', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire();
+    render(<WikiPage />);
+    await screen.findByTestId('wiki-rule-row');
+
+    await user.selectOptions(screen.getByTestId('wiki-filter-severity'), 'info');
+    expect(screen.getByTestId('wiki-rules-empty')).toHaveTextContent('No rules match these facets.');
+  });
+});
+
+describe('filterRules — the facet predicate, pinned', () => {
+  it('an absent layer facet on the rule only matches the all filter', () => {
+    const noLayer = rule({ id: 'PAT-003', targets: {} });
+    expect(filterRules([noLayer], { severity: 'all', layer: 'foundation', rule_type: 'all', status: 'all' })).toHaveLength(0);
+    expect(filterRules([noLayer], { severity: 'all', layer: 'all', rule_type: 'all', status: 'all' })).toHaveLength(1);
+  });
+
+  it('status active excludes retired and vice versa; all keeps both', () => {
+    const rules = [rule(), rule({ id: 'PAT-002', retired: true })];
+    const f = (status: 'all' | 'active' | 'retired') => ({ severity: 'all', layer: 'all', rule_type: 'all', status });
+    expect(filterRules(rules, f('active')).map((r) => r.id)).toEqual(['PAT-001']);
+    expect(filterRules(rules, f('retired')).map((r) => r.id)).toEqual(['PAT-002']);
+    expect(filterRules(rules, f('all'))).toHaveLength(2);
+  });
+});
+
+describe('WikiPage — rule detail', () => {
+  it('joins wiki URI, provenance path@sha, evidence counts, and enforcement class', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire({
+      scoreboard: () => Promise.resolve({ scoreboard: scoreboard() }),
+      meta: () => Promise.resolve({
+        meta: { seeded: true, docs: [{ path: 'docs/agent-behavior.md', enforcement_class: 'policy' }] },
+      }),
+    });
+    render(<WikiPage />);
+
+    await user.click(await screen.findByTestId('wiki-rule-row'));
+    const detail = await screen.findByTestId('wiki-rule-detail');
+    expect(within(detail).getByTestId('wiki-rule-wiki-uri')).toHaveTextContent(`docs/agent-behavior.md@${SHA}#PAT-001`);
+    expect(within(detail).getByTestId('wiki-rule-provenance')).toHaveTextContent(`docs/agent-behavior.md@${SHA.slice(0, 12)}`);
+    expect(within(detail).getByTestId('wiki-rule-evidence')).toHaveTextContent('3 denial claims · 7 governs evidence');
+    expect(within(detail).getByTestId('wiki-rule-class')).toHaveTextContent('policy');
+    expect(within(detail).getByTestId('wiki-rule-statement')).toHaveTextContent('Never use printf without %s');
+  });
+
+  it('renders honest dashes when the joins have no producer on this daemon', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire(); // no scoreboard (evidence join), no meta (class join)
+    render(<WikiPage />);
+
+    await user.click(await screen.findByTestId('wiki-rule-row'));
+    const detail = await screen.findByTestId('wiki-rule-detail');
+    expect(within(detail).getByTestId('wiki-rule-evidence')).toHaveTextContent('—');
+    expect(within(detail).getByTestId('wiki-rule-class')).toHaveTextContent('—');
+  });
+
+  it('flags a legacy digest-less ref as needing re-ingest instead of inventing a sha', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({
+      rules: [rule({ provenance: { source: 'markdown', ref: 'docs/a.md#PAT-001', source_kinds: ['doc'] } })],
+    });
+    wire();
+    render(<WikiPage />);
+
+    await user.click(await screen.findByTestId('wiki-rule-row'));
+    expect(await screen.findByTestId('wiki-rule-provenance')).toHaveTextContent(/no digest — re-ingest/);
+  });
+});
+
+describe('WikiPage — the retire kill switch', () => {
+  async function openModal(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+    await user.click(await screen.findByTestId('wiki-rule-row'));
+    await user.click(await screen.findByTestId('wiki-retire-open'));
+    await screen.findByTestId('wiki-retire-modal');
+  }
+
+  it('stays disarmed until the EXACT rule id is typed AND a reason is given', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire();
+    render(<WikiPage />);
+    await openModal(user);
+
+    const confirm = screen.getByTestId('wiki-retire-confirm');
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByTestId('wiki-retire-confirm-input'), 'PAT-00'); // wrong id
+    await user.type(screen.getByTestId('wiki-retire-reason'), 'superseded by PAT-050');
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByTestId('wiki-retire-confirm-input'), '1'); // now exact
+    expect(confirm).toBeEnabled();
+    expect(retireConformanceRule).not.toHaveBeenCalled();
+  });
+
+  it('fires the existing retire wire, reloads for the server state, and echoes the reason', async () => {
+    const user = userEvent.setup();
+    listConformanceRules
+      .mockResolvedValueOnce({ rules: [rule()] })
+      .mockResolvedValueOnce({ rules: [rule({ retired: true })] });
+    retireConformanceRule.mockResolvedValue({ status: 'retired', id: 'PAT-001' });
+    wire();
+    render(<WikiPage />);
+    await openModal(user);
+
+    await user.type(screen.getByTestId('wiki-retire-confirm-input'), 'PAT-001');
+    await user.type(screen.getByTestId('wiki-retire-reason'), 'superseded by PAT-050');
+    await user.click(screen.getByTestId('wiki-retire-confirm'));
+
+    await waitFor(() => expect(retireConformanceRule).toHaveBeenCalledWith('PAT-001'));
+    // The row shows the SERVER's state, never this surface's optimism.
+    await waitFor(() => expect(listConformanceRules).toHaveBeenCalledTimes(2));
+    expect(await screen.findByTestId('wiki-rule-retired-chip')).toBeInTheDocument();
+    // Git is the source of truth — the reason's durable home is the doc PR, so it is echoed back.
+    expect(screen.getByTestId('wiki-retired-note')).toHaveTextContent('superseded by PAT-050');
+    expect(screen.queryByTestId('wiki-retire-modal')).toBeNull();
+  });
+
+  it('surfaces a failed retire in the modal instead of silently leaving the rule enforcing', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    retireConformanceRule.mockRejectedValue(new ApiError(404, 'unknown rule: PAT-001'));
+    wire();
+    render(<WikiPage />);
+    await openModal(user);
+
+    await user.type(screen.getByTestId('wiki-retire-confirm-input'), 'PAT-001');
+    await user.type(screen.getByTestId('wiki-retire-reason'), 'gone already');
+    await user.click(screen.getByTestId('wiki-retire-confirm'));
+
+    expect(await screen.findByTestId('wiki-retire-error')).toHaveTextContent(/unknown rule/);
+    expect(screen.getByTestId('wiki-retire-modal')).toBeInTheDocument();
+    expect(listConformanceRules).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers no retire button on an already-retired rule', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: [rule({ retired: true })] });
+    wire();
+    render(<WikiPage />);
+
+    await user.click(await screen.findByTestId('wiki-rule-row'));
+    await screen.findByTestId('wiki-rule-detail');
+    expect(screen.queryByTestId('wiki-retire-open')).toBeNull();
+    expect(screen.getByTestId('wiki-rule-retired-note')).toHaveTextContent(/withdrawn from recall/);
+  });
+});
+
+describe('WikiPage — RuleSet grouping', () => {
+  const corpus = [
+    rule(),
+    rule({ id: 'POL-100', rule_type: 'policy', severity: 'critical', statement: 'One writer per store' }),
+  ];
+
+  it('groups by doctrine domain with an ungrouped bucket, behind the toggle', async () => {
+    const user = userEvent.setup();
+    listConformanceRules.mockResolvedValue({ rules: corpus });
+    wire({ rulesets: () => Promise.resolve({ rulesets: [{ domain: 'agent-behavior', rule_ids: ['PAT-001'] }] }) });
+    render(<WikiPage />);
+    await screen.findAllByTestId('wiki-rule-row');
+
+    await user.click(await screen.findByTestId('wiki-group-toggle'));
+    const groups = screen.getAllByTestId('wiki-ruleset-group');
+    expect(groups.map((g) => g.getAttribute('data-domain'))).toEqual(['agent-behavior', 'ungrouped']);
+    expect(within(groups[0]!).getByTestId('wiki-rule-row')).toHaveAttribute('data-rule-id', 'PAT-001');
+    expect(within(groups[1]!).getByTestId('wiki-rule-row')).toHaveAttribute('data-rule-id', 'POL-100');
+
+    // The toggle flips back to the flat list.
+    await user.click(screen.getByTestId('wiki-group-toggle'));
+    expect(screen.queryByTestId('wiki-ruleset-group')).toBeNull();
+  });
+
+  it('says plainly when this daemon does not serve grouping', async () => {
+    listConformanceRules.mockResolvedValue({ rules: corpus });
+    wire(); // rulesets route absent
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-groups-unsupported')).toHaveTextContent(/not served by this daemon/);
+    expect(screen.queryByTestId('wiki-group-toggle')).toBeNull();
+  });
+});

--- a/tests/WikiPage.test.tsx
+++ b/tests/WikiPage.test.tsx
@@ -170,6 +170,17 @@ describe('WikiPage — seededness', () => {
     expect(await screen.findByTestId('wiki-rules-empty')).toHaveTextContent('No rules in the store.');
     expect(screen.queryByTestId('wiki-unseeded')).toBeNull();
   });
+
+  it('a mis-shaped meta payload (no wrapper) degrades like an unanswerable route, never a crash', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    // A daemon serving the meta object BARE instead of `{ meta: ... }` — a contract bug on the
+    // wire, which must read as "cannot tell", not throw through the page render.
+    wire({ meta: () => Promise.resolve({ seeded: false } as unknown as { meta: WikiMeta }) });
+    render(<WikiPage />);
+
+    expect(await screen.findByTestId('wiki-rules-empty')).toHaveTextContent('No rules in the store.');
+    expect(screen.queryByTestId('wiki-unseeded')).toBeNull();
+  });
 });
 
 describe('WikiPage — rules browser facets', () => {

--- a/tests/wikiApi.test.ts
+++ b/tests/wikiApi.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isWikiUnsupported,
+  parseProvenanceRef,
+  scoreboardVerdict,
+  type WikiScoreboard,
+} from '../src/api/wiki.js';
+import { ApiError } from '../src/api/errors.js';
+
+/**
+ * The wiki wire's pure halves, pinned:
+ *  - `parseProvenanceRef` mirrors the engine's `parse_provenance_ref` (provenance.rs, AW-10)
+ *    exactly — every HISTORICAL ref shape keeps parsing, and a stray `@` inside a path never
+ *    false-positives as a digest (the right-hand side must be exactly 40 lowercase hex);
+ *  - `scoreboardVerdict` is studio's populated-vs-decaying reading of the AW-23 raw signals
+ *    (the engine deliberately reports signals, not adjectives) — decay signals dominate;
+ *  - `isWikiUnsupported` folds the TWO adoption-gap answers (bare unknown-route 404 = crew
+ *    predates the wiki routes; 501 = crew has the route, its engine predates the method) and
+ *    keeps a NAMED 404 as the real answer it is.
+ */
+
+const SHA = 'a'.repeat(40);
+
+describe('parseProvenanceRef — every historical ref shape', () => {
+  it('parses the full digest-bearing form path@sha#anchor', () => {
+    expect(parseProvenanceRef(`docs/agent-behavior.md@${SHA}#PAT-001`)).toEqual({
+      path: 'docs/agent-behavior.md',
+      sha: SHA,
+      anchor: 'PAT-001',
+    });
+  });
+
+  it('parses a legacy pre-digest ref path#anchor to sha: null (drift residue, never a crash)', () => {
+    expect(parseProvenanceRef('docs/a.md#POL-042')).toEqual({ path: 'docs/a.md', sha: null, anchor: 'POL-042' });
+  });
+
+  it('parses path@sha with no anchor', () => {
+    expect(parseProvenanceRef(`docs/a.md@${SHA}`)).toEqual({ path: 'docs/a.md', sha: SHA, anchor: null });
+  });
+
+  it('parses a bare path', () => {
+    expect(parseProvenanceRef('docs/a.md')).toEqual({ path: 'docs/a.md', sha: null, anchor: null });
+  });
+
+  it('does not mistake an @ inside an ordinary ref for a digest', () => {
+    // The right-hand side must be exactly a 40-hex blob sha — `1.2.3` is not one.
+    expect(parseProvenanceRef('pkg@1.2.3#X')).toEqual({ path: 'pkg@1.2.3', sha: null, anchor: 'X' });
+  });
+
+  it('rejects a 40-char right-hand side that is not lowercase hex', () => {
+    const notSha = 'A'.repeat(40);
+    expect(parseProvenanceRef(`docs/a.md@${notSha}`)).toEqual({ path: `docs/a.md@${notSha}`, sha: null, anchor: null });
+  });
+});
+
+/** A healthy baseline scoreboard the cases below perturb one signal at a time. */
+function sb(over: Partial<WikiScoreboard> = {}): WikiScoreboard {
+  return {
+    rules_total: 10,
+    rules_active: 9,
+    rules_retired: 1,
+    typing: {
+      available: true,
+      docs_scanned: 4,
+      statements_total: 20,
+      statements_typed: 18,
+      percent: 90,
+      by_class: { policy: 10, guidance: 8 },
+      docs_untyped: [],
+    },
+    connection: { rules_with_ref: 3, refs_resolving: 3, refs_unresolvable: 0, percent: 100, rules_linked: 3 },
+    evidence: { denial_claims: 2, rules_evidenced: 2, evidenced_by_edges: 2, governs_evidence_total: 5, per_rule: [] },
+    recall_volume: { available: false, reason: 'nothing writes recall telemetry yet' },
+    ...over,
+  };
+}
+
+describe('scoreboardVerdict — the populated-vs-decaying derivation', () => {
+  it('no active rules → empty', () => {
+    expect(scoreboardVerdict(sb({ rules_active: 0 }))).toBe('empty');
+  });
+
+  it('typed + connected + cited by enforcement → populated', () => {
+    expect(scoreboardVerdict(sb())).toBe('populated');
+  });
+
+  it('an unresolvable symbol ref → decaying, even with evidence (decay dominates)', () => {
+    const s = sb();
+    s.connection = { ...s.connection, refs_unresolvable: 1, refs_resolving: 2, percent: 66.7 };
+    expect(scoreboardVerdict(s)).toBe('decaying');
+  });
+
+  it('measured typing under half → decaying', () => {
+    const s = sb();
+    s.typing = { ...s.typing, statements_typed: 5, percent: 25 };
+    expect(scoreboardVerdict(s)).toBe('decaying');
+  });
+
+  it('UNMEASURED typing (no docs root) is not decay — the daemon could not tell', () => {
+    const s = sb();
+    s.typing = { available: false, reason: 'no docs root', docs_scanned: 0, statements_total: 0, statements_typed: 0, by_class: {}, docs_untyped: [] };
+    expect(scoreboardVerdict(s)).toBe('populated');
+  });
+
+  it('rules with no live links or enforcement evidence → unproven (the honest middle)', () => {
+    const s = sb();
+    s.connection = { ...s.connection, rules_linked: 0 };
+    s.evidence = { ...s.evidence, denial_claims: 0, governs_evidence_total: 0 };
+    expect(scoreboardVerdict(s)).toBe('unproven');
+  });
+});
+
+describe('isWikiUnsupported — the two adoption-gap answers, and only those', () => {
+  it('501 (route present, engine method absent) → unsupported', () => {
+    expect(isWikiUnsupported(new ApiError(501, 'engine predates wiki scoreboard'))).toBe(true);
+  });
+
+  it("Fastify's bare unknown-route 404 (crew predates the wiki routes) → unsupported", () => {
+    expect(isWikiUnsupported(new ApiError(404, 'Not Found'))).toBe(true);
+  });
+
+  it('a NAMED 404 from a daemon WITH the route is a real answer, never an adoption gap', () => {
+    expect(isWikiUnsupported(new ApiError(404, 'unknown rule: PAT-999'))).toBe(false);
+  });
+
+  it('an ordinary error is not an adoption gap', () => {
+    expect(isWikiUnsupported(new Error('boom'))).toBe(false);
+  });
+});


### PR DESCRIPTION
New nav surface: scoreboard health header (honest 501/empty states), faceted rules browser w/ provenance + wiki URIs + evidence_count, RuleSet grouping (degrades to flat until crew ships the route), retire with typed confirmation + reason, About panel (how doctrine flows: doc PR → ingest → fanout → relink; agents consume via rules.recall). 36 component tests across all states; testid inventory regenerated.

Part of the wiki-management + clean-release program (user directive 2026-08-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)