### PR TITLE
fix(test-polish): campaign→test rename, project tests, deck section dashboards, memories stats, evals guidance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -492,7 +492,7 @@ export function App(): React.ReactElement {
               Campaigns
             </span>
           </div>
-          <CampaignsPage runs={runs} navigate={navigate} />
+          <CampaignsPage runs={runs} navigate={navigate} projectId={projectId} />
         </div>
       );
     }

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -565,7 +565,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
         testId="campaigns-filter"
         query={query}
         onQuery={setQuery}
-        placeholder="Search campaigns…"
+        placeholder="Search tests…"
         chips={chips}
         active={chip}
         onChip={(id) => setChip(id as CampaignChip)}

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -301,9 +301,11 @@ interface Props {
   /** The board's live run list — KPI windows, gate jumps and narration read it, zero extra fetches. */
   runs: SessionView[];
   navigate: (path: string) => void;
+  /** When rendered inside a project shell (`/p/:id/campaigns`), the project a new test auto-scopes to. */
+  projectId?: string | null;
 }
 
-export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
+export function CampaignsPage({ runs, navigate, projectId = null }: Props): React.ReactElement {
   const support = useCampaignsStore((s) => s.support);
   const campaigns = useCampaignsStore((s) => s.campaigns);
   const groups = useCampaignsStore((s) => s.groups);
@@ -451,6 +453,7 @@ export function CampaignsPage({ runs, navigate }: Props): React.ReactElement {
           navigate={navigate}
           onClose={() => setPanel(null)}
           onLaunched={() => void refresh()}
+          initialProjectId={projectId ?? undefined}
         />
       )}
       {/* The steering AuthorPanel, REUSED VERBATIM with this surface's type: the authoring run

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -956,8 +956,8 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         </span>
         <select
           data-testid="group-attach"
-          aria-label="File this run under a campaign or group"
-          title="Attach this launch to a campaign or an ad-hoc group — provenance only, the run executes unchanged"
+          aria-label="File this run under a test or group"
+          title="Attach this launch to a test or an ad-hoc group — provenance only, the run executes unchanged"
           className="rounded-lg px-2 py-1 text-[11px] font-mono"
           style={{
             background: 'var(--surface-card)',
@@ -971,7 +971,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         >
           <option value="">none</option>
           {knownCampaigns.length > 0 && (
-            <optgroup label="campaigns">
+            <optgroup label="tests">
               {knownCampaigns.map((c) => (
                 <option key={c.id} value={`c:${c.id}`}>
                   {c.def.name !== '' ? c.def.name : c.id}

--- a/src/components/HomeCommand.tsx
+++ b/src/components/HomeCommand.tsx
@@ -255,7 +255,7 @@ export function essenceEntries(inputs: {
   }
   out.push({ id: 'repos', label: 'Repos', value: String(inputs.repos.length), path: '/repos', title: 'Registered repositories' });
   if (inputs.campaigns !== null) {
-    out.push({ id: 'campaigns', label: 'Tests', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Test runs' });
+    out.push({ id: 'campaigns', label: 'Tests', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Governed tests (each groups its sibling runs)' });
   }
   if (inputs.rules !== null) {
     const unused = inputs.perRule !== null ? ruleUsage(inputs.rules, inputs.perRule).unusedIds.length : null;

--- a/src/components/HomeCommand.tsx
+++ b/src/components/HomeCommand.tsx
@@ -255,7 +255,7 @@ export function essenceEntries(inputs: {
   }
   out.push({ id: 'repos', label: 'Repos', value: String(inputs.repos.length), path: '/repos', title: 'Registered repositories' });
   if (inputs.campaigns !== null) {
-    out.push({ id: 'campaigns', label: 'Campaigns', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Test campaigns' });
+    out.push({ id: 'campaigns', label: 'Tests', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Test runs' });
   }
   if (inputs.rules !== null) {
     const unused = inputs.perRule !== null ? ruleUsage(inputs.rules, inputs.perRule).unusedIds.length : null;

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -883,7 +883,6 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             path={P_TESTING}
             open={openHeading === 'testing'}
             onToggle={() => toggle('testing')}
-            onNew={() => navigate(testingPath('evals'))}
             navigate={navigate}
           >
             <EvalsRailRows navigate={navigate} />

--- a/src/components/MemoriesPanel.tsx
+++ b/src/components/MemoriesPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from '../api/memory.js';
 import { FacetAutocomplete } from './FacetAutocomplete.js';
 import { KeyValueChips } from './ProposalChips.js';
+import { KpiBand, KpiGroup, StatTile } from './dashboardKit.js';
 
 /**
  * The Steering surface's MEMORIES sub-section (`/steering/memories`, DES-MEM-FACETED-001 unified
@@ -111,6 +112,16 @@ export function MemoriesPanel(): React.ReactElement {
   };
 
   const coverageTotal = typeof coverage?.total === 'number' ? coverage.total : null;
+  // Per-tier tiles (session / project / global / …) from the coverage wire — the store's shape at a
+  // glance, capped so the band stays a band. Absent → no tier group.
+  const tierTiles = useMemo(() => {
+    const byTier = coverage?.by_tier;
+    if (byTier === undefined || byTier === null) return [];
+    return Object.entries(byTier)
+      .filter(([, n]) => typeof n === 'number')
+      .slice(0, 3)
+      .map(([tier, n]) => <StatTile key={tier} testId={`mem-stat-tier-${tier}`} label={tier} value={n} />);
+  }, [coverage]);
 
   return (
     <div
@@ -140,6 +151,35 @@ export function MemoriesPanel(): React.ReactElement {
           Refresh
         </button>
       </div>
+
+      {/* The store stats — mirrors the Policies store-health band (usability wave): the memory
+          store's size, its per-tier split, and the distinct facet values it is annotated with. An
+          absent coverage wire omits the band rather than fabricating zeros. */}
+      {coverage !== null && (
+        <KpiBand testId="memories-stats">
+          <KpiGroup label="Store" grow={1}>
+            <StatTile
+              testId="mem-stat-total"
+              label="Memories"
+              value={coverageTotal ?? memories.length}
+              context="in the store"
+            />
+          </KpiGroup>
+          {tierTiles.length > 0 && (
+            <KpiGroup label="By tier" grow={Math.min(3, tierTiles.length)}>
+              {tierTiles}
+            </KpiGroup>
+          )}
+          <KpiGroup label="Annotation" grow={1}>
+            <StatTile
+              testId="mem-stat-facets"
+              label="Facet values"
+              value={facetPairs.length}
+              context="distinct key=value"
+            />
+          </KpiGroup>
+        </KpiBand>
+      )}
 
       {/* The store browser — search re-queries the wire; the facet chips narrow client-side. */}
       <div className="flex flex-wrap items-center gap-2">

