### PR TITLE
feat: Chat and Repositories become command surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/src/board/chatStats.ts
+++ b/src/board/chatStats.ts
@@ -1,0 +1,42 @@
+/**
+ * The Chat section's fold layer (lane B, the 0.4.6 command-surface treatment):
+ * pure derivations over the TWO chat wires —
+ *
+ *  - `GET /runs` carries chat HISTORY: chat sessions are runs (workflow
+ *    `chat`, plus legacy unstamped runs — `isChatRun`'s partition), so every
+ *    windowed count reuses `windowBuckets`/`windowDelta`/`statusCounts`
+ *    verbatim (never re-implemented here);
+ *  - `GET /chats` carries only the LIVE seat pool: `{chatId, seats, idleSecs}`
+ *    per warm session, nothing more — so the only live-side metrics are the
+ *    ones that wire honestly answers: how many warm sessions, how many seats
+ *    they hold, and which have sat idle past a threshold.
+ *
+ * Message/turn counts are NOT served by either wire, so no fold invents them.
+ */
+
+/** One warm chat session as `GET /chats` serves it (FINDING-027's shape). */
+export interface LiveChatSnapshot {
+  chatId: string;
+  seats: string[];
+  /** `null` = the daemon holds no idle age for this session. */
+  idleSecs: number | null;
+}
+
+/** Warm agent seats across every live session — the wire's own seat lists. */
+export function liveSeatCount(chats: readonly LiveChatSnapshot[]): number {
+  return chats.reduce((a, c) => a + c.seats.length, 0);
+}
+
+/**
+ * A live session counts as STALLED once its daemon-reported idle age passes
+ * this threshold — warm seats someone paid for that nothing is driving.
+ * `idleSecs: null` (age unknown) never counts: absence stays absent.
+ */
+export const STALLED_IDLE_SECS = 600;
+
+export function stalledLiveChats(
+  chats: readonly LiveChatSnapshot[],
+  stalledAfterSecs: number = STALLED_IDLE_SECS,
+): LiveChatSnapshot[] {
+  return chats.filter((c) => c.idleSecs !== null && c.idleSecs >= stalledAfterSecs);
+}

--- a/src/board/repoStats.ts
+++ b/src/board/repoStats.ts
@@ -1,0 +1,126 @@
+import type { RepoEntry, SessionView } from '../api/types.js';
+import { outcomeOf } from './metrics.js';
+import { statusCounts, type StatusCounts } from './windowStats.js';
+
+/**
+ * The Repositories section's fold layer (lane B, the 0.4.6 command-surface
+ * treatment): pure derivations over what the wires HONESTLY serve —
+ *
+ *  - `GET /repos` carries the register only: `{id, name, root_path,
+ *    default_branch, registered_at, git_url?, code_graph_db?}` — NO
+ *    indexed-version or last-indexed field exists on this wire, so a "stale
+ *    graph" clock cannot be derived from it and no fold here pretends to;
+ *  - `GET /runs` carries every run's `repo_ref` + `workflow_id`, and the
+ *    onboarding workflow (`onboarding` — index + annotate) IS the graph
+ *    build. So the honest per-repo graph story is the repo's newest
+ *    onboarding run: completed = ready, failed = the graph build failed,
+ *    non-terminal = building now, none on record = never onboarded (as far
+ *    as the run history can say).
+ *
+ * Windowed counts reuse `statusCounts`/`outcomeOf` — never re-implemented.
+ */
+
+/** The graph-building workflow's id (crew's BUILTIN_WORKFLOWS). */
+export const ONBOARDING_WORKFLOW_ID = 'onboarding';
+
+/**
+ * A repo's graph state, derived from its newest onboarding run:
+ *  - `ready`      — newest decisive onboard completed;
+ *  - `onboarding` — an onboard run is in flight right now;
+ *  - `failed`     — newest decisive onboard failed;
+ *  - `never`      — no onboarding run on record (the run history is the only
+ *    witness this wire offers, and the label must say so).
+ * Cancelled onboards are skipped, not verdicts — an operator withdrew them.
+ */
+export type OnboardState = 'ready' | 'onboarding' | 'failed' | 'never';
+
+export interface RepoOnboard {
+  state: OnboardState;
+  /** The run the state derives from (`null` only for `never`). */
+  run: SessionView | null;
+}
+
+/** One repo's fleet-card model — one fold per card, shared by grid and chips. */
+export interface RepoFleetModel {
+  repo: RepoEntry;
+  /** The repo's runs inside the current recency window (unarchived). */
+  windowed: SessionView[];
+  counts: StatusCounts;
+  /** Runs waiting on a human RIGHT NOW — unwindowed (a gate is a gate). */
+  waiting: SessionView[];
+  activeNow: boolean;
+  /** Failed runs in the window, or the graph build itself failed. */
+  failing: boolean;
+  onboard: RepoOnboard;
+  /** Newest attach clock among the repo's runs; `null` = no clock known. */
+  lastAt: number | null;
+}
+
+/**
+ * A repo's graph state off the salience-ordered run list (daemon order:
+ * actionable first, then newest first — the same positional idiom every
+ * window fold rides). First in-flight onboard wins (`onboarding`); otherwise
+ * the first terminal, non-cancelled onboard is the verdict.
+ */
+export function repoOnboard(runs: readonly SessionView[], repoId: string): RepoOnboard {
+  let verdict: RepoOnboard | null = null;
+  for (const v of runs) {
+    const s = v.session;
+    if (s.archived_at != null || s.repo_ref !== repoId || s.workflow_id !== ONBOARDING_WORKFLOW_ID) continue;
+    const o = outcomeOf(s.status);
+    if (o === 'run' || o === 'gate') return { state: 'onboarding', run: v };
+    if (o === 'cancelled') continue; // withdrawn, not a verdict — look further back
+    if (verdict === null) verdict = { state: o === 'done' ? 'ready' : 'failed', run: v };
+  }
+  return verdict ?? { state: 'never', run: null };
+}
+
+/**
+ * Every repo's card model, attention-ordered: needs-you floats FIRST, then
+ * failing, then active, then newest activity, then name. `repoRuns` is the
+ * unarchived repo-linked run list in daemon order; `windowIds` is the current
+ * recency window's membership (the page's `windowBuckets` output).
+ */
+export function repoFleetModels(
+  repos: readonly RepoEntry[],
+  repoRuns: readonly SessionView[],
+  attachedAt: Record<string, number>,
+  windowIds: ReadonlySet<string>,
+): RepoFleetModel[] {
+  return repos.map((repo) => {
+    const mine = repoRuns.filter((v) => v.session.repo_ref === repo.id);
+    const windowed = mine.filter((v) => windowIds.has(v.session.id));
+    const counts = statusCounts(windowed);
+    const onboard = repoOnboard(mine, repo.id);
+    const clocks = mine
+      .map((v) => attachedAt[v.session.id])
+      .filter((t): t is number => typeof t === 'number');
+    return {
+      repo,
+      windowed,
+      counts,
+      waiting: mine.filter((v) => v.session.status === 'awaiting_human'),
+      activeNow: mine.some((v) => outcomeOf(v.session.status) === 'run'),
+      failing: counts.failed > 0 || onboard.state === 'failed',
+      onboard,
+      lastAt: clocks.length > 0 ? Math.max(...clocks) : null,
+    };
+  }).sort((a, b) =>
+    (b.waiting.length > 0 ? 1 : 0) - (a.waiting.length > 0 ? 1 : 0)
+    || (b.failing ? 1 : 0) - (a.failing ? 1 : 0)
+    || (b.activeNow ? 1 : 0) - (a.activeNow ? 1 : 0)
+    || (b.lastAt ?? 0) - (a.lastAt ?? 0)
+    || a.repo.name.localeCompare(b.repo.name),
+  );
+}
+
+export type RepoChip = 'all' | 'needs-you' | 'active' | 'failing' | 'ready' | 'never';
+
+export function matchesRepoChip(m: RepoFleetModel, chip: RepoChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'needs-you') return m.waiting.length > 0;
+  if (chip === 'active') return m.activeNow;
+  if (chip === 'failing') return m.failing;
+  if (chip === 'ready') return m.onboard.state === 'ready';
+  return m.onboard.state === 'never'; // never onboarded (no run on record)
+}

--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -104,6 +104,24 @@ export function statusCounts(runs: SessionView[]): StatusCounts {
   return c;
 }
 
+// ── Attention ordering (needs-you floats FIRST — the north-star routing) ─────
+
+const ORDER_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
+
+/**
+ * The one list order every section grid shares: runs waiting on a human
+ * FIRST, then runs moving under their own power, then terminal history —
+ * incoming (daemon/salience) order preserved within each group. Extracted
+ * from MakeDashboard so /make, /chats and /repos cannot drift on what
+ * "needs you floats first" means.
+ */
+export function orderByAttention(runs: SessionView[]): SessionView[] {
+  const gated = runs.filter((v) => v.session.status === 'awaiting_human');
+  const active = runs.filter((v) => v.session.status !== 'awaiting_human' && !ORDER_TERMINAL.has(v.session.status));
+  const terminal = runs.filter((v) => ORDER_TERMINAL.has(v.session.status));
+  return [...gated, ...active, ...terminal];
+}
+
 // ── Threshold health (usability review #9: no success-green on a 30% rate) ───
 
 export type Health = 'good' | 'warn' | 'bad' | 'none';

--- a/src/components/ChatsPage.tsx
+++ b/src/components/ChatsPage.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api } from '../api/client.js';
 import type { SessionView } from '../api/types.js';
+import {
+  liveSeatCount, stalledLiveChats, STALLED_IDLE_SECS, type LiveChatSnapshot,
+} from '../board/chatStats.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import { outcomeOf } from '../board/metrics.js';
+import {
+  attachSeries, deltaWord, orderByAttention, statusCounts, windowBuckets, windowDelta,
+} from '../board/windowStats.js';
 import { useEventStream } from '../hooks/useEventStream.js';
