### PR TITLE
feat(repos): 'Capture learnings' action → capture-learnings run

### DIFF
--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -112,6 +112,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
   const projectIdByRun = useMembershipStore((s) => s.projectIdByRun);
 
   const [rerunning, setRerunning] = useState<Record<string, boolean>>({});
+  const [capturing, setCapturing] = useState<Record<string, boolean>>({});
   const [rerunError, setRerunError] = useState<Record<string, string>>({});
   const [showRegister, setShowRegister] = useState(autoShowRegister ?? false);
   const [sourceMode, setSourceMode] = useState<SourceMode>('local');
@@ -187,6 +188,35 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
       }));
     } finally {
       setRerunning((prev) => ({ ...prev, [repoId]: false }));
+    }
+  }
+
+  /**
+   * Capture learnings (studio "Capture learnings" verb): launch the governed
+   * capture-learnings workflow over this repo — a REAL governed run (mine the
+   * repo's history/graph into durable memory + knowledge), so it lands on the
+   * run the operator can watch, never a hidden relaunch. Reuses the shared
+   * `launchRun` wire (`POST /runs {problem, repoRef, workflow}`) — no new type.
+   * Failures surface in the card's existing `rerunError` slot (only one card
+   * action runs at a time), the loading label rides its own `capturing` map.
+   */
+  async function captureLearnings(repoId: string, repoName: string): Promise<void> {
+    setCapturing((prev) => ({ ...prev, [repoId]: true }));
+    setRerunError((prev) => ({ ...prev, [repoId]: '' }));
+    try {
+      const { runId } = await api.launchRun({
+        problem: `Capture learnings from ${repoName}`,
+        repoRef: repoId,
+        workflow: 'capture-learnings',
+      });
+      onSelectRun?.(runId);
+    } catch (err) {
+      setRerunError((prev) => ({
+        ...prev,
+        [repoId]: err instanceof Error ? err.message : String(err),
+      }));
+    } finally {
+      setCapturing((prev) => ({ ...prev, [repoId]: false }));
     }
   }
 
@@ -766,6 +796,26 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                     >
                       View →
                     </button>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    {/* Capture learnings — a REAL governed run (launchRun), not a prefill:
+                        mine this repo's history/graph into durable memory. */}
+                    <button
+                      type="button"
+                      data-testid="repo-capture-learnings"
+                      data-repo-id={repo.id}
+                      disabled={capturing[repo.id] ?? false}
+                      title="Launch a governed run that mines this repo's history into durable memory + knowledge — a tracked run you can watch"
+                      onClick={() => void captureLearnings(repo.id, repo.name)}
+                      className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
+                      style={{
+                        background: 'transparent',
+                        color: 'var(--ink-muted)',
+                        border: '1px solid var(--surface-raised)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {(capturing[repo.id] ?? false) ? 'Starting…' : 'Capture learnings'}
+                    </button>
                     {m.onboard.run !== null ? (
                       <button
                         type="button"
@@ -799,6 +849,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                         {isRerunning ? 'Starting…' : 'Onboard'}
                       </button>
                     )}
+                    </div>
                   </div>
                 </div>
               );

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -114,6 +114,9 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
 
   const [rerunning, setRerunning] = useState<Record<string, boolean>>({});
   const [capturing, setCapturing] = useState<Record<string, boolean>>({});
+  // Synchronous in-flight guard: the button's `disabled` only applies after a
+  // re-render, so a fast double-click can fire captureLearnings twice before then.
+  const capturingRef = useRef<Set<string>>(new Set());
   const [rerunError, setRerunError] = useState<Record<string, string>>({});
   const [showRegister, setShowRegister] = useState(autoShowRegister ?? false);
   const [sourceMode, setSourceMode] = useState<SourceMode>('local');
@@ -202,6 +205,10 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
    * action runs at a time), the loading label rides its own `capturing` map.
    */
   async function captureLearnings(repoId: string, repoName: string): Promise<void> {
+    // Bail if a capture for this repo is already in flight (double-click before the
+    // disabled state re-renders) — the ref is updated synchronously, unlike state.
+    if (capturingRef.current.has(repoId)) return;
+    capturingRef.current.add(repoId);
     setCapturing((prev) => ({ ...prev, [repoId]: true }));
     setRerunError((prev) => ({ ...prev, [repoId]: '' }));
     try {
@@ -220,6 +227,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
         [repoId]: err instanceof Error ? err.message : String(err),
       }));
     } finally {
+      capturingRef.current.delete(repoId);
       setCapturing((prev) => ({ ...prev, [repoId]: false }));
     }
   }

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from '../board/windowStats.js';
 import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useMembershipStore } from '../store/membership.js';
+import { useProvenanceStore } from '../store/provenance.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
 import {
   DashboardGrid, FilterStrip, KpiBand, KpiGroup, Sparkline, StatTile, type FilterChip,
@@ -209,6 +210,9 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
         repoRef: repoId,
         workflow: 'capture-learnings',
       });
+      // Studio witnessed this launch — record it so the run's provenance line
+      // reads 'via studio', not the API fallback (same as ChatInput's launch).
+      useProvenanceStore.getState().markLaunchedHere(runId);
       onSelectRun?.(runId);
     } catch (err) {
       setRerunError((prev) => ({
@@ -803,7 +807,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                       type="button"
                       data-testid="repo-capture-learnings"
                       data-repo-id={repo.id}
-                      disabled={capturing[repo.id] ?? false}
+                      disabled={(capturing[repo.id] ?? false) || isRerunning}
                       title="Launch a governed run that mines this repo's history into durable memory + knowledge — a tracked run you can watch"
                       onClick={() => void captureLearnings(repo.id, repo.name)}
                       className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
@@ -837,7 +841,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                       <button
                         type="button"
                         data-testid="repo-onboard"
-                        disabled={isRerunning}
+                        disabled={isRerunning || (capturing[repo.id] ?? false)}
                         onClick={() => void rerunOnboarding(repo.id)}
                         className="rounded-md px-3 py-1 text-[11px] font-mono disabled:opacity-50"
                         style={{

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.13",
   "counts": {
     "files": 121,
-    "occurrences": 982,
-    "static": 842,
+    "occurrences": 983,
+    "static": 843,
     "dynamic": 43,
     "computed": 6
   },
@@ -3231,6 +3231,12 @@
       "testId": "raw-event",
       "files": [
         "src/components/NarratorFeed.tsx"
+      ]
+    },
+    {
+      "testId": "repo-capture-learnings",
+      "files": [
+        "src/components/RepositoriesPanel.tsx"
       ]
     },
     {


### PR DESCRIPTION
Adds a per-repo **Capture learnings** verb to the Repositories panel. It launches the governed `capture-learnings` workflow over the repo via the shared `launchRun` wire (`POST /runs {problem, repoRef, workflow:'capture-learnings'}`) — a real tracked run the operator watches, not a hidden relaunch. Reuses `launchRun` (no new wire type); failures surface in the card's existing error slot; a `capturing` map drives the per-repo loading label. `data-testid=repo-capture-learnings`.

This is the studio trigger for the repo-learning feature — pairs with wicked-crew #458 (the workflow + policy landing) and wicked-garden #1107 (the skill the run's worker loads). Runtime order: garden skill installed → crew serving `capture-learnings` → this button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)