### PR TITLE
feat: the run narrator — one chronological feed, sticky now-bar, pinned approval dock, artifact cards

### DIFF
--- a/.product/DES-RUN-NARRATOR.md
+++ b/.product/DES-RUN-NARRATOR.md
@@ -107,7 +107,7 @@ frames the feed does not speak. Tones: `info` (dim ink) · `work` (run-emerald) 
 |---|---|---|
 | `sessionStarted` | `Run started` | work |
 | `workflowSelected` | `Workflow "<id>" — <n> phases planned` | info |
-| `unitPlanned` | `Planned <phase> — <description ≤120>` | info |
+| `unitPlanned` | `Planned <phase> — <description ≤120>`; the daemon's duplicated `<phase> — ` prefix is stripped, and a description that merely restates the run intent (already the feed's opening bubble) is dropped — `Planned <phase>` alone | info |
 | `councilConvened` | `Council convened — polling <n> agents` | info |
 | `councilDeliberated` | `Ballot <round>: <pct>% — below the <needed>% bar, runoff` | info |
 | `councilVoted` | `Council voted — <pct>% agreement (<votes> votes)` | info |
@@ -140,7 +140,8 @@ frames the feed does not speak. Tones: `info` (dim ink) · `work` (run-emerald) 
 | `sessionFailed` | `Run failed` | fail |
 | `runCancelled` | `Run cancelled` | info |
 | `error` | `Error: <message ≤160>` | fail |
