### PR TITLE
feat(nav): logo dot removed, health-colored heart, Ask as ?-circle, Test relabel, custom site name

### DIFF
--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,6 +1,4 @@
-import { useConnectionStore } from '../store/connection.js';
-import { useAppearanceStore } from '../theming/appearance.js';
-import { prefersReducedMotion } from './LiveEdge.js';
+import { DEFAULT_SITE_NAME, useAppearanceStore } from '../theming/appearance.js';
 import { WickedLogo } from './WickedLogo.js';
 
 /**
@@ -24,90 +22,37 @@ import { WickedLogo } from './WickedLogo.js';
  *   - the default mark is an SVG path stroked in `var(--accent)` (WickedLogo);
  *     the old `[W]` font-character fallback is gone.
  *
- * The connection dot carries `data-state` = the websocket state, and its color
- * is the STATUS layer, not the accent (§2.6): live = run-emerald, connecting =
- * gate-amber, lost = fail-red. The reconnecting pulse is the ONE loop the
- * motion grammar allows (§1.6) — it is state communication, and it stops for
- * `prefers-reduced-motion`.
+ * The connection status dot RETIRED from the chrome (nav-ui-tweaks): the logo
+ * slot and the product name are the only branding the header carries now.
+ * Health detail lives in ONE place — the rail-foot HealthRailSection, opened
+ * from its own header toggle (its ♥ glyph is colored by health there).
  *
- * The health POPOVER retired (DES-FEEDBACK-003 §6.2/§8.2, slice O): the dot
- * stays as glanceable ws state, and clicking it now expands the rail-foot
- * HealthRailSection (one surface for health detail, not two) — CheckRow and
- * the `getHealth()` fetch moved there verbatim.
- *
- * The dot's status WORD retired too (rail-header restyle): the `live` /
- * `connecting…` / `offline` label that once sat next to the logo/name is
- * REPLACED by the Ask entry (the accent-dressed action that opens the app-wide
- * assist dock). The bare dot stays as the minimal glanceable state — its click
- * still expands the rail-foot Health; the word slot next to it is now Ask.
+ * The Ask entry took the slot the connection word once held (rail-header
+ * restyle): a compact circular `?` button that opens the app-wide assist dock.
  */
 
 interface Props {
   /** The rail's collapsed state: icon-only column instead of the header row. */
   collapsed: boolean;
   navigate: (path: string) => void;
-  /** Clicking the dot expands the rail-foot Health section (§6.2, slice O). */
-  onDotClick?: () => void;
-  /** Opens the app-wide ASK dock (AskDock). The Ask entry — which took the
-   *  connection word's slot — renders only when the app wires this; the chrome
-   *  never paints a dead door. The Ctrl/⌘+Shift+A chord does the same. */
+  /** Opens the app-wide ASK dock (AskDock). The Ask entry renders only when the
+   *  app wires this; the chrome never paints a dead door. The Ctrl/⌘+Shift+A
+   *  chord does the same. */
   onOpenAsk?: () => void;
 }
 
