### PR TITLE
feat: the delivery surface — PR-by-default toggle, stranded runs visible and recoverable in place

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,9 +4,10 @@ import type {
   AuditPage,
   CoreEvent,
   CreateProjectBody,
+  DeliverRunResult,
   GateDecision,
   GateInfo,
-  LaunchRunBody,
+  LaunchBodyWithDeliver,
   OnboardRef,
   OpenTerminalBody,
   Project,
@@ -178,9 +179,21 @@ export const api = {
   getRunAcceptance: (id: string) =>
     apiFetch<import('./types.js').RunAcceptanceView>(`/runs/${encodeURIComponent(id)}/acceptance`),
 
-  /** Launch a run → the new run id. */
-  launchRun: (body: LaunchRunBody) =>
+  /** Launch a run → the new run id. (`LaunchBodyWithDeliver` = `LaunchRunBody`
+   *  with 0.18.0's widened `deliver: 'pr' | 'none'` — see api/types.ts.) */
+  launchRun: (body: LaunchBodyWithDeliver) =>
     apiFetch<{ runId: string }>('/runs', { method: 'POST', body: JSON.stringify(body) }),
+
+  /**
+   * Post-hoc delivery (crew#393): lift a COMPLETED run's stranded worktree into
+   * a PR — the same hardened script the deliver phase runs, idempotent (a
+   * delivered run answers the same `prUrl` without re-running it). Takes no
+   * body. Failure is LOUD: 404 unknown run; 409 not-completed / repo-less /
+   * worktree-gone / in-flight / the script's own refusal (the message carries
+   * the script's own words); 500 no verifiable PR URL or spawn failure.
+   */
+  deliverRun: (id: string) =>
+    apiFetch<DeliverRunResult>(`/runs/${encodeURIComponent(id)}/deliver`, { method: 'POST' }),
 
   /**
    * The steering gate (§11.1). `{approve:true}` = approve; `{approve:true, amend}`

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,34 +12,82 @@
  * (DES-STUDIO-001 §5.1); no `any` at the boundary.
  */
 
-import type { AgentSession } from 'wicked-crew-api-types';
+import type { AgentSession, LaunchRunBody } from 'wicked-crew-api-types';
 
 export type * from 'wicked-crew-api-types';
 
 
+// ── Delivery wire (crew#393 — api-types 0.18.0) ──────────────────────────────
+//
+// TODO(api-types 0.18.0): studio's installed `wicked-crew-api-types` is STALE at
+// 0.8.0 and every declaration in this section ships in 0.18.0. Delete this whole
+// section — `RunDeliveryState`, `SessionDelivery`, `SessionWithDelivery`,
+// `DeliverRunResult`, `LaunchBodyWithDeliver` — and read the fields straight off
+// `AgentSession` / `LaunchRunBody` the moment studio bumps to it.
+
 /**
- * `AgentSession.delivery` — the server-carried PR reference (CREW-UX-8,
- * wicked-crew#321), declared HERE and nowhere else because studio's installed
- * `wicked-crew-api-types` is STALE at 0.8.0 and the field ships in a later
- * version. This is the ONE hand-written shape in this module, and it is a
- * temporary one: **delete both declarations below and read `delivery` straight
- * off `AgentSession`** the moment studio bumps to the api-types version that
- * carries it.
+ * `AgentSession.delivery` (crew#393; api-types 0.18.0) — the run's delivery
+ * state, derived at DTO assembly on BOTH `GET /runs` and `GET /runs/:id`:
  *
- * Read it as `session.delivery?.url` (see `src/components/delivery.ts`): the
- * field is absent on every daemon shipping today, so the surface falls back to
- * the single per-run transcript fetch and lights up — link on the project rows,
- * zero fetches in the right panel — the day the server starts sending it, with
- * no adoption work here. `kind` is the whole concession to a future second kind
- * of deliverable, and it is free.
+ *  - `'delivered'` — a PR was opened for this run (by the deliver phase, or
+ *    post-hoc via `POST /runs/:id/deliver`); `deliverUrl` carries the PR URL.
+ *  - `'stranded'`  — a COMPLETED repo-scoped run with no recorded PR whose
+ *    worktree still exists on disk: reviewable work nobody lifted.
+ *  - `'none'`      — everything else: repo-less runs, non-terminal runs,
+ *    failed/cancelled runs, and completed runs whose worktree is gone.
+ *
+ * Always present on runs served by a 0.18.0+ daemon; absent from older servers.
+ *
+ * ⚠ WIRE RESHAPE (0.17.0 → 0.18.0, NOT additive): 0.11.0–0.17.0 spelled the
+ * field as `delivery?: { kind: 'pull_request'; url: string }`. The object form
+ * is GONE — the state moved into this string and the URL into `deliverUrl`. A
+ * client reading `delivery?.url` must move to `deliverUrl`. Studio's derivation
+ * (`src/components/delivery.ts`) still TOLERATES the legacy object from a
+ * 0.11–0.17 daemon, which is why {@link SessionDelivery} survives below.
  */
+export type RunDeliveryState = 'delivered' | 'stranded' | 'none';
+
+/** The LEGACY 0.11.0–0.17.0 object spelling of `session.delivery` (crew#321).
+ *  Gone from the 0.18.0 wire; kept only so the derivation can read the url off
+ *  an older daemon instead of crashing on it. */
 export interface SessionDelivery {
   kind: 'pull_request';
   url: string;
 }
 
-/** `AgentSession` as the post-#321 daemon sends it. See {@link SessionDelivery}. */
-export type SessionWithDelivery = AgentSession & { delivery?: SessionDelivery | null };
+/** `AgentSession` as the daemon sends it: 0.18.0's string + `deliverUrl`, or the
+ *  legacy 0.11–0.17 object, or neither (≤0.10). See {@link RunDeliveryState}. */
+export type SessionWithDelivery = AgentSession & {
+  delivery?: RunDeliveryState | SessionDelivery | null;
+  /** The delivered PR's URL — present exactly when `delivery === 'delivered'`. */
+  deliverUrl?: string;
+};
+
+/**
+ * Response of `POST /runs/:id/deliver` (crew#393) — post-hoc delivery: lift a
+ * COMPLETED repo-scoped run's stranded worktree into a PR with the SAME hardened
+ * script the deliver phase runs. Idempotent — a delivered run answers 200 with
+ * the same recorded `prUrl`. Failure is loud, never silent: 404 unknown run,
+ * 409 not-completed / repo-less / worktree-gone / delivery-in-flight / the
+ * script's own refusal (the error carries the script's own words), 500 when no
+ * verifiable PR URL came back or the script could not be spawned.
+ */
+export interface DeliverRunResult {
+  prUrl: string;
+}
+
+/**
+ * `LaunchRunBody` with 0.18.0's widened `deliver`. `'pr'` appends the hardened
+ * deliver phase; `'none'` explicitly declines (the completed run reads
+ * `delivery: 'stranded'` on the wire, recoverable via `POST /runs/:id/deliver`);
+ * OMITTED lets the daemon decide — a repo-scoped code-work launch defaults to
+ * `'pr'` (flippable by the daemon's `deliverDefault` setting), everything else
+ * to `'none'`. `'none'` is additive at 0.18.0: older daemons 400 on it, so the
+ * composer only sends the key where it would have been licensed to send `'pr'`.
+ */
+export type LaunchBodyWithDeliver = Omit<LaunchRunBody, 'deliver'> & {
+  deliver?: 'pr' | 'none';
+};
 
 // ── GET /runs/:id/acceptance (AW-14 / AW-18 — arch-R13a + R16) ────────────────
 //

--- a/src/board/needsYou.ts
+++ b/src/board/needsYou.ts
@@ -1,6 +1,7 @@
 import type { CampaignSummary } from '../api/campaigns.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
-import { narrate, type NarrationTone } from '../components/narrator.js';
+import { deliveryOf } from '../components/delivery.js';
+import { narrate, narrateStranded, type NarrationTone } from '../components/narrator.js';
 import type { RetryPrefill } from '../store/retryPrefill.js';
 import { STALLED_IDLE_SECS, stalledLiveChats, type LiveChatSnapshot } from './chatStats.js';
 import { gateOpenPath } from './gateActions.js';
@@ -25,6 +26,10 @@ import { repoOnboard } from './repoStats.js';
  *                   rides — the run wire carries no timestamps, so recency is
  *                   positional and the label says so); clock = the durable-log
  *                   tail (`failedAt`), else attach, else unknown.
+ *  - stranded runs — completed runs the 0.18.0 wire marks `delivery: 'stranded'`
+ *                   (crew#393): reviewable work sitting uncommitted in a live
+ *                   worktree. Unwindowed like gates — the wire clears the state
+ *                   itself once delivered or reaped; clock = attach, else unknown.
  *  - campaigns    — subtraction-dedupe (§3): a campaign row fires only for the
  *                   waiting/failed members the live run list CANNOT already show
  *                   as rows (server counts cover archived/rolled-off members).
@@ -36,7 +41,8 @@ import { repoOnboard } from './repoStats.js';
  *                   (`stalledLiveChats`, reused verbatim).
  */
 
-export type NeedKind = 'gate' | 'failed-run' | 'campaign' | 'repo-graph' | 'stalled-chat';
+export type NeedKind =
+  | 'gate' | 'failed-run' | 'stranded-run' | 'campaign' | 'repo-graph' | 'stalled-chat';
 
 /** The act-in-place affordance a row carries — the component wires the verbs. */
 export type NeedAction =
@@ -72,6 +78,9 @@ const FAILED_KEY = (id: string): string => `fail:${id}`;
 const SEVERITY: Record<NeedKind, number> = {
   gate: 100,
   'failed-run': 70,
+  // Below a failure (nothing broke) but above the ambient rows: finished,
+  // reviewable work sitting invisible in a worktree IS a person's job (crew#393).
+  'stranded-run': 65,
   campaign: 60,
   'repo-graph': 50, // 'never' drops to 30 below
   'stalled-chat': 25,
@@ -212,6 +221,29 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
         at: failedAt[s.id] ?? attachedAt[s.id] ?? null,
         subjectPath: `/runs/${encodeURIComponent(s.id)}`,
         action: { kind: 'retry-prefill', prefill: retryPrefillOf(v), label: 'Retry ›' },
+      });
+    } else if (s.status === 'completed' && deliveryOf(v).state === 'stranded') {
+      // Stranded completed runs (crew#393): the daemon's OWN wire verdict — a
+      // completed repo-scoped run with no recorded PR whose worktree still
+      // exists. Reviewable work nobody lifted is a person's job, so it queues.
+      // Deliberately UNWINDOWED, like gates and unlike failures: the state
+      // clears itself the moment the run is delivered (or its worktree is
+      // reaped, when the wire flips to 'none') — the row lives exactly as long
+      // as the work sits there. Text via the narrator's one template source.
+      const line = narrateStranded();
+      shownRunIds.add(s.id);
+      rows.push({
+        key: `stranded:${s.id}`,
+        kind: 'stranded-run',
+        severity: SEVERITY['stranded-run'],
+        subject: s.problem,
+        text: line.text,
+        tone: line.tone,
+        at: attachedAt[s.id] ?? null,
+        subjectPath: `/runs/${encodeURIComponent(s.id)}`,
+        // Open-in-place, never a POST from the queue (the fold's standing rule):
+        // the run's Delivery card carries the one-click Deliver.
+        action: { kind: 'open', path: `/runs/${encodeURIComponent(s.id)}`, label: 'Open run ›' },
       });
     }
   }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -504,8 +504,9 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           err.status === 400 &&
           err.message.includes('deliver')
         ) {
-          const { deliver: _deliver, ...withoutDeliver } = body;
-          launched = await api.launchRun(withoutDeliver as typeof body);
+          const withoutDeliver = { ...body };
+          delete withoutDeliver.deliver;
+          launched = await api.launchRun(withoutDeliver);
         } else {
           throw err;
         }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { EntityMode, LaunchRunBody, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
+import type { EntityMode, LaunchBodyWithDeliver, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
 import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
 import { useComposerPrefsStore } from '../store/composerPrefs.js';
@@ -196,10 +196,15 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   );
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
 
-  // Delivery (studio#123): the composer carries no default of its own — the
-  // persisted `studio.composer` preference decides, and it ships ON. The two
-  // guards below are what keeps an ON default from producing a body crew 400s.
+  // Delivery (studio#123, reworked by crew#393): the persisted `studio.composer`
+  // preference SEEDS the default (it ships ON), and the per-launch "Open a PR
+  // when done" toggle overrides it for THIS launch only — the override never
+  // persists. The two guards below are what keeps an ON default from producing
+  // a body crew 400s.
   const deliverPr = useComposerPrefsStore((s) => s.prefs.deliverPr);
+  /** Per-launch override; `null` = follow the preference. */
+  const [deliverOverride, setDeliverOverride] = useState<boolean | null>(null);
+  const deliverOn = deliverOverride ?? deliverPr;
 
   // ── Preflight (DES-UX-001 §7.8, EC43, slice AC) ────────────────────────────
   // A code-shaped intent with no repo attached warns-and-blocks: zero POST
@@ -447,7 +452,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // paragraph (see the steer field's own caption) — LaunchRunBody carries
     // no guidance key until CREW-UX-4 lands (DES-UX-002 §7.2).
     const guidance = launchSteer.trim();
-    const body: LaunchRunBody = {
+    const body: LaunchBodyWithDeliver = {
       problem: guidance.length > 0 ? `${problem.trim()}\n\nOperator guidance: ${guidance}` : problem.trim(),
     };
     const seats = roster.filter((s) => selectedClis.has(s.key));
@@ -464,14 +469,17 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     if (firstRepo) body.repoRef = firstRepo;
     const wf = workflowOverride?.trim() || workflow;
     if (wf) body.workflow = wf;
-    // Delivery (crew#293, studio#123): `deliver: 'pr'` appends the daemon's
-    // hardened deliver phase — push the branch, open the PR; merge stays human.
-    // BUILD-kind runs only, and only with both guards met: `deliver` without
-    // `workflow` is a 400 (api-types index.d.ts:955-956), and the deliver
-    // script pushes to a remote, which is the attached repo. Either one missing
-    // and the run launches WITHOUT the key — never a body crew rejects. The
-    // same verdict is on screen before the operator sends (`deliverNotice`).
-    if (deliverPr && deliverKind(wf) === 'build' && firstRepo) body.deliver = 'pr';
+    // Delivery (crew#293/studio#123, wire reworked by crew#393): a repo-scoped
+    // BUILD launch ALWAYS carries the key — `'pr'` when the toggle is on,
+    // `'none'` when it is off. Explicit-off matters on the 0.18.0 wire: the
+    // daemon now DEFAULTS an omitted `deliver` to `'pr'` for exactly these
+    // launches, so an OFF toggle that merely omitted the key would deliver
+    // anyway. Both guards stay: `deliver` without `workflow` is a 400 and the
+    // deliver script pushes to the attached repo — either one missing and the
+    // run launches WITHOUT the key (the daemon defaults those to `'none'`;
+    // older daemons also 400 on `'none'`, so unlicensed bodies never carry it).
+    // The same verdict is on screen before the operator sends (`deliverNotice`).
+    if (deliverKind(wf) === 'build' && firstRepo) body.deliver = deliverOn ? 'pr' : 'none';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -725,30 +733,49 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // when the preference is off (the setting is the answer) and on the chat
   // surface (a system workflow has nothing to deliver).
   const deliverWorkflow = workflowOverride?.trim() || workflow;
+  // The toggle renders exactly where the wire key can go (crew#393): a
+  // repo-scoped BUILD launch. Hidden — not merely disabled — everywhere else:
+  // repo-less, freeform and system launches never carry the key, so a control
+  // there would promise a choice the body cannot honor.
+  const deliverToggleVisible = deliverKind(deliverWorkflow) === 'build' && Boolean(repoRefs[0]);
   const deliverNotice: { state: string; text: string } | null = ((): { state: string; text: string } | null => {
-    if (!deliverPr) return null;
     switch (deliverKind(deliverWorkflow)) {
       case 'system':
         return null;
       case 'freeform':
-        return {
-          state: 'no-workflow',
-          text: 'No PR when this finishes — a run needs a workflow to deliver one. Pick one in launch options.',
-        };
+        // With delivery off there was nothing to warn about — the guard notices
+        // only matter to an operator who expected a PR.
+        return deliverOn
+          ? {
+              state: 'no-workflow',
+              text: 'No PR when this finishes — a run needs a workflow to deliver one. Pick one in launch options.',
+            }
+          : null;
       case 'build':
         // The SAME truthiness the submit site guards on (`const firstRepo =
         // repoRefs[0]`), not `repoRefs.length > 0` — otherwise a falsy first
         // entry renders "a PR is coming" over a body that carries no
         // `deliver`, and the notice's whole contract is that it cannot
         // disagree with the wire.
-        return repoRefs[0]
+        if (!repoRefs[0]) {
+          return deliverOn
+            ? {
+                state: 'no-repo',
+                text: 'No PR when this finishes — delivery pushes to a repository, and none is attached.',
+              }
+            : null;
+        }
+        return deliverOn
           ? {
               state: 'on',
               text: 'When this finishes it pushes its branch and opens a PR. Merging stays yours.',
             }
           : {
-              state: 'no-repo',
-              text: 'No PR when this finishes — delivery pushes to a repository, and none is attached.',
+              // The consequence of OFF, said before the send (crew#393): the
+              // wire carries an explicit `deliver: 'none'` and the completed
+              // run will read `stranded` — recoverable from its run page.
+              state: 'off',
+              text: 'No PR when this finishes — the work will stay in the run’s worktree. You can still deliver it later from the run page.',
             };
     }
   })();
@@ -991,17 +1018,44 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         </div>
       )}
 
