### PR TITLE
fix: the usability review's dead ends — routing, overlays, honest numbers, human titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,9 @@ import { LeftSidebar } from './components/LeftSidebar.js';
 import { DocumentCanvas } from './components/DocumentCanvas.js';
 import { DocumentThread } from './components/DocumentThread.js';
 import { VideoStoryboard } from './components/VideoStoryboard.js';
+import { NotFoundPage } from './components/NotFoundPage.js';
 import { ProjectDashboard } from './components/ProjectDashboard.js';
+import { SkipLink } from './components/SkipLink.js';
 import { ProjectShell } from './components/ProjectShell.js';
 import { ProjectDetailPage } from './components/ProjectDetailPage.js';
 import { ProjectsPage } from './components/ProjectsPage.js';
@@ -415,6 +417,15 @@ export function App(): React.ReactElement {
 
   // Center panel content based on route
   function renderCenter(): React.ReactElement {
+    // A dead address (usability review #4): the honest not-found view. Checked
+    // FIRST — no redirect hook fires for this panel, so the typed URL stays.
+    if (panel === 'not-found') {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <NotFoundPage pathname={pathname} navigate={navigate} />
+        </div>
+      );
+    }
     // The project shell owns every `/p/*` route and is checked FIRST — the panel parse
     // below is untouched and still owns the flat cross-project lists and side panels.
     if (projectId !== null && mode !== null) {
@@ -457,6 +468,7 @@ export function App(): React.ReactElement {
           <SteeringPage
             type={steeringType !== null && isSteeringType(steeringType) ? steeringType : null}
             navigate={navigate}
+            search={search}
           />
         </div>
       );
@@ -584,6 +596,9 @@ export function App(): React.ReactElement {
     // with it the version strip's proximity-sensor band, which ends at the
     // canvas edge) ends ABOVE the bar. Nothing is ever covered while collapsed.
     <div className="flex h-screen overflow-hidden bg-surface-base" style={{ paddingBottom: RUNS_BAR_PX }}>
+      {/* The FIRST tabbable element (usability review #10): one Tab reaches a
+          jump to the main content instead of a page's top-right Refresh. */}
+      <SkipLink />
       <LeftSidebar
         runs={runs}
         navigate={navigate}
@@ -592,7 +607,7 @@ export function App(): React.ReactElement {
         immersive={immersive}
       />
 
-      <div className="flex flex-1 overflow-hidden">
+      <div id="main" tabIndex={-1} className="flex flex-1 overflow-hidden" style={{ outline: 'none' }}>
         {renderCenter()}
       </div>
 

--- a/src/api/wiki.ts
+++ b/src/api/wiki.ts
@@ -81,12 +81,14 @@ export interface WikiRecallVolume {
   reason: string;
 }
 
-/** Per-steering-type rule counts — the steering-model lane's scoreboard growth. Optional on
- *  every wire shipping today; the Steering pages render per-type numbers only when served. */
+/** Per-steering-type rule counts — one row of the engine's `by_type` map
+ *  (wicked-governance `SteeringTypeCount`, serde field spellings verbatim). */
 export interface SteeringTypeCounts {
-  rules_total: number;
-  rules_active: number;
-  rules_retired: number;
+  total: number;
+  active: number;
+  retired: number;
+  /** Decide-lane (effect-bearing) rows within this type. */
+  enforcing?: number;
   [k: string]: unknown;
 }
 
@@ -99,9 +101,10 @@ export interface WikiScoreboard {
   connection: WikiConnectionCoverage;
   evidence: WikiEnforcementEvidence;
   recall_volume: WikiRecallVolume;
-  /** Keyed by steering type (`architecture` … `design-ux`). Absent pre-0.7.5 — the pages then
-   *  show the store-wide numbers, labeled as store-wide, never a fabricated per-type zero. */
-  by_steering_type?: Record<string, SteeringTypeCounts>;
+  /** Keyed by steering type (`architecture` … `design-ux`) — only types holding rules appear
+   *  (wicked-governance `Scoreboard.by_type`). Optional so a pre-steering engine's report still
+   *  parses — the pages then fall back to a client-side count, labeled as exactly that. */
+  by_type?: Record<string, SteeringTypeCounts>;
   [k: string]: unknown;
 }
 

--- a/src/api/wiki.ts
+++ b/src/api/wiki.ts
@@ -210,10 +210,12 @@ export function parseProvenanceRef(ref: string): ParsedProvenanceRef {
 export type WikiVerdict = 'empty' | 'populated' | 'decaying' | 'unproven';
 
 export const VERDICT_COPY: Record<WikiVerdict, string> = {
-  empty: 'No active rules — the wiki is not populated.',
+  empty: 'No active rules yet.',
+  // Honest wording with the action a user can actually take (usability review
+  // #5: the old copy was alarming, unexplained, and pointed at nothing in-UI).
   decaying:
-    'Ingested once and drifting: unresolvable symbol refs or mostly-untyped doctrine. Re-run ingest/relink.',
-  populated: 'Typed, connected to code, and cited by enforcement — the wiki is alive.',
+    'Some rules point at code that no longer resolves, or most rules are missing a type. Re-import your rules docs (Import on any type page) to refresh the links.',
+  populated: 'Typed, connected to code, and cited by enforcement — the rules are alive.',
   unproven:
     'Rules exist but nothing proves they are wired: no live code links or enforcement evidence yet.',
 };

--- a/src/components/CampaignScoreboard.tsx
+++ b/src/components/CampaignScoreboard.tsx
@@ -161,7 +161,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
       <div data-testid="campaign-notfound" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
         <p style={{ marginBottom: '12px' }}>
           No campaign is filed under <b style={{ color: 'var(--ink-high)' }}>{campaignId}</b> on
-          this daemon — a campaign is minted by its first filed run, so this label either never
+          this daemon — a campaign appears with its first run, so this label either never
           launched one or lives on another daemon.
         </p>
         <button

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { campaignPath } from '../api/testing.js';
+import { campaignPath, testingPath } from '../api/testing.js';
 import { useCampaignsStore } from '../store/campaigns.js';
 
 /**
@@ -50,10 +50,31 @@ export function CampaignsPage({ navigate }: Props): React.ReactElement {
         Campaigns
       </h1>
       {summaries.length === 0 ? (
-        <p data-testid="campaigns-empty" style={{ marginTop: '16px', color: 'var(--ink-muted)' }}>
-          No campaigns yet. A campaign is minted by its first filed run — launch a run with a
-          campaign label and it appears here.
-        </p>
+        // Quick win #3 + review #6: plain words, and a way OUT of the dead end —
+        // the Harness is where a campaign starts.
+        <div data-testid="campaigns-empty" style={{ marginTop: '16px', color: 'var(--ink-muted)' }}>
+          <p style={{ margin: 0 }}>
+            Campaigns appear when you launch a run with a campaign label — start one from Harness.
+          </p>
+          <button
+            type="button"
+            data-testid="campaigns-empty-cta"
+            onClick={() => navigate(testingPath('harness'))}
+            style={{
+              marginTop: '12px',
+              padding: '6px 14px',
+              borderRadius: 'var(--radius-md)',
+              background: 'var(--accent)',
+              color: 'var(--accent-fg)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 600,
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Go to Harness
+          </button>
+        </div>
       ) : (
         <div style={{ marginTop: '16px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
           {summaries.map((s) => {

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -2,11 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
-import { useTimeRange, type TimeRange } from '../hooks/useTimeRange.js';
+import { rangeWord, useTimeRange, type TimeRange } from '../hooks/useTimeRange.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { GatesWaitingTile, TileBand } from './DashboardTiles.js';
 import { MetricTile } from './MetricTile.js';
+import { humanTitle } from './runIdentity.js';
 import { RunSparkline } from './RunSparkline.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
@@ -29,7 +30,10 @@ export const isChatRun = (v: SessionView): boolean =>
 
 // ── The chats-over-time tile (DES-FEEDBACK-003 §4.3 row 1, slice P) ───────────
 
-const RANGE_DAYS: Record<TimeRange, number> = { '30d': 30, '60d': 60, '90d': 90 };
+const RANGE_DAYS: Record<TimeRange, number> = { '30d': 30, '60d': 60, '90d': 90, all: 365 };
+
+/** The honest window phrase: "in the last 30" (runs), or "overall" for `all`. */
+const windowWordOf = (r: TimeRange): string => (r === 'all' ? 'overall' : `in the ${rangeWord(r)}`);
 const BUCKETS = 12;
 const DAY_MS = 86_400_000;
 
@@ -69,8 +73,8 @@ function ChatsOverTimeTile({ chats, range, now }: {
     <MetricTile
       testId="chats-over-time-tile"
       question="Is conversation increasing or drying up?"
-      title={`Chats (${range})`}
-      value={placed === 0 ? `no placed chats in ${range}` : `${placed} in ${range}`}
+      title={`Chats (${rangeWord(range)})`}
+      value={placed === 0 ? `no placed chats ${windowWordOf(range)}` : `${placed} ${windowWordOf(range)}`}
       data={{ 'data-total': placed, 'data-unplaced': chats.length - placed }}
     >
       {placed === 0 ? (
@@ -243,8 +247,8 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
             // "0 of 0" can never sit beside a visible live row.
             value={
               liveCount > 0
-                ? `${liveCount} live session${liveCount === 1 ? '' : 's'} · ${active.length} chat run${active.length === 1 ? '' : 's'} in ${range}`
-                : `${active.length} of ${chats.length} chat runs in ${range}`
+                ? `${liveCount} live session${liveCount === 1 ? '' : 's'} · ${active.length} chat run${active.length === 1 ? '' : 's'} ${windowWordOf(range)}`
+                : `${active.length} of ${chats.length} chat runs ${windowWordOf(range)}`
             }
             data={{ 'data-count': active.length + liveCount, 'data-live': liveCount }}
           >
@@ -402,7 +406,9 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
               className="w-full text-left rounded-2xl px-5 py-4 transition-colors"
               style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
             >
-              <p className="text-sm font-mono truncate">{v.session.problem}</p>
+              <p className="text-sm font-mono truncate" title={v.session.problem}>
+                {humanTitle(v.session.problem)}
+              </p>
               <p className="text-xs mt-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
                 {v.session.id.slice(0, 8)} · {v.session.status}
               </p>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -16,7 +16,7 @@ import { decideGate, GATE_HASH } from '../board/gateActions.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { Modal } from './Modal.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
-import { INTENT_MAX, runTitle, runWhenWord, WHEN_TITLE } from './runIdentity.js';
+import { humanTitle, INTENT_MAX, runTitle, runWhenWord, WHEN_TITLE } from './runIdentity.js';
 import { Terminal } from './Terminal.js';
 
 /**
@@ -320,8 +320,11 @@ export function CommandPalette({
         // match stays on the full problem (prose corpus, §5.2). Highlight
         // positions survive only when they land inside the displayed intent
         // fragment — a hit past the truncation is a real hit with no honest
-        // highlight, never a misplaced one.
-        const intentLen = Math.min(v.session.problem.length, INTENT_MAX);
+        // highlight, never a misplaced one. The fragment length comes from the
+        // ACTUAL clause humanTitle displays (a literal prefix of the problem),
+        // not the raw INTENT_MAX budget the clause may stop short of.
+        const shownIntent = humanTitle(v.session.problem, INTENT_MAX);
+        const intentLen = shownIntent.endsWith('…') ? shownIntent.length - 1 : shownIntent.length;
         hits.push({
           en: {
             id: `s-run-${id}`,

--- a/src/components/DecisionsLedger.tsx
+++ b/src/components/DecisionsLedger.tsx
@@ -131,8 +131,11 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                       {g.combined ? 'ALLOW' : 'DENY'}
                     </span>
                     <span style={{ color: 'var(--ink-muted)' }}>
-                      {' · '}{gateDecider(g)}
-                      {g.criterion ? ` · ${g.criterion}` : ' · (ungated)'}
+                      {/* Usability review #7: "ALLOW · ungated · (ungated)" said the same
+                          nothing twice. An ungated allow is ONE honest line. */}
+                      {g.combined && gateDecider(g) === 'ungated' && !g.criterion
+                        ? ' · allowed — no policy applied'
+                        : <>{' · '}{gateDecider(g)}{g.criterion ? ` · ${g.criterion}` : ' · no criterion recorded'}</>}
                     </span>
                   </p>
                   {g.hasDeterministicFloor && (
@@ -146,16 +149,16 @@ export function DecisionsLedger({ model }: Props): React.ReactElement {
                       {g.agentReasoning ? ` — ${g.agentReasoning}` : ''}
                     </p>
                   )}
-                  {g.evaluatorPass !== null && (
+                  {/* A vacuous pass (true with zero policies) renders NO evaluator line:
+                      the headline above already says "allowed — no policy applied", and
+                      repeating it dressed as an evaluator verdict is the theater review
+                      #7 flagged. A fail, or a pass that names its policies, still shows. */}
+                  {g.evaluatorPass !== null && !(g.evaluatorPass && g.evaluatorPolicies.length === 0) && (
                     <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                       evaluator: {g.evaluatorPass ? 'pass' : 'fail'}
-                      {/* Name the policies that ran, or say plainly that none did — "pass" on its
-                          own reads as an enforced approval when it is a default-allow. */}
                       {g.evaluatorPolicies.length > 0
                         ? ` — ${g.evaluatorPolicies.join(', ')}`
-                        : g.evaluatorPass
-                          ? ' (no policy applied)'
-                          : ''}
+                        : ''}
                     </p>
                   )}
                   {g.denialReason && (

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -12,6 +12,7 @@ import { BatchGateBar } from './BatchGateBar.js';
 import { LiveFeed } from './LiveFeed.js';
 import { NarrativeBand } from './NarrativeBand.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
+import { humanTitle } from './runIdentity.js';
 import { ProjectSparkline } from './ProjectSparkline.js';
 
 /**
@@ -458,7 +459,7 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
           >
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
               <p style={{ ...CSS.bandLabel, color: 'var(--ink-dim)', margin: 0 }}>
-                Not in a project ({unfiled.length})
+                Unfiled runs ({unfiled.length})
               </p>
               <button
                 type="button"
@@ -477,9 +478,12 @@ export function HomeBoard({ runs, navigate }: Props): React.ReactElement {
                     {...link(`/runs/${v.session.id}`)}
                     data-testid="unfiled-run"
                     data-run-id={v.session.id}
+                    title={v.session.problem}
                     style={{ ...CSS.chip, alignSelf: 'flex-start', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
                   >
-                    {v.session.problem}
+                    {/* Review #2: the human title, never the raw prompt — the
+                        full intent moves to this chip's hover title. */}
+                    {humanTitle(v.session.problem)}
                     <span style={{ color: 'var(--ink-dim)' }}>· {v.session.status}</span>
                   </a>
                 ))}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -15,6 +15,7 @@ import { HealthRailSection } from './HealthRailSection.js';
 import { MODE_SPECS } from './ModeSwitcher.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { NotificationBell } from './NotificationBell.js';
+import { humanTitle } from './runIdentity.js';
 import { ATTENTION_DOT } from './ProjectCard.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
 import { phaseWord, RUN_DOT } from './RunsSection.js';
@@ -201,7 +202,7 @@ function RunRow({ view, onOpen }: { view: SessionView; onOpen: () => void }): Re
           className="truncate leading-tight"
           style={{ maxWidth: '24ch', fontSize: 'var(--text-xs)', color: S.ink, fontFamily: 'var(--font-sans)' }}
         >
-          {view.session.problem}
+          {humanTitle(view.session.problem)}
         </span>
         <span
           className="ml-auto shrink-0"

--- a/src/components/MakeDashboard.tsx
+++ b/src/components/MakeDashboard.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { SessionView } from '../api/types.js';
 import { UNFILED_MOUNT, type DocSummary } from '../api/interactive.js';
+import { useDismissable } from '../hooks/useDismissable.js';
 import { versionPath, type Mode } from '../hooks/useRoute.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { isChatRun } from './ChatsPage.js';
 import { MetricTile } from './MetricTile.js';
+import { humanTitle } from './runIdentity.js';
 import { RunOutcomeBar } from './RunOutcomeBar.js';
 import { phaseWord, RUN_DOT } from './RunsSection.js';
 import { TokenBurnSparkline } from './TokenBurnSparkline.js';
@@ -151,6 +153,12 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
   const fanoutDone = useDocsCache((s) => s.fanoutDone);
   const fanoutProgress = useDocsCache((s) => s.fanoutProgress);
   const [whyOpen, setWhyOpen] = useState(false);
+  // The overlay contract (usability review #10): the [why?] popover is a
+  // transient surface — Escape closes it and refocuses its trigger.
+  const whyRef = useRef<HTMLDivElement>(null);
+  const whyTriggerRef = useRef<HTMLButtonElement>(null);
+  const closeWhy = useCallback(() => setWhyOpen(false), []);
+  useDismissable(whyOpen, closeWhy, whyRef, whyTriggerRef);
 
   // The spine (§4.2.2): non-chat runs — complete, all projects, active first.
   const made = useMemo(
@@ -214,7 +222,7 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
       </div>
 
       {/* ── The corpus label (EC24 grammar, §4.2.2) heads the list ───────────── */}
-      <div className="relative px-8 pb-2 flex items-center gap-3 flex-wrap">
+      <div ref={whyRef} className="relative px-8 pb-2 flex items-center gap-3 flex-wrap">
         <p
           data-testid="make-corpus-label"
           style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
@@ -222,6 +230,7 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
           Listing: build runs (all projects) · documents (projects opened this session)
           {' — '}
           <button
+            ref={whyTriggerRef}
             type="button"
             data-testid="make-corpus-why"
             aria-expanded={whyOpen}
@@ -242,8 +251,8 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
               fontSize: 'var(--text-2xs)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)',
             }}
           >
-            Documents live behind each project's bridge; the studio lists what it
-            has loaded rather than querying every project on page-open.
+            Documents load per project. Open a project — or use &lsquo;load docs for all
+            projects&rsquo; — to list them here.
           </p>
         )}
         {fanoutProgress !== null ? (
@@ -297,7 +306,9 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
               style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
             />
             <span className="truncate" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
-              {view.session.problem}
+              {/* The ONE human-title derivation (review #2) — the raw prompt
+                  moves to this row's hover title. */}
+              {humanTitle(view.session.problem)}
             </span>
             <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}>
               {projectNameByRun[view.session.id] ?? 'Unfiled'}

--- a/src/components/NarrativeBand.tsx
+++ b/src/components/NarrativeBand.tsx
@@ -165,14 +165,19 @@ export function NarrativeBand({ items, runs, attachedAt, failedAt, navigate, now
         </span>
         {counts.undatable > 0 && (
           // EC39 (J5): the windowed fold EXCLUDES runs that carry no observed
-          // clock, and says so in the same breath — never a number a user
-          // cannot rebuild from the rows a list can show them.
+          // clock. Quick win #1 (usability review): the caveat moves into an
+          // ⓘ tooltip — still discoverable, no longer headline copy. The count
+          // stays machine-readable on data-undatable.
           <span
             data-testid="lede-undatable"
             data-undatable={counts.undatable}
-            style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0 }}
+            tabIndex={0}
+            role="note"
+            aria-label={`excludes ${counts.undatable} undated run${counts.undatable === 1 ? '' : 's'}`}
+            title={`This count excludes ${counts.undatable} run${counts.undatable === 1 ? '' : 's'} with no observed clock — they cannot be placed in the 24h window.`}
+            style={{ ...WINDOW_LABEL_STYLE, flexShrink: 0, cursor: 'help' }}
           >
-            · excludes {counts.undatable} undated run{counts.undatable === 1 ? '' : 's'}
+            ⓘ
           </span>
         )}
         {spend !== null && (

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -1,0 +1,67 @@
+import type { Navigate } from '../hooks/useRoute.js';
+
+/**
+ * The honest dead-address view (usability review #4). Before this, an unknown
+ * route silently normalized onto a nearby default — garbage → `/work`,
+ * `/steering/zzz` → the steering landing, a typo'd testing page → Harness —
+ * so a mistyped bookmark LOOKED like a working page with the wrong content.
+ *
+ * The contract: PRESERVE the typed URL (no redirect fires for this panel; the
+ * address stays in the bar and is echoed on the page), say plainly that no
+ * page lives there, and offer the four ways out as real links.
+ */
+
+const LINKS: { label: string; path: string }[] = [
+  { label: 'Home', path: '/' },
+  { label: 'Work', path: '/work' },
+  { label: 'Steering', path: '/steering' },
+  { label: 'Testing', path: '/testing/harness' },
+];
+
+export function NotFoundPage({ pathname, navigate }: {
+  /** The address as typed — echoed verbatim so the user sees what missed. */
+  pathname: string;
+  navigate: Navigate;
+}): React.ReactElement {
+  return (
+    <div data-testid="not-found" className="flex max-w-xl flex-col gap-3 p-8">
+      <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)', margin: 0 }}>
+        Page not found
+      </h2>
+      <p className="text-xs" style={{ color: 'var(--ink-muted)', margin: 0 }}>
+        Nothing lives at{' '}
+        <code
+          data-testid="not-found-path"
+          className="rounded px-1 py-0.5 font-mono text-[11px]"
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
+        >
+          {pathname}
+        </code>
+        . The address may be mistyped, or the page it named may have moved.
+      </p>
+      <nav aria-label="Places to go instead" className="flex flex-wrap items-center gap-2">
+        {LINKS.map((l) => (
+          <a
+            key={l.path}
+            data-testid="not-found-link"
+            data-path={l.path}
+            href={l.path}
+            onClick={(e) => {
+              e.preventDefault();
+              navigate(l.path);
+            }}
+            className="rounded px-2.5 py-1 text-[11px] font-semibold"
+            style={{
+              color: 'var(--ink-high)',
+              border: '1px solid var(--surface-raised)',
+              background: 'var(--surface-rail)',
+              textDecoration: 'none',
+            }}
+          >
+            {l.label}
+          </a>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -477,8 +477,8 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                   BUILTIN_WORKFLOWS; the third `domain` phase was removed in FINDING-068 —
                   domain extraction is a separate downstream workflow). Don't re-add it here. */}
               {sourceMode === 'remote'
-                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then runs the onboarding workflow as a governed run — writes the repo's code graph and annotates its clusters; typically minutes.`
-                : "Runs the onboarding workflow (index → annotate) as a governed run — writes the repo's code graph and annotates its clusters; typically minutes."}
+                ? `Clones to ${checkoutPath.trim() || `~/.wicked/repos/${newName || '<name>'}`}, then indexes the repository and annotates its code map so runs can navigate it — a tracked run you can watch; typically minutes.`
+                : 'Indexes the repository and annotates its code map so runs can navigate it — a tracked run you can watch; typically minutes.'}
             </p>
 
             {registerError && (

--- a/src/components/RoutingProvenance.tsx
+++ b/src/components/RoutingProvenance.tsx
@@ -9,6 +9,17 @@ export function RoutingProvenance({ routing }: Props): React.ReactElement | null
   if (!routing) return null;
 
   if (routing.method === 'council') {
+    // A single-seat council held no election (usability review #7: "claude won
+    // · 100% agreement · 1 of 1 seats · 0 dissent" is governance theater — it
+    // won against nobody). Say what happened: one seat, no vote.
+    if (routing.seated === 1) {
+      return (
+        <p className="text-[11px] font-mono" style={{ color: 'var(--ink-muted)' }} data-testid="routing-provenance" data-seats="1">
+          <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>Council:</span>{' '}
+          {routing.winner} — single seat, no vote held
+        </p>
+      );
+    }
     return (
       <p className="text-[11px] font-mono" style={{ color: 'var(--ink-muted)' }} data-testid="routing-provenance">
         <span className="font-medium" style={{ color: 'var(--ink-muted)' }}>Council:</span>{' '}

--- a/src/components/RunCard.tsx
+++ b/src/components/RunCard.tsx
@@ -1,5 +1,6 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
 import { edgeStateOf, LiveEdge } from './LiveEdge.js';
+import { humanTitle } from './runIdentity.js';
 
 // Status metadata — colors speak the §2.6 status layer
 export const STATUS_STYLE: Record<SessionStatus, { label: string; color: string }> = {
@@ -43,8 +44,13 @@ export function RunCard({ view, selected, onSelect }: Props): React.ReactElement
       {/* Same treatment as the board card, so a run reads identically on both surfaces. */}
       <LiveEdge state={edgeStateOf([session.status])} />
       <div className="flex justify-between items-start gap-2 mb-1">
-        <p className="font-semibold text-sm line-clamp-2 flex-1 font-mono" style={{ color: 'var(--ink-high)' }}>
-          {session.problem}
+        <p
+          className="font-semibold text-sm line-clamp-2 flex-1 font-mono"
+          style={{ color: 'var(--ink-high)' }}
+          title={session.problem}
+        >
+          {/* Review #2: the human title leads; the raw prompt is hover-only. */}
+          {humanTitle(session.problem)}
         </p>
         {awaiting && (
           <span

--- a/src/components/RunOutcomeBar.tsx
+++ b/src/components/RunOutcomeBar.tsx
@@ -150,14 +150,19 @@ export function RunOutcomeBar({
         </svg>
       )}
       {unplaced > 0 && (
-        // EC39: the windowed count states its exclusions VISIBLY — runs with
-        // no clock in this window are not painted, and the label says so, so
-        // the number stays reproducible from the rows a user can see.
+        // EC39 + quick win #1: the exclusion stays STATED (the count is
+        // machine-readable and the ⓘ names it on hover/focus) but no longer
+        // runs as headline copy under the tile.
         <p
           data-testid="outcome-unplaced-note"
-          style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+          data-unplaced={unplaced}
+          tabIndex={0}
+          role="note"
+          aria-label={`excludes ${unplaced} run${unplaced === 1 ? '' : 's'} with no clock in this window`}
+          title={`This tile excludes ${unplaced} run${unplaced === 1 ? '' : 's'} with no clock in this window — they cannot be placed on the 24h axis.`}
+          style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', cursor: 'help' }}
         >
-          excludes {unplaced} run{unplaced === 1 ? '' : 's'} with no clock in this window
+          ⓘ {unplaced} not shown
         </p>
       )}
     </MetricTile>

--- a/src/components/RunsSection.tsx
+++ b/src/components/RunsSection.tsx
@@ -1,4 +1,5 @@
 import type { SessionStatus, SessionView } from '../api/types.js';
+import { humanTitle } from './runIdentity.js';
 
 /**
  * The rail's inline runs section (DES-FEEDBACK-001 §1.4, slice A): the five
@@ -91,7 +92,7 @@ export function RunsSection({ runs, runPath, navigate }: Props): React.ReactElem
                 fontFamily: 'var(--font-sans)',
               }}
             >
-              {view.session.problem}
+              {humanTitle(view.session.problem)}
             </span>
             <span
               data-testid="rail-run-phase"

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,0 +1,26 @@
+/**
+ * The skip link (usability review #10): the app's FIRST tabbable element, so
+ * the first Tab reaches something sensible — a jump to the main content —
+ * instead of landing on a page's top-right "Refresh". Visually hidden until
+ * focused (the `.skip-link` rules in global.css); on activation it moves focus
+ * to the `#main` region App marks around the center surface.
+ */
+export function SkipLink(): React.ReactElement {
+  return (
+    <a
+      href="#main"
+      data-testid="skip-link"
+      className="skip-link"
+      onClick={(e) => {
+        e.preventDefault();
+        const main = document.getElementById('main');
+        if (main !== null) {
+          main.focus();
+          main.scrollIntoView?.({ block: 'start' });
+        }
+      }}
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/src/components/SteeringAddMenu.tsx
+++ b/src/components/SteeringAddMenu.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { SteeringRule, SteeringType } from '../api/steering.js';
+import { useDismissable } from '../hooks/useDismissable.js';
 import { AuthorPanel } from './SteeringAuthorPanel.js';
 import { SteeringImportPanel } from './SteeringImportPanel.js';
 import { SteeringRuleFormModal } from './SteeringRuleForm.js';
@@ -31,16 +32,13 @@ export function SteeringAddMenu({ type, rules, onSaved, onRulesChanged }: {
   const [menuOpen, setMenuOpen] = useState(false);
   const [flow, setFlow] = useState<Flow | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
-  // The MakePicker grammar: a click outside the anchored menu closes it.
-  useEffect(() => {
-    if (!menuOpen) return;
-    function onOutside(e: MouseEvent): void {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
-    }
-    document.addEventListener('mousedown', onOutside);
-    return () => document.removeEventListener('mousedown', onOutside);
-  }, [menuOpen]);
+  // The overlay contract (usability review #10): Escape closes the menu and
+  // returns focus to the Add trigger; a click outside closes it too. This menu
+  // was the live-verified gap — it survived Escape while the drawer honored it.
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  useDismissable(menuOpen, closeMenu, menuRef, triggerRef);
 
   const pick = (f: Flow): void => {
     setMenuOpen(false);
@@ -65,6 +63,7 @@ export function SteeringAddMenu({ type, rules, onSaved, onRulesChanged }: {
     <div className="flex flex-col gap-2">
       <div ref={menuRef} className="relative self-start">
         <button
+          ref={triggerRef}
           data-testid="steering-add-menu"
           type="button"
           aria-haspopup="menu"
@@ -87,7 +86,7 @@ export function SteeringAddMenu({ type, rules, onSaved, onRulesChanged }: {
             }}
           >
             {item('steering-add-open', 'Add individual', 'One rule, the full form — saved on this page’s type', 'form')}
-            {item('steering-import-open', 'Import', 'A .md doctrine doc or a .json rule batch', 'import')}
+            {item('steering-import-open', 'Import', 'A Markdown rules doc or a .json rule batch', 'import')}
             {item('steering-author-open', 'Add with chat', 'A governed run drafts rules and stops at a propose gate', 'author')}
           </div>
         )}

--- a/src/components/SteeringAuthorPanel.tsx
+++ b/src/components/SteeringAuthorPanel.tsx
@@ -82,7 +82,7 @@ export function AuthorPanel({ type, onClose, onAuthored }: {
         <>
           <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
             Launches a governed authoring run: it reads what you attach, drafts{' '}
-            <span className="font-mono">{type}</span> steering rules, and STOPS at a propose gate —
+            <span className="font-mono">{type}</span> steering rules, and stops at a propose gate —
             nothing is written until you approve it here.
           </p>
           <textarea

--- a/src/components/SteeringHealth.tsx
+++ b/src/components/SteeringHealth.tsx
@@ -2,10 +2,17 @@ import { STEERING_TYPE_LABELS, type SteeringType } from '../api/steering.js';
 import { scoreboardVerdict, VERDICT_COPY, type WikiScoreboard, type WikiVerdict } from '../api/wiki.js';
 
 /**
- * The Steering type page's health header (AW-23 scoreboard) — extracted verbatim from the old
- * monolithic SteeringPage: per-type numbers when the wire serves `by_steering_type`, the
- * store-wide numbers labeled as store-wide when it does not, and the honest "engine predates
- * the scoreboard" state on 501/route-absent (a pre-0.7.5 engine keeps its existing callout).
+ * The Steering health surfaces, re-scoped by the usability review (#5 — the
+ * store-wide "36 active" + red "decaying" pill + CLI-flag diagnostics rendered
+ * on EVERY type page, including Security holding zero rules of its own):
+ *
+ *  - `SteeringHealth` (type pages) shows ONLY that type's numbers — the wire's
+ *    per-type split when served, otherwise a client-side count of the loaded
+ *    rules, labeled as exactly that. An EMPTY type page renders no stats at
+ *    all: the rule list's own empty state and the Add menu are the message.
+ *  - `SteeringStoreHealth` (the landing — the one place the store-wide verdict
+ *    is actionable) carries the verdict pill, the store-wide rule count, and
+ *    the ingest diagnostics COLLAPSED behind a details toggle.
  */
 
 export type ScoreboardState =
@@ -21,7 +28,7 @@ const VERDICT_COLOR: Record<WikiVerdict, string> = {
   unproven: 'var(--status-gate)',
 };
 
-/** One health-header stat: the number, its label, and the honest sub-line when it cannot be measured. */
+/** One health stat: the number, its label, and the honest sub-line when it cannot be measured. */
 function Stat({ testid, label, value, sub }: {
   testid: string;
   label: string;
@@ -45,7 +52,16 @@ function Stat({ testid, label, value, sub }: {
 
 const pct = (v: number | undefined): string => (v === undefined ? '—' : `${Math.round(v)}%`);
 
-export function SteeringHealth({ state, type }: { state: ScoreboardState; type: SteeringType }): React.ReactElement {
+/**
+ * The TYPE page's health header: this type's numbers, nothing store-wide.
+ * `typeRuleCount` is the client-side count of loaded rules filed under this
+ * type — the honest fallback when the wire serves no per-type split.
+ */
+export function SteeringHealth({ state, type, typeRuleCount }: {
+  state: ScoreboardState;
+  type: SteeringType;
+  typeRuleCount: number;
+}): React.ReactElement | null {
   if (state.kind === 'loading') {
     return <p data-testid="steering-health-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Measuring steering health…</p>;
   }
@@ -71,63 +87,97 @@ export function SteeringHealth({ state, type }: { state: ScoreboardState; type: 
     );
   }
   const sb = state.scoreboard;
-  const verdict = scoreboardVerdict(sb);
-  // Per-type numbers ONLY when the wire serves them (`by_steering_type`, steering-model lane);
-  // otherwise the store-wide numbers, labeled as store-wide — never a fabricated per-type zero.
   const perType = sb.by_steering_type?.[type];
+  // An EMPTY type page loses the stats entirely (review #5): the rule list's
+  // empty state + the Add menu carry the message; store-wide numbers rendered
+  // here read as this type's and lie.
+  const empty = perType !== undefined ? perType.rules_total === 0 : typeRuleCount === 0;
+  if (empty) return null;
   return (
-    <div data-testid="steering-health" className="flex flex-col gap-2">
+    <div data-testid="steering-health" className="flex flex-wrap gap-2">
+      {perType !== undefined ? (
+        <Stat
+          testid="steering-stat-rules-type"
+          label={`${STEERING_TYPE_LABELS[type]} rules`}
+          value={`${perType.rules_active} active`}
+          sub={`${perType.rules_total} total · ${perType.rules_retired} retired`}
+        />
+      ) : (
+        <Stat
+          testid="steering-stat-rules-type"
+          label={`${STEERING_TYPE_LABELS[type]} rules`}
+          value={`${typeRuleCount} loaded`}
+          sub="counted from the loaded rules — this engine reports no per-type split"
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * The LANDING's store-wide health block — the one place the store-wide verdict
+ * is actionable (review #5). The verdict pill + its honest sentence lead; the
+ * raw ingest diagnostics (typing coverage, symbol refs, denial evidence) fold
+ * behind a details toggle instead of shouting CLI flags on every page.
+ */
+export function SteeringStoreHealth({ state }: { state: ScoreboardState }): React.ReactElement | null {
+  if (state.kind !== 'loaded') return null;
+  const sb = state.scoreboard;
+  const verdict = scoreboardVerdict(sb);
+  return (
+    <div data-testid="steering-store-health" className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <span
           data-testid="steering-verdict"
           data-verdict={verdict}
-          title={`${VERDICT_COPY[verdict]} (derived in studio from the raw AW-23 signals shown beside it)`}
+          title={`${VERDICT_COPY[verdict]} (derived in studio from the raw AW-23 signals in the diagnostics below)`}
           className="inline-flex rounded-full px-2.5 py-0.5 text-[11px] font-semibold"
           style={{ color: VERDICT_COLOR[verdict], border: `1px solid ${VERDICT_COLOR[verdict]}` }}
         >
           {verdict}
         </span>
-        <span className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>{VERDICT_COPY[verdict]}</span>
+        <span className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{VERDICT_COPY[verdict]}</span>
       </div>
-      <div className="flex flex-wrap gap-2">
-        {perType !== undefined ? (
-          <Stat
-            testid="steering-stat-rules-type"
-            label={`${STEERING_TYPE_LABELS[type]} rules`}
-            value={`${perType.rules_active} active`}
-            sub={`${perType.rules_total} total · ${perType.rules_retired} retired`}
-          />
-        ) : (
+      <details data-testid="steering-diagnostics">
+        <summary
+          className="cursor-pointer text-[11px]"
+          style={{ color: 'var(--ink-dim)' }}
+          data-testid="steering-diagnostics-toggle"
+        >
+          Store-wide diagnostics
+        </summary>
+        <div className="mt-2 flex flex-wrap gap-2">
           <Stat
             testid="steering-stat-rules"
             label="Rules (store-wide)"
             value={`${sb.rules_active} active`}
-            sub={`${sb.rules_total} total · ${sb.rules_retired} retired — this engine reports no per-type split`}
+            sub={`${sb.rules_total} total · ${sb.rules_retired} retired`}
           />
-        )}
-        <Stat
-          testid="steering-stat-typed"
-          label="Typed"
-          value={sb.typing.available ? pct(sb.typing.percent) : 'not measured'}
-          sub={
-            sb.typing.available
-              ? `${sb.typing.statements_typed} of ${sb.typing.statements_total} statements across ${sb.typing.docs_scanned} docs`
-              : sb.typing.reason ?? 'no docs root supplied to the daemon'
-          }
-        />
-        <Stat
-          testid="steering-stat-resolving"
-          label="Refs resolving"
-          value={sb.connection.rules_with_ref === 0 ? 'no refs' : pct(sb.connection.percent)}
-          sub={`${sb.connection.refs_resolving} of ${sb.connection.rules_with_ref} symbol refs · ${sb.connection.rules_linked} rules linked to code`}
-        />
-        <Stat
-          testid="steering-stat-denials"
-          label="Denials citing rules"
-          value={String(sb.evidence.denial_claims)}
-          sub={`${sb.evidence.rules_evidenced} rules evidenced · ${sb.evidence.governs_evidence_total} governs-evidence total`}
-        />
-      </div>
+          <Stat
+            testid="steering-stat-typed"
+            label="Typed"
+            value={sb.typing.available ? pct(sb.typing.percent) : 'not measured'}
+            sub={
+              sb.typing.available
+                ? `${sb.typing.statements_typed} of ${sb.typing.statements_total} statements across ${sb.typing.docs_scanned} docs`
+                // Quick win #4: plain words, no CLI flags.
+                : 'Typing coverage needs a docs root — re-run ingest with one to measure it.'
+            }
+          />
+          <Stat
+            testid="steering-stat-resolving"
+            label="Refs resolving"
+            value={sb.connection.rules_with_ref === 0 ? 'no refs' : pct(sb.connection.percent)}
+            sub={`${sb.connection.refs_resolving} of ${sb.connection.rules_with_ref} symbol refs · ${sb.connection.rules_linked} rules linked to code`}
+          />
+          <Stat
+            testid="steering-stat-denials"
+            label="Denials citing rules"
+            value={String(sb.evidence.denial_claims)}
+            sub={`${sb.evidence.rules_evidenced} rules evidenced · ${sb.evidence.governs_evidence_total} governs-evidence total`}
+          />
+        </div>
+      </details>
     </div>
   );
 }

--- a/src/components/SteeringHealth.tsx
+++ b/src/components/SteeringHealth.tsx
@@ -87,11 +87,14 @@ export function SteeringHealth({ state, type, typeRuleCount }: {
     );
   }
   const sb = state.scoreboard;
-  const perType = sb.by_steering_type?.[type];
+  // The engine's `by_type` map (wicked-governance Scoreboard) holds one row per
+  // type that HAS rules — an absent row on a served map means zero, so the map's
+  // presence alone selects the wire path.
+  const perType = sb.by_type?.[type] ?? (sb.by_type !== undefined ? { total: 0, active: 0, retired: 0 } : undefined);
   // An EMPTY type page loses the stats entirely (review #5): the rule list's
   // empty state + the Add menu carry the message; store-wide numbers rendered
   // here read as this type's and lie.
-  const empty = perType !== undefined ? perType.rules_total === 0 : typeRuleCount === 0;
+  const empty = perType !== undefined ? perType.total === 0 : typeRuleCount === 0;
   if (empty) return null;
   return (
     <div data-testid="steering-health" className="flex flex-wrap gap-2">
@@ -99,8 +102,8 @@ export function SteeringHealth({ state, type, typeRuleCount }: {
         <Stat
           testid="steering-stat-rules-type"
           label={`${STEERING_TYPE_LABELS[type]} rules`}
-          value={`${perType.rules_active} active`}
-          sub={`${perType.rules_total} total · ${perType.rules_retired} retired`}
+          value={`${perType.active} active`}
+          sub={`${perType.total} total · ${perType.retired} retired`}
         />
       ) : (
         <Stat

--- a/src/components/SteeringImportPanel.tsx
+++ b/src/components/SteeringImportPanel.tsx
@@ -86,7 +86,7 @@ export function SteeringImportPanel({ type, onClose, onImported }: {
         </button>
       </div>
       <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
-        A frontmattered <span className="font-mono">.md</span> doctrine doc or a{' '}
+        A <span className="font-mono">.md</span> rules doc (with frontmatter) or a{' '}
         <span className="font-mono">.json</span> rule batch — every imported rule lands typed{' '}
         <span className="font-mono">{type}</span> (this page).
       </p>

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -16,7 +16,7 @@ import {
   type WikiMeta,
 } from '../api/wiki.js';
 import { SteeringAddMenu } from './SteeringAddMenu.js';
-import { SteeringHealth, type ScoreboardState } from './SteeringHealth.js';
+import { SteeringHealth, SteeringStoreHealth, type ScoreboardState } from './SteeringHealth.js';
 import { SteeringRuleDrawer } from './SteeringRuleDrawer.js';
 import { SteeringRuleFormModal } from './SteeringRuleForm.js';
 import { SteeringRuleList } from './SteeringRuleList.js';
@@ -44,10 +44,13 @@ import { SteeringTypeCards } from './SteeringTypeCards.js';
  * estate MCP stays read-only (AW-11).
  */
 
-export function SteeringPage({ type, navigate }: {
+export function SteeringPage({ type, navigate, search = '' }: {
   /** The routed steering type — null on the bare `/steering` landing. */
   type: SteeringType | null;
   navigate: (path: string) => void;
+  /** The URL search string — `?rule=<id>` deep-links a rule's drawer open
+   *  (the Evals gap rows link here, qe finding: hints became links). */
+  search?: string;
 }): React.ReactElement {
   const [scoreboard, setScoreboard] = useState<ScoreboardState>({ kind: 'loading' });
   const [meta, setMeta] = useState<WikiMeta | null>(null);
@@ -101,6 +104,14 @@ export function SteeringPage({ type, navigate }: {
     setRetiredNote(null);
   }, [type]);
 
+  // `?rule=<id>` deep-links a rule's drawer open (the Evals gap rows link
+  // here). Declared AFTER the type-reset effect so a cross-page navigation
+  // that carries both a new type and a rule id lands with the drawer open.
+  useEffect(() => {
+    const routed = new URLSearchParams(search).get('rule');
+    if (routed !== null && rules.some((r) => r.id === routed)) setSelectedId(routed);
+  }, [search, rules]);
+
   /** evidence_count join: the AW-23 per-rule evidence rows, when the scoreboard is served. */
   const evidenceOf = (id: string): { denial_claims: number; governs_evidence: number } | null => {
     if (scoreboard.kind !== 'loaded') return null;
@@ -143,6 +154,9 @@ export function SteeringPage({ type, navigate }: {
             browse and manage its rules.
           </p>
         </div>
+        {/* The store-wide verdict lives HERE, the one place it is actionable
+            (review #5) — its raw diagnostics fold behind a details toggle. */}
+        <SteeringStoreHealth state={scoreboard} />
         {rulesLoading ? (
           <p data-testid="steering-rules-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading rules…</p>
         ) : rulesError !== null ? (
@@ -158,9 +172,12 @@ export function SteeringPage({ type, navigate }: {
 
   // ── A type page (`/steering/:type`) ─────────────────────────────────────────────────────────
 
+  // The id alone selects (no type gate): the type-change effect above already
+  // resets a stale selection, and a `?rule=` deep link may name a rule filed
+  // under a neighbouring type — the drawer must still open for it.
   const selected = selectedId === null
     ? null
-    : rules.find((r) => r.id === selectedId && steeringTypeOf(r) === type) ?? null;
+    : rules.find((r) => r.id === selectedId) ?? null;
 
   // The EMPTY-STORE state keys on an EXPLICIT `seeded: false` from the meta route — a daemon
   // that cannot answer must not be accused of an unseeded store. It does NOT replace the Add
@@ -195,7 +212,14 @@ export function SteeringPage({ type, navigate }: {
         </button>
       </div>
 
-      <SteeringHealth state={scoreboard} type={type} />
+      {/* TYPE-scoped numbers only (review #5); an empty type page renders no
+          stats at all — the store-wide verdict + diagnostics live on the
+          landing, where they are actionable. */}
+      <SteeringHealth
+        state={scoreboard}
+        type={type}
+        typeRuleCount={rules.filter((r) => steeringTypeOf(r) === type).length}
+      />
 
       {unseeded && (
         <div

--- a/src/components/SteeringRuleForm.tsx
+++ b/src/components/SteeringRuleForm.tsx
@@ -298,7 +298,7 @@ export function SteeringRuleFormModal({ type, rules, initial, onClose, onSaved }
         />
         <ChipsInput
           testid="steering-form-excludes"
-          label="Excludes (exclusion twin)"
+          label="Excludes (phases/tools this rule skips)"
           values={form.excludes}
           onChange={(v) => onChange({ ...form, excludes: v })}
           placeholder="add and press Enter"
@@ -322,7 +322,7 @@ export function SteeringRuleFormModal({ type, rules, initial, onClose, onSaved }
             </select>
           </label>
           <label className="flex flex-1 flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-            Trigger regex (optional; needs an effect)
+            Trigger text (optional; needs an effect)
             <input
               data-testid="steering-form-trigger"
               type="text"
@@ -330,7 +330,7 @@ export function SteeringRuleFormModal({ type, rules, initial, onClose, onSaved }
               disabled={form.effect === ''}
               spellCheck={false}
               onChange={(e) => onChange({ ...form, triggerContains: e.target.value })}
-              placeholder="contains — tested over the evaluated context"
+              placeholder='e.g. "rm -rf" — the effect fires when the evaluated context contains this'
               className="rounded px-2 py-1 font-mono text-[11px] focus:outline-none disabled:opacity-50"
               style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
             />

--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -154,7 +154,7 @@ export function SystemSettings({ navigate = (p) => { history.pushState(null, '',
       <div className="mb-6">
         <h1 className="text-lg font-semibold" style={{ color: 'var(--ink-high)' }}>System</h1>
         <p className="text-sm mt-1" style={{ color: 'var(--ink-muted)' }}>
-          Runtime tunables persisted to{' '}
+          Settings are saved to{' '}
           <code
             className="font-mono text-xs rounded px-1 py-0.5"
             style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -130,7 +130,7 @@ function ReconPanel({ navigate, onClose }: {
         <>
           <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
             Launches a governed recon run: it surveys the target, drafts a test campaign — the
-            scenarios and their dependencies — and STOPS at its intake gate. Nothing runs until
+            scenarios and their dependencies — and stops at its intake gate. Nothing runs until
             you approve the gate here.
           </p>
           <textarea
@@ -150,7 +150,7 @@ function ReconPanel({ navigate, onClose }: {
               className="rounded px-1 py-0.5 text-[10px] font-mono"
               style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
             >
-              <option value="">none — unscoped</option>
+              <option value="">all repositories</option>
               {repos.map((r) => (
                 <option key={r.id} value={r.id}>
                   {r.name}
@@ -225,10 +225,13 @@ function HarnessPage({ navigate }: { navigate: (path: string) => void }): React.
 
   return (
     <div data-testid="testing-harness" className="flex flex-col gap-4">
-      <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-        The harness is where a testing effort starts: a campaign recon proposes the work and
-        stops at its intake gate; chat-authoring drafts testing steering rules the same governed
-        way. Both launch runs that gate before anything is written or executed.
+      {/* The plain-language explainer (usability review #6 + qe findings): what
+          this page is FOR, in words a first-time tester can act on. */}
+      <p data-testid="testing-harness-explainer" className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+        Start a testing effort here. A recon run looks over your code and proposes a test
+        campaign — you see the proposal and approve or reject it before anything runs. You can
+        also draft testing rules in chat, with the same approval step. Approved campaigns and
+        their progress live on the Campaigns tab.
       </p>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -269,7 +272,10 @@ type EvalsRunState =
   | { kind: 'busy' }
   | { kind: 'unsupported' }
   | { kind: 'failed'; message: string }
-  | { kind: 'done'; report: EvalReport };
+  // `corpus` records what THIS report ran against (null = the built-in default
+  // set) — the report header's provenance line, pinned at run time so a later
+  // edit of the corpus field cannot relabel finished numbers.
+  | { kind: 'done'; report: EvalReport; corpus: string | null };
 
 type CorpusImportState =
   | { kind: 'idle' }
@@ -278,17 +284,26 @@ type CorpusImportState =
   | { kind: 'failed'; message: string }
   | { kind: 'done'; filename: string; result: CorpusImportResult };
 
+// Gap wears the attention amber, not failure red (qe finding: a gap is an
+// UNCOVERED BEHAVIOR — a place to write a rule — not a red failure).
 const EVAL_VERDICT_COLOR: Record<EvalResult['verdict'], string> = {
   caught: 'var(--status-done)',
-  gap: 'var(--status-fail)',
+  gap: 'var(--status-gate)',
   false_positive: 'var(--status-gate)',
 };
 
-const EVAL_VERDICT_WORD: Record<EvalResult['verdict'], string> = {
-  caught: 'caught',
-  gap: 'gap',
-  false_positive: 'false positive',
-};
+/**
+ * The verdict word, split by what "caught" actually meant (qe finding): a BAD
+ * sample the rules fired on was **blocked**; a GOOD sample the rules let
+ * through **passed**. One word for both hid which half the store is good at.
+ */
+export function evalVerdictWord(r: { verdict: EvalResult['verdict']; sample: { kind: string } }): string {
+  if (r.verdict === 'gap') return 'gap';
+  if (r.verdict === 'false_positive') return 'false positive';
+  // A sample kind the report echo doesn't name keeps the unsplit word — never
+  // a guessed half.
+  return r.sample.kind === 'bad' ? 'blocked' : r.sample.kind === 'good' ? 'passed' : 'caught';
+}
 
 /** The honest engine-gap callout — 501 / route-absent, shared by run + import. */
 function UnsupportedNote({ testid }: { testid: string }): React.ReactElement {
@@ -299,8 +314,15 @@ function UnsupportedNote({ testid }: { testid: string }): React.ReactElement {
   );
 }
 
-function GapNearestRules({ result }: { result: EvalResult }): React.ReactElement {
+function GapNearestRules({ result, navigate }: {
+  result: EvalResult;
+  navigate: (path: string) => void;
+}): React.ReactElement {
   const nearest = result.nearest_rules ?? [];
+  // Where a nearest-rule link lands (qe finding: hints become LINKS): the
+  // sample's own type page, with `?rule=<id>` opening that rule's drawer.
+  const rulePath = (id: string): string =>
+    `/steering/${encodeURIComponent(result.sample.steering_type)}?rule=${encodeURIComponent(id)}`;
   return (
     <div
       data-testid="testing-evals-nearest"
@@ -317,7 +339,19 @@ function GapNearestRules({ result }: { result: EvalResult }): React.ReactElement
       ) : (
         nearest.map((n) => (
           <span key={n.rule_id} data-testid="testing-evals-nearest-rule" className="flex items-baseline gap-2 text-[10px] font-mono">
-            <span style={{ color: 'var(--ink-high)' }}>{n.rule_id}</span>
+            <a
+              data-testid="testing-evals-nearest-link"
+              data-rule-id={n.rule_id}
+              href={rulePath(n.rule_id)}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(rulePath(n.rule_id));
+              }}
+              className="underline"
+              style={{ color: 'var(--accent)' }}
+            >
+              {n.rule_id}
+            </a>
             <span style={{ color: 'var(--ink-muted)' }}>similarity {n.similarity.toFixed(2)}</span>
           </span>
         ))
@@ -326,12 +360,26 @@ function GapNearestRules({ result }: { result: EvalResult }): React.ReactElement
   );
 }
 
-function EvalReportView({ report }: { report: EvalReport }): React.ReactElement {
+function EvalReportView({ report, corpus, navigate }: {
+  report: EvalReport;
+  /** The corpus the run targeted — null = the built-in default set. */
+  corpus: string | null;
+  navigate: (path: string) => void;
+}): React.ReactElement {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const s = report.summary;
+  // Split "caught" into its two honest halves (qe finding): bad samples the
+  // rules BLOCKED vs good samples the rules PASSED. Derived from the result
+  // rows; when the report carries none, the unsplit summary count stands.
+  const blocked = report.results.filter((r) => r.verdict === 'caught' && r.sample.kind === 'bad').length;
+  const passed = report.results.filter((r) => r.verdict === 'caught' && r.sample.kind === 'good').length;
 
   return (
     <div className="flex flex-col gap-3">
+      {/* Corpus provenance (qe finding): which samples produced these numbers. */}
+      <p data-testid="testing-evals-provenance" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+        corpus: {corpus ?? 'built-in default'} · {s.total} sample{s.total === 1 ? '' : 's'}
+      </p>
       {report.degraded === 'facet-only' && (
         <p
           data-testid="testing-evals-degraded"
@@ -346,8 +394,18 @@ function EvalReportView({ report }: { report: EvalReport }): React.ReactElement 
 
       <p data-testid="testing-evals-summary" className="flex flex-wrap items-baseline gap-3 text-[11px]">
         <span style={{ color: 'var(--ink-high)', fontWeight: 600 }}>{s.total} samples</span>
-        <span style={{ color: EVAL_VERDICT_COLOR.caught }}>{s.caught} caught</span>
-        <span style={{ color: EVAL_VERDICT_COLOR.gap }}>{s.gaps} gaps</span>
+        {report.results.length > 0 ? (
+          <>
+            <span data-testid="testing-evals-blocked" style={{ color: EVAL_VERDICT_COLOR.caught }}>{blocked} blocked</span>
+            <span data-testid="testing-evals-passed" style={{ color: EVAL_VERDICT_COLOR.caught }}>{passed} passed</span>
+          </>
+        ) : (
+          <span style={{ color: EVAL_VERDICT_COLOR.caught }}>{s.caught} caught</span>
+        )}
+        {/* Gaps are UNCOVERED BEHAVIORS — work to do, not a red failure. */}
+        <span data-testid="testing-evals-gaps" style={{ color: EVAL_VERDICT_COLOR.gap }}>
+          {s.gaps} uncovered behavior{s.gaps === 1 ? '' : 's'}
+        </span>
         <span style={{ color: EVAL_VERDICT_COLOR.false_positive }}>{s.false_positives} false positives</span>
       </p>
 
@@ -393,10 +451,11 @@ function EvalReportView({ report }: { report: EvalReport }): React.ReactElement 
                       </td>
                       <td className="px-2 py-1.5 align-top">
                         <span
+                          data-testid="testing-evals-verdict-word"
                           className="rounded px-1.5 text-[10px] font-semibold"
                           style={{ color: EVAL_VERDICT_COLOR[r.verdict], border: `1px solid ${EVAL_VERDICT_COLOR[r.verdict]}` }}
                         >
-                          {EVAL_VERDICT_WORD[r.verdict]}
+                          {evalVerdictWord(r)}
                         </span>
                         {isGap && (
                           <button
@@ -415,7 +474,7 @@ function EvalReportView({ report }: { report: EvalReport }): React.ReactElement 
                     {isGap && expanded && (
                       <tr data-testid="testing-evals-gap-detail">
                         <td colSpan={5} className="px-2 pb-2">
-                          <GapNearestRules result={r} />
+                          <GapNearestRules result={r} navigate={navigate} />
                         </td>
                       </tr>
                     )}
@@ -430,7 +489,7 @@ function EvalReportView({ report }: { report: EvalReport }): React.ReactElement 
   );
 }
 
-function EvalsPage(): React.ReactElement {
+function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.ReactElement {
   /** `''` = all seven types (the body omits `type`). */
   const [type, setType] = useState('');
   /** `''` = the built-in default corpus (the body omits `corpus`). */
@@ -442,12 +501,13 @@ function EvalsPage(): React.ReactElement {
   const run = async (): Promise<void> => {
     if (state.kind === 'busy') return;
     setState({ kind: 'busy' });
+    const corpusUsed = corpus.trim() !== '' ? corpus.trim() : null;
     try {
       const report = await runEvals({
         ...(type !== '' ? { type } : {}),
-        ...(corpus.trim() !== '' ? { corpus: corpus.trim() } : {}),
+        ...(corpusUsed !== null ? { corpus: corpusUsed } : {}),
       });
-      setState({ kind: 'done', report });
+      setState({ kind: 'done', report, corpus: corpusUsed });
     } catch (e) {
       if (isTestingUnsupported(e)) setState({ kind: 'unsupported' });
       else setState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
@@ -515,7 +575,7 @@ function EvalsPage(): React.ReactElement {
           </select>
         </label>
         <label className="flex flex-col gap-0.5 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
-          corpus (estate scope; blank = built-in default)
+          corpus (leave blank for the built-in sample set)
           <input
             data-testid="testing-evals-corpus"
             value={corpus}
@@ -548,7 +608,9 @@ function EvalsPage(): React.ReactElement {
           {state.message}
         </p>
       )}
-      {state.kind === 'done' && <EvalReportView report={state.report} />}
+      {state.kind === 'done' && (
+        <EvalReportView report={state.report} corpus={state.corpus} navigate={navigate} />
+      )}
 
       {/* Corpus import — a JSON file of samples lands in the estate as `evals:<name>`. */}
       <div
@@ -667,7 +729,7 @@ export function TestingPage({ page, campaignId, runs, navigate }: {
         )
       ) : (
         <div className="max-w-5xl px-6 py-4">
-          {page === 'harness' ? <HarnessPage navigate={navigate} /> : <EvalsPage />}
+          {page === 'harness' ? <HarnessPage navigate={navigate} /> : <EvalsPage navigate={navigate} />}
         </div>
       )}
     </div>

--- a/src/components/TimeRangeSelector.tsx
+++ b/src/components/TimeRangeSelector.tsx
@@ -1,5 +1,7 @@
 /**
- * TimeRangeSelector — shared pill-group for 30d / 60d / 90d time windows.
+ * TimeRangeSelector — shared pill-group for the recency window (usability
+ * review #9: the run DTO carries no timestamps, so the window is the newest
+ * N runs and the labels say so honestly — "last 30", never "30d").
  * Visual style matches the existing range pills in CenterDashboard.
  */
 import type { TimeRange } from '../hooks/useTimeRange.js';
@@ -14,11 +16,12 @@ interface Props {
 
 export function TimeRangeSelector({ value, onChange }: Props): React.ReactElement {
   return (
-    <div role="group" aria-label="Time range" style={{ display: 'flex', gap: '4px' }}>
+    <div role="group" aria-label="Show newest runs" style={{ display: 'flex', gap: '4px' }}>
       {TIME_RANGE_OPTIONS.map(({ value: r, label }) => (
         <button
           key={r}
           type="button"
+          data-range={r}
           aria-pressed={value === r}
           onClick={() => onChange(r)}
           style={{

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -3,7 +3,7 @@ import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
 import { outcomeOf } from '../board/metrics.js';
 import { RunLink } from './RunLink.js';
-import { useTimeRange } from '../hooks/useTimeRange.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 
 type StatusTab = 'all' | 'active' | 'completed' | 'failed' | 'cancelled';
@@ -93,15 +93,18 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
 
   const windowedRuns = useMemo(() => filterByRange(allWorkRuns), [allWorkRuns, filterByRange]);
 
+  // Search looks at the FULL set (usability review #9): typing a query lifts
+  // the recency window, so a match cannot hide behind "last 30". The window
+  // applies only to the unsearched browse view.
   const normalizedQuery = query.toLowerCase();
   const searched = useMemo(
     () => query
-      ? windowedRuns.filter(v => v.session.problem.toLowerCase().includes(normalizedQuery))
+      ? allWorkRuns.filter(v => v.session.problem.toLowerCase().includes(normalizedQuery))
       : windowedRuns,
-    [windowedRuns, query, normalizedQuery],
+    [allWorkRuns, windowedRuns, query, normalizedQuery],
   );
 
-  // ── Metrics (scoped to time window, before search filter) ────────────────
+  // ── Metrics (scoped to the recency window, before search filter) ─────────
   const metrics = useMemo(() => {
     const total = windowedRuns.length;
     const active = windowedRuns.filter(v => isActiveStatus(v.session.status)).length;
@@ -110,6 +113,12 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
     const successRate = terminal > 0
       ? `${Math.round((completed / terminal) * 100)}%`
       : '—';
+    // Threshold health (usability review #9: "SUCCESS RATE 30%" rendered in
+    // success-green): green only when actually healthy, amber borderline, red
+    // failing; no terminal runs = no verdict.
+    const ratio = terminal > 0 ? completed / terminal : null;
+    const successHealth: 'good' | 'warn' | 'bad' | 'none' =
+      ratio === null ? 'none' : ratio >= 0.8 ? 'good' : ratio >= 0.5 ? 'warn' : 'bad';
 
     // Top workflow by frequency (work sessions only)
     const freq = new Map<string, number>();
@@ -127,7 +136,7 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
       if (count > topCount) { topCount = count; topWorkflow = wf; }
     });
 
-    return { total, active, successRate, topWorkflow };
+    return { total, active, successRate, successHealth, topWorkflow };
   }, [windowedRuns]);
 
   const activeGroup = searched.filter(v => isActiveStatus(v.session.status));
@@ -162,8 +171,13 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
     : tab === 'completed' ? isCompletedStatus(v.session.status)
     : tab === 'failed' ? isFailedStatus(v.session.status)
     : isCancelledStatus(v.session.status);
+  // While a query is typed the search already covers the FULL set — nothing is
+  // window-hidden, so neither the note nor the chip may claim otherwise.
   const windowedTabCount = windowedRuns.filter(inTabGroup).length;
-  const hiddenByRange = allWorkRuns.filter(inTabGroup).length - windowedTabCount;
+  const hiddenByRange = query ? 0 : allWorkRuns.filter(inTabGroup).length - windowedTabCount;
+  // The first-class chip's count (review #9): everything the window holds back
+  // across ALL statuses — a peer of the status tabs, not a footnote.
+  const hiddenTotal = query ? 0 : allWorkRuns.length - windowedRuns.length;
 
   return (
     <div className="flex flex-col h-full" style={{ color: 'var(--ink-high)' }}>
@@ -195,16 +209,30 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
         </button>
       </div>
 
-      {/* Metrics row */}
+      {/* Metrics row — scoped to the honest recency window, and each label
+          SAYS so ("last 30 runs", never a fabricated "30d"). */}
       <div className="px-8 pb-4 grid gap-3" style={{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
         {([
-          { label: 'Total Runs',    value: String(metrics.total),       accent: undefined },
-          { label: 'Active',        value: String(metrics.active),       accent: 'var(--status-run)' },
-          { label: 'Success Rate',  value: metrics.successRate,          accent: 'var(--status-run)' },
-          { label: 'Top Workflow',  value: metrics.topWorkflow,          accent: undefined },
+          { label: `Runs (${rangeWord(range)})`,   value: String(metrics.total),  accent: undefined,      testid: 'work-metric-total',   health: undefined },
+          { label: 'Active',                       value: String(metrics.active), accent: 'var(--status-run)', testid: 'work-metric-active',  health: undefined },
+          // Threshold color (review #9): green ONLY when actually healthy.
+          {
+            label: `Success rate (${rangeWord(range)})`,
+            value: metrics.successRate,
+            accent:
+              metrics.successHealth === 'good' ? 'var(--status-done)'
+              : metrics.successHealth === 'warn' ? 'var(--status-gate)'
+              : metrics.successHealth === 'bad' ? 'var(--status-fail)'
+              : undefined,
+            testid: 'work-success-rate',
+            health: metrics.successHealth,
+          },
+          { label: 'Top Workflow', value: metrics.topWorkflow, accent: undefined, testid: 'work-metric-top', health: undefined },
         ] as const).map(s => (
           <div
             key={s.label}
+            data-testid={s.testid}
+            {...(s.health === undefined ? {} : { 'data-health': s.health })}
             className="rounded-xl px-4 py-3"
             style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
@@ -268,6 +296,21 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
             {t.label} {counts[t.id]}
           </button>
         ))}
+        {/* The window's held-back rows as a FIRST-CLASS chip (review #9), a
+            peer of the status tabs — click reveals everything. */}
+        {hiddenTotal > 0 && (
+          <button
+            type="button"
+            data-testid="work-hidden-chip"
+            data-hidden={hiddenTotal}
+            onClick={() => setRange('all')}
+            className="rounded-full px-3 py-1 text-xs font-mono"
+            style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+            title={`the ${rangeWord(range)} window holds back ${hiddenTotal} older run${hiddenTotal === 1 ? '' : 's'} — click to show all`}
+          >
+            +{hiddenTotal} older · show all
+          </button>
+        )}
         <div className="flex-1" />
         {/* Archived is orthogonal to status: a write-off toggle, not a fifth status tab. */}
         <button
@@ -300,23 +343,17 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
             style={{ color: 'var(--ink-muted)', margin: 0 }}
           >
             {hiddenByRange} more{tab === 'all' ? '' : ` ${tab}`} run{hiddenByRange === 1 ? '' : 's'} sit
-            {hiddenByRange === 1 ? 's' : ''} outside this {range} view
-            {range !== '90d' ? (
-              <>
-                {' — '}
-                <button
-                  type="button"
-                  data-testid="work-range-widen"
-                  onClick={() => setRange('90d')}
-                  className="underline"
-                  style={{ color: 'var(--ink-muted)', background: 'none', border: 'none', padding: 0, font: 'inherit', cursor: 'pointer' }}
-                >
-                  widen to 90d
-                </button>
-              </>
-            ) : (
-              ' (the view is positional — newest first)'
-            )}
+            {hiddenByRange === 1 ? 's' : ''} outside the {rangeWord(range)}-runs window
+            {' — '}
+            <button
+              type="button"
+              data-testid="work-range-widen"
+              onClick={() => setRange('all')}
+              className="underline"
+              style={{ color: 'var(--ink-muted)', background: 'none', border: 'none', padding: 0, font: 'inherit', cursor: 'pointer' }}
+            >
+              show all
+            </button>
           </p>
         )}
         {tab === 'all' ? (

--- a/src/components/runIdentity.tsx
+++ b/src/components/runIdentity.tsx
@@ -32,21 +32,49 @@ const SHORT_ID = 6;
  *  palette can clip match-highlight positions to the intent it displays. */
 export const INTENT_MAX = 40;
 
+/** The default title budget where a list has room for a real headline
+ *  (usability review #2: word-boundary trim at ~64 chars). */
+export const HUMAN_TITLE_MAX = 64;
+
 export function runShortId(id: string): string {
   return id.slice(0, SHORT_ID);
 }
 
 /**
- * §7.5's synthesized display title: `truncated intent · short-id · #ordinal`.
+ * The ONE human-title derivation (usability review #2: raw prompt text was the
+ * run title on Make, Work, Home's unfiled shelf and the run header — five
+ * identical 300-char rows were indistinguishable). Client-side, zero wires:
+ *
+ *  - the FIRST sentence/clause is the title (cut at `.`/`!`/`?`/`:`/`;`
+ *    followed by whitespace, or at the first line break);
+ *  - still too long → word-boundary trim to ~`max` chars plus an ellipsis;
+ *  - the full intent moves to the hover title / detail, never the row.
+ *
+ * The fragment before the ellipsis stays a literal PREFIX of the raw intent
+ * (only trailing whitespace/punctuation is dropped), so the palette's
+ * match-highlight positions — computed against the raw problem — keep landing
+ * on the characters they name.
+ */
+export function humanTitle(intent: string, max: number = HUMAN_TITLE_MAX): string {
+  const stop = intent.search(/[.!?:;](?=\s)|\n/);
+  let clause = (stop === -1 ? intent : intent.slice(0, stop)).trimEnd();
+  if (clause === '') clause = intent.trimEnd();
+  if (clause.length <= max) return clause;
+  const cut = clause.slice(0, max + 1);
+  const atWord = cut.lastIndexOf(' ');
+  const head = (atWord > 0 ? cut.slice(0, atWord) : cut.slice(0, max)).replace(/[\s,;:·—-]+$/, '');
+  return `${head}…`;
+}
+
+/**
+ * §7.5's synthesized display title: `intent clause · short-id · #ordinal`.
  * The attempt ordinal is 1-based off the DTO's 0-based `attempt`, so five
  * identical prompts stop being quintuplets — the short-id alone already
- * distinguishes them; the ordinal names reworks.
+ * distinguishes them; the ordinal names reworks. The intent half goes through
+ * {@link humanTitle} — one derivation, not four copies.
  */
 export function runTitle(session: AgentSession, intentMax: number = INTENT_MAX): string {
-  const intent = session.problem.length > intentMax
-    ? `${session.problem.slice(0, intentMax)}…`
-    : session.problem;
-  return `${intent} · ${runShortId(session.id)} · #${session.attempt + 1}`;
+  return `${humanTitle(session.problem, intentMax)} · ${runShortId(session.id)} · #${session.attempt + 1}`;
 }
 
 /**

--- a/src/hooks/useDismissable.ts
+++ b/src/hooks/useDismissable.ts
@@ -1,0 +1,42 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * The ONE overlay contract (usability review #10): every transient surface —
+ * an anchored menu, a popover — closes the same three ways:
+ *
+ *  1. **Escape** closes it and RETURNS FOCUS to the trigger that opened it
+ *     (the live-verified gap: the rule drawer honored Escape, the Add menu
+ *     survived it);
+ *  2. a **click outside** the surface closes it;
+ *  3. the caller's own close affordance keeps working (it owns `close`).
+ *
+ * `containerRef` bounds the outside-click test and should wrap trigger AND
+ * surface; `triggerRef` (optional) is where Escape sends focus back.
+ * Modal dialogs with their own focus management (Modal.tsx) keep theirs —
+ * this hook is for the lightweight anchored surfaces that had nothing.
+ */
+export function useDismissable(
+  open: boolean,
+  close: () => void,
+  containerRef: RefObject<HTMLElement | null>,
+  triggerRef?: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent): void {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      close();
+      triggerRef?.current?.focus();
+    }
+    function onOutside(e: MouseEvent): void {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) close();
+    }
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onOutside);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onOutside);
+    };
+  }, [open, close, containerRef, triggerRef]);
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -17,7 +17,13 @@ import { isTestingSubPage } from '../api/testing.js';
 // The orphaned `coverage` and `domain` settings panels retired in the same wave:
 // their paths parse to `system` and `useRetiredSettingsRedirect` rewrites the
 // address onto `/system`.
-export type Panel = 'home' | 'runs' | 'workflows' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make';
+// `not-found` is the honest dead-address state (usability review #4): an address
+// that matches NO page renders a not-found view that PRESERVES the typed URL and
+// offers the way out — it never silently normalizes onto a nearby default. Only
+// the RETIRED addresses (wiki/rules/policies, coverage/domain, the flat
+// campaigns, the bare /runs listing) keep their redirects: those are moves with
+// a known destination, not typos.
+export type Panel = 'home' | 'runs' | 'workflows' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'not-found';
 
 const PANELS: Panel[] = ['runs', 'workflows', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
 
@@ -196,10 +202,13 @@ function parse(pathname: string): Route {
   }
   // `/steering[/:type]` — the STEERING surface: one page component, parameterized by type.
   // The bare `/steering` address IS the landing (the seven type cards); an address that names
-  // an invalid type (a typo'd `/steering/foo`) parses with `steeringType: null` too, and
-  // `useSteeringRedirect` replaces it with the landing's real URL.
+  // an INVALID type (a typo'd `/steering/foo`) is a dead address — the not-found view, never a
+  // silent swap onto the landing (usability review #4).
   if (first === 'steering') {
-    return route({ panel: 'steering', steeringType: isSteeringType(second) ? second : null });
+    if (!second) return route({ panel: 'steering', steeringType: null });
+    return isSteeringType(second)
+      ? route({ panel: 'steering', steeringType: second })
+      : route({ panel: 'not-found' });
   }
   // The RETIRED governance addresses: `/wiki` (the old Architecture Wiki page), `/rules` (the
   // old RuleManager), and `/policies` (the old policies settings panel — merged into steering
@@ -223,7 +232,12 @@ function parse(pathname: string): Route {
     if (second === 'campaigns' && third) {
       return route({ panel: 'testing', testingPage: 'campaigns', campaignId: safeDecode(third) });
     }
-    return route({ panel: 'testing', testingPage: isTestingSubPage(second) ? second : null });
+    // Bare `/testing` is a parent path with one honest home (Harness) — it keeps its redirect.
+    // A typo'd sub-page (`/testing/harnes`) is a dead address: not-found, never a silent swap.
+    if (!second) return route({ panel: 'testing', testingPage: null });
+    return isTestingSubPage(second)
+      ? route({ panel: 'testing', testingPage: second })
+      : route({ panel: 'not-found' });
   }
   // The RETIRED flat campaign addresses: `/campaigns` and `/campaigns/:id` fold into the
   // Testing surface — parsed here so the pages render instantly, redirected (replace) by
@@ -261,9 +275,15 @@ function parse(pathname: string): Route {
   if ((PANELS as string[]).includes(first) && first !== 'runs') {
     return route({ panel: first as Panel });
   }
-  if (second === 'new') return route({ panel: 'runs', showLaunch: true });
-  if (second) return route({ panel: 'runs', runId: safeDecode(second) });
-  return route({ panel: 'runs' });
+  // `/runs[...]` — the run detail / launch form (and the retired bare listing,
+  // which useLegacyRedirect replaces with /work). ONLY `/runs` reaches these
+  // arms: a garbage top-level address is a dead address, not a run list.
+  if (first === 'runs') {
+    if (second === 'new') return route({ panel: 'runs', showLaunch: true });
+    if (second) return route({ panel: 'runs', runId: safeDecode(second) });
+    return route({ panel: 'runs' });
+  }
+  return route({ panel: 'not-found' });
 }
 
 /** `replace` swaps the current history entry — used by redirects so Back never re-enters them. */

--- a/src/hooks/useTimeRange.ts
+++ b/src/hooks/useTimeRange.ts
@@ -1,36 +1,52 @@
 /**
- * useTimeRange — shared time-range selection hook + filterByWindow utility.
+ * useTimeRange — shared recency-window selection hook + filterByWindow utility.
  *
- * NOTE on "time range": AgentSession has no timestamp field in the current
- * daemon API. filterByWindow therefore uses a positional-slice heuristic —
- * runs are status-sorted server-side (active first), so slicing to the first
- * n entries captures the n most-recently-salient sessions as a proxy for
- * recency. This comment intentionally documents the limitation; swap the
- * implementation for a real date filter once AgentSession.started_at exists.
+ * HONESTY NOTE (usability review #9): AgentSession has no timestamp field in
+ * the current daemon API, so this is NOT a time filter and no longer claims to
+ * be one. filterByWindow is a positional slice — runs are status-sorted
+ * server-side (active first), so the first n entries are the n most-recently-
+ * salient sessions — and the labels now SAY that ("last 30" runs, not "30d").
+ * `all` lifts the window entirely. Swap the implementation for a real date
+ * filter once AgentSession.started_at exists.
  */
 import { useCallback, useState } from 'react';
 import type { SessionView } from '../api/types.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export type TimeRange = '30d' | '60d' | '90d';
+export type TimeRange = '30d' | '60d' | '90d' | 'all';
+
+/** The rows the positional window keeps, per range. `null` = unbounded. */
+export const RANGE_LIMITS: Record<TimeRange, number | null> = {
+  '30d': 30,
+  '60d': 60,
+  '90d': 90,
+  all: null,
+};
+
+/** The honest label: what the window really is — the newest N runs. */
+export function rangeWord(range: TimeRange): string {
+  const limit = RANGE_LIMITS[range];
+  return limit === null ? 'all' : `last ${limit}`;
+}
 
 export const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
-  { value: '30d', label: '30d' },
-  { value: '60d', label: '60d' },
-  { value: '90d', label: '90d' },
+  { value: '30d', label: rangeWord('30d') },
+  { value: '60d', label: rangeWord('60d') },
+  { value: '90d', label: rangeWord('90d') },
+  { value: 'all', label: rangeWord('all') },
 ];
 
 // ── Pure utility ──────────────────────────────────────────────────────────────
 
 /**
- * Returns a subset of `runs` scoped to the given time range.
- * Uses positional slicing as a recency proxy (no timestamp on AgentSession).
- * 30d → first 30 entries, 60d → first 60, 90d → first 90.
+ * Returns a subset of `runs` scoped to the given window.
+ * Positional slicing as a recency proxy (no timestamp on AgentSession):
+ * `30d` → first 30 entries, `60d` → 60, `90d` → 90, `all` → everything.
  */
 export function filterByWindow(runs: SessionView[], range: TimeRange): SessionView[] {
-  const limit = range === '30d' ? 30 : range === '60d' ? 60 : 90;
-  return runs.slice(0, limit);
+  const limit = RANGE_LIMITS[range];
+  return limit === null ? runs : runs.slice(0, limit);
 }
 
 // ── Hook ──────────────────────────────────────────────────────────────────────

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,3 +211,26 @@ code, pre, .font-mono {
   margin-left: 4px;
 }
 .wk-feed-link:hover::after { opacity: 1; }
+
+/* The skip link (usability review #10): the app's first tabbable element.
+   Off-canvas until keyboard focus lands on it, then a visible pill at the
+   top-left — one Tab from a fresh load reaches "Skip to main content". */
+.skip-link {
+  position: fixed;
+  top: -100px;
+  left: 12px;
+  z-index: 100;
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: top 0.1s ease-out;
+}
+.skip-link:focus {
+  top: 12px;
+  outline: 2px solid var(--accent-dim);
+  outline-offset: 2px;
+}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,11 +10,11 @@
   "version": 1,
   "studioVersion": "0.4.3",
   "counts": {
-    "files": 106,
-    "occurrences": 790,
-    "static": 677,
+    "files": 108,
+    "occurrences": 808,
+    "static": 693,
     "dynamic": 39,
-    "computed": 5
+    "computed": 6
   },
   "static": [
     {
@@ -471,6 +471,12 @@
     },
     {
       "testId": "campaigns-empty",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-empty-cta",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]
@@ -2031,6 +2037,24 @@
       ]
     },
     {
+      "testId": "not-found",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
+      "testId": "not-found-link",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
+      "testId": "not-found-path",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
       "testId": "notif-chime",
       "files": [
         "src/components/NotificationSettings.tsx"
@@ -2794,6 +2818,12 @@
       ]
     },
     {
+      "testId": "skip-link",
+      "files": [
+        "src/components/SkipLink.tsx"
+      ]
+    },
+    {
       "testId": "source-attach",
       "files": [
         "src/components/ComposerContext.tsx"
@@ -2923,6 +2953,18 @@
       "testId": "steering-chip",
       "files": [
         "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "steering-diagnostics",
+      "files": [
+        "src/components/SteeringHealth.tsx"
+      ]
+    },
+    {
+      "testId": "steering-diagnostics-toggle",
+      "files": [
+        "src/components/SteeringHealth.tsx"
       ]
     },
     {
@@ -3276,6 +3318,12 @@
       ]
     },
     {
+      "testId": "steering-store-health",
+      "files": [
+        "src/components/SteeringHealth.tsx"
+      ]
+    },
+    {
       "testId": "steering-timeline",
       "files": [
         "src/components/SteeringTimeline.tsx"
@@ -3402,6 +3450,12 @@
       ]
     },
     {
+      "testId": "testing-evals-blocked",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-busy",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3444,6 +3498,12 @@
       ]
     },
     {
+      "testId": "testing-evals-gaps",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-nearest",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3456,7 +3516,25 @@
       ]
     },
     {
+      "testId": "testing-evals-nearest-link",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-nearest-rule",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-passed",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-provenance",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -3492,7 +3570,19 @@
       ]
     },
     {
+      "testId": "testing-evals-verdict-word",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-harness",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-harness-explainer",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -4073,6 +4163,12 @@
       ]
     },
     {
+      "testId": "work-hidden-chip",
+      "files": [
+        "src/components/WorkPage.tsx"
+      ]
+    },
+    {
       "testId": "work-range-hidden-note",
       "files": [
         "src/components/WorkPage.tsx"
@@ -4351,6 +4447,12 @@
       "expression": "a.testId",
       "files": [
         "src/components/ComposerContext.tsx"
+      ]
+    },
+    {
+      "expression": "s.testid",
+      "files": [
+        "src/components/WorkPage.tsx"
       ]
     },
     {

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -45,11 +45,19 @@ describe('the §1.5 probe states', () => {
     expect(screen.getByTestId('campaigns-unsupported').textContent).toContain('predates campaign grouping');
   });
 
-  it('200 [] is the "no campaigns yet" answer, in words that name how one is minted', async () => {
+  it('200 [] is the "no campaigns yet" answer, in plain words, with a CTA to Harness (quick win #3)', async () => {
+    const navigate = vi.fn();
     listCampaigns.mockResolvedValue({ campaigns: [] });
-    render(<CampaignsPage navigate={() => {}} />);
+    render(<CampaignsPage navigate={navigate} />);
     await waitFor(() => expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument());
-    expect(screen.getByTestId('campaigns-empty').textContent).toContain('minted by its first filed run');
+    // Plain words — "minted" is banned vocabulary on user surfaces (review #6).
+    expect(screen.getByTestId('campaigns-empty').textContent).toContain(
+      'launch a run with a campaign label — start one from Harness',
+    );
+    expect(screen.getByTestId('campaigns-empty').textContent).not.toContain('minted');
+    // The dead end gains its way out: the CTA navigates to the Harness page.
+    fireEvent.click(screen.getByTestId('campaigns-empty-cta'));
+    expect(navigate).toHaveBeenCalledWith('/testing/harness');
   });
 });
 

--- a/tests/ChatsPage.dashboard.test.tsx
+++ b/tests/ChatsPage.dashboard.test.tsx
@@ -106,7 +106,7 @@ describe('the register below (§4.3: "the list below is the existing ChatsPage l
     page(onSelect);
     expect(screen.getByPlaceholderText('Search chats…')).toBeInTheDocument();
     expect(screen.getByText('New Chat')).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Time range' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Show newest runs' })).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('Search chats…'), { target: { value: 'auth' } });
     const rows = screen.getAllByTestId('chat-row');
     expect(rows).toHaveLength(1);

--- a/tests/DecisionsLedger.test.tsx
+++ b/tests/DecisionsLedger.test.tsx
@@ -142,12 +142,13 @@ describe('DecisionsLedger — an approval is only credited to a layer that ran (
 
   // This is the exact shape every unit of run 7620a086 emitted: all three layers inert, yet the
   // ledger credited the pass to "evaluator (2nd pass)". A default-allow is not a governed pass.
-  it('reports ungated when no layer ran, even though evaluatorPass is true', () => {
+  it('reports one honest line when no layer ran, even though evaluatorPass is true', () => {
     renderGate({});
     const row = screen.getByTestId('ledger-row');
-    // The decider itself must say "ungated"; the criterion placeholder renders "(ungated)" too, so
-    // the negative assertion is the one that actually binds.
-    expect(row).toHaveTextContent('ungated');
+    // Usability review #7: "ALLOW · ungated · (ungated)" said the same nothing
+    // twice — the ungated allow is ONE line now, and no layer gets the credit.
+    expect(row).toHaveTextContent('allowed — no policy applied');
+    expect(row).not.toHaveTextContent('ungated');
     expect(row).not.toHaveTextContent('evaluator (2nd pass)');
   });
 
@@ -221,8 +222,12 @@ describe('DecisionsLedger — the evaluator chip states whether a policy ran (FI
     return screen.getByTestId('ledger-row');
   };
 
-  it('says no policy applied when the pass was vacuous', () => {
-    expect(row({})).toHaveTextContent('evaluator: pass (no policy applied)');
+  it('renders NO evaluator chip for a vacuous pass — the headline already says no policy applied', () => {
+    const r = row({});
+    // Review #7 dedupe: "evaluator: pass (no policy applied)" under "allowed —
+    // no policy applied" was the same fact dressed as a second verdict.
+    expect(r).toHaveTextContent('allowed — no policy applied');
+    expect(r).not.toHaveTextContent('evaluator: pass');
   });
 
   it('names the policies when the pass was enforced', () => {

--- a/tests/MakeDashboard.test.tsx
+++ b/tests/MakeDashboard.test.tsx
@@ -111,9 +111,20 @@ describe('the corpus label + fan-out gesture (§4.2.2, EC24)', () => {
     );
     expect(screen.queryByTestId('make-corpus-why-popover')).toBeNull();
     fireEvent.click(screen.getByTestId('make-corpus-why'));
+    // Quick win #5: plain words — no bridge internals in the popover.
     expect(screen.getByTestId('make-corpus-why-popover').textContent).toContain(
-      "Documents live behind each project's bridge; the studio lists what it",
+      'Documents load per project',
     );
+  });
+
+  it('Escape closes the why popover and returns focus to its trigger (review #10 overlay contract)', () => {
+    dash();
+    const trigger = screen.getByTestId('make-corpus-why');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('make-corpus-why-popover')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('make-corpus-why-popover')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it('fires ZERO doc requests on render; the fan-out click fires exactly P (non-default projects)', async () => {

--- a/tests/RoutingProvenance.test.tsx
+++ b/tests/RoutingProvenance.test.tsx
@@ -15,6 +15,30 @@ describe('RoutingProvenance (§11.5 — why this CLI won)', () => {
     expect(el).toHaveTextContent('1 dissent');
   });
 
+  it('a single-seat council suppresses won/agreement/dissent — no election was held (review #7)', () => {
+    render(
+      <RoutingProvenance
+        routing={{ method: 'council', winner: 'claude', agreement_pct: 100, returned: 1, seated: 1, dissent: 0 }}
+      />,
+    );
+    const el = screen.getByTestId('routing-provenance');
+    expect(el).toHaveAttribute('data-seats', '1');
+    expect(el).toHaveTextContent('claude — single seat, no vote held');
+    expect(el).not.toHaveTextContent('won');
+    expect(el).not.toHaveTextContent('agreement');
+    expect(el).not.toHaveTextContent('dissent');
+  });
+
+  it('a multi-seat council keeps the full verdict line (seated known)', () => {
+    render(
+      <RoutingProvenance
+        routing={{ method: 'council', winner: 'claude', agreement_pct: 67, returned: 4, seated: 6, dissent: 2 }}
+      />,
+    );
+    const el = screen.getByTestId('routing-provenance');
+    expect(el).toHaveTextContent('claude won · 67% agreement · 4 of 6 seats · 2 dissent');
+  });
+
   it('renders a degraded fallback with its reason', () => {
     render(<RoutingProvenance routing={{ method: 'degraded', reason: 'no quorum' }} />);
     expect(screen.getByTestId('routing-provenance')).toHaveTextContent('no quorum');

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -254,8 +254,8 @@ describe('filterSteeringRules — the page-scope + facet predicate, pinned', () 
   });
 });
 
-describe('SteeringPage — health header', () => {
-  it('renders per-type numbers when the wire serves by_steering_type', async () => {
+describe('SteeringPage — health header (TYPE-scoped, usability review #5)', () => {
+  it('renders per-type numbers when the wire serves by_steering_type — and NOTHING store-wide', async () => {
     listConformanceRules.mockResolvedValue({ rules: [rule({ steering_type: 'security' })] });
     const sb = scoreboard({
       by_steering_type: {
@@ -270,22 +270,54 @@ describe('SteeringPage — health header', () => {
     expect(stat).toHaveTextContent('Security rules');
     expect(stat).toHaveTextContent('4 active');
     expect(stat).toHaveTextContent('5 total · 1 retired');
+    // The store-wide stats, the verdict pill and the ingest diagnostics moved
+    // to the LANDING (the one place they are actionable) — never a type page.
     expect(screen.queryByTestId('steering-stat-rules')).toBeNull();
-    // The rest of the AW-23 raw signals still render beside the derived verdict chip.
-    expect(screen.getByTestId('steering-verdict')).toHaveAttribute('data-verdict', 'populated');
-    expect(screen.getByTestId('steering-stat-typed')).toHaveTextContent('90%');
+    expect(screen.queryByTestId('steering-verdict')).toBeNull();
+    expect(screen.queryByTestId('steering-stat-typed')).toBeNull();
+    expect(screen.queryByTestId('steering-diagnostics')).toBeNull();
   });
 
-  it('falls back to store-wide numbers, LABELED store-wide, when the wire has no per-type split', async () => {
-    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+  it('falls back to a CLIENT-side count of this type’s loaded rules when the wire has no per-type split', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [rule()] }); // architecture via serde default
     wire({ scoreboard: () => Promise.resolve({ scoreboard: scoreboard() }) });
     page('architecture');
 
-    const stat = await screen.findByTestId('steering-stat-rules');
-    expect(stat).toHaveTextContent('Rules (store-wide)');
-    expect(stat).toHaveTextContent('2 active');
+    const stat = await screen.findByTestId('steering-stat-rules-type');
+    expect(stat).toHaveTextContent('Architecture rules');
+    expect(stat).toHaveTextContent('1 loaded');
     expect(stat).toHaveTextContent(/no per-type split/);
+    // Never the store-wide "2 active" wearing this type's label.
+    expect(screen.queryByTestId('steering-stat-rules')).toBeNull();
+  });
+
+  it('an EMPTY type page loses the stats entirely — no store-wide numbers over an empty list', async () => {
+    // The live-verified finding: Security with 0 rules of its own said "36
+    // active" + a red decaying pill. Now: no health block at all.
+    listConformanceRules.mockResolvedValue({ rules: [rule()] }); // architecture only
+    wire({ scoreboard: () => Promise.resolve({ scoreboard: scoreboard() }) });
+    page('security');
+
+    await screen.findByTestId('steering-page');
+    await waitFor(() => expect(listConformanceRules).toHaveBeenCalled());
+    expect(screen.queryByTestId('steering-health')).toBeNull();
+    expect(screen.queryByTestId('steering-verdict')).toBeNull();
+    expect(screen.queryByTestId('steering-stat-rules')).toBeNull();
     expect(screen.queryByTestId('steering-stat-rules-type')).toBeNull();
+  });
+
+  it('the LANDING carries the store-wide verdict, with diagnostics behind a details toggle', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire({ scoreboard: () => Promise.resolve({ scoreboard: scoreboard() }) });
+    page(null);
+
+    const health = await screen.findByTestId('steering-store-health');
+    expect(within(health).getByTestId('steering-verdict')).toHaveAttribute('data-verdict', 'populated');
+    // The raw signals are PRESENT but folded — a details element, closed by default.
+    const details = within(health).getByTestId('steering-diagnostics');
+    expect(details).not.toHaveAttribute('open');
+    expect(within(health).getByTestId('steering-stat-typed')).toHaveTextContent('90%');
+    expect(within(health).getByTestId('steering-stat-rules')).toHaveTextContent('Rules (store-wide)');
   });
 
   it('a 501 renders the honest "engine predates the scoreboard" state, never an error card', async () => {
@@ -533,5 +565,38 @@ describe('SteeringPage — the retire kill switch (opened from the drawer)', () 
     expect(screen.queryByTestId('steering-retire-open')).toBeNull();
     expect(screen.queryByTestId('steering-edit-open')).toBeNull();
     expect(screen.getByTestId('steering-rule-retired-note')).toHaveTextContent(/withdrawn from recall/);
+  });
+});
+
+describe('SteeringPage — ?rule deep link opens the drawer (qe finding: eval gap hints are links)', () => {
+  it('landing on /steering/security?rule=POL-100 opens POL-100’s drawer', async () => {
+    listConformanceRules.mockResolvedValue({
+      rules: [rule({ id: 'POL-100', rule_type: 'policy', statement: 'No secrets in logs', steering_type: 'security' })],
+    });
+    wire();
+    render(<SteeringPage type="security" navigate={() => {}} search="?rule=POL-100" />);
+
+    const drawer = await screen.findByTestId('steering-rule-drawer');
+    expect(drawer).toHaveTextContent('POL-100');
+    expect(drawer).toHaveTextContent('No secrets in logs');
+  });
+
+  it('a routed rule filed under a NEIGHBOURING type still opens (the link came from an eval sample)', async () => {
+    listConformanceRules.mockResolvedValue({
+      rules: [rule({ id: 'PAT-777', statement: 'Pin the fetch boundary', steering_type: 'development' })],
+    });
+    wire();
+    render(<SteeringPage type="security" navigate={() => {}} search="?rule=PAT-777" />);
+
+    expect(await screen.findByTestId('steering-rule-drawer')).toHaveTextContent('PAT-777');
+  });
+
+  it('an unknown ?rule id opens nothing — never a fabricated drawer', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [rule()] });
+    wire();
+    render(<SteeringPage type="architecture" navigate={() => {}} search="?rule=NOPE-1" />);
+
+    await screen.findByTestId('steering-rule-row');
+    expect(screen.queryByTestId('steering-rule-drawer')).toBeNull();
   });
 });

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -17,8 +17,8 @@ import type { WikiMeta, WikiScoreboard } from '../src/api/wiki.js';
  *    steering_type, with absent `steering_type` folding to architecture (the engine's serde
  *    default); the breadcrumb walks back to the landing;
  *  - the health header renders the AW-23 raw signals; PER-TYPE numbers when the wire serves
- *    `by_steering_type`, the store-wide numbers LABELED store-wide when it does not; a 501 is
- *    the honest adoption state, never an error card;
+ *    `by_type` (the wicked-governance Scoreboard spelling), the store-wide numbers LABELED
+ *    store-wide when it does not; a 501 is the honest adoption state, never an error card;
  *  - `meta.seeded === false` + an empty store is the unseeded state (seed command shown), and a
  *    daemon that cannot answer meta is never accused of an unseeded store; an empty TYPE on a
  *    populated store names the management flows instead;
@@ -255,12 +255,13 @@ describe('filterSteeringRules — the page-scope + facet predicate, pinned', () 
 });
 
 describe('SteeringPage — health header (TYPE-scoped, usability review #5)', () => {
-  it('renders per-type numbers when the wire serves by_steering_type — and NOTHING store-wide', async () => {
+  it('renders per-type numbers when the wire serves by_type — and NOTHING store-wide', async () => {
     listConformanceRules.mockResolvedValue({ rules: [rule({ steering_type: 'security' })] });
+    // The wicked-governance `Scoreboard.by_type` shape, serde spellings verbatim.
     const sb = scoreboard({
-      by_steering_type: {
-        security: { rules_total: 5, rules_active: 4, rules_retired: 1 },
-        architecture: { rules_total: 30, rules_active: 28, rules_retired: 2 },
+      by_type: {
+        security: { total: 5, active: 4, retired: 1, enforcing: 0 },
+        architecture: { total: 30, active: 28, retired: 2, enforcing: 3 },
       },
     });
     wire({ scoreboard: () => Promise.resolve({ scoreboard: sb }) });
@@ -276,6 +277,20 @@ describe('SteeringPage — health header (TYPE-scoped, usability review #5)', ()
     expect(screen.queryByTestId('steering-verdict')).toBeNull();
     expect(screen.queryByTestId('steering-stat-typed')).toBeNull();
     expect(screen.queryByTestId('steering-diagnostics')).toBeNull();
+  });
+
+  it('a served by_type map with NO row for this type means zero — no stats block (only types holding rules appear)', async () => {
+    // The live 0.7.3 shape: by_type carries architecture only; Security must
+    // read as empty through the WIRE path, never inherit a fallback count.
+    listConformanceRules.mockResolvedValue({ rules: [rule({ steering_type: 'security' })] });
+    const sb = scoreboard({ by_type: { architecture: { total: 36, active: 36, retired: 0, enforcing: 0 } } });
+    wire({ scoreboard: () => Promise.resolve({ scoreboard: sb }) });
+    page('security');
+
+    await screen.findByTestId('steering-page');
+    await waitFor(() => expect(listConformanceRules).toHaveBeenCalled());
+    expect(screen.queryByTestId('steering-health')).toBeNull();
+    expect(screen.queryByTestId('steering-stat-rules-type')).toBeNull();
   });
 
   it('falls back to a CLIENT-side count of this type’s loaded rules when the wire has no per-type split', async () => {

--- a/tests/TestingEvals.test.tsx
+++ b/tests/TestingEvals.test.tsx
@@ -101,13 +101,24 @@ describe('Evals — the run', () => {
     expect(await screen.findByTestId('testing-evals-summary')).toHaveTextContent('3 samples');
     expect(runBody).toEqual({ type: 'security', corpus: 'evals:dev-behaviors' });
 
+    // The qe finding: "caught" split into its two honest halves (S-1 is a bad
+    // sample the rules BLOCKED; no good sample was caught here), and the gap
+    // count framed as uncovered behaviors — work to do, not red failure.
     const summary = screen.getByTestId('testing-evals-summary');
-    expect(summary).toHaveTextContent('1 caught');
-    expect(summary).toHaveTextContent('1 gaps');
+    expect(summary).toHaveTextContent('1 blocked');
+    expect(summary).toHaveTextContent('0 passed');
+    expect(summary).toHaveTextContent('1 uncovered behavior');
     expect(summary).toHaveTextContent('1 false positives');
+
+    // The report header names its corpus (provenance, qe finding).
+    expect(screen.getByTestId('testing-evals-provenance')).toHaveTextContent(
+      'corpus: evals:dev-behaviors · 3 samples',
+    );
 
     const rows = screen.getAllByTestId('testing-evals-row');
     expect(rows.map((r) => r.getAttribute('data-verdict'))).toEqual(['caught', 'gap', 'false_positive']);
+    // The verdict WORD distinguishes a blocked bad sample from a passed good one.
+    expect(rows[0]).toHaveTextContent('blocked');
     expect(rows[0]).toHaveTextContent('POL-101');
     // A sample that fired nothing says so — never a blank cell.
     expect(rows[1]).toHaveTextContent('—');
@@ -156,6 +167,23 @@ describe('Evals — the run', () => {
     // Toggling again collapses.
     await user.click(screen.getByTestId('testing-evals-gap-toggle'));
     expect(screen.queryByTestId('testing-evals-nearest')).toBeNull();
+  });
+
+  it('a nearest-rule hint is a LINK into Steering that deep-links the rule drawer (qe finding)', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    wire({ '/testing/evals/run': () => Promise.resolve(REPORT) });
+    render(<TestingPage page="evals" campaignId={null} runs={[]} navigate={navigate} />);
+
+    await user.click(screen.getByTestId('testing-evals-run'));
+    await screen.findByTestId('testing-evals-table');
+    await user.click(screen.getByTestId('testing-evals-gap-toggle'));
+
+    const links = await screen.findAllByTestId('testing-evals-nearest-link');
+    expect(links[0]).toHaveAttribute('href', '/steering/security?rule=POL-104');
+    await user.click(links[0]!);
+    // The sample's type page, with ?rule opening that rule's drawer.
+    expect(navigate).toHaveBeenCalledWith('/steering/security?rule=POL-104');
   });
 
   it('a gap whose nearest_rules is EMPTY says "nothing nearby" in words — never a blank panel', async () => {

--- a/tests/WorkPage.filter.test.tsx
+++ b/tests/WorkPage.filter.test.tsx
@@ -89,18 +89,19 @@ describe('WorkPage — range-hidden rows are stated, never silent (EC39)', () =>
     makeView({ id: 'r-cxl', workflow_id: 'feature', problem: 'called off', status: 'cancelled' }),
   ];
 
-  it('states the hidden count on a filter whose rows the window excludes, and widens on demand', async () => {
+  it('states the hidden count on a filter whose rows the window excludes, and shows all on demand', async () => {
     render(
       <WorkPage runs={MANY} selectedRunId={null} onSelect={() => {}} navigate={() => {}} search="?filter=cancelled" />,
     );
-    // The 30d window (first 30 rows) holds no cancelled run — the note says so.
+    // The last-30 window (first 30 rows) holds no cancelled run — the note
+    // says so, in the window's HONEST name (review #9: never "30d").
     const note = screen.getByTestId('work-range-hidden-note');
     expect(note).toHaveAttribute('data-hidden', '1');
-    expect(note.textContent).toMatch(/1 more cancelled run sits outside this 30d view/);
+    expect(note.textContent).toMatch(/1 more cancelled run sits outside the last 30-runs window/);
     // The empty state tells the SAME truth — never "No cancelled runs yet."
     // one line under a note saying they exist.
     expect(screen.getByText(/No cancelled runs in this range view — 1 exists outside it\./)).toBeInTheDocument();
-    // Widen → the row appears and the note goes away (90d covers all 32).
+    // Show all → the row appears and the note goes away.
     await userEvent.click(screen.getByTestId('work-range-widen'));
     expect(screen.getByText(/called off/)).toBeInTheDocument();
     expect(screen.queryByTestId('work-range-hidden-note')).toBeNull();
@@ -111,5 +112,59 @@ describe('WorkPage — range-hidden rows are stated, never silent (EC39)', () =>
       <WorkPage runs={RUNS} selectedRunId={null} onSelect={() => {}} navigate={() => {}} search="?filter=failed" />,
     );
     expect(screen.queryByTestId('work-range-hidden-note')).toBeNull();
+  });
+
+  it('surfaces the held-back rows as a FIRST-CLASS chip beside the tabs; clicking shows all (review #9)', async () => {
+    render(<WorkPage runs={MANY} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />);
+    const chip = screen.getByTestId('work-hidden-chip');
+    // 32 work runs, 30 in the window → 2 held back across all statuses.
+    expect(chip).toHaveAttribute('data-hidden', '2');
+    await userEvent.click(chip);
+    // Everything shows; the chip retires with nothing left to reveal.
+    expect(screen.queryByTestId('work-hidden-chip')).toBeNull();
+    expect(screen.getByText(/called off/)).toBeInTheDocument();
+  });
+
+  it('search looks at the FULL set — a match outside the window is found, and no hidden note contradicts it', async () => {
+    render(<WorkPage runs={MANY} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />);
+    // "called off" is row 32 — outside the last-30 window.
+    await userEvent.type(screen.getByPlaceholderText('Search work…'), 'called off');
+    expect(screen.getByText(/called off/)).toBeInTheDocument();
+    expect(screen.queryByTestId('work-range-hidden-note')).toBeNull();
+    expect(screen.queryByTestId('work-hidden-chip')).toBeNull();
+  });
+});
+
+describe('WorkPage — the success-rate tile wears threshold colors (review #9)', () => {
+  const mixed = (completed: number, failed: number): ReturnType<typeof makeView>[] => [
+    ...Array.from({ length: completed }, (_, i) =>
+      makeView({ id: `r-ok${i}`, workflow_id: 'feature', problem: `ok ${i}`, status: 'completed' })),
+    ...Array.from({ length: failed }, (_, i) =>
+      makeView({ id: `r-no${i}`, workflow_id: 'feature', problem: `no ${i}`, status: 'failed' })),
+  ];
+
+  it('9 completed vs 21 failed (the live 30%) is BAD — never success-green', () => {
+    render(<WorkPage runs={mixed(9, 21)} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />);
+    const tile = screen.getByTestId('work-success-rate');
+    expect(tile).toHaveAttribute('data-health', 'bad');
+    expect(tile).toHaveTextContent('30%');
+  });
+
+  it('a borderline rate is amber; a healthy one green; no terminal runs, no verdict', () => {
+    const { unmount } = render(
+      <WorkPage runs={mixed(6, 4)} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />,
+    );
+    expect(screen.getByTestId('work-success-rate')).toHaveAttribute('data-health', 'warn');
+    unmount();
+
+    const second = render(
+      <WorkPage runs={mixed(9, 1)} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />,
+    );
+    expect(screen.getByTestId('work-success-rate')).toHaveAttribute('data-health', 'good');
+    second.unmount();
+
+    render(<WorkPage runs={[]} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />);
+    expect(screen.getByTestId('work-success-rate')).toHaveAttribute('data-health', 'none');
+    expect(screen.getByTestId('work-success-rate')).toHaveTextContent('—');
   });
 });

--- a/tests/liveChats.rail.test.tsx
+++ b/tests/liveChats.rail.test.tsx
@@ -116,12 +116,12 @@ describe('/chats "Active now" counts what the screen shows (J4 finding 4a, EC39)
     const tile = screen.getByTestId('chats-active-tile');
     expect(tile).toHaveAttribute('data-count', '1');
     expect(tile).toHaveAttribute('data-live', '1');
-    expect(tile).toHaveTextContent('1 live session · 0 chat runs in 30d');
+    expect(tile).toHaveTextContent('1 live session · 0 chat runs in the last 30');
   });
 
   it('with no live sessions the range-scoped count is labeled with its window', async () => {
     render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
     await screen.findByTestId('chats-active-tile');
-    expect(screen.getByTestId('chats-active-tile')).toHaveTextContent('0 of 0 chat runs in 30d');
+    expect(screen.getByTestId('chats-active-tile')).toHaveTextContent('0 of 0 chat runs in the last 30');
   });
 });

--- a/tests/metricsBar.test.tsx
+++ b/tests/metricsBar.test.tsx
@@ -109,7 +109,7 @@ describe('RunOutcomeBar (§2.1 — "Is the system healthy right now?")', () => {
     expect(tile.textContent).toContain('1 cancelled');
   });
 
-  it('states its exclusions: undated runs are named beside the number (EC39)', () => {
+  it('states its exclusions as an ⓘ note whose tooltip names the count (EC39 + quick win #1)', () => {
     render(
       <RunOutcomeBar
         runs={[
@@ -120,8 +120,12 @@ describe('RunOutcomeBar (§2.1 — "Is the system healthy right now?")', () => {
         now={NOW}
       />,
     );
-    expect(screen.getByTestId('outcome-unplaced-note').textContent)
-      .toBe('excludes 1 run with no clock in this window');
+    const note = screen.getByTestId('outcome-unplaced-note');
+    // The exclusion is still STATED (machine-readable count + hover words),
+    // but no longer runs as headline copy under the tile.
+    expect(note).toHaveAttribute('data-unplaced', '1');
+    expect(note.textContent).toContain('1 not shown');
+    expect(note.getAttribute('title')).toContain('excludes 1 run with no clock in this window');
   });
 });
 

--- a/tests/notFoundRoute.test.tsx
+++ b/tests/notFoundRoute.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { useRoute } from '../src/hooks/useRoute.js';
+import { useLegacyRedirect } from '../src/hooks/useLegacyRedirect.js';
+import { NotFoundPage } from '../src/components/NotFoundPage.js';
+
+/**
+ * Usability review #4 (live-verified): unknown routes silently normalized onto
+ * a nearby default — garbage → `/work`, `/steering/zzz` → the landing, a
+ * typo'd testing page → Harness — so a mistyped bookmark LOOKED like a working
+ * page with the wrong content. The contract now:
+ *
+ *  - an address matching NO page parses to the `not-found` panel;
+ *  - NO redirect fires for it (the typed URL is preserved);
+ *  - the view echoes the address and links Home / Work / Steering / Testing;
+ *  - the RETIRED addresses (wiki/rules/policies, coverage/domain, flat
+ *    campaigns, the bare /runs listing) KEEP their redirects — those are
+ *    moves with a known destination, not typos.
+ */
+
+function routeAt(path: string) {
+  window.history.replaceState(null, '', path);
+  return renderHook(() => useRoute()).result;
+}
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('useRoute — dead addresses parse to the not-found panel', () => {
+  it('a garbage top-level route is not-found — never the runs panel (which redirected to /work)', () => {
+    expect(routeAt('/zzzgarbage').current.panel).toBe('not-found');
+    expect(routeAt('/definitely-not-a-page').current.panel).toBe('not-found');
+  });
+
+  it('a garbage route with a second segment is not-found — never a fabricated run id', () => {
+    const r = routeAt('/garbage/xyz').current;
+    expect(r.panel).toBe('not-found');
+    expect(r.runId).toBeNull();
+  });
+
+  it('typo’d steering and testing SUB-routes are not-found', () => {
+    expect(routeAt('/steering/zzz').current.panel).toBe('not-found');
+    expect(routeAt('/testing/harnes').current.panel).toBe('not-found');
+    expect(routeAt('/testing/evalss').current.panel).toBe('not-found');
+  });
+
+  it('every real page still parses to itself', () => {
+    expect(routeAt('/').current.panel).toBe('home');
+    expect(routeAt('/work').current.panel).toBe('work');
+    expect(routeAt('/make').current.panel).toBe('make');
+    expect(routeAt('/steering').current.panel).toBe('steering');
+    expect(routeAt('/steering/security').current.panel).toBe('steering');
+    expect(routeAt('/testing/harness').current.panel).toBe('testing');
+    expect(routeAt('/runs/r-1').current).toMatchObject({ panel: 'runs', runId: 'r-1' });
+    expect(routeAt('/runs/new').current).toMatchObject({ panel: 'runs', showLaunch: true });
+  });
+
+  it('the retired addresses still parse to their destinations (moves, not typos)', () => {
+    expect(routeAt('/runs').current.panel).toBe('runs'); // → /work via useLegacyRedirect
+    expect(routeAt('/wiki').current.panel).toBe('steering');
+    expect(routeAt('/coverage').current.panel).toBe('system');
+    expect(routeAt('/campaigns').current).toMatchObject({ panel: 'testing', testingPage: 'campaigns' });
+    expect(routeAt('/testing').current).toMatchObject({ panel: 'testing', testingPage: null });
+  });
+});
+
+describe('the not-found panel never redirects — the typed URL is preserved', () => {
+  it('useLegacyRedirect leaves a not-found route alone', () => {
+    const navigate = vi.fn();
+    renderHook(() =>
+      useLegacyRedirect(
+        { panel: 'not-found', runId: null, projectId: null, mode: null, showLaunch: false, chatMode: false },
+        navigate,
+      ),
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('NotFoundPage — the honest dead-address view', () => {
+  it('echoes the typed address verbatim and says nothing lives there', () => {
+    render(<NotFoundPage pathname="/steering/zzz" navigate={() => {}} />);
+    expect(screen.getByTestId('not-found')).toHaveTextContent('Page not found');
+    expect(screen.getByTestId('not-found-path')).toHaveTextContent('/steering/zzz');
+  });
+
+  it('offers Home / Work / Steering / Testing as real links that navigate', () => {
+    const navigate = vi.fn();
+    render(<NotFoundPage pathname="/zzz" navigate={navigate} />);
+    const links = screen.getAllByTestId('not-found-link');
+    expect(links.map((l) => l.getAttribute('data-path'))).toEqual([
+      '/', '/work', '/steering', '/testing/harness',
+    ]);
+    // Real hrefs (middle-click / copy-link work) AND SPA navigation on click.
+    expect(links[1]).toHaveAttribute('href', '/work');
+    fireEvent.click(links[2]!);
+    expect(navigate).toHaveBeenCalledWith('/steering');
+  });
+});

--- a/tests/overlayContract.test.tsx
+++ b/tests/overlayContract.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SteeringAddMenu } from '../src/components/SteeringAddMenu.js';
+import { SkipLink } from '../src/components/SkipLink.js';
+
+/**
+ * The ONE overlay contract (usability review #10, live-verified broken): the
+ * Steering Add menu survived Escape while the rule drawer honored it. Pinned:
+ *
+ *  - Escape closes the menu and RETURNS FOCUS to the trigger that opened it;
+ *  - a click outside closes it (the behavior that already existed);
+ *  - the skip link is the app's first tabbable element and jumps to #main.
+ */
+
+vi.mock('../src/api/client.js', () => ({
+  api: {},
+  apiFetch: vi.fn(() => Promise.reject(new Error('no wire in this rig'))),
+}));
+
+afterEach(cleanup);
+
+function menu(): void {
+  render(
+    <SteeringAddMenu type="security" rules={[]} onSaved={() => {}} onRulesChanged={() => {}} />,
+  );
+}
+
+describe('SteeringAddMenu — the Escape gap, closed', () => {
+  it('Escape closes the open Add menu and returns focus to the Add trigger', () => {
+    menu();
+    const trigger = screen.getByTestId('steering-add-menu');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('steering-add-menu-list')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('steering-add-menu-list')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('a click outside still closes it (the pre-existing half of the contract)', () => {
+    menu();
+    fireEvent.click(screen.getByTestId('steering-add-menu'));
+    expect(screen.getByTestId('steering-add-menu-list')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('steering-add-menu-list')).toBeNull();
+  });
+
+  it('Escape with the menu closed does nothing (no listener leak)', () => {
+    menu();
+    expect(() => fireEvent.keyDown(document, { key: 'Escape' })).not.toThrow();
+    expect(screen.queryByTestId('steering-add-menu-list')).toBeNull();
+  });
+});
+
+describe('SkipLink — first Tab reaches something sensible (review #10)', () => {
+  it('renders a real link to #main and moves focus there on activation', () => {
+    render(
+      <>
+        <SkipLink />
+        <div id="main" tabIndex={-1}>
+          content
+        </div>
+      </>,
+    );
+    const link = screen.getByTestId('skip-link');
+    expect(link).toHaveAttribute('href', '#main');
+    expect(link).toHaveTextContent('Skip to main content');
+    fireEvent.click(link);
+    expect(document.activeElement).toBe(document.getElementById('main'));
+  });
+});

--- a/tests/runIdentity.test.ts
+++ b/tests/runIdentity.test.ts
@@ -4,6 +4,7 @@ import type { LoggedEvent } from '../src/store/runtime.js';
 import {
   deriveRunClocks,
   durationWord,
+  humanTitle,
   runShortId,
   runTitle,
   runWhenWord,
@@ -25,10 +26,11 @@ describe('runTitle (EC40: identical prompts never render identical titles)', () 
       .toBe('fix the auth flow · 3eda21 · #2');
   });
 
-  it('truncates a paragraph intent, keeping the short-id visible past it', () => {
+  it('truncates a paragraph intent at a WORD boundary, keeping the short-id visible past it', () => {
     const long = 'refactor the ingestion pipeline so that every incoming webhook payload is validated';
     const t = runTitle(session('r-long-000', long));
-    expect(t).toBe(`${long.slice(0, 40)}… · r-long · #1`);
+    // 40-char budget, trimmed back to the last whole word — never a mid-word cut.
+    expect(t).toBe('refactor the ingestion pipeline so that… · r-long · #1');
   });
 
   it('two identical prompts differ by short-id alone', () => {
@@ -36,6 +38,52 @@ describe('runTitle (EC40: identical prompts never render identical titles)', () 
     const b = runTitle(session('r-retry-999', 'refactor the auth middleware'));
     expect(a).not.toBe(b);
     expect(runShortId('r-auth-1234')).toBe('r-auth');
+  });
+});
+
+describe('humanTitle (usability review #2 — the ONE title derivation, not four copies)', () => {
+  it('a short intent is its own title, untouched', () => {
+    expect(humanTitle('fix the auth flow')).toBe('fix the auth flow');
+  });
+
+  it('the FIRST clause is the title — the 300-char issue prompt stops at its colon', () => {
+    const prompt =
+      'Implement GitHub issue #167 in this repo (wicked-interactive): the doc-creation wizard project picker lists crew projects but offers no way to CREATE a project.';
+    expect(humanTitle(prompt)).toBe('Implement GitHub issue #167 in this repo (wicked-interactive)');
+  });
+
+  it('a sentence end cuts before a paragraph does', () => {
+    expect(humanTitle('Fix the flaky test. Then refactor the runner and every helper it drags in.'))
+      .toBe('Fix the flaky test');
+  });
+
+  it('a line break ends the clause', () => {
+    expect(humanTitle('Ship the header\nAnd a body of details that should never be a title'))
+      .toBe('Ship the header');
+  });
+
+  it('a long clause word-boundary-trims to ~64 chars with an ellipsis', () => {
+    const clause =
+      'refactor the ingestion pipeline so that every incoming webhook payload is validated before persistence';
+    const t = humanTitle(clause);
+    expect(t.endsWith('…')).toBe(true);
+    expect(t.length).toBeLessThanOrEqual(65);
+    // Never a mid-word cut: dropping the ellipsis leaves whole words only.
+    expect(clause.startsWith(t.slice(0, -1))).toBe(true);
+    expect(clause[t.length - 1]).toBe(' ');
+  });
+
+  it('the kept fragment is a literal PREFIX of the raw intent (palette highlight contract)', () => {
+    const prompt = 'Implement GitHub issue #167 in this repo (wicked-interactive): details follow';
+    const t = humanTitle(prompt, 40);
+    const frag = t.endsWith('…') ? t.slice(0, -1) : t;
+    expect(prompt.startsWith(frag)).toBe(true);
+  });
+
+  it('five identical raw prompts produce the SAME clause — identity comes from runTitle', () => {
+    const p = 'Implement GitHub issue #167 in this repo: long tail '.repeat(6);
+    expect(humanTitle(p)).toBe(humanTitle(p));
+    expect(runTitle(session('a-000001', p))).not.toBe(runTitle(session('b-000002', p)));
   });
 });
 

--- a/tests/steeringRoutes.test.tsx
+++ b/tests/steeringRoutes.test.tsx
@@ -41,9 +41,14 @@ describe('useRoute — /steering[/:type]', () => {
     }
   });
 
-  it('a bare or unknown-type /steering parses with steeringType null (the landing / its redirect)', () => {
+  it('a bare /steering parses with steeringType null — the landing IS the page', () => {
     expect(routeAt('/steering').current).toMatchObject({ panel: 'steering', steeringType: null });
-    expect(routeAt('/steering/bogus').current).toMatchObject({ panel: 'steering', steeringType: null });
+    expect(routeAt('/steering/').current).toMatchObject({ panel: 'steering', steeringType: null });
+  });
+
+  it('an unknown steering type is a DEAD address — not-found, never a silent swap (review #4)', () => {
+    expect(routeAt('/steering/bogus').current).toMatchObject({ panel: 'not-found' });
+    expect(routeAt('/steering/securty').current).toMatchObject({ panel: 'not-found' });
   });
 
   it('the retired /wiki, /rules and /policies addresses fold into the steering panel', () => {
@@ -72,12 +77,17 @@ describe('useSteeringRedirect', () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it('REPLACES the retired addresses and a typo’d type with the landing', () => {
-    for (const path of ['/wiki', '/rules', '/policies', '/steering/bogus']) {
+  it('REPLACES the retired addresses with the landing — a typo’d type is not-found instead, no redirect', () => {
+    for (const path of ['/wiki', '/rules', '/policies']) {
       const navigate = vi.fn();
       renderHook(() => useSteeringRedirect('steering', null, path, navigate));
       expect(navigate).toHaveBeenCalledWith('/steering', { replace: true });
     }
+    // `/steering/bogus` parses to the not-found panel (review #4), so this hook
+    // never sees `panel: 'steering'` for it and MUST leave the address alone.
+    const navigate = vi.fn();
+    renderHook(() => useSteeringRedirect('not-found', null, '/steering/bogus', navigate));
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it('leaves a valid type alone, and every non-steering panel alone', () => {

--- a/tests/testingRoutes.test.tsx
+++ b/tests/testingRoutes.test.tsx
@@ -44,9 +44,13 @@ describe('useRoute — /testing/:page', () => {
     expect(r.campaignId).toBe('DES MERGE');
   });
 
-  it('a bare or unknown-page /testing parses with testingPage null (the redirect normalizes it)', () => {
+  it('a bare /testing parses with testingPage null (the redirect normalizes it onto Harness)', () => {
     expect(routeAt('/testing').current).toMatchObject({ panel: 'testing', testingPage: null });
-    expect(routeAt('/testing/bogus').current).toMatchObject({ panel: 'testing', testingPage: null });
+  });
+
+  it('an unknown testing sub-page is a DEAD address — not-found, never a silent Harness (review #4)', () => {
+    expect(routeAt('/testing/bogus').current).toMatchObject({ panel: 'not-found' });
+    expect(routeAt('/testing/harnes').current).toMatchObject({ panel: 'not-found' });
   });
 
   it('the retired flat /campaigns addresses fold into the testing panel, campaign id intact', () => {


### PR DESCRIPTION
The bug/dead-end half of the 2026-08-31 visual usability review (scratch/usability-review/): a real not-found view (typed URL preserved) replacing silent route normalization; the Escape/overlay contract with focus return + skip link; the Work window's slice(0,30) lie becomes an honest "last 30" with full-set search, a first-class show-all chip, and threshold-colored success rate; derived human run titles everywhere lists rendered raw prompts; type-scoped Steering stats (empty types lose store-wide noise, diagnostics fold behind a toggle); council-theater suppression at seats=1; evals honesty (blocked/passed split, gap hints link into the rule drawer, corpus provenance line, gaps framed as uncovered behaviors); dead-end empty states + all ten copy quick wins. Verifier also fixed a dead wire branch: the per-type scoreboard read a shape no shipping engine serializes (by_steering_type vs by_type) — now pinned to the canonical serde. 2010 tests green, testid inventory regenerated, every fix screenshot-proven against the live daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)