### PR TITLE
ci(release): cut a GitHub Release after npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,19 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          python3 scripts/changelog-section.py "$TAG" > /tmp/relnotes.md \
-            || printf 'Release %s\n' "$TAG" > /tmp/relnotes.md
+          # Notes = this version's CHANGELOG section. Distinguish "no section" (exit 1 → generic
+          # note) from a real script failure (exit 2 → missing/unreadable CHANGELOG, usage bug),
+          # which must FAIL rather than silently ship a generic note.
+          set +e
+          python3 scripts/changelog-section.py "$TAG" > /tmp/relnotes.md
+          code=$?
+          set -e
+          if [ "$code" -eq 1 ]; then
+            printf 'Release %s\n' "$TAG" > /tmp/relnotes.md
+          elif [ "$code" -ne 0 ]; then
+            echo "::error::changelog-section.py failed (exit $code) — refusing to publish a release with fallback notes"
+            exit "$code"
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --notes-file /tmp/relnotes.md
             echo "updated existing GitHub Release $TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write # create the GitHub Release after a successful npm publish
   # OIDC trusted publishing — no NPM_TOKEN stored in this repo.
   id-token: write
 
@@ -79,3 +79,24 @@ jobs:
           done
           echo "::error::wicked-studio@${TAG_VERSION} is still not resolvable after publish (FINDING-096)."
           exit 1
+
+      # Cut the GitHub Release only after npm publish AND the registry-serve check pass — so a
+      # release is advertised only for a version the registry can actually serve, never a tag whose
+      # publish failed. This is the step studio lacked: it published to npm every release but never
+      # created a GitHub Release, so the Releases page stayed empty while npm shipped through
+      # v0.4.14. Idempotent — an existing release (e.g. a hand-backfilled one) is updated in place.
+      - name: Create the GitHub Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          python3 scripts/changelog-section.py "$TAG" > /tmp/relnotes.md \
+            || printf 'Release %s\n' "$TAG" > /tmp/relnotes.md
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file /tmp/relnotes.md
+            echo "updated existing GitHub Release $TAG"
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/relnotes.md --verify-tag
+            echo "created GitHub Release $TAG"
+          fi

--- a/scripts/changelog-section.py
+++ b/scripts/changelog-section.py
@@ -1,28 +1,43 @@
 #!/usr/bin/env python3
 """Print the CHANGELOG.md section body for a given version.
 
-Usage: changelog-section.py <version>   (accepts "0.4.14" or "v0.4.14")
+Usage: changelog-section.py <version>   (accepts "0.16.6" or "v0.16.6")
 
 Emits the body of the matching `## [X.Y.Z] — …` section with the heading and the
 trailing `[X.Y.Z]: https://…` link-reference lines stripped, so it can be piped
-straight into `gh release create --notes-file`. Exits 1 (no output) when the
-version has no section, letting the release workflow fall back to a generic note.
+straight into `gh release create --notes-file`.
 
-Stdlib-only and cross-platform: the release workflow runs it on the runner, but it
-is equally runnable locally to preview a version's release notes before a tag push.
+Exit codes are meaningful so a caller can tell "no section" from a real failure:
+  0 — section found (body written to stdout)
+  1 — no section for this version (nothing written; caller may fall back to a generic note)
+  2 — a real error (bad usage, CHANGELOG.md missing/unreadable) — caller should FAIL, not fall back
+
+Resolves CHANGELOG.md from the current directory first, then relative to this
+script (repo-root/scripts/..), so it works both in CI (run from the repo root) and
+locally from any directory. Stdlib-only and cross-platform.
 """
 
+import os
 import re
 import sys
+
+
+def _changelog_path() -> str:
+    """CHANGELOG.md in the CWD if present, else next to the repo root above scripts/."""
+    if os.path.exists("CHANGELOG.md"):
+        return "CHANGELOG.md"
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(here, "..", "CHANGELOG.md"))
 
 
 def main() -> int:
     if len(sys.argv) != 2:
         sys.stderr.write("usage: changelog-section.py <version>\n")
         return 2
-    ver = sys.argv[1].lstrip("v")
+    arg = sys.argv[1]
+    ver = arg.lstrip("v")
     try:
-        txt = open("CHANGELOG.md", encoding="utf-8").read()
+        txt = open(_changelog_path(), encoding="utf-8").read()
     except OSError as e:
         sys.stderr.write(f"cannot read CHANGELOG.md: {e}\n")
         return 2
@@ -33,7 +48,9 @@ def main() -> int:
             end = heads[i + 1].start() if i + 1 < len(heads) else len(txt)
             body = txt[start:end].strip()
             body = re.sub(r"(?m)^\[[^\]]+\]:\s*https?://\S+$", "", body).strip()
-            sys.stdout.write(body if body else f"Release {ver}\n")
+            # An empty section still counts as found; echo the arg verbatim (keeping any
+            # leading "v") so the note stays consistent with the tag/title the caller uses.
+            sys.stdout.write(body if body else f"Release {arg}\n")
             return 0
     return 1  # no section → caller falls back to a generic note
 

--- a/scripts/changelog-section.py
+++ b/scripts/changelog-section.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Print the CHANGELOG.md section body for a given version.
+
+Usage: changelog-section.py <version>   (accepts "0.4.14" or "v0.4.14")
+
+Emits the body of the matching `## [X.Y.Z] — …` section with the heading and the
+trailing `[X.Y.Z]: https://…` link-reference lines stripped, so it can be piped
+straight into `gh release create --notes-file`. Exits 1 (no output) when the
+version has no section, letting the release workflow fall back to a generic note.
+
+Stdlib-only and cross-platform: the release workflow runs it on the runner, but it
+is equally runnable locally to preview a version's release notes before a tag push.
+"""
+
+import re
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: changelog-section.py <version>\n")
+        return 2
+    ver = sys.argv[1].lstrip("v")
+    try:
+        txt = open("CHANGELOG.md", encoding="utf-8").read()
+    except OSError as e:
+        sys.stderr.write(f"cannot read CHANGELOG.md: {e}\n")
+        return 2
+    heads = list(re.finditer(r"^## \[(\d+\.\d+\.\d+)\][^\n]*$", txt, re.M))
+    for i, h in enumerate(heads):
+        if h.group(1) == ver:
+            start = h.end()
+            end = heads[i + 1].start() if i + 1 < len(heads) else len(txt)
+            body = txt[start:end].strip()
+            body = re.sub(r"(?m)^\[[^\]]+\]:\s*https?://\S+$", "", body).strip()
+            sys.stdout.write(body if body else f"Release {ver}\n")
+            return 0
+    return 1  # no section → caller falls back to a generic note
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

studio's `release.yml` publishes to **npm** on every tag (`npm publish --provenance`) but **never creates a GitHub Release**, so the Releases page stayed **empty** while npm shipped through **v0.4.14**. Same gap just fixed in [estate #170](https://github.com/mikeparcewski/wicked-estate/pull/170).

(v0.4.0…v0.4.14 have been **hand-backfilled** from the CHANGELOG to populate the page now; this PR makes it automatic.)

## Fix

- New final step in the release job, after the npm publish **and** the registry-serve check — so a release is advertised only for a version the registry can actually serve.
- `permissions: contents: write` (was `read`) so the job can create the release.
- Notes lifted from the matching `## [X.Y.Z]` CHANGELOG section via a new stdlib-only `scripts/changelog-section.py` (exit-1 fallback to a generic note).
- **Idempotent** — an existing release is updated with `gh release edit`, so a re-run never errors on "already exists".

## Test

- `scripts/changelog-section.py v0.4.14` → correct section body.
- `release.yml` validates as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)