### PR TITLE
release: 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ npm publish dates. Every version listed here exists on
   re-record → substitution lands in the spec diff; no agentic fallback inside the model-free
   runner) travels in the artifact's `$doc` header.
 
+## [0.4.2] — 2026-08-30
+
+### Added
+- **Architecture Wiki page** (nav): scoreboard health header, faceted rules browser
+  (provenance, wiki URIs, evidence counts), RuleSet grouping, retire kill-switch with
+  typed confirmation, About/authoring panel; honest 501/unseeded/empty states throughout.
+- **Campaign scoreboard** (TH-14): ladder + node status from Campaign* WS frames, verdict
+  chips, evidence links, cost column; sibling-run delivery rollup off `session.delivery`.
+- **GovernanceAudit honesty** (AW-18): renders the acceptance conformance section with an
+  explicit "unenforced" state — an unenforced run is never claimed guardrailed.
+- **data-testid inventory** as a versioned build artifact with a CI drift test (TH-13).
+
 ## [0.4.1] — 2026-08-29
 
 The truth-pass release: the docs and the site describe the product that shipped, and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.1",
-  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "version": "0.4.2",
+  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Wiki page, campaign scoreboard, GovernanceAudit, testid inventory. Tag v0.4.2 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)