--- a/src/components/MemoriesPanel.tsx
+++ b/src/components/MemoriesPanel.tsx
@@ -153,15 +153,16 @@ export function MemoriesPanel(): React.ReactElement {
       </div>
 
       {/* The store stats — mirrors the Policies store-health band (usability wave): the memory
-          store's size, its per-tier split, and the distinct facet values it is annotated with. An
-          absent coverage wire omits the band rather than fabricating zeros. */}
+          store's size and its per-tier split come from the store-wide coverage wire; the facet-value
+          count is over the loaded set (the current query/recall page), not store-wide — its context
+          says so. An absent coverage wire omits the band rather than fabricating zeros. */}
       {coverage !== null && (
         <KpiBand testId="memories-stats">
           <KpiGroup label="Store" grow={1}>
             <StatTile
               testId="mem-stat-total"
               label="Memories"
-              value={coverageTotal ?? memories.length}
+              value={coverageTotal ?? '—'}
               context="in the store"
             />
           </KpiGroup>
@@ -175,7 +176,7 @@ export function MemoriesPanel(): React.ReactElement {
               testId="mem-stat-facets"
               label="Facet values"
               value={facetPairs.length}
-              context="distinct key=value"
+              context="distinct key=value, loaded set"
             />
           </KpiGroup>
         </KpiBand>

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -373,14 +373,15 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
                 {MODE_LABEL[m]}
               </a>
             ))}
