### PR TITLE
feat: the Testing surface — harness, campaigns, evals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CenterDashboard } from './components/CenterDashboard.js';
 import { CommandPalette, paletteShortcutEntries } from './components/CommandPalette.js';
-import { CampaignScoreboard } from './components/CampaignScoreboard.js';
-import { CampaignsPage } from './components/CampaignsPage.js';
 import { ChatsPage } from './components/ChatsPage.js';
 import { CoverageView } from './components/CoverageView.js';
 import { DomainModelBrowser } from './components/DomainModelBrowser.js';
@@ -23,6 +21,7 @@ import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
 import { SteeringPage } from './components/SteeringPage.js';
+import { TestingPage } from './components/TestingPage.js';
 import { RunsBottomPanel, RUNS_BAR_PX } from './components/RunsBottomPanel.js';
 import { ChatPanel } from './components/ChatPanel.js';
 import { GroupChat } from './components/GroupChat.js';
@@ -34,7 +33,7 @@ import { ThemePage } from './components/ThemePage.js';
 import { ambientProjectId } from './hooks/ambientProject.js';
 import { useEventStream } from './hooks/useEventStream.js';
 import { setShortcutsPaletteOpen, useGlobalShortcuts } from './hooks/useGlobalShortcuts.js';
-import { useLegacyRedirect, useSteeringRedirect } from './hooks/useLegacyRedirect.js';
+import { useLegacyRedirect, useSteeringRedirect, useTestingRedirect } from './hooks/useLegacyRedirect.js';
 import { modePath, routedVersion, useRoute, type Mode } from './hooks/useRoute.js';
 import { useRuns } from './hooks/useRuns.js';
 import { useAnnotationStore } from './store/annotations.js';
@@ -48,6 +47,7 @@ import { useRunEventStore } from './store/events.js';
 import { useDocThreadStore } from './store/docThread.js';
 import type { CoreEvent, RepoEntry } from './api/types.js';
 import { DEFAULT_STEERING_TYPE, isSteeringType } from './api/steering.js';
+import { isTestingSubPage } from './api/testing.js';
 import { api } from './api/client.js';
 import { useAppearanceStore } from './theming/appearance.js';
 import { useNotifPrefsStore } from './store/notifPrefs.js';
