### PR TITLE
fix: condense the run header — Feed is the view, Timeline/Units behind Inspect

### DIFF
--- a/.product/DES-RUN-NARRATOR.md
+++ b/.product/DES-RUN-NARRATOR.md
@@ -207,12 +207,27 @@ No new wire calls: both sources are already on this page's data.
 
 ## 8. What is preserved (contracts other surfaces own)
 
-- `ProcessStepper`, `RunTimes`, header, Retry, ModePill (read-only when terminal),
-  evidence export — untouched.
-- Terminal runs keep the evidence lenses: tabs are now **Feed | Timeline | Units**, with
-  Feed the default lens (the story), Timeline the recorded-trail navigator (slice BB,
-  unchanged), Units the post-mortem/output spine (slice R, unchanged — FailureBanner
-  stays the headline in every lens).
+- `ProcessStepper`, Retry, ModePill (read-only when terminal), evidence export —
+  untouched. (`RunTimes` and the header: revised below, 2026-08-31.)
+- Terminal runs keep the evidence lenses — **revised 2026-08-31**. As shipped, the three
+  lenses rendered as sibling tabs (**Feed | Timeline | Units**). Operator feedback on the
+  shipped surface: *"I don't know what value timeline and units have. I feel like they
+  will confuse most users. Also think you could condense the header."* So: the Feed IS
+  the run view; Timeline (the recorded-trail navigator, slice BB, unchanged) and Units
+  (the post-mortem/output spine, slice R, unchanged — FailureBanner stays the headline
+  in every lens) DEMOTE from primary tabs to ONE unobtrusive header control, **Inspect ▾**
+  (`run-inspect` → a `run-inspect-menu` whose items keep the `tab-feed` / `tab-timeline` /
+  `tab-unit-list` testids, so the selector contract survives the demotion; the `t`/`u`
+  shortcuts land on the same state). Demoted, never deleted: both lenses carry evidence
+  flows and tests that stay pinned.
+- The header — **revised 2026-08-31, same feedback**: condensed to ONE row
+  (`run-header`): back · status dot · **derived title** (the `runTitle` helper — the raw
+  intent paragraph is the hover and the feed's opening bubble) · status chip ·
+  Retry/Inspect/mode/export/kill. The started/ended/took strip moved off the page chrome
+  into the What/Where insights panel as a compact when block (started · ended · took —
+  `RunTimes`, same `run-times` testid, same event-log derivation and honesty grammar).
+  The phase strip stays: it earns its height. At 1440×700 the fold shows ~75px more feed
+  than the tabbed layout did.
 - `live-narration-*`, `unit-output-*`, `steering-gate`, avatar inject-targeting, the
   `⌨` per-agent terminal button, FileViewer wiring — same testids, same behavior, now
   rendered by `NarratorFeed`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -19,7 +19,7 @@ import { Markdown } from './Markdown.js';
 import { NarratorFeed, phaseName, unitKey } from './NarratorFeed.js';
 import { NowBar } from './NowBar.js';
 import { deriveArtifacts, lastNarration, type NarratorContext } from './narrator.js';
-import { RunTimes } from './runIdentity.js';
+import { runTitle } from './runIdentity.js';
 import { RunTimeline } from './RunTimeline.js';
 import { UnitList } from './UnitList.js';
 import { VerdictDetail } from './VerdictDetail.js';
@@ -359,6 +359,110 @@ function ModePill({
   );
 }
 
+/** The three lenses on one run record (DES-RUN-NARRATOR §8, revised). */
+type RunLens = 'feed' | 'timeline' | 'units';
+
+/**
+ * The power-user lens switcher (DES-RUN-NARRATOR §8, revised 2026-08-31 on
+ * operator feedback: "I don't know what value timeline and units have. I feel
+ * like they will confuse most users."): the Feed IS the run view, so Timeline
+ * and Units no longer render as sibling tabs of it. They stay ONE unobtrusive
+ * header control away — demoted, never deleted (they carry the slice-BB
+ * evidence trail and the slice-R output spine, tests and all). Menu items keep
+ * the tab-* testids so the selector contract survives the demotion, and the
+ * `t`/`u` shortcuts keep landing on the same state.
+ */
+function InspectMenu({ lens, onSelect }: {
+  lens: RunLens;
+  onSelect: (lens: RunLens) => void;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!open) return undefined;
+    function onDown(e: MouseEvent): void {
+      if (rootRef.current !== null && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const lenses: readonly (readonly [RunLens, string, string])[] = [
+    ['feed', 'Feed — the narrated run', 'tab-feed'],
+    ['timeline', 'Timeline — the recorded event trail', 'tab-timeline'],
+    ['units', 'Units — per-phase output', 'tab-unit-list'],
+  ];
+  const active = lens === 'feed' ? null : lens === 'timeline' ? 'Timeline' : 'Units';
+
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        data-testid="run-inspect"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        title="Inspect this run through the evidence lenses — the recorded event timeline or the per-phase output spine"
+        className="rounded-lg px-2 py-1 text-[11px] font-mono transition-colors"
+        style={{
+          color: active === null ? 'var(--ink-dim)' : 'var(--ink-high)',
+          background: active === null ? 'transparent' : 'var(--surface-raised)',
+          border: '1px solid var(--surface-raised)',
+          cursor: 'pointer',
+        }}
+      >
+        {active ?? 'Inspect'} ▾
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Run lenses"
+          data-testid="run-inspect-menu"
+          className="absolute right-0 top-full mt-1 z-30 flex flex-col rounded-lg overflow-hidden py-1"
+          style={{
+            background: 'var(--surface-card)',
+            border: '1px solid var(--surface-raised)',
+            boxShadow: 'var(--shadow-overlay)',
+            minWidth: '15rem',
+          }}
+        >
+          {lenses.map(([id, label, testId]) => (
+            <button
+              key={id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={lens === id}
+              data-testid={testId}
+              onClick={() => { onSelect(id); setOpen(false); }}
+              className="flex items-center gap-2 px-3 py-1.5 text-left text-[11px] font-mono transition-colors"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                color: lens === id ? 'var(--ink-high)' : 'var(--ink-muted)',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+            >
+              <span aria-hidden="true" className="shrink-0" style={{ color: lens === id ? 'var(--accent)' : 'var(--ink-dim)' }}>
+                {lens === id ? '●' : '○'}
+              </span>
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * Read-only view for legacy workflow_id='chat' runs (old council-routed single-unit sessions).
  * Renders as a simple conversation without governance chrome or a work-launcher input.
@@ -562,10 +666,12 @@ function RunChat({
   // the Units tab, with FailureBanner as the HEADLINE in every lens.
   const isPostMortem = session.status === 'failed' || session.status === 'cancelled';
 
-  // DES-RUN-NARRATOR §8: a TERMINAL run carries three lenses — the narrated
-  // Feed (default: the story), the evidence Timeline (slice BB, unchanged), and
-  // the Units spine (slice R, unchanged). Live runs are always the feed.
-  const [runTab, setRunTab] = useState<'feed' | 'timeline' | 'units'>('feed');
+  // DES-RUN-NARRATOR §8 (revised): a TERMINAL run still carries three lenses —
+  // the narrated Feed (default: the story), the evidence Timeline (slice BB,
+  // unchanged) and the Units spine (slice R, unchanged) — but the Feed IS the
+  // run view now; Timeline/Units live behind the header's Inspect ▾ control,
+  // not as sibling tabs. Live runs are always the feed.
+  const [runTab, setRunTab] = useState<RunLens>('feed');
 
   const style = STATUS_STYLE[session.status] ?? { label: session.status, className: '', color: 'var(--ink-muted)' };
   const isTerminal = ['completed', 'cancelled', 'failed'].includes(session.status);
@@ -622,16 +728,21 @@ function RunChat({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Run header */}
+      {/* Run header — ONE row (DES-RUN-NARRATOR §8, revised: "think you could
+          condense the header"): back · status dot · derived title · status chip
+          · Retry/actions. The started/ended/took strip moved into the What/Where
+          insights panel (RunTimes, same testid); the lens tabs became the
+          Inspect ▾ control at the row's end. */}
       <div
-        className="flex items-center gap-3 px-6 py-4 shrink-0"
+        data-testid="run-header"
+        className="flex items-center gap-3 px-6 py-2 shrink-0"
         style={{ borderBottom: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
       >
         <button
           type="button"
           onClick={onNavigateBack}
           aria-label="Back to run list"
-          className="w-8 h-8 flex items-center justify-center rounded-lg transition-colors shrink-0"
+          className="w-7 h-7 flex items-center justify-center rounded-lg transition-colors shrink-0"
           style={{ color: 'var(--ink-dim)' }}
           onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-raised)'; e.currentTarget.style.color = 'var(--ink-high)'; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--ink-dim)'; }}
@@ -642,8 +753,10 @@ function RunChat({
           className={`w-2.5 h-2.5 rounded-full shrink-0 ${pulse ? 'animate-pulse' : ''}`}
           style={{ background: dotColor }}
         />
+        {/* The derived title (usability review #2's runTitle helper) — the raw
+            intent paragraph stays one hover away and opens the feed's story. */}
         <p className="flex-1 text-base font-semibold truncate" style={{ color: 'var(--ink-high)' }} title={session.problem}>
-          {session.problem}
+          {runTitle(session)}
         </p>
         <span className="text-xs font-medium shrink-0 font-mono" style={{ color: style.color }}>{style.label}</span>
         {/* Retry — failed/cancelled only (§4.5: the loop closes failures, not
@@ -660,6 +773,7 @@ function RunChat({
             Retry
           </button>
         )}
+        {isTerminal && <InspectMenu lens={runTab} onSelect={setRunTab} />}
         <ModePill mode={mode} onChange={onModeChange} readOnly={isTerminal} />
         <ExportEvidenceButton runId={session.id} disabled={!isTerminal} />
         {!isTerminal && onKill && (
@@ -678,11 +792,6 @@ function RunChat({
         )}
       </div>
 
-      {/* Run times (DES-UX-001 §7.5, slice Y2): started/ended/duration derived
-          from the event log App already backfills — the DTO carries no
-          timestamps; where the log lacks the events the line says so. */}
-      <RunTimes runId={session.id} status={session.status} />
-
       {/* Process stepper — the run's map: every phase, in order, with its state at a glance. */}
       <ProcessStepper runId={session.id} units={ordered} executingUnitOrd={executingUnitOrd} />
 
@@ -699,32 +808,6 @@ function RunChat({
         onJumpToLatest={jumpToLatest}
         onOpenFile={setEvidenceFile}
       />
-
-      {/* Terminal runs carry three lenses on the same record (§8): the narrated
-          feed (default), the evidence timeline (BB) and the Units spine (R). */}
-      {isTerminal && (
-        <div className="flex items-center gap-1 px-6 pt-2 shrink-0" role="tablist" aria-label="Run detail view">
-          {([['feed', 'Feed', 'tab-feed'], ['timeline', 'Timeline', 'tab-timeline'], ['units', 'Units', 'tab-unit-list']] as const).map(([id, label, testId]) => (
-            <button
-              key={id}
-              type="button"
-              role="tab"
-              data-testid={testId}
-              aria-selected={runTab === id}
-              onClick={() => setRunTab(id)}
-              className="rounded-t px-3 py-1 text-xs font-semibold font-mono transition-colors"
-              style={{
-                background: runTab === id ? 'var(--surface-raised)' : 'transparent',
-                color: runTab === id ? 'var(--ink-high)' : 'var(--ink-muted)',
-                borderBottom: `2px solid ${runTab === id ? 'var(--accent)' : 'transparent'}`,
-                cursor: 'pointer',
-              }}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      )}
 
       {/* The evidence timeline (§2, EC48) — FailureBanner stays the HEADLINE on a
           post-mortem run in EVERY lens (DES-UX-001 §1.3-1 is not undone). */}

--- a/src/components/WhatWhere.tsx
+++ b/src/components/WhatWhere.tsx
@@ -1,6 +1,7 @@
 import type { RunModel } from '../hooks/useRunModel.js';
 import type { Provenance } from '../store/provenance.js';
 import { ProvenanceLine } from './ProvenanceLine.js';
+import { RunTimes } from './runIdentity.js';
 
 interface Props {
   model: RunModel;
@@ -55,6 +56,10 @@ export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props):
         onSelectRun={onSelectRun}
         testId="run-provenance"
       />
+      {/* The when block (started · ended · duration) — moved here from the run
+          header strip (DES-RUN-NARRATOR §8, revised 2026-08-31): the header
+          condensed to one row and this is where the run's context rows live. */}
+      <RunTimes runId={session.id} status={session.status} />
       <Row label="intent" value={session.problem} />
       <Row label="repo" value={session.repo_ref ?? '—'} mono />
       {/* §7.10: the compact tail, full path on hover — never the 5-line wrap.

--- a/src/components/runIdentity.tsx
+++ b/src/components/runIdentity.tsx
@@ -137,9 +137,13 @@ export function durationWord(ms: number): string {
 const TERMINAL: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled']);
 
 /**
- * The run detail's times line (§7.5 DOM AC: `[data-testid="run-times"]`).
- * Reads the two stores the app already fills for the selected run — zero new
- * requests. Every absent half is stated in operator language.
+ * The run detail's when block (§7.5 DOM AC: `[data-testid="run-times"]`) —
+ * started · ended · duration. It began life as a full-width strip under the
+ * run header; the 2026-08-31 header condense (DES-RUN-NARRATOR §8, revised)
+ * moved it into the What/Where insights panel, where the run's other
+ * context rows already live. Same derivation, same testid, same honesty
+ * grammar — reads the two stores the app already fills for the selected run
+ * (zero new requests), and every absent half is stated in operator language.
  */
 export function RunTimes({ runId, status }: { runId: string; status: string }): React.ReactElement {
   const durable = useRunEventStore((s) => s.byRun[runId]);
@@ -148,37 +152,39 @@ export function RunTimes({ runId, status }: { runId: string; status: string }): 
   const now = Date.now();
   const terminal = TERMINAL.has(status);
 
-  const parts: string[] = [];
-  if (started !== null) {
-    parts.push(`started ${ageWord(now - started.ms)} ago${started.observed ? ' (observed)' : ''}`);
-  }
-  if (ended !== null) {
-    parts.push(`ended ${ageWord(now - ended.ms)} ago${ended.observed ? ' (observed)' : ''}`);
-  } else if (!terminal && started !== null) {
-    parts.push('running');
-  } else if (terminal && started !== null) {
-    parts.push('end not in the event log');
-  }
-  if (started !== null && ended !== null) {
-    parts.push(`took ${durationWord(ended.ms - started.ms)}`);
-  }
-  const line = parts.length > 0
-    ? parts.join(' · ')
+  const startedText = started !== null
+    ? `${ageWord(now - started.ms)} ago${started.observed ? ' (observed)' : ''}`
     : terminal
-      ? "no start or end times survive in this run's event log"
-      : "no start time in this run's event log yet";
+      ? 'not in the event log'
+      : 'not in the event log yet';
+  const endedText = ended !== null
+    ? `${ageWord(now - ended.ms)} ago${ended.observed ? ' (observed)' : ''}`
+    : terminal
+      ? 'not in the event log'
+      : 'still running';
+  // No fabricated durations: both clocks or a stated absence ("—").
+  const tookText = started !== null && ended !== null ? durationWord(ended.ms - started.ms) : '—';
 
   const iso = (c: DerivedClock | null): string => (c === null ? '—' : new Date(c.ms).toISOString());
+  const rows: readonly (readonly [string, string])[] = [
+    ['started', startedText],
+    ['ended', endedText],
+    ['took', tookText],
+  ];
   return (
-    <p
+    <div
       data-testid="run-times"
       data-started={started === null ? 'none' : started.observed ? 'observed' : 'log'}
       data-ended={ended === null ? (terminal ? 'none' : 'running') : ended.observed ? 'observed' : 'log'}
-      className="px-6 py-1 text-[11px] font-mono truncate shrink-0"
-      style={{ color: 'var(--ink-dim)', margin: 0, borderBottom: '1px solid var(--surface-raised)' }}
+      className="flex flex-col gap-1.5"
       title={`derived from the run's event log (the run record carries no timestamps) — started: ${iso(started)} · ended: ${iso(ended)}`}
     >
-      {line}
-    </p>
+      {rows.map(([label, value]) => (
+        <div key={label} className="flex gap-2 text-[11px]">
+          <span className="w-20 shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>{label}</span>
+          <span className="font-mono" style={{ color: 'var(--ink-muted)' }}>{value}</span>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.5",
   "counts": {
     "files": 115,
-    "occurrences": 836,
-    "static": 717,
+    "occurrences": 839,
+    "static": 720,
     "dynamic": 41,
     "computed": 6
   },
@@ -2781,6 +2781,24 @@
       "testId": "run-delivery-reason",
       "files": [
         "src/components/RunDelivery.tsx"
+      ]
+    },
+    {
+      "testId": "run-header",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-inspect",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-inspect-menu",
+      "files": [
+        "src/components/ChatPanel.tsx"
       ]
     },
     {

--- a/tests/ChatPanel.lenses.test.tsx
+++ b/tests/ChatPanel.lenses.test.tsx
@@ -1,0 +1,131 @@
+// DES-RUN-NARRATOR §8 (revised 2026-08-31) — the lens demotion + header condense.
+//
+// Operator feedback on the shipped three-tab layout: "I don't know what value
+// timeline and units have. I feel like they will confuse most users. Also think
+// you could condense the header." These tests pin the revision:
+//
+//   1. the Feed IS the run view — a terminal run renders NO primary tabs
+//      (no tablist, no role=tab siblings of the feed);
+//   2. Timeline and Units stay REACHABLE — demoted behind the header's single
+//      Inspect ▾ control (`run-inspect` → `run-inspect-menu`), never deleted;
+//      the menu items keep the tab-* testids (selector contract);
+//   3. a LIVE run has no Inspect control at all (lenses are terminal-only,
+//      exactly as the tabs were);
+//   4. the header is ONE row (`run-header`): back + status dot + DERIVED title
+//      (runTitle) + status chip + actions — and the started/ended/took strip is
+//      GONE from the run page chrome (it moved into What/Where, its test lives
+//      with that panel).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'captured output' });
+});
+
+const TERMINAL_VIEW = makeView({ status: 'completed' }, [
+  makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+]);
+
+function renderPanel(view = TERMINAL_VIEW): void {
+  render(
+    <ChatPanel
+      view={view}
+      onLaunched={vi.fn()}
+      onNavigateBack={vi.fn()}
+      onRefresh={vi.fn()}
+      navigate={vi.fn()}
+    />,
+  );
+}
+
+describe('ChatPanel — lens demotion (DES-RUN-NARRATOR §8, revised)', () => {
+  it('the Feed is the run view: no primary tabs render on a terminal run', async () => {
+    renderPanel();
+    expect(await screen.findByTestId('thread')).toBeInTheDocument();
+    // The old sibling-tab strip is gone entirely.
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryByRole('tab')).toBeNull();
+    // The lens entries are NOT in the DOM until the Inspect control opens them.
+    expect(screen.queryByTestId('tab-timeline')).toBeNull();
+    expect(screen.queryByTestId('tab-unit-list')).toBeNull();
+  });
+
+  it('Inspect ▾ opens the lens menu with Feed checked as the default', async () => {
+    renderPanel();
+    expect(screen.queryByTestId('run-inspect-menu')).toBeNull();
+    await userEvent.click(await screen.findByTestId('run-inspect'));
+    const menu = await screen.findByTestId('run-inspect-menu');
+    expect(within(menu).getByTestId('tab-feed')).toHaveAttribute('aria-checked', 'true');
+    expect(within(menu).getByTestId('tab-timeline')).toHaveAttribute('aria-checked', 'false');
+    expect(within(menu).getByTestId('tab-unit-list')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('Timeline is reachable through the menu — and Feed is one more click back', async () => {
+    renderPanel();
+    await userEvent.click(await screen.findByTestId('run-inspect'));
+    await userEvent.click(await screen.findByTestId('tab-timeline'));
+    // The evidence timeline (slice BB) renders; the menu closed on selection.
+    expect(await screen.findByTestId('timeline')).toBeInTheDocument();
+    expect(screen.queryByTestId('run-inspect-menu')).toBeNull();
+    expect(screen.queryByTestId('thread')).toBeNull();
+    // Back to the story.
+    await userEvent.click(screen.getByTestId('run-inspect'));
+    await userEvent.click(await screen.findByTestId('tab-feed'));
+    expect(await screen.findByTestId('thread')).toBeInTheDocument();
+    expect(screen.queryByTestId('timeline')).toBeNull();
+  });
+
+  it('Units is reachable through the menu (the crew#272 output blocks, unchanged)', async () => {
+    renderPanel();
+    await userEvent.click(await screen.findByTestId('run-inspect'));
+    await userEvent.click(await screen.findByTestId('tab-unit-list'));
+    // The units lens: output spine without the feed's narration header.
+    expect(await screen.findByTestId('unit-output-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-view-narrated')).toBeNull();
+  });
+
+  it('a LIVE run has no Inspect control — the feed is the only surface', async () => {
+    renderPanel(makeView({ status: 'executing' }, [
+      makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'distributed', assigned_cli: 'claude' }),
+    ]));
+    expect(await screen.findByTestId('thread')).toBeInTheDocument();
+    expect(screen.queryByTestId('run-inspect')).toBeNull();
+  });
+});
+
+describe('ChatPanel — the condensed one-row header (§8, revised)', () => {
+  it('one header row: back + derived runTitle + status chip; the times strip is gone from the page chrome', async () => {
+    renderPanel();
+    const header = await screen.findByTestId('run-header');
+    // Back, derived title (runTitle: intent · short-id · #attempt) and the
+    // status chip all live in the ONE row.
+    expect(within(header).getByLabelText('Back to run list')).toBeInTheDocument();
+    expect(within(header).getByText('do the thing · run-1 · #1')).toBeInTheDocument();
+    expect(within(header).getByText('Completed')).toBeInTheDocument();
+    // The raw intent stays one hover away.
+    expect(within(header).getByTitle('do the thing')).toBeInTheDocument();
+    // started/ended/took moved into the What/Where insights panel — the run
+    // page chrome no longer renders it.
+    expect(screen.queryByTestId('run-times')).toBeNull();
+  });
+
+  it('Retry (post-mortem) renders inside the one header row', async () => {
+    renderPanel(makeView({ status: 'failed' }, [
+      makeUnit({ id: 'run-1:survey', ord: 0, stage: 'recon', status: 'rejected', denial_reason: 'nope' }),
+    ]));
+    const header = await screen.findByTestId('run-header');
+    expect(within(header).getByTestId('run-retry')).toBeInTheDocument();
+    expect(within(header).getByTestId('run-inspect')).toBeInTheDocument();
+  });
+});

--- a/tests/ChatPanel.output.test.tsx
+++ b/tests/ChatPanel.output.test.tsx
@@ -12,10 +12,11 @@ beforeEach(() => {
   vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
 });
 
-// Slice BB (DES-UX-002 §2.3): a terminal run's DEFAULT lens is the evidence
-// timeline; the pre-BB output blocks live under the preserved Units tab —
-// these tests re-verify that view renders UNCHANGED there (§8.3's re-scope).
+// DES-RUN-NARRATOR §8 (revised 2026-08-31): the Units lens is no longer a
+// sibling tab — it lives behind the header's Inspect ▾ control. The output
+// blocks themselves render UNCHANGED there (§8.3's re-scope holds).
 async function openUnitsTab(): Promise<void> {
+  await userEvent.click(await screen.findByTestId('run-inspect'));
   await userEvent.click(await screen.findByTestId('tab-unit-list'));
 }
 

--- a/tests/ChatPanel.postmortem.test.tsx
+++ b/tests/ChatPanel.postmortem.test.tsx
@@ -37,10 +37,11 @@ const FAILED_VIEW = makeView({ status: 'failed' }, [
   }),
 ]);
 
-// Slice BB (DES-UX-002 §2.3): a terminal run's DEFAULT lens is the evidence
-// timeline; the slice-R post-mortem spine is the preserved Units tab. These
-// tests re-verify every spine AC holds UNCHANGED there (§8.3's re-scope) —
-// the panel opens on the Units tab before each assertion.
+// DES-RUN-NARRATOR §8 (revised 2026-08-31): the slice-R post-mortem spine is
+// the preserved Units lens, now reached through the header's Inspect ▾ control
+// rather than a sibling tab. These tests re-verify every spine AC holds
+// UNCHANGED there (§8.3's re-scope) — the panel opens the Units lens via the
+// menu before each assertion.
 async function renderPanel(view = FAILED_VIEW): Promise<void> {
   render(
     <ChatPanel
@@ -50,6 +51,7 @@ async function renderPanel(view = FAILED_VIEW): Promise<void> {
       onRefresh={vi.fn()}
     />,
   );
+  await userEvent.click(await screen.findByTestId('run-inspect'));
   await userEvent.click(await screen.findByTestId('tab-unit-list'));
 }
 

--- a/tests/cockpitPanels.test.tsx
+++ b/tests/cockpitPanels.test.tsx
@@ -10,6 +10,7 @@ import { DataUsed } from '../src/components/DataUsed.js';
 import { WhatWhere } from '../src/components/WhatWhere.js';
 import { AssumptionsPanel } from '../src/components/AssumptionsPanel.js';
 import { SteeringTimeline } from '../src/components/SteeringTimeline.js';
+import { useRunEventStore } from '../src/store/events.js';
 import { useRuntimeStore } from '../src/store/runtime.js';
 import { useSteeringStore } from '../src/store/steering.js';
 
@@ -159,6 +160,10 @@ describe('DataUsed (FR-8)', () => {
 });
 
 describe('WhatWhere (FR-8)', () => {
+  afterEach(() => {
+    useRunEventStore.setState({ byRun: {} });
+  });
+
   it('renders intent + roster; the DTO debug note is retired (DES-UX-001 §7.10)', () => {
     render(<WhatWhere model={modelWith()} />);
     const el = screen.getByTestId('what-where');
@@ -168,6 +173,38 @@ describe('WhatWhere (FR-8)', () => {
     // note, not user copy — it must NOT render (the diff lives in Files).
     expect(el.textContent).not.toContain('work_output');
     expect(el.textContent).not.toContain('DTO');
+  });
+
+  // DES-RUN-NARRATOR §8 (revised 2026-08-31): the started/ended/took strip
+  // moved off the run header INTO this panel — same run-times testid, same
+  // event-log derivation, same honesty grammar (absent halves are stated,
+  // durations are never fabricated).
+  it('carries the when block (started · ended · took) moved from the run header', () => {
+    useRunEventStore.setState({
+      byRun: {
+        'run-1': [
+          { type: 'sessionStarted', session: 'run-1', ts: Date.now() - 90_000, seq: 1 } as unknown as CoreEvent,
+        ],
+      },
+    });
+    render(<WhatWhere model={modelWith()} />);
+    const el = screen.getByTestId('what-where');
+    const when = screen.getByTestId('run-times');
+    expect(el.contains(when)).toBe(true);
+    expect(when).toHaveTextContent('started');
+    expect(when).toHaveTextContent('1m ago');
+    // The run is executing and the log records no end — the block says so.
+    expect(when).toHaveTextContent('still running');
+    // No fabricated duration without both clocks.
+    expect(when).toHaveTextContent('took');
+    expect(when).toHaveTextContent('—');
+  });
+
+  it('states the honest absence when the event log has no clocks at all', () => {
+    render(<WhatWhere model={modelWith()} />);
+    const when = screen.getByTestId('run-times');
+    expect(when).toHaveAttribute('data-started', 'none');
+    expect(when).toHaveTextContent('not in the event log yet');
   });
 });
 


### PR DESCRIPTION
Direct user feedback: "I don't know what value timeline and units have... condense the header. You can move the started/ended/took to the what/where insights panel." The header is now one 45px row (was 65 + a 26px times strip) with the phase strip kept; started/ended/took renders inside the What/Where panel; Timeline and Units left the primary tab strip — the Feed is THE run view — and stay reachable behind an unobtrusive Inspect ▾ menu (both lenses click-through verified). Measured result: +79px (+19.3%) more feed above the 1440×700 fold. DES-RUN-NARRATOR §8 records the revision. 2134 tests green, testid inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)