-            {/* The project-scoped Campaigns surface (nav-reorg) — re-homed under the project
-                shell at `/p/:id/campaigns`, not a fifth mode. */}
+            {/* The project-scoped Test surface (usability wave) — re-homed under the project shell
+                at `/p/:id/campaigns`, where "New test" / "Run recon" launch a test scoped to THIS
+                project. Labeled Test (the section's name), not a fifth mode. */}
             <a
               {...link(`/p/${encodeURIComponent(projectId)}/campaigns`)}
               data-testid="dashboard-campaigns"
               style={CSS.modeBtn}
             >
-              Campaigns
+              Test
             </a>
           </div>
           <span style={{ flex: 1 }} />

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -45,7 +45,7 @@ export const RECON_PROBLEM_PREFIX =
   'proposed plan at the intake gate and launch nothing until it is approved.';
 
 /** The test-kickoff framing — "New test" sends this prefix + blank line + brief. */
-export const CAMPAIGN_PROBLEM_PREFIX =
+export const TEST_PROBLEM_PREFIX =
   'New test: plan the test for the attached scope — the scenarios, their ' +
   'dependencies, and which are deterministic tool checks vs governed agent runs — and run the ' +
   'approved plan as governed sibling runs under one test. Present the plan at the ' +
@@ -70,7 +70,7 @@ const INTENT_COPY: Record<LaunchIntent, { title: string; blurb: string; cta: str
       'codebases and stops at its intake gate — you approve the plan before anything runs. ' +
       'The test appears below with its first run.',
     cta: 'Launch test',
-    prefix: CAMPAIGN_PROBLEM_PREFIX,
+    prefix: TEST_PROBLEM_PREFIX,
   },
 };
 

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -40,36 +40,36 @@ import { SteeringGate } from './SteeringGate.js';
 
 /** The recon framing — what "Run recon" sends is this prefix, a blank line, then the brief. */
 export const RECON_PROBLEM_PREFIX =
-  'Campaign recon: survey the target and propose a test campaign — the scenarios, their ' +
+  'Recon: survey the target and propose a test plan — the scenarios, their ' +
   'dependencies, and which are deterministic tool checks vs governed agent runs. Present the ' +
-  'proposed campaign at the intake gate and launch nothing until it is approved.';
+  'proposed plan at the intake gate and launch nothing until it is approved.';
 
-/** The campaign-kickoff framing — "New campaign" sends this prefix + blank line + brief. */
+/** The test-kickoff framing — "New test" sends this prefix + blank line + brief. */
 export const CAMPAIGN_PROBLEM_PREFIX =
-  'New test campaign: plan the campaign for the attached scope — the scenarios, their ' +
+  'New test: plan the test for the attached scope — the scenarios, their ' +
   'dependencies, and which are deterministic tool checks vs governed agent runs — and run the ' +
-  'approved plan as governed sibling runs under one campaign label. Present the plan at the ' +
+  'approved plan as governed sibling runs under one test. Present the plan at the ' +
   'intake gate and launch nothing until it is approved.';
 
 export type LaunchIntent = 'recon' | 'campaign';
 
 const INTENT_COPY: Record<LaunchIntent, { title: string; blurb: string; cta: string; prefix: string }> = {
   recon: {
-    title: 'Run a campaign recon',
+    title: 'Run recon',
     blurb:
-      'Launches a governed recon run: it surveys the attached codebases, drafts a test ' +
-      'campaign — the scenarios and their dependencies — and stops at its intake gate. ' +
+      'Launches a governed recon run: it surveys the attached codebases, drafts a test plan ' +
+      '— the scenarios and their dependencies — and stops at its intake gate. ' +
       'Nothing runs until you approve the gate here.',
     cta: 'Launch recon',
     prefix: RECON_PROBLEM_PREFIX,
   },
   campaign: {
-    title: 'New campaign',
+    title: 'New test',
     blurb:
-      'Launches a governed campaign kickoff: it plans the campaign over the attached ' +
+      'Launches a governed test kickoff: it plans the test over the attached ' +
       'codebases and stops at its intake gate — you approve the plan before anything runs. ' +
-      'The campaign appears below with its first run.',
-    cta: 'Launch campaign',
+      'The test appears below with its first run.',
+    cta: 'Launch test',
     prefix: CAMPAIGN_PROBLEM_PREFIX,
   },
 };
