### PR TITLE
release: wicked-studio 0.4.13 (unified Steering surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.13] — 2026-09-06
+
+### Changed
+- **Unified governed-knowledge surface (DES-MEM-FACETED-001, #187).** Steering is now the home for both **Policies** and **Memories**, each sub-section carrying *manage existing* AND *proposals*: the seven steering-type pages collapse into one type-filtered Policies view (all rule-management preserved) with policy proposals folded in; a new Memories sub-section browses the memory store, retires (subtree-scoped), and reviews memory proposals. The standalone Proposals surface is retired into these sub-sections (`/proposals` and legacy `/steering/:type` redirect).
+
 ## [0.4.12] — 2026-09-06
 
 ### Added
@@ -344,7 +349,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.12...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.13...HEAD
+[0.4.13]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.12...v0.4.13
 [0.4.12]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.11...v0.4.12
 [0.4.11]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.9...v0.4.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.12",
+  "studioVersion": "0.4.13",
   "counts": {
     "files": 121,
     "occurrences": 982,


### PR DESCRIPTION
Version bump **0.4.12 → 0.4.13** — ships the unified governed-knowledge surface (#187): Steering → **Policies + Memories** sub-sections, each with *manage-existing* + *proposals*; the 7 policy pages collapsed into one type filter; the standalone Proposals surface retired into the sub-sections.

Bumped: `package.json`, `package-lock.json`, `testid-inventory.json` (`studioVersion` gate), CHANGELOG + link-refs. Tag `v0.4.13` after merge → `release.yml` publishes; then wicked-crew bumps its `wicked-studio` devDep to `^0.4.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)