### PR TITLE
release: 0.4.11 — rail/chrome control affordances (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.11] — 2026-09-05
+
+### Changed
+- **Chrome + rail control affordances (#183, operator direction).** The rail header now spaces
+  Notifications, Ask, and the menu as distinct actions rather than one cluster. NotificationBell
+  is centered inside a token border, with the unread count moved from an overlaid badge to inside
+  the border (right of the label, shown only when unread > 0). Ask takes the slot next to the
+  logo where the connection "live" word used to sit; the status dot stays as the minimal
+  glanceable state and still expands the rail-foot Health section on click.
+
 ## [0.4.10] — 2026-09-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.10",
+  "studioVersion": "0.4.11",
   "counts": {
     "files": 117,
     "occurrences": 947,


### PR DESCRIPTION
Release cut for the UI changes (#183): rail spacing between Notifications/Ask/menu, bordered centered NotificationBell with the count inside the border, Ask relocated next to the logo (dot retained, opens Health). After merge: tag v0.4.11 → publish → crew rebundles its dist via build:with-studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)