### PR TITLE
fix: steering client wire reconciliation (import entries / author documents / runId)

### DIFF
--- a/src/api/steering.ts
+++ b/src/api/steering.ts
@@ -152,12 +152,14 @@ export function isValidRuleId(id: string, ruleType: 'pattern' | 'policy'): boole
 
 // ── Import (`POST /governance/steering/import`) ───────────────────────────────────────────────
 
+export type SteeringImportEntryInput =
+  | { kind: 'doc'; name?: string; content: string }
+  | { kind: 'rule'; rule: Record<string, unknown> };
+
 export interface SteeringImportBody {
-  steering_type: SteeringType;
-  /** `.md` frontmattered doctrine or a `.json` rule batch — inferred from the picked file. */
-  format: 'markdown' | 'json';
-  filename: string;
-  content: string;
+  /** Default steering_type for entries that omit it — the page's type. */
+  type?: SteeringType;
+  entries: SteeringImportEntryInput[];
 }
 
 /** One entry's fate, reported per-rule so a half-good batch renders honestly. */
@@ -179,16 +181,19 @@ export function importSteeringRules(body: SteeringImportBody): Promise<{ results
 // ── Add with chat (`POST /governance/steering/author`) ────────────────────────────────────────
 
 export interface SteeringAuthorBody {
-  steering_type: SteeringType;
   instructions: string;
+  /** The page's type — a default the authoring run applies to proposals. */
+  type?: SteeringType;
+  /** Daemon-visible paths the run may read (dirs allowed). */
+  paths?: string[];
   /** File contents read client-side and carried inline — the authoring run's source material. */
-  attachments?: { name: string; content: string }[];
+  documents?: { name: string; content: string }[];
 }
 
 /** Launches the authoring run; its PROPOSE gate arrives as a normal `awaitingHuman` frame on
  *  the returned run — the existing gate components render and answer it. */
-export function authorSteeringRules(body: SteeringAuthorBody): Promise<{ run_id: string }> {
-  return apiFetch<{ run_id: string }>('/governance/steering/author', {
+export function authorSteeringRules(body: SteeringAuthorBody): Promise<{ runId: string }> {
+  return apiFetch<{ runId: string }>('/governance/steering/author', {
     method: 'POST',
     body: JSON.stringify(body),
   });

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -1053,15 +1053,15 @@ function AuthorPanel({ type, onClose, onAuthored }: {
     setBusy(true);
     setError(null);
     try {
-      const attachments = await Promise.all(
+      const documents = await Promise.all(
         files.map(async (f) => ({ name: f.name, content: await readFileText(f) })),
       );
-      const { run_id } = await authorSteeringRules({
-        steering_type: type,
+      const { runId } = await authorSteeringRules({
         instructions: instructions.trim(),
-        ...(attachments.length > 0 ? { attachments } : {}),
+        type,
+        ...(documents.length > 0 ? { documents } : {}),
       });
-      setRunId(run_id);
+      setRunId(runId);
     } catch (e) {
       if (isSteeringUnsupported(e)) setUnsupported(true);
       else setError(e instanceof Error ? e.message : String(e));
@@ -1288,12 +1288,20 @@ export function SteeringPage({ type, navigate }: {
   };
 
   const onImportPick = (file: File): void => {
-    const format: 'markdown' | 'json' = file.name.toLowerCase().endsWith('.json') ? 'json' : 'markdown';
+    const isJson = file.name.toLowerCase().endsWith('.json');
     setImportState({ kind: 'busy', filename: file.name });
     void readFileText(file)
-      .then((content) =>
-        importSteeringRules({ steering_type: type, format, filename: file.name, content }),
-      )
+      .then((content) => {
+        // .md = one doc entry through the MarkdownAdapter path; .json = a rule batch,
+        // each object its own entry so a half-good batch reports per rule.
+        const entries = isJson
+          ? (JSON.parse(content) as Record<string, unknown>[]).map((rule) => ({
+              kind: 'rule' as const,
+              rule,
+            }))
+          : [{ kind: 'doc' as const, name: file.name, content }];
+        return importSteeringRules({ type, entries });
+      })
       .then(({ results }) => {
         setImportState({ kind: 'done', filename: file.name, results });
         // Something may have landed even in a half-good batch — show the server's state.

--- a/tests/SteeringPage.manage.test.tsx
+++ b/tests/SteeringPage.manage.test.tsx
@@ -102,10 +102,8 @@ describe('SteeringPage — import', () => {
       'security-rules.md: 1 created · 1 updated · 1 failed',
     );
     expect(importBody).toMatchObject({
-      steering_type: 'security',
-      format: 'markdown',
-      filename: 'security-rules.md',
-      content: '# doctrine\n',
+      type: 'security',
+      entries: [{ kind: 'doc', name: 'security-rules.md', content: '# doctrine\n' }],
     });
     const rows = screen.getAllByTestId('steering-import-result');
     expect(rows.map((r) => r.getAttribute('data-status'))).toEqual(['created', 'updated', 'error']);
@@ -114,13 +112,13 @@ describe('SteeringPage — import', () => {
     await waitFor(() => expect(listConformanceRules).toHaveBeenCalledTimes(2));
   });
 
-  it('infers the json format from the extension', async () => {
+  it('parses a .json file into per-rule entries', async () => {
     const user = userEvent.setup();
     listConformanceRules.mockResolvedValue({ rules: [] });
-    let importBody: { format?: string } | null = null;
+    let importBody: { entries?: unknown[] } | null = null;
     wireManagement({
       '/governance/steering/import': (body) => {
-        importBody = body as { format?: string };
+        importBody = body as { entries?: unknown[] };
         return Promise.resolve({ results: [] });
       },
     });
@@ -129,9 +127,11 @@ describe('SteeringPage — import', () => {
     await user.click(await screen.findByTestId('steering-import-open'));
     await user.upload(
       screen.getByTestId('steering-import-file'),
-      new File(['[]'], 'batch.JSON', { type: 'application/json' }),
+      new File(['[{"id":"SEC-9"}]'], 'batch.JSON', { type: 'application/json' }),
     );
-    await waitFor(() => expect(importBody).toMatchObject({ format: 'json', steering_type: 'testing' }));
+    await waitFor(() =>
+      expect(importBody).toMatchObject({ type: 'testing', entries: [{ kind: 'rule', rule: { id: 'SEC-9' } }] }),
+    );
   });
 
   it('a 501/route-absent daemon gets the honest unsupported copy, never a raw refusal', async () => {
@@ -337,7 +337,7 @@ describe('SteeringPage — edit', () => {
 });
 
 describe('SteeringPage — add with chat (the authoring run + its propose gate)', () => {
-  it('POSTs instructions + attachments with THIS page type, then renders the EXISTING gate card when the propose gate arrives', async () => {
+  it('POSTs instructions + documents with THIS page type, then renders the EXISTING gate card when the propose gate arrives', async () => {
     const user = userEvent.setup();
     listConformanceRules.mockResolvedValue({ rules: [] });
     confirmGate.mockResolvedValue({ status: 'ok' });
@@ -345,7 +345,7 @@ describe('SteeringPage — add with chat (the authoring run + its propose gate)'
     wireManagement({
       '/governance/steering/author': (body) => {
         authorBody = body;
-        return Promise.resolve({ run_id: 'run-author-1' });
+        return Promise.resolve({ runId: 'run-author-1' });
       },
     });
     page('compliance');
@@ -366,9 +366,9 @@ describe('SteeringPage — add with chat (the authoring run + its propose gate)'
     // Launched: the honest waiting state until the run actually asks.
     expect(await screen.findByTestId('steering-author-waiting')).toHaveTextContent(/run-auth/);
     expect(authorBody).toMatchObject({
-      steering_type: 'compliance',
+      type: 'compliance',
       instructions: 'Derive rules from the attached SOC2 doc',
-      attachments: [{ name: 'soc2.md', content: 'CC6.1 …' }],
+      documents: [{ name: 'soc2.md', content: 'CC6.1 …' }],
     });
 
     // The propose gate arrives as a normal awaitingHuman frame on the run — the app's one /ws


### PR DESCRIPTION
Studio's hand-mirrored steering contract drifted from crew#369's strict schemas — a real 400/shape break at runtime. Reconciled: import {type, entries[]}, author {instructions, type, paths, documents} → {runId}. 46/46 steering tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)