### PR TITLE
release: studio 0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.14] — 2026-09-07
+
+### Added
+- **Capture learnings action (#189).** A per-repo verb on the Repositories panel
+  launches the governed `capture-learnings` workflow over the repo (`launchRun`
+  with `workflow:'capture-learnings'`) — a tracked run the operator watches that
+  mines the repo's churn + hotspots into faceted memory and policy proposals,
+  reviewed in the Steering surfaces. Marks the run launched-here (studio
+  provenance), mutually disables with Onboard, and guards against double-click.
+
 ## [0.4.13] — 2026-09-06
 
 ### Changed
@@ -349,7 +359,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.13...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.14...HEAD
+[0.4.14]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.13...v0.4.14
 [0.4.13]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.12...v0.4.13
 [0.4.12]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.11...v0.4.12
 [0.4.11]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.10...v0.4.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.13",
+  "studioVersion": "0.4.14",
   "counts": {
     "files": 121,
     "occurrences": 983,


### PR DESCRIPTION
Ships the **Capture learnings** action (#189): a per-repo verb on the Repositories panel that launches the governed `capture-learnings` workflow, mining a repo's churn + hotspots into faceted memory + policy proposals reviewed in Steering.

- package.json + lockfile 0.4.13 → 0.4.14
- regenerated testid-inventory.json (embeds 0.4.14)
- CHANGELOG [0.4.14] + compare link-refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)