+      {/* ── "Open a PR when done" (crew#393) — the per-launch delivery toggle.
+          Rendered exactly where the wire key can go (repo-scoped build work);
+          hidden for repo-less/freeform/system launches. Defaults to the
+          persisted preference (ships ON); the override lasts one composer. ── */}
+      {deliverToggleVisible && (
+        <label
+          data-testid="deliver-toggle-row"
+          className="flex items-center gap-2 text-xs px-1 font-mono cursor-pointer select-none"
+          style={{ color: 'var(--ink-muted)' }}
+        >
+          <input
+            type="checkbox"
+            data-testid="deliver-toggle"
+            checked={deliverOn}
+            onChange={(e) => setDeliverOverride(e.target.checked)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          Open a PR when done
+        </label>
+      )}
+
       {/* ── Delivery verdict (studio#123) — visible text, never a tooltip: the
           operator reads whether a PR is coming, or which guard stopped it,
-          before sending. `--ink-muted` when delivery is on (a statement of
-          fact), `--status-gate` when a guard withheld it (something to act
-          on) — the composer's own warn dress, one notch below the fail red. ── */}
+          before sending. `--ink-muted` when the state was CHOSEN (on/off — a
+          statement of fact), `--status-gate` when a guard withheld it
+          (something to act on) — the composer's own warn dress, one notch
+          below the fail red. ── */}
       {deliverNotice !== null && (
         <p
           data-testid="deliver-notice"
           data-deliver-state={deliverNotice.state}
           className="text-xs px-1 font-mono"
-          style={{ color: deliverNotice.state === 'on' ? 'var(--ink-muted)' : 'var(--status-gate)' }}
+          style={{
+            color:
+              deliverNotice.state === 'on' || deliverNotice.state === 'off'
+                ? 'var(--ink-muted)'
+                : 'var(--status-gate)',
+          }}
         >
           {deliverNotice.text}
         </p>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { api } from '../api/client.js';
+import { api, ApiError } from '../api/client.js';
 import type { EntityMode, LaunchBodyWithDeliver, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
 import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
@@ -490,7 +490,27 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     if (retryOf) body.retryOf = retryOf;
 
     try {
-      const { runId: newRunId } = await api.launchRun(body);
+      let launched;
+      try {
+        launched = await api.launchRun(body);
+      } catch (err) {
+        // A pre-0.18 daemon 400s on the `deliver` key itself. Such a daemon HAS no deliver
+        // phase — omitting the key reproduces the only behavior it is capable of (no
+        // delivery), for either toggle state — so retry once without it rather than failing
+        // a launch over a field the daemon cannot honor.
+        if (
+          body.deliver !== undefined &&
+          err instanceof ApiError &&
+          err.status === 400 &&
+          err.message.includes('deliver')
+        ) {
+          const { deliver: _deliver, ...withoutDeliver } = body;
+          launched = await api.launchRun(withoutDeliver as typeof body);
+        } else {
+          throw err;
+        }
+      }
+      const { runId: newRunId } = launched;
       // The studio witnessed this launch — the provenance line's honest
       // 'via studio' channel derives from exactly this record (§3.3).
       useProvenanceStore.getState().markLaunchedHere(newRunId);

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { SessionView } from '../api/types.js';
 import { useDeliveryStore } from '../store/delivery.js';
+import { usePostHocDeliverStore } from '../store/postHocDeliver.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import {
   DELIVERY_COLOR,
@@ -48,7 +49,12 @@ interface Props {
  */
 export function DeliveryBadge({ view }: Props): React.ReactElement | null {
   const fetched = useDeliveryStore((s) => s.byRun[view.session.id]);
-  const { claim } = resolveDelivery(deliveryOf(view), fetched?.url ?? null);
+  // The post-hoc deliver result (crew#393) feeds the SAME resolution the body
+  // reads, so clicking Deliver in the body flips this badge in the same paint —
+  // a header that lags its own body is the D1 bug again.
+  const postHoc = usePostHocDeliverStore((s) => s.byRun[view.session.id]);
+  const readUrl = postHoc?.phase === 'delivered' ? postHoc.prUrl : (fetched?.url ?? null);
+  const { claim } = resolveDelivery(deliveryOf(view), readUrl);
   if (claim === 'none') return null;
   return (
     <span
@@ -138,6 +144,13 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
   // The 665a9aeb wording. Approved is not the same as produced, and this line
   // is the whole difference said out loud.
   'delivered':          'The deliver phase ran and crew approved it. That alone is not a PR.',
+  // The daemon's own verdict (crew#393): completed + repo-scoped + no RECORDED
+  // PR + the worktree still on disk. Loud by design — this is the run 83052f0b
+  // failure mode, reviewable work that was invisible. "No PR is on record" is
+  // the exact wire-evidenced claim (the daemon checked its own delivery index),
+  // deliberately not "no PR exists" — an ungoverned worker may have opened one
+  // crew never saw (crew#391), and this module never claims past its evidence.
+  'stranded':           'Stranded — this run finished, but its work is sitting uncommitted in its worktree. No PR is on record.',
   'pr-open':            'PR open — merge stays human.',
   'nothing-to-deliver': 'Delivered nothing. Crew refused the push:',
   'failed':             'Delivery failed. Crew recorded:',
@@ -214,9 +227,14 @@ export const HEADLINE: Record<DeliveryClaim, string> = {
 export function RunDelivery({ view }: Props): React.ReactElement {
   const runId = view.session.id;
   const fetched = useDeliveryStore((s) => s.byRun[runId]);
+  // Post-hoc delivery (crew#393): the one write this card can make. Its answered
+  // `prUrl` rides the SAME `readUrl` seam as the transcript read, so a stranded
+  // run that just delivered resolves to the ordinary pr-open arm — one claim
+  // path, never a parallel "just delivered" rendering that could drift from it.
+  const postHoc = usePostHocDeliverStore((s) => s.byRun[runId]);
   const { state, claim, unitId, reason, href } = resolveDelivery(
     deliveryOf(view),
-    fetched?.url ?? null,
+    postHoc?.phase === 'delivered' ? postHoc.prUrl : (fetched?.url ?? null),
   );
 
   // The ONE per-run fetch, and only when there may be something to point at: an
@@ -273,12 +291,15 @@ export function RunDelivery({ view }: Props): React.ReactElement {
           {href} <span aria-hidden>↗</span>
         </a>
       )}
-      {claim === 'delivered' && fetched === undefined && (
+      {claim === 'delivered' && fetched === undefined && unitId !== null && (
         <p className="font-mono" style={{ color: 'var(--ink-dim)' }}>
           reading the deliver phase transcript for the PR link…
         </p>
       )}
-      {claim === 'delivered' && fetched !== undefined && (
+      {/* `unitId === null` = wire-delivered with NO deliver unit to read (the
+        * post-hoc path on a run whose in-run phase never existed) — there is no
+        * transcript to wait on, so the absence itself is the finding. */}
+      {claim === 'delivered' && (fetched !== undefined || unitId === null) && (
         // The 665a9aeb case, said out loud: crew approved the phase and the
         // transcript carries no PR url (its overlay pushed an empty branch and
         // reported success — crew#317). `unavailable` is the daemon's OWN words
@@ -286,8 +307,57 @@ export function RunDelivery({ view }: Props): React.ReactElement {
         // not `--status-fail`: an approved phase that produced no PR is a gap in
         // the EVIDENCE, not a run that failed.
         <p data-testid="run-delivery-nolink" className="font-mono" style={{ color: 'var(--ink-muted)' }}>
-          {fetched.unavailable ?? 'the deliver phase recorded no PR link — nothing can be pointed at'}
+          {fetched?.unavailable ?? 'the deliver phase recorded no PR link — nothing can be pointed at'}
         </p>
+      )}
+
+      {/* The stranded arm (crew#393, issue #393's run 83052f0b): the loudest
+        * state this card has. The wire itself said the reviewable work is
+        * sitting uncommitted in the run's worktree, so the card names the
+        * worktree AND carries the one-click remedy — POST /runs/:id/deliver,
+        * the same hardened script the deliver phase runs (idempotent; merge
+        * stays human). Success feeds `resolveDelivery` above and this whole arm
+        * is REPLACED by the ordinary pr-open link; failure renders below,
+        * denialCopy-style: studio's plain headline, then the daemon's own words
+        * VERBATIM — never re-worded, never silent. */}
+      {claim === 'stranded' && (
+        <>
+          {workdir !== undefined && workdir !== null && (
+            <p className="font-mono" style={{ color: 'var(--ink-dim)' }} title={workdir}>
+              the work is in {compactPath(workdir)}
+            </p>
+          )}
+          <div>
+            <button
+              type="button"
+              data-testid="run-deliver-button"
+              onClick={() => usePostHocDeliverStore.getState().deliver(runId)}
+              disabled={postHoc?.phase === 'delivering'}
+              className="rounded-lg px-3 py-1.5 text-xs font-semibold font-mono transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+            >
+              {postHoc?.phase === 'delivering' ? 'Delivering…' : 'Deliver — open a PR'}
+            </button>
+          </div>
+          {postHoc?.phase === 'error' && (
+            <div data-testid="run-deliver-error" className="flex flex-col gap-1">
+              <p style={{ color: 'var(--status-fail)' }}>
+                Delivery failed — the run is still stranded.
+              </p>
+              {/* ApiError.message is ALREADY the translated operator sentence
+                * (EC33: "the daemon refused this — {the script's own words}"),
+                * the detail carried WHOLE and verbatim — rendered as-is, per
+                * the denialCopy convention: studio's headline, the engine's
+                * words. */}
+              <p
+                className="font-mono break-words whitespace-pre-wrap"
+                style={{ color: 'var(--status-fail)' }}
+              >
+                {postHoc.error}
+              </p>
+            </div>
+          )}
+        </>
       )}
 
       {(claim === 'nothing-to-deliver' || claim === 'failed') && (

--- a/src/components/delivery.ts
+++ b/src/components/delivery.ts
@@ -48,14 +48,21 @@ import { deliverKindOf, type IsSystemWorkflow } from './runMode.js';
  * the phase, never the artifact — see {@link DeliveryClaim} for what a surface
  * is allowed to say out loud.
  *
- *  - `delivered` — the deliver phase was APPROVED (`done`). It is not "a PR",
- *    it is not "shipped" and it is not "merged".
+ *  - `delivered` — the deliver phase was APPROVED (`done`), or the 0.18.0 wire
+ *    says `delivery: 'delivered'` (a PR was recorded — in-run or post-hoc). It
+ *    is not "shipped" and it is not "merged".
+ *  - `stranded` — the 0.18.0 wire's own verdict (crew#393): a COMPLETED
+ *    repo-scoped run with no recorded PR whose worktree still exists on disk —
+ *    reviewable work nobody lifted. WIRE-ONLY: studio never infers it (the
+ *    "worktree still exists" half lives on the daemon's disk, not in the DTO),
+ *    so a pre-0.18 daemon simply never produces this state.
  *  - `nothing-to-deliver` — denied because the run committed nothing (crew#318).
  *  - `failed` — denied for any other reason; the reason is rendered verbatim.
  *  - `in-flight` — the deliver phase has not resolved (`pending`/`distributed`).
  *  - `none` — this run has no deliver phase at all.
  */
-export type DeliveryState = 'none' | 'in-flight' | 'delivered' | 'nothing-to-deliver' | 'failed';
+export type DeliveryState =
+  | 'none' | 'in-flight' | 'delivered' | 'stranded' | 'nothing-to-deliver' | 'failed';
 
 /**
  * What a surface may SAY — {@link DeliveryState} with `delivered` split by the
@@ -207,26 +214,47 @@ export function deliverUnit(view: SessionView): WorkUnit | null {
 
 /** The whole derivation, from the DTO the caller already holds. Never fetches. */
 export function deliveryOf(view: SessionView): Delivery {
+  // `session.delivery`/`deliverUrl` are declared in ../api/types.js, not in the
+  // installed api-types — the cast is the honest spelling until studio bumps.
+  const s = view.session as SessionWithDelivery;
+  // The 0.18.0 tri-state (crew#393). `typeof === 'string'` doubles as the
+  // legacy guard: a 0.11–0.17 daemon sends the OBJECT form here, which must
+  // never be mistaken for a state word.
+  const wire = typeof s.delivery === 'string' ? s.delivery : null;
+  // The url, best-first: 0.18.0's `deliverUrl`, else the legacy object's `url`.
+  // Same shape gate as the transcript path — a wire-carried url is not more
+  // trustworthy for being wire-carried (Copilot on #125). Non-conforming ⇒ no
+  // url ⇒ no PR claim.
+  const legacyUrl =
+    typeof s.delivery === 'object' && s.delivery !== null && typeof s.delivery.url === 'string'
+      ? s.delivery.url
+      : null;
+  const declared = typeof s.deliverUrl === 'string' ? s.deliverUrl : legacyUrl;
+  const url = declared !== null && isPrUrl(declared) ? declared : null;
+
   const unit = deliverUnit(view);
-  if (unit === null) return { state: 'none', unitId: null, reason: null, url: null };
 
   // Absent and empty are the same "crew recorded nothing" — see `Delivery.reason`.
-  const reason = unit.denial_reason === '' ? null : unit.denial_reason;
-  const state: DeliveryState =
-    unit.status === 'done' ? 'delivered'
+  const reason = unit === null || unit.denial_reason === '' ? null : unit.denial_reason;
+  const unitState: DeliveryState =
+    unit === null ? 'none'
+    : unit.status === 'done' ? 'delivered'
     : unit.status === 'rejected'
       ? (reason !== null && NOTHING_TO_DELIVER.test(reason) ? 'nothing-to-deliver' : 'failed')
       : 'in-flight';
 
-  // `session.delivery` is declared in ../api/types.js, not in the installed
-  // api-types — the cast is the honest spelling until studio bumps (see there).
-  const declared = (view.session as SessionWithDelivery).delivery;
-  // Same gate as the transcript path — a wire-carried url is not more trustworthy
-  // for being wire-carried (Copilot on #125). Non-conforming ⇒ no url ⇒ no PR claim.
-  const url =
-    typeof declared?.url === 'string' && isPrUrl(declared.url) ? declared.url : null;
+  // The wire's positive verdicts are AUTHORITATIVE where they say more than the
+  // units can: `'delivered'` covers the post-hoc path (no deliver unit ever ran)
+  // and `'stranded'` needs the daemon's own worktree-still-exists check. The
+  // wire's `'none'` deliberately defers to the unit facts — a failed/cancelled
+  // run with a rejected deliver unit reads `'none'` on the 0.18.0 wire while the
+  // unit's `denial_reason` still tells the richer, equally-true story.
+  const state: DeliveryState =
+    wire === 'delivered' ? 'delivered'
+    : wire === 'stranded' ? 'stranded'
+    : unitState;
 
-  return { state, unitId: unit.id, reason, url };
+  return { state, unitId: unit?.id ?? null, reason, url };
 }
 
 /** A {@link Delivery} plus the claim it licenses and the url that licensed it. */
@@ -245,10 +273,22 @@ export interface ResolvedDelivery extends Delivery {
  *
  * @param d        the phase fact, from {@link deliveryOf}.
  * @param readUrl  a url recovered by the ONE sanctioned per-run transcript read
- *                 (`store/delivery.ts`). Omit it — as every zero-fetch list
- *                 surface does — and the delivered arm stays phase-only.
+ *                 (`store/delivery.ts`) — or, for a `'stranded'` run, the
+ *                 `prUrl` the post-hoc deliver POST answered with
+ *                 (`store/postHocDeliver.ts`). Omit it — as every zero-fetch
+ *                 list surface does — and the delivered arm stays phase-only.
  */
 export function resolveDelivery(d: Delivery, readUrl: string | null = null): ResolvedDelivery {
+  // A stranded run that just POST-delivered (crew#393): the answered `prUrl`
+  // upgrades it to a full pr-open IN PLACE, so the card, the badge and the
+  // header flip together without waiting for the next DTO refresh. Same shape
+  // gate as every other PR claim — this is the one choke point.
+  if (d.state === 'stranded') {
+    const href = readUrl !== null && isPrUrl(readUrl) ? readUrl : null;
+    return href === null
+      ? { ...d, claim: 'stranded', href: null }
+      : { ...d, state: 'delivered', url: href, claim: 'pr-open', href };
+  }
   if (d.state !== 'delivered') return { ...d, claim: d.state, href: null };
   // Empty is absent — the third member of the same class already normalized at
   // `Delivery.reason` and in `store/delivery.ts`. `deliveryOf` maps an empty
@@ -284,6 +324,9 @@ export const DELIVERY_LABEL: Record<DeliveryClaim, string> = {
   // (10 cancelled, 2 failed) — not one of them is going to move again.
   'in-flight':          'pending',
   'delivered':          'deliver ran',
+  // The daemon's own word (crew#393): completed, repo-scoped, no PR, worktree
+  // still on disk. Not a failure — work waiting on a person.
+  'stranded':           'stranded',
   'pr-open':            'PR open',
   'nothing-to-deliver': 'nothing delivered',
   'failed':             'deliver failed',
@@ -299,6 +342,11 @@ export const DELIVERY_COLOR: Record<DeliveryClaim, string> = {
   'none':               'var(--ink-dim)',
   'in-flight':          'var(--ink-muted)',
   'delivered':          'var(--ink-muted)',
+  // Amber, deliberately: not `--status-fail` (nothing failed — the work is
+  // sitting there, finished) and never the accent (no PR exists to claim). The
+  // gate token is studio's "waiting on a person" color, which is exactly what
+  // stranded is.
+  'stranded':           'var(--status-gate)',
   'pr-open':            'var(--accent)',
   'nothing-to-deliver': 'var(--status-fail)',
   'failed':             'var(--status-fail)',
@@ -461,7 +509,8 @@ export function deliverySummary(
   isSystemWorkflow?: IsSystemWorkflow,
 ): string {
   const counts: Record<DeliveryClaim, number> = {
-    'none': 0, 'in-flight': 0, 'delivered': 0, 'pr-open': 0, 'nothing-to-deliver': 0, 'failed': 0,
+    'none': 0, 'in-flight': 0, 'delivered': 0, 'stranded': 0, 'pr-open': 0,
+    'nothing-to-deliver': 0, 'failed': 0,
   };
   for (const v of views) {
     if (!canDeliver(v, isSystemWorkflow)) continue;
@@ -473,6 +522,9 @@ export function deliverySummary(
   const parts: string[] = [];
   if (counts['pr-open'] > 0) parts.push(`${counts['pr-open']} PR open`);
   if (counts['delivered'] > 0) parts.push(`${counts['delivered']} ran deliver`);
+  // Right after the delivered buckets — stranded is the actionable one, and its
+  // wording tracks DELIVERY_LABEL exactly (crew#393: work waiting on a person).
+  if (counts['stranded'] > 0) parts.push(`${counts['stranded']} stranded`);
   if (counts['nothing-to-deliver'] > 0) parts.push(`${counts['nothing-to-deliver']} delivered nothing`);
   if (counts['failed'] > 0) parts.push(`${counts['failed']} failed to deliver`);
   if (counts['in-flight'] > 0) parts.push(`${counts['in-flight']} deliver pending`);

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -309,11 +309,34 @@ export function deriveArtifacts(
       out.push({ kind: 'file', ref: f, name: basename(f), phase });
     }
   }
-  const delivery = (view?.session as { delivery?: { kind: string; url: string } } | undefined)?.delivery;
-  if (delivery && typeof delivery.url === 'string' && delivery.url !== '' && !seen.has(delivery.url)) {
-    out.push({ kind: 'pr', ref: delivery.url, name: 'Pull request', phase: null });
+  // The delivered PR off the 0.18.0 wire (crew#393 reshape: the state is the
+  // `delivery` STRING and the url moved to `deliverUrl`); the legacy 0.11–0.17
+  // object form is still read so an older daemon keeps its PR card.
+  const s = view?.session as
+    | { delivery?: string | { kind: string; url: string } | null; deliverUrl?: string }
+    | undefined;
+  const prUrl =
+    typeof s?.deliverUrl === 'string' && s.deliverUrl !== ''
+      ? s.deliverUrl
+      : typeof s?.delivery === 'object' && s?.delivery !== null && typeof s.delivery.url === 'string' && s.delivery.url !== ''
+        ? s.delivery.url
+        : null;
+  if (prUrl !== null && !seen.has(prUrl)) {
+    out.push({ kind: 'pr', ref: prUrl, name: 'Pull request', phase: null });
   }
   return out;
+}
+
+/**
+ * The STRANDED one-liner (crew#393) — the template every surface that narrates
+ * a stranded run reads (the home needs-you queue today; any future now-bar or
+ * feed line joins it HERE). narrator.ts is the one narration template source
+ * (§11's rule, held for run vocabulary too), so the wording cannot fork between
+ * the queue and a card. Tone `gate`: finished work waiting on a person — not a
+ * failure, not motion.
+ */
+export function narrateStranded(): { text: string; tone: NarrationTone } {
+  return { text: 'Finished, but the work is stranded in its worktree — no PR', tone: 'gate' };
 }
 
 /** The old timeline filter, verbatim (FINDING-052): units that have run or are running. */

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -1,4 +1,5 @@
 import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
+import { isPrUrl } from './delivery.js';
 
 /**
  * The run narrator (DES-RUN-NARRATOR §4-§6): a DETERMINISTIC template layer —
@@ -315,12 +316,15 @@ export function deriveArtifacts(
   const s = view?.session as
     | { delivery?: string | { kind: string; url: string } | null; deliverUrl?: string }
     | undefined;
-  const prUrl =
+  const rawPrUrl =
     typeof s?.deliverUrl === 'string' && s.deliverUrl !== ''
       ? s.deliverUrl
       : typeof s?.delivery === 'object' && s?.delivery !== null && typeof s.delivery.url === 'string' && s.delivery.url !== ''
         ? s.delivery.url
         : null;
+  // The same shape gate every PR link passes (delivery.ts): the ref becomes a clickable
+  // <a href>, so a wire value that is not an https…/pull/<n> URL never becomes an artifact.
+  const prUrl = rawPrUrl !== null && isPrUrl(rawPrUrl) ? rawPrUrl : null;
   if (prUrl !== null && !seen.has(prUrl)) {
     out.push({ kind: 'pr', ref: prUrl, name: 'Pull request', phase: null });
   }

--- a/src/store/postHocDeliver.ts
+++ b/src/store/postHocDeliver.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { api } from '../api/client.js';
+
+/**
+ * Post-hoc delivery (crew#393) — the one-click "Deliver" on a STRANDED run's
+ * Delivery card: `POST /runs/:id/deliver` lifts the completed run's worktree
+ * into a PR with the same hardened script the deliver phase runs.
+ *
+ * The store holds one {@link PostHocDeliver} per run id so the card, the rail
+ * badge and any future surface read the SAME in-flight/answered fact and cannot
+ * disagree (the D1 rule, applied to this write):
+ *
+ *  - `'delivering'` — the POST is in flight; the button disables. A synchronous
+ *    in-flight guard means a double-click never doubles the POST (the endpoint
+ *    is idempotent AND 409s an in-flight duplicate, but studio does not lean on
+ *    either — one click, one request).
+ *  - `'delivered'`  — 200 `{prUrl}`. The url feeds `resolveDelivery` as its
+ *    `readUrl`, so the card flips to the pr-open arm in place, without waiting
+ *    for the next DTO refresh.
+ *  - `'error'`      — the LOUD failure, verbatim (denialCopy's standing rule:
+ *    the headline is studio's, the detail is the engine's own words — a 409
+ *    carries the deliver script's own message, e.g. the rebase-conflict text
+ *    with nothing pushed). Never silent, never re-worded. A later click retries
+ *    from scratch — the endpoint is idempotent, so a retry can never open a
+ *    second PR.
+ */
+export type PostHocDeliver =
+  | { phase: 'delivering' }
+  | { phase: 'delivered'; prUrl: string }
+  | { phase: 'error'; error: string };
+
+interface PostHocDeliverStore {
+  /** Per run id. ABSENT = never attempted this session. */
+  byRun: Record<string, PostHocDeliver>;
+  /** Fire the POST for one run. No-op while one is already in flight, and after
+   *  a success (the answered `prUrl` stands — idempotent server-side too). */
+  deliver: (runId: string) => void;
+}
+
+export const usePostHocDeliverStore = create<PostHocDeliverStore>((set, get) => ({
+  byRun: {},
+
+  deliver: (runId) => {
+    const current = get().byRun[runId];
+    if (current?.phase === 'delivering' || current?.phase === 'delivered') return;
+    set((s) => ({ byRun: { ...s.byRun, [runId]: { phase: 'delivering' } } }));
+    api
+      .deliverRun(runId)
+      .then(({ prUrl }) => {
+        set((s) => ({ byRun: { ...s.byRun, [runId]: { phase: 'delivered', prUrl } } }));
+      })
+      .catch((err: unknown) => {
+        // ApiError.message is already the body's `error` (the script's own
+        // words) — apiFetch extracted it. Kept VERBATIM; empty degrades to a
+        // plain sentence rather than a blank red paragraph (the absent-and-
+        // empty-are-one-thing rule from store/delivery.ts).
+        const raw = err instanceof Error ? err.message : String(err);
+        const error = raw.trim() !== '' ? raw : 'the daemon rejected the delivery and gave no reason';
+        set((s) => ({ byRun: { ...s.byRun, [runId]: { phase: 'error', error } } }));
+      });
+  },
+}));

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.8",
   "counts": {
     "files": 116,
-    "occurrences": 930,
-    "static": 795,
+    "occurrences": 934,
+    "static": 799,
     "dynamic": 43,
     "computed": 6
   },
@@ -1197,6 +1197,18 @@
       "testId": "deliver-pr-unsaved",
       "files": [
         "src/components/SystemSettings.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-toggle",
+      "files": [
+        "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-toggle-row",
+      "files": [
+        "src/components/ChatInput.tsx"
       ]
     },
     {
@@ -3069,6 +3081,18 @@
       "testId": "run-chip",
       "files": [
         "src/components/ProjectCard.tsx"
+      ]
+    },
+    {
+      "testId": "run-deliver-button",
+      "files": [
+        "src/components/RunDelivery.tsx"
+      ]
+    },
+    {
+      "testId": "run-deliver-error",
+      "files": [
+        "src/components/RunDelivery.tsx"
       ]
     },
     {

--- a/tests/ChatInput.deliver.test.tsx
+++ b/tests/ChatInput.deliver.test.tsx
@@ -3,19 +3,23 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatInput } from '../src/components/ChatInput.js';
 import * as client from '../src/api/client.js';
-import type { LaunchRunBody } from '../src/api/types.js';
+import type { LaunchBodyWithDeliver } from '../src/api/types.js';
 import { DEFAULT_COMPOSER_PREFS, useComposerPrefsStore } from '../src/store/composerPrefs.js';
 import { clearRetryPrefill, setRetryPrefill } from '../src/store/retryPrefill.js';
 
 /**
- * studio#123 — the composer reaches for `deliver: 'pr'` (crew#293,
- * api-types index.d.ts:950), from the persisted `studio.composer` preference
- * rather than a hardcoded composer default:
- *   - a BUILD-kind run with a workflow AND a repo bound carries the key;
+ * studio#123, wire reworked by crew#393 (api-types 0.18.0) — the composer's
+ * "Open a PR when done" toggle:
+ *   - a BUILD-kind run with a workflow AND a repo bound ALWAYS carries the key:
+ *     `'pr'` with the toggle on, `'none'` with it off. Explicit-off matters —
+ *     the 0.18.0 daemon defaults an OMITTED `deliver` to `'pr'` for exactly
+ *     these launches, so omission would deliver against the operator's OFF;
  *   - either guard unmet ⇒ the run still LAUNCHES, without the key — crew 400s
- *     on `deliver` without `workflow` (index.d.ts:955-956), and the deliver
- *     phase pushes to a remote it would not have;
- *   - the preference off ⇒ never sent;
+ *     on `deliver` without `workflow` (and older daemons 400 on `'none'`), and
+ *     the deliver phase pushes to a remote it would not have;
+ *   - the toggle is VISIBLE exactly where the key can go (repo-scoped build
+ *     work), hidden for repo-less/freeform/system launches, defaulted from the
+ *     persisted `studio.composer` preference (ships ON), per-launch override;
  *   - and in every case the verdict is VISIBLE text above the composer before
  *     the operator sends, never a tooltip.
  */
@@ -64,7 +68,7 @@ async function send(user: ReturnType<typeof userEvent.setup>, text: string): Pro
   await user.click(screen.getByTestId('launch-submit'));
 }
 
-function sentBody(): LaunchRunBody {
+function sentBody(): LaunchBodyWithDeliver {
   return vi.mocked(client.api.launchRun).mock.calls[0]![0];
 }
 
@@ -125,17 +129,68 @@ describe('ChatInput delivery (#123)', () => {
     expect(body.workflow).toBe('feature');
   });
 
-  it('the preference OFF sends no deliver key and renders no notice', async () => {
+  it('the preference OFF sends an EXPLICIT deliver: none — omission would deliver (crew#393)', async () => {
+    // The 0.18.0 wire reshape: the daemon now defaults an omitted `deliver` to
+    // `'pr'` for repo-scoped code work, so "off" must be said on the wire. The
+    // consequence is visible text, not silence: the run's work will strand.
     useComposerPrefsStore.setState({ prefs: { deliverPr: false } });
     const user = userEvent.setup();
     render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
     await bind(user, { workflow: 'feature', repo: 'studio-api' });
 
-    expect(screen.queryByTestId('deliver-notice')).toBeNull();
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverState).toBe('off');
+    expect(notice.textContent).toMatch(/stay in the run.s worktree/i);
+    // The toggle reflects the preference-seeded default.
+    expect(screen.getByTestId('deliver-toggle')).not.toBeChecked();
 
     await send(user, 'add the delivery toggle');
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    expect('deliver' in sentBody(), 'preference off = no deliver key at all').toBe(false);
+    expect(sentBody().deliver, 'off = explicit none, never omission').toBe('none');
+  });
+
+  it('the toggle defaults ON for a repo-scoped build launch, and unchecking it sends none', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    // Hidden until the launch is repo-scoped build work — nowhere for the key to go.
+    expect(screen.queryByTestId('deliver-toggle')).toBeNull();
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+
+    const toggle = screen.getByTestId('deliver-toggle');
+    expect(toggle).toBeChecked(); // the shipped default: ON
+
+    await user.click(toggle);
+    expect(screen.getByTestId('deliver-toggle')).not.toBeChecked();
+    expect(screen.getByTestId('deliver-notice').dataset.deliverState).toBe('off');
+
+    await send(user, 'add the delivery toggle');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    expect(sentBody().deliver).toBe('none');
+  });
+
+  it('the per-launch override flips back ON over an OFF preference', async () => {
+    useComposerPrefsStore.setState({ prefs: { deliverPr: false } });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+
+    await user.click(screen.getByTestId('deliver-toggle'));
+    expect(screen.getByTestId('deliver-toggle')).toBeChecked();
+    expect(screen.getByTestId('deliver-notice').dataset.deliverState).toBe('on');
+
+    await send(user, 'add the delivery toggle');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    expect(sentBody().deliver).toBe('pr');
+  });
+
+  it('the toggle stays hidden for a repo-less launch — nothing to push to', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature' });
+    // Repo-less: the guard notice explains; the toggle would promise a choice
+    // the body cannot honor, so it does not render at all.
+    expect(screen.queryByTestId('deliver-toggle')).toBeNull();
+    expect(screen.getByTestId('deliver-notice').dataset.deliverState).toBe('no-repo');
   });
 
   it('a retry prefill of an is_system workflow NOT on the denylist never delivers', async () => {

--- a/tests/ChatInput.preflight.test.tsx
+++ b/tests/ChatInput.preflight.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { ChatInput } from '../src/components/ChatInput.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from '../src/components/composerDefaults.js';
 import * as client from '../src/api/client.js';
-import type { LaunchRunBody } from '../src/api/types.js';
+import type { LaunchBodyWithDeliver } from '../src/api/types.js';
 
 /**
  * DES-UX-001 §7.8 (slice AC, EC43) — composer preflight intelligence:
@@ -78,7 +78,7 @@ describe('ChatInput preflight (§7.8, EC43)', () => {
     // The attached repo satisfies preflight: the code intent launches directly.
     await typeAndSend(user, 'fix the login bug');
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    const body: LaunchBodyWithDeliver = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect(body.repoRef).toBe('studio-api');
   });
 
@@ -108,7 +108,7 @@ describe('ChatInput gate posture (§7.8 + §13)', () => {
 
     await typeAndSend(user, 'summarize the release notes');
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    const body: LaunchBodyWithDeliver = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect(body.humanConfirm).toBe(`before:${COMPOSER_DEFAULT_GATE_POSTURE.beforeOrd}`);
   });
 
@@ -124,7 +124,7 @@ describe('ChatInput gate posture (§7.8 + §13)', () => {
     await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
     await typeAndSend(user, 'summarize the release notes');
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    const body: LaunchBodyWithDeliver = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect('humanConfirm' in body).toBe(false);
   });
 });

--- a/tests/ChatInput.project.test.tsx
+++ b/tests/ChatInput.project.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatInput } from '../src/components/ChatInput.js';
 import * as client from '../src/api/client.js';
-import type { LaunchRunBody, Project } from '../src/api/types.js';
+import type { LaunchBodyWithDeliver, Project } from '../src/api/types.js';
 
 /**
  * DES-FEEDBACK-001 slice B (§5.1/§5.2/§4.3) — the Build launch form's project
@@ -43,7 +43,7 @@ beforeEach(() => {
   localStorage.clear();
 });
 
-async function typeAndLaunch(user: ReturnType<typeof userEvent.setup>): Promise<LaunchRunBody> {
+async function typeAndLaunch(user: ReturnType<typeof userEvent.setup>): Promise<LaunchBodyWithDeliver> {
   await user.type(screen.getByTestId('launch-problem'), 'build the thing');
   // The Send button enables once the roster load has landed a selected CLI.
   await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());

--- a/tests/ChatInput.retry.test.tsx
+++ b/tests/ChatInput.retry.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatInput } from '../src/components/ChatInput.js';
 import * as client from '../src/api/client.js';
-import type { LaunchRunBody } from '../src/api/types.js';
+import type { LaunchBodyWithDeliver } from '../src/api/types.js';
 import { confirmModeOf, setRetryPrefill, takeRetryPrefill } from '../src/store/retryPrefill.js';
 import { useProvenanceStore } from '../src/store/provenance.js';
 
@@ -65,7 +65,7 @@ describe('ChatInput — retry-as-prefill (§4.3)', () => {
     await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
     await user.click(screen.getByTestId('launch-submit'));
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    const body: LaunchBodyWithDeliver = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect(body.retryOf).toBe('r-original');
     expect(body.problem).toBe('refactor the auth middleware');
     expect(body.workflow).toBe('feature');
@@ -86,7 +86,7 @@ describe('ChatInput — retry-as-prefill (§4.3)', () => {
     await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
     await user.click(screen.getByTestId('launch-submit'));
     await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
-    const body: LaunchRunBody = vi.mocked(client.api.launchRun).mock.calls[0]![0];
+    const body: LaunchBodyWithDeliver = vi.mocked(client.api.launchRun).mock.calls[0]![0];
     expect('retryOf' in body, 'cleared pill = no lineage key at all').toBe(false);
   });
 

--- a/tests/HomeBoard.live.test.tsx
+++ b/tests/HomeBoard.live.test.tsx
@@ -128,9 +128,13 @@ describe('HomeBoard — live activity (slice 6)', () => {
     push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Reading src/App.tsx\n' } as CoreEvent);
     push({ type: 'unitOutputDelta', session: 'run-b', ord: 0, text: 'Rewriting slide 3\n' } as CoreEvent);
 
-    const line = within(card('p-b')).getByTestId('live-line');
-    expect(line).toHaveTextContent('build — Rewriting slide 3');
-    expect(line.textContent).not.toContain('Reading src/App.tsx');
+    // waitFor: the live line renders off a store subscription — under CI load the
+    // subscribed re-render can land a tick after the push (seen twice on CI runners).
+    await vi.waitFor(() => {
+      const line = within(card('p-b')).getByTestId('live-line');
+      expect(line).toHaveTextContent('build — Rewriting slide 3');
+      expect(line.textContent).not.toContain('Reading src/App.tsx');
+    });
   });
 
   it('a terminal run has no live line — the card is the QUIET one-liner, not "Nothing running"', async () => {

--- a/tests/RunDelivery.stranded.test.tsx
+++ b/tests/RunDelivery.stranded.test.tsx
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as client from '../src/api/client.js';
+import { ApiError } from '../src/api/errors.js';
+import { DeliveryBadge, RunDelivery } from '../src/components/RunDelivery.js';
+import { useDeliveryStore } from '../src/store/delivery.js';
+import { usePostHocDeliverStore } from '../src/store/postHocDeliver.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import type { SessionView, SessionWithDelivery } from '../src/api/types.js';
+
+/**
+ * The STRANDED Delivery card (crew#393, issue #393's run 83052f0b): a completed
+ * run whose reviewable work sits uncommitted in its worktree must be LOUD —
+ * amber state, the worktree named, and the one-click remedy in place:
+ * `POST /runs/:id/deliver`.
+ *
+ *  - success swaps the whole arm for the ordinary pr-open link (one claim path
+ *    — `resolveDelivery` with the answered `prUrl` as its readUrl), and the
+ *    header badge flips in the same paint (the D1 rule);
+ *  - failure renders denialCopy-style: studio's plain headline, then the
+ *    daemon's own words VERBATIM — never re-worded, never silent — and the
+ *    button re-arms (the endpoint is idempotent, so a retry cannot double a PR);
+ *  - a double-click while in flight fires ONE POST.
+ */
+
+const PR = 'https://github.com/o/r/pull/77';
+const REFUSAL =
+  'rebase onto origin/main hit a conflict in src/api/routes.ts — nothing was pushed';
+
+function strandedView(id = 'r-str'): SessionView {
+  const v = makeView(
+    { id, workflow_id: 'feature', status: 'completed', workdir: '/w/trees/r-str', repo_ref: 'studio-api' },
+    [makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' })],
+  );
+  (v.session as SessionWithDelivery).delivery = 'stranded';
+  return v;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  clearCachedWorkflows();
+  useDeliveryStore.setState({ byRun: {} });
+  usePostHocDeliverStore.setState({ byRun: {} });
+});
+afterEach(() => { cleanup(); clearCachedWorkflows(); });
+
+describe('the delivered card off the 0.18.0 wire', () => {
+  it("delivery: 'delivered' + deliverUrl renders the PR link straight off the DTO — zero fetches", () => {
+    const getUnitOutput = vi.spyOn(client.api, 'getUnitOutput');
+    const v = strandedView('r-del');
+    (v.session as SessionWithDelivery).delivery = 'delivered';
+    (v.session as SessionWithDelivery).deliverUrl = PR;
+    render(
+      <>
+        <DeliveryBadge view={v} />
+        <RunDelivery view={v} />
+      </>,
+    );
+    expect(screen.getByTestId('run-delivery').dataset.state).toBe('pr-open');
+    expect(screen.getByTestId('run-delivery-link')).toHaveAttribute('href', PR);
+    expect(screen.getByTestId('run-delivery-badge').textContent).toBe('PR open');
+    expect(screen.queryByTestId('run-deliver-button')).toBeNull();
+    // The wire carried the url, so the one sanctioned transcript read never fires.
+    expect(getUnitOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe('the stranded card', () => {
+  it('renders amber, names the worktree, and offers the one-click Deliver', () => {
+    render(<RunDelivery view={strandedView()} />);
+    const card = screen.getByTestId('run-delivery');
+    expect(card.dataset.state).toBe('stranded');
+    // The loud sentence, in the stranded (gate) color — not fail, not accent.
+    expect(card.textContent).toMatch(/sitting uncommitted in its worktree/i);
+    expect(card.textContent).toMatch(/No PR is on record/);
+    // The DTO fact: where the work is.
+    expect(card.textContent).toContain('the work is in');
+    expect(screen.getByTitle('/w/trees/r-str')).toBeInTheDocument();
+    // The remedy, armed.
+    expect(screen.getByTestId('run-deliver-button')).toBeEnabled();
+    expect(screen.getByTestId('run-deliver-button').textContent).toMatch(/Deliver/);
+  });
+
+  it('the header badge says stranded off the same resolution the body renders', () => {
+    render(<DeliveryBadge view={strandedView()} />);
+    const badge = screen.getByTestId('run-delivery-badge');
+    expect(badge.dataset.state).toBe('stranded');
+    expect(badge.textContent).toBe('stranded');
+  });
+
+  it('Deliver → POST /runs/:id/deliver: loading, then the pr-open link in place', async () => {
+    let resolvePost!: (v: { prUrl: string }) => void;
+    vi.spyOn(client.api, 'deliverRun').mockReturnValue(
+      new Promise((r) => { resolvePost = r; }),
+    );
+    const user = userEvent.setup();
+    render(
+      <>
+        <DeliveryBadge view={strandedView()} />
+        <RunDelivery view={strandedView()} />
+      </>,
+    );
+
+    await user.click(screen.getByTestId('run-deliver-button'));
+    expect(client.api.deliverRun).toHaveBeenCalledExactlyOnceWith('r-str');
+    // In flight: the button says so and disarms.
+    const button = screen.getByTestId('run-deliver-button');
+    expect(button).toBeDisabled();
+    expect(button.textContent).toMatch(/Delivering…/);
+
+    resolvePost({ prUrl: PR });
+    // Success IS the ordinary pr-open arm — link, accent claim, no leftover
+    // stranded copy — and the badge flipped with it (D1: one resolution).
+    await waitFor(() => expect(screen.getByTestId('run-delivery-link')).toBeInTheDocument());
+    expect(screen.getByTestId('run-delivery-link')).toHaveAttribute('href', PR);
+    expect(screen.getByTestId('run-delivery').dataset.state).toBe('pr-open');
+    expect(screen.getByTestId('run-delivery-badge').dataset.state).toBe('pr-open');
+    expect(screen.queryByTestId('run-deliver-button')).toBeNull();
+    expect(screen.getByTestId('run-delivery').textContent).not.toMatch(/stranded/i);
+  });
+
+  it('a double-click while in flight fires ONE POST', async () => {
+    vi.spyOn(client.api, 'deliverRun').mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    render(<RunDelivery view={strandedView()} />);
+    const button = screen.getByTestId('run-deliver-button');
+    await user.click(button);
+    // The DOM disables it, and the store's synchronous in-flight guard holds
+    // even if a stale handler fires anyway.
+    usePostHocDeliverStore.getState().deliver('r-str');
+    expect(client.api.deliverRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('failure is LOUD and VERBATIM — the daemon’s own words, then the button re-arms', async () => {
+    // The 409 shape: apiFetch already extracted the body's `error` into the
+    // ApiError message — the deliver script's own refusal, e.g. the rebase
+    // conflict with nothing pushed.
+    vi.spyOn(client.api, 'deliverRun').mockRejectedValue(new ApiError(409, REFUSAL));
+    const user = userEvent.setup();
+    render(<RunDelivery view={strandedView()} />);
+
+    await user.click(screen.getByTestId('run-deliver-button'));
+    const error = await screen.findByTestId('run-deliver-error');
+    // denialCopy conventions: studio's plain headline…
+    expect(error.textContent).toMatch(/Delivery failed — the run is still stranded\./);
+    // …and the engine detail VERBATIM inside the EC33 translated sentence,
+    // never re-worded (ApiError.message carries the daemon's words whole).
+    expect(error.textContent).toContain(REFUSAL);
+    // The card stays stranded (nothing was delivered) and the remedy re-arms —
+    // idempotent server-side, so a retry can never open a second PR.
+    expect(screen.getByTestId('run-delivery').dataset.state).toBe('stranded');
+    expect(screen.getByTestId('run-deliver-button')).toBeEnabled();
+  });
+
+  it('a retry after failure fires a fresh POST and can succeed', async () => {
+    const spy = vi
+      .spyOn(client.api, 'deliverRun')
+      .mockRejectedValueOnce(new ApiError(409, REFUSAL))
+      .mockResolvedValueOnce({ prUrl: PR });
+    const user = userEvent.setup();
+    render(<RunDelivery view={strandedView()} />);
+
+    await user.click(screen.getByTestId('run-deliver-button'));
+    await screen.findByTestId('run-deliver-error');
+    await user.click(screen.getByTestId('run-deliver-button'));
+    await waitFor(() => expect(screen.getByTestId('run-delivery-link')).toBeInTheDocument());
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId('run-deliver-error')).toBeNull();
+  });
+
+  it('a DETAIL-LESS refusal still renders a complete sentence, never a blank red paragraph', async () => {
+    // ApiError itself mints the honest fallback for an empty wire body (EC33);
+    // the store's own empty-degrade covers non-ApiError throws.
+    vi.spyOn(client.api, 'deliverRun').mockRejectedValue(new ApiError(500, '   '));
+    const user = userEvent.setup();
+    render(<RunDelivery view={strandedView()} />);
+    await user.click(screen.getByTestId('run-deliver-button'));
+    const error = await screen.findByTestId('run-deliver-error');
+    expect(error.textContent).toMatch(/HTTP 500 with no detail/);
+  });
+});

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -358,10 +358,19 @@ describe('HEADLINE — the rail body says what the badge says', () => {
     // which the wire cannot evidence either: the deliver script creates the PR partway through
     // the phase, so a still-running unit may already have one. Same rule, both directions.
     const EXISTENCE = /\b(no PR|PR exists|PR was (?:not )?(?:created|opened)|there is no PR|without a PR)\b/i;
+    // `stranded` is the ONE exemption besides `pr-open`, and for the same
+    // reason pointed the other way: its negative IS wire-evidenced. The
+    // 0.18.0 daemon derives `delivery: 'stranded'` from its own delivery
+    // record (crew#393) — "No PR is on record" is the daemon's verdict, not a
+    // studio guess off a unit status. The wording is pinned below to the
+    // RECORD claim, never bare existence (an ungoverned worker may have opened
+    // a PR crew never saw — crew#391).
     const offenders = Object.entries(HEADLINE)
-      .filter(([k, sentence]) => k !== 'pr-open' && EXISTENCE.test(sentence))
+      .filter(([k, sentence]) => k !== 'pr-open' && k !== 'stranded' && EXISTENCE.test(sentence))
       .map(([k]) => k);
     expect(offenders).toStrictEqual([]);
+    expect(HEADLINE['stranded']).toMatch(/No PR is on record/);
+    expect(HEADLINE['stranded']).not.toMatch(/PR (?:was opened|exists)/i);
   });
 
   it('NO headline asserts a phase is EXECUTING — `pending` means unresolved, not running', () => {

--- a/tests/delivery.wire.test.ts
+++ b/tests/delivery.wire.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionView, SessionWithDelivery } from '../src/api/types.js';
+import {
+  canDeliver,
+  DELIVERY_COLOR,
+  DELIVERY_LABEL,
+  deliveryOf,
+  deliverySummary,
+  resolveDelivery,
+} from '../src/components/delivery.js';
+import { makeUnit, makeView } from './factories.js';
+
+/**
+ * The 0.18.0 delivery wire (crew#393) — `session.delivery` is now the daemon's
+ * OWN tri-state string (`delivered | stranded | none`) with the PR url in
+ * `deliverUrl`, RESHAPED from 0.11–0.17's `{ kind, url }` object. The
+ * derivation's contract:
+ *
+ *  - the wire's POSITIVE verdicts (`delivered`, `stranded`) are authoritative —
+ *    `stranded` in particular is WIRE-ONLY (its "worktree still exists" half
+ *    lives on the daemon's disk, and studio never guesses it);
+ *  - the wire's `'none'` DEFERS to the unit facts, which say more (a rejected
+ *    deliver unit's `denial_reason` is the richer, equally-true story);
+ *  - the legacy object form is still read for its url, never mistaken for a
+ *    state word;
+ *  - every url — `deliverUrl` included — passes the same shape gate as always.
+ */
+
+function stamped(
+  v: SessionView,
+  delivery: Exclude<SessionWithDelivery['delivery'], undefined>,
+  deliverUrl?: string,
+): SessionView {
+  const session = { ...v.session } as SessionWithDelivery;
+  session.delivery = delivery;
+  if (deliverUrl !== undefined) session.deliverUrl = deliverUrl;
+  return { ...v, session: session as SessionView['session'] };
+}
+
+/** A completed repo-scoped build run with NO deliver unit (the 83052f0b shape). */
+function completedRun(id = 'r-1'): SessionView {
+  return makeView(
+    { id, workflow_id: 'feature', status: 'completed', workdir: '/w/tree', repo_ref: 'studio-api' },
+    [makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' })],
+  );
+}
+
+const PR = 'https://github.com/o/r/pull/42';
+
+describe('the wire tri-state (crew#393)', () => {
+  it("delivery: 'delivered' + deliverUrl ⇒ pr-open, straight off the DTO, zero reads", () => {
+    const d = deliveryOf(stamped(completedRun(), 'delivered', PR));
+    expect(d.state).toBe('delivered');
+    expect(d.url).toBe(PR);
+    const r = resolveDelivery(d);
+    expect(r.claim).toBe('pr-open');
+    expect(r.href).toBe(PR);
+  });
+
+  it("delivery: 'delivered' with a NON-CONFORMING deliverUrl claims the phase, never the link", () => {
+    for (const bad of ['javascript:alert(1)', 'https://x/pull/new/wicked/r-1', '']) {
+      const r = resolveDelivery(deliveryOf(stamped(completedRun(), 'delivered', bad)));
+      expect(r.claim, bad).toBe('delivered');
+      expect(r.href, bad).toBeNull();
+    }
+  });
+
+  it("delivery: 'stranded' ⇒ the stranded state — wire-only, whatever the units say", () => {
+    const d = deliveryOf(stamped(completedRun(), 'stranded'));
+    expect(d.state).toBe('stranded');
+    const r = resolveDelivery(d);
+    expect(r.claim).toBe('stranded');
+    expect(r.href).toBeNull();
+    // Amber, never fail-red and never the accent: finished work waiting on a
+    // person is not a failure and not a PR.
+    expect(DELIVERY_LABEL['stranded']).toBe('stranded');
+    expect(DELIVERY_COLOR['stranded']).toBe('var(--status-gate)');
+  });
+
+  it('studio NEVER infers stranded — a bare completed run without the wire word stays as it was', () => {
+    // The "worktree still exists" half of the definition lives on the daemon's
+    // disk. Without the wire field this run reads exactly as it did pre-0.18.
+    expect(deliveryOf(completedRun()).state).toBe('none');
+  });
+
+  it("the post-hoc prUrl upgrades a stranded run to pr-open IN PLACE (resolveDelivery's readUrl)", () => {
+    const r = resolveDelivery(deliveryOf(stamped(completedRun(), 'stranded')), PR);
+    expect(r.state).toBe('delivered');
+    expect(r.claim).toBe('pr-open');
+    expect(r.href).toBe(PR);
+  });
+
+  it('…but only through the same shape gate as every other PR claim', () => {
+    const r = resolveDelivery(
+      deliveryOf(stamped(completedRun(), 'stranded')),
+      'https://x/pull/new/wicked/r-1',
+    );
+    expect(r.claim).toBe('stranded');
+    expect(r.href).toBeNull();
+  });
+
+  it("the wire's 'none' DEFERS to the unit facts — a rejected deliver unit keeps its story", () => {
+    const v = makeView(
+      { id: 'r-2', workflow_id: 'feature', status: 'failed' },
+      [makeUnit({ id: 'r-2:deliver', session_id: 'r-2', ord: 1, status: 'rejected', denial_reason: 'rebase conflict — nothing pushed' })],
+    );
+    const d = deliveryOf(stamped(v, 'none'));
+    expect(d.state).toBe('failed');
+    expect(d.reason).toBe('rebase conflict — nothing pushed');
+  });
+
+  it('the LEGACY 0.11–0.17 object form is still read for its url, never as a state word', () => {
+    const v = makeView(
+      { id: 'r-3', workflow_id: 'feature', status: 'completed' },
+      [makeUnit({ id: 'r-3:deliver', session_id: 'r-3', ord: 1, status: 'done' })],
+    );
+    const d = deliveryOf(stamped(v, { kind: 'pull_request', url: PR }));
+    expect(d.state).toBe('delivered'); // from the unit, not the object
+    expect(d.url).toBe(PR);            // from the object's url
+    expect(resolveDelivery(d).claim).toBe('pr-open');
+  });
+
+  it('a wire-stranded run is deliverable with NO catalog lookup — the wire is the evidence', () => {
+    // The materialised `wf-<runId>` id is in no catalog, ever; the `'none'`
+    // licence would withhold. The daemon's own verdict outranks classification,
+    // exactly as a deliver unit in hand does.
+    const v = makeView(
+      { id: 'r-4', workflow_id: 'wf-r-4-materialised', status: 'completed', workdir: '/w/t' },
+      [],
+    );
+    expect(canDeliver(stamped(v, 'stranded'))).toBe(true);
+    expect(canDeliver(v), 'without the wire word, nothing changes').toBe(false);
+  });
+
+  it('deliverySummary counts the stranded bucket, in DELIVERY_LABEL wording', () => {
+    const views = [
+      stamped(completedRun('r-a'), 'stranded'),
+      stamped(completedRun('r-b'), 'stranded'),
+      stamped(completedRun('r-c'), 'delivered', PR),
+    ];
+    expect(deliverySummary(views)).toBe('1 PR open · 2 stranded');
+  });
+});

--- a/tests/needsYou.stranded.test.tsx
+++ b/tests/needsYou.stranded.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { needsYouRows, type NeedsYouInputs } from '../src/board/needsYou.js';
+import { narrateStranded } from '../src/components/narrator.js';
+import { NeedsYouQueue } from '../src/components/NeedsYouQueue.js';
+import { makeUnit, makeView } from './factories.js';
+import type { SessionView, SessionWithDelivery } from '../src/api/types.js';
+
+/**
+ * Stranded completed runs in the needs-you queue (crew#393): a completed run
+ * the 0.18.0 wire marks `delivery: 'stranded'` is reviewable work sitting
+ * invisible in a worktree — a person's job, so it queues. The row:
+ *
+ *  - fires ONLY off the wire's own verdict (studio never infers stranded);
+ *  - sits below failures (nothing broke) and above the ambient rows;
+ *  - speaks the narrator's ONE stranded template (single template source);
+ *  - is UNWINDOWED, like gates: the wire clears the state itself once the run
+ *    is delivered or its worktree is reaped;
+ *  - opens the run in place (the Delivery card carries the one-click Deliver —
+ *    the queue never POSTs).
+ */
+
+const NOW = 1_700_000_000_000;
+
+function inputs(over: Partial<NeedsYouInputs>): NeedsYouInputs {
+  return {
+    runs: [], gates: {}, failedAt: {}, attachedAt: {}, projectIds: {},
+    chats: [], repos: [], campaigns: [], now: NOW, ...over,
+  };
+}
+
+function completedRun(id: string, delivery?: 'delivered' | 'stranded' | 'none'): SessionView {
+  const v = makeView(
+    { id, workflow_id: 'feature', status: 'completed', problem: `problem of ${id}`, workdir: `/w/${id}` },
+    [makeUnit({ id: `${id}:build`, session_id: id, ord: 0, status: 'done' })],
+  );
+  if (delivery !== undefined) (v.session as SessionWithDelivery).delivery = delivery;
+  return v;
+}
+
+describe('stranded completed runs queue (crew#393)', () => {
+  it('a wire-stranded completed run gets a row; delivered / none / wireless ones do not', () => {
+    const rows = needsYouRows(inputs({
+      runs: [
+        completedRun('r-stranded', 'stranded'),
+        completedRun('r-delivered', 'delivered'),
+        completedRun('r-none', 'none'),
+        completedRun('r-pre-018'), // no wire field at all (older daemon)
+      ],
+    }));
+    expect(rows.map((r) => r.key)).toStrictEqual(['stranded:r-stranded']);
+    const row = rows[0]!;
+    expect(row.kind).toBe('stranded-run');
+    expect(row.subject).toBe('problem of r-stranded');
+    expect(row.subjectPath).toBe('/runs/r-stranded');
+    expect(row.action).toStrictEqual({ kind: 'open', path: '/runs/r-stranded', label: 'Open run ›' });
+  });
+
+  it('speaks the narrator’s ONE stranded template — queue and template cannot fork', () => {
+    const rows = needsYouRows(inputs({ runs: [completedRun('r-1', 'stranded')] }));
+    const line = narrateStranded();
+    expect(rows[0]!.text).toBe(line.text);
+    expect(rows[0]!.tone).toBe(line.tone);
+    expect(line.tone).toBe('gate'); // waiting on a person — not a failure, not motion
+  });
+
+  it('orders below a failed run and above a campaign row', () => {
+    const rows = needsYouRows(inputs({
+      runs: [
+        completedRun('r-str', 'stranded'),
+        makeView({ id: 'r-fail', status: 'failed', problem: 'broke' }),
+      ],
+    }));
+    expect(rows.map((r) => r.kind)).toStrictEqual(['failed-run', 'stranded-run']);
+  });
+
+  it('is UNWINDOWED — a stranded run beyond the failed-run window still queues', () => {
+    // 35 newer runs push the stranded one past FAILED_WINDOW (30). A failure
+    // that old would roll off; stranded work does not — it stays until the
+    // wire itself clears it.
+    const newer = Array.from({ length: 35 }, (_, i) => completedRun(`r-new-${i}`, 'none'));
+    const rows = needsYouRows(inputs({ runs: [...newer, completedRun('r-old', 'stranded')] }));
+    expect(rows.map((r) => r.key)).toStrictEqual(['stranded:r-old']);
+  });
+
+  it('an ARCHIVED stranded run is written off — no row', () => {
+    const v = completedRun('r-arch', 'stranded');
+    const rows = needsYouRows(inputs({
+      runs: [{ ...v, session: { ...v.session, archived_at: NOW - 1000 } }],
+    }));
+    expect(rows).toStrictEqual([]);
+  });
+
+  it('the honest clock: attach when known, otherwise unknown', () => {
+    const dated = needsYouRows(inputs({
+      runs: [completedRun('r-1', 'stranded')],
+      attachedAt: { 'r-1': NOW - 5000 },
+    }));
+    expect(dated[0]!.at).toBe(NOW - 5000);
+    const undated = needsYouRows(inputs({ runs: [completedRun('r-1', 'stranded')] }));
+    expect(undated[0]!.at).toBeNull();
+  });
+
+  it('only COMPLETED runs strand — the wire never marks others, and the fold double-guards', () => {
+    // Defense in depth: even a (contractually impossible) stranded word on a
+    // non-completed run adds no row, because the fold gates on the status arm.
+    const v = completedRun('r-x', 'stranded');
+    const rows = needsYouRows(inputs({
+      runs: [{ ...v, session: { ...v.session, status: 'executing' } }],
+    }));
+    expect(rows).toStrictEqual([]);
+  });
+});
+
+describe('the home queue component counts stranded runs', () => {
+  afterEach(cleanup);
+
+  it('renders the stranded row in the needs-you count, never the calm copy', () => {
+    const runs = [completedRun('r-str', 'stranded'), completedRun('r-ok', 'delivered')];
+    const rows = needsYouRows(inputs({ runs }));
+    render(<NeedsYouQueue rows={rows} runs={runs} navigate={vi.fn()} now={NOW} />);
+
+    const queue = screen.getByTestId('needs-you-queue');
+    expect(queue.dataset.count).toBe('1');
+    expect(queue.textContent).toContain('Needs you (1)');
+    expect(screen.queryByTestId('home-calm')).toBeNull(); // a row bans calm (§3)
+
+    const row = screen.getByTestId('need-row');
+    expect(row.dataset.kind).toBe('stranded-run');
+    expect(screen.getByTestId('need-line').textContent).toBe(narrateStranded().text);
+    // Open-in-place — the queue never POSTs; the Delivery card owns the click.
+    const act = screen.getByTestId('need-act');
+    expect(act.dataset.act).toBe('open');
+    expect(act).toHaveAttribute('href', '/runs/r-str');
+  });
+});


### PR DESCRIPTION
The studio half of wicked-crew#393 (crew PR mikeparcewski/wicked-crew#400 shipped the wire):

- The launch composer gains an **"Open a PR when done"** toggle — default ON exactly for repo-scoped code-work launches, posting the wire's `deliver` key explicitly so the UI can never drift from a daemon default.
- The run detail's **Delivery card** renders the tri-state: delivered (PR link via `deliverUrl`), **stranded** (amber, explains the work is sitting uncommitted in the run's worktree, one-click **Deliver** → `POST /runs/:id/deliver` with loading, success swapping to the PR link, failure showing the daemon's own words — the 409 conflict text renders verbatim).
- **Home needs-you counts stranded completed runs** — finished work nobody can see is exactly what needs a human.
- Wire types follow `wicked-crew-api-types` 0.18.0 including its one reshape (the old `delivery` object → tri-state string + `deliverUrl`); 'stranded' is wire-only — the UI never guesses at daemon disk state.

Verified against a live scratch daemon built from the crew branch with playwright: toggle-state matrix network-proven, stranded card → Deliver → delivered flow, forced conflict failure shown not swallowed, home count includes the stranded run. jsdom tests per state; typecheck/eslint/build/testid inventory clean.

Part of the wicked-crew#393 fix program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)