-const DOT_COLOR = {
-  connected: 'var(--status-run)',
-  connecting: 'var(--status-gate)',
-  disconnected: 'var(--status-fail)',
-} as const;
-
 /**
- * The connection status dot — glanceable ws state. Its old health popover is
- * RETIRED (§8.2): a click hands off to the rail-foot Health section instead.
- */
-function ConnectionDot({ onClick }: { onClick?: (() => void) | undefined }): React.ReactElement {
-  const wsStatus = useConnectionStore((s) => s.status);
-
-  const pillLabel =
-    wsStatus === 'connected' ? 'Connected' :
-    wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
-
-  return (
-    <div style={{ position: 'relative', flexShrink: 0 }}>
-      <button
-        type="button"
-        onClick={onClick}
-        title={`Connection: ${pillLabel} — health details below`}
-        aria-label={`Connection: ${pillLabel}`}
-        style={{
-          display: 'flex', alignItems: 'center', gap: '5px', background: 'transparent',
-          border: 'none', padding: 'var(--space-1)', cursor: 'pointer',
-        }}
-      >
-        <span
-          data-testid="connection-dot"
-          data-state={wsStatus}
-          style={{
-            width: '7px', height: '7px', borderRadius: 'var(--radius-full)',
-            background: DOT_COLOR[wsStatus], flexShrink: 0,
-            // §1.6's one allowed loop: reconnecting IS a state, and it reads as one.
-            animation: wsStatus === 'connecting' && !prefersReducedMotion()
-              ? 'wk-live-pulse 2s ease-in-out infinite' : undefined,
-          }}
-        />
-      </button>
-    </div>
-  );
-}
-
-/**
- * The Ask entry — the accent-dressed action that took the connection word's
- * slot (rail-header restyle). Its OWN idiom, not a nav row and not a bell
- * sibling; opening the app-wide assist dock (AskDock). The chord
+ * The Ask entry — a compact CIRCULAR `?` button (nav-ui-tweaks) that opens the
+ * app-wide assist dock (AskDock). Its OWN idiom, not a nav row and not a bell
+ * sibling; the accent dress keeps it visually distinct. The chord
  * Ctrl/⌘+Shift+A does the same and is documented in the '?' overlay. Renders
  * only when the app wires `onOpenAsk` — the chrome never paints a dead door.
  */
 const ASK_LABEL = 'Ask — governed answers about your projects, repos, and this studio (Ctrl/⌘+Shift+A)';
 function AskEntry({ collapsed, onOpenAsk }: { collapsed: boolean; onOpenAsk: () => void }): React.ReactElement {
+  // A circle either way; collapsed keeps the 28px hit target, expanded is a
+  // touch smaller to sit inside the header row.
+  const size = collapsed ? '28px' : '24px';
   return (
     <button
       type="button"
@@ -115,31 +60,28 @@ function AskEntry({ collapsed, onOpenAsk }: { collapsed: boolean; onOpenAsk: () 
       data-idiom="ask"
       aria-label={ASK_LABEL}
       aria-keyshortcuts="Control+Shift+A Meta+Shift+A"
-      title={ASK_LABEL}
+      title="ask"
       onClick={onOpenAsk}
-      className="flex items-center gap-1 rounded-lg transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-1"
+      className="flex items-center justify-center transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-1"
       style={{
         flexShrink: 0,
+        width: size, height: size, padding: 0,
+        borderRadius: 'var(--radius-full)',
         background: 'var(--accent-subtle)',
         border: '1px solid var(--accent)',
         color: 'var(--accent)',
-        ...(collapsed
-          ? { width: '28px', height: '28px', justifyContent: 'center', padding: 0 }
-          : { height: '24px', padding: '0 var(--space-2)' }),
       }}
     >
-      <span aria-hidden style={{ fontSize: 'var(--text-xs)', lineHeight: 1 }}>✦</span>
-      {!collapsed && (
-        <span style={{ fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)', fontFamily: 'var(--font-sans)' }}>
-          Ask
-        </span>
-      )}
+      <span aria-hidden style={{ fontSize: 'var(--text-xs)', lineHeight: 1, fontWeight: 'var(--weight-semi)' }}>?</span>
     </button>
   );
 }
 
-export function AppChrome({ collapsed, navigate, onDotClick, onOpenAsk }: Props): React.ReactElement {
+export function AppChrome({ collapsed, navigate, onOpenAsk }: Props): React.ReactElement {
   const logoUrl = useAppearanceStore((s) => s.appearance.logo_url);
+  // The product name shown in the chrome (nav-ui-tweaks): a Settings override,
+  // falling back to the default wordmark when unset.
+  const siteName = useAppearanceStore((s) => s.appearance.site_name) ?? DEFAULT_SITE_NAME;
 
   // The §3.1 slot: 32×32 exactly, clearspace by margin, contain-fit custom
   // asset via the --logo-url custom property. The accent-stroked default mark
@@ -172,7 +114,6 @@ export function AppChrome({ collapsed, navigate, onDotClick, onOpenAsk }: Props)
         style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-1)' }}
       >
         {logoSlot}
-        <ConnectionDot onClick={onDotClick} />
         {onOpenAsk !== undefined && <AskEntry collapsed onOpenAsk={onOpenAsk} />}
       </div>
     );
@@ -198,10 +139,9 @@ export function AppChrome({ collapsed, navigate, onDotClick, onOpenAsk }: Props)
           fontWeight: 'var(--weight-semi)', color: 'var(--ink-body)',
         }}
       >
-        wicked-studio
+        {siteName}
       </button>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', flexShrink: 0 }}>
-        <ConnectionDot onClick={onDotClick} />
         {onOpenAsk !== undefined && <AskEntry collapsed={false} onOpenAsk={onOpenAsk} />}
       </div>
     </div>

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -81,7 +81,7 @@ export function AppChrome({ collapsed, navigate, onOpenAsk }: Props): React.Reac
   const logoUrl = useAppearanceStore((s) => s.appearance.logo_url);
   // The product name shown in the chrome (nav-ui-tweaks): a Settings override,
   // falling back to the default wordmark when unset.
-  const siteName = useAppearanceStore((s) => s.appearance.site_name) ?? DEFAULT_SITE_NAME;
+  const siteName = useAppearanceStore((s) => s.appearance.site_name)?.trim() || DEFAULT_SITE_NAME;
 
   // The §3.1 slot: 32×32 exactly, clearspace by margin, contain-fit custom
   // asset via the --logo-url custom property. The accent-stroked default mark

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useAppearanceStore } from '../theming/appearance.js';
+import { DEFAULT_SITE_NAME, useAppearanceStore } from '../theming/appearance.js';
 import { WickedLogo } from './WickedLogo.js';
 
 /**
@@ -299,6 +299,27 @@ export function AppearanceSettings(): React.ReactElement {
           {logoError !== null && (
             <p className="text-xs mt-1" style={{ color: 'var(--status-fail)' }} data-testid="logo-error">{logoError}</p>
           )}
+        </div>
+      </div>
+
+      {/* ── Site name (nav-ui-tweaks): overrides the chrome wordmark; blank reverts ── */}
+      <div className="flex items-start gap-4 py-4 border-b" style={{ borderColor: 'var(--surface-raised)' }}>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium" style={{ color: 'var(--ink-high)' }}>Site name</p>
+          <p className="text-xs mt-0.5 mb-2" style={{ color: 'var(--ink-muted)' }}>
+            The product name shown beside the logo in the chrome. Leave blank for the
+            default (<span className="font-mono">{DEFAULT_SITE_NAME}</span>).
+          </p>
+          <input
+            type="text"
+            data-testid="site-name-input"
+            aria-label="Site name"
+            placeholder={DEFAULT_SITE_NAME}
+            value={appearance.site_name ?? ''}
+            onChange={(e) => update({ site_name: e.target.value.trim() === '' ? null : e.target.value })}
+            className="w-64 rounded px-2 py-1 text-xs font-mono focus:outline-none"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
         </div>
       </div>
 

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -119,6 +119,18 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   // The passive header summary (§6.2): fail-red if any seat is inactive or the
   // socket is down — the rail's foot says "look inside" without being opened.
   const sick = wsDown || (roster ?? []).some((s) => s.health?.status === 'inactive');
