### PR TITLE
fix: plain-language failure banner — the blocker's copy half

### DIFF
--- a/src/components/FailureBanner.tsx
+++ b/src/components/FailureBanner.tsx
@@ -1,5 +1,6 @@
 import type { SessionView } from '../api/types.js';
 import type { LoggedEvent } from '../store/runtime.js';
+import { denialAdvice, denialHeadline, parseDenial, type StructuredDenial } from './denialCopy.js';
 
 interface Props {
   view: SessionView;
@@ -64,13 +65,42 @@ export function FailureBanner({ view, log, navigate }: Props): React.ReactElemen
       <p className="font-semibold">Run halted.</p>
       {lastError && <p className="mt-1" style={{ color: 'var(--ink-muted)' }}>{lastError.detail}</p>}
       {denied.length > 0 && (
-        <ul className="mt-1 list-disc pl-4" style={{ color: 'var(--ink-muted)' }}>
-          {denied.map((u) => (
-            <li key={u.id}>
-              Unit #{u.ord}: {u.denial_reason ?? 'rejected'}
-            </li>
-          ))}
-        </ul>
+        <div className="mt-1 flex flex-col gap-2">
+          {denied.map((u) => {
+            // 0.7.6+ engines attach a structured denial to the rejected unit; older engines
+            // leave only the prose — parseDenial reads whichever this daemon serves.
+            const facts = parseDenial(
+              u.denial_reason,
+              (u as unknown as { denial?: StructuredDenial }).denial ?? null,
+            );
+            return (
+              <div key={u.id} data-testid="failure-plain">
+                <p style={{ color: 'var(--ink)' }}>{denialHeadline(facts, u.ord)}</p>
+                <p className="mt-0.5" style={{ color: 'var(--ink-muted)' }}>
+                  {denialAdvice(facts)}
+                  {navigate !== undefined &&
+                    facts.ruleIds.map((id) => (
+                      <a
+                        key={id}
+                        href={`/steering?rule=${id}`}
+                        data-testid="failure-rule-link"
+                        className="ml-2 transition-opacity hover:opacity-80"
+                        style={{ color: 'var(--accent)', textDecoration: 'none' }}
+                        onClick={(e) => { e.preventDefault(); navigate(`/steering?rule=${id}`); }}
+                      >
+                        Review {id} ›
+                      </a>
+                    ))}
+                </p>
+                {facts.raw.length > 0 && (
+                  <p className="mt-0.5 opacity-70" style={{ color: 'var(--ink-muted)' }} data-testid="failure-engine-detail">
+                    engine detail: {facts.raw}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
       )}
       {navigate !== undefined && <AllRunsLink navigate={navigate} />}
     </div>

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -112,6 +112,17 @@ export function SteeringPage({ type, navigate, search = '' }: {
     if (routed !== null && rules.some((r) => r.id === routed)) setSelectedId(routed);
   }, [search, rules]);
 
+  // A `?rule=<id>` deep link on the LANDING (the failure banner links here because a rule id
+  // alone does not name its type page): once rules load, resolve the id to its type and land on
+  // that page with the drawer open. Unknown ids stay on the landing — no dead redirect.
+  useEffect(() => {
+    if (type !== null || rulesLoading || rulesError !== null) return;
+    const routed = new URLSearchParams(search).get('rule');
+    if (routed === null) return;
+    const hit = rules.find((r) => r.id === routed);
+    if (hit !== undefined) navigate(`/steering/${steeringTypeOf(hit)}?rule=${encodeURIComponent(routed)}`);
+  }, [type, search, rules, rulesLoading, rulesError, navigate]);
+
   /** evidence_count join: the AW-23 per-rule evidence rows, when the scoreboard is served. */
   const evidenceOf = (id: string): { denial_claims: number; governs_evidence: number } | null => {
     if (scoreboard.kind !== 'loaded') return null;

--- a/src/components/denialCopy.ts
+++ b/src/components/denialCopy.ts
@@ -1,0 +1,111 @@
+/**
+ * denialCopy — turns an engine denial into words a person can act on (usability review Top-10 #1:
+ * the failure banner read "input governance denied a tool-call in unit-2 (claim boundary-deny:unit-2)").
+ *
+ * Two inputs, best-first: the STRUCTURED denial that wicked-core-ts ≥ 0.7.6 attaches to rejected
+ * units and gateEvaluated events ({source, claim_id/claimId, rule_ids/ruleIds}), and — for every
+ * engine before it — the known prose spellings of `denial_reason`. The raw prose always survives
+ * as the "engine detail" line; this module only decides the HEADLINE and the ADVICE.
+ *
+ * Claim-id vocabulary (wicked-core gate_hook.rs): `boundary-deny:` = a WRITE outside the unit's
+ * sandbox (unit-fatal), `boundary-read-deny:` = a blocked read (advisory), phase-scope denies are
+ * stamped by the `wicked-governance-phase-scope` evaluator and carry an `engine:` rule id.
+ */
+
+/** The structured denial as 0.7.6+ engines spell it (either casing survives the wire). */
+export interface StructuredDenial {
+  source?: string;
+  claim_id?: string;
+  claimId?: string;
+  rule_ids?: string[];
+  ruleIds?: string[];
+}
+
+export type DenialKind =
+  | 'sandbox-write'
+  | 'sandbox-read'
+  | 'phase-scope'
+  | 'rule'
+  | 'triage'
+  | 'worker-failed'
+  | 'unknown';
+
+export interface DenialFacts {
+  kind: DenialKind;
+  /** Steering/policy rule ids worth linking (engine-owned `engine:*` ids are named, not linked). */
+  ruleIds: string[];
+  claimId: string | null;
+  /** The engine's own prose, verbatim — the banner's dim "engine detail" line. */
+  raw: string;
+}
+
+const CLAIM_IN_PROSE = /\(claim ([^)]+)\)/;
+
+/** Rule ids that name a real steering/policy row a drawer can open (never engine-internal ids). */
+function linkable(ids: string[]): string[] {
+  return ids.filter((id) => id.length > 0 && !id.startsWith('engine:'));
+}
+
+export function parseDenial(raw: string | null | undefined, structured?: StructuredDenial | null): DenialFacts {
+  const text = raw ?? '';
+  const claimId =
+    structured?.claim_id ?? structured?.claimId ?? CLAIM_IN_PROSE.exec(text)?.[1] ?? null;
+  const ruleIds = linkable(structured?.rule_ids ?? structured?.ruleIds ?? []);
+
+  const kind: DenialKind = (() => {
+    if (claimId?.startsWith('boundary-read-deny:')) return 'sandbox-read';
+    if (claimId?.startsWith('boundary-deny:')) return 'sandbox-write';
+    if (claimId?.startsWith('phase-scope') || text.includes('phase-scope')) return 'phase-scope';
+    if (structured?.source === 'phase-scope') return 'phase-scope';
+    if (ruleIds.length > 0) return 'rule';
+    if (text.startsWith('triage escalation:')) return 'triage';
+    if (text.startsWith('Worker FAILED')) return 'worker-failed';
+    if (text.includes('denied a tool-call') || claimId !== null) return 'rule';
+    return text.length > 0 ? 'unknown' : 'unknown';
+  })();
+
+  return { kind, ruleIds, claimId, raw: text };
+}
+
+/** One plain sentence saying what stopped the unit. */
+export function denialHeadline(f: DenialFacts, ord: number): string {
+  switch (f.kind) {
+    case 'sandbox-write':
+      return `Unit #${ord} tried to write outside its workspace and was stopped to protect your files.`;
+    case 'sandbox-read':
+      return `Unit #${ord} tried to read outside its workspace — the read was blocked.`;
+    case 'phase-scope':
+      return `Unit #${ord} tried to change a kind of file this phase isn't allowed to touch.`;
+    case 'rule':
+      return f.ruleIds.length > 0
+        ? `A steering rule (${f.ruleIds.join(', ')}) stopped unit #${ord}.`
+        : `Governance stopped one of unit #${ord}'s actions.`;
+    case 'triage':
+      return `Unit #${ord} failed and was escalated for review.`;
+    case 'worker-failed':
+      return `The worker failed on unit #${ord}.`;
+    default:
+      return `Unit #${ord} was stopped.`;
+  }
+}
+
+/** One plain sentence saying what to do about it. */
+export function denialAdvice(f: DenialFacts): string {
+  switch (f.kind) {
+    case 'sandbox-write':
+    case 'phase-scope':
+      return 'Check the unit transcript to see what it attempted, then retry — amend the intent if the attempt was off-course.';
+    case 'sandbox-read':
+      return 'Usually harmless — the worker adapts. If the run failed for another reason, that reason is the one to chase.';
+    case 'rule':
+      return f.ruleIds.length > 0
+        ? 'Open the rule to review (or retire) it, or amend the intent and retry.'
+        : 'Check the unit transcript for the denied action, then amend the intent and retry.';
+    case 'triage':
+      return 'Read the failure output in the transcript, then retry — or reassign the unit to a different CLI.';
+    case 'worker-failed':
+      return 'Read the failure output in the transcript, then retry.';
+    default:
+      return 'Check the unit transcript, then retry.';
+  }
+}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.3",
   "counts": {
     "files": 114,
-    "occurrences": 827,
-    "static": 710,
+    "occurrences": 830,
+    "static": 713,
     "dynamic": 40,
     "computed": 6
   },
@@ -1165,6 +1165,24 @@
     },
     {
       "testId": "failure-banner",
+      "files": [
+        "src/components/FailureBanner.tsx"
+      ]
+    },
+    {
+      "testId": "failure-engine-detail",
+      "files": [
+        "src/components/FailureBanner.tsx"
+      ]
+    },
+    {
+      "testId": "failure-plain",
+      "files": [
+        "src/components/FailureBanner.tsx"
+      ]
+    },
+    {
+      "testId": "failure-rule-link",
       "files": [
         "src/components/FailureBanner.tsx"
       ]

--- a/tests/FailureBanner.test.tsx
+++ b/tests/FailureBanner.test.tsx
@@ -36,6 +36,38 @@ describe('FailureBanner (§11.5 — run-halted explainer)', () => {
 
   // Slice Y (DES-UX-001 §7.4): the banner's All-runs is a FAILURE-CONTEXT entry —
   // it lands on /work with the Failed filter active, never on the retired /runs.
+
+  // Review Top-10 #1: the deny banner speaks plain language FIRST; the engine prose survives
+  // as a dim detail line, and rule denials link into the Steering drawer.
+  it('translates a boundary-deny into plain words with the engine detail beneath', () => {
+    const view = makeView({ status: 'failed' }, [
+      makeUnit({
+        id: 'u2', ord: 2, status: 'rejected',
+        denial_reason: 'input governance denied a tool-call in unit-2 (claim boundary-deny:unit-2)',
+      }),
+    ]);
+    render(<FailureBanner view={view} log={[]} />);
+    expect(screen.getByTestId('failure-plain')).toHaveTextContent(
+      'Unit #2 tried to write outside its workspace and was stopped to protect your files.',
+    );
+    expect(screen.getByTestId('failure-engine-detail')).toHaveTextContent('claim boundary-deny:unit-2');
+  });
+
+  it('links a rule denial to the Steering drawer via /steering?rule=', () => {
+    const navigate = vi.fn();
+    const view = makeView({ status: 'failed' }, [
+      Object.assign(
+        makeUnit({ id: 'u3', ord: 3, status: 'rejected', denial_reason: 'denied by policy' }),
+        { denial: { claim_id: 'gate:unit-3', rule_ids: ['SEC-101'] } },
+      ),
+    ]);
+    render(<FailureBanner view={view} log={[]} navigate={navigate} />);
+    const link = screen.getByTestId('failure-rule-link');
+    expect(link).toHaveTextContent('SEC-101');
+    fireEvent.click(link);
+    expect(navigate).toHaveBeenCalledWith('/steering?rule=SEC-101');
+  });
+
   it('carries the failure-context "All runs ›" link to /work?filter=failed', () => {
     const navigate = vi.fn();
     render(<FailureBanner view={makeView({ status: 'failed' })} log={errorLog} navigate={navigate} />);

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -614,4 +614,29 @@ describe('SteeringPage — ?rule deep link opens the drawer (qe finding: eval ga
     await screen.findByTestId('steering-rule-row');
     expect(screen.queryByTestId('steering-rule-drawer')).toBeNull();
   });
+
+  // The failure banner links `/steering?rule=<id>` (a rule id alone does not name its type
+  // page): the LANDING resolves the id to its type once rules load and navigates there with
+  // the drawer param intact. Unknown ids stay put — no dead redirect.
+  it('landing resolves ?rule=<id> to the rule\'s type page', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [
+      { id: 'SEC-101', rule_type: 'policy', statement: 's', severity: 'critical', confidence: 1,
+        targets: {}, provenance: { source: 'policy', source_kinds: [] }, retired: false,
+        steering_type: 'security' },
+    ] });
+    wire();
+    const navigate = vi.fn();
+    render(<SteeringPage type={null} navigate={navigate} search="?rule=SEC-101" />);
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/steering/security?rule=SEC-101'));
+  });
+
+  it('landing stays put on an unknown ?rule id', async () => {
+    listConformanceRules.mockResolvedValue({ rules: [] });
+    wire();
+    const navigate = vi.fn();
+    render(<SteeringPage type={null} navigate={navigate} search="?rule=NOPE-1" />);
+    await screen.findByTestId('steering-landing');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
 });

--- a/tests/denialCopy.test.ts
+++ b/tests/denialCopy.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { denialAdvice, denialHeadline, parseDenial } from '../src/components/denialCopy.js';
+
+// The review's exact blocker prose (run 61fcefaa): the banner must translate this, not echo it.
+const BOUNDARY_PROSE = 'input governance denied a tool-call in unit-2 (claim boundary-deny:unit-2)';
+
+describe('denialCopy (review Top-10 #1 — plain-language failure copy)', () => {
+  it('translates the boundary-deny prose into the sandbox-write sentence', () => {
+    const f = parseDenial(BOUNDARY_PROSE);
+    expect(f.kind).toBe('sandbox-write');
+    expect(f.claimId).toBe('boundary-deny:unit-2');
+    expect(denialHeadline(f, 2)).toBe(
+      'Unit #2 tried to write outside its workspace and was stopped to protect your files.',
+    );
+    expect(denialAdvice(f)).toMatch(/retry/i);
+    expect(f.raw).toBe(BOUNDARY_PROSE); // the engine detail line keeps the verbatim prose
+  });
+
+  it('reads the STRUCTURED denial when a 0.7.6+ engine serves it (both casings)', () => {
+    const snake = parseDenial('whatever prose', { claim_id: 'x', rule_ids: ['SEC-101'] });
+    expect(snake.kind).toBe('rule');
+    expect(snake.ruleIds).toEqual(['SEC-101']);
+    const camel = parseDenial(null, { claimId: 'x', ruleIds: ['SEC-101', 'POL-9'] });
+    expect(camel.ruleIds).toEqual(['SEC-101', 'POL-9']);
+    expect(denialHeadline(camel, 3)).toContain('SEC-101');
+  });
+
+  it('never links engine-internal rule ids', () => {
+    const f = parseDenial(null, { claim_id: 'phase-scope:unit-1', rule_ids: ['engine:phase-scope'] });
+    expect(f.kind).toBe('phase-scope');
+    expect(f.ruleIds).toEqual([]); // named in prose maybe, never a drawer link
+  });
+
+  it('classifies triage and worker failures', () => {
+    expect(parseDenial('triage escalation: flaky network — retry likely').kind).toBe('triage');
+    expect(parseDenial('Worker FAILED on unit 4 (triage: bad merge): tail...').kind).toBe('worker-failed');
+  });
+
+  it('advisory read denies say so instead of alarming', () => {
+    const f = parseDenial('read blocked (claim boundary-read-deny:unit-1)');
+    expect(f.kind).toBe('sandbox-read');
+    expect(denialAdvice(f)).toMatch(/harmless/i);
+  });
+});


### PR DESCRIPTION
Closes the cross-lane gap from the ux-fix wave: core#334 made denials structured and transcripts survive rejection, but nobody rewrote the banner's words. `denialCopy` maps the deny vocabulary (boundary-deny / boundary-read-deny / phase-scope / rule / triage / worker-failed) to a plain headline + actionable advice — "Unit #2 tried to write outside its workspace and was stopped to protect your files." — reading the structured denial from 0.7.6+ engines with an honest prose-pattern fallback for older daemons. The verbatim engine reason stays as a dim detail line; rule denials link into the Steering drawer (`/steering?rule=<id>`, with the landing resolving bare ids to their type page). 2098 tests green, testid inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)