### PR TITLE
fix: Ask seeds the newest failure, the dock renders markdown, collapse keeps bytes, one seat-attribution source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.6",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.6",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/src/board/needsYou.ts
+++ b/src/board/needsYou.ts
@@ -65,6 +65,10 @@ export interface NeedRow {
 /** The failed-run recency window — the sections' "last 30" positional idiom. */
 export const FAILED_WINDOW = 30;
 
+/** The failed-run row's dedupe key — shared with {@link newestFailedRun} so the
+ *  row→run mapping can never drift from the fold's own spelling. */
+const FAILED_KEY = (id: string): string => `fail:${id}`;
+
 const SEVERITY: Record<NeedKind, number> = {
   gate: 100,
   'failed-run': 70,
@@ -199,7 +203,7 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
     } else if (s.status === 'failed' && windowIds.has(s.id) && !suppressed.has(s.id)) {
       shownRunIds.add(s.id);
       rows.push({
-        key: `fail:${s.id}`,
+        key: FAILED_KEY(s.id),
         kind: 'failed-run',
         severity: SEVERITY['failed-run'],
         subject: s.problem,
@@ -287,6 +291,23 @@ export function calmCopy(runs: SessionView[]): string {
  *  (verbs + Ask prominent, no fabricated zeros anywhere). */
 export function isFreshInstall(projects: number, runs: SessionView[], repos: readonly RepoEntry[]): boolean {
   return projects === 0 && runs.length === 0 && repos.length === 0;
+}
+
+/**
+ * The queue's NEWEST failed run — the FIRST failed-run row of
+ * {@link needsYouRows} (severity-ordered, newest-clock first), mapped back to
+ * its SessionView. THE derivation the Ask quick-prompt seeds from (E1: the
+ * campaign caught the chip seeding a 17-day-old failure): the home queue's own
+ * ordering — durable failure tail, else attach clock — with its window and its
+ * repo-onboard suppression included, never a second recency derivation.
+ */
+export function newestFailedRun(
+  rows: readonly NeedRow[],
+  runs: readonly SessionView[],
+): SessionView | undefined {
+  const row = rows.find((r) => r.kind === 'failed-run');
+  if (row === undefined) return undefined;
+  return runs.find((v) => FAILED_KEY(v.session.id) === row.key);
 }
 
 /** The queue's oldest waiting clock — the KPI tile's context line. */

--- a/src/components/AskDock.tsx
+++ b/src/components/AskDock.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import { getDiagnostics, isDiagnosticsUnsupported } from '../api/diagnostics.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
+import { needsYouRows } from '../board/needsYou.js';
+import { useFailureClocks } from '../store/failureClocks.js';
+import { useGateStore } from '../store/gates.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
+import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { getCachedRoster, setCachedRoster } from '../store/rosterCache.js';
@@ -43,6 +47,13 @@ export function AskDock({ runs, pathname, onClose }: {
   const [repos, setRepos] = useState<RepoEntry[]>(() => getCachedRepos() ?? []);
   const projects = useProjectsStore((s) => s.projects);
   const liveChats = useLiveChatsStore((s) => s.sessions);
+  // The needs-you fold's inputs, from the stores the app already holds (all
+  // written elsewhere — the gate stream, the board model's mirrors): zero
+  // requests ride on reading them here.
+  const gates = useGateStore((s) => s.gates);
+  const failedAt = useFailureClocks((s) => s.failedAtByRun);
+  const attachedAt = useMembershipStore((s) => s.attachedAtByRun);
+  const projectIds = useMembershipStore((s) => s.projectIdByRun);
 
   // The diagnostics read — presence-gated: absence is an ANSWER (older crew), never an error.
   useEffect(() => {
@@ -131,10 +142,27 @@ export function AskDock({ runs, pathname, onClose }: {
     () =>
       askPrompts({
         runs,
+        // THE home-queue fold (needsYouRows — DES-HOME-COMMAND-CENTER §3), so
+        // the failed-run chip seeds the SAME newest failed run the queue shows
+        // (E1) — never a second recency derivation. Chats/campaigns ride empty
+        // here: absence adds no rows, and the failed-run pick reads none of
+        // them. `now` feeds only the (absent) stalled-chat rows — the fold
+        // stays effectively pure in this memo's deps.
+        needRows: needsYouRows({
+          runs,
+          gates,
+          failedAt,
+          attachedAt,
+          projectIds,
+          chats: [],
+          repos,
+          campaigns: [],
+          now: Date.now(),
+        }),
         projects: [...projects].sort((a, b) => b.updated_at - a.updated_at),
         repos,
       }),
-    [runs, projects, repos],
+    [runs, gates, failedAt, attachedAt, projectIds, projects, repos],
   );
 
   return (

--- a/src/components/AssistDock.tsx
+++ b/src/components/AssistDock.tsx
@@ -6,7 +6,9 @@ import { useEventStream } from '../hooks/useEventStream.js';
 import { pinAwaiting } from '../store/awaitingPins.js';
 import { useRunEventStore } from '../store/events.js';
 import { ApprovalDock } from './ApprovalDock.js';
+import { retainOnFinalize } from './ChatThread.js';
 import { readFileText } from './fileText.js';
+import { Markdown } from './Markdown.js';
 import { NarratorFeed, phaseName } from './NarratorFeed.js';
 import { NowBar } from './NowBar.js';
 import {
@@ -290,14 +292,18 @@ function DockChat({ chatId }: { chatId: string }): React.ReactElement {
     });
   };
 
-  /** The terminal reply is authoritative — it REPLACES the oldest pending bubble's deltas. */
+  /** The terminal reply finalizes the oldest pending bubble — through
+   *  {@link retainOnFinalize}: the wire keeps no history, so a terminal text
+   *  SHORTER than the accumulated deltas never clobbers what streamed (E4);
+   *  the longer text stands, ties to the terminal reply (the healing path for
+   *  a block that mounted mid-stream, intact). */
   const finalize = (cliKey: string, text: string, ok: boolean): void => {
     setMsgs((prev) => {
       const next = [...prev];
       for (let i = 0; i < next.length; i += 1) {
         const m = next[i];
         if (m !== undefined && m.cliKey === cliKey && m.pending) {
-          next[i] = { ...m, text, pending: false, ok };
+          next[i] = { ...m, text: retainOnFinalize(m.text, text), pending: false, ok };
           return next;
         }
       }
@@ -374,13 +380,22 @@ function DockChat({ chatId }: { chatId: string }): React.ReactElement {
               <span className="font-mono text-[10px] font-semibold" style={{ color: 'var(--accent)' }}>
                 {m.cliKey}
               </span>
-              <p
-                className="whitespace-pre-wrap text-[11px] leading-relaxed"
-                style={{ color: m.pending || m.ok ? 'var(--ink-body)' : 'var(--status-fail)' }}
-              >
-                {m.text}
-                {m.pending && <span aria-hidden className="animate-pulse"> …</span>}
-              </p>
+              {!m.pending && !m.ok ? (
+                // A failed turn's text is the daemon's error prose — it stays
+                // verbatim in the fail ink, never dressed as markdown.
+                <p className="whitespace-pre-wrap text-[11px] leading-relaxed" style={{ color: 'var(--status-fail)' }}>
+                  {m.text}
+                </p>
+              ) : (
+                // E3 (campaign): seat replies ARE markdown — rendered with the
+                // SAME component the chat thread already uses (react-markdown +
+                // GFM; raw HTML is never parsed, so nothing injects), not
+                // dumped as ##-visible raw text.
+                <div className="text-[11px] leading-relaxed">
+                  <Markdown>{m.text}</Markdown>
+                  {m.pending && <span aria-hidden className="animate-pulse"> …</span>}
+                </div>
+              )}
             </div>
           ))
         )}

--- a/src/components/ChatThread.tsx
+++ b/src/components/ChatThread.tsx
@@ -52,6 +52,20 @@ export interface SysMsg {
 export type Msg = UserMsg | SeatMsg | SysMsg;
 
 /**
+ * Finalize-time retention (E4: "claude's complete plan was lost to the
+ * collapse"). The chat wire keeps NO history — what the client streamed is the
+ * ONLY copy — so a terminal `chatReply` that arrives SHORTER than the
+ * accumulated deltas (an upstream output cap trimming older text, a failure
+ * reframed as its reason line) must never clobber them. The LONGER text
+ * stands; at equal length the terminal reply is authoritative — which also
+ * keeps the §7.9-3 healing intact: a block mounted mid-stream holds partial
+ * deltas, and the (longer) terminal reply still replaces them whole.
+ */
+export function retainOnFinalize(streamed: string, terminal: string): string {
+  return terminal.length >= streamed.length ? terminal : streamed;
+}
+
+/**
  * Seat identity under the token contract (DES-VISION-001 §2.11): every chip and
  * avatar wears the SAME surface/ink pair, and identity rides the monogram +
  * name, not a per-CLI hue. Color is reserved for signal (§1.5 rule 2).

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -12,6 +12,7 @@ import {
   SEAT_CHIP,
   readStoredLayout,
   readStoredView,
+  retainOnFinalize,
   seatColumnOrder,
   writeStoredLayout,
   writeStoredView,
@@ -28,6 +29,7 @@ import {
   deriveChatArtifacts,
   narrateSeatLifecycle,
   newestChatNow,
+  seatLogPosture,
   type NarrationLine,
   type NarrationTone,
 } from './narrator.js';
@@ -631,15 +633,18 @@ export function GroupChat({
     });
   }
 
-  /** The terminal reply text is authoritative — it replaces the accumulated
-   *  deltas of the seat's OLDEST pending turn (the same FIFO as the chunks). */
+  /** The terminal reply finalizes the seat's OLDEST pending turn (the same
+   *  FIFO as the chunks) — through {@link retainOnFinalize}: the wire keeps no
+   *  history, so a terminal text SHORTER than the accumulated deltas must not
+   *  clobber what already streamed (E4 — the lost plan); the longer text
+   *  stands, ties to the terminal reply (the §7.9-3 healing, intact). */
   function finalizePending(cliKey: string, text: string, ok: boolean): void {
     setMessages((prev) => {
       const next = [...prev];
       for (let i = 0; i < next.length; i++) {
         const m = next[i];
         if (m && m.kind === 'seat' && m.cliKey === cliKey && m.pending) {
-          next[i] = { ...m, text, pending: false, ok };
+          next[i] = { ...m, text: retainOnFinalize(m.text, text), pending: false, ok };
           return next;
         }
       }
@@ -904,9 +909,10 @@ export function GroupChat({
 
   // §7.9-4 / EC44: every seat chip SAYS its state — connecting / ready /
   // working / replied / failed — and a failed seat carries its reason inline
-  // (the daemon's open-time answer or the chatSessionFailed frame), truncated
-  // in CSS with the full text on the title. No unlabeled "working" anywhere.
-  const seatChip = (cliKey: string, st: SeatState): React.ReactElement => (
+  // (the daemon's open-time answer, the chatSessionFailed frame, or the failed
+  // turn's own head), truncated in CSS with the full text on the title. No
+  // unlabeled "working" anywhere.
+  const seatChip = (cliKey: string, st: SeatState, reason?: string): React.ReactElement => (
     // wk-disclose: the roster disclosure animates in at --dur-base ease-out
     // (§5.3 motion) — once per chip mount, never a loop (§1.6).
     <span
@@ -914,7 +920,7 @@ export function GroupChat({
       data-testid="seat-chip"
       data-agent={cliKey}
       data-state={st}
-      title={st === 'failed' ? seatErrors[cliKey] : st}
+      title={st === 'failed' ? reason : st}
       className="wk-disclose inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-[11px] font-mono"
       style={{ background: SEAT_CHIP.bg, color: SEAT_CHIP.fg, opacity: st === 'failed' ? 0.5 : 1 }}
     >
@@ -928,10 +934,28 @@ export function GroupChat({
         className="truncate"
         style={{ color: st === 'failed' ? 'var(--status-fail)' : 'var(--ink-dim)', maxWidth: '180px' }}
       >
-        {st === 'failed' && seatErrors[cliKey] ? `failed — ${seatErrors[cliKey]}` : st}
+        {st === 'failed' && reason !== undefined && reason !== '' ? `failed — ${reason}` : st}
       </span>
     </span>
   );
+
+  // ── E4 one-source seat truth ────────────────────────────────────────────────
+  // The TURN axis of the header chips (working / replied / failed-turn) reads
+  // THE message log — `seatLogPosture`, the same source the narrated feed
+  // classifies from — so a chip can never again say "replied" while the feed
+  // says "failed" for the same turn (the campaign's E4 catch: the chip was a
+  // second, frame-driven derivation that ignored the reply's `ok`). The
+  // CONNECTION axis (connecting; the session itself failed) stays with the
+  // frame-driven `seats` record — the log carries no bubbles for it yet.
+  const posture = useMemo(() => seatLogPosture(messages), [messages]);
+  const displaySeat = (cliKey: string, st: SeatState): { st: SeatState; reason?: string } => {
+    if (st === 'connecting' || st === 'failed') {
+      return { st, ...(seatErrors[cliKey] !== undefined ? { reason: seatErrors[cliKey] } : {}) };
+    }
+    const p = posture[cliKey];
+    if (p === undefined) return { st };
+    return { st: p.state, ...(p.reason !== null ? { reason: p.reason } : {}) };
+  };
 
   // §6.2: the layout toggle is visible only when the chat has ≥2 distinct
   // REPLYING seats — a single-agent transcript has nothing to compare, and the
@@ -1010,7 +1034,12 @@ export function GroupChat({
   const currentProject = projects.find((p) => p.id === selectedProjectId) ?? null;
 
   // ── The §11.4 now-bar: what is happening RIGHT NOW, pinned above the thread.
-  const warmCount = Object.values(seats).filter((st) => WARM_STATES.has(st)).length;
+  // The census wears the SAME display overlay as the chips (E4): a seat whose
+  // newest turn FAILED is not "ready" — the bar may not contradict the feed
+  // either. (The send audience below still reads the frame-driven `seats`
+  // record — warmth on the daemon is a different question from turn truth.)
+  const warmCount = Object.entries(seats)
+    .filter(([k, st]) => WARM_STATES.has(displaySeat(k, st).st)).length;
   const connecting = arming || resolving || Object.values(seats).some((st) => st === 'connecting');
   const chatStatus = ended
     ? 'completed'
@@ -1059,7 +1088,10 @@ export function GroupChat({
         <button type="button" onClick={onBack} className="text-sm font-mono opacity-60 hover:opacity-100">←</button>
         <span className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Chat</span>
         <div className="flex items-center gap-1.5 flex-wrap">
-          {Object.entries(seats).map(([k, st]) => seatChip(k, st))}
+          {Object.entries(seats).map(([k, st]) => {
+            const d = displaySeat(k, st);
+            return seatChip(k, d.st, d.reason);
+          })}
         </div>
         {/* §6.2: the layout toggle sits right of the seat chips — a two-state
             segmented pair, present only with ≥2 distinct replying seats. */}

--- a/src/components/askContext.ts
+++ b/src/components/askContext.ts
@@ -1,5 +1,6 @@
 import type { Project, RepoEntry, SessionView } from '../api/types.js';
 import type { Diagnostics } from '../api/diagnostics.js';
+import { newestFailedRun, type NeedRow } from '../board/needsYou.js';
 import { statusCounts } from '../board/windowStats.js';
 import { headingForPath } from './LeftSidebar.js';
 import { humanTitle } from './runIdentity.js';
@@ -177,15 +178,20 @@ export function buildContextPack(args: {
 
 export interface AskPromptSeed {
   runs: SessionView[];
+  /** THE home-queue fold's rows (`needsYouRows` — the caller computes it from
+   *  the stores the app already holds). The failed-run chip seeds from its
+   *  first failed-run row via {@link newestFailedRun} — the queue's own
+   *  newest-first ordering, never a second recency derivation (E1). */
+  needRows: readonly NeedRow[];
   projects: Project[];
   repos: RepoEntry[];
 }
 
 /** The quick-prompt chips. Chips whose referent the app does not hold are OMITTED, never
  *  fabricated (no failed run ⇒ no "why did it fail" chip). */
-export function askPrompts({ runs, projects, repos }: AskPromptSeed): { label: string; text: string }[] {
+export function askPrompts({ runs, needRows, projects, repos }: AskPromptSeed): { label: string; text: string }[] {
   const prompts: { label: string; text: string }[] = [];
-  const failed = runs.find((v) => v.session.status === 'failed' && v.session.archived_at == null);
+  const failed = newestFailedRun(needRows, runs);
   if (failed !== undefined) {
     const title = humanTitle(failed.session.problem);
     prompts.push({

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -482,6 +482,41 @@ export function narrateChatSeat(m: ChatSeatView): { text: string; tone: Narratio
   return { text: `replied (${chatSizeLabel(m.text)})${firstLine ? ` — ${firstLine}` : ''}`, tone: 'work' };
 }
 
+/** A seat's turn posture, derived from the message log (see {@link seatLogPosture}). */
+export interface SeatTurnPosture {
+  state: 'working' | 'replied' | 'failed';
+  /** The failed turn's head — the SAME clip the feed's fail narration shows. */
+  reason: string | null;
+}
+
+/**
+ * Per-seat TURN posture from the one message log — the SOURCE the narrated
+ * feed classifies from (§11.1), exported so the chat header's seat chips read
+ * the same fold and can never contradict the feed (the E4 campaign catch: the
+ * chip said "replied" while the feed said "failed" for the same turn, because
+ * the chip was a second, frame-driven derivation that ignored the reply's
+ * `ok`). Any pending bubble means the seat is still WORKING (per-seat FIFO —
+ * its oldest unfinished turn); otherwise its newest finalized reply decides:
+ * ok = replied, not-ok = failed, the reason being the feed's own clipped head.
+ */
+export function seatLogPosture(messages: readonly ChatMsgView[]): Record<string, SeatTurnPosture> {
+  const out: Record<string, SeatTurnPosture> = {};
+  for (const m of messages) {
+    if (m.kind !== 'seat') continue;
+    if (m.pending) {
+      out[m.cliKey] = { state: 'working', reason: null };
+      continue;
+    }
+    // A still-streaming turn outranks any finalized one, wherever it sits in
+    // the log — a seat with bytes in flight is working, full stop.
+    if (out[m.cliKey]?.state === 'working') continue;
+    out[m.cliKey] = m.ok
+      ? { state: 'replied', reason: null }
+      : { state: 'failed', reason: clip(m.text.trim(), 120) || null };
+  }
+  return out;
+}
+
 /**
  * §11.1 seat lifecycle: joined / could not join. The TEMPLATE lives here —
  * narrator.ts is the one narration template source — while the caller owns the

--- a/src/hooks/useBoardModel.ts
+++ b/src/hooks/useBoardModel.ts
@@ -11,6 +11,7 @@ import {
 } from '../board/boardAttention.js';
 import { sessionProjectId } from './ambientProject.js';
 import { useDocsCache } from '../store/docsCache.js';
+import { useFailureClocks } from '../store/failureClocks.js';
 import { useGateStore, type OpenGate } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useProjectsStore } from '../store/projects.js';
@@ -272,8 +273,10 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   /** The decay clock (D7): scores are recomputed on this coarse tick. */
   const [now, setNow] = useState(() => Date.now());
   /** Backfilled durable-log tail per FAILED run id — the one age the client
-   *  cannot otherwise know, and the one F3 is about (D3 step 2). */
-  const [failedAt, setFailedAt] = useState<Record<string, number>>({});
+   *  cannot otherwise know, and the one F3 is about (D3 step 2). Held in the
+   *  app-wide mirror store (the membership idiom): this hook is the only
+   *  WRITER; the Ask dock's needs-you fold reads the same clocks (E1). */
+  const failedAt = useFailureClocks((s) => s.failedAtByRun);
   const gates = useGateStore((s) => s.gates);
   // Relayed doc statuses (slice 6) — REACTIVE, unlike `logs`: a `status.posted`
   // is rare (one per doc edit, not one per streamed frame) and it must be able
@@ -284,13 +287,6 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
   const placed = useRef<Set<string>>(new Set());
   /** Run ids whose event tail has been asked for — once per run id, ever (R2). */
   const backfilled = useRef<Set<string>>(new Set());
-  const mounted = useRef(true);
-
-  useEffect(() => {
-    mounted.current = true;
-    return () => { mounted.current = false; };
-  }, []);
-
   useEffect(() => {
     const t = setInterval(() => setNow(Date.now()), TICK_MS);
     return () => clearInterval(t);
@@ -379,19 +375,23 @@ export function useBoardModel(runs: SessionView[]): BoardModel {
     if (loading) return;
     for (const v of runs) {
       if (v.session.status !== 'failed' || backfilled.current.has(v.session.id)) continue;
+      // Another instance's backfill already mirrored this clock — no re-fetch.
+      if (failedAt[v.session.id] !== undefined) continue;
       if (backfilled.current.size >= MAX_BACKFILL) break;
       const id = v.session.id;
       backfilled.current.add(id);
       void api.getRunEvents(id)
         .then(({ events }) => {
           const ts = events[events.length - 1]?.ts;
-          if (mounted.current && typeof ts === 'number') {
-            setFailedAt((m) => ({ ...m, [id]: ts }));
+          if (typeof ts === 'number') {
+            // The mirror write (store, not local state): merge-only, so parallel
+            // board-model instances never erase each other's clocks.
+            useFailureClocks.getState().merge({ [id]: ts });
           }
         })
         .catch(() => { /* no durable log — the fallback clock stands */ });
     }
-  }, [runs, loading]);
+  }, [runs, loading, failedAt]);
 
   const items = useMemo(
     () => {

--- a/src/store/failureClocks.ts
+++ b/src/store/failureClocks.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+/**
+ * The durable-log failure tails (FAILED run id → its log's last event ts) —
+ * the one honest failure clock — mirrored app-wide exactly the way membership
+ * is mirrored (src/store/membership.ts): `useBoardModel` (mounted app-wide by
+ * the rail) fetches the tails for its D3-step-2 backfill and WRITES them here;
+ * consumers READ and never fetch. The app-wide Ask dock's needs-you fold
+ * (E1: the quick-prompt must seed the queue's NEWEST failed run, the same
+ * ordering the home queue renders) is the reading consumer.
+ *
+ * Merged, never replaced: several board-model instances (the rail, home, the
+ * projects page) each backfill their own slice, and none may erase another's.
+ */
+interface FailureClockStore {
+  failedAtByRun: Record<string, number>;
+  merge: (entries: Record<string, number>) => void;
+}
+
+export const useFailureClocks = create<FailureClockStore>((set) => ({
+  failedAtByRun: {},
+  merge: (entries) =>
+    set((s) => ({ failedAtByRun: { ...s.failedAtByRun, ...entries } })),
+}));

--- a/tests/AskDock.test.tsx
+++ b/tests/AskDock.test.tsx
@@ -46,6 +46,7 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
 const { AskDock } = await import('../src/components/AskDock.js');
 const { clearCachedRoster, setCachedRoster } = await import('../src/store/rosterCache.js');
 const { clearRepoCache } = await import('../src/store/repoCache.js');
+const { useFailureClocks } = await import('../src/store/failureClocks.js');
 const { useProjectsStore } = await import('../src/store/projects.js');
 const { useLiveChatsStore } = await import('../src/store/liveChats.js');
 
@@ -110,6 +111,7 @@ beforeEach(() => {
   sendChatMessage.mockResolvedValue({ seats: ['claude', 'pi'] });
   useProjectsStore.setState({ projects: [], loading: false, error: null });
   useLiveChatsStore.setState({ sessions: {} });
+  useFailureClocks.setState({ failedAtByRun: {} });
   try { localStorage.clear(); } catch { /* stubbed in setup */ }
 });
 
@@ -182,6 +184,27 @@ describe('nothing launches without the user sending', () => {
     // NOTHING was sent by any of that.
     expect(openChat).not.toHaveBeenCalled();
     expect(sendChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('the failed-run chip seeds the NEWEST failure by the home queue’s own fold — never list order (E1)', async () => {
+    wireDiagnostics('present');
+    // List order leads with the STALE failure (the E1 campaign defect: a
+    // 17-day-old run was seeded); the durable failure clocks — the same mirror
+    // the home queue reads — say the other one is newest.
+    useFailureClocks.setState({
+      failedAtByRun: { 'stale-run-fail': Date.now() - 17 * 24 * 3_600_000, 'fresh-run-fail': Date.now() - 600_000 },
+    });
+    dock([
+      makeView({ id: 'stale-run-fail', status: 'failed', problem: 'ancient breakage' }),
+      makeView({ id: 'fresh-run-fail', status: 'failed', problem: 'fresh breakage' }),
+    ]);
+
+    await waitFor(() => expect(screen.getByTestId('assist-prompts')).toBeInTheDocument());
+    const chips = screen.getAllByTestId('assist-prompt');
+    const failChips = chips.filter((c) => c.getAttribute('data-prompt')?.startsWith('Why did run'));
+    // ONE failed-run chip, and it names the queue's newest failure.
+    expect(failChips).toHaveLength(1);
+    expect(failChips[0]).toHaveAttribute('data-prompt', 'Why did run fresh-ru fail?');
   });
 });
 

--- a/tests/AssistDock.chat.test.tsx
+++ b/tests/AssistDock.chat.test.tsx
@@ -112,4 +112,56 @@ describe('AssistDock — the chat block', () => {
     await waitFor(() => expect(screen.getAllByTestId('assist-user-msg')).toHaveLength(2));
     expect(screen.getAllByTestId('assist-chat')).toHaveLength(1); // one session, one block
   });
+
+  it('seat replies render as MARKDOWN — the shared component, never ##-visible raw text (E3)', async () => {
+    const user = userEvent.setup();
+    const v: AssistVerbs = { send: vi.fn().mockResolvedValue({ chatId: 'chat-1' }) };
+    dock(v);
+
+    await user.type(screen.getByTestId('assist-input'), 'diagnose');
+    await user.click(screen.getByTestId('assist-send'));
+    await screen.findByTestId('assist-chat');
+
+    act(() => {
+      emit?.(frame({
+        type: 'chatReply', chat: 'chat-1', cliKey: 'claude',
+        text: '## Root cause\n\nThe daemon dropped `/ws` — check `core.db`.\n\n<img src=x onerror="window.pwned=1">',
+        ok: true,
+      }));
+    });
+
+    const msg = screen.getByTestId('assist-chat-msg');
+    // Markdown structure, not raw syntax:
+    expect(msg.querySelector('h2')).toHaveTextContent('Root cause');
+    const codes = Array.from(msg.querySelectorAll('code')).map((c) => c.textContent);
+    expect(codes).toContain('/ws');
+    expect(codes).toContain('core.db');
+    expect(msg.textContent).not.toContain('##');
+    expect(msg.textContent).not.toContain('`');
+    // …and SANITIZED: raw HTML in a reply never becomes live DOM (react-markdown
+    // parses no raw HTML — there is no rehype-raw anywhere in this app).
+    expect(msg.querySelector('img')).toBeNull();
+    expect((window as { pwned?: number }).pwned).toBeUndefined();
+  });
+
+  it('a terminal reply SHORTER than the accumulated deltas never clobbers them (the wire has no history)', async () => {
+    const user = userEvent.setup();
+    const v: AssistVerbs = { send: vi.fn().mockResolvedValue({ chatId: 'chat-1' }) };
+    dock(v);
+
+    await user.type(screen.getByTestId('assist-input'), 'plan it');
+    await user.click(screen.getByTestId('assist-send'));
+    await screen.findByTestId('assist-chat');
+
+    const streamed = `the whole plan ${'x'.repeat(2000)} plan tail`;
+    act(() => {
+      emit?.(frame({ type: 'chatDelta', chat: 'chat-1', cliKey: 'claude', text: streamed.slice(0, 900) }));
+      emit?.(frame({ type: 'chatDelta', chat: 'chat-1', cliKey: 'claude', text: streamed.slice(900) }));
+      emit?.(frame({ type: 'chatReply', chat: 'chat-1', cliKey: 'claude', text: 'plan tail', ok: true }));
+    });
+
+    const msg = screen.getByTestId('assist-chat-msg');
+    expect(msg).toHaveAttribute('data-pending', 'false');
+    expect(msg.textContent).toContain(streamed); // every streamed byte retained
+  });
 });

--- a/tests/AssistDock.chat.test.tsx
+++ b/tests/AssistDock.chat.test.tsx
@@ -125,7 +125,7 @@ describe('AssistDock — the chat block', () => {
     act(() => {
       emit?.(frame({
         type: 'chatReply', chat: 'chat-1', cliKey: 'claude',
-        text: '## Root cause\n\nThe daemon dropped `/ws` — check `core.db`.\n\n<img src=x onerror="window.pwned=1">',
+        text: '## Root cause\n\nThe daemon dropped `/ws` — check `core.db`.\n\n<script>window.pwnedByScript=1</script>\n\n<img src=x onerror="window.pwned=1">',
         ok: true,
       }));
     });
@@ -139,7 +139,11 @@ describe('AssistDock — the chat block', () => {
     expect(msg.textContent).not.toContain('##');
     expect(msg.textContent).not.toContain('`');
     // …and SANITIZED: raw HTML in a reply never becomes live DOM (react-markdown
-    // parses no raw HTML — there is no rehype-raw anywhere in this app).
+    // parses no raw HTML — there is no rehype-raw anywhere in this app). A
+    // <script> payload neither mounts nor runs, and the onerror vector is inert.
+    expect(msg.querySelector('script')).toBeNull();
+    expect(document.querySelector('script[data-testid], [data-testid="assist-chat-msg"] script')).toBeNull();
+    expect((window as { pwnedByScript?: number }).pwnedByScript).toBeUndefined();
     expect(msg.querySelector('img')).toBeNull();
     expect((window as { pwned?: number }).pwned).toBeUndefined();
   });

--- a/tests/GroupChat.seatTruth.test.tsx
+++ b/tests/GroupChat.seatTruth.test.tsx
@@ -1,0 +1,205 @@
+// studio#176 (campaign E4) — two seat-truth defects, pinned:
+//
+//  1. COLLAPSE MUST NOT LOSE TEXT: the chat wire keeps NO history, so what the
+//     client streamed is the only copy. A long reply collapses to a narration
+//     line (§11.1) and its terminal `chatReply` may arrive SHORTER than the
+//     accumulated deltas (an upstream output cap, a reframed failure) — the
+//     streamed bytes must survive finalize, and expanding the collapsed line
+//     must restore them BYTE-EQUAL. (`retainOnFinalize`: the longer text
+//     stands; ties go to the terminal reply so the §7.9-3 late-mount healing
+//     stays intact.)
+//
+//  2. ONE SOURCE FOR SEAT TRUTH: the header's seat chip said "replied" while
+//     the feed said "failed" for the SAME turn (api/groupE/e4-chat.json),
+//     because the chip was a second, frame-driven derivation that ignored the
+//     reply's `ok`. The chip's turn axis now reads `seatLogPosture` — the same
+//     message log the feed narrates from — so the two can never disagree.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupChat } from '../src/components/GroupChat.js';
+import { retainOnFinalize } from '../src/components/ChatThread.js';
+import { seatLogPosture } from '../src/components/narrator.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useElicitationStore } from '../src/store/elicitations.js';
+import type { RosterSeat } from '../src/api/types.js';
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    confirmGate: vi.fn(),
+    cancelRun: vi.fn(),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+let emit: ((ev: unknown) => void) | null = null;
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: (fn: (ev: unknown) => void): void => {
+    emit = fn;
+  },
+}));
+
+const ROSTER = [
+  { key: 'claude', enabled_for_council: true },
+  { key: 'codex', enabled_for_council: true },
+] as unknown as RosterSeat[];
+
+beforeEach(() => {
+  for (const spy of [openChat, getChat, closeChat, getRoster, sendChatMessage]) spy.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  openChat.mockImplementation((body: { chatId: string; clis?: string[] }) =>
+    Promise.resolve({
+      chatId: body.chatId,
+      seats: (body.clis ?? ['claude', 'codex']).map((cliKey) => ({ cliKey, ok: true })),
+    }),
+  );
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  sessionStorage.clear();
+  clearCachedRoster();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useElicitationStore.setState({ elicitations: {}, generations: {} });
+  emit = null;
+  setCachedRoster(ROSTER);
+});
+
+const chatId = (): string => (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
+
+async function sendText(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.type(screen.getByRole('textbox'), text);
+  await user.keyboard('{Enter}');
+  await waitFor(() => expect(sendChatMessage).toHaveBeenCalledWith(chatId(), text));
+}
+
+const chip = (agent: string): HTMLElement =>
+  document.querySelector(`[data-testid="seat-chip"][data-agent="${agent}"]`) as HTMLElement;
+
+describe('collapse retention — expanding restores every streamed byte', () => {
+  it('a >collapse-threshold stream survives a SHORTER terminal reply; collapse → expand is byte-equal', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'plan it');
+
+    // Stream well past CHAT_TURN_MAX_CHARS (1400) in several deltas — one line,
+    // so the markdown paragraph's textContent is the exact byte sequence.
+    const parts = [
+      `plan head ${'a'.repeat(600)} `,
+      `middle ${'b'.repeat(600)} `,
+      `the actual plan tail ${'c'.repeat(600)}`,
+    ];
+    const streamed = parts.join('');
+    act(() => {
+      for (const text of parts) {
+        emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'claude', text });
+      }
+    });
+
+    // The terminal reply arrives TRUNCATED (the E4 loss shape): shorter than
+    // what already streamed — it must NOT clobber the streamed bytes.
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: streamed.slice(-64), ok: true });
+    });
+
+    // Over-long ⇒ still narration (collapsed), with the raw stream mounted behind
+    // the expander.
+    const lines = screen.getAllByTestId('chat-narration-line');
+    expect(lines.some((l) => l.dataset['agent'] === 'claude' && /replied \(2 KB\)/.test(l.textContent!))).toBe(true);
+    const bubble = document.querySelector('[data-testid="seat-bubble"][data-agent="claude"]') as HTMLElement;
+    const wrapper = bubble.closest('[data-testid^="chat-narration-raw-"]') as HTMLElement;
+    expect(wrapper.style.display).toBe('none');
+
+    // Expand → the FULL streamed text, byte-equal. Then collapse and expand
+    // again — retention is not a one-shot.
+    const index = wrapper.getAttribute('data-testid')!.replace('chat-narration-raw-', '');
+    const toggle = (): Promise<void> => user.click(screen.getByTestId(`chat-narration-toggle-${index}`));
+    await toggle();
+    expect(wrapper.style.display).not.toBe('none');
+    expect(bubble.textContent).toBe(streamed);
+    await toggle(); // collapse
+    expect(wrapper.style.display).toBe('none');
+    await toggle(); // expand again
+    expect(bubble.textContent).toBe(streamed);
+  });
+
+  it('retainOnFinalize: longer stands, ties go to the terminal reply (late-mount healing intact)', () => {
+    expect(retainOnFinalize('the full streamed plan', 'tail')).toBe('the full streamed plan');
+    expect(retainOnFinalize('partial tail', 'the whole authoritative reply text')).toBe(
+      'the whole authoritative reply text',
+    );
+    expect(retainOnFinalize('same-length A', 'same-length B')).toBe('same-length B');
+    expect(retainOnFinalize('', 'reply')).toBe('reply');
+  });
+});
+
+describe('one source for seat truth — the chip reads the feed’s own log', () => {
+  it('a not-ok reply shows FAILED on the header chip (with the turn’s reason), never "replied" (E4)', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'plan it');
+
+    act(() => {
+      emit!({ type: 'chatDelta', chat: chatId(), cliKey: 'codex', text: 'streaming a partial plan… ' });
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'short answer', ok: true });
+      emit!({
+        type: 'chatReply', chat: chatId(), cliKey: 'codex',
+        text: "seat 'codex' turn ended Cancelled: the bridge dropped mid-turn", ok: false,
+      });
+    });
+
+    // The feed narrates the failure…
+    const lines = screen.getAllByTestId('chat-narration-line');
+    expect(
+      lines.some((l) => l.dataset['agent'] === 'codex' && l.dataset['tone'] === 'fail' && /failed —/.test(l.textContent!)),
+    ).toBe(true);
+    // …and the header chip AGREES — same log, one derivation.
+    expect(chip('codex').dataset['state']).toBe('failed');
+    expect(chip('codex')).toHaveTextContent(/failed — seat 'codex' turn ended Cancelled/);
+    expect(chip('claude').dataset['state']).toBe('replied');
+    // The census may not contradict the feed either: one seat is ready, not two.
+    expect(screen.getByTestId('now-bar-phase')).toHaveTextContent('1 agent ready');
+  });
+
+  it('a seat streaming its next turn is WORKING again — the posture heals forward', async () => {
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendText(user, 'plan it');
+    act(() => {
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'nope', ok: false });
+      emit!({ type: 'chatReply', chat: chatId(), cliKey: 'codex', text: 'ok', ok: true });
+    });
+    expect(chip('claude').dataset['state']).toBe('failed');
+
+    // A new turn fans out to the warm audience; a fresh pending bubble means
+    // the seat is working, full stop — the stale failure no longer speaks.
+    await user.type(screen.getByRole('textbox'), 'try again');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(2));
+    expect(chip('claude').dataset['state']).toBe('working');
+  });
+
+  it('seatLogPosture — the pure fold: pending outranks finals; newest final decides; reason is the feed’s clip', () => {
+    expect(seatLogPosture([
+      { kind: 'seat', cliKey: 'a', text: 'old', pending: false, ok: true },
+      { kind: 'seat', cliKey: 'a', text: 'streaming…', pending: true, ok: false },
+      { kind: 'seat', cliKey: 'b', text: 'boom', pending: false, ok: false },
+      { kind: 'seat', cliKey: 'c', text: 'fine', pending: false, ok: true },
+      { kind: 'user', text: 'hi' },
+    ])).toEqual({
+      a: { state: 'working', reason: null },
+      b: { state: 'failed', reason: 'boom' },
+      c: { state: 'replied', reason: null },
+    });
+  });
+});

--- a/tests/HomeBoard.bands.test.tsx
+++ b/tests/HomeBoard.bands.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { DocSummary } from '../src/api/interactive.js';
 import type { CoreEvent, Project, ProjectMember, SessionView } from '../src/api/types.js';
+import { useFailureClocks } from '../src/store/failureClocks.js';
 import { useGateStore } from '../src/store/gates.js';
 import { useRuntimeStore } from '../src/store/runtime.js';
 import { makeView } from './factories.js';
@@ -124,6 +125,9 @@ describe('HomeBoard — NEEDS YOU / QUIET bands (slice 1)', () => {
     members = {};
     docs = {};
     runEvents = {};
+    // The failure-clock mirror is app-wide state now — reset it per test, as
+    // the pre-mirror per-mount state effectively was.
+    useFailureClocks.setState({ failedAtByRun: {} });
     useGateStore.setState({ gates: {} });
     useRuntimeStore.setState({ outputs: {}, logs: {}, deltaSeq: {}, docActivity: {}, seq: 0 });
   });

--- a/tests/HomeBoard.queue.test.tsx
+++ b/tests/HomeBoard.queue.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Project } from '../src/api/types.js';
+import { useFailureClocks } from '../src/store/failureClocks.js';
 import { useGateStore } from '../src/store/gates.js';
 import { takeRetryPrefill } from '../src/store/retryPrefill.js';
 import { makeView } from './factories.js';
@@ -51,6 +52,7 @@ describe('HomeBoard — the needs-you queue', () => {
     projects = [];
     repos = [];
     chats = [];
+    useFailureClocks.setState({ failedAtByRun: {} });
     useGateStore.setState({ gates: {}, approaching: {} });
     takeRetryPrefill(); // drain any deposit a prior test left
   });

--- a/tests/needsYou.test.ts
+++ b/tests/needsYou.test.ts
@@ -6,6 +6,7 @@ import {
   FAILED_WINDOW,
   isFreshInstall,
   needsYouRows,
+  newestFailedRun,
   oldestNeedAt,
   retryPrefillOf,
   type NeedsYouInputs,
@@ -179,6 +180,40 @@ describe('needsYouRows — dedupe', () => {
     expect(rows[0]!.text).toContain('Idle 12m');
     expect(rows[0]!.text).toContain('2 warm seats');
     expect(rows[0]!.action).toEqual({ kind: 'open', path: '/chat/stalled', label: 'Open chat ›' });
+  });
+});
+
+describe('newestFailedRun — the Ask quick-prompt seed (E1)', () => {
+  it('answers the fold’s FIRST failed-run row — the queue’s newest clock, never list order', () => {
+    // List order puts the STALE failure first (the E1 defect: the chip seeded a
+    // 17-day-old run because it read list order instead of the queue's clocks).
+    const stale = makeView({ id: 'r-fail-stale', status: 'failed', problem: 'old breakage' });
+    const fresh = makeView({ id: 'r-fail-fresh', status: 'failed', problem: 'new breakage' });
+    const runs = [stale, fresh];
+    const rows = needsYouRows(inputs({
+      runs,
+      failedAt: { 'r-fail-stale': NOW - 17 * 24 * HOUR, 'r-fail-fresh': NOW - 10 * MIN },
+    }));
+    expect(newestFailedRun(rows, runs)).toBe(fresh);
+  });
+
+  it('answers undefined when the fold has no failed-run row — nothing is fabricated', () => {
+    const runs = [makeView({ id: 'r-live', status: 'executing' })];
+    expect(newestFailedRun(needsYouRows(inputs({ runs })), runs)).toBeUndefined();
+  });
+
+  it('respects the fold’s own dedupe: a suppressed onboard failure yields the NEXT failed run', () => {
+    // The onboard failure is newest, but the queue shows it as a repo row —
+    // the seed follows the queue, so the plain failure is the answer.
+    const onboard = makeView({ id: 'r-onboard', status: 'failed', workflow_id: 'onboarding', repo_ref: 'repo-1' });
+    const plain = makeView({ id: 'r-plain-fail', status: 'failed' });
+    const runs = [onboard, plain];
+    const rows = needsYouRows(inputs({
+      runs,
+      failedAt: { 'r-onboard': NOW - MIN, 'r-plain-fail': NOW - HOUR },
+      repos: [repo('repo-1')],
+    }));
+    expect(newestFailedRun(rows, runs)).toBe(plain);
   });
 });
 


### PR DESCRIPTION
The four verified findings from the live campaign (studio#176):
1. The Ask quick-prompt now seeds the MOST RECENT failed run via the home queue's own fold (live-verified: e3d49ed1, not the 17-day-old list-order head).
2. Dock replies render markdown via react-markdown — headings/code/bullets, no raw ##; sanitization proven by a fixture carrying a literal <script> (nothing mounts, no rehype-raw anywhere).
3. Collapsing a long seat reply retains what was streamed — expand restores byte-equal text (mutation-tested: reverting retention breaks three tests including the DOM-level byte-equality one).
4. The chat header's seat chips and the feed now read ONE attribution source (the message log's seat posture); the dual frame-driven derivation is gone.

2295 tests green, tsc/eslint/build clean, testid inventory regenerated; live shots verified against :7701 with a zero-non-GET route guard.

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)