-| deltas, heartbeat, terminal*, cliUsage, workerSession*, acp*, validationPin*, unitContextInjected, allow-hooks, assumptionRecorded | *(silent — burn/terminal/assumption panels own these)* | — |
+| deltas, heartbeat, terminal*, cliUsage, workerSession*, acp*, validationPin*, unitContextInjected, allow-hooks, governanceContextArmed, toolExecutorDispatched, assumptionRecorded | *(silent — burn/terminal/assumption panels own these)* | — |
+| chat* (GroupChat's surface), campaign*, repoRegistered, runOrphaned, toolInvoked, unknown | *(silent — not run-follow frames; other surfaces own them)* | — |
 
 Unknown/future types are silent (additive-safe, §5.1 of the wire contract).
 

--- a/.product/DES-RUN-NARRATOR.md
+++ b/.product/DES-RUN-NARRATOR.md
@@ -1,0 +1,242 @@
+# DES-RUN-NARRATOR — one narrated feed for following a run
+
+**Status:** implemented (feat/run-narrator)
+**Scope:** the run-follow surface (`ChatPanel.tsx` → `RunChat`), the run-detail feed
+composition, and the composer-on-terminal-runs ambiguity (usability review 2026-08-31,
+finding #8; run-operator persona findings).
+**Out of scope:** WorkPage list, SteeringPage, TestingPage, the decisions rail (lane L1),
+and GroupChat's multi-seat chat (its transcript is already turn-stamped and per-seat FIFO;
+nothing here touches it — the mandate is that it must not GROW, and it does not change).
+
+## 1. The problem (verbatim intent)
+
+> "Build chat is confusing — chats are out of order, hard to follow along whats happening.
+> I'm thinking for the interface we have an assistant that is watching everything and
+> providing status updates (except approvals which need to go direct to user). This includes
+> any artifacts created along the way. Interface needs to be clean and easy to follow/interact
+> (e.g. how am I supposed to know what to steer if work is being done on part of chat thats
+> offscreen or above)."
+
+What the pre-narrator run page actually did, and why it reads out of order:
+
+1. **The thread was three appended sections, not one stream.** `RunChat` rendered
+   (a) every unit block from `timeline.flatMap(...)`, then (b) ALL system-event pills
+   from the runtime log, then (c) the gate card in a fallback slot at the very bottom.
+   A gate decided at 12:02 rendered *below* a unit that finished at 12:20 — the literal
+   "chats are out of order" complaint.
+2. **The event store dropped history on a race.** `useRunEventStore.hydrate` was
+   all-or-nothing: if ONE live `/ws` frame arrived before `GET /runs/:id/events`
+   resolved, the entire backfill was discarded and the feed began mid-story.
+3. **The thing to steer could be offscreen.** The gate card lived inside the scrolling
+   thread; live output above it kept growing, so the approval was routinely above or
+   below the viewport exactly when it needed a decision.
+4. **Terminal runs wore the launch composer.** `ChatInput` with `runId=null` renders the
+   full "What do you need built?" form — Gate chip, project switcher, mode toggle — on a
+   dead run's page (review #8: "unclear if it steers this run or starts a new one").
+
+## 2. The concept
+
+A deterministic **narrator** — a pure template layer, **no LLM call** — watches the run's
+CoreEvent trail and speaks one short human line per meaningful event. The run page becomes:
+
+```
+┌────────────────────────────────────────────────────────┐
+│ header (back · status dot · title · retry · mode · …)  │  shrink-0
+│ RunTimes · ProcessStepper (the map — unchanged)        │  shrink-0
+│ NOW-BAR: ▶ build — unit 2/6 · "Worker started…" · 📎3  │  shrink-0, always visible
+├────────────────────────────────────────────────────────┤
+│ NARRATED FEED (the only scrolling region)              │  flex-1
+│   you: <intent bubble>                                 │
+│   · Run started                                        │
+│   · Workflow "feature" — 6 phases planned              │
+│   · Council picked claude for clarify (100%, 4 votes)  │
+│   · Worker started clarify                             │
+│   ┌ clarify — done ─ [▸ show output] ┐   ← unit group  │
+│   · Checks passed — clarify approved                   │
+│   · 📄 src/retry.ts · 📄 tests/retry.test.ts (touched) │  ← artifact cards
+│   · Gate: waiting on you — "Approve the design phase?" │  ← the gate MOMENT (inline)
+├────────────────────────────────────────────────────────┤
+│ APPROVAL DOCK (pinned — never scrolls away)            │  shrink-0
+│   [SteeringGate: approve / approve+steer / reject+note]│
+├────────────────────────────────────────────────────────┤
+│ composer: steer/inject (live) · follow-up bar (dead)   │  shrink-0
+└────────────────────────────────────────────────────────┘
+```
+
+- The **feed** is the single chronological stream: narration lines, unit output groups,
+  artifact cards, gate moments — one order, fixed at the source.
+- The **now-bar** answers "what is happening RIGHT NOW" from any scroll position:
+  run state, the active phase, the latest narration line, an artifact-count chip, and a
+  "Latest ↓" jump that scrolls the feed to its live tail. It sits outside the scroll
+  region, so it is visible by construction.
+- The **approval dock** is where anything awaiting the human lives: the steering gate
+  and MCP elicitations render as pinned cards between the feed and the composer. They
+  can NEVER scroll away. The feed still records the gate moment inline (that is history);
+  the dock is the action surface (that is now).
+- **At 1440×700** the now-bar, the dock and the feed's latest line are all visible with
+  zero scrolling: header + times + stepper + now-bar ≈ 190px, dock ≈ 300px, composer ≈ 90px,
+  leaving ≈ 120px of feed pinned to its tail.
+
+Approvals deliberately do NOT become narrator speech — per the directive, they go
+direct to the user (the dock); the narrator only *records* that they happened.
+
+## 3. Ordering — fixed at the source
+
+Two changes kill the out-of-order class:
+
+1. **`useRunEventStore.hydrate` now MERGES instead of dropping.** The durable trail
+   (`GET /runs/:id/events`, every frame carrying the run-wide `seq`) is the authoritative
+   prefix; live frames that arrived before the fetch resolved are de-duplicated against it
+   by content fingerprint (the frame minus `ts`/`seq`, which only the recorded copy carries)
+   and the remainder is appended in arrival order. Result: `[recorded by seq] + [live tail
+   in arrival order]` — complete history, one order, for every consumer (feed, RunTimeline,
+   useRunModel alike).
+2. **`buildFeed` sorts defensively.** Frames that both carry the durable `seq` compare by
+   it; everything else keeps stable input order (live frames have no comparable clock —
+   arrival IS their order, per the wire contract). Out-of-order backfill arrival therefore
+   renders sorted, and live ordering is never scrambled by a fabricated key.
+
+## 4. The narrator — event → narration mapping
+
+`narrate(event, ctx)` in `src/components/narrator.ts`. `ctx` resolves ords to phase
+names (`unitKey` suffix, stage fallback — same rule as the stepper). Returns `null` for
+frames the feed does not speak. Tones: `info` (dim ink) · `work` (run-emerald) ·
+`gate` (amber) · `fail` (red) · `human` (accent).
+
+| CoreEvent type | Narration (template) | Tone |
+|---|---|---|
+| `sessionStarted` | `Run started` | work |
+| `workflowSelected` | `Workflow "<id>" — <n> phases planned` | info |
+| `unitPlanned` | `Planned <phase> — <description ≤120>` | info |
+| `councilConvened` | `Council convened — polling <n> agents` | info |
+| `councilDeliberated` | `Ballot <round>: <pct>% — below the <needed>% bar, runoff` | info |
+| `councilVoted` | `Council voted — <pct>% agreement (<votes> votes)` | info |
+| `councilSeatFailed` | `Seat <cli> did not vote (<kind>)` | fail |
+| `unitDistributed` | `<phase> routed to <cli>` (+ `— council <pct>%` when carried) | info |
+| `unitDispatched` | `Worker started <phase> — <description ≤120>` (attempt>0: `re-dispatched (attempt n)`) | work |
+| `unitExecuting` | `<phase> is running` | work |
+| `unitOutputCaptured` | `<phase> finished — output captured (<kb> KB)` / `finished with errors` | work/fail |
+| `dataUsed` | `<phase> touched <n> file(s)` (+ artifact cards, §6) | info |
+| `gateEscalated` | `Gate approaching — <condition>` | gate |
+| `awaitingHuman` | `Gate: waiting on you — <prompt headline>` | gate |
+| `gateEvaluated` | `Checks ran on <phase> — pass` / `— deny: <denialReason>` | work/fail |
+| `gateDecided` | `Gate: approved` / `Gate: denied` | work/fail |
+| `unitReworkAmended` | `You amended <phase> — re-dispatching with your note` | human |
+| `unitDone` | `<phase> approved and done` | work |
+| `unitDenied` | `<phase> denied` | fail |
+| `unitReassigned` | `<phase> reassigned <prev> → <new / council re-vote>` | info |
+| `resumed` | `Run resumed` | work |
+| `stepFailed` | `Step failed on <phase> — <first line of detail ≤160>` | fail |
+| `crashRecoveryRedrive` | `Engine restarted — re-dispatching <phase> (attempt <n>)` | fail |
+| `workerStalled` | `Worker quiet for <n>s — may be waiting at a prompt (open Term or send a message)` | gate |
+| `failureTriaged` | `Failure triaged: <decision> — <analysis ≤120>` | info |
+| `workerMessageQueued` | `Your message is queued for <target>'s next turn` | human |
+| `workerMessageInjected` | `Your message was delivered to <target>` | human |
+| `elicitationCreated` | `The agent asks: <message headline>` | gate |
+| `elicitationResolved` | `Answer sent — the agent continues` | human |
+| `governanceHookFired` (deny only) | `Blocked a tool call — <policy>` | fail |
+| `governanceUnenforced` | `Governance was requested but is not enforced for <cli>` | gate |
+| `sessionCompleted` | `Run completed` | work |
+| `sessionFailed` | `Run failed` | fail |
+| `runCancelled` | `Run cancelled` | info |
+| `error` | `Error: <message ≤160>` | fail |
+| deltas, heartbeat, terminal*, cliUsage, workerSession*, acp*, validationPin*, unitContextInjected, allow-hooks, assumptionRecorded | *(silent — burn/terminal/assumption panels own these)* | — |
+
+Unknown/future types are silent (additive-safe, §5.1 of the wire contract).
+
+**Verbose output stays collapsed.** The worker's streamed text and the durable transcript
+render INSIDE the unit's group behind the existing expanders (`LiveNarration` for the
+cursor unit — moved to its own file, same testids; `unit-output-<ord>` blocks for done
+units). The narrator line is the headline; the bytes are one click below it.
+
+**Raw view survives.** A `narrated | raw` toggle on the feed header switches every line
+to the undecorated frame (`type · ord · summary`) for operators who want the wire.
+
+## 5. Feed composition (`buildFeed`)
+
+Pure function over `(events, units, executingOrd)`:
+
+1. Sort events (§3 rule 2).
+2. Map to narration lines; drop silent frames.
+3. **Unit anchors:** every unit that has run or is running (done / rejected / cursor —
+   exactly the old `timeline` filter, FINDING-052 preserved) gets ONE group block,
+   placed after its LAST narration line (its story ends with its evidence); units with
+   no spoken events (empty trail — pruned log, or a test) append in ord order at the end.
+   Queued units get nothing — the stepper is their surface (operator directive upheld).
+4. **Artifact items** (§6) follow the `dataUsed` line that produced them.
+
+The feed container owns `data-testid="thread"`; unit groups keep `data-message-id`
+(the version-strip anchor contract, DES-MERGE-001 §7.6).
+
+## 6. Artifacts
+
+`deriveArtifacts(events, session)` collects, deduped by path, newest last:
+
+- `dataUsed.files[]` → kind `file` — the files the unit's CLI touched. Inline: an
+  artifact card per NEW path (name, dir, phase, "View ›" → the existing FileViewer via
+  `onOpenFile`, capped at 6 per event with a `+n more` tail). Strip: total count.
+- `session.delivery` (`{kind:'pull_request', url}`) → kind `pr` — an external link card.
+
+The now-bar carries the compact collected-artifacts chip (`📎 <n>`); clicking it opens a
+popover listing every artifact (same view/link affordances) without leaving the tail.
+No new wire calls: both sources are already on this page's data.
+
+## 7. What dies
+
+- The two-section body (units-then-event-pills) and the bottom-slot gate card in the
+  live thread — replaced by the one feed + the dock.
+- The inline council/evaluator/degraded routing PILLS in the live thread — narration
+  lines carry routing now (the stepper tooltip keeps the queued-unit provenance).
+- The full launch composer on terminal runs (#8): a dead run's footer is now a one-line
+  **follow-up bar** — "This run is finished — steering is closed." + a single
+  `Start a follow-up run in this project →` action that expands the labelled launch form
+  (collapsed by default; the label is the review's exact fix). Live runs keep the
+  steer/inject composer, which now sits directly under the dock — steering happens where
+  the user is already looking.
+- `SteeringGate`'s note-less reject: the steer textarea's text now rides **reject** as
+  `amend` too (`{approve:false, amend}` — the same wire `GateRejectNote` already speaks;
+  the daemon's gate audit records it). This closes the known reject-note gap. An empty
+  textarea still sends the bare `{approve:false}`.
+
+## 8. What is preserved (contracts other surfaces own)
+
+- `ProcessStepper`, `RunTimes`, header, Retry, ModePill (read-only when terminal),
+  evidence export — untouched.
+- Terminal runs keep the evidence lenses: tabs are now **Feed | Timeline | Units**, with
+  Feed the default lens (the story), Timeline the recorded-trail navigator (slice BB,
+  unchanged), Units the post-mortem/output spine (slice R, unchanged — FailureBanner
+  stays the headline in every lens).
+- `live-narration-*`, `unit-output-*`, `steering-gate`, avatar inject-targeting, the
+  `⌨` per-agent terminal button, FileViewer wiring — same testids, same behavior, now
+  rendered by `NarratorFeed`.
+- `LegacyChatHistory` (workflow_id='chat') — untouched.
+
+## 9. New modules (ChatPanel shrinks)
+
+| File | Owns |
+|---|---|
+| `src/components/narrator.ts` | `narrate`, `sortFeedEvents`, `buildFeed`, `deriveArtifacts` (pure) |
+| `src/components/NarratorFeed.tsx` | the feed renderer + unit groups + raw toggle |
+| `src/components/NowBar.tsx` | the pinned status strip + artifacts chip + jump-to-latest |
+| `src/components/ApprovalDock.tsx` | the pinned gate/elicitation dock |
+| `src/components/ArtifactCard.tsx` | inline artifact card |
+| `src/components/LiveNarration.tsx` | moved out of ChatPanel (shared with RightPanel's Term tab) |
+| `src/components/FollowUpComposer.tsx` | the terminal-run follow-up bar (#8) |
+
+## 10. Tests
+
+- `narrator.test.ts` — template per event type; out-of-order `seq` renders sorted; stable
+  order for live frames; unit-anchor placement; artifact derivation + dedupe.
+- `events-merge.test.ts` — hydrate AFTER live frames merges the recorded prefix and
+  de-duplicates (the FINDING-013 guard upgraded, not weakened).
+- `NarratorFeed.test.tsx` — out-of-order arrival renders sorted in the DOM; expanders;
+  raw toggle; inline artifact cards.
+- `ApprovalDock` (in `ChatPanel.dock.test.tsx`) — the dock is a SIBLING of the scroll
+  region (structure-level: pinned while the feed scrolls); gate renders in the dock; the
+  feed still shows the gate moment inline; elicitation renders in the dock.
+- `SteeringGate.rejectNote.test.tsx` — reject carries the typed note on the wire
+  (`{approve:false, amend}`), empty note stays bare.
+- `ChatPanel.followup.test.tsx` — composer labeling per run state: terminal → collapsed
+  follow-up bar with the exact label; expanding shows the launch form; live executing →
+  inject composer; awaiting_human → steer composer.
+- `NowBar.test.tsx` — phase + active unit + last narration; artifact count; jump button.

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -1,0 +1,55 @@
+import { sessionGuidance } from '../api/guidance.js';
+import type { SessionView } from '../api/types.js';
+import { useElicitationStore } from '../store/elicitations.js';
+import { useGateStore } from '../store/gates.js';
+import { ElicitationPrompt } from './ElicitationPrompt.js';
+import { SteeringGate } from './SteeringGate.js';
+
+/**
+ * The pinned approval dock (DES-RUN-NARRATOR §2): anything awaiting the HUMAN
+ * — the steering gate, an MCP elicitation — renders here, as a sibling of the
+ * scrolling feed, between it and the composer. It can NEVER scroll away: the
+ * directive's "approvals go direct to user" surface. The feed still records
+ * the gate moment inline as history; this dock is the action.
+ *
+ * Renders nothing when nothing awaits (and never on a terminal run) — the
+ * layout gives the feed the space back.
+ */
+export function ApprovalDock({
+  view,
+  onResolved,
+}: {
+  view: SessionView;
+  onResolved: () => void;
+}): React.ReactElement | null {
+  const { session } = view;
+  const gate = useGateStore((s) => s.gates[session.id]);
+  const elicitation = useElicitationStore((s) => s.elicitations[session.id]);
+  const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
+
+  const showGate = !isTerminal && (session.status === 'awaiting_human' || gate !== undefined);
+  const showElicitation = !isTerminal && elicitation !== undefined;
+  if (!showGate && !showElicitation) return null;
+
+  return (
+    <div
+      data-testid="approval-dock"
+      className="shrink-0 px-4 pt-2 pb-1 flex flex-col gap-2 max-w-3xl w-full mx-auto"
+    >
+      {/* An open MCP elicitation suspends the agent's turn, so it leads the dock (DES-002).
+          `key` is REQUIRED: React reuses the instance across prop changes, so without it a
+          half-typed answer to elicitation A survives into B (v0.24 F3). */}
+      {showElicitation && elicitation !== undefined && (
+        <ElicitationPrompt key={elicitation.elicitationId} e={elicitation} />
+      )}
+      {showGate && (
+        <SteeringGate
+          runId={session.id}
+          guidance={sessionGuidance(session)}
+          {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
+          onResolved={onResolved}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ArtifactCard.tsx
+++ b/src/components/ArtifactCard.tsx
@@ -1,0 +1,66 @@
+import type { RunArtifact } from './narrator.js';
+
+/**
+ * One artifact the run produced (DES-RUN-NARRATOR §6): a file the worker
+ * touched (opens in the existing FileViewer — never a dead click) or the
+ * delivered PR (an external link). Rendered inline in the narrated feed right
+ * behind the narration line that produced it, and reused by the now-bar's
+ * collected-artifacts popover.
+ */
+export function ArtifactCard({
+  artifact,
+  onOpenFile,
+  compact = false,
+}: {
+  artifact: RunArtifact;
+  onOpenFile?: ((path: string) => void) | undefined;
+  /** Popover dress: tighter padding, no phase caption. */
+  compact?: boolean;
+}): React.ReactElement {
+  const dir = artifact.kind === 'file' ? artifact.ref.slice(0, artifact.ref.length - artifact.name.length) : '';
+  return (
+    <div
+      data-testid="artifact-card"
+      data-artifact-kind={artifact.kind}
+      className={`flex items-center gap-2 rounded-lg font-mono ${compact ? 'px-2 py-1 text-[11px]' : 'px-3 py-1.5 text-xs self-start max-w-[85%]'}`}
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    >
+      <span aria-hidden="true" className="shrink-0" style={{ color: 'var(--ink-dim)' }}>
+        {artifact.kind === 'pr' ? '⇡' : '▤'}
+      </span>
+      <span className="min-w-0 flex items-baseline gap-1.5">
+        <span className="truncate font-medium" style={{ color: 'var(--ink-body)' }} title={artifact.ref}>
+          {artifact.name}
+        </span>
+        {!compact && dir !== '' && (
+          <span className="truncate" style={{ color: 'var(--ink-dim)', maxWidth: '18rem' }}>{dir}</span>
+        )}
+        {!compact && artifact.phase !== null && (
+          <span className="shrink-0" style={{ color: 'var(--ink-dim)' }}>· {artifact.phase}</span>
+        )}
+      </span>
+      {artifact.kind === 'pr' ? (
+        <a
+          data-testid="artifact-open"
+          href={artifact.ref}
+          target="_blank"
+          rel="noreferrer"
+          className="ml-auto shrink-0 hover:underline"
+          style={{ color: 'var(--accent)' }}
+        >
+          Open ›
+        </a>
+      ) : onOpenFile !== undefined ? (
+        <button
+          type="button"
+          data-testid="artifact-open"
+          onClick={() => onOpenFile(artifact.ref)}
+          className="ml-auto shrink-0 hover:underline"
+          style={{ color: 'var(--accent)', background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit' }}
+        >
+          View ›
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,23 +1,24 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { lostQuorum, quorumLabel } from './councilQuorum.js';
 import { api, downloadRunEvidence } from '../api/client.js';
-import { sessionGuidance } from '../api/guidance.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
-import type { SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
+import type { SessionView, WorkUnit } from '../api/types.js';
 import { executingOrd } from '../api/run-state.js';
-import { useGateStore } from '../store/gates.js';
-import { useElicitationStore } from '../store/elicitations.js';
-import { ElicitationPrompt } from './ElicitationPrompt.js';
-import { useRuntimeStore, outputKey, type CouncilStatus } from '../store/runtime.js';
+import { useRunEventStore } from '../store/events.js';
+import { useRuntimeStore, type CouncilStatus } from '../store/runtime.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
 import { LiveEdge } from './LiveEdge.js';
 import { STATUS_STYLE } from './RunCard.js';
-import { SteeringGate } from './SteeringGate.js';
+import { ApprovalDock } from './ApprovalDock.js';
 import { ChatInput } from './ChatInput.js';
 import { AgentTerminal } from './AgentTerminal.js';
 import { FailureBanner } from './FailureBanner.js';
 import { FileViewer } from './FileViewer.js';
+import { FollowUpComposer } from './FollowUpComposer.js';
 import { Markdown } from './Markdown.js';
+import { NarratorFeed, phaseName, unitKey } from './NarratorFeed.js';
+import { NowBar } from './NowBar.js';
+import { deriveArtifacts, lastNarration, type NarratorContext } from './narrator.js';
 import { RunTimes } from './runIdentity.js';
 import { RunTimeline } from './RunTimeline.js';
 import { UnitList } from './UnitList.js';
@@ -25,6 +26,9 @@ import { VerdictDetail } from './VerdictDetail.js';
 import type { RunMode } from './runMode.js';
 import { MODE_LABELS } from './runMode.js';
 export type { RunMode } from './runMode.js';
+// Moved to its own module (DES-RUN-NARRATOR §9); re-exported so existing
+// importers (RightPanel's Term tab, tests) keep resolving.
+export { LiveNarration } from './LiveNarration.js';
 
 interface Props {
   view: SessionView | null;
@@ -128,7 +132,7 @@ const STEP_STYLE: Record<StepState, { color: string; background: string; border:
 /**
  * Compact process stepper at the top of the run thread (operator UX directive): every phase
  * of the workflow in ord order — done phases checked, the executing one highlighted, future
- * ones dimmed. This is the run's map; the conversational timeline below it carries only the
+ * ones dimmed. This is the run's map; the narrated feed below it carries only the
  * phases that have actually run (or are running), so queued work no longer renders as a
  * column of tall empty "Not started" blocks. Routing provenance and live council chatter for
  * a queued phase live here, in the phase's tooltip, until the phase starts.
@@ -201,198 +205,6 @@ function ProcessStepper({
       })}
     </div>
   );
-}
-
-/** Trailing window of live narration rendered per unit (~4KB). */
-const NARRATION_TAIL = 4096;
-
-/**
- * Live narration for the ACTIVE unit — the streamed `unitOutputDelta` /
- * `cliOutputDelta` text from the `/ws` CoreEvent stream (accumulated by the
- * runtime store into `outputs`), rendered inside the unit's block in place of
- * the old empty "Working…" wait. Collapsible, autoscrolled to the newest text,
- * and windowed to the trailing ~{@link NARRATION_TAIL} bytes so a chatty
- * worker never grows the thread's DOM unbounded (the store keeps its own
- * larger cap for the full-output consumers).
- *
- * Exported for the Term tab (DES-UX-001 §7.6, slice Z): during a live run the
- * terminal modal shows this SAME region — one live-output component, two
- * mounts, never a fork. The streamed region carries `data-testid="live-output"`
- * (EC41: between start and verdict, something true streams on the run's own
- * page) and the honest label for what the deltas are — relayed live output,
- * not the durable transcript (§13: richer streaming is a crew concern).
- */
-export function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phase: string }): React.ReactElement {
-  const live = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
-  const [visible, setVisible] = useState(true);
-  const scrollRef = useRef<HTMLPreElement>(null);
-
-  // Pin the narration viewport to the newest text as chunks stream in.
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [live, visible]);
-
-  const hasText = typeof live === 'string' && live.length > 0;
-  const tail =
-    hasText && live.length > NARRATION_TAIL ? '…' + live.slice(live.length - NARRATION_TAIL) : live;
-
-  return (
-    <div data-testid={`live-narration-${ord}`}>
-      <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
-        <span className="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-run)' }} />
-        {/* Phase label leads the entry (operator UX directive) — mirrors the done-unit header. */}
-        <span className="font-medium" style={{ color: 'var(--status-run)' }}>{phase}</span>
-        <span>{hasText ? 'Working — live output' : 'Working…'}</span>
-        {hasText && (
-          <button
-            type="button"
-            data-testid={`live-narration-toggle-${ord}`}
-            onClick={() => setVisible((v) => !v)}
-            className="ml-auto text-xs font-medium font-mono hover:underline"
-            style={{ color: 'var(--accent)' }}
-          >
-            {visible ? '▾ Hide live output' : '▸ Show live output'}
-          </button>
-        )}
-      </div>
-      {hasText && (
-        <div data-testid="live-output" className="mt-2">
-          {/* The honest label (§7.6): what streams is the relayed delta feed,
-              not the durable record — say exactly that, house grammar. */}
-          <p
-            data-testid="live-output-label"
-            className="mb-1 text-[10px] font-mono"
-            style={{ color: 'var(--ink-dim)' }}
-          >
-            Live output — the full transcript lands when the unit completes.
-          </p>
-          {visible && (
-            <pre
-              ref={scrollRef}
-              data-testid={`live-narration-text-${ord}`}
-              className="max-h-64 overflow-auto rounded-lg p-2.5 text-[11px] leading-snug whitespace-pre-wrap break-words font-mono"
-              style={{ background: 'var(--surface-base)', color: 'var(--ink-body)', border: '1px solid var(--surface-raised)' }}
-            >
-              {tail}
-            </pre>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function DegradedRoutingBanner({ reason }: { reason: string }): React.ReactElement {
-  const [dismissed, setDismissed] = useState(false);
-  const [expanded, setExpanded] = useState(false);
-  const detailId = 'degraded-routing-detail';
-  if (dismissed) return <></>;
-  return (
-    <div
-      className="self-start max-w-[85%] rounded-xl px-4 py-2.5 text-xs font-mono flex flex-col gap-1.5"
-      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)', color: 'var(--status-gate)' }}
-    >
-      <div className="flex items-center gap-2">
-        <span className="shrink-0" aria-hidden="true">⚠</span>
-        <span className="flex-1">Degraded routing: {reason}</span>
-        <button
-          type="button"
-          onClick={() => setExpanded(v => !v)}
-          className="shrink-0 text-[10px] transition-opacity hover:opacity-70"
-          style={{ color: 'var(--status-gate)', opacity: 0.7 }}
-          aria-expanded={expanded}
-          aria-controls={detailId}
-          aria-label={expanded ? 'Hide explanation' : 'Show explanation'}
-        >
-          {expanded ? '▲' : '▼'}
-        </button>
-        <button
-          type="button"
-          onClick={() => setDismissed(true)}
-          className="shrink-0 transition-opacity hover:opacity-70"
-          style={{ color: 'var(--status-gate)', opacity: 0.6 }}
-          aria-label="Dismiss degraded routing warning"
-        >
-          <span aria-hidden="true">✕</span>
-        </button>
-      </div>
-      {expanded && (
-        <p id={detailId} className="text-[10px] leading-relaxed pl-5" style={{ color: 'var(--status-gate)', opacity: 0.7 }}>
-          The multi-model council could not reach a quorum vote. The unit proceeded using a
-          fallback routing strategy. Open the <strong>Decisions</strong> section in the Insights
-          panel on the right to see each reviewer's verdict.
-        </p>
-      )}
-    </div>
-  );
-}
-
-function CliAvatar({ cli }: { cli: string }): React.ReactElement {
-  return (
-    <span
-      aria-hidden="true"
-      className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold font-mono select-none"
-      style={{ background: CLI_AVATAR.bg, color: CLI_AVATAR.fg }}
-    >
-      {cliInitials(cli)}
-    </span>
-  );
-}
-
-// Stage pill — the methodology stage is process vocabulary, not run state, so
-// it reads as quiet ink on a raised surface (§1.5 rule 2: color is signal;
-// four always-on badge hues would out-shout the actual status layer).
-const STAGE_BADGE: Record<StageKind, { bg: string; color: string }> = {
-  recon:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
-  build:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
-  review:  { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
-  test:    { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
-};
-
-const UNIT_STATUS_TEXT: Record<UnitStatus, string> = {
-  pending:     'queued',
-  distributed: 'dispatched',
-  done:        'done',
-  rejected:    'rejected',
-};
-
-function unitKey(runId: string, unitId: string, ord: number): string {
-  return unitId.startsWith(`${runId}:`) ? unitId.slice(runId.length + 1) : `u${ord}`;
-}
-
-/**
- * The unit's phase name for its output header (crew#272). Workflow units are keyed
- * `<run>:<phase_id>` (`run-1:survey` → `survey`); free-text units carry only the
- * synthetic `u<ord>` suffix, so the methodology stage is the closest thing to a
- * phase name they have.
- */
-function phaseName(runId: string, unit: WorkUnit): string {
-  const key = unitKey(runId, unit.id, unit.ord);
-  return /^u\d+$/.test(key) ? unit.stage : key;
-}
-
-const SYSTEM_EVENT_TYPES = new Set([
-  'sessionStarted', 'sessionCompleted', 'sessionFailed',
-  'awaitingHuman', 'gateDecided', 'resumed', 'runCancelled',
-  'workerMessageQueued', 'workerMessageInjected',
-]);
-
-const ACTION_EVENT_TYPES = new Set(['stepFailed', 'crashRecoveryRedrive', 'workerStalled', 'failureTriaged']);
-
-function systemEventLabel(type: string, detail: string): string {
-  switch (type) {
-    case 'sessionStarted':   return 'Run started';
-    case 'sessionCompleted': return '✓ Run completed';
-    case 'sessionFailed':    return '✗ Run failed';
-    case 'awaitingHuman':    return 'Waiting for your input…';
-    case 'gateDecided':      return detail.includes('allow') ? 'Gate: allow' : 'Gate: deny';
-    case 'resumed':          return 'Run resumed';
-    case 'runCancelled':     return 'Run cancelled';
-    case 'workerMessageQueued':   return `Message queued for next turn — ${detail}`;
-    case 'workerMessageInjected': return `Message delivered — ${detail}`;
-    default:                 return detail;
-  }
 }
 
 // The header dot speaks the §2.6 status layer: emerald while anything is
@@ -477,70 +289,6 @@ function ExportEvidenceButton({ runId, disabled }: { runId: string; disabled: bo
         <DownloadIcon />
       </button>
     </>
-  );
-}
-
-function StepFailedCard({
-  detail,
-  onStop,
-  canStop,
-}: {
-  detail: string;
-  onStop: () => void;
-  canStop: boolean;
-}): React.ReactElement {
-  return (
-    <div
-      className="self-start max-w-[85%] rounded-xl px-4 py-3 flex flex-col gap-2 font-mono text-xs"
-      style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)', color: 'var(--status-fail)' }}
-    >
-      <div className="flex items-center gap-2 font-semibold text-[11px] uppercase tracking-wide">
-        <span>⚠</span>
-        <span>Step failure</span>
-      </div>
-      {detail && (
-        <pre className="text-[11px] leading-relaxed whitespace-pre-wrap break-words m-0 overflow-hidden" style={{ color: 'var(--ink-muted)', fontFamily: 'inherit' }}>
-          {detail.length > 200 ? `${detail.slice(0, 200)}…` : detail}
-        </pre>
-      )}
-      <div className="flex items-center gap-2 mt-1">
-        <button
-          type="button"
-          title="Reassign not yet available"
-          disabled
-          className="rounded px-3 py-1 text-[11px] font-semibold opacity-30 cursor-not-allowed"
-          style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}
-        >
-          Reassign
-        </button>
-        <button
-          type="button"
-          onClick={canStop ? onStop : undefined}
-          disabled={!canStop}
-          className="rounded px-3 py-1 text-[11px] font-semibold transition-opacity hover:opacity-100 opacity-80 disabled:opacity-30 disabled:cursor-not-allowed"
-          style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
-        >
-          Stop run
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function CrashRedriveCard({ attempt }: { attempt: number }): React.ReactElement {
-  return (
-    <div
-      className="self-start max-w-[85%] rounded-xl px-4 py-3 flex flex-col gap-1 font-mono text-xs"
-      style={{ background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)', color: 'var(--status-gate)' }}
-    >
-      <div className="flex items-center gap-2 font-semibold text-[11px] uppercase tracking-wide">
-        <span>↺</span>
-        <span>Crash recovery — attempt {attempt}</span>
-      </div>
-      <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-        The engine restarted and is re-dispatching this unit automatically.
-      </p>
-    </div>
   );
 }
 
@@ -695,7 +443,13 @@ function LegacyChatHistory({
               <div className="flex items-center gap-2">
                 {unit.assigned_cli ? (
                   <>
-                    <CliAvatar cli={unit.assigned_cli} />
+                    <span
+                      aria-hidden="true"
+                      className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold font-mono select-none"
+                      style={{ background: CLI_AVATAR.bg, color: CLI_AVATAR.fg }}
+                    >
+                      {cliInitials(unit.assigned_cli)}
+                    </span>
                     <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
                       {unit.assigned_cli}
                     </span>
@@ -742,6 +496,8 @@ function LegacyChatHistory({
   );
 }
 
+const EMPTY_EVENTS_FOR_NARRATOR: never[] = [];
+
 function RunChat({
   view,
   mode,
@@ -763,114 +519,57 @@ function RunChat({
 }): React.ReactElement {
   const { session, units } = view;
   // `ord` order is what `unit_ix` indexes into, so both the render order and the cursor derive from
-  // it. Memoized so neither reruns while `units` is unchanged; the cursor read in particular used to
-  // happen per unit, each call re-sorting the plan from inside the loop (PR #179 review).
+  // it. Memoized so neither reruns while `units` is unchanged (PR #179 review).
   const ordered = useMemo(() => [...units].sort((a, b) => a.ord - b.ord), [units]);
   const executingUnitOrd = useMemo(() => executingOrd(session, units), [session, units]);
-  // The conversational timeline holds ONLY phases that have run or are running (rejected counts:
-  // it ran far enough to be judged). Future work is the stepper's job — a queued unit used to
-  // render one tall, empty "Not started" block per phase, which is what the operator flagged.
-  //
-  // The CURSOR unit of an executing run enters regardless of its own status (DES-UX-001
-  // §7.6, slice Z / EC41): a run can be executing while its cursor unit still reads
-  // `pending` on the DTO (the status flip trails the deltas on the wire), and gating the
-  // live region on `distributed` alone left exactly that run's page silent while its
-  // output streamed. `executingOrd` already returns null for a finished cursor, so this
-  // never adds a done/rejected duplicate — and still only the ONE cursor unit, never the
-  // queue (FINDING-052 holds).
-  const timeline = useMemo(
-    () =>
-      ordered.filter(
-        (u) => u.status === 'done' || u.status === 'rejected' || u.ord === executingUnitOrd,
-      ),
-    [ordered, executingUnitOrd],
-  );
-  const gate = useGateStore((s) => s.gates[session.id]);
-  const elicitation = useElicitationStore((s) => s.elicitations[session.id]);
   const log = useRuntimeStore((s) => s.logs[session.id]) ?? [];
+  const events = useRunEventStore((s) => s.byRun[session.id]) ?? EMPTY_EVENTS_FOR_NARRATOR;
+
   /** "all" broadcasts; any other value is a CLI key (set by clicking an agent card). */
   const [injectTarget, setInjectTarget] = useState<string>('all');
-  const terminalIds = useRuntimeStore((s) => s.terminalIds);
-
   const [agentTerminal, setAgentTerminal] = useState<{ cliKey: string; terminalId: string } | null>(null);
-  const [transcripts, setTranscripts] = useState<
-    Record<number, { text: string | null; loading: boolean; visible: boolean }>
-  >({});
   // Evidence-reference wiring (DES-UX-001 §1.3-4c): a file link clicked in any
   // transcript opens the slice-I FileViewer on that path — never a dead click.
   const [evidenceFile, setEvidenceFile] = useState<string | null>(null);
-  const autoLoadedOrds = useRef<Set<number>>(new Set());
-  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // The narrator's phase vocabulary (DES-RUN-NARRATOR §4): unit-id suffix,
+  // stage fallback — the same rule the stepper renders with.
+  const byOrd = useMemo(() => new Map(ordered.map((u) => [u.ord, u])), [ordered]);
+  const phaseOf = useCallback(
+    (ord: number | null | undefined): string => {
+      if (typeof ord !== 'number') return 'this phase';
+      const unit = byOrd.get(ord);
+      return unit === undefined ? `unit ${ord}` : phaseName(session.id, unit);
+    },
+    [byOrd, session.id],
+  );
+  const ctx: NarratorContext = useMemo(() => ({ phaseOf }), [phaseOf]);
+  const lastLine = useMemo(() => lastNarration(events, ctx), [events, ctx]);
+  const artifacts = useMemo(() => deriveArtifacts(events, view, ctx), [events, view, ctx]);
+
+  // The now-bar's "Latest ↓" scrolls the ONE scrolling region to its tail.
+  const feedScrollRef = useRef<HTMLDivElement | null>(null);
+  const jumpToLatest = useCallback(() => {
+    const el = feedScrollRef.current;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }, []);
 
   // Units-as-spine for EVERY terminal failure (DES-UX-001 §1.3-1): a failed or
-  // cancelled run renders the ordered UnitList → WorkUnitDetail post-mortem
-  // (each unit's captured transcript auto-opens, WorkUnitDetail.tsx:38), with
-  // FailureBanner as the HEADLINE above the list — not the whole story.
+  // cancelled run keeps the ordered UnitList → WorkUnitDetail post-mortem under
+  // the Units tab, with FailureBanner as the HEADLINE in every lens.
   const isPostMortem = session.status === 'failed' || session.status === 'cancelled';
 
-  // DES-UX-002 §2 (slice BB / EC48): a TERMINAL run's default layout is the
-  // evidence timeline — rail + detail panel over the recorded event trail. The
-  // pre-BB body (the post-mortem spine / the conversational thread) is not
-  // evicted: it remains the Units tab, rendered unchanged. Live runs keep the
-  // conversational layout — the timeline reads a finished run's story.
-  const [runTab, setRunTab] = useState<'timeline' | 'units'>('timeline');
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [timeline.length, log.length]);
-
-  useEffect(() => {
-    // Post-mortem runs render the unit spine, whose WorkUnitDetail owns the
-    // per-unit transcript fetch — skipping here avoids a duplicate request.
-    if (isPostMortem) return;
-    for (const unit of units) {
-      if (unit.status === 'done' && !autoLoadedOrds.current.has(unit.ord)) {
-        autoLoadedOrds.current.add(unit.ord);
-        setTranscripts((prev) => ({
-          ...prev,
-          [unit.ord]: { text: null, loading: true, visible: true },
-        }));
-        void api
-          .getUnitOutput(session.id, unitKey(session.id, unit.id, unit.ord))
-          .then(({ output, outputUnavailable }) => {
-            // "(no transcript captured)" is FALSE for a denied unit — its output was captured and
-            // then deliberately not stored. Say what the daemon says (FINDING-006).
-            setTranscripts((prev) => ({
-              ...prev,
-              [unit.ord]: {
-                text: output ?? outputUnavailable ?? '(no transcript captured)',
-                loading: false,
-                visible: true,
-              },
-            }));
-          })
-          .catch(() => {
-            setTranscripts((prev) => ({
-              ...prev,
-              [unit.ord]: { text: '(transcript unavailable)', loading: false, visible: true },
-            }));
-          });
-      }
-    }
-  }, [units, session.id, isPostMortem]);
-
-  function toggleTranscript(ord: number): void {
-    setTranscripts((prev) => {
-      const entry = prev[ord];
-      if (!entry) return prev;
-      return { ...prev, [ord]: { ...entry, visible: !entry.visible } };
-    });
-  }
+  // DES-RUN-NARRATOR §8: a TERMINAL run carries three lenses — the narrated
+  // Feed (default: the story), the evidence Timeline (slice BB, unchanged), and
+  // the Units spine (slice R, unchanged). Live runs are always the feed.
+  const [runTab, setRunTab] = useState<'feed' | 'timeline' | 'units'>('feed');
 
   const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'var(--ink-muted)' };
   const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
 
-  // DES-UX-002 §5.4 (slice BE): `t` / `u` switch the terminal run's two lenses
-  // — timeline / unit list — through the ONE shortcut registry (EC42: the '?'
-  // overlay documents them from the registration itself, exactly where they
-  // work). Guarded on the run being terminal: a live run has no tab row, so
-  // the keys yield silently there; the shared typing guard keeps letters as
-  // letters in the steer textarea.
+  // DES-UX-002 §5.4 (slice BE): `t` / `u` switch the terminal run's lenses
+  // through the ONE shortcut registry (EC42). Guarded on the run being
+  // terminal; the shared typing guard keeps letters as letters in textareas.
   const tabsLive = useRef(isTerminal);
   tabsLive.current = isTerminal;
   const tabEntries = useMemo<ShortcutEntry[]>(() => [
@@ -892,14 +591,8 @@ function RunChat({
     },
   ], []);
   useGlobalShortcuts(tabEntries);
-  // Keep action + system events interleaved in arrival order (log is seq-ordered).
-  const eventLog = log.filter((e) => SYSTEM_EVENT_TYPES.has(e.type) || ACTION_EVENT_TYPES.has(e.type));
   const dotColor = statusDotColor(session.status);
   const pulse = ['executing', 'distributing', 'planning', 'awaiting_human'].includes(session.status);
-
-  function stopRun(): void {
-    void onKill?.(session.id);
-  }
 
   /**
    * Retry (DES-UX-001 §4.3): reopen the standard composer PREFILLED with this
@@ -921,6 +614,8 @@ function RunChat({
     });
     navigate?.('/runs/new');
   }
+
+  const showFeed = !isTerminal || runTab === 'feed';
 
   return (
     <div className="flex flex-col h-full">
@@ -985,15 +680,28 @@ function RunChat({
           timestamps; where the log lacks the events the line says so. */}
       <RunTimes runId={session.id} status={session.status} />
 
-      {/* Process stepper — the run's map: every phase, in order, with its state at a glance.
-          The timeline below renders only the phases that have entered the conversation. */}
+      {/* Process stepper — the run's map: every phase, in order, with its state at a glance. */}
       <ProcessStepper runId={session.id} units={ordered} executingUnitOrd={executingUnitOrd} />
 
-      {/* Slice BB (DES-UX-002 §2.3): terminal runs carry two lenses on the same record —
-          the evidence timeline (default) and the pre-BB Units view, preserved unchanged. */}
+      {/* The sticky now-bar (DES-RUN-NARRATOR §2): what is happening RIGHT NOW —
+          always visible, outside the scroll region, with the artifacts chip and
+          the jump-to-latest affordance. */}
+      <NowBar
+        view={view}
+        orderedUnits={ordered}
+        executingUnitOrd={executingUnitOrd}
+        phaseOf={phaseOf}
+        lastLine={lastLine}
+        artifacts={artifacts}
+        onJumpToLatest={jumpToLatest}
+        onOpenFile={setEvidenceFile}
+      />
+
+      {/* Terminal runs carry three lenses on the same record (§8): the narrated
+          feed (default), the evidence timeline (BB) and the Units spine (R). */}
       {isTerminal && (
         <div className="flex items-center gap-1 px-6 pt-2 shrink-0" role="tablist" aria-label="Run detail view">
-          {([['timeline', 'Timeline', 'tab-timeline'], ['units', 'Units', 'tab-unit-list']] as const).map(([id, label, testId]) => (
+          {([['feed', 'Feed', 'tab-feed'], ['timeline', 'Timeline', 'tab-timeline'], ['units', 'Units', 'tab-unit-list']] as const).map(([id, label, testId]) => (
             <button
               key={id}
               type="button"
@@ -1016,7 +724,7 @@ function RunChat({
       )}
 
       {/* The evidence timeline (§2, EC48) — FailureBanner stays the HEADLINE on a
-          post-mortem run in BOTH lenses (DES-UX-001 §1.3-1 is not undone by BB). */}
+          post-mortem run in EVERY lens (DES-UX-001 §1.3-1 is not undone). */}
       {isTerminal && runTab === 'timeline' && (
         <div className="flex-1 min-h-0 flex flex-col gap-3 px-4 py-3">
           {isPostMortem && (
@@ -1030,271 +738,56 @@ function RunChat({
         </div>
       )}
 
-      {/* Message thread. `data-testid="thread"` + `data-message-id` are the contract the
-          version → message cross-link resolves against (DES-MERGE-001 §7.6); the strip
-          addresses the thread through the DOM because they are sibling surfaces. */}
-      {!(isTerminal && runTab === 'timeline') && (
-      <div
-        data-testid="thread"
-        className="flex-1 overflow-y-auto px-4 py-6 flex flex-col gap-6 max-w-3xl w-full mx-auto"
-      >
-        {/* An open MCP elicitation suspends the agent's turn, so it leads the stream (DES-002).
-            `key` is REQUIRED: React reuses the instance across prop changes, so without it a
-            half-typed answer to elicitation A survives into B (v0.24 F3). */}
-        {elicitation !== undefined && (
-          <div className="self-center w-full max-w-lg">
-            <ElicitationPrompt key={elicitation.elicitationId} e={elicitation} />
-          </div>
-        )}
-
-        {/* User prompt bubble */}
-        <div className="flex justify-end">
+      {/* The Units lens: the slice-R post-mortem spine for failed/cancelled runs
+          (unchanged), the crew#272 output blocks for completed ones. */}
+      {isTerminal && runTab === 'units' && (
+        isPostMortem ? (
           <div
-            // §5.3 token usage: the user's message is transparent — a hairline
-            // keeps the bubble shape without claiming a surface of its own.
-            className="max-w-[72%] rounded-2xl text-base px-5 py-3.5 leading-relaxed"
-            style={{ background: 'transparent', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
+            data-testid="thread"
+            className="flex-1 overflow-y-auto px-4 py-6 flex flex-col gap-3 max-w-3xl w-full mx-auto"
           >
-            {session.problem}
-          </div>
-        </div>
-
-        {/* The post-mortem spine (DES-UX-001 §1.3, slice R): a failed/cancelled run
-            renders FailureBanner as the headline, the evaluator's VerdictDetail card,
-            and the ordered unit spine — each captured transcript auto-opened — in
-            place of the conversational timeline. The transcripts were on the wire
-            all along (GET /runs/:id/units/:unitKey/output); this is the render path
-            that finally takes them for the statuses that need them most. */}
-        {isPostMortem && (
-          <div className="flex flex-col gap-3">
             {/* slice Y (§7.4): the banner's "All runs ›" is a FAILURE-CONTEXT
                 entry — it lands on /work with the Failed filter active. */}
             <FailureBanner view={view} log={log} {...(navigate === undefined ? {} : { navigate })} />
             <VerdictDetail runId={session.id} units={ordered} />
             <UnitList runId={session.id} units={ordered} onOpenFile={setEvidenceFile} />
           </div>
-        )}
+        ) : (
+          <NarratorFeed
+            view={view}
+            orderedUnits={ordered}
+            executingUnitOrd={executingUnitOrd}
+            phaseOf={phaseOf}
+            lens="units"
+            onOpenFile={setEvidenceFile}
+          />
+        )
+      )}
 
-        {/* Phase entries — only phases that have run or are running; gate panel injected
-            inline before the unit it blocks when that unit has already entered the thread */}
-        {!isPostMortem && timeline.flatMap((unit) => {
-          const tc = transcripts[unit.ord];
-          const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' };
-          const gateBeforeThis = session.status === 'awaiting_human' && gate?.ord === unit.ord;
-          const unitEl = (
-            <div key={unit.id} data-message-id={unit.id} className="flex flex-col gap-2">
-              {/* Council routing pill */}
-              {unit.routing !== null && unit.routing.method === 'council' && (
-                <div
-                  className="self-start max-w-[85%] rounded-xl px-4 py-2 text-xs flex items-center gap-2 font-mono"
-                  style={{ background: 'var(--accent-subtle)', border: '1px solid var(--accent-subtle)', color: 'var(--accent)' }}
-                >
-                  <span className="shrink-0">⚖</span>
-                  <span>
-                    <span className="font-semibold">Council → {unit.assigned_cli ?? '?'}</span>
-                    <span className="ml-2" style={{ color: 'var(--accent)', opacity: 0.7 }}>
-                      {quorumLabel(unit.routing)} · {unit.routing.agreement_pct}% agree · {unit.routing.dissent} dissent
-                      {lostQuorum(unit.routing) && (
-                        <span className="ml-2" style={{ color: 'var(--status-gate)' }}>· quorum lost</span>
-                      )}
-                    </span>
-                  </span>
-                </div>
-              )}
-              {unit.routing !== null && unit.routing.method === 'evaluator_distinct' && (
-                <div
-                  className="self-start max-w-[85%] rounded-xl px-4 py-2 text-xs flex items-center gap-2 font-mono"
-                  style={{ background: 'var(--accent-subtle)', border: '1px solid var(--accent-subtle)', color: 'var(--accent)' }}
-                >
-                  <span className="shrink-0">⚖</span>
-                  <span>
-                    <span className="font-semibold">Evaluator-distinct → {unit.assigned_cli ?? '?'}</span>
-                    <span className="ml-2" style={{ color: 'var(--accent)', opacity: 0.7 }}>(was: {unit.routing.was})</span>
-                  </span>
-                </div>
-              )}
-              {unit.routing !== null && unit.routing.method === 'degraded' && (
-                <DegradedRoutingBanner reason={unit.routing.reason} />
-              )}
-
-              {/* Agent response card */}
-              <div className="self-start max-w-[85%] flex flex-col gap-2">
-                {/* Meta row: avatar + attribution + stage + governance (clickable to target inject when agent is assigned) */}
-                <div className="flex items-center gap-2 flex-wrap">
-                  {unit.assigned_cli ? (
-                    <div className="flex items-center gap-1">
-                      <button
-                        type="button"
-                        onClick={() => setInjectTarget(unit.assigned_cli!)}
-                        title={`Target ${unit.assigned_cli}`}
-                        aria-label={`Send message to ${unit.assigned_cli} only`}
-                        className="flex items-center gap-2 rounded-lg p-0 pr-1 transition-opacity hover:opacity-80"
-                        style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
-                      >
-                        <CliAvatar cli={unit.assigned_cli} />
-                        <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
-                          {unit.assigned_cli}
-                          <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
-                        </span>
-                      </button>
-                      {terminalIds[`${session.id}:${unit.assigned_cli}`] && (
-                        <button
-                          type="button"
-                          aria-pressed={agentTerminal?.cliKey === unit.assigned_cli}
-                          aria-label={agentTerminal?.cliKey === unit.assigned_cli ? `Close ${unit.assigned_cli} terminal` : `Open ${unit.assigned_cli} terminal`}
-                          title={agentTerminal?.cliKey === unit.assigned_cli ? `Close ${unit.assigned_cli} terminal` : `Open ${unit.assigned_cli} terminal`}
-                          onClick={() => {
-                            const cli = unit.assigned_cli!;
-                            const tid = terminalIds[`${session.id}:${cli}`];
-                            setAgentTerminal(agentTerminal?.cliKey === cli ? null : { cliKey: cli, terminalId: tid! });
-                          }}
-                          className="text-xs rounded px-1 py-0.5 transition-opacity hover:opacity-80"
-                          style={{ background: 'var(--surface-raised)', border: 'none', cursor: 'pointer', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}
-                        >
-                          ⌨
-                        </button>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <span className="w-7 h-7 rounded-full shrink-0" style={{ background: 'var(--surface-raised)' }} />
-                      <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
-                        agent
-                        <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
-                      </span>
-                    </div>
-                  )}
-                  <span
-                    className="rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide font-mono"
-                    style={{ background: stageBadge.bg, color: stageBadge.color }}
-                  >
-                    {unit.stage}
-                  </span>
-                  {unit.has_validator_pin && (
-                    <span role="img" aria-label="Governance floor armed" style={{ color: 'var(--status-gate)', fontSize: '12px' }}>🔒</span>
-                  )}
-                  <span className="text-xs font-mono truncate max-w-xs" style={{ color: 'var(--ink-dim)' }} title={unit.description}>
-                    {unit.description}
-                  </span>
-                </div>
-
-                {/* Content card */}
-                <div
-                  className="rounded-2xl px-5 py-4"
-                  style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
-                >
-                  {/* A non-terminal unit is in the timeline ONLY as the cursor unit of an
-                      executing run (FINDING-052: distributed = routed, not running — queued
-                      units live in the stepper now, never as thread blocks). Slice Z widens
-                      the cursor's live region past `distributed`: a pending-status cursor of
-                      an executing run streams too (EC41). */}
-                  {unit.status !== 'done' && unit.status !== 'rejected' && (
-                    <LiveNarration runId={session.id} ord={unit.ord} phase={phaseName(session.id, unit)} />
-                  )}
-                  {unit.status === 'done' && (
-                    <div data-testid={`unit-output-${unit.ord}`}>
-                      {/* Output header: phase name + status (crew#272) */}
-                      <div className="flex items-center gap-2 text-sm font-mono">
-                        <span style={{ color: 'var(--status-done)' }}>✓</span>
-                        <span className="font-medium" style={{ color: 'var(--status-done)' }}>{phaseName(session.id, unit)}</span>
-                        <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>{UNIT_STATUS_TEXT[unit.status]}</span>
-                        <button
-                          type="button"
-                          data-testid={`unit-output-toggle-${unit.ord}`}
-                          onClick={() => toggleTranscript(unit.ord)}
-                          className="ml-auto text-xs font-medium font-mono hover:underline"
-                          style={{ color: 'var(--accent)' }}
-                        >
-                          {tc?.visible ? '▾ Hide output' : '▸ Show output'}
-                        </button>
-                      </div>
-                      {/* The unit's OUTPUT is the primary message body (crew#272): auto-loaded,
-                          expanded, and rendered in the main flow — not buried behind a
-                          transcript toggle the user has to dig for. */}
-                      {tc?.visible && (
-                        <div className="mt-2.5 max-h-[28rem] overflow-y-auto">
-                          {tc.loading
-                            ? <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>Loading output…</span>
-                            : <Markdown className="whitespace-pre-wrap" onOpenFile={setEvidenceFile}>{tc.text ?? ''}</Markdown>
-                          }
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  {unit.status === 'rejected' && (
-                    <div className="text-sm font-medium font-mono" style={{ color: 'var(--status-fail)' }}>
-                      Rejected{unit.denial_reason ? `: ${unit.denial_reason}` : ''}
-                    </div>
-                  )}
-                </div>
-              </div>
+      {/* The narrated feed (§2): the ONE chronological stream — and the only
+          scrolling region. On a post-mortem run FailureBanner stays the headline
+          above it. */}
+      {showFeed && (
+        <>
+          {isPostMortem && (
+            <div className="px-4 pt-3 shrink-0 max-w-3xl w-full mx-auto">
+              <FailureBanner view={view} log={log} {...(navigate === undefined ? {} : { navigate })} />
             </div>
-          );
-          if (gateBeforeThis) {
-            return [
-              <div key={`gate-before-${unit.id}`} className="self-center w-full max-w-lg">
-                <SteeringGate
-                  runId={session.id}
-                  guidance={sessionGuidance(session)}
-                  {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
-                  onResolved={onRefresh}
-                />
-              </div>,
-              unitEl,
-            ];
-          }
-          return [unitEl];
-        })}
-
-        {/* Action cards + system event pills — rendered in arrival (seq) order */}
-        {eventLog.map((entry) => {
-          if (entry.type === 'stepFailed') {
-            return (
-              <div key={entry.seq} className="flex flex-col gap-2">
-                <StepFailedCard
-                  detail={entry.detail}
-                  onStop={stopRun}
-                  canStop={onKill !== undefined && !isTerminal}
-                />
-              </div>
-            );
-          }
-          if (entry.type === 'crashRecoveryRedrive') {
-            return (
-              <div key={entry.seq} className="flex flex-col gap-2">
-                <CrashRedriveCard attempt={entry.attempt ?? 1} />
-              </div>
-            );
-          }
-          return (
-            <div key={entry.seq} className="flex justify-center">
-              <span
-                className="text-xs rounded-full px-3 py-1 font-mono"
-                style={{ color: 'var(--ink-dim)', background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
-              >
-                {systemEventLabel(entry.type, entry.detail)}
-              </span>
-            </div>
-          );
-        })}
-
-        {/* Steering gate — fallback position when the gated unit has no timeline entry. This is
-            now the COMMON path: awaiting_human pauses BEFORE a not-yet-started unit, and queued
-            units no longer render as thread blocks, so the card lands here — after everything
-            that has already run, which is exactly where the pause chronologically is. */}
-        {session.status === 'awaiting_human' && !timeline.some((u) => gate?.ord === u.ord) && (
-          <div className="self-center w-full max-w-lg">
-            <SteeringGate
-              runId={session.id}
-              guidance={sessionGuidance(session)}
-              {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
-              onResolved={onRefresh}
-            />
-          </div>
-        )}
-
-        <div ref={bottomRef} />
-      </div>
+          )}
+          <NarratorFeed
+            view={view}
+            orderedUnits={ordered}
+            executingUnitOrd={executingUnitOrd}
+            phaseOf={phaseOf}
+            lens="feed"
+            onTargetInject={isTerminal ? undefined : setInjectTarget}
+            onToggleTerminal={(cli, terminalId) =>
+              setAgentTerminal((cur) => (cur?.cliKey === cli ? null : { cliKey: cli, terminalId }))}
+            agentTerminalCli={agentTerminal?.cliKey ?? null}
+            onOpenFile={setEvidenceFile}
+            scrollRef={feedScrollRef}
+          />
+        </>
       )}
 
       {/* The evidence viewer: slice I's FileViewer, reused verbatim — populated
@@ -1326,15 +819,31 @@ function RunChat({
           />
         </div>
       )}
-      <ChatInput
-        runId={isTerminal ? null : session.id}
-        runStatus={isTerminal ? null : session.status}
-        mode={mode}
-        onLaunched={onLaunched}
-        injectTarget={injectTarget}
-        onClearInjectTarget={() => setInjectTarget('all')}
-        {...(navigate !== undefined ? { navigate } : {})}
-      />
+
+      {/* The pinned approval dock (§2): gates and elicitations live HERE — a
+          sibling of the scroll region, never inside it, directly above the
+          composer so steering happens where the user is already looking. */}
+      <ApprovalDock view={view} onResolved={onRefresh} />
+
+      {/* Composer (§7): live runs steer/inject; a terminal run's footer is the
+          labelled follow-up bar (review #8), never an unlabelled launch form. */}
+      {isTerminal ? (
+        <FollowUpComposer
+          session={session}
+          onLaunched={onLaunched}
+          navigate={navigate}
+        />
+      ) : (
+        <ChatInput
+          runId={session.id}
+          runStatus={session.status}
+          mode={mode}
+          onLaunched={onLaunched}
+          injectTarget={injectTarget}
+          onClearInjectTarget={() => setInjectTarget('all')}
+          {...(navigate !== undefined ? { navigate } : {})}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -543,7 +543,10 @@ function RunChat({
     },
     [byOrd, session.id],
   );
-  const ctx: NarratorContext = useMemo(() => ({ phaseOf }), [phaseOf]);
+  const ctx: NarratorContext = useMemo(
+    () => ({ phaseOf, intent: session.problem ?? null }),
+    [phaseOf, session.problem],
+  );
   const lastLine = useMemo(() => lastNarration(events, ctx), [events, ctx]);
   const artifacts = useMemo(() => deriveArtifacts(events, view, ctx), [events, view, ctx]);
 

--- a/src/components/FollowUpComposer.tsx
+++ b/src/components/FollowUpComposer.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import type { AgentSession } from '../api/types.js';
+import { ChatInput } from './ChatInput.js';
+
+/**
+ * The terminal-run composer (DES-RUN-NARRATOR §7; usability review 2026-08-31
+ * finding #8): a finished run's footer used to wear the FULL launch composer —
+ * "What do you need built?", gate chip, project switcher — with nothing saying
+ * whether it steered THIS run or started a new one. Now a dead run's footer is
+ * one honest line plus one labelled action; the launch form appears only after
+ * the operator asks for it, under the label that says exactly what it does.
+ */
+export function FollowUpComposer({
+  session,
+  onLaunched,
+  navigate,
+}: {
+  session: AgentSession;
+  onLaunched: (runId: string) => void;
+  navigate?: ((path: string) => void) | undefined;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const projectId = typeof session.project_id === 'string' ? session.project_id : null;
+  const label = projectId !== null ? 'Start a follow-up run in this project' : 'Start a follow-up run';
+
+  if (!open) {
+    return (
+      <div
+        data-testid="followup-bar"
+        className="px-5 py-3 shrink-0 flex items-center gap-3"
+        style={{ borderTop: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
+      >
+        <p className="text-xs font-mono flex-1" style={{ color: 'var(--ink-dim)' }}>
+          This run is finished — steering is closed.
+        </p>
+        <button
+          type="button"
+          data-testid="followup-open"
+          onClick={() => setOpen(true)}
+          className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold font-mono transition-opacity hover:opacity-80"
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-body)', border: '1px solid var(--surface-overlay)' }}
+        >
+          {label} →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="followup-composer"
+      className="px-5 py-3 shrink-0 flex flex-col gap-1"
+      style={{ borderTop: '1px solid var(--surface-raised)', background: 'var(--surface-rail)' }}
+    >
+      <div className="flex items-center gap-2">
+        <p data-testid="followup-label" className="text-xs font-semibold font-mono flex-1" style={{ color: 'var(--ink-body)' }}>
+          {label} — a NEW run, separate from this one
+        </p>
+        <button
+          type="button"
+          data-testid="followup-close"
+          onClick={() => setOpen(false)}
+          aria-label="Close the follow-up composer"
+          className="shrink-0 text-xs font-mono opacity-60 hover:opacity-100"
+          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--ink-muted)' }}
+        >
+          ✕
+        </button>
+      </div>
+      <ChatInput
+        embedded
+        onLaunched={onLaunched}
+        lockedProjectId={projectId}
+        {...(navigate !== undefined ? { navigate } : {})}
+      />
+    </div>
+  );
+}

--- a/src/components/LiveNarration.tsx
+++ b/src/components/LiveNarration.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRuntimeStore, outputKey } from '../store/runtime.js';
+
+/** Trailing window of live narration rendered per unit (~4KB). */
+const NARRATION_TAIL = 4096;
+
+/**
+ * Live narration for the ACTIVE unit — the streamed `unitOutputDelta` /
+ * `cliOutputDelta` text from the `/ws` CoreEvent stream (accumulated by the
+ * runtime store into `outputs`), rendered inside the unit's block in place of
+ * the old empty "Working…" wait. Collapsible, autoscrolled to the newest text,
+ * and windowed to the trailing ~{@link NARRATION_TAIL} bytes so a chatty
+ * worker never grows the thread's DOM unbounded (the store keeps its own
+ * larger cap for the full-output consumers).
+ *
+ * Shared with the Term tab (DES-UX-001 §7.6, slice Z): during a live run the
+ * terminal modal shows this SAME region — one live-output component, two
+ * mounts, never a fork. The streamed region carries `data-testid="live-output"`
+ * (EC41: between start and verdict, something true streams on the run's own
+ * page) and the honest label for what the deltas are — relayed live output,
+ * not the durable transcript (§13: richer streaming is a crew concern).
+ *
+ * Moved out of ChatPanel.tsx by DES-RUN-NARRATOR §9 (the feed decomposition);
+ * behavior and testids are verbatim.
+ */
+export function LiveNarration({ runId, ord, phase }: { runId: string; ord: number; phase: string }): React.ReactElement {
+  const live = useRuntimeStore((s) => s.outputs[outputKey(runId, ord)]);
+  const [visible, setVisible] = useState(true);
+  const scrollRef = useRef<HTMLPreElement>(null);
+
+  // Pin the narration viewport to the newest text as chunks stream in.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [live, visible]);
+
+  const hasText = typeof live === 'string' && live.length > 0;
+  const tail =
+    hasText && live.length > NARRATION_TAIL ? '…' + live.slice(live.length - NARRATION_TAIL) : live;
+
+  return (
+    <div data-testid={`live-narration-${ord}`}>
+      <div className="flex items-center gap-2 text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
+        <span className="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: 'var(--status-run)' }} />
+        {/* Phase label leads the entry (operator UX directive) — mirrors the done-unit header. */}
+        <span className="font-medium" style={{ color: 'var(--status-run)' }}>{phase}</span>
+        <span>{hasText ? 'Working — live output' : 'Working…'}</span>
+        {hasText && (
+          <button
+            type="button"
+            data-testid={`live-narration-toggle-${ord}`}
+            onClick={() => setVisible((v) => !v)}
+            className="ml-auto text-xs font-medium font-mono hover:underline"
+            style={{ color: 'var(--accent)' }}
+          >
+            {visible ? '▾ Hide live output' : '▸ Show live output'}
+          </button>
+        )}
+      </div>
+      {hasText && (
+        <div data-testid="live-output" className="mt-2">
+          {/* The honest label (§7.6): what streams is the relayed delta feed,
+              not the durable record — say exactly that, house grammar. */}
+          <p
+            data-testid="live-output-label"
+            className="mb-1 text-[10px] font-mono"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            Live output — the full transcript lands when the unit completes.
+          </p>
+          {visible && (
+            <pre
+              ref={scrollRef}
+              data-testid={`live-narration-text-${ord}`}
+              className="max-h-64 overflow-auto rounded-lg p-2.5 text-[11px] leading-snug whitespace-pre-wrap break-words font-mono"
+              style={{ background: 'var(--surface-base)', color: 'var(--ink-body)', border: '1px solid var(--surface-raised)' }}
+            >
+              {tail}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/NarratorFeed.tsx
+++ b/src/components/NarratorFeed.tsx
@@ -1,0 +1,415 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+import type { CoreEvent, SessionView, StageKind, UnitStatus, WorkUnit } from '../api/types.js';
+import { useRunEventStore } from '../store/events.js';
+import { useRuntimeStore } from '../store/runtime.js';
+import { LiveNarration } from './LiveNarration.js';
+import { Markdown } from './Markdown.js';
+import { ArtifactCard } from './ArtifactCard.js';
+import {
+  buildFeed,
+  narrate,
+  sortFeedEvents,
+  type FeedItem,
+  type NarrationTone,
+  type NarratorContext,
+} from './narrator.js';
+
+/**
+ * The narrated run feed (DES-RUN-NARRATOR §2, §4-§5): ONE chronological stream
+ * — deterministic narration lines over the run's CoreEvent trail, each spoken
+ * unit's output group anchored where its story ends, artifact cards behind the
+ * lines that produced them. This is the only scrolling region of the run page;
+ * the now-bar and the approval dock are pinned siblings.
+ *
+ * Two lenses share the renderer: `feed` (lines + units + artifacts) and
+ * `units` (the unit groups alone, ord order — the terminal run's Units tab for
+ * non-post-mortem runs, preserving the crew#272 output blocks verbatim).
+ */
+
+const EMPTY_EVENTS: CoreEvent[] = [];
+
+// Agent identity under the token contract (DES-VISION-001 §2.11).
+const CLI_AVATAR = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
+
+function cliInitials(key: string): string {
+  const parts = key.split(/[-_]/);
+  if (parts.length > 1) return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+  return key.slice(0, 2).toUpperCase();
+}
+
+function CliAvatar({ cli }: { cli: string }): React.ReactElement {
+  return (
+    <span
+      aria-hidden="true"
+      className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold font-mono select-none"
+      style={{ background: CLI_AVATAR.bg, color: CLI_AVATAR.fg }}
+    >
+      {cliInitials(cli)}
+    </span>
+  );
+}
+
+// Stage pill — process vocabulary, not run state (§1.5 rule 2).
+const STAGE_BADGE: Record<StageKind, { bg: string; color: string }> = {
+  recon:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  build:   { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  review:  { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+  test:    { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' },
+};
+
+const UNIT_STATUS_TEXT: Record<UnitStatus, string> = {
+  pending:     'queued',
+  distributed: 'dispatched',
+  done:        'done',
+  rejected:    'rejected',
+};
+
+export function unitKey(runId: string, unitId: string, ord: number): string {
+  return unitId.startsWith(`${runId}:`) ? unitId.slice(runId.length + 1) : `u${ord}`;
+}
+
+/**
+ * The unit's phase name (crew#272): the unit-id suffix (`run-1:survey` →
+ * `survey`); free-text units (`u<ord>`) fall back to the methodology stage.
+ */
+export function phaseName(runId: string, unit: WorkUnit): string {
+  const key = unitKey(runId, unit.id, unit.ord);
+  return /^u\d+$/.test(key) ? unit.stage : key;
+}
+
+const TONE_COLOR: Record<NarrationTone, string> = {
+  info: 'var(--ink-muted)',
+  work: 'var(--status-run)',
+  gate: 'var(--status-gate)',
+  fail: 'var(--status-fail)',
+  human: 'var(--accent)',
+};
+
+const TONE_GLYPH: Record<NarrationTone, string> = {
+  info: '·',
+  work: '●',
+  gate: '◆',
+  fail: '✗',
+  human: '➤',
+};
+
+interface Props {
+  view: SessionView;
+  /** ord-sorted units (the caller's memo). */
+  orderedUnits: WorkUnit[];
+  executingUnitOrd: number | null;
+  phaseOf: (ord: number | null | undefined) => string;
+  /** `feed` = the narrated stream; `units` = unit groups only (the Units tab). */
+  lens: 'feed' | 'units';
+  /** Click-to-target inject (crew#74) — live runs only. */
+  onTargetInject?: ((cli: string) => void) | undefined;
+  /** Open/close the observer terminal for an agent (⌨). */
+  onToggleTerminal?: ((cli: string, terminalId: string) => void) | undefined;
+  /** The agent whose terminal is open (aria-pressed on its ⌨). */
+  agentTerminalCli?: string | null;
+  onOpenFile?: ((path: string) => void) | undefined;
+  /** The scrolling container ref — the now-bar's "Latest ↓" scrolls it. */
+  scrollRef?: React.MutableRefObject<HTMLDivElement | null> | undefined;
+}
+
+export function NarratorFeed({
+  view,
+  orderedUnits,
+  executingUnitOrd,
+  phaseOf,
+  lens,
+  onTargetInject,
+  onToggleTerminal,
+  agentTerminalCli = null,
+  onOpenFile,
+  scrollRef,
+}: Props): React.ReactElement {
+  const { session } = view;
+  const events = useRunEventStore((s) => s.byRun[session.id]) ?? EMPTY_EVENTS;
+  const terminalIds = useRuntimeStore((s) => s.terminalIds);
+
+  // Raw view (§4): the same trail, undecorated — for operators who want the wire.
+  const [raw, setRaw] = useState(false);
+
+  const feedEvents = lens === 'feed' ? events : EMPTY_EVENTS;
+  const ctx: NarratorContext = useMemo(() => ({ phaseOf }), [phaseOf]);
+  const items: FeedItem[] = useMemo(
+    () => buildFeed(feedEvents, orderedUnits, executingUnitOrd, ctx),
+    [feedEvents, orderedUnits, executingUnitOrd, ctx],
+  );
+
+  // The inline gate MOMENT (§2): when the run is paused on a human and the trail
+  // never spoke an awaitingHuman line (empty/pruned log), say it at the tail —
+  // the feed records history even when the log cannot.
+  const gateSpoken = useMemo(
+    () => feedEvents.some((e) => e.type === 'awaitingHuman'),
+    [feedEvents],
+  );
+  const syntheticGateLine =
+    lens === 'feed' && session.status === 'awaiting_human' && !gateSpoken;
+
+  // Transcript auto-load for done units (crew#272) — the output IS the message
+  // body; loaded with no click, collapsible behind its toggle.
+  const [transcripts, setTranscripts] = useState<
+    Record<number, { text: string | null; loading: boolean; visible: boolean }>
+  >({});
+  const autoLoadedOrds = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    for (const unit of orderedUnits) {
+      if (unit.status === 'done' && !autoLoadedOrds.current.has(unit.ord)) {
+        autoLoadedOrds.current.add(unit.ord);
+        setTranscripts((prev) => ({ ...prev, [unit.ord]: { text: null, loading: true, visible: true } }));
+        void api
+          .getUnitOutput(session.id, unitKey(session.id, unit.id, unit.ord))
+          .then(({ output, outputUnavailable }) => {
+            // "(no transcript captured)" is FALSE for a denied unit — say what
+            // the daemon says (FINDING-006).
+            setTranscripts((prev) => ({
+              ...prev,
+              [unit.ord]: {
+                text: output ?? outputUnavailable ?? '(no transcript captured)',
+                loading: false,
+                visible: true,
+              },
+            }));
+          })
+          .catch(() => {
+            setTranscripts((prev) => ({
+              ...prev,
+              [unit.ord]: { text: '(transcript unavailable)', loading: false, visible: true },
+            }));
+          });
+      }
+    }
+  }, [orderedUnits, session.id]);
+
+  function toggleTranscript(ord: number): void {
+    setTranscripts((prev) => {
+      const entry = prev[ord];
+      if (!entry) return prev;
+      return { ...prev, [ord]: { ...entry, visible: !entry.visible } };
+    });
+  }
+
+  // Pinned to the tail as items land (the live-follow posture). `transcripts`
+  // is a dep too: a done unit's output loads AFTER the first pin and grows the
+  // block above the tail — without the re-pin the latest narration slid below
+  // the fold (caught on the 1440x700 evidence pass).
+  const bottomRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [items.length, transcripts]);
+
+  const byOrd = useMemo(() => new Map(orderedUnits.map((u) => [u.ord, u])), [orderedUnits]);
+
+  /** One unit's group block — meta row + content card (testids preserved verbatim). */
+  function unitBlock(ord: number): React.ReactElement | null {
+    const unit = byOrd.get(ord);
+    if (unit === undefined) return null;
+    const tc = transcripts[unit.ord];
+    const stageBadge = STAGE_BADGE[unit.stage] ?? { bg: 'var(--surface-raised)', color: 'var(--ink-muted)' };
+    return (
+      <div key={`unit-${unit.id}`} data-message-id={unit.id} className="flex flex-col gap-2">
+        <div className="self-start w-full max-w-[85%] flex flex-col gap-2">
+          {/* Meta row: avatar + attribution + stage (clickable to target inject). */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {unit.assigned_cli ? (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={onTargetInject === undefined ? undefined : () => onTargetInject(unit.assigned_cli!)}
+                  title={`Target ${unit.assigned_cli}`}
+                  aria-label={`Send message to ${unit.assigned_cli} only`}
+                  className="flex items-center gap-2 rounded-lg p-0 pr-1 transition-opacity hover:opacity-80"
+                  style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
+                >
+                  <CliAvatar cli={unit.assigned_cli} />
+                  <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+                    {unit.assigned_cli}
+                    <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
+                  </span>
+                </button>
+                {onToggleTerminal !== undefined && terminalIds[`${session.id}:${unit.assigned_cli}`] && (
+                  <button
+                    type="button"
+                    aria-pressed={agentTerminalCli === unit.assigned_cli}
+                    aria-label={agentTerminalCli === unit.assigned_cli ? `Close ${unit.assigned_cli} terminal` : `Open ${unit.assigned_cli} terminal`}
+                    title={agentTerminalCli === unit.assigned_cli ? `Close ${unit.assigned_cli} terminal` : `Open ${unit.assigned_cli} terminal`}
+                    onClick={() => {
+                      const cli = unit.assigned_cli!;
+                      const tid = terminalIds[`${session.id}:${cli}`];
+                      if (tid) onToggleTerminal(cli, tid);
+                    }}
+                    className="text-xs rounded px-1 py-0.5 transition-opacity hover:opacity-80"
+                    style={{ background: 'var(--surface-raised)', border: 'none', cursor: 'pointer', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}
+                  >
+                    ⌨
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <span className="w-7 h-7 rounded-full shrink-0" style={{ background: 'var(--surface-raised)' }} />
+                <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+                  agent
+                  <span style={{ color: 'var(--ink-dim)' }}> · unit {unit.ord}</span>
+                </span>
+              </div>
+            )}
+            <span
+              className="rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide font-mono"
+              style={{ background: stageBadge.bg, color: stageBadge.color }}
+            >
+              {unit.stage}
+            </span>
+            {unit.has_validator_pin && (
+              <span role="img" aria-label="Governance floor armed" style={{ color: 'var(--status-gate)', fontSize: '12px' }}>🔒</span>
+            )}
+            <span className="text-xs font-mono truncate max-w-xs" style={{ color: 'var(--ink-dim)' }} title={unit.description}>
+              {unit.description}
+            </span>
+          </div>
+
+          {/* Content card: live output for the cursor, transcript for done, reason for rejected. */}
+          <div
+            className="rounded-2xl px-5 py-4"
+            style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+          >
+            {unit.status !== 'done' && unit.status !== 'rejected' && (
+              <LiveNarration runId={session.id} ord={unit.ord} phase={phaseName(session.id, unit)} />
+            )}
+            {unit.status === 'done' && (
+              <div data-testid={`unit-output-${unit.ord}`}>
+                <div className="flex items-center gap-2 text-sm font-mono">
+                  <span style={{ color: 'var(--status-done)' }}>✓</span>
+                  <span className="font-medium" style={{ color: 'var(--status-done)' }}>{phaseName(session.id, unit)}</span>
+                  <span className="text-xs" style={{ color: 'var(--ink-dim)' }}>{UNIT_STATUS_TEXT[unit.status]}</span>
+                  <button
+                    type="button"
+                    data-testid={`unit-output-toggle-${unit.ord}`}
+                    onClick={() => toggleTranscript(unit.ord)}
+                    className="ml-auto text-xs font-medium font-mono hover:underline"
+                    style={{ color: 'var(--accent)' }}
+                  >
+                    {tc?.visible ? '▾ Hide output' : '▸ Show output'}
+                  </button>
+                </div>
+                {tc?.visible && (
+                  <div className="mt-2.5 max-h-[28rem] overflow-y-auto">
+                    {tc.loading
+                      ? <span className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>Loading output…</span>
+                      : <Markdown className="whitespace-pre-wrap" {...(onOpenFile !== undefined ? { onOpenFile } : {})}>{tc.text ?? ''}</Markdown>
+                    }
+                  </div>
+                )}
+              </div>
+            )}
+            {unit.status === 'rejected' && (
+              <div className="text-sm font-medium font-mono" style={{ color: 'var(--status-fail)' }}>
+                Rejected{unit.denial_reason ? `: ${unit.denial_reason}` : ''}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const narrationLine = (key: string, text: string, tone: NarrationTone): React.ReactElement => (
+    <div key={key} data-testid="narration-line" data-tone={tone} className="flex items-baseline gap-2 px-1">
+      <span aria-hidden="true" className="shrink-0 text-[10px] font-mono" style={{ color: TONE_COLOR[tone] }}>
+        {TONE_GLYPH[tone]}
+      </span>
+      <span className="text-[12.5px] font-mono leading-relaxed min-w-0" style={{ color: tone === 'info' ? 'var(--ink-muted)' : 'var(--ink-body)' }}>
+        {text}
+      </span>
+    </div>
+  );
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="thread"
+      className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-3 max-w-3xl w-full mx-auto"
+    >
+      {/* Feed header: what this stream is + the raw-wire toggle (§4). */}
+      {lens === 'feed' && (
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-wider font-mono" style={{ color: 'var(--ink-dim)' }}>
+            run narration
+          </span>
+          <div className="flex-1" />
+          <div
+            role="group"
+            aria-label="Feed view"
+            className="inline-flex items-center gap-0.5"
+            style={{ border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md, 6px)', padding: '1px' }}
+          >
+            {([['narrated', false], ['raw', true]] as const).map(([label, isRaw]) => (
+              <button
+                key={label}
+                type="button"
+                data-testid={`feed-view-${label}`}
+                aria-pressed={raw === isRaw}
+                onClick={() => setRaw(isRaw)}
+                className="text-[10px] font-mono rounded px-1.5 py-0.5"
+                style={{
+                  background: raw === isRaw ? 'var(--surface-raised)' : 'transparent',
+                  color: raw === isRaw ? 'var(--ink-high)' : 'var(--ink-dim)',
+                  border: 'none',
+                  cursor: 'pointer',
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* The user's intent opens the story. */}
+      <div className="flex justify-end">
+        <div
+          className="max-w-[72%] rounded-2xl text-base px-5 py-3.5 leading-relaxed"
+          style={{ background: 'transparent', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
+        >
+          {session.problem}
+        </div>
+      </div>
+
+      {raw && lens === 'feed'
+        ? // Raw wire view: every recorded frame, undecorated, same order.
+          sortFeedEvents(feedEvents).map((e, i) => (
+            <div
+              key={typeof e.seq === 'number' ? `s${e.seq}` : `r${i}`}
+              data-testid="raw-event"
+              className="flex items-baseline gap-2 px-1 font-mono text-[11px]"
+            >
+              <span className="shrink-0" style={{ color: 'var(--ink-dim)' }}>
+                {typeof e.seq === 'number' ? String(e.seq).padStart(5, ' ') : '     '}
+              </span>
+              <span className="shrink-0 font-semibold" style={{ color: 'var(--ink-body)' }}>{e.type}</span>
+              {typeof e.ord === 'number' && <span className="shrink-0" style={{ color: 'var(--ink-dim)' }}>u{e.ord}</span>}
+              <span className="truncate" style={{ color: 'var(--ink-muted)' }}>
+                {narrate(e, ctx)?.text ?? ''}
+              </span>
+            </div>
+          ))
+        : items.map((item) => {
+            if (item.kind === 'line') return narrationLine(item.key, item.line.text, item.line.tone);
+            if (item.kind === 'artifact') {
+              return (
+                <ArtifactCard key={item.key} artifact={item.artifact} onOpenFile={onOpenFile} />
+              );
+            }
+            return unitBlock(item.ord);
+          })}
+
+      {syntheticGateLine && !raw &&
+        narrationLine('synthetic-gate', 'Gate: waiting on you — decide below', 'gate')}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/NarratorFeed.tsx
+++ b/src/components/NarratorFeed.tsx
@@ -133,7 +133,10 @@ export function NarratorFeed({
   const [raw, setRaw] = useState(false);
 
   const feedEvents = lens === 'feed' ? events : EMPTY_EVENTS;
-  const ctx: NarratorContext = useMemo(() => ({ phaseOf }), [phaseOf]);
+  const ctx: NarratorContext = useMemo(
+    () => ({ phaseOf, intent: session.problem ?? null }),
+    [phaseOf, session.problem],
+  );
   const items: FeedItem[] = useMemo(
     () => buildFeed(feedEvents, orderedUnits, executingUnitOrd, ctx),
     [feedEvents, orderedUnits, executingUnitOrd, ctx],
@@ -155,6 +158,15 @@ export function NarratorFeed({
     Record<number, { text: string | null; loading: boolean; visible: boolean }>
   >({});
   const autoLoadedOrds = useRef<Set<number>>(new Set());
+  // Component-lifetime guard: transcript fetches resolve after unmount when the
+  // user navigates away mid-load — never setState on a dead tree.
+  const disposedRef = useRef(false);
+  useEffect(
+    () => () => {
+      disposedRef.current = true;
+    },
+    [],
+  );
   useEffect(() => {
     for (const unit of orderedUnits) {
       if (unit.status === 'done' && !autoLoadedOrds.current.has(unit.ord)) {
@@ -163,6 +175,7 @@ export function NarratorFeed({
         void api
           .getUnitOutput(session.id, unitKey(session.id, unit.id, unit.ord))
           .then(({ output, outputUnavailable }) => {
+            if (disposedRef.current) return;
             // "(no transcript captured)" is FALSE for a denied unit — say what
             // the daemon says (FINDING-006).
             setTranscripts((prev) => ({
@@ -175,6 +188,7 @@ export function NarratorFeed({
             }));
           })
           .catch(() => {
+            if (disposedRef.current) return;
             setTranscripts((prev) => ({
               ...prev,
               [unit.ord]: { text: '(transcript unavailable)', loading: false, visible: true },

--- a/src/components/NowBar.tsx
+++ b/src/components/NowBar.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'react';
+import type { SessionView, WorkUnit } from '../api/types.js';
+import type { NarrationLine, NarrationTone, RunArtifact } from './narrator.js';
+import { ArtifactCard } from './ArtifactCard.js';
+
+/**
+ * The sticky now-bar (DES-RUN-NARRATOR §2): a pinned strip that always answers
+ * "what is happening RIGHT NOW" — run state, the active phase (unit K of N),
+ * the latest narration line, and the collected-artifacts chip — visible
+ * regardless of where the feed is scrolled, because it lives OUTSIDE the
+ * scroll region. "Latest ↓" scrolls the feed to its live tail.
+ */
+
+const TONE_COLOR: Record<NarrationTone, string> = {
+  info: 'var(--ink-muted)',
+  work: 'var(--status-run)',
+  gate: 'var(--status-gate)',
+  fail: 'var(--status-fail)',
+  human: 'var(--accent)',
+};
+
+function statusPhrase(status: string): { text: string; color: string } {
+  switch (status) {
+    case 'completed':      return { text: 'completed', color: 'var(--status-done)' };
+    case 'failed':         return { text: 'failed', color: 'var(--status-fail)' };
+    case 'cancelled':      return { text: 'cancelled', color: 'var(--ink-dim)' };
+    case 'awaiting_human': return { text: 'waiting on you', color: 'var(--status-gate)' };
+    case 'planning':       return { text: 'planning', color: 'var(--status-run)' };
+    case 'distributing':   return { text: 'routing', color: 'var(--status-run)' };
+    default:               return { text: 'working', color: 'var(--status-run)' };
+  }
+}
+
+export function NowBar({
+  view,
+  orderedUnits,
+  executingUnitOrd,
+  phaseOf,
+  lastLine,
+  artifacts,
+  onJumpToLatest,
+  onOpenFile,
+}: {
+  view: SessionView;
+  /** ord-sorted units (the caller's memo). */
+  orderedUnits: WorkUnit[];
+  executingUnitOrd: number | null;
+  phaseOf: (ord: number | null | undefined) => string;
+  /** The newest spoken narration line, or null when the trail is silent. */
+  lastLine: NarrationLine | null;
+  artifacts: RunArtifact[];
+  onJumpToLatest: () => void;
+  onOpenFile?: ((path: string) => void) | undefined;
+}): React.ReactElement {
+  const { session } = view;
+  const { text: statusText, color: statusColor } = statusPhrase(session.status);
+  const live = !['completed', 'cancelled', 'failed'].includes(session.status);
+
+  const cursorIx = executingUnitOrd === null ? -1 : orderedUnits.findIndex((u) => u.ord === executingUnitOrd);
+  const activeUnit = cursorIx === -1 ? null : orderedUnits[cursorIx] ?? null;
+
+  // The "now" phrase: the active phase while one runs, otherwise the run state.
+  const phaseLabel =
+    activeUnit !== null
+      ? `${phaseOf(activeUnit.ord)} — unit ${cursorIx + 1} of ${orderedUnits.length}`
+      : session.status === 'awaiting_human'
+        ? 'paused at a gate'
+        : orderedUnits.length > 0
+          ? `${orderedUnits.filter((u) => u.status === 'done').length} of ${orderedUnits.length} phases done`
+          : null;
+
+  // Fallback narration when the trail is silent (pruned log / no events yet).
+  const nowText =
+    lastLine?.text ??
+    (activeUnit !== null
+      ? `Working on ${phaseOf(activeUnit.ord)}${activeUnit.description ? ` — ${activeUnit.description}` : ''}`
+      : session.status === 'awaiting_human'
+        ? 'Waiting on your decision below'
+        : `Run ${statusText}`);
+  const nowColor = lastLine !== null ? TONE_COLOR[lastLine.tone] : 'var(--ink-muted)';
+
+  const [artifactsOpen, setArtifactsOpen] = useState(false);
+  const popRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!artifactsOpen) return;
+    function onOutside(e: MouseEvent): void {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) setArtifactsOpen(false);
+    }
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, [artifactsOpen]);
+
+  return (
+    <div
+      data-testid="now-bar"
+      className="flex items-center gap-2.5 px-6 py-2 shrink-0 font-mono text-[12px] relative"
+      style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
+    >
+      <span
+        className={`inline-block w-2 h-2 rounded-full shrink-0 ${live ? 'animate-pulse' : ''}`}
+        style={{ background: statusColor }}
+        aria-hidden="true"
+      />
+      <span data-testid="now-bar-status" className="shrink-0 font-semibold" style={{ color: statusColor }}>
+        {statusText}
+      </span>
+      {phaseLabel !== null && (
+        <span data-testid="now-bar-phase" className="shrink-0" style={{ color: 'var(--ink-body)' }}>
+          {phaseLabel}
+        </span>
+      )}
+      <span
+        data-testid="now-bar-narration"
+        className="flex-1 min-w-0 truncate"
+        style={{ color: nowColor }}
+        title={nowText}
+      >
+        {nowText}
+      </span>
+      {artifacts.length > 0 && (
+        <div ref={popRef} className="relative shrink-0">
+          <button
+            type="button"
+            data-testid="now-bar-artifacts"
+            onClick={() => setArtifactsOpen((v) => !v)}
+            aria-expanded={artifactsOpen}
+            title={`${artifacts.length} artifact${artifacts.length === 1 ? '' : 's'} so far — files touched, deliverables`}
+            className="rounded-full px-2.5 py-0.5 text-[11px]"
+            style={{
+              background: 'var(--surface-raised)',
+              color: 'var(--ink-body)',
+              border: '1px solid var(--surface-overlay)',
+              cursor: 'pointer',
+            }}
+          >
+            ▤ {artifacts.length}
+          </button>
+          {artifactsOpen && (
+            <div
+              data-testid="now-bar-artifacts-pop"
+              className="absolute right-0 top-full mt-1 z-20 flex flex-col gap-1 rounded-lg p-2 max-h-64 overflow-y-auto"
+              style={{
+                background: 'var(--surface-card)',
+                border: '1px solid var(--surface-overlay)',
+                minWidth: '18rem',
+                boxShadow: 'var(--shadow-overlay)',
+              }}
+            >
+              {artifacts.map((a) => (
+                <ArtifactCard key={a.ref} artifact={a} onOpenFile={onOpenFile} compact />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        data-testid="now-bar-jump"
+        onClick={onJumpToLatest}
+        title="Scroll the feed to the latest activity"
+        className="shrink-0 rounded-full px-2.5 py-0.5 text-[11px]"
+        style={{
+          background: 'var(--surface-raised)',
+          color: 'var(--ink-muted)',
+          border: '1px solid var(--surface-overlay)',
+          cursor: 'pointer',
+        }}
+      >
+        Latest ↓
+      </button>
+    </div>
+  );
+}

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -140,8 +140,18 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, onResolved
     return run(() => api.confirmGate(runId, decision), { kind: 'approve-with-steer', amend: text });
   };
 
-  const reject = (): Promise<void> =>
-    run(() => api.confirmGate(runId, { approve: false }), { kind: 'reject' });
+  // The steer text rides REJECT too (DES-RUN-NARRATOR §7 — the reject-note gap):
+  // `{approve:false, amend}` is the same wire GateRejectNote already speaks, and
+  // the daemon's gate audit durably records the note on the decision. An empty
+  // textarea still sends the bare reject.
+  const reject = (): Promise<void> => {
+    const text = amend.trim();
+    const decision: GateDecision = text === '' ? { approve: false } : { approve: false, amend: text };
+    return run(() => api.confirmGate(runId, decision), {
+      kind: 'reject',
+      ...(text !== '' ? { amend: text } : {}),
+    });
+  };
 
   const cancel = (): Promise<void> =>
     run(() => api.cancelRun(runId), { kind: 'cancel' });
@@ -275,7 +285,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, onResolved
         placeholder={
           isCoverageFail && coverage && coverage.unaccounted > 0
             ? `${coverage.unaccounted} nodes unaccounted — add guidance for the evaluator, e.g. "focus on services/ directory"`
-            : 'Optional steer — guide the next unit when approving with steer'
+            : 'Optional note — rides "Approve + steer" as guidance, or "Reject" as the recorded reason'
         }
         value={amend}
         onChange={(e) => applyAmend(e.target.value)}

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -24,6 +24,14 @@ export interface NarrationLine {
 export interface NarratorContext {
   /** Phase name for a unit ord (unit-id suffix, stage fallback) — '?'-safe. */
   phaseOf: (ord: number | null | undefined) => string;
+  /**
+   * The run's intent (`session.problem`), when the caller has it. The daemon's
+   * `unitPlanned.description` is "<phase> — <the full intent>" for every unit
+   * of a planned workflow; with the intent known, the narrator drops that
+   * restatement — the intent bubble already opens the feed, and six identical
+   * raw-prompt lines are exactly the noise the usability review flagged.
+   */
+  intent?: string | null;
 }
 
 /** Longest free-text fragment kept on one narration line. */
@@ -40,6 +48,23 @@ function num(v: unknown): number | null {
 
 function str(v: unknown): string {
   return typeof v === 'string' ? v : '';
+}
+
+function norm(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * True when one string restates the other's head — either may be the daemon's
+ * truncated copy of the other. Requires ≥24 significant chars in common so a
+ * short genuine description never false-positives against a long intent.
+ */
+function restates(a: string, b: string): boolean {
+  const na = norm(a);
+  const nb = norm(b);
+  const n = Math.min(na.length, nb.length);
+  if (n < 24) return false;
+  return na.slice(0, n) === nb.slice(0, n);
 }
 
 /**
@@ -70,7 +95,17 @@ export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine |
       return line(`Workflow "${id || 'unnamed'}"${n !== null ? ` — ${n} phase${n === 1 ? '' : 's'} planned` : ''}`, 'info');
     }
     case 'unitPlanned': {
-      const desc = clip(str(event.description));
+      // The daemon writes description as "<phase> — <intent…>"; the narrator
+      // already speaks the phase, so the duplicated prefix goes.
+      let raw = str(event.description);
+      const dash = raw.indexOf('—');
+      if (dash > 0 && raw.slice(0, dash).trim().toLowerCase() === phase.toLowerCase()) {
+        raw = raw.slice(dash + 1).trim();
+      }
+      // A description that merely restates the run's intent says nothing the
+      // feed's opening bubble didn't — "Planned <phase>" alone is the story.
+      if (restates(raw, str(ctx.intent ?? ''))) raw = '';
+      const desc = clip(raw, 120);
       return line(`Planned ${phase}${desc ? ` — ${desc}` : ''}`, 'info');
     }
     case 'councilConvened': {

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -1,0 +1,351 @@
+import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
+
+/**
+ * The run narrator (DES-RUN-NARRATOR §4-§6): a DETERMINISTIC template layer —
+ * no LLM call anywhere — that turns the run's CoreEvent trail into the short
+ * human status lines the narrated feed renders. Pure functions only: the feed,
+ * the now-bar and the tests all derive from the same derivations here.
+ */
+
+/** The §4 tone layer: which status color a narration line wears. */
+export type NarrationTone = 'info' | 'work' | 'gate' | 'fail' | 'human';
+
+export interface NarrationLine {
+  /** The short human line ("Worker started clarify — survey the repo"). */
+  text: string;
+  tone: NarrationTone;
+  /** The unit the line is about, when the frame named one. */
+  ord: number | null;
+  /** The raw frame, for the feed's raw-view toggle. */
+  event: CoreEvent;
+}
+
+/** Resolves an ord to the phase vocabulary the stepper already speaks. */
+export interface NarratorContext {
+  /** Phase name for a unit ord (unit-id suffix, stage fallback) — '?'-safe. */
+  phaseOf: (ord: number | null | undefined) => string;
+}
+
+/** Longest free-text fragment kept on one narration line. */
+const CLIP = 140;
+
+function clip(text: string, max = CLIP): string {
+  const line = text.replace(/\r/g, '').split('\n')[0] ?? '';
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * The gate prompt's actionable headline — the bracketed architectural footnote
+ * (the SteeringGate's `cleanPrompt` contract) stays out of the one-liner.
+ */
+function promptHeadline(raw: string): string {
+  const bracket = raw.indexOf('[');
+  return clip((bracket === -1 ? raw : raw.slice(0, bracket)).trim());
+}
+
+/**
+ * One CoreEvent → one short narration line, or `null` for frames the feed does
+ * not speak (deltas, heartbeats, terminal bytes, burn — those have their own
+ * panels). Unknown/future frame types are silent: additive-safe (§5.1).
+ */
+export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine | null {
+  const ord = num(event.ord);
+  const phase = ctx.phaseOf(ord);
+  const line = (text: string, tone: NarrationTone): NarrationLine => ({ text, tone, ord, event });
+
+  switch (event.type) {
+    case 'sessionStarted':
+      return line('Run started', 'work');
+    case 'workflowSelected': {
+      const id = str(event.workflowId) || str(event.workflow_id);
+      const n = num(event.unitCount);
+      return line(`Workflow "${id || 'unnamed'}"${n !== null ? ` — ${n} phase${n === 1 ? '' : 's'} planned` : ''}`, 'info');
+    }
+    case 'unitPlanned': {
+      const desc = clip(str(event.description));
+      return line(`Planned ${phase}${desc ? ` — ${desc}` : ''}`, 'info');
+    }
+    case 'councilConvened': {
+      const n = Array.isArray(event.clis) ? event.clis.length : null;
+      return line(`Council convened — polling ${n ?? '?'} agent${n === 1 ? '' : 's'}`, 'info');
+    }
+    case 'councilDeliberated':
+      return line(
+        `Ballot ${num(event.round) ?? '?'}: ${num(event.agreementPct) ?? '?'}% — below the ${num(event.neededPct) ?? 75}% bar, runoff`,
+        'info',
+      );
+    case 'councilVoted':
+      return line(
+        `Council voted — ${num(event.agreementPct) ?? '?'}% agreement (${num(event.votes) ?? '?'} vote${num(event.votes) === 1 ? '' : 's'})`,
+        'info',
+      );
+    case 'councilSeatFailed':
+      return line(`Seat ${str(event.cli) || '?'} did not vote (${str(event.kind) || 'unreported'})`, 'fail');
+    case 'unitDistributed': {
+      const pct = num(event.agreement_pct);
+      return line(
+        `${phase} routed to ${str(event.cli) || '?'}${pct !== null ? ` — council ${pct}%` : ''}`,
+        'info',
+      );
+    }
+    case 'unitDispatched': {
+      const attempt = num(event.attempt) ?? 0;
+      return attempt > 0
+        ? line(`${phase} re-dispatched (attempt ${attempt + 1})`, 'work')
+        : line(`Worker started ${phase}`, 'work');
+    }
+    case 'unitExecuting':
+      return line(`${phase} is running`, 'work');
+    case 'unitOutputCaptured': {
+      const kb = num(event.outputBytes) !== null ? `${Math.max(1, Math.round((event.outputBytes as number) / 1024))} KB` : null;
+      if (event.stepStatus === 'failed') return line(`${phase} finished with errors`, 'fail');
+      if (event.stepStatus === 'cancelled') return line(`${phase} was cancelled mid-step`, 'info');
+      return line(`${phase} finished — output captured${kb !== null ? ` (${kb})` : ''}`, 'work');
+    }
+    case 'dataUsed': {
+      const n = Array.isArray(event.files) ? event.files.length : 0;
+      if (n === 0) return null;
+      return line(`${phase} touched ${n} file${n === 1 ? '' : 's'}`, 'info');
+    }
+    case 'gateEscalated':
+      return line(`Gate approaching — ${clip(str(event['condition'])) || 'a check escalated to you'}`, 'gate');
+    case 'awaitingHuman':
+      return line(`Gate: waiting on you${str(event.prompt) ? ` — ${promptHeadline(str(event.prompt))}` : ''}`, 'gate');
+    case 'gateEvaluated':
+      return event.combined === false
+        ? line(`Checks ran on ${phase} — deny${str(event.denialReason ?? '') ? `: ${clip(str(event.denialReason ?? ''))}` : ''}`, 'fail')
+        : line(`Checks ran on ${phase} — pass`, 'work');
+    case 'gateDecided':
+      return event.allow === true ? line('Gate: approved', 'work') : line('Gate: denied', 'fail');
+    case 'unitReworkAmended':
+      return line(`You amended ${phase} — re-dispatching with your note`, 'human');
+    case 'unitDone':
+      return line(`${phase} approved and done`, 'work');
+    case 'unitDenied':
+      return line(`${phase} denied`, 'fail');
+    case 'unitReassigned': {
+      const next = str(event['newCli']);
+      return line(`${phase} reassigned ${str(event['previousCli']) || '?'} → ${next || 'council re-vote'}`, 'info');
+    }
+    case 'resumed':
+      return line('Run resumed', 'work');
+    case 'stepFailed':
+      return line(`Step failed on ${phase}${str(event.detail) ? ` — ${clip(str(event.detail))}` : ''}`, 'fail');
+    case 'crashRecoveryRedrive':
+      return line(`Engine restarted — re-dispatching ${phase} (attempt ${num(event.attempt) ?? 1})`, 'fail');
+    case 'workerStalled':
+      return line(
+        `Worker quiet for ${num(event.stalledSecs) ?? '?'}s — may be waiting at a prompt (open Term or send a message)`,
+        'gate',
+      );
+    case 'failureTriaged':
+      return line(
+        `Failure triaged: ${str(event.decision) || '?'}${str(event.analysis) ? ` — ${clip(str(event.analysis), 120)}` : ''}`,
+        'info',
+      );
+    case 'workerMessageQueued':
+      return line(`Your message is queued for ${str(event['target']) || 'all'}'s next turn`, 'human');
+    case 'workerMessageInjected':
+      return line(`Your message was delivered to ${str(event['target']) || 'all'}`, 'human');
+    case 'elicitationCreated':
+      return line(`The agent asks: ${promptHeadline(str(event.message) || str(event.prompt)) || '(a question)'}`, 'gate');
+    case 'elicitationResolved':
+      return line('Answer sent — the agent continues', 'human');
+    case 'governanceHookFired':
+      // Allows are the noise floor; only a deny is a story beat.
+      return event['decision'] === 'deny'
+        ? line(`Blocked a tool call${str(event['denyingPolicy']) ? ` — ${str(event['denyingPolicy'])}` : ''}`, 'fail')
+        : null;
+    case 'governanceUnenforced':
+      return line(`Governance was requested but is not enforced for ${str(event.cli) || 'this seat'}`, 'gate');
+    case 'sessionCompleted':
+      return line('Run completed', 'work');
+    case 'sessionFailed':
+      return line('Run failed', 'fail');
+    case 'runCancelled':
+      return line('Run cancelled', 'info');
+    case 'error':
+      return line(`Error: ${clip(str(event.message)) || 'unspecified'}`, 'fail');
+    default:
+      return null; // silent: deltas, heartbeat, terminal*, cliUsage, workerSession*, acp*, …
+  }
+}
+
+/**
+ * Stable feed order (DES-RUN-NARRATOR §3 rule 2): frames that BOTH carry the
+ * durable run-wide `seq` (replayed from `GET /runs/:id/events`) compare by it;
+ * every other pair keeps input order — live `/ws` frames carry no comparable
+ * clock (`CoreEvent.seq` is terminal-scoped when present live), so arrival IS
+ * their order and fabricating a key would scramble it. `Array.prototype.sort`
+ * is stable, so the two regimes interleave without tearing.
+ */
+export function sortFeedEvents(events: readonly CoreEvent[]): CoreEvent[] {
+  return [...events].sort((a, b) => {
+    const as = typeof a.ts === 'number' && typeof a.seq === 'number' ? a.seq : null;
+    const bs = typeof b.ts === 'number' && typeof b.seq === 'number' ? b.seq : null;
+    if (as === null || bs === null) return 0;
+    return as - bs;
+  });
+}
+
+// ── Feed composition (§5) ────────────────────────────────────────────────────
+
+export interface FeedLineItem {
+  kind: 'line';
+  key: string;
+  line: NarrationLine;
+}
+export interface FeedUnitItem {
+  kind: 'unit';
+  key: string;
+  ord: number;
+}
+export interface FeedArtifactItem {
+  kind: 'artifact';
+  key: string;
+  artifact: RunArtifact;
+}
+export type FeedItem = FeedLineItem | FeedUnitItem | FeedArtifactItem;
+
+/** One artifact the run produced/touched (§6). */
+export interface RunArtifact {
+  /** `file` = a path on the daemon host (FileViewer-openable); `pr` = external link. */
+  kind: 'file' | 'pr';
+  /** Path for files; URL for PRs. */
+  ref: string;
+  /** Display name (basename for files). */
+  name: string;
+  /** The phase that produced it, when known. */
+  phase: string | null;
+}
+
+/** Inline artifact cards per dataUsed event are capped; the strip holds them all. */
+export const INLINE_ARTIFACT_CAP = 6;
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter((p) => p !== '');
+  return parts[parts.length - 1] ?? path;
+}
+
+/**
+ * Every artifact the run has produced so far, deduped by ref, first-seen order
+ * (§6). Files come from `dataUsed` frames; the delivered PR (when the DTO
+ * carries one) is appended last — it is the run's final artifact.
+ */
+export function deriveArtifacts(
+  events: readonly CoreEvent[],
+  view: SessionView | null,
+  ctx: NarratorContext,
+): RunArtifact[] {
+  const seen = new Set<string>();
+  const out: RunArtifact[] = [];
+  for (const e of events) {
+    if (e.type !== 'dataUsed' || !Array.isArray(e.files)) continue;
+    const phase = ctx.phaseOf(num(e.ord));
+    for (const f of e.files) {
+      if (typeof f !== 'string' || f === '' || seen.has(f)) continue;
+      seen.add(f);
+      out.push({ kind: 'file', ref: f, name: basename(f), phase });
+    }
+  }
+  const delivery = (view?.session as { delivery?: { kind: string; url: string } } | undefined)?.delivery;
+  if (delivery && typeof delivery.url === 'string' && delivery.url !== '' && !seen.has(delivery.url)) {
+    out.push({ kind: 'pr', ref: delivery.url, name: 'Pull request', phase: null });
+  }
+  return out;
+}
+
+/** The old timeline filter, verbatim (FINDING-052): units that have run or are running. */
+export function feedUnits(units: readonly WorkUnit[], executingUnitOrd: number | null): WorkUnit[] {
+  return [...units]
+    .sort((a, b) => a.ord - b.ord)
+    .filter((u) => u.status === 'done' || u.status === 'rejected' || u.ord === executingUnitOrd);
+}
+
+/**
+ * The one chronological feed (§5): narration lines in event order, each spoken
+ * unit's group block anchored after its LAST line (its story ends with its
+ * evidence), unspoken units appended in ord order, artifact cards following the
+ * `dataUsed` line that produced them. Pure — the renderer maps over the result.
+ */
+export function buildFeed(
+  events: readonly CoreEvent[],
+  units: readonly WorkUnit[],
+  executingUnitOrd: number | null,
+  ctx: NarratorContext,
+): FeedItem[] {
+  const sorted = sortFeedEvents(events);
+  const items: FeedItem[] = [];
+  const seenArtifacts = new Set<string>();
+  let lineNo = 0;
+
+  for (const event of sorted) {
+    const line = narrate(event, ctx);
+    if (line === null) continue;
+    lineNo += 1;
+    items.push({ kind: 'line', key: `l${lineNo}`, line });
+    // Artifact cards ride directly behind the dataUsed line that produced them (§6).
+    if (event.type === 'dataUsed' && Array.isArray(event.files)) {
+      const phase = ctx.phaseOf(num(event.ord));
+      let inlined = 0;
+      for (const f of event.files) {
+        if (typeof f !== 'string' || f === '' || seenArtifacts.has(f)) continue;
+        seenArtifacts.add(f);
+        if (inlined >= INLINE_ARTIFACT_CAP) continue; // strip still collects them
+        inlined += 1;
+        items.push({
+          kind: 'artifact',
+          key: `a${lineNo}:${f}`,
+          artifact: { kind: 'file', ref: f, name: basename(f), phase },
+        });
+      }
+    }
+  }
+
+  // Anchor each spoken unit's group after its LAST narration line; append the rest.
+  const anchored: FeedItem[] = [];
+  const speaks = new Map<number, number>(); // ord -> index of last line item in `items`
+  items.forEach((it, i) => {
+    if (it.kind === 'line' && it.line.ord !== null) speaks.set(it.line.ord, i);
+  });
+  const unitsToAnchor = feedUnits(units, executingUnitOrd);
+  const byLastLine = new Map<number, WorkUnit[]>();
+  const unanchored: WorkUnit[] = [];
+  for (const u of unitsToAnchor) {
+    const at = speaks.get(u.ord);
+    if (at === undefined) unanchored.push(u);
+    else byLastLine.set(at, [...(byLastLine.get(at) ?? []), u]);
+  }
+  items.forEach((it, i) => {
+    anchored.push(it);
+    for (const u of byLastLine.get(i) ?? []) {
+      anchored.push({ kind: 'unit', key: `u${u.ord}`, ord: u.ord });
+    }
+  });
+  for (const u of unanchored) {
+    anchored.push({ kind: 'unit', key: `u${u.ord}`, ord: u.ord });
+  }
+  return anchored;
+}
+
+/**
+ * The now-bar's "last narration" line (§2): the newest spoken line of the trail,
+ * or `null` when nothing has been spoken yet (empty/pruned trail — the caller
+ * falls back to a unit-derived status phrase).
+ */
+export function lastNarration(events: readonly CoreEvent[], ctx: NarratorContext): NarrationLine | null {
+  const sorted = sortFeedEvents(events);
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const line = narrate(sorted[i]!, ctx);
+    if (line !== null) return line;
+  }
+  return null;
+}

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -25,16 +25,37 @@ const CAP = 50000;
 
 const IGNORED: ReadonlySet<string> = new Set(['cliOutputDelta', 'unitOutputDelta', 'heartbeat']);
 
+/**
+ * Content identity of a frame, ignoring the two fields only the DURABLE copy
+ * carries (`ts`/`seq` are stamped by the event log at capture — the live `/ws`
+ * copy of the same emission lacks both). Key order is normalized so the same
+ * frame always fingerprints the same. Used by {@link RunEventStore.hydrate}'s
+ * merge to de-duplicate live frames that raced the backfill fetch.
+ */
+function fingerprint(event: CoreEvent): string {
+  const bag: Record<string, unknown> = {};
+  for (const key of Object.keys(event).sort()) {
+    if (key === 'ts' || key === 'seq') continue;
+    bag[key] = (event as Record<string, unknown>)[key];
+  }
+  return JSON.stringify(bag);
+}
+
 interface RunEventStore {
   /** Ordered, capped structured frames keyed by run id. */
   byRun: Record<string, CoreEvent[]>;
   /** Fold one CoreEvent (drops output deltas / heartbeats / run-less frames). */
   ingest: (event: CoreEvent) => void;
-  /** Seed a run's log from the durably-persisted event trail (`GET /runs/:id/events`), ONLY when the
-   * run has no frames yet. The studio's `/ws` stream has no late-join replay, so a page reloaded
-   * against a finished (or already-running) run showed an empty Burn panel ("usage not yet reported")
-   * even though the usage was persisted. This backfills it. Guarded on emptiness so it never
-   * double-counts a live `cliUsage` already ingested from the socket (FINDING-013). */
+  /** Seed a run's log from the durably-persisted event trail (`GET /runs/:id/events`).
+   * The studio's `/ws` stream has no late-join replay, so a page reloaded against a
+   * finished (or already-running) run showed an empty Burn panel even though the usage
+   * was persisted. FINDING-013's original guard was all-or-nothing — ONE live frame
+   * arriving before the fetch resolved dropped the ENTIRE backfill and the feed began
+   * mid-story (DES-RUN-NARRATOR §3 rule 1). Now the recorded trail (every frame
+   * carrying the run-wide `seq`) is merged as the authoritative PREFIX: live frames
+   * that duplicate it (the same emission seen on both wires) are removed by content
+   * fingerprint, the live remainder appends in arrival order. A live `cliUsage` is
+   * therefore still never double-counted — the guard is upgraded, not weakened. */
   hydrate: (runId: string, events: CoreEvent[]) => void;
   /** Drop a run's log. */
   clear: (runId: string) => void;
@@ -57,14 +78,35 @@ export const useRunEventStore = create<RunEventStore>((set) => ({
 
   hydrate: (runId, events) =>
     set((s) => {
-      // Never clobber live frames already streamed from /ws — hydration is a backfill for the
-      // reload-with-no-socket case only.
-      if ((s.byRun[runId] ?? []).length > 0) return s;
-      const frames = events.filter(
-        (e) => e.session === runId && !IGNORED.has(e.type),
-      );
-      if (frames.length === 0) return s;
-      return { byRun: { ...s.byRun, [runId]: frames } };
+      const recorded = events
+        .filter((e) => e.session === runId && !IGNORED.has(e.type))
+        .sort((a, b) => (typeof a.seq === 'number' && typeof b.seq === 'number' ? a.seq - b.seq : 0));
+      if (recorded.length === 0) return s;
+      const live = s.byRun[runId] ?? [];
+      if (live.length === 0) {
+        return { byRun: { ...s.byRun, [runId]: recorded } };
+      }
+      // Merge (§3 rule 1): the recorded trail is complete up to the fetch, so any
+      // live frame emitted before then exists in BOTH lists. Multiset-subtract the
+      // recorded fingerprints from the live list (never clobbering a live-only
+      // frame), then append what remains, in arrival order, behind the prefix.
+      const counts = new Map<string, number>();
+      for (const e of recorded) {
+        const f = fingerprint(e);
+        counts.set(f, (counts.get(f) ?? 0) + 1);
+      }
+      const tail = live.filter((e) => {
+        const f = fingerprint(e);
+        const n = counts.get(f) ?? 0;
+        if (n > 0) {
+          counts.set(f, n - 1);
+          return false; // the recorded copy (with ts/seq) stands in for it
+        }
+        return true; // live-only — never lost
+      });
+      const merged = [...recorded, ...tail];
+      if (merged.length > CAP) merged.splice(0, merged.length - CAP);
+      return { byRun: { ...s.byRun, [runId]: merged } };
     }),
 
   clear: (runId) =>

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,11 +10,11 @@
   "version": 1,
   "studioVersion": "0.4.3",
   "counts": {
-    "files": 112,
-    "occurrences": 809,
-    "static": 694,
+    "files": 114,
+    "occurrences": 827,
+    "static": 710,
     "dynamic": 40,
-    "computed": 5
+    "computed": 6
   },
   "static": [
     {
@@ -489,6 +489,12 @@
     },
     {
       "testId": "campaigns-empty",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaigns-empty-cta",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]
@@ -2085,6 +2091,24 @@
       ]
     },
     {
+      "testId": "not-found",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
+      "testId": "not-found-link",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
+      "testId": "not-found-path",
+      "files": [
+        "src/components/NotFoundPage.tsx"
+      ]
+    },
+    {
       "testId": "notif-chime",
       "files": [
         "src/components/NotificationSettings.tsx"
@@ -2896,6 +2920,12 @@
       ]
     },
     {
+      "testId": "skip-link",
+      "files": [
+        "src/components/SkipLink.tsx"
+      ]
+    },
+    {
       "testId": "source-attach",
       "files": [
         "src/components/ComposerContext.tsx"
@@ -3025,6 +3055,18 @@
       "testId": "steering-chip",
       "files": [
         "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "steering-diagnostics",
+      "files": [
+        "src/components/SteeringHealth.tsx"
+      ]
+    },
+    {
+      "testId": "steering-diagnostics-toggle",
+      "files": [
+        "src/components/SteeringHealth.tsx"
       ]
     },
     {
@@ -3378,6 +3420,12 @@
       ]
     },
     {
+      "testId": "steering-store-health",
+      "files": [
+        "src/components/SteeringHealth.tsx"
+      ]
+    },
+    {
       "testId": "steering-timeline",
       "files": [
         "src/components/SteeringTimeline.tsx"
@@ -3504,6 +3552,12 @@
       ]
     },
     {
+      "testId": "testing-evals-blocked",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-busy",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3546,6 +3600,12 @@
       ]
     },
     {
+      "testId": "testing-evals-gaps",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-nearest",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3558,7 +3618,25 @@
       ]
     },
     {
+      "testId": "testing-evals-nearest-link",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-evals-nearest-rule",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-passed",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-provenance",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -3594,7 +3672,19 @@
       ]
     },
     {
+      "testId": "testing-evals-verdict-word",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
       "testId": "testing-harness",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-harness-explainer",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -4176,6 +4266,12 @@
       ]
     },
     {
+      "testId": "work-hidden-chip",
+      "files": [
+        "src/components/WorkPage.tsx"
+      ]
+    },
+    {
       "testId": "work-range-hidden-note",
       "files": [
         "src/components/WorkPage.tsx"
@@ -4460,6 +4556,12 @@
       "expression": "a.testId",
       "files": [
         "src/components/ComposerContext.tsx"
+      ]
+    },
+    {
+      "expression": "s.testid",
+      "files": [
+        "src/components/WorkPage.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,11 +10,11 @@
   "version": 1,
   "studioVersion": "0.4.3",
   "counts": {
-    "files": 108,
-    "occurrences": 808,
-    "static": 693,
-    "dynamic": 39,
-    "computed": 6
+    "files": 112,
+    "occurrences": 809,
+    "static": 694,
+    "dynamic": 40,
+    "computed": 5
   },
   "static": [
     {
@@ -167,6 +167,24 @@
       "testId": "appearance-settings",
       "files": [
         "src/components/AppearanceSettings.tsx"
+      ]
+    },
+    {
+      "testId": "approval-dock",
+      "files": [
+        "src/components/ApprovalDock.tsx"
+      ]
+    },
+    {
+      "testId": "artifact-card",
+      "files": [
+        "src/components/ArtifactCard.tsx"
+      ]
+    },
+    {
+      "testId": "artifact-open",
+      "files": [
+        "src/components/ArtifactCard.tsx"
       ]
     },
     {
@@ -471,12 +489,6 @@
     },
     {
       "testId": "campaigns-empty",
-      "files": [
-        "src/components/CampaignsPage.tsx"
-      ]
-    },
-    {
-      "testId": "campaigns-empty-cta",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]
@@ -1290,6 +1302,36 @@
       ]
     },
     {
+      "testId": "followup-bar",
+      "files": [
+        "src/components/FollowUpComposer.tsx"
+      ]
+    },
+    {
+      "testId": "followup-close",
+      "files": [
+        "src/components/FollowUpComposer.tsx"
+      ]
+    },
+    {
+      "testId": "followup-composer",
+      "files": [
+        "src/components/FollowUpComposer.tsx"
+      ]
+    },
+    {
+      "testId": "followup-label",
+      "files": [
+        "src/components/FollowUpComposer.tsx"
+      ]
+    },
+    {
+      "testId": "followup-open",
+      "files": [
+        "src/components/FollowUpComposer.tsx"
+      ]
+    },
+    {
       "testId": "gate-approaching",
       "files": [
         "src/components/ProjectCard.tsx"
@@ -1786,14 +1828,14 @@
     {
       "testId": "live-output",
       "files": [
-        "src/components/ChatPanel.tsx",
+        "src/components/LiveNarration.tsx",
         "src/components/LiveOutput.tsx"
       ]
     },
     {
       "testId": "live-output-label",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/LiveNarration.tsx"
       ]
     },
     {
@@ -1971,6 +2013,12 @@
       ]
     },
     {
+      "testId": "narration-line",
+      "files": [
+        "src/components/NarratorFeed.tsx"
+      ]
+    },
+    {
       "testId": "narrative-band",
       "files": [
         "src/components/NarrativeBand.tsx"
@@ -2037,24 +2085,6 @@
       ]
     },
     {
-      "testId": "not-found",
-      "files": [
-        "src/components/NotFoundPage.tsx"
-      ]
-    },
-    {
-      "testId": "not-found-link",
-      "files": [
-        "src/components/NotFoundPage.tsx"
-      ]
-    },
-    {
-      "testId": "not-found-path",
-      "files": [
-        "src/components/NotFoundPage.tsx"
-      ]
-    },
-    {
       "testId": "notif-chime",
       "files": [
         "src/components/NotificationSettings.tsx"
@@ -2082,6 +2112,48 @@
       "testId": "notif-settings",
       "files": [
         "src/components/NotificationSettings.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-artifacts",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-artifacts-pop",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-jump",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-narration",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-phase",
+      "files": [
+        "src/components/NowBar.tsx"
+      ]
+    },
+    {
+      "testId": "now-bar-status",
+      "files": [
+        "src/components/NowBar.tsx"
       ]
     },
     {
@@ -2484,6 +2556,12 @@
       ]
     },
     {
+      "testId": "raw-event",
+      "files": [
+        "src/components/NarratorFeed.tsx"
+      ]
+    },
+    {
       "testId": "repo-card",
       "files": [
         "src/components/RepositoriesPanel.tsx"
@@ -2818,12 +2896,6 @@
       ]
     },
     {
-      "testId": "skip-link",
-      "files": [
-        "src/components/SkipLink.tsx"
-      ]
-    },
-    {
       "testId": "source-attach",
       "files": [
         "src/components/ComposerContext.tsx"
@@ -2953,18 +3025,6 @@
       "testId": "steering-chip",
       "files": [
         "src/components/DocumentThread.tsx"
-      ]
-    },
-    {
-      "testId": "steering-diagnostics",
-      "files": [
-        "src/components/SteeringHealth.tsx"
-      ]
-    },
-    {
-      "testId": "steering-diagnostics-toggle",
-      "files": [
-        "src/components/SteeringHealth.tsx"
       ]
     },
     {
@@ -3318,12 +3378,6 @@
       ]
     },
     {
-      "testId": "steering-store-health",
-      "files": [
-        "src/components/SteeringHealth.tsx"
-      ]
-    },
-    {
       "testId": "steering-timeline",
       "files": [
         "src/components/SteeringTimeline.tsx"
@@ -3450,12 +3504,6 @@
       ]
     },
     {
-      "testId": "testing-evals-blocked",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
       "testId": "testing-evals-busy",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3498,12 +3546,6 @@
       ]
     },
     {
-      "testId": "testing-evals-gaps",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
       "testId": "testing-evals-nearest",
       "files": [
         "src/components/TestingPage.tsx"
@@ -3516,25 +3558,7 @@
       ]
     },
     {
-      "testId": "testing-evals-nearest-link",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
       "testId": "testing-evals-nearest-rule",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
-      "testId": "testing-evals-passed",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
-      "testId": "testing-evals-provenance",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -3570,19 +3594,7 @@
       ]
     },
     {
-      "testId": "testing-evals-verdict-word",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
       "testId": "testing-harness",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
-      "testId": "testing-harness-explainer",
       "files": [
         "src/components/TestingPage.tsx"
       ]
@@ -3724,6 +3736,7 @@
       "files": [
         "src/components/ChatPanel.tsx",
         "src/components/DocumentThread.tsx",
+        "src/components/NarratorFeed.tsx",
         "src/components/threadAnchor.ts"
       ]
     },
@@ -4163,12 +4176,6 @@
       ]
     },
     {
-      "testId": "work-hidden-chip",
-      "files": [
-        "src/components/WorkPage.tsx"
-      ]
-    },
-    {
       "testId": "work-range-hidden-note",
       "files": [
         "src/components/WorkPage.tsx"
@@ -4279,6 +4286,12 @@
       ]
     },
     {
+      "pattern": "feed-view-*",
+      "files": [
+        "src/components/NarratorFeed.tsx"
+      ]
+    },
+    {
       "pattern": "feedback-mode-*",
       "files": [
         "src/components/FeedbackOverlay.tsx"
@@ -4359,19 +4372,19 @@
     {
       "pattern": "live-narration-*",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/LiveNarration.tsx"
       ]
     },
     {
       "pattern": "live-narration-text-*",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/LiveNarration.tsx"
       ]
     },
     {
       "pattern": "live-narration-toggle-*",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/LiveNarration.tsx"
       ]
     },
     {
@@ -4426,13 +4439,13 @@
     {
       "pattern": "unit-output-*",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/NarratorFeed.tsx"
       ]
     },
     {
       "pattern": "unit-output-toggle-*",
       "files": [
-        "src/components/ChatPanel.tsx"
+        "src/components/NarratorFeed.tsx"
       ]
     }
   ],
@@ -4447,12 +4460,6 @@
       "expression": "a.testId",
       "files": [
         "src/components/ComposerContext.tsx"
-      ]
-    },
-    {
-      "expression": "s.testid",
-      "files": [
-        "src/components/WorkPage.tsx"
       ]
     },
     {

--- a/tests/ChatPanel.dock.test.tsx
+++ b/tests/ChatPanel.dock.test.tsx
@@ -1,0 +1,105 @@
+// DES-RUN-NARRATOR §2: the pinned approval dock — anything awaiting the human
+// renders OUTSIDE the scrolling feed, as its sibling, so it can never scroll
+// away. Structure-level pinning: the dock is not a descendant of the scroll
+// region; the feed remains the only scrolling region.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useElicitationStore } from '../src/store/elicitations.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useElicitationStore.setState({ elicitations: {}, generations: {} });
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'out' });
+});
+
+const gatedView = (): ReturnType<typeof makeView> =>
+  makeView({ status: 'awaiting_human', unit_ix: 1 }, [
+    makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+  ]);
+
+function renderPanel(v = gatedView()): void {
+  render(<ChatPanel view={v} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+}
+
+describe('ApprovalDock — pinned, never scrolls away', () => {
+  it('renders the gate card in the dock, as a SIBLING of the scroll region (never inside it)', () => {
+    act(() => {
+      useGateStore.setState({
+        gates: { 'run-1': { runId: 'run-1', ord: 2, prompt: 'Approve the build phase?', lifecycle: 'open', receivedAt: 0 } },
+        approaching: {},
+      });
+    });
+    renderPanel();
+    const dock = screen.getByTestId('approval-dock');
+    const gate = screen.getByTestId('steering-gate');
+    const feed = screen.getByTestId('thread');
+    // The action lives in the dock…
+    expect(dock.contains(gate)).toBe(true);
+    // …and the dock is structurally OUTSIDE the one scrolling region, so no
+    // amount of feed growth can push the approval offscreen.
+    expect(feed.contains(dock)).toBe(false);
+    expect(dock.contains(feed)).toBe(false);
+    // The feed stays the only scroll container of the pair.
+    expect(feed.className).toContain('overflow-y-auto');
+    expect(dock.className).not.toContain('overflow-y-auto');
+  });
+
+  it('renders the dock even when the daemon restarted and only the status survives (no cached gate)', () => {
+    renderPanel(); // status awaiting_human, gate store empty
+    expect(screen.getByTestId('approval-dock')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-gate')).toBeInTheDocument();
+    // SteeringGate's own id-only fallback copy renders (§3.3).
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent(/prompt unavailable/i);
+  });
+
+  it('docks an open MCP elicitation the same way', () => {
+    act(() => {
+      useElicitationStore.getState().setElicitation({
+        runId: 'run-1',
+        elicitationId: 'e1',
+        message: 'Which database?',
+        options: ['postgres', 'sqlite'],
+        receivedAt: new Date().toISOString(),
+      });
+    });
+    renderPanel(makeView({ status: 'executing', unit_ix: 1 }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+      makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+    ]));
+    const dock = screen.getByTestId('approval-dock');
+    expect(dock).toHaveTextContent('Which database?');
+    expect(screen.getByTestId('thread').contains(dock)).toBe(false);
+  });
+
+  it('renders no dock when nothing awaits the human', () => {
+    renderPanel(makeView({ status: 'executing', unit_ix: 0 }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'distributed', assigned_cli: 'claude' }),
+    ]));
+    expect(screen.queryByTestId('approval-dock')).not.toBeInTheDocument();
+  });
+
+  it('renders no dock on a terminal run — a stale gate cannot invite a dead decision', () => {
+    act(() => {
+      useGateStore.setState({
+        gates: { 'run-1': { runId: 'run-1', ord: 2, prompt: 'stale', lifecycle: 'open', receivedAt: 0 } },
+        approaching: {},
+      });
+    });
+    renderPanel(makeView({ status: 'completed' }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done' }),
+    ]));
+    expect(screen.queryByTestId('approval-dock')).not.toBeInTheDocument();
+  });
+});

--- a/tests/ChatPanel.followup.test.tsx
+++ b/tests/ChatPanel.followup.test.tsx
@@ -1,0 +1,78 @@
+// Usability review 2026-08-31 finding #8 (DES-RUN-NARRATOR §7): the composer
+// says what it does, per run state. A TERMINAL run's footer is a labelled
+// follow-up bar (collapsed launch form behind one action) — never the bare
+// "What do you need built?" form that read as maybe-steering-this-run. Live
+// runs keep steer/inject primacy.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'out' });
+});
+
+function renderStatus(status: 'completed' | 'failed' | 'executing' | 'awaiting_human', extra: Record<string, unknown> = {}): void {
+  render(
+    <ChatPanel
+      view={makeView({ status, unit_ix: 0, ...extra }, [
+        makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: status === 'executing' ? 'distributed' : 'done', assigned_cli: 'claude' }),
+      ])}
+      onLaunched={vi.fn()}
+      onNavigateBack={vi.fn()}
+      onRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('composer labeling per run state (#8)', () => {
+  it('a COMPLETED run gets the collapsed follow-up bar — no launch form, no gate chip', () => {
+    renderStatus('completed');
+    expect(screen.getByTestId('followup-bar')).toHaveTextContent('This run is finished — steering is closed.');
+    expect(screen.getByTestId('followup-open')).toHaveTextContent('Start a follow-up run');
+    // The ambiguous full composer is GONE from the dead run's footer.
+    expect(screen.queryByPlaceholderText('What do you need built?')).not.toBeInTheDocument();
+  });
+
+  it('expanding the follow-up reveals the launch form under the explicit label', async () => {
+    renderStatus('failed');
+    await userEvent.click(screen.getByTestId('followup-open'));
+    expect(screen.getByTestId('followup-label')).toHaveTextContent(/Start a follow-up run.*a NEW run, separate from this one/);
+    expect(await screen.findByPlaceholderText('What do you need built?')).toBeInTheDocument();
+    // And it collapses back.
+    await userEvent.click(screen.getByTestId('followup-close'));
+    expect(screen.queryByPlaceholderText('What do you need built?')).not.toBeInTheDocument();
+    expect(screen.getByTestId('followup-bar')).toBeInTheDocument();
+  });
+
+  it('names the project when the dead run is filed in one', () => {
+    renderStatus('completed', { project_id: 'proj-9' });
+    expect(screen.getByTestId('followup-open')).toHaveTextContent('Start a follow-up run in this project');
+  });
+
+  it('an EXECUTING run keeps the inject composer (steering a live run, labelled as such)', () => {
+    renderStatus('executing');
+    expect(screen.getByPlaceholderText(/send message to all agents/i)).toBeInTheDocument();
+    expect(screen.getByTestId('steering-live-chip')).toHaveTextContent('steering live run');
+    expect(screen.queryByTestId('followup-bar')).not.toBeInTheDocument();
+  });
+
+  it('an AWAITING_HUMAN run keeps the steer composer next to the approval dock', () => {
+    renderStatus('awaiting_human');
+    const steer = screen.getByPlaceholderText(/send steering guidance/i);
+    const dock = screen.getByTestId('approval-dock');
+    expect(steer).toBeInTheDocument();
+    // The dock (the decision) PRECEDES the steer composer (the words) — one glance covers both.
+    expect(dock.compareDocumentPosition(steer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByTestId('followup-bar')).not.toBeInTheDocument();
+  });
+});

--- a/tests/NarratorFeed.test.tsx
+++ b/tests/NarratorFeed.test.tsx
@@ -1,0 +1,126 @@
+// DES-RUN-NARRATOR §2/§4/§5: the narrated feed — one chronological stream of
+// deterministic status lines, verbose output behind expanders, artifacts
+// inline, the raw wire view behind a toggle.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeView, makeUnit } from './factories.js';
+
+const rec = (bag: Record<string, unknown>, seq: number): CoreEvent =>
+  ({ ...bag, ts: 1000 + seq, seq }) as unknown as CoreEvent;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  useRuntimeStore.setState({
+    outputs: {}, deltaSeq: {}, docActivity: {}, councilStatus: {}, assumptions: {}, logs: {}, executorTypes: {}, terminalIds: {}, seq: 0,
+  });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'unit output' });
+});
+
+const view = (): ReturnType<typeof makeView> =>
+  makeView({ status: 'executing', unit_ix: 1 }, [
+    makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+  ]);
+
+function renderPanel(v = view()): void {
+  render(<ChatPanel view={v} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+}
+
+describe('NarratorFeed — the one chronological narrated stream', () => {
+  it('renders narration lines for the trail, sorted even on out-of-order arrival', () => {
+    act(() => {
+      // Deliberately hydrated out of seq order — the feed must render sorted.
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'unitDispatched', session: 'run-1', ord: 2, attempt: 0 }, 5),
+        rec({ type: 'sessionStarted', session: 'run-1', problem: 'p' }, 1),
+        rec({ type: 'unitOutputCaptured', session: 'run-1', ord: 1, outputBytes: 2048, stepStatus: 'ok' }, 3),
+        rec({ type: 'unitDispatched', session: 'run-1', ord: 1, attempt: 0 }, 2),
+      ]);
+    });
+    renderPanel();
+    const lines = screen.getAllByTestId('narration-line').map((el) => el.textContent ?? '');
+    expect(lines[0]).toContain('Run started');
+    expect(lines[1]).toContain('Worker started survey');
+    expect(lines[2]).toContain('survey finished — output captured (2 KB)');
+    expect(lines[3]).toContain('Worker started build');
+  });
+
+  it('collapses verbose output behind the unit expander INSIDE the narration group', async () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'unitDispatched', session: 'run-1', ord: 1, attempt: 0 }, 1),
+      ]);
+    });
+    renderPanel();
+    // The done unit's transcript auto-loads, expanded, behind its toggle…
+    expect(await screen.findByText('unit output')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('unit-output-toggle-1'));
+    expect(screen.queryByText('unit output')).not.toBeInTheDocument();
+    // …and the unit group sits AFTER its dispatch line in the DOM.
+    const line = screen.getAllByTestId('narration-line')[0]!;
+    const unit = screen.getByTestId('unit-output-1');
+    expect(line.compareDocumentPosition(unit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders inline artifact cards behind the dataUsed line, wired to the FileViewer', () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'dataUsed', session: 'run-1', ord: 1, files: ['/w/src/retry.ts'] }, 1),
+      ]);
+    });
+    renderPanel();
+    const card = screen.getByTestId('artifact-card');
+    expect(card).toHaveTextContent('retry.ts');
+    expect(card).toHaveAttribute('data-artifact-kind', 'file');
+    expect(screen.getByTestId('artifact-open')).toBeInTheDocument();
+  });
+
+  it('keeps the raw wire view one toggle away, and switches back', async () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'sessionStarted', session: 'run-1', problem: 'p' }, 1),
+        rec({ type: 'unitDispatched', session: 'run-1', ord: 1, attempt: 0 }, 2),
+      ]);
+    });
+    renderPanel();
+    expect(screen.getAllByTestId('narration-line').length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByTestId('feed-view-raw'));
+    const raws = screen.getAllByTestId('raw-event');
+    expect(raws).toHaveLength(2);
+    expect(raws[0]).toHaveTextContent('sessionStarted');
+    expect(raws[1]).toHaveTextContent('unitDispatched');
+    expect(screen.queryAllByTestId('narration-line')).toHaveLength(0);
+
+    await userEvent.click(screen.getByTestId('feed-view-narrated'));
+    expect(screen.getAllByTestId('narration-line').length).toBeGreaterThan(0);
+  });
+
+  it('shows the gate moment inline in the feed (history) while the dock holds the action', () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'awaitingHuman', session: 'run-1', ord: 2, prompt: 'Approve the build phase?' }, 1),
+      ]);
+    });
+    renderPanel(makeView({ status: 'awaiting_human', unit_ix: 1 }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+      makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+    ]));
+    const gateLine = screen
+      .getAllByTestId('narration-line')
+      .find((el) => (el.textContent ?? '').includes('Gate: waiting on you'));
+    expect(gateLine).toBeDefined();
+    expect(gateLine).toHaveAttribute('data-tone', 'gate');
+  });
+});

--- a/tests/NowBar.test.tsx
+++ b/tests/NowBar.test.tsx
@@ -1,0 +1,97 @@
+// DES-RUN-NARRATOR §2: the sticky now-bar — always-visible "what is happening
+// RIGHT NOW": run state, active phase (unit K of N), the latest narration
+// line, the collected-artifacts chip, and the jump-to-latest affordance.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeView, makeUnit } from './factories.js';
+
+const rec = (bag: Record<string, unknown>, seq: number): CoreEvent =>
+  ({ ...bag, ts: 1000 + seq, seq }) as unknown as CoreEvent;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'out' });
+});
+
+const executingView = (): ReturnType<typeof makeView> =>
+  makeView({ status: 'executing', unit_ix: 1 }, [
+    makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:design', ord: 2, stage: 'recon', status: 'distributed', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:build', ord: 3, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+  ]);
+
+function renderPanel(v = executingView()): void {
+  render(<ChatPanel view={v} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
+}
+
+describe('NowBar — what is happening right now, always visible', () => {
+  it('names the run state, the active phase as unit K of N, and the latest narration line', () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'sessionStarted', session: 'run-1', problem: 'p' }, 1),
+        rec({ type: 'unitDispatched', session: 'run-1', ord: 2, attempt: 0 }, 2),
+      ]);
+    });
+    renderPanel();
+    expect(screen.getByTestId('now-bar-status')).toHaveTextContent('working');
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('design — unit 2 of 3');
+    expect(screen.getByTestId('now-bar-narration')).toHaveTextContent('Worker started design');
+  });
+
+  it('falls back to a unit-derived phrase when the trail is silent', () => {
+    renderPanel();
+    expect(screen.getByTestId('now-bar-narration')).toHaveTextContent(/Working on design/);
+  });
+
+  it('speaks the paused state on a gated run', () => {
+    renderPanel(makeView({ status: 'awaiting_human', unit_ix: 1 }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done' }),
+      makeUnit({ id: 'run-1:design', ord: 2, stage: 'recon', status: 'distributed' }),
+    ]));
+    expect(screen.getByTestId('now-bar-status')).toHaveTextContent('waiting on you');
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('paused at a gate');
+  });
+
+  it('counts collected artifacts in the chip and lists them in the popover', async () => {
+    act(() => {
+      useRunEventStore.getState().hydrate('run-1', [
+        rec({ type: 'dataUsed', session: 'run-1', ord: 1, files: ['/w/a.ts', '/w/b.ts'] }, 1),
+      ]);
+    });
+    renderPanel();
+    const chip = screen.getByTestId('now-bar-artifacts');
+    expect(chip).toHaveTextContent('2');
+    await userEvent.click(chip);
+    const pop = screen.getByTestId('now-bar-artifacts-pop');
+    expect(pop).toHaveTextContent('a.ts');
+    expect(pop).toHaveTextContent('b.ts');
+  });
+
+  it('offers the jump-to-latest affordance that scrolls the feed tail into view', async () => {
+    renderPanel();
+    const feed = screen.getByTestId('thread');
+    const scrollTo = vi.fn();
+    (feed as unknown as { scrollTo: typeof scrollTo }).scrollTo = scrollTo;
+    await userEvent.click(screen.getByTestId('now-bar-jump'));
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+  });
+
+  it('summarizes a terminal run honestly (phases done, no pulse verbs)', () => {
+    renderPanel(makeView({ status: 'completed' }, [
+      makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done' }),
+      makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'done' }),
+    ]));
+    expect(screen.getByTestId('now-bar-status')).toHaveTextContent('completed');
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('2 of 2 phases done');
+  });
+});

--- a/tests/SteeringGate.rejectNote.test.tsx
+++ b/tests/SteeringGate.rejectNote.test.tsx
@@ -1,0 +1,42 @@
+// DES-RUN-NARRATOR §7 — the reject-note gap: the steer textarea's text now
+// rides REJECT as `amend` (the same `{approve:false, amend}` wire
+// GateRejectNote already speaks; the daemon's gate audit records the note on
+// the decision). An empty textarea still sends the bare reject — pinned by
+// the pre-existing SteeringGate.test.tsx case, unchanged.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SteeringGate } from '../src/components/SteeringGate.js';
+import * as client from '../src/api/client.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SteeringGate reject carries the typed note (wire assertion)', () => {
+  it('Reject with a note → confirmGate(id, {approve:false, amend: note})', async () => {
+    const confirm = vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ ok: true } as never);
+    render(<SteeringGate runId="run-1" ord={2} prompt="Approve the design phase?" />);
+
+    await userEvent.type(
+      screen.getByTestId('steering-amend'),
+      'wrong direction — the retry path must be config-driven',
+    );
+    await userEvent.click(screen.getByTestId('steering-reject'));
+
+    await waitFor(() =>
+      expect(confirm).toHaveBeenCalledWith('run-1', {
+        approve: false,
+        amend: 'wrong direction — the retry path must be config-driven',
+      }),
+    );
+  });
+
+  it('Reject with an empty note stays the bare {approve:false}', async () => {
+    const confirm = vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ ok: true } as never);
+    render(<SteeringGate runId="run-1" ord={2} prompt="Approve?" />);
+    await userEvent.click(screen.getByTestId('steering-reject'));
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith('run-1', { approve: false }));
+  });
+});

--- a/tests/events-merge.test.ts
+++ b/tests/events-merge.test.ts
@@ -1,0 +1,71 @@
+// DES-RUN-NARRATOR §3 rule 1: `useRunEventStore.hydrate` merges instead of
+// dropping. FINDING-013's original guard was all-or-nothing — one live frame
+// arriving before GET /runs/:id/events resolved discarded the ENTIRE backfill,
+// so the feed began mid-story. The recorded trail is now the authoritative
+// prefix; live frames that duplicate it are removed by content fingerprint
+// (never double-counting a cliUsage), and live-only frames are never lost.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useRunEventStore } from '../src/store/events.js';
+import type { CoreEvent } from '../src/api/types.js';
+
+const live = (bag: Record<string, unknown>): CoreEvent => bag as unknown as CoreEvent;
+/** The recorded copy of the same emission: identical content + the log's ts/seq. */
+const recorded = (bag: Record<string, unknown>, seq: number): CoreEvent =>
+  ({ ...bag, ts: 1000 + seq, seq }) as unknown as CoreEvent;
+
+describe('run-event hydrate merge (out-of-order arrival dies at the source)', () => {
+  beforeEach(() => useRunEventStore.setState({ byRun: {} }));
+
+  it('merges the recorded prefix under live frames that raced the fetch', () => {
+    // A live frame lands first (the page opened mid-run)…
+    const liveGate = { type: 'gateDecided', session: 'run1', ord: 2, allow: true };
+    useRunEventStore.getState().ingest(live(liveGate));
+
+    // …then the backfill resolves with the FULL history, including the same
+    // gateDecided emission as its recorded copy.
+    useRunEventStore.getState().hydrate('run1', [
+      recorded({ type: 'sessionStarted', session: 'run1', problem: 'p' }, 1),
+      recorded({ type: 'unitDispatched', session: 'run1', ord: 1, attempt: 0 }, 2),
+      recorded(liveGate, 3),
+    ]);
+
+    const frames = useRunEventStore.getState().byRun['run1'] ?? [];
+    // History is NOT dropped (the pre-merge behavior lost all three)…
+    expect(frames.map((e) => e.type)).toEqual(['sessionStarted', 'unitDispatched', 'gateDecided']);
+    // …and the duplicated emission appears exactly once.
+    expect(frames.filter((e) => e.type === 'gateDecided')).toHaveLength(1);
+  });
+
+  it('keeps live-only frames (emitted after the fetch) behind the recorded prefix', () => {
+    useRunEventStore.getState().ingest(live({ type: 'unitDone', session: 'run1', ord: 1 }));
+    useRunEventStore.getState().hydrate('run1', [
+      recorded({ type: 'sessionStarted', session: 'run1', problem: 'p' }, 1),
+    ]);
+    const frames = useRunEventStore.getState().byRun['run1'] ?? [];
+    expect(frames.map((e) => e.type)).toEqual(['sessionStarted', 'unitDone']);
+  });
+
+  it('sorts a backfill that arrives out of seq order', () => {
+    useRunEventStore.getState().hydrate('run1', [
+      recorded({ type: 'unitDone', session: 'run1', ord: 1 }, 9),
+      recorded({ type: 'sessionStarted', session: 'run1', problem: 'p' }, 1),
+      recorded({ type: 'unitDispatched', session: 'run1', ord: 1, attempt: 0 }, 4),
+    ]);
+    const frames = useRunEventStore.getState().byRun['run1'] ?? [];
+    expect(frames.map((e) => e.seq)).toEqual([1, 4, 9]);
+  });
+
+  it('is idempotent: re-hydrating the same trail never duplicates', () => {
+    const trail = [
+      recorded({ type: 'sessionStarted', session: 'run1', problem: 'p' }, 1),
+      recorded({ type: 'cliUsage', session: 'run1', ord: 0, attempt: 0, inputTokens: 5, outputTokens: 5, costUsd: 0.1 }, 2),
+    ];
+    useRunEventStore.getState().hydrate('run1', trail);
+    useRunEventStore.getState().hydrate('run1', trail);
+    const frames = useRunEventStore.getState().byRun['run1'] ?? [];
+    // The Burn fold reads these — a doubled cliUsage would double the total (FINDING-013).
+    expect(frames.filter((e) => e.type === 'cliUsage')).toHaveLength(1);
+    expect(frames).toHaveLength(2);
+  });
+});

--- a/tests/narrator.test.ts
+++ b/tests/narrator.test.ts
@@ -1,0 +1,214 @@
+// DES-RUN-NARRATOR §4-§6: the deterministic narrator — a pure template layer
+// (no LLM call) over the run's CoreEvent trail — and the feed composition:
+// stable ordering fixed at the source, unit anchors, artifact derivation.
+
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+import {
+  buildFeed,
+  deriveArtifacts,
+  lastNarration,
+  narrate,
+  sortFeedEvents,
+  type NarratorContext,
+} from '../src/components/narrator.js';
+import { makeUnit, makeView } from './factories.js';
+
+const ctx: NarratorContext = {
+  phaseOf: (ord) => (typeof ord === 'number' ? `phase-${ord}` : 'this phase'),
+};
+
+const ev = (bag: Record<string, unknown>): CoreEvent => bag as unknown as CoreEvent;
+
+describe('narrate — the event → status-line templates (§4)', () => {
+  const CASES: Array<[Record<string, unknown>, string | RegExp, string]> = [
+    [{ type: 'sessionStarted', session: 'r' }, 'Run started', 'work'],
+    [{ type: 'workflowSelected', session: 'r', workflowId: 'feature', unitCount: 6 }, 'Workflow "feature" — 6 phases planned', 'info'],
+    [{ type: 'unitPlanned', session: 'r', ord: 1, description: 'survey the repo' }, 'Planned phase-1 — survey the repo', 'info'],
+    [{ type: 'councilConvened', session: 'r', ord: 1, clis: ['a', 'b', 'c'] }, 'Council convened — polling 3 agents', 'info'],
+    [{ type: 'councilDeliberated', session: 'r', ord: 1, round: 2, agreementPct: 50, neededPct: 75 }, 'Ballot 2: 50% — below the 75% bar, runoff', 'info'],
+    [{ type: 'councilVoted', session: 'r', ord: 1, agreementPct: 100, votes: 4 }, 'Council voted — 100% agreement (4 votes)', 'info'],
+    [{ type: 'councilSeatFailed', session: 'r', ord: 1, cli: 'codex', kind: 'timed_out' }, 'Seat codex did not vote (timed_out)', 'fail'],
+    [{ type: 'unitDistributed', session: 'r', ord: 2, cli: 'claude', agreement_pct: 83 }, 'phase-2 routed to claude — council 83%', 'info'],
+    [{ type: 'unitDispatched', session: 'r', ord: 2, attempt: 0 }, 'Worker started phase-2', 'work'],
+    [{ type: 'unitDispatched', session: 'r', ord: 2, attempt: 1 }, 'phase-2 re-dispatched (attempt 2)', 'work'],
+    [{ type: 'unitExecuting', session: 'r', ord: 2 }, 'phase-2 is running', 'work'],
+    [{ type: 'unitOutputCaptured', session: 'r', ord: 2, outputBytes: 4096, stepStatus: 'ok' }, 'phase-2 finished — output captured (4 KB)', 'work'],
+    [{ type: 'unitOutputCaptured', session: 'r', ord: 2, outputBytes: 10, stepStatus: 'failed' }, 'phase-2 finished with errors', 'fail'],
+    [{ type: 'dataUsed', session: 'r', ord: 2, files: ['/a/b.ts', '/a/c.ts'] }, 'phase-2 touched 2 files', 'info'],
+    [{ type: 'gateEscalated', session: 'r', ord: 3, condition: 'coverage >= 80%' }, 'Gate approaching — coverage >= 80%', 'gate'],
+    [{ type: 'awaitingHuman', session: 'r', ord: 3, prompt: 'Approve the design phase? [internals]' }, 'Gate: waiting on you — Approve the design phase?', 'gate'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true }, 'Checks ran on phase-2 — pass', 'work'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: false, denialReason: 'no tests' }, 'Checks ran on phase-2 — deny: no tests', 'fail'],
+    [{ type: 'gateDecided', session: 'r', ord: 2, allow: true }, 'Gate: approved', 'work'],
+    [{ type: 'gateDecided', session: 'r', ord: 2, allow: false }, 'Gate: denied', 'fail'],
+    [{ type: 'unitReworkAmended', session: 'r', ord: 2, amendment: 'focus on x' }, 'You amended phase-2 — re-dispatching with your note', 'human'],
+    [{ type: 'unitDone', session: 'r', ord: 2 }, 'phase-2 approved and done', 'work'],
+    [{ type: 'unitDenied', session: 'r', ord: 2 }, 'phase-2 denied', 'fail'],
+    [{ type: 'unitReassigned', session: 'r', ord: 2, previousCli: 'codex', newCli: 'claude' }, 'phase-2 reassigned codex → claude', 'info'],
+    [{ type: 'resumed', session: 'r' }, 'Run resumed', 'work'],
+    [{ type: 'stepFailed', session: 'r', ord: 2, detail: 'worker exited 1\nstack…' }, 'Step failed on phase-2 — worker exited 1', 'fail'],
+    [{ type: 'crashRecoveryRedrive', session: 'r', ord: 2, attempt: 2 }, 'Engine restarted — re-dispatching phase-2 (attempt 2)', 'fail'],
+    [{ type: 'workerStalled', session: 'r', ord: 2, stalledSecs: 120 }, /Worker quiet for 120s/, 'gate'],
+    [{ type: 'failureTriaged', session: 'r', decision: 'retry', analysis: 'transient' }, 'Failure triaged: retry — transient', 'info'],
+    [{ type: 'workerMessageQueued', session: 'r', target: 'claude', message: 'hi' }, "Your message is queued for claude's next turn", 'human'],
+    [{ type: 'workerMessageInjected', session: 'r', target: 'all', message: 'hi' }, 'Your message was delivered to all', 'human'],
+    [{ type: 'elicitationCreated', session: 'r', elicitationId: 'e1', message: 'Which db?' }, 'The agent asks: Which db?', 'gate'],
+    [{ type: 'elicitationResolved', session: 'r' }, 'Answer sent — the agent continues', 'human'],
+    [{ type: 'governanceHookFired', session: 'r', ord: 2, decision: 'deny', denyingPolicy: 'POL-1' }, 'Blocked a tool call — POL-1', 'fail'],
+    [{ type: 'governanceUnenforced', session: 'r', ord: 2, cli: 'codex' }, 'Governance was requested but is not enforced for codex', 'gate'],
+    [{ type: 'sessionCompleted', session: 'r' }, 'Run completed', 'work'],
+    [{ type: 'sessionFailed', session: 'r' }, 'Run failed', 'fail'],
+    [{ type: 'runCancelled', session: 'r' }, 'Run cancelled', 'info'],
+    [{ type: 'error', session: 'r', message: 'boom' }, 'Error: boom', 'fail'],
+  ];
+
+  it.each(CASES)('narrates %j', (bag, expected, tone) => {
+    const line = narrate(ev(bag), ctx);
+    expect(line).not.toBeNull();
+    if (typeof expected === 'string') expect(line!.text).toBe(expected);
+    else expect(line!.text).toMatch(expected);
+    expect(line!.tone).toBe(tone);
+  });
+
+  it('stays silent on noise frames (deltas, heartbeat, terminal bytes, burn, allow-hooks, unknown)', () => {
+    for (const bag of [
+      { type: 'unitOutputDelta', session: 'r', ord: 0, text: 'x' },
+      { type: 'cliOutputDelta', session: 'r', ord: 0, chunk: 'x' },
+      { type: 'heartbeat' },
+      { type: 'terminalOutput', id: 't1', bytesB64: 'eA==' },
+      { type: 'cliUsage', session: 'r', ord: 0, attempt: 0, inputTokens: 1, outputTokens: 1, costUsd: null },
+      { type: 'governanceHookFired', session: 'r', ord: 0, decision: 'allow', denyingPolicy: null },
+      { type: 'someFutureFrame', session: 'r' },
+    ]) {
+      expect(narrate(ev(bag), ctx)).toBeNull();
+    }
+  });
+});
+
+describe('sortFeedEvents — ordering fixed at the source (§3)', () => {
+  it('sorts recorded frames (ts+seq) by seq even when they arrive out of order', () => {
+    const events = [
+      ev({ type: 'unitDone', session: 'r', ord: 1, ts: 3, seq: 30 }),
+      ev({ type: 'sessionStarted', session: 'r', ts: 1, seq: 10 }),
+      ev({ type: 'unitDispatched', session: 'r', ord: 1, attempt: 0, ts: 2, seq: 20 }),
+    ];
+    expect(sortFeedEvents(events).map((e) => e.type)).toEqual([
+      'sessionStarted',
+      'unitDispatched',
+      'unitDone',
+    ]);
+  });
+
+  it('never scrambles live frames (no comparable clock — arrival IS the order)', () => {
+    const events = [
+      ev({ type: 'unitDispatched', session: 'r', ord: 1, attempt: 0 }),
+      ev({ type: 'gateDecided', session: 'r', ord: 1, allow: true }),
+      ev({ type: 'unitDone', session: 'r', ord: 1 }),
+    ];
+    expect(sortFeedEvents(events).map((e) => e.type)).toEqual([
+      'unitDispatched',
+      'gateDecided',
+      'unitDone',
+    ]);
+  });
+
+  it('keeps the recorded prefix + live tail interleave stable', () => {
+    const events = [
+      ev({ type: 'sessionStarted', session: 'r', ts: 1, seq: 2 }),
+      ev({ type: 'unitPlanned', session: 'r', ord: 1, description: 'd', ts: 1, seq: 1 }),
+      ev({ type: 'unitDone', session: 'r', ord: 1 }), // live — stays last
+    ];
+    expect(sortFeedEvents(events).map((e) => e.type)).toEqual([
+      'unitPlanned',
+      'sessionStarted',
+      'unitDone',
+    ]);
+  });
+});
+
+describe('buildFeed — the one chronological stream (§5)', () => {
+  const units = [
+    makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:review', ord: 3, stage: 'review', status: 'pending' }),
+  ];
+
+  it('anchors a spoken unit group after its LAST narration line', () => {
+    const events = [
+      ev({ type: 'unitDispatched', session: 'run-1', ord: 1, attempt: 0, ts: 1, seq: 1 }),
+      ev({ type: 'unitOutputCaptured', session: 'run-1', ord: 1, outputBytes: 10, stepStatus: 'ok', ts: 2, seq: 2 }),
+      ev({ type: 'unitDispatched', session: 'run-1', ord: 2, attempt: 0, ts: 3, seq: 3 }),
+    ];
+    const feed = buildFeed(events, units, 2, ctx);
+    const kinds = feed.map((i) => (i.kind === 'unit' ? `unit${i.ord}` : i.kind === 'line' ? i.line.text : 'artifact'));
+    expect(kinds).toEqual([
+      'Worker started phase-1',
+      'phase-1 finished — output captured (1 KB)',
+      'unit1', // after its last line
+      'Worker started phase-2',
+      'unit2', // the cursor unit, after its dispatch line
+    ]);
+  });
+
+  it('renders sorted even when the trail arrives out of order', () => {
+    const events = [
+      ev({ type: 'unitDispatched', session: 'run-1', ord: 2, attempt: 0, ts: 3, seq: 3 }),
+      ev({ type: 'unitDispatched', session: 'run-1', ord: 1, attempt: 0, ts: 1, seq: 1 }),
+      ev({ type: 'unitOutputCaptured', session: 'run-1', ord: 1, outputBytes: 10, stepStatus: 'ok', ts: 2, seq: 2 }),
+    ];
+    const feed = buildFeed(events, units, 2, ctx);
+    const lines = feed.filter((i) => i.kind === 'line').map((i) => (i.kind === 'line' ? i.line.text : ''));
+    expect(lines).toEqual([
+      'Worker started phase-1',
+      'phase-1 finished — output captured (1 KB)',
+      'Worker started phase-2',
+    ]);
+  });
+
+  it('appends unspoken units (empty trail) in ord order — queued units get nothing', () => {
+    const feed = buildFeed([], units, 2, ctx);
+    expect(feed.map((i) => (i.kind === 'unit' ? i.ord : null))).toEqual([1, 2]); // never ord 3 (pending)
+  });
+
+  it('rides artifact cards behind the dataUsed line that produced them, deduped', () => {
+    const events = [
+      ev({ type: 'dataUsed', session: 'run-1', ord: 1, files: ['/w/src/a.ts', '/w/src/b.ts'], ts: 1, seq: 1 }),
+      ev({ type: 'dataUsed', session: 'run-1', ord: 2, files: ['/w/src/a.ts'], ts: 2, seq: 2 }), // duplicate path
+    ];
+    const feed = buildFeed(events, units, null, ctx);
+    const artifacts = feed.filter((i) => i.kind === 'artifact');
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts.map((a) => (a.kind === 'artifact' ? a.artifact.name : ''))).toEqual(['a.ts', 'b.ts']);
+  });
+});
+
+describe('deriveArtifacts (§6)', () => {
+  it('collects dataUsed files (deduped, first-seen order) and the delivered PR', () => {
+    const events = [
+      ev({ type: 'dataUsed', session: 'run-1', ord: 1, files: ['/w/a.ts', '/w/b.ts'] }),
+      ev({ type: 'dataUsed', session: 'run-1', ord: 2, files: ['/w/a.ts', '/w/c.ts'] }),
+    ];
+    const view = makeView({ status: 'completed' });
+    (view.session as unknown as Record<string, unknown>)['delivery'] = { kind: 'pull_request', url: 'https://github.com/x/y/pull/7' };
+    const artifacts = deriveArtifacts(events, view, ctx);
+    expect(artifacts.map((a) => a.ref)).toEqual(['/w/a.ts', '/w/b.ts', '/w/c.ts', 'https://github.com/x/y/pull/7']);
+    expect(artifacts[3]!.kind).toBe('pr');
+    expect(artifacts[0]!.name).toBe('a.ts');
+  });
+});
+
+describe('lastNarration — the now-bar line (§2)', () => {
+  it('returns the newest SPOKEN line, skipping silent frames', () => {
+    const events = [
+      ev({ type: 'sessionStarted', session: 'r', ts: 1, seq: 1 }),
+      ev({ type: 'unitDispatched', session: 'r', ord: 1, attempt: 0, ts: 2, seq: 2 }),
+      ev({ type: 'cliUsage', session: 'r', ord: 1, attempt: 0, inputTokens: 1, outputTokens: 1, costUsd: null, ts: 3, seq: 3 }),
+    ];
+    expect(lastNarration(events, ctx)?.text).toBe('Worker started phase-1');
+  });
+
+  it('is null on a silent trail', () => {
+    expect(lastNarration([], ctx)).toBeNull();
+  });
+});

--- a/tests/narrator.test.ts
+++ b/tests/narrator.test.ts
@@ -71,6 +71,31 @@ describe('narrate — the event → status-line templates (§4)', () => {
     expect(line!.tone).toBe(tone);
   });
 
+  it('unitPlanned strips the daemon\'s duplicated "<phase> — " description prefix', () => {
+    const line = narrate(
+      ev({ type: 'unitPlanned', session: 'r', ord: 1, description: 'phase-1 — survey the repo' }),
+      ctx,
+    );
+    expect(line!.text).toBe('Planned phase-1 — survey the repo');
+  });
+
+  it('unitPlanned drops a description that merely restates the run intent (ctx.intent)', () => {
+    const intent = 'Implement GitHub issue #167 in this repo: the doc-creation wizard project picker lists stale projects';
+    const withIntent: NarratorContext = { ...ctx, intent };
+    // The daemon truncates the restated intent per-unit; head-match still catches it.
+    const line = narrate(
+      ev({ type: 'unitPlanned', session: 'r', ord: 2, description: `phase-2 — ${intent.slice(0, 80)}` }),
+      withIntent,
+    );
+    expect(line!.text).toBe('Planned phase-2');
+    // A REAL description (not the intent) survives untouched.
+    const real = narrate(
+      ev({ type: 'unitPlanned', session: 'r', ord: 3, description: 'write the acceptance test plan for the picker' }),
+      withIntent,
+    );
+    expect(real!.text).toBe('Planned phase-3 — write the acceptance test plan for the picker');
+  });
+
   it('stays silent on noise frames (deltas, heartbeat, terminal bytes, burn, allow-hooks, unknown)', () => {
     for (const bag of [
       { type: 'unitOutputDelta', session: 'r', ord: 0, text: 'x' },


### PR DESCRIPTION
The build-chat redesign (design doc: .product/DES-RUN-NARRATOR.md). One chronologically stable narrated feed — a deterministic template narrator over CoreEvents (mapping table covers all 30 wire discriminators, cross-checked against core's 72 serialized types), raw output collapsed behind expanders, ordering fixed at the source for backfill and live-merge. A sticky now-bar always shows what is happening right now (click scrolls to the live tail; gate prompts ride it). Anything awaiting a human renders in a pinned approval dock that never scrolls away — approve / amend / reject-with-note ({approve:false, amend} asserted on the wire, closing the old SteeringGate note gap). Artifacts appear as inline cards + a now-bar chip. Terminal runs replace the ambiguous composer with a labelled follow-up bar. ChatPanel shrank 1494→1003 via extracted NarratorFeed/NowBar/ApprovalDock/ArtifactCard. At 1440×700 the now-bar, dock, and latest narration are all visible without scrolling (screenshot-proven on the review's exact failed run). 2010+ tests green, testid inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)