+  // The ♥ glyph is colored by health (nav-ui-tweaks): red when unhealthy (a
+  // seat down or the socket gone), amber when degraded (socket still connecting,
+  // a probe errored, or the API server not reporting ok), green otherwise. It
+  // reads the same signals the section already computes — no new data source.
+  const degraded =
+    wsStatus === 'connecting' || healthError || rosterError || (health !== null && health.status !== 'ok');
+  const heartState = sick ? 'unhealthy' : degraded ? 'degraded' : 'healthy';
+  const heartColor = sick
+    ? 'var(--status-fail)'
+    : degraded
+      ? 'var(--status-gate)'
+      : 'var(--status-run)';
 
   return (
     <div
@@ -153,7 +165,14 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
         >
           ›
         </span>
-        <span aria-hidden>♥</span>
+        <span
+          aria-hidden
+          data-testid="rail-health-heart"
+          data-health={heartState}
+          style={{ color: heartColor }}
+        >
+          ♥
+        </span>
         <span>Health</span>
         {sick && (
           <span

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -84,11 +84,12 @@ const P_PROJECTS: PathSpec = { key: 'projects', title: 'Projects',     noun: 'Pr
 const P_MAKE: PathSpec     = { key: 'make',     title: 'Make',         noun: 'Document',   glyph: '⚒', dash: '/make',     collapsedHref: '/make' };
 const P_CHAT: PathSpec     = { key: 'chat',     title: 'Chat',         noun: 'Chat',       glyph: '💬', dash: '/chats',    collapsedHref: '/chats' };
 const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Repository', glyph: '⬡', dash: '/repos',    collapsedHref: '/repos' };
-// Testing (the testing wave; landing re-aimed by the testing-UX wave): the quality surface, a PRIMARY path placed immediately BEFORE
-// Steering (order: … Testing, Steering, Settings). Like Steering it is title-only (no ▦/＋ —
-// its verbs live on the pages); its accordion rows are the two sub-pages, its collapsed
-// glyph links the Campaigns landing (THE testing dashboard — the retired Harness folded in).
-const P_TESTING: PathSpec  = { key: 'testing',  title: 'Testing',      noun: 'Campaign',   glyph: '✓', dash: null,        collapsedHref: testingPath('campaigns') };
+// Test (the testing wave; nav-ui-tweaks re-placed + relabelled it): the quality surface, a
+// PRIMARY path placed immediately BELOW Make (order: Projects, Make, Test, Chat, …). Its
+// display label is "Test" though its key + routes stay `testing`. Like Steering it is
+// title-only (no ▦/＋ — its verbs live on the pages); its accordion rows are the two
+// sub-pages, its collapsed glyph links the Campaigns landing (THE testing dashboard).
+const P_TESTING: PathSpec  = { key: 'testing',  title: 'Test',         noun: 'Campaign',   glyph: '✓', dash: null,        collapsedHref: testingPath('campaigns') };
 // Steering (DES-MEM-FACETED-001, unified surface): the governed-knowledge home, a PRIMARY path
 // placed immediately BEFORE Settings. Like Settings it is title-only (no ▦/＋ — its management +
 // review verbs live on the pages); its accordion rows are the TWO sub-sections (Policies /
@@ -96,7 +97,8 @@ const P_TESTING: PathSpec  = { key: 'testing',  title: 'Testing',      noun: 'Ca
 // the Policies home (the default sub-section — the standalone Proposals queue folded in here).
 const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: null,        collapsedHref: policiesPath() };
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
-const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_CHAT, P_REPOS, P_TESTING, P_STEERING, P_SETTINGS];
+// Order (nav-ui-tweaks): Test sits immediately below Make; Steering + Settings tail.
+const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_TESTING, P_CHAT, P_REPOS, P_STEERING, P_SETTINGS];
 
 // `wiki`, `rules` and `policies` retired into Steering (they redirect to /steering); the
 // retired `coverage` and `domain` panels redirect to /system — kept mapped here so the rail
@@ -548,13 +550,10 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
   const [hovered, setHovered] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [makePickerOpen, setMakePickerOpen] = useState(false);
-  // The rail-foot health section (§6.2, slice O) — controlled here so the
-  // chrome's connection dot can expand it (its old popover retired, §8.2).
+  // The rail-foot health section (§6.2, slice O) — controlled here; it toggles
+  // from its own header (the chrome connection dot that used to expand it was
+  // removed in nav-ui-tweaks).
   const [healthOpen, setHealthOpen] = useState(false);
-  const onDotClick = (): void => {
-    setCollapsed(false);
-    setHealthOpen(true);
-  };
   // §7.3 auto-collapse: entering an immersive mode stashes the user's state and
   // collapses; leaving restores it. `null` = nothing stashed. The user can still
   // re-expand mid-mode — this fires only on the transition, never per render.
@@ -642,13 +641,14 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
       onMouseEnter={() => { if (collapsed) setHovered(true); }}
       onMouseLeave={() => setHovered(false)}
     >
-      {/* The app chrome (DES-VISION-001 §6.3 slice 3): logo slot + product name
-          + connection dot — and, in the connection word's old slot, the Ask entry
-          (rail-header restyle). `gap-2` gives the chrome cluster (Ask) and the
+      {/* The app chrome (DES-VISION-001 §6.3 slice 3): logo slot + product name,
+          and — in the connection word's old slot — the Ask entry (a compact
+          `?` circle, rail-header restyle; the connection dot was removed in
+          nav-ui-tweaks). `gap-2` gives the chrome cluster (Ask) and the
           collapse/expand "menu" control clear separation — distinct actions,
           not one cluster (item 1). */}
       <div className={`flex shrink-0 ${isExpanded ? 'items-center gap-2 pr-2' : 'flex-col items-center pt-2 gap-2'}`}>
-        <AppChrome collapsed={!isExpanded} navigate={navigate} onDotClick={onDotClick} {...(onOpenAsk !== undefined ? { onOpenAsk } : {})} />
+        <AppChrome collapsed={!isExpanded} navigate={navigate} {...(onOpenAsk !== undefined ? { onOpenAsk } : {})} />
         <button
           type="button"
           onClick={() => setCollapsed(v => !v)}
@@ -714,6 +714,16 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
                 </>
               )}
             <ViewAll href="/make" navigate={navigate} />