-import { rangeWord, useTimeRange, type TimeRange } from '../hooks/useTimeRange.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
-import { GatesWaitingTile, TileBand } from './DashboardTiles.js';
-import { MetricTile } from './MetricTile.js';
-import { humanTitle } from './runIdentity.js';
-import { RunSparkline } from './RunSparkline.js';
-import { TimeRangeSelector } from './TimeRangeSelector.js';
+import { ageWord } from './DashboardTiles.js';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, StatTile, type FilterChip,
+} from './dashboardKit.js';
+import { humanTitle, runShortId, runWhenWord } from './runIdentity.js';
+import { RUN_DOT } from './RunsSection.js';
 
 interface Props {
   runs: SessionView[];
@@ -17,8 +26,23 @@ interface Props {
   navigate: (path: string) => void;
 }
 
-const terminal = (s: string): boolean =>
-  ['completed', 'failed', 'cancelled'].includes(s);
+/**
+ * The /chats landing as a COMMAND SURFACE (lane B, the 0.4.6 treatment): the
+ * conversations you direct. A KPI band organized around the command-center
+ * questions (performance / pipeline / risk), then one card per conversation —
+ * LIVE warm sessions first (the daemon's seat pool, findable + endable, the
+ * §7.9-5 zombie-cleanup contract preserved), then chat runs ordered needs-you
+ * first. Every tile and card clicks through; "needs you" jumps STRAIGHT to
+ * the waiting run's gate; the creation verb (New Chat) lives in the header.
+ *
+ * Wire honesty: chat HISTORY rides the app's one `GET /runs` (chat sessions
+ * are runs — `isChatRun`'s partition), so windowed counts use the shared
+ * positional window folds ("last 30", never a fabricated "30d", "—" when no
+ * full prior bucket exists). The LIVE band rides the page's one declared
+ * `GET /chats` (`{chatId, seats, idleSecs}` — nothing more), so the only live
+ * metrics are seats, warm-session count, and idle age. Neither wire serves a
+ * message/turn count, so no card claims one.
+ */
 
 /**
  * The Chat predicate — exported so Make's complement is VERBATIM this filter
@@ -28,71 +52,8 @@ const terminal = (s: string): boolean =>
 export const isChatRun = (v: SessionView): boolean =>
   !v.session.workflow_id || v.session.workflow_id === 'chat';
 
-// ── The chats-over-time tile (DES-FEEDBACK-003 §4.3 row 1, slice P) ───────────
-
-const RANGE_DAYS: Record<TimeRange, number> = { '30d': 30, '60d': 60, '90d': 90, all: 365 };
-
-/** The honest window phrase: "in the last 30" (runs), or "overall" for `all`. */
-const windowWordOf = (r: TimeRange): string => (r === 'all' ? 'overall' : `in the ${rangeWord(r)}`);
-const BUCKETS = 12;
-const DAY_MS = 86_400_000;
-
-/**
- * "Is conversation increasing or drying up?" — the range-filtered chat runs,
- * bucketed over the range's span on the membership attach clock (the one
- * honest per-run clock; `AgentSession` carries no timestamps — the same
- * wire-honesty note RunOutcomeBar carries). Chats the mirror cannot place in
- * the window (unfiled, or older than the range) are excluded from the bars
- * and counted in `data-unplaced` rather than painted at an invented time.
- * Reads the mirror + the `runs` prop only: zero requests.
- */
-function ChatsOverTimeTile({ chats, range, now }: {
-  chats: SessionView[];
-  range: TimeRange;
-  now?: number;
-}): React.ReactElement {
-  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
-  const at = now ?? Date.now();
-  const days = RANGE_DAYS[range];
-  const { counts, placed } = useMemo(() => {
-    const span = days * DAY_MS;
-    const start = at - span;
-    const buckets = new Array<number>(BUCKETS).fill(0);
-    let inWindow = 0;
-    for (const v of chats) {
-      const clock = attachedAt[v.session.id];
-      if (clock === undefined || clock < start || clock > at) continue;
-      const ix = Math.min(BUCKETS - 1, Math.floor(((clock - start) / span) * BUCKETS));
-      buckets[ix] = (buckets[ix] ?? 0) + 1;
-      inWindow += 1;
-    }
-    return { counts: buckets, placed: inWindow };
-  }, [chats, attachedAt, at, days]);
-
-  return (
-    <MetricTile
-      testId="chats-over-time-tile"
-      question="Is conversation increasing or drying up?"
-      title={`Chats (${rangeWord(range)})`}
-      value={placed === 0 ? `no placed chats ${windowWordOf(range)}` : `${placed} ${windowWordOf(range)}`}
-      data={{ 'data-total': placed, 'data-unplaced': chats.length - placed }}
-    >
-      {placed === 0 ? (
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-          No chats with an attach clock in the window.
-        </p>
-      ) : (
-        <RunSparkline counts={counts} width={168} height={26} color="var(--accent)" />
-      )}
-    </MetricTile>
-  );
-}
-
 /** One warm chat session on the daemon (`GET /chats` — the FINDING-027 wire). */
-interface LiveChatRow {
-  chatId: string;
-  seats: string[];
-  idleSecs: number | null;
+interface LiveChatRow extends LiveChatSnapshot {
   /** When this page last SAW a stream frame for the chat (0 = never). */
   lastFrameAt: number;
 }
@@ -100,17 +61,69 @@ interface LiveChatRow {
 /** A frame this recent reads as "streaming now" — observed, never asserted. */
 const STREAMING_WINDOW_MS = 30_000;
 
+type StatusChip = 'all' | 'live' | 'needs-you' | 'active' | 'failed' | 'done';
+
+function matchesChip(status: string, chip: StatusChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'live') return false; // runs never match the live chip
+  const o = outcomeOf(status);
+  if (chip === 'needs-you') return o === 'gate';
+  if (chip === 'active') return o === 'run';
+  if (chip === 'failed') return o === 'fail';
+  return o === 'done' || o === 'cancelled';
+}
+
+const CARD: React.CSSProperties = {
+  display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+  background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+  borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+  cursor: 'pointer',
+};
+
+const CARD_META: React.CSSProperties = {
+  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
+  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+};
+
+/** One agent seat as a chip (claude / pi / codex…) — the wire's own names. */
+function SeatChips({ seats }: { seats: readonly string[] }): React.ReactElement | null {
+  if (seats.length === 0) return null;
+  return (
+    <span style={{ display: 'flex', gap: '4px', flexShrink: 0, minWidth: 0, overflow: 'hidden' }}>
+      {seats.map((s) => (
+        <span
+          key={s}
+          data-testid="chat-seat"
+          data-seat={s}
+          style={{
+            fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+            border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-full)',
+            padding: '0 7px', whiteSpace: 'nowrap',
+          }}
+        >
+          {s}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
-  const { range, setRange, filter: filterByRange } = useTimeRange('30d');
+  const [chip, setChip] = useState<StatusChip>('all');
+  const { range, setRange } = useTimeRange('30d');
+
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
+  const gates = useGateStore((s) => s.gates);
 
   // ── Live sessions (DES-UX-001 §7.9-5): the warm seat pool, findable ────────
   // The review's zombie class — "abandoned tabs leak working agents nothing
-  // points at" — dies here: every live chat the daemon holds is LISTED on
-  // /chats (one GET /chats riding this navigation — a page-load read, not a
-  // mount ambush on another surface), each with its seats, idle age, and an
-  // End control (`DELETE /chats/:id`, the same teardown Chat's Close uses).
-  // Streams announce themselves: a chatDelta/chatReply frame flags its session
+  // points at" — dies here: every live chat the daemon holds is LISTED (one
+  // GET /chats riding this navigation — a page-load read, not a mount ambush
+  // on another surface), each with its seats, idle age, and an End control
+  // (`DELETE /chats/:id`, the same teardown Chat's Close uses). Streams
+  // announce themselves: a chatDelta/chatReply frame flags its session
   // "streaming now" from the FIRST frame — a session is visible here while it
   // streams, even one this list fetch predates.
   const [liveChats, setLiveChats] = useState<LiveChatRow[] | null>(null);
@@ -123,7 +136,7 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
         setLiveChats(chats.map((c) => ({ ...c, lastFrameAt: 0 })));
       })
       .catch(() => {
-        if (!cancelled) setLiveChats([]); // unreachable — the band stays absent
+        if (!cancelled) setLiveChats([]); // unreachable — the live cards stay absent
       });
     return () => {
       cancelled = true;
@@ -171,130 +184,220 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
       });
   }
 
-  // Strict filter: include 'chat' runs and legacy runs with no workflow stamp as a transitional fallback.
-  const allChats = useMemo(() => runs.filter(isChatRun), [runs]);
+  // ── The chat-run partition + the window (the shared positional idiom) ──────
+  const allChats = useMemo(
+    () => orderByAttention(runs.filter((v) => isChatRun(v) && v.session.archived_at == null)),
+    [runs],
+  );
+  const now = Date.now();
+  const buckets = useMemo(() => windowBuckets(allChats, range), [allChats, range]);
+  const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
 
-  const chats = useMemo(() => filterByRange(allChats), [allChats, filterByRange]);
-
-  const active = useMemo(() => chats.filter(v => !terminal(v.session.status)), [chats]);
-
-  /** Live pool sessions visible on this screen — the Active-now headline
-   *  counts them too (round 2, J4 minor / EC39: the number matches the page). */
-  const liveCount = liveChats?.length ?? 0;
-
-  // Gates from chats (§4.3 row 3): the gate store filtered to THIS partition —
-  // "Did a conversation stall on me?" is asked of every chat, not just the
-  // range-filtered slice, so the filter is the partition predicate alone.
-  const gates = useGateStore((s) => s.gates);
-  const chatGates = useMemo(() => {
+  // ── KPI folds — one selector each, over the two wires ──────────────────────
+  const liveCounts = useMemo(() => statusCounts(allChats), [allChats]);
+  const chatsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
+  const failedDelta = useMemo(
+    () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
+    [buckets],
+  );
+  const chatSpark = useMemo(
+    () => attachSeries(buckets.current.map((v) => v.session.id), attachedAt, 14, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` re-derives with the data, not a timer
+    [buckets, attachedAt],
+  );
+  const live = liveChats ?? [];
+  const liveN = live.length;
+  const seatN = liveSeatCount(live);
+  const stalled = stalledLiveChats(live);
+  // "Did a conversation stall on me?" is asked of every chat run, not just the
+  // windowed slice — the oldest open chat gate's age off the gate store.
+  const oldestChatGate = useMemo(() => {
     const ids = new Set(allChats.map((v) => v.session.id));
-    return Object.values(gates).filter((g) => ids.has(g.runId));
+    return Object.values(gates)
+      .filter((g) => ids.has(g.runId))
+      .reduce<number | null>((acc, g) => (acc === null || g.receivedAt < acc ? g.receivedAt : acc), null);
   }, [gates, allChats]);
 
-  const filtered = useMemo(
-    () => query
-      ? chats.filter(v => v.session.problem.toLowerCase().includes(query.toLowerCase()))
-      : chats,
-    [chats, query],
-  );
+  /** The gate jump: the run's thread AT the gate when its project is known;
+   *  the flat run detail (where the approval dock lives) when unfiled. */
+  const gateJump = (id: string): string => {
+    const pid = projectIdByRun[id];
+    return pid !== undefined ? gateOpenPath(pid, id) : `/runs/${encodeURIComponent(id)}`;
+  };
+
+  // ── Filtering (search lifts the window — the Work page idiom) ──────────────
+  const q = query.trim().toLowerCase();
+  const searchedRuns = q === ''
+    ? allChats.filter((v) => windowIds.has(v.session.id))
+    : allChats.filter((v) =>
+        v.session.problem.toLowerCase().includes(q)
+        || runShortId(v.session.id).includes(q)
+        || v.session.clis.some((c) => c.toLowerCase().includes(q)));
+  const visibleRuns = chip === 'live' ? [] : searchedRuns.filter((v) => matchesChip(v.session.status, chip));
+  const searchedLive = q === ''
+    ? live
+    : live.filter((c) => c.chatId.toLowerCase().includes(q) || c.seats.some((s) => s.toLowerCase().includes(q)));
+  const visibleLive = (chip === 'all' || chip === 'live') ? searchedLive : [];
+  const hiddenByWindow = q === '' ? allChats.length - buckets.current.length : 0;
+
+  const chipCounts = useMemo(() => {
+    const counts: Record<StatusChip, number> = { all: 0, live: searchedLive.length, 'needs-you': 0, active: 0, failed: 0, done: 0 };
+    for (const v of searchedRuns) {
+      counts.all += 1;
+      for (const c of ['needs-you', 'active', 'failed', 'done'] as const) {
+        if (matchesChip(v.session.status, c)) counts[c] += 1;
+      }
+    }
+    counts.all += searchedLive.length;
+    return counts;
+  }, [searchedRuns, searchedLive.length]);
+
+  const chips: FilterChip[] = [
+    { id: 'all', label: 'All', count: chipCounts.all },
+    { id: 'live', label: 'Live', count: chipCounts.live },
+    { id: 'needs-you', label: 'Needs you', count: chipCounts['needs-you'] },
+    { id: 'active', label: 'Active', count: chipCounts.active },
+    { id: 'failed', label: 'Failed', count: chipCounts.failed },
+    { id: 'done', label: 'Done', count: chipCounts.done },
+  ];
 
   return (
-    <div className="flex flex-col gap-6" style={{ color: 'var(--ink-high)' }}>
+    // FULL WIDTH — the section flows with the viewport; no max-width column.
+    <div
+      data-testid="chats-page"
+      className="flex flex-col"
+      style={{ color: 'var(--ink-high)', padding: '0 var(--space-8) var(--space-8)', gap: 'var(--space-4)' }}
+    >
+      {/* ── Header: the section name + its creation verb ── */}
+      <div className="pt-8 flex items-center justify-between gap-4">
+        <div className="flex items-baseline gap-4 min-w-0">
+          <h1 className="text-2xl font-semibold font-mono" style={{ margin: 0 }}>Chats</h1>
+          <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
+            the conversations you direct — live seats · chat runs
+          </p>
+        </div>
+        <button
+          type="button"
+          data-testid="chats-new"
+          onClick={() => navigate('/chat/new')}
+          className="rounded-lg px-4 py-2 text-sm font-semibold font-mono shrink-0"
+          style={{ background: 'var(--accent)', color: 'var(--accent-fg)', border: 'none', cursor: 'pointer' }}
+        >
+          New Chat
+        </button>
+      </div>
 
-      {/* ── Header ── */}
-      <div className="px-8 pt-8 pb-4 flex items-center justify-between gap-4">
-        <h1 className="text-2xl font-semibold font-mono">Chats</h1>
-        <div className="flex items-center gap-3">
-          <TimeRangeSelector value={range} onChange={setRange} />
-          <input
-            type="text"
-            placeholder="Search chats…"
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            className="rounded-xl px-4 py-2 text-sm font-mono outline-none"
-            style={{
-              background: 'var(--surface-card)',
-              border: '1px solid var(--surface-raised)',
-              color: 'var(--ink-high)',
-              width: '220px',
-            }}
+      {/* ── The KPI band — the command-center model: three questions ── */}
+      <KpiBand testId="chats-kpis">
+        <KpiGroup label="Performance" grow={2}>
+          <StatTile
+            testId="stat-chats"
+            label="Chats"
+            value={buckets.current.length}
+            delta={chatsDelta}
+            context={deltaWord(range, chatsDelta)}
+            spark={chatSpark}
+            title="Chat runs in the window — click to clear filters"
+            onOpen={() => { setChip('all'); setQuery(''); }}
           />
+          <StatTile
+            testId="stat-live-seats"
+            label="Live seats"
+            value={seatN}
+            context={liveN > 0 ? `${liveN} warm session${liveN === 1 ? '' : 's'}` : 'no live sessions'}
+            title="Warm agent seats on the daemon — filter to the live sessions"
+            onOpen={() => setChip('live')}
+          />
+        </KpiGroup>
+        <KpiGroup label="Pipeline" grow={2}>
+          <StatTile
+            testId="stat-active"
+            label="Conversations now"
+            value={liveN + liveCounts.active}
+            context={liveN > 0 ? `${liveN} live · ${liveCounts.active} runs moving` : 'right now'}
+            title="Live sessions plus chat runs moving — filter the grid to them"
+            onOpen={() => setChip(liveCounts.active > 0 ? 'active' : 'live')}
+          />
+          <StatTile
+            testId="stat-gates"
+            label="Needs you"
+            value={liveCounts.gates}
+            valueColor={liveCounts.gates > 0 ? 'var(--status-gate)' : undefined}
+            context={oldestChatGate !== null ? `oldest waiting ${ageWord(now - oldestChatGate)}` : 'nothing waiting'}
+            title="Chat runs waiting on a human — filter the grid to them"
+            onOpen={() => setChip('needs-you')}
+          />
+        </KpiGroup>
+        <KpiGroup label="Risk" grow={2}>
+          <StatTile
+            testId="stat-failed"
+            label="Failed"
+            value={failedDelta.current}
+            valueColor={failedDelta.current > 0 ? 'var(--status-fail)' : undefined}
+            delta={failedDelta}
+            deltaSense="bad-up"
+            context={deltaWord(range, failedDelta)}
+            title="Failed chat runs in the window — filter the grid to them"
+            onOpen={() => setChip('failed')}
+          />
+          <StatTile
+            testId="stat-stalled"
+            label="Stalled live"
+            value={stalled.length}
+            valueColor={stalled.length > 0 ? 'var(--status-gate)' : undefined}
+            context={liveN > 0 ? `idle ≥ ${STALLED_IDLE_SECS / 60}m of ${liveN} live` : 'no live sessions'}
+            title="Warm sessions idle past 10 minutes — filter to the live sessions"
+            onOpen={() => setChip('live')}
+          />
+        </KpiGroup>
+      </KpiBand>
+
+      {/* ── Filters — first-class at the top of the list ── */}
+      <FilterStrip
+        testId="chats-filter"
+        query={query}
+        onQuery={setQuery}
+        placeholder="Search chats…"
+        chips={chips}
+        active={chip}
+        onChip={(id) => setChip(id as StatusChip)}
+        range={range}
+        onRange={setRange}
+      >
+        {hiddenByWindow > 0 && (
           <button
             type="button"
-            onClick={() => navigate('/chat/new')}
-            className="rounded-lg px-4 py-2 text-sm font-semibold font-mono shrink-0"
-            style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+            data-testid="chats-hidden-chip"
+            data-hidden={hiddenByWindow}
+            onClick={() => setRange('all')}
+            title={`the ${rangeWord(range)} window holds back ${hiddenByWindow} older chat${hiddenByWindow === 1 ? '' : 's'} — click to show all`}
+            style={{
+              borderRadius: 'var(--radius-full)', padding: '3px 10px',
+              fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
+              border: '1px solid var(--surface-raised)', background: 'transparent',
+              color: 'var(--ink-muted)',
+            }}
           >
-            New Chat
+            +{hiddenByWindow} older · show all
           </button>
-        </div>
-      </div>
+        )}
+      </FilterStrip>
 
-      {/* ── The reporting band (DES-FEEDBACK-003 §4.3, slice P): the page's
-             derived numbers promoted into the shared MetricTile dress, ABOVE
-             the untouched list (EC28); every tile answers its named question
-             (EC19); the old stat cards are superseded by this band. ── */}
-      <div className="px-8">
-        <TileBand testId="chats-dashboard-tiles">
-          <ChatsOverTimeTile chats={chats} range={range} />
-          <MetricTile
-            testId="chats-active-tile"
-            question="How many threads are warm?"
-            title="Active now"
-            // Round 2, J4 minor / EC39: the headline counts what THIS SCREEN
-            // shows — live pool sessions (the band below) plus non-terminal
-            // chat runs in the selected range — and labels each part, so
-            // "0 of 0" can never sit beside a visible live row.
-            value={
-              liveCount > 0
-                ? `${liveCount} live session${liveCount === 1 ? '' : 's'} · ${active.length} chat run${active.length === 1 ? '' : 's'} ${windowWordOf(range)}`
-                : `${active.length} of ${chats.length} chat runs ${windowWordOf(range)}`
-            }
-            data={{ 'data-count': active.length + liveCount, 'data-live': liveCount }}
-          >
-            <p
-              className="text-lg font-semibold leading-none"
-              style={{
-                margin: 0,
-                color: active.length + liveCount > 0 ? 'var(--status-run)' : 'var(--ink-dim)',
-              }}
-            >
-              {active.length + liveCount}
-            </p>
-          </MetricTile>
-          <GatesWaitingTile
-            gates={chatGates}
-            question="Did a conversation stall on me?"
-            title="Gates from chats"
-            testId="chats-gates-tile"
-          />
-        </TileBand>
-      </div>
-
-      {/* ── Live sessions (DES-UX-001 §7.9-5): warm seats, findable + endable.
-             Absent entirely when the daemon holds none — the run list below is
-             history; this band is the NOW. ── */}
-      {liveChats !== null && liveChats.length > 0 && (
-        <div className="px-8 flex flex-col gap-2" data-testid="live-chats" data-count={liveChats.length}>
-          <p
-            className="text-[10px] font-mono uppercase tracking-widest m-0"
-            style={{ color: 'var(--ink-dim)' }}
-          >
-            Live sessions — warm agent seats on the daemon
-          </p>
-          {liveChats.map((c) => {
-            const streaming = c.lastFrameAt !== 0 && Date.now() - c.lastFrameAt < STREAMING_WINDOW_MS;
+      {/* ── The grid: live sessions FIRST (the NOW), then chat-run history ── */}
+      {(visibleLive.length > 0 || visibleRuns.length > 0) && (
+        <DashboardGrid testId="chats-list" min={340}>
+          {visibleLive.map((c) => {
+            const streaming = c.lastFrameAt !== 0 && now - c.lastFrameAt < STREAMING_WINDOW_MS;
             return (
-              // J4/C6: a live row is a DOOR, not a plaque — clicking it (or
-              // Enter/Space with focus) opens the session at its real URL,
-              // `/chat/:id`, where the surface rejoins the warm seats. The End
-              // control stays its own gesture (stopPropagation).
+              // J4/C6: a live card is a DOOR — clicking it (or Enter/Space)
+              // opens the session at its real URL, `/chat/:id`, where the
+              // surface rejoins the warm seats. End stays its own gesture.
               <div
                 key={c.chatId}
                 data-testid="live-chat-row"
                 data-chat-id={c.chatId}
                 data-streaming={streaming}
-                role="button"
+                role="link"
                 tabIndex={0}
                 title="Open this live session"
                 onClick={() => navigate(`/chat/${encodeURIComponent(c.chatId)}`)}
@@ -304,82 +407,165 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
                     navigate(`/chat/${encodeURIComponent(c.chatId)}`);
                   }
                 }}
-                className="w-full flex items-center gap-3 rounded-2xl px-5 py-3 cursor-pointer"
-                style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+                className="transition-colors hover:bg-surface-raised"
+                style={CARD}
               >
-                <span className="text-sm font-mono truncate" style={{ color: 'var(--ink-high)' }}>
-                  {c.chatId.slice(0, 8)}
-                </span>
-                <span className="text-xs font-mono truncate" style={{ color: 'var(--ink-muted)' }}>
-                  {c.seats.length > 0 ? c.seats.join(' · ') : 'seats unknown'}
-                </span>
-                {streaming ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
                   <span
-                    data-testid="live-chat-streaming"
-                    title="A reply frame from this session was observed in the last 30s"
-                    className="text-[10px] font-mono px-2 py-0.5 rounded-full shrink-0"
-                    style={{ color: 'var(--status-run)', border: '1px solid var(--status-run-dim)' }}
+                    aria-hidden
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ background: 'var(--status-run)' }}
+                  />
+                  <span className="text-sm font-mono truncate" style={{ color: 'var(--ink-high)', minWidth: 0 }}>
+                    live · {c.chatId.slice(0, 8)}
+                  </span>
+                  {streaming ? (
+                    <span
+                      data-testid="live-chat-streaming"
+                      title="A reply frame from this session was observed in the last 30s"
+                      className="text-[10px] font-mono px-2 py-0.5 rounded-full shrink-0"
+                      style={{ color: 'var(--status-run)', border: '1px solid var(--status-run-dim)' }}
+                    >
+                      streaming now
+                    </span>
+                  ) : (
+                    <span className="text-[10px] font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>
+                      {c.idleSecs === null ? 'idle (age unknown)' : `idle ${Math.round(c.idleSecs)}s`}
+                    </span>
+                  )}
+                  <span style={{ flex: 1 }} />
+                  <button
+                    type="button"
+                    data-testid="live-chat-end"
+                    title="Disconnect this session's agents and end it"
+                    onClick={(e) => {
+                      e.stopPropagation(); // End is not Open
+                      endLiveChat(c.chatId);
+                    }}
+                    className="text-[11px] px-2.5 py-1 rounded-lg shrink-0"
+                    style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-overlay)', cursor: 'pointer' }}
                   >
-                    streaming now
-                  </span>
-                ) : (
-                  <span className="text-[10px] font-mono shrink-0" style={{ color: 'var(--ink-dim)' }}>
-                    {c.idleSecs === null ? 'idle (age unknown)' : `idle ${Math.round(c.idleSecs)}s`}
-                  </span>
-                )}
-                <div className="flex-1" />
-                <button
-                  type="button"
-                  data-testid="live-chat-end"
-                  title="Disconnect this session's agents and end it"
-                  onClick={(e) => {
-                    e.stopPropagation(); // End is not Open
-                    endLiveChat(c.chatId);
-                  }}
-                  className="text-[11px] px-2.5 py-1 rounded-lg shrink-0"
-                  style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-overlay)' }}
-                >
-                  End
-                </button>
+                    End
+                  </button>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                  {c.seats.length > 0
+                    ? <SeatChips seats={c.seats} />
+                    : <span style={CARD_META}>seats unknown</span>}
+                  <span style={{ ...CARD_META, marginLeft: 'auto' }}>warm on the daemon</span>
+                </div>
               </div>
             );
           })}
-        </div>
+          {visibleRuns.map((v) => {
+            const { session } = v;
+            const id = session.id;
+            return (
+              <div
+                key={id}
+                data-testid="chat-row"
+                data-run-id={id}
+                data-status={session.status}
+                role="link"
+                tabIndex={0}
+                onClick={() => onSelect(id)}
+                onKeyDown={(e) => { if (e.key === 'Enter') onSelect(id); }}
+                className="transition-colors hover:bg-surface-raised"
+                style={CARD}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                  <span
+                    aria-hidden
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ background: RUN_DOT[session.status] ?? 'var(--ink-dim)' }}
+                  />
+                  {/* Derived title (runTitle's grammar) — the raw prompt lives
+                      on the hover title, never the row. */}
+                  <span
+                    data-testid="chat-run-title"
+                    title={session.problem}
+                    style={{
+                      flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap', fontSize: 'var(--text-xs)',
+                      fontFamily: 'var(--font-sans)', color: 'var(--ink-body)',
+                    }}
+                  >
+                    {humanTitle(session.problem)}
+                  </span>
+                  <span className="shrink-0" style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
+                    {session.status}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                  <SeatChips seats={session.clis} />
+                  <span style={CARD_META}>
+                    {runShortId(id)} · #{session.attempt + 1} · {runWhenWord(attachedAt[id], now)}
+                  </span>
+                  <span style={{ flex: 1 }} />
+                  {session.status === 'awaiting_human' && (
+                    <button
+                      type="button"
+                      data-testid="chat-needs-you"
+                      data-run-id={id}
+                      title="Jump straight to this conversation's gate"
+                      onClick={(e) => { e.stopPropagation(); navigate(gateJump(id)); }}
+                      style={{
+                        flexShrink: 0, cursor: 'pointer',
+                        background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+                        borderRadius: 'var(--radius-full)', padding: '2px 10px',
+                        fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                        fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+                      }}
+                    >
+                      needs you →
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </DashboardGrid>
       )}
 
-      {/* ── List / Empty state (below the band, §4.3) ── */}
-      <div className="px-8 pb-8 flex flex-col gap-2" data-testid="chats-list">
-        {filtered.length === 0 ? (
-          // ONE truth per screen (J4/C6): "No chat sessions yet" may never sit
-          // beside a non-empty live band. With live sessions above, this rail
-          // says what it actually holds — recorded chat RUNS — and states the
-          // persistence boundary honestly (chat transcripts are not stored
-          // beyond the live session; there is no history wire to list here).
-          (liveChats?.length ?? 0) > 0 ? (
-            <div
-              data-testid="chats-empty-live"
-              className="rounded-2xl p-10 text-center"
-              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+      {/* ── The honest corpus boundary (J4/C6): live sessions but no recorded
+             chat runs — say WHY the history is empty, never "No chat sessions
+             yet" beside a live card. ── */}
+      {liveN > 0 && allChats.length === 0 && (
+        <p
+          data-testid="chats-empty-live"
+          style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+        >
+          No recorded chat runs — your live sessions are above. Chat transcripts
+          aren’t stored beyond the live session, so ended chats don’t appear here.
+        </p>
+      )}
+
+      {/* ── Empty states — every one carries its CTA ── */}
+      {visibleLive.length === 0 && visibleRuns.length === 0 && (
+        (allChats.length > 0 || liveN > 0) ? (
+          <p data-testid="chats-empty-filter" style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', fontStyle: 'italic' }}>
+            No conversations match this filter
+            {hiddenByWindow > 0 ? ` — ${hiddenByWindow} sit outside the ${rangeWord(range)} window` : ''}.{' '}
+            <button
+              type="button"
+              data-testid="chats-clear-filters"
+              onClick={() => { setChip('all'); setQuery(''); }}
+              style={{
+                background: 'none', border: 'none', padding: 0, font: 'inherit',
+                color: 'var(--ink-muted)', textDecoration: 'underline', cursor: 'pointer',
+              }}
             >
-              <p className="text-base font-mono font-semibold mb-3">
-                No recorded chat runs — your live sessions are above
-              </p>
-              <p className="text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
-                Open a live session to continue it. Chat transcripts aren’t stored
-                beyond the live session, so ended chats don’t appear here.
-              </p>
-            </div>
-          ) : (
+              clear filters
+            </button>
+          </p>
+        ) : (
           <div
             data-testid="chats-empty"
             className="rounded-2xl p-10 text-center"
             style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             <p className="text-base font-mono font-semibold mb-3">No chat sessions yet</p>
-            <p
-              className="text-sm font-mono"
-              style={{ color: 'var(--ink-muted)' }}
-            >
+            <p className="text-sm font-mono" style={{ color: 'var(--ink-muted)' }}>
               Chat sessions let you explore your repos, ask questions, and get answers
               without kicking off a full build workflow.
             </p>
@@ -394,29 +580,8 @@ export function ChatsPage({ runs, onSelect, navigate }: Props): React.ReactEleme
               </button>
             </p>
           </div>
-          )
-        ) : (
-          filtered.map(v => (
-            <button
-              key={v.session.id}
-              type="button"
-              data-testid="chat-row"
-              data-run-id={v.session.id}
-              onClick={() => onSelect(v.session.id)}
-              className="w-full text-left rounded-2xl px-5 py-4 transition-colors"
-              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
-            >
-              <p className="text-sm font-mono truncate" title={v.session.problem}>
-                {humanTitle(v.session.problem)}
-              </p>
-              <p className="text-xs mt-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
-                {v.session.id.slice(0, 8)} · {v.session.status}
-              </p>
-            </button>
-          ))
-        )}
-      </div>
-
+        )
+      )}
     </div>
   );
 }

--- a/src/components/MakeDashboard.tsx
+++ b/src/components/MakeDashboard.tsx
@@ -4,7 +4,7 @@ import { UNFILED_MOUNT } from '../api/interactive.js';
 import { gateOpenPath } from '../board/gateActions.js';
 import { outcomeOf } from '../board/metrics.js';
 import {
-  attachSeries, deltaWord, statusCounts, windowBuckets, windowDelta,
+  attachSeries, deltaWord, orderByAttention, statusCounts, windowBuckets, windowDelta,
 } from '../board/windowStats.js';
 import { useDismissable } from '../hooks/useDismissable.js';
 import { versionPath, type Mode } from '../hooks/useRoute.js';
@@ -43,16 +43,6 @@ interface Props {
   navigate: (path: string) => void;
   /** Where a run row lands — the caller's routing (flat `/runs/:id` here). */
   runPath: (id: string) => string;
-}
-
-const RUN_TERMINAL = new Set(['completed', 'cancelled', 'failed']);
-
-/** Needs-you FIRST, then active, then terminal — incoming order within groups. */
-function orderRuns(runs: SessionView[]): SessionView[] {
-  const gated = runs.filter((v) => v.session.status === 'awaiting_human');
-  const active = runs.filter((v) => v.session.status !== 'awaiting_human' && !RUN_TERMINAL.has(v.session.status));
-  const terminal = runs.filter((v) => RUN_TERMINAL.has(v.session.status));
-  return [...gated, ...active, ...terminal];
 }
 
 type StatusChip = 'all' | 'needs-you' | 'active' | 'failed' | 'done' | 'docs';
@@ -104,7 +94,7 @@ export function MakeDashboard({ runs, navigate, runPath }: Props): React.ReactEl
 
   // The spine (§4.2.2): non-chat runs — complete, all projects, needs-you first.
   const made = useMemo(
-    () => orderRuns(runs.filter((v) => !isChatRun(v) && v.session.archived_at == null)),
+    () => orderByAttention(runs.filter((v) => !isChatRun(v) && v.session.archived_at == null)),
     [runs],
   );
 

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -1,10 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { Project, RepoEntry, SessionView } from '../api/types.js';
+import { gateOpenPath } from '../board/gateActions.js';
+import {
+  matchesRepoChip, repoFleetModels, type RepoChip, type RepoFleetModel,
+} from '../board/repoStats.js';
+import {
+  attachSeries, deltaWord, healthColor, healthOf, statusCounts, windowBuckets, windowDelta,
+} from '../board/windowStats.js';
+import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useMembershipStore } from '../store/membership.js';
-import { TileBand } from './DashboardTiles.js';
-import { MetricTile } from './MetricTile.js';
+import { setRetryPrefill } from '../store/retryPrefill.js';
+import {
+  DashboardGrid, FilterStrip, KpiBand, KpiGroup, Sparkline, StatTile, type FilterChip,
+} from './dashboardKit.js';
 import { NewProjectModal } from './NewProjectModal.js';
+import { ago } from './ProjectCard.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
 
 type SourceMode = 'local' | 'remote';
@@ -23,7 +34,25 @@ interface Props {
   ambientProject?: string | null;
 }
 
-const TERMINAL = new Set(['completed', 'cancelled', 'failed']);
+/**
+ * The /repos landing as a COMMAND SURFACE (lane B, the 0.4.6 treatment): the
+ * fleet view of what the agents work ON. A KPI band organized around the
+ * command-center questions (performance / pipeline / risk), then one card per
+ * registered repo behind a first-class FilterStrip — needs-you floats first
+ * and jumps STRAIGHT to the waiting run's gate; Re-index is a PREFILL into
+ * the governed-run composer (the Retry-as-prefill idiom — never a hidden
+ * relaunch); the header keeps the section's creation verb (+ Add Repository,
+ * the existing register + onboard flow, untouched).
+ *
+ * Wire honesty: `GET /repos` serves the register only (name, path, branch,
+ * `registered_at` — NO index-freshness field), so the per-repo graph story is
+ * derived from the runs wire instead: the repo's newest onboarding run
+ * (completed = ready, failed = build failed, in flight = building, none on
+ * record = never onboarded). Windowed counts ride the shared positional
+ * window folds ("last 30", never a fabricated "30d"; "—" when no full prior
+ * bucket exists). Attach clocks read the membership mirror — never a new
+ * request; the old per-repo graph fan-out stays retired.
+ */
 
 function relativeTime(tsSeconds: number): string {
   const tsMs = tsSeconds * 1000;
@@ -46,146 +75,28 @@ const inputCss: React.CSSProperties = {
   width: '100%',
 };
 
-// ── The §4.4 reporting tiles (DES-FEEDBACK-003, slice P) ──────────────────────
-//
-// Every number derives from data this page ALREADY fetches (its own
-// `GET /repos` + `GET /runs`) or the membership mirror the board model keeps
-// warm — the tiles never cost a request. Runs are placed in time on the
-// membership attach clock (the one honest per-run clock; `AgentSession`
-// carries no timestamps), exactly as every other dashboard buckets; runs the
-// mirror cannot place inside the window are excluded, never painted at an
-// invented time. Per-repo language bars stay on the detail page (§4.4: a
-// cross-repo language wall answers no asked question — rejected per EC19).
+const CARD_STAT: React.CSSProperties = {
+  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-muted)',
+  whiteSpace: 'nowrap',
+};
 
-const DAY_MS = 86_400_000;
-const TILE_W = 168;
-const TILE_H = 26;
-const TOP_REPOS = 6;
-
-/** Group in-window runs by `repo_ref`, joined to display names via the page's
- *  repo list; count desc. Runs without a repo_ref or an in-window attach
- *  clock are excluded (and reported by the callers' data attributes). */
-function groupByRepo(
-  runs: SessionView[],
-  repos: RepoEntry[],
-  attachedAt: Record<string, number>,
-  windowMs: number,
-  at: number,
-): Array<{ id: string; name: string; count: number }> {
-  const names = new Map(repos.map((r) => [r.id, r.name]));
-  const counts = new Map<string, number>();
-  for (const v of runs) {
-    const ref = v.session.repo_ref;
-    if (ref === null) continue;
-    const clock = attachedAt[v.session.id];
-    if (clock === undefined || clock < at - windowMs || clock > at) continue;
-    counts.set(ref, (counts.get(ref) ?? 0) + 1);
-  }
-  return [...counts.entries()]
-    .map(([id, count]) => ({ id, name: names.get(id) ?? id, count }))
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+/** The graph-state line's words — one honest sentence per state. */
+function graphStateWord(m: RepoFleetModel, attachedAt: Record<string, number>, now: number): string {
+  const { state, run } = m.onboard;
+  const clock = run === null ? undefined : attachedAt[run.session.id];
+  const when = clock === undefined ? '' : ` · ${ago(clock, now)} ago`;
+  if (state === 'ready') return `graph ready — onboard completed${when}`;
+  if (state === 'onboarding') return 'onboarding now — index + annotate in flight';
+  if (state === 'failed') return `onboard FAILED${when} — the graph may be stale or absent`;
+  return 'never onboarded — no onboard run on record';
 }
 
-/** §4.4 row 1 — "Where is the work concentrating?": 7d runs per repo, top 6,
- *  horizontal bars. */
-function RunsPerRepoTile({ runs, repos, attachedAt, now }: {
-  runs: SessionView[];
-  repos: RepoEntry[];
-  attachedAt: Record<string, number>;
-  now?: number;
-}): React.ReactElement {
-  const at = now ?? Date.now();
-  const grouped = useMemo(
-    () => groupByRepo(runs, repos, attachedAt, 7 * DAY_MS, at),
-    [runs, repos, attachedAt, at],
-  );
-  const top = grouped.slice(0, TOP_REPOS);
-  const placed = grouped.reduce((a, g) => a + g.count, 0);
-  const max = top[0]?.count ?? 0;
-  const rowH = TILE_H / Math.max(1, top.length);
-  return (
-    <MetricTile
-      testId="runs-per-repo-tile"
-      question="Where is the work concentrating?"
-      title="Runs per repo (7d)"
-      value={top.length === 0 ? 'no repo-linked runs in 7d' : `${top[0]!.name} leads (${top[0]!.count})`}
-      data={{ 'data-total': placed, 'data-repos': grouped.length }}
-    >
-      {top.length === 0 ? (
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-          No runs carried a repo in the last 7 days.
-        </p>
-      ) : (
-        <svg
-          width="100%"
-          height={TILE_H}
-          viewBox={`0 0 ${TILE_W} ${TILE_H}`}
-          preserveAspectRatio="none"
-          role="img"
-          aria-label={`runs per repo, 7d: ${top.map((g) => `${g.name} ${g.count}`).join(', ')}`}
-          style={{ display: 'block' }}
-        >
-          {top.map((g, i) => (
-            <rect
-              key={g.id}
-              x={0}
-              y={i * rowH + 1}
-              width={(g.count / max) * TILE_W}
-              height={Math.max(2, rowH - 2)}
-              rx={1}
-              fill="var(--accent)"
-            >
-              <title>{`${g.name}: ${g.count}`}</title>
-            </rect>
-          ))}
-        </svg>
-      )}
-    </MetricTile>
-  );
-}
-
-/** §4.4 row 3 — "Is any repo a failure hotspot?": 24h failed runs by repo. */
-function FailingReposTile({ runs, repos, attachedAt, now }: {
-  runs: SessionView[];
-  repos: RepoEntry[];
-  attachedAt: Record<string, number>;
-  now?: number;
-}): React.ReactElement {
-  const at = now ?? Date.now();
-  const failing = useMemo(
-    () => groupByRepo(
-      runs.filter((v) => v.session.status === 'failed'),
-      repos, attachedAt, DAY_MS, at,
-    ),
-    [runs, repos, attachedAt, at],
-  );
-  const failures = failing.reduce((a, g) => a + g.count, 0);
-  return (
-    <MetricTile
-      testId="failing-repos-tile"
-      question="Is any repo a failure hotspot?"
-      title="Failing repos (24h)"
-      value={failing.length === 0 ? 'none' : `${failures} failed in ${failing.length} repo${failing.length === 1 ? '' : 's'}`}
-      data={{ 'data-count': failing.length, 'data-failures': failures }}
-    >
-      {failing.length === 0 ? (
-        <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-          No repo-linked failures in the last 24h.
-        </p>
-      ) : (
-        <p
-          style={{
-            margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--status-fail)',
-            fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {failing.map((g) => `${g.name} (${g.count})`).join(' · ')}
-        </p>
-      )}
-    </MetricTile>
-  );
-}
+const GRAPH_STATE_COLOR: Record<string, string> = {
+  ready: 'var(--ink-dim)',
+  onboarding: 'var(--status-run)',
+  failed: 'var(--status-fail)',
+  never: 'var(--status-gate)',
+};
 
 export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, ambientProject = null }: Props): React.ReactElement {
   const [repos, setRepos] = useState<RepoEntry[]>([]);
@@ -193,9 +104,12 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [chip, setChip] = useState<RepoChip>('all');
+  const { range, setRange } = useTimeRange('30d');
   // Attach clocks off the membership mirror (the board model keeps it warm) —
   // a store read, never a request (§4.4: tiles derive from data already held).
   const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
 
   const [rerunning, setRerunning] = useState<Record<string, boolean>>({});
   const [rerunError, setRerunError] = useState<Record<string, string>>({});
@@ -259,6 +173,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
     if (segment) setNewName(segment);
   }
 
+  /** The never-onboarded card's launch verb — the EXISTING onboard wire. */
   async function rerunOnboarding(repoId: string): Promise<void> {
     setRerunning((prev) => ({ ...prev, [repoId]: true }));
     setRerunError((prev) => ({ ...prev, [repoId]: '' }));
@@ -273,6 +188,29 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
     } finally {
       setRerunning((prev) => ({ ...prev, [repoId]: false }));
     }
+  }
+
+  /**
+   * Re-index as PREFILL (the Retry-as-prefill idiom, DES-UX-001 §4.3): the
+   * repo's recorded onboard run's setup is deposited for the composer and the
+   * operator lands on `/runs/new` to tweak-before-send — nothing auto-launches,
+   * no POST fires here.
+   */
+  function reindexAsPrefill(m: RepoFleetModel): void {
+    const run = m.onboard.run;
+    if (run === null) return; // never-onboarded repos keep the launch verb instead
+    const s = run.session;
+    setRetryPrefill({
+      retryOf: s.id,
+      problem: s.problem,
+      clis: s.clis,
+      workflowId: s.workflow_id || null,
+      repoRef: m.repo.id,
+      entityMode: s.entity_mode,
+      humanConfirm: s.human_confirm,
+      projectId: typeof s.project_id === 'string' ? s.project_id : null,
+    });
+    navigate('/runs/new');
   }
 
   async function registerRepo(): Promise<void> {
@@ -322,61 +260,180 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
     newName.trim() && (sourceMode === 'remote' ? newGitUrl.trim() : newPath.trim()),
   );
 
-  const activeRuns = runs.filter((r) => !TERMINAL.has(r.session.status));
+  // ── The window + KPI folds (the shared positional idiom) ────────────────────
+  const now = Date.now();
+  const repoRuns = useMemo(
+    () => runs.filter((v) => v.session.archived_at == null && v.session.repo_ref !== null),
+    [runs],
+  );
+  const buckets = useMemo(() => windowBuckets(repoRuns, range), [repoRuns, range]);
+  const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
+  const liveCounts = useMemo(() => statusCounts(repoRuns), [repoRuns]);
+  const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
+  const failedDelta = useMemo(
+    () => windowDelta(buckets, (rs) => rs.filter((v) => v.session.status === 'failed').length),
+    [buckets],
+  );
+  const runSpark = useMemo(
+    () => attachSeries(buckets.current.map((v) => v.session.id), attachedAt, 14, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` re-derives with the data, not a timer
+    [buckets, attachedAt],
+  );
 
-  const filteredRepos =
-    search.trim() === ''
-      ? repos
-      : repos.filter((r) => r.name.toLowerCase().includes(search.trim().toLowerCase()));
+  // ── The fleet models — one fold per card, shared by grid, chips and tiles ──
+  const fleet = useMemo(
+    () => repoFleetModels(repos, repoRuns, attachedAt, windowIds),
+    [repos, repoRuns, attachedAt, windowIds],
+  );
+  const activeRepoN = fleet.filter((m) => m.activeNow).length;
+  const readyN = fleet.filter((m) => m.onboard.state === 'ready').length;
+  const gapFailedN = fleet.filter((m) => m.onboard.state === 'failed').length;
+  const gapNeverN = fleet.filter((m) => m.onboard.state === 'never').length;
 
-  function repoActiveRunCount(repoId: string): number {
-    return activeRuns.filter((r) => r.session.repo_ref === repoId).length;
-  }
+  /** The gate jump: the run's thread AT the gate when its project is known;
+   *  the flat run detail (where the approval dock lives) when unfiled. */
+  const gateJump = (id: string): string => {
+    const pid = projectIdByRun[id];
+    return pid !== undefined ? gateOpenPath(pid, id) : `/runs/${encodeURIComponent(id)}`;
+  };
+
+  // ── Filtering ────────────────────────────────────────────────────────────────
+  const q = search.trim().toLowerCase();
+  const searched = fleet.filter((m) =>
+    q === ''
+    || m.repo.name.toLowerCase().includes(q)
+    || m.repo.root_path.toLowerCase().includes(q));
+  const visible = searched.filter((m) => matchesRepoChip(m, chip));
+
+  const chipCounts = useMemo(() => {
+    const counts: Record<RepoChip, number> = { all: 0, 'needs-you': 0, active: 0, failing: 0, ready: 0, never: 0 };
+    for (const m of searched) {
+      counts.all += 1;
+      for (const c of ['needs-you', 'active', 'failing', 'ready', 'never'] as const) {
+        if (matchesRepoChip(m, c)) counts[c] += 1;
+      }
+    }
+    return counts;
+  }, [searched]);
+
+  const chips: FilterChip[] = [
+    { id: 'all', label: 'All', count: chipCounts.all },
+    { id: 'needs-you', label: 'Needs you', count: chipCounts['needs-you'] },
+    { id: 'active', label: 'Active', count: chipCounts.active },
+    { id: 'failing', label: 'Failing', count: chipCounts.failing },
+    { id: 'ready', label: 'Ready', count: chipCounts.ready },
+    { id: 'never', label: 'Never onboarded', count: chipCounts.never },
+  ];
 
   return (
     <div className="h-full overflow-y-auto">
-      {/* ── Header ── */}
-      <div className="px-8 pt-8 pb-4">
-        <div className="flex items-center gap-3 mb-5">
-          <h1
-            className="text-base font-bold font-mono flex-1"
-            style={{ color: 'var(--ink-high)', letterSpacing: '-0.01em' }}
-          >
-            Repositories
-          </h1>
-          <input
-            style={{
-              background: 'var(--surface-card)',
-              border: '1px solid var(--surface-raised)',
-              color: 'var(--ink-high)',
-              borderRadius: '6px',
-              padding: '6px 12px',
-              fontSize: '12px',
-              fontFamily: 'var(--wk-font-mono, monospace)',
-              outline: 'none',
-              width: '200px',
-            }}
-            placeholder="Search repos…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
+      {/* FULL WIDTH — the fleet flows with the viewport; no max-width column. */}
+      <div
+        data-testid="repos-page"
+        className="flex flex-col"
+        style={{ color: 'var(--ink-high)', padding: '0 var(--space-8) var(--space-8)', gap: 'var(--space-4)' }}
+      >
+        {/* ── Header: the section name + its creation verb ── */}
+        <div className="pt-8 flex items-center justify-between gap-4">
+          <div className="flex items-baseline gap-4 min-w-0">
+            <h1 className="text-2xl font-semibold font-mono" style={{ margin: 0 }}>Repositories</h1>
+            <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-sans)' }}>
+              the fleet the agents work on — graphs · runs · gates
+            </p>
+          </div>
           <button
             type="button"
+            data-testid="repos-add"
             onClick={() => {
               if (showRegister) { setShowRegister(false); navigate('/repos'); }
               else { setShowRegister(true); navigate('/repos/new'); }
             }}
-            className="shrink-0 rounded-lg px-4 py-1.5 text-xs font-semibold font-mono"
-            style={{ background: showRegister ? 'var(--surface-raised)' : 'var(--accent)', color: showRegister ? 'var(--ink-high)' : 'var(--accent-fg)' }}
+            className="shrink-0 rounded-lg px-4 py-2 text-sm font-semibold font-mono"
+            style={{
+              background: showRegister ? 'var(--surface-raised)' : 'var(--accent)',
+              color: showRegister ? 'var(--ink-high)' : 'var(--accent-fg)',
+              border: 'none', cursor: 'pointer',
+            }}
           >
             {showRegister ? 'Cancel' : '+ Add Repository'}
           </button>
         </div>
 
-        {/* ── Registration form ── */}
+        {/* ── The KPI band — the command-center model: three questions ── */}
+        {!loading && !error && (
+          <KpiBand testId="repos-kpis">
+            <KpiGroup label="Performance" grow={2}>
+              <StatTile
+                testId="stat-repos"
+                label="Repositories"
+                value={repos.length}
+                context={repos.length === 0 ? 'none registered' : `newest ${relativeTime(Math.max(...repos.map((r) => r.registered_at)))}`}
+                title="Every registered repo — click to clear filters"
+                onOpen={() => { setChip('all'); setSearch(''); }}
+              />
+              <StatTile
+                testId="stat-repo-runs"
+                label="Repo runs"
+                value={buckets.current.length}
+                delta={runsDelta}
+                context={deltaWord(range, runsDelta)}
+                spark={runSpark}
+                title="Runs touching a repo in the window — open the Work list"
+                href="/work"
+                onOpen={() => navigate('/work')}
+              />
+            </KpiGroup>
+            <KpiGroup label="Pipeline" grow={2}>
+              <StatTile
+                testId="stat-active"
+                label="Active now"
+                value={liveCounts.active}
+                context={activeRepoN > 0 ? `across ${activeRepoN} repo${activeRepoN === 1 ? '' : 's'}` : 'right now'}
+                title="Runs moving on a repo — filter the fleet to them"
+                onOpen={() => setChip('active')}
+              />
+              <StatTile
+                testId="stat-ready"
+                label="Graphs ready"
+                value={readyN}
+                context={`of ${repos.length} repo${repos.length === 1 ? '' : 's'} onboarded`}
+                title="Repos whose newest onboard run completed — filter to them"
+                onOpen={() => setChip('ready')}
+              />
+            </KpiGroup>
+            <KpiGroup label="Risk" grow={2}>
+              <StatTile
+                testId="stat-failed"
+                label="Failed"
+                value={failedDelta.current}
+                valueColor={failedDelta.current > 0 ? 'var(--status-fail)' : undefined}
+                delta={failedDelta}
+                deltaSense="bad-up"
+                context={deltaWord(range, failedDelta)}
+                title="Failed repo-linked runs in the window — filter the fleet"
+                onOpen={() => setChip('failing')}
+              />
+              <StatTile
+                testId="stat-gaps"
+                label="Index gaps"
+                value={gapFailedN + gapNeverN}
+                valueColor={gapFailedN > 0 ? 'var(--status-fail)' : undefined}
+                context={
+                  gapFailedN + gapNeverN === 0
+                    ? 'every graph ready'
+                    : `${gapFailedN} onboard failed · ${gapNeverN} never onboarded`
+                }
+                title="Repos without a completed onboard — the graph story is derived from the run history (the repos wire carries no index-freshness field)"
+                onOpen={() => setChip(gapFailedN > 0 ? 'failing' : 'never')}
+              />
+            </KpiGroup>
+          </KpiBand>
+        )}
+
+        {/* ── Registration form (the slice-B flow, untouched) ── */}
         {showRegister && (
           <div
-            className="flex flex-col gap-3 rounded-2xl p-5 mb-5"
+            className="flex flex-col gap-3 rounded-2xl p-5"
             style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
           >
             {/* §5.2: the project field is the FIRST field — Unfiled by default;
@@ -508,36 +565,20 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
         {showNewProject && (
           <NewProjectModal navigate={navigate} onClose={() => setShowNewProject(false)} />
         )}
-      </div>
 
-      <div className="px-8 pb-10">
-        {/* ── The reporting band (§4.4, EC19/EC28): three tiles ABOVE the
-               register, from data this page already fetched + the membership
-               mirror — never a new request. The old stat cards (numbers
-               without named questions) are superseded by this band; their
-               Total Repos count lives on in the repo-count tile, and the
-               Tracked card's per-repo graph fan-out on mount is retired with
-               it (a mount cost the fetch budget bans). ── */}
-        {!loading && !error && (
-          <div className="mb-6">
-            <TileBand testId="repos-dashboard-tiles">
-              <RunsPerRepoTile runs={runs} repos={repos} attachedAt={attachedAt} />
-              <MetricTile
-                testId="repo-count-tile"
-                question="Is the estate growing?"
-                title="Repositories"
-                value={repos.length === 0 ? 'none registered' : `${repos.length} registered`}
-                data={{ 'data-count': repos.length }}
-              >
-                <p style={{ margin: 0, fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}>
-                  {repos.length === 0
-                    ? 'Register the first repository to grow the estate.'
-                    : `newest: ${relativeTime(Math.max(...repos.map((r) => r.registered_at)))}`}
-                </p>
-              </MetricTile>
-              <FailingReposTile runs={runs} repos={repos} attachedAt={attachedAt} />
-            </TileBand>
-          </div>
+        {/* ── Filters — first-class at the top of the fleet ── */}
+        {!loading && !error && repos.length > 0 && (
+          <FilterStrip
+            testId="repos-filter"
+            query={search}
+            onQuery={setSearch}
+            placeholder="Search repos…"
+            chips={chips}
+            active={chip}
+            onChip={(id) => setChip(id as RepoChip)}
+            range={range}
+            onRange={setRange}
+          />
         )}
 
         {/* ── Content area ── */}
@@ -548,7 +589,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
         ) : error ? (
           <p className="text-xs font-mono" style={{ color: 'var(--status-fail)' }}>{error}</p>
         ) : repos.length === 0 ? (
-          /* Empty state */
+          /* Empty state — carries the section's creation verb */
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <div
               className="rounded-2xl p-10 flex flex-col items-center gap-4"
@@ -571,76 +612,141 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
               </button>
             </div>
           </div>
-        ) : filteredRepos.length === 0 ? (
-          <p className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
-            No repos match &ldquo;{search}&rdquo;.
+        ) : visible.length === 0 ? (
+          <p data-testid="repos-empty-filter" className="text-xs font-mono" style={{ color: 'var(--ink-dim)' }}>
+            No repos match —{' '}
+            <button
+              type="button"
+              data-testid="repos-clear-filters"
+              onClick={() => { setChip('all'); setSearch(''); }}
+              style={{ background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'var(--ink-muted)', textDecoration: 'underline', cursor: 'pointer' }}
+            >
+              clear filters
+            </button>
           </p>
         ) : (
-          /* Repo cards grid */
-          <div className="grid grid-cols-2 gap-4" data-testid="repos-list">
-            {filteredRepos.map((repo) => {
-              const activeCount = repoActiveRunCount(repo.id);
+          /* ── The fleet grid — one mini-dashboard card per repo ── */
+          <DashboardGrid testId="repos-list" min={360}>
+            {visible.map((m) => {
+              const { repo, counts, waiting } = m;
+              const health = healthOf(counts.done, counts.terminal);
               const isRerunning = rerunning[repo.id] ?? false;
               const runErr = rerunError[repo.id];
+              const firstGate = waiting[0]?.session.id;
+              const spark = attachSeries(m.windowed.map((v) => v.session.id), attachedAt, 14, now);
+              const activeCount = m.windowed.filter((v) => !['completed', 'cancelled', 'failed', 'awaiting_human'].includes(v.session.status)).length;
               return (
                 <div
                   key={repo.id}
                   data-testid="repo-card"
                   data-repo-id={repo.id}
-                  className="rounded-2xl p-5 flex flex-col gap-3 cursor-pointer transition-colors"
-                  style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
-                  onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}
-                  role="button"
+                  data-state={m.onboard.state}
+                  data-gates={waiting.length}
+                  data-runs={counts.total}
+                  role="link"
                   tabIndex={0}
+                  onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       navigate('/repo-detail/' + encodeURIComponent(repo.id));
                     }
                   }}
+                  className="transition-colors hover:bg-surface-raised"
+                  style={{
+                    display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
+                    background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+                    borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', cursor: 'pointer',
+                  }}
                 >
-                  {/* Card header */}
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <p
-                        className="text-sm font-bold font-mono truncate"
-                        style={{ color: 'var(--ink-high)' }}
+                  {/* Card header — name, then the attention badges */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                    <span
+                      className="text-sm font-bold font-mono truncate"
+                      style={{ color: 'var(--ink-high)', minWidth: 0 }}
+                    >
+                      {repo.name}
+                    </span>
+                    <span style={{ flex: 1 }} />
+                    {/* Attention routing beats navigation: the gate jump,
+                        STRAIGHT to the waiting run's approval dock. */}
+                    {waiting.length > 0 && firstGate !== undefined && (
+                      <button
+                        type="button"
+                        data-testid="repo-needs-you"
+                        data-run-id={firstGate}
+                        title="A run on this repo is waiting on you — jump to its gate"
+                        onClick={(e) => { e.stopPropagation(); navigate(gateJump(firstGate)); }}
+                        style={{
+                          flexShrink: 0, cursor: 'pointer',
+                          background: 'var(--status-gate-dim)', border: '1px solid var(--status-gate-dim)',
+                          borderRadius: 'var(--radius-full)', padding: '2px 10px',
+                          fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                          fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
+                        }}
                       >
-                        {repo.name}
-                      </p>
-                      <p
-                        className="text-[11px] font-mono mt-0.5 truncate"
-                        style={{ color: 'var(--ink-dim)' }}
-                        title={repo.root_path}
-                      >
-                        {repo.root_path}
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      {activeCount > 0 && (
-                        <span
-                          className="rounded-full px-2 py-0.5 text-[10px] font-mono font-semibold"
-                          style={{ background: 'var(--status-run-dim)', color: 'var(--status-run)' }}
-                        >
-                          {activeCount} active
-                        </span>
-                      )}
+                        needs you · {waiting.length} →
+                      </button>
+                    )}
+                    {activeCount > 0 && (
                       <span
-                        className="rounded-full px-2 py-0.5 text-[10px] font-mono"
-                        style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
+                        className="rounded-full px-2 py-0.5 text-[10px] font-mono font-semibold shrink-0"
+                        style={{ background: 'var(--status-run-dim)', color: 'var(--status-run)' }}
                       >
-                        {repo.default_branch}
+                        {activeCount} active
                       </span>
-                    </div>
+                    )}
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[10px] font-mono shrink-0"
+                      style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
+                    >
+                      {repo.default_branch}
+                    </span>
                   </div>
 
-                  {/* Timestamp */}
-                  <p className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
-                    {relativeTime(repo.registered_at)}
+                  <p
+                    className="text-[11px] font-mono truncate"
+                    style={{ color: 'var(--ink-dim)', margin: 0 }}
+                    title={repo.root_path}
+                  >
+                    {repo.root_path}
                   </p>
 
-                  {/* Error (if onboard failed) */}
+                  {/* The graph state — derived from the run history, honestly */}
+                  <p
+                    data-testid="repo-graph-state"
+                    data-state={m.onboard.state}
+                    className="text-[11px] font-mono truncate"
+                    style={{ color: GRAPH_STATE_COLOR[m.onboard.state] ?? 'var(--ink-dim)', margin: 0 }}
+                    title="Derived from the repo's newest onboarding run — the repos wire carries no index-freshness field"
+                  >
+                    {graphStateWord(m, attachedAt, now)}
+                  </p>
+
+                  {/* Stats row — the window's counts, the honest clocks */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+                    <span style={CARD_STAT} data-testid="repo-card-runs">
+                      {counts.total} run{counts.total === 1 ? '' : 's'} · {rangeWord(range)}
+                    </span>
+                    {counts.terminal > 0 && (
+                      <span
+                        style={{ ...CARD_STAT, color: healthColor(health) ?? CARD_STAT.color }}
+                        data-testid="repo-card-split"
+                        data-health={health}
+                        title={`${counts.done} succeeded, ${counts.failed} failed of ${counts.terminal} finished in this window`}
+                      >
+                        ✓{counts.done} · ✕{counts.failed}
+                      </span>
+                    )}
+                    <span style={{ ...CARD_STAT, marginLeft: 'auto' }} title="last activity (run attach clocks; falls back to the registration date)">
+                      {m.lastAt !== null ? `${ago(m.lastAt, now)} ago` : relativeTime(repo.registered_at)}
+                    </span>
+                  </div>
+
+                  <Sparkline counts={spark} height={18} />
+
+                  {/* Error (if a launch failed) */}
                   {runErr && (
-                    <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
+                    <p className="text-[11px] font-mono" style={{ color: 'var(--status-fail)', margin: 0 }}>
                       {runErr}
                     </p>
                   )}
@@ -656,28 +762,48 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                       type="button"
                       onClick={() => navigate('/repo-detail/' + encodeURIComponent(repo.id))}
                       className="text-xs font-mono hover:underline"
-                      style={{ color: 'var(--accent)' }}
+                      style={{ color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
                     >
                       View →
                     </button>
-                    <button
-                      type="button"
-                      disabled={isRerunning}
-                      onClick={() => void rerunOnboarding(repo.id)}
-                      className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
-                      style={{
-                        background: 'var(--surface-raised)',
-                        color: 'var(--ink-muted)',
-                        border: '1px solid var(--surface-raised)',
-                      }}
-                    >
-                      {isRerunning ? 'Starting…' : 'Onboard'}
-                    </button>
+                    {m.onboard.run !== null ? (
+                      <button
+                        type="button"
+                        data-testid="repo-reindex"
+                        data-repo-id={repo.id}
+                        title="Reopen the composer prefilled with this repo's onboard setup — nothing auto-launches"
+                        onClick={() => reindexAsPrefill(m)}
+                        className="rounded-md px-3 py-1 text-[11px] font-mono"
+                        style={{
+                          background: 'transparent',
+                          color: 'var(--ink-muted)',
+                          border: '1px solid var(--surface-raised)',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Re-index
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        data-testid="repo-onboard"
+                        disabled={isRerunning}
+                        onClick={() => void rerunOnboarding(repo.id)}
+                        className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
+                        style={{
+                          background: 'var(--surface-raised)',
+                          color: 'var(--ink-muted)',
+                          border: '1px solid var(--surface-raised)',
+                        }}
+                      >
+                        {isRerunning ? 'Starting…' : 'Onboard'}
+                      </button>
+                    )}
                   </div>
                 </div>
               );
             })}
-          </div>
+          </DashboardGrid>
         )}
       </div>
     </div>

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -590,7 +590,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
           <p className="text-xs font-mono" style={{ color: 'var(--status-fail)' }}>{error}</p>
         ) : repos.length === 0 ? (
           /* Empty state — carries the section's creation verb */
-          <div className="flex flex-col items-center justify-center py-24 text-center">
+          <div data-testid="repos-empty" className="flex flex-col items-center justify-center py-24 text-center">
             <div
               className="rounded-2xl p-10 flex flex-col items-center gap-4"
               style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)', maxWidth: 420 }}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.6",
   "counts": {
     "files": 116,
-    "occurrences": 886,
-    "static": 758,
+    "occurrences": 887,
+    "static": 759,
     "dynamic": 42,
     "computed": 6
   },
@@ -2839,6 +2839,12 @@
     },
     {
       "testId": "repos-clear-filters",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repos-empty",
       "files": [
         "src/components/RepositoriesPanel.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.6",
   "counts": {
     "files": 116,
-    "occurrences": 871,
-    "static": 743,
+    "occurrences": 886,
+    "static": 758,
     "dynamic": 42,
     "computed": 6
   },
@@ -596,6 +596,12 @@
       ]
     },
     {
+      "testId": "chat-needs-you",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
       "testId": "chat-project-row",
       "files": [
         "src/components/GroupChat.tsx"
@@ -632,6 +638,18 @@
       ]
     },
     {
+      "testId": "chat-run-title",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chat-seat",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
       "testId": "chat-send-failed",
       "files": [
         "src/components/GroupChat.tsx"
@@ -662,7 +680,19 @@
       ]
     },
     {
+      "testId": "chats-clear-filters",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
       "testId": "chats-empty",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chats-empty-filter",
       "files": [
         "src/components/ChatsPage.tsx"
       ]
@@ -674,7 +704,19 @@
       ]
     },
     {
-      "testId": "chats-list",
+      "testId": "chats-hidden-chip",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chats-new",
+      "files": [
+        "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chats-page",
       "files": [
         "src/components/ChatsPage.tsx"
       ]
@@ -1910,12 +1952,6 @@
       ]
     },
     {
-      "testId": "live-chats",
-      "files": [
-        "src/components/ChatsPage.tsx"
-      ]
-    },
-    {
       "testId": "live-edge",
       "files": [
         "src/components/LiveEdge.tsx"
@@ -2748,9 +2784,39 @@
       ]
     },
     {
+      "testId": "repo-card-runs",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repo-card-split",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
       "testId": "repo-chip",
       "files": [
         "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "repo-graph-state",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repo-needs-you",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repo-onboard",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
       ]
     },
     {
@@ -2760,7 +2826,31 @@
       ]
     },
     {
-      "testId": "repos-list",
+      "testId": "repo-reindex",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repos-add",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repos-clear-filters",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repos-empty-filter",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
+      ]
+    },
+    {
+      "testId": "repos-page",
       "files": [
         "src/components/RepositoriesPanel.tsx"
       ]

--- a/tests/ChatsPage.dashboard.test.tsx
+++ b/tests/ChatsPage.dashboard.test.tsx
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { makeView } from './factories.js';
 
 /**
- * The /chats dashboard (DES-FEEDBACK-003 §4.3, slice P): the page's derived
- * numbers promoted into the tile band, above the untouched list. Pinned here:
- * the three §4.3 tiles with their named questions (EC19/EC28), the partition
- * invariant (the list is exactly the isChatRun set), the attach-clock honesty
- * of the chats-over-time tile, gate scoping to the chat partition, the
- * preserved search/time-range/list affordances, and the zero-requests-on-
- * mount discipline (the page reads props + loaded stores only).
+ * The /chats landing as a COMMAND SURFACE (lane B, the 0.4.6 treatment).
+ * Pinned here: the KPI band under the three operator questions with honest
+ * window deltas ("—" when no full prior bucket exists), the partition
+ * invariant (the grid is exactly the isChatRun set), needs-you-first
+ * ordering + the gate jump, derived titles + seat chips off the wire's own
+ * fields, the first-class FilterStrip, and the fetch budget — exactly ONE
+ * declared GET /chats on mount, nothing else.
  */
 
 const { ChatsPage, isChatRun } = await import('../src/components/ChatsPage.js');
@@ -18,11 +18,13 @@ const { useMembershipStore } = await import('../src/store/membership.js');
 
 const NOW = Date.now();
 
-/** 3 chat runs (one active, one legacy-unstamped, one done) + 2 build runs. */
+/** 3 chat runs (one gated, one active, one legacy-unstamped done, one failed)
+ *  + 2 build runs the partition must exclude. */
 const RUNS = [
-  makeView({ id: 'c-live', workflow_id: 'chat', status: 'executing', problem: 'talk through the uploader' }),
-  makeView({ id: 'c-gated', workflow_id: 'chat', status: 'awaiting_human', problem: 'which auth flow?' }),
+  makeView({ id: 'c-live', workflow_id: 'chat', status: 'executing', problem: 'talk through the uploader', clis: ['claude', 'codex'] }),
+  makeView({ id: 'c-gated', workflow_id: 'chat', status: 'awaiting_human', problem: 'which auth flow?', clis: ['claude'] }),
   makeView({ id: 'c-legacy', workflow_id: undefined as unknown as string, status: 'completed', problem: 'old thread' }),
+  makeView({ id: 'c-broken', workflow_id: 'chat', status: 'failed', problem: 'the flaky session' }),
   makeView({ id: 'b-build', workflow_id: 'wf-w2', status: 'executing', problem: 'build the thing' }),
   makeView({ id: 'b-gated', workflow_id: 'wf-w2', status: 'awaiting_human', problem: 'approve the plan?' }),
 ];
@@ -31,68 +33,71 @@ function gate(runId: string, prompt: string, receivedAt: number): void {
   useGateStore.getState().setGate({ runId, ord: 0, prompt, lifecycle: 'open', receivedAt });
 }
 
-function page(onSelect: (id: string) => void = () => {}): ReturnType<typeof render> {
-  return render(<ChatsPage runs={RUNS} onSelect={onSelect} navigate={() => {}} />);
+function page(
+  onSelect: (id: string) => void = () => {},
+  navigate: (path: string) => void = () => {},
+): ReturnType<typeof render> {
+  return render(<ChatsPage runs={RUNS} onSelect={onSelect} navigate={navigate} />);
 }
 
 beforeEach(() => {
   useGateStore.setState({ gates: {} });
   useMembershipStore.setState({
     projectNameByRun: {},
-    // c-live placed 2h ago, c-gated 3 days ago; c-legacy has NO attach clock
-    // (unfiled) — the tile must exclude it honestly, never invent a time.
+    projectIdByRun: { 'c-gated': 'p-auth' },
+    // c-live placed 2h ago, c-gated 3 days ago; the rest have NO attach clock
+    // (unfiled) — the sparkline excludes them honestly, never invents a time.
     attachedAtByRun: { 'c-live': NOW - 2 * 3_600_000, 'c-gated': NOW - 3 * 86_400_000 },
   });
 });
 afterEach(() => cleanup());
 
-describe('the tile band (§4.3, EC19/EC28)', () => {
-  it('renders the three tiles with their named questions, above the untouched list', () => {
+describe('the KPI band — performance / pipeline / risk', () => {
+  it('renders the six tiles above the grid with live values', () => {
     page();
-    const band = screen.getByTestId('chats-dashboard-tiles');
-    const q = (tid: string): string | null =>
-      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
-    expect(q('chats-over-time-tile')).toBe('Is conversation increasing or drying up?');
-    expect(q('chats-active-tile')).toBe('How many threads are warm?');
-    expect(q('chats-gates-tile')).toBe('Did a conversation stall on me?');
+    const band = screen.getByTestId('chats-kpis');
+    const value = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
+    expect(value('stat-chats')).toBe('4');       // the windowed chat partition
+    expect(value('stat-live-seats')).toBe('0');  // GET /chats unmocked → no live pool
+    expect(value('stat-active')).toBe('1');      // c-live moving
+    expect(value('stat-gates')).toBe('1');       // c-gated waiting
+    expect(value('stat-failed')).toBe('1');      // c-broken
+    expect(value('stat-stalled')).toBe('0');
+    // The band precedes the grid in DOM order.
     const list = screen.getByTestId('chats-list');
     expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('buckets chats on the attach clock and reports the clockless honestly', () => {
+  it('4 chats against a 30-run window has NO prior bucket — the delta reads "—", never 0%', () => {
     page();
-    const tile = screen.getByTestId('chats-over-time-tile');
-    // c-live + c-gated placed; c-legacy has no clock → unplaced, not painted.
-    expect(tile.getAttribute('data-total')).toBe('2');
-    expect(tile.getAttribute('data-unplaced')).toBe('1');
+    expect(screen.getByTestId('stat-chats').getAttribute('data-delta')).toBe('none');
+    expect(within(screen.getByTestId('stat-chats')).getByTestId('stat-delta')).toHaveTextContent('—');
+    expect(screen.getByTestId('stat-chats').textContent).toContain('no prior window');
   });
 
-  it('counts warm threads off the existing active derivation', () => {
-    page();
-    const tile = screen.getByTestId('chats-active-tile');
-    expect(tile.getAttribute('data-count')).toBe('2'); // c-live + c-gated
-  });
-
-  it('scopes the gates tile to the chat partition — a build gate never counts', () => {
+  it('the gates tile scopes to the CHAT partition and doors into the needs-you filter', () => {
     gate('c-gated', 'which auth flow?', NOW - 5 * 60_000);
-    gate('b-gated', 'approve the plan?', NOW - 60 * 60_000);
+    gate('b-gated', 'approve the plan?', NOW - 60 * 60_000); // a build gate never counts
     page();
-    const tile = screen.getByTestId('chats-gates-tile');
-    expect(tile.getAttribute('data-count')).toBe('1');
-    expect(tile.textContent).toContain('1 waiting');
-    expect(tile.textContent).toContain('oldest 5m');
-    expect(tile.textContent).toContain('which auth flow?');
-    expect(tile.textContent).not.toContain('approve the plan?');
+    const tile = screen.getByTestId('stat-gates');
+    expect(tile.getAttribute('data-value')).toBe('1');
+    expect(tile.textContent).toContain('oldest waiting 5m'); // c-gated's clock, not b-gated's
+    fireEvent.click(tile);
+    expect(screen.getByTestId('chats-filter').getAttribute('data-filter')).toBe('needs-you');
+    expect(screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['c-gated']);
   });
 
-  it('says "none waiting" honestly when no chat gate is open', () => {
-    gate('b-gated', 'approve the plan?', NOW - 60_000);
+  it('the failed tile wears the fail token and doors into the failed filter', () => {
     page();
-    expect(screen.getByTestId('chats-gates-tile').textContent).toContain('none waiting');
+    const failed = screen.getByTestId('stat-failed');
+    expect((within(failed).getByTestId('stat-value') as HTMLElement).style.color).toBe('var(--status-fail)');
+    fireEvent.click(failed);
+    expect(screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['c-broken']);
   });
 });
 
-describe('the register below (§4.3: "the list below is the existing ChatsPage list, untouched")', () => {
+describe('the grid — the partition invariant, needs-you first, cards are doors', () => {
   it('lists exactly the chat partition — the verbatim isChatRun set', () => {
     page();
     const ids = screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'));
@@ -101,33 +106,97 @@ describe('the register below (§4.3: "the list below is the existing ChatsPage l
     for (const v of RUNS) expect(ids.includes(v.session.id)).toBe(isChatRun(v));
   });
 
-  it('preserves search, the time-range selector, New Chat, and row navigation', () => {
-    const onSelect = vi.fn();
-    page(onSelect);
-    expect(screen.getByPlaceholderText('Search chats…')).toBeInTheDocument();
-    expect(screen.getByText('New Chat')).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Show newest runs' })).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText('Search chats…'), { target: { value: 'auth' } });
+  it('needs-you FIRST, then active, then terminal; titles derived, seats chipped off the wire', () => {
+    page();
     const rows = screen.getAllByTestId('chat-row');
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.getAttribute('data-run-id')).toBe('c-gated');
-    fireEvent.click(rows[0]!);
-    expect(onSelect).toHaveBeenCalledWith('c-gated');
+    expect(rows.map((r) => r.getAttribute('data-run-id'))).toEqual(
+      ['c-gated', 'c-live', 'c-legacy', 'c-broken'], // gated → active → terminal
+    );
+    // Derived title on the row; the raw prompt only on the hover title.
+    const title = within(rows[0]!).getByTestId('chat-run-title');
+    expect(title.textContent).toBe('which auth flow?');
+    expect(title.getAttribute('title')).toBe('which auth flow?');
+    // Seat chips are the DTO's own clis.
+    const seats = within(rows[1]!).getAllByTestId('chat-seat').map((c) => c.getAttribute('data-seat'));
+    expect(seats).toEqual(['claude', 'codex']);
   });
 
-  it('fires exactly ONE declared request on mount — GET /chats, the §7.9-5 live-session listing (re-scoped by DES-UX-001 slice AB)', async () => {
-    // Pre-slice-AB this page read props + loaded stores only. Slice AB adds the
-    // ONE named exception (the §3.3-style declared fetch): the live-session
-    // listing rides the /chats navigation so warm seats are findable (the
-    // zombie-cleanup wire, FINDING-027's GET /chats). Nothing else may fire.
+  it('a card is a door: clicking it opens the run', () => {
+    const onSelect = vi.fn();
+    page(onSelect);
+    const row = screen.getAllByTestId('chat-row').find((r) => r.getAttribute('data-run-id') === 'c-live')!;
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith('c-live');
+  });
+
+  it('the needs-you badge jumps STRAIGHT to the gate (project known ⇒ the thread AT the gate)', () => {
+    const onSelect = vi.fn();
+    const navigate = vi.fn();
+    page(onSelect, navigate);
+    const jump = screen.getByTestId('chat-needs-you');
+    expect(jump.getAttribute('data-run-id')).toBe('c-gated');
+    fireEvent.click(jump);
+    expect(navigate).toHaveBeenCalledWith('/p/p-auth/build/c-gated#gate');
+    expect(onSelect).not.toHaveBeenCalled(); // no card navigation leaked
+  });
+});
+
+describe('the FilterStrip drives the grid', () => {
+  it('status chips narrow the cards; clear-filters restores everything', () => {
+    page();
+    const chip = (id: string) => screen.getAllByTestId('chats-filter-chip')
+      .find((c) => c.getAttribute('data-chip') === id)!;
+    fireEvent.click(chip('done'));
+    expect(screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['c-legacy']);
+    fireEvent.click(chip('live'));
+    expect(screen.queryAllByTestId('chat-row')).toHaveLength(0); // no live pool here
+    expect(screen.getByTestId('chats-empty-filter')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('chats-clear-filters'));
+    expect(screen.getAllByTestId('chat-row')).toHaveLength(4);
+  });
+
+  it('search narrows by derived title and seat name', () => {
+    page();
+    fireEvent.change(screen.getByTestId('chats-filter-search'), { target: { value: 'uploader' } });
+    expect(screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['c-live']);
+    fireEvent.change(screen.getByTestId('chats-filter-search'), { target: { value: 'codex' } });
+    expect(screen.getAllByTestId('chat-row').map((r) => r.getAttribute('data-run-id'))).toEqual(['c-live']);
+  });
+});
+
+describe('full width, the creation verb, the empty state', () => {
+  it('the grid is a real CSS grid with no maxWidth; New Chat lives on the header', () => {
+    const navigate = vi.fn();
+    page(() => {}, navigate);
+    const grid = screen.getByTestId('chats-list') as HTMLElement;
+    expect(grid.style.maxWidth).toBe('');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fill');
+    fireEvent.click(screen.getByTestId('chats-new'));
+    expect(navigate).toHaveBeenCalledWith('/chat/new');
+  });
+
+  it('with nothing at all, the empty state carries the New Chat CTA', () => {
+    cleanup();
+    const navigate = vi.fn();
+    render(<ChatsPage runs={[]} onSelect={() => {}} navigate={navigate} />);
+    const empty = screen.getByTestId('chats-empty');
+    expect(empty).toHaveTextContent('No chat sessions yet');
+    fireEvent.click(within(empty).getByText('Click New Chat to start'));
+    expect(navigate).toHaveBeenCalledWith('/chat/new');
+  });
+
+  it('fires exactly ONE declared request on mount — GET /chats, the §7.9-5 live-session listing', async () => {
+    // The band and grid read props + loaded stores; the one named exception is
+    // the live-session listing riding the /chats navigation (FINDING-027's
+    // zombie-cleanup wire). Nothing else may fire.
     const spy = vi.fn().mockRejectedValue(new Error('offline'));
     vi.stubGlobal('fetch', spy);
     page();
     await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
     const url = String(spy.mock.calls[0]?.[0] ?? '');
     expect(url.endsWith('/api/v1/chats')).toBe(true);
-    // An unreachable daemon keeps the band absent — the page still renders.
-    expect(screen.queryByTestId('live-chats')).toBeNull();
+    // An unreachable daemon keeps the live cards absent — the page still renders.
+    expect(screen.queryAllByTestId('live-chat-row')).toHaveLength(0);
     vi.unstubAllGlobals();
   });
 });

--- a/tests/ChatsPage.live.test.tsx
+++ b/tests/ChatsPage.live.test.tsx
@@ -51,10 +51,13 @@ describe('the live-session band (§7.9-5)', () => {
     page();
     const row = await screen.findByTestId('live-chat-row');
     expect(row.dataset['chatId']).toBe('warm-chat-1');
-    expect(row).toHaveTextContent('claude · codex');
+    // The seats are chips off the wire's own list (claude / codex …).
+    const seats = Array.from(row.querySelectorAll('[data-testid="chat-seat"]'))
+      .map((c) => c.getAttribute('data-seat'));
+    expect(seats).toEqual(['claude', 'codex']);
     expect(row).toHaveTextContent('idle 42s');
     expect(row.dataset['streaming']).toBe('false');
-    expect(screen.getByTestId('live-chats').dataset['count']).toBe('1');
+    expect(screen.getAllByTestId('live-chat-row')).toHaveLength(1);
   });
 
   it('a session is listed from its FIRST frame — visible while it streams, even when the fetch predates it', async () => {

--- a/tests/RepositoriesPanel.dashboard.test.tsx
+++ b/tests/RepositoriesPanel.dashboard.test.tsx
@@ -1,16 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { RepoEntry } from '../src/api/types.js';
 import { makeView } from './factories.js';
 
 /**
- * The /repos dashboard (DES-FEEDBACK-003 §4.4, slice P): the repo register +
- * the three-tile reporting band. Pinned here: the §4.4 tiles with their named
- * questions (EC19/EC28), the repo_ref×attach-clock grouping honesty (clockless
- * or windowless runs excluded, never painted), the preserved register /
- * search / navigation affordances, and the fetch budget — exactly the page's
- * existing GET /repos + GET /runs, with the old Tracked card's per-repo graph
- * fan-out RETIRED.
+ * The /repos landing as a COMMAND SURFACE (lane B, the 0.4.6 treatment): the
+ * fleet view of what the agents work ON. Pinned here: the KPI band under the
+ * three operator questions with honest window deltas ("—" when no full prior
+ * bucket exists), the graph story derived from the run history (the repos
+ * wire carries NO index-freshness field — never invented), needs-you-first
+ * ordering + the gate jump, Re-index as PREFILL (posts NOTHING), the
+ * first-class FilterStrip, and the fetch budget — exactly the page's
+ * GET /repos + GET /runs, the per-repo graph fan-out still retired.
  */
 
 const NOW = Date.now();
@@ -22,36 +23,41 @@ const repo = (id: string, name: string, registered_at: number): RepoEntry => ({
 const REPOS = [
   repo('studio-api', 'studio-api', 1_700_000_000),
   repo('billing', 'billing', 1_760_000_000),
+  repo('fresh', 'fresh', 1_760_100_000),
 ];
 
 const RUNS = [
-  makeView({ id: 'r-a1', repo_ref: 'studio-api', status: 'executing', problem: 'wire uploads' }),
-  makeView({ id: 'r-a2', repo_ref: 'studio-api', status: 'failed', problem: 'refactor auth' }),
-  makeView({ id: 'r-b1', repo_ref: 'billing', status: 'completed', problem: 'invoice math' }),
-  makeView({ id: 'r-old', repo_ref: 'billing', status: 'failed', problem: 'stale failure' }),
-  makeView({ id: 'r-none', repo_ref: null, status: 'executing', problem: 'no repo' }),
-  makeView({ id: 'r-unclocked', repo_ref: 'billing', status: 'executing', problem: 'no clock' }),
+  makeView({ id: 'r-gate', repo_ref: 'billing', workflow_id: 'feature', status: 'awaiting_human', problem: 'invoice gate' }),
+  makeView({ id: 'r-a1', repo_ref: 'studio-api', workflow_id: 'feature', status: 'executing', problem: 'wire uploads' }),
+  makeView({ id: 'r-a2', repo_ref: 'studio-api', workflow_id: 'feature', status: 'failed', problem: 'refactor auth' }),
+  makeView({ id: 'r-b1', repo_ref: 'billing', workflow_id: 'feature', status: 'completed', problem: 'invoice math' }),
+  makeView({ id: 'o-api', repo_ref: 'studio-api', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard studio-api', clis: ['claude'] }),
+  makeView({ id: 'o-billing', repo_ref: 'billing', workflow_id: 'onboarding', status: 'failed', problem: 'Onboard billing' }),
+  // 'fresh' has NO onboard run on record — the honest "never onboarded" state.
 ];
 
 const listRepos = vi.fn(() => Promise.resolve({ repos: REPOS }));
 const listRuns = vi.fn(() => Promise.resolve({ runs: RUNS }));
 const getRepoGraph = vi.fn();
+const rerunOnboarding = vi.fn(() => Promise.resolve({ runId: 'r-new' }));
 
 vi.mock('../src/api/client.js', () => ({
   api: {
     listRepos: () => listRepos(),
     listRuns: () => listRuns(),
     getRepoGraph: (...a: unknown[]) => getRepoGraph(...a),
+    rerunOnboarding: () => rerunOnboarding(),
     listProjects: () => Promise.resolve({ projects: [] }),
   },
 }));
 
 const { RepositoriesPanel } = await import('../src/components/RepositoriesPanel.js');
 const { useMembershipStore } = await import('../src/store/membership.js');
+const { clearRetryPrefill, peekRetryPrefill } = await import('../src/store/retryPrefill.js');
 
 async function panel(navigate: (p: string) => void = () => {}): Promise<void> {
   render(<RepositoriesPanel navigate={navigate} />);
-  await screen.findByTestId('repos-dashboard-tiles');
+  await screen.findByTestId('repos-kpis');
   await screen.findByTestId('repos-list');
 }
 
@@ -59,78 +65,151 @@ beforeEach(() => {
   listRepos.mockClear();
   listRuns.mockClear();
   getRepoGraph.mockClear();
+  rerunOnboarding.mockClear();
+  clearRetryPrefill();
   useMembershipStore.setState({
     projectNameByRun: {},
+    projectIdByRun: { 'r-gate': 'p-billing' },
     attachedAtByRun: {
-      'r-a1': NOW - 3_600_000,            // studio-api, in 7d + 24h
-      'r-a2': NOW - 2 * 3_600_000,        // studio-api failed, in 24h
-      'r-b1': NOW - 3 * 86_400_000,       // billing, in 7d, outside 24h
-      'r-old': NOW - 8 * 86_400_000,      // billing failed, OUTSIDE 7d and 24h
-      // r-unclocked: no attach clock — excluded everywhere, never invented.
+      'r-a1': NOW - 3_600_000,
+      'r-a2': NOW - 2 * 3_600_000,
+      'r-b1': NOW - 3 * 86_400_000,
+      'o-api': NOW - 5 * 86_400_000,
+      // o-billing / r-gate: no attach clock — excluded from clocks, never invented.
     },
   });
 });
 afterEach(() => cleanup());
 
-describe('the tile band (§4.4, EC19/EC28)', () => {
-  it('renders the three tiles with their named questions, above the register', async () => {
+describe('the KPI band — performance / pipeline / risk', () => {
+  it('renders the six tiles above the fleet with live values', async () => {
     await panel();
-    const band = screen.getByTestId('repos-dashboard-tiles');
-    const q = (tid: string): string | null =>
-      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-question') ?? null;
-    expect(q('runs-per-repo-tile')).toBe('Where is the work concentrating?');
-    expect(q('repo-count-tile')).toBe('Is the estate growing?');
-    expect(q('failing-repos-tile')).toBe('Is any repo a failure hotspot?');
+    const band = screen.getByTestId('repos-kpis');
+    const value = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
+    expect(value('stat-repos')).toBe('3');
+    expect(value('stat-repo-runs')).toBe('6');   // every repo-linked run sits in the last-30 window
+    expect(value('stat-active')).toBe('1');      // r-a1 moving
+    expect(value('stat-ready')).toBe('1');       // studio-api's onboard completed
+    expect(value('stat-failed')).toBe('2');      // r-a2 + o-billing failed in the window
+    expect(value('stat-gaps')).toBe('2');        // billing (onboard failed) + fresh (never)
     const list = screen.getByTestId('repos-list');
     expect(band.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('groups 7d runs by repo_ref on the attach clock, names joined via the repo list', async () => {
+  it('6 runs against a 30-run window has NO prior bucket — the delta reads "—", never 0%', async () => {
     await panel();
-    const tile = screen.getByTestId('runs-per-repo-tile');
-    // r-a1 + r-a2 + r-b1 placed; r-old (outside 7d), r-none (no ref) and
-    // r-unclocked (no clock) excluded.
-    expect(tile.getAttribute('data-total')).toBe('3');
-    expect(tile.getAttribute('data-repos')).toBe('2');
-    expect(tile.textContent).toContain('studio-api leads (2)');
+    expect(screen.getByTestId('stat-repo-runs').getAttribute('data-delta')).toBe('none');
+    expect(within(screen.getByTestId('stat-repo-runs')).getByTestId('stat-delta')).toHaveTextContent('—');
+    expect(screen.getByTestId('stat-repo-runs').textContent).toContain('no prior window');
   });
 
-  it('counts the register and names the newest registration', async () => {
+  it('the index-gaps tile names both gap kinds and doors into the fleet filter', async () => {
     await panel();
-    const tile = screen.getByTestId('repo-count-tile');
-    expect(tile.getAttribute('data-count')).toBe('2');
-    expect(tile.textContent).toContain('2 registered');
-    expect(tile.textContent).toContain('newest:');
-  });
-
-  it('flags only 24h repo-linked failures as hotspots', async () => {
-    await panel();
-    const tile = screen.getByTestId('failing-repos-tile');
-    // r-a2 (failed, 2h ago) counts; r-old (failed, 3d ago) does not.
-    expect(tile.getAttribute('data-count')).toBe('1');
-    expect(tile.getAttribute('data-failures')).toBe('1');
-    expect(tile.textContent).toContain('studio-api (1)');
-    expect(tile.textContent).not.toContain('billing (');
+    const gaps = screen.getByTestId('stat-gaps');
+    expect(gaps.textContent).toContain('1 onboard failed · 1 never onboarded');
+    fireEvent.click(gaps);
+    // An onboard failure outranks "never" — the door lands on Failing.
+    expect(screen.getByTestId('repos-filter').getAttribute('data-filter')).toBe('failing');
+    expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id'))).toEqual(['billing', 'studio-api']);
   });
 });
 
-describe('the register below — affordances preserved, budget held (§4.4)', () => {
-  it('keeps the register/search/add affordances and row navigation', async () => {
-    const navigate = vi.fn();
-    await panel(navigate);
-    expect(screen.getByText('+ Add Repository')).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText('Search repos…'), { target: { value: 'bill' } });
+describe('the fleet grid — graph honesty, needs-you first, cards are doors', () => {
+  it('orders needs-you FIRST and derives each graph state from the run history', async () => {
+    await panel();
     const cards = screen.getAllByTestId('repo-card');
-    expect(cards).toHaveLength(1);
-    expect(cards[0]!.getAttribute('data-repo-id')).toBe('billing');
-    fireEvent.click(cards[0]!);
-    expect(navigate).toHaveBeenCalledWith('/repo-detail/billing');
+    // billing gated → first; studio-api failing (r-a2) → next; fresh quiet last.
+    expect(cards.map((c) => c.getAttribute('data-repo-id'))).toEqual(['billing', 'studio-api', 'fresh']);
+    const state = (card: HTMLElement) => within(card).getByTestId('repo-graph-state');
+    expect(state(cards[0]!).getAttribute('data-state')).toBe('failed');
+    expect(state(cards[0]!).textContent).toContain('onboard FAILED');
+    expect(state(cards[1]!).getAttribute('data-state')).toBe('ready');
+    expect(state(cards[1]!).textContent).toContain('graph ready — onboard completed');
+    // The honest never state SAYS it is a no-record claim, not a fact about disk.
+    expect(state(cards[2]!).getAttribute('data-state')).toBe('never');
+    expect(state(cards[2]!).textContent).toContain('never onboarded — no onboard run on record');
   });
 
-  it('fires exactly the existing GET /repos + GET /runs — the graph fan-out is retired', async () => {
+  it('a card is a door: clicking it opens the repo detail', async () => {
+    const navigate = vi.fn();
+    await panel(navigate);
+    const card = screen.getAllByTestId('repo-card').find((c) => c.getAttribute('data-repo-id') === 'studio-api')!;
+    fireEvent.click(card);
+    expect(navigate).toHaveBeenCalledWith('/repo-detail/studio-api');
+  });
+
+  it('the needs-you badge jumps STRAIGHT to the gate (project known ⇒ the thread AT the gate)', async () => {
+    const navigate = vi.fn();
+    await panel(navigate);
+    const jump = screen.getByTestId('repo-needs-you');
+    expect(jump.getAttribute('data-run-id')).toBe('r-gate');
+    fireEvent.click(jump);
+    expect(navigate).toHaveBeenCalledWith('/p/p-billing/build/r-gate#gate');
+    expect(navigate).not.toHaveBeenCalledWith('/repo-detail/billing'); // no card navigation leaked
+  });
+
+  it('shows the windowed run counts with the ✓/✕ split', async () => {
     await panel();
+    const api = screen.getAllByTestId('repo-card').find((c) => c.getAttribute('data-repo-id') === 'studio-api')!;
+    expect(within(api).getByTestId('repo-card-runs').textContent).toContain('3 runs · last 30');
+    expect(within(api).getByTestId('repo-card-split').textContent).toBe('✓1 · ✕1');
+  });
+});
+
+describe('Re-index is a PREFILL — never a hidden relaunch', () => {
+  it('deposits the recorded onboard run\'s setup and opens the composer; NOTHING posts', async () => {
+    const navigate = vi.fn();
+    await panel(navigate);
+    const reindex = screen.getAllByTestId('repo-reindex').find((b) => b.getAttribute('data-repo-id') === 'studio-api')!;
+    fireEvent.click(reindex);
+    const prefill = peekRetryPrefill();
+    expect(prefill).not.toBeNull();
+    expect(prefill!.retryOf).toBe('o-api');
+    expect(prefill!.workflowId).toBe('onboarding');
+    expect(prefill!.repoRef).toBe('studio-api');
+    expect(prefill!.problem).toBe('Onboard studio-api');
+    expect(prefill!.clis).toEqual(['claude']);
+    expect(navigate).toHaveBeenCalledWith('/runs/new');
+    expect(navigate).not.toHaveBeenCalledWith('/repo-detail/studio-api'); // Re-index is not Open
+    expect(rerunOnboarding).not.toHaveBeenCalled(); // the prefill posts nothing
+  });
+
+  it('a never-onboarded repo keeps the existing Onboard launch verb instead', async () => {
+    await panel();
+    const fresh = screen.getAllByTestId('repo-card').find((c) => c.getAttribute('data-repo-id') === 'fresh')!;
+    expect(within(fresh).queryByTestId('repo-reindex')).toBeNull();
+    expect(within(fresh).getByTestId('repo-onboard')).toBeInTheDocument();
+  });
+});
+
+describe('the FilterStrip drives the fleet; the register flow is untouched', () => {
+  it('chips narrow the cards; search matches name and path; clear-filters restores', async () => {
+    await panel();
+    const chip = (id: string) => screen.getAllByTestId('repos-filter-chip')
+      .find((c) => c.getAttribute('data-chip') === id)!;
+    fireEvent.click(chip('never'));
+    expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id'))).toEqual(['fresh']);
+    fireEvent.click(chip('needs-you'));
+    expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id'))).toEqual(['billing']);
+    fireEvent.change(screen.getByTestId('repos-filter-search'), { target: { value: 'studio' } });
+    expect(screen.getByTestId('repos-empty-filter')).toBeInTheDocument(); // studio-api holds no gate
+    fireEvent.click(screen.getByTestId('repos-clear-filters'));
+    expect(screen.getAllByTestId('repo-card')).toHaveLength(3);
+  });
+
+  it('keeps the add affordance and fires exactly GET /repos + GET /runs — the graph fan-out stays retired', async () => {
+    await panel();
+    expect(screen.getByText('+ Add Repository')).toBeInTheDocument();
     expect(listRepos).toHaveBeenCalledTimes(1);
     expect(listRuns).toHaveBeenCalledTimes(1);
     expect(getRepoGraph).not.toHaveBeenCalled();
+  });
+
+  it('the fleet is a real CSS grid with no maxWidth anywhere on the surface', async () => {
+    await panel();
+    const grid = screen.getByTestId('repos-list') as HTMLElement;
+    expect(grid.style.maxWidth).toBe('');
+    expect(grid.style.gridTemplateColumns).toContain('auto-fill');
   });
 });

--- a/tests/RepositoriesPanel.dashboard.test.tsx
+++ b/tests/RepositoriesPanel.dashboard.test.tsx
@@ -212,4 +212,18 @@ describe('the FilterStrip drives the fleet; the register flow is untouched', () 
     expect(grid.style.maxWidth).toBe('');
     expect(grid.style.gridTemplateColumns).toContain('auto-fill');
   });
+
+  it('with no repos at all, the empty state carries the creation CTA — clicking opens the form, posts nothing', async () => {
+    listRepos.mockImplementationOnce(() => Promise.resolve({ repos: [] }));
+    listRuns.mockImplementationOnce(() => Promise.resolve({ runs: [] }));
+    render(<RepositoriesPanel navigate={() => {}} />);
+    const empty = await screen.findByTestId('repos-empty');
+    expect(empty.textContent).toContain('No repositories');
+    // The CTA is the section's creation verb, INSIDE the empty state.
+    const cta = within(empty).getByRole('button', { name: '+ Add Repository' });
+    fireEvent.click(cta);
+    // The register form opens (the slice-B flow) — nothing was posted.
+    expect(screen.getByTestId('repo-project-row')).toBeInTheDocument();
+    expect(rerunOnboarding).not.toHaveBeenCalled();
+  });
 });

--- a/tests/chatStats.test.ts
+++ b/tests/chatStats.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  liveSeatCount, stalledLiveChats, STALLED_IDLE_SECS, type LiveChatSnapshot,
+} from '../src/board/chatStats.js';
+
+/**
+ * The Chat section's fold layer (lane B): pure derivations over the LIVE wire
+ * (`GET /chats` — `{chatId, seats, idleSecs}` and nothing more). The windowed
+ * chat-run metrics reuse the shared window folds (windowStats.test.ts pins
+ * those); only the live-side folds live here.
+ */
+
+const chat = (chatId: string, seats: string[], idleSecs: number | null): LiveChatSnapshot =>
+  ({ chatId, seats, idleSecs });
+
+describe('liveSeatCount — warm seats across every live session', () => {
+  it('sums the wire-served seat lists', () => {
+    expect(liveSeatCount([
+      chat('c1', ['claude', 'codex'], 10),
+      chat('c2', ['pi'], null),
+      chat('c3', [], 5),
+    ])).toBe(3);
+  });
+
+  it('an empty pool holds zero seats', () => {
+    expect(liveSeatCount([])).toBe(0);
+  });
+});
+
+describe('stalledLiveChats — idle past the threshold, off the daemon clock', () => {
+  it('counts sessions whose daemon-reported idle age passed the threshold', () => {
+    const pool = [
+      chat('c-fresh', ['claude'], 30),
+      chat('c-exactly', ['pi'], STALLED_IDLE_SECS),
+      chat('c-stalled', ['codex'], STALLED_IDLE_SECS + 500),
+    ];
+    expect(stalledLiveChats(pool).map((c) => c.chatId)).toEqual(['c-exactly', 'c-stalled']);
+  });
+
+  it('an unknown idle age (null) never counts — absence stays absent', () => {
+    expect(stalledLiveChats([chat('c-unknown', ['claude'], null)])).toEqual([]);
+  });
+
+  it('a caller-provided threshold overrides the default', () => {
+    expect(stalledLiveChats([chat('c1', [], 60)], 30).map((c) => c.chatId)).toEqual(['c1']);
+  });
+});

--- a/tests/liveChats.rail.test.tsx
+++ b/tests/liveChats.rail.test.tsx
@@ -103,25 +103,28 @@ describe('the rail beside a live conversation (J4 finding 3)', () => {
   });
 });
 
-describe('/chats "Active now" counts what the screen shows (J4 finding 4a, EC39)', () => {
-  it('a live pool session is IN the headline — never "0 of 0" beside a live row', async () => {
+describe('/chats "Conversations now" counts what the screen shows (J4 finding 4a, EC39)', () => {
+  it('a live pool session is IN the tile — never a zero beside a live card', async () => {
     listChats.mockResolvedValueOnce({
       chats: [{ chatId: 'live-9', seats: ['claude'], idleSecs: 4 }],
     });
     render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
 
-    // The live band lists the session the daemon holds…
+    // The grid lists the live session the daemon holds…
     await screen.findByTestId('live-chat-row');
-    // …and the headline counts it, labeled by part and window.
-    const tile = screen.getByTestId('chats-active-tile');
-    expect(tile).toHaveAttribute('data-count', '1');
-    expect(tile).toHaveAttribute('data-live', '1');
-    expect(tile).toHaveTextContent('1 live session · 0 chat runs in the last 30');
+    // …and the pipeline tile counts it, labeled by part.
+    const tile = screen.getByTestId('stat-active');
+    expect(tile).toHaveAttribute('data-value', '1');
+    expect(tile).toHaveTextContent('1 live · 0 runs moving');
+    // The live-seats tile agrees with the pool it counts.
+    expect(screen.getByTestId('stat-live-seats')).toHaveAttribute('data-value', '1');
   });
 
-  it('with no live sessions the range-scoped count is labeled with its window', async () => {
+  it('with no live sessions the windowed chats tile is labeled with its window', async () => {
     render(<ChatsPage runs={[]} onSelect={() => {}} navigate={() => {}} />);
-    await screen.findByTestId('chats-active-tile');
-    expect(screen.getByTestId('chats-active-tile')).toHaveTextContent('0 of 0 chat runs in the last 30');
+    await screen.findByTestId('stat-active');
+    expect(screen.getByTestId('stat-active')).toHaveAttribute('data-value', '0');
+    expect(screen.getByTestId('stat-chats')).toHaveTextContent('last 30');
+    expect(screen.getByTestId('stat-live-seats')).toHaveTextContent('no live sessions');
   });
 });

--- a/tests/repoStats.test.ts
+++ b/tests/repoStats.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { RepoEntry } from '../src/api/types.js';
+import {
+  matchesRepoChip, ONBOARDING_WORKFLOW_ID, repoFleetModels, repoOnboard,
+} from '../src/board/repoStats.js';
+import { makeView } from './factories.js';
+
+/**
+ * The Repositories section's fold layer (lane B): the per-repo graph story
+ * derived from the run history (the repos wire carries NO index-freshness
+ * field — repoStats never pretends it does), and the attention-ordered fleet
+ * models the /repos grid, chips and tiles all read.
+ */
+
+const repo = (id: string): RepoEntry =>
+  ({ id, name: id, root_path: `/tmp/${id}`, default_branch: 'main', registered_at: 1_700_000_000 });
+
+const onboard = (id: string, repoRef: string, status: string) =>
+  makeView({ id, repo_ref: repoRef, workflow_id: ONBOARDING_WORKFLOW_ID, status: status as never });
+
+describe('repoOnboard — the honest graph state off the run history', () => {
+  it('newest decisive onboard completed ⇒ ready', () => {
+    const runs = [onboard('o-new', 'a', 'completed'), onboard('o-old', 'a', 'failed')];
+    expect(repoOnboard(runs, 'a')).toEqual({ state: 'ready', run: runs[0] });
+  });
+
+  it('newest decisive onboard failed ⇒ failed — even with an older success behind it', () => {
+    const runs = [onboard('o-new', 'a', 'failed'), onboard('o-old', 'a', 'completed')];
+    expect(repoOnboard(runs, 'a').state).toBe('failed');
+    expect(repoOnboard(runs, 'a').run!.session.id).toBe('o-new');
+  });
+
+  it('an in-flight onboard wins ⇒ onboarding (gated onboards count as in flight)', () => {
+    expect(repoOnboard([onboard('o-run', 'a', 'executing')], 'a').state).toBe('onboarding');
+    expect(repoOnboard([onboard('o-gate', 'a', 'awaiting_human')], 'a').state).toBe('onboarding');
+  });
+
+  it('a cancelled onboard is withdrawn, not a verdict — the fold looks further back', () => {
+    const runs = [onboard('o-cancelled', 'a', 'cancelled'), onboard('o-done', 'a', 'completed')];
+    expect(repoOnboard(runs, 'a')).toEqual({ state: 'ready', run: runs[1] });
+  });
+
+  it('no onboard run on record ⇒ never (a build run is not an onboard)', () => {
+    const runs = [
+      makeView({ id: 'r-build', repo_ref: 'a', workflow_id: 'feature', status: 'completed' }),
+      onboard('o-other', 'b', 'completed'), // another repo's onboard never counts
+    ];
+    expect(repoOnboard(runs, 'a')).toEqual({ state: 'never', run: null });
+  });
+
+  it('archived onboards never count', () => {
+    const runs = [makeView({
+      id: 'o-archived', repo_ref: 'a', workflow_id: ONBOARDING_WORKFLOW_ID,
+      status: 'completed', archived_at: 123,
+    })];
+    expect(repoOnboard(runs, 'a').state).toBe('never');
+  });
+});
+
+describe('repoFleetModels — one fold per card, attention-ordered', () => {
+  const NOW = 1_756_000_000_000;
+  const REPOS = [repo('quiet'), repo('gated'), repo('broken'), repo('busy')];
+  const RUNS = [
+    makeView({ id: 'r-gate', repo_ref: 'gated', workflow_id: 'feature', status: 'awaiting_human' }),
+    makeView({ id: 'r-run', repo_ref: 'busy', workflow_id: 'feature', status: 'executing' }),
+    makeView({ id: 'r-fail', repo_ref: 'broken', workflow_id: 'feature', status: 'failed' }),
+    makeView({ id: 'r-done', repo_ref: 'busy', workflow_id: 'feature', status: 'completed' }),
+    makeView({ id: 'r-out', repo_ref: 'busy', workflow_id: 'feature', status: 'failed' }), // outside window
+    onboard('o-busy', 'busy', 'completed'),
+    onboard('o-broken', 'broken', 'failed'),
+  ];
+  const ATTACHED = { 'r-run': NOW - 3_600_000, 'r-done': NOW - 2 * 3_600_000 };
+  // The recency window holds everything but r-out (the positional idiom —
+  // membership is the caller's windowBuckets output).
+  const WINDOW = new Set(RUNS.map((v) => v.session.id).filter((id) => id !== 'r-out'));
+
+  const fleet = repoFleetModels(REPOS, RUNS, ATTACHED, WINDOW);
+  const byId = Object.fromEntries(fleet.map((m) => [m.repo.id, m]));
+
+  it('orders needs-you FIRST, then failing, then active, then quiet', () => {
+    expect(fleet.map((m) => m.repo.id)).toEqual(['gated', 'broken', 'busy', 'quiet']);
+  });
+
+  it('counts only the windowed runs; waiting stays unwindowed (a gate is a gate)', () => {
+    expect(byId['busy']!.counts.total).toBe(3);       // r-run + r-done + o-busy; r-out held back
+    expect(byId['busy']!.counts.done).toBe(2);
+    expect(byId['busy']!.counts.failed).toBe(0);      // r-out is outside the window
+    expect(byId['gated']!.waiting.map((v) => v.session.id)).toEqual(['r-gate']);
+  });
+
+  it('derives the graph story per repo and folds an onboard failure into failing', () => {
+    expect(byId['busy']!.onboard.state).toBe('ready');
+    expect(byId['broken']!.onboard.state).toBe('failed');
+    expect(byId['broken']!.failing).toBe(true);
+    expect(byId['quiet']!.onboard.state).toBe('never');
+    expect(byId['quiet']!.failing).toBe(false);
+  });
+
+  it('lastAt is the newest attach clock — null when no clock is known, never invented', () => {
+    expect(byId['busy']!.lastAt).toBe(NOW - 3_600_000);
+    expect(byId['gated']!.lastAt).toBeNull();
+  });
+
+  it('matchesRepoChip partitions the fleet the chips and tiles agree on', () => {
+    expect(fleet.filter((m) => matchesRepoChip(m, 'needs-you')).map((m) => m.repo.id)).toEqual(['gated']);
+    expect(fleet.filter((m) => matchesRepoChip(m, 'active')).map((m) => m.repo.id)).toEqual(['busy']);
+    expect(fleet.filter((m) => matchesRepoChip(m, 'failing')).map((m) => m.repo.id)).toEqual(['broken']);
+    expect(fleet.filter((m) => matchesRepoChip(m, 'ready')).map((m) => m.repo.id)).toEqual(['busy']);
+    expect(fleet.filter((m) => matchesRepoChip(m, 'never')).map((m) => m.repo.id)).toEqual(['gated', 'quiet']);
+    expect(fleet.filter((m) => matchesRepoChip(m, 'all'))).toHaveLength(4);
+  });
+});

--- a/tests/windowStats.test.ts
+++ b/tests/windowStats.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  attachSeries, deltaWord, healthColor, healthOf, statusCounts, windowBuckets, windowDelta,
+  attachSeries, deltaWord, healthColor, healthOf, orderByAttention, statusCounts, windowBuckets, windowDelta,
 } from '../src/board/windowStats.js';
 import { makeView } from './factories.js';
 import type { SessionStatus } from '../src/api/types.js';
@@ -102,6 +102,22 @@ describe('healthOf — threshold color only where it means something', () => {
     expect(healthOf(0, 0)).toBe('none');
     expect(healthColor('none')).toBeUndefined();
     expect(healthColor('bad')).toBe('var(--status-fail)');
+  });
+});
+
+describe('orderByAttention — the one shared list order (needs-you FIRST)', () => {
+  it('gated → active → terminal, incoming order preserved within each group', () => {
+    const runs = [
+      run('r-done', 'completed'),
+      run('r-exec-1', 'executing'),
+      run('r-gate-1', 'awaiting_human'),
+      run('r-fail', 'failed'),
+      run('r-exec-2', 'planning'),
+      run('r-gate-2', 'awaiting_human'),
+    ];
+    expect(orderByAttention(runs).map((v) => v.session.id)).toEqual([
+      'r-gate-1', 'r-gate-2', 'r-exec-1', 'r-exec-2', 'r-done', 'r-fail',
+    ]);
   });
 });
 


### PR DESCRIPTION
The 0.4.6 kit applied to the last two list sections. Chat: a conversations command surface (chats/live-seats/needs-you/failed KPI band with honest "—" deltas, seat-chip cards live-first, New Chat verb, CTA empty states — the live corpus has zero live chats, so populated states are fixture-proven). Repositories: the fleet view (repos/runs-touching/active/ready/failing band — 13 failures ▲13 in honest red; per-repo cards with windowed ✓/✕ splits, derived graph state labeled as derived, attention-first ordering) with Register-repo verb and Re-index-as-prefill (observed live depositing chips into the composer, posts nothing). Every KPI cross-checked against independent raw-wire folds; kit purity grep-proven (one dashboardKit, zero forks); full width at 1920. 2209 tests green, inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)