### PR TITLE
feat: campaign cards tell the whole story — delivery rollup, live narration, ad-hoc grouping

### DIFF
--- a/.product/DES-CAMPAIGN-001.md
+++ b/.product/DES-CAMPAIGN-001.md
@@ -13,6 +13,17 @@ explains why keeping the engine off the critical path is the point of the chosen
 > `DES-CAMPAIGN-001` and is about a *grouping surface*. Where the two must be distinguished below,
 > the engine's is written **core's DES-CAMPAIGN-001**. §1.3 and §6 say exactly how they relate.
 
+> **Reality note (2026-09, #27 remainder).** The wire crew ACTUALLY shipped (crew#342 + the
+> api-types 0.19.0 additions) superseded §1.4's crew-side label store: `GET /campaigns` serves
+> the ENGINE campaign (`id`/`def`/`node_status`/`node_run_id` + daemon-joined `node_delivery`/
+> `attached_runs`) beside ad-hoc `RunGroup`s (`groups`), and launch-time attach is
+> `LaunchRunBody.campaignId` XOR `groupLabel` on `POST /runs` (404 unknown campaign, 400 both).
+> Studio's surface (`src/api/campaigns.ts`, `board/campaignStats.ts`, `CampaignsPage`,
+> `CampaignScoreboard`, the composer's Group control) is written against THAT contract —
+> verified against a daemon built from the crew branch. §1.4(b)–(e)/§2.3's shapes are the
+> historical design, kept for the rationale (§3's board UX, §3.3 denominator honesty, §1.5's
+> probe), which still governs.
+
 ---
 
 ## 0 The problem

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -1,112 +1,149 @@
 /**
- * The campaign wire (DES-CAMPAIGN-001 §1.4/§4.1 + TH-14) — types and calls for the
- * read-only campaign surface: `GET /campaigns` and `GET /campaigns/:id`.
+ * The campaign wire — types and calls for the campaign surface: `GET /campaigns` and
+ * `GET /campaigns/:id`, as the daemon ACTUALLY serves them (crew#342's shipped shape +
+ * the api-types 0.19.0 additions built for wicked-studio#27).
  *
- * ── INTEGRATION POINT (TH-9 / crew#342, marked per the TH-14 lane) ──────────────────────────
- * These shapes are hand-mirrored from the MERGED design contract in
- * `.product/DES-CAMPAIGN-001.md` §1.4 (b)–(d) because the crew slice that serves them
- * (crew#342 slice 1: api-types Campaign contract + store + read routes) is being built in a
- * parallel lane and studio's installed `wicked-crew-api-types` predates it. Like
- * `SessionDelivery` in `./types.ts`, every declaration here is TEMPORARY: **delete this
- * block and re-export from `wicked-crew-api-types`** the moment studio bumps to the
- * api-types version that carries the Campaign contract. Field names, spellings and null
- * conventions below are the design's, verbatim — a served payload that disagrees is a
- * contract bug, not an adoption gap.
+ * ── INTEGRATION POINT (api-types 0.19.0) ─────────────────────────────────────────────────────
+ * These shapes are hand-mirrored VERBATIM from `wicked-crew-api-types` 0.19.0 (the engine's
+ * persisted `Campaign` plus the daemon-joined rollup fields) because studio's installed
+ * `wicked-crew-api-types` is stale at 0.8.x. Like `SessionDelivery` in `./types.ts`, every
+ * declaration here is TEMPORARY: **delete this block and re-export from
+ * `wicked-crew-api-types`** the moment studio bumps to ≥ 0.19.0.
  *
- * The support probe (§1.5) is the adoption seam: an older daemon has no `/campaigns` route,
- * so `404` means "this daemon predates campaigns" and the surface says so honestly —
- * `200 []` is the "no campaigns yet" answer, never a 404.
+ * ⚠ WIRE CORRECTION over the first cut of this file: crew#342 shipped the ENGINE campaign
+ * shape (`id`/`def`/`node_status`/`node_run_id`…), NOT the DES-CAMPAIGN-001 §1.4 summary DTO
+ * this module used to mirror (`{campaign:{title,expected,…}, counts, prs}`). The old mirror
+ * was checked against the live daemon (`GET :7701/api/v1/campaigns`) and disagrees with every
+ * shipping payload — the design was superseded by the parallel crew lane. What replaces the
+ * design's server-side counts: `node_status` is ENGINE-PERSISTED over the full node set, so
+ * client-side folds over it keep the §4.2 archived-run honesty the old counts existed for.
+ *
+ * The support probe (§1.5) is unchanged: an older daemon has no `/campaigns` route, so `404`
+ * means "this daemon predates campaigns"; `200` with an empty list is "no campaigns yet".
  */
 
 import { apiFetch } from './client.js';
 import type { SessionStatus } from './types.js';
 
