### PR TITLE
release: wicked-studio 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-09-08
+
+### Fixed
+- **Honest dashboard stat framing (#200, Copilot review).** The home essence tile for tests reads
+  "Governed tests (each groups its sibling runs)" instead of "Test runs" — the value is the
+  test/campaign count, not a run count. The Memories store band no longer falls back to the
+  query-scoped loaded count for the store-wide total (shows "—" when coverage is absent), and the
+  facet-value tile states it counts the loaded recall page, not the whole store.
+- Renamed the exported `CAMPAIGN_PROBLEM_PREFIX` → `TEST_PROBLEM_PREFIX` to match the "New test"
+  verb it now frames.
+
 ## [0.5.0] — 2026-09-08
 
 ### Changed
@@ -391,7 +402,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.15...v0.5.0
 [0.4.15]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.14...v0.4.15
 [0.4.14]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.13...v0.4.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ npm publish dates. Every version listed here exists on
 
 ### Fixed
 - **Honest dashboard stat framing (#200, Copilot review).** The home essence tile for tests reads
-  "Governed tests (each groups its sibling runs)" instead of "Test runs" — the value is the
+  "Governed tests (each test groups its sibling runs)" instead of "Test runs" — the value is the
   test/campaign count, not a run count. The Memories store band no longer falls back to the
   query-scoped loaded count for the store-wide total (shows "—" when coverage is absent), and the
   facet-value tile states it counts the loaded recall page, not the whole store.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.0",
-  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "version": "0.5.1",
+  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/components/HomeCommand.tsx
+++ b/src/components/HomeCommand.tsx
@@ -255,7 +255,7 @@ export function essenceEntries(inputs: {
   }
   out.push({ id: 'repos', label: 'Repos', value: String(inputs.repos.length), path: '/repos', title: 'Registered repositories' });
   if (inputs.campaigns !== null) {
-    out.push({ id: 'campaigns', label: 'Tests', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Governed tests (each groups its sibling runs)' });
+    out.push({ id: 'campaigns', label: 'Tests', value: String(inputs.campaigns), path: '/testing/campaigns', title: 'Governed tests (each test groups its sibling runs)' });
   }
   if (inputs.rules !== null) {
     const unused = inputs.perRule !== null ? ruleUsage(inputs.rules, inputs.perRule).unusedIds.length : null;

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.0",
+  "studioVersion": "0.5.1",
   "counts": {
     "files": 128,
     "occurrences": 1030,


### PR DESCRIPTION
Patch release cutting `[Unreleased]` → `[0.5.1]`.

Carries the #200 dashboard-honesty fixes from the Copilot review:
- home essence tile framed as "Governed tests", not "Test runs"
- Memories store band: store-wide total shows "—" when coverage absent (no query-scoped fallback); facet tile labelled as the loaded recall page
- `CAMPAIGN_PROBLEM_PREFIX` → `TEST_PROBLEM_PREFIX`

Version bump + lockfile + testid manifest (v0.5.1) + CHANGELOG (compare link-refs retargeted). Typecheck + build + 2442 tests green. Tag `v0.5.1` after merge → release.yml publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)