### PR TITLE
release: studio 0.4.15 (governed-knowledge dashboard + nav tweaks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.4.15] — 2026-09-07
+
+### Added
+- **Governed-knowledge dashboard (#195).** `/steering/dashboard` is the new Steering
+  landing: a KPI band (Needs review · Memories · Active rules by severity), a
+  consolidated review inbox (memory + policy proposals in one place, approve/reject
+  inline), and browse. A "Needs review" governed-knowledge band on the project homepage.
+  The propose→promote review queue is no longer buried at the bottom of the Policies and
+  Memories pages.
+- **`FacetAutocomplete` (#195).** The facet chip filters became a `key=value` typeahead.
+
+### Changed
+- **Nav tweaks (#194).** Removed the logo connection dot; the Health heart is colored by
+  health; Ask is a compact `?`-circle; Testing is relabelled "Test" and moved below Make;
+  a custom site name in Settings → Appearance.
+
 ## [0.4.14] — 2026-09-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.4.14",
+  "studioVersion": "0.4.15",
   "counts": {
     "files": 123,
     "occurrences": 1006,


### PR DESCRIPTION
Release **0.4.15** — bundles the governed-knowledge dashboard (#195) and the nav tweaks (#194).

Version bump + CHANGELOG only. On merge + tag `v0.4.15`, `release.yml` publishes to npm (provenance) and the github-release job cuts the release from the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)