### PR TITLE
feat: section dashboards — Projects, project home, and Make become command surfaces

### DIFF
--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -1,0 +1,151 @@
+import type { SessionView } from '../api/types.js';
+import { outcomeOf } from './metrics.js';
+import { RANGE_LIMITS, rangeWord, type TimeRange } from '../hooks/useTimeRange.js';
+
+/**
+ * The section-dashboard window folds (studio dashboards, lane B): pure
+ * derivations shared by /projects, /p/:id, and /make so the three KPI bands
+ * cannot disagree on what a window, a delta, or a status count means.
+ *
+ * WINDOW HONESTY — the same contract as `useTimeRange`: the run DTO carries no
+ * timestamps, so a "window" is POSITIONAL (the newest N rows of a
+ * salience-ordered list) and every label says "last 30", never "30d". A delta
+ * compares the current window bucket against the PREVIOUS same-size bucket of
+ * the run history; when no full prior bucket exists there is NO delta —
+ * `previous: null`, rendered as "—", never a fabricated 0%.
+ */
+
+// ── Window buckets + deltas ───────────────────────────────────────────────────
+
+export interface WindowBuckets {
+  /** The newest `limit` rows (or everything for `all`). */
+  current: SessionView[];
+  /** The previous same-size bucket, or `null` when the history holds no FULL
+   *  prior bucket (fewer than two windows of rows, or the window is `all`) —
+   *  a partial bucket would make a lopsided comparison, so it never counts. */
+  previous: SessionView[] | null;
+}
+
+/**
+ * Positional split: rows `[0, N)` are the current window, `[N, 2N)` the prior
+ * bucket — and the prior bucket only exists when it is FULL (≥ 2N rows), so a
+ * delta always compares same-size windows. Callers pass the list already
+ * scoped (archived rows excluded) and ordered the way the surface orders it —
+ * the split never re-sorts.
+ */
+export function windowBuckets(runs: SessionView[], range: TimeRange): WindowBuckets {
+  const limit = RANGE_LIMITS[range];
+  if (limit === null) return { current: runs, previous: null };
+  return {
+    current: runs.slice(0, limit),
+    previous: runs.length >= limit * 2 ? runs.slice(limit, limit * 2) : null,
+  };
+}
+
+/** A tile's delta pair: the current count, and the prior bucket's or `null`. */
+export interface StatDelta {
+  current: number;
+  previous: number | null;
+}
+
+/** Fold one predicate over both buckets. `previous: null` propagates. */
+export function windowDelta(
+  buckets: WindowBuckets,
+  count: (runs: SessionView[]) => number,
+): StatDelta {
+  return {
+    current: count(buckets.current),
+    previous: buckets.previous === null ? null : count(buckets.previous),
+  };
+}
+
+/**
+ * The context line under a windowed tile — names BOTH buckets, honestly.
+ * Pass the tile's delta so a window with NO prior bucket never claims a
+ * "previous N" that does not exist (the label matches the "—" the delta
+ * renders); without one the label assumes the prior bucket is there.
+ */
+export function deltaWord(range: TimeRange, delta?: StatDelta): string {
+  const limit = RANGE_LIMITS[range];
+  if (limit === null) return 'all runs — no prior window';
+  if (delta !== undefined && delta.previous === null) return `${rangeWord(range)} — no prior window`;
+  return `${rangeWord(range)} vs previous ${limit}`;
+}
+
+// ── Status counts (the one outcome partition, re-used) ───────────────────────
+
+export interface StatusCounts {
+  total: number;
+  /** Moving under its own power (planning/distributing/executing). */
+  active: number;
+  /** `awaiting_human` — waiting on a person. */
+  gates: number;
+  /** `status === 'failed'` only (J5/A5: cancelled is not failed). */
+  failed: number;
+  done: number;
+  cancelled: number;
+  /** done + failed + cancelled — the success-rate denominator. */
+  terminal: number;
+}
+
+/** One fold, `outcomeOf`'s partition. Archived rows never count. */
+export function statusCounts(runs: SessionView[]): StatusCounts {
+  const c: StatusCounts = { total: 0, active: 0, gates: 0, failed: 0, done: 0, cancelled: 0, terminal: 0 };
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    c.total += 1;
+    const o = outcomeOf(v.session.status);
+    if (o === 'run') c.active += 1;
+    else if (o === 'gate') c.gates += 1;
+    else if (o === 'fail') { c.failed += 1; c.terminal += 1; }
+    else if (o === 'cancelled') { c.cancelled += 1; c.terminal += 1; }
+    else { c.done += 1; c.terminal += 1; }
+  }
+  return c;
+}
+
+// ── Threshold health (usability review #9: no success-green on a 30% rate) ───
+
+export type Health = 'good' | 'warn' | 'bad' | 'none';
+
+/** Green only ≥80%, amber ≥50%, red below; no terminal runs = no verdict. */
+export function healthOf(done: number, terminal: number): Health {
+  if (terminal === 0) return 'none';
+  const ratio = done / terminal;
+  return ratio >= 0.8 ? 'good' : ratio >= 0.5 ? 'warn' : 'bad';
+}
+
+/** The health's token — `undefined` for 'none' (no verdict, no color). */
+export function healthColor(h: Health): string | undefined {
+  return h === 'good' ? 'var(--status-done)'
+    : h === 'warn' ? 'var(--status-gate)'
+    : h === 'bad' ? 'var(--status-fail)'
+    : undefined;
+}
+
+// ── The sparkline series (the honest attach clock, daily buckets) ─────────────
+
+/**
+ * Daily run counts, oldest first, off the membership attach clock — the one
+ * per-run timestamp the wire carries (the ProjectDashboard/ProjectSparkline
+ * idiom, generalized). Runs with no clock, or outside the span, are simply
+ * absent — absence stays absent, never painted at an invented time.
+ */
+export function attachSeries(
+  runIds: Iterable<string>,
+  attachedAt: Record<string, number>,
+  days: number,
+  now: number,
+): number[] {
+  const DAY = 24 * 3_600_000;
+  const counts = new Array<number>(days).fill(0);
+  for (const id of runIds) {
+    const at = attachedAt[id];
+    if (at === undefined) continue;
+    const age = now - at;
+    if (age < 0 || age >= days * DAY) continue;
+    const bucket = days - 1 - Math.floor(age / DAY);
+    counts[bucket] = (counts[bucket] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -388,7 +388,7 @@ function RailHeading({ path, open, onToggle, onNew, navigate, children, extra }:
 
 const MAKE_MODES: Mode[] = ['build', 'document', 'video'];
 
-function MakePicker({ navigate, onClose, ambient }: {
+export function MakePicker({ navigate, onClose, ambient }: {
   navigate: (p: string) => void;
   onClose: () => void;
   /** The ambient project (shared derivation, DES-UX-001 §2.3 rule 1) — Build

--- a/src/components/MakeDashboard.tsx
+++ b/src/components/MakeDashboard.tsx
@@ -1,35 +1,41 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { SessionView } from '../api/types.js';
-import { UNFILED_MOUNT, type DocSummary } from '../api/interactive.js';
+import { UNFILED_MOUNT } from '../api/interactive.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import { outcomeOf } from '../board/metrics.js';
+import {
+  attachSeries, deltaWord, statusCounts, windowBuckets, windowDelta,
+} from '../board/windowStats.js';
 import { useDismissable } from '../hooks/useDismissable.js';
 import { versionPath, type Mode } from '../hooks/useRoute.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
+import { setRetryPrefill } from '../store/retryPrefill.js';
 import { isChatRun } from './ChatsPage.js';
-import { MetricTile } from './MetricTile.js';
-import { humanTitle } from './runIdentity.js';
-import { RunOutcomeBar } from './RunOutcomeBar.js';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, StatTile, type FilterChip,
+} from './dashboardKit.js';
+import { MakePicker } from './LeftSidebar.js';
+import { ago } from './ProjectCard.js';
+import { humanTitle, runShortId, runWhenWord } from './runIdentity.js';
 import { phaseWord, RUN_DOT } from './RunsSection.js';
-import { TokenBurnSparkline } from './TokenBurnSparkline.js';
 
 /**
- * The Make dashboard — `/make` (DES-FEEDBACK-003 §4.2, slice O): the combined
- * list + reporting over MADE THINGS — build runs and their deliverables,
- * documents, demos. Make = the verbatim complement of ChatsPage's filter
- * (§3.3/§4.2: every run under exactly one path).
+ * The Make dashboard — `/make` (lane B): the command surface over MADE THINGS —
+ * build runs and their deliverables, documents, demos. A KPI band (items, runs
+ * consumed w/ window delta + sparkline, active, failed w/ delta), then every
+ * make item as a stat card behind a first-class FilterStrip. "Needs you" floats
+ * first and jumps straight to the run's gate; failed items carry an inline
+ * Retry (a prefill, never a hidden relaunch); the header carries the section's
+ * creation verb (the same ＋ picker the rail forks: Build / Document / Video).
  *
- * Reporting discipline (EC19/EC28): the tile band sits ABOVE the list, every
- * tile answers its §4.2.1 named question via `data-question`, SVG-first, no
- * chart library, tokens only.
- *
- * Data discipline: ZERO requests on mount. Runs ride the app's one `GET /runs`
- * (the `runs` prop); attach clocks and project names read the membership
- * mirror; spend reads the runtime store's observed `cliUsage` frames; doc
- * lists read the session docsCache — the honest corpus (§4.2.2), which the
- * EC24-grammar label says out loud. The one fan-out (`[load docs for all
- * projects]`) is an explicit gesture: P known-shape GETs, progress named,
- * cached for the session — a button the operator presses, never a mount cost.
+ * Data discipline unchanged: ZERO requests on mount. Runs ride the app's one
+ * `GET /runs`; attach clocks and project names read the membership mirror; doc
+ * lists read the session docsCache — the honest corpus, which the EC24-grammar
+ * label says out loud. The one fan-out (`[load docs for all projects]`) stays
+ * an explicit gesture. Derived titles everywhere — never raw prompts.
  */
 
 interface Props {
@@ -41,118 +47,50 @@ interface Props {
 
 const RUN_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
 
-/** Active before terminal, incoming order preserved (the RunsSection contract). */
+/** Needs-you FIRST, then active, then terminal — incoming order within groups. */
 function orderRuns(runs: SessionView[]): SessionView[] {
-  const active = runs.filter((v) => !RUN_TERMINAL.has(v.session.status));
+  const gated = runs.filter((v) => v.session.status === 'awaiting_human');
+  const active = runs.filter((v) => v.session.status !== 'awaiting_human' && !RUN_TERMINAL.has(v.session.status));
   const terminal = runs.filter((v) => RUN_TERMINAL.has(v.session.status));
-  return [...active, ...terminal];
+  return [...gated, ...active, ...terminal];
 }
 
-// ── The Made (7d) tile (§4.2.1 row 1) ─────────────────────────────────────────
+type StatusChip = 'all' | 'needs-you' | 'active' | 'failed' | 'done' | 'docs';
 
-const DAYS = 7;
-const DAY_MS = 24 * 3_600_000;
-const W = 168;
-const H = 26;
-const COL_GAP = 3;
-
-type MadeKind = 'builds' | 'docs' | 'demos';
-/** Kind → its fill. Kinds, not statuses — the accent family + one status
- *  token keep the three producible things tellable apart (C2: tokens only). */
-const KIND_FILL: ReadonlyArray<{ key: MadeKind; fill: string }> = [
-  { key: 'builds', fill: 'var(--status-run)' },
-  { key: 'docs', fill: 'var(--accent)' },
-  { key: 'demos', fill: 'var(--accent-dim)' },
-];
-
-function MadeTile({ builds, docs, attachedAt, now }: {
-  builds: SessionView[];
-  docs: Array<{ doc: DocSummary }>;
-  attachedAt: Record<string, number>;
-  now?: number;
-}): React.ReactElement {
-  const at = now ?? Date.now();
-  const { buckets, totals } = useMemo(() => {
-    const start = at - DAYS * DAY_MS;
-    const days = Array.from({ length: DAYS }, () => ({ builds: 0, docs: 0, demos: 0 }));
-    const sums = { builds: 0, docs: 0, demos: 0 };
-    const place = (clock: number | undefined, kind: MadeKind): void => {
-      if (clock === undefined || Number.isNaN(clock) || clock < start || clock > at) return;
-      const ix = Math.min(DAYS - 1, Math.floor((clock - start) / DAY_MS));
-      const day = days[ix];
-      if (day !== undefined) day[kind] += 1;
-      sums[kind] += 1;
-    };
-    for (const v of builds) {
-      if (v.session.archived_at != null) continue;
-      place(attachedAt[v.session.id], 'builds');
-    }
-    // Doc/demo versions counted from LOADED manifests only (§4.2.1) — each doc
-    // at its newest update; the corpus label below owns the honesty.
-    for (const { doc } of docs) {
-      place(doc.updated_at === null ? undefined : Date.parse(doc.updated_at), doc.kind === 'demo' ? 'demos' : 'docs');
-    }
-    return { buckets: days, totals: sums };
-  }, [builds, docs, attachedAt, at]);
-
-  const total = totals.builds + totals.docs + totals.demos;
-  const colMax = buckets.reduce((m, d) => Math.max(m, d.builds + d.docs + d.demos), 0);
-  const colW = (W - COL_GAP * (DAYS - 1)) / DAYS;
-  const value = total === 0
-    ? 'nothing made in 7d'
-    : [
-        totals.builds > 0 ? `${totals.builds} builds` : null,
-        totals.docs > 0 ? `${totals.docs} docs` : null,
-        totals.demos > 0 ? `${totals.demos} demos` : null,
-      ].filter((s) => s !== null).join(' · ');
-
-  return (
-    <MetricTile
-      testId="made-tile"
-      question="What is the shop producing, and of what kind?"
-      title="Made (7d) · docs from loaded projects"
-      value={value}
-      data={{ 'data-total': total }}
-    >
-      {total === 0 ? (
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-          Nothing made in the last 7 days.
-        </p>
-      ) : (
-        <svg
-          width="100%"
-          height={H}
-          viewBox={`0 0 ${W} ${H}`}
-          preserveAspectRatio="none"
-          role="img"
-          aria-label={`made over the last 7 days: ${value}`}
-          style={{ display: 'block' }}
-        >
-          {buckets.map((d, i) => {
-            let y = H;
-            return KIND_FILL.map(({ key, fill }) => {
-              if (d[key] === 0) return null;
-              const h = Math.max(2, (d[key] / colMax) * H);
-              y -= h;
-              return <rect key={`${i}-${key}`} x={i * (colW + COL_GAP)} y={y} width={colW} height={h} fill={fill} />;
-            });
-          })}
-        </svg>
-      )}
-    </MetricTile>
-  );
+function matchesChip(status: string, chip: StatusChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'docs') return false; // runs never match the docs chip
+  const o = outcomeOf(status);
+  if (chip === 'needs-you') return o === 'gate';
+  if (chip === 'active') return o === 'run';
+  if (chip === 'failed') return o === 'fail';
+  return o === 'done' || o === 'cancelled';
 }
+
+const CARD: React.CSSProperties = {
+  display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+  background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+  borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+  cursor: 'pointer',
+};
+
+const CARD_META: React.CSSProperties = {
+  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
+  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+};
 
 // ── The dashboard ─────────────────────────────────────────────────────────────
 
 export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactElement {
   const projects = useProjectsStore((s) => s.projects);
   const projectNameByRun = useMembershipStore((s) => s.projectNameByRun);
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
   const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
   const byProject = useDocsCache((s) => s.byProject);
   const fanoutDone = useDocsCache((s) => s.fanoutDone);
   const fanoutProgress = useDocsCache((s) => s.fanoutProgress);
   const [whyOpen, setWhyOpen] = useState(false);
+  const [makeOpen, setMakeOpen] = useState(false);
   // The overlay contract (usability review #10): the [why?] popover is a
   // transient surface — Escape closes it and refocuses its trigger.
   const whyRef = useRef<HTMLDivElement>(null);
@@ -160,7 +98,11 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
   const closeWhy = useCallback(() => setWhyOpen(false), []);
   useDismissable(whyOpen, closeWhy, whyRef, whyTriggerRef);
 
-  // The spine (§4.2.2): non-chat runs — complete, all projects, active first.
+  const [query, setQuery] = useState('');
+  const [chip, setChip] = useState<StatusChip>('all');
+  const { range, setRange } = useTimeRange('30d');
+
+  // The spine (§4.2.2): non-chat runs — complete, all projects, needs-you first.
   const made = useMemo(
     () => orderRuns(runs.filter((v) => !isChatRun(v) && v.session.archived_at == null)),
     [runs],
@@ -173,8 +115,8 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
   // The known corpus: doc rows off the session cache, newest first.
   const docRows = useMemo(
     () => Object.entries(byProject)
-      // Slice U (§6.2): the default bucket never rides the board's store mirror
-      // (F5), so its docs label "Unfiled" — the run rows' exact grammar above.
+      // The default bucket never rides the board's store mirror (F5), so its
+      // docs label "Unfiled" — the run rows' exact grammar.
       .flatMap(([pid, docs]) => docs.map((doc) => ({
         doc, projectId: pid,
         projectName: projectNameById[pid] ?? (pid === UNFILED_MOUNT ? 'Unfiled' : pid),
@@ -183,9 +125,25 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
     [byProject, projectNameById],
   );
 
+  // ── The window + KPI folds ─────────────────────────────────────────────────
+  const now = Date.now();
+  const buckets = useMemo(() => windowBuckets(made, range), [made, range]);
+  const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
+  const liveCounts = useMemo(() => statusCounts(made), [made]);
+  const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
+  const failedDelta = useMemo(
+    () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
+    [buckets],
+  );
+  const runSpark = useMemo(
+    () => attachSeries(buckets.current.map((v) => v.session.id), attachedAt, 14, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` re-derives with the data, not a timer
+    [buckets, attachedAt],
+  );
+
   const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
     href: path,
-    onClick: (e) => { e.preventDefault(); navigate(path); },
+    onClick: (e) => { e.preventDefault(); e.stopPropagation(); navigate(path); },
   });
 
   // The explicit fan-out (§4.2.2): every real project, one known-shape GET each.
@@ -193,36 +151,180 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
     void useDocsCache.getState().loadAll(projects.filter((p) => p.id !== 'default').map((p) => p.id));
   };
 
+  /** Retry-as-prefill — the ChatPanel contract, verbatim: nothing auto-launches. */
+  function startRetry(v: SessionView): void {
+    const s = v.session;
+    setRetryPrefill({
+      retryOf: s.id,
+      problem: s.problem,
+      clis: s.clis,
+      workflowId: s.workflow_id && s.workflow_id !== 'chat' ? s.workflow_id : null,
+      repoRef: s.repo_ref,
+      entityMode: s.entity_mode,
+      humanConfirm: s.human_confirm,
+      projectId: typeof s.project_id === 'string' ? s.project_id : null,
+    });
+    navigate('/runs/new');
+  }
+
+  /** The gate jump: the run's thread AT the gate when its project is known;
+   *  the flat run detail (where the approval dock lives) when unfiled. */
+  const gateJump = (id: string): string => {
+    const pid = projectIdByRun[id];
+    return pid !== undefined ? gateOpenPath(pid, id) : `/runs/${encodeURIComponent(id)}`;
+  };
+
+  // ── Filtering (search lifts the window — the Work page idiom) ──────────────
+  const q = query.trim().toLowerCase();
+  const searchedRuns = q === ''
+    ? made.filter((v) => windowIds.has(v.session.id))
+    : made.filter((v) =>
+        v.session.problem.toLowerCase().includes(q)
+        || runShortId(v.session.id).includes(q)
+        || (projectNameByRun[v.session.id] ?? 'unfiled').toLowerCase().includes(q));
+  const visibleRuns = chip === 'docs' ? [] : searchedRuns.filter((v) => matchesChip(v.session.status, chip));
+  const visibleDocs = (chip === 'all' || chip === 'docs')
+    ? docRows.filter(({ doc, projectName }) =>
+        q === '' || doc.name.toLowerCase().includes(q) || projectName.toLowerCase().includes(q))
+    : [];
+  const hiddenByWindow = q === '' ? made.length - buckets.current.length : 0;
+
+  const chipCounts = useMemo(() => {
+    const counts: Record<StatusChip, number> = { all: 0, 'needs-you': 0, active: 0, failed: 0, done: 0, docs: docRows.length };
+    for (const v of searchedRuns) {
+      counts.all += 1;
+      for (const c of ['needs-you', 'active', 'failed', 'done'] as const) {
+        if (matchesChip(v.session.status, c)) counts[c] += 1;
+      }
+    }
+    counts.all += docRows.length;
+    return counts;
+  }, [searchedRuns, docRows.length]);
+
+  const chips: FilterChip[] = [
+    { id: 'all', label: 'All', count: chipCounts.all },
+    { id: 'needs-you', label: 'Needs you', count: chipCounts['needs-you'] },
+    { id: 'active', label: 'Active', count: chipCounts.active },
+    { id: 'failed', label: 'Failed', count: chipCounts.failed },
+    { id: 'done', label: 'Done', count: chipCounts.done },
+    { id: 'docs', label: 'Docs', count: chipCounts.docs },
+  ];
+
   return (
-    <div className="flex flex-col" style={{ color: 'var(--ink-high)' }}>
-      <div className="px-8 pt-8 pb-4 flex items-baseline justify-between gap-4">
-        <h1 className="text-2xl font-semibold font-mono">Make</h1>
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
-          build runs · documents · demos
-        </p>
+    <div className="flex flex-col" style={{ color: 'var(--ink-high)', padding: '0 var(--space-8) var(--space-8)', gap: 'var(--space-4)' }}>
+      {/* ── Header: the section name + its creation verb ── */}
+      <div className="pt-8 flex items-center justify-between gap-4">
+        <div className="flex items-baseline gap-4 min-w-0">
+          <h1 className="text-2xl font-semibold font-mono" style={{ margin: 0 }}>Make</h1>
+          <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
+            build runs · documents · demos
+          </p>
+        </div>
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            data-testid="make-new"
+            aria-expanded={makeOpen}
+            onClick={() => setMakeOpen((v) => !v)}
+            style={{
+              background: 'var(--accent)', color: 'var(--accent-fg)', border: 'none',
+              borderRadius: 'var(--radius-md)', padding: '6px 14px',
+              fontSize: 'var(--text-xs)', fontWeight: 'var(--weight-bold)', cursor: 'pointer',
+            }}
+          >
+            ＋ Make
+          </button>
+          {makeOpen && (
+            <MakePicker
+              navigate={(p) => { setMakeOpen(false); navigate(p); }}
+              onClose={() => setMakeOpen(false)}
+              ambient={null}
+            />
+          )}
+        </div>
       </div>
 
-      {/* ── The reporting band (§4.2.1) — tiles ABOVE the list (EC28) ────────── */}
-      <div
-        data-testid="make-dashboard-tiles"
-        className="mx-8 mb-6 flex items-stretch"
-        style={{ height: '64px', flexShrink: 0, background: 'var(--surface-rail)', borderRadius: 'var(--radius-md)', padding: '0 var(--space-3)' }}
+      {/* ── The KPI band — items · runs consumed · active · failed ── */}
+      <KpiBand testId="make-kpis">
+        <KpiGroup label="Performance" grow={2}>
+          <StatTile
+            testId="stat-items"
+            label="Make items"
+            value={buckets.current.length + docRows.length}
+            context={`${rangeWord(range)} runs · loaded docs`}
+            title="Everything listed below — click to clear filters"
+            onOpen={() => { setChip('all'); setQuery(''); }}
+          />
+          <StatTile
+            testId="stat-runs"
+            label="Runs consumed"
+            value={buckets.current.length}
+            delta={runsDelta}
+            context={deltaWord(range, runsDelta)}
+            spark={runSpark}
+            title="Build runs in the window — click to clear filters"
+            onOpen={() => { setChip('all'); setQuery(''); }}
+          />
+        </KpiGroup>
+        <KpiGroup label="Pipeline" grow={1}>
+          <StatTile
+            testId="stat-active"
+            label="Active now"
+            value={liveCounts.active + liveCounts.gates}
+            valueColor={liveCounts.gates > 0 ? 'var(--status-gate)' : undefined}
+            context={liveCounts.gates > 0 ? `${liveCounts.gates} waiting on you` : 'right now'}
+            title="Builds in flight — filter the grid to them"
+            onOpen={() => setChip(liveCounts.gates > 0 ? 'needs-you' : 'active')}
+          />
+        </KpiGroup>
+        <KpiGroup label="Risk" grow={1}>
+          <StatTile
+            testId="stat-failed"
+            label="Failed"
+            value={failedDelta.current}
+            valueColor={failedDelta.current > 0 ? 'var(--status-fail)' : undefined}
+            delta={failedDelta}
+            deltaSense="bad-up"
+            context={deltaWord(range, failedDelta)}
+            title="Failed builds in the window — filter the grid to them"
+            onOpen={() => setChip('failed')}
+          />
+        </KpiGroup>
+      </KpiBand>
+
+      {/* ── Filters — first-class at the top of the list ── */}
+      <FilterStrip
+        testId="make-filter"
+        query={query}
+        onQuery={setQuery}
+        placeholder="Search made things…"
+        chips={chips}
+        active={chip}
+        onChip={(id) => setChip(id as StatusChip)}
+        range={range}
+        onRange={setRange}
       >
-        <MadeTile builds={made} docs={docRows} attachedAt={attachedAt} />
-        <RunOutcomeBar
-          runs={made}
-          attachedAt={attachedAt}
-          question="Are makes landing or failing?"
-          title="Outcome split (24h)"
-        />
-        <TokenBurnSparkline
-          question="What is making costing?"
-          title="Spend (observed)"
-        />
-      </div>
+        {hiddenByWindow > 0 && (
+          <button
+            type="button"
+            data-testid="make-hidden-chip"
+            data-hidden={hiddenByWindow}
+            onClick={() => setRange('all')}
+            title={`the ${rangeWord(range)} window holds back ${hiddenByWindow} older run${hiddenByWindow === 1 ? '' : 's'} — click to show all`}
+            style={{
+              borderRadius: 'var(--radius-full)', padding: '3px 10px',
+              fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
+              border: '1px solid var(--surface-raised)', background: 'transparent',
+              color: 'var(--ink-muted)',
+            }}
+          >
+            +{hiddenByWindow} older · show all
+          </button>
+        )}
+      </FilterStrip>
 
-      {/* ── The corpus label (EC24 grammar, §4.2.2) heads the list ───────────── */}
-      <div ref={whyRef} className="relative px-8 pb-2 flex items-center gap-3 flex-wrap">
+      {/* ── The corpus label (EC24 grammar) heads the list ── */}
+      <div ref={whyRef} className="relative flex items-center gap-3 flex-wrap">
         <p
           data-testid="make-corpus-label"
           style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
@@ -243,7 +345,7 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
         {whyOpen && (
           <p
             data-testid="make-corpus-why-popover"
-            className="absolute left-8 top-6 z-20 max-w-md"
+            className="absolute left-0 top-6 z-20 max-w-md"
             style={{
               margin: 0, padding: 'var(--space-2) var(--space-3)',
               background: 'var(--surface-overlay)', border: '1px solid var(--surface-raised)',
@@ -282,81 +384,187 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
         )}
       </div>
 
-      {/* ── The list: run spine, then the known doc corpus (§4.2.2) ──────────── */}
-      <div className="px-8 pb-8 flex flex-col gap-1" data-testid="make-list">
-        {made.length === 0 && (
+      {/* ── The grid: run cards (needs-you first), then the known doc corpus ── */}
+      <div data-testid="make-list" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+        {made.length === 0 && visibleDocs.length === 0 && (
           <p style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)', fontStyle: 'italic' }}>
             Nothing made yet — Make's ＋ forks Build / Document / Video.
           </p>
         )}
-        {made.map((view) => (
-          <a
-            key={view.session.id}
-            data-testid="make-run-row"
-            data-run-id={view.session.id}
-            data-status={view.session.status}
-            {...link(runPath(view.session.id))}
-            title={view.session.problem}
-            className="flex items-center gap-2 min-w-0 px-3 py-1.5 rounded-md transition-colors hover:bg-surface-card"
-            style={{ textDecoration: 'none' }}
-          >
-            <span
-              aria-hidden
-              className="w-2 h-2 rounded-full shrink-0"
-              style={{ background: RUN_DOT[view.session.status] ?? 'var(--ink-dim)' }}
-            />
-            <span className="truncate" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
-              {/* The ONE human-title derivation (review #2) — the raw prompt
-                  moves to this row's hover title. */}
-              {humanTitle(view.session.problem)}
-            </span>
-            <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}>
-              {projectNameByRun[view.session.id] ?? 'Unfiled'}
-            </span>
-            <span className="ml-auto shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-              {phaseWord(view)}
-            </span>
-          </a>
-        ))}
-
-        {docRows.length > 0 && (
-          <p
-            className="pt-3 pb-1"
-            style={{
-              margin: 0, fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', textTransform: 'uppercase',
-              letterSpacing: '0.08em', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)',
-            }}
-          >
-            documents · demos
+        {made.length > 0 && visibleRuns.length === 0 && chip !== 'docs' && (
+          <p data-testid="make-runs-empty" style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', fontStyle: 'italic' }}>
+            No runs match this filter{hiddenByWindow > 0 ? ` — ${hiddenByWindow} sit outside the ${rangeWord(range)} window` : ''}.{' '}
+            <button
+              type="button"
+              data-testid="make-clear-filters"
+              onClick={() => { setChip('all'); setQuery(''); }}
+              style={{
+                background: 'none', border: 'none', padding: 0, font: 'inherit',
+                color: 'var(--ink-muted)', textDecoration: 'underline', cursor: 'pointer',
+              }}
+            >
+              clear filters
+            </button>
           </p>
         )}
-        {docRows.map(({ doc, projectId, projectName }) => {
-          const mode: Mode = doc.kind === 'demo' ? 'video' : 'document';
-          return (
-            <a
-              key={`${projectId}:${doc.name}`}
-              data-testid="make-doc-row"
-              data-doc-kind={doc.kind}
-              {...link(versionPath(projectId, doc.name, null, mode))}
-              title={`${doc.name} · ${projectName}`}
-              className="flex items-center gap-2 min-w-0 px-3 py-1.5 rounded-md transition-colors hover:bg-surface-card"
-              style={{ textDecoration: 'none' }}
+        {visibleRuns.length > 0 && (
+          <DashboardGrid testId="make-runs-grid" min={340}>
+            {visibleRuns.map((view) => {
+              const { session } = view;
+              const id = session.id;
+              const path = runPath(id);
+              const failedish = session.status === 'failed' || session.status === 'cancelled';
+              return (
+                <div
+                  key={id}
+                  data-testid="make-run-row"
+                  data-run-id={id}
+                  data-status={session.status}
+                  role="link"
+                  tabIndex={0}
+                  onClick={() => navigate(path)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') navigate(path); }}
+                  className="transition-colors hover:bg-surface-raised"
+                  style={CARD}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                    <span
+                      aria-hidden
+                      className="w-2 h-2 rounded-full shrink-0"
+                      style={{ background: RUN_DOT[session.status] ?? 'var(--ink-dim)' }}
+                    />
+                    {/* The ONE human-title derivation (review #2) — the raw prompt
+                        lives on this card's hover title, never the row. */}
+                    <a
+                      {...link(path)}
+                      data-testid="make-run-title"
+                      title={session.problem}
+                      style={{
+                        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                        fontFamily: 'var(--font-sans)', color: 'var(--ink-body)',
+                        textDecoration: 'none',
+                      }}
+                    >
+                      {humanTitle(session.problem)}
+                    </a>
+                    <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+                      {phaseWord(view)}
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                    <span style={CARD_META}>
+                      {runShortId(id)} · #{session.attempt + 1} · {runWhenWord(attachedAt[id], now)}
+                    </span>
+                    <span style={{ ...CARD_META, color: 'var(--ink-muted)' }}>
+                      {projectNameByRun[id] ?? 'Unfiled'}
+                    </span>
+                    <span style={{ flex: 1 }} />
+                    {session.status === 'awaiting_human' && (
+                      <button
+                        type="button"
+                        data-testid="make-needs-you"
+                        data-run-id={id}
+                        title="Jump straight to this run's gate"
+                        onClick={(e) => { e.stopPropagation(); navigate(gateJump(id)); }}
+                        style={{
+                          flexShrink: 0, cursor: 'pointer',
+                          background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+                          borderRadius: 'var(--radius-full)', padding: '2px 10px',
+                          fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                          fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+                        }}
+                      >
+                        needs you →
+                      </button>
+                    )}
+                    {failedish && (
+                      <button
+                        type="button"
+                        data-testid="make-retry"
+                        data-run-id={id}
+                        title="Reopen the composer prefilled with this run's setup — nothing auto-launches"
+                        onClick={(e) => { e.stopPropagation(); startRetry(view); }}
+                        style={{
+                          flexShrink: 0, cursor: 'pointer',
+                          background: 'transparent', border: '1px solid var(--surface-raised)',
+                          borderRadius: 'var(--radius-md)', padding: '2px 10px',
+                          fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                          color: 'var(--ink-muted)',
+                        }}
+                      >
+                        Retry
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </DashboardGrid>
+        )}
+
+        {visibleDocs.length > 0 && (
+          <>
+            <p
+              style={{
+                margin: 0, fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', textTransform: 'uppercase',
+                letterSpacing: '0.08em', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)',
+              }}
             >
-              <span aria-hidden className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}>
-                {doc.kind === 'demo' ? '▶' : '▤'}
-              </span>
-              <span className="truncate" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)' }}>
-                {doc.name}
-              </span>
-              <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-                v{doc.head}
-              </span>
-              <span className="ml-auto shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-mono)' }}>
-                {projectName}
-              </span>
-            </a>
-          );
-        })}
+              documents · demos
+            </p>
+            <DashboardGrid testId="make-docs-grid" min={300}>
+              {visibleDocs.map(({ doc, projectId, projectName }) => {
+                const mode: Mode = doc.kind === 'demo' ? 'video' : 'document';
+                const path = versionPath(projectId, doc.name, null, mode);
+                const updated = doc.updated_at === null ? NaN : Date.parse(doc.updated_at);
+                return (
+                  <div
+                    key={`${projectId}:${doc.name}`}
+                    data-testid="make-doc-row"
+                    data-doc-kind={doc.kind}
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => navigate(path)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') navigate(path); }}
+                    className="transition-colors hover:bg-surface-raised"
+                    style={CARD}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                      <span aria-hidden className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)' }}>
+                        {doc.kind === 'demo' ? '▶' : '▤'}
+                      </span>
+                      <a
+                        {...link(path)}
+                        title={`${doc.name} · ${projectName}`}
+                        style={{
+                          flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                          fontFamily: 'var(--font-sans)', color: 'var(--ink-body)',
+                          textDecoration: 'none',
+                        }}
+                      >
+                        {doc.name}
+                      </a>
+                      <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+                        v{doc.head}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                      <span style={CARD_META}>
+                        {doc.versions} version{doc.versions === 1 ? '' : 's'}
+                        {Number.isFinite(updated) ? ` · updated ${ago(updated, now)} ago` : ''}
+                      </span>
+                      <span style={{ ...CARD_META, color: 'var(--ink-muted)', marginLeft: 'auto' }}>
+                        {projectName}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </DashboardGrid>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -4,36 +4,47 @@ import { listDocs, type DocSummary } from '../api/interactive.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
-import { WINDOW_LABEL_STYLE } from '../board/metrics.js';
-import { sessionProjectId } from '../hooks/ambientProject.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import { outcomeOf, WINDOW_LABEL_STYLE } from '../board/metrics.js';
+import {
+  attachSeries, deltaWord, statusCounts, windowBuckets, windowDelta,
+} from '../board/windowStats.js';
+import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { interactiveRootOf } from '../hooks/useBoardModel.js';
 import { modePath, type Mode, type Navigate } from '../hooks/useRoute.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useTriageCursor, type TriageItem } from '../hooks/useTriageCursor.js';
 import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
 import { getCachedRepos } from '../store/repoCache.js';
+import { setRetryPrefill } from '../store/retryPrefill.js';
 import { BatchGateBar, BatchSelectBox } from './BatchGateBar.js';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, StatTile, type FilterChip,
+} from './dashboardKit.js';
 import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { ageWord } from './DashboardTiles.js';
 import { deliverySummary } from './delivery.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import { DeliveryChip } from './RunDelivery.js';
-import { RunSparkline } from './RunSparkline.js';
+import { humanTitle, runShortId, runWhenWord } from './runIdentity.js';
 import { STATUS_STYLE } from './RunCard.js';
 
 /**
- * The project dashboard (DES-FEEDBACK-001 §4.1, slice D): what `/p/:projectId`
- * with NO mode segment renders — context before actions. It is NOT a fifth
- * mode (no Dashboard tab in the switcher); it is what you see before you
- * choose one, and where the context header's project name leads back to.
+ * The project HOMEPAGE — `/p/:projectId` with no mode segment (lane B): the
+ * same command-surface kit as /projects, scoped to one project. A KPI band
+ * (its runs/active/gates/failed with honest window deltas + a sparkline of its
+ * run history on the attach clock), the gate inbox FIRST (attention routing
+ * beats navigation), then its runs/chats/docs as filterable full-width cards.
+ * The creation verbs live in the header (Do Work + the four mode verbs);
+ * failed runs carry an inline Retry (a prefill, never a hidden relaunch).
  *
- * Everything here derives from data the app already fetches: the shared `runs`
- * list (passed down from App's one `useRuns()`), one membership read (the same
- * call the board makes per project), one `listDocs(projectId)` (the same call
- * Document mode makes — only when the project has an interactive root), and
- * the gate store `useRuns` already reconciles. No polling loops.
+ * Everything derives from data the app already fetches: the shared `runs`
+ * list, one membership read, one `listDocs` (only when the project has an
+ * interactive root), and the gate store. No polling loops, no new wires.
  */
 
 /** Statuses that mean the run is moving under its own power (board's set). */
@@ -42,15 +53,14 @@ const ACTIVE: ReadonlySet<string> = new Set(['planning', 'distributing', 'execut
 /** Membership kinds that make a run/thread a member of a project. */
 const RUN_KINDS: ReadonlySet<string> = new Set(['crew.run', 'crew.chat']);
 
-const DAY = 24 * 3_600_000;
-/** The activity tile's window (§4.1 tile 4): 7 daily run-count buckets. */
-const SPARK_DAYS = 7;
+/** Gate-inbox rows before the list reports a count instead of growing. */
+const MAX_GATE_ROWS = 6;
 
-/** Rows a tile shows before it reports a count instead of growing. */
-const MAX_ROWS = 6;
+const TERMINAL: ReadonlySet<string> = new Set(['completed', 'cancelled', 'failed']);
 
 const CSS = {
-  page: { padding: 'var(--space-5) var(--space-6)', maxWidth: '1080px' },
+  // FULL WIDTH (lane B): the dashboard flows with the viewport.
+  page: { padding: 'var(--space-5) var(--space-6)', display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' },
   name: {
     fontSize: 'var(--text-lg)', fontWeight: 'var(--weight-bold)',
     fontFamily: 'var(--font-sans)', color: 'var(--ink-high)', margin: 0,
@@ -67,41 +77,36 @@ const CSS = {
     fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
     color: 'var(--ink-muted)', margin: '6px 0 0',
   },
-  grid: {
-    display: 'grid', gap: 'var(--space-3)', marginTop: 'var(--space-4)',
-    // §4.1's 2x2: two columns at the page's 1080px max (auto-fit's only job is
-    // the 1-column fallback below ~430px tiles — never a 3+1 row).
-    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 420px), 1fr))',
-  },
-  tile: {
-    background: 'var(--surface-card)', boxShadow: 'var(--shadow-card)',
-    borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', minWidth: 0,
-  },
-  tileHead: {
+  sectionHead: {
     fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-bold)',
     letterSpacing: '0.08em', textTransform: 'uppercase',
-    color: 'var(--ink-muted)', margin: '0 0 10px',
+    color: 'var(--ink-muted)', margin: '0 0 8px',
   },
-  row: {
-    display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0,
-    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
-    border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)',
-    padding: '5px 8px', textDecoration: 'none',
+  card: {
+    display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+    background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+    cursor: 'pointer',
   },
-  rowText: {
-    flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  cardMeta: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
+    whiteSpace: 'nowrap',
   },
   empty: { fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', margin: 0 },
-  overflow: { fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '6px 0 0' },
-  // studio#122: the delivery census, directly under the RUNS head. Data, so mono
-  // and dim — the tile's own count stays the headline.
+  // The empty state's CTA — the named verb IS the door (never dead prose).
+  emptyCta: { color: 'var(--ink-muted)', textDecoration: 'underline', cursor: 'pointer' },
+  emptyCtaBtn: {
+    background: 'none', border: 'none', padding: 0, font: 'inherit',
+    color: 'var(--ink-muted)', textDecoration: 'underline', cursor: 'pointer',
+  },
+  // studio#122: the delivery census under the RUNS head. Data, so mono + dim.
   deliverySummary: {
     fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
-    color: 'var(--ink-dim)', margin: '-6px 0 10px',
+    color: 'var(--ink-dim)', margin: '-4px 0 8px',
   },
 } as const satisfies Record<string, React.CSSProperties>;
 
-/** The per-run attention signal — the home board's model (§2.1.3) scoped to one run. */
+/** The per-run attention signal — the home board's model scoped to one run. */
 function runSignal(v: SessionView, gateAt: number | undefined, fallback: number): Signal | null {
   const status = v.session.status;
   const kind: SignalKind | null =
@@ -110,6 +115,17 @@ function runSignal(v: SessionView, gateAt: number | undefined, fallback: number)
     : ACTIVE.has(status) ? 'running'
     : null;
   return kind === null ? null : { kind, at: gateAt ?? fallback, runId: v.session.id };
+}
+
+type StatusChip = 'all' | 'needs-you' | 'active' | 'failed' | 'done';
+
+function matchesChip(status: string, chip: StatusChip): boolean {
+  if (chip === 'all') return true;
+  const o = outcomeOf(status);
+  if (chip === 'needs-you') return o === 'gate';
+  if (chip === 'active') return o === 'run';
+  if (chip === 'failed') return o === 'fail';
+  return o === 'done' || o === 'cancelled';
 }
 
 interface Props {
@@ -124,6 +140,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   const loadProjects = useProjectsStore((s) => s.load);
   const gates = useGateStore((s) => s.gates);
 
+  const [query, setQuery] = useState('');
+  const [chip, setChip] = useState<StatusChip>('all');
+  const { range, setRange } = useTimeRange('30d');
+
   useEffect(() => {
     if (projects.length === 0) void loadProjects();
   }, [projects.length, loadProjects]);
@@ -132,13 +152,8 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   const name = project?.name ?? projectId;
 
   // One membership read on mount — the same call the board makes per project.
-  // ref → kind (a `crew.chat` member opens in Chat), ref → attached_at (the
-  // honest per-run clock this wire carries; `AgentSession` has no timestamps).
   const [memberKinds, setMemberKinds] = useState<Record<string, string>>({});
   const [attachedAt, setAttachedAt] = useState<Record<string, number>>({});
-  // Slice J (DES-FEEDBACK-002 §10.2): the same read already returns the
-  // project's `crew.repo` members — the wire grammar names the kind — and the
-  // RUN_KINDS filter used to drop them on the floor. Zero new requests.
   const [repoRefs, setRepoRefs] = useState<string[]>([]);
   useEffect(() => {
     let cancelled = false;
@@ -165,31 +180,25 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
     return () => { cancelled = true; };
   }, [projectId]);
 
-  // One listDocs on mount — the same call Document mode makes — and only when
-  // the project HAS an interactive root (the board's §7.12 guard: no root, no
-  // bridge to cold-start).
+  // One listDocs on mount — only when the project HAS an interactive root.
   const [docs, setDocs] = useState<DocSummary[]>([]);
   useEffect(() => {
     if (project === null || interactiveRootOf(project) === null) return;
     let cancelled = false;
     listDocs(projectId)
       .then((d) => {
-        useDocsCache.getState().deposit(projectId, d); // slice O §4.2.2: the session doc cache
+        useDocsCache.getState().deposit(projectId, d); // the session doc cache
         if (!cancelled) setDocs(d);
       })
-      .catch(() => { /* bridge cold/unreachable — no doc tiles, never an error wall */ });
+      .catch(() => { /* bridge cold/unreachable — no doc cards, never an error wall */ });
     return () => { cancelled = true; };
   }, [projectId, project]);
 
-  // ── The project's runs, attention-ordered (the board's model, §4.1 tile 1) ──
+  // ── The project's runs, attention-ordered (needs-you floats FIRST) ─────────
   const fallbackAt = project?.updated_at ?? 0;
   const myRuns = useMemo(() => {
     const now = Date.now();
     return runs
-      // Slice S (DES-UX-001 §2.3 rule 3): the run DTO's own `project_id` claim
-      // (CREW-UX-2) places a run here the instant `GET /runs` reconciles — no
-      // waiting on the mount-time members snapshot. The membership join stays
-      // as the pre-0.8.0 fallback (field absent) and as the kind/clock source.
       .filter((v) => {
         if (v.session.archived_at != null) return false;
         const claimed = sessionProjectId(v.session);
@@ -210,48 +219,39 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
       ));
   }, [runs, memberKinds, attachedAt, gates, fallbackAt, projectId]);
 
-  // studio#122: the delivery census, over every run in the project (not the
-  // MAX_ROWS window) and over deliverable runs only (not the chats). `''` when
-  // there is nothing to census — see the render guard below.
-  //
-  // The `is_system` lookup is the app's ONE `GET /workflows`, shared and cached
-  // (D-1): the denylist alone knows five of the daemon's eleven system
-  // workflows, so an interactive doc or video thread was counted under "no
-  // deliver phase" — a number about chats dressed as a delivery finding, which
-  // is the exact D5 complaint. The "no deliver phase" bucket now counts only
-  // runs a def in hand says could have delivered: a materialised `wf-<runId>`
-  // workflow — 86 of the 129 live runs — is unclassifiable forever, and this
-  // project's line read "8 no deliver phase" over eight document threads.
-  // O(1) per app, never O(runs): the cache is module state, so the row chips
-  // share this same one request rather than adding any of their own.
+  // studio#122: the delivery census, over EVERY run in the project.
   const isSystemWorkflow = useIsSystemWorkflow();
   const deliveryCensus = useMemo(
     () => deliverySummary(myRuns.map(({ view }) => view), isSystemWorkflow),
     [myRuns, isSystemWorkflow],
   );
 
-  const openRuns = myRuns.filter(({ view }) => !['completed', 'cancelled', 'failed'].includes(view.session.status));
+  const openRuns = myRuns.filter(({ view }) => !TERMINAL.has(view.session.status));
   const waiting = myRuns.filter(({ view }) => view.session.status === 'awaiting_human');
 
-  // ── The 7-day run-count sparkline (§4.1 tile 4): one bucket per day, oldest
-  // first, counted off the membership attach clock — when each run entered the
-  // project, the one per-run timestamp this wire carries. ──
+  // ── The window (positional recency, honestly labeled) + KPI folds ──────────
+  const orderedViews = useMemo(() => myRuns.map(({ view }) => view), [myRuns]);
+  const buckets = useMemo(() => windowBuckets(orderedViews, range), [orderedViews, range]);
+  const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
   const now = Date.now();
-  const sparkCounts = useMemo(() => {
-    const counts = new Array<number>(SPARK_DAYS).fill(0);
-    for (const id of Object.keys(attachedAt)) {
-      const age = now - (attachedAt[id] ?? 0);
-      if (age < 0 || age >= SPARK_DAYS * DAY) continue;
-      const bucket = SPARK_DAYS - 1 - Math.floor(age / DAY);
-      counts[bucket] = (counts[bucket] ?? 0) + 1;
-    }
-    return counts;
-    // `now` deliberately not a dep: the tile re-derives when the data moves, not on a timer.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [attachedAt]);
-  const sparkTotal = sparkCounts.reduce((a, c) => a + c, 0);
 
-  // Meta line (§4.1): last activity + open runs. Cost is NOT here on purpose —
+  const liveCounts = useMemo(() => statusCounts(orderedViews), [orderedViews]);
+  const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
+  const failedDelta = useMemo(
+    () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
+    [buckets],
+  );
+  const runSpark = useMemo(
+    () => attachSeries(Object.keys(attachedAt), attachedAt, 14, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` re-derives with the data, not a timer
+    [attachedAt],
+  );
+  const oldestGate = waiting.reduce<number | null>((acc, { view }) => {
+    const at = gates[view.session.id]?.receivedAt;
+    return at === undefined ? acc : acc === null || at < acc ? at : acc;
+  }, null);
+
+  // Meta line: last activity + open runs. Cost is NOT here on purpose —
   // the `/runs` wire carries no cost field, and the dashboard never invents one.
   const lastActivity = Math.max(
     fallbackAt,
@@ -262,16 +262,32 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   /** Every affordance is a real link — deep-linkable, middle-clickable. */
   const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
     href: path,
-    onClick: (e) => { e.preventDefault(); navigate(path); },
+    onClick: (e) => { e.preventDefault(); e.stopPropagation(); navigate(path); },
   });
 
   /** Where a run row opens: its OWN mode view — Chat for a chat thread, Build otherwise. */
   const runModeOf = (id: string): Mode => (memberKinds[id] === 'crew.chat' ? 'chat' : 'build');
 
-  // ── Slice H (DES-FEEDBACK-002 §2.2): the triage cursor walks the gate-inbox
-  // rows — the tile the surface already renders, in its order. `resetKey`
-  // clears the cursor when the dashboard pivots projects without unmounting.
-  const inboxRows = waiting.slice(0, MAX_ROWS);
+  /** Retry-as-prefill (DES-UX-001 §4.3) — the ChatPanel contract, verbatim:
+   *  deposit the failed run's launch config, open the composer, nothing
+   *  auto-launches. The launch then carries `retryOf` (CREW-UX-3). */
+  function startRetry(v: SessionView): void {
+    const s = v.session;
+    setRetryPrefill({
+      retryOf: s.id,
+      problem: s.problem,
+      clis: s.clis,
+      workflowId: s.workflow_id && s.workflow_id !== 'chat' ? s.workflow_id : null,
+      repoRef: s.repo_ref,
+      entityMode: s.entity_mode,
+      humanConfirm: s.human_confirm,
+      projectId: typeof s.project_id === 'string' ? s.project_id : projectId,
+    });
+    navigate('/runs/new');
+  }
+
+  // ── The triage cursor walks the gate-inbox rows, in their order ─────────────
+  const inboxRows = waiting.slice(0, MAX_GATE_ROWS);
   const triageItems = useMemo<TriageItem[]>(
     () =>
       inboxRows.map(({ view }) => {
@@ -289,9 +305,40 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   );
   const cursor = useTriageCursor(triageItems, navigate, projectId);
 
+  // ── The filtered run cards (search lifts the window — Work page idiom) ─────
+  const q = query.trim().toLowerCase();
+  const searched = q === ''
+    ? myRuns.filter(({ view }) => windowIds.has(view.session.id))
+    : myRuns.filter(({ view }) =>
+        view.session.problem.toLowerCase().includes(q)
+        || runShortId(view.session.id).includes(q));
+  const visibleRuns = searched.filter(({ view }) => matchesChip(view.session.status, chip));
+  const hiddenByWindow = q === '' ? orderedViews.length - buckets.current.length : 0;
+
+  const chipCounts: Record<StatusChip, number> = useMemo(() => {
+    const counts: Record<StatusChip, number> = { all: 0, 'needs-you': 0, active: 0, failed: 0, done: 0 };
+    for (const { view } of searched) {
+      counts.all += 1;
+      for (const c of ['needs-you', 'active', 'failed', 'done'] as const) {
+        if (matchesChip(view.session.status, c)) counts[c] += 1;
+      }
+    }
+    return counts;
+  }, [searched]);
+
+  const chips: FilterChip[] = [
+    { id: 'all', label: 'All', count: chipCounts.all },
+    { id: 'needs-you', label: 'Needs you', count: chipCounts['needs-you'] },
+    { id: 'active', label: 'Active', count: chipCounts.active },
+    { id: 'failed', label: 'Failed', count: chipCounts.failed },
+    { id: 'done', label: 'Done', count: chipCounts.done },
+  ];
+
+  const visibleDocs = q === '' ? docs : docs.filter((d) => d.name.toLowerCase().includes(q));
+
   return (
     <div data-testid="project-dashboard" data-project-id={projectId} style={CSS.page}>
-      {/* ── Project header: name, the four mode verbs, the meta line (§4.1) ── */}
+      {/* ── Project header: name, the creation verbs, the meta line ── */}
       <header>
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
           <h1 style={CSS.name}>{name}</h1>
@@ -307,16 +354,27 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
               </a>
             ))}
           </div>
+          <span style={{ flex: 1 }} />
+          {/* The section's creation verb — one click from wherever the need appears. */}
+          <a
+            {...link(launchPath(projectId, 'build'))}
+            data-testid="dashboard-do-work"
+            style={{
+              display: 'inline-flex', alignItems: 'center', textDecoration: 'none',
+              background: 'var(--accent)', color: 'var(--accent-fg)', border: 'none',
+              borderRadius: 'var(--radius-md)', padding: '6px 14px',
+              fontSize: 'var(--text-xs)', fontWeight: 'var(--weight-bold)',
+              whiteSpace: 'nowrap', flexShrink: 0, cursor: 'pointer',
+            }}
+          >
+            Do Work
+          </a>
         </div>
         <p style={CSS.meta} data-testid="dashboard-meta">
           last activity {ago(lastActivity)} ago · {openRuns.length} open {openRuns.length === 1 ? 'run' : 'runs'}
         </p>
-        {/* ── Slice J (§10.2): bound repos in the header's meta-line region —
-            not a fifth tile (the 2×2 grid is a load-bearing §4.1 shape). Names
-            resolve from the SAME session repo cache the palette holds (§1.4) —
-            never a fetch; an unresolvable ref renders the raw ref in --ink-dim
-            (membership is the truth even when the repo listing lags). Zero
-            repos = the row is absent (empty-state budget). ── */}
+        {/* Bound repos in the header's meta-line region — names resolve from the
+            SAME session repo cache the palette holds; never a fetch. */}
         {repoRefs.length > 0 && (
           <p data-testid="dashboard-repos" style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', margin: '6px 0 0' }}>
             {repoRefs.map((ref) => {
@@ -343,186 +401,334 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         )}
       </header>
 
-      {/* Slice L (§9.2): the batch bar docks above the tiles while ≥1 simple
-          gate is selected — the same bar (and fan-out) as the home board. */}
+      {/* The batch bar docks above the band while ≥1 simple gate is selected. */}
       <BatchGateBar navigate={navigate} />
 
-      <div style={CSS.grid}>
-        {/* ── Tile 1: runs, attention-ordered, each a link into its mode view ── */}
-        {/* Slice W (§5.3, EC34): the header counts the SAME collection its rows
-            render — the old "Active runs (open-count)" over an all-runs list was
-            the "ACTIVE RUNS (0) over two rows" contradiction class. `data-count`
-            is the RENDERED row count (set-equal on the same paint); the cap
-            declares itself in the head, and the window is named (EC39). */}
-        <section
-          data-testid="dashboard-runs"
-          data-count={Math.min(myRuns.length, MAX_ROWS)}
-          data-window="all"
-          style={CSS.tile}
-        >
-          <p style={CSS.tileHead}>
-            Runs ({myRuns.length > MAX_ROWS ? `${MAX_ROWS} of ${myRuns.length}` : myRuns.length}){' '}
-            <span data-testid="dashboard-runs-window" style={WINDOW_LABEL_STYLE}>all</span>
-          </p>
-          {/* ── studio#122: what these runs PRODUCED, counted over ALL of them,
-              never the MAX_ROWS window — 665a9aeb (the run that read as the most
-              productive in the project and delivered nothing) is not in the
-              visible six, and a census that could not see it would be exactly
-              the lie this slice exists to remove. Pure DTO: zero requests.
+      {/* ── The KPI band — this project's command center ── */}
+      <KpiBand testId="project-kpis">
+        <KpiGroup label="Performance" grow={1}>
+          <StatTile
+            testId="stat-runs"
+            label="Runs"
+            value={buckets.current.length}
+            delta={runsDelta}
+            context={deltaWord(range, runsDelta)}
+            spark={runSpark}
+            title="Runs in the window — clear the grid filters"
+            onOpen={() => { setChip('all'); setQuery(''); }}
+          />
+        </KpiGroup>
+        <KpiGroup label="Pipeline" grow={2}>
+          <StatTile
+            testId="stat-active"
+            label="Active now"
+            value={liveCounts.active}
+            context="right now"
+            title="Runs moving under their own power — filter the grid"
+            onOpen={() => setChip('active')}
+          />
+          <StatTile
+            testId="stat-gates"
+            label="Needs you"
+            value={waiting.length}
+            valueColor={waiting.length > 0 ? 'var(--status-gate)' : undefined}
+            context={oldestGate !== null ? `oldest waiting ${ageWord(now - oldestGate)}` : 'nothing waiting'}
+            title={waiting.length > 0 ? 'Jump straight to the waiting gate' : 'Nothing is waiting on you'}
+            {...(waiting.length > 0 && waiting[0] !== undefined
+              ? {
+                  href: gateOpenPath(projectId, waiting[0].view.session.id),
+                  onOpen: () => navigate(gateOpenPath(projectId, waiting[0]!.view.session.id)),
+                }
+              : {})}
+          />
+        </KpiGroup>
+        <KpiGroup label="Risk" grow={1}>
+          <StatTile
+            testId="stat-failed"
+            label="Failed"
+            value={failedDelta.current}
+            valueColor={failedDelta.current > 0 ? 'var(--status-fail)' : undefined}
+            delta={failedDelta}
+            deltaSense="bad-up"
+            context={deltaWord(range, failedDelta)}
+            title="Failed runs in the window — filter the grid to them"
+            onOpen={() => setChip('failed')}
+          />
+        </KpiGroup>
+      </KpiBand>
 
-              `deliverySummary` counts DELIVERABLE runs only, so a project whose
-              runs are all chats has nothing to census and gets no line rather
-              than an empty paragraph — the `!== ''` guard, not `length > 0`. ── */}
-          {deliveryCensus !== '' && (
-            <p data-testid="dashboard-delivery-summary" style={CSS.deliverySummary}>
-              {deliveryCensus}
-            </p>
-          )}
-          {myRuns.length === 0 ? (
-            <p style={CSS.empty}>No runs yet — Build starts one.</p>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-              {myRuns.slice(0, MAX_ROWS).map(({ view, signal }) => {
-                const { session } = view;
-                const style = STATUS_STYLE[session.status];
-                return (
-                  <a
-                    key={session.id}
-                    {...link(modePath(projectId, runModeOf(session.id), session.id))}
-                    data-testid="dashboard-run"
-                    data-run-id={session.id}
-                    data-status={session.status}
-                    style={CSS.row}
-                  >
+      {/* ── The gate inbox — FIRST: attention routing beats navigation ── */}
+      {waiting.length > 0 && (
+        <section
+          data-testid="dashboard-gates"
+          data-count={Math.min(waiting.length, MAX_GATE_ROWS)}
+          style={{
+            background: 'var(--surface-card)', border: '1px solid var(--status-gate-dim)',
+            borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)',
+          }}
+        >
+          <p style={{ ...CSS.sectionHead, color: 'var(--status-gate)' }}>
+            Needs you ({waiting.length > MAX_GATE_ROWS ? `${MAX_GATE_ROWS} of ${waiting.length}` : waiting.length})
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {inboxRows.map(({ view }) => {
+              const id = view.session.id;
+              const gate = gates[id];
+              const selected = cursor.selectedKey === id;
+              return (
+                <div
+                  key={id}
+                  data-testid="dashboard-gate"
+                  data-run-id={id}
+                  tabIndex={-1}
+                  data-kbd-item={id}
+                  {...(selected ? { 'data-kbd-selected': 'true' } : {})}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0,
+                    outline: selected ? '2px solid var(--accent)' : 'none',
+                    outlineOffset: '2px',
+                  }}
+                >
+                  {cursor.noteFor === id ? (
+                    <GateRejectNote runId={id} onClose={cursor.closeNote} />
+                  ) : (
+                    <>
+                      <BatchSelectBox runId={id} gate={gate} />
+                      <span
+                        title={gate?.prompt}
+                        style={{
+                          flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                          fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+                        }}
+                      >
+                        {gate?.prompt ?? view.session.problem}
+                      </span>
+                      <GateChip runId={id} projectId={projectId} gate={gate} navigate={navigate} />
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* ── Filters — first-class at the top of the list ── */}
+      <FilterStrip
+        testId="dashboard-filter"
+        query={query}
+        onQuery={setQuery}
+        placeholder="Search runs & docs…"
+        chips={chips}
+        active={chip}
+        onChip={(id) => setChip(id as StatusChip)}
+        range={range}
+        onRange={setRange}
+      >
+        {hiddenByWindow > 0 && (
+          <button
+            type="button"
+            data-testid="dashboard-hidden-chip"
+            data-hidden={hiddenByWindow}
+            onClick={() => setRange('all')}
+            title={`the ${rangeWord(range)} window holds back ${hiddenByWindow} older run${hiddenByWindow === 1 ? '' : 's'} — click to show all`}
+            style={{
+              borderRadius: 'var(--radius-full)', padding: '3px 10px',
+              fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
+              border: '1px solid var(--surface-raised)', background: 'transparent',
+              color: 'var(--ink-muted)',
+            }}
+          >
+            +{hiddenByWindow} older · show all
+          </button>
+        )}
+      </FilterStrip>
+
+      {/* ── Runs as full-width cards ── */}
+      <section
+        data-testid="dashboard-runs"
+        data-count={visibleRuns.length}
+        data-window={range}
+      >
+        <p style={CSS.sectionHead}>
+          Runs ({visibleRuns.length}){' '}
+          <span data-testid="dashboard-runs-window" style={WINDOW_LABEL_STYLE}>{rangeWord(range)}</span>
+        </p>
+        {/* studio#122: what these runs PRODUCED, counted over ALL of them. */}
+        {deliveryCensus !== '' && (
+          <p data-testid="dashboard-delivery-summary" style={CSS.deliverySummary}>
+            {deliveryCensus}
+          </p>
+        )}
+        {myRuns.length === 0 ? (
+          <p style={CSS.empty}>
+            No runs yet —{' '}
+            <a {...link(launchPath(projectId, 'build'))} data-testid="dashboard-empty-build" style={CSS.emptyCta}>
+              Build
+            </a>{' '}
+            starts one.
+          </p>
+        ) : visibleRuns.length === 0 ? (
+          <p style={CSS.empty} data-testid="dashboard-runs-empty">
+            No runs match this filter{hiddenByWindow > 0 ? ` — ${hiddenByWindow} sit outside the ${rangeWord(range)} window` : ''}.{' '}
+            <button
+              type="button"
+              data-testid="dashboard-clear-filters"
+              onClick={() => { setChip('all'); setQuery(''); }}
+              style={CSS.emptyCtaBtn}
+            >
+              clear filters
+            </button>
+          </p>
+        ) : (
+          <DashboardGrid testId="dashboard-runs-grid" min={340}>
+            {visibleRuns.map(({ view, signal }) => {
+              const { session } = view;
+              const style = STATUS_STYLE[session.status];
+              const path = modePath(projectId, runModeOf(session.id), session.id);
+              const failedish = session.status === 'failed' || session.status === 'cancelled';
+              return (
+                <div
+                  key={session.id}
+                  data-testid="dashboard-run"
+                  data-run-id={session.id}
+                  data-status={session.status}
+                  role="link"
+                  tabIndex={0}
+                  onClick={() => navigate(path)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') navigate(path); }}
+                  className="transition-colors hover:bg-surface-raised"
+                  style={CSS.card}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
                     <span
                       aria-hidden
                       style={{
                         width: '6px', height: '6px', borderRadius: 'var(--radius-full)', flexShrink: 0,
-                        // SignalKind is a subset of Attention, so the board's dot map reads directly.
                         background: signal !== null ? ATTENTION_DOT[signal.kind] : 'var(--ink-dim)',
                       }}
                     />
-                    <span style={CSS.rowText}>{session.problem}</span>
-                    {/* studio#122: what the run produced, beside what it is
-                        doing — DTO-derived, so the row costs no request. */}
-                    <DeliveryChip view={view} />
-                    <span style={{ flexShrink: 0, color: style?.color ?? 'var(--ink-dim)' }}>
+                    {/* Derived title (runTitle grammar) — the raw prompt is hover-only. */}
+                    <a
+                      {...link(path)}
+                      data-testid="dashboard-run-title"
+                      title={session.problem}
+                      style={{
+                        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                        fontFamily: 'var(--font-sans)', color: 'var(--ink-body)',
+                        textDecoration: 'none',
+                      }}
+                    >
+                      {humanTitle(session.problem)}
+                    </a>
+                    <span style={{ flexShrink: 0, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: style?.color ?? 'var(--ink-dim)' }}>
                       {style?.label ?? session.status}
                     </span>
-                  </a>
-                );
-              })}
-              {myRuns.length > MAX_ROWS && (
-                <p style={CSS.overflow}>{myRuns.length - MAX_ROWS} more</p>
-              )}
-            </div>
-          )}
-        </section>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                    <span style={CSS.cardMeta}>
+                      {runShortId(session.id)} · #{session.attempt + 1} · {runWhenWord(attachedAt[session.id], now)}
+                    </span>
+                    <DeliveryChip view={view} />
+                    <span style={{ flex: 1 }} />
+                    {session.status === 'awaiting_human' && (
+                      <button
+                        type="button"
+                        data-testid="dashboard-run-needs-you"
+                        data-run-id={session.id}
+                        title="Jump straight to this run's gate"
+                        onClick={(e) => { e.stopPropagation(); navigate(gateOpenPath(projectId, session.id)); }}
+                        style={{
+                          flexShrink: 0, cursor: 'pointer',
+                          background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+                          borderRadius: 'var(--radius-full)', padding: '2px 10px',
+                          fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                          fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+                        }}
+                      >
+                        needs you →
+                      </button>
+                    )}
+                    {failedish && (
+                      <button
+                        type="button"
+                        data-testid="dashboard-run-retry"
+                        data-run-id={session.id}
+                        title="Reopen the composer prefilled with this run's setup — nothing auto-launches"
+                        onClick={(e) => { e.stopPropagation(); startRetry(view); }}
+                        style={{
+                          flexShrink: 0, cursor: 'pointer',
+                          background: 'transparent', border: '1px solid var(--surface-raised)',
+                          borderRadius: 'var(--radius-md)', padding: '2px 10px',
+                          fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                          color: 'var(--ink-muted)',
+                        }}
+                      >
+                        Retry
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </DashboardGrid>
+        )}
+      </section>
 
-        {/* ── Tile 2: documents, from the one listDocs the Document mode makes ── */}
-        <section data-testid="dashboard-docs" data-count={Math.min(docs.length, MAX_ROWS)} style={CSS.tile}>
-          {/* EC34 (slice W): head + data-count name the RENDERED rows; the cap
-              declares itself in the same breath ("N of M", plus "more" below). */}
-          <p style={CSS.tileHead}>
-            Documents ({docs.length > MAX_ROWS ? `${MAX_ROWS} of ${docs.length}` : docs.length})
+      {/* ── Documents as cards, from the one listDocs Document mode makes ── */}
+      <section data-testid="dashboard-docs" data-count={visibleDocs.length}>
+        <p style={CSS.sectionHead}>
+          Documents ({visibleDocs.length})
+        </p>
+        {docs.length === 0 ? (
+          <p style={CSS.empty}>
+            No documents yet —{' '}
+            <a {...link(modePath(projectId, 'document'))} data-testid="dashboard-empty-doc" style={CSS.emptyCta}>
+              Document
+            </a>{' '}
+            drafts one.
           </p>
-          {docs.length === 0 ? (
-            <p style={CSS.empty}>No documents yet — Document drafts one.</p>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-              {docs.slice(0, MAX_ROWS).map((d) => (
-                <a
+        ) : visibleDocs.length === 0 ? (
+          <p style={CSS.empty}>No documents match this search.</p>
+        ) : (
+          <DashboardGrid testId="dashboard-docs-grid" min={280}>
+            {visibleDocs.map((d) => {
+              const path = modePath(projectId, d.kind === 'demo' ? 'video' : 'document', d.name);
+              return (
+                <div
                   key={d.name}
-                  {...link(modePath(projectId, d.kind === 'demo' ? 'video' : 'document', d.name))}
                   data-testid="dashboard-doc"
                   data-doc-id={d.name}
-                  style={CSS.row}
+                  role="link"
+                  tabIndex={0}
+                  onClick={() => navigate(path)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') navigate(path); }}
+                  className="transition-colors hover:bg-surface-raised"
+                  style={{ ...CSS.card, flexDirection: 'row', alignItems: 'center', gap: '8px' }}
                 >
                   <span aria-hidden style={{ flexShrink: 0, color: 'var(--ink-dim)' }}>
                     {d.kind === 'demo' ? '▶' : '▤'}
                   </span>
-                  <span style={CSS.rowText}>{d.name}</span>
-                  <span style={{ flexShrink: 0, color: 'var(--ink-dim)' }}>v{d.head}</span>
-                </a>
-              ))}
-              {docs.length > MAX_ROWS && (
-                <p style={CSS.overflow}>{docs.length - MAX_ROWS} more</p>
-              )}
-            </div>
-          )}
-        </section>
-
-        {/* ── Tile 3: the gate inbox — the SAME answerable chip as the board (§4.1) ── */}
-        <section data-testid="dashboard-gates" data-count={Math.min(waiting.length, MAX_ROWS)} style={CSS.tile}>
-          <p style={CSS.tileHead}>
-            Gate inbox ({waiting.length > MAX_ROWS ? `${MAX_ROWS} of ${waiting.length}` : waiting.length})
-          </p>
-          {waiting.length === 0 ? (
-            <p style={CSS.empty}>Nothing is waiting on you.</p>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              {inboxRows.map(({ view }) => {
-                const id = view.session.id;
-                const gate = gates[id];
-                const selected = cursor.selectedKey === id;
-                return (
-                  <div
-                    key={id}
-                    data-testid="dashboard-gate"
-                    data-run-id={id}
-                    // Slice H (§2.2, EC22): the cursor is real focus — the row
-                    // takes programmatic focus and the 2px `--accent` ring.
-                    tabIndex={-1}
-                    data-kbd-item={id}
-                    {...(selected ? { 'data-kbd-selected': 'true' } : {})}
+                  <a
+                    {...link(path)}
                     style={{
-                      display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0,
-                      outline: selected ? '2px solid var(--accent)' : 'none',
-                      outlineOffset: '2px',
+                      flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                      fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+                      textDecoration: 'none',
                     }}
                   >
-                    {cursor.noteFor === id ? (
-                      // §2.3: the open reject note replaces the chip row.
-                      <GateRejectNote runId={id} onClose={cursor.closeNote} />
-                    ) : (
-                      <>
-                        {/* Slice L (§9.2): checkbox / ↗ marker, once ≥1 selected. */}
-                        <BatchSelectBox runId={id} gate={gate} />
-                        <span
-                          title={gate?.prompt}
-                          style={{
-                            flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
-                            fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
-                          }}
-                        >
-                          {gate?.prompt ?? view.session.problem}
-                        </span>
-                        <GateChip runId={id} projectId={projectId} gate={gate} navigate={navigate} />
-                      </>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </section>
-
-        {/* ── Tile 4: 7-day activity sparkline (§2.3's SVG approach, own component) ── */}
-        <section data-testid="dashboard-activity" data-total={sparkTotal} style={CSS.tile}>
-          <p style={CSS.tileHead}>Activity (7d)</p>
-          {sparkTotal === 0 ? (
-            <p style={CSS.empty}>No runs in the last 7 days.</p>
-          ) : (
-            <div style={{ display: 'flex', alignItems: 'flex-end', gap: '12px' }}>
-              <RunSparkline counts={sparkCounts} width={168} height={40} color="var(--accent)" testId="activity-sparkline" />
-              <span style={{ fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)' }}>
-                {sparkTotal} {sparkTotal === 1 ? 'run' : 'runs'} this week
-              </span>
-            </div>
-          )}
-        </section>
-      </div>
+                    {d.name}
+                  </a>
+                  <span style={{ ...CSS.cardMeta, flexShrink: 0 }}>v{d.head}</span>
+                </div>
+              );
+            })}
+          </DashboardGrid>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/ProjectsPage.tsx
+++ b/src/components/ProjectsPage.tsx
@@ -1,13 +1,37 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, SessionView } from '../api/types.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import { outcomeOf } from '../board/metrics.js';
+import {
+  attachSeries, deltaWord, healthColor, healthOf, statusCounts, windowBuckets, windowDelta,
+  type StatusCounts,
+} from '../board/windowStats.js';
 import { useBoardModel, type BoardProject } from '../hooks/useBoardModel.js';
+import { projectPath } from '../hooks/useRoute.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useGateStore } from '../store/gates.js';
 import { useProjectsStore } from '../store/projects.js';
-import { GatesWaitingTile, TileBand } from './DashboardTiles.js';
-import { MetricTile } from './MetricTile.js';
-import { ProjectSparkline } from './ProjectSparkline.js';
-import { RunOutcomeBar } from './RunOutcomeBar.js';
+import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { ageWord } from './DashboardTiles.js';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, Sparkline, StatTile, type FilterChip,
+} from './dashboardKit.js';
+
+/**
+ * The /projects landing as a COMMAND SURFACE (lane B): a full-width reporting
+ * dashboard over the estate — a KPI band organized around the command-center
+ * questions (performance / pipeline / risk), then a filterable grid of project
+ * cards, each a mini-dashboard row. Cards are doors; "needs you" floats first
+ * and jumps STRAIGHT to the waiting run's gate; the creation verbs (New
+ * project, Do Work) live in the header — one click from wherever the need
+ * appears.
+ *
+ * Every number derives from state the app already holds (`GET /runs` + the
+ * board model's one members read); the recency window is the Work page's
+ * honest positional idiom ("last 30 runs", never a fabricated "30d"), and a
+ * window with no prior bucket shows "—", never 0%.
+ */
 
 const S = {
   bg:     'var(--surface-base)',
@@ -80,6 +104,7 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
         borderRadius: '10px',
         padding: '20px',
         marginBottom: '16px',
+        maxWidth: '560px',
       }}
     >
       <p style={{ fontSize: '13px', fontWeight: 600, color: S.ink, marginBottom: '14px' }}>New project</p>
@@ -138,145 +163,210 @@ function CreateProjectForm({ onCreated, onCancel }: { onCreated: (p: Project) =>
   );
 }
 
-// ── The attention-split tile (DES-FEEDBACK-003 §4.1 row 1, slice P) ───────────
+// ── The project card model — one fold per card, shared by grid and chips ──────
 
-const SPLIT_W = 168;
-const SPLIT_H = 26;
-const BAR_H = 10;
-
-/**
- * "How much of my estate needs me?" — the board model's OWN bands, counted,
- * as a proportional bar (needs-you vs quiet). The bands are read, never
- * re-derived (C3): `/projects` reports the split; the wall itself stays on `/`
- * (§4.1's landing-vs-register line — this dashboard never re-implements bands).
- */
-function AttentionSplitTile({ items }: { items: BoardProject[] }): React.ReactElement {
-  const needsYou = items.filter((i) => i.band === 'needs-you').length;
-  const quiet = items.length - needsYou;
-  const total = items.length;
-  return (
-    <MetricTile
-      testId="attention-split-tile"
-      question="How much of my estate needs me?"
-      title="Attention split"
-      value={total === 0 ? 'no projects yet' : `${needsYou} need you · ${quiet} quiet · ${total} total`}
-      data={{ 'data-needs-you': needsYou, 'data-quiet': quiet, 'data-total': total }}
-    >
-      {total === 0 ? (
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-          Nothing on the board yet.
-        </p>
-      ) : (
-        <svg
-          width="100%"
-          height={SPLIT_H}
-          viewBox={`0 0 ${SPLIT_W} ${SPLIT_H}`}
-          preserveAspectRatio="none"
-          role="img"
-          aria-label={`attention split: ${needsYou} need you, ${quiet} quiet, of ${total}`}
-          style={{ display: 'block' }}
-        >
-          {needsYou > 0 && (
-            <rect
-              x={0} y={(SPLIT_H - BAR_H) / 2}
-              width={(needsYou / total) * SPLIT_W} height={BAR_H} rx={2}
-              fill="var(--status-gate)"
-            />
-          )}
-          {quiet > 0 && (
-            <rect
-              x={(needsYou / total) * SPLIT_W} y={(SPLIT_H - BAR_H) / 2}
-              width={(quiet / total) * SPLIT_W} height={BAR_H} rx={2}
-              fill="var(--ink-dim)"
-            />
-          )}
-        </svg>
-      )}
-    </MetricTile>
-  );
+interface CardModel {
+  project: Project;
+  item: BoardProject | null;
+  /** The project's runs inside the current recency window (unarchived). */
+  windowed: SessionView[];
+  counts: StatusCounts;
+  /** Runs waiting on a human RIGHT NOW — unwindowed (a gate is a gate). */
+  waiting: SessionView[];
+  failing: boolean;
+  activeNow: boolean;
+  lastAt: number;
+  repoCount: number;
+  /** Board score-order index; register-only projects sort after the board. */
+  boardIx: number;
 }
 
-function ProjectCard({ project, onClick, sparkline }: {
-  project: Project;
-  onClick: () => void;
-  sparkline?: React.ReactNode;
+type StatusChip = 'all' | 'needs-you' | 'active' | 'failing' | 'quiet';
+
+function matchesChip(m: CardModel, chip: StatusChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'needs-you') return m.waiting.length > 0;
+  if (chip === 'active') return m.activeNow;
+  if (chip === 'failing') return m.failing;
+  return m.waiting.length === 0 && !m.activeNow && !m.failing; // quiet
+}
+
+const CARD_STAT: React.CSSProperties = {
+  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+  whiteSpace: 'nowrap',
+};
+
+/** One project as a mini-dashboard row — the card IS a door to `/p/:id`. */
+function ProjectStatCard({ m, range, navigate, now }: {
+  m: CardModel;
+  range: ReturnType<typeof useTimeRange>['range'];
+  navigate: (path: string) => void;
+  now: number;
 }): React.ReactElement {
-  const [hovered, setHovered] = useState(false);
-  const isArchived = project.status === 'archived';
-  const isDefault = project.id === 'default';
+  const { project, counts, waiting } = m;
+  const health = healthOf(counts.done, counts.terminal);
+  const spark = m.item === null ? [] : attachSeries(Object.keys(m.item.attachedAt), m.item.attachedAt, 14, now);
+  const firstGate = waiting[0]?.session.id;
+  const dot = m.item !== null ? ATTENTION_DOT[m.item.attention] : 'var(--ink-dim)';
 
   return (
-    <button
-      type="button"
+    <div
       data-testid="project-card"
       data-project-id={project.id}
       data-status={project.status}
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      data-gates={waiting.length}
+      data-runs={counts.total}
+      role="link"
+      tabIndex={0}
+      onClick={() => navigate(projectPath(project.id))}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(projectPath(project.id)); }}
+      className="transition-colors hover:bg-surface-raised"
       style={{
-        display: 'block', width: '100%', textAlign: 'left',
-        background: hovered ? 'var(--surface-raised)' : S.card,
-        border: `1px solid ${S.border}`,
-        borderRadius: '10px', padding: '16px', cursor: 'pointer',
-        transition: 'background 0.1s',
+        display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+        background: S.card, border: `1px solid ${S.border}`,
+        borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', cursor: 'pointer',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
-        <span style={{ color: isArchived ? S.faint : S.accent, marginTop: '1px', flexShrink: 0 }}>
-          <IconFolder />
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+        <span aria-hidden style={{ width: '7px', height: '7px', borderRadius: 'var(--radius-full)', background: dot, flexShrink: 0 }} />
+        <span style={{
+          fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-semi)', color: S.ink,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+        }}>
+          {project.name}
         </span>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
-            <span style={{
-              fontSize: '14px', fontWeight: 600, color: isArchived ? S.muted : S.ink,
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-            }}>
-              {project.name}
-            </span>
-            {isArchived && (
-              <span style={{
-                fontSize: '10px', fontFamily: 'monospace', color: S.faint,
-                border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '1px 5px',
-                flexShrink: 0,
-              }}>
-                archived
-              </span>
-            )}
-            {isDefault && (
-              <span style={{
-                fontSize: '10px', fontFamily: 'monospace', color: S.faint,
-                border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '1px 5px',
-                flexShrink: 0,
-              }}>
-                default
-              </span>
-            )}
-            {/* The 7-day activity sparkline (§4.1) — the list half of
-                "combined list and reporting". Absent when the board holds no
-                in-window runs for this project (absence stays absent). */}
-            {sparkline != null && (
-              <span style={{ marginLeft: 'auto', flexShrink: 0, display: 'inline-flex' }}>
-                {sparkline}
-              </span>
-            )}
-          </div>
-          {project.description && (
-            <p style={{
-              fontSize: '12px', color: S.muted, margin: 0,
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-            }}>
-              {project.description}
-            </p>
-          )}
-          {project.created_at > 0 && (
-            <p style={{ fontSize: '11px', color: S.faint, margin: 0, marginTop: '6px', fontFamily: 'monospace' }}>
-              Created {new Date(project.created_at).toLocaleDateString()}
-            </p>
-          )}
-        </div>
+        {project.id === 'default' && (
+          <span style={{ fontSize: '10px', fontFamily: 'var(--font-mono)', color: S.faint, border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '0 5px', flexShrink: 0 }}>
+            default
+          </span>
+        )}
+        {/* Attention routing beats navigation: the gate jump, STRAIGHT to the
+            waiting run's approval dock — never a hunt. */}
+        {waiting.length > 0 && firstGate !== undefined && (
+          <button
+            type="button"
+            data-testid="project-needs-you"
+            data-run-id={firstGate}
+            title="A run is waiting on you — jump to its gate"
+            onClick={(e) => { e.stopPropagation(); navigate(gateOpenPath(project.id, firstGate)); }}
+            style={{
+              marginLeft: 'auto', flexShrink: 0, cursor: 'pointer',
+              background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+              borderRadius: 'var(--radius-full)', padding: '2px 10px',
+              fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+              fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+            }}
+          >
+            needs you · {waiting.length} →
+          </button>
+        )}
       </div>
-    </button>
+      {project.description && (
+        <p style={{
+          fontSize: 'var(--text-xs)', color: S.muted, margin: 0,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {project.description}
+        </p>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+        <span style={CARD_STAT} data-testid="card-runs">
+          {counts.total} run{counts.total === 1 ? '' : 's'} · {rangeWord(range)}
+        </span>
+        {counts.terminal > 0 && (
+          <span
+            style={{ ...CARD_STAT, color: healthColor(health) ?? CARD_STAT.color }}
+            data-testid="card-split"
+            data-health={health}
+            title={`${counts.done} succeeded, ${counts.failed} failed of ${counts.terminal} finished in this window`}
+          >
+            ✓{counts.done} · ✕{counts.failed}
+          </span>
+        )}
+        <span style={CARD_STAT}>
+          {m.repoCount} repo{m.repoCount === 1 ? '' : 's'}
+        </span>
+        <span style={{ ...CARD_STAT, marginLeft: 'auto' }} title="last activity (attach clocks + gates)">
+          {ago(m.lastAt, now)} ago
+        </span>
+      </div>
+      <Sparkline counts={spark} height={18} />
+    </div>
+  );
+}
+
+/** Unfiled runs get a card too — honest, not hidden. */
+function UnfiledCard({ windowed, all, range, navigate, now, gateAt }: {
+  /** Unfiled runs inside the recency window — the counted set. */
+  windowed: SessionView[];
+  /** Every live unfiled run — a gate is a gate, windowed or not. */
+  all: SessionView[];
+  range: ReturnType<typeof useTimeRange>['range'];
+  navigate: (path: string) => void;
+  now: number;
+  gateAt: (id: string) => number | undefined;
+}): React.ReactElement {
+  const counts = statusCounts(windowed);
+  const waiting = all.filter((v) => v.session.status === 'awaiting_human');
+  const health = healthOf(counts.done, counts.terminal);
+  const firstGate = waiting[0]?.session.id;
+  const lastGate = waiting.reduce<number>((acc, v) => Math.max(acc, gateAt(v.session.id) ?? 0), 0);
+
+  return (
+    <div
+      data-testid="unfiled-card"
+      data-gates={waiting.length}
+      data-runs={counts.total}
+      role="link"
+      tabIndex={0}
+      onClick={() => navigate('/work')}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate('/work'); }}
+      className="transition-colors hover:bg-surface-raised"
+      style={{
+        display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+        background: S.card, border: `1px dashed ${S.border}`,
+        borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', cursor: 'pointer',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+        <span aria-hidden style={{ width: '7px', height: '7px', borderRadius: 'var(--radius-full)', background: 'var(--ink-dim)', flexShrink: 0 }} />
+        <span style={{ fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-semi)', color: S.muted }}>
+          Unfiled runs
+        </span>
+        {waiting.length > 0 && firstGate !== undefined && (
+          <button
+            type="button"
+            data-testid="unfiled-needs-you"
+            data-run-id={firstGate}
+            title="An unfiled run is waiting on you — open it"
+            onClick={(e) => { e.stopPropagation(); navigate(`/runs/${encodeURIComponent(firstGate)}`); }}
+            style={{
+              marginLeft: 'auto', flexShrink: 0, cursor: 'pointer',
+              background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+              borderRadius: 'var(--radius-full)', padding: '2px 10px',
+              fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+              fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+            }}
+          >
+            needs you · {waiting.length} →
+          </button>
+        )}
+      </div>
+      <p style={{ fontSize: 'var(--text-xs)', color: S.faint, margin: 0 }}>
+        Runs filed into no project — they live on the Work list.
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+        <span style={CARD_STAT}>{counts.total} run{counts.total === 1 ? '' : 's'} · {rangeWord(range)}</span>
+        {counts.terminal > 0 && (
+          <span style={{ ...CARD_STAT, color: healthColor(health) ?? CARD_STAT.color }} data-health={health}>
+            ✓{counts.done} · ✕{counts.failed}
+          </span>
+        )}
+        {lastGate > 0 && (
+          <span style={{ ...CARD_STAT, marginLeft: 'auto' }}>oldest gate {ageWord(now - lastGate)}</span>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -286,16 +376,18 @@ interface Props {
 }
 
 export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
-  // The COMPLETE register (DES-FEEDBACK-003 §4.1: "/projects is the REGISTER —
-  // every project, complete") is held locally: the shared projects store is
-  // also the board model's mirror target (active, non-default only), so a
-  // store read here could lose the archived rows to a mirror write mid-race.
-  // One GET, page-owned; creates land in both the register and the store.
+  // The COMPLETE register (every project, archived included) stays page-owned:
+  // the shared projects store is the board mirror's target (active, non-default
+  // only), so a store read could lose archived rows to a mirror write mid-race.
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
+
+  const [query, setQuery] = useState('');
+  const [chip, setChip] = useState<StatusChip>('all');
+  const { range, setRange } = useTimeRange('30d');
 
   useEffect(() => {
     let cancelled = false;
@@ -310,12 +402,12 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
     return () => { cancelled = true; };
   }, []);
 
-  // The reporting half (§4.1): the board's own model — bands read, never
-  // re-derived (C3); its per-project attach clocks feed the row sparklines
-  // and, merged, the 24h outcome bar (the honest clock, reused).
   const board = useBoardModel(runs);
+  const gates = useGateStore((s) => s.gates);
+  const now = Date.now();
+
   const byProjectId = useMemo(
-    () => new Map(board.items.map((i) => [i.project.id, i])),
+    () => new Map(board.items.map((i, ix) => [i.project.id, { item: i, ix }])),
     [board.items],
   );
   const attachedAt = useMemo(() => {
@@ -323,11 +415,98 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
     for (const item of board.items) Object.assign(merged, item.attachedAt);
     return merged;
   }, [board.items]);
-  const gates = useGateStore((s) => s.gates);
-  const openGates = useMemo(() => Object.values(gates), [gates]);
 
-  const active = projects.filter((p) => p.status === 'active');
+  // ── The window (Work page idiom: positional, honestly labeled) ─────────────
+  const live = useMemo(() => runs.filter((v) => v.session.archived_at == null), [runs]);
+  const buckets = useMemo(() => windowBuckets(live, range), [live, range]);
+  const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
+
+  // ── KPI folds ───────────────────────────────────────────────────────────────
+  const liveCounts = useMemo(() => statusCounts(live), [live]);
+  const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
+  const failedDelta = useMemo(
+    () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
+    [buckets],
+  );
+  const runSpark = useMemo(
+    () => attachSeries(buckets.current.map((v) => v.session.id), attachedAt, 14, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` re-derives with the data, not a timer
+    [buckets, attachedAt],
+  );
+  const openGates = useMemo(() => Object.values(gates), [gates]);
+  const oldestGate = openGates.reduce<number | null>(
+    (acc, g) => (acc === null || g.receivedAt < acc ? g.receivedAt : acc), null);
+  const unfiled = useMemo(
+    () => board.unfiled.filter((v) => v.session.archived_at == null && windowIds.has(v.session.id)),
+    [board.unfiled, windowIds],
+  );
+  const unfiledAll = useMemo(
+    () => board.unfiled.filter((v) => v.session.archived_at == null),
+    [board.unfiled],
+  );
+
+  // ── The card models ─────────────────────────────────────────────────────────
+  const active = projects.filter((p) => p.status === 'active' && p.id !== 'default');
   const archived = projects.filter((p) => p.status === 'archived');
+
+  const cards = useMemo<CardModel[]>(() => {
+    return active.map((p) => {
+      const hit = byProjectId.get(p.id);
+      const item = hit?.item ?? null;
+      const mine = item === null ? [] : item.runs.filter((v) => v.session.archived_at == null);
+      const windowed = mine.filter((v) => windowIds.has(v.session.id));
+      const waiting = mine.filter((v) => v.session.status === 'awaiting_human');
+      const lastAt = Math.max(
+        p.updated_at,
+        ...Object.values(item?.attachedAt ?? {}),
+        ...waiting.map((v) => gates[v.session.id]?.receivedAt ?? 0),
+      );
+      return {
+        project: p,
+        item,
+        windowed,
+        counts: statusCounts(windowed),
+        waiting,
+        failing: mine.some((v) => v.session.status === 'failed'),
+        activeNow: mine.some((v) => outcomeOf(v.session.status) === 'run'),
+        lastAt,
+        repoCount: item?.repoCount ?? 0,
+        boardIx: hit?.ix ?? Number.MAX_SAFE_INTEGER,
+      };
+    }).sort((a, b) =>
+      // Attention routing: needs-you floats FIRST, then failing, then board score order.
+      (b.waiting.length > 0 ? 1 : 0) - (a.waiting.length > 0 ? 1 : 0)
+      || (b.failing ? 1 : 0) - (a.failing ? 1 : 0)
+      || a.boardIx - b.boardIx
+      || b.project.updated_at - a.project.updated_at,
+    );
+  }, [active, byProjectId, windowIds, gates]);
+
+  const chipCounts: Record<StatusChip, number> = useMemo(() => ({
+    all: cards.length,
+    'needs-you': cards.filter((m) => matchesChip(m, 'needs-you')).length,
+    active: cards.filter((m) => matchesChip(m, 'active')).length,
+    failing: cards.filter((m) => matchesChip(m, 'failing')).length,
+    quiet: cards.filter((m) => matchesChip(m, 'quiet')).length,
+  }), [cards]);
+
+  const q = query.trim().toLowerCase();
+  const visible = cards.filter((m) =>
+    matchesChip(m, chip)
+    && (q === ''
+      || m.project.name.toLowerCase().includes(q)
+      || (m.project.description ?? '').toLowerCase().includes(q)));
+  // The unfiled card obeys the same filters (it is a real row, not furniture).
+  const unfiledWaiting = unfiledAll.some((v) => v.session.status === 'awaiting_human');
+  const unfiledFailing = unfiledAll.some((v) => v.session.status === 'failed');
+  const unfiledActive = unfiledAll.some((v) => outcomeOf(v.session.status) === 'run');
+  const showUnfiled = unfiledAll.length > 0
+    && (q === '' || 'unfiled runs'.includes(q))
+    && (chip === 'all'
+      || (chip === 'needs-you' && unfiledWaiting)
+      || (chip === 'failing' && unfiledFailing)
+      || (chip === 'active' && unfiledActive)
+      || (chip === 'quiet' && !unfiledWaiting && !unfiledFailing && !unfiledActive));
 
   function handleCreated(p: Project): void {
     setProjects((prev) => [p, ...prev.filter((x) => x.id !== p.id)]);
@@ -335,24 +514,37 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
     setShowCreate(false);
   }
 
-  /** The row's 7-day sparkline off the board item — null when the board holds
-   *  no entry (archived / default / still loading): absence stays absent. */
-  function sparklineFor(p: Project): React.ReactNode {
-    const item = byProjectId.get(p.id);
-    if (item === undefined) return null;
-    return <ProjectSparkline runs={item.runs} attachedAt={item.attachedAt} />;
-  }
+  const chips: FilterChip[] = [
+    { id: 'all', label: 'All', count: chipCounts.all },
+    { id: 'needs-you', label: 'Needs you', count: chipCounts['needs-you'] },
+    { id: 'active', label: 'Active', count: chipCounts.active },
+    { id: 'failing', label: 'Failing', count: chipCounts.failing },
+    { id: 'quiet', label: 'Quiet', count: chipCounts.quiet },
+  ];
 
   return (
-    <div style={{ padding: '28px 32px', maxWidth: '760px' }}>
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px' }}>
-        <div>
+    // FULL WIDTH — the register flows with the viewport; no max-width constraint.
+    <div data-testid="projects-page" style={{ padding: '24px 32px', display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+      {/* ── Header: name + the creation verbs (one click from here) ── */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <h1 style={{ fontSize: '20px', fontWeight: 700, color: S.ink, margin: 0, marginBottom: '4px' }}>Projects</h1>
           <p style={{ fontSize: '13px', color: S.muted, margin: 0 }}>
             Group runs, chats, and repos into named containers.
           </p>
         </div>
+        <button
+          type="button"
+          data-testid="projects-do-work"
+          onClick={() => navigate('/runs/new')}
+          style={{
+            background: 'transparent', color: S.muted, border: `1px solid ${S.border}`,
+            borderRadius: '7px', padding: '8px 14px', fontSize: '12px', fontWeight: 600,
+            cursor: 'pointer', flexShrink: 0,
+          }}
+        >
+          Do Work
+        </button>
         <button
           type="button"
           onClick={() => setShowCreate(true)}
@@ -367,20 +559,73 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
         </button>
       </div>
 
-      {/* ── The reporting band (§4.1, EC28): three tiles ABOVE the register,
-             every number derived from state the app already holds. ── */}
-      <div style={{ marginBottom: '16px' }}>
-        <TileBand testId="projects-dashboard-tiles">
-          <AttentionSplitTile items={board.items} />
-          <RunOutcomeBar runs={runs} attachedAt={attachedAt} title="Run outcomes (24h)" />
-          <GatesWaitingTile
-            gates={openGates}
-            question="Am I the blocker anywhere?"
-            title="Gates waiting"
-            testId="gates-waiting-tile"
+      {/* ── The KPI band — the command-center model: three questions ── */}
+      <KpiBand testId="projects-kpis">
+        <KpiGroup label="Performance" grow={2}>
+          <StatTile
+            testId="stat-projects"
+            label="Projects"
+            value={active.length}
+            context={archived.length > 0 ? `${archived.length} archived` : 'active register'}
+            title="Every active project — click to clear filters"
+            onOpen={() => { setChip('all'); setQuery(''); }}
           />
-        </TileBand>
-      </div>
+          <StatTile
+            testId="stat-runs"
+            label="Runs"
+            value={buckets.current.length}
+            delta={runsDelta}
+            context={deltaWord(range, runsDelta)}
+            spark={runSpark}
+            title="Runs in the window — open the Work list"
+            href="/work"
+            onOpen={() => navigate('/work')}
+          />
+        </KpiGroup>
+        <KpiGroup label="Pipeline" grow={2}>
+          <StatTile
+            testId="stat-active"
+            label="Active now"
+            value={liveCounts.active}
+            context="right now"
+            title="Runs moving under their own power — open the Work list"
+            href="/work?filter=active"
+            onOpen={() => navigate('/work?filter=active')}
+          />
+          <StatTile
+            testId="stat-gates"
+            label="Needs you"
+            value={liveCounts.gates}
+            valueColor={liveCounts.gates > 0 ? 'var(--status-gate)' : undefined}
+            context={oldestGate !== null ? `oldest waiting ${ageWord(now - oldestGate)}` : 'nothing waiting'}
+            title="Runs waiting on a human — filter the grid to them"
+            onOpen={() => setChip('needs-you')}
+          />
+        </KpiGroup>
+        <KpiGroup label="Risk" grow={2}>
+          <StatTile
+            testId="stat-failed"
+            label="Failed"
+            value={failedDelta.current}
+            valueColor={failedDelta.current > 0 ? 'var(--status-fail)' : undefined}
+            delta={failedDelta}
+            deltaSense="bad-up"
+            context={deltaWord(range, failedDelta)}
+            title="Failed runs in the window — open them on the Work list"
+            href="/work?filter=failed"
+            onOpen={() => navigate('/work?filter=failed')}
+          />
+          <StatTile
+            testId="stat-unfiled"
+            label="Unfiled"
+            value={unfiledAll.length}
+            context="runs in no project"
+            title="Runs not filed anywhere — they live on the Work list"
+            href="/work"
+            onOpen={() => navigate('/work')}
+          />
+        </KpiGroup>
+      </KpiBand>
 
       {showCreate && (
         <CreateProjectForm
@@ -388,6 +633,19 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
           onCancel={() => setShowCreate(false)}
         />
       )}
+
+      {/* ── Filters — first-class, never hidden ── */}
+      <FilterStrip
+        testId="projects-filter"
+        query={query}
+        onQuery={setQuery}
+        placeholder="Search projects…"
+        chips={chips}
+        active={chip}
+        onChip={(id) => setChip(id as StatusChip)}
+        range={range}
+        onRange={setRange}
+      />
 
       {loading && (
         <p style={{ fontSize: '13px', color: S.faint, fontFamily: 'monospace' }}>Loading…</p>
@@ -412,21 +670,39 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
         </div>
       )}
 
-      {active.length > 0 && (
-        <div data-testid="projects-list" style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
-          {active.map((p) => (
-            <ProjectCard
-              key={p.id}
-              project={p}
-              sparkline={sparklineFor(p)}
-              onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
-            />
+      {!loading && !error && active.length > 0 && visible.length === 0 && !showUnfiled && (
+        <p data-testid="projects-empty-filter" style={{ fontSize: '13px', color: S.faint, margin: 0 }}>
+          No projects match —{' '}
+          <button
+            type="button"
+            onClick={() => { setChip('all'); setQuery(''); }}
+            style={{ background: 'none', border: 'none', padding: 0, font: 'inherit', color: S.muted, textDecoration: 'underline', cursor: 'pointer' }}
+          >
+            clear filters
+          </button>
+        </p>
+      )}
+
+      {(visible.length > 0 || showUnfiled) && (
+        <DashboardGrid testId="projects-list" min={340}>
+          {visible.map((m) => (
+            <ProjectStatCard key={m.project.id} m={m} range={range} navigate={navigate} now={now} />
           ))}
-        </div>
+          {showUnfiled && (
+            <UnfiledCard
+              windowed={unfiled}
+              all={unfiledAll}
+              range={range}
+              navigate={navigate}
+              now={now}
+              gateAt={(id) => gates[id]?.receivedAt}
+            />
+          )}
+        </DashboardGrid>
       )}
 
       {archived.length > 0 && (
-        <div style={{ marginTop: '16px' }}>
+        <div>
           <button
             type="button"
             onClick={() => setShowArchived((v) => !v)}
@@ -440,16 +716,35 @@ export function ProjectsPage({ runs, navigate }: Props): React.ReactElement {
             {showArchived ? 'Hide' : 'Show'} {archived.length} archived project{archived.length !== 1 ? 's' : ''}
           </button>
           {showArchived && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            <DashboardGrid testId="projects-archived" min={340}>
               {archived.map((p) => (
-                <ProjectCard
+                <div
                   key={p.id}
-                  project={p}
-                  sparkline={sparklineFor(p)}
-                  onClick={() => navigate(`/projects/${encodeURIComponent(p.id)}`)}
-                />
+                  data-testid="project-card"
+                  data-project-id={p.id}
+                  data-status={p.status}
+                  role="link"
+                  tabIndex={0}
+                  onClick={() => navigate(projectPath(p.id))}
+                  onKeyDown={(e) => { if (e.key === 'Enter') navigate(projectPath(p.id)); }}
+                  className="transition-colors hover:bg-surface-raised"
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0,
+                    background: S.card, border: `1px solid ${S.border}`,
+                    borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <span style={{ color: S.faint, flexShrink: 0 }}><IconFolder /></span>
+                  <span style={{ fontSize: 'var(--text-sm)', color: S.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {p.name}
+                  </span>
+                  <span style={{ marginLeft: 'auto', fontSize: '10px', fontFamily: 'var(--font-mono)', color: S.faint, border: `1px solid ${S.faint}`, borderRadius: '4px', padding: '0 5px', flexShrink: 0 }}>
+                    archived
+                  </span>
+                </div>
               ))}
-            </div>
+            </DashboardGrid>
           )}
         </div>
       )}

--- a/src/components/dashboardKit.tsx
+++ b/src/components/dashboardKit.tsx
@@ -1,0 +1,360 @@
+import { TimeRangeSelector } from './TimeRangeSelector.js';
+import type { TimeRange } from '../hooks/useTimeRange.js';
+import type { StatDelta } from '../board/windowStats.js';
+
+/**
+ * The section-dashboard kit (lane B): built once, worn by /projects, /p/:id
+ * and /make so the three command surfaces read as one system.
+ *
+ *  - `StatTile` — one KPI: small uppercase label, ONE big tabular number, an
+ *    HONEST delta vs the previous window ("—" when no prior bucket exists,
+ *    never a fabricated 0%), a tiny context line, and a subtle inline area
+ *    sparkline. Every tile is a door (`onOpen`) — nothing is decorative.
+ *  - `KpiBand` / `KpiGroup` — the command-center model: tiles organized under
+ *    the three operator questions (performance / pipeline / risk).
+ *  - `FilterStrip` — search + status chips + the recency-window picker (the
+ *    Work page's "last 30/60/90/all" idiom), first-class at the top of every
+ *    list.
+ *  - `DashboardGrid` — the full-width responsive card grid (CSS grid, min
+ *    column width, gap-based) — no max-width constraint anywhere.
+ *  - `Sparkline` / `sparkPoints` — inline SVG, no chart library.
+ *
+ * Tokens only (EC15): the app's existing dark palette, thin borders, threshold
+ * colors ONLY where they mean something.
+ */
+
+// ── The sparkline helper (inline SVG, no chart lib) ───────────────────────────
+
+/**
+ * Polyline points for a bucket series, oldest→newest, normalized to the series
+ * max. Pure — unit-tested. Empty input yields an empty string.
+ */
+export function sparkPoints(counts: readonly number[], width: number, height: number): string {
+  const n = counts.length;
+  if (n === 0) return '';
+  const max = Math.max(...counts, 1);
+  const stepX = n > 1 ? width / (n - 1) : width;
+  return counts
+    .map((c, i) => `${(i * stepX).toFixed(1)},${(height - (c / max) * height).toFixed(1)}`)
+    .join(' ');
+}
+
+export function Sparkline({ counts, width = 120, height = 20, stroke = 'var(--accent)', testId }: {
+  /** Bucket counts, oldest first. */
+  counts: readonly number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  testId?: string;
+}): React.ReactElement | null {
+  const total = counts.reduce((a, c) => a + c, 0);
+  // Honest emptiness: no data draws nothing — never a flat line pretending.
+  if (counts.length === 0 || total === 0) return null;
+  const series = counts.length === 1 ? [counts[0]!, counts[0]!] : [...counts];
+  const pts = sparkPoints(series, width, height - 2);
+  return (
+    <svg
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={`trend: ${counts.join(', ')}`}
+      {...(testId !== undefined ? { 'data-testid': testId } : {})}
+      style={{ display: 'block', marginTop: '2px' }}
+    >
+      <polygon points={`0,${height} ${pts} ${width},${height}`} fill="var(--accent-subtle)" opacity={0.6} />
+      <polyline points={pts} fill="none" stroke={stroke} strokeWidth={1.5} vectorEffect="non-scaling-stroke" opacity={0.9} />
+    </svg>
+  );
+}
+
+// ── StatTile ──────────────────────────────────────────────────────────────────
+
+export interface StatTileProps {
+  testId: string;
+  /** Small uppercase label. */
+  label: string;
+  /** THE number (rendered tabular-nums). Strings allowed for e.g. "—". */
+  value: string | number;
+  /** Delta vs the previous same-size window. `previous: null` renders "—". */
+  delta?: StatDelta | undefined;
+  /** How to color a delta: neutral (ink) or bad-up (more failed = red). */
+  deltaSense?: 'neutral' | 'bad-up' | undefined;
+  /** Tiny context line (the window, honestly named). */
+  context?: string | undefined;
+  /** Inline area sparkline series (oldest first). Absent/all-zero = no chart. */
+  spark?: readonly number[] | undefined;
+  /** Threshold color for the number itself — only where it MEANS something. */
+  valueColor?: string | undefined;
+  /** The door: every tile clicks through to the thing it counts. */
+  onOpen?: (() => void) | undefined;
+  /** Optional real href for the door (middle-click / a11y). */
+  href?: string | undefined;
+  title?: string | undefined;
+  data?: Record<string, string | number> | undefined;
+}
+
+function DeltaMark({ delta, sense }: { delta: StatDelta; sense: 'neutral' | 'bad-up' }): React.ReactElement {
+  if (delta.previous === null) {
+    // No prior window ⇒ no delta. "—", never 0%.
+    return (
+      <span
+        data-testid="stat-delta"
+        data-delta="none"
+        title="no prior window to compare against"
+        style={{ fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)' }}
+      >
+        —
+      </span>
+    );
+  }
+  const diff = delta.current - delta.previous;
+  const arrow = diff > 0 ? '▲' : diff < 0 ? '▼' : '·';
+  const color =
+    sense === 'bad-up' && diff > 0 ? 'var(--status-fail)'
+    : sense === 'bad-up' && diff < 0 ? 'var(--status-run)'
+    : 'var(--ink-muted)';
+  return (
+    <span
+      data-testid="stat-delta"
+      data-delta={String(diff)}
+      title={`vs the previous window: ${delta.previous} before, ${delta.current} now`}
+      style={{ fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color, fontVariantNumeric: 'tabular-nums' }}
+    >
+      {arrow} {Math.abs(diff)}
+    </span>
+  );
+}
+
+export function StatTile({
+  testId, label, value, delta, deltaSense = 'neutral', context, spark,
+  valueColor, onOpen, href, title, data,
+}: StatTileProps): React.ReactElement {
+  const body = (
+    <>
+      <span
+        style={{
+          fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)',
+          letterSpacing: '0.08em', textTransform: 'uppercase',
+          color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)',
+        }}
+      >
+        {label}
+      </span>
+      <span style={{ display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0 }}>
+        <span
+          data-testid="stat-value"
+          style={{
+            fontSize: 'var(--text-2xl)', fontWeight: 'var(--weight-semi)',
+            fontFamily: 'var(--font-mono)', fontVariantNumeric: 'tabular-nums',
+            lineHeight: 1.1, color: valueColor ?? 'var(--ink-high)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}
+        >
+          {value}
+        </span>
+        {delta !== undefined && <DeltaMark delta={delta} sense={deltaSense} />}
+      </span>
+      {context !== undefined && (
+        <span
+          style={{
+            fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}
+        >
+          {context}
+        </span>
+      )}
+      {spark !== undefined && <Sparkline counts={spark} />}
+    </>
+  );
+
+  const style: React.CSSProperties = {
+    flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column',
+    alignItems: 'stretch', gap: '4px', textAlign: 'left', textDecoration: 'none',
+    background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+    cursor: onOpen !== undefined ? 'pointer' : 'default',
+    color: 'inherit', font: 'inherit',
+  };
+  const common = {
+    'data-testid': testId,
+    'data-value': String(value),
+    ...(delta !== undefined
+      ? { 'data-delta': delta.previous === null ? 'none' : String(delta.current - delta.previous) }
+      : {}),
+    ...(data ?? {}),
+    ...(title !== undefined ? { title } : {}),
+    style,
+  };
+
+  if (onOpen !== undefined && href !== undefined) {
+    return (
+      <a {...common} href={href} onClick={(e) => { e.preventDefault(); onOpen(); }}>
+        {body}
+      </a>
+    );
+  }
+  if (onOpen !== undefined) {
+    return (
+      <button {...common} type="button" onClick={onOpen}>
+        {body}
+      </button>
+    );
+  }
+  return <div {...common}>{body}</div>;
+}
+
+// ── KpiBand — the command-center model ────────────────────────────────────────
+
+/** The three operator questions the band is organized around. */
+export function KpiBand({ testId, children }: {
+  testId: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      style={{ display: 'flex', gap: 'var(--space-4)', alignItems: 'stretch', flexWrap: 'wrap', width: '100%' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** One question's tiles under a tiny kicker (PERFORMANCE / PIPELINE / RISK). */
+export function KpiGroup({ label, children, grow = 1 }: {
+  label: string;
+  children: React.ReactNode;
+  /** Relative width — a two-tile group grows twice a one-tile group. */
+  grow?: number;
+}): React.ReactElement {
+  return (
+    <section
+      data-kpi-group={label.toLowerCase()}
+      style={{
+        flex: `${grow} 1 ${grow * 150}px`, minWidth: `${grow * 140}px`,
+        display: 'flex', flexDirection: 'column', gap: '6px',
+      }}
+    >
+      <p
+        style={{
+          margin: 0, fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)',
+          letterSpacing: '0.1em', textTransform: 'uppercase',
+          color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)',
+        }}
+      >
+        {label}
+      </p>
+      <div style={{ display: 'flex', gap: 'var(--space-3)', flex: 1, alignItems: 'stretch' }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// ── FilterStrip ───────────────────────────────────────────────────────────────
+
+export interface FilterChip {
+  id: string;
+  label: string;
+  /** The chip's live count — rendered beside the label when present. */
+  count?: number;
+}
+
+export interface FilterStripProps {
+  testId: string;
+  query: string;
+  onQuery: (q: string) => void;
+  placeholder?: string;
+  chips: readonly FilterChip[];
+  active: string;
+  onChip: (id: string) => void;
+  /** The recency-window picker (Work page idiom) — omitted where no window applies. */
+  range?: TimeRange;
+  onRange?: (r: TimeRange) => void;
+  /** Extra first-class chips (e.g. "+N older · show all"). */
+  children?: React.ReactNode;
+}
+
+export function FilterStrip({
+  testId, query, onQuery, placeholder = 'Search…', chips, active, onChip, range, onRange, children,
+}: FilterStripProps): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      data-filter={active}
+      role="group"
+      aria-label="Filters"
+      style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', width: '100%' }}
+    >
+      <input
+        type="text"
+        data-testid={`${testId}-search`}
+        placeholder={placeholder}
+        value={query}
+        onChange={(e) => onQuery(e.target.value)}
+        style={{
+          background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+          borderRadius: 'var(--radius-md)', padding: '5px 10px',
+          fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)',
+          color: 'var(--ink-high)', outline: 'none', width: '200px',
+        }}
+      />
+      {chips.map((c) => (
+        <button
+          key={c.id}
+          type="button"
+          data-testid={`${testId}-chip`}
+          data-chip={c.id}
+          aria-pressed={active === c.id}
+          onClick={() => onChip(c.id)}
+          style={{
+            borderRadius: 'var(--radius-full)', padding: '3px 10px',
+            fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
+            border: '1px solid',
+            borderColor: active === c.id ? 'var(--accent)' : 'var(--surface-raised)',
+            background: active === c.id ? 'var(--accent-subtle)' : 'transparent',
+            color: active === c.id ? 'var(--accent)' : 'var(--ink-muted)',
+          }}
+        >
+          {c.label}
+          {c.count !== undefined && (
+            <span style={{ marginLeft: '5px', fontVariantNumeric: 'tabular-nums', opacity: 0.8 }}>{c.count}</span>
+          )}
+        </button>
+      ))}
+      {children}
+      <span style={{ flex: 1 }} />
+      {range !== undefined && onRange !== undefined && (
+        <TimeRangeSelector value={range} onChange={onRange} />
+      )}
+    </div>
+  );
+}
+
+// ── DashboardGrid ─────────────────────────────────────────────────────────────
+
+/** Full-width responsive card grid — flows with the viewport, never a max-width. */
+export function DashboardGrid({ testId, min = 320, children }: {
+  testId: string;
+  /** Minimum card column width in px. */
+  min?: number;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(auto-fill, minmax(min(100%, ${min}px), 1fr))`,
+        gap: 'var(--space-3)',
+        width: '100%',
+        alignItems: 'stretch',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -64,6 +64,10 @@ export interface BoardProject {
   project: Project;
   /** Display name of the bound repo (`crew.repo` member), or `null` when unbound. */
   repo: string | null;
+  /** How many `crew.repo` members the project holds (lane B: the /projects
+   *  card's repo count) — off the SAME members read, zero new requests.
+   *  Optional so hand-built fixtures predating it stay valid; absent = 0. */
+  repoCount?: number;
   runs: SessionView[];
   docs: DocSummary[];
   /**
@@ -165,12 +169,14 @@ function signalsOf(
 interface Bindings {
   runIds: ReadonlySet<string>;
   repo: string | null;
+  /** Count of `crew.repo` members — the /projects card's repo count. */
+  repoCount: number;
   docs: DocSummary[];
   /** Run id → `attached_at` (epoch ms) off the same members read. */
   attachedAt: Record<string, number>;
 }
 
-const EMPTY: Bindings = { runIds: new Set(), repo: null, docs: [], attachedAt: {} };
+const EMPTY: Bindings = { runIds: new Set(), repo: null, repoCount: 0, docs: [], attachedAt: {} };
 
 /**
  * DTO-truth placement (DES-UX-001 §2.3 rule 3): the run's own `project_id`
@@ -222,13 +228,15 @@ async function loadBindings(p: Project, repoNames: Map<string, string>): Promise
           .catch((): DocSummary[] => [])
       : Promise.resolve([]),
   ]);
-  const repoRef = members.find((m) => m.member_kind === 'crew.repo')?.member_ref ?? null;
+  const repoMembers = members.filter((m) => m.member_kind === 'crew.repo');
+  const repoRef = repoMembers[0]?.member_ref ?? null;
   const runMembers = members.filter((m) => RUN_KINDS.has(m.member_kind));
   const attachedAt: Record<string, number> = {};
   for (const m of runMembers) attachedAt[m.member_ref] = m.attached_at;
   return {
     runIds: new Set(runMembers.map((m) => m.member_ref)),
     repo: repoRef === null ? null : repoNames.get(repoRef) ?? repoRef,
+    repoCount: repoMembers.length,
     docs,
     attachedAt,
   };
@@ -401,7 +409,7 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
           // matter how stale the clocks are. Decay orders; status bands.
           const hasActiveRun = mine.some((v) => ACTIVE.has(v.session.status));
           return {
-            project, repo: b.repo, runs: mine, docs: b.docs, attachedAt: b.attachedAt,
+            project, repo: b.repo, repoCount: b.repoCount, runs: mine, docs: b.docs, attachedAt: b.attachedAt,
             attention: deriveAttention(mine, b.docs),
             score, band: bandFor(signals, hasActiveRun, now), signal,
           };

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,10 +10,10 @@
   "version": 1,
   "studioVersion": "0.4.5",
   "counts": {
-    "files": 115,
-    "occurrences": 839,
-    "static": 720,
-    "dynamic": 41,
+    "files": 116,
+    "occurrences": 871,
+    "static": 743,
+    "dynamic": 42,
     "computed": 6
   },
   "static": [
@@ -518,6 +518,18 @@
       ]
     },
     {
+      "testId": "card-runs",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
+      "testId": "card-split",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
       "testId": "chain-header",
       "files": [
         "src/components/WorkChronicle.tsx"
@@ -810,13 +822,19 @@
       ]
     },
     {
-      "testId": "dashboard-activity",
+      "testId": "dashboard-clear-filters",
       "files": [
         "src/components/ProjectDashboard.tsx"
       ]
     },
     {
       "testId": "dashboard-delivery-summary",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-do-work",
       "files": [
         "src/components/ProjectDashboard.tsx"
       ]
@@ -834,6 +852,18 @@
       ]
     },
     {
+      "testId": "dashboard-empty-build",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-empty-doc",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
       "testId": "dashboard-gate",
       "files": [
         "src/components/ProjectDashboard.tsx"
@@ -841,6 +871,12 @@
     },
     {
       "testId": "dashboard-gates",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-hidden-chip",
       "files": [
         "src/components/ProjectDashboard.tsx"
       ]
@@ -870,7 +906,31 @@
       ]
     },
     {
+      "testId": "dashboard-run-needs-you",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-run-retry",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-run-title",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
       "testId": "dashboard-runs",
+      "files": [
+        "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "dashboard-runs-empty",
       "files": [
         "src/components/ProjectDashboard.tsx"
       ]
@@ -1953,6 +2013,12 @@
       ]
     },
     {
+      "testId": "make-clear-filters",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
       "testId": "make-corpus-label",
       "files": [
         "src/components/MakeDashboard.tsx"
@@ -1977,12 +2043,6 @@
       ]
     },
     {
-      "testId": "make-dashboard-tiles",
-      "files": [
-        "src/components/MakeDashboard.tsx"
-      ]
-    },
-    {
       "testId": "make-doc-row",
       "files": [
         "src/components/MakeDashboard.tsx"
@@ -1995,6 +2055,12 @@
       ]
     },
     {
+      "testId": "make-hidden-chip",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
       "testId": "make-list",
       "files": [
         "src/components/MakeDashboard.tsx"
@@ -2002,6 +2068,18 @@
     },
     {
       "testId": "make-load-all-docs",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "make-needs-you",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "make-new",
       "files": [
         "src/components/MakeDashboard.tsx"
       ]
@@ -2025,7 +2103,25 @@
       ]
     },
     {
+      "testId": "make-retry",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
       "testId": "make-run-row",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "make-run-title",
+      "files": [
+        "src/components/MakeDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "make-runs-empty",
       "files": [
         "src/components/MakeDashboard.tsx"
       ]
@@ -2399,6 +2495,12 @@
       ]
     },
     {
+      "testId": "project-needs-you",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
       "testId": "project-repo",
       "files": [
         "src/components/ProjectCard.tsx"
@@ -2465,7 +2567,19 @@
       ]
     },
     {
-      "testId": "projects-list",
+      "testId": "projects-do-work",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
+      "testId": "projects-empty-filter",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
+      "testId": "projects-page",
       "files": [
         "src/components/ProjectsPage.tsx"
       ]
@@ -3007,6 +3121,18 @@
       "testId": "sources-panel",
       "files": [
         "src/components/ComposerContext.tsx"
+      ]
+    },
+    {
+      "testId": "stat-delta",
+      "files": [
+        "src/components/dashboardKit.tsx"
+      ]
+    },
+    {
+      "testId": "stat-value",
+      "files": [
+        "src/components/dashboardKit.tsx"
       ]
     },
     {
@@ -3999,6 +4125,18 @@
       ]
     },
     {
+      "testId": "unfiled-card",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
+      "testId": "unfiled-needs-you",
+      "files": [
+        "src/components/ProjectsPage.tsx"
+      ]
+    },
+    {
       "testId": "unfiled-run",
       "files": [
         "src/components/HomeBoard.tsx"
@@ -4390,13 +4528,20 @@
     {
       "pattern": "*-chip",
       "files": [
-        "src/components/SteeringRuleForm.tsx"
+        "src/components/SteeringRuleForm.tsx",
+        "src/components/dashboardKit.tsx"
       ]
     },
     {
       "pattern": "*-error-detail",
       "files": [
         "src/components/SurfaceState.tsx"
+      ]
+    },
+    {
+      "pattern": "*-search",
+      "files": [
+        "src/components/dashboardKit.tsx"
       ]
     },
     {
@@ -4639,7 +4784,8 @@
         "src/components/MetricTile.tsx",
         "src/components/ProvenanceLine.tsx",
         "src/components/RunSparkline.tsx",
-        "src/components/RunsBottomPanel.tsx"
+        "src/components/RunsBottomPanel.tsx",
+        "src/components/dashboardKit.tsx"
       ]
     },
     {

--- a/tests/MakeDashboard.test.tsx
+++ b/tests/MakeDashboard.test.tsx
@@ -1,16 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { Project } from '../src/api/types.js';
 import type { DocSummary } from '../src/api/interactive.js';
 import { makeView } from './factories.js';
 
 /**
- * The /make dashboard (DES-FEEDBACK-003 §4.2, slice O): combined list +
- * reporting over made things. Pinned here: the EC24 corpus label + why
- * popover, the explicit fan-out gesture (zero doc requests on render, exactly
- * P on click), the §4.2.1 tile band with its named questions (EC19/EC28), and
- * the partition invariant — Make lists exactly the complement of ChatsPage's
- * verbatim filter.
+ * The /make dashboard as a command surface (lane B): combined list + reporting
+ * over made things. Pinned here: the partition invariant (Make = the verbatim
+ * ChatsPage complement), the KPI band with honest window deltas, the
+ * first-class FilterStrip, needs-you-first ordering + the gate jump, the
+ * inline Retry (prefill, never a relaunch), derived titles (never raw
+ * prompts), and the unchanged EC24 corpus label + explicit fan-out gesture.
  */
 
 const listDocs = vi.fn((pid: string): Promise<DocSummary[]> =>
@@ -30,19 +30,21 @@ const { useDocsCache } = await import('../src/store/docsCache.js');
 const { useMembershipStore } = await import('../src/store/membership.js');
 const { useProjectsStore } = await import('../src/store/projects.js');
 const { useRuntimeStore } = await import('../src/store/runtime.js');
+const { clearRetryPrefill, peekRetryPrefill } = await import('../src/store/retryPrefill.js');
 
 const project = (id: string, name: string): Project => ({
   id, name, description: null, status: 'active', scope: `project:${id}`,
   created_at: 1, updated_at: 1,
 });
 
-/** 2 chat runs + 3 make runs — the partition's mixed W2-shaped input. */
+/** 2 chat runs + 4 make runs — the partition's mixed W2-shaped input. */
 const RUNS = [
   makeView({ id: 'r-build-1', workflow_id: 'wf-w2', status: 'executing', problem: 'build the uploader' }),
   makeView({ id: 'r-chat-1', workflow_id: 'chat', status: 'executing', problem: 'talk it through' }),
   makeView({ id: 'r-build-2', workflow_id: 'wf-w2', status: 'completed', problem: 'migrate the API' }),
   makeView({ id: 'r-chat-2', workflow_id: undefined as unknown as string, status: 'completed', problem: 'legacy thread' }),
   makeView({ id: 'r-build-3', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'refactor auth' }),
+  makeView({ id: 'r-build-4', workflow_id: 'wf-w2', status: 'failed', problem: 'ship the exporter' }),
 ];
 
 const flatRunPath = (id: string): string => `/runs/${id}`;
@@ -53,12 +55,14 @@ function dash(navigate: (p: string) => void = () => {}): ReturnType<typeof rende
 
 beforeEach(() => {
   listDocs.mockClear();
+  clearRetryPrefill();
   useDocsCache.setState({ byProject: {}, fanoutDone: false, fanoutProgress: null });
   useProjectsStore.setState({
     projects: [project('default', 'Unfiled'), project('p-notes', 'notes'), project('p-api', 'api-migration'), project('p-auth', 'auth-refactor')],
   });
   useMembershipStore.setState({
     projectNameByRun: { 'r-build-1': 'api-migration', 'r-build-3': 'auth-refactor' },
+    projectIdByRun: { 'r-build-3': 'p-auth' },
     attachedAtByRun: { 'r-build-1': Date.now() - 3_600_000, 'r-build-3': Date.now() - 7_200_000 },
   });
   useRuntimeStore.setState({ logs: {} });
@@ -77,29 +81,122 @@ describe('the partition invariant (§4.2/§3.3)', () => {
     }
   });
 
-  it('rows are real links to runPath, active before terminal, with project names off the mirror', () => {
+  it('needs-you FIRST, then active, then terminal; titles are real links; project names off the mirror', () => {
     dash();
     const rows = screen.getAllByTestId('make-run-row');
-    expect(rows.map((r) => r.getAttribute('href'))).toEqual(
-      ['/runs/r-build-1', '/runs/r-build-3', '/runs/r-build-2'], // active first
+    expect(rows.map((r) => r.getAttribute('data-run-id'))).toEqual(
+      ['r-build-3', 'r-build-1', 'r-build-2', 'r-build-4'], // gated → active → terminal
     );
-    expect(rows[0]!.textContent).toContain('api-migration');
+    const title = (row: HTMLElement) => within(row).getByTestId('make-run-title');
+    expect(title(rows[0] as HTMLElement)).toHaveAttribute('href', '/runs/r-build-3');
+    expect(rows[1]!.textContent).toContain('api-migration');
     expect(rows[2]!.textContent).toContain('Unfiled'); // unmapped run stays honest
+  });
+
+  it('a card is a door: clicking it navigates to the run', () => {
+    const navigate = vi.fn();
+    dash(navigate);
+    const row = screen.getAllByTestId('make-run-row')
+      .find((r) => r.getAttribute('data-run-id') === 'r-build-1')!;
+    fireEvent.click(row);
+    expect(navigate).toHaveBeenCalledWith('/runs/r-build-1');
   });
 });
 
-describe('the tile band (§4.2.1, EC19/EC28)', () => {
-  it('renders the three tiles above the list, each with its named data-question', () => {
+describe('the KPI band — items · runs consumed · active · failed', () => {
+  it('renders the four tiles above the list with live values', () => {
     dash();
-    const band = screen.getByTestId('make-dashboard-tiles');
-    const q = (tid: string): string | null =>
-      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
-    expect(q('made-tile')).toBe('What is the shop producing, and of what kind?');
-    expect(q('run-outcome-bar')).toBe('Are makes landing or failing?');
-    expect(q('token-burn-sparkline')).toBe('What is making costing?');
+    const band = screen.getByTestId('make-kpis');
+    const value = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
+    expect(value('stat-items')).toBe('4');     // 4 windowed builds + 0 loaded docs
+    expect(value('stat-runs')).toBe('4');
+    expect(value('stat-active')).toBe('2');    // executing + awaiting_human (1 waiting on you)
+    expect(value('stat-failed')).toBe('1');
     // EC28: the band precedes the list in DOM order.
     const list = screen.getByTestId('make-list');
     expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('4 runs against a 30-run window has NO prior bucket — the delta reads "—"', () => {
+    dash();
+    expect(screen.getByTestId('stat-runs').getAttribute('data-delta')).toBe('none');
+    expect(within(screen.getByTestId('stat-runs')).getByTestId('stat-delta')).toHaveTextContent('—');
+  });
+
+  it('the failed tile wears the fail token and doors into the failed filter', () => {
+    dash();
+    const failed = screen.getByTestId('stat-failed');
+    expect((within(failed).getByTestId('stat-value') as HTMLElement).style.color).toBe('var(--status-fail)');
+    fireEvent.click(failed);
+    expect(screen.getByTestId('make-filter').getAttribute('data-filter')).toBe('failed');
+    expect(screen.getAllByTestId('make-run-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-build-4']);
+  });
+});
+
+describe('the action layer — needs-you jump + inline Retry', () => {
+  it('a waiting run’s card jumps STRAIGHT to its gate (project known ⇒ the thread AT the gate)', () => {
+    const navigate = vi.fn();
+    dash(navigate);
+    const jump = screen.getByTestId('make-needs-you');
+    expect(jump.getAttribute('data-run-id')).toBe('r-build-3');
+    fireEvent.click(jump);
+    expect(navigate).toHaveBeenCalledWith('/p/p-auth/build/r-build-3#gate');
+    expect(navigate).not.toHaveBeenCalledWith('/runs/r-build-3'); // no card navigation leaked
+  });
+
+  it('a FAILED item offers inline Retry — a prefill deposit + the composer, nothing auto-launches', () => {
+    const navigate = vi.fn();
+    dash(navigate);
+    const retry = screen.getAllByTestId('make-retry').find((b) => b.getAttribute('data-run-id') === 'r-build-4')!;
+    fireEvent.click(retry);
+    const prefill = peekRetryPrefill();
+    expect(prefill).not.toBeNull();
+    expect(prefill!.retryOf).toBe('r-build-4');
+    expect(prefill!.problem).toBe('ship the exporter');
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+  });
+});
+
+describe('the FilterStrip drives the grid', () => {
+  it('status chips narrow the run cards; docs chip shows only documents', async () => {
+    useDocsCache.getState().deposit('p-notes', [
+      { name: 'roadmap', kind: 'doc', head: 2, versions: 2, updated_at: '2026-08-20T00:00:00Z' },
+    ]);
+    dash();
+    const chip = (id: string) => screen.getAllByTestId('make-filter-chip')
+      .find((c) => c.getAttribute('data-chip') === id)!;
+    fireEvent.click(chip('needs-you'));
+    expect(screen.getAllByTestId('make-run-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-build-3']);
+    expect(screen.queryAllByTestId('make-doc-row')).toHaveLength(0);
+    fireEvent.click(chip('docs'));
+    expect(screen.queryAllByTestId('make-run-row')).toHaveLength(0);
+    expect(screen.getAllByTestId('make-doc-row')).toHaveLength(1);
+  });
+
+  it('search narrows by derived title and project name', () => {
+    dash();
+    fireEvent.change(screen.getByTestId('make-filter-search'), { target: { value: 'uploader' } });
+    expect(screen.getAllByTestId('make-run-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-build-1']);
+  });
+});
+
+describe('full width + the creation verb', () => {
+  it('the grid is a real CSS grid with no maxWidth anywhere on the surface', () => {
+    dash();
+    const grid = screen.getByTestId('make-runs-grid') as HTMLElement;
+    expect(grid.style.maxWidth).toBe('');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fill');
+  });
+
+  it('the header carries the section’s make entry — the same ＋ picker the rail forks', () => {
+    dash();
+    expect(screen.queryByTestId('make-picker')).toBeNull();
+    fireEvent.click(screen.getByTestId('make-new'));
+    const picker = screen.getByTestId('make-picker');
+    const modes = within(picker as HTMLElement).getAllByTestId('make-picker-row')
+      .map((r) => r.getAttribute('data-mode'));
+    expect(modes).toEqual(['build', 'document', 'video']);
   });
 });
 
@@ -136,15 +233,15 @@ describe('the corpus label + fan-out gesture (§4.2.2, EC24)', () => {
     expect(new Set(listDocs.mock.calls.map((c) => c[0]))).toEqual(new Set(['p-notes', 'p-api', 'p-auth']));
     // Cached for the session: the button collapses to the quiet note.
     expect(screen.getByText('docs loaded for all projects')).toBeInTheDocument();
-    // The landed corpus renders: ▤/▶ name · vN · project rows.
+    // The landed corpus renders as cards: glyph/name · vN · versions · project.
     const docRows = screen.getAllByTestId('make-doc-row');
     expect(docRows).toHaveLength(2);
     expect(docRows[0]!.getAttribute('data-doc-kind')).toBe('demo');
     expect(docRows[0]!.textContent).toContain('launch-demo');
     expect(docRows[0]!.textContent).toContain('v1');
     expect(docRows[0]!.textContent).toContain('notes');
-    expect(docRows[0]!.getAttribute('href')).toBe('/p/p-notes/video/launch-demo');
-    expect(docRows[1]!.getAttribute('href')).toBe('/p/p-notes/document/roadmap');
+    expect(docRows[0]!.querySelector('a')).toHaveAttribute('href', '/p/p-notes/video/launch-demo');
+    expect(docRows[1]!.querySelector('a')).toHaveAttribute('href', '/p/p-notes/document/roadmap');
   });
 
   it('renders session-known docs WITHOUT any gesture when the cache already holds them', () => {

--- a/tests/ProjectDashboard.test.tsx
+++ b/tests/ProjectDashboard.test.tsx
@@ -4,13 +4,16 @@ import { ProjectDashboard } from '../src/components/ProjectDashboard.js';
 import { clearRepoCache, fetchReposCached } from '../src/store/repoCache.js';
 import { useGateStore } from '../src/store/gates.js';
 import { useProjectsStore } from '../src/store/projects.js';
+import { clearRetryPrefill, peekRetryPrefill } from '../src/store/retryPrefill.js';
 import type { Project, ProjectMember, SessionStatus } from '../src/api/types.js';
 import type { DocSummary } from '../src/api/interactive.js';
 import { makeUnit, makeView } from './factories.js';
 
 /**
- * The project dashboard (DES-FEEDBACK-001 §4.1, slice D): the `/p/:projectId`
- * no-mode landing — four tiles, all derived from data the app already holds.
+ * The project HOMEPAGE — `/p/:projectId` (lane B): full-width command surface.
+ * A project-scoped KPI band with honest window deltas, the gate inbox FIRST,
+ * then runs/docs as filterable cards with derived titles, a needs-you jump
+ * straight to the gate, and an inline Retry (prefill, never a relaunch).
  */
 
 const listProjectMembers = vi.fn();
@@ -69,32 +72,40 @@ beforeEach(() => {
   listDocs.mockResolvedValue([]);
   useGateStore.setState({ gates: {} });
   useProjectsStore.setState({ projects: [project('proj-1')], loading: false, error: null });
+  clearRetryPrefill(); // drop any deposit a prior test left
 });
 afterEach(cleanup);
 
-describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
-  it('renders the dashboard with all four tiles, the mode verbs, and the meta line', async () => {
+describe('ProjectDashboard — the full-width project command surface', () => {
+  it('renders FULL WIDTH with the KPI band, the mode verbs, Do Work, and the meta line', async () => {
     render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
 
-    expect(screen.getByTestId('project-dashboard')).toBeInTheDocument();
-    expect(screen.getByTestId('dashboard-runs')).toBeInTheDocument();
-    expect(screen.getByTestId('dashboard-docs')).toBeInTheDocument();
-    expect(screen.getByTestId('dashboard-gates')).toBeInTheDocument();
-    expect(screen.getByTestId('dashboard-activity')).toBeInTheDocument();
+    const root = screen.getByTestId('project-dashboard') as HTMLElement;
+    expect(root.style.maxWidth).toBe('');
 
-    // NOT a fifth mode: no switcher on this surface — the four verbs are header links.
+    // The command-center band, project-scoped.
+    const band = screen.getByTestId('project-kpis');
+    for (const tid of ['stat-runs', 'stat-active', 'stat-gates', 'stat-failed']) {
+      expect(within(band as HTMLElement).getByTestId(tid)).toBeInTheDocument();
+    }
+
+    // NOT a fifth mode: the four verbs are header links, plus the creation verb.
     expect(screen.queryByTestId('mode-switcher')).toBeNull();
     for (const m of ['chat', 'build', 'document', 'video']) {
       expect(screen.getByTestId(`dashboard-mode-${m}`)).toHaveAttribute('href', `/p/proj-1/${m}`);
     }
+    expect(screen.getByTestId('dashboard-do-work')).toHaveAttribute('href', '/p/proj-1/build/new');
 
     // The meta line: last activity + open runs. NO cost — the wire carries none.
     expect(screen.getByTestId('dashboard-meta')).toHaveTextContent(/last activity .* · 0 open runs/);
     expect(screen.getByTestId('dashboard-meta').textContent).not.toMatch(/\$/);
+    // The gate inbox earns its space only when something waits.
+    expect(screen.queryByTestId('dashboard-gates')).toBeNull();
+    expect(screen.getByTestId('dashboard-runs')).toHaveTextContent('No runs yet — Build starts one.');
     await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('proj-1'));
   });
 
-  it('runs tile: scoped to the project and attention-ordered — gate first, then failing, then working, then done', async () => {
+  it('run cards: scoped to the project and attention-ordered — gate first, then failing, then working, then done', async () => {
     listProjectMembers.mockResolvedValue({
       members: [member('r-done'), member('r-work'), member('r-gate'), member('r-fail')],
     });
@@ -116,9 +127,12 @@ describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
     expect(ids).not.toContain('r-other');
     // Open count excludes terminal states.
     expect(screen.getByTestId('dashboard-meta')).toHaveTextContent('2 open runs');
+    // EC34: the section head counts exactly the rendered cards.
+    expect(screen.getByTestId('dashboard-runs')).toHaveAttribute('data-count', '4');
   });
 
-  it('a run row links into the run’s mode view — Build for a run, Chat for a chat thread', async () => {
+  it('a run card carries a DERIVED title (raw prompt hover-only) and doors into its mode view', async () => {
+    const longIntent = 'Implement the auth flow refactor across every consumer of the session token; then re-run the full suite and file the follow-ups.';
     listProjectMembers.mockResolvedValue({
       members: [member('r-1', 'crew.run'), member('t-1', 'crew.chat')],
     });
@@ -126,21 +140,88 @@ describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
     render(
       <ProjectDashboard
         projectId="proj-1"
-        runs={[run('r-1', 'executing'), run('t-1', 'executing')]}
+        runs={[run('r-1', 'executing', longIntent), run('t-1', 'executing')]}
         navigate={navigate}
       />,
     );
     await waitFor(() => expect(screen.getAllByTestId('dashboard-run')).toHaveLength(2));
 
     const rows = screen.getAllByTestId('dashboard-run');
-    const byId = (id: string) => rows.find((r) => r.getAttribute('data-run-id') === id)!;
-    expect(byId('r-1')).toHaveAttribute('href', '/p/proj-1/build/r-1');
-    expect(byId('t-1')).toHaveAttribute('href', '/p/proj-1/chat/t-1');
+    const byId = (id: string) => rows.find((r) => r.getAttribute('data-run-id') === id)! as HTMLElement;
+    // The title link is a real href — Build for a run, Chat for a chat thread.
+    const title = within(byId('r-1')).getByTestId('dashboard-run-title');
+    expect(title).toHaveAttribute('href', '/p/proj-1/build/r-1');
+    expect(within(byId('t-1')).getByTestId('dashboard-run-title')).toHaveAttribute('href', '/p/proj-1/chat/t-1');
+    // Derived, word-trimmed, ellipsized — never the raw 140-char prompt.
+    expect(title.textContent!.length).toBeLessThan(70);
+    expect(title.textContent).toMatch(/…$/);
+    expect(title).toHaveAttribute('title', longIntent);
     fireEvent.click(byId('r-1'));
     expect(navigate).toHaveBeenCalledWith('/p/proj-1/build/r-1');
   });
 
-  it('docs tile: lists listDocs(projectId) results (root present) and navigates into Document mode', async () => {
+  it('a waiting run’s card shows the needs-you jump STRAIGHT to its gate', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-gate')] });
+    useGateStore.setState({
+      gates: { 'r-gate': { runId: 'r-gate', ord: 0, prompt: 'ok?', lifecycle: 'open', receivedAt: NOW - HOUR } },
+    });
+    const navigate = vi.fn();
+    render(<ProjectDashboard projectId="proj-1" runs={[run('r-gate', 'awaiting_human')]} navigate={navigate} />);
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-run-needs-you')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dashboard-run-needs-you'));
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1/build/r-gate#gate');
+    // The KPI gate tile is the same door.
+    expect(screen.getByTestId('stat-gates')).toHaveAttribute('href', '/p/proj-1/build/r-gate#gate');
+  });
+
+  it('a FAILED run’s card offers inline Retry — a prefill deposit + composer, never a relaunch', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-fail')] });
+    const navigate = vi.fn();
+    render(<ProjectDashboard projectId="proj-1" runs={[run('r-fail', 'failed', 'ship the uploader')]} navigate={navigate} />);
+
+    await waitFor(() => expect(screen.getByTestId('dashboard-run-retry')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dashboard-run-retry'));
+    const prefill = peekRetryPrefill();
+    expect(prefill).not.toBeNull();
+    expect(prefill!.retryOf).toBe('r-fail');
+    expect(prefill!.problem).toBe('ship the uploader');
+    expect(prefill!.projectId).toBe('proj-1');
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+  });
+
+  it('the FilterStrip drives the card grid; search lifts the recency window', async () => {
+    listProjectMembers.mockResolvedValue({
+      members: [member('r-done'), member('r-work'), member('r-fail')],
+    });
+    render(
+      <ProjectDashboard
+        projectId="proj-1"
+        runs={[run('r-done', 'completed'), run('r-work', 'executing'), run('r-fail', 'failed')]}
+        navigate={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('dashboard-run')).toHaveLength(3));
+
+    const chip = (id: string) => screen.getAllByTestId('dashboard-filter-chip')
+      .find((c) => c.getAttribute('data-chip') === id)!;
+    fireEvent.click(chip('failed'));
+    expect(screen.getAllByTestId('dashboard-run').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-fail']);
+    fireEvent.click(chip('active'));
+    expect(screen.getAllByTestId('dashboard-run').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-work']);
+    fireEvent.click(chip('all'));
+    fireEvent.change(screen.getByTestId('dashboard-filter-search'), { target: { value: 'r-done' } });
+    expect(screen.getAllByTestId('dashboard-run').map((r) => r.getAttribute('data-run-id'))).toEqual(['r-done']);
+  });
+
+  it('the runs KPI tile shows an honest "—" delta when no prior window exists', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-a')] });
+    render(<ProjectDashboard projectId="proj-1" runs={[run('r-a', 'executing')]} navigate={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId('stat-runs').getAttribute('data-value')).toBe('1'));
+    expect(screen.getByTestId('stat-runs').getAttribute('data-delta')).toBe('none');
+  });
+
+  it('docs cards: lists listDocs(projectId) results (root present) and doors into Document mode', async () => {
     useProjectsStore.setState({
       projects: [project('proj-1', { interactiveRoot: '/tmp/wi-proj-1' })],
       loading: false, error: null,
@@ -154,21 +235,21 @@ describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
     expect(screen.getByTestId('dashboard-docs')).toHaveAttribute('data-count', '3');
 
     const rows = screen.getAllByTestId('dashboard-doc');
-    expect(rows[0]).toHaveAttribute('href', '/p/proj-1/document/spec');
-    // A demo doc opens in Video mode — a demo is a doc whose manifest says so (§7.4).
-    expect(rows[2]).toHaveAttribute('href', '/p/proj-1/video/walkthrough');
+    expect(rows[0]!.querySelector('a')).toHaveAttribute('href', '/p/proj-1/document/spec');
+    // A demo doc opens in Video mode — a demo is a doc whose manifest says so.
+    expect(rows[2]!.querySelector('a')).toHaveAttribute('href', '/p/proj-1/video/walkthrough');
     fireEvent.click(rows[0]!);
     expect(navigate).toHaveBeenCalledWith('/p/proj-1/document/spec');
   });
 
-  it('docs tile: no interactive root ⇒ no listDocs call, and the tile states its empty case', async () => {
+  it('docs cards: no interactive root ⇒ no listDocs call, and the section states its empty case', async () => {
     render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
     await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
     expect(listDocs).not.toHaveBeenCalled();
     expect(screen.getByTestId('dashboard-docs')).toHaveTextContent('No documents yet');
   });
 
-  it('gate tile: approve fires the SAME action as the board chip — POST confirmGate {approve:true}', async () => {
+  it('gate inbox: approve fires the SAME action as the board chip — POST confirmGate {approve:true}', async () => {
     listProjectMembers.mockResolvedValue({ members: [member('r-gate')] });
     useGateStore.setState({
       gates: { 'r-gate': { runId: 'r-gate', ord: 0, prompt: 'Approve the outline?', lifecycle: 'open', receivedAt: NOW - HOUR } },
@@ -188,27 +269,23 @@ describe('ProjectDashboard (DES-FEEDBACK-001 §4.1, slice D)', () => {
     expect(useGateStore.getState().gates['r-gate']).toBeUndefined();
   });
 
-  it('activity tile: 7-day sparkline reads the membership attach clock, one bucket per day', async () => {
+  it('the runs KPI sparkline reads the membership attach clock', async () => {
     listProjectMembers.mockResolvedValue({
       members: [
         member('r-a', 'crew.run', NOW - 1 * HOUR),      // today
         member('r-b', 'crew.run', NOW - 1 * HOUR - 1),  // today
         member('r-c', 'crew.run', NOW - 3 * DAY),       // 3 days back
-        member('r-old', 'crew.run', NOW - 20 * DAY),    // outside the window
+        member('r-old', 'crew.run', NOW - 20 * DAY),    // outside the span
       ],
     });
     render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
 
-    await waitFor(() =>
-      expect(screen.getByTestId('dashboard-activity')).toHaveAttribute('data-total', '3'));
-    const svg = screen.getByTestId('activity-sparkline');
-    // Two buckets with counts ⇒ two bars; the max bucket (2) renders full height.
-    expect(svg.querySelectorAll('rect')).toHaveLength(2);
-    expect(screen.getByTestId('dashboard-activity')).toHaveTextContent('3 runs this week');
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('stat-runs').querySelector('svg')).not.toBeNull());
   });
 });
 
-describe('bound repos row (DES-FEEDBACK-002 §10.2, slice J)', () => {
+describe('bound repos row (unchanged contract)', () => {
   beforeEach(() => {
     clearRepoCache();
     listRepos.mockReset();
@@ -217,7 +294,7 @@ describe('bound repos row (DES-FEEDBACK-002 §10.2, slice J)', () => {
     });
   });
 
-  it('a crew.repo member renders one chip linking to the repo page — name resolved from the warm §1.4 cache, ZERO new requests', async () => {
+  it('a crew.repo member renders one chip linking to the repo page — warm cache, ZERO new requests', async () => {
     await fetchReposCached(); // the palette/rail gesture already warmed it
     const fetchesBefore = listRepos.mock.calls.length;
     listProjectMembers.mockResolvedValue({
@@ -232,7 +309,7 @@ describe('bound repos row (DES-FEEDBACK-002 §10.2, slice J)', () => {
     expect(chips[0]).toHaveTextContent('studio-api');
     // Zero new requests: the SAME membership read, the SAME repo cache.
     expect(listRepos.mock.calls.length).toBe(fetchesBefore);
-    // And the repo member never leaks into the runs tile.
+    // And the repo member never leaks into the runs section.
     expect(screen.getByTestId('dashboard-runs')).toHaveAttribute('data-count', '1');
   });
 

--- a/tests/ProjectsPage.dashboard.test.tsx
+++ b/tests/ProjectsPage.dashboard.test.tsx
@@ -4,15 +4,17 @@ import type { Project, ProjectMember } from '../src/api/types.js';
 import { makeView } from './factories.js';
 
 /**
- * The /projects dashboard (DES-FEEDBACK-003 §4.1, slice P): the complete
- * register + the three-tile reporting band. Pinned here: the §4.1 tiles with
- * their named questions (EC19/EC28) above the list, the REGISTER completeness
- * (every project incl. archived — never the board mirror's active-only
- * subset), the row sparklines off the board's attach clocks, and the
- * preserved create/archive-toggle/navigation affordances.
+ * The /projects landing as a command surface (lane B): a FULL-WIDTH reporting
+ * dashboard — the command-center KPI band (performance / pipeline / risk) with
+ * honest window deltas ("—" when no prior bucket exists), then a filterable
+ * grid of project cards, each a mini-dashboard row. Cards are doors; needs-you
+ * floats first and jumps straight to the waiting run's gate; unfiled runs get
+ * an honest card of their own.
  */
 
 const NOW = Date.now();
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
 
 const project = (over: Partial<Project> & { id: string; name: string }): Project => ({
   description: null, status: 'active', scope: `project:${over.id}`,
@@ -22,18 +24,23 @@ const project = (over: Partial<Project> & { id: string; name: string }): Project
 const PROJECTS: Project[] = [
   project({ id: 'default', name: 'Unfiled' }),
   project({ id: 'p-hot', name: 'auth-refactor', updated_at: NOW }),
-  project({ id: 'p-cold', name: 'smoke-tests', updated_at: NOW - 30 * 86_400_000 }),
+  project({ id: 'p-cold', name: 'smoke-tests', updated_at: NOW - 30 * DAY }),
   project({ id: 'p-old', name: 'retired-spike', status: 'archived', updated_at: 1 }),
 ];
 
-const member = (project_id: string, ref: string, attached_at: number): ProjectMember => ({
-  id: `${project_id}:crew.run:${ref}`, project_id, member_kind: 'crew.run',
+const member = (project_id: string, ref: string, attached_at: number, kind = 'crew.run'): ProjectMember => ({
+  id: `${project_id}:${kind}:${ref}`, project_id, member_kind: kind,
   member_ref: ref, meta: null, attached_at, attached_by: 'studio',
 });
 
 const MEMBERS: Record<string, ProjectMember[]> = {
-  'p-hot': [member('p-hot', 'r-gated', NOW - 60_000)],
-  'p-cold': [member('p-cold', 'r-done', NOW - 2 * 86_400_000)],
+  'p-hot': [
+    member('p-hot', 'r-gated', NOW - 60_000),
+    member('p-hot', 'r-failed', NOW - 3 * DAY),
+    member('p-hot', 'repo-a', NOW - 5 * DAY, 'crew.repo'),
+    member('p-hot', 'repo-b', NOW - 5 * DAY, 'crew.repo'),
+  ],
+  'p-cold': [member('p-cold', 'r-done', NOW - 2 * DAY)],
 };
 
 const listProjects = vi.fn(() => Promise.resolve({ projects: PROJECTS }));
@@ -45,7 +52,8 @@ vi.mock('../src/api/client.js', () => ({
     getRunEvents: () => Promise.resolve({ events: [] }),
   },
 }));
-vi.mock('../src/api/interactive.js', () => ({
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
   listDocs: () => Promise.resolve([]),
 }));
 
@@ -54,16 +62,22 @@ const { useGateStore } = await import('../src/store/gates.js');
 
 const RUNS = [
   makeView({ id: 'r-gated', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'refactor auth' }),
+  makeView({ id: 'r-failed', workflow_id: 'wf-w2', status: 'failed', problem: 'ship the uploader' }),
   makeView({ id: 'r-done', workflow_id: 'wf-w2', status: 'completed', problem: 'smoke it' }),
+  // A member of NO project and carrying no project_id claim — unfiled once the join lands.
+  makeView({ id: 'r-stray', workflow_id: 'wf-w2', status: 'completed', problem: 'stray work' }),
 ];
 
-async function page(navigate: (p: string) => void = () => {}): Promise<void> {
-  render(<ProjectsPage runs={RUNS} navigate={navigate} />);
-  // The register (page-owned GET) and the board model both settle async.
+async function page(navigate: (p: string) => void = () => {}): Promise<ReturnType<typeof render>> {
+  const view = render(<ProjectsPage runs={RUNS} navigate={navigate} />);
   await screen.findByTestId('projects-list');
+  // Both async settles: the register GET and the board's membership join.
   await vi.waitFor(() => {
-    expect(screen.getByTestId('attention-split-tile').getAttribute('data-total')).toBe('2');
+    const hot = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-hot');
+    expect(hot?.getAttribute('data-gates')).toBe('1');
   });
+  return view;
 }
 
 beforeEach(() => {
@@ -72,85 +86,137 @@ beforeEach(() => {
 });
 afterEach(() => cleanup());
 
-describe('the tile band (§4.1, EC19/EC28)', () => {
-  it('renders the three tiles with their named questions, above the register', async () => {
-    useGateStore.getState().setGate({
-      runId: 'r-gated', ord: 0, prompt: 'Approve the refactor?', lifecycle: 'open',
-      receivedAt: NOW - 3 * 60_000,
-    });
+describe('full width — a reporting dashboard, not a 760px column', () => {
+  it('the page root carries NO maxWidth and the grid is a real CSS grid', async () => {
     await page();
-    const band = screen.getByTestId('projects-dashboard-tiles');
-    const q = (tid: string): string | null =>
-      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
-    expect(q('attention-split-tile')).toBe('How much of my estate needs me?');
-    expect(q('run-outcome-bar')).toBe('Is the system healthy right now?');
-    expect(q('gates-waiting-tile')).toBe('Am I the blocker anywhere?');
-    const list = screen.getByTestId('projects-list');
-    expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  it('reads the board bands, never re-deriving them: a fresh gate = needs-you', async () => {
-    await page();
-    const split = screen.getByTestId('attention-split-tile');
-    expect(split.getAttribute('data-needs-you')).toBe('1'); // p-hot's waiting run
-    expect(split.getAttribute('data-quiet')).toBe('1');
-    expect(split.textContent).toContain('1 need you · 1 quiet · 2 total');
-  });
-
-  it('buckets the outcome bar on the merged attach clocks (24h window)', async () => {
-    await page();
-    const bar = screen.getByTestId('run-outcome-bar');
-    // r-gated attached 1min ago (in window); r-done 2 days ago (outside).
-    expect(bar.getAttribute('data-total')).toBe('1');
-    expect(bar.getAttribute('data-unplaced')).toBe('1');
-  });
-
-  it('counts waiting gates with the oldest age', async () => {
-    useGateStore.getState().setGate({
-      runId: 'r-gated', ord: 0, prompt: 'Approve the refactor?', lifecycle: 'open',
-      receivedAt: NOW - 3 * 60_000,
-    });
-    await page();
-    const tile = screen.getByTestId('gates-waiting-tile');
-    expect(tile.getAttribute('data-count')).toBe('1');
-    expect(tile.textContent).toContain('1 waiting');
-    expect(tile.textContent).toContain('Approve the refactor?');
+    const root = screen.getByTestId('projects-page') as HTMLElement;
+    expect(root.style.maxWidth).toBe('');
+    const grid = screen.getByTestId('projects-list') as HTMLElement;
+    expect(grid.style.display).toBe('grid');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fill');
   });
 });
 
-describe('the complete register (§4.1: every project, incl. archived)', () => {
-  it('lists every active project (default included) and archived behind the toggle', async () => {
+describe('the KPI band — performance / pipeline / risk, honest numbers', () => {
+  it('renders the command-center tiles with live values', async () => {
+    useGateStore.getState().setGate({
+      runId: 'r-gated', ord: 0, prompt: 'Approve the refactor?', lifecycle: 'open',
+      receivedAt: NOW - 3 * 60_000,
+    });
     await page();
-    const activeIds = within(screen.getByTestId('projects-list'))
+    const band = screen.getByTestId('projects-kpis');
+    const value = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
+    expect(value('stat-projects')).toBe('2');       // p-hot + p-cold (default/archived never cards)
+    expect(value('stat-runs')).toBe('4');           // all four live runs sit in the last-30 window
+    expect(value('stat-active')).toBe('0');
+    expect(value('stat-gates')).toBe('1');
+    expect(value('stat-failed')).toBe('1');
+    expect(value('stat-unfiled')).toBe('1');        // r-stray, honest and visible
+    // The gate tile wears the gate token — it means something.
+    const gatesValue = within(band.querySelector('[data-testid="stat-gates"]') as HTMLElement).getByTestId('stat-value');
+    expect((gatesValue as HTMLElement).style.color).toBe('var(--status-gate)');
+  });
+
+  it('4 runs against a 30-run window has NO prior bucket — the delta reads "—", never 0%', async () => {
+    await page();
+    const runsTile = screen.getByTestId('stat-runs');
+    expect(runsTile.getAttribute('data-delta')).toBe('none');
+    expect(within(runsTile).getByTestId('stat-delta')).toHaveTextContent('—');
+  });
+
+  it('tiles are doors: Failed opens the Work list pre-filtered', async () => {
+    const navigate = vi.fn();
+    await page(navigate);
+    fireEvent.click(screen.getByTestId('stat-failed'));
+    expect(navigate).toHaveBeenCalledWith('/work?filter=failed');
+  });
+});
+
+describe('the project cards — mini-dashboard rows, needs-you first', () => {
+  it('cards carry runs (window), the success/failed split, repo count, and last activity', async () => {
+    await page();
+    const hot = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-hot')! as HTMLElement;
+    expect(hot.getAttribute('data-runs')).toBe('2');
+    expect(within(hot).getByTestId('card-runs')).toHaveTextContent('2 runs · last 30');
+    // 0 done of 1 terminal (the failed run) — red, never success-green.
+    const split = within(hot).getByTestId('card-split');
+    expect(split.getAttribute('data-health')).toBe('bad');
+    expect(split).toHaveTextContent('✓0 · ✕1');
+    expect(hot).toHaveTextContent('2 repos');
+    expect(hot).toHaveTextContent(/ago/);
+  });
+
+  it('needs-you sorts FIRST and its badge deep-links STRAIGHT to the waiting run’s gate', async () => {
+    const navigate = vi.fn();
+    await page(navigate);
+    const ids = within(screen.getByTestId('projects-list'))
       .getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
-    expect(new Set(activeIds)).toEqual(new Set(['default', 'p-hot', 'p-cold']));
-    // Archived: present, behind the existing toggle — completeness survives the
-    // board mirror's active-only store write.
+    expect(ids[0]).toBe('p-hot'); // the gated project floats first
+    const badge = screen.getByTestId('project-needs-you');
+    expect(badge).toHaveTextContent('needs you · 1');
+    fireEvent.click(badge);
+    expect(navigate).toHaveBeenCalledWith('/p/p-hot/build/r-gated#gate');
+    // The badge click never triggered the card's own navigation.
+    expect(navigate).not.toHaveBeenCalledWith('/p/p-hot');
+  });
+
+  it('the card itself is a door to the project homepage /p/:id', async () => {
+    const navigate = vi.fn();
+    await page(navigate);
+    const cold = screen.getAllByTestId('project-card')
+      .find((c) => c.getAttribute('data-project-id') === 'p-cold')!;
+    fireEvent.click(cold);
+    expect(navigate).toHaveBeenCalledWith('/p/p-cold');
+  });
+
+  it('unfiled runs get a card too — honest, not hidden — opening the Work list', async () => {
+    const navigate = vi.fn();
+    await page(navigate);
+    const unfiled = screen.getByTestId('unfiled-card');
+    expect(unfiled.getAttribute('data-runs')).toBe('1');
+    fireEvent.click(unfiled);
+    expect(navigate).toHaveBeenCalledWith('/work');
+  });
+});
+
+describe('the FilterStrip drives the grid', () => {
+  it('the needs-you chip narrows the grid to gated projects', async () => {
+    await page();
+    const chip = screen.getAllByTestId('projects-filter-chip')
+      .find((c) => c.getAttribute('data-chip') === 'needs-you')!;
+    fireEvent.click(chip);
+    const ids = within(screen.getByTestId('projects-list'))
+      .getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
+    expect(ids).toEqual(['p-hot']);
+    expect(screen.queryByTestId('unfiled-card')).toBeNull(); // no unfiled gate waits
+  });
+
+  it('search narrows by name and the empty state offers clearing', async () => {
+    await page();
+    fireEvent.change(screen.getByTestId('projects-filter-search'), { target: { value: 'smoke' } });
+    const ids = within(screen.getByTestId('projects-list'))
+      .getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
+    expect(ids).toEqual(['p-cold']);
+    fireEvent.change(screen.getByTestId('projects-filter-search'), { target: { value: 'zzz-nothing' } });
+    expect(screen.getByTestId('projects-empty-filter')).toHaveTextContent('No projects match');
+  });
+});
+
+describe('the register stays complete', () => {
+  it('archived projects stay reachable behind the toggle', async () => {
+    await page();
     fireEvent.click(screen.getByText(/Show 1 archived project/));
     const all = screen.getAllByTestId('project-card').map((c) => c.getAttribute('data-project-id'));
     expect(all).toContain('p-old');
-    expect(all).toHaveLength(4);
   });
 
-  it('rows carry the 7-day sparkline where the board holds in-window runs', async () => {
-    await page();
-    const hot = screen.getAllByTestId('project-card')
-      .find((c) => c.getAttribute('data-project-id') === 'p-hot')!;
-    expect(within(hot as HTMLElement).getByTestId('project-sparkline')).toBeInTheDocument();
-    // p-old (archived) has no board entry — absence stays absent.
-    fireEvent.click(screen.getByText(/Show 1 archived project/));
-    const old = screen.getAllByTestId('project-card')
-      .find((c) => c.getAttribute('data-project-id') === 'p-old')!;
-    expect(within(old as HTMLElement).queryByTestId('project-sparkline')).toBeNull();
-  });
-
-  it('preserves create and row navigation', async () => {
+  it('preserves create and the creation verbs in the header', async () => {
     const navigate = vi.fn();
     await page(navigate);
     expect(screen.getByText('New project')).toBeInTheDocument();
-    const hot = screen.getAllByTestId('project-card')
-      .find((c) => c.getAttribute('data-project-id') === 'p-hot')!;
-    fireEvent.click(hot);
-    expect(navigate).toHaveBeenCalledWith('/projects/p-hot');
+    fireEvent.click(screen.getByTestId('projects-do-work'));
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
   });
 });

--- a/tests/dashboardKit.test.tsx
+++ b/tests/dashboardKit.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, Sparkline, sparkPoints, StatTile,
+} from '../src/components/dashboardKit.js';
+
+/**
+ * The shared section-dashboard kit (lane B): StatTile renders its delta
+ * HONESTLY (a window with no prior bucket shows "—", never 0%), the sparkline
+ * derives from a bucket series (and draws NOTHING for an empty one), the
+ * FilterStrip drives its grid through plain callbacks, and the grid imposes
+ * no max-width — full-width by construction.
+ */
+
+afterEach(cleanup);
+
+describe('StatTile — the honest KPI tile', () => {
+  it('renders label, ONE big tabular number, and the context line', () => {
+    render(<StatTile testId="t" label="Runs" value={42} context="last 30 vs previous 30" />);
+    const tile = screen.getByTestId('t');
+    expect(tile).toHaveTextContent('Runs');
+    expect(within(tile).getByTestId('stat-value')).toHaveTextContent('42');
+    expect((within(tile).getByTestId('stat-value') as HTMLElement).style.fontVariantNumeric).toBe('tabular-nums');
+    expect(tile).toHaveTextContent('last 30 vs previous 30');
+    expect(tile.getAttribute('data-value')).toBe('42');
+  });
+
+  it('no prior window ⇒ the delta is "—", never a fabricated 0%', () => {
+    render(<StatTile testId="t" label="Runs" value={8} delta={{ current: 8, previous: null }} />);
+    const delta = within(screen.getByTestId('t')).getByTestId('stat-delta');
+    expect(delta).toHaveTextContent('—');
+    expect(delta.getAttribute('data-delta')).toBe('none');
+    expect(screen.getByTestId('t').getAttribute('data-delta')).toBe('none');
+  });
+
+  it('renders ▲ with the absolute diff when the window grew', () => {
+    render(<StatTile testId="t" label="Runs" value={30} delta={{ current: 30, previous: 22 }} />);
+    const delta = within(screen.getByTestId('t')).getByTestId('stat-delta');
+    expect(delta).toHaveTextContent('▲ 8');
+    expect(delta.getAttribute('data-delta')).toBe('8');
+  });
+
+  it('renders ▼ when it shrank, and a flat mark for zero change', () => {
+    const { unmount } = render(<StatTile testId="t" label="Failed" value={1} delta={{ current: 1, previous: 4 }} />);
+    expect(within(screen.getByTestId('t')).getByTestId('stat-delta')).toHaveTextContent('▼ 3');
+    unmount();
+    render(<StatTile testId="t2" label="Failed" value={4} delta={{ current: 4, previous: 4 }} />);
+    const flat = within(screen.getByTestId('t2')).getByTestId('stat-delta');
+    expect(flat.getAttribute('data-delta')).toBe('0');
+  });
+
+  it('bad-up sense paints a RISING delta with the fail token — threshold color only where it means something', () => {
+    render(<StatTile testId="t" label="Failed" value={5} delta={{ current: 5, previous: 2 }} deltaSense="bad-up" />);
+    const delta = within(screen.getByTestId('t')).getByTestId('stat-delta');
+    expect((delta as HTMLElement).style.color).toBe('var(--status-fail)');
+  });
+
+  it('neutral sense keeps the delta in ink — a run-count move is not a verdict', () => {
+    render(<StatTile testId="t" label="Runs" value={5} delta={{ current: 5, previous: 2 }} />);
+    const delta = within(screen.getByTestId('t')).getByTestId('stat-delta');
+    expect((delta as HTMLElement).style.color).toBe('var(--ink-muted)');
+  });
+
+  it('is a door: onOpen fires on click, and an href renders a real link', () => {
+    const onOpen = vi.fn();
+    render(<StatTile testId="t" label="Runs" value={1} href="/work" onOpen={onOpen} />);
+    const tile = screen.getByTestId('t');
+    expect(tile.tagName).toBe('A');
+    expect(tile).toHaveAttribute('href', '/work');
+    fireEvent.click(tile);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('embeds the sparkline under the number when a series is passed', () => {
+    render(<StatTile testId="t" label="Runs" value={3} spark={[0, 1, 2]} />);
+    expect(screen.getByTestId('t').querySelector('svg')).not.toBeNull();
+  });
+});
+
+describe('Sparkline — inline SVG from a bucket series, no chart lib', () => {
+  it('computes polyline points normalized to the series max', () => {
+    // 3 buckets over 100x10: x at 0/50/100, y at 10 (zero), 5 (half), 0 (max).
+    expect(sparkPoints([0, 1, 2], 100, 10)).toBe('0.0,10.0 50.0,5.0 100.0,0.0');
+  });
+
+  it('renders a polyline + area for a live series', () => {
+    render(<Sparkline counts={[1, 0, 3, 2]} testId="spark" />);
+    const svg = screen.getByTestId('spark');
+    expect(svg.querySelector('polyline')).not.toBeNull();
+    expect(svg.querySelector('polygon')).not.toBeNull();
+  });
+
+  it('draws NOTHING for an all-zero or empty series — absence stays absent', () => {
+    const { container } = render(<Sparkline counts={[0, 0, 0]} testId="spark" />);
+    expect(container.querySelector('svg')).toBeNull();
+    const { container: c2 } = render(<Sparkline counts={[]} testId="spark2" />);
+    expect(c2.querySelector('svg')).toBeNull();
+  });
+});
+
+describe('FilterStrip — search + status chips + window picker, first-class', () => {
+  const chips = [
+    { id: 'all', label: 'All', count: 9 },
+    { id: 'failed', label: 'Failed', count: 2 },
+  ];
+
+  it('drives the grid: search, chip, and window changes all call back', () => {
+    const onQuery = vi.fn();
+    const onChip = vi.fn();
+    const onRange = vi.fn();
+    render(
+      <FilterStrip
+        testId="fs" query="" onQuery={onQuery}
+        chips={chips} active="all" onChip={onChip}
+        range="30d" onRange={onRange}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('fs-search'), { target: { value: 'auth' } });
+    expect(onQuery).toHaveBeenCalledWith('auth');
+
+    const failedChip = screen.getAllByTestId('fs-chip').find((c) => c.getAttribute('data-chip') === 'failed')!;
+    expect(failedChip).toHaveTextContent('Failed');
+    expect(failedChip).toHaveTextContent('2'); // the chip carries its live count
+    fireEvent.click(failedChip);
+    expect(onChip).toHaveBeenCalledWith('failed');
+
+    // The window picker is the Work page's honest idiom — "last 60", not "60d".
+    fireEvent.click(screen.getByText('last 60'));
+    expect(onRange).toHaveBeenCalledWith('60d');
+  });
+
+  it('marks the active chip and mirrors it on the container', () => {
+    render(
+      <FilterStrip testId="fs" query="" onQuery={() => {}} chips={chips} active="failed" onChip={() => {}} />,
+    );
+    expect(screen.getByTestId('fs').getAttribute('data-filter')).toBe('failed');
+    const failedChip = screen.getAllByTestId('fs-chip').find((c) => c.getAttribute('data-chip') === 'failed')!;
+    expect(failedChip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('omits the window picker when no window applies', () => {
+    render(<FilterStrip testId="fs" query="" onQuery={() => {}} chips={chips} active="all" onChip={() => {}} />);
+    expect(screen.queryByText('last 30')).toBeNull();
+  });
+});
+
+describe('DashboardGrid + KpiBand — full-width, never max-width constrained', () => {
+  it('the grid flows with the viewport: auto-fill columns, no maxWidth', () => {
+    render(<DashboardGrid testId="grid" min={340}><div>a</div><div>b</div></DashboardGrid>);
+    const grid = screen.getByTestId('grid') as HTMLElement;
+    expect(grid.style.maxWidth).toBe('');
+    expect(grid.style.width).toBe('100%');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fill');
+    expect(grid.style.gridTemplateColumns).toContain('340px');
+  });
+
+  it('the KPI band groups tiles under the command-center kickers', () => {
+    render(
+      <KpiBand testId="band">
+        <KpiGroup label="Performance"><StatTile testId="a" label="A" value={1} /></KpiGroup>
+        <KpiGroup label="Risk"><StatTile testId="b" label="B" value={2} /></KpiGroup>
+      </KpiBand>,
+    );
+    const band = screen.getByTestId('band') as HTMLElement;
+    expect(band.style.maxWidth).toBe('');
+    expect(band).toHaveTextContent('Performance');
+    expect(band).toHaveTextContent('Risk');
+    expect(band.querySelector('[data-kpi-group="performance"]')).not.toBeNull();
+  });
+});

--- a/tests/delivery.surfaces.test.tsx
+++ b/tests/delivery.surfaces.test.tsx
@@ -118,7 +118,7 @@ describe('the project page (EC57, EC58)', () => {
     render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
 
     const rows = await screen.findAllByTestId('dashboard-run');
-    expect(rows).toHaveLength(6); // MAX_ROWS
+    expect(rows).toHaveLength(19); // the full last-30 window — no row cap on the card grid
 
     const chipped = rows.filter((r) => within(r).queryByTestId('run-delivery-chip') !== null);
     for (const row of chipped) {
@@ -159,7 +159,7 @@ describe('the project page (EC57, EC58)', () => {
     render(<ProjectDashboard projectId="proj-1" runs={corpus()} navigate={() => {}} />);
 
     const summary = await screen.findByTestId('dashboard-delivery-summary');
-    // 19 runs; 6 rows rendered. The census sees all nineteen — and says "ran
+    // 19 runs, all in the last-30 window. The census sees all nineteen — and says "ran
     // deliver", never "delivered": zero fetches means zero urls in hand.
     // The fourteen land in "no deliver phase" only because the defs prove
     // `feature` is an ordinary workflow — the bucket is a claim about a
@@ -170,7 +170,7 @@ describe('the project page (EC57, EC58)', () => {
         .toStrictEqual('3 ran deliver · 2 delivered nothing · 14 no deliver phase'),
     );
     expect(summary.textContent).not.toMatch(/\bPR\b/);
-    expect(screen.getAllByTestId('dashboard-run')).toHaveLength(6);
+    expect(screen.getAllByTestId('dashboard-run')).toHaveLength(19);
   });
 
   it('D5: chat threads are OUT of the census — the rail hides Delivery from them', async () => {

--- a/tests/windowStats.test.ts
+++ b/tests/windowStats.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attachSeries, deltaWord, healthColor, healthOf, statusCounts, windowBuckets, windowDelta,
+} from '../src/board/windowStats.js';
+import { makeView } from './factories.js';
+import type { SessionStatus } from '../src/api/types.js';
+
+/**
+ * The section-dashboard window folds (lane B): positional windows with honest
+ * deltas (no prior bucket = null, rendered "—"), the shared status partition,
+ * threshold health, and the attach-clock sparkline series.
+ */
+
+const run = (id: string, status: SessionStatus, archived = false) =>
+  makeView({ id, status, ...(archived ? { archived_at: 123 } : {}) });
+
+const fleet = (n: number, status: SessionStatus = 'completed') =>
+  Array.from({ length: n }, (_, i) => run(`r-${i}`, status));
+
+describe('windowBuckets — positional split, previous same-size bucket', () => {
+  it('splits 130 runs at last-30 into a 30-run window and a full 30-run prior bucket', () => {
+    const runs = fleet(130);
+    const b = windowBuckets(runs, '30d');
+    expect(b.current).toHaveLength(30);
+    expect(b.current[0]!.session.id).toBe('r-0');
+    expect(b.previous).not.toBeNull();
+    expect(b.previous).toHaveLength(30);
+    expect(b.previous![0]!.session.id).toBe('r-30');
+  });
+
+  it('NO prior bucket when the history is one window or less — previous is null', () => {
+    expect(windowBuckets(fleet(30), '30d').previous).toBeNull();
+    expect(windowBuckets(fleet(8), '30d').previous).toBeNull();
+    expect(windowBuckets([], '30d').previous).toBeNull();
+  });
+
+  it('a PARTIAL prior bucket never counts — same-size windows or no delta at all', () => {
+    // 40 rows: the 10 older rows are NOT a previous-30 bucket; comparing 30
+    // against 10 would fabricate a surge, so previous stays null ("—").
+    const b = windowBuckets(fleet(40), '30d');
+    expect(b.current).toHaveLength(30);
+    expect(b.previous).toBeNull();
+    // Exactly two windows: the prior bucket is full, so it counts.
+    const full = windowBuckets(fleet(60), '30d');
+    expect(full.previous).toHaveLength(30);
+  });
+
+  it('the all window has no prior bucket by definition', () => {
+    const b = windowBuckets(fleet(90), 'all');
+    expect(b.current).toHaveLength(90);
+    expect(b.previous).toBeNull();
+  });
+});
+
+describe('windowDelta — the honest delta pair', () => {
+  it('counts both buckets with the same predicate', () => {
+    const runs = [...fleet(30, 'failed').slice(0, 2), ...fleet(28, 'completed'), ...fleet(30, 'failed')]
+      .map((v, i) => makeView({ ...v.session, id: `x-${i}` }));
+    const d = windowDelta(windowBuckets(runs, '30d'), (rs) => rs.filter((v) => v.session.status === 'failed').length);
+    expect(d.current).toBe(2);
+    expect(d.previous).toBe(30);
+  });
+
+  it('propagates the missing prior bucket as null — never 0', () => {
+    const d = windowDelta(windowBuckets(fleet(5), '30d'), (rs) => rs.length);
+    expect(d.current).toBe(5);
+    expect(d.previous).toBeNull();
+  });
+});
+
+describe('deltaWord — the label names BOTH buckets, and only buckets that exist', () => {
+  it('names the window and its prior twin', () => {
+    expect(deltaWord('30d')).toBe('last 30 vs previous 30');
+    expect(deltaWord('90d')).toBe('last 90 vs previous 90');
+  });
+  it('says out loud that all has no prior window', () => {
+    expect(deltaWord('all')).toBe('all runs — no prior window');
+  });
+  it('given the delta, a missing prior bucket never claims a "previous N"', () => {
+    expect(deltaWord('30d', { current: 16, previous: null })).toBe('last 30 — no prior window');
+    expect(deltaWord('30d', { current: 30, previous: 12 })).toBe('last 30 vs previous 30');
+  });
+});
+
+describe('statusCounts — the one outcome partition, archived excluded', () => {
+  it('folds each status into its bucket (cancelled ≠ failed)', () => {
+    const c = statusCounts([
+      run('a', 'executing'), run('b', 'planning'),
+      run('c', 'awaiting_human'),
+      run('d', 'failed'), run('e', 'cancelled'), run('f', 'completed'),
+      run('g', 'completed', true), // archived: never counted
+    ]);
+    expect(c).toEqual({ total: 6, active: 2, gates: 1, failed: 1, done: 1, cancelled: 1, terminal: 3 });
+  });
+});
+
+describe('healthOf — threshold color only where it means something', () => {
+  it('green ≥80%, amber ≥50%, red below, none without terminal runs', () => {
+    expect(healthOf(8, 10)).toBe('good');
+    expect(healthOf(5, 10)).toBe('warn');
+    expect(healthOf(3, 10)).toBe('bad'); // the review's 30%: never success-green
+    expect(healthOf(0, 0)).toBe('none');
+    expect(healthColor('none')).toBeUndefined();
+    expect(healthColor('bad')).toBe('var(--status-fail)');
+  });
+});
+
+describe('attachSeries — daily buckets on the honest attach clock', () => {
+  const DAY = 24 * 3_600_000;
+  const NOW = 1_756_000_000_000;
+
+  it('buckets runs by attach day, oldest first; clockless runs are absent', () => {
+    const at = {
+      'r-today-1': NOW - 3_600_000,
+      'r-today-2': NOW - 2 * 3_600_000,
+      'r-3d': NOW - 3 * DAY,
+      'r-old': NOW - 20 * DAY,          // outside the span — dropped
+      // r-noclock has no entry — absent, never painted at an invented time
+    };
+    const series = attachSeries(['r-today-1', 'r-today-2', 'r-3d', 'r-old', 'r-noclock'], at, 7, NOW);
+    expect(series).toHaveLength(7);
+    expect(series[6]).toBe(2);          // today
+    expect(series[3]).toBe(1);          // three days back
+    expect(series.reduce((a, c) => a + c, 0)).toBe(3);
+  });
+});


### PR DESCRIPTION
The exec-dashboard treatment (user's style reference) with the north star baked in — part analytics, part action panel, for directing many workstreams at once. One shared kit (StatTile with delta+sparkline, FilterStrip, DashboardGrid — no per-surface forks) applied three times: the Projects landing, the project homepage, and Make — all full-width (grid ~1576px at 1920, the 760px column is gone), each with a ≤6-tile KPI band on the performance/pipeline/risk model and a filterable card grid where every card is a door (five click-throughs verified live).

The action layer: creation verbs on every header, "needs you" floats first with gate cards deep-linking straight to the approval dock, failed items carry Retry-as-prefill (deposits into the composer, never auto-launches). Honesty throughout: every KPI cross-checked against independent GET /runs folds on the live store (Runs 30, Failed 21 ▲21 red, Unfiled 91...); a delta renders only when a FULL same-size prior window exists — the verifier caught windowBuckets comparing against partial priors (fabricated surges) and fixed it, plus misleading "vs previous 30" context on dash-deltas and missing empty-state CTAs. 2171 tests green, testid inventory regenerated (740 static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)