### PR TITLE
feat(studio): proposal approval-queue surface — DES-MEM-FACETED-001

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
 import { SteeringPage } from './components/SteeringPage.js';
+import { ProposalsPage } from './components/ProposalsPage.js';
 import { TestingPage } from './components/TestingPage.js';
 import { RunsBottomPanel, RUNS_BAR_PX } from './components/RunsBottomPanel.js';
 import { ChatPanel } from './components/ChatPanel.js';
@@ -492,6 +493,16 @@ export function App(): React.ReactElement {
             search={search}
             runs={runs}
           />
+        </div>
+      );
+    }
+    // `/proposals` — the governed-knowledge review queue (DES-MEM-FACETED-001), Steering-adjacent:
+    // Steering authors policies, this reviews the agent-proposed memories AND policies. The type
+    // filter rides `?type=` in `search`, which the page reads.
+    if (panel === 'proposals') {
+      return (
+        <div className="flex-1 overflow-y-auto">
+          <ProposalsPage navigate={navigate} search={search} />
         </div>
       );
     }

--- a/src/api/proposals.ts
+++ b/src/api/proposals.ts
@@ -1,0 +1,199 @@
+/**
+ * The proposal-queue wire (DES-MEM-FACETED-001) — types and calls for the "policies and
+ * memories" review queue (`/proposals`): the surface where agent-proposed governed-knowledge
+ * items wait, each `pending`, for a human to approve or reject.
+ *
+ * ── INTEGRATION POINT (faceted-memory build, paired estate/crew lane) ─────────────────────────
+ * The `Proposal` shape is hand-mirrored from the engine that PRODUCES it — the estate proposal
+ * store, surfaced through crew's `/api/v1/proposals*` slice (built in a parallel lane) — because
+ * that crew slice is not yet in studio's installed `wicked-crew-api-types`. Like the wiki shapes
+ * in `./wiki.ts` and the steering shapes in `./steering.ts`, every declaration here is
+ * TEMPORARY: **delete this block and re-export from `wicked-crew-api-types`** the moment studio
+ * bumps to the api-types version that carries the proposal contract. Field names are the
+ * engine's serde output, verbatim — a served payload that disagrees is a contract bug, not an
+ * adoption gap.
+ *
+ * The support probe is the same two-layer adoption seam as the wiki/steering reads: a bare 404
+ * (Fastify's unknown-route answer) means "this crew daemon predates the proposal routes"; a 501
+ * means "the route exists but the embedded engine predates the proposal-store method".
+ * {@link isProposalsUnsupported} folds both so every caller renders the honest state, never a
+ * raw refusal.
+ *
+ * estate MCP stays READ-ONLY: every write below (approve / reject) goes through crew's API, the
+ * governed operator path — studio never touches estate directly.
+ */
+
+import { apiFetch } from './client.js';
+import { ApiError, isRouteAbsent } from './errors.js';
+
+// ── The proposal (mirrored from the estate proposal store; DELETE once api-types carries it) ──
+
+/** A proposal's lifecycle state. `pending` is the only one the queue lists by default. */
+export type ProposalState = 'pending' | 'approved' | 'rejected';
+
+/**
+ * One agent-proposed governed-knowledge item awaiting human review. `kind_type` is the
+ * discriminator — `"memory"` for a proposed memory, `"policy:<steering_type>"` for a proposed
+ * steering policy (e.g. `"policy:security"`). `payload` is `unknown` because its shape depends
+ * on the kind — read it through the narrowing helpers below, never by blind cast.
+ */
+export interface Proposal {
+  id: string;
+  /** `"memory"` | `"policy:<steering_type>"` — the type dimension the queue filters on. */
+  kind_type: string;
+  /** Kind-dependent body — narrow with {@link memoryPayload} / {@link policyPayload}. */
+  payload: unknown;
+  /** Facet dimensions the proposal is tagged with (project, repo, domain, …). */
+  facets: Record<string, string>;
+  /** Which run/agent proposed it (run id, agent, source, …). */
+  provenance: Record<string, string>;
+  state: ProposalState;
+  /** Unix-epoch seconds the proposal was created. */
+  created_at: number;
+}
+
+/** Approve returns the engine's outcome — its exact shape is not in api-types yet, so it is
+ *  read permissively (a stored item id, an ok flag). */
+export interface ProposalApproveOutcome {
+  ok?: boolean;
+  id?: string;
+  [k: string]: unknown;
+}
+
+// ── The type filter (first-class, so more kinds can be added) ─────────────────────────────────
+
+/** The queue's type dimension. `all` is the default view; every other value is a kind the
+ *  queue can filter to. New governed-knowledge kinds add a member here and a label below — the
+ *  page derives its filter chips from this list, so nothing else changes. */
+export const PROPOSAL_KINDS = ['all', 'memory', 'policy'] as const;
+
+export type ProposalKind = (typeof PROPOSAL_KINDS)[number];
+
+export const PROPOSAL_KIND_LABELS: Record<ProposalKind, string> = {
+  all: 'All',
+  memory: 'Memory',
+  policy: 'Policy',
+};
+
+export function isProposalKind(s: string): s is ProposalKind {
+  return (PROPOSAL_KINDS as readonly string[]).includes(s);
+}
+
+/** The one spelling of the queue's route — bare `/proposals` for `all`, `?type=<kind>` for a
+ *  filtered view (deep-linkable, back-button-correct; shared by the page and the rail). */
+export function proposalsPath(kind: ProposalKind = 'all'): string {
+  return kind === 'all' ? '/proposals' : `/proposals?type=${kind}`;
+}
+
+/** The active type filter read from a `location.search` string; an absent or unknown `type`
+ *  resolves to `all` — a mangled bookmark shows the whole queue, never an error. */
+export function readProposalKind(search: string): ProposalKind {
+  const raw = new URLSearchParams(search).get('type');
+  return raw !== null && isProposalKind(raw) ? raw : 'all';
+}
+
+/**
+ * The concrete kind a proposal belongs to, folded from its `kind_type`: `"memory"` → `memory`,
+ * anything starting `"policy"` (`"policy:security"`, `"policy"`) → `policy`, everything else →
+ * `other`. A proposal whose kind studio does not recognize is still LISTED (under `all`) — a
+ * proposal the operator cannot see is a proposal the operator cannot decide.
+ */
+export function proposalKind(p: Proposal): 'memory' | 'policy' | 'other' {
+  const raw = p.kind_type.trim().toLowerCase();
+  if (raw === 'memory') return 'memory';
+  if (raw === 'policy' || raw.startsWith('policy:')) return 'policy';
+  return 'other';
+}
+
+/** The steering type a `policy:<steering_type>` proposal carries, or null for a bare `"policy"`
+ *  / non-policy kind. Surfaced beside the kind chip so the operator sees which steering page a
+ *  policy would land on. */
+export function policySteeringType(p: Proposal): string | null {
+  const raw = p.kind_type.trim();
+  const at = raw.indexOf(':');
+  if (at === -1) return null;
+  const tail = raw.slice(at + 1).trim();
+  return tail === '' ? null : tail;
+}
+
+/** Whether a proposal passes the active type filter (`all` matches everything). */
+export function proposalMatchesKind(p: Proposal, filter: ProposalKind): boolean {
+  return filter === 'all' || proposalKind(p) === filter;
+}
+
+// ── Payload narrowing (payload is `unknown`; read it safely, never by blind cast) ─────────────
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+/** A memory proposal's body: the `content` line and its memory `tier`, each read defensively. */
+export function memoryPayload(p: Proposal): { content: string | null; tier: string | null } {
+  const rec = asRecord(p.payload);
+  if (rec === null) return { content: null, tier: null };
+  return { content: asString(rec.content), tier: asString(rec.tier) };
+}
+
+/** A policy proposal's body: the `rule` statement and its `severity`. The rule text is read
+ *  from `rule` first, then `statement` (the steering wire's spelling) — whichever the engine
+ *  serializes. */
+export function policyPayload(p: Proposal): { rule: string | null; severity: string | null } {
+  const rec = asRecord(p.payload);
+  if (rec === null) return { rule: null, severity: null };
+  return { rule: asString(rec.rule) ?? asString(rec.statement), severity: asString(rec.severity) };
+}
+
+// ── Calls (the governed operator path — every write goes through crew's `/api/v1`) ────────────
+
+/**
+ * `GET /proposals` — the queue, filtered server-side by `kind_type` and/or `state`. Both are
+ * optional; omitting `state` lists every state, so the page passes `state: 'pending'` for its
+ * default review view. `kind_type` here is the RAW discriminator (`"memory"`,
+ * `"policy:security"`) — the page's coarse type filter (memory vs policy) is applied client-side
+ * over the loaded rows, so switching it never re-hits the wire.
+ */
+export function listProposals(
+  query: { kind_type?: string; state?: ProposalState } = {},
+): Promise<Proposal[]> {
+  const params = new URLSearchParams();
+  if (query.kind_type !== undefined && query.kind_type !== '') params.set('kind_type', query.kind_type);
+  if (query.state !== undefined) params.set('state', query.state);
+  const qs = params.toString();
+  return apiFetch<{ proposals: Proposal[] }>(`/proposals${qs === '' ? '' : `?${qs}`}`).then(
+    (r) => r.proposals,
+  );
+}
+
+/** `POST /proposals/:id/approve` — approve a pending proposal; the engine writes the
+ *  governed-knowledge item and returns its outcome. */
+export function approveProposal(id: string): Promise<ProposalApproveOutcome> {
+  return apiFetch<ProposalApproveOutcome>(`/proposals/${encodeURIComponent(id)}/approve`, {
+    method: 'POST',
+  });
+}
+
+/** `POST /proposals/:id/reject` — reject a pending proposal; nothing is written to the store. */
+export function rejectProposal(id: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/proposals/${encodeURIComponent(id)}/reject`, {
+    method: 'POST',
+  });
+}
+
+// ── The adoption seam ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * True when this daemon cannot serve the proposal queue yet: a 501 (route present, engine
+ * method absent) or Fastify's bare unknown-route 404 (crew predates the proposal routes). A
+ * NAMED 404/4xx from a daemon WITH the route is a real answer and surfaces as one.
+ */
+export function isProposalsUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}
+
+/** The honest in-band copy for {@link isProposalsUnsupported} refusals. */
+export const PROPOSALS_UNSUPPORTED_COPY =
+  'This daemon predates the proposal queue (its crew/estate slice) — there is nothing to review here yet. Governed-knowledge proposals will appear once the daemon serves them.';

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -8,6 +8,7 @@ import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
 import { steeringPath, STEERING_TYPE_LABELS, STEERING_TYPES } from '../api/steering.js';
+import { proposalsPath, PROPOSAL_KIND_LABELS, PROPOSAL_KINDS } from '../api/proposals.js';
 import { testingPath, TESTING_PAGE_LABELS, TESTING_PAGES } from '../api/testing.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
@@ -73,7 +74,7 @@ const S = {
 
 // ── The five paths (§2.1) ─────────────────────────────────────────────────────
 
-export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'testing' | 'steering' | 'settings';
+export type PathKey = 'projects' | 'make' | 'chat' | 'repos' | 'testing' | 'steering' | 'proposals' | 'settings';
 
 /** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
  *  links `/system` in the collapsed column — it has no dashboard). `noun` is
@@ -94,8 +95,13 @@ const P_TESTING: PathSpec  = { key: 'testing',  title: 'Testing',      noun: 'Ca
 // pages); its accordion rows are the seven steering types, its collapsed glyph links the
 // `/steering` landing (the seven type cards — the steering-UX wave's calm entry).
 const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: null,        collapsedHref: '/steering' };
+// Proposals (DES-MEM-FACETED-001): the governed-knowledge REVIEW queue, a PRIMARY path placed
+// immediately AFTER Steering (Steering authors rules; this reviews the agent-proposed memories +
+// policies). Like Steering it is title-only (no ▦/＋ — approve/reject live on the cards); its
+// accordion rows are the type filters, its collapsed glyph links the unfiltered `/proposals` queue.
+const P_PROPOSALS: PathSpec = { key: 'proposals', title: 'Proposals',   noun: 'Proposal',   glyph: '📥', dash: null,        collapsedHref: '/proposals' };
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
-const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_TESTING, P_STEERING, P_SETTINGS];
+const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_TESTING, P_STEERING, P_PROPOSALS, P_SETTINGS];
 
 // `wiki`, `rules` and `policies` retired into Steering (they redirect to /steering); the
 // retired `coverage` and `domain` panels redirect to /system — kept mapped here so the rail
@@ -120,6 +126,7 @@ export function headingForPath(pathname: string): PathKey | null {
   // The retired `/wiki` + `/rules` + `/policies` addresses redirect into Steering — map them
   // there too, so the rail never flashes Settings open on the pre-redirect tick.
   if (first === 'steering' || first === 'wiki' || first === 'rules' || first === 'policies') return 'steering';
+  if (first === 'proposals') return 'proposals';
   if (SETTINGS_ROUTES.has(first)) return 'settings';
   return null;
 }
@@ -534,6 +541,29 @@ function SteeringTypeRows({ navigate }: { navigate: (p: string) => void }): Reac
   );
 }
 
+/** The Proposals accordion's rows: one per type filter (all | memory | policy), each a
+ *  navigate() shortcut to the deep-linked queue — the SteeringTypeRows grammar. */
+function ProposalKindRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <div role="menu" className="flex flex-col pt-0.5">
+      {PROPOSAL_KINDS.map((k) => (
+        <button
+          key={k}
+          type="button"
+          role="menuitem"
+          data-testid="rail-proposal-kind"
+          data-kind={k}
+          onClick={() => navigate(proposalsPath(k))}
+          className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
+          style={{ color: 'var(--ink-muted)' }}
+        >
+          {PROPOSAL_KIND_LABELS[k]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 const flatRunPath = (id: string): string => `/runs/${encodeURIComponent(id)}`;
@@ -822,6 +852,16 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             navigate={navigate}
           >
             <SteeringTypeRows navigate={navigate} />
+          </RailHeading>
+
+          {/* ── Proposals — the governed-knowledge review queue, AFTER Steering. ─ */}
+          <RailHeading
+            path={P_PROPOSALS}
+            open={openHeading === 'proposals'}
+            onToggle={() => toggle('proposals')}
+            navigate={navigate}
+          >
+            <ProposalKindRows navigate={navigate} />
           </RailHeading>
 
           {/* ── Settings — title only, no ▦/＋ (the operator's word, §3.1) ───── */}

--- a/src/components/ProposalChips.tsx
+++ b/src/components/ProposalChips.tsx
@@ -1,0 +1,52 @@
+import { proposalKind, type Proposal } from '../api/proposals.js';
+
+/** The proposal queue's shared chip grammar — the kind chip (memory / policy), one spelling for
+ *  the queue list, mirroring SteeringChips' severity/effect grammar. Policy severity reuses
+ *  SteeringChips' SeverityChip, so the two governance surfaces read identically. */
+
+export const KIND_COLOR: Record<'memory' | 'policy' | 'other', string> = {
+  memory: 'var(--accent)',
+  policy: 'var(--status-gate)',
+  other: 'var(--ink-muted)',
+};
+
+/** The kind badge — shows the RAW `kind_type` (`memory`, `policy:security`) so the operator
+ *  sees exactly what was proposed, colored by the folded kind. */
+export function KindChip({ proposal }: { proposal: Proposal }): React.ReactElement {
+  const kind = proposalKind(proposal);
+  return (
+    <span
+      data-testid="proposal-kind-chip"
+      data-kind={kind}
+      className="inline-flex shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
+      style={{ color: KIND_COLOR[kind], border: `1px solid ${KIND_COLOR[kind]}` }}
+    >
+      {proposal.kind_type}
+    </span>
+  );
+}
+
+/** A key:value facet/provenance chip list — the drawer's ChipList grammar, keyed so React is
+ *  happy and each pair stays legible. Renders a dash when the map is empty. */
+export function KeyValueChips({ testid, entries }: {
+  testid: string;
+  entries: Record<string, string>;
+}): React.ReactElement {
+  const pairs = Object.entries(entries);
+  if (pairs.length === 0) {
+    return <span data-testid={testid} style={{ color: 'var(--ink-dim)' }}>—</span>;
+  }
+  return (
+    <span data-testid={testid} className="inline-flex flex-wrap gap-1">
+      {pairs.map(([k, v]) => (
+        <span
+          key={k}
+          className="rounded px-1.5 py-0.5 text-[10px] font-mono"
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
+        >
+          <span style={{ color: 'var(--ink-dim)' }}>{k}:</span> {v}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/components/ProposalsList.tsx
+++ b/src/components/ProposalsList.tsx
@@ -1,0 +1,173 @@
+import {
+  memoryPayload,
+  policyPayload,
+  policySteeringType,
+  proposalKind,
+  type Proposal,
+} from '../api/proposals.js';
+import { SeverityChip } from './SteeringChips.js';
+import { KeyValueChips, KindChip } from './ProposalChips.js';
+
+/**
+ * The proposal QUEUE list — one card per pending proposal, the review-surface twin of
+ * SteeringGrid's spreadsheet. Each card shows the kind chip, the payload (memory: content +
+ * tier; policy: the rule + severity), the facets, and the provenance (which run/agent proposed
+ * it), with Approve / Reject actions. The page owns the wire calls + optimistic state; this
+ * component is presentational (loading / error / empty states handled here, exactly like
+ * SteeringGrid).
+ */
+
+/** One label:value detail line — the drawer's DetailRow grammar. */
+function DetailRow({ label, testid, children }: {
+  label: string;
+  testid: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex gap-2 text-[11px]">
+      <span className="w-24 shrink-0 text-[10px] uppercase tracking-wider" style={{ color: 'var(--ink-dim)' }}>{label}</span>
+      <span data-testid={testid} className="min-w-0 break-words" style={{ color: 'var(--ink-muted)' }}>{children}</span>
+    </div>
+  );
+}
+
+/** The payload, rendered by kind — memory shows content + tier, policy shows the rule +
+ *  severity chip, an unrecognized kind shows the raw JSON so nothing is silently swallowed. */
+function PayloadDetail({ proposal }: { proposal: Proposal }): React.ReactElement {
+  const kind = proposalKind(proposal);
+  if (kind === 'memory') {
+    const { content, tier } = memoryPayload(proposal);
+    return (
+      <>
+        <DetailRow label="Content" testid="proposal-memory-content">
+          {content ?? <span style={{ color: 'var(--ink-dim)' }}>— (no content)</span>}
+        </DetailRow>
+        <DetailRow label="Tier" testid="proposal-memory-tier">
+          {tier !== null ? <span className="font-mono">{tier}</span> : <span style={{ color: 'var(--ink-dim)' }}>—</span>}
+        </DetailRow>
+      </>
+    );
+  }
+  if (kind === 'policy') {
+    const { rule, severity } = policyPayload(proposal);
+    return (
+      <>
+        <DetailRow label="Rule" testid="proposal-policy-rule">
+          {rule ?? <span style={{ color: 'var(--ink-dim)' }}>— (no rule text)</span>}
+        </DetailRow>
+        <DetailRow label="Severity" testid="proposal-policy-severity">
+          {severity !== null ? <SeverityChip severity={severity} /> : <span style={{ color: 'var(--ink-dim)' }}>—</span>}
+        </DetailRow>
+      </>
+    );
+  }
+  return (
+    <DetailRow label="Payload" testid="proposal-raw-payload">
+      <code className="whitespace-pre-wrap break-all font-mono text-[10px]">
+        {JSON.stringify(proposal.payload)}
+      </code>
+    </DetailRow>
+  );
+}
+
+function ProposalCard({ proposal, deciding, onApprove, onReject }: {
+  proposal: Proposal;
+  deciding: boolean;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}): React.ReactElement {
+  const steeringType = policySteeringType(proposal);
+  return (
+    <li
+      data-testid="proposal-card"
+      data-proposal-id={proposal.id}
+      data-kind={proposalKind(proposal)}
+      className="flex flex-col gap-2 rounded p-3"
+      style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+    >
+      <div className="flex items-center gap-2">
+        <KindChip proposal={proposal} />
+        {steeringType !== null && (
+          <span data-testid="proposal-policy-target" className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            → {steeringType}
+          </span>
+        )}
+        <span className="font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>{proposal.id}</span>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <PayloadDetail proposal={proposal} />
+        <DetailRow label="Facets" testid="proposal-facets">
+          <KeyValueChips testid="proposal-facets-chips" entries={proposal.facets} />
+        </DetailRow>
+        <DetailRow label="Proposed by" testid="proposal-provenance">
+          <KeyValueChips testid="proposal-provenance-chips" entries={proposal.provenance} />
+        </DetailRow>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-0.5">
+        <button
+          data-testid="proposal-reject"
+          type="button"
+          disabled={deciding}
+          onClick={() => onReject(proposal.id)}
+          className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-50"
+          style={{ color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
+        >
+          Reject
+        </button>
+        <button
+          data-testid="proposal-approve"
+          type="button"
+          disabled={deciding}
+          onClick={() => onApprove(proposal.id)}
+          className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-50"
+          style={{ color: 'var(--status-done)', border: '1px solid var(--surface-raised)' }}
+        >
+          Approve
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export function ProposalsList({ proposals, loading, error, decidingIds, onApprove, onReject }: {
+  proposals: Proposal[];
+  loading: boolean;
+  error: string | null;
+  /** Ids whose approve/reject is in flight — their buttons disable. */
+  decidingIds: ReadonlySet<string>;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}): React.ReactElement {
+  if (loading) {
+    return <p data-testid="proposals-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading proposals…</p>;
+  }
+  if (error !== null) {
+    return (
+      <p data-testid="proposals-error" className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+        {error}
+      </p>
+    );
+  }
+  if (proposals.length === 0) {
+    return (
+      <p data-testid="proposals-empty" className="rounded px-3 py-2 text-xs" style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}>
+        No proposals to review.
+      </p>
+    );
+  }
+  return (
+    <ul data-testid="proposals-list" className="flex flex-col gap-3">
+      {proposals.map((p) => (
+        <ProposalCard
+          key={p.id}
+          proposal={p}
+          deciding={decidingIds.has(p.id)}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ProposalsList.tsx
+++ b/src/components/ProposalsList.tsx
@@ -64,7 +64,7 @@ function PayloadDetail({ proposal }: { proposal: Proposal }): React.ReactElement
   return (
     <DetailRow label="Payload" testid="proposal-raw-payload">
       <code className="whitespace-pre-wrap break-all font-mono text-[10px]">
-        {JSON.stringify(proposal.payload)}
+        {proposal.payload === undefined ? '(no payload)' : JSON.stringify(proposal.payload)}
       </code>
     </DetailRow>
   );

--- a/src/components/ProposalsPage.tsx
+++ b/src/components/ProposalsPage.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  approveProposal,
+  isProposalsUnsupported,
+  listProposals,
+  PROPOSAL_KIND_LABELS,
+  PROPOSAL_KINDS,
+  PROPOSALS_UNSUPPORTED_COPY,
+  proposalMatchesKind,
+  proposalsPath,
+  readProposalKind,
+  rejectProposal,
+  type Proposal,
+  type ProposalKind,
+} from '../api/proposals.js';
+import { ProposalsList } from './ProposalsList.js';
+
+/**
+ * The proposal-queue surface (DES-MEM-FACETED-001) — the "policies and memories, one surface
+ * with a type filter" review queue, the read/decide twin of the Steering management surface
+ * (SteeringPage). It lists the PENDING governed-knowledge proposals the estate store holds
+ * (memories + steering policies), each awaiting a human approve/reject.
+ *
+ *  - Default view: `state=pending`, all kinds. The TYPE FILTER (all | memory | policy) is a
+ *    first-class dimension driven by `PROPOSAL_KINDS`, deep-linked via `?type=<kind>` so it is
+ *    back-button-correct and shared with the rail's accordion rows — adding a kind is a
+ *    one-line change in `../api/proposals.ts`, nothing here.
+ *  - Approve / Reject ride crew's `/api/v1/proposals/:id/{approve,reject}` (the governed
+ *    operator path — estate MCP stays read-only); on success the row leaves the queue and the
+ *    list reloads for the server's state, exactly the honesty posture SteeringPage keeps.
+ *  - Loading / error / empty ("No proposals to review.") and the forward-compat unsupported
+ *    state all render honestly in-band — a daemon that predates the routes is never an error card.
+ */
+
+export function ProposalsPage({ navigate, search = '' }: {
+  navigate: (path: string) => void;
+  /** The URL search string — `?type=<kind>` selects the active type filter. */
+  search?: string;
+}): React.ReactElement {
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [unsupported, setUnsupported] = useState(false);
+  /** Ids whose approve/reject is in flight — their buttons disable until it resolves. */
+  const [decidingIds, setDecidingIds] = useState<ReadonlySet<string>>(new Set<string>());
+  /** The post-decision note (approved / rejected / a failed decision), in-band. */
+  const [note, setNote] = useState<string | null>(null);
+
+  const filter = readProposalKind(search);
+
+  const loadProposals = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    setUnsupported(false);
+    try {
+      // Load every PENDING proposal once; the coarse memory-vs-policy filter is applied
+      // client-side below, so switching it never re-hits the wire.
+      const ps = await listProposals({ state: 'pending' });
+      setProposals(ps);
+    } catch (e) {
+      if (isProposalsUnsupported(e)) setUnsupported(true);
+      else setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProposals();
+  }, [loadProposals]);
+
+  const visible = useMemo(
+    () => proposals.filter((p) => proposalMatchesKind(p, filter)),
+    [proposals, filter],
+  );
+
+  /** Per-kind counts for the filter chips — computed over the full loaded set (unfiltered). */
+  const counts = useMemo(() => {
+    const c: Record<ProposalKind, number> = { all: proposals.length, memory: 0, policy: 0 };
+    for (const p of proposals) {
+      if (proposalMatchesKind(p, 'memory')) c.memory += 1;
+      else if (proposalMatchesKind(p, 'policy')) c.policy += 1;
+    }
+    return c;
+  }, [proposals]);
+
+  const decide = useCallback((id: string, verb: 'approve' | 'reject'): void => {
+    setNote(null);
+    setDecidingIds((cur) => new Set(cur).add(id));
+    const call = verb === 'approve' ? approveProposal(id) : rejectProposal(id);
+    void call
+      .then(() => {
+        // The row leaves the queue optimistically; a background reload reconciles with the
+        // server's state (another reviewer may have decided others in the meantime).
+        setProposals((cur) => cur.filter((p) => p.id !== id));
+        setNote(`${verb === 'approve' ? 'Approved' : 'Rejected'} ${id}.`);
+        void loadProposals();
+      })
+      .catch((e: unknown) => {
+        setNote(`Could not ${verb} ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      })
+      .finally(() => {
+        setDecidingIds((cur) => {
+          const next = new Set(cur);
+          next.delete(id);
+          return next;
+        });
+      });
+  }, [loadProposals]);
+
+  const onApprove = useCallback((id: string) => decide(id, 'approve'), [decide]);
+  const onReject = useCallback((id: string) => decide(id, 'reject'), [decide]);
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <div data-testid="proposals-page" className="flex max-w-4xl flex-col gap-4">
+        <div className="flex items-center gap-2">
+          <div>
+            <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Proposals</h2>
+            <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+              The governed-knowledge review queue — agent-proposed memories and steering policies,
+              each pending until you approve or reject it.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void loadProposals()}
+            className="ml-auto text-[10px] hover:underline"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            Refresh
+          </button>
+        </div>
+
+        {/* The type filter — first-class, data-driven from PROPOSAL_KINDS (all | memory | policy),
+            deep-linked via ?type= so it is back-button-correct and shared with the rail. */}
+        <div data-testid="proposals-filter" role="tablist" aria-label="Filter proposals by type" className="flex flex-wrap gap-1.5">
+          {PROPOSAL_KINDS.map((k) => {
+            const active = filter === k;
+            return (
+              <button
+                key={k}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                data-testid="proposals-filter-chip"
+                data-kind={k}
+                data-active={active}
+                onClick={() => navigate(proposalsPath(k))}
+                className="rounded px-2 py-1 text-[11px] font-semibold transition-colors"
+                style={{
+                  background: active ? 'var(--surface-raised)' : 'transparent',
+                  color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
+                  border: '1px solid var(--surface-raised)',
+                }}
+              >
+                {PROPOSAL_KIND_LABELS[k]} <span style={{ color: 'var(--ink-dim)' }}>({counts[k]})</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {note !== null && (
+          <p
+            data-testid="proposals-note"
+            className="rounded px-3 py-2 text-[11px]"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {note}
+          </p>
+        )}
+
+        {unsupported ? (
+          <p
+            data-testid="proposals-unsupported"
+            className="rounded px-3 py-2 text-xs"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+          >
+            {PROPOSALS_UNSUPPORTED_COPY}
+          </p>
+        ) : (
+          <ProposalsList
+            proposals={visible}
+            loading={loading}
+            error={error}
+            decidingIds={decidingIds}
+            onApprove={onApprove}
+            onReject={onReject}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -24,9 +24,13 @@ import { isTestingSubPage } from '../api/testing.js';
 // the RETIRED addresses (wiki/rules/policies, coverage/domain, the flat
 // campaigns, the bare /runs listing) keep their redirects: those are moves with
 // a known destination, not typos.
-export type Panel = 'home' | 'runs' | 'workflows' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'not-found';
+// `proposals` is the governed-knowledge review queue (`/proposals`, DES-MEM-FACETED-001) —
+// Steering-adjacent (Steering authors policies; this reviews the proposed memories AND policies).
+// It carries no sub-type path segment: its type filter (all | memory | policy) rides `?type=` in
+// the search string, so the bare `/proposals` parse below is all it needs.
+export type Panel = 'home' | 'runs' | 'workflows' | 'steering' | 'proposals' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'make' | 'not-found';
 
-const PANELS: Panel[] = ['runs', 'workflows', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
+const PANELS: Panel[] = ['runs', 'workflows', 'proposals', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'make'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.11",
   "counts": {
-    "files": 117,
-    "occurrences": 947,
-    "static": 811,
+    "files": 120,
+    "occurrences": 965,
+    "static": 826,
     "dynamic": 43,
     "computed": 6
   },
@@ -2867,6 +2867,90 @@
       ]
     },
     {
+      "testId": "proposal-approve",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposal-card",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposal-kind-chip",
+      "files": [
+        "src/components/ProposalChips.tsx"
+      ]
+    },
+    {
+      "testId": "proposal-policy-target",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposal-reject",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-empty",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-error",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-filter",
+      "files": [
+        "src/components/ProposalsPage.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-filter-chip",
+      "files": [
+        "src/components/ProposalsPage.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-list",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-loading",
+      "files": [
+        "src/components/ProposalsList.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-note",
+      "files": [
+        "src/components/ProposalsPage.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-page",
+      "files": [
+        "src/components/ProposalsPage.tsx"
+      ]
+    },
+    {
+      "testId": "proposals-unsupported",
+      "files": [
+        "src/components/ProposalsPage.tsx"
+      ]
+    },
+    {
       "testId": "quick-action",
       "files": [
         "src/components/ProjectCard.tsx"
@@ -2964,6 +3048,12 @@
     },
     {
       "testId": "rail-project",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
+      "testId": "rail-proposal-kind",
       "files": [
         "src/components/LeftSidebar.tsx"
       ]
@@ -5208,6 +5298,8 @@
       "files": [
         "src/components/CampaignScoreboard.tsx",
         "src/components/GroupChat.tsx",
+        "src/components/ProposalChips.tsx",
+        "src/components/ProposalsList.tsx",
         "src/components/SteeringAddMenu.tsx",
         "src/components/SteeringGrid.tsx",
         "src/components/SteeringHealth.tsx",

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -58,7 +58,7 @@ const W2_ORDERED = [
   bp('scratch', 'quiet', 0),
 ];
 
-const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'testing', 'steering', 'settings'] as const;
+const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'testing', 'steering', 'proposals', 'settings'] as const;
 
 function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
   return render(
@@ -107,6 +107,9 @@ describe('the route→heading map (§3.2)', () => {
     for (const p of ['/steering', '/steering/architecture', '/steering/security', '/wiki', '/rules', '/policies']) {
       expect(headingForPath(p)).toBe('steering');
     }
+    // Proposals owns its route (the governed-knowledge review queue, DES-MEM-FACETED-001).
+    // headingForPath receives the bare pathname (the ?type= filter rides the search string).
+    expect(headingForPath('/proposals')).toBe('proposals');
     // Testing owns its routes AND the retired flat /campaigns addresses (they
     // redirect to /testing/campaigns — same pre-redirect-tick contract).
     for (const p of ['/testing/harness', '/testing/evals', '/testing/campaigns', '/testing/campaigns/c-1', '/campaigns', '/campaigns/c-1']) {
@@ -118,15 +121,15 @@ describe('the route→heading map (§3.2)', () => {
   });
 });
 
-describe('the seven heading rows (§3.1 + STEERING + the testing wave)', () => {
-  it('renders all seven headings; Testing, Steering and Settings are icon-less, the other four carry ▦ and ＋', async () => {
+describe('the eight heading rows (§3.1 + STEERING + the testing wave + Proposals)', () => {
+  it('renders all eight headings; Testing, Steering, Proposals and Settings are icon-less, the other four carry ▦ and ＋', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     for (const k of HEADING_KEYS) {
       expect(screen.getByTestId(`rail-heading-${k}`)).toBeInTheDocument();
     }
-    for (const k of ['testing', 'steering', 'settings']) {
+    for (const k of ['testing', 'steering', 'proposals', 'settings']) {
       const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).queryByTestId('heading-dashboard')).toBeNull();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
@@ -138,18 +141,19 @@ describe('the seven heading rows (§3.1 + STEERING + the testing wave)', () => {
     }
   });
 
-  it('Testing sits immediately BEFORE Steering, which sits immediately BEFORE Settings (the placement contract)', async () => {
+  it('Testing → Steering → Proposals → Settings, each immediately before the next (the placement contract)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     const testing = screen.getByTestId('rail-heading-testing');
     const steering = screen.getByTestId('rail-heading-steering');
+    const proposals = screen.getByTestId('rail-heading-proposals');
     const settings = screen.getByTestId('rail-heading-settings');
-    // Same container, adjacent, testing → steering → settings — DOM-order assertions, not style ones.
-    expect(testing.compareDocumentPosition(steering) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Same container, adjacent, testing → steering → proposals → settings — DOM-order assertions.
     expect(testing.nextElementSibling).toBe(steering);
+    expect(steering.nextElementSibling).toBe(proposals);
+    expect(proposals.nextElementSibling).toBe(settings);
     expect(steering.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(steering.nextElementSibling).toBe(settings);
   });
 
   it('▦ icons are real links to the §2.1 dashboard routes', async () => {
@@ -411,15 +415,15 @@ describe('accordion contents (§3.3)', () => {
 });
 
 describe('the collapsed rail (§3.2)', () => {
-  it('shows exactly seven glyph links (Testing → its Campaigns landing, Steering → its landing, Settings → /system)', async () => {
+  it('shows exactly eight glyph links (Testing → its Campaigns landing, Steering → its landing, Proposals → its queue, Settings → /system)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
-    expect(glyphs).toHaveLength(7);
+    expect(glyphs).toHaveLength(8);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/make', '/chats', '/repos', '/testing/campaigns', '/steering', '/system',
+      '/projects', '/make', '/chats', '/repos', '/testing/campaigns', '/steering', '/proposals', '/system',
     ]);
     // Accordions don't exist at this width.
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();

--- a/tests/ProposalsPage.test.tsx
+++ b/tests/ProposalsPage.test.tsx
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * The proposal-queue surface (DES-MEM-FACETED-001), the read/decide twin of SteeringPage:
+ *  - lists the PENDING proposals (`GET /proposals?state=pending`), rendering memory content+tier
+ *    and policy rule+severity, plus each proposal's facets and provenance;
+ *  - the first-class type filter (all | memory | policy) narrows the loaded rows client-side and
+ *    deep-links via `?type=` (a chip click navigates, the page reads `search`);
+ *  - Approve / Reject ride `POST /proposals/:id/{approve,reject}`; on success the row leaves the
+ *    queue and the list reloads for the server's state;
+ *  - loading / error / empty / forward-compat-unsupported all render honestly in-band.
+ */
+
+const apiFetch = vi.fn();
+vi.mock('../src/api/client.js', () => ({
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+const { ProposalsPage } = await import('../src/components/ProposalsPage.js');
+const { ApiError } = await import('../src/api/errors.js');
+type Proposal = import('../src/api/proposals.js').Proposal;
+
+function proposal(over: Partial<Proposal> = {}): Proposal {
+  return {
+    id: 'p-mem',
+    kind_type: 'memory',
+    payload: { content: 'Remember the gh account flip', tier: 'session' },
+    facets: { project: 'wicked', domain: 'ops' },
+    provenance: { run_id: 'run-1', agent: 'claude' },
+    state: 'pending',
+    created_at: 1_700_000_000,
+    ...over,
+  };
+}
+
+const MEM = proposal();
+const POL = proposal({
+  id: 'p-pol',
+  kind_type: 'policy:security',
+  payload: { rule: 'Never log secrets', severity: 'critical' },
+  provenance: { run_id: 'run-2', agent: 'codex' },
+});
+
+/** A stateful wire: GET returns the current pending set; approve/reject remove from it. */
+function wire(initial: Proposal[]): { calls: string[] } {
+  let pending = [...initial];
+  const calls: string[] = [];
+  apiFetch.mockImplementation((path: unknown) => {
+    const s = String(path);
+    calls.push(s);
+    const parts = s.split('/'); // ['', 'proposals', '<id>', 'approve']
+    if (s.endsWith('/approve')) {
+      pending = pending.filter((p) => p.id !== parts[2]);
+      return Promise.resolve({ ok: true, id: parts[2] });
+    }
+    if (s.endsWith('/reject')) {
+      pending = pending.filter((p) => p.id !== parts[2]);
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.resolve({ proposals: pending });
+  });
+  return { calls };
+}
+
+function page(search = ''): { navigate: ReturnType<typeof vi.fn> } {
+  const navigate = vi.fn();
+  render(<ProposalsPage navigate={navigate} search={search} />);
+  return { navigate };
+}
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+describe('ProposalsPage — the pending queue', () => {
+  it('lists pending proposals with payload, facets, and provenance', async () => {
+    wire([MEM, POL]);
+    page();
+
+    const cards = await screen.findAllByTestId('proposal-card');
+    expect(cards).toHaveLength(2);
+
+    const mem = cards.find((c) => c.getAttribute('data-proposal-id') === 'p-mem')!;
+    expect(mem).toHaveAttribute('data-proposal-id', 'p-mem');
+    expect(within(mem).getByTestId('proposal-memory-content')).toHaveTextContent('Remember the gh account flip');
+    expect(within(mem).getByTestId('proposal-memory-tier')).toHaveTextContent('session');
+    expect(within(mem).getByTestId('proposal-facets-chips')).toHaveTextContent('project:');
+    expect(within(mem).getByTestId('proposal-provenance-chips')).toHaveTextContent('run-1');
+
+    // The policy card renders the rule + severity chip and its steering-type target.
+    const pol = cards.find((c) => c.getAttribute('data-proposal-id') === 'p-pol')!;
+    expect(within(pol).getByTestId('proposal-policy-rule')).toHaveTextContent('Never log secrets');
+    expect(within(pol).getByTestId('proposal-policy-severity')).toHaveTextContent('critical');
+    expect(within(pol).getByTestId('proposal-policy-target')).toHaveTextContent('security');
+
+    // The default view asks the wire for pending only.
+    expect(apiFetch).toHaveBeenCalledWith('/proposals?state=pending');
+  });
+
+  it('shows the empty state when nothing is pending', async () => {
+    wire([]);
+    page();
+    expect(await screen.findByTestId('proposals-empty')).toHaveTextContent('No proposals to review.');
+  });
+
+  it('surfaces a real error as an error card', async () => {
+    apiFetch.mockRejectedValue(new ApiError(500, 'boom'));
+    page();
+    expect(await screen.findByTestId('proposals-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposals-list')).toBeNull();
+  });
+
+  it('renders the honest unsupported state on a daemon that predates the routes', async () => {
+    apiFetch.mockRejectedValue(new ApiError(404, 'Not Found'));
+    page();
+    expect(await screen.findByTestId('proposals-unsupported')).toHaveTextContent(/predates the proposal queue/);
+  });
+});
+
+describe('ProposalsPage — the type filter', () => {
+  it('narrows to memory when ?type=memory, and the chip counts reflect the full set', async () => {
+    wire([MEM, POL]);
+    page('?type=memory');
+
+    await screen.findByTestId('proposals-list');
+    const cards = screen.getAllByTestId('proposal-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveAttribute('data-proposal-id', 'p-mem');
+
+    // Counts are computed over the full loaded set (all=2, memory=1, policy=1).
+    const chipText = (kind: string): string =>
+      screen.getByTestId('proposals-filter').querySelector(`[data-kind="${kind}"]`)?.textContent ?? '';
+    expect(chipText('all')).toContain('(2)');
+    expect(chipText('memory')).toContain('(1)');
+    expect(chipText('policy')).toContain('(1)');
+  });
+
+  it('a filter chip click navigates to the deep-linked queue', async () => {
+    wire([MEM, POL]);
+    const { navigate } = page();
+    const user = userEvent.setup();
+
+    await screen.findByTestId('proposals-list');
+    await user.click(screen.getByTestId('proposals-filter').querySelector('[data-kind="policy"]') as HTMLElement);
+    expect(navigate).toHaveBeenCalledWith('/proposals?type=policy');
+  });
+});
+
+describe('ProposalsPage — approve / reject', () => {
+  it('approve POSTs the approve wire, drops the row, notes it, and reloads', async () => {
+    const { calls } = wire([MEM, POL]);
+    page();
+    const user = userEvent.setup();
+
+    const mem = (await screen.findAllByTestId('proposal-card')).find(
+      (c) => c.getAttribute('data-proposal-id') === 'p-mem',
+    )!;
+    await user.click(within(mem).getByTestId('proposal-approve'));
+
+    await waitFor(() => expect(calls).toContain('/proposals/p-mem/approve'));
+    // A note confirms it; the queue reloaded (GET called twice — mount + after-decision).
+    expect(await screen.findByTestId('proposals-note')).toHaveTextContent('Approved p-mem.');
+    expect(calls.filter((c) => c === '/proposals?state=pending')).toHaveLength(2);
+    // The approved row is gone; p-pol remains in the queue.
+    await waitFor(() => {
+      const remaining = screen.getAllByTestId('proposal-card');
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]).toHaveAttribute('data-proposal-id', 'p-pol');
+    });
+  });
+
+  it('reject POSTs the reject wire and drops the row', async () => {
+    const { calls } = wire([MEM, POL]);
+    page();
+    const user = userEvent.setup();
+
+    const pol = (await screen.findAllByTestId('proposal-card')).find(
+      (c) => c.getAttribute('data-proposal-id') === 'p-pol',
+    )!;
+    await user.click(within(pol).getByTestId('proposal-reject'));
+
+    await waitFor(() => expect(calls).toContain('/proposals/p-pol/reject'));
+    expect(await screen.findByTestId('proposals-note')).toHaveTextContent('Rejected p-pol.');
+    await waitFor(() => {
+      const remaining = screen.getAllByTestId('proposal-card');
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]).toHaveAttribute('data-proposal-id', 'p-mem');
+    });
+  });
+
+  it('a failed decision keeps the row and notes the failure', async () => {
+    apiFetch.mockImplementation((path: unknown) => {
+      const s = String(path);
+      if (s.endsWith('/approve')) return Promise.reject(new ApiError(409, 'already decided'));
+      return Promise.resolve({ proposals: [MEM] });
+    });
+    page();
+    const user = userEvent.setup();
+
+    const card = await screen.findByTestId('proposal-card');
+    await user.click(within(card).getByTestId('proposal-approve'));
+
+    expect(await screen.findByTestId('proposals-note')).toHaveTextContent(/Could not approve p-mem/);
+    // The row stays — the decision did not take.
+    expect(screen.getByTestId('proposal-card')).toBeInTheDocument();
+  });
+});

--- a/tests/proposalsApi.test.ts
+++ b/tests/proposalsApi.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The proposal-queue wire (DES-MEM-FACETED-001), pinned:
+ *  - `proposalKind` folds `kind_type` to memory / policy / other; an unrecognized kind is still
+ *    classified `other` (LISTED under `all`, never invisible) and `policySteeringType` pulls the
+ *    steering type out of `policy:<type>`;
+ *  - the payload narrowers read `unknown` payloads defensively — a non-object payload, or a
+ *    missing field, degrades to null, never a throw;
+ *  - `listProposals` / `approveProposal` / `rejectProposal` hit the crew `/api/v1/proposals*`
+ *    paths with the right query + method;
+ *  - `isProposalsUnsupported` folds the two adoption-gap answers (bare 404 / 501) and keeps a
+ *    NAMED 404 as the real answer it is — the same seam as the wiki/steering reads.
+ */
+
+const apiFetch = vi.fn();
+vi.mock('../src/api/client.js', () => ({
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+const {
+  approveProposal,
+  isProposalsUnsupported,
+  listProposals,
+  memoryPayload,
+  policyPayload,
+  policySteeringType,
+  proposalKind,
+  proposalMatchesKind,
+  proposalsPath,
+  PROPOSAL_KINDS,
+  readProposalKind,
+  rejectProposal,
+} = await import('../src/api/proposals.js');
+const { ApiError } = await import('../src/api/errors.js');
+type Proposal = import('../src/api/proposals.js').Proposal;
+
+function proposal(over: Partial<Proposal> = {}): Proposal {
+  return {
+    id: 'p1',
+    kind_type: 'memory',
+    payload: { content: 'remember X', tier: 'session' },
+    facets: { project: 'wicked' },
+    provenance: { run_id: 'run-1', agent: 'claude' },
+    state: 'pending',
+    created_at: 1_700_000_000,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('proposalKind + policySteeringType — the kind fold', () => {
+  it('classifies memory, policy:<type>, bare policy, and unknown', () => {
+    expect(proposalKind(proposal({ kind_type: 'memory' }))).toBe('memory');
+    expect(proposalKind(proposal({ kind_type: 'policy:security' }))).toBe('policy');
+    expect(proposalKind(proposal({ kind_type: 'policy' }))).toBe('policy');
+    // An unrecognized kind is classified `other` — LISTED under `all`, never invisible.
+    expect(proposalKind(proposal({ kind_type: 'insight:foo' }))).toBe('other');
+  });
+
+  it('pulls the steering type out of policy:<type>, null otherwise', () => {
+    expect(policySteeringType(proposal({ kind_type: 'policy:security' }))).toBe('security');
+    expect(policySteeringType(proposal({ kind_type: 'policy' }))).toBeNull();
+    expect(policySteeringType(proposal({ kind_type: 'memory' }))).toBeNull();
+  });
+});
+
+describe('proposalMatchesKind — the filter predicate', () => {
+  it('all matches everything; a specific kind matches only its own', () => {
+    const mem = proposal({ kind_type: 'memory' });
+    const pol = proposal({ kind_type: 'policy:testing' });
+    expect(proposalMatchesKind(mem, 'all')).toBe(true);
+    expect(proposalMatchesKind(pol, 'all')).toBe(true);
+    expect(proposalMatchesKind(mem, 'memory')).toBe(true);
+    expect(proposalMatchesKind(mem, 'policy')).toBe(false);
+    expect(proposalMatchesKind(pol, 'policy')).toBe(true);
+  });
+});
+
+describe('payload narrowers — read unknown payloads defensively', () => {
+  it('memoryPayload reads content + tier, null-degrading a non-object or missing field', () => {
+    expect(memoryPayload(proposal({ payload: { content: 'X', tier: 'project' } }))).toEqual({ content: 'X', tier: 'project' });
+    expect(memoryPayload(proposal({ payload: { content: 'X' } }))).toEqual({ content: 'X', tier: null });
+    expect(memoryPayload(proposal({ payload: 'not-an-object' }))).toEqual({ content: null, tier: null });
+    expect(memoryPayload(proposal({ payload: null }))).toEqual({ content: null, tier: null });
+  });
+
+  it('policyPayload reads rule (or the statement fallback) + severity', () => {
+    expect(policyPayload(proposal({ payload: { rule: 'do X', severity: 'error' } }))).toEqual({ rule: 'do X', severity: 'error' });
+    // The steering wire spells the rule text `statement` — fall back to it.
+    expect(policyPayload(proposal({ payload: { statement: 'do Y', severity: 'warn' } }))).toEqual({ rule: 'do Y', severity: 'warn' });
+    expect(policyPayload(proposal({ payload: 42 }))).toEqual({ rule: null, severity: null });
+  });
+});
+
+describe('proposalsPath + readProposalKind — the one URL spelling', () => {
+  it('bare /proposals for all, ?type= for a kind', () => {
+    expect(proposalsPath('all')).toBe('/proposals');
+    expect(proposalsPath('memory')).toBe('/proposals?type=memory');
+    expect(proposalsPath('policy')).toBe('/proposals?type=policy');
+  });
+
+  it('reads the filter back from a search string; unknown/absent → all', () => {
+    expect(readProposalKind('?type=memory')).toBe('memory');
+    expect(readProposalKind('?type=policy')).toBe('policy');
+    expect(readProposalKind('')).toBe('all');
+    expect(readProposalKind('?type=bogus')).toBe('all');
+    for (const k of PROPOSAL_KINDS) expect(readProposalKind(proposalsPath(k).replace('/proposals', ''))).toBe(k);
+  });
+});
+
+describe('the wire calls — path + method', () => {
+  it('listProposals GETs /proposals with the state (and kind_type) query, unwrapping proposals[]', async () => {
+    const rows = [proposal()];
+    apiFetch.mockResolvedValue({ proposals: rows });
+
+    await expect(listProposals({ state: 'pending' })).resolves.toEqual(rows);
+    expect(apiFetch).toHaveBeenCalledWith('/proposals?state=pending');
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValue({ proposals: [] });
+    await listProposals({ kind_type: 'memory', state: 'pending' });
+    expect(apiFetch).toHaveBeenCalledWith('/proposals?kind_type=memory&state=pending');
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValue({ proposals: [] });
+    await listProposals();
+    expect(apiFetch).toHaveBeenCalledWith('/proposals');
+  });
+
+  it('approveProposal POSTs /proposals/:id/approve', async () => {
+    apiFetch.mockResolvedValue({ ok: true, id: 'p1' });
+    await expect(approveProposal('p1')).resolves.toEqual({ ok: true, id: 'p1' });
+    expect(apiFetch).toHaveBeenCalledWith('/proposals/p1/approve', { method: 'POST' });
+  });
+
+  it('rejectProposal POSTs /proposals/:id/reject', async () => {
+    apiFetch.mockResolvedValue({ ok: true });
+    await expect(rejectProposal('p2')).resolves.toEqual({ ok: true });
+    expect(apiFetch).toHaveBeenCalledWith('/proposals/p2/reject', { method: 'POST' });
+  });
+});
+
+describe('isProposalsUnsupported — the two adoption-gap answers, and only those', () => {
+  it('501 and the bare unknown-route 404 → unsupported', () => {
+    expect(isProposalsUnsupported(new ApiError(501, 'engine predates proposals'))).toBe(true);
+    expect(isProposalsUnsupported(new ApiError(404, 'Not Found'))).toBe(true);
+    expect(isProposalsUnsupported(new ApiError(404, 'not found'))).toBe(true);
+  });
+
+  it('a NAMED 404 is a real answer, and an ordinary error is not an adoption gap', () => {
+    expect(isProposalsUnsupported(new ApiError(404, 'unknown proposal: p9'))).toBe(false);
+    expect(isProposalsUnsupported(new Error('boom'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## The 'policies and memories' review surface

The human approval queue for agent-proposed governed-knowledge items. Browse **pending** proposals, filter by **type** (all / memory / policy), **approve** / **reject** — mirroring the Steering surface, placed Steering-adjacent (the 'governed knowledge' area: Steering = policies, this = the proposal queue for both).

### Files
- **`src/api/proposals.ts`** — wire client (`list`/`approve`/`reject` over `/api/v1/proposals`). `Proposal` type defined **locally** per the `wiki.ts` precedent, with a migration note to `wicked-crew-api-types` once studio bumps to the version carrying the contract (crew's proposals-API PR).
- **`ProposalsPage`/`ProposalsList`/`ProposalChips`** — mirror `SteeringPage`/`Grid`/`Chips`; a **first-class type dimension** (all/memory/policy, deep-linked `?type=`) so new kinds are a one-line add.
- Route + nav wiring (`useRoute` panel, `App` render arm, `LeftSidebar` — after Steering, before Settings).

### Depends on
Crew's proposals API (`/api/v1/proposals*`, parallel PR). Until `crew-api-types` publishes the `Proposal` contract, the local type is the source (per `wiki.ts`); a follow-up swaps to the package.

### Green
typecheck + lint clean · **43** proposal/rail tests pass (full suite 2398/228 files) · build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)