-/** The campaign — the launch-time label that groups the sibling runs of one effort (§1.4b). */
-export interface Campaign {
-  /** The label itself; minted by first use, never by a create call. */
+/** Per-node lifecycle status. Terminal = `completed` | `failed` | `blocked` | `cancelled`. */
+export type CampaignNodeStatus =
+  | 'pending'
+  | 'ready'
+  | 'running'
+  | 'awaiting_human'
+  | 'ready_to_resume'
+  | 'completed'
+  | 'failed'
+  | 'blocked'
+  | 'cancelled';
+
+/** Campaign lifecycle status — also what `/resume` / `/cancel` resolve to. */
+export type CampaignStatus =
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'partially_completed'
+  | 'failed'
+  | 'cancelled';
+
+/** What one campaign node runs — only the fields studio reads are typed. */
+export interface CampaignRunSpec {
+  /** The free-text problem this node's run decomposes (a short label for scenario nodes). */
+  problem: string;
+  /** The registered repo the node's run targets, if any. */
+  repo_ref?: string | null;
+  workflow_id?: string | null;
+  [k: string]: unknown;
+}
+
+/** A schedulable unit of the DAG — one node = one governed core run. */
+export interface CampaignNode {
+  /** Stable node id, unique within the campaign (never contains `:`). */
+  node_id: string;
+  run_spec: CampaignRunSpec;
+  [k: string]: unknown;
+}
+
+/** The static campaign definition, persisted verbatim inside the live {@link Campaign}. */
+export interface CampaignDef {
   id: string;
-  /** Operator-set display title; `null` ⇒ surfaces render the id. */
-  title: string | null;
-  /**
-   * Operator-declared total run count (>= 1), or `null` when undeclared — the DENOMINATOR of
-   * "n of m landed". §3.3: a surface must SAY which denominator it is using (the "so far"
-   * suffix), never render the two identically.
-   */
-  expected: number | null;
-  /** Unix millis — the first launch that used this label. */
-  created_at: number;
-  /** Unix millis — the newest launch filed here, or the newest metadata write. */
-  updated_at: number;
+  name: string;
+  nodes: CampaignNode[];
   [k: string]: unknown;
 }
 
 /**
- * Run counts over the campaign's FULL filed set, INCLUDING archived runs — computed
- * server-side (§4.2: the client's run list is archive-filtered, so a client-derived
- * denominator shrinks when the operator archives a landed run — remembering what the run
- * list forgets is the campaign's entire job).
+ * One member's delivery snapshot on the campaigns surface (api-types 0.19.0) — the same
+ * tri-state + URL contract as `AgentSession.delivery`/`deliverUrl` (crew#393/#311), derived
+ * by the same daemon code at DTO assembly. `deliverUrl` present exactly when
+ * `delivery === 'delivered'`.
  */
-export interface CampaignCounts {
-  filed: number;
-  landed: number;
-  failed: number;
-  cancelled: number;
-  /** `planning | distributing | executing`. */
-  running: number;
-  awaitingHuman: number;
-  /** Any status the daemon could not classify — never folded into another bucket. */
-  other: number;
-  /** How many of `filed` are archived — reported so a surface can explain a gap it cannot show. */
-  archived: number;
+export interface CampaignNodeDelivery {
+  delivery: 'delivered' | 'stranded' | 'vacuous' | 'none';
+  /** Untrusted until it passes `isPrUrl` — every rendering goes through that gate. */
+  deliverUrl?: string;
 }
 
-/** A landed run's pull request (§4.3) — the URL verbatim as the deliver phase printed it. */
-export interface CampaignPr {
+/**
+ * An ad-hoc run on the campaigns surface (api-types 0.19.0) — a member of
+ * `Campaign.attached_runs` or `RunGroup.runs`. `runId` is the engine session id: live `/ws`
+ * CoreEvent frames for it carry it as `session`, so narration correlation is client-side.
+ */
+export interface AttachedRunView {
   runId: string;
-  url: string;
+  status: SessionStatus;
+  delivery: CampaignNodeDelivery['delivery'];
+  deliverUrl?: string;
 }
 
-/** One row of `GET /campaigns` (§1.4c). */
-export interface CampaignSummary {
-  campaign: Campaign;
-  /** Every run filed under this label, newest launch first. INCLUDES archived runs (§4.2). */
-  runIds: string[];
-  /** The projects those runs are filed into, deduped, first-seen order (§3.4). */
-  projectIds: string[];
-  counts: CampaignCounts;
-  /** Landed runs that opened a PR, newest first; capped server-side. */
-  prs: CampaignPr[];
-  prsTruncated: boolean;
-}
-
-/** One run's place in a campaign (§1.4d). Status is a SNAPSHOT — live status stays the run list's job. */
-export interface CampaignRun {
-  runId: string;
-  /** The run's status at read time; `null` when the engine no longer holds the run. */
-  status: SessionStatus | null;
-  /** The project this run is filed into, or `null` for an unfiled run. */
-  projectId: string | null;
-  problem: string;
-  /** Unix millis — when the label was attached. */
-  filed_at: number;
-  /** The PR this run opened, when it opened one. */
-  prUrl?: string;
-  /** True when the run is archived and therefore absent from the default `GET /runs` list. */
-  archived: boolean;
+/**
+ * The live campaign instance as `GET /campaigns` serves it: the engine's persisted shape
+ * verbatim, plus two DAEMON-JOINED 0.19.0 fields (`node_delivery`, `attached_runs`) that are
+ * assembled per request and never engine-persisted.
+ */
+export interface Campaign {
+  id: string;
+  def_id: string;
+  status: CampaignStatus;
+  /** The full definition, embedded — `def.nodes` is the ladder and the real denominator. */
+  def: CampaignDef;
+  node_status: Record<string, CampaignNodeStatus>;
   /**
-   * INTEGRATION POINT (TH-20 / test-R22, NOT in DES-CAMPAIGN-001 §1.4): per-node cost, once
-   * campaign budget governance folds token/cost accounting into the evidence manifest and
-   * crew serves it here. Absent on every daemon shipping today — the scoreboard's cost
-   * column renders an honest "—" until the producer exists.
+   * node_id → live run id (`{campaign}:{node}:a{attempt}`). These ARE engine session ids:
+   * served by `GET /runs/:id`, and every session-scoped `/ws` frame carries one as `session`
+   * — so a campaign card's live narration is a pure client-side correlation, no extra wire.
    */
-  cost?: number;
+  node_run_id: Record<string, string>;
+  /** node_id → 0-based attempt counter. */
+  node_attempt?: Record<string, number>;
+  /**
+   * Per-node delivery (api-types 0.19.0), keyed like `node_status`; a node appears once its
+   * current-attempt run exists on the store. ABSENT (the whole field) only from a pre-0.19
+   * daemon — which is the honest "no rollup" discriminator, per-field, not per-route.
+   */
+  node_delivery?: Record<string, CampaignNodeDelivery>;
+  /**
+   * Ad-hoc runs attached at launch (`LaunchRunBody.campaignId`) — NOT DAG nodes: the
+   * scheduler ignores them; provenance only. Absent from a pre-0.19 daemon; `[]` when none.
+   */
+  attached_runs?: AttachedRunView[];
+  [k: string]: unknown;
 }
 
-/** `GET /campaigns/:id` — the summary plus the per-run roll-up the list route is too hot to carry. */
-export interface CampaignDetail {
-  campaign: Campaign;
-  runs: CampaignRun[];
-  counts: CampaignCounts;
+/**
+ * An ad-hoc label group (api-types 0.19.0): the runs launched with the same
+ * `LaunchRunBody.groupLabel`, in launch order. NOT an engine campaign — no DAG, no scheduler,
+ * no status of its own; it exists the moment the first run is launched under the label.
+ */
+export interface RunGroup {
+  label: string;
+  runs: AttachedRunView[];
+}
+
+/** `GET /campaigns` 200 body — `groups` is ADDITIVE (a pre-0.19 daemon sends only campaigns). */
+export interface CampaignsListResponse {
+  campaigns: Campaign[];
+  groups: RunGroup[];
 }
 
 /**
@@ -126,14 +163,20 @@ export interface RunAcceptance {
   [k: string]: unknown;
 }
 
-/** `GET /campaigns` — always 200 with `[]` on an empty store; 404 = daemon predates campaigns (§1.5). */
-export function listCampaigns(): Promise<{ campaigns: CampaignSummary[] }> {
-  return apiFetch<{ campaigns: CampaignSummary[] }>('/campaigns');
+/**
+ * `GET /campaigns` — 200 with empty lists on an empty store; 404/501 = daemon predates
+ * campaigns (§1.5). A pre-0.19 daemon omits `groups`, normalized here to `[]` so no consumer
+ * carries the `undefined` arm.
+ */
+export async function listCampaigns(): Promise<CampaignsListResponse> {
+  const res = await apiFetch<{ campaigns?: Campaign[]; groups?: RunGroup[] }>('/campaigns');
+  return { campaigns: res.campaigns ?? [], groups: res.groups ?? [] };
 }
 
-/** `GET /campaigns/:id` — 404 on an unknown label. */
-export function getCampaign(id: string): Promise<CampaignDetail> {
-  return apiFetch<CampaignDetail>(`/campaigns/${encodeURIComponent(id)}`);
+/** `GET /campaigns/:id` — `{ campaign }`, the same daemon-side join as the list; 404 unknown. */
+export async function getCampaign(id: string): Promise<Campaign> {
+  const res = await apiFetch<{ campaign: Campaign }>(`/campaigns/${encodeURIComponent(id)}`);
+  return res.campaign;
 }
 
 /** `GET /runs/:id/acceptance` — always 200 for a known run ("no ledger" is an answer, not an error). */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -87,6 +87,20 @@ export interface DeliverRunResult {
  */
 export type LaunchBodyWithDeliver = Omit<LaunchRunBody, 'deliver'> & {
   deliver?: 'pr' | 'none';
+  /**
+   * Ad-hoc campaign attach (wicked-studio#27; api-types 0.19.0): file this run onto an
+   * EXISTING campaign's surface. Provenance only — the run executes byte-identically, never
+   * becomes a DAG node. Validated at launch, loudly: unknown campaign = 404 (nothing
+   * launched); a pre-0.19 daemon 400s naming the field. Mutually exclusive with `groupLabel`
+   * (both ⇒ 400). Hand-declared here like `deliver` — delete on the ≥0.19 api-types bump.
+   */
+  campaignId?: string;
+  /**
+   * Ad-hoc label grouping (wicked-studio#27; api-types 0.19.0): runs launched with the same
+   * label form one `RunGroup` on `GET /campaigns` — created on first use, 1–200 chars.
+   * Mutually exclusive with `campaignId`. Echoed as `AgentSession.group_label`.
+   */
+  groupLabel?: string;
 };
 
 // ── GET /runs/:id/acceptance (AW-14 / AW-18 — arch-R13a + R16) ────────────────

--- a/src/board/campaignStats.ts
+++ b/src/board/campaignStats.ts
@@ -1,107 +1,220 @@
-import type { CampaignSummary } from '../api/campaigns.js';
+import type {
+  AttachedRunView,
+  Campaign,
+  CampaignNodeDelivery,
+  CampaignNodeStatus,
+  RunGroup,
+} from '../api/campaigns.js';
 import type { SessionView } from '../api/types.js';
-import { healthOf, type Health, type StatDelta } from './windowStats.js';
+import { isPrUrl } from '../components/delivery.js';
+import { healthOf, type Health } from './windowStats.js';
 
 /**
- * The Campaigns landing's pure folds (the testing-UX wave) — everything the KPI band and the
- * card grid derive from the ONE `GET /campaigns` answer plus the run list the app already
- * holds. Pure and unit-tested, like `windowStats`, so the band and the cards cannot disagree.
+ * The Campaigns landing's pure folds — everything the KPI band and the card grid derive from
+ * the ONE `GET /campaigns` answer (engine campaigns + ad-hoc `RunGroup`s, api-types 0.19.0)
+ * plus the live run list the app already holds. Pure and unit-tested, like `windowStats`, so
+ * the band and the cards cannot disagree.
  *
  * HONESTY NOTES:
- *  - Campaign counts are SERVER aggregates over the FULL filed set (archived included, §4.2)
- *    — they are never re-derived from the archive-filtered run list.
- *  - Campaigns carry REAL clocks (`created_at`/`updated_at`), unlike the run DTO — so the
- *    campaigns tile's delta and sparkline are time-based (days), while every run-derived
- *    number stays on the positional window idiom (`windowStats`). The two models are never
- *    mixed inside one number.
- *  - There is NO per-run timestamp on the campaign LIST wire, so a per-card time sparkline is
- *    not derivable without N detail fetches — the card renders the scoreboard's segmented
- *    status bar (real, wire-carried counts) instead of a fabricated series.
+ *  - Node statuses are ENGINE-PERSISTED over the FULL node set — folding over `node_status`
+ *    keeps the §4.2 archived-run honesty (the live run list is archive-filtered; the campaign
+ *    is not).
+ *  - The engine campaign carries NO clocks, so nothing here fabricates a time series or an
+ *    "N ago" — recency stays the positional window idiom over the live member runs.
+ *  - The delivery rollup reads ONLY wire-carried facts: `node_delivery` / the members'
+ *    `delivery`+`deliverUrl` (both daemon-joined, 0.19.0). A pre-0.19 daemon omits them and
+ *    the rollup says so by being absent (`onWire: false`) — never a fabricated "0 of N".
+ *  - Every PR href passes {@link isPrUrl} — the one shape gate every PR claim in studio takes.
  */
 
-// ── Aggregates for the KPI band ───────────────────────────────────────────────
+// ── Status folding ─────────────────────────────────────────────────────────────
 
-export interface CampaignTotals {
-  campaigns: number;
-  /** Campaigns with anything moving or waiting right now (running or awaitingHuman > 0). */
-  activeNow: number;
-  filed: number;
+/** Run counts folded CLIENT-SIDE from the engine's persisted per-node statuses. */
+export interface CampaignCounts {
+  /** DAG nodes — the campaign's own declared denominator. */
+  nodes: number;
   landed: number;
   failed: number;
   cancelled: number;
+  running: number;
+  awaitingHuman: number;
+  /** pending | ready — declared work not yet moving. */
+  queued: number;
+  /** Ad-hoc runs filed onto this campaign at launch (provenance, not DAG nodes). */
+  attached: number;
+}
+
+const NODE_BUCKET: Record<CampaignNodeStatus, keyof Omit<CampaignCounts, 'nodes' | 'attached'>> = {
+  pending: 'queued',
+  ready: 'queued',
+  running: 'running',
+  ready_to_resume: 'running',
+  awaiting_human: 'awaitingHuman',
+  completed: 'landed',
+  // `blocked` is a terminal non-delivery: a dep failed, this node will not run.
+  blocked: 'failed',
+  failed: 'failed',
+  cancelled: 'cancelled',
+};
+
+export function campaignCounts(c: Campaign): CampaignCounts {
+  const t: CampaignCounts = {
+    nodes: c.def.nodes.length, landed: 0, failed: 0, cancelled: 0,
+    running: 0, awaitingHuman: 0, queued: 0, attached: c.attached_runs?.length ?? 0,
+  };
+  for (const node of c.def.nodes) {
+    const s = c.node_status[node.node_id];
+    // A node the status map does not name yet is declared-but-unmoved work.
+    t[s === undefined ? 'queued' : NODE_BUCKET[s]] += 1;
+  }
+  return t;
+}
+
+// ── Members: the run-id join against the live list ─────────────────────────────
+
+/** Every member run id of one campaign — DAG-node runs first, attached runs after. */
+export function campaignMemberRunIds(c: Campaign): string[] {
+  const ids: string[] = [];
+  for (const node of c.def.nodes) {
+    const id = c.node_run_id[node.node_id];
+    if (id !== undefined) ids.push(id);
+  }
+  for (const a of c.attached_runs ?? []) ids.push(a.runId);
+  return ids;
+}
+
+/** Every member run id across campaigns AND groups — the window join key. */
+export function memberRunIdSet(campaigns: readonly Campaign[], groups: readonly RunGroup[]): Set<string> {
+  const ids = new Set<string>();
+  for (const c of campaigns) for (const id of campaignMemberRunIds(c)) ids.add(id);
+  for (const g of groups) for (const r of g.runs) ids.add(r.runId);
+  return ids;
+}
+
+// ── The delivery rollup (wire facts only) ──────────────────────────────────────
+
+/** One delivered member's linkable PR — the href already passed {@link isPrUrl}. */
+export interface RollupPr {
+  runId: string;
+  href: string;
+}
+
+/** One stranded member — finished work waiting on a person, no PR (needs-you class). */
+export interface StrandedMember {
+  runId: string;
+  /** node_id for a DAG node; the run id for an attached/grouped run. */
+  label: string;
+}
+
+export interface DeliveryRollup {
+  /** Whether this daemon carried per-member delivery at all (api-types 0.19.0). */
+  onWire: boolean;
+  /** Members whose wire-carried delivery is `'delivered'`. */
+  delivered: number;
+  /** The rollup denominator — every member that could deliver (nodes + attached/grouped). */
+  total: number;
+  /** Delivered members' PR links, {@link isPrUrl}-gated; wire order. */
+  prs: RollupPr[];
+  stranded: StrandedMember[];
+}
+
+function foldMember(
+  rollup: DeliveryRollup,
+  runId: string,
+  label: string,
+  d: CampaignNodeDelivery | AttachedRunView,
+): void {
+  if (d.delivery === 'delivered') {
+    rollup.delivered += 1;
+    if (typeof d.deliverUrl === 'string' && isPrUrl(d.deliverUrl)) {
+      rollup.prs.push({ runId, href: d.deliverUrl });
+    }
+  } else if (d.delivery === 'stranded') {
+    rollup.stranded.push({ runId, label });
+  }
+}
+
+/**
+ * The campaign's "n of N delivered" — N is every DAG node plus every attached run (declared
+ * work counts before it dispatches; an undispatched node simply has no delivery fact yet).
+ */
+export function campaignDeliveryRollup(c: Campaign): DeliveryRollup {
+  const rollup: DeliveryRollup = {
+    onWire: c.node_delivery !== undefined || c.attached_runs !== undefined,
+    delivered: 0,
+    total: c.def.nodes.length + (c.attached_runs?.length ?? 0),
+    prs: [],
+    stranded: [],
+  };
+  for (const node of c.def.nodes) {
+    const d = c.node_delivery?.[node.node_id];
+    if (d === undefined) continue;
+    foldMember(rollup, c.node_run_id[node.node_id] ?? node.node_id, node.node_id, d);
+  }
+  for (const a of c.attached_runs ?? []) foldMember(rollup, a.runId, a.runId, a);
+  return rollup;
+}
+
+/** A group's rollup — same fold, members are the label's runs (always wire-carried). */
+export function groupDeliveryRollup(g: RunGroup): DeliveryRollup {
+  const rollup: DeliveryRollup = {
+    onWire: true, delivered: 0, total: g.runs.length, prs: [], stranded: [],
+  };
+  for (const r of g.runs) foldMember(rollup, r.runId, r.runId, r);
+  return rollup;
+}
+
+// ── Aggregates for the KPI band ────────────────────────────────────────────────
+
+export interface CampaignTotals {
+  campaigns: number;
+  groups: number;
+  /** Campaigns/groups with anything moving or waiting right now. */
+  activeNow: number;
+  landed: number;
+  failed: number;
   running: number;
   awaitingHuman: number;
   /** landed + failed + cancelled — the pass-rate denominator. */
   terminal: number;
 }
 
-export function campaignTotals(summaries: readonly CampaignSummary[]): CampaignTotals {
-  const t: CampaignTotals = {
-    campaigns: summaries.length, activeNow: 0, filed: 0, landed: 0, failed: 0,
-    cancelled: 0, running: 0, awaitingHuman: 0, terminal: 0,
-  };
-  for (const s of summaries) {
-    const c = s.counts;
-    if (c.running > 0 || c.awaitingHuman > 0) t.activeNow += 1;
-    t.filed += c.filed;
-    t.landed += c.landed;
-    t.failed += c.failed;
-    t.cancelled += c.cancelled;
-    t.running += c.running;
-    t.awaitingHuman += c.awaitingHuman;
-    t.terminal += c.landed + c.failed + c.cancelled;
+function groupStatusCounts(g: RunGroup): { running: number; awaitingHuman: number; landed: number; failed: number; cancelled: number } {
+  const t = { running: 0, awaitingHuman: 0, landed: 0, failed: 0, cancelled: 0 };
+  for (const r of g.runs) {
+    if (r.status === 'awaiting_human') t.awaitingHuman += 1;
+    else if (r.status === 'completed') t.landed += 1;
+    else if (r.status === 'failed') t.failed += 1;
+    else if (r.status === 'cancelled') t.cancelled += 1;
+    else t.running += 1; // planning | distributing | executing
   }
   return t;
 }
 
-/** Every run id filed under any campaign — the join key against the live run list. */
-export function campaignRunIdSet(summaries: readonly CampaignSummary[]): Set<string> {
-  const ids = new Set<string>();
-  for (const s of summaries) for (const id of s.runIds) ids.add(id);
-  return ids;
-}
-
-/**
- * Daily campaign-activity buckets off `updated_at` (the newest launch filed, or the newest
- * metadata write), oldest first — REAL clocks, so this series is time-based. Campaigns
- * outside the span are simply absent, never painted at an invented time.
- */
-export function campaignActivitySeries(
-  summaries: readonly CampaignSummary[],
-  days: number,
-  now: number,
-): number[] {
-  const DAY = 24 * 3_600_000;
-  const counts = new Array<number>(days).fill(0);
-  for (const s of summaries) {
-    const age = now - s.campaign.updated_at;
-    if (age < 0 || age >= days * DAY) continue;
-    const bucket = days - 1 - Math.floor(age / DAY);
-    counts[bucket] = (counts[bucket] ?? 0) + 1;
+export function campaignTotals(campaigns: readonly Campaign[], groups: readonly RunGroup[]): CampaignTotals {
+  const t: CampaignTotals = {
+    campaigns: campaigns.length, groups: groups.length, activeNow: 0,
+    landed: 0, failed: 0, running: 0, awaitingHuman: 0, terminal: 0,
+  };
+  for (const c of campaigns) {
+    const n = campaignCounts(c);
+    if (n.running > 0 || n.awaitingHuman > 0) t.activeNow += 1;
+    t.landed += n.landed;
+    t.failed += n.failed;
+    t.running += n.running;
+    t.awaitingHuman += n.awaitingHuman;
+    t.terminal += n.landed + n.failed + n.cancelled;
   }
-  return counts;
-}
-
-/**
- * Campaigns created in the last `days` vs the `days` before that — a TIME delta (real
- * `created_at` clocks), unlike the run tiles' positional deltas. Always comparable: both
- * buckets are the same span, so `previous` is never null here.
- */
-export function campaignCreatedDelta(
-  summaries: readonly CampaignSummary[],
-  days: number,
-  now: number,
-): StatDelta {
-  const DAY = 24 * 3_600_000;
-  let current = 0;
-  let previous = 0;
-  for (const s of summaries) {
-    const age = now - s.campaign.created_at;
-    if (age < 0) continue;
-    if (age < days * DAY) current += 1;
-    else if (age < 2 * days * DAY) previous += 1;
+  for (const g of groups) {
+    const n = groupStatusCounts(g);
+    if (n.running > 0 || n.awaitingHuman > 0) t.activeNow += 1;
+    t.landed += n.landed;
+    t.failed += n.failed;
+    t.running += n.running;
+    t.awaitingHuman += n.awaitingHuman;
+    t.terminal += n.landed + n.failed + n.cancelled;
   }
-  return { current, previous };
+  return t;
 }
 
 /** The pass-rate word: whole-percent when a denominator exists, an honest "—" otherwise. */
@@ -115,10 +228,26 @@ export function passRateHealth(landed: number, terminal: number): Health {
   return healthOf(landed, terminal);
 }
 
-// ── The card models (needs-you first) ─────────────────────────────────────────
+// ── The card models (needs-you first) ──────────────────────────────────────────
 
+/** One campaign OR one ad-hoc group, as the grid renders it — one sort, one chip fold. */
 export interface CampaignCardModel {
-  summary: CampaignSummary;
+  kind: 'campaign' | 'group';
+  /** Campaign id, or the group's label. */
+  id: string;
+  /** def.name for a campaign (id fallback); the label for a group. */
+  title: string;
+  campaign: Campaign | null;
+  group: RunGroup | null;
+  /** Landed / total for the progress word; campaign = nodes, group = member runs. */
+  landed: number;
+  total: number;
+  failed: number;
+  running: number;
+  awaitingHuman: number;
+  attached: number;
+  rollup: DeliveryRollup;
+  memberRunIds: string[];
   /** Member runs waiting on a human RIGHT NOW, from the live run list (a gate is a gate). */
   waiting: SessionView[];
   failing: boolean;
@@ -131,47 +260,104 @@ export type CampaignChip = 'all' | 'needs-you' | 'running' | 'failing' | 'quiet'
 
 export function matchesCampaignChip(m: CampaignCardModel, chip: CampaignChip): boolean {
   if (chip === 'all') return true;
-  if (chip === 'needs-you') return m.summary.counts.awaitingHuman > 0;
+  // Stranded siblings are needs-you: finished work waiting on a person (crew#393's word).
+  if (chip === 'needs-you') return m.awaitingHuman > 0 || m.rollup.stranded.length > 0;
   if (chip === 'running') return m.runningNow;
   if (chip === 'failing') return m.failing;
-  return m.summary.counts.awaitingHuman === 0 && !m.runningNow && !m.failing; // quiet
+  return m.awaitingHuman === 0 && m.rollup.stranded.length === 0 && !m.runningNow && !m.failing; // quiet
+}
+
+function withLiveJoin(
+  m: Omit<CampaignCardModel, 'waiting' | 'inWindow'>,
+  runsById: ReadonlyMap<string, SessionView>,
+  windowIds: ReadonlySet<string>,
+): CampaignCardModel {
+  const members = m.memberRunIds
+    .map((id) => runsById.get(id))
+    .filter((v): v is SessionView => v !== undefined);
+  return {
+    ...m,
+    waiting: members.filter((v) => v.session.status === 'awaiting_human'),
+    inWindow: m.memberRunIds.some((id) => windowIds.has(id)),
+  };
 }
 
 /**
- * One fold per campaign, sorted the attention-routing way: needs-you FIRST, then failing,
- * then newest-updated — the same order the /projects grid taught.
+ * One fold per campaign AND per ad-hoc group, sorted the attention-routing way: needs-you
+ * FIRST (gates, then stranded work), then failing, then server order — the same order the
+ * /projects grid taught. Groups ride the same grid as campaigns: one sort, no second surface.
  */
 export function campaignCards(
-  summaries: readonly CampaignSummary[],
+  campaigns: readonly Campaign[],
+  groups: readonly RunGroup[],
   runsById: ReadonlyMap<string, SessionView>,
   windowIds: ReadonlySet<string>,
 ): CampaignCardModel[] {
-  return summaries
-    .map((s) => {
-      const members = s.runIds
-        .map((id) => runsById.get(id))
-        .filter((v): v is SessionView => v !== undefined);
-      return {
-        summary: s,
-        waiting: members.filter((v) => v.session.status === 'awaiting_human'),
-        failing: s.counts.failed > 0,
-        runningNow: s.counts.running > 0,
-        inWindow: s.runIds.some((id) => windowIds.has(id)),
-      };
-    })
-    .sort((a, b) =>
-      (b.summary.counts.awaitingHuman > 0 ? 1 : 0) - (a.summary.counts.awaitingHuman > 0 ? 1 : 0)
-      || (b.failing ? 1 : 0) - (a.failing ? 1 : 0)
-      || b.summary.campaign.updated_at - a.summary.campaign.updated_at,
-    );
+  const models: CampaignCardModel[] = [];
+  for (const c of campaigns) {
+    const n = campaignCounts(c);
+    models.push(withLiveJoin({
+      kind: 'campaign',
+      id: c.id,
+      title: c.def.name !== '' ? c.def.name : c.id,
+      campaign: c,
+      group: null,
+      landed: n.landed,
+      total: n.nodes,
+      failed: n.failed,
+      running: n.running,
+      awaitingHuman: n.awaitingHuman,
+      attached: n.attached,
+      rollup: campaignDeliveryRollup(c),
+      memberRunIds: campaignMemberRunIds(c),
+      failing: n.failed > 0,
+      runningNow: n.running > 0,
+    }, runsById, windowIds));
+  }
+  for (const g of groups) {
+    const n = groupStatusCounts(g);
+    models.push(withLiveJoin({
+      kind: 'group',
+      id: g.label,
+      title: g.label,
+      campaign: null,
+      group: g,
+      landed: n.landed,
+      total: g.runs.length,
+      failed: n.failed,
+      running: n.running,
+      awaitingHuman: n.awaitingHuman,
+      attached: 0,
+      rollup: groupDeliveryRollup(g),
+      memberRunIds: g.runs.map((r) => r.runId),
+      failing: n.failed > 0,
+      runningNow: n.running > 0,
+    }, runsById, windowIds));
+  }
+  return models.sort((a, b) =>
+    (b.awaitingHuman > 0 ? 1 : 0) - (a.awaitingHuman > 0 ? 1 : 0)
+    || (b.rollup.stranded.length > 0 ? 1 : 0) - (a.rollup.stranded.length > 0 ? 1 : 0)
+    || (b.failing ? 1 : 0) - (a.failing ? 1 : 0),
+  );
 }
 
 /**
- * §3.3 denominator honesty, the ONE spelling shared by card, row and scoreboard: a declared
- * `expected` is a real denominator; an undeclared one MUST say "so far" because it can grow.
+ * §3.3 denominator honesty, the ONE spelling shared by card and scoreboard: a campaign's DAG
+ * is a DECLARED denominator ("n of N landed"); an ad-hoc group's grows with every launch
+ * under the label, so it MUST say "so far" — two different strings, never rendered
+ * identically, because one of them can grow.
  */
-export function campaignProgressWord(s: CampaignSummary): string {
-  return s.campaign.expected !== null
-    ? `${s.counts.landed} of ${s.campaign.expected} landed`
-    : `${s.counts.landed} of ${s.counts.filed} landed so far`;
+export function progressWord(m: Pick<CampaignCardModel, 'kind' | 'landed' | 'total'>): string {
+  return m.kind === 'campaign'
+    ? `${m.landed} of ${m.total} landed`
+    : `${m.landed} of ${m.total} landed so far`;
+}
+
+/**
+ * The delivery-rollup sentence — the card's second line, wire facts only. `null` when this
+ * daemon does not carry per-member delivery (pre-0.19): absence, never a fabricated zero.
+ */
+export function deliveryRollupWord(r: DeliveryRollup): string | null {
+  if (!r.onWire) return null;
+  return `${r.delivered} of ${r.total} delivered`;
 }

--- a/src/board/needsYou.ts
+++ b/src/board/needsYou.ts
@@ -1,8 +1,9 @@
-import type { CampaignSummary } from '../api/campaigns.js';
+import type { Campaign } from '../api/campaigns.js';
 import type { RepoEntry, SessionView } from '../api/types.js';
 import { deliveryOf } from '../components/delivery.js';
 import { narrate, narrateStranded, type NarrationTone } from '../components/narrator.js';
 import type { RetryPrefill } from '../store/retryPrefill.js';
+import { campaignCounts, campaignMemberRunIds } from './campaignStats.js';
 import { STALLED_IDLE_SECS, stalledLiveChats, type LiveChatSnapshot } from './chatStats.js';
 import { gateOpenPath } from './gateActions.js';
 import { outcomeOf, runStats } from './metrics.js';
@@ -107,7 +108,7 @@ export interface NeedsYouInputs {
   chats: readonly LiveChatSnapshot[];
   repos: readonly RepoEntry[];
   /** `GET /campaigns` snapshot; empty when unsupported. */
-  campaigns: readonly CampaignSummary[];
+  campaigns: readonly Campaign[];
   now: number;
 }
 
@@ -251,11 +252,14 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
   // ── Campaign rows — subtraction-dedupe against the member rows above ───────
   const liveById = new Map(live.map((v) => [v.session.id, v]));
   for (const c of campaigns) {
-    const troubled = c.counts.awaitingHuman + c.counts.failed;
+    // Engine-persisted per-node statuses (campaignStats' fold — the same one the
+    // Campaigns landing folds with, so the two surfaces cannot disagree).
+    const n = campaignCounts(c);
+    const troubled = n.awaitingHuman + n.failed;
     if (troubled === 0) continue;
     // Members the queue ALREADY shows (as gate or failed rows) subtract out.
     let covered = 0;
-    for (const id of c.runIds) {
+    for (const id of campaignMemberRunIds(c)) {
       if (!shownRunIds.has(id)) continue;
       const st = liveById.get(id)?.session.status;
       if (st === 'awaiting_human' || st === 'failed') covered += 1;
@@ -263,20 +267,21 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
     const surplus = troubled - covered;
     if (surplus <= 0) continue;
     const bits: string[] = [];
-    if (c.counts.awaitingHuman > 0) bits.push(`${c.counts.awaitingHuman} waiting`);
-    if (c.counts.failed > 0) bits.push(`${plural(c.counts.failed, 'run')} failed`);
+    if (n.awaitingHuman > 0) bits.push(`${n.awaitingHuman} waiting`);
+    if (n.failed > 0) bits.push(`${plural(n.failed, 'run')} failed`);
     rows.push({
-      key: `campaign:${c.campaign.id}`,
+      key: `campaign:${c.id}`,
       kind: 'campaign',
       severity: SEVERITY.campaign,
-      subject: c.campaign.title ?? c.campaign.id,
+      subject: c.def.name !== '' ? c.def.name : c.id,
       text: `Campaign gaps — ${bits.join(' · ')} (${surplus} beyond the list below)`,
-      tone: c.counts.awaitingHuman > 0 ? 'gate' : 'fail',
-      at: c.campaign.updated_at,
-      subjectPath: `/testing/campaigns/${encodeURIComponent(c.campaign.id)}`,
+      tone: n.awaitingHuman > 0 ? 'gate' : 'fail',
+      // The engine campaign carries no clocks — age unknown, said honestly.
+      at: null,
+      subjectPath: `/testing/campaigns/${encodeURIComponent(c.id)}`,
       action: {
         kind: 'open',
-        path: `/testing/campaigns/${encodeURIComponent(c.campaign.id)}`,
+        path: `/testing/campaigns/${encodeURIComponent(c.id)}`,
         label: 'Open campaign ›',
       },
     });

--- a/src/components/CampaignScoreboard.tsx
+++ b/src/components/CampaignScoreboard.tsx
@@ -1,49 +1,69 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getCampaign, type CampaignDetail, type CampaignRun } from '../api/campaigns.js';
+import { getCampaign, type Campaign, type CampaignNodeStatus } from '../api/campaigns.js';
 import { testingPath } from '../api/testing.js';
 import { downloadRunEvidence } from '../api/client.js';
 import { apiStatus } from '../api/errors.js';
 import type { SessionView } from '../api/types.js';
+import {
+  campaignCounts, campaignDeliveryRollup, deliveryRollupWord,
+} from '../board/campaignStats.js';
 import { useAcceptanceStore } from '../store/acceptance.js';
-import { useCampaignsStore, type CampaignNodeLive } from '../store/campaigns.js';
+import { useCampaignsStore } from '../store/campaigns.js';
 import { deliveryOf, isPrUrl, resolveDelivery, DELIVERY_LABEL } from './delivery.js';
 import { STATUS_STYLE } from './RunCard.js';
 import { runShortId } from './runIdentity.js';
 
 /**
  * The campaign scoreboard (TH-14, extends wicked-studio#27) — READ-ONLY: one surface that
- * groups a campaign's sibling runs. The ladder is one row per filed run (DES-CAMPAIGN-001
- * §4.4's table, deliberately not a graph — there is no edge data in this model to draw);
- * node status goes live off core's Campaign* `/ws` frames the moment the daemon relays them
- * (TH-9 — see `store/campaigns.ts` for the fold and the frame shapes), and falls back to the
- * live run list, then to the detail snapshot, in that order.
+ * groups a campaign's sibling runs. The ladder is one row per DAG NODE of the engine's
+ * embedded `def` (the wire crew#342 actually serves — deliberately not a graph: the edges
+ * exist but a table names the work; a DAG view is a later, additive lane), followed by the
+ * ad-hoc runs attached at launch (api-types 0.19.0 — provenance rows, marked as such). Node
+ * status goes live off core's Campaign* `/ws` frames (see `store/campaigns.ts` for the fold),
+ * falling back to the live run list, then to the engine's persisted `node_status`, in that
+ * order.
  *
  * ── THE WIRE RULES THIS SURFACE HOLDS ────────────────────────────────────────────────────────
- *  - The delivery rollup ("K of N siblings delivered") reads `session.delivery` off the run
- *    LIST wire (CREW-UX-8, crew#321) plus the server-resolved `prUrl` snapshot the detail
- *    payload carries (§4.3) — NEVER a per-run transcript fetch. Zero requests beyond the one
- *    `GET /campaigns/:id`.
+ *  - The delivery rollup ("K of N siblings delivered") reads the DAEMON-JOINED
+ *    `node_delivery` / `attached_runs` facts off the ONE `GET /campaigns/:id`, upgraded live
+ *    by `session.delivery` where the run list still holds the sibling — NEVER a per-run
+ *    transcript fetch. Zero requests beyond that one GET.
+ *  - Every PR href passes the `isPrUrl` shape gate (delivery.ts's one invariant), whichever
+ *    wire carried it.
  *  - Verdict chips are a per-run acceptance read (`GET /runs/:id/acceptance`) behind ONE
  *    explicit gesture (the MakeDashboard fan-out precedent): zero requests on render,
  *    exactly N on click, cached per run id forever after (`store/acceptance.ts`).
  *  - Evidence links download through the existing `GET /runs/:id/evidence` — on click only.
- *  - The cost column is an honest "—" until TH-20 folds per-node cost into the wire (the
- *    integration point is typed on `CampaignRun.cost`); flake/coverage trends need the
- *    TH-6 per-scenario flake history, which has no studio-reachable wire yet — named here so
- *    it is a known gap, not an invisible one.
  */
 
-const terminal = (s: string | null): boolean =>
-  s !== null && ['completed', 'failed', 'cancelled'].includes(s);
+const TERMINAL_NODE: ReadonlySet<CampaignNodeStatus> = new Set([
+  'completed', 'failed', 'blocked', 'cancelled',
+]);
 
-/** The node-frame status words, rendered with the closest run-status token. */
+const terminalRun = (s: string | null | undefined): boolean =>
+  s != null && ['completed', 'failed', 'cancelled'].includes(s);
+
+/** The engine node statuses + the frame vocabulary, in the closest run-status tokens. */
 const NODE_STATUS_STYLE: Record<string, { label: string; color: string }> = {
-  ready:          { label: 'Ready',          color: 'var(--ink-muted)' },
-  started:        { label: 'Executing',      color: 'var(--status-run)' },
-  awaiting_human: { label: 'Awaiting human', color: 'var(--status-gate)' },
-  completed:      { label: 'Completed',      color: 'var(--status-done)' },
-  failed:         { label: 'Failed',         color: 'var(--status-fail)' },
-  blocked:        { label: 'Blocked',        color: 'var(--status-fail)' },
+  pending:         { label: 'Pending',        color: 'var(--ink-dim)' },
+  ready:           { label: 'Ready',          color: 'var(--ink-muted)' },
+  running:         { label: 'Executing',      color: 'var(--status-run)' },
+  started:         { label: 'Executing',      color: 'var(--status-run)' },
+  ready_to_resume: { label: 'Resuming',       color: 'var(--status-run)' },
+  awaiting_human:  { label: 'Awaiting human', color: 'var(--status-gate)' },
+  completed:       { label: 'Completed',      color: 'var(--status-done)' },
+  failed:          { label: 'Failed',         color: 'var(--status-fail)' },
+  blocked:         { label: 'Blocked',        color: 'var(--status-fail)' },
+  cancelled:       { label: 'Cancelled',      color: 'var(--ink-dim)' },
+};
+
+const CAMPAIGN_STATUS_COLOR: Record<string, string> = {
+  running: 'var(--status-run)',
+  paused: 'var(--status-gate)',
+  completed: 'var(--status-done)',
+  partially_completed: 'var(--status-gate)',
+  failed: 'var(--status-fail)',
+  cancelled: 'var(--ink-dim)',
 };
 
 const CELL: React.CSSProperties = { padding: '8px 10px', verticalAlign: 'top' };
@@ -84,23 +104,44 @@ function Chip({ label, color, testid, title, extra }: {
   );
 }
 
+/** One ladder row, whatever wire it came off — node or attached run, joined zero-fetch. */
+interface LadderRow {
+  kind: 'node' | 'attached';
+  /** node_id, or the attached run's id. */
+  label: string;
+  runId: string | null;
+  problem: string;
+  /** Engine snapshot status (node_status for nodes; the DTO's status for attached). */
+  snapshotStatus: string | null;
+  /** Wire-carried delivery (node_delivery / the attached view) — the snapshot arm. */
+  delivery: { delivery: string; deliverUrl?: string } | null;
+}
+
 /**
- * One sibling's row-level facts, joined zero-fetch: live view (run list) over snapshot
- * (detail), Campaign* node fold over both for the status chip.
+ * The row's status chip, joined zero-fetch: Campaign* frame fold over the live run list over
+ * the engine snapshot, in that order — each arm labels its source honestly.
  */
 function rowStatus(
-  row: CampaignRun,
+  row: LadderRow,
   view: SessionView | undefined,
-  node: CampaignNodeLive | undefined,
+  frameStatus: string | undefined,
 ): { label: string; color: string; source: 'frame' | 'live' | 'snapshot' | 'gone' } {
-  if (node !== undefined) {
-    const s = NODE_STATUS_STYLE[node.status] ?? { label: node.status, color: 'var(--ink-dim)' };
+  if (frameStatus !== undefined) {
+    const s = NODE_STATUS_STYLE[frameStatus] ?? { label: frameStatus, color: 'var(--ink-dim)' };
     return { ...s, source: 'frame' };
   }
-  const status = view?.session.status ?? row.status;
-  if (status === null) return { label: 'No longer held', color: 'var(--ink-dim)', source: 'gone' };
-  const s = STATUS_STYLE[status] ?? { label: status, color: 'var(--ink-dim)' };
-  return { ...s, source: view !== undefined ? 'live' : 'snapshot' };
+  if (view !== undefined) {
+    const st = view.session.status;
+    const s = STATUS_STYLE[st] ?? { label: st, color: 'var(--ink-dim)' };
+    return { ...s, source: 'live' };
+  }
+  if (row.snapshotStatus === null) {
+    return { label: 'No longer held', color: 'var(--ink-dim)', source: 'gone' };
+  }
+  const s = NODE_STATUS_STYLE[row.snapshotStatus]
+    ?? (STATUS_STYLE as Record<string, { label: string; color: string }>)[row.snapshotStatus]
+    ?? { label: row.snapshotStatus, color: 'var(--ink-dim)' };
+  return { ...s, source: 'snapshot' };
 }
 
 interface Props {
@@ -111,7 +152,7 @@ interface Props {
 }
 
 export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React.ReactElement {
-  const [detail, setDetail] = useState<CampaignDetail | null>(null);
+  const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [failed, setFailed] = useState<string | null>(null);
   const live = useCampaignsStore((s) => s.live[campaignId]);
@@ -119,16 +160,16 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
   const loadVerdict = useAcceptanceStore((s) => s.load);
   const [verdictsRequested, setVerdictsRequested] = useState(false);
 
-  // The one fetch this surface makes on its own: the campaign's per-run roll-up. Re-read when
-  // a Campaign* frame for THIS campaign lands (`live` identity changes) — new nodes mean new
-  // filed runs the snapshot does not hold yet. The run list itself arrives via props.
+  // The one fetch this surface makes on its own: the campaign with its daemon-joined rollup.
+  // Re-read when a Campaign* frame for THIS campaign lands (`live` identity changes) — new
+  // node statuses mean the snapshot moved. The run list itself arrives via props.
   useEffect(() => {
     let cancelled = false;
     setNotFound(false);
     setFailed(null);
     getCampaign(campaignId)
-      .then((d) => {
-        if (!cancelled) setDetail(d);
+      .then((c) => {
+        if (!cancelled) setCampaign(c);
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -145,16 +186,6 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
     for (const v of runs) m.set(v.session.id, v);
     return m;
   }, [runs]);
-
-  /** Campaign* node fold joined by the runId the started/awaitingHuman frames carry. */
-  const nodeByRun = useMemo(() => {
-    const m = new Map<string, CampaignNodeLive>();
-    for (const id of live?.nodeOrder ?? []) {
-      const n = live?.nodes[id];
-      if (n?.runId != null) m.set(n.runId, n);
-    }
-    return m;
-  }, [live]);
 
   if (notFound) {
     return (
@@ -181,7 +212,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
       </div>
     );
   }
-  if (detail === null) {
+  if (campaign === null) {
     return (
       <div data-testid="campaign-loading" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
         Loading campaign {campaignId}…
@@ -189,70 +220,91 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
     );
   }
 
-  const { campaign, counts } = detail;
-  // §3.3 denominator honesty: `expected` set ⇒ a real denominator; unset ⇒ "so far" — two
-  // DIFFERENT strings, never rendered identically, because one of them can grow.
-  const progress =
-    campaign.expected !== null
-      ? `${counts.landed} of ${campaign.expected} landed`
-      : `${counts.landed} of ${counts.filed} landed so far`;
+  const counts = campaignCounts(campaign);
+  // The campaign's DAG is a DECLARED denominator (§3.3) — no "so far" here; the ad-hoc
+  // attached runs are provenance and counted beside it, never folded into the DAG number.
+  const progress = `${counts.landed} of ${counts.nodes} landed`;
 
-  // The delivery rollup, strictly off wire-carried facts (never a transcript fetch): a
-  // sibling counts as delivered when its live DTO's deliver phase is approved (state
-  // 'delivered' — `session.delivery` is what upgrades the CLAIM to a linkable pr-open), or —
-  // for a run the list no longer shows (archived/gone) — when the detail snapshot carries the
-  // server-resolved prUrl (§4.3).
-  const deliveredCount = detail.runs.filter((row) => {
-    const view = runsById.get(row.runId);
-    if (view !== undefined) return deliveryOf(view).state === 'delivered';
-    return typeof row.prUrl === 'string' && isPrUrl(row.prUrl);
-  }).length;
+  // The delivery rollup, strictly off wire-carried facts (never a transcript fetch) — the
+  // campaignStats fold over `node_delivery` + `attached_runs` (api-types 0.19.0).
+  const rollup = campaignDeliveryRollup(campaign);
+  const rollupWord = deliveryRollupWord(rollup);
 
   const seg = [
     { n: counts.landed, color: 'var(--status-done)' },
     { n: counts.failed, color: 'var(--status-fail)' },
     { n: counts.awaitingHuman, color: 'var(--status-gate)' },
     { n: counts.running, color: 'var(--status-run)' },
-    { n: counts.cancelled + counts.other, color: 'var(--ink-dim)' },
+    { n: counts.cancelled + counts.queued, color: 'var(--ink-dim)' },
   ];
-  const segTotal = Math.max(
-    1,
-    campaign.expected ?? counts.filed,
-    seg.reduce((a, s) => a + s.n, 0),
-  );
+  const segTotal = Math.max(1, counts.nodes, seg.reduce((a, s) => a + s.n, 0));
+
+  // ── The ladder: one row per DAG node, then the attached provenance rows ──────
+  const rows: LadderRow[] = [
+    ...campaign.def.nodes.map((node): LadderRow => ({
+      kind: 'node',
+      label: node.node_id,
+      runId: campaign.node_run_id[node.node_id] ?? null,
+      problem: node.run_spec.problem,
+      snapshotStatus: campaign.node_status[node.node_id] ?? null,
+      delivery: campaign.node_delivery?.[node.node_id] ?? null,
+    })),
+    ...(campaign.attached_runs ?? []).map((a): LadderRow => ({
+      kind: 'attached',
+      label: a.runId,
+      runId: a.runId,
+      problem: runsById.get(a.runId)?.session.problem ?? a.runId,
+      snapshotStatus: a.status,
+      delivery: { delivery: a.delivery, ...(a.deliverUrl !== undefined ? { deliverUrl: a.deliverUrl } : {}) },
+    })),
+  ];
+
+  const rowTerminal = (row: LadderRow, view: SessionView | undefined): boolean => {
+    if (view !== undefined) return terminalRun(view.session.status);
+    if (row.kind === 'node') {
+      return row.snapshotStatus !== null && TERMINAL_NODE.has(row.snapshotStatus as CampaignNodeStatus);
+    }
+    return terminalRun(row.snapshotStatus);
+  };
+
+  const liveStatus = live?.status ?? null;
+  const statusWord = liveStatus ?? campaign.status;
 
   return (
     <div data-testid="campaign-scoreboard" style={{ padding: '24px', maxWidth: '1100px' }}>
       <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', flexWrap: 'wrap' }}>
         <h1 style={{ fontSize: 'var(--text-xl)', color: 'var(--ink-high)', fontWeight: 600 }}>
-          {campaign.title ?? campaign.id}
+          {campaign.def.name !== '' ? campaign.def.name : campaign.id}
         </h1>
-        {campaign.title !== null && (
-          <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-sm)' }}>{campaign.id}</span>
-        )}
-        {live?.status != null && (
-          <Chip
-            testid="campaign-live-status"
-            label={live.status}
-            color={
-              live.status === 'completed' ? 'var(--status-done)'
-              : live.status === 'paused' ? 'var(--status-gate)'
-              : 'var(--status-fail)'
-            }
-          />
-        )}
+        <span style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-sm)' }}>{campaign.id}</span>
+        <Chip
+          testid="campaign-live-status"
+          label={statusWord}
+          color={CAMPAIGN_STATUS_COLOR[statusWord] ?? 'var(--ink-dim)'}
+          extra={{ 'data-status-source': liveStatus !== null ? 'frame' : 'snapshot' }}
+        />
       </div>
 
       <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
         <span data-testid="campaign-progress" style={{ color: 'var(--ink-high)', fontSize: 'var(--text-sm)' }}>
           {progress}
-          {counts.archived > 0 && (
-            <span style={{ color: 'var(--ink-dim)' }}> ({counts.archived} archived)</span>
+          {counts.attached > 0 && (
+            <span style={{ color: 'var(--ink-dim)' }}> (+{counts.attached} attached)</span>
           )}
         </span>
-        <span data-testid="campaign-delivery-rollup" style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>
-          {deliveredCount} of {detail.runs.length} siblings delivered
-        </span>
+        {rollupWord !== null && (
+          <span data-testid="campaign-delivery-rollup" style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>
+            {rollup.delivered} of {rollup.total} siblings delivered
+          </span>
+        )}
+        {rollup.stranded.length > 0 && (
+          <Chip
+            testid="campaign-stranded-chip"
+            label={`stranded · ${rollup.stranded.length}`}
+            color="var(--status-gate)"
+            title={`Finished, but the work is stranded in its worktree — no PR: ${rollup.stranded.map((s) => s.label).join(', ')}`}
+          />
+        )}
       </div>
 
       <div
@@ -276,7 +328,11 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
             data-testid="campaign-load-verdicts"
             onClick={() => {
               setVerdictsRequested(true);
-              for (const row of detail.runs) if (terminal(runsById.get(row.runId)?.session.status ?? row.status)) loadVerdict(row.runId);
+              for (const row of rows) {
+                if (row.runId !== null && rowTerminal(row, runsById.get(row.runId))) {
+                  loadVerdict(row.runId);
+                }
+              }
             }}
             style={{ color: 'var(--status-run)', fontSize: 'var(--text-xs)', textDecoration: 'underline' }}
           >
@@ -294,53 +350,68 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
               <th style={HEAD}>Verdict</th>
               <th style={HEAD}>Delivery</th>
               <th style={HEAD}>Evidence</th>
-              <th style={HEAD} title="Per-node cost lands with campaign budget governance (TH-20); no daemon serves it yet">
-                Cost
-              </th>
             </tr>
           </thead>
           <tbody>
-            {detail.runs.map((row) => {
-              const view = runsById.get(row.runId);
-              const node = nodeByRun.get(row.runId);
-              const status = rowStatus(row, view, node);
-              // Delivery, zero-fetch: the DTO derivation (which reads the wire-carried
-              // `session.delivery`) with the detail's server-resolved prUrl as the read-back
+            {rows.map((row) => {
+              const view = row.runId !== null ? runsById.get(row.runId) : undefined;
+              const frameNode = row.kind === 'node' ? live?.nodes[row.label] : undefined;
+              const status = rowStatus(row, view, frameNode?.status);
+              // Delivery, zero-fetch: the live DTO derivation (which reads the wire-carried
+              // `session.delivery`) with the campaign's own daemon-joined url as the read-back
               // source — `resolveDelivery` re-validates the shape of both.
               const d = view !== undefined
-                ? resolveDelivery(deliveryOf(view), row.prUrl ?? null)
+                ? resolveDelivery(deliveryOf(view), row.delivery?.deliverUrl ?? null)
                 : null;
               const href = d?.href ?? null;
               // The snapshot-only arm (archived / no longer listed) goes through the SAME
               // shape gate as every other PR claim (delivery.ts's one invariant).
               const snapshotHref =
-                view === undefined && typeof row.prUrl === 'string' && isPrUrl(row.prUrl)
-                  ? row.prUrl
+                view === undefined
+                  && row.delivery !== null
+                  && typeof row.delivery.deliverUrl === 'string'
+                  && isPrUrl(row.delivery.deliverUrl)
+                  ? row.delivery.deliverUrl
                   : null;
-              const verdict = verdicts[row.runId];
+              const snapshotStranded = view === undefined && row.delivery?.delivery === 'stranded';
+              const verdict = row.runId !== null ? verdicts[row.runId] : undefined;
               return (
                 <tr
-                  key={row.runId}
+                  key={`${row.kind}:${row.label}`}
                   data-testid="campaign-ladder-row"
-                  data-run-id={row.runId}
+                  data-kind={row.kind}
+                  data-node-id={row.kind === 'node' ? row.label : undefined}
+                  {...(row.runId !== null ? { 'data-run-id': row.runId } : {})}
                   style={{ borderBottom: '1px solid var(--surface-raised)' }}
                 >
                   <td style={CELL}>
-                    <button
-                      type="button"
-                      data-testid="campaign-run-link"
-                      onClick={() => navigate(`/runs/${encodeURIComponent(row.runId)}`)}
-                      style={{ color: 'var(--ink-high)', textAlign: 'left' }}
-                      title={row.runId}
-                    >
-                      <span style={{ color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', marginRight: '8px' }}>
-                        {runShortId(row.runId)}
+                    {row.runId !== null ? (
+                      <button
+                        type="button"
+                        data-testid="campaign-run-link"
+                        onClick={() => navigate(`/runs/${encodeURIComponent(row.runId!)}`)}
+                        style={{ color: 'var(--ink-high)', textAlign: 'left' }}
+                        title={row.runId}
+                      >
+                        <span style={{ color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', marginRight: '8px' }}>
+                          {row.kind === 'node' ? row.label : runShortId(row.runId)}
+                        </span>
+                        {row.problem}
+                      </button>
+                    ) : (
+                      <span style={{ color: 'var(--ink-muted)' }}>
+                        <span style={{ color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', marginRight: '8px' }}>
+                          {row.label}
+                        </span>
+                        {row.problem}
                       </span>
-                      {row.problem}
-                    </button>
-                    {row.archived && (
-                      <span style={{ marginLeft: '8px', color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}>
-                        archived
+                    )}
+                    {row.kind === 'attached' && (
+                      <span
+                        style={{ marginLeft: '8px', color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}
+                        title="Filed onto this campaign at launch — not a DAG node; the campaign never schedules, gates or cancels it."
+                      >
+                        attached
                       </span>
                     )}
                   </td>
@@ -351,7 +422,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
                       color={status.color}
                       extra={{ 'data-status-source': status.source }}
                       title={
-                        node?.prompt != null ? node.prompt
+                        frameNode?.prompt != null ? frameNode.prompt
                         : status.source === 'snapshot' ? 'status at last read — the run is not in the live list'
                         : undefined
                       }
@@ -390,6 +461,8 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
                       >
                         {DELIVERY_LABEL['pr-open']}
                       </a>
+                    ) : snapshotStranded ? (
+                      <span style={{ color: 'var(--status-gate)' }}>{DELIVERY_LABEL['stranded']}</span>
                     ) : (
                       <span style={{ color: d !== null && d.claim === 'failed' ? 'var(--status-fail)' : 'var(--ink-dim)' }} title={d?.reason ?? undefined}>
                         {d !== null && DELIVERY_LABEL[d.claim] !== '' ? DELIVERY_LABEL[d.claim] : '—'}
@@ -397,18 +470,15 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
                     )}
                   </td>
                   <td style={CELL}>
-                    <button
-                      type="button"
-                      data-testid="campaign-evidence-link"
-                      onClick={() => void downloadRunEvidence(row.runId)}
-                      style={{ color: 'var(--status-run)', fontSize: 'var(--text-xs)', textDecoration: 'underline' }}
-                    >
-                      download
-                    </button>
-                  </td>
-                  <td style={CELL} data-testid="campaign-cost-cell">
-                    {typeof row.cost === 'number' ? (
-                      <span style={{ color: 'var(--ink-high)' }}>${row.cost.toFixed(2)}</span>
+                    {row.runId !== null ? (
+                      <button
+                        type="button"
+                        data-testid="campaign-evidence-link"
+                        onClick={() => void downloadRunEvidence(row.runId!)}
+                        style={{ color: 'var(--status-run)', fontSize: 'var(--text-xs)', textDecoration: 'underline' }}
+                      >
+                        download
+                      </button>
                     ) : (
                       <span style={{ color: 'var(--ink-dim)' }}>—</span>
                     )}
@@ -419,31 +489,6 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
           </tbody>
         </table>
       </div>
-
-      {/* Ladder rungs the frames announced but no filed run answers yet (a node whose run has
-          not been dispatched, or whose filing the snapshot has not caught up with). */}
-      {(live?.nodeOrder ?? []).filter((id) => {
-        const n = live?.nodes[id];
-        return n !== undefined && (n.runId === null || !detail.runs.some((r) => r.runId === n.runId));
-      }).length > 0 && (
-        <div style={{ marginTop: '12px' }} data-testid="campaign-pending-nodes">
-          {(live?.nodeOrder ?? [])
-            .filter((id) => {
-              const n = live?.nodes[id];
-              return n !== undefined && (n.runId === null || !detail.runs.some((r) => r.runId === n.runId));
-            })
-            .map((id) => {
-              const n = live!.nodes[id]!;
-              const s = NODE_STATUS_STYLE[n.status] ?? { label: n.status, color: 'var(--ink-dim)' };
-              return (
-                <div key={id} data-testid="campaign-pending-node" style={{ display: 'flex', gap: '10px', alignItems: 'center', padding: '4px 0' }}>
-                  <Chip testid="campaign-node-status" label={s.label} color={s.color} extra={{ 'data-status-source': 'frame' }} title={n.prompt ?? undefined} />
-                  <span style={{ color: 'var(--ink-muted)', fontSize: 'var(--text-sm)' }}>{id}</span>
-                </div>
-              );
-            })}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -1,40 +1,49 @@
 import { useEffect, useMemo, useState } from 'react';
 import { campaignPath } from '../api/testing.js';
-import type { CampaignSummary, CampaignCounts } from '../api/campaigns.js';
 import type { SessionView } from '../api/types.js';
 import {
-  campaignActivitySeries, campaignCards, campaignCreatedDelta, campaignProgressWord,
-  campaignRunIdSet, campaignTotals, matchesCampaignChip, passRateHealth, passRateWord,
+  campaignCards, campaignTotals, deliveryRollupWord, matchesCampaignChip, memberRunIdSet,
+  passRateHealth, passRateWord, progressWord,
   type CampaignCardModel, type CampaignChip,
 } from '../board/campaignStats.js';
+import { recentActivity } from '../board/homeActivity.js';
 import { outcomeOf } from '../board/metrics.js';
 import { healthColor, windowBuckets, windowDelta, deltaWord } from '../board/windowStats.js';
 import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useCampaignsStore } from '../store/campaigns.js';
+import { useRunEventStore } from '../store/events.js';
+import { useRuntimeStore } from '../store/runtime.js';
 import {
   DashboardGrid, FilterStrip, KpiBand, KpiGroup, StatTile, type FilterChip,
 } from './dashboardKit.js';
-import { ago } from './ProjectCard.js';
+import { TONE_COLOR, TONE_GLYPH, type NarrationLine } from './narrator.js';
+import { runShortId } from './runIdentity.js';
 import { AuthorPanel } from './SteeringAuthorPanel.js';
 import { TestingLaunchPanel } from './TestingLaunchPanel.js';
 
 /**
- * `/testing/campaigns` — THE Testing landing (the testing-UX wave), rebuilt as a COMMAND
- * SURFACE with the section-dashboard kit (`dashboardKit`, zero forks — the /projects //make
- * grammar): a KPI band under the three operator questions, the creation verbs in the header
- * (the retired Harness folded in: Run recon / New campaign / Add with chat — one panel open
- * at a time, the management-bar grammar), then a filterable grid of campaign cards, each the
- * scoreboard's stats condensed and a door to it.
+ * `/testing/campaigns` — THE Testing landing (the testing-UX wave), a COMMAND SURFACE with
+ * the section-dashboard kit (`dashboardKit`, zero forks — the /projects //make grammar): a
+ * KPI band under the three operator questions, the creation verbs in the header (Run recon /
+ * New campaign / Add with chat — one panel open at a time), then a filterable grid where
+ * engine campaigns AND ad-hoc label groups (wicked-studio#27, api-types 0.19.0) render as one
+ * sorted set of cards — needs-you first, attention routing before navigation.
  *
  * Every number derives from state the surface already holds — the store's ONE
- * `GET /campaigns` (server aggregates over the FULL filed set, §4.2) plus the app's live run
- * list — through the pure folds in `board/campaignStats.ts`. Campaign clocks are real, so the
- * campaigns tile's delta/spark are time-based (14d); run-derived tiles keep the positional
- * window idiom, honestly labeled ("last 30", never "30d"). The §1.5 probe keeps its three
- * honest states — probing / supported / unsupported, never a boolean — and the creation verbs
- * stay usable on an unsupported daemon (launching rides `POST /testing/recon` with
- * `launchTestingRun`'s presence-gated `POST /runs` fallback; only the LISTING needs the
- * campaigns route).
+ * `GET /campaigns` (engine campaigns + `groups`) plus the app's live run list — through the
+ * pure folds in `board/campaignStats.ts`. The engine campaign carries NO clocks, so no tile
+ * fabricates a time series; run-derived tiles keep the positional window idiom, honestly
+ * labeled ("last 30", never "30d"). The §1.5 probe keeps its three honest states — probing /
+ * supported / unsupported, never a boolean — and the creation verbs stay usable on an
+ * unsupported daemon.
+ *
+ * What each card adds for #27's remainder:
+ *  - the DELIVERY ROLLUP ("n of N delivered") off the wire-carried per-member facts, with
+ *    per-sibling PR links (every href `isPrUrl`-gated in the fold) and stranded siblings
+ *    surfaced as needs-you;
+ *  - a LIVE NARRATION line — the freshest member-run CoreEvent this client observed, spoken
+ *    by `narrator.ts` via the home board's `recentActivity` fold (ONE template source, zero
+ *    per-surface wording forks; absence stays absent).
  */
 
 const S = {
@@ -53,16 +62,20 @@ const CARD_STAT: React.CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
+/** Most per-sibling PR links a card renders inline; the rest fold into a "+n" word. */
+const CARD_PR_CAP = 4;
+
 /** The scoreboard's segmented status bar, condensed onto the card — real counts, no series. */
-function StatusBar({ counts, expected }: { counts: CampaignCounts; expected: number | null }): React.ReactElement | null {
+function StatusBar({ m }: { m: CampaignCardModel }): React.ReactElement | null {
+  const rest = Math.max(0, m.total - m.landed - m.failed - m.awaitingHuman - m.running);
   const seg = [
-    { n: counts.landed, color: 'var(--status-done)' },
-    { n: counts.failed, color: 'var(--status-fail)' },
-    { n: counts.awaitingHuman, color: 'var(--status-gate)' },
-    { n: counts.running, color: 'var(--status-run)' },
-    { n: counts.cancelled + counts.other, color: 'var(--ink-dim)' },
+    { n: m.landed, color: 'var(--status-done)' },
+    { n: m.failed, color: 'var(--status-fail)' },
+    { n: m.awaitingHuman, color: 'var(--status-gate)' },
+    { n: m.running, color: 'var(--status-run)' },
+    { n: rest, color: 'var(--ink-dim)' },
   ];
-  const total = Math.max(1, expected ?? counts.filed, seg.reduce((a, s) => a + s.n, 0));
+  const total = Math.max(1, m.total);
   if (seg.every((s) => s.n === 0)) return null;
   return (
     <div
@@ -77,34 +90,69 @@ function StatusBar({ counts, expected }: { counts: CampaignCounts; expected: num
   );
 }
 
-/** One campaign as a mini-scoreboard row — the card IS a door to its scoreboard. */
-function CampaignCard({ m, navigate, now }: {
+/**
+ * The card's one-line live narration — the freshest member-run CoreEvent, spoken by the ONE
+ * narrator template layer. `null` (absent, never a placeholder) when this client has observed
+ * nothing for any member run.
+ */
+function CardNarration({ line, runId }: { line: NarrationLine; runId: string }): React.ReactElement {
+  return (
+    <div
+      data-testid="campaign-card-narration"
+      data-run-id={runId}
+      data-tone={line.tone}
+      style={{
+        display: 'flex', alignItems: 'baseline', gap: '6px', minWidth: 0,
+        fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+      }}
+    >
+      <span aria-hidden style={{ color: TONE_COLOR[line.tone], flexShrink: 0 }}>
+        {TONE_GLYPH[line.tone]}
+      </span>
+      <span style={{
+        color: TONE_COLOR[line.tone], overflow: 'hidden', textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap', minWidth: 0,
+      }}>
+        {line.text}
+      </span>
+      <span style={{ color: 'var(--ink-dim)', flexShrink: 0 }}>{runShortId(runId)}</span>
+    </div>
+  );
+}
+
+/** One campaign or ad-hoc group as a mini-scoreboard row. A campaign card IS a door to its
+ *  scoreboard; a group has no detail route, so its member runs link out directly. */
+function CampaignCard({ m, narration, navigate }: {
   m: CampaignCardModel;
+  narration: { runId: string; line: NarrationLine } | null;
   navigate: (path: string) => void;
-  now: number;
 }): React.ReactElement {
-  const s = m.summary;
-  const { counts } = s;
-  const health = passRateHealth(counts.landed, counts.landed + counts.failed + counts.cancelled);
+  const health = passRateHealth(m.landed, m.landed + m.failed);
   // The gate jump: STRAIGHT to the waiting run's page, where the approval dock is pinned —
-  // when the live list still holds one; otherwise the scoreboard names the waiting sibling.
+  // when the live list still holds one; otherwise the campaign's own surface.
   const firstWaiting = m.waiting[0]?.session.id ?? null;
+  const rollupWord = deliveryRollupWord(m.rollup);
+  const isCampaign = m.kind === 'campaign';
+  const open = (): void => {
+    if (isCampaign) navigate(campaignPath(m.id));
+  };
 
   return (
     <div
       data-testid="campaign-card"
-      data-campaign-id={s.campaign.id}
-      data-gates={counts.awaitingHuman}
-      data-runs={counts.filed}
-      role="link"
-      tabIndex={0}
-      onClick={() => navigate(campaignPath(s.campaign.id))}
-      onKeyDown={(e) => { if (e.key === 'Enter') navigate(campaignPath(s.campaign.id)); }}
-      className="transition-colors hover:bg-surface-raised"
+      data-kind={m.kind}
+      data-campaign-id={m.id}
+      data-gates={m.awaitingHuman}
+      data-runs={m.total}
+      {...(isCampaign ? { role: 'link', tabIndex: 0 } : {})}
+      onClick={open}
+      onKeyDown={(e) => { if (e.key === 'Enter') open(); }}
+      className={isCampaign ? 'transition-colors hover:bg-surface-raised' : undefined}
       style={{
         display: 'flex', flexDirection: 'column', gap: '8px', minWidth: 0,
         background: S.card, border: `1px solid ${S.border}`,
-        borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', cursor: 'pointer',
+        borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)',
+        cursor: isCampaign ? 'pointer' : 'default',
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
@@ -112,19 +160,27 @@ function CampaignCard({ m, navigate, now }: {
           fontSize: 'var(--text-sm)', fontWeight: 'var(--weight-semi)', color: S.ink,
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
         }}>
-          {s.campaign.title ?? s.campaign.id}
+          {m.title}
         </span>
-        {counts.awaitingHuman > 0 && (
+        {!isCampaign && (
+          <span style={{ ...CARD_STAT, color: S.faint, flexShrink: 0 }} title="An ad-hoc label group — runs launched under one groupLabel; no scheduler, no DAG.">
+            group
+          </span>
+        )}
+        {m.awaitingHuman > 0 && (
           <button
             type="button"
             data-testid="campaign-needs-you"
             {...(firstWaiting !== null ? { 'data-run-id': firstWaiting } : {})}
             title={firstWaiting !== null
               ? 'A sibling run is waiting on you — jump to its approval dock'
-              : 'A sibling run is waiting on you — open the scoreboard'}
+              : isCampaign
+                ? 'A sibling run is waiting on you — open the scoreboard'
+                : 'A sibling run is waiting on you'}
             onClick={(e) => {
               e.stopPropagation();
-              navigate(firstWaiting !== null ? `/runs/${encodeURIComponent(firstWaiting)}` : campaignPath(s.campaign.id));
+              if (firstWaiting !== null) navigate(`/runs/${encodeURIComponent(firstWaiting)}`);
+              else if (isCampaign) navigate(campaignPath(m.id));
             }}
             style={{
               marginLeft: 'auto', flexShrink: 0, cursor: 'pointer',
@@ -134,49 +190,106 @@ function CampaignCard({ m, navigate, now }: {
               fontWeight: 'var(--weight-bold)', color: 'var(--status-gate)',
             }}
           >
-            needs you · {counts.awaitingHuman} →
+            needs you · {m.awaitingHuman} →
           </button>
         )}
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-        {/* §3.3 denominator honesty — the scoreboard's exact two strings. */}
+        {/* §3.3 denominator honesty — a campaign's DAG is declared; a group's grows ("so far"). */}
         <span style={{ ...CARD_STAT, color: S.ink }} data-testid="campaign-card-progress">
-          {campaignProgressWord(s)}
+          {progressWord(m)}
         </span>
-        {counts.landed + counts.failed + counts.cancelled > 0 && (
+        {m.landed + m.failed > 0 && (
           <span
             style={{ ...CARD_STAT, color: healthColor(health) ?? CARD_STAT.color }}
             data-testid="campaign-card-split"
             data-health={health}
-            title={`${counts.landed} landed, ${counts.failed} failed, ${counts.cancelled} cancelled of ${counts.filed} filed`}
+            title={`${m.landed} landed, ${m.failed} failed of ${m.total}`}
           >
-            ✓{counts.landed} · ✕{counts.failed}
+            ✓{m.landed} · ✕{m.failed}
           </span>
         )}
-        {counts.running > 0 && (
-          <span style={{ ...CARD_STAT, color: 'var(--status-run)' }}>{counts.running} running</span>
+        {m.running > 0 && (
+          <span style={{ ...CARD_STAT, color: 'var(--status-run)' }}>{m.running} running</span>
         )}
-        <span style={{ ...CARD_STAT, marginLeft: 'auto' }} title="last activity (newest launch filed, or newest metadata write)">
-          {ago(s.campaign.updated_at, now)} ago
-        </span>
       </div>
 
-      <StatusBar counts={counts} expected={s.campaign.expected} />
+      <StatusBar m={m} />
+
+      {/* ── The delivery rollup — wire facts only; absent on a pre-0.19 daemon ── */}
+      {rollupWord !== null && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+          <span data-testid="campaign-card-delivery" style={{ ...CARD_STAT, color: S.ink }}>
+            {rollupWord}
+          </span>
+          {m.rollup.prs.slice(0, CARD_PR_CAP).map((pr) => (
+            <a
+              key={pr.runId + pr.href}
+              data-testid="campaign-card-pr"
+              data-run-id={pr.runId}
+              href={pr.href}
+              target="_blank"
+              rel="noreferrer"
+              title={`${runShortId(pr.runId)} — ${pr.href}`}
+              onClick={(e) => e.stopPropagation()}
+              style={{ ...CARD_STAT, color: S.accent, textDecoration: 'underline' }}
+            >
+              #{pr.href.split('/').pop()}
+            </a>
+          ))}
+          {m.rollup.prs.length > CARD_PR_CAP && (
+            <span style={CARD_STAT} title="More PRs — open the scoreboard for the full ladder">
+              +{m.rollup.prs.length - CARD_PR_CAP} more
+            </span>
+          )}
+          {m.rollup.stranded.length > 0 && (
+            <button
+              type="button"
+              data-testid="campaign-card-stranded"
+              data-run-id={m.rollup.stranded[0]!.runId}
+              title={`Finished, but the work is stranded in its worktree — no PR: ${m.rollup.stranded.map((s) => s.label).join(', ')}. Open the run to lift it.`}
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/runs/${encodeURIComponent(m.rollup.stranded[0]!.runId)}`);
+              }}
+              style={{
+                cursor: 'pointer', flexShrink: 0,
+                background: 'transparent', border: '1px solid var(--status-gate)',
+                borderRadius: 'var(--radius-full)', padding: '1px 8px',
+                fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                color: 'var(--status-gate)',
+              }}
+            >
+              stranded · {m.rollup.stranded.length}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── Live narration — the freshest member-run frame, narrator-spoken ── */}
+      {narration !== null && <CardNarration line={narration.line} runId={narration.runId} />}
 
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
         <span style={CARD_STAT}>
-          {counts.filed} run{counts.filed === 1 ? '' : 's'}
-          {counts.archived > 0 && ` (${counts.archived} archived)`}
+          {isCampaign
+            ? `${m.total} node${m.total === 1 ? '' : 's'}${m.attached > 0 ? ` · +${m.attached} attached` : ''}`
+            : `${m.total} run${m.total === 1 ? '' : 's'}`}
         </span>
-        {s.projectIds.length > 0 && (
-          <span style={CARD_STAT}>
-            {s.projectIds.length === 1 ? '1 project' : `${s.projectIds.length} projects`}
-          </span>
-        )}
-        {s.prs.length > 0 && (
-          <span style={CARD_STAT}>
-            {s.prs.length}{s.prsTruncated ? '+' : ''} PR{s.prs.length === 1 && !s.prsTruncated ? '' : 's'}
+        {!isCampaign && m.group !== null && (
+          <span style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {m.group.runs.map((r) => (
+              <button
+                key={r.runId}
+                type="button"
+                data-testid="campaign-card-run"
+                data-run-id={r.runId}
+                onClick={(e) => { e.stopPropagation(); navigate(`/runs/${encodeURIComponent(r.runId)}`); }}
+                style={{ ...CARD_STAT, color: S.muted, textDecoration: 'underline', cursor: 'pointer' }}
+              >
+                {runShortId(r.runId)}
+              </button>
+            ))}
           </span>
         )}
       </div>
@@ -185,15 +298,18 @@ function CampaignCard({ m, navigate, now }: {
 }
 
 interface Props {
-  /** The board's live run list — KPI windows and the gate jumps read it, zero extra fetches. */
+  /** The board's live run list — KPI windows, gate jumps and narration read it, zero extra fetches. */
   runs: SessionView[];
   navigate: (path: string) => void;
 }
 
 export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
   const support = useCampaignsStore((s) => s.support);
-  const summaries = useCampaignsStore((s) => s.summaries);
+  const campaigns = useCampaignsStore((s) => s.campaigns);
+  const groups = useCampaignsStore((s) => s.groups);
   const refresh = useCampaignsStore((s) => s.refresh);
+  const byRun = useRunEventStore((s) => s.byRun);
+  const logs = useRuntimeStore((s) => s.logs);
 
   const [panel, setPanel] = useState<PanelKind>(null);
   const openPanel = (p: Exclude<PanelKind, null>): void => setPanel((cur) => (cur === p ? null : p));
@@ -206,39 +322,54 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
     void refresh();
   }, [refresh]);
 
-  const now = Date.now();
-
-  // ── The window (Work page idiom, over the CAMPAIGN-member runs) ─────────────
+  // ── The window (Work page idiom, over the CAMPAIGN/GROUP-member runs) ────────
   const runsById = useMemo(() => {
     const m = new Map<string, SessionView>();
     for (const v of runs) m.set(v.session.id, v);
     return m;
   }, [runs]);
-  const memberIds = useMemo(() => campaignRunIdSet(summaries), [summaries]);
-  const campaignRuns = useMemo(
+  const memberIds = useMemo(() => memberRunIdSet(campaigns, groups), [campaigns, groups]);
+  const memberRuns = useMemo(
     () => runs.filter((v) => v.session.archived_at == null && memberIds.has(v.session.id)),
     [runs, memberIds],
   );
-  const buckets = useMemo(() => windowBuckets(campaignRuns, range), [campaignRuns, range]);
+  const buckets = useMemo(() => windowBuckets(memberRuns, range), [memberRuns, range]);
   const windowIds = useMemo(() => new Set(buckets.current.map((v) => v.session.id)), [buckets]);
 
   // ── KPI folds (pure, board/campaignStats) ───────────────────────────────────
-  const totals = useMemo(() => campaignTotals(summaries), [summaries]);
-  const createdDelta = useMemo(() => campaignCreatedDelta(summaries, 14, now), [summaries, now]);
-  const activitySpark = useMemo(() => campaignActivitySeries(summaries, 14, now), [summaries, now]);
+  const totals = useMemo(() => campaignTotals(campaigns, groups), [campaigns, groups]);
   const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
   const failedDelta = useMemo(
     () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
     [buckets],
   );
-  const firstWaiting = campaignRuns.find((v) => v.session.status === 'awaiting_human')?.session.id ?? null;
+  const firstWaiting = memberRuns.find((v) => v.session.status === 'awaiting_human')?.session.id ?? null;
   const passHealth = passRateHealth(totals.landed, totals.terminal);
 
-  // ── The card models (needs-you first) ───────────────────────────────────────
+  // ── The card models (needs-you first; campaigns and groups, one sorted set) ──
   const cards = useMemo(
-    () => campaignCards(summaries, runsById, windowIds),
-    [summaries, runsById, windowIds],
+    () => campaignCards(campaigns, groups, runsById, windowIds),
+    [campaigns, groups, runsById, windowIds],
   );
+
+  // The freshest member-run narration per card — `recentActivity` capped at 1 (the ONE
+  // narrator fold the home pulse reads; a second derivation could contradict it), clocked by
+  // the runtime log's arrival tail exactly like the home pulse.
+  const narrationByCard = useMemo(() => {
+    const tailAt = (id: string): number | undefined => {
+      const log = logs[id];
+      return log !== undefined && log.length > 0 ? log[log.length - 1]?.ts : undefined;
+    };
+    const out = new Map<string, { runId: string; line: NarrationLine }>();
+    for (const m of cards) {
+      const memberViews = m.memberRunIds
+        .map((id) => runsById.get(id))
+        .filter((v): v is SessionView => v !== undefined);
+      const row = recentActivity(memberViews, byRun, tailAt, 1)[0];
+      if (row !== undefined) out.set(m.id, { runId: row.runId, line: row.line });
+    }
+    return out;
+  }, [cards, runsById, byRun, logs]);
 
   const chipCounts: Record<CampaignChip, number> = useMemo(() => ({
     all: cards.length,
@@ -251,9 +382,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
   const q = query.trim().toLowerCase();
   const filtered = cards.filter((m) =>
     matchesCampaignChip(m, chip)
-    && (q === ''
-      || (m.summary.campaign.title ?? '').toLowerCase().includes(q)
-      || m.summary.campaign.id.toLowerCase().includes(q)));
+    && (q === '' || m.title.toLowerCase().includes(q) || m.id.toLowerCase().includes(q)));
   // The recency window scopes the GRID to campaigns with a member run in it; older campaigns
   // stay one honest chip away ("+N older"), never silently gone — the FilterStrip idiom.
   const visible = range === 'all' ? filtered : filtered.filter((m) => m.inWindow);
@@ -364,11 +493,9 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
           <StatTile
             testId="stat-campaigns"
             label="Campaigns"
-            value={totals.campaigns}
-            delta={createdDelta}
-            context={`${totals.activeNow} active now · created, 14d vs prior`}
-            spark={activitySpark}
-            title="Every campaign on this daemon — click to clear filters"
+            value={totals.campaigns + totals.groups}
+            context={`${totals.activeNow} active now${totals.groups > 0 ? ` · ${totals.groups} ad-hoc group${totals.groups === 1 ? '' : 's'}` : ''}`}
+            title="Every campaign and ad-hoc group on this daemon — click to clear filters"
             onOpen={() => { setChip('all'); setQuery(''); }}
           />
           <StatTile
@@ -463,7 +590,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
         )}
       </FilterStrip>
 
-      {summaries.length === 0 ? (
+      {cards.length === 0 ? (
         // The honest empty state, with the way in: a campaign appears with its first run.
         <div data-testid="campaigns-empty" style={{
           textAlign: 'center', padding: '48px 24px',
@@ -502,12 +629,15 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
       ) : (
         <DashboardGrid testId="campaigns-grid" min={340}>
           {visible.map((m) => (
-            <CampaignCard key={m.summary.campaign.id} m={m} navigate={navigate} now={now} />
+            <CampaignCard
+              key={`${m.kind}:${m.id}`}
+              m={m}
+              narration={narrationByCard.get(m.id) ?? null}
+              navigate={navigate}
+            />
           ))}
         </DashboardGrid>
       )}
     </div>
   );
 }
-
-export type { CampaignSummary };

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -3,6 +3,7 @@ import { api, ApiError } from '../api/client.js';
 import type { EntityMode, LaunchBodyWithDeliver, Project, RepoEntry, RosterSeat, WorkflowDef } from '../api/types.js';
 import { COMPOSER_DEFAULT_GATE_POSTURE } from './composerDefaults.js';
 import { isShortcutsPaletteOpen } from '../hooks/useGlobalShortcuts.js';
+import { useCampaignsStore } from '../store/campaigns.js';
 import { useComposerPrefsStore } from '../store/composerPrefs.js';
 import { useGateStore } from '../store/gates.js';
 import { anyModalOpen, useLayerStore } from '../store/layers.js';
@@ -147,6 +148,32 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // Synchronous guard prevents a second inject from firing before the first
   // setInjecting(true) call re-renders the disabled state.
   const injectInflightRef = useRef(false);
+
+  // ── Ad-hoc grouping (wicked-studio#27, api-types 0.19.0) ───────────────────
+  // ONE structural control, so the wire's mutual exclusivity (campaignId XOR
+  // groupLabel, both ⇒ 400) cannot be violated from here: none, an EXISTING
+  // campaign to attach onto (`c:<id>`), an existing group label (`g:<label>`),
+  // or `new` — a label typed free-form (a group is created on first use, never
+  // pre-registered). DELIBERATELY STICKY across launches: filing several
+  // sibling launches under one label is the feature. Validation stays the
+  // daemon's, loudly — an unknown campaign is a 404 with NOTHING launched, a
+  // pre-0.19 daemon 400s naming the field; both render verbatim in the launch
+  // error, never a silent ungrouped launch.
+  const [groupChoice, setGroupChoice] = useState('');
+  /** The free-text label while `new` is selected (submitted trimmed). */
+  const [newGroupLabel, setNewGroupLabel] = useState('');
+  const knownCampaigns = useCampaignsStore((s) => s.campaigns);
+  const knownGroups = useCampaignsStore((s) => s.groups);
+  const refreshCampaigns = useCampaignsStore((s) => s.refresh);
+  /** The wire keys the current choice resolves to — `{}` for none/blank-label. */
+  const groupAttach = ((): { campaignId?: string; groupLabel?: string } => {
+    if (groupChoice.startsWith('c:')) return { campaignId: groupChoice.slice(2) };
+    if (groupChoice.startsWith('g:')) return { groupLabel: groupChoice.slice(2) };
+    if (groupChoice === 'new' && newGroupLabel.trim() !== '') {
+      return { groupLabel: newGroupLabel.trim() };
+    }
+    return {};
+  })();
 
   // ── Launch form state — a retry prefill seeds the initial values (§4.3);
   //    everything stays fully editable before send. ──────────────────────────
@@ -488,6 +515,12 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // never inferred from prompt equality. The pill above is the operator's
     // way to drop the claim before sending.
     if (retryOf) body.retryOf = retryOf;
+    // Ad-hoc grouping (wicked-studio#27, api-types 0.19.0): provenance only —
+    // the run executes byte-identically. One control ⇒ never both keys. An
+    // empty typed label sends NOTHING (omitting the key is pre-0.19 behavior,
+    // byte for byte) rather than a 400 the operator didn't mean.
+    if (groupAttach.campaignId !== undefined) body.campaignId = groupAttach.campaignId;
+    if (groupAttach.groupLabel !== undefined) body.groupLabel = groupAttach.groupLabel;
 
     try {
       let launched;
@@ -867,6 +900,15 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
       onClear: resetCliSelection,
     });
   }
+  if (groupAttach.campaignId !== undefined || groupAttach.groupLabel !== undefined) {
+    activePills.push({
+      label: groupAttach.campaignId !== undefined
+        ? `Campaign: ${groupAttach.campaignId}`
+        : `Group: ${groupAttach.groupLabel!}`,
+      onClear: () => { setGroupChoice(''); setNewGroupLabel(''); },
+      attrs: { 'data-testid': 'group-pill' },
+    });
+  }
 
   return (
     <div
@@ -900,11 +942,75 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           dropUp={!embedded}
         />
 
+        {/* ── Ad-hoc grouping (wicked-studio#27, api-types 0.19.0): file this
+            launch under an existing campaign, an existing group label, or a
+            new label — ONE control, so campaignId XOR groupLabel is structural.
+            The lists load lazily on first interaction (the ProjectSwitcher
+            idiom); a daemon that predates campaigns simply lists none, and the
+            typed-label path still works where the daemon accepts the field. ── */}
+        <span
+          className="text-[11px] font-mono uppercase tracking-widest ml-auto"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          Group
+        </span>
+        <select
+          data-testid="group-attach"
+          aria-label="File this run under a campaign or group"
+          title="Attach this launch to a campaign or an ad-hoc group — provenance only, the run executes unchanged"
+          className="rounded-lg px-2 py-1 text-[11px] font-mono"
+          style={{
+            background: 'var(--surface-card)',
+            border: '1px solid var(--surface-raised)',
+            color: 'var(--ink-high)',
+            maxWidth: '160px',
+          }}
+          value={groupChoice}
+          onMouseDown={() => void refreshCampaigns()}
+          onChange={(e) => setGroupChoice(e.target.value)}
+        >
+          <option value="">none</option>
+          {knownCampaigns.length > 0 && (
+            <optgroup label="campaigns">
+              {knownCampaigns.map((c) => (
+                <option key={c.id} value={`c:${c.id}`}>
+                  {c.def.name !== '' ? c.def.name : c.id}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {knownGroups.length > 0 && (
+            <optgroup label="groups">
+              {knownGroups.map((g) => (
+                <option key={g.label} value={`g:${g.label}`}>{g.label}</option>
+              ))}
+            </optgroup>
+          )}
+          <option value="new">new group…</option>
+        </select>
+        {groupChoice === 'new' && (
+          <input
+            data-testid="group-label-input"
+            aria-label="New group label"
+            value={newGroupLabel}
+            onChange={(e) => setNewGroupLabel(e.target.value)}
+            placeholder="group label…"
+            maxLength={200}
+            className="rounded-lg px-2 py-1 text-[11px] font-mono"
+            style={{
+              background: 'var(--surface-card)',
+              border: '1px solid var(--surface-raised)',
+              color: 'var(--ink-high)',
+              width: '140px',
+            }}
+          />
+        )}
+
         {/* ── Gate posture at top level (§7.8, slice AC) — the + drawer keeps
             the full matrix; this is the always-visible control whose shipped
             default is COMPOSER_DEFAULT_GATE_POSTURE (never "none"). ── */}
         <span
-          className="text-[11px] font-mono uppercase tracking-widest ml-auto"
+          className="text-[11px] font-mono uppercase tracking-widest"
           style={{ color: 'var(--ink-dim)' }}
         >
           Gate

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import { listCampaigns, type CampaignSummary } from '../api/campaigns.js';
+import { listCampaigns, type Campaign } from '../api/campaigns.js';
 import { getDiagnostics, type Diagnostics } from '../api/diagnostics.js';
 import type { SteeringRule } from '../api/steering.js';
 import type { GovernanceClaim, SessionView } from '../api/types.js';
@@ -133,7 +133,7 @@ function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate, cursor }:
  *  unless) each answers; absence degrades the feature, never the page. */
 interface HomeWires {
   chats: LiveChatSnapshot[] | null;
-  campaigns: CampaignSummary[] | null;
+  campaigns: Campaign[] | null;
   claims: GovernanceClaim[] | null;
   rules: SteeringRule[] | null;
   perRule: WikiRuleEvidenceRow[] | null;

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { listCampaigns, type CampaignSummary } from '../api/campaigns.js';
+import { listCampaigns, type Campaign, type RunGroup } from '../api/campaigns.js';
 import type { CoreEvent } from '../api/types.js';
 
 /**
@@ -75,8 +75,10 @@ const CAMPAIGN_STATUS_BY_TYPE: Record<string, CampaignLiveStatus> = {
 
 interface CampaignsStore {
   support: CampaignSupport;
-  /** `GET /campaigns` rows, server-ordered (newest-updated first). */
-  summaries: CampaignSummary[];
+  /** `GET /campaigns` rows, server-ordered. */
+  campaigns: Campaign[];
+  /** Ad-hoc label groups (api-types 0.19.0) — `[]` on a pre-0.19 daemon (normalized). */
+  groups: RunGroup[];
   /** Live frame fold, keyed by campaign id. */
   live: Record<string, CampaignLive>;
   /** Probe + (re)fetch the list. Sets `support` from the answer (§1.5). */
@@ -90,19 +92,20 @@ let inflight: Promise<void> | null = null;
 
 export const useCampaignsStore = create<CampaignsStore>((set) => ({
   support: 'unknown',
-  summaries: [],
+  campaigns: [],
+  groups: [],
   live: {},
 
   refresh: () => {
     if (inflight !== null) return inflight;
     inflight = listCampaigns()
-      .then(({ campaigns }) => {
-        set({ support: 'supported', summaries: campaigns });
+      .then(({ campaigns, groups }) => {
+        set({ support: 'supported', campaigns, groups });
       })
       .catch(() => {
-        // 404 = the route does not exist on this daemon (§1.5's whole discriminator);
+        // 404/501 = this daemon predates campaigns (§1.5's whole discriminator);
         // anything else (network, 500) also reads as unsupported — said once, not spun on.
-        set({ support: 'unsupported', summaries: [] });
+        set({ support: 'unsupported', campaigns: [], groups: [] });
       })
       .finally(() => {
         inflight = null;

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.9",
   "counts": {
     "files": 117,
-    "occurrences": 942,
-    "static": 806,
+    "occurrences": 947,
+    "static": 811,
     "dynamic": 43,
     "computed": 6
   },
@@ -530,7 +530,31 @@
       ]
     },
     {
+      "testId": "campaign-card-delivery",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-card-narration",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-card-pr",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
       "testId": "campaign-card-progress",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-card-run",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]
@@ -542,9 +566,9 @@
       ]
     },
     {
-      "testId": "campaign-cost-cell",
+      "testId": "campaign-card-stranded",
       "files": [
-        "src/components/CampaignScoreboard.tsx"
+        "src/components/CampaignsPage.tsx"
       ]
     },
     {
@@ -597,18 +621,6 @@
     },
     {
       "testId": "campaign-notfound",
-      "files": [
-        "src/components/CampaignScoreboard.tsx"
-      ]
-    },
-    {
-      "testId": "campaign-pending-node",
-      "files": [
-        "src/components/CampaignScoreboard.tsx"
-      ]
-    },
-    {
-      "testId": "campaign-pending-nodes",
       "files": [
         "src/components/CampaignScoreboard.tsx"
       ]
@@ -1785,6 +1797,24 @@
       "testId": "graph-node-stats",
       "files": [
         "src/components/RepoGraphModal.tsx"
+      ]
+    },
+    {
+      "testId": "group-attach",
+      "files": [
+        "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "group-label-input",
+      "files": [
+        "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "group-pill",
+      "files": [
+        "src/components/ChatInput.tsx"
       ]
     },
     {

--- a/tests/CampaignScoreboard.test.tsx
+++ b/tests/CampaignScoreboard.test.tsx
@@ -2,20 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { CoreEvent, SessionView } from '../src/api/types.js';
 import type { SessionWithDelivery } from '../src/api/types.js';
-import type { CampaignDetail } from '../src/api/campaigns.js';
+import { attachedRun, makeCampaign, type NodeFixture } from './campaignFactories.js';
 import { makeUnit, makeView } from './factories.js';
 
 /**
  * The campaign scoreboard (TH-14, extends studio#27) — ONE surface groups a campaign's
- * sibling runs, demo-able entirely off mocked wire payloads + mocked Campaign* frames.
- * Pinned here:
- *   - the ladder is one row per filed sibling, joined live to the run list;
- *   - the delivery rollup reads `session.delivery` (crew#321) / the detail's server-resolved
- *     prUrl — NEVER a per-run transcript fetch (asserted: zero network calls on render);
+ * sibling runs, over the REAL wire (`GET /campaigns/:id` → the engine Campaign + the
+ * daemon-joined 0.19.0 rollup fields), demo-able entirely off mocked payloads + mocked
+ * Campaign* frames. Pinned here:
+ *   - the ladder is one row per DAG node (undispatched included), attached runs after,
+ *     marked as provenance;
+ *   - the delivery rollup reads `node_delivery`/`attached_runs` + the live list's
+ *     `session.delivery` — NEVER a per-run transcript fetch (asserted: zero network calls);
+ *   - every PR href passes the isPrUrl shape gate, whichever wire carried it;
  *   - node status flips LIVE off Campaign* frames (data-status-source="frame");
  *   - verdict chips load behind ONE explicit gesture, terminal rows only;
- *   - §3.3 denominator honesty ("of N landed" vs "of N landed so far" — two strings);
- *   - the cost column is an honest "—" until TH-20's wire exists;
  *   - an unknown campaign states the fact and offers /campaigns, never a spinner.
  */
 
@@ -36,42 +37,15 @@ const { ApiError } = await import('../src/api/errors.js');
 const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
   ({ type, ...fields }) as CoreEvent;
 
-function detail(over: Partial<CampaignDetail['campaign']> = {}, runs: CampaignDetail['runs'] = []): CampaignDetail {
-  return {
-    campaign: { id: 'DES-X', title: null, expected: null, created_at: 1, updated_at: 2, ...over },
-    runs,
-    counts: {
-      filed: runs.length,
-      landed: runs.filter((r) => r.status === 'completed').length,
-      failed: 0,
-      cancelled: 0,
-      running: 0,
-      awaitingHuman: 0,
-      other: 0,
-      archived: runs.filter((r) => r.archived).length,
-    },
-  };
-}
+const campaign = (nodes: NodeFixture[], over = {}) => makeCampaign('DES-X', nodes, over);
 
-const row = (
-  runId: string,
-  over: Partial<CampaignDetail['runs'][number]> = {},
-): CampaignDetail['runs'][number] => ({
-  runId,
-  status: 'completed',
-  projectId: null,
-  problem: `problem of ${runId}`,
-  filed_at: 10,
-  archived: false,
-  ...over,
-});
-
-/** A sibling that DELIVERED: approved deliver unit + the wire-carried session.delivery. */
+/** A sibling that DELIVERED per the LIVE run list: the 0.18.0 wire string + url. */
 function deliveredView(id: string, url: string): SessionView {
   const v = makeView({ id, status: 'completed' }, [
     makeUnit({ id: `wf-${id}:deliver`, session_id: id, status: 'done' }),
   ]);
-  (v.session as SessionWithDelivery).delivery = { kind: 'pull_request', url };
+  (v.session as SessionWithDelivery).delivery = 'delivered';
+  (v.session as SessionWithDelivery).deliverUrl = url;
   return v;
 }
 
@@ -82,7 +56,7 @@ beforeEach(() => {
   getRunAcceptance.mockReset();
   fetchSpy.mockClear();
   vi.stubGlobal('fetch', fetchSpy);
-  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
   useAcceptanceStore.setState({ byRun: {} });
 });
 afterEach(() => {
@@ -95,31 +69,34 @@ function board(runs: SessionView[], navigate: (p: string) => void = () => {}) {
 }
 
 describe('one surface groups the sibling runs', () => {
-  it('renders one ladder row per filed sibling — live, archived and gone alike', async () => {
-    getCampaign.mockResolvedValue(
-      detail({ expected: 3 }, [
-        row('r1'),
-        row('r2', { status: 'executing' }),
-        row('r3', { archived: true, prUrl: 'https://github.com/o/x/pull/7' }),
-      ]),
-    );
+  it('renders one ladder row per DAG node — live, gone and undispatched alike — then the attached provenance rows', async () => {
+    getCampaign.mockResolvedValue(campaign(
+      [
+        { id: 'n-api', status: 'completed', runId: 'r1' },
+        { id: 'n-ui', status: 'running', runId: 'r2' },
+        { id: 'n-later' }, // declared, not yet dispatched — still a rung
+      ],
+      { attached_runs: [attachedRun('r-adhoc', { status: 'executing', delivery: 'none' })] },
+    ));
     board([deliveredView('r1', 'https://github.com/o/x/pull/5'), makeView({ id: 'r2', status: 'executing' })]);
 
     await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
-    const rows = screen.getAllByTestId('campaign-ladder-row').map((r) => r.getAttribute('data-run-id'));
-    expect(rows).toEqual(['r1', 'r2', 'r3']);
-    // The archived sibling is stated, never dropped (§4.2's whole argument).
-    expect(screen.getByText('archived')).toBeInTheDocument();
+    const rows = screen.getAllByTestId('campaign-ladder-row');
+    expect(rows.map((r) => r.getAttribute('data-run-id'))).toEqual(['r1', 'r2', null, 'r-adhoc']);
+    expect(rows.map((r) => r.getAttribute('data-kind'))).toEqual(['node', 'node', 'node', 'attached']);
+    // The attached run is provenance, said so on the row.
+    expect(rows[3]!.textContent).toContain('attached');
   });
 
-  it('the delivery rollup reads session.delivery + the snapshot prUrl — ZERO fetches', async () => {
-    getCampaign.mockResolvedValue(
-      detail({ expected: 3 }, [
-        row('r1'),
-        row('r2', { status: 'executing' }),
-        row('r3', { archived: true, prUrl: 'https://github.com/o/x/pull/7' }),
-      ]),
-    );
+  it('the delivery rollup reads the wire facts + session.delivery — ZERO fetches', async () => {
+    getCampaign.mockResolvedValue(campaign(
+      [
+        { id: 'n1', status: 'completed', runId: 'r1', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/5' } },
+        { id: 'n2', status: 'running', runId: 'r2' },
+        // Archived/gone from the live list — the daemon-joined snapshot still answers (§4.2).
+        { id: 'n3', status: 'completed', runId: 'r3', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/7' } },
+      ],
+    ));
     board([deliveredView('r1', 'https://github.com/o/x/pull/5'), makeView({ id: 'r2', status: 'executing' })]);
 
     await waitFor(() =>
@@ -129,34 +106,51 @@ describe('one surface groups the sibling runs', () => {
     // beyond the mocked GET /campaigns/:id this surface owns.
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(getRunAcceptance).not.toHaveBeenCalled();
-    // The wire-carried url renders as the linkable PR claim on the delivered row.
     const links = screen.getAllByRole('link');
+    // The live sibling's wire-carried url renders as the linkable PR claim.
     expect(links.map((l) => l.getAttribute('href'))).toContain('https://github.com/o/x/pull/5');
-    // The archived row's server-resolved snapshot url is linkable too (§4.3).
+    // The gone sibling's daemon-joined snapshot url is linkable too.
     expect(links.map((l) => l.getAttribute('href'))).toContain('https://github.com/o/x/pull/7');
   });
 
-  it('§3.3 denominator honesty: expected set vs unset are two DIFFERENT strings', async () => {
-    getCampaign.mockResolvedValue(detail({ expected: 18 }, [row('r1')]));
+  it('a snapshot url that fails the isPrUrl shape gate never becomes an anchor', async () => {
+    getCampaign.mockResolvedValue(campaign([
+      { id: 'n1', status: 'completed', runId: 'r-gone', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/new/branch' } },
+    ]));
+    board([]);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('a stranded sibling is surfaced on the header chip AND its row', async () => {
+    getCampaign.mockResolvedValue(campaign([
+      { id: 'n1', status: 'completed', runId: 'r1', delivery: { delivery: 'stranded' } },
+      { id: 'n2', status: 'completed', runId: 'r2', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/9' } },
+    ]));
+    board([]);
+    await waitFor(() => expect(screen.getByTestId('campaign-stranded-chip')).toBeInTheDocument());
+    expect(screen.getByTestId('campaign-stranded-chip').textContent).toContain('stranded · 1');
+    // The row itself wears the daemon's own word.
+    const cells = screen.getAllByTestId('campaign-run-delivery').map((c) => c.textContent);
+    expect(cells).toContain('stranded');
+  });
+
+  it('the campaign DAG is a DECLARED denominator — "n of N landed", never "so far"', async () => {
+    getCampaign.mockResolvedValue(campaign([
+      { id: 'n1', status: 'completed', runId: 'r1' }, { id: 'n2', status: 'running' }, { id: 'n3' },
+    ]));
     board([]);
     await waitFor(() =>
-      expect(screen.getByTestId('campaign-progress').textContent).toContain('1 of 18 landed'),
+      expect(screen.getByTestId('campaign-progress').textContent).toContain('1 of 3 landed'),
     );
     expect(screen.getByTestId('campaign-progress').textContent).not.toContain('so far');
-    cleanup();
-
-    getCampaign.mockResolvedValue(detail({ expected: null }, [row('r1')]));
-    board([]);
-    await waitFor(() =>
-      expect(screen.getByTestId('campaign-progress').textContent).toContain('1 of 1 landed so far'),
-    );
   });
 });
 
 describe('node status from Campaign* WS frames (mocked — the TH-9 wire shape)', () => {
-  it('a campaignNodeStarted frame flips the joined row to frame-sourced Executing, live', async () => {
-    getCampaign.mockResolvedValue(detail({}, [row('r1', { status: 'planning' })]));
-    board([makeView({ id: 'r1', status: 'planning' })]);
+  it('a campaignNodeStarted frame flips the node row to frame-sourced Executing, live', async () => {
+    getCampaign.mockResolvedValue(campaign([{ id: 'n-r1', status: 'pending', runId: 'r1' }]));
+    board([]);
     await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
 
     act(() => {
@@ -168,50 +162,53 @@ describe('node status from Campaign* WS frames (mocked — the TH-9 wire shape)'
     await waitFor(() => {
       const chip = screen
         .getAllByTestId('campaign-node-status')
-        .find((c) => c.closest('[data-run-id]')?.getAttribute('data-run-id') === 'r1');
+        .find((c) => c.closest('[data-node-id]')?.getAttribute('data-node-id') === 'n-r1');
       expect(chip?.getAttribute('data-status-source')).toBe('frame');
       expect(chip?.textContent).toBe('Executing');
     });
   });
 
-  it('an awaitingHuman frame carries its prompt onto the chip; nodes with no filed run render as pending rungs', async () => {
-    getCampaign.mockResolvedValue(detail({}, [row('r1', { status: 'executing' })]));
-    board([makeView({ id: 'r1', status: 'executing' })]);
+  it('an awaitingHuman frame carries its prompt onto the chip', async () => {
+    getCampaign.mockResolvedValue(campaign([{ id: 'n-r1', status: 'running', runId: 'r1' }]));
+    board([]);
     await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
 
     act(() => {
       useCampaignsStore.getState().ingest(
         frame('campaignNodeAwaitingHuman', { campaign: 'DES-X', node: 'n-r1', runId: 'r1', prompt: 'approve AC-3?' }),
       );
-      useCampaignsStore.getState().ingest(frame('campaignNodeReady', { campaign: 'DES-X', node: 'n-later' }));
     });
 
     await waitFor(() => {
       const chip = screen
         .getAllByTestId('campaign-node-status')
-        .find((c) => c.closest('[data-run-id]')?.getAttribute('data-run-id') === 'r1');
+        .find((c) => c.closest('[data-node-id]')?.getAttribute('data-node-id') === 'n-r1');
       expect(chip?.textContent).toBe('Awaiting human');
       expect(chip?.getAttribute('title')).toBe('approve AC-3?');
     });
-    expect(screen.getByTestId('campaign-pending-nodes').textContent).toContain('n-later');
   });
 
-  it('campaign-level frames render the live-status chip', async () => {
-    getCampaign.mockResolvedValue(detail({}, [row('r1')]));
+  it('campaign-level frames override the wire status chip', async () => {
+    getCampaign.mockResolvedValue(campaign([{ id: 'n1', status: 'running', runId: 'r1' }]));
     board([]);
-    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('campaign-live-status').textContent).toBe('running'));
+    expect(screen.getByTestId('campaign-live-status').getAttribute('data-status-source')).toBe('snapshot');
     act(() => {
       useCampaignsStore.getState().ingest(frame('campaignPaused', { campaign: 'DES-X' }));
     });
     await waitFor(() => expect(screen.getByTestId('campaign-live-status').textContent).toBe('paused'));
+    expect(screen.getByTestId('campaign-live-status').getAttribute('data-status-source')).toBe('frame');
   });
 });
 
 describe('verdict chips — per-run acceptance behind ONE explicit gesture', () => {
-  it('zero acceptance reads on render; the gesture fires exactly one per TERMINAL sibling', async () => {
-    getCampaign.mockResolvedValue(
-      detail({}, [row('r1'), row('r2', { status: 'executing' }), row('r3', { status: 'failed' })]),
-    );
+  it('zero acceptance reads on render; the gesture fires exactly one per TERMINAL sibling with a run', async () => {
+    getCampaign.mockResolvedValue(campaign([
+      { id: 'n1', status: 'completed', runId: 'r1' },
+      { id: 'n2', status: 'running', runId: 'r2' },
+      { id: 'n3', status: 'failed', runId: 'r3' },
+      { id: 'n4' }, // undispatched — no run to read
+    ]));
     getRunAcceptance.mockImplementation((id: string) =>
       Promise.resolve({
         runId: id,
@@ -227,7 +224,7 @@ describe('verdict chips — per-run acceptance behind ONE explicit gesture', () 
 
     fireEvent.click(screen.getByTestId('campaign-load-verdicts'));
     await waitFor(() => expect(screen.getAllByTestId('campaign-verdict-chip')).toHaveLength(2));
-    // Exactly the terminal siblings — never the executing one.
+    // Exactly the terminal siblings — never the executing one, never a run-less node.
     expect(getRunAcceptance.mock.calls.map((c) => c[0]).sort()).toEqual(['r1', 'r3']);
 
     const chips = screen.getAllByTestId('campaign-verdict-chip');
@@ -249,11 +246,10 @@ describe('honest degradation', () => {
     expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
   });
 
-  it('the cost column renders an honest "—" until TH-20 wires per-node cost', async () => {
-    getCampaign.mockResolvedValue(detail({}, [row('r1'), row('r2', { cost: 1.5 })]));
+  it('a pre-0.19 payload (no node_delivery) renders NO delivery rollup — absence, never "0 of N"', async () => {
+    getCampaign.mockResolvedValue(campaign([{ id: 'n1', status: 'completed', runId: 'r1' }]));
     board([]);
-    await waitFor(() => expect(screen.getAllByTestId('campaign-cost-cell')).toHaveLength(2));
-    const cells = screen.getAllByTestId('campaign-cost-cell').map((c) => c.textContent);
-    expect(cells).toEqual(['—', '$1.50']);
+    await waitFor(() => expect(screen.getByTestId('campaign-scoreboard')).toBeInTheDocument());
+    expect(screen.queryByTestId('campaign-delivery-rollup')).toBeNull();
   });
 });

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import type { CampaignSummary } from '../src/api/campaigns.js';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { SessionView } from '../src/api/types.js';
+import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
+import { makeView } from './factories.js';
 
 /**
- * `/testing/campaigns` — THE Testing landing as a COMMAND SURFACE (the testing-UX wave):
- * the section-dashboard kit worn unforked (KPI band / FilterStrip / DashboardGrid), the
- * creation verbs in the header (the folded-in Harness), campaign cards with the scoreboard's
- * stats condensed and needs-you floated FIRST. Pinned: the §1.5 probe's three honest states,
- * the KPI folds off the fixtures, §3.3 denominator honesty on the cards, and every door.
+ * `/testing/campaigns` — THE Testing landing as a COMMAND SURFACE over the REAL wire (engine
+ * campaigns + ad-hoc `RunGroup`s, api-types 0.19.0): the section-dashboard kit worn unforked
+ * (KPI band / FilterStrip / DashboardGrid), the creation verbs in the header, campaign AND
+ * group cards in one needs-you-first grid. Pinned for wicked-studio#27's remainder:
+ *   - the delivery rollup on the card — wire facts only, per-sibling PR links `isPrUrl`-gated,
+ *     stranded siblings surfaced as a needs-you chip;
+ *   - the live narration line — the freshest member-run CoreEvent through narrator.ts (ONE
+ *     template source), updating as newer frames arrive; absent when nothing was observed;
+ *   - grouped runs render together (a group card with member run links);
+ *   - the §1.5 probe's three honest states and every door.
  */
 
 const listCampaigns = vi.fn();
@@ -31,26 +37,12 @@ vi.mock('../src/api/client.js', () => ({
 
 const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
 const { useCampaignsStore } = await import('../src/store/campaigns.js');
+const { useRunEventStore } = await import('../src/store/events.js');
+const { useRuntimeStore } = await import('../src/store/runtime.js');
 const { ApiError } = await import('../src/api/errors.js');
 
-function summary(
-  id: string,
-  over: Partial<CampaignSummary['campaign']> = {},
-  counts: Partial<CampaignSummary['counts']> = {},
-  runIds: string[] = [],
-): CampaignSummary {
-  return {
-    campaign: { id, title: null, expected: null, created_at: 1, updated_at: 2, ...over },
-    runIds,
-    projectIds: ['p1'],
-    counts: { filed: 0, landed: 0, failed: 0, cancelled: 0, running: 0, awaitingHuman: 0, other: 0, archived: 0, ...counts },
-    prs: [],
-    prsTruncated: false,
-  };
-}
-
 function view(id: string, status = 'executing'): SessionView {
-  return { session: { id, status, archived_at: null } } as unknown as SessionView;
+  return makeView({ id, status: status as SessionView['session']['status'], problem: `problem of ${id}` });
 }
 
 function page(navigate: (p: string) => void = () => {}, runs: SessionView[] = []): ReturnType<typeof render> {
@@ -63,7 +55,9 @@ beforeEach(() => {
   listRepos.mockResolvedValue({ repos: [] });
   listProjects.mockReset();
   listProjects.mockResolvedValue({ projects: [] });
-  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
+  useRunEventStore.setState({ byRun: {} });
+  useRuntimeStore.setState({ logs: {} });
 });
 afterEach(() => cleanup());
 
@@ -73,34 +67,38 @@ describe('the §1.5 probe states', () => {
     page();
     await waitFor(() => expect(screen.getByTestId('campaigns-unsupported')).toBeInTheDocument());
     expect(screen.getByTestId('campaigns-unsupported').textContent).toContain('predates campaign grouping');
-    // Launching rides POST /testing/recon with launchTestingRun's presence-gated POST /runs
-    // fallback — the folded-in Harness must not regress on a daemon this old.
     expect(screen.getByTestId('testing-recon-open')).toBeInTheDocument();
     expect(screen.getByTestId('testing-campaign-open')).toBeInTheDocument();
     expect(screen.getByTestId('testing-author-open')).toBeInTheDocument();
   });
 
-  it('200 [] is the "no campaigns yet" answer, in plain words, with a CTA that opens the New campaign flow', async () => {
-    listCampaigns.mockResolvedValue({ campaigns: [] });
+  it('200 with empty lists is the "no campaigns yet" answer, with a CTA that opens the New campaign flow', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     page();
     await waitFor(() => expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument());
     expect(screen.getByTestId('campaigns-empty').textContent).toContain('launch a run with a campaign label');
-    expect(screen.getByTestId('campaigns-empty').textContent).not.toContain('minted');
-    // The dead end gains its way in: the CTA opens the launch panel, campaign intent.
     fireEvent.click(screen.getByTestId('campaigns-empty-cta'));
     expect(await screen.findByTestId('testing-launch-panel')).toHaveAttribute('data-intent', 'campaign');
   });
 });
 
-describe('the KPI band — folds from the fixtures, ≤6 tiles under the three questions', () => {
-  it('campaigns / pass rate / running / needs-you / failed fold honestly, threshold-colored where it means something', async () => {
+describe('the KPI band — folds from the wire fixtures, ≤6 tiles under the three questions', () => {
+  it('campaigns / pass rate / running / needs-you / failed fold honestly', async () => {
     listCampaigns.mockResolvedValue({
       campaigns: [
-        // 5 landed, 1 failed, 0 cancelled → 6 terminal; 1 running; 2 waiting.
-        summary('alpha', { expected: 8 }, { filed: 7, landed: 5, failed: 1, running: 1, awaitingHuman: 2 }, ['run-1', 'run-2']),
+        // 5 landed, 1 failed, 1 running, 2 waiting of 9 nodes.
+        makeCampaign('alpha', [
+          { status: 'completed', runId: 'run-1' }, { status: 'completed' }, { status: 'completed' },
+          { status: 'completed' }, { status: 'completed' }, { status: 'failed', runId: 'run-2' },
+          { status: 'running' }, { status: 'awaiting_human' }, { status: 'awaiting_human' },
+        ]),
         // all landed, quiet.
-        summary('beta', {}, { filed: 4, landed: 4 }, ['run-3']),
+        makeCampaign('beta', [
+          { status: 'completed', runId: 'run-3' }, { status: 'completed' },
+          { status: 'completed' }, { status: 'completed' },
+        ]),
       ],
+      groups: [],
     });
     const runs = [view('run-1', 'awaiting_human'), view('run-2', 'failed'), view('run-3', 'completed')];
     page(() => {}, runs);
@@ -113,14 +111,17 @@ describe('the KPI band — folds from the fixtures, ≤6 tiles under the three q
     expect(screen.getByTestId('stat-campaign-gates')).toHaveAttribute('data-value', '2');
     // Failed in the positional window, from the run list — run-2.
     expect(screen.getByTestId('stat-campaign-failed')).toHaveAttribute('data-value', '1');
-    // Pass rate: 9 landed of 10 finished = 90%, threshold-colored good.
+    // Pass rate: 9 landed of 10 finished = 90%.
     const pass = screen.getByTestId('stat-campaign-pass-rate');
     expect(pass).toHaveAttribute('data-value', '90%');
     expect(pass.textContent).toContain('9 landed of 10 finished');
   });
 
   it('no finished runs = an honest "—" pass rate, never a fabricated 0%', async () => {
-    listCampaigns.mockResolvedValue({ campaigns: [summary('fresh', {}, { filed: 2, running: 2 })] });
+    listCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign('fresh', [{ status: 'running' }, { status: 'running' }])],
+      groups: [],
+    });
     page();
     await screen.findByTestId('campaigns-kpis');
     expect(screen.getByTestId('stat-campaign-pass-rate')).toHaveAttribute('data-value', '—');
@@ -129,7 +130,8 @@ describe('the KPI band — folds from the fixtures, ≤6 tiles under the three q
 
   it('the needs-you tile deep-links STRAIGHT to the waiting run (its pinned approval dock)', async () => {
     listCampaigns.mockResolvedValue({
-      campaigns: [summary('alpha', {}, { filed: 2, awaitingHuman: 1 }, ['run-g'])],
+      campaigns: [makeCampaign('alpha', [{ status: 'awaiting_human', runId: 'run-g' }, { status: 'running' }])],
+      groups: [],
     });
     const navigate = vi.fn();
     page(navigate, [view('run-g', 'awaiting_human')]);
@@ -143,19 +145,29 @@ describe('the cards — scoreboard stats condensed, needs-you FIRST', () => {
   it('carries the honest §3.3 denominator, the split, the status bar, and doors to the scoreboard', async () => {
     listCampaigns.mockResolvedValue({
       campaigns: [
-        summary('DES-MERGE-001', { expected: 18 }, { filed: 17, landed: 15, failed: 1 }, ['run-m']),
-        summary('estate-rollout', {}, { filed: 6, landed: 2, awaitingHuman: 1 }, ['run-e']),
+        makeCampaign('DES-MERGE-001', [
+          ...Array.from({ length: 15 }, (_, i) => ({ status: 'completed' as const, runId: `m${i}` })),
+          { status: 'failed' }, { status: 'running' }, { status: 'pending' },
+        ]),
+        makeCampaign('estate-rollout', [
+          { status: 'completed' }, { status: 'completed' },
+          { status: 'awaiting_human', runId: 'run-e' },
+          { status: 'running' }, { status: 'pending' }, { status: 'pending' },
+        ]),
       ],
+      groups: [],
     });
     const navigate = vi.fn();
-    page(navigate, [view('run-m', 'completed'), view('run-e', 'awaiting_human')]);
+    // One LIVE member run per campaign — the recency window scopes the grid to campaigns
+    // with a member in it (the "+N older" idiom, pinned below).
+    page(navigate, [view('run-e', 'awaiting_human'), view('m0', 'completed')]);
     await waitFor(() => expect(screen.getAllByTestId('campaign-card')).toHaveLength(2));
 
     const cards = screen.getAllByTestId('campaign-card');
     // needs-you floats FIRST: estate-rollout (1 waiting) ahead of the failing one.
     expect(cards[0]!.dataset.campaignId).toBe('estate-rollout');
-    // §3.3: a declared denominator has no "so far"; an undeclared one MUST say it.
-    expect(within(cards[0]!).getByTestId('campaign-card-progress').textContent).toBe('2 of 6 landed so far');
+    // §3.3: a campaign's DAG is a DECLARED denominator — no "so far" on campaign cards.
+    expect(within(cards[0]!).getByTestId('campaign-card-progress').textContent).toBe('2 of 6 landed');
     expect(within(cards[1]!).getByTestId('campaign-card-progress').textContent).toBe('15 of 18 landed');
     expect(within(cards[1]!).getByTestId('campaign-card-split').textContent).toContain('✓15');
     expect(within(cards[1]!).getByTestId('campaign-card-split').textContent).toContain('✕1');
@@ -167,7 +179,10 @@ describe('the cards — scoreboard stats condensed, needs-you FIRST', () => {
 
   it('the needs-you badge jumps STRAIGHT to the waiting sibling when the live list holds it', async () => {
     listCampaigns.mockResolvedValue({
-      campaigns: [summary('alpha', {}, { filed: 3, awaitingHuman: 1 }, ['run-w', 'run-x'])],
+      campaigns: [makeCampaign('alpha', [
+        { status: 'awaiting_human', runId: 'run-w' }, { status: 'completed', runId: 'run-x' },
+      ])],
+      groups: [],
     });
     const navigate = vi.fn();
     page(navigate, [view('run-w', 'awaiting_human'), view('run-x', 'completed')]);
@@ -179,14 +194,146 @@ describe('the cards — scoreboard stats condensed, needs-you FIRST', () => {
   });
 });
 
+describe('the delivery rollup on the card (#27) — wire facts, gated links, stranded = needs-you', () => {
+  const CAMPAIGN = makeCampaign('rollout', [
+    { status: 'completed', runId: 'r-pr', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/12' } },
+    // The wire says delivered but the url fails the ONE shape gate — counted, never linked.
+    { status: 'completed', runId: 'r-bad', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/new/branch' } },
+    { status: 'completed', runId: 'r-str', delivery: { delivery: 'stranded' } },
+    { status: 'running', runId: 'r-run' },
+  ]);
+
+  it('renders "n of N delivered", one isPrUrl-gated link per delivered sibling, and the stranded chip', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [CAMPAIGN], groups: [] });
+    const navigate = vi.fn();
+    page(navigate, [view('r-run')]);
+    const card = (await screen.findAllByTestId('campaign-card'))[0]!;
+
+    expect(within(card).getByTestId('campaign-card-delivery').textContent).toBe('2 of 4 delivered');
+    // Exactly ONE link — the shape-refused url never becomes an anchor.
+    const prs = within(card).getAllByTestId('campaign-card-pr');
+    expect(prs).toHaveLength(1);
+    expect(prs[0]!.getAttribute('href')).toBe('https://github.com/o/x/pull/12');
+    expect(prs[0]!.textContent).toBe('#12');
+
+    // Stranded = needs-you: the chip names the count and jumps to the stranded run.
+    const stranded = within(card).getByTestId('campaign-card-stranded');
+    expect(stranded.textContent).toContain('stranded · 1');
+    fireEvent.click(stranded);
+    expect(navigate).toHaveBeenCalledWith('/runs/r-str');
+  });
+
+  it('a pre-0.19 campaign renders NO rollup line — absence, never a fabricated "0 of N"', async () => {
+    listCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign('old', [{ status: 'completed', runId: 'r1' }])],
+      groups: [],
+    });
+    page(() => {}, [view('r1', 'completed')]);
+    const card = (await screen.findAllByTestId('campaign-card'))[0]!;
+    expect(within(card).queryByTestId('campaign-card-delivery')).toBeNull();
+  });
+
+  it('the stranded chip routes the card into the needs-you filter', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [CAMPAIGN], groups: [] });
+    page(() => {}, [view('r-run')]);
+    await screen.findAllByTestId('campaign-card');
+    const chips = screen.getAllByTestId('campaigns-filter-chip');
+    const needsYou = chips.find((c) => c.dataset.chip === 'needs-you')!;
+    expect(needsYou.textContent).toContain('1');
+  });
+});
+
+describe('the live narration line (#27) — the freshest member-run frame, ONE template source', () => {
+  const CAMPAIGN = makeCampaign('narrated', [
+    { status: 'running', runId: 'r-a' },
+    { status: 'running', runId: 'r-b' },
+  ]);
+  const log = (ts: number) => [{ seq: 1, type: 'x', ts, detail: '' }];
+
+  it('speaks the newest member frame through narrator.ts, and updates when a fresher one lands', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [CAMPAIGN], groups: [] });
+    useRunEventStore.setState({ byRun: { 'r-a': [{ type: 'sessionStarted', session: 'r-a' }] } });
+    useRuntimeStore.setState({ logs: { 'r-a': log(1000) } });
+    page(() => {}, [view('r-a'), view('r-b')]);
+    const card = (await screen.findAllByTestId('campaign-card'))[0]!;
+
+    const line = within(card).getByTestId('campaign-card-narration');
+    expect(line.textContent).toContain('Run started');
+    expect(line.dataset.runId).toBe('r-a');
+
+    // A FRESHER frame on the sibling flips the line to it — narrator wording, verbatim.
+    act(() => {
+      useRunEventStore.setState({
+        byRun: {
+          'r-a': [{ type: 'sessionStarted', session: 'r-a' }],
+          'r-b': [{ type: 'awaitingHuman', session: 'r-b', prompt: 'approve AC-3?' }],
+        },
+      });
+      useRuntimeStore.setState({ logs: { 'r-a': log(1000), 'r-b': log(2000) } });
+    });
+    await waitFor(() => {
+      const updated = within(card).getByTestId('campaign-card-narration');
+      expect(updated.dataset.runId).toBe('r-b');
+      expect(updated.textContent).toContain('Gate: waiting on you — approve AC-3?');
+      expect(updated.dataset.tone).toBe('gate');
+    });
+  });
+
+  it('no observed frames = NO narration line (absence stays absent, never a placeholder)', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [CAMPAIGN], groups: [] });
+    page(() => {}, [view('r-a'), view('r-b')]);
+    const card = (await screen.findAllByTestId('campaign-card'))[0]!;
+    expect(within(card).queryByTestId('campaign-card-narration')).toBeNull();
+  });
+});
+
+describe('ad-hoc groups (#27) — grouped runs render together on this dashboard', () => {
+  it('a group card carries the label, the "so far" denominator, member links, and its rollup', async () => {
+    listCampaigns.mockResolvedValue({
+      campaigns: [],
+      groups: [makeGroup('perf-sweep', [
+        attachedRun('g-1', { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/3' }),
+        attachedRun('g-2', { status: 'executing', delivery: 'none' }),
+      ])],
+    });
+    const navigate = vi.fn();
+    page(navigate, [view('g-1', 'completed'), view('g-2')]);
+    const card = (await screen.findAllByTestId('campaign-card'))[0]!;
+    expect(card.dataset.kind).toBe('group');
+    expect(card.textContent).toContain('perf-sweep');
+    // A label group's denominator GROWS with each launch — it MUST say "so far" (§3.3).
+    expect(within(card).getByTestId('campaign-card-progress').textContent).toBe('1 of 2 landed so far');
+    expect(within(card).getByTestId('campaign-card-delivery').textContent).toBe('1 of 2 delivered');
+    // Member runs link out directly — a group has no scoreboard route.
+    const links = within(card).getAllByTestId('campaign-card-run');
+    expect(links).toHaveLength(2);
+    fireEvent.click(links[1]!);
+    expect(navigate).toHaveBeenCalledWith('/runs/g-2');
+  });
+
+  it('groups and campaigns share ONE grid and ONE search', async () => {
+    listCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign('alpha-camp', [{ status: 'completed', runId: 'c-1' }])],
+      groups: [makeGroup('beta-group', [attachedRun('g-1')])],
+    });
+    page(() => {}, [view('c-1', 'completed'), view('g-1', 'completed')]);
+    await waitFor(() => expect(screen.getAllByTestId('campaign-card')).toHaveLength(2));
+    fireEvent.change(screen.getByTestId('campaigns-filter-search'), { target: { value: 'beta' } });
+    const cards = screen.getAllByTestId('campaign-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]!.dataset.kind).toBe('group');
+  });
+});
+
 describe('the filterable grid — search / status / window', () => {
   const FIXTURES = {
     campaigns: [
-      summary('gates-waiting', {}, { filed: 2, awaitingHuman: 1 }, ['run-a']),
-      summary('red-alert', {}, { filed: 3, landed: 1, failed: 2 }, ['run-b']),
-      summary('cruising', { title: 'Checkout hardening' }, { filed: 2, running: 2 }, ['run-c']),
-      summary('done-quiet', {}, { filed: 2, landed: 2 }, ['run-d']),
+      makeCampaign('gates-waiting', [{ status: 'awaiting_human', runId: 'run-a' }, { status: 'pending' }]),
+      makeCampaign('red-alert', [{ status: 'completed', runId: 'run-b' }, { status: 'failed' }, { status: 'failed' }]),
+      makeCampaign('cruising', [{ status: 'running', runId: 'run-c' }, { status: 'running' }]),
+      makeCampaign('done-quiet', [{ status: 'completed', runId: 'run-d' }, { status: 'completed' }]),
     ],
+    groups: [],
   };
   const RUNS = [view('run-a', 'awaiting_human'), view('run-b', 'failed'), view('run-c'), view('run-d', 'completed')];
 
@@ -209,13 +356,10 @@ describe('the filterable grid — search / status / window', () => {
     expect(screen.getAllByTestId('campaign-card').map((c) => c.dataset.campaignId)).toEqual(['done-quiet']);
   });
 
-  it('search matches title AND id', async () => {
+  it('search matches the campaign name AND id', async () => {
     listCampaigns.mockResolvedValue(FIXTURES);
     page(() => {}, RUNS);
     await waitFor(() => expect(screen.getAllByTestId('campaign-card')).toHaveLength(4));
-
-    fireEvent.change(screen.getByTestId('campaigns-filter-search'), { target: { value: 'checkout' } });
-    expect(screen.getAllByTestId('campaign-card').map((c) => c.dataset.campaignId)).toEqual(['cruising']);
 
     fireEvent.change(screen.getByTestId('campaigns-filter-search'), { target: { value: 'red-al' } });
     expect(screen.getAllByTestId('campaign-card').map((c) => c.dataset.campaignId)).toEqual(['red-alert']);
@@ -224,10 +368,13 @@ describe('the filterable grid — search / status / window', () => {
   it('a campaign with NO member run in the window hides behind an honest "+N older · show all" chip', async () => {
     listCampaigns.mockResolvedValue({
       campaigns: [
-        summary('current', {}, { filed: 1, running: 1 }, ['run-live']),
-        // Every filed run archived/gone from the live list — outside any positional window.
-        summary('ancient', {}, { filed: 2, landed: 2, archived: 2 }, ['run-gone-1', 'run-gone-2']),
+        makeCampaign('current', [{ status: 'running', runId: 'run-live' }]),
+        // Every member run archived/gone from the live list — outside any positional window.
+        makeCampaign('ancient', [
+          { status: 'completed', runId: 'run-gone-1' }, { status: 'completed', runId: 'run-gone-2' },
+        ]),
       ],
+      groups: [],
     });
     page(() => {}, [view('run-live')]);
     await waitFor(() => expect(screen.getAllByTestId('campaign-card')).toHaveLength(1));

--- a/tests/ChatInput.group.test.tsx
+++ b/tests/ChatInput.group.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../src/components/ChatInput.js';
+import * as client from '../src/api/client.js';
+import { ApiError } from '../src/api/errors.js';
+import type { LaunchBodyWithDeliver } from '../src/api/types.js';
+import { useCampaignsStore } from '../src/store/campaigns.js';
+import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
+
+/**
+ * Ad-hoc grouping on the launch composer (wicked-studio#27; api-types 0.19.0):
+ *   - ONE structural control — none / an existing campaign / an existing group label / a
+ *     typed new label — so `campaignId` XOR `groupLabel` cannot be violated from studio;
+ *   - default = NEITHER key on the body (pre-0.19 behavior, byte for byte);
+ *   - an empty typed label sends nothing rather than a 400 the operator didn't mean;
+ *   - validation stays the daemon's, LOUDLY: an unknown campaign's 404 renders verbatim and
+ *     nothing silently relaunches ungrouped;
+ *   - the attach is sticky across launches (filing several siblings is the feature), with a
+ *     pill to drop it.
+ */
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  localStorage.clear();
+  // The known campaigns/groups the select lists — seeded directly; the lazy refresh the
+  // control fires on interaction is stubbed to a no-op so this suite owns the fixture.
+  useCampaignsStore.setState({
+    support: 'supported',
+    campaigns: [makeCampaign('camp-1', [{ status: 'running', runId: 'r1' }])],
+    groups: [makeGroup('perf-sweep', [attachedRun('g-1')])],
+    live: {},
+    refresh: () => Promise.resolve(),
+  });
+});
+
+async function typeAndLaunch(user: ReturnType<typeof userEvent.setup>): Promise<LaunchBodyWithDeliver> {
+  await user.type(screen.getByTestId('launch-problem'), 'build the thing');
+  await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+  await user.click(screen.getByTestId('launch-submit'));
+  await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+  return vi.mocked(client.api.launchRun).mock.calls[0]![0];
+}
+
+describe('ChatInput launch form — ad-hoc grouping (#27)', () => {
+  it('defaults to none: the body carries NEITHER campaignId NOR groupLabel (pre-0.19, byte for byte)', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    const body = await typeAndLaunch(user);
+    expect('campaignId' in body).toBe(false);
+    expect('groupLabel' in body).toBe(false);
+  });
+
+  it('an existing group label rides the body as groupLabel — and NEVER alongside campaignId', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'g:perf-sweep');
+    // The active-pill states the attach and offers the drop.
+    expect(screen.getByTestId('group-pill').textContent).toContain('Group: perf-sweep');
+    const body = await typeAndLaunch(user);
+    expect(body.groupLabel).toBe('perf-sweep');
+    expect('campaignId' in body).toBe(false);
+  });
+
+  it('an existing campaign rides the body as campaignId — and NEVER alongside groupLabel', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'c:camp-1');
+    expect(screen.getByTestId('group-pill').textContent).toContain('Campaign: camp-1');
+    const body = await typeAndLaunch(user);
+    expect(body.campaignId).toBe('camp-1');
+    expect('groupLabel' in body).toBe(false);
+  });
+
+  it('"new group…" reveals the label input; the TRIMMED label rides the body and creates on first use', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    expect(screen.queryByTestId('group-label-input')).toBeNull();
+    await user.selectOptions(screen.getByTestId('group-attach'), 'new');
+    await user.type(screen.getByTestId('group-label-input'), '  s27-lane  ');
+    const body = await typeAndLaunch(user);
+    expect(body.groupLabel).toBe('s27-lane');
+  });
+
+  it('a BLANK typed label sends nothing — omitting the key, never a 400 the operator did not mean', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'new');
+    const body = await typeAndLaunch(user);
+    expect('groupLabel' in body).toBe(false);
+  });
+
+  it('the pill clears the attach — the next launch is ungrouped again', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'g:perf-sweep');
+    await user.click(screen.getByLabelText('Clear Group: perf-sweep'));
+    expect(screen.queryByTestId('group-pill')).toBeNull();
+    const body = await typeAndLaunch(user);
+    expect('groupLabel' in body).toBe(false);
+  });
+
+  it('an unknown campaign is LOUD: the daemon 404 renders verbatim and nothing relaunches ungrouped', async () => {
+    vi.mocked(client.api.launchRun).mockRejectedValue(
+      new ApiError(404, 'unknown campaign `camp-gone` — nothing was launched'),
+    );
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'c:camp-1');
+    await user.type(screen.getByTestId('launch-problem'), 'build the thing');
+    await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+    await user.click(screen.getByTestId('launch-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('launch-error').textContent).toContain(
+        'unknown campaign `camp-gone` — nothing was launched',
+      ),
+    );
+    // LOUD means loud: no silent second POST with the field stripped.
+    expect(client.api.launchRun).toHaveBeenCalledTimes(1);
+    // The attach survives the failure — the operator fixes the target, not the intent.
+    expect(screen.getByTestId('group-pill')).toBeInTheDocument();
+  });
+
+  it('a pre-0.19 daemon 400 naming the field renders verbatim too — never a silent ungrouped launch', async () => {
+    vi.mocked(client.api.launchRun).mockRejectedValue(
+      new ApiError(400, 'Invalid request body: unknown field `groupLabel` — this endpoint does not accept it'),
+    );
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'g:perf-sweep');
+    await user.type(screen.getByTestId('launch-problem'), 'build the thing');
+    await waitFor(() => expect(screen.getByTestId('launch-submit')).toBeEnabled());
+    await user.click(screen.getByTestId('launch-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('launch-error').textContent).toContain('unknown field `groupLabel`'),
+    );
+    expect(client.api.launchRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('the attach is STICKY across launches — filing several siblings under one label is the feature', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'g:perf-sweep');
+    await typeAndLaunch(user);
+    // Second launch, no re-selection.
+    await user.type(screen.getByTestId('launch-problem'), 'the sibling');
+    await user.click(screen.getByTestId('launch-submit'));
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(2));
+    const second = vi.mocked(client.api.launchRun).mock.calls[1]![0];
+    expect(second.groupLabel).toBe('perf-sweep');
+  });
+});

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -118,7 +118,7 @@ beforeEach(() => {
   });
   listProjectMembers.mockResolvedValue({ members: [] });
   useGateStore.setState({ gates: {}, approaching: {} });
-  useCampaignsStore.setState({ support: 'supported', summaries: [], live: {} });
+  useCampaignsStore.setState({ support: 'supported', campaigns: [], groups: [], live: {} });
 });
 
 async function openPanel(user: ReturnType<typeof userEvent.setup>, verb: string): Promise<HTMLElement> {

--- a/tests/campaignFactories.ts
+++ b/tests/campaignFactories.ts
@@ -1,0 +1,66 @@
+import type {
+  AttachedRunView,
+  Campaign,
+  CampaignNodeDelivery,
+  CampaignNodeStatus,
+  RunGroup,
+} from '../src/api/campaigns.js';
+import type { SessionStatus } from '../src/api/types.js';
+
+/**
+ * Wire-shape factories for the campaign surface tests — the ENGINE `Campaign` (+ the
+ * daemon-joined api-types 0.19.0 fields) and the ad-hoc `RunGroup`, exactly as
+ * `GET /campaigns` serves them. One spelling for every suite, so a fixture cannot drift
+ * from the contract in one file and silently keep passing in another.
+ */
+
+export interface NodeFixture {
+  /** node_id; defaults to `n<i>`. */
+  id?: string;
+  status?: CampaignNodeStatus;
+  /** The dispatched run id — absent = the node has not dispatched yet. */
+  runId?: string;
+  /** The daemon-joined per-node delivery (0.19.0). Setting it on ANY node marks the
+   *  campaign as a 0.19 payload (`node_delivery` present). */
+  delivery?: CampaignNodeDelivery;
+  problem?: string;
+}
+
+export function makeCampaign(
+  id: string,
+  nodes: NodeFixture[],
+  over: Partial<Campaign> = {},
+): Campaign {
+  const node_status: Record<string, CampaignNodeStatus> = {};
+  const node_run_id: Record<string, string> = {};
+  const node_delivery: Record<string, CampaignNodeDelivery> = {};
+  let anyDelivery = false;
+  const defNodes = nodes.map((n, i) => {
+    const nid = n.id ?? `n${i}`;
+    if (n.status !== undefined) node_status[nid] = n.status;
+    if (n.runId !== undefined) node_run_id[nid] = n.runId;
+    if (n.delivery !== undefined) {
+      node_delivery[nid] = n.delivery;
+      anyDelivery = true;
+    }
+    return { node_id: nid, run_spec: { problem: n.problem ?? `problem of ${nid}` } };
+  });
+  return {
+    id,
+    def_id: id,
+    status: 'running',
+    def: { id, name: id, nodes: defNodes },
+    node_status,
+    node_run_id,
+    ...(anyDelivery ? { node_delivery } : {}),
+    ...over,
+  };
+}
+
+export function attachedRun(runId: string, over: Partial<AttachedRunView> = {}): AttachedRunView {
+  return { runId, status: 'completed' as SessionStatus, delivery: 'none', ...over };
+}
+
+export function makeGroup(label: string, runs: AttachedRunView[]): RunGroup {
+  return { label, runs };
+}

--- a/tests/campaignStats.test.ts
+++ b/tests/campaignStats.test.ts
@@ -1,90 +1,121 @@
 import { describe, expect, it } from 'vitest';
-import type { CampaignSummary } from '../src/api/campaigns.js';
 import type { SessionView } from '../src/api/types.js';
 import {
-  campaignActivitySeries, campaignCards, campaignCreatedDelta, campaignProgressWord,
-  campaignRunIdSet, campaignTotals, matchesCampaignChip, passRateWord,
+  campaignCards, campaignCounts, campaignDeliveryRollup, campaignMemberRunIds,
+  campaignTotals, deliveryRollupWord, groupDeliveryRollup, matchesCampaignChip,
+  memberRunIdSet, passRateWord, progressWord,
 } from '../src/board/campaignStats.js';
+import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
 
 /**
- * The Campaigns landing's pure folds — the KPI band and the card grid derive every number
- * through these, so their honesty rules are pinned HERE: server aggregates never re-derived,
- * time-based deltas only where real clocks exist, "so far" only on an undeclared denominator.
+ * The Campaigns landing's pure folds over the REAL wire (engine `Campaign` + `RunGroup`,
+ * api-types 0.19.0) — the KPI band and the card grid derive every number through these, so
+ * their honesty rules are pinned HERE: engine-persisted node statuses (never re-derived from
+ * the archive-filtered run list), the delivery rollup off wire facts only (absent on a
+ * pre-0.19 daemon, never a fabricated zero), every PR href through the `isPrUrl` shape gate,
+ * and "so far" exactly on the denominator that can grow (a group's).
  */
-
-const DAY = 24 * 3_600_000;
-
-function summary(
-  id: string,
-  counts: Partial<CampaignSummary['counts']> = {},
-  over: Partial<CampaignSummary['campaign']> = {},
-  runIds: string[] = [],
-): CampaignSummary {
-  return {
-    campaign: { id, title: null, expected: null, created_at: 1, updated_at: 2, ...over },
-    runIds,
-    projectIds: [],
-    counts: { filed: 0, landed: 0, failed: 0, cancelled: 0, running: 0, awaitingHuman: 0, other: 0, archived: 0, ...counts },
-    prs: [],
-    prsTruncated: false,
-  };
-}
 
 function view(id: string, status = 'executing'): SessionView {
   return { session: { id, status, archived_at: null } } as unknown as SessionView;
 }
 
-describe('campaignTotals', () => {
-  it('sums the server aggregates and counts active campaigns (running or waiting)', () => {
-    const t = campaignTotals([
-      summary('a', { filed: 5, landed: 3, failed: 1, cancelled: 1, running: 0, awaitingHuman: 0 }),
-      summary('b', { filed: 4, landed: 1, running: 2, awaitingHuman: 1 }),
-    ]);
-    expect(t).toEqual({
-      campaigns: 2, activeNow: 1, filed: 9, landed: 4, failed: 1, cancelled: 1,
-      running: 2, awaitingHuman: 1, terminal: 6,
+describe('campaignCounts — engine-persisted node statuses, honestly bucketed', () => {
+  it('buckets every node; unnamed statuses count as queued; attached runs counted beside, never in', () => {
+    const c = makeCampaign('camp', [
+      { status: 'completed' }, { status: 'failed' }, { status: 'blocked' },
+      { status: 'awaiting_human' }, { status: 'running' }, { status: 'ready_to_resume' },
+      { status: 'pending' }, { status: 'ready' }, { status: 'cancelled' },
+      {}, // not in node_status at all — declared work, not yet moved
+    ], { attached_runs: [attachedRun('extra')] });
+    expect(campaignCounts(c)).toEqual({
+      nodes: 10, landed: 1, failed: 2, cancelled: 1,
+      running: 2, awaitingHuman: 1, queued: 3, attached: 1,
     });
   });
 });
 
-describe('campaignRunIdSet', () => {
-  it('is the deduped union of every filed run id', () => {
-    const ids = campaignRunIdSet([
-      summary('a', {}, {}, ['r1', 'r2']),
-      summary('b', {}, {}, ['r2', 'r3']),
-    ]);
+describe('member run ids — the live-list join key', () => {
+  it('collects dispatched node runs (in def order) then attached runs', () => {
+    const c = makeCampaign('camp', [
+      { runId: 'r1', status: 'completed' },
+      {}, // undispatched — no run id
+      { runId: 'r2', status: 'running' },
+    ], { attached_runs: [attachedRun('r3')] });
+    expect(campaignMemberRunIds(c)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('memberRunIdSet unions campaigns and groups, deduped', () => {
+    const ids = memberRunIdSet(
+      [makeCampaign('a', [{ runId: 'r1' }, { runId: 'r2' }])],
+      [makeGroup('g', [attachedRun('r2'), attachedRun('r3')])],
+    );
     expect([...ids].sort()).toEqual(['r1', 'r2', 'r3']);
   });
 });
 
-describe('the time-based folds (campaigns carry REAL clocks)', () => {
-  const now = 100 * DAY;
-
-  it('campaignActivitySeries buckets updated_at daily, oldest first; out-of-span rows are absent', () => {
-    const s = campaignActivitySeries(
-      [
-        summary('today', {}, { updated_at: now - DAY / 2 }),
-        summary('yesterday', {}, { updated_at: now - DAY - 1 }),
-        summary('ancient', {}, { updated_at: now - 40 * DAY }),
-      ],
-      3,
-      now,
-    );
-    expect(s).toEqual([0, 1, 1]);
+describe('the delivery rollup — wire facts only, isPrUrl-gated', () => {
+  it('counts delivered members and collects only shape-valid PR hrefs', () => {
+    const c = makeCampaign('camp', [
+      { runId: 'r1', status: 'completed', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/5' } },
+      // Delivered per the wire but the url fails the shape gate — counted, NOT linked.
+      { runId: 'r2', status: 'completed', delivery: { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/new/branch' } },
+      { runId: 'r3', status: 'completed', delivery: { delivery: 'stranded' } },
+      { runId: 'r4', status: 'running' }, // no delivery fact yet
+      {}, // undispatched
+    ], { attached_runs: [attachedRun('r5', { delivery: 'delivered', deliverUrl: 'https://github.com/o/y/pull/9' })] });
+    const r = campaignDeliveryRollup(c);
+    expect(r.onWire).toBe(true);
+    // 5 nodes + 1 attached — declared work counts before it dispatches.
+    expect(r.total).toBe(6);
+    expect(r.delivered).toBe(3);
+    expect(r.prs).toEqual([
+      { runId: 'r1', href: 'https://github.com/o/x/pull/5' },
+      { runId: 'r5', href: 'https://github.com/o/y/pull/9' },
+    ]);
+    expect(r.stranded).toEqual([{ runId: 'r3', label: 'n2' }]);
   });
 
-  it('campaignCreatedDelta compares two REAL same-length spans — never null, never fabricated', () => {
-    const d = campaignCreatedDelta(
+  it('a pre-0.19 campaign (no node_delivery, no attached_runs) is onWire=false — absence, never 0 of N', () => {
+    const c = makeCampaign('old', [{ runId: 'r1', status: 'completed' }]);
+    const r = campaignDeliveryRollup(c);
+    expect(r.onWire).toBe(false);
+    expect(deliveryRollupWord(r)).toBeNull();
+  });
+
+  it('groupDeliveryRollup folds the label members; deliveryRollupWord speaks it', () => {
+    const r = groupDeliveryRollup(makeGroup('g', [
+      attachedRun('r1', { delivery: 'delivered', deliverUrl: 'https://github.com/o/x/pull/7' }),
+      attachedRun('r2', { delivery: 'stranded', status: 'completed' }),
+      attachedRun('r3', { delivery: 'none', status: 'executing' }),
+    ]));
+    expect(r.delivered).toBe(1);
+    expect(r.total).toBe(3);
+    expect(r.prs).toEqual([{ runId: 'r1', href: 'https://github.com/o/x/pull/7' }]);
+    expect(r.stranded).toEqual([{ runId: 'r2', label: 'r2' }]);
+    expect(deliveryRollupWord(r)).toBe('1 of 3 delivered');
+  });
+});
+
+describe('campaignTotals — campaigns and groups, one aggregate', () => {
+  it('sums node buckets and group member statuses; active = anything moving or waiting', () => {
+    const t = campaignTotals(
       [
-        summary('new-1', {}, { created_at: now - DAY }),
-        summary('new-2', {}, { created_at: now - 2 * DAY }),
-        summary('prior', {}, { created_at: now - 20 * DAY }),
-        summary('older-than-both', {}, { created_at: now - 40 * DAY }),
+        makeCampaign('a', [
+          { status: 'completed' }, { status: 'completed' }, { status: 'completed' },
+          { status: 'failed' }, { status: 'cancelled' },
+        ]),
+        makeCampaign('b', [
+          { status: 'completed' }, { status: 'running' }, { status: 'running' },
+          { status: 'awaiting_human' },
+        ]),
       ],
-      14,
-      now,
+      [makeGroup('g', [attachedRun('r1'), attachedRun('r2', { status: 'executing', delivery: 'none' })])],
     );
-    expect(d).toEqual({ current: 2, previous: 1 });
+    expect(t).toEqual({
+      campaigns: 2, groups: 1, activeNow: 2, landed: 5, failed: 1,
+      running: 3, awaitingHuman: 1, terminal: 7,
+    });
   });
 });
 
@@ -96,51 +127,59 @@ describe('passRateWord', () => {
   });
 });
 
-describe('campaignCards — attention routing', () => {
-  it('sorts needs-you FIRST, then failing, then newest-updated; joins waiting runs off the live list', () => {
+describe('campaignCards — attention routing over campaigns AND groups', () => {
+  it('sorts needs-you FIRST, then stranded work, then failing; joins waiting runs off the live list', () => {
     const runsById = new Map([['rw', view('rw', 'awaiting_human')]]);
     const cards = campaignCards(
       [
-        summary('quiet-new', { landed: 1 }, { updated_at: 90 }),
-        summary('failing', { failed: 2 }, { updated_at: 50 }),
-        summary('waiting', { awaitingHuman: 1 }, { updated_at: 10 }, ['rw']),
-        summary('quiet-old', { landed: 1 }, { updated_at: 20 }),
+        makeCampaign('quiet', [{ status: 'completed' }]),
+        makeCampaign('failing', [{ status: 'failed' }, { status: 'failed' }]),
+        makeCampaign('waiting', [{ status: 'awaiting_human', runId: 'rw' }]),
       ],
+      [makeGroup('stranded-group', [attachedRun('rs', { delivery: 'stranded' })])],
       runsById,
       new Set(),
     );
-    expect(cards.map((c) => c.summary.campaign.id)).toEqual(['waiting', 'failing', 'quiet-new', 'quiet-old']);
+    expect(cards.map((c) => c.id)).toEqual(['waiting', 'stranded-group', 'failing', 'quiet']);
     expect(cards[0]!.waiting.map((v) => v.session.id)).toEqual(['rw']);
+    expect(cards[1]!.kind).toBe('group');
   });
 
   it('inWindow is true only when a member run sits in the window id set', () => {
     const cards = campaignCards(
-      [summary('in', {}, {}, ['r1']), summary('out', {}, {}, ['r2'])],
+      [makeCampaign('in', [{ runId: 'r1' }]), makeCampaign('out', [{ runId: 'r2' }])],
+      [],
       new Map(),
       new Set(['r1']),
     );
-    expect(cards.find((c) => c.summary.campaign.id === 'in')!.inWindow).toBe(true);
-    expect(cards.find((c) => c.summary.campaign.id === 'out')!.inWindow).toBe(false);
+    expect(cards.find((c) => c.id === 'in')!.inWindow).toBe(true);
+    expect(cards.find((c) => c.id === 'out')!.inWindow).toBe(false);
   });
 });
 
 describe('matchesCampaignChip', () => {
-  const model = (counts: Partial<CampaignSummary['counts']>) =>
-    campaignCards([summary('x', counts)], new Map(), new Set())[0]!;
+  const model = (nodes: Parameters<typeof makeCampaign>[1]) =>
+    campaignCards([makeCampaign('x', nodes)], [], new Map(), new Set())[0]!;
 
-  it('routes by the server counts; quiet = none of the three', () => {
-    expect(matchesCampaignChip(model({ awaitingHuman: 1 }), 'needs-you')).toBe(true);
-    expect(matchesCampaignChip(model({ running: 1 }), 'running')).toBe(true);
-    expect(matchesCampaignChip(model({ failed: 1 }), 'failing')).toBe(true);
-    expect(matchesCampaignChip(model({ landed: 2 }), 'quiet')).toBe(true);
-    expect(matchesCampaignChip(model({ awaitingHuman: 1 }), 'quiet')).toBe(false);
-    expect(matchesCampaignChip(model({}), 'all')).toBe(true);
+  it('routes by the folded node statuses; quiet = none of the three', () => {
+    expect(matchesCampaignChip(model([{ status: 'awaiting_human' }]), 'needs-you')).toBe(true);
+    expect(matchesCampaignChip(model([{ status: 'running' }]), 'running')).toBe(true);
+    expect(matchesCampaignChip(model([{ status: 'failed' }]), 'failing')).toBe(true);
+    expect(matchesCampaignChip(model([{ status: 'completed' }, { status: 'completed' }]), 'quiet')).toBe(true);
+    expect(matchesCampaignChip(model([{ status: 'awaiting_human' }]), 'quiet')).toBe(false);
+    expect(matchesCampaignChip(model([]), 'all')).toBe(true);
+  });
+
+  it('stranded work routes to needs-you (finished work waiting on a person)', () => {
+    const m = model([{ runId: 'r1', status: 'completed', delivery: { delivery: 'stranded' } }]);
+    expect(matchesCampaignChip(m, 'needs-you')).toBe(true);
+    expect(matchesCampaignChip(m, 'quiet')).toBe(false);
   });
 });
 
-describe('campaignProgressWord — §3.3 denominator honesty', () => {
-  it('a declared expected has no "so far"; an undeclared one MUST say it', () => {
-    expect(campaignProgressWord(summary('a', { filed: 17, landed: 15 }, { expected: 18 }))).toBe('15 of 18 landed');
-    expect(campaignProgressWord(summary('b', { filed: 6, landed: 2 }))).toBe('2 of 6 landed so far');
+describe('progressWord — §3.3 denominator honesty', () => {
+  it('a campaign DAG is declared (no "so far"); a group label can grow (MUST say it)', () => {
+    expect(progressWord({ kind: 'campaign', landed: 15, total: 18 })).toBe('15 of 18 landed');
+    expect(progressWord({ kind: 'group', landed: 2, total: 6 })).toBe('2 of 6 landed so far');
   });
 });

--- a/tests/campaigns.store.test.ts
+++ b/tests/campaigns.store.test.ts
@@ -24,7 +24,7 @@ const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
 
 beforeEach(() => {
   listCampaigns.mockReset();
-  useCampaignsStore.setState({ support: 'unknown', summaries: [], live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -33,11 +33,12 @@ describe('the §1.5 support probe — three states, never a boolean', () => {
     expect(useCampaignsStore.getState().support).toBe('unknown');
   });
 
-  it('200 with [] is SUPPORTED — the "no campaigns yet" answer, never a 404', async () => {
-    listCampaigns.mockResolvedValue({ campaigns: [] });
+  it('200 with empty lists is SUPPORTED — the "no campaigns yet" answer, never a 404', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     await useCampaignsStore.getState().refresh();
     expect(useCampaignsStore.getState().support).toBe('supported');
-    expect(useCampaignsStore.getState().summaries).toEqual([]);
+    expect(useCampaignsStore.getState().campaigns).toEqual([]);
+    expect(useCampaignsStore.getState().groups).toEqual([]);
   });
 
   it('404 = this daemon predates campaigns → unsupported', async () => {

--- a/tests/needsYou.test.ts
+++ b/tests/needsYou.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { CampaignSummary } from '../src/api/campaigns.js';
+import type { Campaign, CampaignNodeStatus } from '../src/api/campaigns.js';
 import type { RepoEntry } from '../src/api/types.js';
 import {
   calmCopy,
@@ -29,17 +29,30 @@ function repo(id: string, name = id): RepoEntry {
   return { id, name, root_path: `/repos/${id}`, default_branch: 'main', registered_at: NOW - 10 * HOUR };
 }
 
-function campaign(id: string, over: Partial<CampaignSummary['counts']>, runIds: string[] = []): CampaignSummary {
+/** An engine campaign (the REAL `GET /campaigns` shape) with one node per status entry;
+ *  `runIds` pair up with the entries in order (a node without one is undispatched). */
+function campaign(
+  id: string,
+  over: Partial<Record<'awaitingHuman' | 'failed', number>>,
+  runIds: string[] = [],
+): Campaign {
+  const statuses: CampaignNodeStatus[] = [
+    ...Array<CampaignNodeStatus>(over.awaitingHuman ?? 0).fill('awaiting_human'),
+    ...Array<CampaignNodeStatus>(over.failed ?? 0).fill('failed'),
+  ];
+  while (statuses.length < runIds.length) statuses.push('completed');
+  const node_status: Record<string, CampaignNodeStatus> = {};
+  const node_run_id: Record<string, string> = {};
+  const nodes = statuses.map((status, i) => {
+    const nid = `n${i}`;
+    node_status[nid] = status;
+    const runId = runIds[i];
+    if (runId !== undefined) node_run_id[nid] = runId;
+    return { node_id: nid, run_spec: { problem: `${id} ${nid}` } };
+  });
   return {
-    campaign: { id, title: null, expected: null, created_at: NOW - HOUR, updated_at: NOW - MIN },
-    runIds,
-    projectIds: [],
-    counts: {
-      filed: runIds.length, landed: 0, failed: 0, cancelled: 0,
-      running: 0, awaitingHuman: 0, other: 0, archived: 0, ...over,
-    },
-    prs: [],
-    prsTruncated: false,
+    id, def_id: id, status: 'running',
+    def: { id, name: id, nodes }, node_status, node_run_id,
   };
 }
 


### PR DESCRIPTION
The #27 remainder as narrowed on 2026-09-01, on the 0.19.0 wire (wicked-crew#412):

- **Delivery rollup**: campaign cards show "n of N landed" with per-sibling PR links (`isPrUrl`-gated — a non-PR-shaped `deliverUrl` never becomes an anchor); stranded siblings surface as needs-you.
- **Live narration**: each campaign card carries a one-line narration from the freshest member-run CoreEvent, rendered through `narrator.ts` — the one template source, verified structurally (no per-surface wording fork).
- **Ad-hoc grouping**: the launch composer attaches a run to an existing campaign or a create-on-first-use label group; grouped runs co-render on the campaigns dashboard; unknown-group errors render loud.

Explicitly out (and honestly so): board-level grouping on the orchestrator board — the campaigns dashboard is the grouping surface; if the board wants it too, that's a fresh, separately-scoped issue.

Verified live with playwright against a scratch daemon built from the crew branch (delivered + stranded members, truthful rollup, narration updating on member events, attach round-trip); jsdom per state; typecheck/lint/build/testid inventory clean.

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)