### PR TITLE
release: 0.4.6 — section command surfaces, condensed run header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-09-01
+
+### Added
+
+- **Section dashboards** (#167) — Projects, the project homepage, and Make become full-width
+  command surfaces on the executive-dashboard model: a ≤6-tile KPI band per section
+  (performance / pipeline / risk) with honest deltas (a delta renders only against a full
+  same-size prior window — never a fabricated surge) and inline sparklines, a first-class
+  FilterStrip (search + status chips + window picker), and card grids where every card is a
+  door. The action layer rides on top: creation verbs on every header, "needs you" floats
+  first with gate cards deep-linking straight to the approval dock, and failed items carry
+  Retry-as-prefill. One shared kit (StatTile / FilterStrip / DashboardGrid / sparklines).
+
+### Changed
+
+- **The run header condensed** (#166): one row + the phase strip; started/ended/took moved
+  into the What/Where insights panel; Timeline and Units left the primary tabs for an
+  Inspect ▾ menu — the Feed is the run view. +79px (+19%) more feed above the 1440×700 fold.
+
 ## [0.4.5] — 2026-08-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.5",
+  "studioVersion": "0.4.6",
   "counts": {
     "files": 116,
     "occurrences": 871,


### PR DESCRIPTION
Version bump + CHANGELOG + testid inventory regenerated at 0.4.6. Ships #166 (condensed run header, Timeline/Units behind Inspect, +79px feed) and #167 (the Projects / project-home / Make command surfaces: KPI bands with honest deltas + sparklines, filters, full width, needs-you-first action layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)