### PR TITLE
release: 0.4.5 — the narrator on the chat surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.5] — 2026-08-31
+
+### Fixed
+
+- **The narrator reaches the chat surface** (#164): GroupChat now renders the narrative by
+  default — user messages and short crew replies stay first-class turns, long per-seat worker
+  output collapses to seat-chip narration lines with the raw bytes behind expanders (the full
+  verbatim transcript stays behind the view toggle), streaming shows as honest progress lines,
+  artifacts render as cards, and the now-bar + pinned approval dock mount on chat too. Direct
+  follow-up to 0.4.4 user feedback: "what I see is still the outputs from the individual agents."
+- The approval dock no longer vanishes mid-decision on chat sessions: the run-refresh reconcile
+  pruned gate ids absent from `GET /runs` (a chat session id never appears there), unmounting the
+  gate card ~400ms after it appeared and eating any half-typed note — a counted pin registry
+  (`awaitingPins`) both reconciles respect keeps a mounted surface's gate alive (#164).
+
 ## [0.4.4] — 2026-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.4",
+  "studioVersion": "0.4.5",
   "counts": {
     "files": 115,
     "occurrences": 836,


### PR DESCRIPTION
Version bump + CHANGELOG + testid inventory regenerated at 0.4.5. Ships #164: GroupChat narrates by default (seat-chip narration lines, collapsed raw output, now-bar + pinned approval dock on chat) plus the awaitingPins fix for the vanishing gate card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)