### PR TITLE
feat(home): the command-deck landing rebuild + nav usability wave + eval-store wiring

### DIFF
--- a/.product/mockups/command-deck.html
+++ b/.product/mockups/command-deck.html
@@ -1,0 +1,599 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Command Deck</title>
+<meta name="description" content="A redesigned wicked-studio landing — a mission-control command deck with a luminous KPI ribbon, an attention feed, and a live-pulse column." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />
+<style>
+  :root {
+    /* wicked-studio dark identity, painted explicitly */
+    --s0:#08080e; --s1:#101019; --s2:#171724; --s3:#20202f; --s4:#2a2a3c;
+    --ink-dim:rgba(233,233,255,.36); --ink-muted:rgba(233,233,255,.56);
+    --ink-body:rgba(233,233,255,.82); --ink-high:#f5f5ff;
+    --accent:hsl(258 78% 66%); --accent-2:hsl(268 70% 60%); --accent-dim:hsl(258 60% 46%);
+    --accent-deep:hsl(258 40% 26%);
+    --gate:hsl(43 92% 66%); --gate-dim:hsl(43 55% 20%);
+    --fail:hsl(2 84% 64%); --fail-dim:hsl(2 48% 18%);
+    --run:hsl(151 60% 55%); --run-dim:hsl(151 40% 15%);
+    --hair:rgba(233,233,255,.08); --hair-2:rgba(233,233,255,.14);
+    --mono:'JetBrains Mono',ui-monospace,monospace;
+    --sans:'Inter',system-ui,sans-serif;
+    --ease:cubic-bezier(.16,1,.3,1);
+  }
+  * { box-sizing:border-box; }
+  html { color-scheme:dark; }
+  body {
+    background:var(--s0); color:var(--ink-body); font-family:var(--sans); margin:0;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility; position:relative;
+    min-height:100vh; overflow-x:hidden;
+  }
+  /* Ambient console atmosphere — a low violet aurora top-center + a whisper of grid */
+  body::before {
+    content:''; position:fixed; inset:0; pointer-events:none; z-index:0;
+    background:
+      radial-gradient(1200px 480px at 24% -8%, hsl(258 70% 40% / .20), transparent 60%),
+      radial-gradient(900px 420px at 92% 0%, hsl(151 50% 34% / .08), transparent 55%);
+  }
+  body::after {
+    content:''; position:fixed; inset:0; pointer-events:none; z-index:0; opacity:.4;
+    background-image:linear-gradient(var(--hair) 1px,transparent 1px),linear-gradient(90deg,var(--hair) 1px,transparent 1px);
+    background-size:48px 48px; mask-image:radial-gradient(1000px 600px at 50% -10%,#000,transparent 75%);
+  }
+  /* ── App shell: left rail + main ── */
+  .shell { position:relative; z-index:1; display:flex; min-height:100vh; }
+  .rail { width:236px; flex-shrink:0; background:linear-gradient(180deg,var(--s1),#0d0d15);
+    border-right:1px solid var(--hair); display:flex; flex-direction:column; padding:16px 12px 12px;
+    position:sticky; top:0; height:100vh; }
+  @media (max-width:820px){ .rail{ display:none; } }
+  .brand-top { display:flex; align-items:center; gap:10px; padding:6px 8px 16px; cursor:pointer; }
+  .logo { width:30px; height:30px; border-radius:9px; flex-shrink:0; display:grid; place-items:center;
+    background:linear-gradient(140deg,var(--accent),var(--accent-2)); color:#fff; font-weight:800;
+    font-size:15px; box-shadow:0 3px 14px hsl(258 78% 50% /.4); }
+  .wordmark { font-weight:700; font-size:14px; color:var(--ink-high); letter-spacing:-.01em; }
+  .wordmark span { color:var(--ink-dim); font-weight:500; }
+  .nav { display:flex; flex-direction:column; gap:1px; flex:1; }
+  .nav .sec { display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:11px;
+    padding:8px 9px; border-radius:9px; cursor:pointer; color:var(--ink-muted); transition:.14s; position:relative; }
+  .nav .sec:hover { background:hsl(258 40% 50% /.09); color:var(--ink-body); }
+  .nav .sec.on { background:hsl(258 45% 45% /.16); color:var(--ink-high); }
+  .nav .sec.on::before { content:''; position:absolute; left:-12px; top:8px; bottom:8px; width:3px;
+    border-radius:0 3px 3px 0; background:var(--accent); box-shadow:0 0 10px hsl(258 78% 60% /.6); }
+  .nav .sec .g { font-size:14px; width:18px; text-align:center; opacity:.9; }
+  .nav .sec .tt { font-size:13px; font-weight:500; }
+  .nav .sec .dash { font-size:12px; color:var(--ink-dim); opacity:0; transition:.14s; }
+  .nav .sec:hover .dash, .nav .sec.on .dash { opacity:1; }
+  .nav .kids { display:flex; flex-direction:column; gap:1px; margin:1px 0 3px 30px; padding-left:9px;
+    border-left:1px solid var(--hair); }
+  .nav .kid { font-size:12px; color:var(--ink-muted); font-family:var(--mono); padding:5px 8px;
+    border-radius:6px; cursor:pointer; display:flex; align-items:center; gap:8px; transition:.14s; }
+  .nav .kid:hover { color:var(--ink-body); background:hsl(258 40% 50% /.07); }
+  .nav .kid .kd { width:5px; height:5px; border-radius:50%; flex-shrink:0; }
+  .nav .divider { height:1px; background:var(--hair); margin:8px 6px; }
+  .nav .spacer { flex:1; }
+  /* Daemon health bar — pinned at the rail's foot */
+  .health { display:flex; align-items:center; gap:10px; width:100%; text-align:left; cursor:pointer;
+    margin-top:8px; padding:10px 11px; border-radius:10px; border:1px solid var(--hair);
+    background:linear-gradient(180deg,var(--s2),var(--s1)); transition:.14s; font-family:var(--sans); }
+  .health:hover { border-color:var(--run-dim); }
+  .health .hdot { width:8px; height:8px; border-radius:50%; background:var(--run); flex-shrink:0;
+    box-shadow:0 0 0 3px var(--run-dim), 0 0 10px hsl(151 60% 55% /.7); animation:breathe 2.6s ease-in-out infinite; }
+  @media (prefers-reduced-motion:reduce){ .health .hdot{animation:none} }
+  .health .hinfo { display:flex; flex-direction:column; gap:1px; min-width:0; }
+  .health .hl { font-size:12px; font-weight:600; color:var(--ink-high); }
+  .health .hs { font-size:10px; color:var(--ink-dim); font-family:var(--mono); }
+  .deck { position:relative; z-index:1; flex:1; min-width:0; max-width:1320px; margin:0 auto;
+    padding:26px 32px 56px; animation:rise .5s var(--ease) both; }
+  @keyframes rise { from{opacity:0; transform:translateY(8px)} to{opacity:1; transform:none} }
+  @media (prefers-reduced-motion:reduce){ .deck{animation:none} }
+  h1,h2,h3 { margin:0; }
+  a { color:inherit; text-decoration:none; }
+  .num { font-family:var(--mono); font-variant-numeric:tabular-nums; }
+  .eyebrow { font-size:10px; letter-spacing:.16em; text-transform:uppercase; font-weight:700;
+    color:var(--ink-dim); }
+
+  /* ── Status header ── */
+  .head { display:flex; align-items:flex-end; gap:24px; flex-wrap:wrap; padding-bottom:22px;
+    position:relative; }
+  .head::after { content:''; position:absolute; left:0; right:0; bottom:0; height:1px;
+    background:linear-gradient(90deg,var(--hair-2),transparent 40%); }
+  .brand { display:flex; flex-direction:column; gap:9px; min-width:0; }
+  .kicker { display:flex; align-items:center; gap:10px; }
+  .dot { width:8px; height:8px; border-radius:50%; background:var(--run);
+    box-shadow:0 0 0 3px var(--run-dim), 0 0 12px hsl(151 60% 55% / .7); animation:breathe 2.6s ease-in-out infinite; }
+  @keyframes breathe { 0%,100%{opacity:1} 50%{opacity:.4} }
+  @media (prefers-reduced-motion:reduce){ .dot{animation:none} }
+  .brand h1 { font-size:34px; font-weight:800; letter-spacing:-.025em; color:var(--ink-high);
+    line-height:1; text-wrap:balance; }
+  .situation { font-size:13.5px; color:var(--ink-muted); letter-spacing:.005em; }
+  .situation b { color:var(--ink-body); font-weight:600; }
+  .situation .hot { color:var(--gate); font-weight:700; }
+  .verbs { margin-left:auto; display:flex; align-items:center; gap:9px; flex-wrap:wrap; align-self:center; }
+  .verb { font-size:12.5px; font-weight:600; padding:9px 15px; border-radius:9px;
+    border:1px solid var(--hair-2); color:var(--ink-body);
+    background:linear-gradient(180deg,var(--s2),var(--s1)); display:inline-flex; align-items:center; gap:8px;
+    cursor:pointer; transition:.16s var(--ease); }
+  .verb:hover { border-color:var(--accent-dim); color:var(--ink-high); transform:translateY(-1px); }
+  .verb .k { font-family:var(--mono); font-size:13px; opacity:.7; }
+  /* The Make breakout — Execute / Vibe / Demo as one segmented "work" control */
+  .makeseg { display:inline-flex; border:1px solid var(--hair-2); border-radius:10px; overflow:hidden;
+    background:linear-gradient(180deg,var(--s2),var(--s1)); box-shadow:inset 0 1px 0 hsl(0 0% 100% /.04); }
+  .makeseg button { border:0; background:none; cursor:pointer; font-family:var(--sans);
+    font-size:12.5px; font-weight:600; color:var(--ink-body); padding:9px 15px;
+    display:inline-flex; align-items:center; gap:7px; border-right:1px solid var(--hair);
+    transition:.16s var(--ease); }
+  .makeseg button:last-child { border-right:0; }
+  .makeseg button:hover { color:var(--ink-high); background:hsl(258 40% 50% /.10); }
+  .makeseg button .glyph { font-size:11px; opacity:.7; }
+  .makeseg button.primary { background:linear-gradient(180deg,var(--accent),var(--accent-2));
+    color:#fff; box-shadow:0 4px 18px hsl(258 78% 50% /.38); }
+  .makeseg button.primary:hover { background:linear-gradient(180deg,var(--accent),var(--accent-2)); filter:brightness(1.06); }
+  .makeseg button.primary .glyph { opacity:.85; }
+  .vdiv { width:1px; height:24px; background:var(--hair-2); margin:0 3px; }
+
+  /* ── KPI ribbon: the hero — luminous telemetry ── */
+  .ribbon { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; margin:24px 0 26px; }
+  @media (max-width:1080px){ .ribbon{grid-template-columns:1fr} }
+  .group {
+    position:relative; border-radius:16px; padding:17px 19px 18px; overflow:hidden;
+    background:
+      radial-gradient(120% 100% at 0% 0%, var(--gtint,transparent), transparent 46%),
+      linear-gradient(180deg,var(--s2),var(--s1));
+    border:1px solid var(--hair);
+    box-shadow: inset 0 1px 0 hsl(0 0% 100% / .05), 0 2px 8px rgba(0,0,0,.4);
+  }
+  .group::before { content:''; position:absolute; inset:0 0 auto; height:2px;
+    background:linear-gradient(90deg,var(--gcol),transparent 72%); }
+  .group.flow  { --gcol:var(--run);   --gtint:hsl(151 60% 40% / .10); }
+  .group.attn  { --gcol:var(--gate);  --gtint:hsl(43 80% 45% / .10); }
+  .group.trust { --gcol:var(--accent);--gtint:hsl(258 70% 50% / .12); }
+  .ghead { display:flex; align-items:center; gap:8px; margin-bottom:15px; }
+  .ghead .tag { color:var(--gcol); letter-spacing:.14em; }
+  .ghead .glyph { color:var(--gcol); font-size:11px; filter:drop-shadow(0 0 6px currentColor); opacity:.9; }
+  .tiles { display:flex; gap:14px; }
+  .tile { flex:1; min-width:0; }
+  .tile.lead { flex:1.15; }
+  .tile .lab { font-size:11px; color:var(--ink-muted); white-space:nowrap; overflow:hidden;
+    text-overflow:ellipsis; font-weight:500; }
+  .tile .val { display:flex; align-items:baseline; gap:7px; margin-top:5px; }
+  .big { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:34px; font-weight:700;
+    color:var(--ink-high); line-height:.95; letter-spacing:-.02em;
+    text-shadow:0 0 24px hsl(0 0% 100% / .10); }
+  .big.accent { color:var(--gate); text-shadow:0 0 22px hsl(43 92% 60% / .28); }
+  .unit { font-size:13px; color:var(--ink-dim); font-family:var(--mono); font-weight:500; }
+  .delta { font-size:11px; font-family:var(--mono); font-weight:600; display:inline-flex;
+    align-items:center; gap:2px; padding:1px 5px; border-radius:5px; }
+  .delta.up { color:var(--run); background:var(--run-dim); }
+  .delta.down { color:var(--fail); background:var(--fail-dim); }
+  .spark { margin-top:11px; height:26px; width:100%; display:block; }
+  .tile .sub { font-size:10.5px; color:var(--ink-dim); margin-top:7px; line-height:1.4; }
+  .splitbar { display:flex; height:6px; border-radius:3px; overflow:hidden; margin-top:11px;
+    background:var(--s3); }
+  .splitbar i { display:block; height:100%; box-shadow:0 0 10px hsl(258 78% 60% / .5); }
+
+  /* ── Workbench ── */
+  .bench { display:grid; grid-template-columns:1.38fr 1fr; gap:18px; align-items:start; }
+  @media (max-width:1080px){ .bench{grid-template-columns:1fr} }
+  .panel { background:linear-gradient(180deg,var(--s1),#0e0e16); border:1px solid var(--hair);
+    border-radius:16px; box-shadow:inset 0 1px 0 hsl(0 0% 100% / .04), 0 2px 10px rgba(0,0,0,.35); overflow:hidden; }
+  .panel > header { display:flex; align-items:center; gap:12px; padding:15px 18px 13px;
+    border-bottom:1px solid var(--hair); }
+  .panel > header h2 { font-size:13px; font-weight:700; color:var(--ink-high); letter-spacing:.01em;
+    display:flex; align-items:center; gap:9px; }
+  .panel > header .gl { filter:drop-shadow(0 0 6px currentColor); }
+  .panel > header .count { font-family:var(--mono); font-size:11.5px; font-weight:600; color:var(--gate);
+    background:var(--gate-dim); padding:2px 9px; border-radius:999px; }
+  .panel > header .link { font-size:11px; color:var(--ink-muted); transition:.14s; }
+  .panel > header .link:hover { color:var(--ink-high); }
+
+  .feed { display:flex; flex-direction:column; }
+  .item { display:grid; grid-template-columns:3px 1fr auto; gap:15px; align-items:center;
+    padding:15px 18px; border-bottom:1px solid var(--hair); transition:background .16s; }
+  .item:last-child { border-bottom:0; }
+  .item:hover { background:hsl(258 40% 50% / .05); }
+  .item .stripe { align-self:stretch; border-radius:3px; }
+  .item.gate .stripe{ background:linear-gradient(180deg,var(--gate),transparent); box-shadow:0 0 10px hsl(43 92% 60% /.5);}
+  .item.fail .stripe{ background:linear-gradient(180deg,var(--fail),transparent); box-shadow:0 0 10px hsl(2 84% 60% /.5);}
+  .item.strand .stripe{ background:linear-gradient(180deg,var(--accent),transparent); box-shadow:0 0 10px hsl(258 78% 60% /.5);}
+  .item.prop .stripe{ background:linear-gradient(180deg,var(--run),transparent); box-shadow:0 0 10px hsl(151 60% 55% /.5);}
+  .item .body { min-width:0; }
+  .item .top { display:flex; align-items:center; gap:10px; }
+  .kind { font-family:var(--mono); font-size:9.5px; font-weight:700; letter-spacing:.08em;
+    text-transform:uppercase; padding:3px 8px; border-radius:5px; }
+  .item.gate .kind{ color:var(--gate); background:var(--gate-dim);}
+  .item.fail .kind{ color:var(--fail); background:var(--fail-dim);}
+  .item.strand .kind{ color:hsl(258 78% 80%); background:var(--accent-deep);}
+  .item.prop .kind{ color:var(--run); background:var(--run-dim);}
+  .item .who { font-size:11.5px; color:var(--ink-dim); font-family:var(--mono); }
+  .item .title { font-size:13px; color:var(--ink-high); font-weight:500; margin-top:6px; line-height:1.4; }
+  .item .meta { font-size:11px; color:var(--ink-muted); margin-top:4px; }
+  .act { font-size:12px; font-weight:600; padding:8px 14px; border-radius:9px; white-space:nowrap;
+    border:1px solid var(--hair-2); background:var(--s2); color:var(--ink-high); cursor:pointer;
+    transition:.16s var(--ease); }
+  .act:hover{ border-color:var(--accent-dim); transform:translateY(-1px);}
+  .act.go { background:linear-gradient(180deg,var(--gate),hsl(40 90% 58%)); border-color:transparent;
+    color:#1c1405; box-shadow:0 3px 14px hsl(43 92% 55% / .35); }
+  .act.go:hover{ box-shadow:0 5px 18px hsl(43 92% 55% / .5);}
+
+  .vrbar { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--hair);
+    border:1px solid var(--hair); border-radius:14px; overflow:hidden; margin-top:16px;
+    box-shadow:0 2px 10px rgba(0,0,0,.3); }
+  .vrcell { background:linear-gradient(180deg,var(--s1),#0e0e16); padding:15px 17px;
+    display:flex; flex-direction:column; gap:4px; cursor:pointer; transition:.16s; position:relative; }
+  .vrcell:hover{ background:var(--s2);}
+  .vrcell .n { font-family:var(--mono); font-size:24px; font-weight:700; letter-spacing:-.01em; }
+  .vrcell .n.ok{ color:var(--run); text-shadow:0 0 18px hsl(151 60% 50% /.3);}
+  .vrcell .n.warn{ color:var(--gate);} .vrcell .n.bad{ color:var(--fail);}
+  .vrcell .l { font-size:11px; color:var(--ink-muted); }
+
+  /* live pulse */
+  .pulse-card { padding:16px 18px 8px; }
+  .pulse-head { display:flex; align-items:baseline; justify-content:space-between; }
+  .pulse-head .t { font-size:11px; color:var(--ink-muted); font-weight:500; }
+  .pulse-head .v { font-family:var(--mono); font-size:16px; color:var(--ink-high); font-weight:700; }
+  .pulse-head .v small{ color:var(--ink-dim); font-weight:400; font-size:11px; }
+  .chart { width:100%; height:104px; display:block; margin-top:10px; }
+  .rangebtns { display:flex; gap:6px; }
+  .rb { font-family:var(--mono); font-size:10px; padding:4px 9px; border-radius:7px;
+    border:1px solid var(--hair); color:var(--ink-muted); cursor:pointer; transition:.14s; }
+  .rb:hover{ color:var(--ink-body);}
+  .rb.on { color:var(--ink-high); border-color:var(--accent-dim); background:hsl(258 40% 40% /.18); }
+
+  .activity { display:flex; flex-direction:column; padding-bottom:4px; }
+  .act-row { display:grid; grid-template-columns:auto 1fr auto; gap:11px; align-items:center;
+    padding:10px 18px; border-top:1px solid var(--hair); font-size:12px; }
+  .act-row .sd { width:6px; height:6px; border-radius:50%; box-shadow:0 0 8px currentColor; }
+  .act-row .msg { color:var(--ink-body); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .act-row .msg b { color:var(--ink-high); font-weight:600; }
+  .act-row .ts { font-family:var(--mono); font-size:10px; color:var(--ink-dim); }
+
+  /* ── Section doors (the nav made legible on the landing) ── */
+  .doors { display:flex; gap:10px; flex-wrap:wrap; margin-top:20px; }
+  .door { flex:1 1 0; min-width:132px; display:flex; align-items:center; gap:11px;
+    padding:12px 14px; border-radius:12px; border:1px solid var(--hair); cursor:pointer;
+    background:linear-gradient(180deg,var(--s1),#0e0e16); transition:.16s var(--ease); }
+  .door:hover { border-color:var(--accent-dim); transform:translateY(-1px); }
+  .door .dg { width:30px; height:30px; border-radius:9px; display:grid; place-items:center;
+    font-size:14px; color:var(--dcol,var(--accent)); background:hsl(258 40% 40% /.14);
+    border:1px solid var(--hair); flex-shrink:0; }
+  .door.exec .dg{ --dcol:var(--run); background:var(--run-dim);}
+  .door.test .dg{ --dcol:hsl(168 62% 55%); background:hsl(168 50% 28% /.2);}
+  .door.vibe .dg{ --dcol:hsl(198 80% 62%); background:hsl(198 60% 30% /.2);}
+  .door.demo .dg{ --dcol:hsl(320 70% 66%); background:hsl(320 50% 34% /.2);}
+  .door.evals .dg{ --dcol:var(--gate); background:var(--gate-dim);}
+  .door.steer .dg{ --dcol:var(--accent); background:hsl(258 50% 40% /.2);}
+  .door .dt { min-width:0; }
+  .door .dl { font-size:12px; font-weight:600; color:var(--ink-high); }
+  .door .dc { font-size:10.5px; color:var(--ink-muted); font-family:var(--mono); margin-top:1px; }
+
+  /* ── Portfolio wall ── */
+  .wall { margin-top:28px; }
+  .wall-head { display:flex; align-items:baseline; gap:13px; margin-bottom:14px; }
+  .wall-head h2 { font-size:14px; font-weight:700; color:var(--ink-high); letter-spacing:.01em; }
+  .wall-head .sub { font-size:11px; color:var(--ink-dim); }
+  .cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(276px,1fr)); gap:14px; }
+  .card { position:relative; border:1px solid var(--hair); border-radius:14px; padding:16px;
+    cursor:pointer; transition:.18s var(--ease); overflow:hidden;
+    background:linear-gradient(180deg,var(--s2),var(--s1));
+    box-shadow:inset 0 1px 0 hsl(0 0% 100% /.04); }
+  .card:hover{ border-color:var(--accent-dim); transform:translateY(-2px);
+    box-shadow:0 8px 26px rgba(0,0,0,.4), inset 0 1px 0 hsl(0 0% 100% /.05); }
+  .card.hot::before{ content:''; position:absolute; inset:0 0 auto; height:2px;
+    background:linear-gradient(90deg,var(--hotcol),transparent 70%); }
+  .card.hot.gatehot{ --hotcol:var(--gate); } .card.hot.strandhot{ --hotcol:var(--accent); }
+  .card.hot.failhot{ --hotcol:var(--fail); }
+  .card .ct { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+  .card .nm { font-size:14.5px; font-weight:600; color:var(--ink-high); }
+  .card .stt { font-family:var(--mono); font-size:9.5px; font-weight:600; padding:3px 8px; border-radius:5px;
+    letter-spacing:.04em; text-transform:uppercase; }
+  .stt.running{ color:var(--run); background:var(--run-dim);}
+  .stt.gate{ color:var(--gate); background:var(--gate-dim);}
+  .stt.failed{ color:var(--fail); background:var(--fail-dim);}
+  .stt.quiet{ color:var(--ink-dim); border:1px solid var(--hair);}
+  .card .stat { display:flex; gap:18px; margin-top:14px; }
+  .card .stat .k { font-family:var(--mono); font-size:17px; font-weight:700; color:var(--ink-body); letter-spacing:-.01em; }
+  .card .stat .kl { font-size:9.5px; color:var(--ink-dim); margin-top:2px; letter-spacing:.04em; text-transform:uppercase; }
+  .card .cspark { margin-top:12px; height:22px; width:100%; display:block; }
+  .card .gatechip { margin-top:12px; font-size:11px; color:var(--gate); display:flex; gap:8px;
+    align-items:center; font-weight:500; }
+  .card .gatechip .g { width:5px; height:5px; border-radius:50%; box-shadow:0 0 8px currentColor; }
+  footer.note { margin-top:30px; font-size:11px; color:var(--ink-dim); font-family:var(--mono);
+    border-top:1px solid var(--hair); padding-top:16px; line-height:1.7; }
+</style>
+
+</head>
+<body>
+<div class="shell">
+  <aside class="rail" aria-label="Sections">
+    <div class="brand-top">
+      <div class="logo">w</div>
+      <div class="wordmark">wicked <span>studio</span></div>
+    </div>
+    <nav class="nav">
+      <div class="sec"><span class="g">◇</span><span class="tt">Projects</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">▸</span><span class="tt">Execute</span><span class="dash">▦</span></div>
+      <div class="kids">
+        <div class="kid"><span class="kd" style="background:var(--run)"></span>auth-refactor</div>
+        <div class="kid"><span class="kd" style="background:var(--gate)"></span>api-migration</div>
+        <div class="kid" style="color:var(--ink-dim)">view all ›</div>
+      </div>
+      <div class="sec"><span class="g">✓</span><span class="tt">Test</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">▤</span><span class="tt">Vibe</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">▶</span><span class="tt">Demo</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">💬</span><span class="tt">Chat</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">⬡</span><span class="tt">Repositories</span><span class="dash">▦</span></div>
+      <div class="divider"></div>
+      <div class="sec"><span class="g">☸</span><span class="tt">Steering</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">◈</span><span class="tt">Evals</span><span class="dash">▦</span></div>
+      <div class="divider"></div>
+      <div class="sec"><span class="g">⚙</span><span class="tt">Settings</span><span class="dash">▦</span></div>
+      <div class="spacer"></div>
+      <button class="health" title="Daemon status">
+        <span class="hdot"></span>
+        <span class="hinfo">
+          <span class="hl">Daemon healthy</span>
+          <span class="hs">v0.7.24 · :7701 · 3 active</span>
+        </span>
+      </button>
+    </nav>
+  </aside>
+
+  <div class="deck">
+  <header class="head">
+    <div class="brand">
+      <div class="kicker">
+        <span class="dot"></span>
+        <span class="eyebrow">Command Deck · daemon healthy · :7701</span>
+      </div>
+      <h1>Good afternoon, Mike.</h1>
+      <p class="situation">
+        <span class="hot">4 things need you</span> ·
+        <b>3</b> runs executing · <b>41</b> verified this month ·
+        last delivery <b>8 min ago</b>
+      </p>
+    </div>
+    <nav class="verbs" aria-label="Start work">
+      <div class="makeseg" role="group" aria-label="New work — Execute, Vibe or Demo">
+        <button class="primary" title="Execute — a build run"><span class="glyph">▸</span> Execute</button>
+        <button title="Vibe — a document"><span class="glyph">▤</span> Vibe</button>
+        <button title="Demo — a video"><span class="glyph">▶</span> Demo</button>
+      </div>
+      <span class="vdiv" aria-hidden="true"></span>
+      <button class="verb">＋ Project</button>
+      <button class="verb">＋ Chat</button>
+      <button class="verb">Ask <span class="k">⌘K</span></button>
+    </nav>
+  </header>
+
+  <section class="ribbon" aria-label="Key metrics">
+    <div class="group flow">
+      <div class="ghead"><span class="glyph">◆</span><span class="eyebrow tag">Flow</span></div>
+      <div class="tiles">
+        <div class="tile lead">
+          <div class="lab">Runs · 30d</div>
+          <div class="val"><span class="big">128</span><span class="delta up">▲ 12</span></div>
+          <svg class="spark" viewBox="0 0 120 26" preserveAspectRatio="none" aria-hidden="true">
+            <defs><linearGradient id="gf" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stop-color="hsl(151 60% 55%)" stop-opacity=".4"/>
+              <stop offset="1" stop-color="hsl(151 60% 55%)" stop-opacity="0"/></linearGradient></defs>
+            <path d="M0,21 6,20 12,18 18,19 24,15 30,16 36,12 42,14 48,10 54,11 60,8 66,10 72,7 78,9 84,6 90,8 96,5 102,7 108,4 114,5 120,3 120,26 0,26 Z" fill="url(#gf)"/>
+            <polyline points="0,21 6,20 12,18 18,19 24,15 30,16 36,12 42,14 48,10 54,11 60,8 66,10 72,7 78,9 84,6 90,8 96,5 102,7 108,4 114,5 120,3" fill="none" stroke="hsl(151 62% 60%)" stroke-width="1.6" style="filter:drop-shadow(0 0 4px hsl(151 60% 55% /.6))"/>
+            <circle cx="120" cy="3" r="2.2" fill="hsl(151 65% 66%)"/>
+          </svg>
+        </div>
+        <div class="tile">
+          <div class="lab">Active</div>
+          <div class="val"><span class="big">3</span></div>
+          <div class="sub">2 building<br/>1 in council</div>
+        </div>
+        <div class="tile">
+          <div class="lab">Success</div>
+          <div class="val"><span class="big">88</span><span class="unit">%</span></div>
+          <div class="sub"><span class="delta up">▲ 4pt</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="group attn">
+      <div class="ghead"><span class="glyph">▲</span><span class="eyebrow tag">Attention</span></div>
+      <div class="tiles">
+        <div class="tile lead">
+          <div class="lab">Needs you</div>
+          <div class="val"><span class="big accent">4</span></div>
+          <div class="sub">2 gates · 1 stranded<br/>1 proposal</div>
+        </div>
+        <div class="tile">
+          <div class="lab">Failed · 30d</div>
+          <div class="val"><span class="big">6</span><span class="delta down">▼ 2</span></div>
+          <div class="sub">rework 7%</div>
+        </div>
+        <div class="tile">
+          <div class="lab">Review</div>
+          <div class="val"><span class="big">6</span></div>
+          <div class="sub">stranded + vacuous</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="group trust">
+      <div class="ghead"><span class="glyph">◈</span><span class="eyebrow tag">Trust &amp; Spend</span></div>
+      <div class="tiles">
+        <div class="tile lead">
+          <div class="lab">Governed</div>
+          <div class="val"><span class="big">92</span><span class="unit">%</span></div>
+          <div class="splitbar"><i style="width:92%;background:linear-gradient(90deg,var(--accent),var(--accent-2))"></i></div>
+        </div>
+        <div class="tile">
+          <div class="lab">Spend · session</div>
+          <div class="val"><span class="big">2</span><span class="unit">.10$</span></div>
+          <div class="sub">1.9M tokens</div>
+        </div>
+        <div class="tile">
+          <div class="lab">Rework</div>
+          <div class="val"><span class="big">7</span><span class="unit">%</span></div>
+          <div class="sub"><span class="delta up">▲ better</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="bench">
+    <div>
+      <section class="panel">
+        <header>
+          <h2><span class="gl" style="color:var(--gate)">▲</span> Needs you</h2>
+          <span class="count">4 open</span>
+          <a class="link" href="#" style="margin-left:auto">Work queue ›</a>
+        </header>
+        <div class="feed">
+          <div class="item gate">
+            <span class="stripe"></span>
+            <div class="body">
+              <div class="top"><span class="kind">Gate</span><span class="who">auth-refactor · claude</span></div>
+              <div class="title">Approve the deliver plan — 3 files, opens PR to <span class="num">main</span></div>
+              <div class="meta">waiting 6 min · evaluator passed 5/5</div>
+            </div>
+            <button class="act go">Review →</button>
+          </div>
+          <div class="item strand">
+            <span class="stripe"></span>
+            <div class="body">
+              <div class="top"><span class="kind">Stranded</span><span class="who">api-migration · codex</span></div>
+              <div class="title">Deliver hit a lift conflict — worktree held for re-lift</div>
+              <div class="meta">completed 22 min ago · recoverable</div>
+            </div>
+            <button class="act">Open run →</button>
+          </div>
+          <div class="item fail">
+            <span class="stripe"></span>
+            <div class="body">
+              <div class="top"><span class="kind">Failed</span><span class="who">upload-endpoint · opencode</span></div>
+              <div class="title">Build failed at unit 3 — <span class="num">tsc</span> type error in the route handler</div>
+              <div class="meta">14 min ago · retry as prefill</div>
+            </div>
+            <button class="act">Retry →</button>
+          </div>
+          <div class="item prop">
+            <span class="stripe"></span>
+            <div class="body">
+              <div class="top"><span class="kind">Proposal</span><span class="who">steering · security</span></div>
+              <div class="title">2 rules proposed from a chat — awaiting your promote</div>
+              <div class="meta">pending review · POL-041, PAT-118</div>
+            </div>
+            <button class="act">Decide →</button>
+          </div>
+        </div>
+      </section>
+
+      <div class="vrbar" role="group" aria-label="Delivery outcomes">
+        <div class="vrcell"><span class="n ok num">41</span><span class="l">Verified &amp; delivered</span></div>
+        <div class="vrcell"><span class="n warn num">5</span><span class="l">Stranded — needs review</span></div>
+        <div class="vrcell"><span class="n bad num">1</span><span class="l">Vacuous — needs retry</span></div>
+      </div>
+    </div>
+
+    <div>
+      <section class="panel">
+        <header>
+          <h2><span class="gl" style="color:var(--accent)">◆</span> Live pulse</h2>
+          <div class="rangebtns" style="margin-left:auto"><span class="rb">7d</span><span class="rb on">30d</span><span class="rb">90d</span></div>
+        </header>
+        <div class="pulse-card">
+          <div class="pulse-head">
+            <span class="t">Run cadence &amp; spend</span>
+            <span class="v">$2.10 <small>· session</small></span>
+          </div>
+          <svg class="chart" viewBox="0 0 320 104" preserveAspectRatio="none" aria-hidden="true">
+            <defs>
+              <linearGradient id="burn" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0" stop-color="hsl(258 78% 66%)" stop-opacity=".42"/>
+                <stop offset="1" stop-color="hsl(258 78% 66%)" stop-opacity="0"/></linearGradient>
+            </defs>
+            <line x1="0" y1="26" x2="320" y2="26" stroke="hsl(233 30% 60% /.07)"/>
+            <line x1="0" y1="65" x2="320" y2="65" stroke="hsl(233 30% 60% /.07)"/>
+            <g fill="hsl(151 55% 52% /.32)">
+              <rect x="6"  y="86" width="7" height="14" rx="1.5"/><rect x="32" y="82" width="7" height="18" rx="1.5"/>
+              <rect x="58" y="78" width="7" height="22" rx="1.5"/><rect x="84" y="84" width="7" height="16" rx="1.5"/>
+              <rect x="110" y="72" width="7" height="28" rx="1.5"/><rect x="136" y="76" width="7" height="24" rx="1.5"/>
+              <rect x="162" y="66" width="7" height="34" rx="1.5"/><rect x="188" y="70" width="7" height="30" rx="1.5"/>
+              <rect x="214" y="60" width="7" height="40" rx="1.5"/><rect x="240" y="64" width="7" height="36" rx="1.5"/>
+              <rect x="266" y="54" width="7" height="46" rx="1.5"/><rect x="292" y="50" width="7" height="50" rx="1.5"/>
+            </g>
+            <path d="M0,92 20,86 40,88 60,78 80,80 100,68 120,70 140,58 160,61 180,48 200,51 220,42 240,44 260,34 280,37 300,27 320,23 320,104 0,104 Z" fill="url(#burn)"/>
+            <polyline points="0,92 20,86 40,88 60,78 80,80 100,68 120,70 140,58 160,61 180,48 200,51 220,42 240,44 260,34 280,37 300,27 320,23" fill="none" stroke="hsl(258 82% 72%)" stroke-width="1.9" style="filter:drop-shadow(0 0 5px hsl(258 78% 60% /.7))"/>
+            <circle cx="320" cy="23" r="2.6" fill="hsl(258 85% 78%)"/>
+          </svg>
+        </div>
+        <div class="activity">
+          <div class="act-row"><span class="sd" style="background:var(--run);color:var(--run)"></span><span class="msg"><b>auth-refactor</b> council reached agreement 5/5</span><span class="ts">now</span></div>
+          <div class="act-row"><span class="sd" style="background:var(--gate);color:var(--gate)"></span><span class="msg"><b>api-migration</b> paused at deliver gate</span><span class="ts">2m</span></div>
+          <div class="act-row"><span class="sd" style="background:var(--run);color:var(--run)"></span><span class="msg"><b>q3-review-deck</b> delivered → PR #218</span><span class="ts">8m</span></div>
+          <div class="act-row"><span class="sd" style="background:var(--fail);color:var(--fail)"></span><span class="msg"><b>upload-endpoint</b> failed at unit 3</span><span class="ts">14m</span></div>
+          <div class="act-row"><span class="sd" style="background:var(--ink-dim)"></span><span class="msg"><b>notes</b> completed · no delivery</span><span class="ts">31m</span></div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- ── Section doors — the Execute/Vibe/Demo/Evals/Steering breakout, made legible ── -->
+  <nav class="doors" aria-label="Sections">
+    <a class="door exec"><span class="dg">▸</span><span class="dt"><div class="dl">Execute</div><div class="dc">128 runs · 3 active</div></span></a>
+    <a class="door test"><span class="dg">✓</span><span class="dt"><div class="dl">Test</div><div class="dc">4 campaigns · 1 active</div></span></a>
+    <a class="door vibe"><span class="dg">▤</span><span class="dt"><div class="dl">Vibe</div><div class="dc">14 documents</div></span></a>
+    <a class="door demo"><span class="dg">▶</span><span class="dt"><div class="dl">Demo</div><div class="dc">3 videos</div></span></a>
+    <a class="door evals"><span class="dg">◈</span><span class="dt"><div class="dl">Evals</div><div class="dc">12 runs · 2 gaps</div></span></a>
+    <a class="door steer"><span class="dg">☸</span><span class="dt"><div class="dl">Steering</div><div class="dc">48 rules · 92% governed</div></span></a>
+  </nav>
+
+  <section class="wall">
+    <div class="wall-head">
+      <h2>Portfolio</h2>
+      <span class="sub">6 projects · sorted by attention</span>
+    </div>
+    <div class="cards">
+      <div class="card hot gatehot">
+        <div class="ct"><span class="nm">auth-refactor</span><span class="stt gate">gate</span></div>
+        <div class="stat"><div><div class="k num">12</div><div class="kl">runs 30d</div></div><div><div class="k num">2</div><div class="kl">active</div></div><div><div class="k num">92%</div><div class="kl">success</div></div></div>
+        <div class="gatechip"><span class="g" style="background:var(--gate)"></span>Deliver gate waiting · 6 min</div>
+      </div>
+      <div class="card hot strandhot">
+        <div class="ct"><span class="nm">api-migration</span><span class="stt gate">review</span></div>
+        <div class="stat"><div><div class="k num">31</div><div class="kl">runs 30d</div></div><div><div class="k num">1</div><div class="kl">active</div></div><div><div class="k num">84%</div><div class="kl">success</div></div></div>
+        <div class="gatechip" style="color:hsl(258 78% 78%)"><span class="g" style="background:var(--accent)"></span>1 stranded · needs re-lift</div>
+      </div>
+      <div class="card">
+        <div class="ct"><span class="nm">q3-review-deck</span><span class="stt running">running</span></div>
+        <div class="stat"><div><div class="k num">7</div><div class="kl">runs 30d</div></div><div><div class="k num">1</div><div class="kl">active</div></div><div><div class="k num">100%</div><div class="kl">success</div></div></div>
+        <svg class="cspark" viewBox="0 0 200 22" preserveAspectRatio="none" aria-hidden="true"><polyline points="0,17 20,16 40,13 60,15 80,10 100,12 120,8 140,10 160,6 180,8 200,4" fill="none" stroke="hsl(151 60% 55%)" stroke-width="1.6" opacity=".85"/></svg>
+      </div>
+      <div class="card hot failhot">
+        <div class="ct"><span class="nm">upload-endpoint</span><span class="stt failed">failed</span></div>
+        <div class="stat"><div><div class="k num">9</div><div class="kl">runs 30d</div></div><div><div class="k num">0</div><div class="kl">active</div></div><div><div class="k num">67%</div><div class="kl">success</div></div></div>
+        <div class="gatechip" style="color:var(--fail)"><span class="g" style="background:var(--fail)"></span>Last run failed · retry</div>
+      </div>
+      <div class="card">
+        <div class="ct"><span class="nm">notes</span><span class="stt quiet">quiet</span></div>
+        <div class="stat"><div><div class="k num">3</div><div class="kl">runs 30d</div></div><div><div class="k num">0</div><div class="kl">active</div></div><div><div class="k num">100%</div><div class="kl">success</div></div></div>
+        <svg class="cspark" viewBox="0 0 200 22" preserveAspectRatio="none" aria-hidden="true"><polyline points="0,11 40,12 80,10 120,13 160,11 200,12" fill="none" stroke="hsl(233 20% 60% /.4)" stroke-width="1.6"/></svg>
+      </div>
+      <div class="card">
+        <div class="ct"><span class="nm">smoke-tests</span><span class="stt quiet">quiet</span></div>
+        <div class="stat"><div><div class="k num">2</div><div class="kl">runs 30d</div></div><div><div class="k num">0</div><div class="kl">active</div></div><div><div class="k num">100%</div><div class="kl">success</div></div></div>
+        <svg class="cspark" viewBox="0 0 200 22" preserveAspectRatio="none" aria-hidden="true"><polyline points="0,13 40,11 80,12 120,10 160,12 200,11" fill="none" stroke="hsl(233 20% 60% /.4)" stroke-width="1.6"/></svg>
+      </div>
+    </div>
+  </section>
+
+  <footer class="note">
+    Mockup — every number is real once wired: runs bucketed on the new AgentSession.created_at (7/30/90d),
+    delivery split from the run DTO, spend summed from live cliUsage frames.<br/>
+    Sections: Execute · Vibe · Demo · Evals · Steering.
+  </footer>
+  </div>
+</div>
+
+</body>
+</html>

--- a/.product/mockups/execute-dashboard.html
+++ b/.product/mockups/execute-dashboard.html
@@ -1,0 +1,473 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Execute Dashboard</title>
+<meta name="description" content="A wicked-studio section dashboard (Execute) — a mission-control command deck with a luminous KPI ribbon, an attention feed, and a live-pulse column." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" />
+<style>
+  :root {
+    /* wicked-studio dark identity, painted explicitly */
+    --s0:#08080e; --s1:#101019; --s2:#171724; --s3:#20202f; --s4:#2a2a3c;
+    --ink-dim:rgba(233,233,255,.36); --ink-muted:rgba(233,233,255,.56);
+    --ink-body:rgba(233,233,255,.82); --ink-high:#f5f5ff;
+    --accent:hsl(258 78% 66%); --accent-2:hsl(268 70% 60%); --accent-dim:hsl(258 60% 46%);
+    --accent-deep:hsl(258 40% 26%);
+    --gate:hsl(43 92% 66%); --gate-dim:hsl(43 55% 20%);
+    --fail:hsl(2 84% 64%); --fail-dim:hsl(2 48% 18%);
+    --run:hsl(151 60% 55%); --run-dim:hsl(151 40% 15%);
+    --hair:rgba(233,233,255,.08); --hair-2:rgba(233,233,255,.14);
+    --mono:'JetBrains Mono',ui-monospace,monospace;
+    --sans:'Inter',system-ui,sans-serif;
+    --ease:cubic-bezier(.16,1,.3,1);
+  }
+  * { box-sizing:border-box; }
+  html { color-scheme:dark; }
+  body {
+    background:var(--s0); color:var(--ink-body); font-family:var(--sans); margin:0;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility; position:relative;
+    min-height:100vh; overflow-x:hidden;
+  }
+  /* Ambient console atmosphere — a low violet aurora top-center + a whisper of grid */
+  body::before {
+    content:''; position:fixed; inset:0; pointer-events:none; z-index:0;
+    background:
+      radial-gradient(1200px 480px at 24% -8%, hsl(258 70% 40% / .20), transparent 60%),
+      radial-gradient(900px 420px at 92% 0%, hsl(151 50% 34% / .08), transparent 55%);
+  }
+  body::after {
+    content:''; position:fixed; inset:0; pointer-events:none; z-index:0; opacity:.4;
+    background-image:linear-gradient(var(--hair) 1px,transparent 1px),linear-gradient(90deg,var(--hair) 1px,transparent 1px);
+    background-size:48px 48px; mask-image:radial-gradient(1000px 600px at 50% -10%,#000,transparent 75%);
+  }
+  /* ── App shell: left rail + main ── */
+  .shell { position:relative; z-index:1; display:flex; min-height:100vh; }
+  .rail { width:236px; flex-shrink:0; background:linear-gradient(180deg,var(--s1),#0d0d15);
+    border-right:1px solid var(--hair); display:flex; flex-direction:column; padding:16px 12px 12px;
+    position:sticky; top:0; height:100vh; }
+  @media (max-width:820px){ .rail{ display:none; } }
+  .brand-top { display:flex; align-items:center; gap:10px; padding:6px 8px 16px; cursor:pointer; }
+  .logo { width:30px; height:30px; border-radius:9px; flex-shrink:0; display:grid; place-items:center;
+    background:linear-gradient(140deg,var(--accent),var(--accent-2)); color:#fff; font-weight:800;
+    font-size:15px; box-shadow:0 3px 14px hsl(258 78% 50% /.4); }
+  .wordmark { font-weight:700; font-size:14px; color:var(--ink-high); letter-spacing:-.01em; }
+  .wordmark span { color:var(--ink-dim); font-weight:500; }
+  .nav { display:flex; flex-direction:column; gap:1px; flex:1; }
+  .nav .sec { display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:11px;
+    padding:8px 9px; border-radius:9px; cursor:pointer; color:var(--ink-muted); transition:.14s; position:relative; }
+  .nav .sec:hover { background:hsl(258 40% 50% /.09); color:var(--ink-body); }
+  .nav .sec.on { background:hsl(258 45% 45% /.16); color:var(--ink-high); }
+  .nav .sec.on::before { content:''; position:absolute; left:-12px; top:8px; bottom:8px; width:3px;
+    border-radius:0 3px 3px 0; background:var(--accent); box-shadow:0 0 10px hsl(258 78% 60% /.6); }
+  .nav .sec .g { font-size:14px; width:18px; text-align:center; opacity:.9; }
+  .nav .sec .tt { font-size:13px; font-weight:500; }
+  .nav .sec .dash { font-size:12px; color:var(--ink-dim); opacity:0; transition:.14s; }
+  .nav .sec:hover .dash, .nav .sec.on .dash { opacity:1; }
+  .nav .kids { display:flex; flex-direction:column; gap:1px; margin:1px 0 3px 30px; padding-left:9px;
+    border-left:1px solid var(--hair); }
+  .nav .kid { font-size:12px; color:var(--ink-muted); font-family:var(--mono); padding:5px 8px;
+    border-radius:6px; cursor:pointer; display:flex; align-items:center; gap:8px; transition:.14s; }
+  .nav .kid:hover { color:var(--ink-body); background:hsl(258 40% 50% /.07); }
+  .nav .kid .kd { width:5px; height:5px; border-radius:50%; flex-shrink:0; }
+  .nav .divider { height:1px; background:var(--hair); margin:8px 6px; }
+  .nav .spacer { flex:1; }
+  /* Daemon health bar — pinned at the rail's foot */
+  .health { display:flex; align-items:center; gap:10px; width:100%; text-align:left; cursor:pointer;
+    margin-top:8px; padding:10px 11px; border-radius:10px; border:1px solid var(--hair);
+    background:linear-gradient(180deg,var(--s2),var(--s1)); transition:.14s; font-family:var(--sans); }
+  .health:hover { border-color:var(--run-dim); }
+  .health .hdot { width:8px; height:8px; border-radius:50%; background:var(--run); flex-shrink:0;
+    box-shadow:0 0 0 3px var(--run-dim), 0 0 10px hsl(151 60% 55% /.7); animation:breathe 2.6s ease-in-out infinite; }
+  @media (prefers-reduced-motion:reduce){ .health .hdot{animation:none} }
+  .health .hinfo { display:flex; flex-direction:column; gap:1px; min-width:0; }
+  .health .hl { font-size:12px; font-weight:600; color:var(--ink-high); }
+  .health .hs { font-size:10px; color:var(--ink-dim); font-family:var(--mono); }
+  .deck { position:relative; z-index:1; flex:1; min-width:0; max-width:1320px; margin:0 auto;
+    padding:26px 32px 56px; animation:rise .5s var(--ease) both; }
+  @keyframes rise { from{opacity:0; transform:translateY(8px)} to{opacity:1; transform:none} }
+  @media (prefers-reduced-motion:reduce){ .deck{animation:none} }
+  h1,h2,h3 { margin:0; }
+  a { color:inherit; text-decoration:none; }
+  .num { font-family:var(--mono); font-variant-numeric:tabular-nums; }
+  .eyebrow { font-size:10px; letter-spacing:.16em; text-transform:uppercase; font-weight:700;
+    color:var(--ink-dim); }
+
+  /* ── Status header ── */
+  .head { display:flex; align-items:flex-end; gap:24px; flex-wrap:wrap; padding-bottom:22px;
+    position:relative; }
+  .head::after { content:''; position:absolute; left:0; right:0; bottom:0; height:1px;
+    background:linear-gradient(90deg,var(--hair-2),transparent 40%); }
+  .brand { display:flex; flex-direction:column; gap:9px; min-width:0; }
+  .kicker { display:flex; align-items:center; gap:10px; }
+  .dot { width:8px; height:8px; border-radius:50%; background:var(--run);
+    box-shadow:0 0 0 3px var(--run-dim), 0 0 12px hsl(151 60% 55% / .7); animation:breathe 2.6s ease-in-out infinite; }
+  @keyframes breathe { 0%,100%{opacity:1} 50%{opacity:.4} }
+  @media (prefers-reduced-motion:reduce){ .dot{animation:none} }
+  .brand h1 { font-size:34px; font-weight:800; letter-spacing:-.025em; color:var(--ink-high);
+    line-height:1; text-wrap:balance; }
+  .situation { font-size:13.5px; color:var(--ink-muted); letter-spacing:.005em; }
+  .situation b { color:var(--ink-body); font-weight:600; }
+  .situation .hot { color:var(--gate); font-weight:700; }
+  .verbs { margin-left:auto; display:flex; align-items:center; gap:9px; flex-wrap:wrap; align-self:center; }
+  .verb { font-size:12.5px; font-weight:600; padding:9px 15px; border-radius:9px;
+    border:1px solid var(--hair-2); color:var(--ink-body);
+    background:linear-gradient(180deg,var(--s2),var(--s1)); display:inline-flex; align-items:center; gap:8px;
+    cursor:pointer; transition:.16s var(--ease); }
+  .verb:hover { border-color:var(--accent-dim); color:var(--ink-high); transform:translateY(-1px); }
+  .verb .k { font-family:var(--mono); font-size:13px; opacity:.7; }
+  /* The Make breakout — Execute / Vibe / Demo as one segmented "work" control */
+  .makeseg { display:inline-flex; border:1px solid var(--hair-2); border-radius:10px; overflow:hidden;
+    background:linear-gradient(180deg,var(--s2),var(--s1)); box-shadow:inset 0 1px 0 hsl(0 0% 100% /.04); }
+  .makeseg button { border:0; background:none; cursor:pointer; font-family:var(--sans);
+    font-size:12.5px; font-weight:600; color:var(--ink-body); padding:9px 15px;
+    display:inline-flex; align-items:center; gap:7px; border-right:1px solid var(--hair);
+    transition:.16s var(--ease); }
+  .makeseg button:last-child { border-right:0; }
+  .makeseg button:hover { color:var(--ink-high); background:hsl(258 40% 50% /.10); }
+  .makeseg button .glyph { font-size:11px; opacity:.7; }
+  .makeseg button.primary { background:linear-gradient(180deg,var(--accent),var(--accent-2));
+    color:#fff; box-shadow:0 4px 18px hsl(258 78% 50% /.38); }
+  .makeseg button.primary:hover { background:linear-gradient(180deg,var(--accent),var(--accent-2)); filter:brightness(1.06); }
+  .makeseg button.primary .glyph { opacity:.85; }
+  .vdiv { width:1px; height:24px; background:var(--hair-2); margin:0 3px; }
+
+  /* ── KPI ribbon: the hero — luminous telemetry ── */
+  .ribbon { display:grid; grid-template-columns:repeat(3,1fr); gap:16px; margin:24px 0 26px; }
+  @media (max-width:1080px){ .ribbon{grid-template-columns:1fr} }
+  .group {
+    position:relative; border-radius:16px; padding:17px 19px 18px; overflow:hidden;
+    background:
+      radial-gradient(120% 100% at 0% 0%, var(--gtint,transparent), transparent 46%),
+      linear-gradient(180deg,var(--s2),var(--s1));
+    border:1px solid var(--hair);
+    box-shadow: inset 0 1px 0 hsl(0 0% 100% / .05), 0 2px 8px rgba(0,0,0,.4);
+  }
+  .group::before { content:''; position:absolute; inset:0 0 auto; height:2px;
+    background:linear-gradient(90deg,var(--gcol),transparent 72%); }
+  .group.flow  { --gcol:var(--run);   --gtint:hsl(151 60% 40% / .10); }
+  .group.attn  { --gcol:var(--gate);  --gtint:hsl(43 80% 45% / .10); }
+  .group.trust { --gcol:var(--accent);--gtint:hsl(258 70% 50% / .12); }
+  .ghead { display:flex; align-items:center; gap:8px; margin-bottom:15px; }
+  .ghead .tag { color:var(--gcol); letter-spacing:.14em; }
+  .ghead .glyph { color:var(--gcol); font-size:11px; filter:drop-shadow(0 0 6px currentColor); opacity:.9; }
+  .tiles { display:flex; gap:14px; }
+  .tile { flex:1; min-width:0; }
+  .tile.lead { flex:1.15; }
+  .tile .lab { font-size:11px; color:var(--ink-muted); white-space:nowrap; overflow:hidden;
+    text-overflow:ellipsis; font-weight:500; }
+  .tile .val { display:flex; align-items:baseline; gap:7px; margin-top:5px; }
+  .big { font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:34px; font-weight:700;
+    color:var(--ink-high); line-height:.95; letter-spacing:-.02em;
+    text-shadow:0 0 24px hsl(0 0% 100% / .10); }
+  .big.accent { color:var(--gate); text-shadow:0 0 22px hsl(43 92% 60% / .28); }
+  .unit { font-size:13px; color:var(--ink-dim); font-family:var(--mono); font-weight:500; }
+  .delta { font-size:11px; font-family:var(--mono); font-weight:600; display:inline-flex;
+    align-items:center; gap:2px; padding:1px 5px; border-radius:5px; }
+  .delta.up { color:var(--run); background:var(--run-dim); }
+  .delta.down { color:var(--fail); background:var(--fail-dim); }
+  .spark { margin-top:11px; height:26px; width:100%; display:block; }
+  .tile .sub { font-size:10.5px; color:var(--ink-dim); margin-top:7px; line-height:1.4; }
+  .splitbar { display:flex; height:6px; border-radius:3px; overflow:hidden; margin-top:11px;
+    background:var(--s3); }
+  .splitbar i { display:block; height:100%; box-shadow:0 0 10px hsl(258 78% 60% / .5); }
+
+  /* ── Workbench ── */
+  .bench { display:grid; grid-template-columns:1.38fr 1fr; gap:18px; align-items:start; }
+  @media (max-width:1080px){ .bench{grid-template-columns:1fr} }
+  .panel { background:linear-gradient(180deg,var(--s1),#0e0e16); border:1px solid var(--hair);
+    border-radius:16px; box-shadow:inset 0 1px 0 hsl(0 0% 100% / .04), 0 2px 10px rgba(0,0,0,.35); overflow:hidden; }
+  .panel > header { display:flex; align-items:center; gap:12px; padding:15px 18px 13px;
+    border-bottom:1px solid var(--hair); }
+  .panel > header h2 { font-size:13px; font-weight:700; color:var(--ink-high); letter-spacing:.01em;
+    display:flex; align-items:center; gap:9px; }
+  .panel > header .gl { filter:drop-shadow(0 0 6px currentColor); }
+  .panel > header .count { font-family:var(--mono); font-size:11.5px; font-weight:600; color:var(--gate);
+    background:var(--gate-dim); padding:2px 9px; border-radius:999px; }
+  .panel > header .link { font-size:11px; color:var(--ink-muted); transition:.14s; }
+  .panel > header .link:hover { color:var(--ink-high); }
+
+  .feed { display:flex; flex-direction:column; }
+  .item { display:grid; grid-template-columns:3px 1fr auto; gap:15px; align-items:center;
+    padding:15px 18px; border-bottom:1px solid var(--hair); transition:background .16s; }
+  .item:last-child { border-bottom:0; }
+  .item:hover { background:hsl(258 40% 50% / .05); }
+  .item .stripe { align-self:stretch; border-radius:3px; }
+  .item.gate .stripe{ background:linear-gradient(180deg,var(--gate),transparent); box-shadow:0 0 10px hsl(43 92% 60% /.5);}
+  .item.fail .stripe{ background:linear-gradient(180deg,var(--fail),transparent); box-shadow:0 0 10px hsl(2 84% 60% /.5);}
+  .item.strand .stripe{ background:linear-gradient(180deg,var(--accent),transparent); box-shadow:0 0 10px hsl(258 78% 60% /.5);}
+  .item.prop .stripe{ background:linear-gradient(180deg,var(--run),transparent); box-shadow:0 0 10px hsl(151 60% 55% /.5);}
+  .item .body { min-width:0; }
+  .item .top { display:flex; align-items:center; gap:10px; }
+  .kind { font-family:var(--mono); font-size:9.5px; font-weight:700; letter-spacing:.08em;
+    text-transform:uppercase; padding:3px 8px; border-radius:5px; }
+  .item.gate .kind{ color:var(--gate); background:var(--gate-dim);}
+  .item.fail .kind{ color:var(--fail); background:var(--fail-dim);}
+  .item.strand .kind{ color:hsl(258 78% 80%); background:var(--accent-deep);}
+  .item.prop .kind{ color:var(--run); background:var(--run-dim);}
+  .item .who { font-size:11.5px; color:var(--ink-dim); font-family:var(--mono); }
+  .item .title { font-size:13px; color:var(--ink-high); font-weight:500; margin-top:6px; line-height:1.4; }
+  .item .meta { font-size:11px; color:var(--ink-muted); margin-top:4px; }
+  .act { font-size:12px; font-weight:600; padding:8px 14px; border-radius:9px; white-space:nowrap;
+    border:1px solid var(--hair-2); background:var(--s2); color:var(--ink-high); cursor:pointer;
+    transition:.16s var(--ease); }
+  .act:hover{ border-color:var(--accent-dim); transform:translateY(-1px);}
+  .act.go { background:linear-gradient(180deg,var(--gate),hsl(40 90% 58%)); border-color:transparent;
+    color:#1c1405; box-shadow:0 3px 14px hsl(43 92% 55% / .35); }
+  .act.go:hover{ box-shadow:0 5px 18px hsl(43 92% 55% / .5);}
+
+  .vrbar { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--hair);
+    border:1px solid var(--hair); border-radius:14px; overflow:hidden; margin-top:16px;
+    box-shadow:0 2px 10px rgba(0,0,0,.3); }
+  .vrcell { background:linear-gradient(180deg,var(--s1),#0e0e16); padding:15px 17px;
+    display:flex; flex-direction:column; gap:4px; cursor:pointer; transition:.16s; position:relative; }
+  .vrcell:hover{ background:var(--s2);}
+  .vrcell .n { font-family:var(--mono); font-size:24px; font-weight:700; letter-spacing:-.01em; }
+  .vrcell .n.ok{ color:var(--run); text-shadow:0 0 18px hsl(151 60% 50% /.3);}
+  .vrcell .n.warn{ color:var(--gate);} .vrcell .n.bad{ color:var(--fail);}
+  .vrcell .l { font-size:11px; color:var(--ink-muted); }
+
+  /* live pulse */
+  .pulse-card { padding:16px 18px 8px; }
+  .pulse-head { display:flex; align-items:baseline; justify-content:space-between; }
+  .pulse-head .t { font-size:11px; color:var(--ink-muted); font-weight:500; }
+  .pulse-head .v { font-family:var(--mono); font-size:16px; color:var(--ink-high); font-weight:700; }
+  .pulse-head .v small{ color:var(--ink-dim); font-weight:400; font-size:11px; }
+  .chart { width:100%; height:104px; display:block; margin-top:10px; }
+  .rangebtns { display:flex; gap:6px; }
+  .rb { font-family:var(--mono); font-size:10px; padding:4px 9px; border-radius:7px;
+    border:1px solid var(--hair); color:var(--ink-muted); cursor:pointer; transition:.14s; }
+  .rb:hover{ color:var(--ink-body);}
+  .rb.on { color:var(--ink-high); border-color:var(--accent-dim); background:hsl(258 40% 40% /.18); }
+
+  .activity { display:flex; flex-direction:column; padding-bottom:4px; }
+  .act-row { display:grid; grid-template-columns:auto 1fr auto; gap:11px; align-items:center;
+    padding:10px 18px; border-top:1px solid var(--hair); font-size:12px; }
+  .act-row .sd { width:6px; height:6px; border-radius:50%; box-shadow:0 0 8px currentColor; }
+  .act-row .msg { color:var(--ink-body); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .act-row .msg b { color:var(--ink-high); font-weight:600; }
+  .act-row .ts { font-family:var(--mono); font-size:10px; color:var(--ink-dim); }
+
+  /* ── Section doors (the nav made legible on the landing) ── */
+  .doors { display:flex; gap:10px; flex-wrap:wrap; margin-top:20px; }
+  .door { flex:1 1 0; min-width:132px; display:flex; align-items:center; gap:11px;
+    padding:12px 14px; border-radius:12px; border:1px solid var(--hair); cursor:pointer;
+    background:linear-gradient(180deg,var(--s1),#0e0e16); transition:.16s var(--ease); }
+  .door:hover { border-color:var(--accent-dim); transform:translateY(-1px); }
+  .door .dg { width:30px; height:30px; border-radius:9px; display:grid; place-items:center;
+    font-size:14px; color:var(--dcol,var(--accent)); background:hsl(258 40% 40% /.14);
+    border:1px solid var(--hair); flex-shrink:0; }
+  .door.exec .dg{ --dcol:var(--run); background:var(--run-dim);}
+  .door.test .dg{ --dcol:hsl(168 62% 55%); background:hsl(168 50% 28% /.2);}
+  .door.vibe .dg{ --dcol:hsl(198 80% 62%); background:hsl(198 60% 30% /.2);}
+  .door.demo .dg{ --dcol:hsl(320 70% 66%); background:hsl(320 50% 34% /.2);}
+  .door.evals .dg{ --dcol:var(--gate); background:var(--gate-dim);}
+  .door.steer .dg{ --dcol:var(--accent); background:hsl(258 50% 40% /.2);}
+  .door .dt { min-width:0; }
+  .door .dl { font-size:12px; font-weight:600; color:var(--ink-high); }
+  .door .dc { font-size:10.5px; color:var(--ink-muted); font-family:var(--mono); margin-top:1px; }
+
+  /* ── Portfolio wall ── */
+  .wall { margin-top:28px; }
+  .wall-head { display:flex; align-items:baseline; gap:13px; margin-bottom:14px; }
+  .wall-head h2 { font-size:14px; font-weight:700; color:var(--ink-high); letter-spacing:.01em; }
+  .wall-head .sub { font-size:11px; color:var(--ink-dim); }
+  .cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(276px,1fr)); gap:14px; }
+  .card { position:relative; border:1px solid var(--hair); border-radius:14px; padding:16px;
+    cursor:pointer; transition:.18s var(--ease); overflow:hidden;
+    background:linear-gradient(180deg,var(--s2),var(--s1));
+    box-shadow:inset 0 1px 0 hsl(0 0% 100% /.04); }
+  .card:hover{ border-color:var(--accent-dim); transform:translateY(-2px);
+    box-shadow:0 8px 26px rgba(0,0,0,.4), inset 0 1px 0 hsl(0 0% 100% /.05); }
+  .card.hot::before{ content:''; position:absolute; inset:0 0 auto; height:2px;
+    background:linear-gradient(90deg,var(--hotcol),transparent 70%); }
+  .card.hot.gatehot{ --hotcol:var(--gate); } .card.hot.strandhot{ --hotcol:var(--accent); }
+  .card.hot.failhot{ --hotcol:var(--fail); }
+  .card .ct { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+  .card .nm { font-size:14.5px; font-weight:600; color:var(--ink-high); }
+  .card .stt { font-family:var(--mono); font-size:9.5px; font-weight:600; padding:3px 8px; border-radius:5px;
+    letter-spacing:.04em; text-transform:uppercase; }
+  .stt.running{ color:var(--run); background:var(--run-dim);}
+  .stt.gate{ color:var(--gate); background:var(--gate-dim);}
+  .stt.failed{ color:var(--fail); background:var(--fail-dim);}
+  .stt.quiet{ color:var(--ink-dim); border:1px solid var(--hair);}
+  .card .stat { display:flex; gap:18px; margin-top:14px; }
+  .card .stat .k { font-family:var(--mono); font-size:17px; font-weight:700; color:var(--ink-body); letter-spacing:-.01em; }
+  .card .stat .kl { font-size:9.5px; color:var(--ink-dim); margin-top:2px; letter-spacing:.04em; text-transform:uppercase; }
+  .card .cspark { margin-top:12px; height:22px; width:100%; display:block; }
+  .card .gatechip { margin-top:12px; font-size:11px; color:var(--gate); display:flex; gap:8px;
+    align-items:center; font-weight:500; }
+  .card .gatechip .g { width:5px; height:5px; border-radius:50%; box-shadow:0 0 8px currentColor; }
+  footer.note { margin-top:30px; font-size:11px; color:var(--ink-dim); font-family:var(--mono);
+    border-top:1px solid var(--hair); padding-top:16px; line-height:1.7; }
+
+  /* ── Section dashboard: filters + run list (shared design language) ── */
+  .filters { display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:8px; }
+  .fchip { font-size:12px; font-family:var(--mono); padding:6px 12px; border-radius:8px;
+    border:1px solid var(--hair); color:var(--ink-muted); cursor:pointer; transition:.14s; }
+  .fchip:hover{ color:var(--ink-body); }
+  .fchip.on { color:var(--ink-high); border-color:var(--accent-dim); background:hsl(258 40% 40% /.16); }
+  .fsearch { font-size:12px; font-family:var(--mono); color:var(--ink-dim); padding:7px 13px;
+    border:1px solid var(--hair); border-radius:8px; }
+  .runlist { display:flex; flex-direction:column; }
+  .runrow { display:grid; grid-template-columns:3px 1fr auto; gap:15px; align-items:center;
+    padding:14px 18px; border-bottom:1px solid var(--hair); transition:background .16s; }
+  .runrow:last-child{ border-bottom:0; }
+  .runrow:hover{ background:hsl(258 40% 50% /.05); }
+  .runrow .stripe { align-self:stretch; border-radius:3px; }
+  .runrow.run .stripe{ background:linear-gradient(180deg,var(--run),transparent); box-shadow:0 0 10px hsl(151 60% 55% /.4);}
+  .runrow.gate .stripe{ background:linear-gradient(180deg,var(--gate),transparent); box-shadow:0 0 10px hsl(43 92% 60% /.5);}
+  .runrow.fail .stripe{ background:linear-gradient(180deg,var(--fail),transparent); box-shadow:0 0 10px hsl(2 84% 60% /.4);}
+  .runrow.done .stripe{ background:linear-gradient(180deg,var(--ink-dim),transparent);}
+  .rbody{ min-width:0; }
+  .rtop{ display:flex; align-items:center; gap:10px; }
+  .pill { font-family:var(--mono); font-size:9.5px; font-weight:700; letter-spacing:.06em;
+    text-transform:uppercase; padding:3px 8px; border-radius:5px; flex-shrink:0; }
+  .pill.running{ color:var(--run); background:var(--run-dim);}
+  .pill.gate{ color:var(--gate); background:var(--gate-dim);}
+  .pill.fail{ color:var(--fail); background:var(--fail-dim);}
+  .pill.done{ color:var(--ink-muted); border:1px solid var(--hair);}
+  .pill.deliv{ color:var(--run); background:var(--run-dim);}
+  .rtitle{ font-size:13px; color:var(--ink-high); font-weight:500; white-space:nowrap;
+    overflow:hidden; text-overflow:ellipsis; }
+  .rmeta{ font-size:11px; color:var(--ink-muted); margin-top:5px; font-family:var(--mono); }
+  .rright{ display:flex; align-items:center; gap:14px; flex-shrink:0; }
+  .rprog{ font-family:var(--mono); font-size:12px; color:var(--run); letter-spacing:2px; }
+</style>
+
+</head>
+<body>
+<div class="shell">
+  <aside class="rail" aria-label="Sections">
+    <div class="brand-top">
+      <div class="logo">w</div>
+      <div class="wordmark">wicked <span>studio</span></div>
+    </div>
+    <nav class="nav">
+      <div class="sec"><span class="g">◇</span><span class="tt">Projects</span><span class="dash">▦</span></div>
+      <div class="sec on"><span class="g">▸</span><span class="tt">Execute</span><span class="dash">▦</span></div>
+      <div class="kids">
+        <div class="kid"><span class="kd" style="background:var(--run)"></span>auth-refactor</div>
+        <div class="kid"><span class="kd" style="background:var(--gate)"></span>api-migration</div>
+        <div class="kid" style="color:var(--ink-dim)">view all ›</div>
+      </div>
+      <div class="sec"><span class="g">✓</span><span class="tt">Test</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">▤</span><span class="tt">Vibe</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">▶</span><span class="tt">Demo</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">💬</span><span class="tt">Chat</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">⬡</span><span class="tt">Repositories</span><span class="dash">▦</span></div>
+      <div class="divider"></div>
+      <div class="sec"><span class="g">☸</span><span class="tt">Steering</span><span class="dash">▦</span></div>
+      <div class="sec"><span class="g">◈</span><span class="tt">Evals</span><span class="dash">▦</span></div>
+      <div class="divider"></div>
+      <div class="sec"><span class="g">⚙</span><span class="tt">Settings</span><span class="dash">▦</span></div>
+      <div class="spacer"></div>
+      <button class="health" title="Daemon status">
+        <span class="hdot"></span>
+        <span class="hinfo">
+          <span class="hl">Daemon healthy</span>
+          <span class="hs">v0.7.24 · :7701 · 3 active</span>
+        </span>
+      </button>
+    </nav>
+  </aside>
+
+  <div class="deck">
+  <header class="head">
+    <div class="brand">
+      <div class="kicker"><span class="dot" style="box-shadow:0 0 0 3px var(--run-dim),0 0 12px hsl(151 60% 55% /.7)"></span><span class="eyebrow">Execute · build runs · works with or without a project</span></div>
+      <h1>Execute</h1>
+      <p class="situation"><b>128</b> runs this month · <b>3</b> executing · <span class="hot">1 needs you</span> · 88% success</p>
+    </div>
+    <nav class="verbs">
+      <button class="verb primary">＋ New run</button>
+      <button class="verb">Ask <span class="k">&#8984;K</span></button>
+    </nav>
+  </header>
+
+  <section class="group flow" style="margin:22px 0 18px">
+    <div class="ghead"><span class="glyph">&#9670;</span><span class="eyebrow tag">This month &#183; last 30 days</span></div>
+    <div class="tiles" style="gap:28px">
+      <div class="tile"><div class="lab">Runs</div><div class="val"><span class="big">128</span><span class="delta up">&#9650; 12</span></div></div>
+      <div class="tile"><div class="lab">Active</div><div class="val"><span class="big">3</span></div></div>
+      <div class="tile"><div class="lab">Success</div><div class="val"><span class="big">88</span><span class="unit">%</span></div></div>
+      <div class="tile"><div class="lab">Failed</div><div class="val"><span class="big">6</span><span class="delta down">&#9660; 2</span></div></div>
+      <div class="tile"><div class="lab">Delivered</div><div class="val"><span class="big">41</span></div></div>
+      <div class="tile"><div class="lab">Spend &#183; session</div><div class="val"><span class="big">2</span><span class="unit">.10$</span></div></div>
+    </div>
+  </section>
+
+  <div class="filters">
+    <span class="fchip on">All 128</span>
+    <span class="fchip">Active 3</span>
+    <span class="fchip">Needs you 1</span>
+    <span class="fchip">Failed 6</span>
+    <span class="fchip">Delivered 41</span>
+    <span class="fsearch" style="margin-left:auto">&#8981; Filter runs&#8230;</span>
+  </div>
+
+  <section class="panel" style="margin-top:14px">
+    <div class="runlist">
+      <div class="runrow gate">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill gate">gate</span><span class="rtitle">Move the auth guard into a shared middleware</span></div>
+          <div class="rmeta">auth-refactor &#183; claude &#183; waiting 6 min &#183; evaluator 5/5 &#183; created today 14:22</div>
+        </div>
+        <div class="rright"><button class="act go">Review &#8594;</button></div>
+      </div>
+      <div class="runrow run">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill running">executing</span><span class="rtitle">Port the upload endpoint to the streaming API</span></div>
+          <div class="rmeta">api-migration &#183; codex &#183; started 4 min ago &#183; unit 2/4 &#183; council 5/5</div>
+        </div>
+        <div class="rright"><span class="rprog">&#9619;&#9619;&#9617;&#9617;</span><button class="act">Open &#8594;</button></div>
+      </div>
+      <div class="runrow run">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill running">executing</span><span class="rtitle">Generate the Q3 review deck from the metrics doc</span></div>
+          <div class="rmeta">q3-review-deck &#183; antigravity &#183; started 11 min ago &#183; unit 3/3 &#183; delivering</div>
+        </div>
+        <div class="rright"><span class="rprog">&#9619;&#9619;&#9619;&#9617;</span><button class="act">Open &#8594;</button></div>
+      </div>
+      <div class="runrow fail">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill fail">failed</span><span class="rtitle">Add rate limiting to the public routes</span></div>
+          <div class="rmeta">upload-endpoint &#183; opencode &#183; 14 min ago &#183; tsc type error at unit 3</div>
+        </div>
+        <div class="rright"><button class="act">Retry &#8594;</button></div>
+      </div>
+      <div class="runrow done">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill deliv">delivered</span><span class="rtitle">Fix the flaky membership-index test</span></div>
+          <div class="rmeta">smoke-tests &#183; claude &#183; 32 min ago &#183; PR #217 merged &#183; 1.2M tokens &#183; $1.40</div>
+        </div>
+        <div class="rright"><button class="act">View PR &#8594;</button></div>
+      </div>
+      <div class="runrow done">
+        <span class="stripe"></span>
+        <div class="rbody">
+          <div class="rtop"><span class="pill done">completed</span><span class="rtitle">Draft the changelog for 0.7.24</span></div>
+          <div class="rmeta">notes &#183; claude &#183; 41 min ago &#183; no delivery &#183; unfiled</div>
+        </div>
+        <div class="rright"><button class="act">Open &#8594;</button></div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="note">
+    Mockup &#8212; the same design language applied to a SECTION dashboard (Execute). Every section
+    &#8212; Test, Vibe, Demo, Evals, Steering &#8212; gets this treatment: a themed KPI header on real
+    created_at/delivery data, filters, and an act-in-place list.
+  </footer>
+  </div>
+</div>
+
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "^0.8.0"
+        "wicked-crew-api-types": "^0.25.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.8.0.tgz",
-      "integrity": "sha512-xlMVonpDuZ5jRgzZB05kyzAHnlwB+P0YY+/t2bYyBQrwND3GHl1HSs6kyYU9UI7SrHVdX0faVUwPlLZUAFB8gg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.25.0.tgz",
+      "integrity": "sha512-l68AmtYu4l40veScYgSHIY3Z+pvB7JuU9TyQIJBayLBR7rozHhFGuJaCdrZRz1nv3rOvarefs21C7lkvGt2Jnw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "^0.8.0"
+    "wicked-crew-api-types": "^0.25.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -25,6 +25,7 @@
 
 import { apiFetch } from './client.js';
 import { ApiError, isRouteAbsent } from './errors.js';
+import type { EvalRunDetail, EvalRunSummary, ListEvalRunsResponse } from './types.js';
 
 // ── The Testing surface's sub-pages (client route vocabulary, not a wire) ────────────────────
 
@@ -254,6 +255,24 @@ export function runEvals(body: RunEvalsBody): Promise<EvalReport> {
     method: 'POST',
     body: JSON.stringify(body),
   });
+}
+
+// ── The eval RUN history (crew-side EvalRunStore, api-types 0.25.0) ────────────────────────────
+
+/** `GET /testing/evals` — the persisted eval-run history, newest first (global per daemon).
+ *  `{ runs: [] }` on a daemon that recorded none (or predates the store). */
+export async function listEvalRuns(filter?: { type?: string; corpus?: string }): Promise<EvalRunSummary[]> {
+  const q = new URLSearchParams();
+  if (filter?.type !== undefined && filter.type !== '') q.set('type', filter.type);
+  if (filter?.corpus !== undefined && filter.corpus !== '') q.set('corpus', filter.corpus);
+  const qs = q.toString();
+  const res = await apiFetch<ListEvalRunsResponse>(`/testing/evals${qs !== '' ? `?${qs}` : ''}`);
+  return res.runs;
+}
+
+/** `GET /testing/evals/:id` — one run WITH its full per-sample results (the drilldown); 404 unknown. */
+export function getEvalRun(id: string): Promise<EvalRunDetail> {
+  return apiFetch<EvalRunDetail>(`/testing/evals/${encodeURIComponent(id)}`);
 }
 
 // ── `POST /testing/corpora/import` ────────────────────────────────────────────────────────────

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -35,8 +35,11 @@ export const TESTING_PAGES = ['campaigns', 'evals'] as const;
 
 export type TestingSubPage = (typeof TESTING_PAGES)[number];
 
+// The `campaigns` sub-page IS the Test section now (usability wave): the rail renames it Test and
+// Evals is a separate section beside Steering. The route stays `/testing/campaigns` (the backend's
+// campaign grouping is the mechanism); only the user-facing label is Test.
 export const TESTING_PAGE_LABELS: Record<TestingSubPage, string> = {
-  campaigns: 'Campaigns',
+  campaigns: 'Test',
   evals: 'Evals',
 };
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -45,7 +45,7 @@ export type * from 'wicked-crew-api-types';
  * (`src/components/delivery.ts`) still TOLERATES the legacy object from a
  * 0.11–0.17 daemon, which is why {@link SessionDelivery} survives below.
  */
-export type RunDeliveryState = 'delivered' | 'stranded' | 'none';
+export type RunDeliveryState = 'delivered' | 'stranded' | 'vacuous' | 'none';
 
 /** The LEGACY 0.11.0–0.17.0 object spelling of `session.delivery` (crew#321).
  *  Gone from the 0.18.0 wire; kept only so the derivation can read the url off
@@ -57,7 +57,10 @@ export interface SessionDelivery {
 
 /** `AgentSession` as the daemon sends it: 0.18.0's string + `deliverUrl`, or the
  *  legacy 0.11–0.17 object, or neither (≤0.10). See {@link RunDeliveryState}. */
-export type SessionWithDelivery = AgentSession & {
+export type SessionWithDelivery = Omit<AgentSession, 'delivery' | 'deliverUrl'> & {
+  // Widen (not intersect) `delivery`: api-types now types it as the string union, but the
+  // derivation still TOLERATES the legacy 0.11–0.17 object at runtime — an intersection would
+  // narrow the object branch to `never`. `Omit`-then-re-add keeps both wire forms readable.
   delivery?: RunDeliveryState | SessionDelivery | null;
   /** The delivered PR's URL — present exactly when `delivery === 'delivered'`. */
   deliverUrl?: string;

--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -1,4 +1,4 @@
-import type { SessionView } from '../api/types.js';
+import type { SessionView, SessionWithDelivery } from '../api/types.js';
 import { outcomeOf } from './metrics.js';
 import { RANGE_LIMITS, rangeWord, type TimeRange } from '../hooks/useTimeRange.js';
 
@@ -223,6 +223,37 @@ export function datedCount(runs: SessionView[]): number {
   let n = 0;
   for (const v of runs) if (createdAtMs(v) !== null) n += 1;
   return n;
+}
+
+// ── Delivery outcomes (the verified-vs-needs-review split, off the run DTO) ───
+
+/** The wire `delivery` state as a plain string (tolerant of the legacy 0.11–0.17 object). */
+export function wireDelivery(v: SessionView): string | null {
+  const d = (v.session as SessionWithDelivery).delivery;
+  return typeof d === 'string' ? d : null;
+}
+
+export interface DeliveryCounts {
+  /** `delivered` — a PR was opened: verified, shipped. */
+  delivered: number;
+  /** `stranded` — completed work nobody lifted: needs review (recoverable). */
+  stranded: number;
+  /** `vacuous` — completed with nothing liftable: needs a retry. */
+  vacuous: number;
+}
+
+/** Count the three delivery outcomes across live runs — the deck's verified/needs-review strip and
+ *  the ATTENTION "review" tile read the SAME fold, so they can never disagree. */
+export function deliveryCounts(runs: SessionView[]): DeliveryCounts {
+  const c: DeliveryCounts = { delivered: 0, stranded: 0, vacuous: 0 };
+  for (const v of runs) {
+    if (v.session.archived_at != null) continue;
+    const d = wireDelivery(v);
+    if (d === 'delivered') c.delivered += 1;
+    else if (d === 'stranded') c.stranded += 1;
+    else if (d === 'vacuous') c.vacuous += 1;
+  }
+  return c;
 }
 
 // ── The sparkline series (the honest attach clock, daily buckets) ─────────────

--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -141,6 +141,90 @@ export function healthColor(h: Health): string | undefined {
     : undefined;
 }
 
+// ── Real TIME windows (AgentSession.created_at, api-types 0.24.0) ─────────────
+//
+// The command deck's numbers are time-honest, not positional: `created_at` (unix SECONDS, present
+// on runs a 0.24.0+ daemon launched) lets a "30d" window mean thirty DAYS, and a delta compare this
+// window against the SAME-LENGTH window immediately before it. A run with no `created_at`
+// (onboarding / campaign-DAG / a pre-field daemon) is EXCLUDED from every time window — never
+// bucketed at an invented time, which would relabel an undated run as "today".
+
+const DAY_MS = 24 * 3_600_000;
+
+/** A run's launch instant in millis, or null when the daemon recorded none (excluded from windows). */
+export function createdAtMs(v: SessionView): number | null {
+  const secs = v.session.created_at;
+  return typeof secs === 'number' && secs > 0 ? secs * 1000 : null;
+}
+
+/** Runs launched within the last `days` days by real `created_at`. Undated runs are excluded. */
+export function withinDays(runs: SessionView[], days: number, now: number): SessionView[] {
+  const floor = now - days * DAY_MS;
+  return runs.filter((v) => {
+    const at = createdAtMs(v);
+    return at !== null && at >= floor && at < now;
+  });
+}
+
+/**
+ * A real time window and the SAME-LENGTH window immediately before it, split by `created_at`:
+ * `current` = `[now - days, now)`, `previous` = `[now - 2·days, now - days)`. Undated runs land in
+ * neither. `previous` is null only for a caller that opts out (days ≤ 0) — otherwise it is a real
+ * (possibly empty) prior window, because a time bucket is always the same length whether or not it
+ * holds rows (unlike the positional split, where a short history has no full prior bucket).
+ */
+export function createdAtWindow(
+  runs: SessionView[],
+  days: number,
+  now: number,
+): { current: SessionView[]; previous: SessionView[] } {
+  const curFloor = now - days * DAY_MS;
+  const prevFloor = now - 2 * days * DAY_MS;
+  const current: SessionView[] = [];
+  const previous: SessionView[] = [];
+  for (const v of runs) {
+    const at = createdAtMs(v);
+    if (at === null) continue;
+    if (at >= curFloor && at < now) current.push(v);
+    else if (at >= prevFloor && at < curFloor) previous.push(v);
+  }
+  return { current, previous };
+}
+
+/** A time-window delta over a predicate: current-window count and prior-window count. */
+export function timeDelta(
+  window: { current: SessionView[]; previous: SessionView[] },
+  count: (runs: SessionView[]) => number,
+): StatDelta {
+  return { current: count(window.current), previous: count(window.previous) };
+}
+
+/**
+ * Daily run counts, oldest→newest, off the REAL `created_at` clock (the honest successor to
+ * {@link attachSeries}, which bucketed on the membership-attach proxy). Undated runs and runs
+ * outside the span are simply absent — absence stays absent, never painted at an invented time.
+ */
+export function createdAtSeries(runs: SessionView[], days: number, now: number): number[] {
+  const counts = new Array<number>(days).fill(0);
+  for (const v of runs) {
+    const at = createdAtMs(v);
+    if (at === null) continue;
+    const age = now - at;
+    if (age < 0 || age >= days * DAY_MS) continue;
+    const bucket = days - 1 - Math.floor(age / DAY_MS);
+    counts[bucket] = (counts[bucket] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/** How many of these runs carry a real `created_at` — the denominator honesty check: when it is 0,
+ *  every time window is empty and the deck should say "positional" / "no dated runs", not "0". */
+export function datedCount(runs: SessionView[]): number {
+  let n = 0;
+  for (const v of runs) if (createdAtMs(v) !== null) n += 1;
+  return n;
+}
+
 // ── The sparkline series (the honest attach clock, daily buckets) ─────────────
 
 /**

--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -227,10 +227,15 @@ export function datedCount(runs: SessionView[]): number {
 
 // ── Delivery outcomes (the verified-vs-needs-review split, off the run DTO) ───
 
-/** The wire `delivery` state as a plain string (tolerant of the legacy 0.11–0.17 object). */
+/** The wire `delivery` state as a plain string, tolerant of the legacy 0.11–0.17 object form (the
+ *  same compatibility `deliveryOf` keeps): that object was `{kind:'pull_request', url}`, which meant
+ *  a PR was opened — i.e. `'delivered'`. Without this, `deliveryCounts` undercounts delivered runs
+ *  on an older daemon even though the object is right there (Copilot #198). */
 export function wireDelivery(v: SessionView): string | null {
   const d = (v.session as SessionWithDelivery).delivery;
-  return typeof d === 'string' ? d : null;
+  if (typeof d === 'string') return d;
+  if (d !== null && typeof d === 'object' && d.kind === 'pull_request') return 'delivered';
+  return null;
 }
 
 export interface DeliveryCounts {

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -401,8 +401,8 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
     <>
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
         <p style={{ flex: 1, minWidth: 0, fontSize: '13px', color: S.muted, margin: 0 }}>
-          Test campaigns over your codebases — recon proposes, you approve at the gate, sibling
-          runs land the work.
+          Test your codebases — recon proposes, you approve at the gate, sibling runs land the work.
+          Works with or without a project.
         </p>
         <button
           type="button"
@@ -441,7 +441,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
             flexShrink: 0,
           }}
         >
-          New campaign
+          New test
         </button>
       </div>
 
@@ -492,19 +492,19 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
         <KpiGroup label="Performance" grow={2}>
           <StatTile
             testId="stat-campaigns"
-            label="Campaigns"
+            label="Tests"
             value={totals.campaigns + totals.groups}
             context={`${totals.activeNow} active now${totals.groups > 0 ? ` · ${totals.groups} ad-hoc group${totals.groups === 1 ? '' : 's'}` : ''}`}
-            title="Every campaign and ad-hoc group on this daemon — click to clear filters"
+            title="Every test and ad-hoc group on this daemon — click to clear filters"
             onOpen={() => { setChip('all'); setQuery(''); }}
           />
           <StatTile
             testId="stat-campaign-runs"
-            label="Campaign runs"
+            label="Test runs"
             value={buckets.current.length}
             delta={runsDelta}
             context={deltaWord(range, runsDelta)}
-            title="Campaign-member runs in the window — open the Work list"
+            title="Test-member runs in the window — open the Work list"
             href="/work"
             onOpen={() => navigate('/work')}
           />
@@ -515,7 +515,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
             label="Running"
             value={totals.running}
             context="right now"
-            title="Campaign runs moving under their own power — open the Work list"
+            title="Test runs moving under their own power — open the Work list"
             href="/work?filter=active"
             onOpen={() => navigate('/work?filter=active')}
           />
@@ -524,7 +524,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
             label="Needs you"
             value={totals.awaitingHuman}
             valueColor={totals.awaitingHuman > 0 ? 'var(--status-gate)' : undefined}
-            context={totals.awaitingHuman > 0 ? `${chipCounts['needs-you']} campaign${chipCounts['needs-you'] === 1 ? '' : 's'} waiting` : 'nothing waiting'}
+            context={totals.awaitingHuman > 0 ? `${chipCounts['needs-you']} test${chipCounts['needs-you'] === 1 ? '' : 's'} waiting` : 'nothing waiting'}
             title={firstWaiting !== null
               ? 'A sibling run is waiting on you — jump to its approval dock'
               : 'Runs waiting on a human — filter the grid to them'}
@@ -544,7 +544,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
             delta={failedDelta}
             deltaSense="bad-up"
             context={deltaWord(range, failedDelta)}
-            title="Failed campaign runs in the window — open them on the Work list"
+            title="Failed test runs in the window — open them on the Work list"
             href="/work?filter=failed"
             onOpen={() => navigate('/work?filter=failed')}
           />
@@ -554,7 +554,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
             value={passRateWord(totals.landed, totals.terminal)}
             valueColor={healthColor(passHealth)}
             context={totals.terminal > 0 ? `${totals.landed} landed of ${totals.terminal} finished` : 'no finished runs yet'}
-            title="Landed over finished, across every campaign — filter to the failing ones"
+            title="Landed over finished, across every test — filter to the failing ones"
             onOpen={() => setChip('failing')}
           />
         </KpiGroup>
@@ -597,10 +597,10 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
           background: S.card, border: `1px solid ${S.border}`, borderRadius: '12px',
         }}>
           <p style={{ fontSize: '14px', color: S.muted, margin: 0, marginBottom: '4px' }}>
-            No campaigns yet
+            No tests yet
           </p>
           <p style={{ fontSize: '12px', color: S.faint, margin: 0 }}>
-            Campaigns appear when you launch a run with a campaign label — start one here.
+            Tests appear when you run recon over a codebase — start one here.
           </p>
           <button
             type="button"
@@ -612,7 +612,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
               fontWeight: 600, border: 'none', cursor: 'pointer',
             }}
           >
-            New campaign
+            New test
           </button>
         </div>
       ) : visible.length === 0 ? (

--- a/src/components/DeckBurnChart.tsx
+++ b/src/components/DeckBurnChart.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { burnSteps } from '../board/metrics.js';
+import { useRuntimeStore } from '../store/runtime.js';
+
+/**
+ * The live-pulse burn chart (command-deck redesign) — the cumulative token/cost spend curve, drawn
+ * from the `cliUsage` frames observed on the /ws stream THIS session (`burnSteps`). Honestly labeled
+ * "session": per-run cost is not on the run DTO yet (api-types defers a durable store), so this is
+ * the live-observed spend, not a historical total. Empty until a run burns tokens — then a glowing
+ * curve with an emphasized endpoint, the deck's one chart flourish.
+ */
+export function DeckBurnChart(): React.ReactElement {
+  const logs = useRuntimeStore((s) => s.logs);
+  const { steps, total } = useMemo(() => burnSteps(logs), [logs]);
+
+  const path = useMemo(() => {
+    if (steps.length < 2) return null;
+    const W = 320;
+    const H = 96;
+    const max = steps[steps.length - 1]!.total || 1;
+    const pts = steps.map((s, i) => {
+      const x = (i / (steps.length - 1)) * W;
+      const y = H - (s.total / max) * (H - 8) - 4;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    });
+    return { line: pts.join(' '), area: `${pts.join(' ')} ${W},${H} 0,${H}`, endX: W, endY: parseFloat(pts[pts.length - 1]!.split(',')[1]!) };
+  }, [steps]);
+
+  return (
+    <section className="deck-pulse" data-testid="home-burn-chart">
+      <div className="deck-pulse-head">
+        <span className="deck-pulse-t">Spend · session</span>
+        <span className="deck-pulse-v" data-testid="burn-total">
+          {total > 0 ? `$${total.toFixed(2)}` : '—'} <small>{steps.length > 0 ? `· ${steps.length} frames` : '· no usage yet'}</small>
+        </span>
+      </div>
+      <svg className="deck-pulse-chart" viewBox="0 0 320 96" preserveAspectRatio="none" aria-hidden="true">
+        <defs>
+          <linearGradient id="deck-burn" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stopColor="var(--accent)" stopOpacity="0.4" />
+            <stop offset="1" stopColor="var(--accent)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <line x1="0" y1="32" x2="320" y2="32" stroke="var(--surface-raised)" strokeWidth="1" />
+        <line x1="0" y1="64" x2="320" y2="64" stroke="var(--surface-raised)" strokeWidth="1" />
+        {path !== null ? (
+          <>
+            <polygon points={path.area} fill="url(#deck-burn)" />
+            <polyline points={path.line} fill="none" stroke="var(--accent)" strokeWidth="1.9" style={{ filter: 'drop-shadow(0 0 5px color-mix(in oklab, var(--accent) 60%, transparent))' }} />
+            <circle cx={path.endX} cy={path.endY} r="2.6" fill="var(--accent)" />
+          </>
+        ) : (
+          <line x1="0" y1="88" x2="320" y2="88" stroke="var(--surface-raised)" strokeWidth="1.5" />
+        )}
+      </svg>
+    </section>
+  );
+}

--- a/src/components/DeckKpiRibbon.tsx
+++ b/src/components/DeckKpiRibbon.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from 'react';
+import type { GovernanceClaim, SessionView, SessionWithDelivery } from '../api/types.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { governedRuns } from '../board/steeringUsage.js';
+import { observedSpend } from '../board/metrics.js';
+import { useRuntimeStore } from '../store/runtime.js';
+import {
+  attachSeries,
+  createdAtSeries,
+  createdAtWindow,
+  datedCount,
+  deltaWord,
+  healthColor,
+  healthOf,
+  statusCounts,
+  timeDelta,
+  windowBuckets,
+  windowDelta,
+  type StatDelta,
+} from '../board/windowStats.js';
+import { Sparkline } from './dashboardKit.js';
+
+/**
+ * The command deck's hero: the KPI ribbon (DES-HOME-COMMAND-CENTER, redesign). Three THEMED groups
+ * — FLOW / ATTENTION / TRUST&SPEND — each a glowing panel of tiles, so "is it healthy?" reads at a
+ * glance instead of as six flat tiles buried in a column.
+ *
+ * TIME HONESTY (the whole point of the redesign): every window is the REAL `created_at` clock
+ * (api-types 0.24.0) — a "30d" tile means thirty days, its delta compares the prior 30 days, its
+ * sparkline buckets by launch day. When NO run carries `created_at` (a pre-0.24 daemon, or the cold
+ * window right after an upgrade before new runs accrue), the ribbon degrades to the POSITIONAL
+ * window (the pre-redesign behavior) and says "last 30" — never a fabricated time.
+ *
+ * Reused by the section dashboards (change 1): the same ribbon, scoped to a section's runs.
+ */
+
+const DAYS = 30;
+const SPARK_DAYS = 14;
+
+/** The wire delivery state as a plain string (verified/needs-review), tolerant of the legacy shape. */
+function wireDelivery(v: SessionView): string | null {
+  const d = (v.session as SessionWithDelivery).delivery;
+  return typeof d === 'string' ? d : null;
+}
+
+interface Props {
+  runs: SessionView[];
+  /** `GET /governance/claims`, or null when the daemon does not serve it. */
+  claims: GovernanceClaim[] | null;
+  /** THE needs-you fold's count — the ribbon shows exactly what the feed lists. */
+  needCount: number;
+  navigate: Navigate;
+  now?: number;
+}
+
+export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props): React.ReactElement {
+  const at = now ?? Date.now();
+  const logs = useRuntimeStore((s) => s.logs);
+
+  const model = useMemo(() => {
+    const live = runs.filter((v) => v.session.archived_at == null);
+    const dated = datedCount(live);
+    const real = dated > 0;
+
+    // Window + deltas: real created_at time-window when any run is dated, else the positional fallback.
+    const timeWin = createdAtWindow(live, DAYS, at);
+    const posBuckets = windowBuckets(live, '30d');
+    const current = real ? timeWin.current : posBuckets.current;
+    const runsDelta: StatDelta = real ? timeDelta(timeWin, (rs) => rs.length) : windowDelta(posBuckets, (rs) => rs.length);
+    const failedDelta: StatDelta = real
+      ? timeDelta(timeWin, (rs) => statusCounts(rs).failed)
+      : windowDelta(posBuckets, (rs) => statusCounts(rs).failed);
+
+    const counts = statusCounts(current);
+    const activeNow = statusCounts(live).active;
+    const spark = real
+      ? createdAtSeries(live, SPARK_DAYS, at)
+      : attachSeries(current.map((v) => v.session.id), {}, SPARK_DAYS, at); // {} → empty spark when undated
+    const health = healthOf(counts.done, counts.terminal);
+    const successWord = counts.terminal === 0 ? '—' : `${Math.round((counts.done / counts.terminal) * 100)}%`;
+
+    // Delivery outcomes across all live runs (the review-queue count + the strip below the feed).
+    let verified = 0;
+    let stranded = 0;
+    let vacuous = 0;
+    for (const v of live) {
+      const d = wireDelivery(v);
+      if (d === 'delivered') verified += 1;
+      else if (d === 'stranded') stranded += 1;
+      else if (d === 'vacuous') vacuous += 1;
+    }
+    const reviewQueue = stranded + vacuous;
+
+    // Rework: share of live runs that are a retry of another.
+    const retries = live.filter((v) => typeof v.session.retry_of === 'string' && v.session.retry_of !== '').length;
+    const reworkPct = live.length === 0 ? null : Math.round((retries / live.length) * 100);
+
+    const governed = claims !== null ? governedRuns(claims, runs) : null;
+    const spend = observedSpend(logs);
+
+    return {
+      real, windowLabel: real ? '30d' : 'last 30',
+      runsCurrent: current.length, runsDelta, failedDelta, counts, activeNow, spark,
+      health, successWord, verified, stranded, vacuous, reviewQueue, reworkPct, governed, spend,
+    };
+  }, [runs, claims, logs, at]);
+
+  const go = (path: string) => (e: React.MouseEvent) => { e.preventDefault(); navigate(path); };
+
+  return (
+    <section className="deck-ribbon" data-testid="home-kpis" aria-label="Key metrics">
+      {/* ── FLOW ── */}
+      <div className="deck-group flow">
+        <div className="deck-ghead"><span className="deck-glyph">◆</span><span className="deck-tag">Flow</span></div>
+        <div className="deck-tiles">
+          <Tile testId="home-kpi-runs" lead label={`Runs · ${model.windowLabel}`} value={String(model.runsCurrent)}
+            delta={model.runsDelta} href="/work" onGo={go('/work')} spark={model.spark}
+            sub={deltaWord(model.real ? '30d' : '30d', model.runsDelta)} />
+          <Tile testId="home-kpi-active" label="Active" value={String(model.activeNow)}
+            href="/work?filter=active" onGo={go('/work?filter=active')} sub="moving now" />
+          <Tile testId="home-kpi-success" label="Success" value={model.successWord} unit=""
+            valueColor={healthColor(model.health)} href="/work?filter=completed" onGo={go('/work?filter=completed')}
+            sub={model.counts.terminal === 0 ? 'no finished runs' : `${model.counts.done}/${model.counts.terminal} passed`} />
+        </div>
+      </div>
+
+      {/* ── ATTENTION ── */}
+      <div className="deck-group attn">
+        <div className="deck-ghead"><span className="deck-glyph">▲</span><span className="deck-tag">Attention</span></div>
+        <div className="deck-tiles">
+          <Tile testId="home-kpi-needs" lead label="Needs you" value={String(needCount)}
+            valueColor={needCount > 0 ? 'var(--status-gate)' : undefined}
+            href="#needs-you" onGo={(e) => { e.preventDefault(); document.querySelector('[data-testid="needs-you-queue"]')?.scrollIntoView({ block: 'start' }); }}
+            sub={needCount > 0 ? 'waiting on you' : 'all clear'} />
+          <Tile testId="home-kpi-failed" label={`Failed · ${model.windowLabel}`} value={String(model.counts.failed)}
+            delta={model.failedDelta} deltaBadUp valueColor={model.counts.failed > 0 ? 'var(--status-fail)' : undefined}
+            href="/work?filter=failed" onGo={go('/work?filter=failed')}
+            sub={model.reworkPct !== null ? `rework ${model.reworkPct}%` : 'no rework'} />
+          <Tile testId="home-kpi-review" label="Review" value={String(model.reviewQueue)}
+            valueColor={model.reviewQueue > 0 ? 'var(--status-gate)' : undefined}
+            href="/work?filter=stranded" onGo={go('/work?filter=stranded')}
+            sub="stranded + vacuous" />
+        </div>
+      </div>
+
+      {/* ── TRUST & SPEND ── */}
+      <div className="deck-group trust">
+        <div className="deck-ghead"><span className="deck-glyph">◈</span><span className="deck-tag">Trust &amp; Spend</span></div>
+        <div className="deck-tiles">
+          <Tile testId="home-kpi-governed" lead label="Governed"
+            value={model.governed !== null && model.governed.pct !== null ? String(model.governed.pct) : '—'}
+            unit={model.governed !== null && model.governed.pct !== null ? '%' : ''}
+            href="/steering" onGo={go('/steering')}
+            bar={model.governed?.pct ?? null}
+            sub={model.governed === null ? 'not served' : `${model.governed.governed}/${model.governed.total} runs`} />
+          <Tile testId="home-kpi-spend" label="Spend · session"
+            value={model.spend.frames === 0 ? '—' : `$${model.spend.total.toFixed(2)}`}
+            href="/work" onGo={go('/work')}
+            sub={model.spend.frames === 0 ? 'no usage yet' : `${model.spend.frames} frames observed`} />
+          <Tile testId="home-kpi-rework" label="Rework"
+            value={model.reworkPct !== null ? String(model.reworkPct) : '—'} unit={model.reworkPct !== null ? '%' : ''}
+            href="/work" onGo={go('/work')} sub="retries of prior runs" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** One ribbon tile — the deck's luminous mono metric, delta pill, optional sparkline or bar. */
+function Tile({ testId, label, value, unit = '', delta, deltaBadUp, valueColor, sub, spark, bar, lead, href, onGo }: {
+  testId: string;
+  label: string;
+  value: string;
+  unit?: string;
+  delta?: StatDelta;
+  deltaBadUp?: boolean;
+  valueColor?: string | undefined;
+  sub?: string;
+  spark?: readonly number[];
+  bar?: number | null;
+  lead?: boolean;
+  href: string;
+  onGo: (e: React.MouseEvent) => void;
+}): React.ReactElement {
+  const hasDelta = delta !== undefined && delta.previous !== null;
+  const d = hasDelta ? delta!.current - delta!.previous! : null;
+  const dir = d === null || d === 0 ? 'flat' : d > 0 ? 'up' : 'down';
+  // "bad-up" tiles (failed) invert the good/bad color of the delta.
+  const good = deltaBadUp ? dir === 'down' : dir === 'up';
+  const deltaClass = dir === 'flat' ? 'flat' : good ? 'up' : 'down';
+  return (
+    <a
+      className={`deck-tile${lead ? ' lead' : ''}`}
+      data-testid={testId}
+      // The testable contract the KPI tests read (matching the old StatTile): the rendered value
+      // (with its unit) and whether a real prior-window delta exists.
+      data-value={`${value}${unit}`}
+      data-delta={hasDelta ? dir : 'none'}
+      href={href}
+      onClick={onGo}
+    >
+      <div className="deck-lab">{label}</div>
+      <div className="deck-val">
+        <span className="deck-big" style={valueColor ? { color: valueColor } : undefined}>{value}</span>
+        {unit !== '' && <span className="deck-unit">{unit}</span>}
+        {d !== null && (
+          <span className={`deck-delta ${deltaClass}`}>{d > 0 ? '▲' : d < 0 ? '▼' : '±'} {Math.abs(d)}</span>
+        )}
+      </div>
+      {spark !== undefined && spark.some((n) => n > 0) && (
+        <div className="deck-spark"><Sparkline counts={spark} width={120} height={24} stroke="var(--status-run)" /></div>
+      )}
+      {bar !== undefined && bar !== null && (
+        <div className="deck-bar"><i style={{ width: `${Math.max(0, Math.min(100, bar))}%` }} /></div>
+      )}
+      {sub !== undefined && <div className="deck-sub">{sub}</div>}
+    </a>
+  );
+}

--- a/src/components/DeckKpiRibbon.tsx
+++ b/src/components/DeckKpiRibbon.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { GovernanceClaim, SessionView, SessionWithDelivery } from '../api/types.js';
+import type { GovernanceClaim, SessionView } from '../api/types.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { governedRuns } from '../board/steeringUsage.js';
 import { observedSpend } from '../board/metrics.js';
@@ -9,6 +9,7 @@ import {
   createdAtSeries,
   createdAtWindow,
   datedCount,
+  deliveryCounts,
   deltaWord,
   healthColor,
   healthOf,
@@ -36,12 +37,6 @@ import { Sparkline } from './dashboardKit.js';
 
 const DAYS = 30;
 const SPARK_DAYS = 14;
-
-/** The wire delivery state as a plain string (verified/needs-review), tolerant of the legacy shape. */
-function wireDelivery(v: SessionView): string | null {
-  const d = (v.session as SessionWithDelivery).delivery;
-  return typeof d === 'string' ? d : null;
-}
 
 interface Props {
   runs: SessionView[];
@@ -80,16 +75,8 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
     const successWord = counts.terminal === 0 ? '—' : `${Math.round((counts.done / counts.terminal) * 100)}%`;
 
     // Delivery outcomes across all live runs (the review-queue count + the strip below the feed).
-    let verified = 0;
-    let stranded = 0;
-    let vacuous = 0;
-    for (const v of live) {
-      const d = wireDelivery(v);
-      if (d === 'delivered') verified += 1;
-      else if (d === 'stranded') stranded += 1;
-      else if (d === 'vacuous') vacuous += 1;
-    }
-    const reviewQueue = stranded + vacuous;
+    const dc = deliveryCounts(live);
+    const reviewQueue = dc.stranded + dc.vacuous;
 
     // Rework: share of live runs that are a retry of another.
     const retries = live.filter((v) => typeof v.session.retry_of === 'string' && v.session.retry_of !== '').length;
@@ -101,7 +88,7 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
     return {
       real, windowLabel: real ? '30d' : 'last 30',
       runsCurrent: current.length, runsDelta, failedDelta, counts, activeNow, spark,
-      health, successWord, verified, stranded, vacuous, reviewQueue, reworkPct, governed, spend,
+      health, successWord, reviewQueue, reworkPct, governed, spend,
     };
   }, [runs, claims, logs, at]);
 

--- a/src/components/DeckSectionDoors.tsx
+++ b/src/components/DeckSectionDoors.tsx
@@ -1,0 +1,46 @@
+import type { Navigate } from '../hooks/useRoute.js';
+
+/** One section door — a glyph, a name, a live count line, its route + accent color. */
+export interface SectionDoor {
+  key: string;
+  label: string;
+  glyph: string;
+  /** The one-line count/context, or null when its wire hasn't answered (the door still links). */
+  count: string | null;
+  href: string;
+  /** The door's accent token (its section color). */
+  color: string;
+}
+
+/**
+ * The section-doors strip (command-deck redesign) — the nav made legible on the landing: Execute /
+ * Test / Vibe / Demo / Evals / Steering as color-coded doors with a live count, the "where do I go"
+ * answer. Absent counts (a wire that hasn't answered) show the door without a number, never a
+ * fabricated zero. Mirrors the rail's Make-breakout so the landing and the nav agree.
+ */
+export function DeckSectionDoors({ doors, navigate }: {
+  doors: SectionDoor[];
+  navigate: Navigate;
+}): React.ReactElement {
+  return (
+    <nav className="deck-doors" data-testid="home-section-doors" aria-label="Sections">
+      {doors.map((d) => (
+        <a
+          key={d.key}
+          className="deck-door"
+          data-testid="section-door"
+          data-section={d.key}
+          href={d.href}
+          onClick={(e) => { e.preventDefault(); navigate(d.href); }}
+          style={{ ['--door-col' as string]: d.color }}
+        >
+          <span className="deck-door-glyph" aria-hidden>{d.glyph}</span>
+          <span className="deck-door-text">
+            <span className="deck-door-label">{d.label}</span>
+            {d.count !== null && <span className="deck-door-count">{d.count}</span>}
+          </span>
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/DeckVerifiedStrip.tsx
+++ b/src/components/DeckVerifiedStrip.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import type { SessionView } from '../api/types.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { deliveryCounts } from '../board/windowStats.js';
+
+/**
+ * The verified-vs-needs-review strip (command-deck redesign) — the delivery outcomes pulled UP from
+ * the run detail into the landing, so "what shipped vs what still needs me" reads at a glance. One
+ * fold ({@link deliveryCounts}) shared with the ribbon's ATTENTION "review" tile, off the run DTO's
+ * `delivery` field — nothing is fetched. Each cell is a door into the matching Work filter.
+ */
+export function DeckVerifiedStrip({ runs, navigate }: {
+  runs: SessionView[];
+  navigate: Navigate;
+}): React.ReactElement {
+  const c = useMemo(() => deliveryCounts(runs), [runs]);
+  const cell = (path: string) => (e: React.MouseEvent): void => { e.preventDefault(); navigate(path); };
+  return (
+    <div className="deck-vrbar" data-testid="home-delivery-strip" role="group" aria-label="Delivery outcomes">
+      <a className="deck-vrcell" data-testid="delivery-verified" href="/work?filter=delivered" onClick={cell('/work?filter=delivered')}>
+        <span className="deck-vn ok">{c.delivered}</span>
+        <span className="deck-vl">Verified &amp; delivered</span>
+      </a>
+      <a className="deck-vrcell" data-testid="delivery-stranded" href="/work?filter=stranded" onClick={cell('/work?filter=stranded')}>
+        <span className="deck-vn warn">{c.stranded}</span>
+        <span className="deck-vl">Stranded — needs review</span>
+      </a>
+      <a className="deck-vrcell" data-testid="delivery-vacuous" href="/work?filter=vacuous" onClick={cell('/work?filter=vacuous')}>
+        <span className="deck-vn bad">{c.vacuous}</span>
+        <span className="deck-vl">Vacuous — needs retry</span>
+      </a>
+    </div>
+  );
+}

--- a/src/components/EvalHistory.tsx
+++ b/src/components/EvalHistory.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import { getEvalRun, listEvalRuns } from '../api/testing.js';
+import { isRouteAbsent } from '../api/errors.js';
+import type { EvalRunDetail, EvalRunSummary } from '../api/types.js';
+
+/**
+ * The eval-run HISTORY (crew-side EvalRunStore, api-types 0.25.0) — the Evals section's real list.
+ * Before the store, an eval run was computed and answered but NOTHING was kept, so the section
+ * could show one session-local report; now `GET /testing/evals` serves a durable, drillable
+ * history. Each row is a rollup (when, corpus, type filter, caught/gaps/false-positives); clicking
+ * one loads its full per-sample results (`GET /testing/evals/:id`).
+ *
+ * `refreshKey` bumps after a run so a freshly-recorded run appears without a reload. A daemon that
+ * predates the store (404 on the route) shows the honest "history unavailable" note, never an error.
+ */
+function ago(sec: number, now: number): string {
+  const s = Math.max(0, Math.floor(now / 1000) - sec);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 48) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+type Load =
+  | { kind: 'loading' }
+  | { kind: 'ready'; runs: EvalRunSummary[] }
+  | { kind: 'unavailable' }
+  | { kind: 'error'; message: string };
+
+export function EvalHistory({ refreshKey = 0, now = Date.now() }: {
+  refreshKey?: number;
+  now?: number;
+}): React.ReactElement {
+  const [load, setLoad] = useState<Load>({ kind: 'loading' });
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<EvalRunDetail | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoad({ kind: 'loading' });
+    void listEvalRuns()
+      .then((runs) => { if (!cancelled) setLoad({ kind: 'ready', runs }); })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (isRouteAbsent(e)) setLoad({ kind: 'unavailable' });
+        else setLoad({ kind: 'error', message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => { cancelled = true; };
+  }, [refreshKey]);
+
+  const toggle = (id: string): void => {
+    if (openId === id) { setOpenId(null); return; }
+    setOpenId(id);
+    setDetail(null);
+    void getEvalRun(id).then((d) => setDetail(d)).catch(() => setDetail(null));
+  };
+
+  if (load.kind === 'loading') {
+    return <p data-testid="eval-history-loading" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Loading eval history…</p>;
+  }
+  if (load.kind === 'unavailable') {
+    return <p data-testid="eval-history-unavailable" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>This daemon keeps no eval history yet — run one above and it will be recorded here.</p>;
+  }
+  if (load.kind === 'error') {
+    return <p data-testid="eval-history-error" className="text-[11px]" style={{ color: 'var(--status-fail)' }}>Could not load eval history: {load.message}</p>;
+  }
+  if (load.runs.length === 0) {
+    return <p data-testid="eval-history-empty" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>No eval runs yet — run one above to start the history.</p>;
+  }
+
+  return (
+    <div data-testid="eval-history" className="flex flex-col gap-2">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--ink-dim)', letterSpacing: '0.08em' }}>
+        Run history · {load.runs.length}
+      </h3>
+      <div className="flex flex-col rounded-lg overflow-hidden" style={{ border: '1px solid var(--surface-raised)' }}>
+        {load.runs.map((r) => {
+          const gaps = r.summary.gaps;
+          const stripe = gaps > 0 ? 'var(--status-gate)' : r.summary.false_positives > 0 ? 'var(--status-fail)' : 'var(--status-run)';
+          return (
+            <div key={r.id} data-testid="eval-history-row" data-run-id={r.id} style={{ borderBottom: '1px solid var(--surface-raised)' }}>
+              <button
+                type="button"
+                onClick={() => toggle(r.id)}
+                aria-expanded={openId === r.id}
+                className="w-full text-left grid items-center gap-3 px-3 py-2.5 transition-colors"
+                style={{ gridTemplateColumns: '3px 1fr auto', background: openId === r.id ? 'var(--surface-card)' : 'transparent' }}
+              >
+                <span aria-hidden style={{ alignSelf: 'stretch', borderRadius: '3px', background: stripe }} />
+                <span className="min-w-0">
+                  <span className="flex items-center gap-2">
+                    <span className="text-[12px] font-medium" style={{ color: 'var(--ink-high)' }}>
+                      {r.corpus ?? 'built-in dev-behaviors'}
+                    </span>
+                    <span className="text-[10px] font-mono px-1.5 py-0.5 rounded" style={{ color: 'var(--ink-muted)', background: 'var(--surface-raised)' }}>
+                      {r.type_filter ?? 'all types'}
+                    </span>
+                    {r.degraded === 'facet-only' && (
+                      <span className="text-[10px] font-mono" style={{ color: 'var(--status-gate)' }} title="Ran facet-only — the embedding side was unavailable">degraded</span>
+                    )}
+                  </span>
+                  <span className="block text-[10px] mt-1 font-mono" style={{ color: 'var(--ink-dim)' }}>
+                    {ago(r.created_at, now)} · {r.actor}
+                  </span>
+                </span>
+                <span className="flex items-center gap-3 font-mono text-[11px] shrink-0" style={{ fontVariantNumeric: 'tabular-nums' }}>
+                  <span title="caught" style={{ color: 'var(--status-run)' }}>✓ {r.summary.caught}</span>
+                  <span title="gaps (uncovered behaviors)" style={{ color: gaps > 0 ? 'var(--status-gate)' : 'var(--ink-dim)' }}>▲ {gaps}</span>
+                  <span title="false positives" style={{ color: r.summary.false_positives > 0 ? 'var(--status-fail)' : 'var(--ink-dim)' }}>✗ {r.summary.false_positives}</span>
+                </span>
+              </button>
+              {openId === r.id && (
+                <div data-testid="eval-history-detail" className="px-6 pb-3" style={{ background: 'var(--surface-card)' }}>
+                  {detail === null ? (
+                    <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>Loading results…</p>
+                  ) : (
+                    <div className="flex flex-col gap-1">
+                      <p className="text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>
+                        {detail.summary.total} samples · {detail.summary.caught} caught · {detail.summary.gaps} gaps · {detail.summary.false_positives} false positives
+                      </p>
+                      {detail.results.filter((x) => x.verdict !== 'caught').slice(0, 12).map((x) => (
+                        <div key={x.sample.id} className="grid gap-2 text-[11px]" style={{ gridTemplateColumns: 'auto auto 1fr' }}>
+                          <span className="font-mono" style={{ color: x.verdict === 'gap' ? 'var(--status-gate)' : 'var(--status-fail)' }}>
+                            {x.verdict === 'gap' ? 'GAP' : 'FP'}
+                          </span>
+                          <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>{x.sample.steering_type}</span>
+                          <span style={{ color: 'var(--ink-body)' }}>{x.sample.description}</span>
+                        </div>
+                      ))}
+                      {detail.results.every((x) => x.verdict === 'caught') && (
+                        <p className="text-[11px]" style={{ color: 'var(--status-run)' }}>Every behavior caught — no gaps or false positives.</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/EvalHistory.tsx
+++ b/src/components/EvalHistory.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getEvalRun, listEvalRuns } from '../api/testing.js';
 import { isRouteAbsent } from '../api/errors.js';
 import type { EvalRunDetail, EvalRunSummary } from '../api/types.js';
@@ -35,7 +35,11 @@ export function EvalHistory({ refreshKey = 0, now = Date.now() }: {
 }): React.ReactElement {
   const [load, setLoad] = useState<Load>({ kind: 'loading' });
   const [openId, setOpenId] = useState<string | null>(null);
-  const [detail, setDetail] = useState<EvalRunDetail | null>(null);
+  // Detail is keyed by the run id + carries its own load state, so a slow response for a row you've
+  // since closed (or swapped) never paints stale results, and a failed fetch shows an error rather
+  // than an endless "Loading…" (Copilot #198). `reqSeq` guards against out-of-order resolutions.
+  const [detail, setDetail] = useState<{ id: string; kind: 'loading' | 'error' | 'ready'; data?: EvalRunDetail } | null>(null);
+  const reqSeq = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -51,10 +55,13 @@ export function EvalHistory({ refreshKey = 0, now = Date.now() }: {
   }, [refreshKey]);
 
   const toggle = (id: string): void => {
-    if (openId === id) { setOpenId(null); return; }
+    if (openId === id) { setOpenId(null); setDetail(null); return; }
     setOpenId(id);
-    setDetail(null);
-    void getEvalRun(id).then((d) => setDetail(d)).catch(() => setDetail(null));
+    const req = (reqSeq.current += 1);
+    setDetail({ id, kind: 'loading' });
+    void getEvalRun(id)
+      .then((d) => { if (reqSeq.current === req) setDetail({ id, kind: 'ready', data: d }); })
+      .catch(() => { if (reqSeq.current === req) setDetail({ id, kind: 'error' }); });
   };
 
   if (load.kind === 'loading') {
@@ -113,26 +120,12 @@ export function EvalHistory({ refreshKey = 0, now = Date.now() }: {
               </button>
               {openId === r.id && (
                 <div data-testid="eval-history-detail" className="px-6 pb-3" style={{ background: 'var(--surface-card)' }}>
-                  {detail === null ? (
+                  {detail === null || detail.id !== r.id || detail.kind === 'loading' ? (
                     <p className="text-[10px]" style={{ color: 'var(--ink-dim)' }}>Loading results…</p>
+                  ) : detail.kind === 'error' || detail.data === undefined ? (
+                    <p data-testid="eval-history-detail-error" className="text-[10px]" style={{ color: 'var(--status-fail)' }}>Could not load this run&rsquo;s results.</p>
                   ) : (
-                    <div className="flex flex-col gap-1">
-                      <p className="text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>
-                        {detail.summary.total} samples · {detail.summary.caught} caught · {detail.summary.gaps} gaps · {detail.summary.false_positives} false positives
-                      </p>
-                      {detail.results.filter((x) => x.verdict !== 'caught').slice(0, 12).map((x) => (
-                        <div key={x.sample.id} className="grid gap-2 text-[11px]" style={{ gridTemplateColumns: 'auto auto 1fr' }}>
-                          <span className="font-mono" style={{ color: x.verdict === 'gap' ? 'var(--status-gate)' : 'var(--status-fail)' }}>
-                            {x.verdict === 'gap' ? 'GAP' : 'FP'}
-                          </span>
-                          <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>{x.sample.steering_type}</span>
-                          <span style={{ color: 'var(--ink-body)' }}>{x.sample.description}</span>
-                        </div>
-                      ))}
-                      {detail.results.every((x) => x.verdict === 'caught') && (
-                        <p className="text-[11px]" style={{ color: 'var(--status-run)' }}>Every behavior caught — no gaps or false positives.</p>
-                      )}
-                    </div>
+                    <DetailBody detail={detail.data} />
                   )}
                 </div>
               )}
@@ -140,6 +133,30 @@ export function EvalHistory({ refreshKey = 0, now = Date.now() }: {
           );
         })}
       </div>
+    </div>
+  );
+}
+
+/** One run's drilldown: the rollup line + the non-caught samples (gaps/false-positives). */
+function DetailBody({ detail }: { detail: EvalRunDetail }): React.ReactElement {
+  const misses = detail.results.filter((x) => x.verdict !== 'caught');
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-[10px] font-mono" style={{ color: 'var(--ink-muted)' }}>
+        {detail.summary.total} samples · {detail.summary.caught} caught · {detail.summary.gaps} gaps · {detail.summary.false_positives} false positives
+      </p>
+      {misses.slice(0, 12).map((x) => (
+        <div key={x.sample.id} className="grid gap-2 text-[11px]" style={{ gridTemplateColumns: 'auto auto 1fr' }}>
+          <span className="font-mono" style={{ color: x.verdict === 'gap' ? 'var(--status-gate)' : 'var(--status-fail)' }}>
+            {x.verdict === 'gap' ? 'GAP' : 'FP'}
+          </span>
+          <span className="font-mono" style={{ color: 'var(--ink-dim)' }}>{x.sample.steering_type}</span>
+          <span style={{ color: 'var(--ink-body)' }}>{x.sample.description}</span>
+        </div>
+      ))}
+      {misses.length === 0 && (
+        <p className="text-[11px]" style={{ color: 'var(--status-run)' }}>Every behavior caught — no gaps or false positives.</p>
+      )}
     </div>
   );
 }

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -16,9 +16,11 @@ import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/us
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { BatchGateBar } from './BatchGateBar.js';
-import { EssenceStrip, essenceEntries, HomeVerbs, RecentActivity } from './HomeCommand.js';
+import { HomeVerbs, RecentActivity } from './HomeCommand.js';
 import { DeckKpiRibbon } from './DeckKpiRibbon.js';
 import { DeckVerifiedStrip } from './DeckVerifiedStrip.js';
+import { DeckSectionDoors, type SectionDoor } from './DeckSectionDoors.js';
+import { listEvalRuns } from '../api/testing.js';
 import { NeedsYouQueue } from './NeedsYouQueue.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 import { humanTitle } from './runIdentity.js';
@@ -140,9 +142,11 @@ interface HomeWires {
   rules: SteeringRule[] | null;
   perRule: WikiRuleEvidenceRow[] | null;
   diag: Diagnostics | null;
+  /** Count of recorded eval runs (the eval store) — the Evals door's number. */
+  evalCount: number | null;
 }
 
-const NO_WIRES: HomeWires = { chats: null, campaigns: null, claims: null, rules: null, perRule: null, diag: null };
+const NO_WIRES: HomeWires = { chats: null, campaigns: null, claims: null, rules: null, perRule: null, diag: null, evalCount: null };
 
 export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElement {
   const { items, unfiled, failedAt, repos, loading, error } = useBoardModel(runs);
@@ -184,6 +188,7 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
       (r) => r !== null && deposit({ perRule: r.scoreboard.evidence.per_rule }),
     );
     void read(() => getDiagnostics()).then((r) => r !== null && deposit({ diag: r }));
+    void read(() => listEvalRuns()).then((r) => r !== null && deposit({ evalCount: r.length }));
     return () => { cancelled = true; };
   }, []);
 
@@ -294,21 +299,20 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
   });
 
   const docsCount = useMemo(() => items.reduce((a, i) => a + i.docs.length, 0), [items]);
-  const essences = useMemo(
-    () =>
-      essenceEntries({
-        projects: items.length,
-        docs: docsCount,
-        chats: wires.chats === null ? null : wires.chats.length,
-        repos,
-        campaigns: wires.campaigns === null ? null : wires.campaigns.length,
-        rules: wires.rules,
-        perRule: wires.perRule,
-        diag: wires.diag,
-        now,
-      }),
-    [items.length, docsCount, wires, repos, now],
-  );
+
+  // The section-doors strip (redesign): the Execute/Test/Vibe/Demo/Evals/Steering breakout made
+  // legible on the landing, each with a live count (absent counts show no number, never a zero).
+  const sectionDoors = useMemo<SectionDoor[]>(() => {
+    const plural = (n: number, w: string): string => `${n} ${w}${n === 1 ? '' : 's'}`;
+    return [
+      { key: 'execute', label: 'Execute', glyph: '▸', count: plural(runs.length, 'run'), href: '/execute', color: 'var(--status-run)' },
+      { key: 'test', label: 'Test', glyph: '✓', count: wires.campaigns === null ? null : plural(wires.campaigns.length, 'test'), href: '/testing/campaigns', color: 'var(--section-test)' },
+      { key: 'vibe', label: 'Vibe', glyph: '▤', count: plural(docsCount, 'document'), href: '/vibe', color: 'var(--section-vibe)' },
+      { key: 'demo', label: 'Demo', glyph: '▶', count: null, href: '/demo', color: 'var(--section-demo)' },
+      { key: 'evals', label: 'Evals', glyph: '◈', count: wires.evalCount === null ? null : plural(wires.evalCount, 'run'), href: '/testing/evals', color: 'var(--status-gate)' },
+      { key: 'steering', label: 'Steering', glyph: '☸', count: wires.rules === null ? null : plural(wires.rules.length, 'rule'), href: '/steering/dashboard', color: 'var(--accent)' },
+    ];
+  }, [runs.length, docsCount, wires.campaigns, wires.evalCount, wires.rules]);
 
   // The fresh-install welcome (§6): verbs + Ask, prominent — and NOTHING
   // measured, because nothing has ever run (no fabricated zeros).
@@ -403,10 +407,10 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
             <DeckVerifiedStrip runs={runs} navigate={navigate} />
           </div>
 
-          {/* The essence strip rides full-width under the command center — a
-              compact row of section doors that can never clip in a column. */}
+          {/* The section doors — the Execute/Test/Vibe/Demo/Evals/Steering breakout, made legible
+              on the landing with live counts (the redesign's "where do I go"). */}
           <div style={{ flexShrink: 0, padding: '0 var(--space-6) var(--space-3)' }}>
-            <EssenceStrip entries={essences} navigate={navigate} />
+            <DeckSectionDoors doors={sectionDoors} navigate={navigate} />
           </div>
 
           {/* Slice L: the batch bar docks above the wall while ≥1 simple gate is selected. */}

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -20,6 +20,7 @@ import { HomeVerbs, RecentActivity } from './HomeCommand.js';
 import { DeckKpiRibbon } from './DeckKpiRibbon.js';
 import { DeckVerifiedStrip } from './DeckVerifiedStrip.js';
 import { DeckSectionDoors, type SectionDoor } from './DeckSectionDoors.js';
+import { DeckBurnChart } from './DeckBurnChart.js';
 import { listEvalRuns } from '../api/testing.js';
 import { NeedsYouQueue } from './NeedsYouQueue.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
@@ -398,6 +399,7 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
                 gap: 'var(--space-3)', overflowY: 'auto', minHeight: 0,
               }}
             >
+              <DeckBurnChart />
               <RecentActivity runs={runs} navigate={navigate} now={now} />
             </div>
           </div>

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -16,7 +16,8 @@ import { useTriageCursor, type TriageCursor, type TriageItem } from '../hooks/us
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { BatchGateBar } from './BatchGateBar.js';
-import { EssenceStrip, essenceEntries, HomeKpiBand, HomeVerbs, RecentActivity } from './HomeCommand.js';
+import { EssenceStrip, essenceEntries, HomeVerbs, RecentActivity } from './HomeCommand.js';
+import { DeckKpiRibbon } from './DeckKpiRibbon.js';
 import { NeedsYouQueue } from './NeedsYouQueue.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 import { humanTitle } from './runIdentity.js';
@@ -371,13 +372,18 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
 
       {!fresh && !loading && error === null && (
         <>
-          {/* ── The command center: queue (spine, left) + the analytics column.
-                 Both the queue and the KPI band are fully visible at 1440×700. ── */}
+          {/* ── The KPI ribbon: the hero, full-width — FLOW / ATTENTION / TRUST&SPEND on the real
+                 created_at clock (the command-deck redesign). ── */}
+          <div style={{ flexShrink: 0, padding: '0 var(--space-6)' }}>
+            <DeckKpiRibbon runs={runs} claims={wires.claims} needCount={needRows.length} navigate={navigate} now={now} />
+          </div>
+
+          {/* ── The command center: the needs-you queue (spine, left) + the live-pulse column. ── */}
           <div
             data-testid="command-center"
             style={{
               flexShrink: 0, display: 'flex', gap: 'var(--space-4)', alignItems: 'stretch',
-              padding: '0 var(--space-6) var(--space-4)', maxHeight: '56vh', minHeight: 0,
+              padding: '0 var(--space-6) var(--space-4)', maxHeight: '52vh', minHeight: 0,
             }}
           >
             <NeedsYouQueue rows={needRows} runs={runs} navigate={navigate} now={now} />
@@ -387,14 +393,6 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
                 gap: 'var(--space-3)', overflowY: 'auto', minHeight: 0,
               }}
             >
-              <HomeKpiBand
-                runs={runs}
-                attachedAt={attachedAt}
-                needRows={needRows}
-                claims={wires.claims}
-                navigate={navigate}
-                now={now}
-              />
               <RecentActivity runs={runs} navigate={navigate} now={now} />
             </div>
           </div>

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -18,6 +18,7 @@ import { useMembershipStore } from '../store/membership.js';
 import { BatchGateBar } from './BatchGateBar.js';
 import { EssenceStrip, essenceEntries, HomeVerbs, RecentActivity } from './HomeCommand.js';
 import { DeckKpiRibbon } from './DeckKpiRibbon.js';
+import { DeckVerifiedStrip } from './DeckVerifiedStrip.js';
 import { NeedsYouQueue } from './NeedsYouQueue.js';
 import { ACTIVE_CARD_H, ago, ProjectCard, QUIET_CARD_H } from './ProjectCard.js';
 import { humanTitle } from './runIdentity.js';
@@ -395,6 +396,11 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
             >
               <RecentActivity runs={runs} navigate={navigate} now={now} />
             </div>
+          </div>
+
+          {/* Verified vs needs-review — the delivery outcomes pulled up from run detail. */}
+          <div style={{ flexShrink: 0, padding: '0 var(--space-6) var(--space-3)' }}>
+            <DeckVerifiedStrip runs={runs} navigate={navigate} />
           </div>
 
           {/* The essence strip rides full-width under the command center — a

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -73,7 +73,7 @@ const S = {
 
 // ── The five paths (§2.1) ─────────────────────────────────────────────────────
 
-export type PathKey = 'projects' | 'execute' | 'vibe' | 'demo' | 'chat' | 'repos' | 'testing' | 'steering' | 'settings';
+export type PathKey = 'projects' | 'execute' | 'test' | 'vibe' | 'demo' | 'chat' | 'repos' | 'testing' | 'steering' | 'settings';
 
 /** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
  *  links `/system` in the collapsed column — it has no dashboard). `noun` is
@@ -95,7 +95,12 @@ const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Re
 // capability with no project home). Campaigns moved into the project shell (`/p/:id/campaigns`),
 // so they are no longer a top-level nav item; the unscoped cross-project sweep keeps its own
 // `/testing/campaigns` route. The key + routes stay `testing`; only the display + list changed.
-const P_TESTING: PathSpec  = { key: 'testing',  title: 'Evals',        noun: 'Eval',       glyph: '✓', dash: testingPath('evals'), collapsedHref: testingPath('evals') };
+// Test — the campaign/recon testing capability as a standalone WORK section (usability wave):
+// project-optional (recon takes an optional project), placed right below Execute. Routes to the
+// existing `/testing/campaigns` page; the rail split (headingForPath) keeps it distinct from Evals.
+const P_TEST: PathSpec      = { key: 'test',     title: 'Test',         noun: 'Campaign',   glyph: '✓', dash: testingPath('campaigns'), collapsedHref: testingPath('campaigns') };
+// Evals — steering-rule evals, moved beside Steering (a SYSTEM concept, not a work one). Glyph ◈.
+const P_TESTING: PathSpec  = { key: 'testing',  title: 'Evals',        noun: 'Eval',       glyph: '◈', dash: testingPath('evals'), collapsedHref: testingPath('evals') };
 // Steering (DES-MEM-FACETED-001, unified surface): the governed-knowledge home, a PRIMARY path
 // placed immediately BEFORE Settings. The nav-reorg moved its Dashboard from a sub-row to the
 // heading's ▦ (dash → the dashboard, same affordance Projects/Execute/Chat/Repos use); it keeps
@@ -104,7 +109,7 @@ const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Ru
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
 // Order (nav-reorg): Execute / Vibe / Demo replace Make and sit before Evals; Chat / Repos /
 // Steering / Settings tail.
-const PATHS: PathSpec[] = [P_PROJECTS, P_EXECUTE, P_VIBE, P_DEMO, P_TESTING, P_CHAT, P_REPOS, P_STEERING, P_SETTINGS];
+const PATHS: PathSpec[] = [P_PROJECTS, P_EXECUTE, P_TEST, P_VIBE, P_DEMO, P_CHAT, P_REPOS, P_STEERING, P_TESTING, P_SETTINGS];
 
 // `wiki`, `rules` and `policies` retired into Steering (they redirect to /steering); the
 // retired `coverage` and `domain` panels redirect to /system — kept mapped here so the rail
@@ -127,9 +132,12 @@ export function headingForPath(pathname: string): PathKey | null {
   // `/chat/new` AND `/chat/:id` (J4/C6: a live session's real URL) are Chat's.
   if (first === 'chats' || (first === 'chat' && second !== '')) return 'chat';
   if (first === 'repos' || first === 'repo-detail') return 'repos';
-  // The retired flat `/campaigns` addresses redirect into Testing — map them there too, so
-  // the rail is already on the right heading on the pre-redirect tick.
-  if (first === 'testing' || first === 'campaigns') return 'testing';
+  // The `/testing/*` surface splits into TWO rail sections (usability wave): Test (campaigns/recon,
+  // a work section that needs no project) and Evals (steering-rule evals, a system section beside
+  // Steering). Both are still panel `testing`; the rail heading is chosen by the sub-page. The
+  // retired flat `/campaigns` addresses (which redirect onto `/testing/campaigns`) map to Test.
+  if (first === 'campaigns') return 'test';
+  if (first === 'testing') return second === 'campaigns' ? 'test' : 'testing';
   // The retired `/wiki` + `/rules` + `/policies` panels AND the retired standalone `/proposals`
   // queue redirect into Steering (proposals now live inside its two sub-sections) — map them
   // there too, so the rail never flashes Settings open on the pre-redirect tick.
@@ -487,6 +495,27 @@ function EvalsRailRows({ navigate }: { navigate: (p: string) => void }): React.R
   );
 }
 
+/** The Test accordion's shortcut row (usability wave): a "Run recon" launcher into the campaigns
+ *  landing — Test works WITHOUT a project (recon takes an optional one), so it lives here as a
+ *  standalone work section. The ▦ links the campaigns dashboard; this row is the create verb's
+ *  sibling. Same grammar as {@link EvalsRailRows}. */
+function TestRailRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <div role="menu" className="flex flex-col pt-0.5">
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="rail-test-recon"
+        onClick={() => navigate(testingPath('campaigns'))}
+        className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
+        style={{ color: 'var(--ink-muted)' }}
+      >
+        Run recon
+      </button>
+    </div>
+  );
+}
+
 /** The Steering accordion's rows: one per MANAGEMENT sub-section (Policies / Memories), each a
  *  navigate() shortcut to its page — the SettingsShortcutRows grammar. The nav-reorg moved the
  *  Dashboard from a sub-row to the heading's ▦ (same affordance Projects/Execute/Chat/Repos use),
@@ -690,6 +719,18 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             <ViewAll href="/execute" navigate={navigate} />
           </RailHeading>
 
+          {/* ── Test — campaigns/recon as a standalone work section (usability wave): below Execute,
+                 works with or without a project. ＋ launches a recon into the campaigns landing. ── */}
+          <RailHeading
+            path={P_TEST}
+            open={openHeading === 'test'}
+            onToggle={() => toggle('test')}
+            onNew={() => navigate(testingPath('campaigns'))}
+            navigate={navigate}
+          >
+            <TestRailRows navigate={navigate} />
+          </RailHeading>
+
           {/* ── Vibe ← documents (nav-reorg): ＋ opens a project-picker locked to Document ── */}
           <RailHeading
             path={P_VIBE}
@@ -726,17 +767,6 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
                   <DocRow key={`${projectId}:${doc.name}`} doc={doc} projectId={projectId} projectName={projectName} navigate={navigate} />
                 ))}
             <ViewAll href="/demo" navigate={navigate} />
-          </RailHeading>
-
-          {/* ── Evals — the steering-rule eval runner, a normal section (nav-reorg) ── */}
-          <RailHeading
-            path={P_TESTING}
-            open={openHeading === 'testing'}
-            onToggle={() => toggle('testing')}
-            onNew={() => navigate(testingPath('evals'))}
-            navigate={navigate}
-          >
-            <EvalsRailRows navigate={navigate} />
           </RailHeading>
 
           {/* ── Chat ─────────────────────────────────────────────────────────── */}
@@ -832,8 +862,12 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             <ViewAll href="/repos" navigate={navigate} />
           </RailHeading>
 
-          {/* ── Steering — the governed-knowledge home, BEFORE Settings. Its three rows:
-                Dashboard (the review-forward home) + the Policies / Memories deep-dives. ─ */}
+          {/* ── The work/system boundary (usability wave): a bar separating the work sections above
+                 from the governance/system sections (Steering, Evals) below. ── */}
+          <div aria-hidden data-testid="rail-divider" style={{ borderTop: '1px solid var(--surface-raised)', margin: '8px 12px' }} />
+
+          {/* ── Steering — the governed-knowledge home. Its three rows: Dashboard (the review-forward
+                home, on the ▦) + the Policies / Memories deep-dives. ─ */}
           <RailHeading
             path={P_STEERING}
             open={openHeading === 'steering'}
@@ -843,7 +877,22 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             <SteeringSectionRows navigate={navigate} />
           </RailHeading>
 
-          {/* ── Settings — title only, no ▦/＋ (the operator's word, §3.1) ───── */}
+          {/* ── Evals — steering-rule evals, moved beside Steering (similar system concepts): the
+                eval runner + its run history. ── */}
+          <RailHeading
+            path={P_TESTING}
+            open={openHeading === 'testing'}
+            onToggle={() => toggle('testing')}
+            onNew={() => navigate(testingPath('evals'))}
+            navigate={navigate}
+          >
+            <EvalsRailRows navigate={navigate} />
+          </RailHeading>
+
+          {/* ── The bar below Steering/Evals, with Settings under it (usability wave). ── */}
+          <div aria-hidden data-testid="rail-divider" style={{ borderTop: '1px solid var(--surface-raised)', margin: '8px 12px' }} />
+
+          {/* ── Settings — title only, no ＋ (the operator's word, §3.1) ───── */}
           <RailHeading
             path={P_SETTINGS}
             open={openHeading === 'settings'}

--- a/src/components/NeedsYouQueue.tsx
+++ b/src/components/NeedsYouQueue.tsx
@@ -129,7 +129,14 @@ export function NeedsYouQueue({ rows, runs, navigate, now }: {
               data-testid="need-row"
               data-kind={row.kind}
               data-key={row.key}
-              style={CSS.row}
+              // Severity stripe (command-deck redesign): a glowing left edge colored by the row's
+              // tone, so what needs you reads by color at a glance (gate/failed/stranded/…).
+              style={{
+                ...CSS.row,
+                borderLeft: `3px solid ${TONE_COLOR[row.tone]}`,
+                paddingLeft: '9px',
+                boxShadow: `inset 4px 0 10px -6px ${TONE_COLOR[row.tone]}`,
+              }}
             >
               <span aria-hidden style={{ color: TONE_COLOR[row.tone], flexShrink: 0, fontSize: 'var(--text-xs)' }}>
                 {TONE_GLYPH[row.tone]}

--- a/src/components/SteeringGrid.tsx
+++ b/src/components/SteeringGrid.tsx
@@ -544,7 +544,7 @@ export function SteeringGrid({ rules, type, loading, error, selectedId, onSelect
                       value={steeringTypeOf(r)}
                       options={TYPE_OPTIONS}
                       disabled={retired}
-                      onCommit={(v) => commitField(r, { steering_type: v })}
+                      onCommit={(v) => commitField(r, { steering_type: v as SteeringType })}
                     />
                   </td>
                   <td className="px-0.5 py-0.5">

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -5,9 +5,7 @@ import {
   importEvalCorpus,
   isTestingUnsupported,
   runEvals,
-  testingPath,
   TESTING_PAGE_LABELS,
-  TESTING_PAGES,
   TESTING_UNSUPPORTED_COPY,
   type CorpusImportResult,
   type EvalReport,
@@ -463,40 +461,15 @@ export function TestingPage({ page, campaignId, runs, navigate }: {
 }): React.ReactElement {
   return (
     <div data-testid="testing-page" data-testing-page={page} className="flex flex-col">
+      {/* Test and Evals are now SEPARATE rail sections (usability wave), so the header is just the
+          section name — no "Testing ·" prefix and no sibling-tab strip (each is standalone). */}
       <div className="flex flex-col gap-4 px-6 pt-6">
         <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>
-          Testing · {TESTING_PAGE_LABELS[page]}
+          {TESTING_PAGE_LABELS[page]}
         </h2>
-
-        {/* The sub-page strip: real navigations — the SteeringPage tab grammar. Campaigns is
-            the landing; Evals stays the sibling page. */}
-        <nav data-testid="testing-tabs" aria-label="Testing pages" className="flex flex-wrap gap-1">
-          {TESTING_PAGES.map((p) => (
-            <a
-              key={p}
-              data-testid="testing-tab"
-              data-page={p}
-              href={testingPath(p)}
-              aria-current={p === page ? 'page' : undefined}
-              onClick={(e) => {
-                e.preventDefault();
-                navigate(testingPath(p));
-              }}
-              className="rounded px-2 py-1 text-[11px] font-semibold"
-              style={{
-                textDecoration: 'none',
-                color: p === page ? 'var(--ink-high)' : 'var(--ink-muted)',
-                background: p === page ? 'var(--surface-raised)' : 'transparent',
-                border: `1px solid ${p === page ? 'var(--surface-raised)' : 'transparent'}`,
-              }}
-            >
-              {TESTING_PAGE_LABELS[p]}
-            </a>
-          ))}
-        </nav>
       </div>
 
-      {/* Campaigns (the landing + scoreboard) keep their own internal padding and full width;
+      {/* Test (the recon landing + scoreboard) keeps its own internal padding and full width;
           Evals content shares this shell's gutter. */}
       {page === 'campaigns' ? (
         campaignId !== null ? (

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -16,6 +16,7 @@ import {
 import { useEvalReportStore } from '../store/evalReport.js';
 import { CampaignScoreboard } from './CampaignScoreboard.js';
 import { CampaignsPage } from './CampaignsPage.js';
+import { EvalHistory } from './EvalHistory.js';
 import { readFileText } from './fileText.js';
 
 /**
@@ -268,6 +269,8 @@ function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.Re
   const [state, setState] = useState<EvalsRunState>({ kind: 'idle' });
   const [corpusName, setCorpusName] = useState('');
   const [importState, setImportState] = useState<CorpusImportState>({ kind: 'idle' });
+  /** Bumped after a successful run so the persisted history (EvalHistory) re-fetches. */
+  const [historyKey, setHistoryKey] = useState(0);
 
   const run = async (): Promise<void> => {
     if (state.kind === 'busy') return;
@@ -279,8 +282,10 @@ function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.Re
         ...(corpusUsed !== null ? { corpus: corpusUsed } : {}),
       });
       setState({ kind: 'done', report, corpus: corpusUsed });
-      // Deposit for the Steering landing's success-lens tile (session-local — the
-      // daemon keeps no queryable eval history, so THIS is the latest-eval record).
+      // The daemon now PERSISTS every run (crew-side EvalRunStore) — refresh the history below so
+      // this run appears without a reload. The session-local deposit stays as the Steering landing's
+      // success-lens tile source (a zero-fetch latest-eval snapshot).
+      setHistoryKey((k) => k + 1);
       useEvalReportStore.getState().deposit(report, corpusUsed);
     } catch (e) {
       if (isTestingUnsupported(e)) setState({ kind: 'unsupported' });
@@ -445,6 +450,10 @@ function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.Re
           </p>
         )}
       </div>
+
+      {/* The persisted run history (crew-side EvalRunStore) — every run above is recorded here,
+          drillable. `historyKey` bumps on a successful run so it refreshes without a reload. */}
+      <EvalHistory refreshKey={historyKey} />
     </div>
   );
 }

--- a/src/components/dashboardKit.tsx
+++ b/src/components/dashboardKit.tsx
@@ -146,9 +146,12 @@ export function StatTile({
         <span
           data-testid="stat-value"
           style={{
-            fontSize: 'var(--text-2xl)', fontWeight: 'var(--weight-semi)',
+            fontSize: 'var(--text-2xl)', fontWeight: 'var(--weight-bold)',
             fontFamily: 'var(--font-mono)', fontVariantNumeric: 'tabular-nums',
-            lineHeight: 1.1, color: valueColor ?? 'var(--ink-high)',
+            lineHeight: 1.05, letterSpacing: '-0.02em', color: valueColor ?? 'var(--ink-high)',
+            // The command-deck signature: a subtle luminance on the metric so the number reads as
+            // live telemetry, not flat text (matches DeckKpiRibbon so home + sections are one look).
+            textShadow: '0 0 22px color-mix(in oklab, var(--ink-high) 11%, transparent)',
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           }}
         >
@@ -173,13 +176,17 @@ export function StatTile({
   const style: React.CSSProperties = {
     flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column',
     alignItems: 'stretch', gap: '4px', textAlign: 'left', textDecoration: 'none',
-    background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+    // Deck panel: a layered gradient + inset top-light + soft shadow (the DeckKpiRibbon material),
+    // so every section dashboard's KPI band reads like the landing's ribbon.
+    background: 'linear-gradient(180deg, var(--surface-card), var(--surface-rail))',
+    border: '1px solid var(--surface-raised)', boxShadow: 'var(--shadow-card)',
     borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
     cursor: onOpen !== undefined ? 'pointer' : 'default',
     color: 'inherit', font: 'inherit',
   };
   const common = {
     'data-testid': testId,
+    className: 'deck-stat',
     'data-value': String(value),
     ...(delta !== undefined
       ? { 'data-delta': delta.previous === null ? 'none' : String(delta.current - delta.previous) }

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -93,3 +93,24 @@
 .deck-vn.warn { color: var(--status-gate); }
 .deck-vn.bad { color: var(--status-fail); }
 .deck-vl { font-size: var(--text-xs); color: var(--ink-muted); }
+
+/* ── Section doors (the nav made legible on the landing) ── */
+.deck-doors { display: flex; gap: 10px; flex-wrap: wrap; }
+.deck-door {
+  flex: 1 1 0; min-width: 132px; display: flex; align-items: center; gap: 11px;
+  padding: 12px 14px; border-radius: var(--radius-lg); border: 1px solid var(--surface-raised);
+  cursor: pointer; text-decoration: none; color: inherit;
+  background: linear-gradient(180deg, var(--surface-rail), var(--surface-base));
+  transition: transform var(--dur-instant, 80ms) var(--ease-out), border-color var(--dur-fast, 120ms);
+}
+.deck-door:hover { border-color: var(--door-col, var(--accent)); transform: translateY(-1px); }
+.deck-door:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.deck-door-glyph {
+  width: 30px; height: 30px; border-radius: var(--radius-md); display: grid; place-items: center;
+  font-size: 14px; color: var(--door-col, var(--accent)); flex-shrink: 0;
+  background: color-mix(in oklab, var(--door-col, var(--accent)) 16%, transparent);
+  border: 1px solid var(--surface-raised);
+}
+.deck-door-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.deck-door-label { font-size: var(--text-xs); font-weight: var(--weight-semi); color: var(--ink-high); }
+.deck-door-count { font-size: 10.5px; color: var(--ink-muted); font-family: var(--font-mono); }

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -1,0 +1,75 @@
+/* deck.css — the Command Deck landing (DES-HOME-COMMAND-CENTER redesign).
+ *
+ * Built on the semantic tokens (tokens.css) so it rides both themes: surfaces from the surface
+ * ramp, the ONE accent for trust/primary, and the status hues (amber/red/emerald) SEMANTIC-only —
+ * never as the accent. The visual signature is the luminous metric ribbon; everything else stays
+ * quiet around it. */
+
+/* ── KPI ribbon: the hero ── */
+.deck-ribbon {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  margin: var(--space-5) 0 var(--space-6);
+}
+@media (max-width: 1080px) { .deck-ribbon { grid-template-columns: 1fr; } }
+
+.deck-group {
+  position: relative;
+  border-radius: var(--radius-xl);
+  padding: 15px 17px 16px;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 100% at 0% 0%, var(--deck-gtint, transparent), transparent 46%),
+    linear-gradient(180deg, var(--surface-card), var(--surface-rail));
+  border: 1px solid var(--surface-raised);
+  box-shadow: var(--shadow-card);
+}
+.deck-group::before {
+  content: '';
+  position: absolute; inset: 0 0 auto; height: 2px;
+  background: linear-gradient(90deg, var(--deck-gcol), transparent 72%);
+}
+.deck-group.flow  { --deck-gcol: var(--status-run);  --deck-gtint: color-mix(in oklab, var(--status-run) 12%, transparent); }
+.deck-group.attn  { --deck-gcol: var(--status-gate); --deck-gtint: color-mix(in oklab, var(--status-gate) 10%, transparent); }
+.deck-group.trust { --deck-gcol: var(--accent);      --deck-gtint: color-mix(in oklab, var(--accent) 14%, transparent); }
+
+.deck-ghead { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+.deck-tag {
+  font-size: var(--text-2xs); font-weight: var(--weight-bold);
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--deck-gcol);
+}
+.deck-glyph { color: var(--deck-gcol); font-size: 11px; filter: drop-shadow(0 0 6px currentColor); opacity: 0.9; }
+
+.deck-tiles { display: flex; gap: 14px; }
+.deck-tile {
+  flex: 1; min-width: 0; text-decoration: none; color: inherit; display: block;
+  border-radius: var(--radius-sm); transition: transform var(--dur-instant, 80ms) var(--ease-out);
+}
+.deck-tile.lead { flex: 1.15; }
+.deck-tile:hover { transform: translateY(-1px); }
+.deck-tile:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+.deck-lab {
+  font-size: var(--text-xs); color: var(--ink-muted); font-weight: var(--weight-medium);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.deck-val { display: flex; align-items: baseline; gap: 7px; margin-top: 5px; }
+.deck-big {
+  font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  font-size: 32px; font-weight: var(--weight-bold); color: var(--ink-high);
+  line-height: 0.95; letter-spacing: -0.02em;
+  text-shadow: 0 0 22px color-mix(in oklab, var(--ink-high) 12%, transparent);
+}
+.deck-unit { font-size: 13px; color: var(--ink-dim); font-family: var(--font-mono); font-weight: var(--weight-medium); }
+.deck-delta {
+  font-size: var(--text-xs); font-family: var(--font-mono); font-weight: var(--weight-semi);
+  display: inline-flex; align-items: center; gap: 2px; padding: 1px 5px; border-radius: var(--radius-sm);
+}
+.deck-delta.up { color: var(--status-run); background: var(--status-run-dim); }
+.deck-delta.down { color: var(--status-fail); background: var(--status-fail-dim); }
+.deck-delta.flat { color: var(--ink-dim); }
+.deck-spark { margin-top: 10px; height: 24px; }
+.deck-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; margin-top: 10px; background: var(--surface-raised); }
+.deck-bar i { display: block; height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-dim));
+  box-shadow: 0 0 10px color-mix(in oklab, var(--accent) 50%, transparent); }
+.deck-sub { font-size: 10.5px; color: var(--ink-dim); margin-top: 7px; line-height: 1.4; }

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -120,3 +120,11 @@
 .deck-stat:hover { border-color: var(--accent-subtle); }
 a.deck-stat:hover, button.deck-stat:hover { transform: translateY(-1px); border-color: var(--accent-dim); }
 .deck-stat:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* ── Live-pulse burn chart ── */
+.deck-pulse { display: flex; flex-direction: column; gap: 6px; padding: 4px 2px 8px; }
+.deck-pulse-head { display: flex; align-items: baseline; justify-content: space-between; }
+.deck-pulse-t { font-size: var(--text-xs); color: var(--ink-muted); font-weight: var(--weight-medium); }
+.deck-pulse-v { font-family: var(--font-mono); font-size: var(--text-md); color: var(--ink-high); font-weight: var(--weight-bold); font-variant-numeric: tabular-nums; }
+.deck-pulse-v small { color: var(--ink-dim); font-weight: var(--weight-normal); font-size: var(--text-xs); }
+.deck-pulse-chart { width: 100%; height: 96px; display: block; }

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -114,3 +114,9 @@
 .deck-door-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .deck-door-label { font-size: var(--text-xs); font-weight: var(--weight-semi); color: var(--ink-high); }
 .deck-door-count { font-size: 10.5px; color: var(--ink-muted); font-family: var(--font-mono); }
+
+/* ── Shared StatTile, elevated to the deck material (applies to every section dashboard) ── */
+.deck-stat { transition: transform var(--dur-instant, 80ms) var(--ease-out), border-color var(--dur-fast, 120ms); }
+.deck-stat:hover { border-color: var(--accent-subtle); }
+a.deck-stat:hover, button.deck-stat:hover { transform: translateY(-1px); border-color: var(--accent-dim); }
+.deck-stat:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -73,3 +73,23 @@
 .deck-bar i { display: block; height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-dim));
   box-shadow: 0 0 10px color-mix(in oklab, var(--accent) 50%, transparent); }
 .deck-sub { font-size: 10.5px; color: var(--ink-dim); margin-top: 7px; line-height: 1.4; }
+
+/* ── Verified / needs-review strip ── */
+.deck-vrbar {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px;
+  background: var(--surface-raised); border: 1px solid var(--surface-raised);
+  border-radius: var(--radius-lg); overflow: hidden; margin-top: var(--space-4);
+  box-shadow: var(--shadow-card);
+}
+.deck-vrcell {
+  background: linear-gradient(180deg, var(--surface-rail), var(--surface-base));
+  padding: 13px 15px; display: flex; flex-direction: column; gap: 3px;
+  text-decoration: none; color: inherit; transition: background var(--dur-fast, 120ms) var(--ease-out);
+}
+.deck-vrcell:hover { background: var(--surface-card); }
+.deck-vrcell:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.deck-vn { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: 22px; font-weight: var(--weight-bold); letter-spacing: -0.01em; }
+.deck-vn.ok { color: var(--status-run); text-shadow: 0 0 16px color-mix(in oklab, var(--status-run) 28%, transparent); }
+.deck-vn.warn { color: var(--status-gate); }
+.deck-vn.bad { color: var(--status-fail); }
+.deck-vl { font-size: var(--text-xs); color: var(--ink-muted); }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,6 +11,7 @@
 @import './tokens.css';
 @import './themes/dark.css';
 @import './themes/light.css';
+@import './deck.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -67,6 +67,15 @@
   --status-done:      var(--_ink-a35);
   --status-done-dim:  transparent;
 
+  /* ── Section-identity accents (§2.6b) — the landing's section doors + rail glyphs. Distinct
+     from the ONE customizable accent and from the status hues: fixed section colors so Execute /
+     Test / Vibe / Demo / Evals / Steering read apart at a glance. Mid-lightness, legible on both
+     grounds (defined once here). Execute reuses the running-emerald, Evals the gate-amber, Steering
+     the accent; Test / Vibe / Demo get their own hues. */
+  --section-test: hsl(168 62% 55%);   /* teal */
+  --section-vibe: hsl(198 80% 62%);   /* cyan */
+  --section-demo: hsl(320 70% 66%);   /* magenta */
+
   /* ── Spacing scale (§2.7) — base unit 4px ── */
   --space-1: 4px;   --space-2: 8px;   --space-3: 12px;  --space-4: 16px;
   --space-5: 20px;  --space-6: 24px;  --space-8: 32px;  --space-10: 40px;

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.15",
   "counts": {
-    "files": 123,
-    "occurrences": 1010,
-    "static": 856,
+    "files": 124,
+    "occurrences": 1012,
+    "static": 857,
     "dynamic": 56,
     "computed": 6
   },
@@ -2049,6 +2049,12 @@
       "testId": "home-essence",
       "files": [
         "src/components/HomeCommand.tsx"
+      ]
+    },
+    {
+      "testId": "home-kpis",
+      "files": [
+        "src/components/DeckKpiRibbon.tsx"
       ]
     },
     {
@@ -5544,6 +5550,7 @@
         "src/components/AppearanceSettings.tsx",
         "src/components/ChatPanel.tsx",
         "src/components/DashboardTiles.tsx",
+        "src/components/DeckKpiRibbon.tsx",
         "src/components/FacetAutocomplete.tsx",
         "src/components/HomeCommand.tsx",
         "src/components/MetricTile.tsx",

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.15",
   "counts": {
     "files": 125,
-    "occurrences": 1016,
-    "static": 861,
+    "occurrences": 1019,
+    "static": 863,
     "dynamic": 56,
     "computed": 6
   },
@@ -3227,6 +3227,12 @@
       ]
     },
     {
+      "testId": "rail-divider",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
       "testId": "rail-doc",
       "files": [
         "src/components/LeftSidebar.tsx"
@@ -3319,6 +3325,12 @@
     },
     {
       "testId": "rail-steering-section",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
+      "testId": "rail-test-recon",
       "files": [
         "src/components/LeftSidebar.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.15",
   "counts": {
-    "files": 125,
-    "occurrences": 1017,
-    "static": 861,
+    "files": 126,
+    "occurrences": 1024,
+    "static": 868,
     "dynamic": 56,
     "computed": 6
   },
@@ -1491,6 +1491,48 @@
       "testId": "essence-entry",
       "files": [
         "src/components/HomeCommand.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-detail",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-empty",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-error",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-loading",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-row",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-unavailable",
+      "files": [
+        "src/components/EvalHistory.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.15",
   "counts": {
-    "files": 126,
-    "occurrences": 1024,
-    "static": 868,
+    "files": 127,
+    "occurrences": 1026,
+    "static": 870,
     "dynamic": 56,
     "computed": 6
   },
@@ -2124,6 +2124,12 @@
       ]
     },
     {
+      "testId": "home-section-doors",
+      "files": [
+        "src/components/DeckSectionDoors.tsx"
+      ]
+    },
+    {
       "testId": "home-verb-project",
       "files": [
         "src/components/HomeCommand.tsx"
@@ -3751,6 +3757,12 @@
       "testId": "seat-state",
       "files": [
         "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "section-door",
+      "files": [
+        "src/components/DeckSectionDoors.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.15",
   "counts": {
-    "files": 124,
-    "occurrences": 1012,
-    "static": 857,
+    "files": 125,
+    "occurrences": 1016,
+    "static": 861,
     "dynamic": 56,
     "computed": 6
   },
@@ -1224,6 +1224,24 @@
       ]
     },
     {
+      "testId": "delivery-stranded",
+      "files": [
+        "src/components/DeckVerifiedStrip.tsx"
+      ]
+    },
+    {
+      "testId": "delivery-vacuous",
+      "files": [
+        "src/components/DeckVerifiedStrip.tsx"
+      ]
+    },
+    {
+      "testId": "delivery-verified",
+      "files": [
+        "src/components/DeckVerifiedStrip.tsx"
+      ]
+    },
+    {
       "testId": "demo-picker",
       "files": [
         "src/components/VideoStoryboard.tsx"
@@ -2043,6 +2061,12 @@
       "testId": "home-calm",
       "files": [
         "src/components/NeedsYouQueue.tsx"
+      ]
+    },
+    {
+      "testId": "home-delivery-strip",
+      "files": [
+        "src/components/DeckVerifiedStrip.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.15",
   "counts": {
     "files": 125,
-    "occurrences": 1019,
-    "static": 863,
+    "occurrences": 1017,
+    "static": 861,
     "dynamic": 56,
     "computed": 6
   },
@@ -4659,18 +4659,6 @@
       "testId": "testing-recon-open",
       "files": [
         "src/components/CampaignsPage.tsx"
-      ]
-    },
-    {
-      "testId": "testing-tab",
-      "files": [
-        "src/components/TestingPage.tsx"
-      ]
-    },
-    {
-      "testId": "testing-tabs",
-      "files": [
-        "src/components/TestingPage.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.4.15",
   "counts": {
     "files": 128,
-    "occurrences": 1028,
-    "static": 872,
+    "occurrences": 1029,
+    "static": 873,
     "dynamic": 56,
     "computed": 6
   },
@@ -1507,6 +1507,12 @@
     },
     {
       "testId": "eval-history-detail",
+      "files": [
+        "src/components/EvalHistory.tsx"
+      ]
+    },
+    {
+      "testId": "eval-history-detail-error",
       "files": [
         "src/components/EvalHistory.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.4.15",
   "counts": {
-    "files": 127,
-    "occurrences": 1026,
-    "static": 870,
+    "files": 128,
+    "occurrences": 1028,
+    "static": 872,
     "dynamic": 56,
     "computed": 6
   },
@@ -509,6 +509,12 @@
       "testId": "burn-rework",
       "files": [
         "src/components/Burn.tsx"
+      ]
+    },
+    {
+      "testId": "burn-total",
+      "files": [
+        "src/components/DeckBurnChart.tsx"
       ]
     },
     {
@@ -2097,6 +2103,12 @@
       "testId": "home-ask",
       "files": [
         "src/components/HomeCommand.tsx"
+      ]
+    },
+    {
+      "testId": "home-burn-chart",
+      "files": [
+        "src/components/DeckBurnChart.tsx"
       ]
     },
     {

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -72,11 +72,11 @@ describe('the §1.5 probe states', () => {
     expect(screen.getByTestId('testing-author-open')).toBeInTheDocument();
   });
 
-  it('200 with empty lists is the "no campaigns yet" answer, with a CTA that opens the New campaign flow', async () => {
+  it('200 with empty lists is the "no tests yet" answer, with a CTA that opens the New test flow', async () => {
     listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     page();
     await waitFor(() => expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument());
-    expect(screen.getByTestId('campaigns-empty').textContent).toContain('launch a run with a campaign label');
+    expect(screen.getByTestId('campaigns-empty').textContent).toContain('run recon over a codebase');
     fireEvent.click(screen.getByTestId('campaigns-empty-cta'));
     expect(await screen.findByTestId('testing-launch-panel')).toHaveAttribute('data-intent', 'campaign');
   });

--- a/tests/DeckBurnChart.test.tsx
+++ b/tests/DeckBurnChart.test.tsx
@@ -1,0 +1,31 @@
+// The live-pulse burn chart — cumulative session spend from the /ws cliUsage frames (burnSteps).
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useRuntimeStore } from '../src/store/runtime.js';
+import { DeckBurnChart } from '../src/components/DeckBurnChart.js';
+
+afterEach(cleanup);
+
+describe('DeckBurnChart', () => {
+  it('shows the session spend total + a curve once cliUsage frames arrive', () => {
+    useRuntimeStore.setState({
+      logs: {
+        'run-a': [
+          { seq: 1, type: 'cliUsage', ts: 1000, costUsd: 0.5, detail: 'usage $0.50' },
+          { seq: 2, type: 'cliUsage', ts: 2000, costUsd: 0.7, detail: 'usage $0.70' },
+        ],
+      } as never,
+    });
+    render(<DeckBurnChart />);
+    expect(screen.getByTestId('burn-total').textContent).toContain('$1.20');
+    expect(screen.getByTestId('home-burn-chart').querySelector('polyline')).not.toBeNull();
+  });
+
+  it('honestly shows no usage when nothing has burned this session', () => {
+    useRuntimeStore.setState({ logs: {} });
+    render(<DeckBurnChart />);
+    expect(screen.getByTestId('burn-total').textContent).toContain('no usage yet');
+    expect(screen.getByTestId('home-burn-chart').querySelector('polyline')).toBeNull();
+  });
+});

--- a/tests/DeckKpiRibbon.test.tsx
+++ b/tests/DeckKpiRibbon.test.tsx
@@ -1,0 +1,59 @@
+// The command-deck KPI ribbon — time honesty on the real created_at clock, with a positional
+// fallback, plus the delivery/rework folds. (The layout/glow is CSS; these pin the DATA contract.)
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DeckKpiRibbon } from '../src/components/DeckKpiRibbon.js';
+import { makeView } from './factories.js';
+
+const NOW = 1_760_000_000_000;
+const DAY = 86_400_000;
+const secs = (ms: number): number => Math.floor(ms / 1000);
+
+afterEach(cleanup);
+
+function ribbon(runs: ReturnType<typeof makeView>[], claims: null = null, need = 0): void {
+  render(<DeckKpiRibbon runs={runs} claims={claims} needCount={need} navigate={() => {}} now={NOW} />);
+}
+
+describe('DeckKpiRibbon — real created_at windows', () => {
+  it('uses the REAL 30d window when runs are dated; a run outside it does not count as current', () => {
+    ribbon([
+      makeView({ id: 'a', status: 'completed', created_at: secs(NOW - 2 * DAY) }), // in window
+      makeView({ id: 'b', status: 'failed', created_at: secs(NOW - 5 * DAY) }), // in window
+      makeView({ id: 'c', status: 'completed', created_at: secs(NOW - 40 * DAY) }), // in the PRIOR window
+    ]);
+    const runsTile = screen.getByTestId('home-kpi-runs');
+    expect(runsTile).toHaveAttribute('data-value', '2'); // a + b in the current 30d window
+    expect(runsTile.textContent).toContain('30d');
+    // c sits in [now-60d, now-30d) → a real prior window ⇒ a real delta, not "no prior window".
+    expect(runsTile).toHaveAttribute('data-delta', 'up');
+    expect(screen.getByTestId('home-kpi-failed')).toHaveAttribute('data-value', '1');
+  });
+
+  it('falls back to the POSITIONAL window (label "last 30") when NO run carries created_at', () => {
+    ribbon([
+      makeView({ id: 'a', status: 'completed' }),
+      makeView({ id: 'b', status: 'failed' }),
+    ]);
+    const runsTile = screen.getByTestId('home-kpi-runs');
+    expect(runsTile).toHaveAttribute('data-value', '2');
+    expect(runsTile.textContent).toContain('last 30');
+  });
+
+  it('counts delivery outcomes (review = stranded + vacuous) and the rework rate', () => {
+    ribbon([
+      makeView({ id: 'a', status: 'completed', created_at: secs(NOW - DAY), delivery: 'delivered' }),
+      makeView({ id: 'b', status: 'completed', created_at: secs(NOW - DAY), delivery: 'stranded' }),
+      makeView({ id: 'c', status: 'completed', created_at: secs(NOW - DAY), delivery: 'vacuous' }),
+      makeView({ id: 'd', status: 'completed', created_at: secs(NOW - DAY), retry_of: 'a' }),
+    ]);
+    expect(screen.getByTestId('home-kpi-review')).toHaveAttribute('data-value', '2'); // stranded + vacuous
+    expect(screen.getByTestId('home-kpi-rework')).toHaveAttribute('data-value', '25%'); // 1 of 4
+  });
+
+  it('a governed tile reads honest "—" when the claims wire is absent', () => {
+    ribbon([makeView({ id: 'a', status: 'completed', created_at: secs(NOW - DAY) })], null);
+    expect(screen.getByTestId('home-kpi-governed')).toHaveAttribute('data-value', '—');
+  });
+});

--- a/tests/DeckVerifiedStrip.test.tsx
+++ b/tests/DeckVerifiedStrip.test.tsx
@@ -27,4 +27,18 @@ describe('DeckVerifiedStrip', () => {
     expect(screen.getByTestId('delivery-stranded').textContent).toContain('1');
     expect(screen.getByTestId('delivery-vacuous').textContent).toContain('1');
   });
+
+  it('counts the LEGACY 0.11–0.17 object delivery form as delivered (copilot #198)', () => {
+    render(
+      <DeckVerifiedStrip
+        runs={[
+          makeView({ id: 'a', delivery: 'delivered' }),
+          // A legacy daemon's object form ({kind:'pull_request', url}) — still a delivered PR.
+          makeView({ id: 'b', delivery: { kind: 'pull_request', url: 'https://x/pull/9' } as unknown as 'delivered' }),
+        ]}
+        navigate={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('delivery-verified').textContent).toContain('2');
+  });
 });

--- a/tests/DeckVerifiedStrip.test.tsx
+++ b/tests/DeckVerifiedStrip.test.tsx
@@ -1,0 +1,30 @@
+// The verified-vs-needs-review strip — the delivery split off the run DTO, one fold shared with the
+// ribbon's ATTENTION tile.
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DeckVerifiedStrip } from '../src/components/DeckVerifiedStrip.js';
+import { makeView } from './factories.js';
+
+afterEach(cleanup);
+
+describe('DeckVerifiedStrip', () => {
+  it('counts delivered / stranded / vacuous off the wire, ignoring other states + archived runs', () => {
+    render(
+      <DeckVerifiedStrip
+        runs={[
+          makeView({ id: 'a', delivery: 'delivered' }),
+          makeView({ id: 'b', delivery: 'delivered' }),
+          makeView({ id: 'c', delivery: 'stranded' }),
+          makeView({ id: 'd', delivery: 'vacuous' }),
+          makeView({ id: 'e', delivery: 'none' }),
+          makeView({ id: 'f', delivery: 'delivered', archived_at: 1 }), // archived → excluded
+        ]}
+        navigate={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('delivery-verified').textContent).toContain('2');
+    expect(screen.getByTestId('delivery-stranded').textContent).toContain('1');
+    expect(screen.getByTestId('delivery-vacuous').textContent).toContain('1');
+  });
+});

--- a/tests/EvalHistory.test.tsx
+++ b/tests/EvalHistory.test.tsx
@@ -1,0 +1,61 @@
+// The eval-run history (crew-side EvalRunStore wiring) — the Evals section's real list + drilldown.
+
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const listEvalRuns = vi.fn();
+const getEvalRun = vi.fn();
+vi.mock('../src/api/testing.js', () => ({ listEvalRuns: () => listEvalRuns(), getEvalRun: (id: string) => getEvalRun(id) }));
+vi.mock('../src/api/errors.js', () => ({ isRouteAbsent: (e: unknown) => e instanceof Error && e.message === '404' }));
+
+const { EvalHistory } = await import('../src/components/EvalHistory.js');
+
+afterEach(cleanup);
+
+const NOW = 1_760_000_000_000;
+const row = (over = {}) => ({
+  id: 'run-1', created_at: Math.floor(NOW / 1000) - 120, actor: 'mikeparcewski',
+  corpus: null, type_filter: null, rule_store: '/x/core.db',
+  summary: { total: 3, caught: 1, gaps: 1, false_positives: 1 },
+  per_type: {}, degraded: null, ...over,
+});
+
+describe('EvalHistory', () => {
+  it('lists recorded runs with their rollup, newest-first from the store', async () => {
+    listEvalRuns.mockResolvedValue([row({ id: 'run-1', corpus: 'evals:dev', type_filter: 'security' })]);
+    render(<EvalHistory now={NOW} />);
+    await waitFor(() => expect(screen.getByTestId('eval-history')).toBeInTheDocument());
+    const r = screen.getByTestId('eval-history-row');
+    expect(r.textContent).toContain('evals:dev');
+    expect(r.textContent).toContain('security');
+    expect(r.textContent).toContain('1'); // caught/gaps/fp counts render
+  });
+
+  it('drills into a run: clicking a row loads its full results', async () => {
+    listEvalRuns.mockResolvedValue([row()]);
+    getEvalRun.mockResolvedValue({
+      ...row(),
+      results: [
+        { sample: { id: 'S-2', description: 'ships a migration with no review', kind: 'bad', steering_type: 'development' }, expected: 'deny', fired: [], verdict: 'gap' },
+      ],
+    });
+    render(<EvalHistory now={NOW} />);
+    await waitFor(() => expect(screen.getByTestId('eval-history-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('eval-history-row').querySelector('button')!);
+    await waitFor(() => expect(screen.getByTestId('eval-history-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('eval-history-detail').textContent).toContain('ships a migration with no review');
+    expect(getEvalRun).toHaveBeenCalledWith('run-1');
+  });
+
+  it('an empty store shows the honest empty state', async () => {
+    listEvalRuns.mockResolvedValue([]);
+    render(<EvalHistory now={NOW} />);
+    await waitFor(() => expect(screen.getByTestId('eval-history-empty')).toBeInTheDocument());
+  });
+
+  it('a daemon that predates the store (404) shows the unavailable note, not an error', async () => {
+    listEvalRuns.mockRejectedValue(new Error('404'));
+    render(<EvalHistory now={NOW} />);
+    await waitFor(() => expect(screen.getByTestId('eval-history-unavailable')).toBeInTheDocument());
+  });
+});

--- a/tests/EvalHistory.test.tsx
+++ b/tests/EvalHistory.test.tsx
@@ -47,6 +47,15 @@ describe('EvalHistory', () => {
     expect(getEvalRun).toHaveBeenCalledWith('run-1');
   });
 
+  it('a failed detail fetch shows an error, not an endless "Loading…" (copilot #198)', async () => {
+    listEvalRuns.mockResolvedValue([row()]);
+    getEvalRun.mockRejectedValue(new Error('boom'));
+    render(<EvalHistory now={NOW} />);
+    await waitFor(() => expect(screen.getByTestId('eval-history-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('eval-history-row').querySelector('button')!);
+    await waitFor(() => expect(screen.getByTestId('eval-history-detail-error')).toBeInTheDocument());
+  });
+
   it('an empty store shows the honest empty state', async () => {
     listEvalRuns.mockResolvedValue([]);
     render(<EvalHistory now={NOW} />);

--- a/tests/HomeBoard.command.test.tsx
+++ b/tests/HomeBoard.command.test.tsx
@@ -146,7 +146,7 @@ describe('HomeBoard — the portfolio KPI band', () => {
   });
 });
 
-describe('HomeBoard — the section essence strip', () => {
+describe('HomeBoard — the section doors', () => {
   beforeEach(() => {
     projects = [{ id: 'p-1', name: 'proj', description: null, status: 'active', scope: 's', created_at: 1, updated_at: 1 }];
     repos = [{ id: 'repo-1', name: 'a' }, { id: 'repo-2', name: 'b' }];
@@ -175,46 +175,42 @@ describe('HomeBoard — the section essence strip', () => {
 
   afterEach(() => cleanup());
 
-  it('one number + one door per ANSWERED section — repos ride the board read', async () => {
-    // The repos' newest state is "never onboarded", which also queues rows —
-    // give each repo a completed onboard so the strip is what's under test.
-    await mountBoard([
-      makeView({ id: 'r-ob1', status: 'completed', workflow_id: 'onboarding', repo_ref: 'repo-1' }),
-      makeView({ id: 'r-ob2', status: 'completed', workflow_id: 'onboarding', repo_ref: 'repo-2' }),
-    ]);
+  it('renders the six section doors (the Execute/Test/Vibe/Demo/Evals/Steering breakout) with live counts', async () => {
+    // campaignsAnswer stays [] (the beforeEach default): an ANSWERED wire, so Test shows "0 tests".
+    await mountBoard([makeView({ id: 'r-1', status: 'completed' })]);
     await vi.waitFor(() => {
-      const strip = screen.getByTestId('home-essence');
+      const doors = screen.getByTestId('home-section-doors');
       const bySection = new Map(
-        within(strip).getAllByTestId('essence-entry').map((e) => [e.getAttribute('data-section'), e]),
+        within(doors).getAllByTestId('section-door').map((d) => [d.getAttribute('data-section'), d]),
       );
-      expect(bySection.get('projects')).toHaveAttribute('data-value', '1');
-      expect(bySection.get('chats')).toHaveAttribute('data-value', '2');
-      expect(bySection.get('repos')).toHaveAttribute('data-value', '2');
-      expect(bySection.get('campaigns')).toHaveAttribute('data-value', '0');
-      expect(bySection.get('steering')).toHaveAttribute('data-value', '2 rules · 1 unused');
-      expect(bySection.get('daemon')).toHaveAttribute('data-value', 'crew 0.7.7 · up 2h');
-      expect(bySection.get('projects')).toHaveAttribute('href', '/projects');
-      expect(bySection.get('steering')).toHaveAttribute('href', '/steering');
+      expect([...bySection.keys()].sort()).toEqual(['demo', 'evals', 'execute', 'steering', 'test', 'vibe']);
+      // Execute always has a count (runs, no wire needed); wired sections carry theirs.
+      expect(bySection.get('execute')?.textContent).toContain('1 run');
+      expect(bySection.get('test')?.textContent).toContain('0 tests');
+      expect(bySection.get('steering')?.textContent).toContain('3 rules'); // 2 active + 1 retired
+      // Each door links its section (the Make-breakout routes).
+      expect(bySection.get('execute')).toHaveAttribute('href', '/execute');
+      expect(bySection.get('test')).toHaveAttribute('href', '/testing/campaigns');
+      expect(bySection.get('evals')).toHaveAttribute('href', '/testing/evals');
+      expect(bySection.get('steering')).toHaveAttribute('href', '/steering/dashboard');
     });
   });
 
-  it('an absent wire is an OMITTED entry — never a fabricated zero', async () => {
-    chats = new Error('no /chats on this daemon');
+  it('an absent wire → the door still renders, but shows NO count (never a fabricated zero)', async () => {
     campaignsAnswer = new Error('404');
     rules = new Error('404');
-    diagAnswer = new Error('404');
     await mountBoard([makeView({ id: 'r-a', status: 'executing' })]);
-    // Let the wires settle (they all reject asynchronously).
-    await vi.waitFor(() => {
-      expect(screen.getByTestId('home-essence')).toBeInTheDocument();
-    });
-    const sections = screen.getAllByTestId('essence-entry').map((e) => e.getAttribute('data-section'));
-    expect(sections).toContain('projects');
-    expect(sections).toContain('repos');
-    expect(sections).not.toContain('chats');
-    expect(sections).not.toContain('campaigns');
-    expect(sections).not.toContain('steering');
-    expect(sections).not.toContain('daemon');
+    await vi.waitFor(() => expect(screen.getByTestId('home-section-doors')).toBeInTheDocument());
+    const doors = screen.getByTestId('home-section-doors');
+    const bySection = new Map(
+      within(doors).getAllByTestId('section-door').map((d) => [d.getAttribute('data-section'), d]),
+    );
+    // Every door still renders (they always link), but the ones whose wire 404'd carry no count.
+    expect([...bySection.keys()].length).toBe(6);
+    expect(bySection.get('test')?.querySelector('.deck-door-count')).toBeNull();
+    expect(bySection.get('steering')?.querySelector('.deck-door-count')).toBeNull();
+    // Execute's count needs no wire — it's always there.
+    expect(bySection.get('execute')?.textContent).toContain('1 run');
   });
 });
 

--- a/tests/HomeBoard.command.test.tsx
+++ b/tests/HomeBoard.command.test.tsx
@@ -127,7 +127,7 @@ describe('HomeBoard — the portfolio KPI band', () => {
     await vi.waitFor(() => {
       expect(screen.getByTestId('home-kpi-governed')).toHaveAttribute('data-value', '18%');
     });
-    expect(screen.getByTestId('home-kpi-governed').textContent).toContain('2 of 11');
+    expect(screen.getByTestId('home-kpi-governed').textContent).toContain('2/11');
   });
 
   it('a daemon without the claims wire gets an honest "—" governed tile', async () => {
@@ -135,14 +135,14 @@ describe('HomeBoard — the portfolio KPI band', () => {
     await mountBoard(RUNS);
     const tile = screen.getByTestId('home-kpi-governed');
     expect(tile).toHaveAttribute('data-value', '—');
-    expect(tile.textContent).toContain('not served by this daemon');
+    expect(tile.textContent).toContain('not served');
   });
 
   it('no terminal runs in the window ⇒ success rate has no verdict, no color', async () => {
     await mountBoard([makeView({ id: 'r-a', status: 'executing' })]);
     const tile = screen.getByTestId('home-kpi-success');
     expect(tile).toHaveAttribute('data-value', '—');
-    expect(tile.textContent).toContain('no finished runs in the window');
+    expect(tile.textContent).toContain('no finished runs');
   });
 });
 

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -57,7 +57,7 @@ const W2_ORDERED = [
   bp('scratch', 'quiet', 0),
 ];
 
-const HEADING_KEYS = ['projects', 'execute', 'vibe', 'demo', 'testing', 'chat', 'repos', 'steering', 'settings'] as const;
+const HEADING_KEYS = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'steering', 'testing', 'settings'] as const;
 
 function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
   return render(
@@ -110,8 +110,12 @@ describe('the route→heading map (§3.2)', () => {
     for (const p of ['/steering', '/steering/policies', '/steering/memories', '/steering/security', '/wiki', '/rules', '/policies', '/proposals']) {
       expect(headingForPath(p)).toBe('steering');
     }
-    // Evals (key stays `testing`) owns its routes AND the retired flat /campaigns addresses.
-    for (const p of ['/testing/harness', '/testing/evals', '/testing/campaigns', '/testing/campaigns/c-1', '/campaigns', '/campaigns/c-1']) {
+    // The /testing surface splits: Test owns campaigns/recon (+ the retired flat /campaigns
+    // addresses), Evals (key stays `testing`) owns the eval runner + bare /testing + the retired harness.
+    for (const p of ['/testing/campaigns', '/testing/campaigns/c-1', '/campaigns', '/campaigns/c-1']) {
+      expect(headingForPath(p)).toBe('test');
+    }
+    for (const p of ['/testing', '/testing/harness', '/testing/evals']) {
       expect(headingForPath(p)).toBe('testing');
     }
     expect(headingForPath('/')).toBeNull();
@@ -120,8 +124,8 @@ describe('the route→heading map (§3.2)', () => {
   });
 });
 
-describe('the nine heading rows (§3.1 + nav-reorg)', () => {
-  it('renders all nine headings; Settings is icon-less, Steering carries ▦ only, the rest carry ▦ and ＋', async () => {
+describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
+  it('renders all ten headings; Settings is icon-less, Steering carries ▦ only, the rest carry ▦ and ＋', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
@@ -142,27 +146,30 @@ describe('the nine heading rows (§3.1 + nav-reorg)', () => {
       expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
     }
-    // Every other heading carries both ▦ and ＋ — including Evals (the normalized Test section).
-    for (const k of ['projects', 'execute', 'vibe', 'demo', 'testing', 'chat', 'repos']) {
+    // Every other heading carries both ▦ and ＋ — including Test and Evals.
+    for (const k of ['projects', 'execute', 'test', 'vibe', 'demo', 'testing', 'chat', 'repos']) {
       const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
       expect(within(h).getByTestId('heading-new')).toBeInTheDocument();
     }
   });
 
-  it('order: Projects → Execute → Vibe → Demo → Evals → Chat → Repos → Steering → Settings', async () => {
+  it('order: Projects → Execute → Test → Vibe → Demo → Chat → Repos ┃ Steering → Evals ┃ Settings', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     const el = (k: string): HTMLElement => screen.getByTestId(`rail-heading-${k}`);
-    expect(el('projects').nextElementSibling).toBe(el('execute'));
-    expect(el('execute').nextElementSibling).toBe(el('vibe'));
-    expect(el('vibe').nextElementSibling).toBe(el('demo'));
-    expect(el('demo').nextElementSibling).toBe(el('testing'));
-    expect(el('testing').nextElementSibling).toBe(el('chat'));
-    expect(el('chat').nextElementSibling).toBe(el('repos'));
-    expect(el('repos').nextElementSibling).toBe(el('steering'));
-    expect(el('steering').nextElementSibling).toBe(el('settings'));
+    // Dividers now sit between the work sections, Steering/Evals and Settings, so check DOCUMENT
+    // order (compareDocumentPosition) rather than nextElementSibling — Test below Execute, Evals
+    // beside Steering.
+    const order = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'steering', 'testing', 'settings'];
+    for (let i = 0; i < order.length - 1; i += 1) {
+      const rel = el(order[i]!).compareDocumentPosition(el(order[i + 1]!));
+      expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+    // Evals sits AFTER Steering (moved there), and Test sits AFTER Execute.
+    expect(el('steering').compareDocumentPosition(el('testing')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(el('execute').compareDocumentPosition(el('test')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('the promoted headings are labelled Execute / Vibe / Demo, and the Test section is labelled Evals', async () => {
@@ -452,15 +459,15 @@ describe('accordion contents (§3.3)', () => {
 });
 
 describe('the collapsed rail (§3.2)', () => {
-  it('shows exactly nine glyph links (Evals → its runner, Steering → its Dashboard, Settings → /system)', async () => {
+  it('shows exactly ten glyph links (Evals → its runner, Steering → its Dashboard, Settings → /system)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
-    expect(glyphs).toHaveLength(9);
+    expect(glyphs).toHaveLength(10);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/execute', '/vibe', '/demo', '/testing/evals', '/chats', '/repos', '/steering/dashboard', '/system',
+      '/projects', '/execute', '/testing/campaigns', '/vibe', '/demo', '/chats', '/repos', '/steering/dashboard', '/testing/evals', '/system',
     ]);
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();
   });

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -182,7 +182,7 @@ describe('countByType — the landing count fold, pinned to agree with the pages
   it('folds absent/out-of-enum steering_type to architecture and splits active/retired', () => {
     const counts = countByType([
       rule(),
-      rule({ id: 'PAT-009', steering_type: 'not-a-type' }),
+      rule({ id: 'PAT-009', steering_type: 'not-a-type' as SteeringType }),
       rule({ id: 'PAT-010', retired: true }),
       rule({ id: 'POL-100', steering_type: 'security' }),
     ]);
@@ -255,7 +255,7 @@ describe('filterSteeringRules — the page-scope + facet predicate, pinned', () 
   });
 
   it('an out-of-enum steering_type folds to architecture rather than vanishing from all pages', () => {
-    const odd = rule({ id: 'PAT-009', steering_type: 'not-a-type' });
+    const odd = rule({ id: 'PAT-009', steering_type: 'not-a-type' as SteeringType });
     expect(filterSteeringRules([odd], 'architecture', f()).map((r) => r.id)).toEqual(['PAT-009']);
   });
 

--- a/tests/SteeringPage.test.tsx
+++ b/tests/SteeringPage.test.tsx
@@ -182,7 +182,7 @@ describe('countByType — the landing count fold, pinned to agree with the pages
   it('folds absent/out-of-enum steering_type to architecture and splits active/retired', () => {
     const counts = countByType([
       rule(),
-      rule({ id: 'PAT-009', steering_type: 'not-a-type' as SteeringType }),
+      rule({ id: 'PAT-009', steering_type: 'not-a-type' as unknown as SteeringType }),
       rule({ id: 'PAT-010', retired: true }),
       rule({ id: 'POL-100', steering_type: 'security' }),
     ]);
@@ -255,7 +255,7 @@ describe('filterSteeringRules — the page-scope + facet predicate, pinned', () 
   });
 
   it('an out-of-enum steering_type folds to architecture rather than vanishing from all pages', () => {
-    const odd = rule({ id: 'PAT-009', steering_type: 'not-a-type' as SteeringType });
+    const odd = rule({ id: 'PAT-009', steering_type: 'not-a-type' as unknown as SteeringType });
     expect(filterSteeringRules([odd], 'architecture', f()).map((r) => r.id)).toEqual(['PAT-009']);
   });
 

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -243,7 +243,7 @@ describe('deliveryOf — five mutually exclusive states, zero fetches', () => {
   it('reads the server-carried url when the daemon carries one (crew#321)', () => {
     const view = composed('done');
     const session = { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } };
-    expect(deliveryOf({ ...view, session: session as typeof view.session }).url)
+    expect(deliveryOf({ ...view, session: session as unknown as typeof view.session }).url)
       .toBe('https://x/pull/9');
   });
 });
@@ -286,7 +286,7 @@ describe('resolveDelivery — the PR claim needs a URL IN HAND (D1/D2)', () => {
   it('a WIRE-carried url earns it with no read at all (crew#321)', () => {
     const view = composed('done');
     const session = { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } };
-    const r = resolveDelivery(deliveryOf({ ...view, session: session as typeof view.session }));
+    const r = resolveDelivery(deliveryOf({ ...view, session: session as unknown as typeof view.session }));
     expect(r.claim).toBe('pr-open');
     expect(r.href).toBe('https://x/pull/9');
   });
@@ -300,7 +300,7 @@ describe('resolveDelivery — the PR claim needs a URL IN HAND (D1/D2)', () => {
     // exported and takes a hand-built `Delivery`).
     const view = composed('done');
     const session = { ...view.session, delivery: { kind: 'pull_request', url: '' } };
-    expect(deliveryOf({ ...view, session: session as typeof view.session }).url).toBeNull();
+    expect(deliveryOf({ ...view, session: session as unknown as typeof view.session }).url).toBeNull();
 
     const hand = { state: 'delivered' as const, unitId: 'r:deliver', reason: null, url: '' };
     expect(resolveDelivery(hand).claim).toBe('delivered');
@@ -446,7 +446,7 @@ describe('deliverySummary — the census over ALL DELIVERABLE runs', () => {
     const view = composed('done');
     const withUrl = {
       ...view,
-      session: { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } } as typeof view.session,
+      session: { ...view.session, delivery: { kind: 'pull_request', url: 'https://x/pull/9' } } as unknown as typeof view.session,
     };
     expect(deliverySummary([withUrl, composed('done')])).toBe('1 PR open · 1 ran deliver');
   });

--- a/tests/steeringApi.test.ts
+++ b/tests/steeringApi.test.ts
@@ -15,6 +15,7 @@ import {
   STEERING_TYPES,
   steeringTypeOf,
   type SteeringRule,
+  type SteeringType,
 } from '../src/api/steering.js';
 
 /**
@@ -76,8 +77,8 @@ describe('STEERING_RULE_TEMPLATE engine-invariant conformance', () => {
 describe('steeringTypeOf — the serde-default fold, pinned', () => {
   it('absent and empty steering_type read as architecture (the engine default)', () => {
     expect(steeringTypeOf(rule())).toBe('architecture');
-    expect(steeringTypeOf(rule({ steering_type: '' }))).toBe('architecture');
-    expect(steeringTypeOf(rule({ steering_type: '  ' }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: '' as SteeringType }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: '  ' as SteeringType }))).toBe('architecture');
   });
 
   it('every enum value reads as itself', () => {
@@ -87,7 +88,7 @@ describe('steeringTypeOf — the serde-default fold, pinned', () => {
   });
 
   it('an out-of-enum value folds to architecture — never invisible on all seven pages', () => {
-    expect(steeringTypeOf(rule({ steering_type: 'bogus' }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: 'bogus' as SteeringType }))).toBe('architecture');
   });
 });
 

--- a/tests/steeringApi.test.ts
+++ b/tests/steeringApi.test.ts
@@ -77,8 +77,8 @@ describe('STEERING_RULE_TEMPLATE engine-invariant conformance', () => {
 describe('steeringTypeOf — the serde-default fold, pinned', () => {
   it('absent and empty steering_type read as architecture (the engine default)', () => {
     expect(steeringTypeOf(rule())).toBe('architecture');
-    expect(steeringTypeOf(rule({ steering_type: '' as SteeringType }))).toBe('architecture');
-    expect(steeringTypeOf(rule({ steering_type: '  ' as SteeringType }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: '' as unknown as SteeringType }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: '  ' as unknown as SteeringType }))).toBe('architecture');
   });
 
   it('every enum value reads as itself', () => {
@@ -88,7 +88,7 @@ describe('steeringTypeOf — the serde-default fold, pinned', () => {
   });
 
   it('an out-of-enum value folds to architecture — never invisible on all seven pages', () => {
-    expect(steeringTypeOf(rule({ steering_type: 'bogus' as SteeringType }))).toBe('architecture');
+    expect(steeringTypeOf(rule({ steering_type: 'bogus' as unknown as SteeringType }))).toBe('architecture');
   });
 });
 


### PR DESCRIPTION
## The command-deck landing rebuild + nav usability wave

A ground-up visual rebuild of the studio landing (mockup-approved) on **real** data, plus the rail usability changes and the eval-store wiring. Every zone is time-honest — the recon found the old landing was structurally a command-center but *faked* every time-number off proxy clocks; `created_at` (api-types 0.24.0) is the fix.

### Landing (the Command Deck)
- **KPI ribbon** — the hero: FLOW / ATTENTION / TRUST&SPEND themed groups with luminous mono numerals, deltas + sparklines on the **real `created_at` clock** (a true 30d window + prior-window delta), degrading to the positional window ("last 30") only when no run is dated yet.
- **Needs-you feed** with severity stripes; **verified-vs-needs-review** strip (delivery split, one fold shared with the ribbon); **live-pulse burn chart** (session spend from `/ws` cliUsage, honestly labeled); **section doors** (Execute/Test/Vibe/Demo/Evals/Steering with live counts); portfolio wall retained.

### Nav (the usability wave)
- **Test** split out below Execute — a standalone work section (project-optional, campaigns/recon), its terminology renamed from "Campaigns" to Test.
- **Evals** moved beside Steering (system concepts, glyph ◈); work/system dividers + Settings under a bar; the daemon health bar stays at the foot.

### Eval store wiring
- The Evals section now lists the persisted eval-run history (`GET /testing/evals[/:id]`, the store from crew #467) with drilldown; a live eval count feeds the landing's Evals door.

### Every section dashboard (change 1)
- The shared `dashboardKit` StatTile is reskinned to the deck material (gradient panel, glowing numeral, hover), so Execute / Vibe / Demo / Test / Projects / Steering all inherit the landing's look in one change — home and the sections are one visual system.

### Foundation
- Bumped `wicked-crew-api-types` 0.8.0 → **0.25.0** (published) and reconciled the accumulated drift (delivery string-union, `SteeringType`, `vacuous`). New tokens: `--section-{test,vibe,demo}`. All new deck CSS is token-built and rides both themes.

**Tests:** all green locally (2439). New suites cover the ribbon's real-vs-positional windows, delivery folds, section doors, eval history, burn chart, and the rail's 10-heading split.

**Follow-ups (noted, not in scope):** a proposals-pending needs-you row (needs `GET /proposals`); a durable per-run cost store for historical SPEND (api-types defers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
