### PR TITLE
chore: regenerate testid inventory at 0.4.2 (release blocker)

### DIFF
--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.1",
+  "studioVersion": "0.4.2",
   "counts": {
     "files": 96,
     "occurrences": 710,


### PR DESCRIPTION
The v0.4.2 Release failed its own testid drift test: the committed inventory carried 0.4.1 while the tag build runs as 0.4.2. Regenerated. Tag moves to the merged sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)