### PR TITLE
release: wicked-studio 0.4.12 (proposal approval-queue surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.12] — 2026-09-06
+
+### Added
+- **The proposal approval-queue surface** (DES-MEM-FACETED-001, #185). A dedicated queue for
+  governed-knowledge proposals: browse pending proposals, filter by type, and approve or reject
+  each in place. The `Proposal` type is defined locally for this release (per the `src/api/wiki.ts`
+  pattern) pending `wicked-crew-api-types@0.21.0`.
+
 ## [0.4.11] — 2026-09-05
 
 ### Changed
@@ -336,7 +344,9 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.10...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.12...HEAD
+[0.4.12]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.11...v0.4.12
+[0.4.11]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.7...v0.4.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.11",
+  "studioVersion": "0.4.12",
   "counts": {
     "files": 120,
     "occurrences": 965,


### PR DESCRIPTION
Version bump **0.4.11 → 0.4.12** — ships the proposal approval-queue surface (#185: browse / filter-by-type / approve-reject for governed-knowledge proposals, DES-MEM-FACETED-001) so wicked-crew's `build:with-studio` bundles it.

Bumped: `package.json`, `package-lock.json`, `testid-inventory.json` (`studioVersion` — the `testidInventory` test asserts it equals the package version), CHANGELOG + compare link-refs (also added the missing `[0.4.11]` link-ref). `grep 0.4.11` clean (only CHANGELOG history remains); typecheck + build pass. The surface's local `Proposal` type stays until `crew-api-types@0.21.0` publishes.

Tag `v0.4.12` after merge → `release.yml` (OIDC trusted publish + post-publish registry probe). Then crew bumps its `wicked-studio` devDep to `^0.4.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)