### PR TITLE
release: 0.4.10 — the campaign surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.10] — 2026-09-02
+
+### Added
+- **Campaign cards tell the whole story** (#27, #181, on the 0.19.0 wire). Delivery rollup —
+  "n of N landed" with per-sibling PR links (`isPrUrl`-gated) and stranded siblings surfaced as
+  needs-you; a live one-line narration per card from the freshest member-run CoreEvent (rendered
+  through `narrator.ts`, the one template source); ad-hoc grouping — the launch composer attaches
+  a run to an existing campaign or a create-on-first-use label group, and grouped runs co-render
+  on the campaigns dashboard.
+
 ## [0.4.9] — 2026-09-01
 
 ### Added
@@ -316,7 +326,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.9...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.10...HEAD
+[0.4.10]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.6...v0.4.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.9",
+  "studioVersion": "0.4.10",
   "counts": {
     "files": 117,
     "occurrences": 947,


### PR DESCRIPTION
Version bump + CHANGELOG (with link refs) + testid inventory stamped at 0.4.10. Ships #181 (delivery rollup, campaign narration, ad-hoc grouping on the 0.19.0 wire). Suite green, typecheck/build clean. Tag `v0.4.10` follows the merge; release.yml publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)