### PR TITLE
feat: Ask — the app-wide assistant entry; Steering learns to report on itself

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CenterDashboard } from './components/CenterDashboard.js';
+import { AskDock } from './components/AskDock.js';
 import { CommandPalette, paletteShortcutEntries } from './components/CommandPalette.js';
 import { ChatsPage } from './components/ChatsPage.js';
 import { GateNotifications } from './components/GateNotifications.js';
@@ -246,9 +247,13 @@ export function App(): React.ReactElement {
     setShortcutsPaletteOpen(paletteOpen);
   }, [paletteOpen]);
 
+  // ASK — the app-wide assist dock (AskDock): opened from the rail's Ask button
+  // or Ctrl/⌘+Shift+A; collapsing the dock closes it entirely.
+  const [askOpen, setAskOpen] = useState(false);
+
   const shortcutEntries = useMemo(
-    () =>
-      paletteShortcutEntries({
+    () => [
+      ...paletteShortcutEntries({
         isOpen: () => paletteOpenRef.current,
         setOpen: (next: boolean) => {
           setPaletteSeed('');
@@ -267,6 +272,18 @@ export function App(): React.ReactElement {
           if (runId) void onKill(runId);
         },
       }),
+      // Ctrl/⌘+Shift+A — the ASK toggle, documented in the '?' overlay via the registry.
+      {
+        id: 'ask-dock',
+        chord: { key: 'a', ctrlOrMeta: true, shift: true },
+        group: 'panels' as const,
+        description: 'Ask — governed answers about your projects, repos, and this studio',
+        handler: (e: KeyboardEvent) => {
+          e.preventDefault();
+          setAskOpen((v) => !v);
+        },
+      },
+    ],
     [runId, runs, onKill],
   );
   useGlobalShortcuts(shortcutEntries);
@@ -472,6 +489,7 @@ export function App(): React.ReactElement {
             type={steeringType !== null && isSteeringType(steeringType) ? steeringType : null}
             navigate={navigate}
             search={search}
+            runs={runs}
           />
         </div>
       );
@@ -609,6 +627,7 @@ export function App(): React.ReactElement {
         pathname={pathname}
         runPath={runPath}
         immersive={immersive}
+        onOpenAsk={() => setAskOpen(true)}
       />
 
       <div id="main" tabIndex={-1} className="flex flex-1 overflow-hidden" style={{ outline: 'none' }}>
@@ -618,6 +637,12 @@ export function App(): React.ReactElement {
       {/* Right panel only when a run is selected */}
       {selected !== null && (
         <RightPanel view={selected} runs={runs} onSelectRun={selectRun} />
+      )}
+
+      {/* ASK — the app-wide assist dock, a right-edge sibling column on every route.
+          Renders only while open; NOTHING launches until the user sends. */}
+      {askOpen && (
+        <AskDock runs={runs} pathname={pathname} onClose={() => setAskOpen(false)} />
       )}
 
       {/* The universal command palette (DES-FEEDBACK-002 §1, slice G) — corpus

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -1,0 +1,76 @@
+/**
+ * The diagnostics wire — `GET /api/v1/diagnostics` (read-only, camelCase), the daemon's
+ * self-description: component versions, daemon vitals, store sizes, a bounded tail of recent
+ * errors, and per-CLI ACP session/fallback counts folded from the durable run event logs
+ * (`<home>/core.db.events/*.ndjson` — `acpSessionStarted` / `acpFallback`).
+ *
+ * ── INTEGRATION POINT (L1 diagnostics lane) ───────────────────────────────────────────────────
+ * The shape below is the PINNED wire from the paired crew lane; it is not yet in studio's
+ * installed `wicked-crew-api-types`. Delete this block and re-export from the contract package
+ * the moment studio bumps to the api-types version that carries it. Fields the daemon cannot
+ * answer are `null`/empty — never fabricated.
+ *
+ * PRESENCE GATE: older crews have no `/diagnostics` at all — a bare unknown-route 404 (or a 501
+ * from a crew whose engine predates the fold). {@link isDiagnosticsUnsupported} folds both so
+ * every consumer (the Ask context pack is consumer #1) says so honestly instead of erroring.
+ */
+
+import { apiFetch } from './client.js';
+import { ApiError, isRouteAbsent } from './errors.js';
+
+/** One CLI's ACP health, folded from the durable run event logs. */
+export interface DiagnosticsAcpCli {
+  sessionsStarted: number;
+  fallbacks: number;
+  /** Fallback counts by kind (e.g. `{"spawn-failed": 3}`). Empty when none recorded. */
+  fallbackKinds: Record<string, number>;
+  /** Unix-millis of the newest `acpSessionStarted`; `null` when none recorded. */
+  lastStartedTs: number | null;
+  /** Unix-millis of the newest `acpFallback`; `null` when none recorded. */
+  lastFallbackTs: number | null;
+}
+
+export interface DiagnosticsStore {
+  name: string;
+  path: string;
+  bytes: number;
+}
+
+export interface DiagnosticsError {
+  ts: number;
+  source: string;
+  line: string;
+}
+
+export interface Diagnostics {
+  components: {
+    crew: string;
+    studioBundle: string | null;
+    coreTs: string | null;
+    /** Engine binary versions by name; `null` = the binary is present but unversionable. */
+    engineBinaries: Record<string, string | null>;
+  };
+  daemon: {
+    uptimeMs: number;
+    startedAt: number;
+    port: number;
+  };
+  stores: DiagnosticsStore[];
+  /** Bounded tail, newest first. */
+  recentErrors: DiagnosticsError[];
+  acp: { byCli: Record<string, DiagnosticsAcpCli> };
+}
+
+/** `GET /diagnostics` — the daemon's self-description. Read-only. */
+export function getDiagnostics(): Promise<Diagnostics> {
+  return apiFetch<Diagnostics>('/diagnostics');
+}
+
+/**
+ * True when this daemon cannot serve diagnostics yet: a bare unknown-route 404 (crew predates
+ * the route) or a 501 (route present, fold absent). A NAMED 4xx from a daemon WITH the route is
+ * a real answer and surfaces as one — the same two-layer adoption seam as the wiki/testing reads.
+ */
+export function isDiagnosticsUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}

--- a/src/board/steeringUsage.ts
+++ b/src/board/steeringUsage.ts
@@ -1,0 +1,156 @@
+import type { GovernanceClaim, SessionView } from '../api/types.js';
+import type { SteeringRule } from '../api/steering.js';
+import { steeringTypeOf, type SteeringType } from '../api/steering.js';
+import type { WikiRuleEvidenceRow } from '../api/wiki.js';
+import type { StatDelta } from './windowStats.js';
+
+/**
+ * The STEERING USAGE folds (the Steering landing's when/how/success band) — pure
+ * derivations over wires the app already speaks, pinned by unit test:
+ *
+ *  - `GET /governance/claims` — every recorded gate evaluation (`GovernanceClaim`), with a
+ *    REAL clock (`evaluated_at`, unix seconds) and a decision. The when/how record.
+ *  - the AW-23 scoreboard's `evidence.per_rule` — which RULES the enforcement record cites
+ *    (denial claims + governs evidence); zero everywhere = dead weight.
+ *  - the one `GET /runs` list — the governed-runs join (claim scopes name their run).
+ *
+ * WINDOW HONESTY: claims carry real timestamps, so the window is TEMPORAL (last N days vs
+ * the previous N). A delta renders only when the record PROVES a full prior window exists —
+ * the oldest claim must predate the prior window's start; otherwise `previous: null`
+ * ("—", never a fabricated 0%). Zero history keeps `current: 0, previous: null`.
+ */
+
+export const USAGE_WINDOW_DAYS = 7;
+const DAY_MS = 24 * 3_600_000;
+
+/** The slice of a claim these folds read (full `GovernanceClaim` satisfies it). */
+export type ClaimLite = Pick<GovernanceClaim, 'decision' | 'evaluated_at' | 'scope'>;
+
+export interface UsageWindows {
+  /** Gate evaluations: claims recorded in the current window vs the previous. */
+  evaluations: StatDelta;
+  /** Denials issued in the same windows. */
+  denials: StatDelta;
+  /** Current-window decision split. */
+  allow: number;
+  deny: number;
+  conditions: number;
+  /** Daily evaluation counts across the current window, oldest first. */
+  spark: number[];
+}
+
+export function usageWindows(claims: ClaimLite[], now: number): UsageWindows {
+  const windowMs = USAGE_WINDOW_DAYS * DAY_MS;
+  const curStart = now - windowMs;
+  const prevStart = now - 2 * windowMs;
+  let oldest = Infinity;
+  let cur = 0;
+  let prev = 0;
+  let curDeny = 0;
+  let prevDeny = 0;
+  let allow = 0;
+  let deny = 0;
+  let conditions = 0;
+  const spark = new Array<number>(USAGE_WINDOW_DAYS).fill(0);
+  for (const c of claims) {
+    const at = c.evaluated_at * 1000;
+    if (at < oldest) oldest = at;
+    if (at >= curStart && at <= now) {
+      cur += 1;
+      if (c.decision === 'deny') { curDeny += 1; deny += 1; }
+      else if (c.decision === 'allow_with_conditions') conditions += 1;
+      else allow += 1;
+      const bucket = Math.min(USAGE_WINDOW_DAYS - 1, Math.floor((at - curStart) / DAY_MS));
+      spark[bucket] = (spark[bucket] ?? 0) + 1;
+    } else if (at >= prevStart && at < curStart) {
+      prev += 1;
+      if (c.decision === 'deny') prevDeny += 1;
+    }
+  }
+  // The prior bucket counts only when the record PROVES it was fully observed: the oldest
+  // claim predates the prior window. A record that starts mid-window cannot distinguish
+  // "no evaluations then" from "nothing was recorded yet" — so no delta, never a lie.
+  const priorProven = oldest !== Infinity && oldest <= prevStart;
+  return {
+    evaluations: { current: cur, previous: priorProven ? prev : null },
+    denials: { current: curDeny, previous: priorProven ? prevDeny : null },
+    allow,
+    deny,
+    conditions,
+    spark,
+  };
+}
+
+// ── The governed-runs join ────────────────────────────────────────────────────────────────────
+
+/**
+ * The run id a claim's scope names. The engine's run grammar is
+ * `wicked-agent/<runId>/<entity…>`; older writers used the bare run id (both spellings are
+ * read by GovernanceAudit — the same two here). A scope that is neither yields itself, which
+ * simply never joins.
+ */
+export function runIdOfScope(scope: string): string {
+  if (scope.startsWith('wicked-agent/')) {
+    const seg = scope.split('/')[1];
+    return seg !== undefined && seg !== '' ? seg : scope;
+  }
+  return scope;
+}
+
+export interface GovernedRuns {
+  /** Non-archived runs with ≥1 recorded gate evaluation. */
+  governed: number;
+  total: number;
+  /** governed/total, or `null` when there are no runs to divide by. */
+  pct: number | null;
+}
+
+export function governedRuns(claims: ClaimLite[], runs: SessionView[]): GovernedRuns {
+  const claimed = new Set(claims.map((c) => runIdOfScope(c.scope)));
+  const live = runs.filter((v) => v.session.archived_at == null);
+  const governed = live.filter((v) => claimed.has(v.session.id)).length;
+  return {
+    governed,
+    total: live.length,
+    pct: live.length === 0 ? null : Math.round((governed / live.length) * 100),
+  };
+}
+
+// ── Rule usage — top-fired vs dead weight ─────────────────────────────────────────────────────
+
+export interface RuleUsage {
+  /** ACTIVE rules with zero enforcement evidence (no denial claims, no governs evidence). */
+  unusedIds: string[];
+  /** The most-cited active rule, or `null` when nothing has fired. */
+  topFired: { ruleId: string; total: number } | null;
+  /** Active rules with ANY evidence. */
+  firedCount: number;
+  /** The steering type holding the most unused rules — where the click-through lands. */
+  unusedHomeType: SteeringType | null;
+}
+
+export function ruleUsage(rules: SteeringRule[], perRule: WikiRuleEvidenceRow[]): RuleUsage {
+  const evidence = new Map(perRule.map((r) => [r.rule_id, r.denial_claims + r.governs_evidence]));
+  const active = rules.filter((r) => r.retired !== true);
+  const unusedIds: string[] = [];
+  let top: { ruleId: string; total: number } | null = null;
+  let firedCount = 0;
+  const unusedByType = new Map<SteeringType, number>();
+  for (const r of active) {
+    const total = evidence.get(r.id) ?? 0;
+    if (total === 0) {
+      unusedIds.push(r.id);
+      const t = steeringTypeOf(r);
+      unusedByType.set(t, (unusedByType.get(t) ?? 0) + 1);
+    } else {
+      firedCount += 1;
+      if (top === null || total > top.total) top = { ruleId: r.id, total };
+    }
+  }
+  let unusedHomeType: SteeringType | null = null;
+  let best = 0;
+  for (const [t, n] of unusedByType) {
+    if (n > best) { best = n; unusedHomeType = t; }
+  }
+  return { unusedIds, topFired: top, firedCount, unusedHomeType };
+}

--- a/src/components/AskDock.tsx
+++ b/src/components/AskDock.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+import { getDiagnostics, isDiagnosticsUnsupported } from '../api/diagnostics.js';
+import type { RepoEntry, SessionView } from '../api/types.js';
+import { useLiveChatsStore } from '../store/liveChats.js';
+import { useProjectsStore } from '../store/projects.js';
+import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
+import { getCachedRoster, setCachedRoster } from '../store/rosterCache.js';
+import {
+  askPrompts,
+  buildContextPack,
+  contextPackSummary,
+  sectionLabel,
+  type DiagnosticsState,
+} from './askContext.js';
+import { AssistDock, type AssistVerbs } from './AssistDock.js';
+import { defaultSelection } from './GroupChat.js';
+
+/**
+ * ASK — the app-wide binding of the ASSIST DOCK (DES-ASSIST-DOCK §5: "the dock becomes
+ * 'ask for work from anywhere'"), opened from the rail's Ask button or Ctrl/⌘+Shift+A.
+ *
+ * A question launches a governed CHAT SESSION over the GroupChat seat machinery
+ * (`POST /chats` warms the chat-capable roster, `POST /chats/:id/messages` fans the
+ * question out) — the seats carry the estate/garden tooling that can actually look at
+ * the databases, the code graph, and the run record. The FIRST message rides with the
+ * context pack (`buildContextPack`): the current route/section, counts from the runs
+ * fold the app already holds, and `GET /api/v1/diagnostics` CITED when the daemon
+ * serves it — when it does not (older crews), the pack says so honestly.
+ *
+ * Opening the dock fires READS only (diagnostics + the session repo/project caches, to
+ * seed honest quick prompts). NOTHING launches until the user sends — the quick-prompt
+ * chips prefill the composer, never submit it.
+ */
+
+export function AskDock({ runs, pathname, onClose }: {
+  runs: SessionView[];
+  pathname: string;
+  /** Collapsing the dock closes Ask entirely — the rail button/shortcut reopen it. */
+  onClose: () => void;
+}): React.ReactElement {
+  const [diag, setDiag] = useState<DiagnosticsState>({ kind: 'loading' });
+  const [repos, setRepos] = useState<RepoEntry[]>(() => getCachedRepos() ?? []);
+  const projects = useProjectsStore((s) => s.projects);
+  const liveChats = useLiveChatsStore((s) => s.sessions);
+
+  // The diagnostics read — presence-gated: absence is an ANSWER (older crew), never an error.
+  useEffect(() => {
+    let cancelled = false;
+    getDiagnostics()
+      .then((d) => {
+        if (!cancelled) setDiag({ kind: 'present', diagnostics: d });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (isDiagnosticsUnsupported(e)) setDiag({ kind: 'unsupported' });
+        else setDiag({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Prompt seeds: the session repo cache (one GET per session, shared with the palette/rail)
+  // and the projects store (loaded here only if nothing has loaded it yet). Opening Ask is
+  // the user gesture that pays for these reads.
+  useEffect(() => {
+    fetchReposCached()
+      .then((rs) => setRepos([...rs].sort((a, b) => b.registered_at - a.registered_at)))
+      .catch(() => {
+        /* prompt seed only — the chip is omitted, never fabricated */
+      });
+    if (useProjectsStore.getState().projects.length === 0) void useProjectsStore.getState().load();
+  }, []);
+
+  // The send verb closes over LIVE state via refs — the pack is assembled AT SEND TIME,
+  // so it cites what the app knows at that moment (not at mount).
+  const packInputs = useRef({ pathname, runs, liveChatCount: 0, diagnostics: diag as DiagnosticsState });
+  packInputs.current = {
+    pathname,
+    runs,
+    liveChatCount: Object.keys(liveChats).length,
+    diagnostics: diag,
+  };
+
+  /** The live chat session this dock opened — later sends reuse its warm seats. */
+  const chatIdRef = useRef<string | null>(null);
+  /** True once the context pack rode a message — it seeds the FIRST send only. */
+  const seededRef = useRef(false);
+
+  const verbs: AssistVerbs = useMemo(
+    () => ({
+      send: async (text) => {
+        let id = chatIdRef.current;
+        if (id === null) {
+          // The chat-capable roster (EC44's derivation, reused verbatim) — cached when any
+          // surface already fetched it; one GET /roster otherwise.
+          let roster = getCachedRoster();
+          if (roster === null) {
+            const { roster: fetched } = await api.getRoster();
+            setCachedRoster(fetched);
+            roster = fetched;
+          }
+          const clis = defaultSelection(roster);
+          id = crypto.randomUUID();
+          const body: { chatId: string; clis?: string[] } = { chatId: id };
+          if (clis.length > 0) body.clis = clis;
+          const { seats } = await api.openChat(body);
+          const ready = seats.filter((s) => s.ok).map((s) => s.cliKey);
+          if (ready.length === 0) {
+            const detail =
+              seats.length > 0
+                ? seats.map((s) => `${s.cliKey}: ${s.error ?? 'failed'}`).join('; ')
+                : 'the daemon warmed no seats';
+            throw new Error(`No agent seat came up — ${detail}`);
+          }
+          chatIdRef.current = id;
+          // The session is live — make it findable on the rail (the J4 live row).
+          useLiveChatsStore.getState().upsert(id, ready);
+        }
+        const message = seededRef.current ? text : `${text}\n\n---\n${buildContextPack(packInputs.current)}`;
+        await api.sendChatMessage(id, message);
+        seededRef.current = true;
+        return { chatId: id };
+      },
+    }),
+    [],
+  );
+
+  const prompts = useMemo(
+    () =>
+      askPrompts({
+        runs,
+        projects: [...projects].sort((a, b) => b.updated_at - a.updated_at),
+        repos,
+      }),
+    [runs, projects, repos],
+  );
+
+  return (
+    <AssistDock
+      context={{
+        surface: 'ask',
+        title: 'Ask',
+        contextLabel: `here: ${sectionLabel(pathname)}`,
+        placeholder: 'Ask about projects, repos, runs — or this studio itself…',
+        hint:
+          'Your question opens a governed chat session — the agents carry the estate/garden ' +
+          'tooling that reads the code graph, the stores, and the run record, so they can answer ' +
+          'about your projects AND diagnose the app itself. ' +
+          contextPackSummary(diag),
+        prompts,
+      }}
+      verbs={verbs}
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    />
+  );
+}

--- a/src/components/AssistDock.tsx
+++ b/src/components/AssistDock.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { executingOrd } from '../api/run-state.js';
 import type { CoreEvent, SessionView } from '../api/types.js';
+import { useEventStream } from '../hooks/useEventStream.js';
+import { pinAwaiting } from '../store/awaitingPins.js';
 import { useRunEventStore } from '../store/events.js';
 import { ApprovalDock } from './ApprovalDock.js';
 import { readFileText } from './fileText.js';
@@ -43,6 +45,15 @@ export interface AssistContext {
   placeholder: string;
   /** One-liner under the header — what a message DOES here. */
   hint?: string;
+  /** Quick-prompt chips for the EMPTY thread: clicking one PREFILLS the composer
+   *  (never sends — nothing launches without the user's own send). */
+  prompts?: readonly AssistPrompt[];
+}
+
+export interface AssistPrompt {
+  label: string;
+  /** What the chip puts into the composer. */
+  text: string;
 }
 
 export interface AssistDocument {
@@ -55,9 +66,14 @@ export interface AssistNote {
   text: string;
 }
 
+/** What a send launched: a governed RUN (narrated by the run block) or a governed CHAT
+ *  session (streamed by the chat block — the GroupChat seat machinery's wire, §11-adjacent). */
+export type AssistLaunch = { runId: string } | { chatId: string };
+
 export interface AssistVerbs {
-  /** A typed message: launch a governed run, return its id — the dock narrates it inline. */
-  send: (text: string, documents: AssistDocument[]) => Promise<{ runId: string }>;
+  /** A typed message: launch a governed run OR chat session, return its id —
+   *  the dock narrates/streams it inline. */
+  send: (text: string, documents: AssistDocument[]) => Promise<AssistLaunch>;
   /** The direct-import fork for rule-shaped attachments; returns notes to echo. Absent ⇒ no fork. */
   importDirect?: (doc: AssistDocument) => Promise<AssistNote[]>;
   /** Fired when a pinned gate/elicitation resolves — the surface reloads its data. */
@@ -67,7 +83,8 @@ export interface AssistVerbs {
 type ThreadItem =
   | { kind: 'user'; text: string; files: string[] }
   | { kind: 'note'; tone: NarrationTone; text: string }
-  | { kind: 'run'; runId: string };
+  | { kind: 'run'; runId: string }
+  | { kind: 'chat'; chatId: string };
 
 interface PendingAttachment {
   name: string;
@@ -207,6 +224,171 @@ function DockRun({ runId }: { runId: string }): React.ReactElement {
   );
 }
 
+// ── The inline chat block — a governed chat session streaming into the thread ────────────────
+
+type DockSeatState = 'ready' | 'failed';
+
+interface DockChatMsg {
+  cliKey: string;
+  text: string;
+  pending: boolean;
+  ok: boolean;
+}
+
+/**
+ * One launched CHAT session (the GroupChat seat machinery's wire — `POST /chats` +
+ * `POST /chats/:id/messages`, replies streaming back as `chatDelta`/`chatReply` frames).
+ * The block folds ONLY frames whose `chat` matches, per-seat FIFO (the GroupChat §7.9-3
+ * correlation: a seat's frames belong to its oldest unfinished turn; the terminal
+ * `chatReply` text is authoritative and replaces the accumulated deltas). Seats come from
+ * the one `GET /chats/:id` snapshot — frames that streamed before this block mounted are
+ * healed by the authoritative reply, never re-invented.
+ */
+function DockChat({ chatId }: { chatId: string }): React.ReactElement {
+  const [seats, setSeats] = useState<Record<string, DockSeatState>>({});
+  const [msgs, setMsgs] = useState<DockChatMsg[]>([]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // §11.5: gates/elicitations the daemon keys by THIS chat id must survive the
+  // run-list reconcile (a chat id is never in GET /runs) — pin for the block's lifetime.
+  useEffect(() => pinAwaiting(chatId), [chatId]);
+
+  // The seats snapshot — one GET; an empty answer means the daemon no longer holds it.
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .getChat(chatId)
+      .then(({ seats: warm }) => {
+        if (cancelled) return;
+        setSeats((prev) => ({
+          ...Object.fromEntries(warm.map((k) => [k, 'ready' as DockSeatState])),
+          ...prev,
+        }));
+      })
+      .catch(() => {
+        /* snapshot unavailable — the frames below still speak for themselves */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatId]);
+
+  /** A seat's streaming chunk belongs to its OLDEST pending bubble (FIFO — the wire
+   *  carries no turn field); a chunk with no pending bubble opens its own. */
+  const append = (cliKey: string, text: string): void => {
+    setMsgs((prev) => {
+      const next = [...prev];
+      for (let i = 0; i < next.length; i += 1) {
+        const m = next[i];
+        if (m !== undefined && m.cliKey === cliKey && m.pending) {
+          next[i] = { ...m, text: m.text + text };
+          return next;
+        }
+      }
+      next.push({ cliKey, text, pending: true, ok: false });
+      return next;
+    });
+  };
+
+  /** The terminal reply is authoritative — it REPLACES the oldest pending bubble's deltas. */
+  const finalize = (cliKey: string, text: string, ok: boolean): void => {
+    setMsgs((prev) => {
+      const next = [...prev];
+      for (let i = 0; i < next.length; i += 1) {
+        const m = next[i];
+        if (m !== undefined && m.cliKey === cliKey && m.pending) {
+          next[i] = { ...m, text, pending: false, ok };
+          return next;
+        }
+      }
+      next.push({ cliKey, text, pending: false, ok });
+      return next;
+    });
+  };
+
+  useEventStream((ev: CoreEvent) => {
+    const frame = ev as { type: string; chat?: string; cliKey?: string; text?: string; ok?: boolean; reason?: string };
+    if (frame.chat !== chatId) return;
+    switch (frame.type) {
+      case 'chatSessionReady':
+        if (frame.cliKey !== undefined) setSeats((s) => ({ ...s, [frame.cliKey!]: 'ready' }));
+        break;
+      case 'chatSessionFailed':
+        if (frame.cliKey !== undefined) setSeats((s) => ({ ...s, [frame.cliKey!]: 'failed' }));
+        break;
+      case 'chatDelta':
+        if (frame.cliKey !== undefined && frame.text !== undefined && frame.text !== '') append(frame.cliKey, frame.text);
+        break;
+      case 'chatReply':
+        if (frame.cliKey !== undefined) finalize(frame.cliKey, frame.text ?? '', frame.ok ?? false);
+        break;
+      default:
+        break;
+    }
+  });
+
+  // Tail-pinned inside the block — replies stream long; the dock thread stays one column.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [msgs]);
+
+  return (
+    <div
+      data-testid="assist-chat"
+      data-chat-id={chatId}
+      className="flex flex-col gap-1.5 overflow-hidden rounded-lg px-3 py-2"
+      style={{ border: '1px solid var(--surface-raised)', background: 'var(--surface-card)' }}
+    >
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: 'var(--ink-dim)' }}>
+          chat session
+        </span>
+        {Object.entries(seats).map(([k, st]) => (
+          <span
+            key={k}
+            data-testid="assist-chat-seat"
+            data-agent={k}
+            data-state={st}
+            title={st === 'failed' ? `${k} could not hold a session` : `${k} — connected`}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px]"
+            style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', opacity: st === 'failed' ? 0.5 : 1 }}
+          >
+            <span
+              aria-hidden
+              className="inline-block h-1.5 w-1.5 rounded-full"
+              style={{ background: st === 'failed' ? 'var(--status-fail)' : 'var(--status-run)' }}
+            />
+            {k}
+          </span>
+        ))}
+      </div>
+      <div ref={scrollRef} className="flex max-h-72 flex-col gap-1.5 overflow-y-auto">
+        {msgs.length === 0 ? (
+          <p data-testid="assist-chat-waiting" className="font-mono text-[11px]" style={{ color: 'var(--ink-dim)' }}>
+            Sent — the agents answer here as their replies stream in.
+          </p>
+        ) : (
+          msgs.map((m, i) => (
+            <div key={i} data-testid="assist-chat-msg" data-agent={m.cliKey} data-pending={m.pending}>
+              <span className="font-mono text-[10px] font-semibold" style={{ color: 'var(--accent)' }}>
+                {m.cliKey}
+              </span>
+              <p
+                className="whitespace-pre-wrap text-[11px] leading-relaxed"
+                style={{ color: m.pending || m.ok ? 'var(--ink-body)' : 'var(--status-fail)' }}
+              >
+                {m.text}
+                {m.pending && <span aria-hidden className="animate-pulse"> …</span>}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── The dock ──────────────────────────────────────────────────────────────────────────────────
 
 export function AssistDock({ context, verbs, importable, open, onOpenChange, onError }: {
@@ -228,11 +410,13 @@ export function AssistDock({ context, verbs, importable, open, onOpenChange, onE
   const threadRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // The ACTIVE run: the newest run item — its gates/elicitations pin below the thread.
-  const activeRunId = useMemo(() => {
+  // The ACTIVE launch: the newest run/chat item — its gates/elicitations pin below the
+  // thread (the daemon keys chat-session gates by the chat id, §11.5).
+  const activeId = useMemo(() => {
     for (let i = items.length - 1; i >= 0; i -= 1) {
       const item = items[i];
       if (item !== undefined && item.kind === 'run') return item.runId;
+      if (item !== undefined && item.kind === 'chat') return item.chatId;
     }
     return null;
   }, [items]);
@@ -290,9 +474,19 @@ export function AssistDock({ context, verbs, importable, open, onOpenChange, onE
     // they attached it and asked; silently dropping it would run a different request.
     const documents = attachments.map((a) => ({ name: a.name, content: a.content }));
     try {
-      const { runId } = await verbs.send(body, documents);
+      const launched = await verbs.send(body, documents);
       push({ kind: 'user', text: body, files: documents.map((d) => d.name) });
-      push({ kind: 'run', runId });
+      if ('chatId' in launched) {
+        // One chat block per SESSION: a later send into the same warm session streams
+        // into the block that already exists — never a duplicate block per message.
+        setItems((cur) =>
+          cur.some((it) => it.kind === 'chat' && it.chatId === launched.chatId)
+            ? cur
+            : [...cur, { kind: 'chat', chatId: launched.chatId }],
+        );
+      } else {
+        push({ kind: 'run', runId: launched.runId });
+      }
       setText('');
       setAttachments([]);
     } catch (e) {
@@ -381,9 +575,32 @@ export function AssistDock({ context, verbs, importable, open, onOpenChange, onE
       {/* Thread — the ONE scrolling region (run blocks scroll inside themselves). */}
       <div ref={threadRef} data-testid="assist-thread" className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-3 py-3">
         {items.length === 0 && (
-          <p data-testid="assist-empty" className="text-[11px] leading-relaxed" style={{ color: 'var(--ink-dim)' }}>
-            {context.hint ?? 'Type below, or drop documents here.'}
-          </p>
+          <>
+            <p data-testid="assist-empty" className="text-[11px] leading-relaxed" style={{ color: 'var(--ink-dim)' }}>
+              {context.hint ?? 'Type below, or drop documents here.'}
+            </p>
+            {context.prompts !== undefined && context.prompts.length > 0 && (
+              <div data-testid="assist-prompts" className="flex flex-wrap gap-1.5">
+                {context.prompts.map((p) => (
+                  <button
+                    key={p.label}
+                    type="button"
+                    data-testid="assist-prompt"
+                    data-prompt={p.label}
+                    title="Prefills the composer — nothing sends until you do"
+                    onClick={() => {
+                      setText(p.text);
+                      textareaRef.current?.focus();
+                    }}
+                    className="rounded-full px-2.5 py-1 text-left text-[10px] focus:outline-none focus-visible:ring-1"
+                    style={{ border: '1px solid var(--surface-overlay)', color: 'var(--accent)', background: 'transparent' }}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
         )}
         {items.map((item, i) => {
           if (item.kind === 'user') {
@@ -405,6 +622,9 @@ export function AssistDock({ context, verbs, importable, open, onOpenChange, onE
               </p>
             );
           }
+          if (item.kind === 'chat') {
+            return <DockChat key={item.chatId} chatId={item.chatId} />;
+          }
           return <DockRun key={item.runId} runId={item.runId} />;
         })}
       </div>
@@ -413,9 +633,9 @@ export function AssistDock({ context, verbs, importable, open, onOpenChange, onE
           a structural sibling of the thread scroll (it can never scroll away). Capped at 60%
           of the panel with its OWN scroll: a long propose prompt must never push the composer
           below the fold (caught on the gated evidence pass). */}
-      {activeRunId !== null && (
+      {activeId !== null && (
         <div className="max-h-[60%] shrink-0 overflow-y-auto" style={{ borderTop: '1px solid var(--surface-raised)' }}>
-          <ApprovalDock chatId={activeRunId} onResolved={onGateResolved} />
+          <ApprovalDock chatId={activeId} onResolved={onGateResolved} />
         </div>
       )}
 

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -53,6 +53,9 @@ interface Props {
    *  auto-collapses the rail to its icon state; leaving restores what the user had.
    *  Hover-peek still works, and the expand control stays live — auto, not locked. */
   immersive?: boolean;
+  /** Opens the app-wide ASK dock (the AskDock binding of the assist panel). The Ask
+   *  entry renders only when the app wires this — the rail never paints a dead door. */
+  onOpenAsk?: () => void;
 }
 
 // The rail is chrome (`--surface-rail`); the token dress is §3.1/§3.5's.
@@ -534,7 +537,7 @@ function SteeringTypeRows({ navigate }: { navigate: (p: string) => void }): Reac
 
 const flatRunPath = (id: string): string => `/runs/${encodeURIComponent(id)}`;
 
-export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, immersive = false }: Props): React.ReactElement {
+export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, immersive = false, onOpenAsk }: Props): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
@@ -652,6 +655,44 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
       <div className={isExpanded ? 'px-4 pb-2' : 'flex justify-center pb-2'}>
         <NotificationBell navigate={navigate} collapsed={!isExpanded} />
       </div>
+
+      {/* ASK — below Notifications, above Projects, and deliberately its OWN idiom:
+          an accent-dressed action button, not a nav heading and not a bell sibling.
+          It opens the app-wide assist dock in the ask context (AskDock); the chord
+          Ctrl/⌘+Shift+A does the same and is documented in the '?' overlay. */}
+      {onOpenAsk !== undefined && (
+        <div className={isExpanded ? 'px-3 pb-2' : 'flex justify-center pb-2'}>
+          <button
+            type="button"
+            data-testid="rail-ask"
+            data-idiom="ask"
+            aria-label="Ask — governed answers about your projects, repos, and this studio (Ctrl/⌘+Shift+A)"
+            aria-keyshortcuts="Control+Shift+A Meta+Shift+A"
+            title="Ask — governed answers about your projects, repos, and this studio (Ctrl/⌘+Shift+A)"
+            onClick={onOpenAsk}
+            className={
+              isExpanded
+                ? 'w-full flex items-center gap-2 rounded-lg px-3 py-2 transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-1'
+                : 'w-9 h-9 flex items-center justify-center rounded-lg transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-1'
+            }
+            style={{
+              background: 'var(--accent-subtle)',
+              border: '1px solid var(--accent)',
+              color: 'var(--accent)',
+            }}
+          >
+            <span aria-hidden style={{ fontSize: 'var(--text-sm)', lineHeight: 1 }}>✦</span>
+            {isExpanded && (
+              <>
+                <span className="flex-1 text-left text-xs" style={{ fontWeight: 'var(--weight-semi)', fontFamily: 'var(--font-sans)' }}>
+                  Ask
+                </span>
+                <kbd className="font-mono text-[9px]" style={{ opacity: 0.75 }}>⌘⇧A</kbd>
+              </>
+            )}
+          </button>
+        </div>
+      )}
 
       {isExpanded ? (
         <div className="flex-1 overflow-y-auto flex flex-col min-h-0 px-2 pt-1" style={{ borderTop: `1px solid ${S.border}` }}>

--- a/src/components/SteeringGrid.tsx
+++ b/src/components/SteeringGrid.tsx
@@ -368,7 +368,7 @@ export function draftRule(d: Pick<DraftState, 'id' | 'steering_type' | 'severity
 const TYPE_OPTIONS = STEERING_TYPES.map((t) => ({ value: t, label: STEERING_TYPE_LABELS[t] }));
 const SEVERITY_OPTIONS = SEVERITIES.map((s) => ({ value: s, label: s }));
 
-export function SteeringGrid({ rules, type, loading, error, selectedId, onSelect, onCommit, onCreate, onRetired, addRequestTick = 0 }: {
+export function SteeringGrid({ rules, type, loading, error, selectedId, onSelect, onCommit, onCreate, onRetired, addRequestTick = 0, idFilter = null }: {
   /** The FULL store — this grid applies the page scope itself, one predicate everywhere. */
   rules: SteeringRule[];
   type: SteeringType;
@@ -386,12 +386,20 @@ export function SteeringGrid({ rules, type, loading, error, selectedId, onSelect
   onRetired: (rule: SteeringRule, reason: string) => void;
   /** Increment to open a draft row from outside (the Add ▾ menu's "Add row"). */
   addRequestTick?: number;
+  /** Restrict the sheet to these rule ids (the `?usage=unused` click-through from the
+   *  usage band). `null` = no restriction; the facets still apply on top. */
+  idFilter?: readonly string[] | null;
 }): React.ReactElement {
   const [facets, setFacets] = useState<GridFacets>(GRID_FACETS_DEFAULT);
   const [draft, setDraft] = useState<DraftState | null>(null);
   const [retiring, setRetiring] = useState<SteeringRule | null>(null);
 
-  const visible = useMemo(() => filterSteeringRules(rules, type, facets), [rules, type, facets]);
+  const visible = useMemo(() => {
+    const faceted = filterSteeringRules(rules, type, facets);
+    if (idFilter === null) return faceted;
+    const allowed = new Set(idFilter);
+    return faceted.filter((r) => allowed.has(r.id));
+  }, [rules, type, facets, idFilter]);
   const typeRules = useMemo(() => rules.filter((r) => steeringTypeOf(r) === type), [rules, type]);
   const severityCounts = useMemo(() => {
     const counts: Record<string, number> = { all: typeRules.length };

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -20,8 +20,11 @@ import {
   SEED_RUNBOOK_URL,
   type WikiMeta,
 } from '../api/wiki.js';
+import type { SessionView } from '../api/types.js';
+import { ruleUsage } from '../board/steeringUsage.js';
 import { AssistDock, useAssistDockOpen, type AssistNote, type AssistVerbs } from './AssistDock.js';
 import { SteeringAddMenu } from './SteeringAddMenu.js';
+import { SteeringUsageBand } from './SteeringUsageBand.js';
 import { SteeringGrid } from './SteeringGrid.js';
 import { SteeringHealth, SteeringStoreHealth, type ScoreboardState } from './SteeringHealth.js';
 import { SteeringRuleDrawer } from './SteeringRuleDrawer.js';
@@ -48,13 +51,17 @@ import { SteeringTypeCards } from './SteeringTypeCards.js';
  * MCP stays read-only (AW-11).
  */
 
-export function SteeringPage({ type, navigate, search = '' }: {
+export function SteeringPage({ type, navigate, search = '', runs = [] }: {
   /** The routed steering type — null on the bare `/steering` landing. */
   type: SteeringType | null;
   navigate: (path: string) => void;
   /** The URL search string — `?rule=<id>` deep-links a rule's drawer open
-   *  (the Evals gap rows link here, qe finding: hints became links). */
+   *  (the Evals gap rows link here, qe finding: hints became links);
+   *  `?usage=unused` filters a type page's grid to the rules the enforcement
+   *  record never cites (the usage band's click-through). */
   search?: string;
+  /** The app's one runs list — the usage band's governed-runs join. */
+  runs?: SessionView[];
 }): React.ReactElement {
   const [scoreboard, setScoreboard] = useState<ScoreboardState>({ kind: 'loading' });
   const [meta, setMeta] = useState<WikiMeta | null>(null);
@@ -258,6 +265,9 @@ export function SteeringPage({ type, navigate, search = '' }: {
           {/* The store-wide verdict lives HERE, the one place it is actionable
               (review #5) — its raw diagnostics fold behind a details toggle. */}
           <SteeringStoreHealth state={scoreboard} />
+          {/* When/how steering was used and its success rate — the usage band
+              (claims + per_rule evidence + the session's latest eval). */}
+          <SteeringUsageBand runs={runs} rules={rules} scoreboard={scoreboard} navigate={navigate} />
           {rulesLoading ? (
             <p data-testid="steering-rules-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading rules…</p>
           ) : rulesError !== null ? (
@@ -286,6 +296,16 @@ export function SteeringPage({ type, navigate, search = '' }: {
   // menu: the draft row and the assistant are exactly how a store gets seeded from here, so
   // the banner names both ways in.
   const unseeded = meta !== null && meta.seeded === false && rules.length === 0 && !rulesLoading;
+
+  // `?usage=unused` (the usage band's click-through): filter the grid to the ACTIVE rules the
+  // enforcement record never cites (per_rule: denial_claims + governs_evidence == 0). Computable
+  // only when the scoreboard is served — otherwise the page SAYS so and the grid stays
+  // unfiltered, never a silently empty sheet.
+  const usageFilterAsked = new URLSearchParams(search).get('usage') === 'unused';
+  const unusedIds =
+    usageFilterAsked && scoreboard.kind === 'loaded'
+      ? ruleUsage(rules, scoreboard.scoreboard.evidence.per_rule).unusedIds
+      : null;
 
   return (
     <div
@@ -365,6 +385,35 @@ export function SteeringPage({ type, navigate, search = '' }: {
           onOpenAssistant={() => setDockOpen(true)}
         />
 
+        {usageFilterAsked && (
+          <p
+            data-testid="steering-usage-filter-note"
+            className="rounded px-3 py-2 text-[11px]"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {unusedIds !== null ? (
+              <>
+                Showing the {unusedIds.length} rule{unusedIds.length === 1 ? '' : 's'} the enforcement
+                record never cites (no denial claims, no governs evidence).{' '}
+              </>
+            ) : (
+              <>
+                This daemon does not serve the governance scoreboard, so &ldquo;unused&rdquo; cannot be
+                computed — showing all rules.{' '}
+              </>
+            )}
+            <a
+              data-testid="steering-usage-filter-clear"
+              href={`/steering/${type}`}
+              onClick={(e) => { e.preventDefault(); navigate(`/steering/${type}`); }}
+              className="underline"
+              style={{ color: 'var(--accent)' }}
+            >
+              Show all
+            </a>
+          </p>
+        )}
+
         {savedNote !== null && (
           <p
             data-testid="steering-saved-note"
@@ -410,6 +459,7 @@ export function SteeringPage({ type, navigate, search = '' }: {
             onCreate={createRule}
             onRetired={onRetired}
             addRequestTick={addTick}
+            idFilter={unusedIds}
           />
         )}
       </div>

--- a/src/components/SteeringUsageBand.tsx
+++ b/src/components/SteeringUsageBand.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client.js';
+import { ApiError, isRouteAbsent } from '../api/errors.js';
+import { steeringPath, STEERING_TYPE_LABELS } from '../api/steering.js';
+import type { SteeringRule } from '../api/steering.js';
+import { testingPath } from '../api/testing.js';
+import type { GovernanceClaim, SessionView } from '../api/types.js';
+import { governedRuns, ruleUsage, usageWindows, USAGE_WINDOW_DAYS } from '../board/steeringUsage.js';
+import { useEvalReportStore } from '../store/evalReport.js';
+import { KpiBand, StatTile } from './dashboardKit.js';
+import type { ScoreboardState } from './SteeringHealth.js';
+
+/**
+ * The STEERING USAGE band — when/how steering was used and how well it works, on the
+ * `/steering` landing (dashboardKit, ≤6 tiles, every tile a door to something real):
+ *
+ *  1. GATE EVALUATIONS — claims recorded this window, delta + daily sparkline
+ *     (`GET /governance/claims`; the claim record IS the gateEvaluated/gateDecided fold,
+ *     durably timestamped) → /work, where the evaluated runs live.
+ *  2. DENIALS ISSUED — same window, bad-up delta → /work.
+ *  3. RUNS GOVERNED — % of live runs with ≥1 recorded evaluation (claim scopes name their
+ *     run; joined against the one runs list) → /work.
+ *  4. ALLOW / DENY — the current window's decision split → /work.
+ *  5. UNUSED RULES — active rules the enforcement record never cites (per_rule evidence:
+ *     denial_claims + governs_evidence == 0) → the type page holding the most, grid
+ *     FILTERED to those ids (`?usage=unused`). Context names the top-fired rule.
+ *  6. LATEST EVAL — the success lens: caught/gaps from THIS SESSION's eval run (the daemon
+ *     keeps no queryable eval history), honest absent tile otherwise → Testing › Evals.
+ *
+ * HONESTY: deltas render only over proven full prior windows (steeringUsage.ts); a daemon
+ * that does not serve the claims wire gets "—" tiles saying so, never zeros dressed as
+ * measurements; the scoreboard-less daemon gets the same on the rules tile.
+ */
+
+type ClaimsState =
+  | { kind: 'loading' }
+  | { kind: 'loaded'; claims: GovernanceClaim[] }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string };
+
+export function SteeringUsageBand({ runs, rules, scoreboard, navigate, now }: {
+  runs: SessionView[];
+  rules: SteeringRule[];
+  scoreboard: ScoreboardState;
+  navigate: (path: string) => void;
+  /** Test seam — defaults to the real clock. */
+  now?: number;
+}): React.ReactElement {
+  const [claims, setClaims] = useState<ClaimsState>({ kind: 'loading' });
+  const latestEval = useEvalReportStore((s) => s.latest);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listClaims()
+      .then(({ claims: all }) => {
+        if (!cancelled) setClaims({ kind: 'loaded', claims: all });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if ((e instanceof ApiError && e.status === 501) || isRouteAbsent(e)) {
+          setClaims({ kind: 'unsupported' });
+        } else {
+          setClaims({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const at = now ?? Date.now();
+  const loaded = claims.kind === 'loaded' ? claims.claims : null;
+  const windows = loaded !== null ? usageWindows(loaded, at) : null;
+  const governed = loaded !== null ? governedRuns(loaded, runs) : null;
+  const usage =
+    scoreboard.kind === 'loaded' ? ruleUsage(rules, scoreboard.scoreboard.evidence.per_rule) : null;
+
+  const windowWord = `last ${USAGE_WINDOW_DAYS}d`;
+  const claimsAbsentWord =
+    claims.kind === 'unsupported'
+      ? 'claims not served by this daemon'
+      : claims.kind === 'failed'
+        ? 'claims read failed'
+        : 'loading…';
+  const deltaContext = (previous: number | null): string =>
+    previous === null ? `${windowWord} — no proven prior window` : `${windowWord} vs previous ${USAGE_WINDOW_DAYS}d`;
+
+  const unusedHome =
+    usage !== null && usage.unusedIds.length > 0
+      ? `${steeringPath(usage.unusedHomeType ?? 'architecture')}?usage=unused`
+      : null;
+
+  return (
+    <KpiBand testId="steering-usage">
+      <StatTile
+        testId="steering-usage-evals"
+        label="Gate evaluations"
+        value={windows !== null ? windows.evaluations.current : '—'}
+        delta={windows?.evaluations}
+        spark={windows?.spark}
+        context={windows !== null ? deltaContext(windows.evaluations.previous) : claimsAbsentWord}
+        title="Recorded governance claims (gate evaluations) in the window — click for the runs they governed"
+        onOpen={() => navigate('/work')}
+        href="/work"
+      />
+      <StatTile
+        testId="steering-usage-denials"
+        label="Denials issued"
+        value={windows !== null ? windows.denials.current : '—'}
+        delta={windows?.denials}
+        deltaSense="bad-up"
+        valueColor={windows !== null && windows.denials.current > 0 ? 'var(--status-fail)' : undefined}
+        context={windows !== null ? deltaContext(windows.denials.previous) : claimsAbsentWord}
+        title="Gate evaluations that decided deny — click for the runs surface"
+        onOpen={() => navigate('/work')}
+        href="/work"
+      />
+      <StatTile
+        testId="steering-usage-governed"
+        label="Runs governed"
+        value={governed !== null && governed.pct !== null ? `${governed.pct}%` : '—'}
+        context={
+          governed !== null
+            ? governed.total === 0
+              ? 'no runs on this daemon yet'
+              : `${governed.governed} of ${governed.total} runs saw ≥1 gate evaluation`
+            : claimsAbsentWord
+        }
+        title="Share of live runs with at least one recorded gate evaluation"
+        onOpen={() => navigate('/work')}
+        href="/work"
+      />
+      <StatTile
+        testId="steering-usage-split"
+        label="Allow / deny"
+        value={windows !== null ? `${windows.allow} / ${windows.deny}` : '—'}
+        context={
+          windows !== null
+            ? `${windowWord} · ${windows.conditions} with conditions`
+            : claimsAbsentWord
+        }
+        title="This window's decision split — click for the runs surface"
+        onOpen={() => navigate('/work')}
+        href="/work"
+      />
+      <StatTile
+        testId="steering-usage-rules"
+        label="Unused rules"
+        value={usage !== null ? usage.unusedIds.length : '—'}
+        valueColor={usage !== null && usage.unusedIds.length > 0 ? 'var(--status-gate)' : undefined}
+        context={
+          usage === null
+            ? scoreboard.kind === 'unsupported'
+              ? 'scoreboard not served by this daemon'
+              : scoreboard.kind === 'failed'
+                ? 'scoreboard read failed'
+                : 'loading…'
+            : usage.topFired !== null
+              ? `top fired: ${usage.topFired.ruleId} ×${usage.topFired.total} · ${usage.firedCount} rules evidenced`
+              : 'no rule has fired yet — nothing in the enforcement record'
+        }
+        title={
+          unusedHome !== null
+            ? `Active rules with zero enforcement evidence — open ${STEERING_TYPE_LABELS[usage?.unusedHomeType ?? 'architecture']} filtered to them`
+            : 'Active rules with zero enforcement evidence (no denial claims, no governs evidence)'
+        }
+        {...(unusedHome !== null ? { onOpen: () => navigate(unusedHome), href: unusedHome } : {})}
+      />
+      <StatTile
+        testId="steering-usage-eval"
+        label="Latest eval"
+        value={
+          latestEval !== null
+            ? `${latestEval.report.summary.caught}/${latestEval.report.summary.total}`
+            : '—'
+        }
+        valueColor={
+          latestEval !== null && latestEval.report.summary.gaps > 0 ? 'var(--status-gate)' : undefined
+        }
+        context={
+          latestEval !== null
+            ? `caught · ${latestEval.report.summary.gaps} gaps · ${latestEval.report.summary.false_positives} false pos — this session`
+            : 'no eval run this session — run one on Testing › Evals'
+        }
+        title="The steering-rule eval verdict (caught vs gap) — the success lens; session-local because the daemon keeps no eval history"
+        onOpen={() => navigate(testingPath('evals'))}
+        href={testingPath('evals')}
+      />
+    </KpiBand>
+  );
+}

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -15,6 +15,7 @@ import {
   type EvalSample,
   type TestingSubPage,
 } from '../api/testing.js';
+import { useEvalReportStore } from '../store/evalReport.js';
 import { CampaignScoreboard } from './CampaignScoreboard.js';
 import { CampaignsPage } from './CampaignsPage.js';
 import { readFileText } from './fileText.js';
@@ -280,6 +281,9 @@ function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.Re
         ...(corpusUsed !== null ? { corpus: corpusUsed } : {}),
       });
       setState({ kind: 'done', report, corpus: corpusUsed });
+      // Deposit for the Steering landing's success-lens tile (session-local — the
+      // daemon keeps no queryable eval history, so THIS is the latest-eval record).
+      useEvalReportStore.getState().deposit(report, corpusUsed);
     } catch (e) {
       if (isTestingUnsupported(e)) setState({ kind: 'unsupported' });
       else setState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });

--- a/src/components/askContext.ts
+++ b/src/components/askContext.ts
@@ -1,0 +1,219 @@
+import type { Project, RepoEntry, SessionView } from '../api/types.js';
+import type { Diagnostics } from '../api/diagnostics.js';
+import { statusCounts } from '../board/windowStats.js';
+import { headingForPath } from './LeftSidebar.js';
+import { humanTitle } from './runIdentity.js';
+
+/**
+ * The ASK context pack (the app-wide Ask feature) — pure derivations, pinned by unit test.
+ *
+ * The pack is what the app KNOWS, spelled as plain text that rides the FIRST message of the
+ * governed chat session (never sent on its own — nothing launches without the user's send):
+ *
+ *  - where the operator is standing (the rail's own route→section map — one derivation);
+ *  - counts from the section folds the app already holds (`statusCounts` over the one runs
+ *    list — zero new requests);
+ *  - the daemon's self-description when `GET /api/v1/diagnostics` is SERVED — versions,
+ *    stores, recent errors, ACP health — each cited as the wire's answer; when the route is
+ *    absent (older crews) the pack SAYS SO honestly instead of fabricating, and instructs
+ *    the answering agents to do the same.
+ */
+
+// ── Where am I — the route → section reading ──────────────────────────────────────────────────
+
+const SECTION_LABELS: Record<string, string> = {
+  projects: 'Projects',
+  make: 'Make',
+  chat: 'Chat',
+  repos: 'Repositories',
+  testing: 'Testing',
+  steering: 'Steering',
+  settings: 'Settings',
+};
+
+/** The current section, from the SAME route→heading map the rail navigates by. */
+export function sectionLabel(pathname: string): string {
+  const heading = headingForPath(pathname);
+  if (heading !== null) return SECTION_LABELS[heading] ?? 'Studio';
+  const [, first = ''] = pathname.split('/');
+  if (first === '') return 'Home';
+  if (first === 'work' || first === 'runs') return 'Work';
+  return 'Studio';
+}
+
+// ── Formatting (display-honest: no invented precision) ───────────────────────────────────────
+
+export function fmtBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function fmtUptime(ms: number): string {
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 48) return `${hours}h ${mins % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+// ── The diagnostics presence gate ─────────────────────────────────────────────────────────────
+
+export type DiagnosticsState =
+  | { kind: 'loading' }
+  | { kind: 'present'; diagnostics: Diagnostics }
+  /** The route is absent/unserved on this daemon — older crews have no /diagnostics. */
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string };
+
+/** The one-line summary the dock's empty state shows about the pack it will send. */
+export function contextPackSummary(diag: DiagnosticsState): string {
+  switch (diag.kind) {
+    case 'present': {
+      const d = diag.diagnostics;
+      const clis = Object.keys(d.acp.byCli).length;
+      return `Context pack ready: diagnostics cited (crew ${d.components.crew} · ${d.stores.length} stores · ACP health for ${clis} CLI${clis === 1 ? '' : 's'}) + route + run counts.`;
+    }
+    case 'unsupported':
+      return 'Context pack ready: route + run counts. Diagnostics are NOT served by this daemon (older crew — no GET /api/v1/diagnostics), so versions, stores, and ACP health ride as honestly absent.';
+    case 'failed':
+      return `Context pack ready: route + run counts. The diagnostics read failed (${diag.message}) — versions, stores, and ACP health ride as honestly absent.`;
+    case 'loading':
+      return 'Assembling the context pack…';
+  }
+}
+
+// ── The pack itself ───────────────────────────────────────────────────────────────────────────
+
+function diagnosticsSection(diag: DiagnosticsState): string[] {
+  if (diag.kind === 'unsupported') {
+    return [
+      'diagnostics: NOT SERVED — this daemon has no GET /api/v1/diagnostics (older crew).',
+      '  Component versions, store sizes, recent errors, and ACP health are unavailable to this',
+      '  pack; say so rather than guess.',
+    ];
+  }
+  if (diag.kind === 'failed') {
+    return [`diagnostics: the read failed (${diag.message}) — treat those facts as unavailable, never guessed.`];
+  }
+  if (diag.kind === 'loading') {
+    return ['diagnostics: the read had not answered when this message was sent.'];
+  }
+  const d = diag.diagnostics;
+  const lines: string[] = ['diagnostics (GET /api/v1/diagnostics):'];
+  const engines = Object.entries(d.components.engineBinaries)
+    .map(([name, v]) => `${name} ${v ?? '(unversioned)'}`)
+    .join(', ');
+  lines.push(
+    `  components: crew ${d.components.crew}` +
+      ` · studio bundle ${d.components.studioBundle ?? '(not reported)'}` +
+      ` · core-ts ${d.components.coreTs ?? '(not reported)'}` +
+      (engines !== '' ? ` · engines: ${engines}` : ''),
+  );
+  lines.push(
+    `  daemon: up ${fmtUptime(d.daemon.uptimeMs)} on port ${d.daemon.port} (started ${new Date(d.daemon.startedAt).toISOString()})`,
+  );
+  if (d.stores.length > 0) {
+    lines.push(
+      `  stores: ${d.stores.map((s) => `${s.name} ${fmtBytes(s.bytes)} (${s.path})`).join(' · ')}`,
+    );
+  } else {
+    lines.push('  stores: none reported');
+  }
+  if (d.recentErrors.length > 0) {
+    const newest = d.recentErrors[0];
+    lines.push(
+      `  recent errors: ${d.recentErrors.length} recorded — newest [${newest?.source ?? '?'}] ${newest?.line ?? ''}`,
+    );
+  } else {
+    lines.push('  recent errors: none recorded');
+  }
+  const acpEntries = Object.entries(d.acp.byCli);
+  if (acpEntries.length > 0) {
+    lines.push(
+      `  acp (from the durable run event logs): ${acpEntries
+        .map(([cli, a]) => {
+          const last =
+            a.lastFallbackTs !== null ? `, last fallback ${new Date(a.lastFallbackTs).toISOString().slice(0, 10)}` : '';
+          return `${cli} ${a.sessionsStarted} sessions/${a.fallbacks} fallbacks${last}`;
+        })
+        .join(' · ')}`,
+    );
+  } else {
+    lines.push('  acp: no session/fallback events recorded');
+  }
+  return lines;
+}
+
+/**
+ * Assemble the pack that rides the first send. Everything in it is something the app
+ * actually holds or the wire actually answered — counts from the one runs list, the
+ * route section, and the diagnostics answer (or its honest absence).
+ */
+export function buildContextPack(args: {
+  pathname: string;
+  runs: SessionView[];
+  liveChatCount: number;
+  diagnostics: DiagnosticsState;
+  now?: number;
+}): string {
+  const { pathname, runs, liveChatCount, diagnostics } = args;
+  const at = new Date(args.now ?? Date.now()).toISOString();
+  const c = statusCounts(runs);
+  const lines: string[] = [
+    `[studio context pack — assembled ${at}]`,
+    `where: ${sectionLabel(pathname)} (${pathname})`,
+    `runs (the studio's live list): ${c.total} total — ${c.active} active, ${c.gates} awaiting a human, ${c.failed} failed, ${c.done} done, ${c.cancelled} cancelled`,
+    `live chat sessions this client knows about: ${liveChatCount}`,
+    ...diagnosticsSection(diagnostics),
+    'Answer from what you can actually read (the estate/garden tooling reaches the code graph,',
+    'stores, and run record); when a fact is not reachable, say so instead of guessing.',
+  ];
+  return lines.join('\n');
+}
+
+// ── Quick prompts (prefill-only chips — nothing sends without the user) ──────────────────────
+
+export interface AskPromptSeed {
+  runs: SessionView[];
+  projects: Project[];
+  repos: RepoEntry[];
+}
+
+/** The quick-prompt chips. Chips whose referent the app does not hold are OMITTED, never
+ *  fabricated (no failed run ⇒ no "why did it fail" chip). */
+export function askPrompts({ runs, projects, repos }: AskPromptSeed): { label: string; text: string }[] {
+  const prompts: { label: string; text: string }[] = [];
+  const failed = runs.find((v) => v.session.status === 'failed' && v.session.archived_at == null);
+  if (failed !== undefined) {
+    const title = humanTitle(failed.session.problem);
+    prompts.push({
+      label: `Why did run ${failed.session.id.slice(0, 8)} fail?`,
+      text: `Why did run ${failed.session.id} ("${title}") fail? Walk the run record and its evidence.`,
+    });
+  }
+  const project = projects.find((p) => p.id !== 'default');
+  if (project !== undefined) {
+    prompts.push({
+      label: `What's in project ${project.name}?`,
+      text: `What's in project "${project.name}" (${project.id}) — runs, docs, repos, and how healthy is it?`,
+    });
+  }
+  const repo = repos[0];
+  if (repo !== undefined) {
+    prompts.push({
+      label: `What changed in repo ${repo.name}?`,
+      text: `What changed in repo "${repo.name}" recently? Use its code graph and run history.`,
+    });
+  }
+  prompts.push({
+    label: 'Diagnose studio',
+    text: 'Diagnose this studio installation — the app, its daemon, and its dependencies. Anything unhealthy in the context pack or the stores?',
+  });
+  prompts.push({
+    label: 'Is ACP healthy across the CLIs?',
+    text: 'Is ACP healthy across the CLIs? Compare sessions started vs fallbacks per CLI and flag anything degrading.',
+  });
+  return prompts;
+}

--- a/src/store/evalReport.ts
+++ b/src/store/evalReport.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import type { EvalReport } from '../api/testing.js';
+
+/**
+ * The LATEST steering-eval report this session ran (Testing › Evals deposits it after a
+ * successful `POST /testing/evals/run`). The daemon keeps no queryable eval history — the
+ * run wire is a POST that computes and answers — so the Steering landing's success-lens
+ * tile reads THIS session-local deposit, and renders the honest absent state ("no eval run
+ * this session") when nothing has run. Never persisted: a stored report would relabel a
+ * stale verdict as current.
+ */
+
+export interface EvalDeposit {
+  report: EvalReport;
+  /** What the report ran against (`null` = the built-in default corpus). */
+  corpus: string | null;
+  /** When the report landed (ms epoch). */
+  at: number;
+}
+
+interface EvalReportState {
+  latest: EvalDeposit | null;
+  deposit: (report: EvalReport, corpus: string | null) => void;
+}
+
+export const useEvalReportStore = create<EvalReportState>((set) => ({
+  latest: null,
+  deposit: (report, corpus) => set({ latest: { report, corpus, at: Date.now() } }),
+}));

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.6",
   "counts": {
     "files": 118,
-    "occurrences": 931,
-    "static": 796,
+    "occurrences": 940,
+    "static": 805,
     "dynamic": 44,
     "computed": 6
   },
@@ -206,6 +206,30 @@
       ]
     },
     {
+      "testId": "assist-chat",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
+      "testId": "assist-chat-msg",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
+      "testId": "assist-chat-seat",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
+      "testId": "assist-chat-waiting",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
       "testId": "assist-context",
       "files": [
         "src/components/AssistDock.tsx"
@@ -249,6 +273,18 @@
     },
     {
       "testId": "assist-note",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
+      "testId": "assist-prompt",
+      "files": [
+        "src/components/AssistDock.tsx"
+      ]
+    },
+    {
+      "testId": "assist-prompts",
       "files": [
         "src/components/AssistDock.tsx"
       ]
@@ -2795,6 +2831,12 @@
       ]
     },
     {
+      "testId": "rail-ask",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
       "testId": "rail-chevron",
       "files": [
         "src/components/LeftSidebar.tsx"
@@ -3895,6 +3937,18 @@
     },
     {
       "testId": "steering-unseeded",
+      "files": [
+        "src/components/SteeringPage.tsx"
+      ]
+    },
+    {
+      "testId": "steering-usage-filter-clear",
+      "files": [
+        "src/components/SteeringPage.tsx"
+      ]
+    },
+    {
+      "testId": "steering-usage-filter-note",
       "files": [
         "src/components/SteeringPage.tsx"
       ]

--- a/tests/AskDock.test.tsx
+++ b/tests/AskDock.test.tsx
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiError } from '../src/api/errors.js';
+import type { Diagnostics } from '../src/api/diagnostics.js';
+import type { RosterSeat } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+/**
+ * ASK — the app-wide assist-dock binding:
+ *  - opening it fires READS only (the diagnostics probe + prompt-seed caches);
+ *    NOTHING launches until the user sends — chips PREFILL, never submit;
+ *  - the context pack CITES `GET /api/v1/diagnostics` when the daemon serves it, and
+ *    DEGRADES HONESTLY when the route is absent (older crews) — both fixtures pinned;
+ *  - a send opens ONE governed chat session over the GroupChat seat wire
+ *    (`POST /chats` with the chat-capable roster, then `POST /chats/:id/messages`
+ *    carrying question + pack) and later sends REUSE the warm session (pack rides
+ *    the first message only).
+ */
+
+const openChat = vi.fn();
+const sendChatMessage = vi.fn();
+const getRoster = vi.fn();
+const getChat = vi.fn();
+const listRepos = vi.fn();
+const listProjects = vi.fn();
+const apiFetch = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+    getRun: () => Promise.reject(new Error('no run snapshot in this rig')),
+  },
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const { AskDock } = await import('../src/components/AskDock.js');
+const { clearCachedRoster, setCachedRoster } = await import('../src/store/rosterCache.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useLiveChatsStore } = await import('../src/store/liveChats.js');
+
+/** The live-daemon roster shape in miniature: acp objects mark the chat-capable seats. */
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true, acp: { binary: 'claude-agent-acp' } },
+  { key: 'codex', enabled_for_council: true }, // speaks-acp roster ⇒ absent key = not capable
+  { key: 'pi', enabled_for_council: false, acp: { binary: 'pi-acp' } },
+] as unknown as RosterSeat[];
+
+const DIAGNOSTICS: Diagnostics = {
+  components: {
+    crew: '0.7.6',
+    studioBundle: '0.4.6',
+    coreTs: '0.7.6',
+    engineBinaries: { 'wicked-core': '0.15.2', 'wicked-estate': null },
+  },
+  daemon: { uptimeMs: 3 * 3_600_000, startedAt: 1_800_000_000_000, port: 7701 },
+  stores: [{ name: 'core.db', path: '/home/x/.wicked-crew/core.db', bytes: 12_400_000 }],
+  recentErrors: [{ ts: 1_800_000_100_000, source: 'daemon', line: 'ECONNRESET on /ws' }],
+  acp: {
+    byCli: {
+      claude: { sessionsStarted: 160, fallbacks: 85, fallbackKinds: { 'spawn-failed': 85 }, lastStartedTs: 1_800_000_000_000, lastFallbackTs: 1_790_000_000_000 },
+      codex: { sessionsStarted: 0, fallbacks: 0, fallbackKinds: {}, lastStartedTs: null, lastFallbackTs: null },
+    },
+  },
+};
+
+function wireDiagnostics(mode: 'present' | 'absent'): void {
+  apiFetch.mockImplementation((path: unknown) => {
+    if (path === '/diagnostics') {
+      return mode === 'present'
+        ? Promise.resolve(DIAGNOSTICS)
+        : Promise.reject(new ApiError(404, 'not found'));
+    }
+    return Promise.reject(new Error(`unexpected apiFetch path: ${String(path)}`));
+  });
+}
+
+function dock(runs: ReturnType<typeof makeView>[] = [], pathname = '/steering'): void {
+  render(<AskDock runs={runs} pathname={pathname} onClose={() => undefined} />);
+}
+
+beforeEach(() => {
+  cleanup();
+  openChat.mockReset();
+  sendChatMessage.mockReset();
+  getRoster.mockReset();
+  getChat.mockReset();
+  listRepos.mockReset();
+  listProjects.mockReset();
+  apiFetch.mockReset();
+  clearCachedRoster();
+  clearRepoCache();
+  setCachedRoster(ROSTER);
+  listRepos.mockResolvedValue({ repos: [] });
+  listProjects.mockResolvedValue({ projects: [] });
+  getChat.mockResolvedValue({ chatId: 'x', seats: ['claude', 'pi'] });
+  openChat.mockImplementation((body: { chatId: string }) =>
+    Promise.resolve({ chatId: body.chatId, seats: [{ cliKey: 'claude', ok: true }, { cliKey: 'pi', ok: true }] }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: ['claude', 'pi'] });
+  useProjectsStore.setState({ projects: [], loading: false, error: null });
+  useLiveChatsStore.setState({ sessions: {} });
+  try { localStorage.clear(); } catch { /* stubbed in setup */ }
+});
+
+describe('the context pack — diagnostics presence-gated, both fixtures', () => {
+  it('CITES diagnostics when the daemon serves them (hint + the pack that rides the send)', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('present');
+    dock();
+
+    // The dock's empty state names what the pack will carry.
+    await waitFor(() =>
+      expect(screen.getByTestId('assist-empty')).toHaveTextContent('diagnostics cited (crew 0.7.6 · 1 stores · ACP health for 2 CLIs)'),
+    );
+
+    await user.type(screen.getByTestId('assist-input'), 'diagnose the studio');
+    await user.click(screen.getByTestId('assist-send'));
+
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(1));
+    const [, message] = sendChatMessage.mock.calls[0] as [string, string];
+    expect(message.startsWith('diagnose the studio')).toBe(true);
+    expect(message).toContain('[studio context pack');
+    expect(message).toContain('where: Steering (/steering)');
+    expect(message).toContain('diagnostics (GET /api/v1/diagnostics):');
+    expect(message).toContain('crew 0.7.6');
+    expect(message).toContain('core.db 11.8 MB');
+    expect(message).toContain('claude 160 sessions/85 fallbacks');
+    expect(message).toContain('recent errors: 1 recorded — newest [daemon] ECONNRESET on /ws');
+  });
+
+  it('DEGRADES honestly when the route is absent — the pack says so, fabricating nothing', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('absent');
+    dock();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('assist-empty')).toHaveTextContent('Diagnostics are NOT served by this daemon (older crew — no GET /api/v1/diagnostics)'),
+    );
+
+    await user.type(screen.getByTestId('assist-input'), 'diagnose the studio');
+    await user.click(screen.getByTestId('assist-send'));
+
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(1));
+    const [, message] = sendChatMessage.mock.calls[0] as [string, string];
+    expect(message).toContain('diagnostics: NOT SERVED — this daemon has no GET /api/v1/diagnostics (older crew).');
+    expect(message).not.toContain('crew 0.7.6');
+  });
+});
+
+describe('nothing launches without the user sending', () => {
+  it('mount + chip click fire NO chat wires — the chip only PREFILLS the composer', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('present');
+    dock([makeView({ id: 'run-dead-1', status: 'failed', problem: 'ship the parser' })]);
+
+    await waitFor(() => expect(screen.getByTestId('assist-prompts')).toBeInTheDocument());
+    const chips = screen.getAllByTestId('assist-prompt');
+    // The failed-run chip prefills with THAT run's identity.
+    const failChip = chips.find((c) => c.getAttribute('data-prompt')?.startsWith('Why did run'));
+    expect(failChip).toBeDefined();
+    expect(failChip).toHaveAttribute('data-prompt', 'Why did run run-dead fail?');
+    await user.click(failChip!);
+    const input = screen.getByTestId('assist-input');
+    expect((input as HTMLTextAreaElement).value).toContain('run-dead-1');
+    expect((input as HTMLTextAreaElement).value).toContain('ship the parser');
+
+    // The always-on diagnostics chips exist too.
+    expect(chips.some((c) => c.getAttribute('data-prompt') === 'Diagnose studio')).toBe(true);
+    expect(chips.some((c) => c.getAttribute('data-prompt') === 'Is ACP healthy across the CLIs?')).toBe(true);
+
+    // NOTHING was sent by any of that.
+    expect(openChat).not.toHaveBeenCalled();
+    expect(sendChatMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('the chat-launch wire — the GroupChat seat machinery, one warm session', () => {
+  it('first send opens the chat with the CHAT-CAPABLE roster and fans the seeded question out', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('present');
+    dock();
+
+    await user.type(screen.getByTestId('assist-input'), 'what is in the estate store?');
+    await user.click(screen.getByTestId('assist-send'));
+
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const body = openChat.mock.calls[0]?.[0] as { chatId: string; clis?: string[] };
+    expect(body.chatId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(body.clis).toEqual(['claude', 'pi']); // acp-capable only — codex has no config
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(body.chatId, expect.stringContaining('what is in the estate store?')));
+
+    // The chat block mounts for the session and the live-chats store knows it (rail row).
+    expect(await screen.findByTestId('assist-chat')).toHaveAttribute('data-chat-id', body.chatId);
+    expect(useLiveChatsStore.getState().sessions[body.chatId]?.seats).toEqual(['claude', 'pi']);
+  });
+
+  it('a second send REUSES the warm session and the pack rides the FIRST message only', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('present');
+    dock();
+
+    await user.type(screen.getByTestId('assist-input'), 'first question');
+    await user.click(screen.getByTestId('assist-send'));
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(1));
+
+    await user.type(screen.getByTestId('assist-input'), 'follow-up');
+    await user.click(screen.getByTestId('assist-send'));
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+
+    expect(openChat).toHaveBeenCalledTimes(1); // one session, reused
+    const first = sendChatMessage.mock.calls[0] as [string, string];
+    const second = sendChatMessage.mock.calls[1] as [string, string];
+    expect(first[0]).toBe(second[0]); // same chat id
+    expect(first[1]).toContain('[studio context pack');
+    expect(second[1]).toBe('follow-up'); // no pack re-sent
+    // Still ONE chat block — the session streams on, never a duplicate block.
+    expect(screen.getAllByTestId('assist-chat')).toHaveLength(1);
+  });
+
+  it('a fully-failed open surfaces as an honest failure note, naming the seats', async () => {
+    const user = userEvent.setup();
+    wireDiagnostics('present');
+    openChat.mockResolvedValue({ chatId: 'x', seats: [{ cliKey: 'claude', ok: false, error: 'no ACP config' }] });
+    dock();
+
+    await user.type(screen.getByTestId('assist-input'), 'hello?');
+    await user.click(screen.getByTestId('assist-send'));
+
+    const note = await screen.findByTestId('assist-note');
+    expect(note).toHaveTextContent('No agent seat came up — claude: no ACP config');
+    expect(sendChatMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/AskRail.test.tsx
+++ b/tests/AskRail.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { chordMatches, registerShortcuts, type ShortcutEntry } from '../src/hooks/useGlobalShortcuts.js';
+
+/**
+ * The rail's ASK entry (the app-wide ask feature): BELOW Notifications, ABOVE Projects,
+ * and its OWN idiom — an accent-dressed action button (`data-idiom="ask"`), not a nav
+ * heading row and not a bell sibling. Its chord (Ctrl/⌘+Shift+A) registers in the ONE
+ * shortcut registry, so the '?' overlay documents it for free.
+ */
+
+vi.mock('../src/hooks/useBoardModel.js', () => ({
+  useBoardModel: () => ({ items: [], unfiled: [], loading: false, error: null }),
+}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ status: 'ok', version: '0.2.0', ping: 'pong' }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+}));
+
+const { LeftSidebar } = await import('../src/components/LeftSidebar.js');
+
+function rail(onOpenAsk?: () => void): void {
+  render(
+    <LeftSidebar
+      runs={[]}
+      navigate={() => undefined}
+      pathname="/"
+      {...(onOpenAsk !== undefined ? { onOpenAsk } : {})}
+    />,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('the Ask rail entry — placement + idiom', () => {
+  it('sits BELOW the notification bell and ABOVE the Projects heading', () => {
+    rail(() => undefined);
+    const ask = screen.getByTestId('rail-ask');
+    const bell = screen.getByTitle('Notifications'); // the bell trigger
+    const projects = screen.getByTestId('rail-heading-projects');
+    // DOM order is the rail order: bell → ask → projects.
+    expect(bell.compareDocumentPosition(ask) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ask.compareDocumentPosition(projects) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('is its OWN idiom: an accent button, not a heading row and not a bell sibling', () => {
+    rail(() => undefined);
+    const ask = screen.getByTestId('rail-ask');
+    expect(ask.tagName).toBe('BUTTON');
+    expect(ask).toHaveAttribute('data-idiom', 'ask');
+    // Not a nav heading: no chevron, no aria-expanded, none of the heading testids.
+    expect(ask).not.toHaveAttribute('aria-expanded');
+    expect(ask.querySelector('[data-testid="rail-chevron"]')).toBeNull();
+    // Accent-dressed — visually distinct from the muted nav rows.
+    expect(ask.style.border).toContain('var(--accent)');
+    // The chord is declared on the control for a11y + at-a-glance discovery.
+    expect(ask.getAttribute('aria-keyshortcuts')).toContain('Shift+A');
+  });
+
+  it('clicking it fires onOpenAsk', async () => {
+    const onOpenAsk = vi.fn();
+    rail(onOpenAsk);
+    await userEvent.setup().click(screen.getByTestId('rail-ask'));
+    expect(onOpenAsk).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders NO Ask entry when the app has not wired one (no dead door)', () => {
+    rail(undefined);
+    expect(screen.queryByTestId('rail-ask')).toBeNull();
+  });
+});
+
+describe('the Ask chord — Ctrl/⌘+Shift+A through the one registry', () => {
+  it('matches exactly Ctrl/⌘+Shift+A and toggles through the registered handler', () => {
+    let open = false;
+    const entry: ShortcutEntry = {
+      id: 'ask-dock',
+      chord: { key: 'a', ctrlOrMeta: true, shift: true },
+      group: 'panels',
+      description: 'Ask — governed answers about your projects, repos, and this studio',
+      handler: () => {
+        open = !open;
+      },
+    };
+    const unregister = registerShortcuts([entry]);
+    try {
+      // The exact chord (macOS reports 'A' with shift down — chordMatches lowercases).
+      const hit = new KeyboardEvent('keydown', { key: 'A', metaKey: true, shiftKey: true });
+      expect(chordMatches(hit, entry.chord)).toBe(true);
+      window.dispatchEvent(hit);
+      expect(open).toBe(true);
+      // Near-misses stay inert: no shift, and a bare 'a'.
+      expect(chordMatches(new KeyboardEvent('keydown', { key: 'a', metaKey: true }), entry.chord)).toBe(false);
+      expect(chordMatches(new KeyboardEvent('keydown', { key: 'a' }), entry.chord)).toBe(false);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', metaKey: true }));
+      expect(open).toBe(true);
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/tests/AssistDock.chat.test.tsx
+++ b/tests/AssistDock.chat.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { CoreEvent } from '../src/api/types.js';
+import type { AssistVerbs } from '../src/components/AssistDock.js';
+
+/**
+ * The assist dock's CHAT launches (the generic contract's second launch shape): a
+ * `verbs.send` that answers `{chatId}` mounts ONE chat block for the session —
+ * the block streams `chatDelta` frames per seat (FIFO), lets the terminal
+ * `chatReply` REPLACE the accumulated deltas (authoritative), marks failed seats,
+ * and a later send into the same session never mounts a duplicate block.
+ */
+
+const getChat = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getChat: (...a: unknown[]) => getChat(...a),
+    getRun: () => Promise.reject(new Error('no run snapshot in this rig')),
+    confirmGate: vi.fn(),
+    cancelRun: vi.fn(),
+  },
+  apiFetch: vi.fn(() => Promise.reject(new Error('no wire in this rig'))),
+}));
+
+// Capture the dock's event-stream fold so the test can push frames through it.
+let emit: ((ev: CoreEvent) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (handler: (ev: CoreEvent) => void) => {
+    emit = handler;
+  },
+}));
+
+const { AssistDock } = await import('../src/components/AssistDock.js');
+
+function frame(f: Record<string, unknown>): CoreEvent {
+  return f as unknown as CoreEvent;
+}
+
+function dock(v: AssistVerbs): void {
+  render(
+    <AssistDock
+      context={{ surface: 'rig', title: 'Assistant', contextLabel: 'Rig', placeholder: 'Type…' }}
+      verbs={v}
+      open
+      onOpenChange={() => undefined}
+    />,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  emit = null;
+  getChat.mockReset();
+  getChat.mockResolvedValue({ chatId: 'chat-1', seats: ['claude', 'pi'] });
+  try { localStorage.clear(); } catch { /* stubbed */ }
+});
+
+describe('AssistDock — the chat block', () => {
+  it('a {chatId} send mounts the block with the snapshot seats; deltas stream FIFO and the reply replaces them', async () => {
+    const user = userEvent.setup();
+    const v: AssistVerbs = { send: vi.fn().mockResolvedValue({ chatId: 'chat-1' }) };
+    dock(v);
+
+    await user.type(screen.getByTestId('assist-input'), 'what changed?');
+    await user.click(screen.getByTestId('assist-send'));
+
+    const block = await screen.findByTestId('assist-chat');
+    expect(block).toHaveAttribute('data-chat-id', 'chat-1');
+    // Seats from the one GET /chats/:id snapshot.
+    await waitFor(() => expect(screen.getAllByTestId('assist-chat-seat')).toHaveLength(2));
+    expect(screen.getByTestId('assist-chat-waiting')).toBeInTheDocument();
+
+    // Foreign chat frames are ignored; this session's stream in.
+    act(() => {
+      emit?.(frame({ type: 'chatDelta', chat: 'other-chat', cliKey: 'claude', text: 'WRONG' }));
+      emit?.(frame({ type: 'chatDelta', chat: 'chat-1', cliKey: 'claude', text: 'The repo ' }));
+      emit?.(frame({ type: 'chatDelta', chat: 'chat-1', cliKey: 'claude', text: 'gained a parser.' }));
+    });
+    const msg = screen.getByTestId('assist-chat-msg');
+    expect(msg).toHaveTextContent('The repo gained a parser.');
+    expect(msg).toHaveAttribute('data-pending', 'true');
+    expect(screen.queryByText(/WRONG/)).toBeNull();
+
+    // The terminal reply is authoritative — it REPLACES the deltas.
+    act(() => {
+      emit?.(frame({ type: 'chatReply', chat: 'chat-1', cliKey: 'claude', text: 'The repo gained a parser module (src/parse.ts).', ok: true }));
+    });
+    expect(screen.getByTestId('assist-chat-msg')).toHaveTextContent('The repo gained a parser module (src/parse.ts).');
+    expect(screen.getByTestId('assist-chat-msg')).toHaveAttribute('data-pending', 'false');
+  });
+
+  it('a failed seat is marked; a second send into the SAME session mounts no duplicate block', async () => {
+    const user = userEvent.setup();
+    const v: AssistVerbs = { send: vi.fn().mockResolvedValue({ chatId: 'chat-1' }) };
+    dock(v);
+
+    await user.type(screen.getByTestId('assist-input'), 'q1');
+    await user.click(screen.getByTestId('assist-send'));
+    await screen.findByTestId('assist-chat');
+
+    act(() => {
+      emit?.(frame({ type: 'chatSessionFailed', chat: 'chat-1', cliKey: 'pi', reason: 'session died' }));
+    });
+    const seats = screen.getAllByTestId('assist-chat-seat');
+    const pi = seats.find((s) => s.getAttribute('data-agent') === 'pi');
+    expect(pi).toHaveAttribute('data-state', 'failed');
+
+    await user.type(screen.getByTestId('assist-input'), 'q2');
+    await user.click(screen.getByTestId('assist-send'));
+    await waitFor(() => expect(screen.getAllByTestId('assist-user-msg')).toHaveLength(2));
+    expect(screen.getAllByTestId('assist-chat')).toHaveLength(1); // one session, one block
+  });
+});

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -34,6 +34,7 @@ import type { WikiMeta, WikiScoreboard } from '../src/api/wiki.js';
 const listConformanceRules = vi.fn();
 const retireConformanceRule = vi.fn();
 const upsertConformanceRule = vi.fn();
+const listClaims = vi.fn();
 const apiFetch = vi.fn();
 
 vi.mock('../src/api/client.js', () => ({
@@ -41,6 +42,7 @@ vi.mock('../src/api/client.js', () => ({
     listConformanceRules: (...a: unknown[]) => listConformanceRules(...a),
     retireConformanceRule: (...a: unknown[]) => retireConformanceRule(...a),
     upsertConformanceRule: (...a: unknown[]) => upsertConformanceRule(...a),
+    listClaims: (...a: unknown[]) => listClaims(...a),
   },
   apiFetch: (...a: unknown[]) => apiFetch(...a),
 }));
@@ -109,6 +111,11 @@ beforeEach(() => {
   retireConformanceRule.mockReset();
   upsertConformanceRule.mockReset();
   apiFetch.mockReset();
+  // The landing's usage band reads the claims wire; default it to the honest
+  // unsupported answer so the band renders its "not served" tiles — its own
+  // loaded-path assertions live in SteeringUsageBand.test.tsx.
+  listClaims.mockReset();
+  listClaims.mockRejectedValue(new ApiError(404, 'not found'));
 });
 
 describe('SteeringPage — the /steering landing (type null)', () => {

--- a/tests/SteeringUsageBand.test.tsx
+++ b/tests/SteeringUsageBand.test.tsx
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SteeringUsageBand } from '../src/components/SteeringUsageBand.js';
+import { SteeringPage } from '../src/components/SteeringPage.js';
+import { useEvalReportStore } from '../src/store/evalReport.js';
+import { ApiError } from '../src/api/errors.js';
+import type { SteeringRule } from '../src/api/steering.js';
+import type { WikiScoreboard } from '../src/api/wiki.js';
+import type { GovernanceClaim } from '../src/api/types.js';
+import type { EvalReport } from '../src/api/testing.js';
+import { makeView } from './factories.js';
+
+/**
+ * The STEERING USAGE band (the /steering landing): when/how steering was used and its
+ * success lens — ≤6 dashboardKit tiles, every one a door, every number from a wire the
+ * app actually speaks:
+ *  - gate evaluations + denials fold the CLAIMS record (real clocks, honest deltas —
+ *    zero history renders 0 with NO delta);
+ *  - runs-governed joins claim scopes against the one runs list;
+ *  - unused rules come from the scoreboard's per_rule evidence, and CLICKING opens the
+ *    type page's grid FILTERED to those ids (?usage=unused);
+ *  - the latest-eval tile reads the session deposit and renders the honest absent state
+ *    when no eval ran;
+ *  - a daemon without the claims wire gets "—" tiles that SAY so.
+ */
+
+const listClaims = vi.fn();
+const listConformanceRules = vi.fn();
+const retireConformanceRule = vi.fn();
+const upsertConformanceRule = vi.fn();
+const apiFetch = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listClaims: (...a: unknown[]) => listClaims(...a),
+    listConformanceRules: (...a: unknown[]) => listConformanceRules(...a),
+    retireConformanceRule: (...a: unknown[]) => retireConformanceRule(...a),
+    upsertConformanceRule: (...a: unknown[]) => upsertConformanceRule(...a),
+  },
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+const DAY = 24 * 3_600_000;
+const NOW = 1_800_000_000_000;
+
+function claim(daysAgo: number, decision: GovernanceClaim['decision'] = 'allow', scope = 'wicked-agent/run-1/shared'): GovernanceClaim {
+  return {
+    claim_id: `c-${daysAgo}-${decision}`,
+    scope,
+    phase: 'unit-1',
+    policy_ids: [],
+    decision,
+    obligations: [],
+    evaluated_context_ref: 'sha256:x',
+    criteria: '',
+    evaluator_identity: 'wicked-governance@0.1.0',
+    evaluated_at: Math.floor((NOW - daysAgo * DAY) / 1000),
+  };
+}
+
+function rule(id: string, over: Partial<SteeringRule> = {}): SteeringRule {
+  return {
+    id,
+    rule_type: 'pattern',
+    statement: `statement for ${id}`,
+    severity: 'warn',
+    confidence: 0.9,
+    targets: {},
+    provenance: { source: 'ui', source_kinds: ['doc'] },
+    ...over,
+  };
+}
+
+function scoreboard(perRule: { rule_id: string; denial_claims: number; governs_evidence: number }[]): WikiScoreboard {
+  return {
+    rules_total: 3,
+    rules_active: 3,
+    rules_retired: 0,
+    typing: { available: false, docs_scanned: 0, statements_total: 0, statements_typed: 0, by_class: {}, docs_untyped: [] },
+    connection: { rules_with_ref: 0, refs_resolving: 0, refs_unresolvable: 0, rules_linked: 0 },
+    evidence: {
+      denial_claims: perRule.reduce((a, r) => a + r.denial_claims, 0),
+      rules_evidenced: perRule.filter((r) => r.denial_claims + r.governs_evidence > 0).length,
+      evidenced_by_edges: 0,
+      governs_evidence_total: perRule.reduce((a, r) => a + r.governs_evidence, 0),
+      per_rule: perRule,
+    },
+    recall_volume: { available: false, reason: 'no writer' },
+  };
+}
+
+const report: EvalReport = {
+  results: [],
+  summary: { total: 12, caught: 9, gaps: 2, false_positives: 1 },
+  degraded: null,
+};
+
+beforeEach(() => {
+  cleanup();
+  listClaims.mockReset();
+  listConformanceRules.mockReset();
+  retireConformanceRule.mockReset();
+  upsertConformanceRule.mockReset();
+  apiFetch.mockReset();
+  useEvalReportStore.setState({ latest: null });
+});
+
+const RULES = [rule('PAT-001'), rule('PAT-002', { steering_type: 'security' }), rule('PAT-003', { steering_type: 'security' })];
+
+function band(over: Partial<{ navigate: (p: string) => void; runs: ReturnType<typeof makeView>[]; sb: WikiScoreboard | null }> = {}): void {
+  const sb = over.sb === undefined ? scoreboard([{ rule_id: 'PAT-001', denial_claims: 3, governs_evidence: 7 }]) : over.sb;
+  render(
+    <SteeringUsageBand
+      runs={over.runs ?? [makeView({ id: 'run-1' }), makeView({ id: 'run-2' })]}
+      rules={RULES}
+      scoreboard={sb === null ? { kind: 'unsupported' } : { kind: 'loaded', scoreboard: sb }}
+      navigate={over.navigate ?? ((): void => undefined)}
+      now={NOW}
+    />,
+  );
+}
+
+describe('SteeringUsageBand — the folds', () => {
+  it('folds the claims record into evaluations/denials/split/governed, honest deltas', async () => {
+    listClaims.mockResolvedValue({
+      claims: [
+        claim(1), claim(2, 'deny'), claim(3),
+        claim(8), claim(9), // prior window
+        claim(20), // proves the prior window
+      ],
+    });
+    band();
+
+    await waitFor(() => expect(screen.getByTestId('steering-usage-evals')).toHaveAttribute('data-value', '3'));
+    // Delta vs the proven prior window: 3 now, 2 before → +1.
+    expect(screen.getByTestId('steering-usage-evals')).toHaveAttribute('data-delta', '1');
+    expect(screen.getByTestId('steering-usage-denials')).toHaveAttribute('data-value', '1');
+    expect(screen.getByTestId('steering-usage-split')).toHaveAttribute('data-value', '2 / 1');
+    // run-1 is claimed, run-2 not → 50%.
+    expect(screen.getByTestId('steering-usage-governed')).toHaveAttribute('data-value', '50%');
+    expect(screen.getByTestId('steering-usage-governed')).toHaveTextContent('1 of 2 runs saw ≥1 gate evaluation');
+  });
+
+  it('ZERO history: 0 evaluations with NO delta ("—", never a fabricated 0%)', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    band();
+
+    await waitFor(() => expect(screen.getByTestId('steering-usage-evals')).toHaveAttribute('data-value', '0'));
+    expect(screen.getByTestId('steering-usage-evals')).toHaveAttribute('data-delta', 'none');
+    expect(within(screen.getByTestId('steering-usage-evals')).getByTestId('stat-delta')).toHaveTextContent('—');
+    expect(screen.getByTestId('steering-usage-evals')).toHaveTextContent('no proven prior window');
+    expect(screen.getByTestId('steering-usage-denials')).toHaveAttribute('data-delta', 'none');
+  });
+
+  it('a daemon without the claims wire gets "—" tiles that SAY so', async () => {
+    listClaims.mockRejectedValue(new ApiError(404, 'not found'));
+    band();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('steering-usage-evals')).toHaveTextContent('claims not served by this daemon'),
+    );
+    expect(screen.getByTestId('steering-usage-evals')).toHaveAttribute('data-value', '—');
+    expect(screen.getByTestId('steering-usage-governed')).toHaveAttribute('data-value', '—');
+  });
+
+  it('unused rules count active zero-evidence rules; context names the top-fired rule', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    band();
+
+    const tile = await screen.findByTestId('steering-usage-rules');
+    expect(tile).toHaveAttribute('data-value', '2'); // PAT-002 + PAT-003 (security)
+    expect(tile).toHaveTextContent('top fired: PAT-001 ×10');
+  });
+
+  it('unused-rules click-through navigates to the majority type page with ?usage=unused', async () => {
+    const user = userEvent.setup();
+    listClaims.mockResolvedValue({ claims: [] });
+    const navigate = vi.fn();
+    band({ navigate });
+
+    await user.click(await screen.findByTestId('steering-usage-rules'));
+    expect(navigate).toHaveBeenCalledWith('/steering/security?usage=unused');
+  });
+
+  it('scoreboard unsupported → the rules tile is honestly absent, not zero', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    band({ sb: null });
+
+    const tile = await screen.findByTestId('steering-usage-rules');
+    expect(tile).toHaveAttribute('data-value', '—');
+    expect(tile).toHaveTextContent('scoreboard not served by this daemon');
+  });
+
+  it('latest eval: absent → the honest absent tile pointing at Testing › Evals', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    const navigate = vi.fn();
+    band({ navigate });
+
+    const tile = await screen.findByTestId('steering-usage-eval');
+    expect(tile).toHaveAttribute('data-value', '—');
+    expect(tile).toHaveTextContent('no eval run this session');
+    await userEvent.setup().click(tile);
+    expect(navigate).toHaveBeenCalledWith('/testing/evals');
+  });
+
+  it('latest eval: a session deposit renders caught/total + gaps', async () => {
+    listClaims.mockResolvedValue({ claims: [] });
+    useEvalReportStore.getState().deposit(report, 'dev-behaviors');
+    band();
+
+    const tile = await screen.findByTestId('steering-usage-eval');
+    expect(tile).toHaveAttribute('data-value', '9/12');
+    expect(tile).toHaveTextContent('2 gaps');
+  });
+});
+
+describe('the ?usage=unused click-through — the grid filters to the unused ids', () => {
+  it('the type page grid shows ONLY zero-evidence rules, with the note + Show all', async () => {
+    listConformanceRules.mockResolvedValue({ rules: RULES });
+    listClaims.mockResolvedValue({ claims: [] });
+    apiFetch.mockImplementation((path: unknown) => {
+      if (path === '/governance/wiki/scoreboard') {
+        return Promise.resolve({ scoreboard: scoreboard([{ rule_id: 'PAT-002', denial_claims: 2, governs_evidence: 0 }]) });
+      }
+      if (path === '/governance/wiki/meta') return Promise.resolve({ meta: { seeded: true } });
+      return Promise.reject(new ApiError(404, 'not found'));
+    });
+
+    render(<SteeringPage type="security" navigate={() => undefined} search="?usage=unused" />);
+
+    // PAT-003 (security, zero evidence) stays; PAT-002 (security, evidenced) is filtered out.
+    await waitFor(() => expect(screen.getByTestId('steering-usage-filter-note')).toBeInTheDocument());
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('steering-grid-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toHaveAttribute('data-rule-id', 'PAT-003');
+    });
+    expect(screen.getByTestId('steering-usage-filter-note')).toHaveTextContent('the enforcement record never cites');
+    expect(screen.getByTestId('steering-usage-filter-clear')).toHaveAttribute('href', '/steering/security');
+  });
+
+  it('without the scoreboard the filter says it cannot compute and shows ALL rules', async () => {
+    listConformanceRules.mockResolvedValue({ rules: RULES });
+    listClaims.mockResolvedValue({ claims: [] });
+    apiFetch.mockRejectedValue(new ApiError(404, 'not found'));
+
+    render(<SteeringPage type="security" navigate={() => undefined} search="?usage=unused" />);
+
+    await waitFor(() => expect(screen.getByTestId('steering-usage-filter-note')).toBeInTheDocument());
+    expect(screen.getByTestId('steering-usage-filter-note')).toHaveTextContent('cannot be computed');
+    await waitFor(() => expect(screen.getAllByTestId('steering-grid-row')).toHaveLength(2)); // both security rules
+  });
+});

--- a/tests/steeringUsage.test.ts
+++ b/tests/steeringUsage.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+  governedRuns,
+  ruleUsage,
+  runIdOfScope,
+  usageWindows,
+  USAGE_WINDOW_DAYS,
+  type ClaimLite,
+} from '../src/board/steeringUsage.js';
+import type { SteeringRule } from '../src/api/steering.js';
+import { makeView } from './factories.js';
+
+/**
+ * The steering-usage folds — pure, wire-shaped fixtures:
+ *  - TEMPORAL windows over the claims record's real clock (`evaluated_at`, unix seconds);
+ *  - delta honesty: `previous` exists ONLY when the record proves a full prior window
+ *    (oldest claim predates it) — zero history and young histories yield `previous: null`;
+ *  - the governed-runs join reads run ids out of claim scopes (both historical spellings);
+ *  - rule usage: active rules with zero per_rule evidence are dead weight; the top-fired
+ *    rule is the most-cited ACTIVE one; retired rules never count as unused.
+ */
+
+const DAY = 24 * 3_600_000;
+const NOW = 1_800_000_000_000; // ms epoch, arbitrary fixed clock
+
+/** A claim `daysAgo` before NOW (evaluated_at is unix SECONDS on the wire). */
+function claim(daysAgo: number, decision: ClaimLite['decision'] = 'allow', scope = 'wicked-agent/run-1/shared'): ClaimLite {
+  return { decision, evaluated_at: Math.floor((NOW - daysAgo * DAY) / 1000), scope };
+}
+
+function rule(id: string, over: Partial<SteeringRule> = {}): SteeringRule {
+  return {
+    id,
+    rule_type: 'pattern',
+    statement: `statement for ${id}`,
+    severity: 'warn',
+    confidence: 0.9,
+    targets: {},
+    provenance: { source: 'ui', source_kinds: ['doc'] },
+    ...over,
+  };
+}
+
+describe('usageWindows — temporal buckets with delta honesty', () => {
+  it('zero history: zero current, NO delta (previous null), all-zero spark', () => {
+    const w = usageWindows([], NOW);
+    expect(w.evaluations).toEqual({ current: 0, previous: null });
+    expect(w.denials).toEqual({ current: 0, previous: null });
+    expect(w.allow).toBe(0);
+    expect(w.deny).toBe(0);
+    expect(w.spark).toHaveLength(USAGE_WINDOW_DAYS);
+    expect(w.spark.every((n) => n === 0)).toBe(true);
+  });
+
+  it('a record younger than two windows yields NO previous — never a fabricated 0', () => {
+    // Oldest claim is 10 days old: the prior window (7–14d ago) was not fully observed.
+    const w = usageWindows([claim(1), claim(3), claim(10)], NOW);
+    expect(w.evaluations.current).toBe(2);
+    expect(w.evaluations.previous).toBeNull();
+    expect(w.denials.previous).toBeNull();
+  });
+
+  it('a proven full prior window yields the real delta pair', () => {
+    const claims = [
+      claim(0.5), claim(1), claim(2, 'deny'), // current window: 3, one deny
+      claim(8), claim(9, 'deny'), claim(10), claim(12), // previous window: 4, one deny
+      claim(15), // proves the prior window was fully observed
+    ];
+    const w = usageWindows(claims, NOW);
+    expect(w.evaluations).toEqual({ current: 3, previous: 4 });
+    expect(w.denials).toEqual({ current: 1, previous: 1 });
+  });
+
+  it('splits the CURRENT window by decision and buckets the spark daily, oldest first', () => {
+    const claims = [
+      claim(0.2, 'allow'),
+      claim(0.4, 'deny'),
+      claim(6.5, 'allow_with_conditions'),
+      claim(20, 'deny'), // outside both windows: counts nowhere but proves the prior window
+    ];
+    const w = usageWindows(claims, NOW);
+    expect(w.allow).toBe(1);
+    expect(w.deny).toBe(1);
+    expect(w.conditions).toBe(1);
+    // 0.2/0.4 days ago land in the NEWEST bucket (last); 6.5 days ago in the oldest.
+    expect(w.spark[USAGE_WINDOW_DAYS - 1]).toBe(2);
+    expect(w.spark[0]).toBe(1);
+    expect(w.evaluations.previous).toBe(0); // proven (the 20d-old claim), and genuinely empty
+  });
+});
+
+describe('runIdOfScope + governedRuns — the claims→runs join', () => {
+  it('reads both historical scope spellings', () => {
+    expect(runIdOfScope('wicked-agent/abc-123/shared')).toBe('abc-123');
+    expect(runIdOfScope('wicked-agent/abc-123/unit/2')).toBe('abc-123');
+    expect(runIdOfScope('bare-run-id')).toBe('bare-run-id');
+  });
+
+  it('counts non-archived runs with ≥1 claim; archived runs never count', () => {
+    const runs = [
+      makeView({ id: 'run-1' }),
+      makeView({ id: 'run-2' }),
+      makeView({ id: 'run-3', archived_at: 123 }),
+    ];
+    const g = governedRuns([claim(1, 'allow', 'wicked-agent/run-1/shared'), claim(2, 'allow', 'run-3')], runs);
+    expect(g).toEqual({ governed: 1, total: 2, pct: 50 });
+  });
+
+  it('no runs → pct null (no denominator), never 0% dressed as a measurement', () => {
+    expect(governedRuns([claim(1)], []).pct).toBeNull();
+  });
+});
+
+describe('ruleUsage — top-fired vs dead weight', () => {
+  const perRule = [
+    { rule_id: 'PAT-001', denial_claims: 3, governs_evidence: 7 },
+    { rule_id: 'PAT-002', denial_claims: 0, governs_evidence: 0 },
+    { rule_id: 'PAT-404', denial_claims: 5, governs_evidence: 0 }, // cites no ACTIVE rule
+  ];
+
+  it('active rules with zero evidence are unused; absent per_rule rows count as zero', () => {
+    const rules = [
+      rule('PAT-001'),
+      rule('PAT-002', { steering_type: 'security' }),
+      rule('PAT-003', { steering_type: 'security' }), // no per_rule row at all
+      rule('PAT-009', { retired: true }), // retired: never dead weight
+    ];
+    const u = ruleUsage(rules, perRule);
+    expect(u.unusedIds).toEqual(['PAT-002', 'PAT-003']);
+    expect(u.topFired).toEqual({ ruleId: 'PAT-001', total: 10 });
+    expect(u.firedCount).toBe(1);
+    expect(u.unusedHomeType).toBe('security');
+  });
+
+  it('nothing fired: every active rule is unused and topFired is null', () => {
+    const u = ruleUsage([rule('PAT-001'), rule('PAT-002')], []);
+    expect(u.unusedIds).toEqual(['PAT-001', 'PAT-002']);
+    expect(u.topFired).toBeNull();
+    expect(u.unusedHomeType).toBe('architecture');
+  });
+});


### PR DESCRIPTION
Ask: a visually distinct entry in the rail below Notifications and above Projects (accent idiom + ⌘⇧A, pixel-judged unmistakable for a nav row or the bell) opening the assist dock in an app-wide ask context — the context pack assembles what the app knows (citing GET /diagnostics when the daemon serves it, with honest degraded copy on older crews), quick-prompt chips prefill (why did run X fail / what's in project Y / what changed in repo Z / diagnose studio / is ACP healthy), and answers ride the governed chat seat machinery with its estate/garden tooling.

Steering usage band on the landing (dashboardKit, live-fold verified number-for-number): gate evaluations with delta+sparkline, denials, % of runs governed (90% live), allow/deny split, and the honest headline — top-fired vs UNUSED rules, where the live store reads "36 unused · no rule has fired yet" and clicks through to the filtered grid. Latest-eval tile honestly absent until an eval is filed. 2295 tests green, inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)