### PR TITLE
feat(steering): governed-knowledge dashboard — un-bury the review queue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
 import { SteeringPage } from './components/SteeringPage.js';
 import { MemoriesPanel } from './components/MemoriesPanel.js';
+import { GovernanceDashboard } from './components/GovernanceDashboard.js';
 import { TestingPage } from './components/TestingPage.js';
 import { RunsBottomPanel, RUNS_BAR_PX } from './components/RunsBottomPanel.js';
 import { ChatPanel } from './components/ChatPanel.js';
@@ -478,15 +479,23 @@ export function App(): React.ReactElement {
         </div>
       );
     }
-    // `/steering/{policies,memories}` — the unified governed-knowledge surface: ONE home, two
-    // sub-sections, each managing existing items AND reviewing proposals. Memories renders the
-    // memory store + memory proposals; Policies (the default — also the tick before
-    // useSteeringRedirect lands for bare `/steering`, a legacy `/steering/:type`, or the retired
-    // `/wiki`/`/rules`/`/policies`/`/proposals` addresses) renders the seven-type rule grid (the
-    // `?type=` filter collapsing the old seven pages) + policy proposals.
+    // `/steering/{dashboard,policies,memories}` — the unified governed-knowledge surface: ONE home,
+    // a review-forward DASHBOARD (the default) plus two management deep-dives. The dashboard
+    // un-buries the propose→promote review inbox; Memories renders the memory store; Policies (also
+    // the tick before useSteeringRedirect lands for a legacy `/steering/:type` or the retired
+    // `/wiki`/`/rules`/`/policies` addresses) renders the seven-type rule grid (the `?type=` filter
+    // collapsing the old seven pages). Bare `/steering` and the retired `/proposals` queue redirect
+    // to the dashboard.
     if (panel === 'steering') {
       // No page-level scroll wrapper here: each sub-section owns its layout — a two-column flex
       // (the management column scrolls, the assist dock is a full-height sibling — DES-ASSIST-DOCK §2).
+      if (steeringSection === 'dashboard') {
+        return (
+          <div className="flex flex-1 overflow-hidden">
+            <GovernanceDashboard navigate={navigate} />
+          </div>
+        );
+      }
       if (steeringSection === 'memories') {
         return (
           <div className="flex flex-1 overflow-hidden">

--- a/src/api/steering.ts
+++ b/src/api/steering.ts
@@ -71,22 +71,31 @@ export function steeringPath(type: SteeringType): string {
 
 // ── The unified governed-knowledge surface (`/steering/{policies,memories}`) ──────────────────
 //
-// Steering is one home with TWO sub-sections, each carrying BOTH "manage existing" and
-// "proposals (review)": Policies (the seven-type rule corpus + policy proposals) and Memories
-// (the memory store + memory proposals). The seven types collapsed into a `?type=` FILTER on the
-// Policies view (All + 7) — a rule still belongs to exactly one type, but the surface is one grid.
+// Steering is one home — a review-forward DASHBOARD (`/steering/dashboard`, the default) that
+// un-buries the propose→promote queue — plus TWO management sub-sections, each carrying BOTH
+// "manage existing" and "proposals (review)": Policies (the seven-type rule corpus) and Memories
+// (the memory store). The seven types collapsed into a `?type=` FILTER on the Policies view
+// (All + 7) — a rule still belongs to exactly one type, but the surface is one grid. `dashboard`
+// leads the list so it is the default sub-section bare `/steering` resolves onto.
 
-export const STEERING_SECTIONS = ['policies', 'memories'] as const;
+export const STEERING_SECTIONS = ['dashboard', 'policies', 'memories'] as const;
 
 export type SteeringSection = (typeof STEERING_SECTIONS)[number];
 
 export const STEERING_SECTION_LABELS: Record<SteeringSection, string> = {
+  dashboard: 'Dashboard',
   policies: 'Policies',
   memories: 'Memories',
 };
 
 export function isSteeringSection(s: string): s is SteeringSection {
   return (STEERING_SECTIONS as readonly string[]).includes(s);
+}
+
+/** The governed-knowledge dashboard's route — the Steering home (review-forward). Bare
+ *  `/steering` redirects here, and the rail's Steering glyph + accordion link it. */
+export function steeringDashboardPath(): string {
+  return '/steering/dashboard';
 }
 
 /** The Policies sub-section's route — bare for the All view, `?type=<type>` for a filtered one

--- a/src/components/FacetAutocomplete.tsx
+++ b/src/components/FacetAutocomplete.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useRef, useState } from 'react';
+
+/**
+ * A reusable facet FILTER as a text input with `key=value` autocomplete (the user's ask:
+ * "tags filter to textbox autocomplete"). The chip-strip facet filters it replaces grew a chip per
+ * distinct pair — unbounded and unscannable once a store carries dozens of facets; a typeahead
+ * stays one line and narrows as you type.
+ *
+ * There is NO facet-vocabulary endpoint: the caller derives the `options` (`key=value` strings)
+ * from the loaded rows and passes them in (exactly the `facetPairs` derivation MemoriesPanel
+ * already did client-side). This component owns only the typeahead UX — the applied facet is
+ * lifted state (`value` / `onChange`), so a page keeps filtering its own rows unchanged.
+ *
+ * Single-select: picking an option REPLACES the applied facet; the × (or picking nothing) clears
+ * it. `value === null` is the unfiltered "all" view.
+ */
+
+export function FacetAutocomplete({
+  testId,
+  options,
+  value,
+  onChange,
+  placeholder = 'Filter by facet (key=value)…',
+  label = 'Filter by facet',
+}: {
+  /** The wrapper's data-testid; the input/options/clear derive theirs from it. */
+  testId: string;
+  /** The facet vocabulary — `key=value` pairs the loaded rows carry (caller-derived). */
+  options: readonly string[];
+  /** The applied facet (`key=value`), or null for the unfiltered view. */
+  value: string | null;
+  /** Apply a facet (a pair) or clear it (null). */
+  onChange: (facet: string | null) => void;
+  placeholder?: string;
+  label?: string;
+}): React.ReactElement {
+  const [text, setText] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** The options that match the typed text (case-insensitive substring); empty text shows all. */
+  const matches = useMemo(() => {
+    const q = text.trim().toLowerCase();
+    const pool = q === '' ? options : options.filter((o) => o.toLowerCase().includes(q));
+    // Cap the rendered list so a huge vocabulary never blows out the dropdown.
+    return pool.slice(0, 50);
+  }, [options, text]);
+
+  const apply = (pair: string): void => {
+    onChange(pair);
+    setText('');
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const pick = matches[highlight] ?? matches[0];
+      if (pick !== undefined) apply(pick);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      data-facet-active={value ?? ''}
+      role="combobox"
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      aria-label={label}
+      className="relative flex flex-wrap items-center gap-1.5"
+    >
+      {value !== null && (
+        <span
+          data-testid={`${testId}-active`}
+          data-facet={value}
+          className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[10px] font-mono"
+          style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px solid var(--surface-raised)' }}
+        >
+          {value}
+          <button
+            type="button"
+            data-testid={`${testId}-clear`}
+            aria-label={`Clear facet ${value}`}
+            onClick={() => onChange(null)}
+            className="rounded px-1 leading-none hover:opacity-70 focus:outline-none focus-visible:ring-1"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            ×
+          </button>
+        </span>
+      )}
+      <input
+        data-testid={`${testId}-input`}
+        type="text"
+        role="searchbox"
+        spellCheck={false}
+        value={text}
+        placeholder={value === null ? placeholder : 'Change facet…'}
+        onChange={(e) => { setText(e.target.value); setOpen(true); setHighlight(0); }}
+        onFocus={() => { if (blurTimer.current !== null) clearTimeout(blurTimer.current); setOpen(true); }}
+        onBlur={() => { blurTimer.current = setTimeout(() => setOpen(false), 120); }}
+        onKeyDown={onKeyDown}
+        className="min-w-[12rem] flex-1 rounded px-2 py-1 text-[11px] focus:outline-none focus-visible:ring-1"
+        style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+      />
+      {open && matches.length > 0 && (
+        <ul
+          data-testid={`${testId}-options`}
+          role="listbox"
+          className="absolute left-0 top-full z-20 mt-1 max-h-56 w-full min-w-[14rem] overflow-y-auto rounded py-1 shadow-lg"
+          style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+        >
+          {matches.map((pair, i) => (
+            <li key={pair} role="option" aria-selected={value === pair}>
+              <button
+                type="button"
+                data-testid={`${testId}-option`}
+                data-facet={pair}
+                data-active={value === pair}
+                // onMouseDown (not onClick) so the pick lands before the input's blur closes the list.
+                onMouseDown={(e) => { e.preventDefault(); apply(pair); }}
+                onMouseEnter={() => setHighlight(i)}
+                className="w-full px-2 py-1 text-left text-[11px] font-mono transition-colors"
+                style={{
+                  background: i === highlight ? 'var(--surface-raised)' : 'transparent',
+                  color: value === pair ? 'var(--ink-high)' : 'var(--ink-muted)',
+                }}
+              >
+                {pair}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/FacetAutocomplete.tsx
+++ b/src/components/FacetAutocomplete.tsx
@@ -57,7 +57,7 @@ export function FacetAutocomplete({
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setOpen(true);
-      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+      setHighlight((h) => Math.min(h + 1, Math.max(0, matches.length - 1)));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setHighlight((h) => Math.max(h - 1, 0));

--- a/src/components/GovernanceDashboard.tsx
+++ b/src/components/GovernanceDashboard.tsx
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import {
+  isProposalsUnsupported,
+  listProposals,
+  proposalKind,
+  type Proposal,
+} from '../api/proposals.js';
+import {
+  isMemoryUnsupported,
+  listMemories,
+  memoryCoverage,
+  MEMORY_UNSUPPORTED_COPY,
+  type MemoryItem,
+} from '../api/memory.js';
+import {
+  memoriesPath,
+  policiesPath,
+  steeringTypeOf,
+  STEERING_TYPE_LABELS,
+  type SteeringRule,
+} from '../api/steering.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { KpiBand, KpiGroup, StatTile } from './dashboardKit.js';
+import { ProposalsSection } from './ProposalsSection.js';
+import { FacetAutocomplete } from './FacetAutocomplete.js';
+import { KeyValueChips } from './ProposalChips.js';
+import { SeverityChip } from './SteeringChips.js';
+
+/**
+ * The GOVERNED-KNOWLEDGE dashboard (`/steering/dashboard`) — the review-forward Steering home
+ * (DES-MEM-FACETED-001; governed-knowledge dashboard). The propose→promote recommendations are the
+ * most valuable output of the estate, and they used to sit BURIED at the bottom of two long
+ * management pages (policy proposals under the full policies grid, memory proposals under the memory
+ * browser). This surface un-buries them: one place, prominent, both kinds together.
+ *
+ * Three parts, top to bottom (the SAME dashboard kit /projects wears — KpiBand / KpiGroup /
+ * StatTile, so the two command surfaces read as one system):
+ *  1. a KPI band — Needs review (the un-buried headline: pending proposals, memory + policy), the
+ *     store size (Memories), and the Active-rules count with a severity breakdown;
+ *  2. the REVIEW inbox — the consolidated propose→promote queue, BOTH kinds side by side, approve/
+ *     reject inline (two reused {@link ProposalsSection}s under one Review heading);
+ *  3. BROWSE — the memory store and the rule corpus, each narrowed by the `key=value` facet
+ *     TYPEAHEAD ({@link FacetAutocomplete}); each row deep-links into its management deep-dive.
+ *
+ * Every read is best-effort and degrades honestly: a daemon that predates a wire renders its
+ * unsupported/empty state in-band, never an error wall.
+ */
+
+const CSS = {
+  page: { padding: 'var(--space-5) var(--space-6)', display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' },
+  name: {
+    fontSize: 'var(--text-lg)', fontWeight: 'var(--weight-bold)',
+    fontFamily: 'var(--font-sans)', color: 'var(--ink-high)', margin: 0,
+  },
+  sub: { fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', margin: '4px 0 0' },
+  sectionHead: {
+    fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-bold)',
+    letterSpacing: '0.08em', textTransform: 'uppercase',
+    color: 'var(--ink-muted)', margin: '0 0 8px',
+  },
+  deepLink: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--accent)', textDecoration: 'none', whiteSpace: 'nowrap',
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+/** The `key=value` facets a rule carries for the browse typeahead: its type, severity, each
+ *  non-empty target, and its inclusion facets — the vocabulary the caller derives from the rows. */
+function ruleFacets(r: SteeringRule): string[] {
+  const out = [`type=${steeringTypeOf(r)}`, `severity=${r.severity}`];
+  for (const [k, v] of Object.entries(r.targets ?? {})) if (typeof v === 'string' && v !== '') out.push(`${k}=${v}`);
+  for (const v of r.applies_to ?? []) if (v !== '') out.push(`applies_to=${v}`);
+  return out;
+}
+
+export function GovernanceDashboard({ navigate }: { navigate: Navigate }): React.ReactElement {
+  // ── The three best-effort KPI reads ────────────────────────────────────────
+  const [pending, setPending] = useState<Proposal[] | null>(null);
+  const [proposalsUnsupported, setProposalsUnsupported] = useState(false);
+  const [coverageTotal, setCoverageTotal] = useState<number | null>(null);
+  const [rules, setRules] = useState<SteeringRule[]>([]);
+
+  const loadPending = useCallback(async (): Promise<void> => {
+    try {
+      const ps = await listProposals({ state: 'pending' });
+      setPending(ps);
+      setProposalsUnsupported(false);
+    } catch (e) {
+      setPending([]);
+      if (isProposalsUnsupported(e)) setProposalsUnsupported(true);
+    }
+  }, []);
+
+  const loadCoverage = useCallback((): void => {
+    void memoryCoverage()
+      .then((c) => setCoverageTotal(typeof c.total === 'number' ? c.total : null))
+      .catch(() => setCoverageTotal(null));
+  }, []);
+
+  const loadRules = useCallback((): void => {
+    void api.listConformanceRules()
+      .then(({ rules: rs }) => setRules(rs as SteeringRule[]))
+      .catch(() => setRules([]));
+  }, []);
+
+  useEffect(() => { void loadPending(); loadCoverage(); loadRules(); }, [loadPending, loadCoverage, loadRules]);
+
+  const refreshHeadline = useCallback((): void => { void loadPending(); loadCoverage(); loadRules(); }, [loadPending, loadCoverage, loadRules]);
+
+  const memPending = useMemo(() => (pending ?? []).filter((p) => proposalKind(p) === 'memory').length, [pending]);
+  const polPending = useMemo(() => (pending ?? []).filter((p) => proposalKind(p) === 'policy').length, [pending]);
+  const needsReview = memPending + polPending;
+
+  const activeRules = useMemo(() => rules.filter((r) => r.retired !== true), [rules]);
+  const sev = useMemo(() => {
+    const s = { critical: 0, error: 0, warn: 0, info: 0 } as Record<string, number>;
+    for (const r of activeRules) if (r.severity in s) s[r.severity] = (s[r.severity] ?? 0) + 1;
+    return s;
+  }, [activeRules]);
+
+  const link = (path: string): { href: string; onClick: (e: React.MouseEvent) => void } => ({
+    href: path,
+    onClick: (e) => { e.preventDefault(); navigate(path); },
+  });
+
+  return (
+    <div data-testid="governance-dashboard" className="flex-1 overflow-y-auto" style={CSS.page}>
+      {/* ── Header ── */}
+      <header>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <h1 style={CSS.name}>Governed Knowledge</h1>
+          <span style={{ flex: 1 }} />
+          <a {...link(policiesPath())} data-testid="governance-manage-policies" style={CSS.deepLink}>Manage policies →</a>
+          <a {...link(memoriesPath())} data-testid="governance-manage-memories" style={CSS.deepLink}>Manage memories →</a>
+          <button
+            type="button"
+            data-testid="governance-refresh"
+            onClick={refreshHeadline}
+            className="text-[10px] hover:underline"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            Refresh
+          </button>
+        </div>
+        <p style={CSS.sub}>
+          The propose→promote recommendations — reviewed here, in one place, both kinds together.
+          Policies and Memories remain the deep-dives for managing what is already promoted.
+        </p>
+      </header>
+
+      {/* ── 1. KPI band ── */}
+      <KpiBand testId="governance-kpis">
+        <KpiGroup label="Review" grow={1}>
+          <StatTile
+            testId="gk-stat-needs-review"
+            label="Needs review"
+            value={proposalsUnsupported ? '—' : needsReview}
+            valueColor={needsReview > 0 ? 'var(--status-gate)' : undefined}
+            context={
+              proposalsUnsupported ? 'not served by this daemon'
+                : needsReview === 0 ? 'nothing waiting'
+                : `${memPending} memory · ${polPending} policy`
+            }
+            title="Pending proposals awaiting your approval — the review inbox is below"
+          />
+        </KpiGroup>
+        <KpiGroup label="Knowledge" grow={2}>
+          <StatTile
+            testId="gk-stat-memories"
+            label="Memories"
+            value={coverageTotal ?? '—'}
+            context={coverageTotal === null ? 'store size unavailable' : 'in the store'}
+            title="Total memories in the store — open the Memories deep-dive"
+            {...link(memoriesPath())}
+            onOpen={() => navigate(memoriesPath())}
+          />
+          <StatTile
+            testId="gk-stat-rules"
+            label="Active rules"
+            value={activeRules.length}
+            context={`crit ${sev.critical} · err ${sev.error} · warn ${sev.warn}`}
+            title="Active conformance rules by severity — open the Policies deep-dive"
+            {...link(policiesPath())}
+            onOpen={() => navigate(policiesPath())}
+          />
+        </KpiGroup>
+        {/* TODO(date-filters): once api-types 0.23.0 lands the created_at/promoted_at wire fields,
+            add a "Recently promoted" StatTile here (promotions in the last N days, with a delta). */}
+      </KpiBand>
+
+      {/* ── 2. Review inbox — the un-burying: both kinds, one place, approve/reject inline ── */}
+      <section
+        data-testid="governance-review"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--status-gate-dim)', borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)' }}
+      >
+        <p style={{ ...CSS.sectionHead, color: 'var(--status-gate)' }}>Review inbox</p>
+        <p style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', margin: '0 0 12px' }}>
+          Agent-proposed memories and policies, each pending until you approve or reject it — the two
+          queues that used to be buried at the bottom of the management pages, now front and center.
+        </p>
+        <div
+          data-testid="governance-review-inbox"
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 360px), 1fr))', gap: 'var(--space-4)', alignItems: 'start' }}
+        >
+          <ProposalsSection kind="memory" heading="Memory proposals" onDecision={refreshHeadline} />
+          <ProposalsSection kind="policy" heading="Policy proposals" onDecision={refreshHeadline} />
+        </div>
+      </section>
+
+      {/* ── 3. Browse — memory store + rule corpus, each with the facet typeahead ── */}
+      <section data-testid="governance-browse" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <p style={CSS.sectionHead}>Browse</p>
+        <MemoriesBrowse link={link} />
+        <RulesBrowse rules={activeRules} link={link} />
+      </section>
+    </div>
+  );
+}
+
+// ── The memory-store browse (read-only preview; retire lives in the Memories deep-dive) ──────────
+
+function MemoriesBrowse({ link }: {
+  link: (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+}): React.ReactElement {
+  const [memories, setMemories] = useState<MemoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unsupported, setUnsupported] = useState(false);
+  const [facet, setFacet] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listMemories()
+      .then((rows) => { if (!cancelled) { setMemories(rows); setUnsupported(false); } })
+      .catch((e: unknown) => { if (!cancelled) { setMemories([]); if (isMemoryUnsupported(e)) setUnsupported(true); } })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const facetPairs = useMemo(() => {
+    const seen = new Set<string>();
+    for (const m of memories) for (const [k, v] of Object.entries(m.facets)) seen.add(`${k}=${v}`);
+    return [...seen].sort();
+  }, [memories]);
+
+  const visible = useMemo(() => {
+    if (facet === null) return memories;
+    const [k, v] = facet.split(/=(.*)/s);
+    return memories.filter((m) => m.facets[k ?? ''] === v);
+  }, [memories, facet]);
+
+  return (
+    <div data-testid="gk-browse-memories" className="flex flex-col gap-2 rounded p-3" style={{ border: '1px solid var(--surface-raised)' }}>
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold" style={{ color: 'var(--ink-high)' }}>
+          Memories <span className="ml-1 font-mono" style={{ color: 'var(--ink-dim)' }}>({memories.length})</span>
+        </h3>
+        <span className="flex-1" />
+        <a {...link(memoriesPath())} data-testid="gk-browse-memories-manage" style={CSS.deepLink}>Manage memories →</a>
+      </div>
+      {facetPairs.length > 0 && (
+        <FacetAutocomplete
+          testId="gk-memories-facet"
+          options={facetPairs}
+          value={facet}
+          onChange={setFacet}
+          label="Filter memories by facet"
+        />
+      )}
+      {loading ? (
+        <p data-testid="gk-memories-loading" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Loading memories…</p>
+      ) : unsupported ? (
+        <p data-testid="gk-memories-unsupported" className="rounded px-3 py-2 text-[11px]" style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}>
+          {MEMORY_UNSUPPORTED_COPY}
+        </p>
+      ) : visible.length === 0 ? (
+        <p data-testid="gk-memories-empty" className="rounded px-3 py-2 text-[11px]" style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}>
+          {memories.length === 0 ? 'No memories in the store.' : 'No memories match this facet.'}
+        </p>
+      ) : (
+        <ul data-testid="gk-memories-list" className="flex flex-col gap-2">
+          {visible.slice(0, 20).map((m) => (
+            <li
+              key={m.id}
+              data-testid="gk-memory-row"
+              data-memory-id={m.id}
+              className="flex flex-col gap-1.5 rounded p-2.5"
+              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+            >
+              <span className="break-words text-[11px]" style={{ color: 'var(--ink-body)' }}>{m.content}</span>
+              <div className="flex flex-wrap items-center gap-2 text-[10px]">
+                <span className="rounded px-1.5 py-0.5 font-mono" style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}>{m.tier}</span>
+                <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>{m.scope}</span>
+                <KeyValueChips testid="gk-memory-facets" entries={m.facets} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── The rule-corpus browse (read-only preview; edit/retire live in the Policies deep-dive) ───────
+
+function RulesBrowse({ rules, link }: {
+  rules: SteeringRule[];
+  link: (path: string) => { href: string; onClick: (e: React.MouseEvent) => void };
+}): React.ReactElement {
+  const [facet, setFacet] = useState<string | null>(null);
+
+  const facetPairs = useMemo(() => {
+    const seen = new Set<string>();
+    for (const r of rules) for (const f of ruleFacets(r)) seen.add(f);
+    return [...seen].sort();
+  }, [rules]);
+
+  const visible = useMemo(
+    () => (facet === null ? rules : rules.filter((r) => ruleFacets(r).includes(facet))),
+    [rules, facet],
+  );
+
+  return (
+    <div data-testid="gk-browse-rules" className="flex flex-col gap-2 rounded p-3" style={{ border: '1px solid var(--surface-raised)' }}>
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold" style={{ color: 'var(--ink-high)' }}>
+          Active rules <span className="ml-1 font-mono" style={{ color: 'var(--ink-dim)' }}>({rules.length})</span>
+        </h3>
+        <span className="flex-1" />
+        <a {...link(policiesPath())} data-testid="gk-browse-rules-manage" style={CSS.deepLink}>Manage policies →</a>
+      </div>
+      {facetPairs.length > 0 && (
+        <FacetAutocomplete
+          testId="gk-rules-facet"
+          options={facetPairs}
+          value={facet}
+          onChange={setFacet}
+          label="Filter rules by facet"
+        />
+      )}
+      {visible.length === 0 ? (
+        <p data-testid="gk-rules-empty" className="rounded px-3 py-2 text-[11px]" style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}>
+          {rules.length === 0 ? 'No active rules in the corpus.' : 'No rules match this facet.'}
+        </p>
+      ) : (
+        <ul data-testid="gk-rules-list" className="flex flex-col gap-2">
+          {visible.slice(0, 20).map((r) => (
+            <li
+              key={r.id}
+              data-testid="gk-rule-row"
+              data-rule-id={r.id}
+              className="flex flex-col gap-1.5 rounded p-2.5"
+              style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+            >
+              <div className="flex items-start gap-2">
+                <span className="font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>{r.id}</span>
+                <span className="min-w-0 flex-1 break-words text-[11px]" style={{ color: 'var(--ink-body)' }}>{r.statement}</span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 text-[10px]">
+                <SeverityChip severity={r.severity} />
+                <span className="rounded px-1.5 py-0.5 font-mono" style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}>
+                  {STEERING_TYPE_LABELS[steeringTypeOf(r)]}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/GovernanceDashboard.tsx
+++ b/src/components/GovernanceDashboard.tsx
@@ -78,6 +78,7 @@ export function GovernanceDashboard({ navigate }: { navigate: Navigate }): React
   // ── The three best-effort KPI reads ────────────────────────────────────────
   const [pending, setPending] = useState<Proposal[] | null>(null);
   const [proposalsUnsupported, setProposalsUnsupported] = useState(false);
+  const [proposalsError, setProposalsError] = useState(false);
   const [coverageTotal, setCoverageTotal] = useState<number | null>(null);
   const [rules, setRules] = useState<SteeringRule[]>([]);
 
@@ -86,9 +87,18 @@ export function GovernanceDashboard({ navigate }: { navigate: Navigate }): React
       const ps = await listProposals({ state: 'pending' });
       setPending(ps);
       setProposalsUnsupported(false);
+      setProposalsError(false);
     } catch (e) {
-      setPending([]);
-      if (isProposalsUnsupported(e)) setProposalsUnsupported(true);
+      if (isProposalsUnsupported(e)) {
+        setProposalsUnsupported(true);
+        setPending([]);
+      } else {
+        // A real load failure must NOT read as "0 needs review" (an empty list is
+        // indistinguishable from "no proposals"). Keep pending unknown (null) and flag the error so
+        // the tile renders "—", never a fabricated zero.
+        setProposalsError(true);
+        setPending(null);
+      }
     }
   }, []);
 
@@ -155,10 +165,11 @@ export function GovernanceDashboard({ navigate }: { navigate: Navigate }): React
           <StatTile
             testId="gk-stat-needs-review"
             label="Needs review"
-            value={proposalsUnsupported ? '—' : needsReview}
-            valueColor={needsReview > 0 ? 'var(--status-gate)' : undefined}
+            value={proposalsUnsupported || proposalsError ? '—' : needsReview}
+            valueColor={!proposalsError && needsReview > 0 ? 'var(--status-gate)' : undefined}
             context={
               proposalsUnsupported ? 'not served by this daemon'
+                : proposalsError ? 'could not load — refresh'
                 : needsReview === 0 ? 'nothing waiting'
                 : `${memPending} memory · ${polPending} policy`
             }

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -7,7 +7,7 @@ import { modePath, projectPath, versionPath, type Mode } from '../hooks/useRoute
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
-import { memoriesPath, policiesPath, STEERING_SECTIONS, STEERING_SECTION_LABELS, type SteeringSection } from '../api/steering.js';
+import { memoriesPath, policiesPath, steeringDashboardPath, STEERING_SECTIONS, STEERING_SECTION_LABELS, type SteeringSection } from '../api/steering.js';
 import { testingPath, TESTING_PAGE_LABELS, TESTING_PAGES } from '../api/testing.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
@@ -95,7 +95,7 @@ const P_TESTING: PathSpec  = { key: 'testing',  title: 'Test',         noun: 'Ca
 // review verbs live on the pages); its accordion rows are the TWO sub-sections (Policies /
 // Memories — each managing existing items AND reviewing proposals), its collapsed glyph links
 // the Policies home (the default sub-section — the standalone Proposals queue folded in here).
-const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: null,        collapsedHref: policiesPath() };
+const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: null,        collapsedHref: steeringDashboardPath() };
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
 // Order (nav-ui-tweaks): Test sits immediately below Make; Steering + Settings tail.
 const PATHS: PathSpec[] = [P_PROJECTS, P_MAKE, P_TESTING, P_CHAT, P_REPOS, P_STEERING, P_SETTINGS];
@@ -515,12 +515,13 @@ function TestingPageRows({ navigate }: { navigate: (p: string) => void }): React
   );
 }
 
-/** The Steering accordion's rows: one per sub-section (Policies / Memories), each a navigate()
- *  shortcut to its page — the SettingsShortcutRows grammar. Each sub-section manages existing
- *  items AND reviews proposals, so there are no per-type or per-kind rows here any more (the seven
- *  types are a `?type=` filter inside Policies; proposals live inside each sub-section). */
+/** The Steering accordion's rows: one per sub-section (Dashboard / Policies / Memories), each a
+ *  navigate() shortcut to its page — the SettingsShortcutRows grammar. The Dashboard is the
+ *  review-forward home (the consolidated propose→promote inbox); Policies and Memories are the
+ *  "manage existing" deep-dives (the seven types are a `?type=` filter inside Policies). */
 function SteeringSectionRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
-  const href = (s: SteeringSection): string => (s === 'memories' ? memoriesPath() : policiesPath());
+  const href = (s: SteeringSection): string =>
+    s === 'memories' ? memoriesPath() : s === 'policies' ? policiesPath() : steeringDashboardPath();
   return (
     <div role="menu" className="flex flex-col pt-0.5">
       {STEERING_SECTIONS.map((s) => (
@@ -819,8 +820,8 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             <ViewAll href="/repos" navigate={navigate} />
           </RailHeading>
 
-          {/* ── Steering — the governed-knowledge home, BEFORE Settings. Its two rows
-                (Policies / Memories) each manage existing items AND review proposals. ─ */}
+          {/* ── Steering — the governed-knowledge home, BEFORE Settings. Its three rows:
+                Dashboard (the review-forward home) + the Policies / Memories deep-dives. ─ */}
           <RailHeading
             path={P_STEERING}
             open={openHeading === 'steering'}

--- a/src/components/MemoriesPanel.tsx
+++ b/src/components/MemoriesPanel.tsx
@@ -8,22 +8,22 @@ import {
   type MemoryCoverage,
   type MemoryItem,
 } from '../api/memory.js';
-import { ProposalsSection } from './ProposalsSection.js';
+import { FacetAutocomplete } from './FacetAutocomplete.js';
 import { KeyValueChips } from './ProposalChips.js';
 
 /**
  * The Steering surface's MEMORIES sub-section (`/steering/memories`, DES-MEM-FACETED-001 unified
- * surface). One page that both MANAGES existing memories and REVIEWS memory proposals:
+ * surface; governed-knowledge dashboard). The "manage existing memories" deep-dive — the REVIEW of
+ * memory proposals now lives in the dashboard's consolidated inbox (`/steering/dashboard`), so it
+ * is no longer buried below this browser:
  *
  *  - the store BROWSER (`GET /memory`): every stored memory, with a text search that re-queries the
- *    wire and a client-side FACET filter (the facet key:value chips the loaded set carries). Each
- *    row shows content, tier, scope, and facets, with a RETIRE action.
+ *    wire and a client-side FACET filter — the facet `key=value` TYPEAHEAD (FacetAutocomplete),
+ *    whose vocabulary is derived from the loaded set. Each row shows content, tier, scope, and
+ *    facets, with a RETIRE action.
  *  - RETIRE is honest about granularity: the wire erases a scope SUBTREE (`POST /memory/retire`
  *    with `scope_prefix`), so retiring a memory reaches everything filed at or under its scope — the
  *    confirm says so, and the note reports how many rows the server erased.
- *  - the MEMORY PROPOSALS section (ProposalsSection, below) reviews the agent-proposed memories
- *    awaiting a human approve/reject — the review half of this sub-section. It has its own adoption
- *    seam, so proposals still render even on a daemon whose memory-management wire is absent.
  *
  * Every write goes through crew's API (the governed operator path) — estate MCP stays read-only.
  */
@@ -121,8 +121,8 @@ export function MemoriesPanel(): React.ReactElement {
         <div>
           <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Steering · Memories</h2>
           <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-            The agent memory store — browse and filter what has been remembered, retire a scope, and
-            review the agent-proposed memories awaiting your approval below.
+            The agent memory store — browse and filter what has been remembered, and retire a scope.
+            Agent-proposed memories are reviewed in the governed-knowledge dashboard.
             {coverageTotal !== null && (
               <span data-testid="memories-coverage" className="ml-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
                 · {coverageTotal} in store
@@ -166,48 +166,14 @@ export function MemoriesPanel(): React.ReactElement {
       </div>
 
       {facetPairs.length > 0 && (
-        <div data-testid="memories-facet-filter" role="tablist" aria-label="Filter memories by facet" className="flex flex-wrap gap-1.5">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={facet === null}
-            data-testid="memories-facet-chip"
-            data-facet="all"
-            data-active={facet === null}
-            onClick={() => setFacet(null)}
-            className="rounded px-2 py-1 text-[10px] font-mono transition-colors"
-            style={{
-              background: facet === null ? 'var(--surface-raised)' : 'transparent',
-              color: facet === null ? 'var(--ink-high)' : 'var(--ink-muted)',
-              border: '1px solid var(--surface-raised)',
-            }}
-          >
-            all
-          </button>
-          {facetPairs.map((pair) => {
-            const active = facet === pair;
-            return (
-              <button
-                key={pair}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                data-testid="memories-facet-chip"
-                data-facet={pair}
-                data-active={active}
-                onClick={() => setFacet(active ? null : pair)}
-                className="rounded px-2 py-1 text-[10px] font-mono transition-colors"
-                style={{
-                  background: active ? 'var(--surface-raised)' : 'transparent',
-                  color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
-                  border: '1px solid var(--surface-raised)',
-                }}
-              >
-                {pair}
-              </button>
-            );
-          })}
-        </div>
+        <FacetAutocomplete
+          testId="memories-facet-filter"
+          options={facetPairs}
+          value={facet}
+          onChange={setFacet}
+          label="Filter memories by facet"
+          placeholder="Filter by facet (key=value)…"
+        />
       )}
 
       {note !== null && (
@@ -306,9 +272,6 @@ export function MemoriesPanel(): React.ReactElement {
           ))}
         </ul>
       )}
-
-      {/* The REVIEW half of this sub-section — the agent-proposed memories. */}
-      <ProposalsSection kind="memory" heading="Memory proposals" />
     </div>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api } from '../api/client.js';
 import { listDocs, type DocSummary } from '../api/interactive.js';
+import { listProposals, proposalKind } from '../api/proposals.js';
+import { steeringDashboardPath } from '../api/steering.js';
 import { useDocsCache } from '../store/docsCache.js';
 import type { SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
@@ -193,6 +195,24 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
       .catch(() => { /* bridge cold/unreachable — no doc cards, never an error wall */ });
     return () => { cancelled = true; };
   }, [projectId, project]);
+
+  // The governed-knowledge headline (DES-MEM-FACETED-001; governed-knowledge dashboard): how many
+  // agent-proposed memories + policies are pending review. `null` = the daemon does not serve the
+  // proposal queue, so the whole GK band is omitted rather than showing a lying zero.
+  const [pendingReview, setPendingReview] = useState<number | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const ps = await listProposals({ state: 'pending' });
+        if (!cancelled) setPendingReview(ps.filter((p) => proposalKind(p) !== 'other').length);
+      } catch {
+        // Unsupported OR any read failure: no GK band, never an error wall on the project home.
+        if (!cancelled) setPendingReview(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // ── The project's runs, attention-ordered (needs-you floats FIRST) ─────────
   const fallbackAt = project?.updated_at ?? 0;
@@ -455,6 +475,23 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
             onOpen={() => setChip('failed')}
           />
         </KpiGroup>
+        {/* ── Governed knowledge (DES-MEM-FACETED-001): the un-buried review headline, a door
+              straight into the dashboard's consolidated inbox. Omitted on a daemon that does not
+              serve the proposal queue (`pendingReview === null`), never a lying zero. ── */}
+        {pendingReview !== null && (
+          <KpiGroup label="Governed knowledge" grow={1}>
+            <StatTile
+              testId="stat-needs-review"
+              label="Needs review"
+              value={pendingReview}
+              valueColor={pendingReview > 0 ? 'var(--status-gate)' : undefined}
+              context={pendingReview > 0 ? 'proposals waiting' : 'nothing waiting'}
+              title="Agent-proposed memories & policies pending review — open the governed-knowledge dashboard"
+              href={steeringDashboardPath()}
+              onOpen={() => navigate(steeringDashboardPath())}
+            />
+          </KpiGroup>
+        )}
       </KpiBand>
 
       {/* ── The gate inbox — FIRST: attention routing beats navigation ── */}

--- a/src/components/ProposalsSection.tsx
+++ b/src/components/ProposalsSection.tsx
@@ -28,11 +28,14 @@ import { ProposalsList } from './ProposalsList.js';
  *    a daemon that predates the routes is never an error card.
  */
 
-export function ProposalsSection({ kind, heading }: {
+export function ProposalsSection({ kind, heading, onDecision }: {
   /** Which proposals this section reviews — the sub-section it lives in. */
   kind: Extract<ProposalKind, 'memory' | 'policy'>;
   /** The section title, e.g. "Policy proposals" / "Memory proposals". */
   heading: string;
+  /** Fired after a successful approve/reject — lets a host (the dashboard) refresh its own
+   *  headline count, which this self-contained section otherwise cannot know changed. */
+  onDecision?: (() => void) | undefined;
 }): React.ReactElement {
   const [proposals, setProposals] = useState<Proposal[]>([]);
   const [loading, setLoading] = useState(true);
@@ -77,6 +80,7 @@ export function ProposalsSection({ kind, heading }: {
         // server's state (another reviewer may have decided others in the meantime).
         setProposals((cur) => cur.filter((p) => p.id !== id));
         setNote(`${verb === 'approve' ? 'Approved' : 'Rejected'} ${id}.`);
+        onDecision?.();
         void loadProposals();
       })
       .catch((e: unknown) => {
@@ -89,7 +93,7 @@ export function ProposalsSection({ kind, heading }: {
           return next;
         });
       });
-  }, [loadProposals]);
+  }, [loadProposals, onDecision]);
 
   const onApprove = useCallback((id: string) => decide(id, 'approve'), [decide]);
   const onReject = useCallback((id: string) => decide(id, 'reject'), [decide]);

--- a/src/components/SteeringPage.tsx
+++ b/src/components/SteeringPage.tsx
@@ -25,7 +25,6 @@ import {
 import type { SessionView } from '../api/types.js';
 import { ruleUsage } from '../board/steeringUsage.js';
 import { AssistDock, useAssistDockOpen, type AssistNote, type AssistVerbs } from './AssistDock.js';
-import { ProposalsSection } from './ProposalsSection.js';
 import { SteeringAddMenu } from './SteeringAddMenu.js';
 import { SteeringUsageBand } from './SteeringUsageBand.js';
 import { SteeringGrid } from './SteeringGrid.js';
@@ -49,8 +48,9 @@ import { SteeringTypeFilter } from './SteeringTypeFilter.js';
  *  - the ASSIST DOCK (DES-ASSIST-DOCK) sits beside the grid: a typed message launches the governed
  *    steering-author run for the active type (architecture in the `All` view) and narrates inline;
  *    rule-shaped attachments fork import-directly vs analyze-with-chat.
- *  - the POLICY PROPOSALS section (ProposalsSection, below the grid) reviews the agent-proposed
- *    steering policies awaiting a human approve/reject — the review half of this sub-section.
+ *  - the agent-proposed steering policies are REVIEWED in the governed-knowledge dashboard's
+ *    consolidated inbox (`/steering/dashboard`) — no longer buried below this grid; this page is
+ *    the pure "manage existing" surface.
  *
  * Every management write still goes through crew's API (the governed operator path) — estate MCP
  * stays read-only (AW-11).
@@ -287,8 +287,8 @@ export function SteeringPage({ type, navigate, search = '', runs = [] }: {
           <div>
             <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Steering · Policies</h2>
             <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-              The governance surface — the seven-type steering-rule corpus. Filter by type, manage
-              rules inline, and review the agent-proposed policies awaiting your approval below.
+              The governance surface — the seven-type steering-rule corpus. Filter by type and manage
+              rules inline. Agent-proposed policies are reviewed in the governed-knowledge dashboard.
             </p>
           </div>
           <button
@@ -440,9 +440,6 @@ export function SteeringPage({ type, navigate, search = '', runs = [] }: {
                 idFilter={unusedIds}
               />
             )}
-
-            {/* The REVIEW half of this sub-section — the agent-proposed steering policies. */}
-            <ProposalsSection kind="policy" heading="Policy proposals" />
           </>
         )}
       </div>

--- a/src/hooks/useLegacyRedirect.ts
+++ b/src/hooks/useLegacyRedirect.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { api } from '../api/client.js';
-import { isSteeringType, policiesPath, memoriesPath } from '../api/steering.js';
+import { isSteeringType, policiesPath, steeringDashboardPath } from '../api/steering.js';
 import { testingPath } from '../api/testing.js';
 import { modePath, projectPath, type Mode, type Navigate } from './useRoute.js';
 
@@ -102,23 +102,24 @@ export function useLegacyRedirect(route: LegacyRoute, navigate: Navigate): void 
 }
 
 /**
- * The unified Steering surface's address normalizer (DES-MEM-FACETED-001, unified surface).
- * `/steering/policies` and `/steering/memories` are the real addresses and never redirect; every
- * OTHER parse that landed on `panel: 'steering'` with `steeringSection === null` is an address
- * that needs to resolve onto one of the two sub-sections:
+ * The unified Steering surface's address normalizer (DES-MEM-FACETED-001, unified surface;
+ * governed-knowledge dashboard). `/steering/dashboard`, `/steering/policies` and
+ * `/steering/memories` are the real addresses and never redirect; every OTHER parse that landed on
+ * `panel: 'steering'` with `steeringSection === null` is an address that needs to resolve onto one
+ * of the sub-sections:
  *
- *   /steering                → /steering/policies             (the default home)
+ *   /steering                → /steering/dashboard            (the review-forward home)
  *   /steering/:type          → /steering/policies?type=:type  (the seven pages collapsed into a
  *                              filter — bookmarks keep their type)
- *   /wiki, /rules, /policies  → /steering/policies             (the retired governance panels)
- *   /proposals               → /steering/policies             (the retired standalone queue)
- *   /proposals?type=memory   → /steering/memories             (its memory filter → the Memories
- *                              sub-section, which reviews memory proposals)
+ *   /wiki, /rules, /policies  → /steering/policies             (the retired governance panels — the
+ *                              rule-management surface)
+ *   /proposals               → /steering/dashboard            (the retired standalone review queue
+ *                              → the dashboard's consolidated review inbox, its successor — for
+ *                              every ?type=, since the inbox reviews BOTH kinds in one place)
  *
  * A typo'd `/steering/foo` parses to `not-found` (usability review #4), so this hook never sees
  * `panel: 'steering'` for it and leaves the address alone. REPLACE, like every redirect in this
- * module, so Back never re-enters the dead address; the parse already lands these on the Policies
- * view (`steeringSection` null renders Policies), so nothing flashes.
+ * module, so Back never re-enters the dead address.
  */
 export function useSteeringRedirect(
   panel: string,
@@ -130,11 +131,11 @@ export function useSteeringRedirect(
   useEffect(() => {
     if (panel !== 'steering' || steeringSection !== null) return;
     const [, first = '', second = ''] = pathname.split('/');
-    // The retired standalone review queue: its memory filter routes to the Memories sub-section,
-    // everything else to Policies.
+    // The retired standalone review queue → the dashboard's consolidated review inbox (its
+    // successor), which reviews memory AND policy proposals in one place (its old ?type= filter no
+    // longer forks the target — `search` stays a dep only so a query-only change still re-runs).
     if (first === 'proposals') {
-      const kind = new URLSearchParams(search).get('type');
-      navigate(kind === 'memory' ? memoriesPath() : policiesPath(), { replace: true });
+      navigate(steeringDashboardPath(), { replace: true });
       return;
     }
     // A legacy `/steering/:type` keeps its type as the Policies filter.
@@ -142,8 +143,13 @@ export function useSteeringRedirect(
       navigate(policiesPath(second), { replace: true });
       return;
     }
-    // Bare `/steering` and the retired `/wiki` `/rules` `/policies` panels → the Policies home.
-    navigate(policiesPath(), { replace: true });
+    // The retired `/wiki` `/rules` `/policies` panels are the rule-management surface → Policies.
+    if (first === 'wiki' || first === 'rules' || first === 'policies') {
+      navigate(policiesPath(), { replace: true });
+      return;
+    }
+    // Bare `/steering` → the review-forward dashboard home.
+    navigate(steeringDashboardPath(), { replace: true });
   }, [panel, steeringSection, pathname, search, navigate]);
 }
 

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,10 +10,10 @@
   "version": 1,
   "studioVersion": "0.4.14",
   "counts": {
-    "files": 121,
-    "occurrences": 984,
-    "static": 844,
-    "dynamic": 43,
+    "files": 123,
+    "occurrences": 1006,
+    "static": 861,
+    "dynamic": 47,
     "computed": 6
   },
   "static": [
@@ -1746,6 +1746,84 @@
       ]
     },
     {
+      "testId": "gk-browse-memories",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-browse-memories-manage",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-browse-rules",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-browse-rules-manage",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-memories-empty",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-memories-list",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-memories-loading",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-memories-unsupported",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-memory-row",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-rule-row",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-rules-empty",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "gk-rules-list",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "governance-browse",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
       "testId": "governance-claims-unavailable",
       "files": [
         "src/components/GovernanceAudit.tsx"
@@ -1758,9 +1836,45 @@
       ]
     },
     {
+      "testId": "governance-dashboard",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
       "testId": "governance-enforcement",
       "files": [
         "src/components/GovernanceAudit.tsx"
+      ]
+    },
+    {
+      "testId": "governance-manage-memories",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "governance-manage-policies",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "governance-refresh",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "governance-review",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "governance-review-inbox",
+      "files": [
+        "src/components/GovernanceDashboard.tsx"
       ]
     },
     {
@@ -2404,18 +2518,6 @@
     },
     {
       "testId": "memories-error",
-      "files": [
-        "src/components/MemoriesPanel.tsx"
-      ]
-    },
-    {
-      "testId": "memories-facet-chip",
-      "files": [
-        "src/components/MemoriesPanel.tsx"
-      ]
-    },
-    {
-      "testId": "memories-facet-filter",
       "files": [
         "src/components/MemoriesPanel.tsx"
       ]
@@ -5108,6 +5210,12 @@
   ],
   "dynamic": [
     {
+      "pattern": "*-active",
+      "files": [
+        "src/components/FacetAutocomplete.tsx"
+      ]
+    },
+    {
       "pattern": "*-bridge-hint",
       "files": [
         "src/components/SurfaceState.tsx"
@@ -5139,6 +5247,12 @@
       ]
     },
     {
+      "pattern": "*-clear",
+      "files": [
+        "src/components/FacetAutocomplete.tsx"
+      ]
+    },
+    {
       "pattern": "*-editor",
       "files": [
         "src/components/SteeringGrid.tsx"
@@ -5153,7 +5267,20 @@
     {
       "pattern": "*-input",
       "files": [
+        "src/components/FacetAutocomplete.tsx",
         "src/components/SteeringGrid.tsx"
+      ]
+    },
+    {
+      "pattern": "*-option",
+      "files": [
+        "src/components/FacetAutocomplete.tsx"
+      ]
+    },
+    {
+      "pattern": "*-options",
+      "files": [
+        "src/components/FacetAutocomplete.tsx"
       ]
     },
     {
@@ -5393,6 +5520,7 @@
         "src/components/AppearanceSettings.tsx",
         "src/components/ChatPanel.tsx",
         "src/components/DashboardTiles.tsx",
+        "src/components/FacetAutocomplete.tsx",
         "src/components/HomeCommand.tsx",
         "src/components/MetricTile.tsx",
         "src/components/ProvenanceLine.tsx",

--- a/tests/FacetAutocomplete.test.tsx
+++ b/tests/FacetAutocomplete.test.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FacetAutocomplete } from '../src/components/FacetAutocomplete.js';
+
+/**
+ * FacetAutocomplete (the user's ask: "tags filter to textbox autocomplete") — a `key=value` facet
+ * filter as a typeahead over a caller-derived vocabulary. Single-select: picking an option applies
+ * it (a clearable pill), and the × clears it back to the unfiltered view. The applied facet is
+ * lifted state, so the host keeps filtering its own rows.
+ */
+
+const OPTIONS = ['domain=macos', 'domain=ops', 'project=wicked', 'repo=studio'];
+
+function Harness({ options = OPTIONS }: { options?: string[] } = {}): React.ReactElement {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <div>
+      <FacetAutocomplete testId="fac" options={options} value={value} onChange={setValue} />
+      <span data-testid="applied">{value ?? '(none)'}</span>
+    </div>
+  );
+}
+
+describe('FacetAutocomplete', () => {
+  it('opens the full option list on focus and filters it as you type', async () => {
+    render(<Harness />);
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId('fac-input');
+    await user.click(input);
+    // Focus shows every option from the derived vocabulary.
+    let opts = within(screen.getByTestId('fac-options')).getAllByTestId('fac-option');
+    expect(opts.map((o) => o.getAttribute('data-facet'))).toEqual(OPTIONS);
+
+    // Typing narrows the list case-insensitively (substring match).
+    await user.type(input, 'domain');
+    opts = within(screen.getByTestId('fac-options')).getAllByTestId('fac-option');
+    expect(opts.map((o) => o.getAttribute('data-facet'))).toEqual(['domain=macos', 'domain=ops']);
+  });
+
+  it('selecting an option applies it (single-select) and shows a clearable pill', async () => {
+    render(<Harness />);
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId('fac-input');
+    await user.click(input);
+    await user.type(input, 'ops');
+    await user.click(screen.getByTestId('fac-option')); // the single match, domain=ops
+
+    expect(screen.getByTestId('applied')).toHaveTextContent('domain=ops');
+    expect(screen.getByTestId('fac-active')).toHaveTextContent('domain=ops');
+    // The list closes after a pick.
+    expect(screen.queryByTestId('fac-options')).toBeNull();
+
+    // Picking a different option REPLACES it (single-select).
+    await user.click(input);
+    await user.type(input, 'wicked');
+    await user.click(screen.getByTestId('fac-option'));
+    expect(screen.getByTestId('applied')).toHaveTextContent('project=wicked');
+
+    // The × clears back to the unfiltered view.
+    await user.click(screen.getByTestId('fac-clear'));
+    expect(screen.getByTestId('applied')).toHaveTextContent('(none)');
+    expect(screen.queryByTestId('fac-active')).toBeNull();
+  });
+
+  it('keyboard: ArrowDown highlights and Enter applies the highlighted option', async () => {
+    render(<Harness />);
+    const user = userEvent.setup();
+
+    const input = screen.getByTestId('fac-input');
+    await user.click(input);
+    await user.keyboard('{ArrowDown}{Enter}'); // highlight moves to index 1, Enter applies it
+    expect(screen.getByTestId('applied')).toHaveTextContent('domain=ops');
+  });
+
+  it('renders nothing to open when the vocabulary is empty', async () => {
+    render(<Harness options={[]} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('fac-input'));
+    expect(screen.queryByTestId('fac-options')).toBeNull();
+  });
+});

--- a/tests/GovernanceDashboard.test.tsx
+++ b/tests/GovernanceDashboard.test.tsx
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * The governed-knowledge dashboard (`/steering/dashboard`) — the review-forward Steering home that
+ * UN-BURIES the propose→promote queue. Three parts: a KPI band (Needs review = pending memory +
+ * policy proposals, the store size, active-rule count + severity), the consolidated REVIEW inbox
+ * (both kinds side by side, reusing ProposalsSection), and a BROWSE of the store + rule corpus,
+ * each with the facet typeahead.
+ */
+
+const apiFetch = vi.fn();
+vi.mock('../src/api/client.js', () => ({
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+  api: { listConformanceRules: () => apiFetch('/governance/rules') },
+}));
+
+const { GovernanceDashboard } = await import('../src/components/GovernanceDashboard.js');
+const { ApiError } = await import('../src/api/errors.js');
+type Proposal = import('../src/api/proposals.js').Proposal;
+type MemoryItem = import('../src/api/memory.js').MemoryItem;
+type SteeringRule = import('../src/api/steering.js').SteeringRule;
+
+const MEM_PROP: Proposal = {
+  id: 'p-mem', kind_type: 'memory',
+  payload: { content: 'Remember the gh account flip', tier: 'session' },
+  facets: { project: 'wicked' }, provenance: { run_id: 'run-1' }, state: 'pending', created_at: 1,
+};
+const POL_PROP: Proposal = {
+  id: 'p-pol', kind_type: 'policy:security',
+  payload: { rule: 'Never log secrets', severity: 'critical' },
+  facets: { project: 'wicked' }, provenance: { run_id: 'run-2' }, state: 'pending', created_at: 2,
+};
+
+const MEMS: MemoryItem[] = [
+  { id: 'm1', content: 'push 403 on account flip', tier: 'project', scope: 'brain:wicked/doc:ops', facets: { project: 'wicked', domain: 'ops' } },
+  { id: 'm2', content: 'codesign after copy', tier: 'global', scope: 'brain:wicked/doc:macos', facets: { project: 'wicked', domain: 'macos' } },
+];
+
+const RULES: SteeringRule[] = [
+  { id: 'POL-001', rule_type: 'policy', statement: 'No secrets in logs', severity: 'critical', confidence: 0.9, targets: {}, provenance: { source: 'ui', source_kinds: ['doc'] }, steering_type: 'security', applies_to: ['api'] },
+  { id: 'PAT-001', rule_type: 'pattern', statement: 'Prefer async handlers', severity: 'warn', confidence: 0.9, targets: { language: 'ts' }, provenance: { source: 'ui', source_kinds: ['doc'] }, steering_type: 'development' },
+  { id: 'PAT-002', rule_type: 'pattern', statement: 'Retired rule', severity: 'error', confidence: 0.9, targets: {}, provenance: { source: 'ui', source_kinds: ['doc'] }, steering_type: 'architecture', retired: true },
+];
+
+function wire(over: { proposals?: Proposal[]; coverage?: unknown; rules?: SteeringRule[]; memories?: MemoryItem[] } = {}): void {
+  const proposals = over.proposals ?? [MEM_PROP, POL_PROP];
+  const coverage = over.coverage ?? { total: 42 };
+  const rules = over.rules ?? RULES;
+  const memories = over.memories ?? MEMS;
+  apiFetch.mockImplementation((path: unknown) => {
+    const s = String(path);
+    if (s.startsWith('/proposals')) return Promise.resolve({ proposals });
+    if (s === '/memory/coverage') return Promise.resolve(coverage);
+    if (s === '/governance/rules') return Promise.resolve({ rules });
+    if (s.startsWith('/memory')) return Promise.resolve({ memories });
+    // Any other path (incl. a stray teardown call) resolves benignly — never an unhandled reject.
+    return Promise.resolve({});
+  });
+}
+
+beforeEach(() => apiFetch.mockReset());
+
+describe('GovernanceDashboard — the KPI band (part 1)', () => {
+  it('Needs review counts pending memory + policy proposals, split in the context line', async () => {
+    wire();
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+    const tile = await screen.findByTestId('gk-stat-needs-review');
+    await waitFor(() => expect(tile).toHaveAttribute('data-value', '2'));
+    expect(tile).toHaveTextContent('1 memory · 1 policy');
+  });
+
+  it('Memories reads the coverage total; Active rules counts the un-retired rules with a severity split', async () => {
+    wire();
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('gk-stat-memories')).toHaveAttribute('data-value', '42'));
+    const rulesTile = screen.getByTestId('gk-stat-rules');
+    // Two active rules (PAT-002 is retired), and the severity breakdown counts them.
+    expect(rulesTile).toHaveAttribute('data-value', '2');
+    expect(rulesTile).toHaveTextContent('crit 1');
+    expect(rulesTile).toHaveTextContent('warn 1');
+  });
+
+  it('a daemon that predates the proposal queue shows an honest "—", never a lying zero', async () => {
+    apiFetch.mockImplementation((path: unknown) => {
+      const s = String(path);
+      // The daemon predates the proposal queue — only the proposals wire 404s (folded to
+      // "unsupported"); every other read answers, so the rest of the dashboard still renders.
+      if (s.startsWith('/proposals')) return Promise.reject(new ApiError(404, 'Not Found'));
+      if (s === '/memory/coverage') return Promise.resolve({ total: 5 });
+      if (s === '/governance/rules') return Promise.resolve({ rules: [] });
+      if (s.startsWith('/memory')) return Promise.resolve({ memories: [] });
+      return Promise.resolve({});
+    });
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('gk-stat-needs-review')).toHaveAttribute('data-value', '—'));
+  });
+});
+
+describe('GovernanceDashboard — the consolidated review inbox (part 2)', () => {
+  it('renders BOTH kinds under one Review heading (memory + policy side by side)', async () => {
+    wire();
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+
+    // Two reused ProposalsSections — one per kind — inside the one review inbox.
+    await waitFor(() => expect(screen.getAllByTestId('proposals-section')).toHaveLength(2));
+    const kinds = screen.getAllByTestId('proposals-section').map((s) => s.getAttribute('data-kind'));
+    expect(kinds.sort()).toEqual(['memory', 'policy']);
+
+    const inbox = screen.getByTestId('governance-review-inbox');
+    const cards = await within(inbox).findAllByTestId('proposal-card');
+    expect(cards.map((c) => c.getAttribute('data-proposal-id')).sort()).toEqual(['p-mem', 'p-pol']);
+  });
+});
+
+describe('GovernanceDashboard — browse (part 3)', () => {
+  it('lists the memory store and the rule corpus, each with a facet typeahead', async () => {
+    wire();
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+
+    const memRows = await within(await screen.findByTestId('gk-browse-memories')).findAllByTestId('gk-memory-row');
+    expect(memRows.map((r) => r.getAttribute('data-memory-id'))).toEqual(['m1', 'm2']);
+    expect(screen.getByTestId('gk-memories-facet-input')).toBeInTheDocument();
+
+    const ruleRows = within(screen.getByTestId('gk-browse-rules')).getAllByTestId('gk-rule-row');
+    // Only the two ACTIVE rules appear (the retired PAT-002 is filtered out).
+    expect(ruleRows.map((r) => r.getAttribute('data-rule-id')).sort()).toEqual(['PAT-001', 'POL-001']);
+    expect(screen.getByTestId('gk-rules-facet-input')).toBeInTheDocument();
+  });
+
+  it('the rules facet typeahead narrows the corpus (severity=warn → the one warn rule)', async () => {
+    wire();
+    render(<GovernanceDashboard navigate={vi.fn()} />);
+    const user = userEvent.setup();
+
+    await within(await screen.findByTestId('gk-browse-rules')).findAllByTestId('gk-rule-row');
+    const input = screen.getByTestId('gk-rules-facet-input');
+    await user.click(input);
+    await user.type(input, 'severity=warn');
+    await user.click(screen.getByTestId('gk-rules-facet-option'));
+
+    const rows = within(screen.getByTestId('gk-browse-rules')).getAllByTestId('gk-rule-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute('data-rule-id', 'PAT-001');
+  });
+});

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -390,7 +390,7 @@ describe('accordion contents (§3.3)', () => {
     expect(within(settings).getByText(/^v\d+\.\d+\.\d+$/)).toBeInTheDocument();
   });
 
-  it('Steering expands to the two sub-section rows (Policies / Memories), each navigating to its page; the route expands it', async () => {
+  it('Steering expands to the three sub-section rows (Dashboard / Policies / Memories), each navigating to its page; the route expands it', async () => {
     const navigate = vi.fn();
     rail({ pathname: '/steering/policies', navigate });
     await screen.findByRole('button', { name: 'wicked-studio' });
@@ -398,13 +398,16 @@ describe('accordion contents (§3.3)', () => {
     const steering = screen.getByTestId('rail-heading-steering');
     expect(steering.getAttribute('aria-expanded')).toBe('true');
     const rows = within(steering).getAllByTestId('rail-steering-section');
-    expect(rows.map((r) => r.dataset.section)).toEqual(['policies', 'memories']);
-    expect(rows[0]).toHaveTextContent('Policies');
-    expect(rows[1]).toHaveTextContent('Memories');
+    expect(rows.map((r) => r.dataset.section)).toEqual(['dashboard', 'policies', 'memories']);
+    expect(rows[0]).toHaveTextContent('Dashboard');
+    expect(rows[1]).toHaveTextContent('Policies');
+    expect(rows[2]).toHaveTextContent('Memories');
     // The seven types retired into a `?type=` filter under Policies — no per-type rail rows now.
     expect(within(steering).queryByTestId('rail-steering-type')).toBeNull();
 
-    fireEvent.click(rows[1]!);
+    fireEvent.click(rows[0]!);
+    expect(navigate).toHaveBeenCalledWith('/steering/dashboard');
+    fireEvent.click(rows[2]!);
     expect(navigate).toHaveBeenCalledWith('/steering/memories');
   });
 
@@ -425,7 +428,7 @@ describe('accordion contents (§3.3)', () => {
 });
 
 describe('the collapsed rail (§3.2)', () => {
-  it('shows exactly seven glyph links (Testing → its Campaigns landing, Steering → its Policies home, Settings → /system)', async () => {
+  it('shows exactly seven glyph links (Testing → its Campaigns landing, Steering → its Dashboard home, Settings → /system)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
@@ -433,7 +436,7 @@ describe('the collapsed rail (§3.2)', () => {
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
     expect(glyphs).toHaveLength(7);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/make', '/testing/campaigns', '/chats', '/repos', '/steering/policies', '/system',
+      '/projects', '/make', '/testing/campaigns', '/chats', '/repos', '/steering/dashboard', '/system',
     ]);
     // Accordions don't exist at this width.
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();

--- a/tests/MemoriesPanel.test.tsx
+++ b/tests/MemoriesPanel.test.tsx
@@ -8,9 +8,10 @@ import userEvent from '@testing-library/user-event';
  *  - the store browser (`GET /memory`) lists content / tier / scope / facets; the search box
  *    re-queries the wire and the facet chips narrow the loaded set client-side;
  *  - RETIRE is honest about granularity — it erases a scope SUBTREE (`POST /memory/retire` with a
- *    `scope_prefix`), the confirm says so, and the note reports how many rows the server erased;
- *  - the memory-proposals section renders below (its own adoption seam), so proposals still appear
- *    even when the memory-management wire is absent.
+ *    `scope_prefix`), the confirm says so, and the note reports how many rows the server erased.
+ *
+ * The memory PROPOSALS review moved to the governed-knowledge dashboard (`/steering/dashboard`) —
+ * this page no longer renders it (the un-burying); it is the pure "manage existing" surface now.
  */
 
 const apiFetch = vi.fn();
@@ -80,19 +81,26 @@ describe('MemoriesPanel — the store browser', () => {
     expect(apiFetch).toHaveBeenCalledWith('/memory');
   });
 
-  it('a facet chip narrows the loaded set client-side', async () => {
+  it('the facet TYPEAHEAD narrows the loaded set client-side (autocomplete over the derived vocab)', async () => {
     wire([M1, M2]);
     render(<MemoriesPanel />);
     const user = userEvent.setup();
 
     await screen.findAllByTestId('memory-row');
-    // The facet chips come from the loaded set (project=wicked, domain=ops, domain=macos).
+    // The facet vocabulary is derived from the loaded set (project=wicked, domain=ops, domain=macos).
+    const input = screen.getByTestId('memories-facet-filter-input');
+    await user.click(input); // focus opens the option list
+    await user.type(input, 'macos'); // narrows the options to the domain=macos pair
     const macos = screen.getByTestId('memories-facet-filter').querySelector('[data-facet="domain=macos"]') as HTMLElement;
     await user.click(macos);
 
     const rows = screen.getAllByTestId('memory-row');
     expect(rows).toHaveLength(1);
     expect(rows[0]).toHaveAttribute('data-memory-id', 'm2');
+    // The applied facet renders as a clearable pill; clearing restores the full set.
+    expect(screen.getByTestId('memories-facet-filter-active')).toHaveTextContent('domain=macos');
+    await user.click(screen.getByTestId('memories-facet-filter-clear'));
+    expect(screen.getAllByTestId('memory-row')).toHaveLength(2);
   });
 
   it('the search box re-queries the wire with the recall query', async () => {
@@ -121,8 +129,13 @@ describe('MemoriesPanel — the store browser', () => {
     });
     render(<MemoriesPanel />);
     expect(await screen.findByTestId('memories-unsupported')).toHaveTextContent(/predates memory management/);
-    // The review half still renders — its own adoption seam, independent of the store wire.
-    expect(screen.getByTestId('proposals-section')).toHaveAttribute('data-kind', 'memory');
+  });
+
+  it('no longer renders the buried proposals-review section — that moved to the dashboard', async () => {
+    wire([M1, M2]);
+    render(<MemoriesPanel />);
+    await screen.findAllByTestId('memory-row');
+    expect(screen.queryByTestId('proposals-section')).toBeNull();
   });
 });
 

--- a/tests/ProjectDashboard.governance.test.tsx
+++ b/tests/ProjectDashboard.governance.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * The project homepage's governed-knowledge band (DES-MEM-FACETED-001; governed-knowledge
+ * dashboard): a "Needs review" KpiGroup tile counting pending memory + policy proposals, a door
+ * straight into the dashboard's consolidated review inbox. Omitted entirely on a daemon that does
+ * not serve the proposal queue — never a lying zero on the project home.
+ */
+
+const apiFetch = vi.fn();
+const listProjectMembers = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+  api: {
+    listProjects: () => Promise.resolve({ projects: [] }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+    confirmGate: () => Promise.resolve({}),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+}));
+
+const listDocs = vi.fn();
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: (...a: unknown[]) => listDocs(...a),
+}));
+
+const { ProjectDashboard } = await import('../src/components/ProjectDashboard.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useGateStore } = await import('../src/store/gates.js');
+const { ApiError } = await import('../src/api/errors.js');
+type Proposal = import('../src/api/proposals.js').Proposal;
+
+const NOW = Date.now();
+const PROJECT = {
+  id: 'proj-1', name: 'The proj-1 project', description: null, status: 'active' as const,
+  scope: 'project:proj-1', created_at: NOW - 1000, updated_at: NOW - 1000,
+};
+
+function proposals(): Proposal[] {
+  return [
+    { id: 'p-mem', kind_type: 'memory', payload: {}, facets: {}, provenance: {}, state: 'pending', created_at: 1 },
+    { id: 'p-pol', kind_type: 'policy:security', payload: {}, facets: {}, provenance: {}, state: 'pending', created_at: 2 },
+  ];
+}
+
+beforeEach(() => {
+  apiFetch.mockReset();
+  listProjectMembers.mockReset();
+  listDocs.mockReset();
+  listProjectMembers.mockResolvedValue({ members: [] });
+  listDocs.mockResolvedValue([]);
+  useGateStore.setState({ gates: {} });
+  useProjectsStore.setState({ projects: [PROJECT], loading: false, error: null });
+});
+afterEach(cleanup);
+
+describe('ProjectDashboard — the governed-knowledge band', () => {
+  it('renders a Needs review tile counting pending proposals, doored into the dashboard', async () => {
+    apiFetch.mockImplementation((path: unknown) =>
+      String(path).startsWith('/proposals') ? Promise.resolve({ proposals: proposals() }) : Promise.resolve({}),
+    );
+    const navigate = vi.fn();
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={navigate} />);
+
+    const tile = await screen.findByTestId('stat-needs-review');
+    await waitFor(() => expect(tile).toHaveAttribute('data-value', '2'));
+    // The tile is a real door into the consolidated review inbox.
+    expect(tile.getAttribute('href')).toBe('/steering/dashboard');
+    await userEvent.setup().click(tile);
+    expect(navigate).toHaveBeenCalledWith('/steering/dashboard');
+  });
+
+  it('omits the band on a daemon that does not serve the proposal queue (no lying zero)', async () => {
+    apiFetch.mockImplementation((path: unknown) =>
+      String(path).startsWith('/proposals')
+        ? Promise.reject(new ApiError(404, 'Not Found'))
+        : Promise.resolve({}),
+    );
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={vi.fn()} />);
+
+    // The project KPI band still renders; the GK tile does not.
+    await screen.findByTestId('project-kpis');
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('stat-needs-review')).toBeNull();
+  });
+});

--- a/tests/steeringApi.test.ts
+++ b/tests/steeringApi.test.ts
@@ -8,6 +8,7 @@ import {
   nextRuleId,
   policiesPath,
   readSteeringTypeFilter,
+  steeringDashboardPath,
   steeringPath,
   STEERING_RULE_TEMPLATE,
   STEERING_SECTIONS,
@@ -118,20 +119,22 @@ describe('the type roster and paths', () => {
 });
 
 describe('the unified sub-section paths + the Policies type filter', () => {
-  it('spells the two sub-sections', () => {
-    expect([...STEERING_SECTIONS]).toEqual(['policies', 'memories']);
+  it('spells the dashboard home + the two management sub-sections (dashboard leads = the default)', () => {
+    expect([...STEERING_SECTIONS]).toEqual(['dashboard', 'policies', 'memories']);
+    expect(isSteeringSection('dashboard')).toBe(true);
     expect(isSteeringSection('policies')).toBe(true);
     expect(isSteeringSection('memories')).toBe(true);
     expect(isSteeringSection('security')).toBe(false);
     expect(isSteeringSection('proposals')).toBe(false);
   });
 
-  it('policiesPath is bare for the All view, ?type= for a filtered one; memoriesPath is fixed', () => {
+  it('policiesPath is bare for the All view, ?type= for a filtered one; memoriesPath + steeringDashboardPath are fixed', () => {
     expect(policiesPath()).toBe('/steering/policies');
     expect(policiesPath(null)).toBe('/steering/policies');
     expect(policiesPath('security')).toBe('/steering/policies?type=security');
     expect(policiesPath('design-ux')).toBe('/steering/policies?type=design-ux');
     expect(memoriesPath()).toBe('/steering/memories');
+    expect(steeringDashboardPath()).toBe('/steering/dashboard');
   });
 
   it('readSteeringTypeFilter reads the type back from search; unknown/absent → null (the All view)', () => {

--- a/tests/steeringRoutes.test.tsx
+++ b/tests/steeringRoutes.test.tsx
@@ -30,8 +30,12 @@ afterEach(() => {
   window.history.replaceState(null, '', '/');
 });
 
-describe('useRoute — /steering/{policies,memories}', () => {
-  it('parses the two sub-sections to the one steering panel', () => {
+describe('useRoute — /steering/{dashboard,policies,memories}', () => {
+  it('parses the dashboard home + the two management sub-sections to the one steering panel', () => {
+    const dash = routeAt('/steering/dashboard').current;
+    expect(dash).toMatchObject({ panel: 'steering', steeringSection: 'dashboard' });
+    expect(dash.runId).toBeNull();
+    expect(dash.projectId).toBeNull();
     const pol = routeAt('/steering/policies').current;
     expect(pol).toMatchObject({ panel: 'steering', steeringSection: 'policies' });
     expect(pol.runId).toBeNull();
@@ -39,7 +43,7 @@ describe('useRoute — /steering/{policies,memories}', () => {
     expect(routeAt('/steering/memories').current).toMatchObject({ panel: 'steering', steeringSection: 'memories' });
   });
 
-  it('a bare /steering parses with steeringSection null — the redirect resolves it onto Policies', () => {
+  it('a bare /steering parses with steeringSection null — the redirect resolves it onto the Dashboard', () => {
     expect(routeAt('/steering').current).toMatchObject({ panel: 'steering', steeringSection: null });
     expect(routeAt('/steering/').current).toMatchObject({ panel: 'steering', steeringSection: null });
   });
@@ -79,15 +83,22 @@ describe('useRoute — /steering/{policies,memories}', () => {
 });
 
 describe('useSteeringRedirect', () => {
-  it('leaves the real sub-section addresses alone', () => {
+  it('leaves the real sub-section addresses alone (dashboard / policies / memories)', () => {
     const navigate = vi.fn();
+    renderHook(() => useSteeringRedirect('steering', 'dashboard', '/steering/dashboard', '', navigate));
     renderHook(() => useSteeringRedirect('steering', 'policies', '/steering/policies', '', navigate));
     renderHook(() => useSteeringRedirect('steering', 'memories', '/steering/memories', '', navigate));
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it('REPLACES bare /steering and the retired panels with the Policies home', () => {
-    for (const path of ['/steering', '/wiki', '/rules', '/policies']) {
+  it('REPLACES bare /steering with the Dashboard home (the review-forward default)', () => {
+    const navigate = vi.fn();
+    renderHook(() => useSteeringRedirect('steering', null, '/steering', '', navigate));
+    expect(navigate).toHaveBeenCalledWith('/steering/dashboard', { replace: true });
+  });
+
+  it('REPLACES the retired /wiki, /rules, /policies rule-management panels with the Policies home', () => {
+    for (const path of ['/wiki', '/rules', '/policies']) {
       const navigate = vi.fn();
       renderHook(() => useSteeringRedirect('steering', null, path, '', navigate));
       expect(navigate).toHaveBeenCalledWith('/steering/policies', { replace: true });
@@ -100,19 +111,14 @@ describe('useSteeringRedirect', () => {
     expect(navigate).toHaveBeenCalledWith('/steering/policies?type=security', { replace: true });
   });
 
-  it('REPLACES the retired /proposals queue onto a sub-section by its ?type= filter', () => {
-    const toPolicies = vi.fn();
-    renderHook(() => useSteeringRedirect('steering', null, '/proposals', '', toPolicies));
-    expect(toPolicies).toHaveBeenCalledWith('/steering/policies', { replace: true });
-
-    const toMemories = vi.fn();
-    renderHook(() => useSteeringRedirect('steering', null, '/proposals', '?type=memory', toMemories));
-    expect(toMemories).toHaveBeenCalledWith('/steering/memories', { replace: true });
-
-    // A policy-filtered proposals bookmark lands on Policies (its proposals live there).
-    const toPolicies2 = vi.fn();
-    renderHook(() => useSteeringRedirect('steering', null, '/proposals', '?type=policy', toPolicies2));
-    expect(toPolicies2).toHaveBeenCalledWith('/steering/policies', { replace: true });
+  it('REPLACES the retired /proposals queue onto the Dashboard review inbox (its successor), for every ?type=', () => {
+    // The standalone review queue folded into the dashboard's consolidated inbox, which reviews
+    // BOTH kinds in one place — so every proposals bookmark (and its old ?type= filter) lands there.
+    for (const search of ['', '?type=memory', '?type=policy']) {
+      const navigate = vi.fn();
+      renderHook(() => useSteeringRedirect('steering', null, '/proposals', search, navigate));
+      expect(navigate).toHaveBeenCalledWith('/steering/dashboard', { replace: true });
+    }
   });
 
   it('leaves a typo (parsed not-found) and every non-steering panel alone', () => {


### PR DESCRIPTION
Surfaces the propose→promote review queue as a review-forward **dashboard** instead of burying it at the bottom of two pages.

## The dashboard (`/steering/dashboard`, the new Steering landing)
- **KPI band** — **Needs review** (pending memory+policy proposals, headline), Memories total, Active rules by severity.
- **Review inbox** — the consolidated pending queue: both memory + policy proposals in one prominent place, approve/reject inline (two reused `ProposalsSection`s under one heading; an `onDecision` hook keeps the KPI headline live).
- **Browse** — memories + rules below, each with the new facet autocomplete.

## Placement (your ask)
- **Steering landing**: bare `/steering` and the retired `/proposals` queue now redirect to the dashboard; Policies/Memories stay as the manage-existing deep-dives (left rail is now a 3-row Steering accordion).
- **Project homepage**: a "Governed knowledge" band with a **Needs review** tile that doors into the dashboard (omitted when the daemon doesn't serve proposals — no lying zero).

## Filters + cleanup
- **Facet chips → `key=value` autocomplete** (`FacetAutocomplete`, options client-derived — no facet-vocab endpoint), used in Memories + the dashboard browse. The fixed 8-value policies type filter stays as chips.
- **Removed the buried `ProposalsSection`s** from `SteeringPage` + `MemoriesPanel`.

## Notes
- **No date filters yet** — a `TODO(date-filters)` marker sits where they go; they need api-types 0.23.0 (merged to crew main via #463) published + pinned. Follow-up.
- Rebased onto main after #194 (nav); resolved the `LeftSidebar` overlap (Testing stays below Make; Steering gets the Dashboard row).
- Gates: typecheck ✓, lint ✓, build ✓, **2436 tests** ✓ (incl. the testid drift test); inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)