+          </RailHeading>
+
+          {/* ── Test — the quality surface, immediately below Make (nav-ui-tweaks). ─ */}
+          <RailHeading
+            path={P_TESTING}
+            open={openHeading === 'testing'}
+            onToggle={() => toggle('testing')}
+            navigate={navigate}
+          >
+            <TestingPageRows navigate={navigate} />
           </RailHeading>
 
           {/* ── Chat ─────────────────────────────────────────────────────────── */}
@@ -807,16 +817,6 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
                   </button>
                 ))}
             <ViewAll href="/repos" navigate={navigate} />
-          </RailHeading>
-
-          {/* ── Testing — the quality surface, BEFORE Steering (testing wave). ─ */}
-          <RailHeading
-            path={P_TESTING}
-            open={openHeading === 'testing'}
-            onToggle={() => toggle('testing')}
-            navigate={navigate}
-          >
-            <TestingPageRows navigate={navigate} />
           </RailHeading>
 
           {/* ── Steering — the governed-knowledge home, BEFORE Settings. Its two rows

--- a/src/theming/appearance.ts
+++ b/src/theming/appearance.ts
@@ -61,7 +61,7 @@ export function sanitizeAppearance(raw: unknown): StudioAppearance {
     accent_l: clamp(o.accent_l, 0, 100, DEFAULT_APPEARANCE.accent_l),
     logo_url: typeof o.logo_url === 'string' && o.logo_url !== '' ? o.logo_url : null,
     theme: o.theme === 'light' ? 'light' : 'dark',
-    site_name: typeof o.site_name === 'string' && o.site_name.trim() !== '' ? o.site_name : null,
+    site_name: typeof o.site_name === 'string' && o.site_name.trim() !== '' ? o.site_name.trim() : null,
   };
 }
 
@@ -109,9 +109,9 @@ function persistSoon(read: () => StudioAppearance): void {
     persistTimer = null;
     // Fire-and-forget with ONE silent retry (§3.3); the retry re-reads the
     // store so a newer edit is never clobbered by a stale snapshot.
-    api.putAppearanceSettings(read()).catch(() => {
+    api.putAppearanceSettings(sanitizeAppearance(read())).catch(() => {
       setTimeout(() => {
-        api.putAppearanceSettings(read()).catch(() => { /* stay silent (§3.3) */ });
+        api.putAppearanceSettings(sanitizeAppearance(read())).catch(() => { /* stay silent (§3.3) */ });
       }, RETRY_MS);
     });
   }, PERSIST_DEBOUNCE_MS);