@@ -276,7 +276,7 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched }: {
             data-testid="testing-launch-instructions"
             value={instructions}
             onChange={(e) => setInstructions(e.target.value)}
-            placeholder="What should this campaign cover? Name the surfaces, risks, or behaviors to test."
+            placeholder="What should this test cover? Name the surfaces, risks, or behaviors to test."
             className="min-h-[4rem] resize-y rounded px-2 py-1 text-[11px] focus:outline-none"
             style={FIELD_STYLE}
           />
@@ -399,7 +399,7 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched }: {
             {launched.campaign !== null ? (
               <> under <span className="font-mono" data-testid="testing-launch-fanout-label">{launched.campaign}</span></>
             ) : (
-              <> — one per attached codebase, under one campaign label</>
+              <> — one per attached codebase, under one test</>
             )}
             .
           </p>

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -131,19 +131,22 @@ interface Launched {
   campaign: string | null;
 }
 
-export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched }: {
+export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, initialProjectId }: {
   intent: LaunchIntent;
   navigate: (path: string) => void;
   onClose: () => void;
   /** Fired once per successful launch with the honest run-id list (fan-out included). */
   onLaunched?: ((ids: string[]) => void) | undefined;
+  /** Pre-select this project (the test is launched FROM a project shell) — so a project-scoped
+   *  "New test" auto-scopes to that project instead of opening unscoped. */
+  initialProjectId?: string | undefined;
 }): React.ReactElement {
   const copy = INTENT_COPY[intent];
   const [instructions, setInstructions] = useState('');
 
   // ── Scope state ────────────────────────────────────────────────────────────
   const [projects, setProjects] = useState<Project[]>([]);
-  const [projectId, setProjectId] = useState('');
+  const [projectId, setProjectId] = useState(initialProjectId ?? '');
   /** The selected project's `crew.repo` member refs — the locked "via project" chips. */
   const [projectRepos, setProjectRepos] = useState<string[] | 'loading'>([]);
   const [repos, setRepos] = useState<RepoEntry[]>([]);

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -181,6 +181,19 @@ function EvalReportView({ report, corpus, navigate }: {
         <span style={{ color: EVAL_VERDICT_COLOR.false_positive }}>{s.false_positives} false positives</span>
       </p>
 
+      {/* Why gaps happen (content-quality guidance): a gap is a behavior no steering rule matched.
+          On the BUILT-IN generic corpus that usually means the corpus tests behaviors your steering
+          doesn't target — not that your rules are broken. Import a corpus that mirrors your steering,
+          or add rules for the behaviors you DO want caught. Facet-only recall also widens gaps. */}
+      {s.gaps > 0 && corpus === null && (
+        <p data-testid="testing-evals-gap-hint" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--surface-rail)', color: 'var(--ink-muted)' }}>
+          A gap is a behavior no steering rule matched. These are from the built-in <em>generic</em>
+          corpus — if your steering targets your own codebase&rsquo;s concerns rather than these, that
+          is expected, not broken rules. Import a corpus that mirrors your steering (Import a corpus,
+          below), or add rules for the behaviors you want caught{report.degraded === 'facet-only' ? ' — and note facet-only recall widens gaps a semantic embedder would close' : ''}.
+        </p>
+      )}
+
       {report.results.length === 0 ? (
         <p data-testid="testing-evals-empty" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>
           The corpus served no samples — import one below, or run against the built-in default

--- a/src/components/dashboardKit.tsx
+++ b/src/components/dashboardKit.tsx
@@ -1,6 +1,11 @@
+import { createContext, useContext } from 'react';
 import { TimeRangeSelector } from './TimeRangeSelector.js';
 import type { TimeRange } from '../hooks/useTimeRange.js';
 import type { StatDelta } from '../board/windowStats.js';
+
+/** True inside a {@link KpiGroup} — tiles render FLAT (transparent) so the GROUP panel is the deck
+ *  material (like DeckKpiRibbon), instead of each tile carrying its own card. */
+const InKpiGroup = createContext(false);
 
 /**
  * The section-dashboard kit (lane B): built once, worn by /projects, /p/:id
@@ -173,20 +178,23 @@ export function StatTile({
     </>
   );
 
+  const flat = useContext(InKpiGroup);
   const style: React.CSSProperties = {
     flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column',
     alignItems: 'stretch', gap: '4px', textAlign: 'left', textDecoration: 'none',
-    // Deck panel: a layered gradient + inset top-light + soft shadow (the DeckKpiRibbon material),
-    // so every section dashboard's KPI band reads like the landing's ribbon.
-    background: 'linear-gradient(180deg, var(--surface-card), var(--surface-rail))',
-    border: '1px solid var(--surface-raised)', boxShadow: 'var(--shadow-card)',
-    borderRadius: 'var(--radius-lg)', padding: 'var(--space-3) var(--space-4)',
+    // Inside a KpiGroup the GROUP is the deck panel, so the tile is FLAT (transparent) — like the
+    // landing ribbon's tiles. Standalone (no group) it carries its own deck-material card.
+    background: flat ? 'transparent' : 'linear-gradient(180deg, var(--surface-card), var(--surface-rail))',
+    border: flat ? 'none' : '1px solid var(--surface-raised)',
+    boxShadow: flat ? 'none' : 'var(--shadow-card)',
+    borderRadius: flat ? 0 : 'var(--radius-lg)',
+    padding: flat ? '2px 0' : 'var(--space-3) var(--space-4)',
     cursor: onOpen !== undefined ? 'pointer' : 'default',
     color: 'inherit', font: 'inherit',
   };
   const common = {
     'data-testid': testId,
-    className: 'deck-stat',
+    className: flat ? 'deck-stat deck-stat-flat' : 'deck-stat',
     'data-value': String(value),
     ...(delta !== undefined
       ? { 'data-delta': delta.previous === null ? 'none' : String(delta.current - delta.previous) }
@@ -237,25 +245,18 @@ export function KpiGroup({ label, children, grow = 1 }: {
   /** Relative width — a two-tile group grows twice a one-tile group. */
   grow?: number;
 }): React.ReactElement {
+  // The deck-group PANEL (the DeckKpiRibbon material): a gradient surface + accent top-edge + a
+  // glowing tag header, wrapping FLAT tiles — so every section dashboard's KPI band reads like the
+  // landing ribbon. `deck-group` / `deck-ghead` / `deck-tag` styles live in deck.css.
   return (
     <section
+      className="deck-group"
       data-kpi-group={label.toLowerCase()}
-      style={{
-        flex: `${grow} 1 ${grow * 150}px`, minWidth: `${grow * 140}px`,
-        display: 'flex', flexDirection: 'column', gap: '6px',
-      }}
+      style={{ flex: `${grow} 1 ${grow * 160}px`, minWidth: `${grow * 150}px` }}
     >
-      <p
-        style={{
-          margin: 0, fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-semi)',
-          letterSpacing: '0.1em', textTransform: 'uppercase',
-          color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)',
-        }}
-      >
-        {label}
-      </p>
-      <div style={{ display: 'flex', gap: 'var(--space-3)', flex: 1, alignItems: 'stretch' }}>
-        {children}
+      <div className="deck-ghead"><span className="deck-tag">{label}</span></div>
+      <div className="deck-tiles">
+        <InKpiGroup.Provider value={true}>{children}</InKpiGroup.Provider>
       </div>
     </section>
   );

--- a/src/styles/deck.css
+++ b/src/styles/deck.css
@@ -28,7 +28,7 @@
 .deck-group::before {
   content: '';
   position: absolute; inset: 0 0 auto; height: 2px;
-  background: linear-gradient(90deg, var(--deck-gcol), transparent 72%);
+  background: linear-gradient(90deg, var(--deck-gcol, var(--accent)), transparent 72%);
 }
 .deck-group.flow  { --deck-gcol: var(--status-run);  --deck-gtint: color-mix(in oklab, var(--status-run) 12%, transparent); }
 .deck-group.attn  { --deck-gcol: var(--status-gate); --deck-gtint: color-mix(in oklab, var(--status-gate) 10%, transparent); }
@@ -37,9 +37,9 @@
 .deck-ghead { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
 .deck-tag {
   font-size: var(--text-2xs); font-weight: var(--weight-bold);
-  letter-spacing: 0.14em; text-transform: uppercase; color: var(--deck-gcol);
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--deck-gcol, var(--accent));
 }
-.deck-glyph { color: var(--deck-gcol); font-size: 11px; filter: drop-shadow(0 0 6px currentColor); opacity: 0.9; }
+.deck-glyph { color: var(--deck-gcol, var(--accent)); font-size: 11px; filter: drop-shadow(0 0 6px currentColor); opacity: 0.9; }
 
 .deck-tiles { display: flex; gap: 14px; }
 .deck-tile {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.0",
   "counts": {
     "files": 128,
-    "occurrences": 1029,
-    "static": 873,
+    "occurrences": 1030,
+    "static": 874,
     "dynamic": 56,
     "computed": 6
   },
@@ -4513,6 +4513,12 @@
     },
     {
       "testId": "testing-evals-gap-detail",
+      "files": [
+        "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "testId": "testing-evals-gap-hint",
       "files": [
         "src/components/TestingPage.tsx"
       ]

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -140,14 +140,15 @@ describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
       expect(within(h).queryByTestId('heading-dashboard')).toBeNull();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
     }
-    // Steering: ▦ (the nav-reorg moved the Dashboard onto the heading), but NO ＋.
-    {
-      const h = screen.getByTestId('rail-heading-steering');
+    // Steering AND Evals carry ▦ (the Dashboard) but NO ＋ — system sections, not create surfaces
+    // (usability wave: Evals lost its ＋, it only opens its dashboard).
+    for (const k of ['steering', 'testing']) {
+      const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
     }
-    // Every other heading carries both ▦ and ＋ — including Test and Evals.
-    for (const k of ['projects', 'execute', 'test', 'vibe', 'demo', 'testing', 'chat', 'repos']) {
+    // Every work heading carries both ▦ and ＋ — including Test.
+    for (const k of ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos']) {
       const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
       expect(within(h).getByTestId('heading-new')).toBeInTheDocument();
@@ -286,7 +287,7 @@ describe('the ＋ create actions (§2.1/§3.4)', () => {
     expect(screen.queryByTestId('new-project-modal')).toBeNull();
   });
 
-  it('Execute ＋ launches a build run directly; Chat ＋ / Repos ＋ / Evals ＋ navigate to their routes', async () => {
+  it('Execute ＋ launches a build run directly; Chat ＋ / Repos ＋ / Test ＋ navigate to their routes (Evals has no ＋)', async () => {
     const navigate = vi.fn();
     rail({ navigate });
     await screen.findByRole('button', { name: 'wicked-studio' });
@@ -297,8 +298,11 @@ describe('the ＋ create actions (§2.1/§3.4)', () => {
     expect(navigate).toHaveBeenCalledWith('/chat/new');
     fireEvent.click(within(screen.getByTestId('rail-heading-repos')).getByTestId('heading-new'));
     expect(navigate).toHaveBeenCalledWith('/repos/new');
-    fireEvent.click(within(screen.getByTestId('rail-heading-testing')).getByTestId('heading-new'));
-    expect(navigate).toHaveBeenCalledWith('/testing/evals');
+    // Test ＋ → the campaigns/recon landing (project-optional).
+    fireEvent.click(within(screen.getByTestId('rail-heading-test')).getByTestId('heading-new'));
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
+    // Evals is a system section now — dashboard only, no ＋.
+    expect(within(screen.getByTestId('rail-heading-testing')).queryByTestId('heading-new')).toBeNull();
   });
 
   it('Vibe ＋ opens a project-picker locked to Document; Demo ＋ one locked to Video', async () => {

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -204,6 +204,17 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     });
   });
 
+  it('a project-scoped page PRE-SELECTS that project in the launch panel — create a test from a project (usability wave)', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-scoped' });
+    render(<CampaignsPage runs={[]} navigate={() => {}} projectId="proj-a" />);
+    const panel = await openPanel(user, 'testing-recon-open');
+    const select = within(panel).getByTestId('testing-launch-project') as HTMLSelectElement;
+    await within(select).findByRole('option', { name: 'alpha' });
+    // The project is already selected — the test auto-scopes to it, no manual pick needed.
+    expect(select.value).toBe('proj-a');
+  });
+
   it('project + extra explicit repos = the UNION body {problem, projectId, repoRefs} exactly', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-u', runIds: ['run-u', 'run-v', 'run-w'] });

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -45,7 +45,7 @@ vi.mock('../src/api/client.js', () => ({
 }));
 
 const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
-const { RECON_PROBLEM_PREFIX, CAMPAIGN_PROBLEM_PREFIX } = await import('../src/components/TestingLaunchPanel.js');
+const { RECON_PROBLEM_PREFIX, TEST_PROBLEM_PREFIX } = await import('../src/components/TestingLaunchPanel.js');
 const { MULTI_SCOPE_UNSUPPORTED_COPY, launchedRunIds, isMultiScopeUnsupported } = await import('../src/api/testing.js');
 const { useCampaignsStore } = await import('../src/store/campaigns.js');
 
@@ -162,7 +162,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
 
     await screen.findByTestId('testing-launch-fanout');
     expect(launchBody()).toEqual({
-      problem: `${CAMPAIGN_PROBLEM_PREFIX}\n\nSmoke both services`,
+      problem: `${TEST_PROBLEM_PREFIX}\n\nSmoke both services`,
       repoRefs: ['r-1', 'r-2'],
     });
   });
@@ -237,7 +237,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
 
     await screen.findByTestId('testing-launch-fanout');
     expect(launchBody()).toEqual({
-      problem: `${CAMPAIGN_PROBLEM_PREFIX}\n\nUnion scope`,
+      problem: `${TEST_PROBLEM_PREFIX}\n\nUnion scope`,
       projectId: 'proj-a',
       repoRefs: ['r-2', 'r-3'],
     });


### PR DESCRIPTION
Addresses the live-review findings on the command-deck release:

1. **Campaign→Test rename completed** — "New test" no longer opens a "New campaign" panel; swept the launch panel (titles/blurbs/CTAs/problem prefixes), the chat file-under, the essence entry, and search boxes.
2. **Create a test from a project** — `/p/:id/campaigns` now threads the projectId into the launch panel (`initialProjectId`), so "New test" / "Run recon" auto-scopes to that project instead of opening unscoped.
3. **Section dashboards get the real deck look** — `KpiGroup` is now the deck-group panel (gradient + accent edge + tag header) wrapping FLAT tiles (via context), matching the landing ribbon — not just the subtle StatTile tweak.
4. **Evals: gap guidance** — a note explains a gap is a behavior no steering rule matched; on the built-in *generic* corpus that usually means the corpus tests behaviors your (codebase-specific) steering doesn't target — not broken rules — and facet-only recall widens gaps a semantic embedder would close. *(Diagnosis: the 50 steering rules are recall-only `proposal:*` promotions with no enforcement fields, tested against a generic corpus → 16 gaps. Not a studio bug; a corpus/steering decision — see the PR discussion.)*
5. **Evals rail heading** drops its ＋ — dashboard icon only (a system section, like Steering).
6. **Memories gets a stats band** like Policies (total + per-tier + facet values).

All 2442 tests green. Validated the surrounding functionality through the crew API (evals ran, rules/memories/eval-store inspected) and deployed to :7701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
