### PR TITLE
release: 0.4.9 — delivery surface, doc delete, campaign nits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.9] — 2026-09-01
+
+### Added
+- **The delivery surface** (crew#393's studio half, #178). The launch composer's "Open a PR when
+  done" toggle (default ON for repo-scoped code-work launches, posted explicitly); the run
+  detail's Delivery card renders the 0.18.0 tri-state — delivered (PR link), **stranded** (amber,
+  one-click Deliver with the daemon's own error shown verbatim on failure), none; home needs-you
+  counts stranded completed runs. Pre-0.18 daemons that 400 on the key get one retry without it.
+- **Docs and demos can be deleted from the UI** (#119, #179). Confirm names the doc; success
+  drops the row and re-lists; a two-store divergence (crew's partial 500) renders the wire
+  sentence verbatim with a retry armed; ghost 404 / build-in-flight 409 / bridge-unavailable 503
+  each render honestly.
+
+### Fixed
+- **Ask & chat nits from the live campaign** (#176, #177). The Ask quick-prompt seeds the NEWEST
+  failed run; dock replies render sanitized markdown; collapsing a long seat reply keeps its bytes
+  (expand restores byte-equal text); the chat header's seat chips and feed read one attribution
+  source.
+
 ## [0.4.8] — 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,7 +316,15 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.9...HEAD
+[0.4.9]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.8...v0.4.9
+[0.4.8]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.7...v0.4.8
+[0.4.7]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.6...v0.4.7
+[0.4.6]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.2.0...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.8",
+  "studioVersion": "0.4.9",
   "counts": {
     "files": 117,
     "occurrences": 942,


### PR DESCRIPTION
Version bump + CHANGELOG cut + testid inventory stamped at 0.4.9. Ships #177 (Ask/chat nits), #178 (the delivery surface), #179 (doc delete). Suite 2350/2350, typecheck/build clean. Tag `v0.4.9` follows the merge; release.yml publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)