--- a/src/theming/appearance.ts
+++ b/src/theming/appearance.ts
@@ -23,17 +23,25 @@ export interface StudioAppearance {
   accent_l: number;
   logo_url: string | null;
   theme: 'dark' | 'light';
+  /** A custom product name for the chrome (nav-ui-tweaks). `null` = the default
+   *  wordmark (`DEFAULT_SITE_NAME`); a non-empty string overrides it. */
+  site_name: string | null;
 }
 
 export const APPEARANCE_KEY = 'studio.appearance';
 
-/** §2.5's defaults: violet-indigo accent, no custom logo, the dark theme (§2.13). */
+/** The default product wordmark shown in the chrome when no custom name is set. */
+export const DEFAULT_SITE_NAME = 'wicked-studio';
+
+/** §2.5's defaults: violet-indigo accent, no custom logo, the dark theme (§2.13),
+ *  the default wordmark (no custom site name). */
 export const DEFAULT_APPEARANCE: StudioAppearance = {
   accent_h: 258,
   accent_s: 72,
   accent_l: 62,
   logo_url: null,
   theme: 'dark',
+  site_name: null,
 };
 
 const PERSIST_DEBOUNCE_MS = 400;
@@ -53,6 +61,7 @@ export function sanitizeAppearance(raw: unknown): StudioAppearance {
     accent_l: clamp(o.accent_l, 0, 100, DEFAULT_APPEARANCE.accent_l),
     logo_url: typeof o.logo_url === 'string' && o.logo_url !== '' ? o.logo_url : null,
     theme: o.theme === 'light' ? 'light' : 'dark',
+    site_name: typeof o.site_name === 'string' && o.site_name.trim() !== '' ? o.site_name : null,
   };
 }
 

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.14",
   "counts": {
     "files": 121,
-    "occurrences": 983,
-    "static": 843,
+    "occurrences": 984,
+    "static": 844,
     "dynamic": 43,
     "computed": 6
   },
