### PR TITLE
release: 0.4.8 — the home command center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.8] — 2026-09-01
+
+### Added
+
+- **The home command center** (#174) — the homepage answers three questions in priority order:
+  *what needs me* (one deduped queue of waiting gates, failed runs, blind repos, stalled chats,
+  and campaign gaps — every row actionable in place: dock deep-links, retry/re-index prefill),
+  *is the portfolio healthy* (six KPIs from the shared folds — the needs-you tile counts the
+  queue's own fold so they can never disagree — plus the narrated activity pulse and the project
+  wall), and *where do I go* (creation verbs, a board-level Ask invite, and the per-section
+  essence strip). Calm copy is owned solely by the queue's zero-row branch, so "All quiet"
+  beside visible failures is structurally impossible. NarrativeBand, ActivityRiver, LiveFeed,
+  and RunOutcomeBar are deleted — their questions are now answered once, not twice.
+
 ## [0.4.7] — 2026-09-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.7",
+  "studioVersion": "0.4.8",
   "counts": {
     "files": 116,
     "occurrences": 930,


### PR DESCRIPTION
Version bump + CHANGELOG + testid inventory regenerated at 0.4.8. Ships #174 — the homepage command center closing the UI program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)