### PR TITLE
feat: the narrator reaches the chat surface — GroupChat narrates, raw output collapses

### DIFF
--- a/.product/DES-RUN-NARRATOR.md
+++ b/.product/DES-RUN-NARRATOR.md
@@ -1,12 +1,18 @@
 # DES-RUN-NARRATOR — one narrated feed for following a run
 
-**Status:** implemented (feat/run-narrator)
+**Status:** implemented (feat/run-narrator); extended to the chat surface (§11,
+feat/narrator-chat)
 **Scope:** the run-follow surface (`ChatPanel.tsx` → `RunChat`), the run-detail feed
-composition, and the composer-on-terminal-runs ambiguity (usability review 2026-08-31,
-finding #8; run-operator persona findings).
-**Out of scope:** WorkPage list, SteeringPage, TestingPage, the decisions rail (lane L1),
-and GroupChat's multi-seat chat (its transcript is already turn-stamped and per-seat FIFO;
-nothing here touches it — the mandate is that it must not GROW, and it does not change).
+composition, the composer-on-terminal-runs ambiguity (usability review 2026-08-31,
+finding #8; run-operator persona findings), and — since §11 — GroupChat's multi-seat
+chat surface.
+**Out of scope:** WorkPage list, SteeringPage, TestingPage, the decisions rail (lane L1).
+GroupChat was originally scoped out ("its transcript is already turn-stamped and per-seat
+FIFO"); the operator overruled that after watching the shipped wave from the chat surface —
+"what I see is still the outputs from the individual agents and not the narrative piece" —
+so §11 brings the narrator THERE, reusing the shipped modules (one narrator.ts, one NowBar,
+one ApprovalDock, one ArtifactCard). The hold-at-1570 mandate on GroupChat.tsx still stands
+(it SHRANK: the transcript rendering moved to ChatThread.tsx).
 
 ## 1. The problem (verbatim intent)
 
@@ -241,3 +247,89 @@ No new wire calls: both sources are already on this page's data.
   follow-up bar with the exact label; expanding shows the launch form; live executing →
   inject composer; awaiting_human → steer composer.
 - `NowBar.test.tsx` — phase + active unit + last narration; artifact count; jump button.
+- `narrator.chat.test.ts` (§11) — classification (stream/failed/dump → narration; short ok
+  reply → turn); arrival-order feed; artifact extraction + dedupe; now-phrase derivations.
+- `GroupChat.narrated.test.tsx` (§11) — the classification IN THE DOM; out-of-order
+  arrival renders chronologically; the dock is a structural sibling of the scroll region
+  and reject-carries-note works from the chat surface; artifact cards + chip; the full
+  transcript stays reachable behind the view toggle.
+
+## 11. The chat surface (GroupChat) — the narrator applied to a CONVERSATION
+
+The user's overrule, verbatim: *"what I see is still the outputs from the individual
+agents and not the narrative piece."* They watch `/p/:pid/chat` and `/chat/:id` —
+GroupChat — where each seat streamed its whole output as raw chat turns. The narrator
+comes to this surface WITHOUT forking it: the same `narrator.ts`, `NowBar`,
+`ApprovalDock` and `ArtifactCard`; a new `ChatThread.tsx` holds the transcript pixels
+GroupChat used to render inline (GroupChat shrank).
+
+### 11.1 Narration vs conversation
+
+This surface is still a conversation, so the classification is different from a run's —
+but it lives in the ONE narrator (`narrateChatSeat`, `buildChatFeed`):
+
+| Message | Rendering |
+|---|---|
+| the user's message | first-class turn (`user-bubble`, unchanged) |
+| a seat's finalized ok reply that reads as conversation (≤1400 chars AND ≤16 lines — `isConversationalReply`, deterministic) | first-class turn (avatar + `seat-bubble`, unchanged) |
+| a seat's STILL-STREAMING output (pending) | narration: `[seat chip] is thinking… / is working — <size> streamed` (work tone), raw stream MOUNTED behind an expander (`chat-narration-toggle-*` / `chat-narration-raw-*`; display-toggled, never unmounted, so streaming keeps flowing into it) |
+| a finalized ok reply over the conversational bar | narration: `[seat chip] replied (<size>) — <first line>`, raw behind the same expander |
+| a failed reply | narration, fail tone: `[seat chip] failed — <headline>`, raw behind the expander |
+| seat lifecycle (open response / `chatSessionReady` / `chatSessionFailed`) | narration sys lines: `joined the chat` / `couldn’t join — <reason>`, deduped per seat by last announced state |
+
+### 11.2 Ordering
+
+The chat wire carries no `seq`/`ts` on live frames — **arrival is the order** (§3's rule
+applied to this wire). The one append-only message log is the clock: per-seat FIFO chunk
+routing (§7.9-3, unchanged) pins a late turn-1 reply to its turn-1 position, so
+out-of-order arrival renders chronologically by construction. `buildChatFeed` maps the
+log in place; it never re-sorts live frames.
+
+### 11.3 Artifacts
+
+No `dataUsed` frames reach a chat; the honest best-effort is what a finalized reply
+NAMES: backticked file paths and http(s) links (`extractChatArtifacts` — conservative,
+deterministic). They render as inline `ArtifactCard`s behind the reply (capped at the
+run feed's `INLINE_ARTIFACT_CAP`, deduped across the transcript) and collect into the
+now-bar chip. File cards carry no View action here (no run id to open a FileViewer
+against) — a card is a reference, never a dead click.
+
+### 11.4 The chat now-bar
+
+The shared `NowBar`, pinned between the header and the thread (outside the one scrolling
+region, `chat-thread`). `view: SessionView` generalized to `status: string` plus an
+optional `contextLabel` (the run page passes `session.status` + its unit derivations,
+unchanged). Chat vocabulary added to the status phrase map: `connecting` (seats warming)
+and `your_turn` (crew idle — honest amber "waiting on you"); replying = `executing`
+("working"). The narration slot speaks the newest story beat (`newestChatNow`): the last
+narration line seat-prefixed, or the latest turn as a phrase ("You: … / <seat> replied…").
+"Latest ↓" scrolls the thread to its tail. At 1440×700 the now-bar, the dock and the
+latest narration are visible with zero scrolling.
+
+### 11.5 The chat approval dock
+
+The shared `ApprovalDock`, pinned between the thread and the composer. It gains a second
+entry point: `chatId` (the run page keeps `view`). Gates/elicitations the daemon keys by
+the CHAT session id render here — a structural sibling of the scroll region, never
+inside it — and answer over the same wire (`SteeringGate` verbatim: approve /
+approve+steer / reject-with-note, `{approve:false, amend}`). With no cached record there
+is no status field to fall back on, so only a held gate/elicitation shows.
+
+### 11.6 The full transcript stays reachable
+
+A `narrated | full` view toggle (header, `chat-view-*`) — narrated is the default; full
+is the OLD transcript verbatim, in the §6 list/columns arrangement (slice K unchanged,
+now rendered by `ChatThread`). Picking a layout arrangement implies full. Both choices
+persist per-session (`wicked.chat.view` beside `wicked.chat.layout`; a stored layout
+with no stored view reads as full, for continuity). The §6.2 layout-toggle visibility
+rule (≥2 replying seats) is untouched; the view toggle appears once any seat has spoken.
+
+### 11.7 New/changed modules
+
+| File | Change |
+|---|---|
+| `src/components/narrator.ts` | +§11 section: `narrateChatSeat`, `isConversationalReply`, `buildChatFeed`, `extractChatArtifacts`, `deriveChatArtifacts`, `newestChatNow`, `chatSizeLabel`; `TONE_COLOR`/`TONE_GLYPH` hoisted here (NarratorFeed/NowBar now import them) |
+| `src/components/ChatThread.tsx` | NEW — the transcript pixels (narrated + full/list/columns), `Msg`/`UserMsg`/`SeatMsg`/`SysMsg`, `groupRounds`, `seatColumnOrder`, view/layout storage (moved OUT of GroupChat; GroupChat re-exports) |
+| `src/components/GroupChat.tsx` | SHRANK (1571 → under the 1570 hold): machinery + header + chips + composer + NowBar/ApprovalDock wiring; thread rendering delegated |
+| `src/components/NowBar.tsx` | `view` → `status` (+ optional `contextLabel`, optional unit props) — one bar, two surfaces |
+| `src/components/ApprovalDock.tsx` | + `chatId` entry point — one dock, two surfaces |

--- a/.product/DES-RUN-NARRATOR.md
+++ b/.product/DES-RUN-NARRATOR.md
@@ -315,6 +315,15 @@ inside it — and answer over the same wire (`SteeringGate` verbatim: approve /
 approve+steer / reject-with-note, `{approve:false, amend}`). With no cached record there
 is no status field to fall back on, so only a held gate/elicitation shows.
 
+**The prune seam** (found live against crew 0.7.4): the gate/elicitation stores
+self-heal against `GET /runs` on every refresh tick, and the `awaitingHuman` frame
+itself bumps that tick — so a chat-keyed gate mounted the dock and was swept ~400 ms
+later, because a chat session id is never in the run list. `src/store/awaitingPins.ts`
+fixes the universe mismatch: GroupChat pins its `chatId` for its mounted lifetime and
+both reconciles skip pinned ids. Real resolutions (`gateDecided`, an answered gate's
+`clearGate`, `sessionCompleted`) still clear as before; unpinned (run) ids still prune
+exactly as they always did.
+
 ### 11.6 The full transcript stays reachable
 
 A `narrated | full` view toggle (header, `chat-view-*`) — narrated is the default; full

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -6,30 +6,44 @@ import { ElicitationPrompt } from './ElicitationPrompt.js';
 import { SteeringGate } from './SteeringGate.js';
 
 /**
- * The pinned approval dock (DES-RUN-NARRATOR §2): anything awaiting the HUMAN
- * — the steering gate, an MCP elicitation — renders here, as a sibling of the
- * scrolling feed, between it and the composer. It can NEVER scroll away: the
- * directive's "approvals go direct to user" surface. The feed still records
+ * The pinned approval dock (DES-RUN-NARRATOR §2, §11.5): anything awaiting the
+ * HUMAN — the steering gate, an MCP elicitation — renders here, as a sibling of
+ * the scrolling feed, between it and the composer. It can NEVER scroll away:
+ * the directive's "approvals go direct to user" surface. The feed still records
  * the gate moment inline as history; this dock is the action.
+ *
+ * Two callers, one dock: the run page passes `view` (status-aware — a gate also
+ * shows on a bare `awaiting_human` with an empty cache, §3.3); the chat surface
+ * passes `chatId` (§11.5 — gates and elicitations the daemon keys by the chat
+ * session id render and answer HERE, on the surface the user is watching; with
+ * no cached record there is no status wire to fall back on, so only a held
+ * gate/elicitation shows).
  *
  * Renders nothing when nothing awaits (and never on a terminal run) — the
  * layout gives the feed the space back.
  */
 export function ApprovalDock({
   view,
+  chatId,
   onResolved,
 }: {
-  view: SessionView;
+  view?: SessionView;
+  chatId?: string;
   onResolved: () => void;
 }): React.ReactElement | null {
-  const { session } = view;
-  const gate = useGateStore((s) => s.gates[session.id]);
-  const elicitation = useElicitationStore((s) => s.elicitations[session.id]);
-  const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
+  const session = view?.session;
+  const id = session?.id ?? chatId ?? null;
+  const gate = useGateStore((s) => (id === null ? undefined : s.gates[id]));
+  const elicitation = useElicitationStore((s) => (id === null ? undefined : s.elicitations[id]));
+  if (id === null) return null;
+  const isTerminal = session !== undefined && ['completed', 'cancelled', 'failed'].includes(session.status);
 
-  const showGate = !isTerminal && (session.status === 'awaiting_human' || gate !== undefined);
+  const showGate =
+    !isTerminal && (session?.status === 'awaiting_human' || gate !== undefined);
   const showElicitation = !isTerminal && elicitation !== undefined;
   if (!showGate && !showElicitation) return null;
+
+  const guidance = session === undefined ? undefined : sessionGuidance(session);
 
   return (
     <div
@@ -44,8 +58,8 @@ export function ApprovalDock({
       )}
       {showGate && (
         <SteeringGate
-          runId={session.id}
-          guidance={sessionGuidance(session)}
+          runId={id}
+          guidance={guidance}
           {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
           onResolved={onResolved}
         />

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -690,7 +690,7 @@ function RunChat({
           always visible, outside the scroll region, with the artifacts chip and
           the jump-to-latest affordance. */}
       <NowBar
-        view={view}
+        status={session.status}
         orderedUnits={ordered}
         executingUnitOrd={executingUnitOrd}
         phaseOf={phaseOf}

--- a/src/components/ChatThread.tsx
+++ b/src/components/ChatThread.tsx
@@ -1,0 +1,395 @@
+import { useState } from 'react';
+import { Markdown } from './Markdown.js';
+import { ArtifactCard } from './ArtifactCard.js';
+import {
+  TONE_COLOR,
+  TONE_GLYPH,
+  type ChatFeedItem,
+  type NarrationTone,
+} from './narrator.js';
+
+/**
+ * The chat transcript renderer (DES-RUN-NARRATOR §11), extracted from
+ * GroupChat so the surface component holds the machinery and this module holds
+ * the pixels. Two views over ONE message log:
+ *
+ * - `narrated` (§11.1, the default): the user's messages and the crew's direct
+ *   conversational replies stay first-class chat turns; a seat's still-
+ *   streaming worker output, over-long output dumps, failed replies and seat
+ *   lifecycle moments collapse into short narration lines — seat identity as a
+ *   chip on the line, the raw bytes behind an expander (the same idiom the run
+ *   feed ships). The classification lives in narrator.ts (`buildChatFeed`);
+ *   this module only renders its items.
+ * - `full` (§11.6): the old transcript, verbatim — every bubble, in the list or
+ *   columns arrangement (DES-FEEDBACK-002 §6, slice K, unchanged).
+ */
+
+// ── Message log types (moved from GroupChat — same shapes, same contracts) ──
+
+export interface UserMsg {
+  kind: 'user';
+  text: string;
+  /** The send ordinal this message opened (1-based) — §7.9-3 turn identity. */
+  turn?: number;
+}
+export interface SeatMsg {
+  kind: 'seat';
+  cliKey: string;
+  text: string;
+  pending: boolean;
+  ok: boolean;
+  /** The send ordinal this reply answers — chunk routing keys on seat+turn. */
+  turn?: number;
+}
+/** A surface-recorded moment (§11.1: seat joined / could not join) — already
+ *  narration; it never renders as a bubble in either view. */
+export interface SysMsg {
+  kind: 'sys';
+  text: string;
+  tone: NarrationTone;
+  seat: string | null;
+}
+export type Msg = UserMsg | SeatMsg | SysMsg;
+
+/**
+ * Seat identity under the token contract (DES-VISION-001 §2.11): every chip and
+ * avatar wears the SAME surface/ink pair, and identity rides the monogram +
+ * name, not a per-CLI hue. Color is reserved for signal (§1.5 rule 2).
+ */
+export const SEAT_CHIP = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
+
+// ── Chat layout: list vs columns (DES-FEEDBACK-002 §6, slice K) ──────────────
+//
+// A round = a user message plus every seat message before the next user message
+// (§6.1: the flat `messages` array already groups naturally — a send appends one
+// UserMsg then N pending SeatMsgs that fill in place). Columns mode re-renders
+// each round as a grid; the grouping below is PURE derivation over transcript
+// state — it can never fire a request (§6.3: the toggle reads and re-arranges
+// `messages` only).
+
+export type ChatLayout = 'list' | 'columns';
+/** §11.6: which rendering of the log — the narrated feed or the full transcript. */
+export type ChatView = 'narrated' | 'full';
+
+export interface ChatRound {
+  user: UserMsg | null;
+  seats: SeatMsg[];
+}
+
+/** §6.1's grouping rule: a new round starts at each user message; replies to
+ *  DIFFERENT prompts (non-siblings) land in different rounds and stay linear —
+ *  only same-round (same-prompt) replies ever sit side by side. Sys narration
+ *  is a §11 feed concern, not a bubble — rounds skip it. */
+export function groupRounds(messages: Msg[]): ChatRound[] {
+  const rounds: ChatRound[] = [];
+  for (const m of messages) {
+    if (m.kind === 'sys') continue;
+    if (m.kind === 'user') {
+      rounds.push({ user: m, seats: [] });
+    } else {
+      let last = rounds[rounds.length - 1];
+      if (last === undefined) {
+        // Defensive: a seat message with no user message before it (cannot
+        // happen via `send`, but the grouping must not throw on it).
+        last = { user: null, seats: [] };
+        rounds.push(last);
+      }
+      last.seats.push(m);
+    }
+  }
+  return rounds;
+}
+
+/** §6.2: column order is stable across rounds — first-seen seat order — so the
+ *  same agent is always in the same column. */
+export function seatColumnOrder(messages: Msg[]): string[] {
+  const order: string[] = [];
+  for (const m of messages) {
+    if (m.kind === 'seat' && !order.includes(m.cliKey)) order.push(m.cliKey);
+  }
+  return order;
+}
+
+/** §6.2: the choice persists per-session — a reading posture, not configuration,
+ *  so it is deliberately NOT a crew setting (a settings write would violate the
+ *  surface's request frugality). sessionStorage, wrapped: private-mode browsers
+ *  degrade to per-mount state, never to a broken surface. */
+const CHAT_LAYOUT_KEY = 'wicked.chat.layout';
+const CHAT_VIEW_KEY = 'wicked.chat.view';
+export function readStoredLayout(): ChatLayout {
+  try {
+    return sessionStorage.getItem(CHAT_LAYOUT_KEY) === 'columns' ? 'columns' : 'list';
+  } catch {
+    return 'list';
+  }
+}
+export function writeStoredLayout(layout: ChatLayout): void {
+  try {
+    sessionStorage.setItem(CHAT_LAYOUT_KEY, layout);
+  } catch {
+    /* non-fatal — see readStoredLayout */
+  }
+}
+/**
+ * §11.6: narrated is the default; a stored view wins, and — for continuity with
+ * transcripts arranged before the narrated view existed — a stored LAYOUT
+ * preference with no stored view reads as "the full transcript, as arranged".
+ */
+export function readStoredView(): ChatView {
+  try {
+    const v = sessionStorage.getItem(CHAT_VIEW_KEY);
+    if (v === 'narrated' || v === 'full') return v;
+    return sessionStorage.getItem(CHAT_LAYOUT_KEY) !== null ? 'full' : 'narrated';
+  } catch {
+    return 'narrated';
+  }
+}
+export function writeStoredView(view: ChatView): void {
+  try {
+    sessionStorage.setItem(CHAT_VIEW_KEY, view);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+// ── Bubbles (§5.3 token usage — moved verbatim from GroupChat) ───────────────
+
+/** §5.3 token usage: user messages are transparent — the hairline keeps the
+ *  bubble shape without claiming a surface of its own. */
+function userBubble(m: UserMsg, key: React.Key): React.ReactElement {
+  return (
+    <div
+      key={key}
+      data-testid="user-bubble"
+      data-turn={m.turn}
+      className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
+      style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+    >
+      {m.text}
+    </div>
+  );
+}
+
+function bubbleBody(m: SeatMsg): React.ReactElement {
+  return (
+    <div
+      // §5.3 token usage: agent bubbles sit on --surface-card; the
+      // border speaks status while a reply is pending or failed.
+      // §7.9-3: the bubble WEARS its seat+turn identity, so chunk routing
+      // is assertable in the DOM (data-turn matches the causing send).
+      data-testid="seat-bubble"
+      data-agent={m.cliKey}
+      data-turn={m.turn}
+      data-pending={m.pending}
+      className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
+      style={{
+        background: 'var(--surface-card)',
+        border: `1px solid ${m.pending ? 'var(--status-run-dim)' : m.ok ? 'var(--surface-raised)' : 'var(--status-fail-dim)'}`,
+      }}
+    >
+      {m.pending && m.text === '' ? (
+        <span className="opacity-50 font-mono text-[11px] animate-pulse">thinking…</span>
+      ) : (
+        <Markdown>{m.text}</Markdown>
+      )}
+    </div>
+  );
+}
+
+/** The seat avatar + bubble row — a seat turn in list/narrated dress. */
+function seatRow(m: SeatMsg, key: React.Key): React.ReactElement {
+  return (
+    <div key={key} className="self-start max-w-[80%] flex gap-2">
+      <span
+        className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-mono font-bold mt-0.5"
+        style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
+      >
+        {m.cliKey.slice(0, 2).toUpperCase()}
+      </span>
+      {bubbleBody(m)}
+    </div>
+  );
+}
+
+/** §6.2 column header: the seat chip in the existing chip dress — monogram
+ *  avatar + cliKey, SEAT_CHIP tokens verbatim. */
+function columnHeader(cliKey: string): React.ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span
+        className="shrink-0 w-5 h-5 rounded-md flex items-center justify-center text-[9px] font-mono font-bold"
+        style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
+      >
+        {cliKey.slice(0, 2).toUpperCase()}
+      </span>
+      <span className="truncate text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>{cliKey}</span>
+    </span>
+  );
+}
+
+// ── The thread ────────────────────────────────────────────────────────────────
+
+interface Props {
+  messages: Msg[];
+  view: ChatView;
+  layout: ChatLayout;
+  /** First-seen seat order (the caller's derivation — §6.2). */
+  seatOrder: string[];
+  /** The §11 narrated feed over `messages` (the caller's `buildChatFeed` memo —
+   *  shared with its now-bar derivations, computed once). */
+  items: ChatFeedItem[];
+}
+
+/**
+ * Renders as a fragment INSIDE the caller's one scrolling region — GroupChat
+ * keeps the container (and its boundary notes) so the dock stays a structural
+ * sibling of the scroll region.
+ */
+export function ChatThread({ messages, view, layout, seatOrder, items }: Props): React.ReactElement {
+  // §11.1 expanders: which narration lines have their raw output open. Keyed by
+  // message index — stable, because the log is append-only. Collapsed default:
+  // the narration is the headline; the bytes are one click below it. The raw
+  // body stays MOUNTED (hidden) so streaming keeps flowing into it.
+  const [openRaw, setOpenRaw] = useState<Record<number, boolean>>({});
+
+  const narrationLine = (item: Extract<ChatFeedItem, { kind: 'narration' }>): React.ReactElement => {
+    const expandable = item.index !== null;
+    const msg = expandable ? messages[item.index as number] : undefined;
+    const open = expandable ? openRaw[item.index as number] === true : false;
+    return (
+      <div key={item.key} className="flex flex-col gap-1.5">
+        <div
+          data-testid="chat-narration-line"
+          data-tone={item.tone}
+          {...(item.seat !== null ? { 'data-agent': item.seat } : {})}
+          className="flex items-center gap-2 px-1"
+        >
+          <span aria-hidden="true" className="shrink-0 text-[10px] font-mono" style={{ color: TONE_COLOR[item.tone] }}>
+            {TONE_GLYPH[item.tone]}
+          </span>
+          {item.seat !== null && (
+            <span
+              data-testid="chat-narration-seat"
+              className="shrink-0 inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-[11px] font-mono"
+              style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
+            >
+              {item.seat}
+            </span>
+          )}
+          <span
+            className="text-[12.5px] font-mono leading-relaxed min-w-0"
+            style={{ color: item.tone === 'info' ? 'var(--ink-muted)' : 'var(--ink-body)' }}
+          >
+            {item.text}
+          </span>
+          {expandable && (
+            <button
+              type="button"
+              data-testid={`chat-narration-toggle-${item.index}`}
+              aria-expanded={open}
+              onClick={() =>
+                setOpenRaw((prev) => ({ ...prev, [item.index as number]: !(prev[item.index as number] === true) }))}
+              className="shrink-0 text-xs font-medium font-mono hover:underline"
+              style={{ color: 'var(--accent)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+            >
+              {open ? '▾ Hide output' : '▸ Show output'}
+            </button>
+          )}
+        </div>
+        {expandable && msg !== undefined && msg.kind === 'seat' && (
+          <div
+            data-testid={`chat-narration-raw-${item.index}`}
+            // Inline display toggle, NOT unmounting: the live stream keeps
+            // accumulating in the (hidden) bubble, and tests/readers can reach
+            // the bytes without a click.
+            style={open ? undefined : { display: 'none' }}
+          >
+            {seatRow(msg, `raw${item.index}`)}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  if (view === 'narrated') {
+    return (
+      <>
+        {items.map((item) => {
+          if (item.kind === 'artifact') {
+            return <ArtifactCard key={item.key} artifact={item.artifact} />;
+          }
+          if (item.kind === 'narration') return narrationLine(item);
+          const m = messages[item.index];
+          if (m === undefined || m.kind === 'sys') return null;
+          return m.kind === 'user' ? userBubble(m, item.key) : seatRow(m, item.key);
+        })}
+      </>
+    );
+  }
+
+  // ── The full transcript (§11.6) — the old rendering, verbatim ──────────────
+  const transcript = messages.filter((m): m is UserMsg | SeatMsg => m.kind !== 'sys');
+  if (layout === 'columns' && seatOrder.length >= 2) {
+    // §6.2 columns mode: each round renders its user bubble (unchanged) then a
+    // grid of the round's replies — one column per seat, order stable across
+    // rounds (first-seen), an empty dimmed cell where a seat did not answer
+    // this round (absence is information). The grid scrolls horizontally
+    // INSIDE its round container past 3 columns — the page never scrolls
+    // horizontally. No motion is added here, so the arrangement is
+    // reduced-motion safe by construction.
+    return (
+      <>
+        {groupRounds(transcript).map((round, ri) => (
+          <div key={ri} data-testid="chat-round" className="flex flex-col gap-3">
+            {round.user !== null && userBubble(round.user, 'u')}
+            <div
+              data-testid="chat-round-grid"
+              data-columns={seatOrder.length}
+              style={{
+                display: 'grid',
+                gap: '8px',
+                gridTemplateColumns: `repeat(${seatOrder.length}, minmax(260px, 1fr))`,
+                overflowX: 'auto',
+              }}
+            >
+              {seatOrder.map((cliKey) => {
+                const reply = round.seats.find((s) => s.cliKey === cliKey);
+                return reply === undefined ? (
+                  <div
+                    key={cliKey}
+                    data-testid="chat-cell-empty"
+                    data-agent={cliKey}
+                    className="flex flex-col gap-1.5 min-w-0"
+                  >
+                    {columnHeader(cliKey)}
+                    <div
+                      className="rounded-xl px-4 py-2 text-[13px] font-mono"
+                      style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
+                    >
+                      —
+                    </div>
+                  </div>
+                ) : (
+                  <div
+                    key={cliKey}
+                    data-testid="chat-cell"
+                    data-agent={cliKey}
+                    className="flex flex-col gap-1.5 min-w-0"
+                  >
+                    {columnHeader(cliKey)}
+                    {bubbleBody(reply)}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </>
+    );
+  }
+  return (
+    <>
+      {transcript.map((m, i) => (m.kind === 'user' ? userBubble(m, i) : seatRow(m, i)))}
+    </>
+  );
+}

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -1,13 +1,41 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
 import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
-import { Markdown } from './Markdown.js';
+import { ApprovalDock } from './ApprovalDock.js';
+import {
+  ChatThread,
+  SEAT_CHIP,
+  readStoredLayout,
+  readStoredView,
+  seatColumnOrder,
+  writeStoredLayout,
+  writeStoredView,
+  type ChatLayout,
+  type ChatView,
+  type Msg,
+  type SeatMsg,
+  type SysMsg,
+} from './ChatThread.js';
 import { NewProjectModal } from './NewProjectModal.js';
+import { NowBar } from './NowBar.js';
+import {
+  buildChatFeed,
+  deriveChatArtifacts,
+  newestChatNow,
+  type NarrationLine,
+  type NarrationTone,
+} from './narrator.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
+
+// The transcript types and the §6 layout machinery moved to ChatThread.tsx
+// (DES-RUN-NARRATOR §11 — this file holds the machinery, that one the pixels);
+// re-exported so existing importers keep working.
+export { groupRounds, seatColumnOrder } from './ChatThread.js';
+export type { ChatLayout, ChatRound, Msg, SeatMsg, SysMsg, UserMsg } from './ChatThread.js';
 
 /**
  * CHAT (crew#165 / core#134): warm persistent CLI sessions + fan-out.
@@ -87,14 +115,9 @@ export function defaultSelection(roster: RosterSeat[]): string[] {
   return roster.filter((s) => chatCapable(s, speaks)).map((s) => s.key);
 }
 
-/**
- * Seat identity under the token contract (DES-VISION-001 §2.11): every chip and
- * avatar wears the SAME surface/ink pair, and identity rides the monogram +
- * name, not a per-CLI hue. Color is reserved for signal (§1.5 rule 2): the
- * chip's dot speaks the §2.6 status layer — warming = amber, ready = emerald,
- * failed = red — and nothing else on the seat is colored.
- */
-const SEAT_CHIP = { bg: 'var(--surface-raised)', fg: 'var(--ink-body)' } as const;
+// Seat identity tokens (DES-VISION-001 §2.11) live in ChatThread.tsx now
+// (SEAT_CHIP): the chip's dot speaks the §2.6 status layer — warming = amber,
+// ready = emerald, failed = red — and nothing else on the seat is colored.
 
 /**
  * The explicit seat lifecycle (DES-UX-001 §7.9-4, EC44): connecting (an open
@@ -152,91 +175,6 @@ function clearStoredChatId(repoId?: string | null): void {
     sessionStorage.removeItem(CHAT_ID_KEY(repoId));
   } catch {
     /* non-fatal — see above */
-  }
-}
-
-export interface UserMsg {
-  kind: 'user';
-  text: string;
-  /** The send ordinal this message opened (1-based) — §7.9-3 turn identity. */
-  turn?: number;
-}
-export interface SeatMsg {
-  kind: 'seat';
-  cliKey: string;
-  text: string;
-  pending: boolean;
-  ok: boolean;
-  /** The send ordinal this reply answers — chunk routing keys on seat+turn. */
-  turn?: number;
-}
-export type Msg = UserMsg | SeatMsg;
-
-// ── Chat layout: list vs columns (DES-FEEDBACK-002 §6, slice K) ──────────────
-//
-// A round = a user message plus every seat message before the next user message
-// (§6.1: the flat `messages` array already groups naturally — a send appends one
-// UserMsg then N pending SeatMsgs that fill in place). Columns mode re-renders
-// each round as a grid; the grouping below is PURE derivation over transcript
-// state — it can never fire a request (§6.3: the toggle reads and re-arranges
-// `messages` only).
-
-export type ChatLayout = 'list' | 'columns';
-
-export interface ChatRound {
-  user: UserMsg | null;
-  seats: SeatMsg[];
-}
-
-/** §6.1's grouping rule: a new round starts at each user message; replies to
- *  DIFFERENT prompts (non-siblings) land in different rounds and stay linear —
- *  only same-round (same-prompt) replies ever sit side by side. */
-export function groupRounds(messages: Msg[]): ChatRound[] {
-  const rounds: ChatRound[] = [];
-  for (const m of messages) {
-    if (m.kind === 'user') {
-      rounds.push({ user: m, seats: [] });
-    } else {
-      let last = rounds[rounds.length - 1];
-      if (last === undefined) {
-        // Defensive: a seat message with no user message before it (cannot
-        // happen via `send`, but the grouping must not throw on it).
-        last = { user: null, seats: [] };
-        rounds.push(last);
-      }
-      last.seats.push(m);
-    }
-  }
-  return rounds;
-}
-
-/** §6.2: column order is stable across rounds — first-seen seat order — so the
- *  same agent is always in the same column. */
-export function seatColumnOrder(messages: Msg[]): string[] {
-  const order: string[] = [];
-  for (const m of messages) {
-    if (m.kind === 'seat' && !order.includes(m.cliKey)) order.push(m.cliKey);
-  }
-  return order;
-}
-
-/** §6.2: the choice persists per-session — a reading posture, not configuration,
- *  so it is deliberately NOT a crew setting (a settings write would violate the
- *  surface's request frugality). sessionStorage, wrapped like the chat id above:
- *  private-mode browsers degrade to per-mount state, never to a broken surface. */
-const CHAT_LAYOUT_KEY = 'wicked.chat.layout';
-function readStoredLayout(): ChatLayout {
-  try {
-    return sessionStorage.getItem(CHAT_LAYOUT_KEY) === 'columns' ? 'columns' : 'list';
-  } catch {
-    return 'list';
-  }
-}
-function writeStoredLayout(layout: ChatLayout): void {
-  try {
-    sessionStorage.setItem(CHAT_LAYOUT_KEY, layout);
-  } catch {
-    /* non-fatal — see readStoredChatId */
   }
 }
 
@@ -308,17 +246,41 @@ export function GroupChat({
    */
   const [routedGone, setRoutedGone] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  /** The one scrolling region — the now-bar's "Latest ↓" scrolls it (§11.4). */
+  const threadScrollRef = useRef<HTMLDivElement>(null);
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
 
-  // ── Transcript layout (DES-FEEDBACK-002 §6, slice K) ────────────────────────
-  // List is the default; columns re-arranges rounds side by side. Initialized
-  // synchronously from sessionStorage — reading it can never fire a request, and
-  // switching it touches nothing but how `messages` is rendered (§6.3).
+  // ── §11.1 seat-lifecycle narration ──────────────────────────────────────────
+  // Seat mechanics (joined / could not join) are narration, recorded into the
+  // one message log at their ARRIVAL position — the chat wire's only clock
+  // (§11.2). Deduped per seat by last announced state, so an open response and
+  // its trailing chatSessionReady frame speak once.
+  const announcedRef = useRef<Map<string, 'ready' | 'failed'>>(new Map());
+  function announceSeat(cliKey: string, state: 'ready' | 'failed', text: string, tone: NarrationTone): void {
+    if (announcedRef.current.get(cliKey) === state) return;
+    announcedRef.current.set(cliKey, state);
+    const sys: SysMsg = { kind: 'sys', text, tone, seat: cliKey };
+    setMessages((prev) => [...prev, sys]);
+  }
+
+  // ── Transcript views (DES-RUN-NARRATOR §11.6 / DES-FEEDBACK-002 §6) ─────────
+  // `view` picks the RENDERING of the one message log: `narrated` (the default
+  // — conversation stays turns, worker output collapses to narration) or `full`
+  // (the old transcript, in the §6 list/columns arrangement). Both initialized
+  // synchronously from sessionStorage — reading them can never fire a request,
+  // and switching touches nothing but how `messages` is rendered (§6.3).
+  const [view, setView] = useState<ChatView>(readStoredView);
   const [layout, setLayout] = useState<ChatLayout>(readStoredLayout);
+  function chooseView(next: ChatView): void {
+    setView(next);
+    writeStoredView(next);
+  }
   function chooseLayout(next: ChatLayout): void {
     setLayout(next);
     writeStoredLayout(next);
+    // Picking an arrangement IS asking for the full transcript (§11.6).
+    chooseView('full');
   }
 
   // ── Default agent chips (DES-FEEDBACK-001 §6 / EC44 — chips are truth) ─────
@@ -485,6 +447,7 @@ export function GroupChat({
     chipsTouchedRef.current = false;
     setSendFailed(null);
     turnRef.current = 0;
+    announcedRef.current = new Map();
     setPickerOpen(false);
     // The id goes too, and it is the one reset that is not cosmetic. Resolving the new repo's chat
     // is ASYNC — a stored id costs a probe round-trip — and until it lands, a `chatId` still holding
@@ -543,6 +506,9 @@ export function GroupChat({
         // J4/C6: that boundary is STATED in the thread (`rejoined`), never a
         // silent blank pretending the conversation never happened.
         setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        // The rejoined boundary note already covers these seats — mark them
+        // announced so a trailing ready frame does not re-speak "joined".
+        for (const k of probe.seats) announcedRef.current.set(k, 'ready');
         // A rejoined session is live — make it findable on the rail (J4).
         useLiveChatsStore.getState().upsert(stored, probe.seats);
         setRejoined(true);
@@ -601,12 +567,14 @@ export function GroupChat({
         // first fan-out already put a reply in flight.
         if (frame.cliKey) {
           setSeats((s) => (s[frame.cliKey!] === 'working' ? s : { ...s, [frame.cliKey!]: 'ready' }));
+          announceSeat(frame.cliKey, 'ready', 'joined the chat', 'info');
         }
         break;
       case 'chatSessionFailed':
         if (frame.cliKey) {
           setSeats((s) => ({ ...s, [frame.cliKey!]: 'failed' }));
           setSeatErrors((e) => ({ ...e, [frame.cliKey!]: frame.reason ?? 'session failed' }));
+          announceSeat(frame.cliKey, 'failed', `couldn’t join — ${frame.reason ?? 'session failed'}`, 'fail');
         }
         break;
       case 'chatDelta':
@@ -745,6 +713,12 @@ export function GroupChat({
           }
           return { ...next, ...errs };
         });
+        // §11.1: the open response is a lifecycle moment too — narrate it at
+        // its arrival position (deduped against the trailing ready frames).
+        for (const s of opened) {
+          if (s.ok) announceSeat(s.cliKey, 'ready', 'joined the chat', 'info');
+          else announceSeat(s.cliKey, 'failed', `couldn’t join — ${s.error ?? 'no reason given'}`, 'fail');
+        }
         // §6.2 recoverable error: a chip may name an agent the daemon no
         // longer has (a stale cache, or an operator-typed name with no seat
         // behind it). When NOTHING came up, say WHICH names were rejected —
@@ -811,7 +785,7 @@ export function GroupChat({
       // §7.9-2: a failed send retracts its optimistic bubbles (nothing went out),
       // keeps the draft in the composer, and renders the failure inline with retry.
       const failSend = (reason: string): void => {
-        setMessages((prev) => prev.filter((m) => m.turn !== turn));
+        setMessages((prev) => prev.filter((m) => m.kind === 'sys' || m.turn !== turn));
         setSendFailed({ text, reason });
       };
       if (warm.length === 0) {
@@ -875,8 +849,8 @@ export function GroupChat({
   function promoteToBuild(): void {
     if (navigate === undefined) return;
     const transcript = messages
-      .filter((m) => m.kind === 'user' || !m.pending)
-      .map((m) => (m.kind === 'user' ? `operator: ${m.text}` : `${m.cliKey}: ${m.text}`))
+      .filter((m) => m.kind === 'user' || (m.kind === 'seat' && !m.pending))
+      .map((m) => (m.kind === 'user' ? `operator: ${m.text}` : `${(m as { cliKey: string }).cliKey}: ${m.text}`))
       .join('\n');
     const MAX = 6000; // keep the prefill a context, not a payload
     const clipped = transcript.length > MAX ? `…${transcript.slice(-MAX)}` : transcript;
@@ -944,33 +918,43 @@ export function GroupChat({
     </span>
   );
 
-  // §6.2: the toggle is visible only when the chat has ≥2 distinct REPLYING
-  // seats — a single-agent transcript has nothing to compare, and the toggle
-  // would be dead chrome. Derived from the transcript, zero requests.
+  // §6.2: the layout toggle is visible only when the chat has ≥2 distinct
+  // REPLYING seats — a single-agent transcript has nothing to compare, and the
+  // toggle would be dead chrome. Derived from the transcript, zero requests.
   const seatOrder = seatColumnOrder(messages);
   const showLayoutToggle = seatOrder.length >= 2;
-  const rounds = layout === 'columns' ? groupRounds(messages) : [];
+  // §11.6: the narrated|full view toggle appears once any seat has spoken —
+  // before that the two views render identically.
+  const showViewToggle = seatOrder.length >= 1;
 
-  // §6.4: the segmented pair in the mode-switcher grammar — active segment
+  // ── The §11 narrated feed + now-bar derivations (pure, zero requests) ──────
+  const feedItems = useMemo(() => buildChatFeed(messages), [messages]);
+  const chatArtifacts = useMemo(() => deriveChatArtifacts(messages), [messages]);
+  const replyingSeats = useMemo(
+    () => new Set(messages.filter((m) => m.kind === 'seat' && m.pending).map((m) => (m as { cliKey: string }).cliKey)).size,
+    [messages],
+  );
+
+  // §6.4: segmented controls in the mode-switcher grammar — active segment
   // --surface-raised + --ink-high, inactive --ink-muted.
-  const layoutSegment = (value: ChatLayout, glyph: string, label: string): React.ReactElement => (
+  const segment = (
+    testid: string, active: boolean, onPick: () => void, glyph: string, label: string, title: string,
+  ): React.ReactElement => (
     <button
-      key={value}
+      key={testid}
       type="button"
-      data-testid={`chat-layout-${value}`}
-      aria-pressed={layout === value}
-      title={value === 'columns'
-        ? 'Arrange each prompt’s agent replies side by side'
-        : 'Show the transcript as one linear column'}
-      // The composer must keep focus and its draft across a layout switch
-      // (§6.5): preventDefault on mousedown stops the click from stealing focus.
+      data-testid={testid}
+      aria-pressed={active}
+      title={title}
+      // The composer must keep focus and its draft across a switch (§6.5):
+      // preventDefault on mousedown stops the click from stealing focus.
       onMouseDown={(e) => e.preventDefault()}
-      onClick={() => chooseLayout(value)}
+      onClick={onPick}
       style={{
-        background: layout === value ? 'var(--surface-raised)' : 'transparent',
+        background: active ? 'var(--surface-raised)' : 'transparent',
         border: 'none',
         borderRadius: 'var(--radius-md)',
-        color: layout === value ? 'var(--ink-high)' : 'var(--ink-muted)',
+        color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
         cursor: 'pointer',
         fontFamily: 'var(--font-sans)',
         fontSize: 'var(--text-2xs)',
@@ -981,60 +965,13 @@ export function GroupChat({
       {glyph} {label}
     </button>
   );
-
-  /** The list-mode bubbles, verbatim (§6.3: list mode is untouched); columns
-   *  mode reuses the same bubble tokens with the avatar promoted to a header. */
-  const userBubble = (m: UserMsg, key: React.Key): React.ReactElement => (
-    // §5.3 token usage: user messages are transparent — the hairline
-    // keeps the bubble shape without claiming a surface of its own.
-    <div
-      key={key}
-      data-testid="user-bubble"
-      data-turn={m.turn}
-      className="self-end max-w-[70%] rounded-xl px-4 py-2 text-[13px]"
-      style={{ background: 'transparent', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
-    >
-      {m.text}
-    </div>
-  );
-
-  const bubbleBody = (m: SeatMsg): React.ReactElement => (
-    <div
-      // §5.3 token usage: agent bubbles sit on --surface-card; the
-      // border speaks status while a reply is pending or failed.
-      // §7.9-3: the bubble WEARS its seat+turn identity, so chunk routing
-      // is assertable in the DOM (data-turn matches the causing send).
-      data-testid="seat-bubble"
-      data-agent={m.cliKey}
-      data-turn={m.turn}
-      data-pending={m.pending}
-      className="rounded-xl px-4 py-2 text-[13px] min-w-[60px]"
-      style={{
-        background: 'var(--surface-card)',
-        border: `1px solid ${m.pending ? 'var(--status-run-dim)' : m.ok ? 'var(--surface-raised)' : 'var(--status-fail-dim)'}`,
-      }}
-    >
-      {m.pending && m.text === '' ? (
-        <span className="opacity-50 font-mono text-[11px] animate-pulse">thinking…</span>
-      ) : (
-        <Markdown>{m.text}</Markdown>
-      )}
-    </div>
-  );
-
-  /** §6.2 column header: the seat chip in the existing chip dress — monogram
-   *  avatar + cliKey, SEAT_CHIP tokens verbatim. */
-  const columnHeader = (cliKey: string): React.ReactElement => (
-    <span className="inline-flex items-center gap-1.5 min-w-0">
-      <span
-        className="shrink-0 w-5 h-5 rounded-md flex items-center justify-center text-[9px] font-mono font-bold"
-        style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
-      >
-        {cliKey.slice(0, 2).toUpperCase()}
-      </span>
-      <span className="truncate text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>{cliKey}</span>
-    </span>
-  );
+  const layoutSegment = (value: ChatLayout, glyph: string, label: string): React.ReactElement =>
+    segment(
+      `chat-layout-${value}`, view === 'full' && layout === value, () => chooseLayout(value), glyph, label,
+      value === 'columns'
+        ? 'Arrange each prompt’s agent replies side by side (full transcript)'
+        : 'Show the full transcript as one linear column',
+    );
 
   const anyReady = Object.values(seats).some((st) => WARM_STATES.has(st));
   // V8: a teardown control exists only once there is something armed to tear down —
@@ -1056,6 +993,47 @@ export function GroupChat({
   // in the shell the context IS the project (§4.3) and rides `projectId` silently.
   const showProjectField = projectId == null && chatId === null && !resolving && !ended;
   const currentProject = projects.find((p) => p.id === selectedProjectId) ?? null;
+
+  // ── The §11.4 now-bar: what is happening RIGHT NOW, pinned above the thread.
+  const warmCount = Object.values(seats).filter((st) => WARM_STATES.has(st)).length;
+  const connecting = arming || resolving || Object.values(seats).some((st) => st === 'connecting');
+  const chatStatus = ended
+    ? 'completed'
+    : replyingSeats > 0
+      ? 'executing'
+      : connecting
+        ? 'connecting'
+        : openError !== null && warmCount === 0
+          ? 'failed'
+          : 'your_turn';
+  const contextLabel =
+    warmCount === 0
+      ? null
+      : replyingSeats > 0
+        ? `${replyingSeats} of ${warmCount} agent${warmCount === 1 ? '' : 's'} replying`
+        : `${warmCount} agent${warmCount === 1 ? '' : 's'} ready`;
+  const CHAT_STATUS_FALLBACK: Record<string, { text: string; tone: NarrationTone }> = {
+    executing: { text: 'The crew is replying…', tone: 'work' },
+    connecting: { text: 'Connecting agents…', tone: 'work' },
+    your_turn: { text: 'Waiting on you — say something below', tone: 'human' },
+    // The full reason renders in the thread (openError) — the bar points, never duplicates.
+    failed: { text: 'Attention needed — see the error in the thread', tone: 'fail' },
+    completed: { text: 'Chat ended', tone: 'info' },
+  };
+  const nowLine: NarrationLine = useMemo(() => {
+    const newest = newestChatNow(feedItems, messages);
+    const fallback = CHAT_STATUS_FALLBACK[chatStatus] ?? CHAT_STATUS_FALLBACK['your_turn']!;
+    const chosen = newest ?? fallback;
+    return { text: chosen.text, tone: chosen.tone, ord: null, event: { type: 'chatStatus' } };
+    // CHAT_STATUS_FALLBACK is rebuilt per render from openError — covered by chatStatus deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [feedItems, messages, chatStatus, openError]);
+  const showNowBar = (chatId !== null || messages.length > 0) && !ended;
+  const jumpToLatest = (): void => {
+    const el = threadScrollRef.current;
+    // feature-guarded: jsdom has no Element.scrollTo
+    if (el && typeof el.scrollTo === 'function') el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  };
 
   return (
     // The surface's own ink (§2.4); labels read in the sans by inheritance —
@@ -1087,6 +1065,26 @@ export function GroupChat({
             {layoutSegment('columns', '⫼', 'columns')}
           </div>
         )}
+        {/* §11.6: narrated (the story) | full (the old transcript, verbatim). */}
+        {showViewToggle && (
+          <div
+            data-testid="chat-view-toggle"
+            data-view={view}
+            role="group"
+            aria-label="Transcript view"
+            className="inline-flex items-center gap-0.5 shrink-0"
+            style={{
+              border: '1px solid var(--surface-raised)',
+              borderRadius: 'var(--radius-md)',
+              padding: '1px',
+            }}
+          >
+            {segment('chat-view-narrated', view === 'narrated', () => chooseView('narrated'), '◈', 'narrated',
+              'The story: conversation stays turns, worker output collapses to narration')}
+            {segment('chat-view-full', view === 'full', () => chooseView('full'), '☰', 'full',
+              'The full transcript — every agent bubble, unabridged')}
+          </div>
+        )}
         <div className="flex-1" />
         {/* §7.9 conversation→action: visible once there is a transcript to carry. */}
         {messages.length > 0 && navigate !== undefined && !ended && (
@@ -1115,8 +1113,25 @@ export function GroupChat({
         )}
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3">
+      {/* The pinned now-bar (§11.4): what is happening RIGHT NOW — outside the
+          scroll region, so it is visible by construction; "Latest ↓" jumps the
+          thread to its live tail; the chip collects the artifacts replies name. */}
+      {showNowBar && (
+        <NowBar
+          status={chatStatus}
+          contextLabel={contextLabel}
+          lastLine={nowLine}
+          artifacts={chatArtifacts}
+          onJumpToLatest={jumpToLatest}
+        />
+      )}
+
+      {/* Messages — the ONE scrolling region (§11.4). */}
+      <div
+        ref={threadScrollRef}
+        data-testid="chat-thread"
+        className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3"
+      >
         {openError !== null && (
           <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
         )}
@@ -1168,74 +1183,16 @@ export function GroupChat({
             </p>
           </div>
         )}
-        {layout === 'columns' && showLayoutToggle
-          ? // §6.2 columns mode: each round renders its user bubble (unchanged)
-            // then a grid of the round's replies — one column per seat, order
-            // stable across rounds (first-seen), an empty dimmed cell where a
-            // seat did not answer this round (absence is information). The grid
-            // scrolls horizontally INSIDE its round container past 3 columns —
-            // the page never scrolls horizontally. No motion is added here, so
-            // the arrangement is reduced-motion safe by construction.
-            rounds.map((round, ri) => (
-              <div key={ri} data-testid="chat-round" className="flex flex-col gap-3">
-                {round.user !== null && userBubble(round.user, 'u')}
-                <div
-                  data-testid="chat-round-grid"
-                  data-columns={seatOrder.length}
-                  style={{
-                    display: 'grid',
-                    gap: '8px',
-                    gridTemplateColumns: `repeat(${seatOrder.length}, minmax(260px, 1fr))`,
-                    overflowX: 'auto',
-                  }}
-                >
-                  {seatOrder.map((cliKey) => {
-                    const reply = round.seats.find((s) => s.cliKey === cliKey);
-                    return reply === undefined ? (
-                      <div
-                        key={cliKey}
-                        data-testid="chat-cell-empty"
-                        data-agent={cliKey}
-                        className="flex flex-col gap-1.5 min-w-0"
-                      >
-                        {columnHeader(cliKey)}
-                        <div
-                          className="rounded-xl px-4 py-2 text-[13px] font-mono"
-                          style={{ border: '1px dashed var(--surface-raised)', color: 'var(--ink-dim)' }}
-                        >
-                          —
-                        </div>
-                      </div>
-                    ) : (
-                      <div
-                        key={cliKey}
-                        data-testid="chat-cell"
-                        data-agent={cliKey}
-                        className="flex flex-col gap-1.5 min-w-0"
-                      >
-                        {columnHeader(cliKey)}
-                        {bubbleBody(reply)}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ))
-          : messages.map((m, i) =>
-              m.kind === 'user' ? (
-                userBubble(m, i)
-              ) : (
-                <div key={i} className="self-start max-w-[80%] flex gap-2">
-                  <span
-                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center text-[10px] font-mono font-bold mt-0.5"
-                    style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg }}
-                  >
-                    {m.cliKey.slice(0, 2).toUpperCase()}
-                  </span>
-                  {bubbleBody(m)}
-                </div>
-              ),
-            )}
+        {/* The transcript (§11): the narrated feed by default — conversation
+            stays turns, worker output collapses to narration with the raw
+            stream one click below — or the full §6 list/columns transcript. */}
+        <ChatThread
+          messages={messages}
+          view={view}
+          layout={layout}
+          seatOrder={seatOrder}
+          items={feedItems}
+        />
         {/* §7.9-2: a failed send is a visible, retryable fact — the draft is
             still in the composer, nothing was fanned out, and Retry re-sends
             exactly what failed. Never a cleared composer, never silence. */}
@@ -1261,6 +1218,15 @@ export function GroupChat({
         )}
         <div ref={bottomRef} />
       </div>
+
+      {/* The pinned approval dock (§11.5): anything the daemon parks on THIS
+          chat session awaiting the human — a gate, an MCP elicitation — renders
+          here, a structural sibling of the scroll region, so it can never
+          scroll away. Approve / approve+steer / reject-with-note work from this
+          surface (SteeringGate, verbatim). Renders nothing when nothing awaits. */}
+      {chatId !== null && !ended && (
+        <ApprovalDock chatId={chatId} onResolved={() => undefined} />
+      )}
 
       {/* Input — §5.3 token usage: the composer sits on --surface-raised at
           --radius-xl; its focus ring is --accent-dim (wk-composer in

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
+import { pinAwaiting } from '../store/awaitingPins.js';
 import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
@@ -25,6 +26,7 @@ import { NowBar } from './NowBar.js';
 import {
   buildChatFeed,
   deriveChatArtifacts,
+  narrateSeatLifecycle,
   newestChatNow,
   type NarrationLine,
   type NarrationTone,
@@ -251,15 +253,28 @@ export function GroupChat({
   const chatIdRef = useRef<string | null>(null);
   chatIdRef.current = chatId;
 
+  // §11.5: gates/elicitations the daemon keys by THIS chat session id must
+  // survive the run-list reconcile — a chat id is never in GET /runs, so the
+  // stores' self-healing prune would sweep the dock ~400ms after it mounted
+  // (the awaitingHuman frame itself bumps the run refresh). Pin the id for the
+  // surface's mounted lifetime; real resolutions (gateDecided, an answered
+  // gate's clearGate, sessionCompleted) still clear as before.
+  useEffect(() => {
+    if (chatId === null) return;
+    return pinAwaiting(chatId);
+  }, [chatId]);
+
   // ── §11.1 seat-lifecycle narration ──────────────────────────────────────────
   // Seat mechanics (joined / could not join) are narration, recorded into the
   // one message log at their ARRIVAL position — the chat wire's only clock
-  // (§11.2). Deduped per seat by last announced state, so an open response and
-  // its trailing chatSessionReady frame speak once.
+  // (§11.2). The template lives in narrator.ts (`narrateSeatLifecycle` — the one
+  // narration template source); this owns the dedup: per seat by last announced
+  // state, so an open response and its trailing chatSessionReady frame speak once.
   const announcedRef = useRef<Map<string, 'ready' | 'failed'>>(new Map());
-  function announceSeat(cliKey: string, state: 'ready' | 'failed', text: string, tone: NarrationTone): void {
+  function announceSeat(cliKey: string, state: 'ready' | 'failed', reason?: string | null): void {
     if (announcedRef.current.get(cliKey) === state) return;
     announcedRef.current.set(cliKey, state);
+    const { text, tone } = narrateSeatLifecycle(state, reason);
     const sys: SysMsg = { kind: 'sys', text, tone, seat: cliKey };
     setMessages((prev) => [...prev, sys]);
   }
@@ -567,14 +582,14 @@ export function GroupChat({
         // first fan-out already put a reply in flight.
         if (frame.cliKey) {
           setSeats((s) => (s[frame.cliKey!] === 'working' ? s : { ...s, [frame.cliKey!]: 'ready' }));
-          announceSeat(frame.cliKey, 'ready', 'joined the chat', 'info');
+          announceSeat(frame.cliKey, 'ready');
         }
         break;
       case 'chatSessionFailed':
         if (frame.cliKey) {
           setSeats((s) => ({ ...s, [frame.cliKey!]: 'failed' }));
           setSeatErrors((e) => ({ ...e, [frame.cliKey!]: frame.reason ?? 'session failed' }));
-          announceSeat(frame.cliKey, 'failed', `couldn’t join — ${frame.reason ?? 'session failed'}`, 'fail');
+          announceSeat(frame.cliKey, 'failed', frame.reason ?? 'session failed');
         }
         break;
       case 'chatDelta':
@@ -716,8 +731,8 @@ export function GroupChat({
         // §11.1: the open response is a lifecycle moment too — narrate it at
         // its arrival position (deduped against the trailing ready frames).
         for (const s of opened) {
-          if (s.ok) announceSeat(s.cliKey, 'ready', 'joined the chat', 'info');
-          else announceSeat(s.cliKey, 'failed', `couldn’t join — ${s.error ?? 'no reason given'}`, 'fail');
+          if (s.ok) announceSeat(s.cliKey, 'ready');
+          else announceSeat(s.cliKey, 'failed', s.error);
         }
         // §6.2 recoverable error: a chip may name an agent the daemon no
         // longer has (a stale cache, or an operator-typed name with no seat

--- a/src/components/NarratorFeed.tsx
+++ b/src/components/NarratorFeed.tsx
@@ -10,6 +10,8 @@ import {
   buildFeed,
   narrate,
   sortFeedEvents,
+  TONE_COLOR,
+  TONE_GLYPH,
   type FeedItem,
   type NarrationTone,
   type NarratorContext,
@@ -77,22 +79,6 @@ export function phaseName(runId: string, unit: WorkUnit): string {
   const key = unitKey(runId, unit.id, unit.ord);
   return /^u\d+$/.test(key) ? unit.stage : key;
 }
-
-const TONE_COLOR: Record<NarrationTone, string> = {
-  info: 'var(--ink-muted)',
-  work: 'var(--status-run)',
-  gate: 'var(--status-gate)',
-  fail: 'var(--status-fail)',
-  human: 'var(--accent)',
-};
-
-const TONE_GLYPH: Record<NarrationTone, string> = {
-  info: '·',
-  work: '●',
-  gate: '◆',
-  fail: '✗',
-  human: '➤',
-};
 
 interface Props {
   view: SessionView;

--- a/src/components/NowBar.tsx
+++ b/src/components/NowBar.tsx
@@ -1,23 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
-import type { SessionView, WorkUnit } from '../api/types.js';
-import type { NarrationLine, NarrationTone, RunArtifact } from './narrator.js';
+import type { WorkUnit } from '../api/types.js';
+import { TONE_COLOR, type NarrationLine, type RunArtifact } from './narrator.js';
 import { ArtifactCard } from './ArtifactCard.js';
 
 /**
- * The sticky now-bar (DES-RUN-NARRATOR §2): a pinned strip that always answers
- * "what is happening RIGHT NOW" — run state, the active phase (unit K of N),
- * the latest narration line, and the collected-artifacts chip — visible
- * regardless of where the feed is scrolled, because it lives OUTSIDE the
- * scroll region. "Latest ↓" scrolls the feed to its live tail.
+ * The sticky now-bar (DES-RUN-NARRATOR §2, §11.4): a pinned strip that always
+ * answers "what is happening RIGHT NOW" — run/chat state, the active phase
+ * (unit K of N; the chat surface passes its own `contextLabel` instead), the
+ * latest narration line, and the collected-artifacts chip — visible regardless
+ * of where the feed is scrolled, because it lives OUTSIDE the scroll region.
+ * "Latest ↓" scrolls the feed to its live tail.
  */
-
-const TONE_COLOR: Record<NarrationTone, string> = {
-  info: 'var(--ink-muted)',
-  work: 'var(--status-run)',
-  gate: 'var(--status-gate)',
-  fail: 'var(--status-fail)',
-  human: 'var(--accent)',
-};
 
 function statusPhrase(status: string): { text: string; color: string } {
   switch (status) {
@@ -27,54 +20,62 @@ function statusPhrase(status: string): { text: string; color: string } {
     case 'awaiting_human': return { text: 'waiting on you', color: 'var(--status-gate)' };
     case 'planning':       return { text: 'planning', color: 'var(--status-run)' };
     case 'distributing':   return { text: 'routing', color: 'var(--status-run)' };
+    // §11.4 chat vocabulary: seats warming, and the idle "it's your move".
+    case 'connecting':     return { text: 'connecting', color: 'var(--status-run)' };
+    case 'your_turn':      return { text: 'your turn', color: 'var(--status-gate)' };
     default:               return { text: 'working', color: 'var(--status-run)' };
   }
 }
 
 export function NowBar({
-  view,
-  orderedUnits,
-  executingUnitOrd,
-  phaseOf,
+  status,
+  orderedUnits = [],
+  executingUnitOrd = null,
+  phaseOf = () => '?',
+  contextLabel,
   lastLine,
   artifacts,
   onJumpToLatest,
   onOpenFile,
 }: {
-  view: SessionView;
-  /** ord-sorted units (the caller's memo). */
-  orderedUnits: WorkUnit[];
-  executingUnitOrd: number | null;
-  phaseOf: (ord: number | null | undefined) => string;
+  /** The run's `session.status`, or the chat surface's derived state (§11.4). */
+  status: string;
+  /** ord-sorted units (the caller's memo) — the run surface only. */
+  orderedUnits?: WorkUnit[];
+  executingUnitOrd?: number | null;
+  phaseOf?: (ord: number | null | undefined) => string;
+  /** A caller-owned phrase for the phase slot (the chat surface's seat census). */
+  contextLabel?: string | null;
   /** The newest spoken narration line, or null when the trail is silent. */
   lastLine: NarrationLine | null;
   artifacts: RunArtifact[];
   onJumpToLatest: () => void;
   onOpenFile?: ((path: string) => void) | undefined;
 }): React.ReactElement {
-  const { session } = view;
-  const { text: statusText, color: statusColor } = statusPhrase(session.status);
-  const live = !['completed', 'cancelled', 'failed'].includes(session.status);
+  const { text: statusText, color: statusColor } = statusPhrase(status);
+  const live = !['completed', 'cancelled', 'failed'].includes(status);
 
   const cursorIx = executingUnitOrd === null ? -1 : orderedUnits.findIndex((u) => u.ord === executingUnitOrd);
   const activeUnit = cursorIx === -1 ? null : orderedUnits[cursorIx] ?? null;
 
-  // The "now" phrase: the active phase while one runs, otherwise the run state.
+  // The "now" phrase: the caller's own label when it has one, else the active
+  // phase while one runs, otherwise the run state.
   const phaseLabel =
-    activeUnit !== null
+    contextLabel ??
+    (activeUnit !== null
       ? `${phaseOf(activeUnit.ord)} — unit ${cursorIx + 1} of ${orderedUnits.length}`
-      : session.status === 'awaiting_human'
+      : status === 'awaiting_human'
         ? 'paused at a gate'
         : orderedUnits.length > 0
           ? `${orderedUnits.filter((u) => u.status === 'done').length} of ${orderedUnits.length} phases done`
-          : null;
+          : null);
 
   // Fallback narration when the trail is silent (pruned log / no events yet).
   const nowText =
     lastLine?.text ??
     (activeUnit !== null
       ? `Working on ${phaseOf(activeUnit.ord)}${activeUnit.description ? ` — ${activeUnit.description}` : ''}`
-      : session.status === 'awaiting_human'
+      : status === 'awaiting_human'
         ? 'Waiting on your decision below'
         : `Run ${statusText}`);
   const nowColor = lastLine !== null ? TONE_COLOR[lastLine.tone] : 'var(--ink-muted)';

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -482,6 +482,21 @@ export function narrateChatSeat(m: ChatSeatView): { text: string; tone: Narratio
   return { text: `replied (${chatSizeLabel(m.text)})${firstLine ? ` — ${firstLine}` : ''}`, tone: 'work' };
 }
 
+/**
+ * §11.1 seat lifecycle: joined / could not join. The TEMPLATE lives here —
+ * narrator.ts is the one narration template source — while the caller owns the
+ * per-seat dedup (last announced state) and records the line into its message
+ * log at arrival position (§11.2: arrival is the chat wire's only clock).
+ */
+export function narrateSeatLifecycle(
+  state: 'ready' | 'failed',
+  reason?: string | null,
+): { text: string; tone: NarrationTone } {
+  return state === 'ready'
+    ? { text: 'joined the chat', tone: 'info' }
+    : { text: `couldn’t join — ${reason ?? 'no reason given'}`, tone: 'fail' };
+}
+
 /** File extensions a bare (slash-less) backticked mention still counts as a file. */
 const FILE_EXT =
   /\.(md|ts|tsx|js|jsx|mjs|cjs|json|rs|py|go|java|rb|css|html|yml|yaml|toml|sql|sh|txt|csv|pdf|png|jpg|svg|pptx|docx|xlsx)$/i;

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -476,7 +476,9 @@ export function narrateChatSeat(m: ChatSeatView): { text: string; tone: Narratio
     return { text: `failed${head ? ` — ${head}` : ''}`, tone: 'fail' };
   }
   if (isConversationalReply(m.text)) return null;
-  const firstLine = clip(m.text.trim(), 100);
+  // The headline drops a leading markdown heading marker — "## Root cause"
+  // reads as syntax, not narration.
+  const firstLine = clip(m.text.trim().replace(/^#+\s*/, ''), 100);
   return { text: `replied (${chatSizeLabel(m.text)})${firstLine ? ` — ${firstLine}` : ''}`, tone: 'work' };
 }
 

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -10,6 +10,24 @@ import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
 /** The §4 tone layer: which status color a narration line wears. */
 export type NarrationTone = 'info' | 'work' | 'gate' | 'fail' | 'human';
 
+/** The tone → color map every narrated surface renders with (§4). */
+export const TONE_COLOR: Record<NarrationTone, string> = {
+  info: 'var(--ink-muted)',
+  work: 'var(--status-run)',
+  gate: 'var(--status-gate)',
+  fail: 'var(--status-fail)',
+  human: 'var(--accent)',
+};
+
+/** The tone → glyph map for narration lines (§4). */
+export const TONE_GLYPH: Record<NarrationTone, string> = {
+  info: '·',
+  work: '●',
+  gate: '◆',
+  fail: '✗',
+  human: '➤',
+};
+
 export interface NarrationLine {
   /** The short human line ("Worker started clarify — survey the repo"). */
   text: string;
@@ -381,6 +399,236 @@ export function lastNarration(events: readonly CoreEvent[], ctx: NarratorContext
   for (let i = sorted.length - 1; i >= 0; i--) {
     const line = narrate(sorted[i]!, ctx);
     if (line !== null) return line;
+  }
+  return null;
+}
+
+// ── The chat surface (DES-RUN-NARRATOR §11) ──────────────────────────────────
+//
+// GroupChat's transcript is a different wire (chatDelta/chatReply — arrival IS
+// the order, §11.2) but the SAME narrator: this section is the one place the
+// chat surface's narration-vs-conversation classification and its templates
+// live. The rule (§11.1): the user's messages and the crew's direct
+// conversational replies stay first-class chat turns; everything else — a
+// seat's still-streaming worker output, an over-long output dump, a failed
+// reply, seat lifecycle mechanics — collapses into a short narration line with
+// the seat's identity as a chip and the raw bytes behind an expander.
+
+/** The structural seat-message view the chat classifier reads (GroupChat's
+ *  `SeatMsg` satisfies it). */
+export interface ChatSeatView {
+  kind: 'seat';
+  cliKey: string;
+  text: string;
+  pending: boolean;
+  ok: boolean;
+}
+export interface ChatUserView {
+  kind: 'user';
+  text: string;
+}
+/** A surface-recorded moment (seat joined/failed, …) — already narration. */
+export interface ChatSysView {
+  kind: 'sys';
+  text: string;
+  tone: NarrationTone;
+  seat: string | null;
+}
+export type ChatMsgView = ChatUserView | ChatSysView | ChatSeatView;
+
+/**
+ * §11.1's conversational bar: a finalized ok reply STAYS a first-class chat
+ * turn while it still reads as conversation. Beyond either bound it is a
+ * worker-output dump wearing a chat bubble — the exact "outputs from the
+ * individual agents" wall — and collapses to narration + expander instead.
+ * Deterministic and documented rather than clever: chars OR lines.
+ */
+export const CHAT_TURN_MAX_CHARS = 1400;
+export const CHAT_TURN_MAX_LINES = 16;
+
+export function isConversationalReply(text: string): boolean {
+  if (text.length > CHAT_TURN_MAX_CHARS) return false;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) lines += 1;
+  return lines <= CHAT_TURN_MAX_LINES;
+}
+
+/** Human size for a streamed text: chars below 1 KiB, KB above. */
+export function chatSizeLabel(text: string): string {
+  return text.length >= 1024
+    ? `${Math.max(1, Math.round(text.length / 1024))} KB`
+    : `${text.length} chars`;
+}
+
+/**
+ * One seat message → its narration, or `null` when the message stays a
+ * first-class conversational turn (§11.1). The seat's identity is NOT in the
+ * text — the renderer wears it as a chip on the line.
+ */
+export function narrateChatSeat(m: ChatSeatView): { text: string; tone: NarrationTone } | null {
+  if (m.pending) {
+    return m.text === ''
+      ? { text: 'is thinking…', tone: 'work' }
+      : { text: `is working — ${chatSizeLabel(m.text)} streamed`, tone: 'work' };
+  }
+  if (!m.ok) {
+    const head = clip(m.text.trim(), 120);
+    return { text: `failed${head ? ` — ${head}` : ''}`, tone: 'fail' };
+  }
+  if (isConversationalReply(m.text)) return null;
+  const firstLine = clip(m.text.trim(), 100);
+  return { text: `replied (${chatSizeLabel(m.text)})${firstLine ? ` — ${firstLine}` : ''}`, tone: 'work' };
+}
+
+/** File extensions a bare (slash-less) backticked mention still counts as a file. */
+const FILE_EXT =
+  /\.(md|ts|tsx|js|jsx|mjs|cjs|json|rs|py|go|java|rb|css|html|yml|yaml|toml|sql|sh|txt|csv|pdf|png|jpg|svg|pptx|docx|xlsx)$/i;
+const PATHISH = /^[\w.@~-]+(?:\/[\w.@~-]+)*$/;
+/** Most artifacts one reply is scanned for — a guard against pathological dumps. */
+const CHAT_ARTIFACT_SCAN_CAP = 12;
+
+/**
+ * Artifacts a chat reply names (§11.3): the wire carries only text — no
+ * `dataUsed` frames reach a chat — so the honest best-effort is the reply's own
+ * references: backticked file paths (a path shape, or a bare name with a known
+ * file extension) and http(s) links. Deterministic and conservative; deduped by
+ * the caller across the transcript.
+ */
+export function extractChatArtifacts(text: string): RunArtifact[] {
+  const out: RunArtifact[] = [];
+  const seen = new Set<string>();
+  const push = (a: RunArtifact): void => {
+    if (seen.has(a.ref) || out.length >= CHAT_ARTIFACT_SCAN_CAP) return;
+    seen.add(a.ref);
+    out.push(a);
+  };
+  for (const m of text.matchAll(/`([^`\n]{3,160})`/g)) {
+    const span = (m[1] ?? '').trim();
+    if (span.includes(' ') || !PATHISH.test(span)) continue;
+    if (!span.includes('/') && !FILE_EXT.test(span)) continue;
+    if (!/\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(span)) continue; // a dir mention is not an artifact
+    push({ kind: 'file', ref: span, name: basename(span), phase: null });
+  }
+  for (const m of text.matchAll(/https?:\/\/[^\s`)\]}>"']+/g)) {
+    const url = m[0].replace(/[.,;:]+$/, '');
+    let name = url;
+    try {
+      const u = new URL(url);
+      name = u.pathname.split('/').filter((p) => p !== '').pop() ?? u.host;
+    } catch {
+      continue;
+    }
+    push({ kind: 'pr', ref: url, name, phase: null });
+  }
+  return out;
+}
+
+export interface ChatTurnItem {
+  kind: 'turn';
+  key: string;
+  /** Index into the caller's message array. */
+  index: number;
+}
+export interface ChatNarrationItem {
+  kind: 'narration';
+  key: string;
+  /** Index of the seat message the raw expander shows; `null` = sys line (nothing to expand). */
+  index: number | null;
+  seat: string | null;
+  text: string;
+  tone: NarrationTone;
+}
+export interface ChatArtifactItem {
+  kind: 'artifact';
+  key: string;
+  artifact: RunArtifact;
+}
+export type ChatFeedItem = ChatTurnItem | ChatNarrationItem | ChatArtifactItem;
+
+/**
+ * The narrated chat feed (§11): messages in their arrival order — the chat
+ * wire's only clock (per-seat FIFO keeps a late turn-1 reply in its turn-1
+ * position, so out-of-order arrival still renders chronologically) — each
+ * classified turn-or-narration, with the artifacts a finalized reply names
+ * riding behind it (deduped across the transcript, capped inline like the run
+ * feed). Pure — the renderer maps over the result.
+ */
+export function buildChatFeed(messages: readonly ChatMsgView[]): ChatFeedItem[] {
+  const items: ChatFeedItem[] = [];
+  const seenArtifacts = new Set<string>();
+  messages.forEach((m, i) => {
+    if (m.kind === 'user') {
+      items.push({ kind: 'turn', key: `m${i}`, index: i });
+      return;
+    }
+    if (m.kind === 'sys') {
+      items.push({ kind: 'narration', key: `n${i}`, index: null, seat: m.seat, text: m.text, tone: m.tone });
+      return;
+    }
+    const n = narrateChatSeat(m);
+    if (n === null) {
+      items.push({ kind: 'turn', key: `m${i}`, index: i });
+    } else {
+      items.push({ kind: 'narration', key: `n${i}`, index: i, seat: m.cliKey, text: n.text, tone: n.tone });
+    }
+    if (!m.pending && m.ok) {
+      let inlined = 0;
+      for (const a of extractChatArtifacts(m.text)) {
+        if (seenArtifacts.has(a.ref)) continue;
+        seenArtifacts.add(a.ref);
+        if (inlined >= INLINE_ARTIFACT_CAP) continue;
+        inlined += 1;
+        items.push({ kind: 'artifact', key: `a${i}:${a.ref}`, artifact: { ...a, phase: m.cliKey } });
+      }
+    }
+  });
+  return items;
+}
+
+/** Every artifact the transcript names so far — the chat now-bar's chip (§11.3). */
+export function deriveChatArtifacts(messages: readonly ChatMsgView[]): RunArtifact[] {
+  const seen = new Set<string>();
+  const out: RunArtifact[] = [];
+  for (const m of messages) {
+    if (m.kind !== 'seat' || m.pending || !m.ok) continue;
+    for (const a of extractChatArtifacts(m.text)) {
+      if (seen.has(a.ref)) continue;
+      seen.add(a.ref);
+      out.push({ ...a, phase: m.cliKey });
+    }
+  }
+  return out;
+}
+
+/** The newest narration line of the chat feed, for the now-bar (§11.4). */
+export function lastChatNarration(items: readonly ChatFeedItem[]): ChatNarrationItem | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const it = items[i]!;
+    if (it.kind === 'narration') return it;
+  }
+  return null;
+}
+
+/**
+ * The now-bar's "what is happening" phrase for the chat surface (§11.4): the
+ * NEWEST story beat — a narration line (seat-prefixed), or the latest turn
+ * spoken as one ("you said… / <seat> replied…"). `null` when the log is empty
+ * (the caller falls back to a status phrase).
+ */
+export function newestChatNow(
+  items: readonly ChatFeedItem[],
+  messages: readonly ChatMsgView[],
+): { text: string; tone: NarrationTone } | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const it = items[i]!;
+    if (it.kind === 'artifact') continue;
+    if (it.kind === 'narration') {
+      return { text: it.seat !== null ? `${it.seat} ${it.text}` : it.text, tone: it.tone };
+    }
+    const m = messages[it.index];
+    if (m === undefined) continue;
+    if (m.kind === 'user') return { text: `You: ${clip(m.text, 100)}`, tone: 'human' };
+    if (m.kind === 'seat') return { text: `${m.cliKey} replied — ${clip(m.text.trim(), 100)}`, tone: 'work' };
   }
   return null;
 }

--- a/src/store/awaitingPins.ts
+++ b/src/store/awaitingPins.ts
@@ -1,0 +1,38 @@
+/**
+ * Awaiting-record pins (DES-RUN-NARRATOR §11.5).
+ *
+ * The gate and elicitation stores self-heal against the RUN list: every
+ * `GET /runs` reconcile prunes records whose id the fetched universe cannot
+ * vouch for. That is correct for runs — and wrong for the chat surface, whose
+ * gates/elicitations the daemon keys by the CHAT session id, an id that is
+ * never in `GET /runs`. Without a pin, the §11.5 dock mounts on
+ * `awaitingHuman` and is swept ~400 ms later by the very refresh that frame
+ * triggered (verified live against crew 0.7.4).
+ *
+ * A surface that OWNS an id outside the run universe pins it for its mounted
+ * lifetime; both reconciles skip pinned ids. Counted, not boolean, so React
+ * StrictMode's synthetic remount (and any future second surface on the same
+ * id) cannot unpin early. Event-driven clears (`gateDecided`,
+ * `sessionCompleted`, an answered gate's `clearGate`) are untouched — a pin
+ * only shields against the run-universe prune, never against real resolution.
+ */
+const counts = new Map<string, number>();
+
+/** Pin `id`; returns the matching unpin (call it exactly once, e.g. as an
+ *  effect cleanup). */
+export function pinAwaiting(id: string): () => void {
+  counts.set(id, (counts.get(id) ?? 0) + 1);
+  let done = false;
+  return () => {
+    if (done) return;
+    done = true;
+    const n = (counts.get(id) ?? 0) - 1;
+    if (n <= 0) counts.delete(id);
+    else counts.set(id, n);
+  };
+}
+
+/** True while any surface holds a pin on `id`. */
+export function isAwaitingPinned(id: string): boolean {
+  return (counts.get(id) ?? 0) > 0;
+}

--- a/src/store/elicitations.ts
+++ b/src/store/elicitations.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { CoreEvent } from '../api/types.js';
+import { isAwaitingPinned } from './awaitingPins.js';
 
 /**
  * A browser-side open-elicitation record, keyed by run id (DES-002).
@@ -145,14 +146,19 @@ export const useElicitationStore = create<ElicitationStore>((set, get) => ({
   reconcile: (liveRunIds) => {
     const live = new Set(liveRunIds);
     set((s) => {
-      const dropped = Object.keys(s.elicitations).filter((runId) => !live.has(runId));
+      // Pinned ids live outside the run universe (§11.5 — a chat-keyed
+      // elicitation is never in GET /runs); the prune must not eat them.
+      const dropped = Object.keys(s.elicitations).filter(
+        (runId) => !live.has(runId) && !isAwaitingPinned(runId),
+      );
       // Identity-stable when nothing is dropped: reconcile runs on EVERY run-list refresh, so
       // returning fresh objects each time rerenders every subscriber for no change.
       if (dropped.length === 0) return s;
 
+      const droppedSet = new Set(dropped);
       const next: Record<string, OpenElicitation> = {};
       for (const [runId, e] of Object.entries(s.elicitations)) {
-        if (live.has(runId)) next[runId] = e;
+        if (!droppedSet.has(runId)) next[runId] = e;
       }
       // Each dropped run must still bump, so a GET in flight for it cannot write back afterwards
       // (DES-002 v0.25 — the zombie-prompt case).

--- a/src/store/gates.ts
+++ b/src/store/gates.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { CoreEvent } from '../api/types.js';
+import { isAwaitingPinned } from './awaitingPins.js';
 
 /**
  * A browser-side open-gate record, keyed by run id. Mirrors the daemon's
@@ -175,7 +176,10 @@ export const useGateStore = create<GateStore>((set) => ({
       const next: Record<string, OpenGate> = {};
       let changed = false;
       for (const [id, gate] of Object.entries(s.gates)) {
-        if (keep.has(id)) next[id] = gate;
+        // Pinned ids live OUTSIDE the run universe this prune reconciles
+        // against (§11.5 — a chat-keyed gate is never in GET /runs); only a
+        // real resolution (ingest/clearGate) may retire them.
+        if (keep.has(id) || isAwaitingPinned(id)) next[id] = gate;
         else changed = true;
       }
       return changed ? { gates: next } : s;

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,10 +10,10 @@
   "version": 1,
   "studioVersion": "0.4.4",
   "counts": {
-    "files": 114,
-    "occurrences": 830,
-    "static": 713,
-    "dynamic": 40,
+    "files": 115,
+    "occurrences": 836,
+    "static": 717,
+    "dynamic": 41,
     "computed": 6
   },
   "static": [
@@ -532,13 +532,13 @@
     {
       "testId": "chat-cell",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
       "testId": "chat-cell-empty",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
@@ -572,6 +572,18 @@
       ]
     },
     {
+      "testId": "chat-narration-line",
+      "files": [
+        "src/components/ChatThread.tsx"
+      ]
+    },
+    {
+      "testId": "chat-narration-seat",
+      "files": [
+        "src/components/ChatThread.tsx"
+      ]
+    },
+    {
       "testId": "chat-project-row",
       "files": [
         "src/components/GroupChat.tsx"
@@ -592,13 +604,13 @@
     {
       "testId": "chat-round",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
       "testId": "chat-round-grid",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
@@ -621,6 +633,18 @@
     },
     {
       "testId": "chat-session-ended",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-thread",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-view-toggle",
       "files": [
         "src/components/GroupChat.tsx"
       ]
@@ -2910,7 +2934,7 @@
     {
       "testId": "seat-bubble",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
@@ -3995,7 +4019,7 @@
     {
       "testId": "user-bubble",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
       ]
     },
     {
@@ -4382,9 +4406,15 @@
       ]
     },
     {
-      "pattern": "chat-layout-*",
+      "pattern": "chat-narration-raw-*",
       "files": [
-        "src/components/GroupChat.tsx"
+        "src/components/ChatThread.tsx"
+      ]
+    },
+    {
+      "pattern": "chat-narration-toggle-*",
+      "files": [
+        "src/components/ChatThread.tsx"
       ]
     },
     {
@@ -4598,6 +4628,7 @@
       "expression": "testid",
       "files": [
         "src/components/CampaignScoreboard.tsx",
+        "src/components/GroupChat.tsx",
         "src/components/SteeringAddMenu.tsx",
         "src/components/SteeringHealth.tsx",
         "src/components/SteeringRuleDrawer.tsx",

--- a/tests/GroupChat.narrated.test.tsx
+++ b/tests/GroupChat.narrated.test.tsx
@@ -280,6 +280,56 @@ describe('§11.5 — the pinned approval dock, answerable from the chat surface'
     expect(screen.getByTestId('chat-thread').contains(dock)).toBe(false);
   });
 
+  it('the chat-keyed gate and elicitation SURVIVE the run-list reconcile (a chat id is never in GET /runs)', async () => {
+    // The live-daemon defect this pins: `awaitingHuman` mounts the dock, the
+    // frame bumps the run refresh, and ~400ms later `reconcile()` — fed only
+    // run ids — swept gates[chatId], unmounting the dock mid-decision.
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+
+    act(() => {
+      useGateStore.setState({
+        gates: { [chatId()]: { runId: chatId(), ord: 1, prompt: 'Approve?', lifecycle: 'open', receivedAt: 0 } },
+        approaching: {},
+      });
+      useElicitationStore.getState().setElicitation({
+        runId: chatId(),
+        elicitationId: 'e9',
+        message: 'Which database?',
+        options: null,
+        receivedAt: new Date().toISOString(),
+      });
+    });
+    expect(screen.getByTestId('approval-dock')).toBeInTheDocument();
+
+    // The run-universe prune, exactly as useRuns fires it — no run is awaiting,
+    // and the chat id is not a run.
+    act(() => {
+      useGateStore.getState().reconcile([]);
+      useElicitationStore.getState().reconcile(['some-other-run']);
+    });
+    expect(useGateStore.getState().gates[chatId()]).toBeDefined();
+    expect(useElicitationStore.getState().elicitations[chatId()]).toBeDefined();
+    expect(screen.getByTestId('approval-dock')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-gate')).toBeInTheDocument();
+
+    // An UNPINNED id (a genuinely stale run gate) is still swept — the
+    // self-healing prune is intact for the run universe.
+    act(() => {
+      useGateStore.setState({
+        gates: {
+          ...useGateStore.getState().gates,
+          'stale-run': { runId: 'stale-run', ord: 0, prompt: 'x', lifecycle: 'open', receivedAt: 0 },
+        },
+        approaching: {},
+      });
+      useGateStore.getState().reconcile([]);
+    });
+    expect(useGateStore.getState().gates['stale-run']).toBeUndefined();
+    expect(useGateStore.getState().gates[chatId()]).toBeDefined();
+  });
+
   it('renders no dock when nothing awaits the human', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);

--- a/tests/GroupChat.narrated.test.tsx
+++ b/tests/GroupChat.narrated.test.tsx
@@ -1,0 +1,331 @@
+// DES-RUN-NARRATOR §11 — the narrator comes to the CHAT surface (the user's
+// overrule of the original out-of-scope line: "what I see is still the outputs
+// from the individual agents and not the narrative piece"). Pinned here:
+//
+//   - §11.1 classification IN THE DOM: the user's message stays a first-class
+//     turn; a seat's still-streaming worker output collapses into a narration
+//     line (seat chip + status), with the raw stream mounted behind an
+//     expander; a short ok reply lands as a conversational turn; an over-long
+//     reply stays collapsed;
+//   - §11.2 ordering: out-of-order arrival renders chronologically (per-seat
+//     FIFO keeps a late turn-1 reply in its turn-1 position);
+//   - §11.4 the pinned now-bar: state, seat census, latest narration, the
+//     artifacts chip, jump-to-latest — outside the scroll region;
+//   - §11.5 the pinned approval dock: a gate keyed by the CHAT session renders
+//     as a structural sibling of the scroll region, and reject carries the
+//     typed note on the wire from THIS surface;
+//   - §11.6 the full transcript stays reachable behind the view toggle.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useElicitationStore } from '../src/store/elicitations.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const confirmGate = vi.fn();
+const cancelRun = vi.fn();
+const getCoverageReportForRepo = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    confirmGate: (...a: unknown[]) => confirmGate(...a),
+    cancelRun: (...a: unknown[]) => cancelRun(...a),
+    getCoverageReportForRepo: (...a: unknown[]) => getCoverageReportForRepo(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+let emit: ((ev: unknown) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (fn: (ev: unknown) => void): void => {
+    emit = fn;
+  },
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+] as unknown as RosterSeat[];
+
+beforeEach(() => {
+  for (const spy of [openChat, getChat, closeChat, getRoster, sendChatMessage, confirmGate, cancelRun, getCoverageReportForRepo]) {
+    spy.mockReset();
+  }
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ['claude', 'codex']).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  confirmGate.mockResolvedValue({ ok: true });
+  sessionStorage.clear();
+  clearCachedRoster();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useElicitationStore.setState({ elicitations: {}, generations: {} });
+  emit = null;
+  setCachedRoster(ROSTER);
+});
+
+const chatId = (): string => (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+
+async function sendText(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.type(screen.getByRole('textbox'), text);
+  await user.keyboard('{Enter}');
+  await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(chatId(), text));
+}
+
+const rawWrapper = (index: number): HTMLElement | null =>
+  document.querySelector(`[data-testid="chat-narration-raw-${index}"]`);
+
+describe('§11.1 — narration vs conversation in the DOM', () => {
+  it('user turn stays a turn; a streaming worker output collapses to narration with the raw stream behind the expander', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'what needs fixing?');
+
+    // The user's message is a first-class bubble.
+    expect(screen.getByTestId('user-bubble')).toHaveTextContent('what needs fixing?');
+
+    act(() => {
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text: 'raw tool chatter '.repeat(20) });
+    });
+
+    // The PRIMARY rendering of the stream is a narration line wearing the seat chip…
+    const lines = screen.getAllByTestId('chat-narration-line');
+    const streamLine = lines.find((l) => l.dataset['agent'] === 'claude' && l.textContent!.includes('is working'));
+    expect(streamLine, 'streaming output must collapse to a narration line').toBeTruthy();
+    // …and the raw bytes are mounted but hidden until the expander opens.
+    const bubble = document.querySelector('[data-testid="seat-bubble"][data-agent="claude"]') as HTMLElement;
+    const wrapper = bubble.closest('[data-testid^="chat-narration-raw-"]') as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.style.display).toBe('none');
+    expect(wrapper.textContent).toContain('raw tool chatter');
+
+    const index = wrapper.getAttribute('data-testid')!.replace('chat-narration-raw-', '');
+    await user.click(screen.getByTestId(`chat-narration-toggle-${index}`));
+    expect(rawWrapper(Number(index))!.style.display).not.toBe('none');
+  });
+
+  it('a short ok reply becomes a first-class conversational turn; an over-long one stays narration', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'Done — two files changed.', ok: true });
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'codex', text: 'x'.repeat(3000), ok: true });
+    });
+
+    // claude's reply: a visible turn (no display:none ancestor wrapper).
+    const claudeBubble = document.querySelector('[data-testid="seat-bubble"][data-agent="claude"]') as HTMLElement;
+    expect(claudeBubble).toHaveTextContent('Done — two files changed.');
+    expect(claudeBubble.closest('[data-testid^="chat-narration-raw-"]')).toBeNull();
+
+    // codex's dump: still narration ("replied (3 KB)"), raw behind the expander.
+    const lines = screen.getAllByTestId('chat-narration-line');
+    expect(lines.some((l) => l.dataset['agent'] === 'codex' && /replied \(3 KB\)/.test(l.textContent!))).toBe(true);
+    const codexBubble = document.querySelector('[data-testid="seat-bubble"][data-agent="codex"]') as HTMLElement;
+    expect(codexBubble.closest('[data-testid^="chat-narration-raw-"]')).not.toBeNull();
+  });
+
+  it('a failed reply collapses to fail-tone narration', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'model refused', ok: false });
+    });
+    const lines = screen.getAllByTestId('chat-narration-line');
+    expect(lines.some((l) => l.dataset['tone'] === 'fail' && l.textContent!.includes('failed — model refused'))).toBe(true);
+  });
+
+  it('seat lifecycle is narration: joined-the-chat lines carry the seat chip', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'hello');
+    const seats = screen.getAllByTestId('chat-narration-seat').map((s) => s.textContent);
+    expect(seats).toContain('claude');
+    expect(seats).toContain('codex');
+    expect(screen.getAllByText('joined the chat').length).toBe(2);
+  });
+});
+
+describe('§11.2 — out-of-order arrival renders chronologically', () => {
+  it('a turn-1 reply finalizing after turn 2 opened stays BEFORE the turn-2 user bubble', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'first ask');
+    await user.type(screen.getByRole('textbox'), 'second ask');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+
+    // Turn 1's reply lands LAST on the wire — after turn 2's user message.
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'answer to the FIRST ask', ok: true });
+    });
+
+    const reply = document.querySelector('[data-testid="seat-bubble"][data-agent="claude"][data-turn="1"]') as HTMLElement;
+    expect(reply).toHaveTextContent('answer to the FIRST ask');
+    const secondAsk = screen.getAllByTestId('user-bubble').find((b) => b.dataset['turn'] === '2')!;
+    // DOM order: the reply PRECEDES the second ask — chronological by source,
+    // not by arrival.
+    expect(reply.compareDocumentPosition(secondAsk) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe('§11.4 — the pinned now-bar', () => {
+  it('says working while a reply streams, your turn when the crew is done, and jumps to the tail', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+
+    expect(screen.getByTestId('now-bar-status')).toHaveTextContent('working');
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('2 of 2 agents replying');
+
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'ok', ok: true });
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'codex', text: 'ok', ok: true });
+    });
+    expect(screen.getByTestId('now-bar-status')).toHaveTextContent('your turn');
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('2 agents ready');
+    expect(screen.getByTestId('now-bar-narration')).toHaveTextContent(/replied/);
+
+    // The now-bar sits OUTSIDE the one scrolling region; the jump targets it.
+    const thread = screen.getByTestId('chat-thread');
+    expect(thread.contains(screen.getByTestId('now-bar'))).toBe(false);
+    await user.click(screen.getByTestId('now-bar-jump')); // no throw = wired
+  });
+
+  it('collects the artifacts replies name into the chip, and renders inline cards', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    act(() => {
+      emit!({
+        type: 'chatReply', chat: chatId(), cliKey: 'claude',
+        text: 'Wrote `src/retry.ts` — see https://github.com/x/y/pull/7', ok: true,
+      });
+    });
+    const cards = screen.getAllByTestId('artifact-card');
+    expect(cards.map((c) => c.getAttribute('data-artifact-kind'))).toEqual(['file', 'pr']);
+    expect(cards[0]).toHaveTextContent('retry.ts');
+    expect(screen.getByTestId('now-bar-artifacts')).toHaveTextContent('2');
+  });
+});
+
+describe('§11.5 — the pinned approval dock, answerable from the chat surface', () => {
+  it('a gate keyed by the chat session renders as a SIBLING of the scroll region, and reject carries the typed note', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+
+    act(() => {
+      useGateStore.setState({
+        gates: { [chatId()]: { runId: chatId(), ord: 1, prompt: 'Approve the plan?', lifecycle: 'open', receivedAt: 0 } },
+        approaching: {},
+      });
+    });
+
+    const dock = screen.getByTestId('approval-dock');
+    const gate = screen.getByTestId('steering-gate');
+    const thread = screen.getByTestId('chat-thread');
+    expect(dock.contains(gate)).toBe(true);
+    // Structure-level pinning: the dock is NOT inside the scroll region, so no
+    // amount of transcript growth can push the approval offscreen.
+    expect(thread.contains(dock)).toBe(false);
+    expect(dock.contains(thread)).toBe(false);
+    expect(thread.className).toContain('overflow-y-auto');
+    expect(dock.className).not.toContain('overflow-y-auto');
+
+    await user.type(screen.getByTestId('steering-amend'), 'not like this — keep the queue');
+    await user.click(screen.getByTestId('steering-reject'));
+    await waitFor(() =>
+      expect(confirmGate).toHaveBeenCalledWith(chatId(), {
+        approve: false,
+        amend: 'not like this — keep the queue',
+      }),
+    );
+  });
+
+  it('an open elicitation docks the same way', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    act(() => {
+      useElicitationStore.getState().setElicitation({
+        runId: chatId(),
+        elicitationId: 'e1',
+        message: 'Which database?',
+        options: ['postgres', 'sqlite'],
+        receivedAt: new Date().toISOString(),
+      });
+    });
+    const dock = screen.getByTestId('approval-dock');
+    expect(dock).toHaveTextContent('Which database?');
+    expect(screen.getByTestId('chat-thread').contains(dock)).toBe(false);
+  });
+
+  it('renders no dock when nothing awaits the human', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    expect(screen.queryByTestId('approval-dock')).not.toBeInTheDocument();
+  });
+});
+
+describe('§11.6 — the full transcript stays reachable', () => {
+  it('the view toggle swaps narration for the old bubbles and back, zero requests', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'y'.repeat(3000), ok: true });
+    });
+
+    // Narrated (default): the dump is a narration line.
+    expect(screen.getAllByTestId('chat-narration-line').length).toBeGreaterThan(0);
+
+    const calls = (): number =>
+      openChat.mock.calls.length + getChat.mock.calls.length + getRoster.mock.calls.length +
+      sendChatMessage.mock.calls.length;
+    const before = calls();
+    await user.click(screen.getByTestId('chat-view-full'));
+    // Full: no narration lines; the raw bubble is a plain visible row.
+    expect(screen.queryByTestId('chat-narration-line')).toBeNull();
+    const bubble = document.querySelector('[data-testid="seat-bubble"][data-agent="claude"]') as HTMLElement;
+    expect(bubble.closest('[data-testid^="chat-narration-raw-"]')).toBeNull();
+    expect(calls()).toBe(before);
+    // The preference persists per-session; narrated comes back on demand.
+    expect(sessionStorage.getItem('wicked.chat.view')).toBe('full');
+    await user.click(screen.getByTestId('chat-view-narrated'));
+    expect(screen.getAllByTestId('chat-narration-line').length).toBeGreaterThan(0);
+  });
+
+  it('picking a layout arrangement implies the full transcript', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'go');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'a', ok: true });
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'codex', text: 'b', ok: true });
+    });
+    await user.click(screen.getByTestId('chat-layout-columns'));
+    expect(screen.getByTestId('chat-view-toggle').getAttribute('data-view')).toBe('full');
+    expect(screen.getAllByTestId('chat-round-grid').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/narrator.chat.test.ts
+++ b/tests/narrator.chat.test.ts
@@ -1,0 +1,173 @@
+// DES-RUN-NARRATOR §11 — the chat surface speaks the same narrator: the
+// narration-vs-conversation classification, the arrival-order feed, and the
+// artifacts a reply names. Pure functions, zero DOM.
+
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_TURN_MAX_CHARS,
+  CHAT_TURN_MAX_LINES,
+  buildChatFeed,
+  chatSizeLabel,
+  deriveChatArtifacts,
+  extractChatArtifacts,
+  isConversationalReply,
+  lastChatNarration,
+  narrateChatSeat,
+  newestChatNow,
+  type ChatMsgView,
+} from '../src/components/narrator.js';
+
+const seat = (over: Partial<Extract<ChatMsgView, { kind: 'seat' }>> = {}): ChatMsgView => ({
+  kind: 'seat',
+  cliKey: 'claude',
+  text: '',
+  pending: false,
+  ok: true,
+  ...over,
+});
+
+describe('§11.1 — narration-vs-conversation classification', () => {
+  it('a still-streaming worker output is NARRATION, never a turn', () => {
+    expect(narrateChatSeat({ kind: 'seat', cliKey: 'claude', text: '', pending: true, ok: false }))
+      .toEqual({ text: 'is thinking…', tone: 'work' });
+    const streaming = narrateChatSeat({
+      kind: 'seat', cliKey: 'claude', text: 'x'.repeat(2048), pending: true, ok: false,
+    });
+    expect(streaming).not.toBeNull();
+    expect(streaming!.tone).toBe('work');
+    expect(streaming!.text).toContain('2 KB');
+  });
+
+  it('a short ok reply is a first-class conversational turn (null narration)', () => {
+    expect(narrateChatSeat(seat({ text: 'Yes — use the retry queue.' }) as never)).toBeNull();
+  });
+
+  it('an over-long ok reply collapses to narration — chars OR lines', () => {
+    const byChars = narrateChatSeat(seat({ text: 'a'.repeat(CHAT_TURN_MAX_CHARS + 1) }) as never);
+    expect(byChars).not.toBeNull();
+    expect(byChars!.text).toMatch(/^replied \(/);
+    const byLines = narrateChatSeat(seat({ text: 'line\n'.repeat(CHAT_TURN_MAX_LINES + 1) }) as never);
+    expect(byLines).not.toBeNull();
+  });
+
+  it('a failed reply collapses to fail-tone narration carrying the headline', () => {
+    const n = narrateChatSeat(seat({ ok: false, text: 'session died\nstack…' }) as never);
+    expect(n).toEqual({ text: 'failed — session died', tone: 'fail' });
+  });
+
+  it('the conversational bar is deterministic', () => {
+    expect(isConversationalReply('a'.repeat(CHAT_TURN_MAX_CHARS))).toBe(true);
+    expect(isConversationalReply('a'.repeat(CHAT_TURN_MAX_CHARS + 1))).toBe(false);
+    // n repeats of "l\n" = n newlines = n+1 logical lines → one over the bar.
+    expect(isConversationalReply('l\n'.repeat(CHAT_TURN_MAX_LINES))).toBe(false);
+  });
+
+  it('sizes read human: chars below 1 KiB, KB above', () => {
+    expect(chatSizeLabel('abc')).toBe('3 chars');
+    expect(chatSizeLabel('x'.repeat(3000))).toBe('3 KB');
+  });
+});
+
+describe('§11 — buildChatFeed: user turns stay turns; worker streams collapse', () => {
+  it('classifies one round: user turn, streaming narration, conversational turn', () => {
+    const messages: ChatMsgView[] = [
+      { kind: 'user', text: 'what broke?' },
+      seat({ cliKey: 'claude', text: 'streaming…', pending: true, ok: false }),
+      seat({ cliKey: 'codex', text: 'The retry queue lost its backoff.' }),
+    ];
+    const items = buildChatFeed(messages);
+    expect(items.map((i) => i.kind)).toEqual(['turn', 'narration', 'turn']);
+    const narration = items[1] as Extract<(typeof items)[number], { kind: 'narration' }>;
+    expect(narration.seat).toBe('claude');
+    expect(narration.index).toBe(1); // the raw stream is reachable behind the line
+  });
+
+  it('sys lifecycle lines are narration with nothing to expand', () => {
+    const items = buildChatFeed([{ kind: 'sys', text: 'joined the chat', tone: 'info', seat: 'claude' }]);
+    expect(items).toEqual([
+      { kind: 'narration', key: 'n0', index: null, seat: 'claude', text: 'joined the chat', tone: 'info' },
+    ]);
+  });
+
+  it('renders in ARRIVAL order — a late turn-1 reply keeps its turn-1 position (per-seat FIFO)', () => {
+    // The log after: send 1, send 2, then turn 1's reply lands (in place).
+    const messages: ChatMsgView[] = [
+      { kind: 'user', text: 'first ask' },
+      seat({ cliKey: 'claude', text: 'answer to the FIRST ask' }), // finalized late, position fixed at append
+      { kind: 'user', text: 'second ask' },
+      seat({ cliKey: 'claude', text: '', pending: true, ok: false }),
+    ];
+    const items = buildChatFeed(messages);
+    expect(items.map((i) => i.kind)).toEqual(['turn', 'turn', 'turn', 'narration']);
+    // The reply's item sits BETWEEN the two user turns — chronological by source.
+    expect((items[1] as { index: number }).index).toBe(1);
+    expect((items[2] as { index: number }).index).toBe(2);
+  });
+
+  it('artifacts a finalized reply names ride behind it, deduped across the transcript', () => {
+    const text = 'Wrote `src/retry.ts` and `src/retry.ts` again; see https://github.com/x/y/pull/7';
+    const messages: ChatMsgView[] = [
+      { kind: 'user', text: 'go' },
+      seat({ cliKey: 'claude', text }),
+      seat({ cliKey: 'codex', text: 'Also touched `src/retry.ts`.' }),
+    ];
+    const items = buildChatFeed(messages);
+    const artifacts = items.filter((i) => i.kind === 'artifact');
+    expect(artifacts.map((a) => (a as { artifact: { ref: string } }).artifact.ref)).toEqual([
+      'src/retry.ts',
+      'https://github.com/x/y/pull/7',
+    ]);
+    // The chip strip sees the same set.
+    expect(deriveChatArtifacts(messages).map((a) => a.ref)).toEqual([
+      'src/retry.ts',
+      'https://github.com/x/y/pull/7',
+    ]);
+    // A pending stream's mentions are NOT artifacts yet.
+    expect(deriveChatArtifacts([seat({ text: '`a/b.ts`', pending: true, ok: false })])).toEqual([]);
+  });
+});
+
+describe('§11.3 — extractChatArtifacts is conservative', () => {
+  it('accepts path shapes and known file extensions; rejects prose and code idioms', () => {
+    const refs = extractChatArtifacts(
+      'Touched `src/components/App.tsx`, `README.md`, called `foo.bar()` and `some words here`, dir `src/components`',
+    ).map((a) => a.ref);
+    expect(refs).toEqual(['src/components/App.tsx', 'README.md']);
+  });
+
+  it('urls become link artifacts, trailing punctuation stripped', () => {
+    const [a] = extractChatArtifacts('see https://github.com/x/y/pull/12.');
+    expect(a).toMatchObject({ kind: 'pr', ref: 'https://github.com/x/y/pull/12', name: '12' });
+  });
+});
+
+describe('§11.4 — the now-bar derivations', () => {
+  it('lastChatNarration finds the newest narration item', () => {
+    const items = buildChatFeed([
+      { kind: 'sys', text: 'joined the chat', tone: 'info', seat: 'claude' },
+      { kind: 'user', text: 'hi' },
+      seat({ cliKey: 'claude', text: '', pending: true, ok: false }),
+    ]);
+    expect(lastChatNarration(items)?.text).toBe('is thinking…');
+  });
+
+  it('newestChatNow speaks the newest story beat — narration seat-prefixed, turns as phrases', () => {
+    const streaming: ChatMsgView[] = [
+      { kind: 'user', text: 'hi' },
+      seat({ cliKey: 'claude', text: '', pending: true, ok: false }),
+    ];
+    expect(newestChatNow(buildChatFeed(streaming), streaming)).toEqual({
+      text: 'claude is thinking…',
+      tone: 'work',
+    });
+    const replied: ChatMsgView[] = [
+      { kind: 'user', text: 'hi' },
+      seat({ cliKey: 'claude', text: 'All done.' }),
+    ];
+    expect(newestChatNow(buildChatFeed(replied), replied)).toEqual({
+      text: 'claude replied — All done.',
+      tone: 'work',
+    });
+    expect(newestChatNow([], [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Direct user feedback on 0.4.4: "what I see is still the outputs from the individual agents and not the narrative piece" — the narrator had shipped only on the Build feed, not the chat surface. Now GroupChat renders the narrative by default: user messages and short crew replies stay first-class turns, long worker output collapses to seat-chip narration lines with the raw bytes behind expanders (full verbatim transcript behind the view toggle), streaming shows as honest progress lines, artifacts render as cards + the now-bar chip, and the now-bar + pinned approval dock mount on the chat surface (reject-with-note wire asserted from here). Reuses the shipped narrator components — narrator.ts is the single template source; GroupChat held at 1551 lines.

Verifier catch worth reading: on the live daemon, the awaitingHuman dock unmounted ~400ms after mounting — the run-refresh reconcile prunes gate ids absent from GET /runs, and a chat session id never appears there, eating the gate card and any half-typed note. Fixed with a counted pin registry (src/store/awaitingPins.ts) both reconciles respect; regression test added; design doc §11.5 records the seam.

2125 tests green, tsc/eslint/build clean, testid inventory regenerated; pixel-verified at 1440×700 against the live daemon (GETs only, wire-shaped WS stub for the gate pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)