@@ -999,12 +999,6 @@
       "testId": "conformance-rule-citation",
       "files": [
         "src/components/GovernanceAudit.tsx"
-      ]
-    },
-    {
-      "testId": "connection-dot",
-      "files": [
-        "src/components/AppChrome.tsx"
       ]
     },
     {
@@ -3143,6 +3137,12 @@
       ]
     },
     {
+      "testId": "rail-health-heart",
+      "files": [
+        "src/components/HealthRailSection.tsx"
+      ]
+    },
+    {
       "testId": "rail-health-section",
       "files": [
         "src/components/HealthRailSection.tsx"
@@ -3607,6 +3607,12 @@
       "testId": "signin-warning",
       "files": [
         "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "site-name-input",
+      "files": [
+        "src/components/AppearanceSettings.tsx"
       ]
     },
     {

--- a/tests/AppChrome.test.tsx
+++ b/tests/AppChrome.test.tsx
@@ -67,38 +67,28 @@ describe('AppChrome (DES-VISION-001 §3.1, §5.2)', () => {
     expect(navigate).toHaveBeenCalledTimes(2);
   });
 
-  it('the connection dot carries data-state matching the websocket state', () => {
+  it('carries NO connection dot — it was removed from the chrome (nav-ui-tweaks)', () => {
     for (const status of ['connecting', 'connected', 'disconnected'] as const) {
       useConnectionStore.setState({ status });
       const { unmount } = render(<AppChrome collapsed={false} navigate={() => {}} />);
-      expect(screen.getByTestId('connection-dot')).toHaveAttribute('data-state', status);
+      // The green/amber/red status dot no longer sits beside the logo/name —
+      // health detail lives in the rail-foot HealthRailSection now.
+      expect(screen.queryByTestId('connection-dot')).toBeNull();
       unmount();
     }
   });
 
-  it('the dot speaks the status layer, never the accent (EC12)', () => {
-    const expected = {
-      connected: 'var(--status-run)',
-      disconnected: 'var(--status-fail)',
-      connecting: 'var(--status-gate)',
-    } as const;
-    for (const [status, token] of Object.entries(expected)) {
-      useConnectionStore.setState({ status: status as keyof typeof expected });
-      const { unmount } = render(<AppChrome collapsed={false} navigate={() => {}} />);
-      expect(screen.getByTestId('connection-dot').style.background).toBe(token);
-      unmount();
-    }
-  });
-
-  it('keeps the bare status dot and replaces its status word with Ask', () => {
+  it('renders the Ask entry (a ? circle) in the slot the connection word held', () => {
     render(<AppChrome collapsed={false} navigate={() => {}} onOpenAsk={() => {}} />);
-    const dot = screen.getByTestId('connection-dot');
     const ask = screen.getByTestId('rail-ask');
 
-    // The dot remains the compact, glanceable connection state; its old text
-    // label has yielded its slot to the working Ask action.
-    expect(dot).toBeInTheDocument();
-    expect(dot.compareDocumentPosition(ask) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The chrome carries no status dot; the Ask action is the only thing beside
+    // the wordmark, and it is a compact circular '?' button.
+    expect(screen.queryByTestId('connection-dot')).toBeNull();
+    expect(ask).toHaveTextContent('?');
+    expect(ask.style.borderRadius).toBe('var(--radius-full)');
+    expect(ask).toHaveAttribute('title', 'ask');
+    // No leftover status words next to the logo/name.
     expect(screen.queryByText('live')).toBeNull();
     expect(screen.queryByText('connecting…')).toBeNull();
     expect(screen.queryByText('offline')).toBeNull();
@@ -113,11 +103,21 @@ describe('AppChrome (DES-VISION-001 §3.1, §5.2)', () => {
     expect(screen.queryByRole('menu')).toBeNull();
   });
 
-  it('collapsed: keeps the slot and the dot — no product name, no gear', () => {
+  it('collapsed: keeps the slot — no dot, no product name, no gear', () => {
     render(<AppChrome collapsed navigate={() => {}} />);
     expect(screen.getByTestId('logo-slot')).toBeInTheDocument();
-    expect(screen.getByTestId('connection-dot')).toBeInTheDocument();
+    expect(screen.queryByTestId('connection-dot')).toBeNull();
     expect(screen.queryByTestId('chrome-settings')).toBeNull();
+    expect(screen.queryByText('wicked-studio')).toBeNull();
+  });
+
+  it('the product name honors the site_name appearance override', () => {
+    useAppearanceStore.setState({
+      appearance: { ...DEFAULT_APPEARANCE, site_name: 'Acme Studio' },
+      loaded: true,
+    });
+    render(<AppChrome collapsed={false} navigate={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Acme Studio' })).toBeInTheDocument();
     expect(screen.queryByText('wicked-studio')).toBeNull();
   });
 });

--- a/tests/AskRail.test.tsx
+++ b/tests/AskRail.test.tsx
@@ -41,13 +41,13 @@ beforeEach(() => {
 });
 
 describe('the Ask entry — placement in the chrome + idiom', () => {
-  it('sits in the chrome NEXT TO the connection dot and ABOVE the notification bell', () => {
+  it('sits in the chrome ABOVE the notification bell; the connection dot is gone', () => {
     rail(() => undefined);
     const ask = screen.getByTestId('rail-ask');
-    const dot = screen.getByTestId('connection-dot');
     const bell = screen.getByTitle('Notifications'); // the bell trigger
-    // The Ask took the connection word's slot: the dot precedes it in the chrome.
-    expect(dot.compareDocumentPosition(ask) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The connection dot was removed (nav-ui-tweaks) — Ask now owns the chrome
+    // slot beside the wordmark.
+    expect(screen.queryByTestId('connection-dot')).toBeNull();
     // The chrome (with Ask) is above the bell row: ask → bell in DOM order.
     expect(ask.compareDocumentPosition(bell) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
@@ -86,7 +86,8 @@ describe('the Ask entry — placement in the chrome + idiom', () => {
     expect(ask.style.width).toBe('28px');
     expect(ask.style.height).toBe('28px');
     expect(ask).not.toHaveTextContent('Ask');
-    expect(screen.getByTestId('connection-dot')).toBeInTheDocument();
+    // The connection dot was removed from the chrome (nav-ui-tweaks).
+    expect(screen.queryByTestId('connection-dot')).toBeNull();
     expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument();
   });
 });

--- a/tests/HealthRailSection.test.tsx
+++ b/tests/HealthRailSection.test.tsx
@@ -159,7 +159,7 @@ describe('the passive summary dot (§6.2/§6.3)', () => {
   });
 });
 
-describe('the chrome dot hands off to the section (§6.2/§8.2)', () => {
+describe('the rail-foot section (nav-ui-tweaks removed the chrome dot)', () => {
   it('renders the section at the rail foot, collapsed, with the old testid gone', () => {
     render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/" />);
     expect(screen.getByTestId('rail-health-section')).toHaveAttribute('data-open', 'false');
@@ -167,13 +167,49 @@ describe('the chrome dot hands off to the section (§6.2/§8.2)', () => {
     expect(getRoster).not.toHaveBeenCalled();
   });
 
-  it('clicking the connection dot expands the section; no popover mounts', async () => {
+  it('the chrome paints no connection dot; the section opens from its own header', async () => {
     render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/" />);
-    fireEvent.click(screen.getByTestId('connection-dot'));
+    // The chrome dot that used to expand this section is gone (nav-ui-tweaks).
+    expect(screen.queryByTestId('connection-dot')).toBeNull();
+    fireEvent.click(screen.getByTestId('rail-health-toggle'));
     expect(screen.getByTestId('rail-health-section')).toHaveAttribute('data-open', 'true');
     await screen.findAllByTestId('rail-seat-row');
     expect(getRoster).toHaveBeenCalledTimes(1);
-    // The retired popover's DOM is absent: health detail has ONE surface now.
-    expect(screen.queryByText('Health checks')).toBeNull();
+  });
+});
+
+describe('the health-colored heart (nav-ui-tweaks)', () => {
+  it('is green when the socket is live and no seat is inactive', async () => {
+    rosterAnswer = [SEATS[0]!, SEATS[2]!]; // active + unknown — neither inactive
+    render(<Harness initialOpen />);
+    await screen.findAllByTestId('rail-seat-row');
+    const heart = screen.getByTestId('rail-health-heart');
+    expect(heart).toHaveAttribute('data-health', 'healthy');
+    expect(heart.style.color).toBe('var(--status-run)');
+  });
+
+  it('is amber (degraded) while the socket is still connecting', () => {
+    useConnectionStore.setState({ status: 'connecting' });
+    render(<Harness />); // collapsed — the ws state alone drives the glyph
+    const heart = screen.getByTestId('rail-health-heart');
+    expect(heart).toHaveAttribute('data-health', 'degraded');
+    expect(heart.style.color).toBe('var(--status-gate)');
+  });
+
+  it('is red (unhealthy) when the socket is down', () => {
+    useConnectionStore.setState({ status: 'disconnected' });
+    render(<Harness />);
+    const heart = screen.getByTestId('rail-health-heart');
+    expect(heart).toHaveAttribute('data-health', 'unhealthy');
+    expect(heart.style.color).toBe('var(--status-fail)');
+  });
+
+  it('is red (unhealthy) once an inactive seat is known', async () => {
+    rosterAnswer = SEATS; // codex is inactive
+    render(<Harness initialOpen />);
+    await screen.findAllByTestId('rail-seat-row');
+    const heart = screen.getByTestId('rail-health-heart');
+    expect(heart).toHaveAttribute('data-health', 'unhealthy');
+    expect(heart.style.color).toBe('var(--status-fail)');
   });
 });

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -58,7 +58,7 @@ const W2_ORDERED = [
   bp('scratch', 'quiet', 0),
 ];
 
-const HEADING_KEYS = ['projects', 'make', 'chat', 'repos', 'testing', 'steering', 'settings'] as const;
+const HEADING_KEYS = ['projects', 'make', 'testing', 'chat', 'repos', 'steering', 'settings'] as const;
 
 function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
   return render(
@@ -140,17 +140,29 @@ describe('the seven heading rows (§3.1 + STEERING + the testing wave)', () => {
     }
   });
 
-  it('Testing → Steering → Settings, each immediately before the next (the placement contract)', async () => {
+  it('Make → Test adjacency, and Steering → Settings (the nav-ui-tweaks placement contract)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
+    const make = screen.getByTestId('rail-heading-make');
     const testing = screen.getByTestId('rail-heading-testing');
+    const chat = screen.getByTestId('rail-heading-chat');
     const steering = screen.getByTestId('rail-heading-steering');
     const settings = screen.getByTestId('rail-heading-settings');
-    // Same container, adjacent, testing → steering → settings — DOM-order assertions.
-    expect(testing.nextElementSibling).toBe(steering);
+    // Test now sits immediately BELOW Make, before Chat (nav-ui-tweaks).
+    expect(make.nextElementSibling).toBe(testing);
+    expect(testing.nextElementSibling).toBe(chat);
+    // Steering → Settings still tail the rail, adjacent.
     expect(steering.nextElementSibling).toBe(settings);
     expect(steering.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('the Test heading is labelled "Test" though its key stays testing', async () => {
+    rail();
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    const title = within(screen.getByTestId('rail-heading-testing')).getByTestId('rail-title-testing');
+    expect(title).toHaveTextContent('Test');
+    expect(title).not.toHaveTextContent('Testing');
   });
 
   it('▦ icons are real links to the §2.1 dashboard routes', async () => {
@@ -421,7 +433,7 @@ describe('the collapsed rail (§3.2)', () => {
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
     expect(glyphs).toHaveLength(7);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/make', '/chats', '/repos', '/testing/campaigns', '/steering/policies', '/system',
+      '/projects', '/make', '/testing/campaigns', '/chats', '/repos', '/steering/policies', '/system',
     ]);
     // Accordions don't exist at this width.
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();

--- a/tests/appearance.store.test.ts
+++ b/tests/appearance.store.test.ts
@@ -80,9 +80,12 @@ describe('load (§3.3 startup)', () => {
 describe('sanitizeAppearance (external store — never trusted)', () => {
   it('clamps channels, defaults junk, and empties logo/theme correctly', () => {
     expect(sanitizeAppearance({ accent_h: 999, accent_s: -4, accent_l: 'x', logo_url: '', theme: 'sepia' }))
-      .toEqual({ accent_h: 359, accent_s: 0, accent_l: 62, logo_url: null, theme: 'dark' });
+      .toEqual({ accent_h: 359, accent_s: 0, accent_l: 62, logo_url: null, theme: 'dark', site_name: null });
     expect(sanitizeAppearance(null)).toEqual(DEFAULT_APPEARANCE);
     expect(sanitizeAppearance({ accent_h: 179.6 }).accent_h).toBe(180);
+    // site_name: a blank/whitespace value is the default (null); a real name is kept.
+    expect(sanitizeAppearance({ site_name: '   ' }).site_name).toBeNull();
+    expect(sanitizeAppearance({ site_name: 'Acme Studio' }).site_name).toBe('Acme Studio');
   });
 });
 

--- a/tests/testidInventory.test.ts
+++ b/tests/testidInventory.test.ts
@@ -60,14 +60,16 @@ describe('testid-inventory.json (TH-13)', () => {
     expect(inv.$doc.join(' ').toLowerCase()).toContain('no agentic fallback');
   });
 
-  it('declares the selectors the 2026-08 campaign drifted on (both must stay declared)', () => {
+  it('declares the connection-status selector the 2026-08 campaign drifted on', () => {
     // The campaign hit exactly this class of drift: the shipped bundle had `connection-dot`
-    // where the spec said `connection-status` (studio-campaign-results.json env_notes).
-    // Both exist in src today as distinct affordances; losing either is a contract change
-    // a generator must see in this file's diff, not discover at runtime.
+    // where the spec said `connection-status` (studio-campaign-results.json env_notes). The
+    // chrome `connection-dot` was since removed (nav-ui-tweaks); `connection-status` remains
+    // the live affordance — losing it is a contract change a generator must see in this
+    // file's diff, not discover at runtime.
     const ids = new Set(committed().static.map((e) => e.testId));
-    expect(ids.has('connection-dot')).toBe(true);
     expect(ids.has('connection-status')).toBe(true);
+    // The retired dot must NOT reappear as a silent duplicate of connection-status.
+    expect(ids.has('connection-dot')).toBe(false);
   });
 
   it('covers the whole declared surface and stays deterministically ordered', () => {


### PR DESCRIPTION
Five nav/UI tweaks.

1. **Removed the green connection dot** next to the logo (deleted `ConnectionDot` + its store/handler wiring in `AppChrome`/`LeftSidebar`). Health detail still opens from the rail-foot Health toggle.
2. **Health heart colored by health** (`HealthRailSection`) — red when unhealthy (socket down / seat inactive), amber when degraded (connecting / probe error / API not ok), green otherwise. Uses signals the section already computes.
3. **Ask → compact circular `?` button** — `title="ask"` tooltip, keeps `onOpenAsk` + aria/keyshortcuts. Replaces the `✦ Ask` pill.
4. **Testing → "Test", moved below Make** — nav order now Projects · Make · **Test** · Chat · Repositories · Steering · Settings (key/routes unchanged).
5. **Custom site name** in Settings → Appearance — a `site_name` field persisted via the existing debounced `studio.appearance` PUT; the chrome renders `site_name ?? 'wicked-studio'`.

`testid-inventory.json` regenerated; unit tests updated (typecheck clean, build ok, 2422 vitest pass).

**Follow-up:** four Python e2e suites still reference the removed connection dot / old Test placement — they need a live daemon so weren't run here; they'll need updating before an e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)