@@ -74,7 +74,7 @@ const LIFECYCLE_EVENTS: ReadonlySet<string> = new Set([
 const TERMINAL_STATES = ['completed', 'cancelled', 'failed'];
 
 export function App(): React.ReactElement {
-  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, chronicleView, campaignId, steeringType, navigate, search, pathname } = useRoute();
+  const { panel, runId, repoId, projectId, mode, artifactId, showLaunch, showRegisterRepo, chatMode, chronicleView, campaignId, steeringType, testingPage, navigate, search, pathname } = useRoute();
   const { runs, refresh, loaded: runsLoaded } = useRuns();
   const ingestGate = useGateStore((s) => s.ingest);
   const ingestCampaign = useCampaignsStore((s) => s.ingest);
@@ -146,6 +146,10 @@ export function App(): React.ReactElement {
   // The retired governance addresses (`/wiki`, `/rules`) and any type-less `/steering` address
   // normalize onto the Architecture steering page (the STEERING program's one redirect).
   useSteeringRedirect(panel, steeringType, navigate);
+
+  // The retired flat campaign addresses (`/campaigns`, `/campaigns/:id`) rewrite onto
+  // `/testing/campaigns[...]`, and any page-less `/testing` address normalizes onto Harness.
+  useTestingRedirect(panel, testingPage, pathname, navigate);
 
   // FINDING-013: /ws has no late-join replay, so a page reloaded against a run shows an empty Burn
   // panel even though usage was durably recorded. When the selected run has no frames yet (a reload
@@ -535,19 +539,18 @@ export function App(): React.ReactElement {
         </div>
       );
     }
-    // `/campaigns` + `/campaigns/:id` — the read-only campaign surface (TH-14, extends
-    // studio#27): the escape-hatch list and the sibling-run scoreboard.
-    if (panel === 'campaigns') {
+    // `/testing/:page` — the Testing surface: ONE component, parameterized by sub-page
+    // (Harness / Campaigns / Evals). The campaign list + scoreboard (TH-14) live under it now;
+    // a page-less address renders Harness for the tick before useTestingRedirect lands.
+    if (panel === 'testing') {
       return (
         <div className="flex-1 overflow-y-auto">
-          <CampaignsPage navigate={navigate} />
-        </div>
-      );
-    }
-    if (panel === 'campaign-detail' && campaignId) {
-      return (
-        <div className="flex-1 overflow-y-auto">
-          <CampaignScoreboard campaignId={campaignId} runs={runs} navigate={navigate} />
+          <TestingPage
+            page={testingPage !== null && isTestingSubPage(testingPage) ? testingPage : 'harness'}
+            campaignId={campaignId}
+            runs={runs}
+            navigate={navigate}
+          />
         </div>
       );
     }

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -1,0 +1,180 @@
+/**
+ * The testing wire — types and calls for the Testing surface (`/testing/:page`): the steering
+ * EVALS runner (`POST /testing/evals/run`) and the eval-corpus import
+ * (`POST /testing/corpora/import`).
+ *
+ * ── INTEGRATION POINT (testing wave, paired core/core-ts/crew lanes) ──────────────────────────
+ * These shapes are the wave's PINNED WIRE CONTRACT, implemented verbatim on BOTH sides —
+ * crew's route slice and this client — because the steering wave shipped a drift when each
+ * side guessed. Do not "improve" a name; a served payload that disagrees with these shapes is
+ * a contract bug on whichever side deviated. Like the steering shapes in `./steering.ts`,
+ * every declaration here is TEMPORARY: **delete this block and re-export from
+ * `wicked-crew-api-types`** the moment studio bumps to the api-types version that carries the
+ * testing contract.
+ *
+ * The report JSON passes the Rust engine's serde output through VERBATIM (snake_case) — crew
+ * neither renames nor reshapes it, and neither does this client.
+ *
+ * The adoption seam is the same two-layer probe as steering: crew presence-gates the routes on
+ * the embedded engine's eval bindings (`typeof core.governanceEvals === 'function'`), so a 501
+ * means "route present, engine method absent — the engine predates core-ts 0.7.5", and a bare
+ * unknown-route 404 means "this crew predates the testing routes". {@link isTestingUnsupported}
+ * folds both so every caller renders the honest state, never a raw refusal.
+ */
+
+import { apiFetch } from './client.js';
+import { ApiError, isRouteAbsent } from './errors.js';
+
+// ── The Testing surface's sub-pages (client route vocabulary, not a wire) ────────────────────
+
+export const TESTING_PAGES = ['harness', 'campaigns', 'evals'] as const;
+
+export type TestingSubPage = (typeof TESTING_PAGES)[number];
+
+export const TESTING_PAGE_LABELS: Record<TestingSubPage, string> = {
+  harness: 'Harness',
+  campaigns: 'Campaigns',
+  evals: 'Evals',
+};
+
+export function isTestingSubPage(s: string): s is TestingSubPage {
+  return (TESTING_PAGES as readonly string[]).includes(s);
+}
+
+/** The one spelling of a testing sub-page's route. */
+export function testingPath(page: TestingSubPage): string {
+  return `/testing/${page}`;
+}
+
+/** One campaign's scoreboard address — MOVED under Testing (the flat `/campaigns/:id`
+ *  redirects here; `useTestingRedirect` is the normalizer). */
+export function campaignPath(id: string): string {
+  return `${testingPath('campaigns')}/${encodeURIComponent(id)}`;
+}
+
+// ── Eval samples (shared by the run report and the corpus import) ─────────────────────────────
+
+/** The recall signals one sample carries — what the engine's recall query is built from. */
+export interface EvalSampleSignals {
+  phase?: string;
+  tool?: string;
+  files?: string[];
+  content?: string;
+  [k: string]: unknown;
+}
+
+/** One eval sample, exactly as the corpus stores it (snake_case, the serde spelling). */
+export interface EvalSample {
+  id: string;
+  description: string;
+  /** `"good"` = behavior the rules should allow; `"bad"` = behavior they should deny. */
+  kind: 'good' | 'bad';
+  /** One of the seven steering types (see `./steering.ts`). */
+  steering_type: string;
+  signals: EvalSampleSignals;
+  [k: string]: unknown;
+}
+
+// ── `POST /testing/evals/run` ─────────────────────────────────────────────────────────────────
+
+export interface RunEvalsBody {
+  /** One of the seven steering types; omit = evaluate every type. */
+  type?: string;
+  /** An estate scope name (e.g. `"evals:dev-behaviors"`); omit = the built-in default corpus. */
+  corpus?: string;
+}
+
+/** The sample as the report echoes it — the identity fields, not the signals. */
+export interface EvalReportSample {
+  id: string;
+  description: string;
+  kind: string;
+  steering_type: string;
+  [k: string]: unknown;
+}
+
+/** A near-miss rule on a gap — how close recall came to firing the right rule. */
+export interface EvalNearestRule {
+  rule_id: string;
+  similarity: number;
+  [k: string]: unknown;
+}
+
+export interface EvalResult {
+  sample: EvalReportSample;
+  /** What the rules SHOULD have said about this sample. */
+  expected: 'deny' | 'allow';
+  /** The rule ids recall actually fired. */
+  fired: string[];
+  verdict: 'caught' | 'gap' | 'false_positive';
+  /** Present on gaps (empty array allowed — recall found nothing nearby). */
+  nearest_rules?: EvalNearestRule[];
+  [k: string]: unknown;
+}
+
+export interface EvalSummary {
+  total: number;
+  caught: number;
+  gaps: number;
+  false_positives: number;
+  [k: string]: unknown;
+}
+
+/** The eval report — the Rust serde output passed through verbatim. */
+export interface EvalReport {
+  results: EvalResult[];
+  summary: EvalSummary;
+  /** `"facet-only"` = the engine has no embedder: recall matched on facets alone and
+   *  similarity-based gap analysis is degraded. `null` = full recall. */
+  degraded: 'facet-only' | null;
+  [k: string]: unknown;
+}
+
+/** Runs the evals — 200 report | 501 (engine predates the eval bindings) | 400 (zod-invalid). */
+export function runEvals(body: RunEvalsBody): Promise<EvalReport> {
+  return apiFetch<EvalReport>('/testing/evals/run', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── `POST /testing/corpora/import` ────────────────────────────────────────────────────────────
+
+export interface CorpusImportBody {
+  /** The corpus name — the store scopes it as `evals:<name>`. */
+  name: string;
+  samples: EvalSample[];
+}
+
+export interface CorpusImportResult {
+  imported: number;
+  /** The estate scope the samples landed in: `evals:<name>` — feed it back to {@link runEvals}. */
+  scope: string;
+  /** False = stored facet-only (no embedder) — evals over this corpus run degraded. */
+  embedded: boolean;
+  [k: string]: unknown;
+}
+
+/** Imports a corpus — 200 result | 501 | 400. */
+export function importEvalCorpus(body: CorpusImportBody): Promise<CorpusImportResult> {
+  return apiFetch<CorpusImportResult>('/testing/corpora/import', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── The adoption seam ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * True when this daemon cannot serve the testing wire yet: a 501 (route present, engine
+ * bindings absent — the embedded engine predates core-ts 0.7.5) or Fastify's bare
+ * unknown-route 404 (crew predates the testing routes). A NAMED 4xx from a daemon WITH the
+ * route is a real answer and surfaces as one.
+ */
+export function isTestingUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}
+
+/** The honest in-band copy for {@link isTestingUnsupported} refusals. */
+export const TESTING_UNSUPPORTED_COPY =
+  'This daemon cannot run steering evals — the embedded engine predates the eval bindings (requires core-ts 0.7.5). The Harness and Campaigns surfaces still work.';

--- a/src/components/CampaignScoreboard.tsx
+++ b/src/components/CampaignScoreboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getCampaign, type CampaignDetail, type CampaignRun } from '../api/campaigns.js';
+import { testingPath } from '../api/testing.js';
 import { downloadRunEvidence } from '../api/client.js';
 import { apiStatus } from '../api/errors.js';
 import type { SessionView } from '../api/types.js';
@@ -165,7 +166,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
         </p>
         <button
           type="button"
-          onClick={() => navigate('/campaigns')}
+          onClick={() => navigate(testingPath('campaigns'))}
           style={{ color: 'var(--status-run)', textDecoration: 'underline' }}
         >
           All campaigns

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from 'react';
+import { campaignPath } from '../api/testing.js';
 import { useCampaignsStore } from '../store/campaigns.js';
 
 /**
- * `/campaigns` — every campaign, active and finished, newest-updated first (DES-CAMPAIGN-001
+ * `/testing/campaigns` (MOVED from the flat `/campaigns`, which redirects here) — every
+ * campaign, active and finished, newest-updated first (DES-CAMPAIGN-001
  * §3.5's escape hatch, exactly as `/runs` is for the board). Read-only (TH-14): each row is
  * the campaign's progress readout and a link into its scoreboard; zero requests beyond the
  * store's one `GET /campaigns`.
@@ -71,7 +73,7 @@ export function CampaignsPage({ navigate }: Props): React.ReactElement {
                 type="button"
                 data-testid="campaign-row"
                 data-campaign-id={s.campaign.id}
-                onClick={() => navigate(`/campaigns/${encodeURIComponent(s.campaign.id)}`)}
+                onClick={() => navigate(campaignPath(s.campaign.id))}
                 style={{
                   display: 'flex',
                   alignItems: 'baseline',

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -8,6 +8,7 @@ import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
 import { steeringPath, STEERING_TYPE_LABELS, STEERING_TYPES } from '../api/steering.js';
+import { testingPath, TESTING_PAGE_LABELS, TESTING_PAGES } from '../api/testing.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
 import { HealthRailSection } from './HealthRailSection.js';
@@ -67,7 +68,7 @@ const S = {
 
 // ── The five paths (§2.1) ─────────────────────────────────────────────────────
 
-export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'steering' | 'settings';
+export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'testing' | 'steering' | 'settings';
 
 /** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
  *  links `/system` in the collapsed column — it has no dashboard). `noun` is
@@ -78,13 +79,18 @@ const P_PROJECTS: PathSpec = { key: 'projects', title: 'Projects',     noun: 'Pr
 const P_MAKE: PathSpec     = { key: 'make',     title: 'Make',         noun: 'Document',   glyph: '⚒', dash: '/make',     collapsedHref: '/make' };
 const P_CHAT: PathSpec     = { key: 'chat',     title: 'Chat',         noun: 'Chat',       glyph: '💬', dash: '/chats',    collapsedHref: '/chats' };
 const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Repository', glyph: '⬡', dash: '/repos',    collapsedHref: '/repos' };
+// Testing (the testing wave): the quality surface, a PRIMARY path placed immediately BEFORE
+// Steering (order: … Testing, Steering, Settings). Like Steering it is title-only (no ▦/＋ —
+// its verbs live on the pages); its accordion rows are the three sub-pages, its collapsed
+// glyph links the Harness page (the first sub-page — there is no separate testing dashboard).
+const P_TESTING: PathSpec  = { key: 'testing',  title: 'Testing',      noun: 'Campaign',   glyph: '✓', dash: null,        collapsedHref: testingPath('harness') };
 // Steering (the STEERING program): the governance surface, a PRIMARY path placed immediately
 // BEFORE Settings. Like Settings it is title-only (no ▦/＋ — its management verbs live on the
 // pages); its accordion rows are the seven steering types, its collapsed glyph links the
 // Architecture page (the first sub-page — there is no separate steering dashboard).
 const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: null,        collapsedHref: steeringPath('architecture') };
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
-const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_STEERING, P_SETTINGS];
+const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_TESTING, P_STEERING, P_SETTINGS];
 
 // `wiki` and `rules` retired into Steering (they redirect to /steering/architecture).
 const SETTINGS_ROUTES = new Set(['system', 'theme', 'coverage', 'domain', 'workflows', 'policies']);
@@ -101,6 +107,9 @@ export function headingForPath(pathname: string): PathKey | null {
   // `/chat/new` AND `/chat/:id` (J4/C6: a live session's real URL) are Chat's.
   if (first === 'chats' || (first === 'chat' && second !== '')) return 'chat';
   if (first === 'repos' || first === 'repo-detail') return 'repos';
+  // The retired flat `/campaigns` addresses redirect into Testing — map them there too, so
+  // the rail is already on the right heading on the pre-redirect tick.
+  if (first === 'testing' || first === 'campaigns') return 'testing';
   // The retired `/wiki` + `/rules` addresses redirect into Steering — map them there too, so
   // the rail never flashes Settings open on the pre-redirect tick.
   if (first === 'steering' || first === 'wiki' || first === 'rules') return 'steering';
@@ -472,6 +481,29 @@ function MakePicker({ navigate, onClose, ambient }: {
   );
 }
 
+/** The Testing accordion's rows: one per sub-page (Harness / Campaigns / Evals), each a
+ *  navigate() shortcut — the SettingsShortcutRows grammar, never a parallel testing surface. */
+function TestingPageRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <div role="menu" className="flex flex-col pt-0.5">
+      {TESTING_PAGES.map((p) => (
+        <button
+          key={p}
+          type="button"
+          role="menuitem"
+          data-testid="rail-testing-page"
+          data-page={p}
+          onClick={() => navigate(testingPath(p))}
+          className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
+          style={{ color: 'var(--ink-muted)' }}
+        >
+          {TESTING_PAGE_LABELS[p]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 /** The Steering accordion's rows: one per steering type, each a navigate() shortcut to its
  *  sub-page — the SettingsShortcutRows grammar, never a parallel steering surface. */
 function SteeringTypeRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
@@ -757,6 +789,16 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
                   </button>
                 ))}
             <ViewAll href="/repos" navigate={navigate} />
+          </RailHeading>
+
+          {/* ── Testing — the quality surface, BEFORE Steering (testing wave). ─ */}
+          <RailHeading
+            path={P_TESTING}
+            open={openHeading === 'testing'}
+            onToggle={() => toggle('testing')}
+            navigate={navigate}
+          >
+            <TestingPageRows navigate={navigate} />
           </RailHeading>
 
           {/* ── Steering — the governance surface, BEFORE Settings (STEERING). ─ */}

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -137,8 +137,9 @@ function Stat({ testid, label, value, sub }: {
 const pct = (v: number | undefined): string => (v === undefined ? '—' : `${Math.round(v)}%`);
 
 /** Read a picked file as text. `File.text()` where the runtime has it (every shipping browser),
- *  the FileReader fallback where it does not (older DOM implementations — jsdom included). */
-function readFileText(file: File): Promise<string> {
+ *  the FileReader fallback where it does not (older DOM implementations — jsdom included).
+ *  Exported for the Testing surface's corpus upload — one reader, not a fork. */
+export function readFileText(file: File): Promise<string> {
   if (typeof file.text === 'function') return file.text();
   return new Promise((resolve, reject) => {
     const r = new FileReader();
@@ -1030,7 +1031,9 @@ function ImportPanel({ type, state, onPick, onClose }: {
 
 // ── Add with chat ─────────────────────────────────────────────────────────────────────────────
 
-function AuthorPanel({ type, onClose, onAuthored }: {
+/** Exported for the Testing surface's Harness page, which reuses this EXACT panel (type
+ *  `"testing"`) for its "add with chat" — one governed-run authoring UX, not a fork. */
+export function AuthorPanel({ type, onClose, onAuthored }: {
   type: SteeringType;
   onClose: () => void;
   /** Fires when the propose gate resolves — the page reloads rules for the server's state. */

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -1,0 +1,674 @@
+import { Fragment, useEffect, useState } from 'react';
+import { api } from '../api/client.js';
+import type { RepoEntry, SessionView } from '../api/types.js';
+import { STEERING_TYPE_LABELS, STEERING_TYPES } from '../api/steering.js';
+import {
+  importEvalCorpus,
+  isTestingUnsupported,
+  runEvals,
+  testingPath,
+  TESTING_PAGE_LABELS,
+  TESTING_PAGES,
+  TESTING_UNSUPPORTED_COPY,
+  type CorpusImportResult,
+  type EvalReport,
+  type EvalResult,
+  type EvalSample,
+  type TestingSubPage,
+} from '../api/testing.js';
+import { useGateStore } from '../store/gates.js';
+import { CampaignScoreboard } from './CampaignScoreboard.js';
+import { CampaignsPage } from './CampaignsPage.js';
+import { AuthorPanel, readFileText } from './SteeringPage.js';
+import { SteeringGate } from './SteeringGate.js';
+
+/**
+ * The Testing surface (`/testing/:page`) — ONE page component parameterized by sub-page,
+ * three sub-pages:
+ *
+ *  - **Harness** — where a testing effort starts: trigger a CAMPAIGN RECON (a governed run,
+ *    launched over the SHIPPING `POST /runs` wire, that surveys the target and proposes a test
+ *    campaign), render its INTAKE gate through the EXISTING SteeringGate card (the run's
+ *    `awaitingHuman` frame arrives on the app's one /ws fold — no second gate UI, no polling),
+ *    and approve to launch. Plus "add with chat": the steering AuthorPanel REUSED VERBATIM
+ *    with type `testing` — the same governed authoring run + propose gate as SteeringPage.
+ *  - **Campaigns** — the campaign list + scoreboard, MOVED here from the flat `/campaigns`
+ *    addresses (which now redirect). The components are the EXISTING CampaignsPage /
+ *    CampaignScoreboard, rendered — never forked.
+ *  - **Evals** — the steering-rule eval runner over the PINNED testing wire
+ *    (`POST /testing/evals/run`, `POST /testing/corpora/import` — see `../api/testing.ts`):
+ *    run per steering type or all, caught/gap/false-positive summary + results table, gap rows
+ *    expanding to nearest-rule similarities, and corpus upload. HONEST states throughout:
+ *    501 names the engine gap (core-ts 0.7.5), `degraded: "facet-only"` renders a visible
+ *    no-embedder notice, an empty corpus is an empty state in words — never a spinner that
+ *    cannot settle, never fabricated numbers.
+ */
+
+// ── Harness: the campaign recon ───────────────────────────────────────────────────────────────
+
+/**
+ * The recon framing the Harness prepends to the operator's brief — exported so the composition
+ * is contract-visible (and pinned by test): what the launch button sends is this prefix, a
+ * blank line, then the operator's own words, verbatim.
+ */
+export const RECON_PROBLEM_PREFIX =
+  'Campaign recon: survey the target and propose a test campaign — the scenarios, their ' +
+  'dependencies, and which are deterministic tool checks vs governed agent runs. Present the ' +
+  'proposed campaign at the intake gate and launch nothing until it is approved.';
+
+function ReconPanel({ navigate, onClose }: {
+  navigate: (path: string) => void;
+  onClose: () => void;
+}): React.ReactElement {
+  const [instructions, setInstructions] = useState('');
+  const [repoRef, setRepoRef] = useState('');
+  const [repos, setRepos] = useState<RepoEntry[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [resolved, setResolved] = useState(false);
+  // The intake gate arrives as a normal awaitingHuman frame on the launched run — the app's
+  // one /ws subscription already folds it into the gate store; this panel just watches for it
+  // and renders the EXISTING gate card (the AuthorPanel grammar). No second gate UI, no polling.
+  const gate = useGateStore((s) => (runId !== null ? s.gates[runId] : undefined));
+
+  useEffect(() => {
+    let disposed = false;
+    api
+      .listRepos()
+      .then(({ repos: rs }) => {
+        if (!disposed) setRepos(rs);
+      })
+      .catch(() => {
+        /* repo picker stays empty — the recon can still launch unscoped */
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  const launch = async (): Promise<void> => {
+    if (busy || instructions.trim() === '') return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { runId: id } = await api.launchRun({
+        problem: `${RECON_PROBLEM_PREFIX}\n\n${instructions.trim()}`,
+        ...(repoRef !== '' ? { repoRef } : {}),
+      });
+      setRunId(id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="testing-recon-panel"
+      className="flex flex-col gap-2 rounded p-3"
+      style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] font-semibold" style={{ color: 'var(--ink-high)' }}>
+          Run a campaign recon
+        </span>
+        <button
+          data-testid="testing-recon-close"
+          type="button"
+          onClick={onClose}
+          className="ml-auto text-[10px] hover:underline"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Close
+        </button>
+      </div>
+
+      {runId === null ? (
+        <>
+          <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            Launches a governed recon run: it surveys the target, drafts a test campaign — the
+            scenarios and their dependencies — and STOPS at its intake gate. Nothing runs until
+            you approve the gate here.
+          </p>
+          <textarea
+            data-testid="testing-recon-instructions"
+            value={instructions}
+            onChange={(e) => setInstructions(e.target.value)}
+            placeholder="What should this campaign cover? Name the surfaces, risks, or behaviors to test."
+            className="min-h-[4rem] resize-y rounded px-2 py-1 text-[11px] focus:outline-none"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+          <label className="flex items-center gap-2 text-[10px]" style={{ color: 'var(--ink-muted)' }}>
+            repository
+            <select
+              data-testid="testing-recon-repo"
+              value={repoRef}
+              onChange={(e) => setRepoRef(e.target.value)}
+              className="rounded px-1 py-0.5 text-[10px] font-mono"
+              style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+            >
+              <option value="">none — unscoped</option>
+              {repos.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {error !== null && (
+            <p data-testid="testing-recon-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+              {error}
+            </p>
+          )}
+          <div>
+            <button
+              data-testid="testing-recon-launch"
+              type="button"
+              disabled={busy || instructions.trim() === ''}
+              onClick={() => void launch()}
+              className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+            >
+              {busy ? 'Launching…' : 'Launch recon'}
+            </button>
+          </div>
+        </>
+      ) : resolved ? (
+        <p data-testid="testing-recon-resolved" className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Intake gate answered — the campaign&rsquo;s progress lands on{' '}
+          <button
+            type="button"
+            data-testid="testing-recon-to-campaigns"
+            onClick={() => navigate(testingPath('campaigns'))}
+            className="underline"
+            style={{ color: 'var(--accent)' }}
+          >
+            Campaigns
+          </button>
+          , and the recon run itself is at{' '}
+          <button
+            type="button"
+            onClick={() => navigate(`/runs/${encodeURIComponent(runId)}`)}
+            className="font-mono underline"
+            style={{ color: 'var(--accent)' }}
+          >
+            {runId.slice(0, 8)}
+          </button>
+          .
+        </p>
+      ) : gate === undefined ? (
+        <p data-testid="testing-recon-waiting" className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Recon run <span className="font-mono">{runId.slice(0, 8)}</span> launched — its intake
+          gate will appear here the moment the run asks. It also shows up everywhere gates do.
+        </p>
+      ) : (
+        // The intake gate — the EXISTING gate card, reused verbatim. Approving (optionally
+        // with steer text) is what launches the proposed campaign; rejecting launches nothing.
+        <SteeringGate
+          runId={runId}
+          ord={gate.ord}
+          prompt={gate.prompt}
+          onResolved={() => setResolved(true)}
+        />
+      )}
+    </div>
+  );
+}
+
+function HarnessPage({ navigate }: { navigate: (path: string) => void }): React.ReactElement {
+  /** Which harness panel is open — one at a time, the SteeringPage management-bar grammar. */
+  const [panel, setPanel] = useState<'recon' | 'author' | null>(null);
+  const openPanel = (p: 'recon' | 'author'): void => setPanel((cur) => (cur === p ? null : p));
+
+  return (
+    <div data-testid="testing-harness" className="flex flex-col gap-4">
+      <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+        The harness is where a testing effort starts: a campaign recon proposes the work and
+        stops at its intake gate; chat-authoring drafts testing steering rules the same governed
+        way. Both launch runs that gate before anything is written or executed.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          data-testid="testing-recon-open"
+          type="button"
+          aria-expanded={panel === 'recon'}
+          onClick={() => openPanel('recon')}
+          className="rounded px-2 py-1 text-[11px] font-semibold"
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+        >
+          Run campaign recon
+        </button>
+        <button
+          data-testid="testing-author-open"
+          type="button"
+          aria-expanded={panel === 'author'}
+          onClick={() => openPanel('author')}
+          className="rounded px-2 py-1 text-[11px] font-semibold"
+          style={{ color: 'var(--ink-high)', border: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
+        >
+          Add with chat
+        </button>
+      </div>
+
+      {panel === 'recon' && <ReconPanel navigate={navigate} onClose={() => setPanel(null)} />}
+      {/* The steering AuthorPanel, REUSED VERBATIM with this surface's type: the authoring run
+          drafts `testing` steering rules and stops at its propose gate — one component set. */}
+      {panel === 'author' && <AuthorPanel type="testing" onClose={() => setPanel(null)} onAuthored={() => {}} />}
+    </div>
+  );
+}
+
+// ── Evals ─────────────────────────────────────────────────────────────────────────────────────
+
+type EvalsRunState =
+  | { kind: 'idle' }
+  | { kind: 'busy' }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string }
+  | { kind: 'done'; report: EvalReport };
+
+type CorpusImportState =
+  | { kind: 'idle' }
+  | { kind: 'busy'; filename: string }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string }
+  | { kind: 'done'; filename: string; result: CorpusImportResult };
+
+const EVAL_VERDICT_COLOR: Record<EvalResult['verdict'], string> = {
+  caught: 'var(--status-done)',
+  gap: 'var(--status-fail)',
+  false_positive: 'var(--status-gate)',
+};
+
+const EVAL_VERDICT_WORD: Record<EvalResult['verdict'], string> = {
+  caught: 'caught',
+  gap: 'gap',
+  false_positive: 'false positive',
+};
+
+/** The honest engine-gap callout — 501 / route-absent, shared by run + import. */
+function UnsupportedNote({ testid }: { testid: string }): React.ReactElement {
+  return (
+    <p data-testid={testid} className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}>
+      {TESTING_UNSUPPORTED_COPY}
+    </p>
+  );
+}
+
+function GapNearestRules({ result }: { result: EvalResult }): React.ReactElement {
+  const nearest = result.nearest_rules ?? [];
+  return (
+    <div
+      data-testid="testing-evals-nearest"
+      className="flex flex-col gap-1 rounded px-3 py-2"
+      style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+    >
+      <span className="text-[10px] font-semibold" style={{ color: 'var(--ink-muted)' }}>
+        Nearest rules — how close recall came to firing the right one
+      </span>
+      {nearest.length === 0 ? (
+        <span data-testid="testing-evals-nearest-empty" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          No nearby rules recalled — nothing in the store is close to this sample.
+        </span>
+      ) : (
+        nearest.map((n) => (
+          <span key={n.rule_id} data-testid="testing-evals-nearest-rule" className="flex items-baseline gap-2 text-[10px] font-mono">
+            <span style={{ color: 'var(--ink-high)' }}>{n.rule_id}</span>
+            <span style={{ color: 'var(--ink-muted)' }}>similarity {n.similarity.toFixed(2)}</span>
+          </span>
+        ))
+      )}
+    </div>
+  );
+}
+
+function EvalReportView({ report }: { report: EvalReport }): React.ReactElement {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const s = report.summary;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {report.degraded === 'facet-only' && (
+        <p
+          data-testid="testing-evals-degraded"
+          className="rounded px-2 py-1 text-[10px]"
+          style={{ background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
+        >
+          Degraded run — this engine has no embedder, so recall matched on facets alone and
+          nearest-rule similarity is unavailable. The verdicts are real; the gap analysis is
+          weaker than an embedded run&rsquo;s.
+        </p>
+      )}
+
+      <p data-testid="testing-evals-summary" className="flex flex-wrap items-baseline gap-3 text-[11px]">
+        <span style={{ color: 'var(--ink-high)', fontWeight: 600 }}>{s.total} samples</span>
+        <span style={{ color: EVAL_VERDICT_COLOR.caught }}>{s.caught} caught</span>
+        <span style={{ color: EVAL_VERDICT_COLOR.gap }}>{s.gaps} gaps</span>
+        <span style={{ color: EVAL_VERDICT_COLOR.false_positive }}>{s.false_positives} false positives</span>
+      </p>
+
+      {report.results.length === 0 ? (
+        <p data-testid="testing-evals-empty" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>
+          The corpus served no samples — import one below, or run against the built-in default
+          corpus by leaving the corpus field blank.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table data-testid="testing-evals-table" className="w-full text-left text-[11px]" style={{ borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ color: 'var(--ink-dim)' }}>
+                <th className="px-2 py-1 font-semibold">sample</th>
+                <th className="px-2 py-1 font-semibold">type</th>
+                <th className="px-2 py-1 font-semibold">expected</th>
+                <th className="px-2 py-1 font-semibold">fired</th>
+                <th className="px-2 py-1 font-semibold">verdict</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.results.map((r) => {
+                const isGap = r.verdict === 'gap';
+                const expanded = expandedId === r.sample.id;
+                return (
+                  <Fragment key={r.sample.id}>
+                    <tr
+                      data-testid="testing-evals-row"
+                      data-sample-id={r.sample.id}
+                      data-verdict={r.verdict}
+                      style={{ borderTop: '1px solid var(--surface-raised)' }}
+                    >
+                      <td className="px-2 py-1.5 align-top">
+                        <span className="font-mono" style={{ color: 'var(--ink-high)' }}>{r.sample.id}</span>
+                        <p className="mt-0.5" style={{ color: 'var(--ink-muted)' }}>{r.sample.description}</p>
+                      </td>
+                      <td className="px-2 py-1.5 align-top font-mono" style={{ color: 'var(--ink-muted)' }}>
+                        {r.sample.steering_type}
+                      </td>
+                      <td className="px-2 py-1.5 align-top font-mono" style={{ color: 'var(--ink-muted)' }}>{r.expected}</td>
+                      <td className="px-2 py-1.5 align-top font-mono" style={{ color: 'var(--ink-muted)' }}>
+                        {r.fired.length === 0 ? '—' : r.fired.join(', ')}
+                      </td>
+                      <td className="px-2 py-1.5 align-top">
+                        <span
+                          className="rounded px-1.5 text-[10px] font-semibold"
+                          style={{ color: EVAL_VERDICT_COLOR[r.verdict], border: `1px solid ${EVAL_VERDICT_COLOR[r.verdict]}` }}
+                        >
+                          {EVAL_VERDICT_WORD[r.verdict]}
+                        </span>
+                        {isGap && (
+                          <button
+                            type="button"
+                            data-testid="testing-evals-gap-toggle"
+                            aria-expanded={expanded}
+                            onClick={() => setExpandedId(expanded ? null : r.sample.id)}
+                            className="ml-2 text-[10px] underline"
+                            style={{ color: 'var(--ink-dim)' }}
+                          >
+                            {expanded ? 'hide nearest' : 'nearest rules'}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                    {isGap && expanded && (
+                      <tr data-testid="testing-evals-gap-detail">
+                        <td colSpan={5} className="px-2 pb-2">
+                          <GapNearestRules result={r} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EvalsPage(): React.ReactElement {
+  /** `''` = all seven types (the body omits `type`). */
+  const [type, setType] = useState('');
+  /** `''` = the built-in default corpus (the body omits `corpus`). */
+  const [corpus, setCorpus] = useState('');
+  const [state, setState] = useState<EvalsRunState>({ kind: 'idle' });
+  const [corpusName, setCorpusName] = useState('');
+  const [importState, setImportState] = useState<CorpusImportState>({ kind: 'idle' });
+
+  const run = async (): Promise<void> => {
+    if (state.kind === 'busy') return;
+    setState({ kind: 'busy' });
+    try {
+      const report = await runEvals({
+        ...(type !== '' ? { type } : {}),
+        ...(corpus.trim() !== '' ? { corpus: corpus.trim() } : {}),
+      });
+      setState({ kind: 'done', report });
+    } catch (e) {
+      if (isTestingUnsupported(e)) setState({ kind: 'unsupported' });
+      else setState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  const onCorpusPick = (file: File): void => {
+    setImportState({ kind: 'busy', filename: file.name });
+    void readFileText(file)
+      .then((content) => {
+        // The file is either a bare `Sample[]` or a `{name, samples}` wrapper; the name field
+        // above wins over the wrapper's, and the filename stem is the last resort.
+        const parsed = JSON.parse(content) as unknown;
+        const wrapper = !Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null
+          ? (parsed as { name?: unknown; samples?: unknown })
+          : null;
+        const samples = Array.isArray(parsed) ? parsed : wrapper?.samples;
+        if (!Array.isArray(samples)) {
+          throw new Error(`${file.name} is not an eval corpus — expected a JSON array of samples, or {name, samples}`);
+        }
+        const name =
+          corpusName.trim() !== ''
+            ? corpusName.trim()
+            : typeof wrapper?.name === 'string' && wrapper.name.trim() !== ''
+              ? wrapper.name.trim()
+              : file.name.replace(/\.json$/i, '');
+        return importEvalCorpus({ name, samples: samples as EvalSample[] });
+      })
+      .then((result) => {
+        setImportState({ kind: 'done', filename: file.name, result });
+        // The imported scope is what the next run should target — pre-fill it, editable.
+        setCorpus(result.scope);
+      })
+      .catch((e: unknown) => {
+        if (isTestingUnsupported(e)) setImportState({ kind: 'unsupported' });
+        else setImportState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+      });
+  };
+
+  return (
+    <div data-testid="testing-evals" className="flex flex-col gap-4">
+      <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+        Evals replay a corpus of good/bad behavior samples against the steering-rule store and
+        report what recall caught, what it missed, and what it flagged wrongly — the measured
+        answer to &ldquo;do the rules actually steer?&rdquo;.
+      </p>
+
+      {/* The run controls — type (one of the seven, or all) + corpus scope. */}
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-0.5 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          steering type
+          <select
+            data-testid="testing-evals-type"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="rounded px-1 py-0.5 text-[11px] font-mono"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          >
+            <option value="">all types</option>
+            {STEERING_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {STEERING_TYPE_LABELS[t]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-0.5 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          corpus (estate scope; blank = built-in default)
+          <input
+            data-testid="testing-evals-corpus"
+            value={corpus}
+            onChange={(e) => setCorpus(e.target.value)}
+            placeholder="evals:dev-behaviors"
+            className="rounded px-2 py-0.5 text-[11px] font-mono"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+        </label>
+        <button
+          data-testid="testing-evals-run"
+          type="button"
+          disabled={state.kind === 'busy'}
+          onClick={() => void run()}
+          className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+        >
+          {state.kind === 'busy' ? 'Running…' : 'Run evals'}
+        </button>
+      </div>
+
+      {state.kind === 'busy' && (
+        <p data-testid="testing-evals-busy" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          Running evals…
+        </p>
+      )}
+      {state.kind === 'unsupported' && <UnsupportedNote testid="testing-evals-unsupported" />}
+      {state.kind === 'failed' && (
+        <p data-testid="testing-evals-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+          {state.message}
+        </p>
+      )}
+      {state.kind === 'done' && <EvalReportView report={state.report} />}
+
+      {/* Corpus import — a JSON file of samples lands in the estate as `evals:<name>`. */}
+      <div
+        className="flex flex-col gap-2 rounded p-3"
+        style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
+      >
+        <span className="text-[11px] font-semibold" style={{ color: 'var(--ink-high)' }}>
+          Import a corpus
+        </span>
+        <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+          A .json file — a bare array of samples, or {'{name, samples}'}. Each sample:{' '}
+          <span className="font-mono">
+            {'{id, description, kind: good|bad, steering_type, signals}'}
+          </span>
+          .
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            data-testid="testing-corpus-name"
+            value={corpusName}
+            onChange={(e) => setCorpusName(e.target.value)}
+            placeholder="corpus name (blank = from the file)"
+            className="rounded px-2 py-0.5 text-[11px] font-mono"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+          <input
+            data-testid="testing-corpus-file"
+            type="file"
+            accept=".json,application/json"
+            aria-label="Import an eval corpus"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file !== undefined) onCorpusPick(file);
+              e.target.value = '';
+            }}
+            className="text-[10px]"
+            style={{ color: 'var(--ink-muted)' }}
+          />
+        </div>
+        {importState.kind === 'busy' && (
+          <p data-testid="testing-corpus-busy" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            Importing {importState.filename}…
+          </p>
+        )}
+        {importState.kind === 'unsupported' && <UnsupportedNote testid="testing-corpus-unsupported" />}
+        {importState.kind === 'failed' && (
+          <p data-testid="testing-corpus-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+            {importState.message}
+          </p>
+        )}
+        {importState.kind === 'done' && (
+          <p data-testid="testing-corpus-summary" className="text-[10px]" style={{ color: 'var(--ink-muted)' }}>
+            {importState.filename}: imported {importState.result.imported} sample
+            {importState.result.imported === 1 ? '' : 's'} into{' '}
+            <span className="font-mono" style={{ color: 'var(--ink-high)' }}>{importState.result.scope}</span>
+            {importState.result.embedded ? ' (embedded)' : ' — stored facet-only: this engine has no embedder, so evals over it run degraded'}
+            .
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── The page ──────────────────────────────────────────────────────────────────────────────────
+
+export function TestingPage({ page, campaignId, runs, navigate }: {
+  page: TestingSubPage;
+  /** Non-null only on `/testing/campaigns/:id` — renders that campaign's scoreboard. */
+  campaignId: string | null;
+  /** The board's live run list — the campaign scoreboard reads sibling status from it. */
+  runs: SessionView[];
+  navigate: (path: string) => void;
+}): React.ReactElement {
+  return (
+    <div data-testid="testing-page" data-testing-page={page} className="flex flex-col">
+      <div className="flex max-w-5xl flex-col gap-4 px-6 pt-6">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>
+          Testing · {TESTING_PAGE_LABELS[page]}
+        </h2>
+
+        {/* The sub-page strip: three real navigations — the SteeringPage tab grammar. */}
+        <nav data-testid="testing-tabs" aria-label="Testing pages" className="flex flex-wrap gap-1">
+          {TESTING_PAGES.map((p) => (
+            <a
+              key={p}
+              data-testid="testing-tab"
+              data-page={p}
+              href={testingPath(p)}
+              aria-current={p === page ? 'page' : undefined}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(testingPath(p));
+              }}
+              className="rounded px-2 py-1 text-[11px] font-semibold"
+              style={{
+                textDecoration: 'none',
+                color: p === page ? 'var(--ink-high)' : 'var(--ink-muted)',
+                background: p === page ? 'var(--surface-raised)' : 'transparent',
+                border: `1px solid ${p === page ? 'var(--surface-raised)' : 'transparent'}`,
+              }}
+            >
+              {TESTING_PAGE_LABELS[p]}
+            </a>
+          ))}
+        </nav>
+      </div>
+
+      {/* Campaigns keep their own internal padding (the moved pages, unforked); Harness and
+          Evals content shares this shell's gutter. */}
+      {page === 'campaigns' ? (
+        campaignId !== null ? (
+          <CampaignScoreboard campaignId={campaignId} runs={runs} navigate={navigate} />
+        ) : (
+          <CampaignsPage navigate={navigate} />
+        )
+      ) : (
+        <div className="max-w-5xl px-6 py-4">
+          {page === 'harness' ? <HarnessPage navigate={navigate} /> : <EvalsPage />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { api } from '../api/client.js';
 import { DEFAULT_STEERING_TYPE, steeringPath } from '../api/steering.js';
+import { testingPath } from '../api/testing.js';
 import { modePath, projectPath, type Mode, type Navigate } from './useRoute.js';
 
 /** The synthesized "unfiled" project — a run that appears only there has no project. */
@@ -113,4 +114,32 @@ export function useSteeringRedirect(panel: string, steeringType: string | null, 
     if (panel !== 'steering' || steeringType !== null) return;
     navigate(steeringPath(DEFAULT_STEERING_TYPE), { replace: true });
   }, [panel, steeringType, navigate]);
+}
+
+/**
+ * The Testing surface's address normalizer (same grammar as {@link useSteeringRedirect}):
+ *
+ *  - the RETIRED flat campaign addresses `/campaigns` and `/campaigns/:id` (the campaign
+ *    surface MOVED under Testing) rewrite onto `/testing/campaigns[...]` — the path tail rides
+ *    along verbatim, so a bookmarked scoreboard lands on the same campaign;
+ *  - a page-less `/testing` address (bare or typo'd) normalizes onto the Harness page.
+ *
+ * REPLACE, like every redirect in this module, so Back never re-enters the dead address; the
+ * parse already lands both on `panel: 'testing'`, so the page renders instantly on the
+ * pre-redirect tick and nothing flashes.
+ */
+export function useTestingRedirect(
+  panel: string,
+  testingPage: string | null,
+  pathname: string,
+  navigate: Navigate,
+): void {
+  useEffect(() => {
+    if (panel !== 'testing') return;
+    if (pathname === '/campaigns' || pathname.startsWith('/campaigns/')) {
+      navigate(`/testing${pathname}`, { replace: true });
+      return;
+    }
+    if (testingPage === null) navigate(testingPath('harness'), { replace: true });
+  }, [panel, testingPage, pathname, navigate]);
 }

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { isSteeringType } from '../api/steering.js';
+import { isTestingSubPage } from '../api/testing.js';
 
 // `make` is the round-4 primary-path dashboard route (DES-FEEDBACK-003 §2.1) —
 // a CLIENT route (a new panel id in this union), not a wire. Slice M registers
@@ -7,9 +8,13 @@ import { isSteeringType } from '../api/steering.js';
 // `steering` is the STEERING program's surface (`/steering/:type`) — the panels
 // it replaced (`wiki`, `rules`) are gone from this union; their old paths parse
 // to `steering` with a null type, which `useSteeringRedirect` normalizes.
-export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'steering' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'campaigns' | 'campaign-detail';
+// `testing` is the Testing surface (`/testing/:page` — harness/campaigns/evals);
+// the flat campaign panels it absorbed (`campaigns`, `campaign-detail`) are gone
+// from this union — their old paths parse to `testing` and `useTestingRedirect`
+// rewrites the address onto `/testing/campaigns[...]`.
+export type Panel = 'home' | 'runs' | 'coverage' | 'workflows' | 'domain' | 'policies' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make';
 
-const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make', 'campaigns'];
+const PANELS: Panel[] = ['runs', 'coverage', 'workflows', 'domain', 'policies', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not
@@ -48,12 +53,18 @@ interface Route {
    *  VIEW of the project's build work, §3's adopted additive position), so
    *  this flag — not a fifth Mode — is what selects the view. */
   chronicleView: boolean;
-  /** Non-null only on `/campaigns/:id` (DES-CAMPAIGN-001 §3.5 / TH-14) — the campaign label. */
+  /** Non-null only on `/testing/campaigns/:id` (DES-CAMPAIGN-001 §3.5 / TH-14) — the campaign
+   *  label. The legacy flat `/campaigns/:id` parses to the same route while `useTestingRedirect`
+   *  rewrites the address. */
   campaignId: string | null;
   /** The steering sub-page's type on `/steering/:type`. `null` while panel === 'steering' means
    *  an address that names no valid type (bare `/steering`, the legacy `/wiki` and `/rules`) —
    *  `useSteeringRedirect` replaces those with the Architecture page's real URL. */
   steeringType: string | null;
+  /** The testing sub-page on `/testing/:page` (`harness` | `campaigns` | `evals`). `null` while
+   *  panel === 'testing' means an address that names no valid page (bare `/testing`, a typo) —
+   *  `useTestingRedirect` replaces those with the Harness page's real URL. */
+  testingPage: string | null;
 }
 
 /** Route options a caller can override; everything else takes its inert default. */
@@ -70,6 +81,7 @@ const INERT: Route = {
   chronicleView: false,
   campaignId: null,
   steeringType: null,
+  testingPage: null,
 };
 
 function route(over: Partial<Route>): Route {
@@ -189,10 +201,26 @@ function parse(pathname: string): Route {
   if (first === 'wiki' || first === 'rules') {
     return route({ panel: 'steering', steeringType: null });
   }
-  // `/campaigns/:id` — one campaign's scoreboard (DES-CAMPAIGN-001 §3.5 / TH-14); the bare
-  // `/campaigns` list resolves through the PANELS catch-all below, same as `/repos`.
-  if (first === 'campaigns' && second) {
-    return route({ panel: 'campaign-detail', campaignId: safeDecode(second) });
+  // `/testing/:page` — the Testing surface: one page component, parameterized by sub-page
+  // (harness / campaigns / evals), with `/testing/campaigns/:id` addressing one campaign's
+  // scoreboard (DES-CAMPAIGN-001 §3.5 / TH-14, MOVED here from the flat `/campaigns/:id`).
+  // A bare or typo'd `/testing` parses with `testingPage: null`; `useTestingRedirect`
+  // replaces it with the Harness page's real URL.
+  if (first === 'testing') {
+    if (second === 'campaigns' && third) {
+      return route({ panel: 'testing', testingPage: 'campaigns', campaignId: safeDecode(third) });
+    }
+    return route({ panel: 'testing', testingPage: isTestingSubPage(second) ? second : null });
+  }
+  // The RETIRED flat campaign addresses: `/campaigns` and `/campaigns/:id` fold into the
+  // Testing surface — parsed here so the pages render instantly, redirected (replace) by
+  // `useTestingRedirect` so bookmarks land on the surface's real URL.
+  if (first === 'campaigns') {
+    return route({
+      panel: 'testing',
+      testingPage: 'campaigns',
+      campaignId: second ? safeDecode(second) : null,
+    });
   }
   if (first === 'repo-detail' && second) {
     return route({ panel: 'repo-detail', repoId: safeDecode(second) });

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.2",
   "counts": {
-    "files": 96,
-    "occurrences": 744,
-    "static": 635,
+    "files": 97,
+    "occurrences": 782,
+    "static": 672,
     "dynamic": 39,
     "computed": 5
   },
@@ -2448,6 +2448,12 @@
       ]
     },
     {
+      "testId": "rail-testing-page",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
       "testId": "rail-view-all",
       "files": [
         "src/components/LeftSidebar.tsx"
@@ -3322,6 +3328,222 @@
       ]
     },
     {
+      "testId": "testing-author-open",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-corpus-busy",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-corpus-error",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-corpus-file",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-corpus-name",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-corpus-summary",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-busy",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-corpus",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-degraded",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-empty",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-error",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-gap-detail",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-gap-toggle",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-nearest",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-nearest-empty",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-nearest-rule",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-row",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-run",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-summary",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-table",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-type",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-harness",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-page",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-close",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-error",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-instructions",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-launch",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-open",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-panel",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-repo",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-resolved",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-to-campaigns",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-recon-waiting",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-tab",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-tabs",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "theme-page-link",
       "files": [
         "src/components/SystemSettings.tsx"
@@ -4115,7 +4337,8 @@
       "expression": "testid",
       "files": [
         "src/components/CampaignScoreboard.tsx",
-        "src/components/SteeringPage.tsx"
+        "src/components/SteeringPage.tsx",
+        "src/components/TestingPage.tsx"
       ]
     },
     {

--- a/tests/CampaignScoreboard.test.tsx
+++ b/tests/CampaignScoreboard.test.tsx
@@ -246,7 +246,7 @@ describe('honest degradation', () => {
     board([], navigate);
     await waitFor(() => expect(screen.getByTestId('campaign-notfound')).toBeInTheDocument());
     fireEvent.click(screen.getByText('All campaigns'));
-    expect(navigate).toHaveBeenCalledWith('/campaigns');
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
   });
 
   it('the cost column renders an honest "—" until TH-20 wires per-node cost', async () => {

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -73,6 +73,6 @@ describe('the list', () => {
     expect(rows[1]!.textContent).toContain('1 waiting on you');
 
     fireEvent.click(rows[0]!);
-    expect(navigate).toHaveBeenCalledWith('/campaigns/DES-MERGE-001');
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns/DES-MERGE-001');
   });
 });

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -58,7 +58,7 @@ const W2_ORDERED = [
   bp('scratch', 'quiet', 0),
 ];
 
-const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'steering', 'settings'] as const;
+const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'testing', 'steering', 'settings'] as const;
 
 function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
   return render(
@@ -104,21 +104,26 @@ describe('the route→heading map (§3.2)', () => {
     for (const p of ['/steering/architecture', '/steering/security', '/wiki', '/rules']) {
       expect(headingForPath(p)).toBe('steering');
     }
+    // Testing owns its routes AND the retired flat /campaigns addresses (they
+    // redirect to /testing/campaigns — same pre-redirect-tick contract).
+    for (const p of ['/testing/harness', '/testing/evals', '/testing/campaigns', '/testing/campaigns/c-1', '/campaigns', '/campaigns/c-1']) {
+      expect(headingForPath(p)).toBe('testing');
+    }
     expect(headingForPath('/')).toBeNull();
     expect(headingForPath('/runs')).toBeNull();
     expect(headingForPath('/runs/r-1')).toBeNull();
   });
 });
 
-describe('the six heading rows (§3.1 + STEERING)', () => {
-  it('renders all six headings; Steering and Settings are icon-less, the other four carry ▦ and ＋', async () => {
+describe('the seven heading rows (§3.1 + STEERING + the testing wave)', () => {
+  it('renders all seven headings; Testing, Steering and Settings are icon-less, the other four carry ▦ and ＋', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     for (const k of HEADING_KEYS) {
       expect(screen.getByTestId(`rail-heading-${k}`)).toBeInTheDocument();
     }
-    for (const k of ['steering', 'settings']) {
+    for (const k of ['testing', 'steering', 'settings']) {
       const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).queryByTestId('heading-dashboard')).toBeNull();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
@@ -130,13 +135,16 @@ describe('the six heading rows (§3.1 + STEERING)', () => {
     }
   });
 
-  it('Steering sits immediately BEFORE Settings (the STEERING placement contract)', async () => {
+  it('Testing sits immediately BEFORE Steering, which sits immediately BEFORE Settings (the placement contract)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
+    const testing = screen.getByTestId('rail-heading-testing');
     const steering = screen.getByTestId('rail-heading-steering');
     const settings = screen.getByTestId('rail-heading-settings');
-    // Same container, adjacent, steering first — a DOM-order assertion, not a style one.
+    // Same container, adjacent, testing → steering → settings — DOM-order assertions, not style ones.
+    expect(testing.compareDocumentPosition(steering) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(testing.nextElementSibling).toBe(steering);
     expect(steering.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(steering.nextElementSibling).toBe(settings);
   });
@@ -381,18 +389,33 @@ describe('accordion contents (§3.3)', () => {
     fireEvent.click(rows[3]!);
     expect(navigate).toHaveBeenCalledWith('/steering/testing');
   });
+
+  it('Testing expands to the three page rows, each navigating to its sub-page; the route expands it', async () => {
+    const navigate = vi.fn();
+    rail({ pathname: '/testing/evals', navigate });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const testing = screen.getByTestId('rail-heading-testing');
+    expect(testing.getAttribute('aria-expanded')).toBe('true');
+    const rows = within(testing).getAllByTestId('rail-testing-page');
+    expect(rows.map((r) => r.dataset.page)).toEqual(['harness', 'campaigns', 'evals']);
+    expect(rows[0]).toHaveTextContent('Harness');
+
+    fireEvent.click(rows[1]!);
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
+  });
 });
 
 describe('the collapsed rail (§3.2)', () => {
-  it('shows exactly six glyph links (Steering → its Architecture page, Settings → /system)', async () => {
+  it('shows exactly seven glyph links (Testing → its Harness page, Steering → its Architecture page, Settings → /system)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
-    expect(glyphs).toHaveLength(6);
+    expect(glyphs).toHaveLength(7);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/make', '/chats', '/repos', '/steering/architecture', '/system',
+      '/projects', '/make', '/chats', '/repos', '/testing/harness', '/steering/architecture', '/system',
     ]);
     // Accordions don't exist at this width.
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();

--- a/tests/TestingEvals.test.tsx
+++ b/tests/TestingEvals.test.tsx
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestingPage } from '../src/components/TestingPage.js';
+import { ApiError } from '../src/api/errors.js';
+import type { EvalReport } from '../src/api/testing.js';
+import { useGateStore } from '../src/store/gates.js';
+
+/**
+ * The Evals sub-page over the PINNED testing wire (`POST /testing/evals/run`,
+ * `POST /testing/corpora/import` — see src/api/testing.ts):
+ *  - the run POSTs exactly {type?, corpus?} (omitted = all types / the built-in corpus) and
+ *    renders the report's summary + results table verbatim from the serde output;
+ *  - GAP rows expand to their nearest_rules with similarity values (an empty array renders the
+ *    honest "nothing nearby" words — never a blank);
+ *  - `degraded: "facet-only"` renders a VISIBLE no-embedder notice;
+ *  - 501 / route-absent renders the honest engine-gap callout naming core-ts 0.7.5;
+ *  - an empty corpus is an empty state in words — never a spinner that cannot settle;
+ *  - corpus upload parses the picked JSON and POSTs {name, samples}, then pre-fills the corpus
+ *    field with the returned scope.
+ */
+
+const apiFetch = vi.fn();
+const listRepos = vi.fn(() => Promise.resolve({ repos: [] }));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: () => listRepos(),
+    launchRun: vi.fn(),
+    confirmGate: vi.fn(),
+    cancelRun: vi.fn(),
+  },
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+/** Route the mocked wire: known paths answer, everything else is route-absent. */
+function wire(handlers: Record<string, (body: unknown) => Promise<unknown>> = {}): void {
+  apiFetch.mockImplementation((path: unknown, init?: { body?: string }) => {
+    const h = handlers[String(path)];
+    if (h !== undefined) return h(init?.body === undefined ? undefined : JSON.parse(init.body));
+    return Promise.reject(new ApiError(404, 'Not Found'));
+  });
+}
+
+function page(): ReturnType<typeof render> {
+  return render(<TestingPage page="evals" campaignId={null} runs={[]} navigate={() => {}} />);
+}
+
+/** The fixture report — the serde output shape, verbatim snake_case. */
+const REPORT: EvalReport = {
+  results: [
+    {
+      sample: { id: 'S-1', description: 'rm -rf ridden into a build phase', kind: 'bad', steering_type: 'security' },
+      expected: 'deny',
+      fired: ['POL-101'],
+      verdict: 'caught',
+    },
+    {
+      sample: { id: 'S-2', description: 'secret echoed into the run log', kind: 'bad', steering_type: 'security' },
+      expected: 'deny',
+      fired: [],
+      verdict: 'gap',
+      nearest_rules: [
+        { rule_id: 'POL-104', similarity: 0.82 },
+        { rule_id: 'PAT-201', similarity: 0.61 },
+      ],
+    },
+    {
+      sample: { id: 'S-3', description: 'a plain rename refactor', kind: 'good', steering_type: 'development' },
+      expected: 'allow',
+      fired: ['PAT-300'],
+      verdict: 'false_positive',
+    },
+  ],
+  summary: { total: 3, caught: 1, gaps: 1, false_positives: 1 },
+  degraded: null,
+};
+
+beforeEach(() => {
+  apiFetch.mockReset();
+  listRepos.mockClear();
+  useGateStore.setState({ gates: {}, approaching: {} });
+});
+
+describe('Evals — the run', () => {
+  it('POSTs {type, corpus} exactly as pinned and renders summary + table from the report', async () => {
+    const user = userEvent.setup();
+    let runBody: unknown = null;
+    wire({
+      '/testing/evals/run': (body) => {
+        runBody = body;
+        return Promise.resolve(REPORT);
+      },
+    });
+    page();
+
+    await user.selectOptions(screen.getByTestId('testing-evals-type'), 'security');
+    await user.type(screen.getByTestId('testing-evals-corpus'), 'evals:dev-behaviors');
+    await user.click(screen.getByTestId('testing-evals-run'));
+
+    expect(await screen.findByTestId('testing-evals-summary')).toHaveTextContent('3 samples');
+    expect(runBody).toEqual({ type: 'security', corpus: 'evals:dev-behaviors' });
+
+    const summary = screen.getByTestId('testing-evals-summary');
+    expect(summary).toHaveTextContent('1 caught');
+    expect(summary).toHaveTextContent('1 gaps');
+    expect(summary).toHaveTextContent('1 false positives');
+
+    const rows = screen.getAllByTestId('testing-evals-row');
+    expect(rows.map((r) => r.getAttribute('data-verdict'))).toEqual(['caught', 'gap', 'false_positive']);
+    expect(rows[0]).toHaveTextContent('POL-101');
+    // A sample that fired nothing says so — never a blank cell.
+    expect(rows[1]).toHaveTextContent('—');
+    // No degraded notice on a full-recall run.
+    expect(screen.queryByTestId('testing-evals-degraded')).toBeNull();
+  });
+
+  it('omits type and corpus from the body when neither is chosen (all types, built-in corpus)', async () => {
+    const user = userEvent.setup();
+    let runBody: unknown = null;
+    wire({
+      '/testing/evals/run': (body) => {
+        runBody = body;
+        return Promise.resolve(REPORT);
+      },
+    });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    await screen.findByTestId('testing-evals-summary');
+    expect(runBody).toEqual({});
+  });
+
+  it('GAP rows expand to nearest_rules with similarity values; the other verdicts carry no toggle', async () => {
+    const user = userEvent.setup();
+    wire({ '/testing/evals/run': () => Promise.resolve(REPORT) });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    await screen.findByTestId('testing-evals-table');
+
+    // Exactly one toggle — the one gap row's.
+    const toggles = screen.getAllByTestId('testing-evals-gap-toggle');
+    expect(toggles).toHaveLength(1);
+    expect(screen.queryByTestId('testing-evals-nearest')).toBeNull();
+
+    await user.click(toggles[0]!);
+    const nearest = await screen.findByTestId('testing-evals-nearest');
+    const ruleRows = within(nearest).getAllByTestId('testing-evals-nearest-rule');
+    expect(ruleRows).toHaveLength(2);
+    expect(ruleRows[0]).toHaveTextContent('POL-104');
+    expect(ruleRows[0]).toHaveTextContent('similarity 0.82');
+    expect(ruleRows[1]).toHaveTextContent('PAT-201');
+    expect(ruleRows[1]).toHaveTextContent('similarity 0.61');
+
+    // Toggling again collapses.
+    await user.click(screen.getByTestId('testing-evals-gap-toggle'));
+    expect(screen.queryByTestId('testing-evals-nearest')).toBeNull();
+  });
+
+  it('a gap whose nearest_rules is EMPTY says "nothing nearby" in words — never a blank panel', async () => {
+    const user = userEvent.setup();
+    const report: EvalReport = {
+      results: [{ ...REPORT.results[1]!, nearest_rules: [] }],
+      summary: { total: 1, caught: 0, gaps: 1, false_positives: 0 },
+      degraded: null,
+    };
+    wire({ '/testing/evals/run': () => Promise.resolve(report) });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    await user.click(await screen.findByTestId('testing-evals-gap-toggle'));
+    expect(await screen.findByTestId('testing-evals-nearest-empty')).toHaveTextContent(/No nearby rules recalled/);
+  });
+
+  it('degraded: "facet-only" renders the VISIBLE no-embedder notice beside the real numbers', async () => {
+    const user = userEvent.setup();
+    wire({ '/testing/evals/run': () => Promise.resolve({ ...REPORT, degraded: 'facet-only' }) });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    expect(await screen.findByTestId('testing-evals-degraded')).toHaveTextContent(/no embedder/);
+    // The report still renders — degraded is a caveat, not a refusal.
+    expect(screen.getByTestId('testing-evals-summary')).toHaveTextContent('3 samples');
+  });
+
+  it('501 renders the honest engine-gap callout naming core-ts 0.7.5 — never a raw refusal', async () => {
+    const user = userEvent.setup();
+    wire({ '/testing/evals/run': () => Promise.reject(new ApiError(501, 'governanceEvals is not a function')) });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    expect(await screen.findByTestId('testing-evals-unsupported')).toHaveTextContent(/requires core-ts 0\.7\.5/);
+    expect(screen.queryByTestId('testing-evals-error')).toBeNull();
+  });
+
+  it('a route-absent daemon (bare 404) folds into the same honest callout', async () => {
+    const user = userEvent.setup();
+    wire(); // no testing routes at all
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    expect(await screen.findByTestId('testing-evals-unsupported')).toHaveTextContent(/requires core-ts 0\.7\.5/);
+  });
+
+  it('an empty corpus is an empty state in words — the run settles, no spinner survives', async () => {
+    const user = userEvent.setup();
+    wire({
+      '/testing/evals/run': () =>
+        Promise.resolve({ results: [], summary: { total: 0, caught: 0, gaps: 0, false_positives: 0 }, degraded: null }),
+    });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    expect(await screen.findByTestId('testing-evals-empty')).toHaveTextContent(/served no samples/);
+    expect(screen.queryByTestId('testing-evals-busy')).toBeNull();
+    expect(screen.queryByTestId('testing-evals-table')).toBeNull();
+  });
+
+  it('a named 4xx surfaces as the translated error, not the unsupported callout', async () => {
+    const user = userEvent.setup();
+    wire({
+      '/testing/evals/run': () => Promise.reject(new ApiError(400, 'Invalid request body: unknown field `corpsu`')),
+    });
+    page();
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    expect(await screen.findByTestId('testing-evals-error')).toHaveTextContent(/corpsu/);
+    expect(screen.queryByTestId('testing-evals-unsupported')).toBeNull();
+  });
+});
+
+describe('Evals — corpus import', () => {
+  const SAMPLES = [
+    {
+      id: 'S-1',
+      description: 'rm -rf ridden into a build phase',
+      kind: 'bad',
+      steering_type: 'security',
+      signals: { phase: 'build', tool: 'bash', content: 'rm -rf /' },
+    },
+  ];
+
+  it('POSTs {name, samples} from the picked JSON array and pre-fills the corpus field with the scope', async () => {
+    const user = userEvent.setup();
+    let importBody: unknown = null;
+    wire({
+      '/testing/corpora/import': (body) => {
+        importBody = body;
+        return Promise.resolve({ imported: 1, scope: 'evals:dev-behaviors', embedded: true });
+      },
+    });
+    page();
+
+    await user.type(screen.getByTestId('testing-corpus-name'), 'dev-behaviors');
+    await user.upload(
+      screen.getByTestId('testing-corpus-file'),
+      new File([JSON.stringify(SAMPLES)], 'dev-behaviors.json', { type: 'application/json' }),
+    );
+
+    expect(await screen.findByTestId('testing-corpus-summary')).toHaveTextContent(
+      'dev-behaviors.json: imported 1 sample into evals:dev-behaviors (embedded)',
+    );
+    expect(importBody).toEqual({ name: 'dev-behaviors', samples: SAMPLES });
+    // The next run targets what just landed.
+    expect(screen.getByTestId('testing-evals-corpus')).toHaveValue('evals:dev-behaviors');
+  });
+
+  it('embedded: false says so — stored facet-only, evals over it run degraded', async () => {
+    const user = userEvent.setup();
+    wire({
+      '/testing/corpora/import': () => Promise.resolve({ imported: 1, scope: 'evals:x', embedded: false }),
+    });
+    page();
+
+    await user.type(screen.getByTestId('testing-corpus-name'), 'x');
+    await user.upload(
+      screen.getByTestId('testing-corpus-file'),
+      new File([JSON.stringify(SAMPLES)], 'x.json', { type: 'application/json' }),
+    );
+    expect(await screen.findByTestId('testing-corpus-summary')).toHaveTextContent(/facet-only/);
+  });
+
+  it('501 on import folds into the same honest core-ts callout', async () => {
+    const user = userEvent.setup();
+    wire({
+      '/testing/corpora/import': () => Promise.reject(new ApiError(501, 'governanceCorpusImport is not a function')),
+    });
+    page();
+
+    await user.upload(
+      screen.getByTestId('testing-corpus-file'),
+      new File([JSON.stringify(SAMPLES)], 'x.json', { type: 'application/json' }),
+    );
+    expect(await screen.findByTestId('testing-corpus-unsupported')).toHaveTextContent(/requires core-ts 0\.7\.5/);
+  });
+
+  it('a file that is not a corpus fails in words, client-side, without a POST', async () => {
+    const user = userEvent.setup();
+    let posted = false;
+    wire({
+      '/testing/corpora/import': () => {
+        posted = true;
+        return Promise.resolve({ imported: 0, scope: 'evals:x', embedded: true });
+      },
+    });
+    page();
+
+    await user.upload(
+      screen.getByTestId('testing-corpus-file'),
+      new File(['{"not":"a corpus"}'], 'nope.json', { type: 'application/json' }),
+    );
+    expect(await screen.findByTestId('testing-corpus-error')).toHaveTextContent(/not an eval corpus/);
+    expect(posted).toBe(false);
+  });
+});

--- a/tests/TestingHarness.test.tsx
+++ b/tests/TestingHarness.test.tsx
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiError } from '../src/api/errors.js';
+import { useGateStore } from '../src/store/gates.js';
+
+/**
+ * The Harness sub-page (`/testing/harness`) — where a testing effort starts:
+ *  - the CAMPAIGN RECON launches a governed run over the SHIPPING `POST /runs` wire (the
+ *    composed problem = the exported RECON_PROBLEM_PREFIX + the operator's brief, verbatim —
+ *    the composition is contract-visible and pinned here); its INTAKE gate arrives as a normal
+ *    awaitingHuman frame and renders through the EXISTING SteeringGate card; approving is what
+ *    launches the proposed campaign;
+ *  - "add with chat" is the steering AuthorPanel REUSED VERBATIM with type `testing` — the
+ *    same governed authoring run + propose gate as SteeringPage, one component set, no fork.
+ */
+
+const launchRun = vi.fn();
+const listRepos = vi.fn();
+const confirmGate = vi.fn();
+const cancelRun = vi.fn();
+const apiFetch = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    launchRun: (...a: unknown[]) => launchRun(...a),
+    listRepos: () => listRepos(),
+    confirmGate: (...a: unknown[]) => confirmGate(...a),
+    cancelRun: (...a: unknown[]) => cancelRun(...a),
+  },
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+const { TestingPage, RECON_PROBLEM_PREFIX } = await import('../src/components/TestingPage.js');
+
+function page(navigate: (p: string) => void = () => {}): ReturnType<typeof render> {
+  return render(<TestingPage page="harness" campaignId={null} runs={[]} navigate={navigate} />);
+}
+
+beforeEach(() => {
+  launchRun.mockReset();
+  listRepos.mockReset();
+  listRepos.mockResolvedValue({ repos: [{ id: 'r-1', name: 'repo-one', root_path: '/tmp/repo-one', registered_at: 1 }] });
+  confirmGate.mockReset();
+  cancelRun.mockReset();
+  apiFetch.mockReset();
+  apiFetch.mockRejectedValue(new ApiError(404, 'Not Found'));
+  useGateStore.setState({ gates: {}, approaching: {} });
+});
+
+describe('Harness — the campaign recon', () => {
+  it('launches over POST /runs with the pinned prefix + the brief, waits honestly, renders the intake gate, and resolves', async () => {
+    const user = userEvent.setup();
+    launchRun.mockResolvedValue({ runId: 'run-recon-1' });
+    confirmGate.mockResolvedValue({ status: 'ok' });
+    page();
+
+    await user.click(screen.getByTestId('testing-recon-open'));
+    const panel = await screen.findByTestId('testing-recon-panel');
+    await user.type(
+      within(panel).getByTestId('testing-recon-instructions'),
+      'Cover the checkout flow end to end',
+    );
+    await user.selectOptions(within(panel).getByTestId('testing-recon-repo'), 'r-1');
+    await user.click(within(panel).getByTestId('testing-recon-launch'));
+
+    // Launched: the honest waiting state until the run actually asks.
+    expect(await screen.findByTestId('testing-recon-waiting')).toHaveTextContent(/run-reco/);
+    expect(launchRun).toHaveBeenCalledWith({
+      problem: `${RECON_PROBLEM_PREFIX}\n\nCover the checkout flow end to end`,
+      repoRef: 'r-1',
+    });
+
+    // The intake gate arrives as a normal awaitingHuman frame — the EXISTING gate card renders.
+    act(() => {
+      useGateStore.getState().ingest({
+        type: 'awaitingHuman',
+        session: 'run-recon-1',
+        ord: 1,
+        prompt: 'Proposed campaign: 4 scenarios — approve to launch',
+      } as never);
+    });
+    const gate = await screen.findByTestId('steering-gate');
+    expect(gate).toHaveAttribute('data-run-id', 'run-recon-1');
+    expect(within(gate).getByTestId('steering-prompt')).toHaveTextContent(/Proposed campaign/);
+
+    // Approving rides the same POST /runs/:id/gate as every gate; the panel lands resolved.
+    await user.click(within(gate).getByTestId('steering-approve'));
+    await waitFor(() => expect(confirmGate).toHaveBeenCalledWith('run-recon-1', { approve: true }));
+    expect(await screen.findByTestId('testing-recon-resolved')).toHaveTextContent(/Campaigns/);
+  });
+
+  it('omits repoRef when no repository is chosen, and the launch button gates on a brief', async () => {
+    const user = userEvent.setup();
+    launchRun.mockResolvedValue({ runId: 'run-recon-2' });
+    page();
+
+    await user.click(screen.getByTestId('testing-recon-open'));
+    expect(screen.getByTestId('testing-recon-launch')).toBeDisabled();
+
+    await user.type(screen.getByTestId('testing-recon-instructions'), 'Smoke the API surface');
+    await user.click(screen.getByTestId('testing-recon-launch'));
+    await screen.findByTestId('testing-recon-waiting');
+    expect(launchRun).toHaveBeenCalledWith({
+      problem: `${RECON_PROBLEM_PREFIX}\n\nSmoke the API surface`,
+    });
+  });
+
+  it('a refused launch surfaces the translated error in-band', async () => {
+    const user = userEvent.setup();
+    launchRun.mockRejectedValue(new ApiError(400, 'no seats configured'));
+    page();
+
+    await user.click(screen.getByTestId('testing-recon-open'));
+    await user.type(screen.getByTestId('testing-recon-instructions'), 'anything');
+    await user.click(screen.getByTestId('testing-recon-launch'));
+    expect(await screen.findByTestId('testing-recon-error')).toHaveTextContent(/no seats configured/);
+    expect(screen.queryByTestId('testing-recon-waiting')).toBeNull();
+  });
+});
+
+describe('Harness — add with chat (the steering AuthorPanel, reused verbatim)', () => {
+  it('opens the SAME author panel and POSTs /governance/steering/author with type "testing"', async () => {
+    const user = userEvent.setup();
+    let authorBody: unknown = null;
+    apiFetch.mockImplementation((path: unknown, init?: { body?: string }) => {
+      if (String(path) === '/governance/steering/author') {
+        authorBody = init?.body === undefined ? undefined : JSON.parse(init.body);
+        return Promise.resolve({ runId: 'run-author-9' });
+      }
+      return Promise.reject(new ApiError(404, 'Not Found'));
+    });
+    page();
+
+    await user.click(screen.getByTestId('testing-author-open'));
+    const panel = await screen.findByTestId('steering-author-panel');
+    expect(panel).toHaveTextContent('Add Testing rules with chat');
+
+    await user.type(
+      within(panel).getByTestId('steering-author-instructions'),
+      'Derive testing doctrine from our flake postmortems',
+    );
+    await user.click(within(panel).getByTestId('steering-author-launch'));
+
+    expect(await screen.findByTestId('steering-author-waiting')).toHaveTextContent(/run-auth/);
+    expect(authorBody).toMatchObject({
+      type: 'testing',
+      instructions: 'Derive testing doctrine from our flake postmortems',
+    });
+  });
+
+  it('the two panels are one-at-a-time, the management-bar grammar', async () => {
+    const user = userEvent.setup();
+    page();
+
+    await user.click(screen.getByTestId('testing-recon-open'));
+    expect(screen.getByTestId('testing-recon-panel')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('testing-author-open'));
+    expect(screen.queryByTestId('testing-recon-panel')).toBeNull();
+    expect(screen.getByTestId('steering-author-panel')).toBeInTheDocument();
+
+    // Again-click closes — zero open is legal.
+    await user.click(screen.getByTestId('testing-author-open'));
+    expect(screen.queryByTestId('steering-author-panel')).toBeNull();
+  });
+});
+
+describe('the sub-page strip', () => {
+  it('renders the three tabs as real navigations, the current one marked', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    page(navigate);
+
+    const tabs = screen.getAllByTestId('testing-tab');
+    expect(tabs.map((t) => t.dataset.page)).toEqual(['harness', 'campaigns', 'evals']);
+    expect(tabs[0]).toHaveAttribute('aria-current', 'page');
+    expect(tabs[1]).not.toHaveAttribute('aria-current');
+
+    await user.click(tabs[2]!);
+    expect(navigate).toHaveBeenCalledWith('/testing/evals');
+  });
+});

--- a/tests/testingRoutes.test.tsx
+++ b/tests/testingRoutes.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRoute } from '../src/hooks/useRoute.js';
+import { useTestingRedirect } from '../src/hooks/useLegacyRedirect.js';
+import { TESTING_PAGES } from '../src/api/testing.js';
+
+/**
+ * The Testing routes (the testing wave):
+ *  - `/testing/:page` parses to the testing panel for each of the three sub-pages
+ *    (harness / campaigns / evals), with `/testing/campaigns/:id` carrying the campaign label;
+ *  - the RETIRED flat campaign addresses `/campaigns` and `/campaigns/:id` (the campaign
+ *    surface MOVED under Testing) parse to the SAME testing panel — kept routable, then
+ *    REPLACED by `useTestingRedirect` with the `/testing/campaigns[...]` spelling, the id
+ *    riding along so a bookmarked scoreboard lands on the same campaign;
+ *  - a bare or typo'd `/testing` address normalizes onto the Harness page;
+ *  - a valid new-spelling address never redirects.
+ */
+
+function routeAt(path: string) {
+  window.history.replaceState(null, '', path);
+  return renderHook(() => useRoute()).result;
+}
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+describe('useRoute — /testing/:page', () => {
+  it('parses every testing sub-page to the one testing panel', () => {
+    for (const p of TESTING_PAGES) {
+      const r = routeAt(`/testing/${p}`).current;
+      expect(r.panel).toBe('testing');
+      expect(r.testingPage).toBe(p);
+      // No run-selected machinery ever fires against a testing address.
+      expect(r.runId).toBeNull();
+      expect(r.projectId).toBeNull();
+    }
+  });
+
+  it('parses /testing/campaigns/:id with the campaign label, decoded', () => {
+    const r = routeAt('/testing/campaigns/DES%20MERGE').current;
+    expect(r.panel).toBe('testing');
+    expect(r.testingPage).toBe('campaigns');
+    expect(r.campaignId).toBe('DES MERGE');
+  });
+
+  it('a bare or unknown-page /testing parses with testingPage null (the redirect normalizes it)', () => {
+    expect(routeAt('/testing').current).toMatchObject({ panel: 'testing', testingPage: null });
+    expect(routeAt('/testing/bogus').current).toMatchObject({ panel: 'testing', testingPage: null });
+  });
+
+  it('the retired flat /campaigns addresses fold into the testing panel, campaign id intact', () => {
+    expect(routeAt('/campaigns').current).toMatchObject({
+      panel: 'testing',
+      testingPage: 'campaigns',
+      campaignId: null,
+    });
+    expect(routeAt('/campaigns/c-42').current).toMatchObject({
+      panel: 'testing',
+      testingPage: 'campaigns',
+      campaignId: 'c-42',
+    });
+  });
+
+  it('every other route spells testingPage null without claiming the testing panel', () => {
+    const r = routeAt('/policies').current;
+    expect(r.panel).toBe('policies');
+    expect(r.testingPage).toBeNull();
+  });
+});
+
+describe('useTestingRedirect', () => {
+  it('REPLACES a page-less testing address with the Harness page', () => {
+    const navigate = vi.fn();
+    renderHook(() => useTestingRedirect('testing', null, '/testing', navigate));
+    expect(navigate).toHaveBeenCalledWith('/testing/harness', { replace: true });
+  });
+
+  it('REWRITES the retired flat campaign addresses onto /testing/campaigns, tail intact', () => {
+    const navigate = vi.fn();
+    renderHook(() => useTestingRedirect('testing', 'campaigns', '/campaigns', navigate));
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns', { replace: true });
+
+    navigate.mockClear();
+    renderHook(() => useTestingRedirect('testing', 'campaigns', '/campaigns/c-42', navigate));
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns/c-42', { replace: true });
+  });
+
+  it('leaves a valid new-spelling address alone, and every non-testing panel alone', () => {
+    const navigate = vi.fn();
+    renderHook(() => useTestingRedirect('testing', 'evals', '/testing/evals', navigate));
+    renderHook(() => useTestingRedirect('testing', 'campaigns', '/testing/campaigns/c-42', navigate));
+    renderHook(() => useTestingRedirect('steering', null, '/steering', navigate));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Top-level Testing nav (before Steering, before Settings) with three pages: Harness (campaign recon trigger + intake gate + launch + add-with-chat via the steering-author pattern), Campaigns (scoreboard moved here; old route redirects), Evals (run per type/all, caught/gap/false-positive table, gap rows expand to nearest rules with similarity, corpus upload, honest 501 / facet-only-degrade / empty states). Client mirrors crew's pinned wire byte-for-byte (asserted in tests). Testid inventory regenerated. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)