### PR TITLE
feat(projects): Repositories section — attach/detach crew.repo members from the project page (#207)

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -4,7 +4,7 @@ import { listDocs, type DocSummary } from '../api/interactive.js';
 import { listProposals, proposalKind } from '../api/proposals.js';
 import { steeringDashboardPath } from '../api/steering.js';
 import { useDocsCache } from '../store/docsCache.js';
-import type { SessionView } from '../api/types.js';
+import type { ProjectMember, SessionView } from '../api/types.js';
 import { compareScored, scoreOf, type Signal, type SignalKind } from '../board/boardAttention.js';
 import { gateOpenPath } from '../board/gateActions.js';
 import { outcomeOf, WINDOW_LABEL_STYLE } from '../board/metrics.js';
@@ -28,6 +28,7 @@ import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { ProjectRepositories } from './ProjectRepositories.js';
 import { ageWord } from './DashboardTiles.js';
 import { deliverySummary } from './delivery.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
@@ -156,7 +157,9 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   // One membership read on mount — the same call the board makes per project.
   const [memberKinds, setMemberKinds] = useState<Record<string, string>>({});
   const [attachedAt, setAttachedAt] = useState<Record<string, number>>({});
-  const [repoRefs, setRepoRefs] = useState<string[]>([]);
+  // The `crew.repo` members as read — the header chips AND the Repositories section
+  // (attach/detach, studio#207) render from this one state, so they can never disagree.
+  const [repoMembers, setRepoMembers] = useState<ProjectMember[]>([]);
   useEffect(() => {
     let cancelled = false;
     api.listProjectMembers(projectId)
@@ -164,10 +167,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         if (cancelled) return;
         const kinds: Record<string, string> = {};
         const at: Record<string, number> = {};
-        const repos: string[] = [];
+        const repos: ProjectMember[] = [];
         for (const m of members) {
           if (m.member_kind === 'crew.repo') {
-            repos.push(m.member_ref);
+            repos.push(m);
             continue;
           }
           if (!RUN_KINDS.has(m.member_kind)) continue;
@@ -176,7 +179,7 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         }
         setMemberKinds(kinds);
         setAttachedAt(at);
-        setRepoRefs(repos);
+        setRepoMembers(repos);
       })
       .catch(() => { /* members unreadable — the tiles simply stay empty */ });
     return () => { cancelled = true; };
@@ -405,13 +408,13 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
         </p>
         {/* Bound repos in the header's meta-line region — names resolve from the
             SAME session repo cache the palette holds; never a fetch. */}
-        {repoRefs.length > 0 && (
+        {repoMembers.length > 0 && (
           <p data-testid="dashboard-repos" style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', margin: '6px 0 0' }}>
-            {repoRefs.map((ref) => {
+            {repoMembers.map(({ id, member_ref: ref }) => {
               const known = getCachedRepos()?.find((r) => r.id === ref || r.name === ref);
               return (
                 <a
-                  key={ref}
+                  key={id}
                   {...link(`/repo-detail/${encodeURIComponent(known?.id ?? ref)}`)}
                   data-testid="dashboard-repo"
                   data-repo-ref={ref}
@@ -776,6 +779,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
           </DashboardGrid>
         )}
       </section>
+
+      {/* ── Repositories — the attach/detach surface for `crew.repo` members (studio#207):
+            a project-scoped test cannot launch until the project carries one. ── */}
+      <ProjectRepositories projectId={projectId} members={repoMembers} onMembersChange={setRepoMembers} />
     </div>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -162,6 +162,13 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
   const [repoMembers, setRepoMembers] = useState<ProjectMember[]>([]);
   useEffect(() => {
     let cancelled = false;
+    // A project change starts from nothing: this component stays mounted across
+    // `/p/A` → `/p/B` (App.tsx keys it on nothing), and A's read must not stand in
+    // for B's while B's is out. (A's attach/detach resolving late is dropped by
+    // ProjectRepositories itself — see its `liveProjectId`.)
+    setMemberKinds({});
+    setAttachedAt({});
+    setRepoMembers([]);
     api.listProjectMembers(projectId)
       .then(({ members }) => {
         if (cancelled) return;
@@ -781,7 +788,10 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
       </section>
 
       {/* ── Repositories — the attach/detach surface for `crew.repo` members (studio#207):
-            a project-scoped test cannot launch until the project carries one. ── */}
+            a project-scoped test cannot launch until the project carries one. The section
+            reports each change as an UPDATER over the current `repoMembers` (so this
+            component's own read landing mid-request is built on, not overwritten) and only
+            for the project it still shows — `setRepoMembers` takes it as-is. ── */}
       <ProjectRepositories projectId={projectId} members={repoMembers} onMembersChange={setRepoMembers} />
     </div>
   );

--- a/src/components/ProjectDetailPage.tsx
+++ b/src/components/ProjectDetailPage.tsx
@@ -369,7 +369,14 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
         <ProjectRepositories
           projectId={projectId}
           members={members}
-          onMembersChange={(next) => setDetail((d) => d ? { ...d, members: next } : d)}
+          onMembersChange={(update) => setDetail((d) => (
+            // Applied to the members held NOW — a run member detached through the
+            // Members list while a repo attach was in flight must stay gone — and
+            // only while `detail` is still this project's: the page stays mounted
+            // across a navigation, so a mutation begun on the previous project can
+            // resolve after the next one loaded.
+            d !== null && d.project.id === projectId ? { ...d, members: update(d.members) } : d
+          ))}
         />
       </div>
 

--- a/src/components/ProjectDetailPage.tsx
+++ b/src/components/ProjectDetailPage.tsx
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api/client.js';
 import type { ActivityEntry, ProjectDetail, ProjectMember } from '../api/types.js';
 import { useProjectsStore } from '../store/projects.js';
+import { ProjectRepositories } from './ProjectRepositories.js';
+
+/** The Repositories section owns these rows; the generic Members list shows the rest. */
+const REPO_KIND = 'crew.repo';
 
 const S = {
   card:   'var(--surface-card)',
@@ -147,6 +151,7 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
   const isDefault = projectId === 'default';
   const project = detail?.project ?? null;
   const members = detail?.members ?? [];
+  const otherMembers = members.filter((m) => m.member_kind !== REPO_KIND);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -359,16 +364,25 @@ export function ProjectDetailPage({ projectId, navigate }: Props): React.ReactEl
         </div>
       )}
 
+      {/* Repositories — attach/detach `crew.repo` members (studio#207); omitted for `default`. */}
+      <div style={{ marginBottom: '28px' }}>
+        <ProjectRepositories
+          projectId={projectId}
+          members={members}
+          onMembersChange={(next) => setDetail((d) => d ? { ...d, members: next } : d)}
+        />
+      </div>
+
       {/* Members */}
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '13px', fontWeight: 600, color: S.muted, margin: 0, marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.06em', fontFamily: 'monospace' }}>
-          Members ({members.length})
+          Members ({otherMembers.length})
         </h2>
-        {members.length === 0 ? (
+        {otherMembers.length === 0 ? (
           <p style={{ fontSize: '13px', color: S.faint }}>No members attached yet.</p>
         ) : (
           <div style={{ background: S.card, border: `1px solid ${S.border}`, borderRadius: '10px', overflow: 'hidden', padding: '4px' }}>
-            {members.map((m) => (
+            {otherMembers.map((m) => (
               <MemberRow key={m.id} member={m} onDetach={handleDetach} />
             ))}
           </div>

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -1,0 +1,297 @@
+import { useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import type { ProjectMember, RepoEntry } from '../api/types.js';
+import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
+
+/**
+ * The project's repositories — the one UI path that attaches a `crew.repo`
+ * member to a project (studio#207). Before this section a UI-created project
+ * could never launch a project-scoped test: crew's multiscope resolver 400s a
+ * project-only launch whose project holds zero repository members, and the
+ * launch panel's own warning pointed at an action the product had no control
+ * for.
+ *
+ * Wire (verified against wicked-crew `projects/routes.ts` + the pinned
+ * `wicked-crew-api-types`): attach is `POST /projects/:id/members` with
+ * `AttachMemberBody` `{ kind: 'crew.repo', ref: <repo id>, attachedBy: 'studio' }`
+ * — the SAME body RepositoriesPanel's register flow sends when a project is
+ * selected at registration — and detach is `DELETE /projects/:id/members/:mid`.
+ * The picker is the registered-repo list from the ONE session repo cache
+ * (DES-FEEDBACK-002 §1.4): fetched on the first gesture that needs it (the
+ * search field's focus), never on mount.
+ *
+ * Membership state stays with the parent (the dashboard's / detail page's one
+ * membership read): this section filters to `crew.repo` and reports every
+ * change through `onMembersChange`, so the header chips and this list can never
+ * disagree. The synthesized `default` project rejects attach on the wire
+ * (routes.ts) and has no stored members to detach, so the section is omitted
+ * there entirely.
+ */
+
+const DEFAULT_PROJECT_ID = 'default';
+const REPO_KIND = 'crew.repo';
+/** Picker rows before the list asks the operator to narrow instead of growing. */
+const MAX_OPTIONS = 8;
+
+const CSS = {
+  sectionHead: {
+    fontSize: 'var(--text-2xs)', fontWeight: 'var(--weight-bold)',
+    letterSpacing: '0.08em', textTransform: 'uppercase',
+    color: 'var(--ink-muted)', margin: '0 0 8px',
+  },
+  list: {
+    display: 'flex', flexDirection: 'column', gap: '2px',
+    background: 'var(--surface-card)', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-lg)', padding: '4px',
+  },
+  row: {
+    display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0,
+    padding: '8px 10px', borderRadius: 'var(--radius-md)',
+  },
+  repoName: {
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+  },
+  repoPath: {
+    flex: 1, minWidth: 0, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+    color: 'var(--ink-dim)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+  },
+  rowMeta: {
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
+    whiteSpace: 'nowrap', flexShrink: 0,
+  },
+  ghostBtn: {
+    background: 'transparent', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-md)', color: 'var(--ink-muted)', cursor: 'pointer',
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-sans)', padding: '2px 10px',
+    flexShrink: 0,
+  },
+  dangerBtn: {
+    background: 'transparent', border: '1px solid var(--status-fail)',
+    borderRadius: 'var(--radius-md)', color: 'var(--status-fail)', cursor: 'pointer',
+    fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-sans)', padding: '2px 10px',
+    flexShrink: 0,
+  },
+  empty: { fontSize: 'var(--text-xs)', color: 'var(--ink-dim)', margin: 0 },
+  search: {
+    width: '100%', maxWidth: '360px', boxSizing: 'border-box',
+    background: 'var(--surface-base)', border: '1px solid var(--surface-raised)',
+    borderRadius: 'var(--radius-sm)', color: 'var(--ink-body)', caretColor: 'var(--accent)',
+    fontSize: 'var(--text-xs)', fontFamily: 'var(--font-mono)', padding: '4px 8px',
+    outline: 'none',
+  },
+  option: {
+    borderRadius: 'var(--radius-full)', padding: '2px 10px', cursor: 'pointer',
+    border: '1px dashed var(--surface-raised)', background: 'transparent',
+    color: 'var(--ink-muted)', fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+  },
+  hint: { fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)', margin: 0 },
+  error: { fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--status-fail)', margin: 0 },
+} as const satisfies Record<string, React.CSSProperties>;
+
+/** A member ref names a registered repo by id; a legacy ref may carry the name instead
+ *  (the dashboard's header chips resolve the same two ways). */
+function repoOf(ref: string, repos: RepoEntry[] | null): RepoEntry | undefined {
+  return repos?.find((r) => r.id === ref || r.name === ref);
+}
+
+function isAttached(repo: RepoEntry, members: ProjectMember[]): boolean {
+  return members.some((m) => m.member_ref === repo.id || m.member_ref === repo.name);
+}
+
+interface Props {
+  projectId: string;
+  /** Every member the parent holds — this section filters to `crew.repo` itself. */
+  members: ProjectMember[];
+  /** The parent's membership state with the change applied: attach appends, detach filters. */
+  onMembersChange: (members: ProjectMember[]) => void;
+}
+
+export function ProjectRepositories({ projectId, members, onMembersChange }: Props): React.ReactElement | null {
+  const [repos, setRepos] = useState<RepoEntry[] | null>(getCachedRepos);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  /** The repo id being attached, or null. */
+  const [attaching, setAttaching] = useState<string | null>(null);
+  /** The member id whose detach awaits confirmation, or null. */
+  const [confirming, setConfirming] = useState<string | null>(null);
+  /** The member id being detached, or null. */
+  const [detaching, setDetaching] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const repoMembers = useMemo(
+    () => members.filter((m) => m.member_kind === REPO_KIND),
+    [members],
+  );
+
+  const options = useMemo(() => {
+    if (repos === null) return [];
+    const q = query.trim().toLowerCase();
+    return repos
+      .filter((r) => !isAttached(r, repoMembers))
+      .filter((r) => q === '' || r.name.toLowerCase().includes(q) || r.id.toLowerCase().includes(q));
+  }, [repos, query, repoMembers]);
+
+  if (projectId === DEFAULT_PROJECT_ID) return null;
+
+  /** The first gesture that needs the registry warms the ONE session cache. */
+  function openPicker(): void {
+    setPickerOpen(true);
+    if (repos !== null) return;
+    fetchReposCached()
+      .then(setRepos)
+      .catch((e: unknown) => setError(`registered repos unreadable: ${e instanceof Error ? e.message : String(e)}`));
+  }
+
+  async function attach(repo: RepoEntry): Promise<void> {
+    if (attaching !== null) return;
+    setAttaching(repo.id);
+    setError(null);
+    try {
+      const { member } = await api.attachProjectMember(projectId, {
+        kind: REPO_KIND,
+        ref: repo.id,
+        attachedBy: 'studio',
+      });
+      onMembersChange([...members, member]);
+      setQuery('');
+    } catch (e) {
+      setError(`attach failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setAttaching(null);
+    }
+  }
+
+  async function detach(member: ProjectMember): Promise<void> {
+    if (detaching !== null) return;
+    setDetaching(member.id);
+    setError(null);
+    try {
+      await api.detachProjectMember(projectId, member.id);
+      onMembersChange(members.filter((m) => m.id !== member.id));
+      setConfirming(null);
+    } catch (e) {
+      setError(`detach failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setDetaching(null);
+    }
+  }
+
+  const shown = options.slice(0, MAX_OPTIONS);
+  const overflow = options.length - shown.length;
+
+  return (
+    <section data-testid="project-repos" data-count={repoMembers.length}>
+      <p style={CSS.sectionHead}>Repositories ({repoMembers.length})</p>
+
+      {repoMembers.length === 0 ? (
+        <p style={CSS.empty} data-testid="project-repos-empty">
+          No repository attached — a project-scoped test cannot launch until one is.
+        </p>
+      ) : (
+        <div style={CSS.list}>
+          {repoMembers.map((m) => {
+            const repo = repoOf(m.member_ref, repos);
+            const label = repo?.name ?? m.member_ref;
+            const isConfirming = confirming === m.id;
+            return (
+              <div key={m.id} data-testid="project-repo-row" data-repo={m.member_ref} style={CSS.row}>
+                <span aria-hidden style={{ color: 'var(--ink-dim)' }}>⬡</span>
+                <span style={CSS.repoName} title={m.member_ref}>{label}</span>
+                <span style={CSS.repoPath} title={repo?.root_path}>{repo?.root_path ?? ''}</span>
+                {isConfirming ? (
+                  <>
+                    <span style={CSS.rowMeta}>detach {label}?</span>
+                    <button
+                      type="button"
+                      data-testid="project-repo-detach-confirm"
+                      data-repo={m.member_ref}
+                      disabled={detaching !== null}
+                      onClick={() => void detach(m)}
+                      style={{ ...CSS.dangerBtn, opacity: detaching === m.id ? 0.5 : 1 }}
+                    >
+                      {detaching === m.id ? 'Detaching…' : 'Detach'}
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="project-repo-detach-cancel"
+                      disabled={detaching !== null}
+                      onClick={() => setConfirming(null)}
+                      style={CSS.ghostBtn}
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span style={CSS.rowMeta}>
+                      {m.attached_by} · {new Date(m.attached_at).toLocaleDateString()}
+                    </span>
+                    <button
+                      type="button"
+                      data-testid="project-repo-detach"
+                      data-repo={m.member_ref}
+                      title="Detach this repository from the project (asks first)"
+                      onClick={() => setConfirming(m.id)}
+                      style={CSS.ghostBtn}
+                    >
+                      Detach
+                    </button>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── Attach: the registered-repo picker (the launch panel's search idiom) ── */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '8px' }}>
+        <input
+          data-testid="project-repo-search"
+          value={query}
+          onFocus={openPicker}
+          onChange={(e) => { setQuery(e.target.value); if (!pickerOpen) openPicker(); }}
+          onKeyDown={(e) => { if (e.key === 'Escape') { setPickerOpen(false); setQuery(''); } }}
+          placeholder="attach a registered repo…"
+          aria-label="Attach a registered repository"
+          style={CSS.search}
+        />
+        {pickerOpen && repos !== null && (
+          shown.length === 0 ? (
+            <p style={CSS.hint} data-testid="project-repo-options-empty">
+              {repos.length === 0
+                ? 'no repos registered yet — register one under Repositories first'
+                : query.trim() === ''
+                  ? 'every registered repo is already attached'
+                  : 'no registered repo matches'}
+            </p>
+          ) : (
+            <div data-testid="project-repo-options" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '4px' }}>
+              {shown.map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  data-testid="project-repo-option"
+                  data-repo={r.id}
+                  title={r.root_path}
+                  disabled={attaching !== null}
+                  onClick={() => void attach(r)}
+                  style={{ ...CSS.option, opacity: attaching === r.id ? 0.5 : 1 }}
+                >
+                  {attaching === r.id ? '… ' : '+ '}{r.name}
+                </button>
+              ))}
+              {overflow > 0 && (
+                <span style={CSS.hint}>+{overflow} more — type to narrow</span>
+              )}
+            </div>
+          )
+        )}
+        {error !== null && (
+          <p data-testid="project-repo-error" style={CSS.error}>{error}</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { ProjectMember, RepoEntry } from '../api/types.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
@@ -23,9 +23,11 @@ import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
  * Membership state stays with the parent (the dashboard's / detail page's one
  * membership read): this section filters to `crew.repo` and reports every
  * change through `onMembersChange`, so the header chips and this list can never
- * disagree. The synthesized `default` project rejects attach on the wire
- * (routes.ts) and has no stored members to detach, so the section is omitted
- * there entirely.
+ * disagree. A change is reported as an UPDATER over the parent's current state,
+ * never as a replacement array, and only for the project the section still
+ * shows — see `Props.onMembersChange`. The synthesized `default` project rejects
+ * attach on the wire (routes.ts) and has no stored members to detach, so the
+ * section is omitted there entirely.
  */
 
 const DEFAULT_PROJECT_ID = 'default';
@@ -99,6 +101,17 @@ function isAttached(repo: RepoEntry, members: ProjectMember[]): boolean {
   return members.some((m) => m.member_ref === repo.id || m.member_ref === repo.name);
 }
 
+/**
+ * A membership change, expressed against whatever the parent holds at APPLY time
+ * — the parent runs it inside its own functional state update. The section
+ * never hands back a replacement array built from the snapshot it rendered with:
+ * that snapshot goes stale the moment anything else touches membership while a
+ * request is in flight (a non-repo member detached through the generic Members
+ * list, the dashboard's membership read landing), and applying it wholesale
+ * would silently undo that change.
+ */
+export type MembersUpdate = (current: ProjectMember[]) => ProjectMember[];
+
 interface Props {
   projectId: string;
   /**
@@ -108,11 +121,15 @@ interface Props {
    */
   members: ProjectMember[];
   /**
-   * The SAME array with only the repo change applied — attach appends the new
-   * member, detach filters the one member out — so whatever non-repo entries the
-   * parent handed in come back untouched.
+   * Reports one repo change as an updater the parent applies to its CURRENT
+   * membership: attach appends the new member (unless it is already there),
+   * detach filters the one member id out, and whatever non-repo entries the
+   * parent holds pass through untouched. Called only for the project this
+   * section is still showing — a result that lands after `projectId` changed
+   * (both parents stay mounted across a navigation) or after unmount is dropped,
+   * never applied to another project's state.
    */
-  onMembersChange: (members: ProjectMember[]) => void;
+  onMembersChange: (update: MembersUpdate) => void;
 }
 
 export function ProjectRepositories({ projectId, members, onMembersChange }: Props): React.ReactElement | null {
@@ -125,16 +142,42 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
   const [confirming, setConfirming] = useState<string | null>(null);
   /** The member id being detached, or null. */
   const [detaching, setDetaching] = useState<string | null>(null);
+  /** The last attach/detach failure, or null. */
   const [error, setError] = useState<string | null>(null);
+  /** The last registry (picker) fetch failure, kept apart from the mutation error
+   *  so the retry gesture clears exactly the one that just went stale. */
+  const [registryError, setRegistryError] = useState<string | null>(null);
 
   /**
-   * ONE mutation at a time. Both `attach` and `detach` derive the next membership
-   * from the `members` they closed over, so two in flight at once would each
-   * report from a stale base and the later one would silently drop the earlier
-   * one's result. The lock also keeps a second row's Detach from re-pointing
-   * `confirming` while a detach is mid-request.
+   * ONE mutation at a time. The lock keeps a second row's Detach from re-pointing
+   * `confirming` while a detach is mid-request, and keeps the picker from
+   * starting an attach on top of it.
    */
   const busy = attaching !== null || detaching !== null;
+
+  /**
+   * The project this section shows RIGHT NOW — `null` once unmounted. Neither
+   * parent is keyed on the project (App.tsx), so navigating `/p/A` → `/p/B`
+   * re-renders this same instance with a new `projectId` while an attach or
+   * detach begun on A may still be in flight; on the detail page the section
+   * unmounts for the loading tick instead. Either way that request's result
+   * belongs to A: each mutation pins the project it started for and reports
+   * only if this still matches. A project change also abandons the previous
+   * project's in-progress UI — its pending confirm, its errors, its picker
+   * query, and its mutation lock (the guarded-out request can no longer act).
+   */
+  const liveProjectId = useRef<string | null>(projectId);
+  useEffect(() => {
+    liveProjectId.current = projectId;
+    setConfirming(null);
+    setError(null);
+    setRegistryError(null);
+    setQuery('');
+    setPickerOpen(false);
+    setAttaching(null);
+    setDetaching(null);
+    return () => { liveProjectId.current = null; };
+  }, [projectId]);
 
   const repoMembers = useMemo(
     () => members.filter((m) => m.member_kind === REPO_KIND),
@@ -151,48 +194,61 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
 
   if (projectId === DEFAULT_PROJECT_ID) return null;
 
-  /** The first gesture that needs the registry warms the ONE session cache. */
+  /** The first gesture that needs the registry warms the ONE session cache. A
+   *  failed fetch caches nothing (repoCache), so every later gesture retries —
+   *  and the retry retires the failure it supersedes before it starts. */
   function openPicker(): void {
     setPickerOpen(true);
     if (repos !== null) return;
+    setRegistryError(null);
     fetchReposCached()
       .then(setRepos)
-      .catch((e: unknown) => setError(`registered repos unreadable: ${e instanceof Error ? e.message : String(e)}`));
+      .catch((e: unknown) => setRegistryError(`registered repos unreadable: ${e instanceof Error ? e.message : String(e)}`));
   }
 
   async function attach(repo: RepoEntry): Promise<void> {
     if (busy) return;
+    const forProject = projectId;
     setAttaching(repo.id);
     setError(null);
     try {
-      const { member } = await api.attachProjectMember(projectId, {
+      const { member } = await api.attachProjectMember(forProject, {
         kind: REPO_KIND,
         ref: repo.id,
         attachedBy: 'studio',
       });
-      onMembersChange([...members, member]);
+      if (liveProjectId.current !== forProject) return; // landed after a navigation — not this project's result
+      onMembersChange((current) => (current.some((m) => m.id === member.id) ? current : [...current, member]));
       setQuery('');
     } catch (e) {
+      if (liveProjectId.current !== forProject) return;
       setError(`attach failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
-      setAttaching(null);
+      // Release the lock only while it is still this request's: a project change
+      // released it already, and a mutation begun since then owns it now.
+      setAttaching((cur) => (cur === repo.id ? null : cur));
     }
   }
 
   async function detach(member: ProjectMember): Promise<void> {
     if (busy) return;
+    const forProject = projectId;
     setDetaching(member.id);
     setError(null);
     try {
-      await api.detachProjectMember(projectId, member.id);
-      onMembersChange(members.filter((m) => m.id !== member.id));
+      await api.detachProjectMember(forProject, member.id);
+      if (liveProjectId.current !== forProject) return; // landed after a navigation — not this project's result
+      onMembersChange((current) => current.filter((m) => m.id !== member.id));
       setConfirming(null);
     } catch (e) {
+      if (liveProjectId.current !== forProject) return;
       setError(`detach failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
-      setDetaching(null);
+      setDetaching((cur) => (cur === member.id ? null : cur));
     }
   }
+
+  const shownError = error ?? registryError;
 
   const shown = options.slice(0, MAX_OPTIONS);
   const overflow = options.length - shown.length;
@@ -306,8 +362,8 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
             </div>
           )
         )}
-        {error !== null && (
-          <p data-testid="project-repo-error" style={CSS.error}>{error}</p>
+        {shownError !== null && (
+          <p data-testid="project-repo-error" style={CSS.error}>{shownError}</p>
         )}
       </div>
     </section>

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -101,9 +101,17 @@ function isAttached(repo: RepoEntry, members: ProjectMember[]): boolean {
 
 interface Props {
   projectId: string;
-  /** Every member the parent holds — this section filters to `crew.repo` itself. */
+  /**
+   * The parent's membership state — every member (ProjectDetailPage) or already
+   * just the `crew.repo` subset (ProjectDashboard). This section filters to
+   * `crew.repo` itself, so either shape is fine; it never inspects the rest.
+   */
   members: ProjectMember[];
-  /** The parent's membership state with the change applied: attach appends, detach filters. */
+  /**
+   * The SAME array with only the repo change applied — attach appends the new
+   * member, detach filters the one member out — so whatever non-repo entries the
+   * parent handed in come back untouched.
+   */
   onMembersChange: (members: ProjectMember[]) => void;
 }
 
@@ -118,6 +126,15 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
   /** The member id being detached, or null. */
   const [detaching, setDetaching] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  /**
+   * ONE mutation at a time. Both `attach` and `detach` derive the next membership
+   * from the `members` they closed over, so two in flight at once would each
+   * report from a stale base and the later one would silently drop the earlier
+   * one's result. The lock also keeps a second row's Detach from re-pointing
+   * `confirming` while a detach is mid-request.
+   */
+  const busy = attaching !== null || detaching !== null;
 
   const repoMembers = useMemo(
     () => members.filter((m) => m.member_kind === REPO_KIND),
@@ -144,7 +161,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
   }
 
   async function attach(repo: RepoEntry): Promise<void> {
-    if (attaching !== null) return;
+    if (busy) return;
     setAttaching(repo.id);
     setError(null);
     try {
@@ -163,7 +180,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
   }
 
   async function detach(member: ProjectMember): Promise<void> {
-    if (detaching !== null) return;
+    if (busy) return;
     setDetaching(member.id);
     setError(null);
     try {
@@ -206,7 +223,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
                       type="button"
                       data-testid="project-repo-detach-confirm"
                       data-repo={m.member_ref}
-                      disabled={detaching !== null}
+                      disabled={busy}
                       onClick={() => void detach(m)}
                       style={{ ...CSS.dangerBtn, opacity: detaching === m.id ? 0.5 : 1 }}
                     >
@@ -215,7 +232,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
                     <button
                       type="button"
                       data-testid="project-repo-detach-cancel"
-                      disabled={detaching !== null}
+                      disabled={busy}
                       onClick={() => setConfirming(null)}
                       style={CSS.ghostBtn}
                     >
@@ -232,8 +249,9 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
                       data-testid="project-repo-detach"
                       data-repo={m.member_ref}
                       title="Detach this repository from the project (asks first)"
+                      disabled={busy}
                       onClick={() => setConfirming(m.id)}
-                      style={CSS.ghostBtn}
+                      style={{ ...CSS.ghostBtn, opacity: busy ? 0.5 : 1 }}
                     >
                       Detach
                     </button>
@@ -275,7 +293,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
                   data-testid="project-repo-option"
                   data-repo={r.id}
                   title={r.root_path}
-                  disabled={attaching !== null}
+                  disabled={busy}
                   onClick={() => void attach(r)}
                   style={{ ...CSS.option, opacity: attaching === r.id ? 0.5 : 1 }}
                 >

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -167,8 +167,22 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
    * query, and its mutation lock (the guarded-out request can no longer act).
    */
   const liveProjectId = useRef<string | null>(projectId);
+  /**
+   * Which mutation is the CURRENT one. `busy` admits one request at a time, but a
+   * project change releases the lock while the request is still out, so a second
+   * mutation can begin before the first settles — for the SAME repo id, when the
+   * operator attaches the same repo on the next project (or navigates back). The
+   * repo id alone cannot tell the two requests apart: the first one's `finally`
+   * would release the lock the second one holds, re-enabling the controls while
+   * its request is still in flight (Copilot on #208). So every mutation, and
+   * every project change, takes the next token; a request applies its result —
+   * the membership update, the error, the lock release — only while it still
+   * holds the token it started with.
+   */
+  const mutationToken = useRef(0);
   useEffect(() => {
     liveProjectId.current = projectId;
+    mutationToken.current += 1;
     setConfirming(null);
     setError(null);
     setRegistryError(null);
@@ -206,9 +220,24 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
       .catch((e: unknown) => setRegistryError(`registered repos unreadable: ${e instanceof Error ? e.message : String(e)}`));
   }
 
+  /**
+   * Begin a mutation: pin the project it is for and take the next token. The
+   * returned predicate is true only while this request is still the current one
+   * — same project shown (a navigation away and back bumps the token too, so a
+   * result from before the round trip is stale even though the id matches), no
+   * project change since, no newer mutation begun since. Everything a request does
+   * after its `await` is gated on it, the lock release included.
+   */
+  function beginMutation(): () => boolean {
+    const forProject = projectId;
+    const token = ++mutationToken.current;
+    return () => liveProjectId.current === forProject && mutationToken.current === token;
+  }
+
   async function attach(repo: RepoEntry): Promise<void> {
     if (busy) return;
     const forProject = projectId;
+    const stillMine = beginMutation();
     setAttaching(repo.id);
     setError(null);
     try {
@@ -217,34 +246,36 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
         ref: repo.id,
         attachedBy: 'studio',
       });
-      if (liveProjectId.current !== forProject) return; // landed after a navigation — not this project's result
+      if (!stillMine()) return; // landed after a navigation or behind a newer mutation — not this request's result to apply
       onMembersChange((current) => (current.some((m) => m.id === member.id) ? current : [...current, member]));
       setQuery('');
     } catch (e) {
-      if (liveProjectId.current !== forProject) return;
+      if (!stillMine()) return;
       setError(`attach failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       // Release the lock only while it is still this request's: a project change
-      // released it already, and a mutation begun since then owns it now.
-      setAttaching((cur) => (cur === repo.id ? null : cur));
+      // released it already, and a mutation begun since then — for this same repo
+      // id included — owns it now. The token, not the repo id, decides.
+      if (stillMine()) setAttaching(null);
     }
   }
 
   async function detach(member: ProjectMember): Promise<void> {
     if (busy) return;
     const forProject = projectId;
+    const stillMine = beginMutation();
     setDetaching(member.id);
     setError(null);
     try {
       await api.detachProjectMember(forProject, member.id);
-      if (liveProjectId.current !== forProject) return; // landed after a navigation — not this project's result
+      if (!stillMine()) return; // landed after a navigation or behind a newer mutation — not this request's result to apply
       onMembersChange((current) => current.filter((m) => m.id !== member.id));
       setConfirming(null);
     } catch (e) {
-      if (liveProjectId.current !== forProject) return;
+      if (!stillMine()) return;
       setError(`detach failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
-      setDetaching((cur) => (cur === member.id ? null : cur));
+      if (stillMine()) setDetaching(null);
     }
   }
 

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.1",
   "counts": {
-    "files": 128,
-    "occurrences": 1030,
-    "static": 874,
+    "files": 129,
+    "occurrences": 1041,
+    "static": 885,
     "dynamic": 56,
     "computed": 6
   },
@@ -3074,6 +3074,72 @@
       "testId": "project-repo",
       "files": [
         "src/components/ProjectCard.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-detach",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-detach-cancel",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-detach-confirm",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-error",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-option",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-options",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-options-empty",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-row",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repo-search",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repos",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
+      "testId": "project-repos-empty",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
       ]
     },
     {

--- a/tests/ProjectDashboard.repos.test.tsx
+++ b/tests/ProjectDashboard.repos.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { Project, ProjectMember, RepoEntry } from '../src/api/types.js';
 
 /**
@@ -54,6 +54,22 @@ function repo(id: string): RepoEntry {
   return { id, name: id, root_path: `/repos/${id}`, default_branch: 'main', registered_at: 1 };
 }
 
+/** A promise the test settles by hand — the request stays in flight exactly as long as the scenario needs. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+/** Settle inside act and drain the continuations (one macrotask tick), so a "nothing
+ *  changed" assertion afterwards describes the settled state, not a race with it. */
+async function settle(fn: () => void): Promise<void> {
+  await act(async () => {
+    fn();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
 beforeEach(() => {
   clearRepoCache();
   for (const m of [listProjectMembers, listRepos, attachProjectMember, detachProjectMember]) m.mockReset();
@@ -104,6 +120,67 @@ describe('ProjectDashboard — Repositories section (studio#207)', () => {
     await waitFor(() => expect(detachProjectMember).toHaveBeenCalledWith('proj-1', 'proj-1:crew.repo:studio-api'));
     await waitFor(() => expect(within(section).queryByTestId('project-repo-row')).toBeNull());
     expect(screen.queryByTestId('dashboard-repos')).toBeNull();
+  });
+
+  it('the dashboard\'s own membership read landing mid-attach is built on, not overwritten', async () => {
+    const read = deferred<{ members: ProjectMember[] }>();
+    listProjectMembers.mockReturnValue(read.promise);
+    const attach = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValue(attach.promise);
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+    const section = await screen.findByTestId('project-repos');
+    expect(section).toHaveAttribute('data-count', '0'); // the read is still out
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    fireEvent.click((await within(section).findAllByTestId('project-repo-option')).find((o) => o.getAttribute('data-repo') === 'studio-web')!);
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledTimes(1));
+
+    // The read lands first, carrying a repo the section had never seen when the attach began.
+    await settle(() => read.resolve({ members: [member('studio-api')] }));
+    expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-api');
+
+    // The attach applies on top of it — one state, both renderings, nothing lost.
+    await settle(() => attach.resolve({ member: member('studio-web') }));
+    expect(within(section).getAllByTestId('project-repo-row').map((r) => r.getAttribute('data-repo'))).toEqual(['studio-api', 'studio-web']);
+    expect(screen.getAllByTestId('dashboard-repo').map((c) => c.getAttribute('data-repo-ref'))).toEqual(['studio-api', 'studio-web']);
+  });
+
+  it('a mutation that resolves after navigating to another project is dropped; the new project shows only its own read', async () => {
+    const readTwo = deferred<{ members: ProjectMember[] }>();
+    listProjectMembers.mockImplementation((id: string) => (id === 'proj-1'
+      ? Promise.resolve({ members: [member('studio-api')] })
+      : readTwo.promise));
+    const attach = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValue(attach.promise);
+    const view = render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+    const section = await screen.findByTestId('project-repos');
+    await waitFor(() => expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-api'));
+
+    const search = within(section).getByTestId('project-repo-search');
+    fireEvent.change(search, { target: { value: 'web' } });
+    fireEvent.click((await within(section).findAllByTestId('project-repo-option')).find((o) => o.getAttribute('data-repo') === 'studio-web')!);
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledWith('proj-1', expect.objectContaining({ ref: 'studio-web' })));
+
+    // Navigate mid-request. The dashboard stays mounted (App.tsx keys it on nothing), so
+    // proj-1's chips, rows and picker query must not stand in for proj-2 while its read is out.
+    view.rerender(<ProjectDashboard projectId="proj-2" runs={[]} navigate={() => {}} />);
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('proj-2'));
+    expect(screen.getByTestId('project-repos')).toHaveAttribute('data-count', '0');
+    expect(screen.queryByTestId('dashboard-repos')).toBeNull();
+    expect(screen.getByTestId('project-repo-search')).toHaveValue('');
+
+    // proj-1's attach lands with proj-2 on screen: dropped, never applied to proj-2's state.
+    await settle(() => attach.resolve({ member: member('studio-web') }));
+    expect(screen.getByTestId('project-repos')).toHaveAttribute('data-count', '0');
+    expect(screen.queryByTestId('dashboard-repos')).toBeNull();
+    expect(screen.queryByTestId('project-repo-error')).toBeNull();
+
+    // Only proj-2's own read fills it — and the abandoned lock did not leak across.
+    await settle(() => readTwo.resolve({ members: [{ ...member('crew'), id: 'proj-2:crew.repo:crew', project_id: 'proj-2' }] }));
+    const after = screen.getByTestId('project-repos');
+    expect(within(after).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'crew');
+    expect(screen.getByTestId('dashboard-repo')).toHaveAttribute('data-repo-ref', 'crew');
+    expect(within(after).getByTestId('project-repo-detach')).toBeEnabled();
   });
 
   it('is omitted on the synthesized default project', async () => {

--- a/tests/ProjectDashboard.repos.test.tsx
+++ b/tests/ProjectDashboard.repos.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { Project, ProjectMember, RepoEntry } from '../src/api/types.js';
+
+/**
+ * studio#207 on the LIVE project surface: `/projects/:id` redirects onto `/p/:id`
+ * (useLegacyRedirect §1.5), so the dashboard is where an operator actually lands
+ * after creating a project. The Repositories section mounts here too, and it
+ * shares the dashboard's one membership read: an attach from the section shows
+ * up in the header's bound-repo chips without a second fetch.
+ */
+
+const listProjectMembers = vi.fn();
+const listRepos = vi.fn();
+const attachProjectMember = vi.fn();
+const detachProjectMember = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects: [] }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+    confirmGate: () => Promise.resolve({}),
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    attachProjectMember: (...a: unknown[]) => attachProjectMember(...a),
+    detachProjectMember: (...a: unknown[]) => detachProjectMember(...a),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: () => Promise.resolve([]),
+}));
+
+const { ProjectDashboard } = await import('../src/components/ProjectDashboard.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { useGateStore } = await import('../src/store/gates.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const NOW = 1_757_300_000_000;
+
+const PROJECT: Project = {
+  id: 'proj-1', name: 'The proj-1 project', description: null, status: 'active',
+  scope: 'project:proj-1', created_at: NOW - 1000, updated_at: NOW - 1000,
+};
+
+function member(ref: string, kind = 'crew.repo'): ProjectMember {
+  return {
+    id: `proj-1:${kind}:${ref}`, project_id: 'proj-1', member_kind: kind,
+    member_ref: ref, meta: null, attached_at: NOW - 2000, attached_by: 'studio',
+  };
+}
+
+function repo(id: string): RepoEntry {
+  return { id, name: id, root_path: `/repos/${id}`, default_branch: 'main', registered_at: 1 };
+}
+
+beforeEach(() => {
+  clearRepoCache();
+  for (const m of [listProjectMembers, listRepos, attachProjectMember, detachProjectMember]) m.mockReset();
+  listProjectMembers.mockResolvedValue({ members: [] });
+  listRepos.mockResolvedValue({ repos: [repo('studio-api'), repo('studio-web')] });
+  useGateStore.setState({ gates: {} });
+  useProjectsStore.setState({ projects: [PROJECT], loading: false, error: null });
+});
+afterEach(cleanup);
+
+describe('ProjectDashboard — Repositories section (studio#207)', () => {
+  it('mounts the section from the dashboard\'s one membership read; attaching lights the header chip too', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('r-1', 'crew.run')] });
+    attachProjectMember.mockResolvedValue({ member: member('studio-api') });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    const section = await screen.findByTestId('project-repos');
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledTimes(1));
+    expect(section).toHaveAttribute('data-count', '0');
+    expect(screen.queryByTestId('dashboard-repos')).toBeNull(); // the empty-state budget
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    const options = await within(section).findAllByTestId('project-repo-option');
+    expect(options.map((o) => o.getAttribute('data-repo'))).toEqual(['studio-api', 'studio-web']);
+    fireEvent.click(options[0]!);
+
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledWith('proj-1', {
+      kind: 'crew.repo', ref: 'studio-api', attachedBy: 'studio',
+    }));
+    // One state, two renderings: the row AND the header chip, with no second membership read.
+    await waitFor(() => expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-api'));
+    expect(screen.getByTestId('dashboard-repo')).toHaveAttribute('data-repo-ref', 'studio-api');
+    expect(screen.getByTestId('dashboard-repo')).toHaveTextContent('studio-api'); // resolved via the warmed cache
+    expect(listProjectMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('detaching from the section retires the header chip as well', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('studio-api')] });
+    detachProjectMember.mockResolvedValue({ ok: true });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+
+    const section = await screen.findByTestId('project-repos');
+    await waitFor(() => expect(within(section).getByTestId('project-repo-row')).toBeInTheDocument());
+    expect(screen.getByTestId('dashboard-repos')).toBeInTheDocument();
+
+    fireEvent.click(within(section).getByTestId('project-repo-detach'));
+    fireEvent.click(within(section).getByTestId('project-repo-detach-confirm'));
+    await waitFor(() => expect(detachProjectMember).toHaveBeenCalledWith('proj-1', 'proj-1:crew.repo:studio-api'));
+    await waitFor(() => expect(within(section).queryByTestId('project-repo-row')).toBeNull());
+    expect(screen.queryByTestId('dashboard-repos')).toBeNull();
+  });
+
+  it('is omitted on the synthesized default project', async () => {
+    useProjectsStore.setState({ projects: [{ ...PROJECT, id: 'default', name: 'Unfiled' }], loading: false, error: null });
+    render(<ProjectDashboard projectId="default" runs={[]} navigate={() => {}} />);
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('default'));
+    expect(screen.getByTestId('project-dashboard')).toBeInTheDocument();
+    expect(screen.queryByTestId('project-repos')).toBeNull();
+  });
+});

--- a/tests/ProjectDetailPage.repos.test.tsx
+++ b/tests/ProjectDetailPage.repos.test.tsx
@@ -169,6 +169,52 @@ describe('ProjectDetailPage — Repositories section (studio#207)', () => {
     expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-web');
   });
 
+  it('one mutation at a time: while a detach is in flight every other Detach and the picker are disabled, then re-enable', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [member('proj-1', 'studio-api'), member('proj-1', 'studio-web')]));
+    let settleDetach!: (v: { ok: true }) => void;
+    detachProjectMember.mockReturnValue(new Promise<{ ok: true }>((resolve) => { settleDetach = resolve; }));
+    const section = await renderPage();
+
+    const [first, second] = within(section).getAllByTestId('project-repo-row') as [HTMLElement, HTMLElement];
+    fireEvent.click(within(first).getByTestId('project-repo-detach'));
+    fireEvent.click(within(first).getByTestId('project-repo-detach-confirm'));
+    await waitFor(() => expect(detachProjectMember).toHaveBeenCalledTimes(1));
+
+    // Mid-request: the other row cannot start a second confirm, and the picker cannot attach.
+    expect(within(second).getByTestId('project-repo-detach')).toBeDisabled();
+    fireEvent.click(within(second).getByTestId('project-repo-detach'));
+    expect(within(second).queryByTestId('project-repo-detach-confirm')).toBeNull();
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    for (const option of await within(section).findAllByTestId('project-repo-option')) expect(option).toBeDisabled();
+    expect(attachProjectMember).not.toHaveBeenCalled();
+
+    settleDetach({ ok: true });
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(1));
+    const remaining = within(section).getByTestId('project-repo-row');
+    expect(remaining).toHaveAttribute('data-repo', 'studio-web');
+    expect(within(remaining).getByTestId('project-repo-detach')).toBeEnabled();
+    for (const option of within(section).getAllByTestId('project-repo-option')) expect(option).toBeEnabled();
+  });
+
+  it('attach and detach hand the parent back its non-repo members untouched', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [member('proj-1', 'r-1', 'crew.run'), member('proj-1', 'studio-api')]));
+    attachProjectMember.mockResolvedValue({ member: member('proj-1', 'crew') });
+    detachProjectMember.mockResolvedValue({ ok: true });
+    const section = await renderPage();
+    expect(screen.getByText('Members (1)')).toBeInTheDocument();
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    fireEvent.click((await within(section).findAllByTestId('project-repo-option')).find((o) => o.getAttribute('data-repo') === 'crew')!);
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(2));
+    expect(screen.getByText('Members (1)')).toBeInTheDocument(); // the run member survived the attach
+
+    const row = within(section).getAllByTestId('project-repo-row').find((r) => r.getAttribute('data-repo') === 'studio-api')!;
+    fireEvent.click(within(row).getByTestId('project-repo-detach'));
+    fireEvent.click(within(row).getByTestId('project-repo-detach-confirm'));
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(1));
+    expect(screen.getByText('Members (1)')).toBeInTheDocument(); // and the detach
+  });
+
   it('is omitted for the synthesized default project (the wire rejects attach there)', async () => {
     getProject.mockResolvedValue(detail('default', [member('default', 'r-1', 'crew.run')]));
     getProjectActivity.mockResolvedValue({ entries: [], nextCursor: null, projectId: 'default' });

--- a/tests/ProjectDetailPage.repos.test.tsx
+++ b/tests/ProjectDetailPage.repos.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { Project, ProjectDetail, ProjectMember, RepoEntry } from '../src/api/types.js';
+
+/**
+ * studio#207 — the Repositories section: the one UI path that attaches a `crew.repo`
+ * member to a project. Mounted on the legacy `/projects/:id` page (this suite) and on
+ * the live `/p/:id` dashboard (ProjectDashboard.repos.test.tsx). Lists the project's
+ * repo members, offers the registered-repo picker minus what is already attached,
+ * attaches with the pinned `AttachMemberBody` wire, detaches behind an inline
+ * confirm, and is omitted for the synthesized `default` project (which rejects
+ * attach on the wire).
+ */
+
+const getProject = vi.fn();
+const getProjectActivity = vi.fn();
+const listRepos = vi.fn();
+const attachProjectMember = vi.fn();
+const detachProjectMember = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getProject: (...a: unknown[]) => getProject(...a),
+    getProjectActivity: (...a: unknown[]) => getProjectActivity(...a),
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    attachProjectMember: (...a: unknown[]) => attachProjectMember(...a),
+    detachProjectMember: (...a: unknown[]) => detachProjectMember(...a),
+  },
+}));
+
+const { ProjectDetailPage } = await import('../src/components/ProjectDetailPage.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const NOW = 1_757_300_000_000;
+
+function project(id: string): Project {
+  return {
+    id, name: `The ${id} project`, description: null, status: 'active',
+    scope: `project:${id}`, created_at: NOW - 1000, updated_at: NOW - 1000,
+  };
+}
+
+function member(projectId: string, ref: string, kind = 'crew.repo'): ProjectMember {
+  return {
+    id: `${projectId}:${kind}:${ref}`, project_id: projectId, member_kind: kind,
+    member_ref: ref, meta: null, attached_at: NOW - 2000, attached_by: 'studio',
+  };
+}
+
+function repo(id: string): RepoEntry {
+  return { id, name: id, root_path: `/repos/${id}`, default_branch: 'main', registered_at: 1 };
+}
+
+function detail(projectId: string, members: ProjectMember[]): ProjectDetail {
+  return { project: project(projectId), members } as ProjectDetail;
+}
+
+beforeEach(() => {
+  clearRepoCache();
+  for (const m of [getProject, getProjectActivity, listRepos, attachProjectMember, detachProjectMember]) m.mockReset();
+  getProjectActivity.mockResolvedValue({ entries: [], nextCursor: null, projectId: 'proj-1' });
+  listRepos.mockResolvedValue({ repos: [repo('studio-api'), repo('studio-web'), repo('crew')] });
+});
+afterEach(cleanup);
+
+async function renderPage(projectId = 'proj-1'): Promise<HTMLElement> {
+  render(<ProjectDetailPage projectId={projectId} navigate={() => {}} />);
+  await waitFor(() => expect(getProject).toHaveBeenCalledWith(projectId));
+  return await screen.findByTestId('project-repos');
+}
+
+describe('ProjectDetailPage — Repositories section (studio#207)', () => {
+  it('lists the crew.repo members as rows keyed by ref; other member kinds stay out of the section', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [
+      member('proj-1', 'studio-api'),
+      member('proj-1', 'r-1', 'crew.run'),
+      member('proj-1', 'studio-web'),
+    ]));
+    const section = await renderPage();
+
+    expect(section).toHaveAttribute('data-count', '2');
+    const rows = within(section).getAllByTestId('project-repo-row');
+    expect(rows.map((r) => r.getAttribute('data-repo'))).toEqual(['studio-api', 'studio-web']);
+    // The run member is a Member, not a repository — and the generic list no longer double-lists repos.
+    expect(within(section).queryByText('r-1')).toBeNull();
+    expect(screen.getByText('Members (1)')).toBeInTheDocument();
+    // Nothing fetched the registry on mount — the picker warms the cache on its first gesture.
+    expect(listRepos).not.toHaveBeenCalled();
+  });
+
+  it('the empty state names the consequence (a project-scoped test cannot launch)', async () => {
+    getProject.mockResolvedValue(detail('proj-1', []));
+    const section = await renderPage();
+    expect(within(section).getByTestId('project-repos-empty')).toHaveTextContent('project-scoped test cannot launch');
+    expect(within(section).queryByTestId('project-repo-row')).toBeNull();
+  });
+
+  it('the picker fetches the registry on focus, excludes already-attached repos, and Attach sends the pinned AttachMemberBody', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [member('proj-1', 'studio-api')]));
+    attachProjectMember.mockResolvedValue({ member: member('proj-1', 'crew') });
+    const section = await renderPage();
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
+    const options = await within(section).findAllByTestId('project-repo-option');
+    // studio-api is attached → not offered; the two unattached repos are.
+    expect(options.map((o) => o.getAttribute('data-repo'))).toEqual(['studio-web', 'crew']);
+
+    fireEvent.click(options[1]!);
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledTimes(1));
+    // The wire is crew's AttachMemberBody — `{kind, ref, attachedBy}`, the same body the
+    // register flow sends — NOT the ProjectMember read shape.
+    expect(attachProjectMember).toHaveBeenCalledWith('proj-1', {
+      kind: 'crew.repo',
+      ref: 'crew',
+      attachedBy: 'studio',
+    });
+
+    // The returned member joins the list; the picker drops it from the offer.
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(2));
+    expect(within(section).getAllByTestId('project-repo-row').map((r) => r.getAttribute('data-repo')))
+      .toEqual(['studio-api', 'crew']);
+    expect(within(section).getAllByTestId('project-repo-option').map((o) => o.getAttribute('data-repo')))
+      .toEqual(['studio-web']);
+    expect(listRepos).toHaveBeenCalledTimes(1); // still the one cached registry read
+  });
+
+  it('typing narrows the picker by name; a miss says so instead of offering nothing silently', async () => {
+    getProject.mockResolvedValue(detail('proj-1', []));
+    const section = await renderPage();
+
+    const search = within(section).getByTestId('project-repo-search');
+    fireEvent.change(search, { target: { value: 'web' } });
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-option')).toHaveLength(1));
+    expect(within(section).getByTestId('project-repo-option')).toHaveAttribute('data-repo', 'studio-web');
+
+    fireEvent.change(search, { target: { value: 'nope' } });
+    expect(within(section).getByTestId('project-repo-options-empty')).toHaveTextContent('no registered repo matches');
+  });
+
+  it('a failed attach surfaces the error and adds no row', async () => {
+    getProject.mockResolvedValue(detail('proj-1', []));
+    attachProjectMember.mockRejectedValue(new Error('repo ref not in the registry'));
+    const section = await renderPage();
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    fireEvent.click((await within(section).findAllByTestId('project-repo-option'))[0]!);
+
+    await waitFor(() => expect(within(section).getByTestId('project-repo-error')).toHaveTextContent('repo ref not in the registry'));
+    expect(within(section).queryByTestId('project-repo-row')).toBeNull();
+  });
+
+  it('Detach asks first: Cancel leaves the member, Confirm DELETEs the member by id and drops the row', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [member('proj-1', 'studio-api'), member('proj-1', 'studio-web')]));
+    detachProjectMember.mockResolvedValue({ ok: true });
+    const section = await renderPage();
+
+    const row = within(section).getAllByTestId('project-repo-row')[0]!;
+    fireEvent.click(within(row).getByTestId('project-repo-detach'));
+    expect(detachProjectMember).not.toHaveBeenCalled();
+    fireEvent.click(within(row).getByTestId('project-repo-detach-cancel'));
+    expect(within(row).queryByTestId('project-repo-detach-confirm')).toBeNull();
+    expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(2);
+
+    fireEvent.click(within(row).getByTestId('project-repo-detach'));
+    fireEvent.click(within(row).getByTestId('project-repo-detach-confirm'));
+    await waitFor(() => expect(detachProjectMember).toHaveBeenCalledWith('proj-1', 'proj-1:crew.repo:studio-api'));
+    await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(1));
+    expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-web');
+  });
+
+  it('is omitted for the synthesized default project (the wire rejects attach there)', async () => {
+    getProject.mockResolvedValue(detail('default', [member('default', 'r-1', 'crew.run')]));
+    getProjectActivity.mockResolvedValue({ entries: [], nextCursor: null, projectId: 'default' });
+    render(<ProjectDetailPage projectId="default" navigate={() => {}} />);
+    await waitFor(() => expect(getProject).toHaveBeenCalledWith('default'));
+    await screen.findByText('Members (1)');
+
+    expect(screen.queryByTestId('project-repos')).toBeNull();
+    expect(screen.queryByTestId('project-repo-search')).toBeNull();
+  });
+});

--- a/tests/ProjectDetailPage.repos.test.tsx
+++ b/tests/ProjectDetailPage.repos.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { Project, ProjectDetail, ProjectMember, RepoEntry } from '../src/api/types.js';
 
 /**
@@ -53,6 +53,22 @@ function repo(id: string): RepoEntry {
 
 function detail(projectId: string, members: ProjectMember[]): ProjectDetail {
   return { project: project(projectId), members } as ProjectDetail;
+}
+
+/** A promise the test settles by hand — the request stays in flight exactly as long as the scenario needs. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+/** Settle inside act and drain the continuations (one macrotask tick), so a "nothing
+ *  changed" assertion afterwards describes the settled state, not a race with it. */
+async function settle(fn: () => void): Promise<void> {
+  await act(async () => {
+    fn();
+    await new Promise((r) => setTimeout(r, 0));
+  });
 }
 
 beforeEach(() => {
@@ -213,6 +229,77 @@ describe('ProjectDetailPage — Repositories section (studio#207)', () => {
     fireEvent.click(within(row).getByTestId('project-repo-detach-confirm'));
     await waitFor(() => expect(within(section).getAllByTestId('project-repo-row')).toHaveLength(1));
     expect(screen.getByText('Members (1)')).toBeInTheDocument(); // and the detach
+  });
+
+  it('a membership change made elsewhere mid-attach survives: a run member detached through the Members list stays gone', async () => {
+    getProject.mockResolvedValue(detail('proj-1', [member('proj-1', 'r-1', 'crew.run'), member('proj-1', 'studio-api')]));
+    const attach = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValue(attach.promise);
+    detachProjectMember.mockResolvedValue({ ok: true });
+    const section = await renderPage();
+    expect(screen.getByText('Members (1)')).toBeInTheDocument();
+
+    fireEvent.focus(within(section).getByTestId('project-repo-search'));
+    fireEvent.click((await within(section).findAllByTestId('project-repo-option')).find((o) => o.getAttribute('data-repo') === 'crew')!);
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledTimes(1));
+
+    // While the attach is in flight, the generic Members list detaches the run member —
+    // a membership change the section's mutation lock does not (and should not) cover.
+    const runRow = screen.getByText('r-1').parentElement!;
+    fireEvent.mouseEnter(runRow);
+    fireEvent.click(within(runRow).getByRole('button', { name: 'Detach' }));
+    await waitFor(() => expect(detachProjectMember).toHaveBeenCalledWith('proj-1', 'proj-1:crew.run:r-1'));
+    expect(screen.getByText('Members (0)')).toBeInTheDocument();
+
+    // The attach applies to the membership held NOW: the repo joins, the run member does not come back.
+    await settle(() => attach.resolve({ member: member('proj-1', 'crew') }));
+    expect(within(section).getAllByTestId('project-repo-row').map((r) => r.getAttribute('data-repo'))).toEqual(['studio-api', 'crew']);
+    expect(screen.getByText('Members (0)')).toBeInTheDocument();
+  });
+
+  it('an attach that resolves after navigating to another project never touches that project\'s membership', async () => {
+    getProject.mockImplementation((id: string) => Promise.resolve(detail(id, id === 'proj-1'
+      ? [member('proj-1', 'studio-api')]
+      : [member('proj-2', 'r-2', 'crew.run'), member('proj-2', 'studio-web')])));
+    const attach = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValue(attach.promise);
+    const view = render(<ProjectDetailPage projectId="proj-1" navigate={() => {}} />);
+    const first = await screen.findByTestId('project-repos');
+
+    fireEvent.focus(within(first).getByTestId('project-repo-search'));
+    fireEvent.click((await within(first).findAllByTestId('project-repo-option')).find((o) => o.getAttribute('data-repo') === 'crew')!);
+    await waitFor(() => expect(attachProjectMember).toHaveBeenCalledWith('proj-1', expect.objectContaining({ ref: 'crew' })));
+
+    // Navigate before it lands. The page stays mounted (App.tsx keys neither project surface),
+    // so the same component instance loads proj-2 while proj-1's attach is still out.
+    view.rerender(<ProjectDetailPage projectId="proj-2" navigate={() => {}} />);
+    await waitFor(() => expect(getProject).toHaveBeenCalledWith('proj-2'));
+    const second = await screen.findByTestId('project-repos');
+    await waitFor(() => expect(within(second).getAllByTestId('project-repo-row').map((r) => r.getAttribute('data-repo'))).toEqual(['studio-web']));
+    expect(screen.getByText('Members (1)')).toBeInTheDocument();
+
+    // proj-1's attach lands with proj-2 on screen: dropped, and proj-2 keeps exactly its own members.
+    await settle(() => attach.resolve({ member: member('proj-1', 'crew') }));
+    const section = screen.getByTestId('project-repos');
+    expect(section).toHaveAttribute('data-count', '1');
+    expect(within(section).getByTestId('project-repo-row')).toHaveAttribute('data-repo', 'studio-web');
+    expect(screen.getByText('Members (1)')).toBeInTheDocument();
+    expect(screen.queryByTestId('project-repo-error')).toBeNull();
+  });
+
+  it('a registry fetch failure clears on the retry gesture instead of outliving the load', async () => {
+    getProject.mockResolvedValue(detail('proj-1', []));
+    listRepos.mockRejectedValueOnce(new Error('daemon unreachable')).mockResolvedValue({ repos: [repo('crew')] });
+    const section = await renderPage();
+
+    const search = within(section).getByTestId('project-repo-search');
+    fireEvent.focus(search);
+    await waitFor(() => expect(within(section).getByTestId('project-repo-error')).toHaveTextContent('daemon unreachable'));
+
+    fireEvent.focus(search); // the retry gesture — a failed fetch caches nothing, so it refetches
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(within(section).getByTestId('project-repo-option')).toHaveAttribute('data-repo', 'crew'));
+    expect(within(section).queryByTestId('project-repo-error')).toBeNull();
   });
 
   it('is omitted for the synthesized default project (the wire rejects attach there)', async () => {

--- a/tests/ProjectRepositories.mutationToken.test.tsx
+++ b/tests/ProjectRepositories.mutationToken.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { ProjectMember, RepoEntry } from '../src/api/types.js';
+
+/**
+ * Copilot on studio#208: `attach()` released the `attaching` lock in `finally` by comparing
+ * the repo id alone. Navigate to another project mid-attach (the effect releases the lock),
+ * attach the SAME repo there, and the first request's `finally` — landing later — matched
+ * the second request on the id and released ITS lock while it was still in flight, so the
+ * mutation controls re-enabled mid-request. The fix keys every mutation on an attempt token
+ * (bumped per mutation AND per project change); a request applies its result and releases
+ * the lock only while it still holds the token it started with. These tests drive the exact
+ * scenarios: same repo id on the next project, a navigation round trip, and detach.
+ */
+
+const listRepos = vi.fn();
+const attachProjectMember = vi.fn();
+const detachProjectMember = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    attachProjectMember: (...a: unknown[]) => attachProjectMember(...a),
+    detachProjectMember: (...a: unknown[]) => detachProjectMember(...a),
+  },
+}));
+
+const { ProjectRepositories } = await import('../src/components/ProjectRepositories.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const NOW = 1_757_300_000_000;
+
+function member(projectId: string, ref: string): ProjectMember {
+  return {
+    id: `${projectId}:crew.repo:${ref}`, project_id: projectId, member_kind: 'crew.repo',
+    member_ref: ref, meta: null, attached_at: NOW - 2000, attached_by: 'studio',
+  };
+}
+
+function repo(id: string): RepoEntry {
+  return { id, name: id, root_path: `/repos/${id}`, default_branch: 'main', registered_at: 1 };
+}
+
+/** A promise the test settles by hand — the request stays in flight exactly as long as the scenario needs. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+/** Settle inside act and drain the continuations (one macrotask tick), so a "nothing
+ *  changed" assertion afterwards describes the settled state, not a race with it. */
+async function settle(fn: () => void): Promise<void> {
+  await act(async () => {
+    fn();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function openPickerAndAttach(section: HTMLElement, repoId: string): Promise<HTMLElement> {
+  fireEvent.focus(within(section).getByTestId('project-repo-search'));
+  const option = (await within(section).findAllByTestId('project-repo-option'))
+    .find((o) => o.getAttribute('data-repo') === repoId)!;
+  fireEvent.click(option);
+  return option;
+}
+
+function optionFor(section: HTMLElement, repoId: string): HTMLElement {
+  return within(section).getAllByTestId('project-repo-option').find((o) => o.getAttribute('data-repo') === repoId)!;
+}
+
+beforeEach(() => {
+  clearRepoCache();
+  for (const m of [listRepos, attachProjectMember, detachProjectMember]) m.mockReset();
+  listRepos.mockResolvedValue({ repos: [repo('studio-api'), repo('studio-web')] });
+});
+afterEach(cleanup);
+
+describe('ProjectRepositories — a mutation releases only the lock it holds (Copilot on #208)', () => {
+  it("a stale attach landing after a project change does NOT release the next project's attach of the SAME repo", async () => {
+    const first = deferred<{ member: ProjectMember }>();
+    const second = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const onMembersChange = vi.fn();
+    const view = render(<ProjectRepositories projectId="proj-a" members={[]} onMembersChange={onMembersChange} />);
+    const section = screen.getByTestId('project-repos');
+
+    // Attach studio-api on A — in flight.
+    await openPickerAndAttach(section, 'studio-api');
+    expect(attachProjectMember).toHaveBeenNthCalledWith(1, 'proj-a', { kind: 'crew.repo', ref: 'studio-api', attachedBy: 'studio' });
+
+    // Navigate to B mid-flight: the same instance, a new projectId; the lock is released for B.
+    view.rerender(<ProjectRepositories projectId="proj-b" members={[]} onMembersChange={onMembersChange} />);
+    await openPickerAndAttach(section, 'studio-api');
+    expect(attachProjectMember).toHaveBeenNthCalledWith(2, 'proj-b', { kind: 'crew.repo', ref: 'studio-api', attachedBy: 'studio' });
+    expect(optionFor(section, 'studio-api')).toBeDisabled();
+    expect(optionFor(section, 'studio-api')).toHaveTextContent('… studio-api');
+
+    // A's request lands now. Before the fix its `finally` matched B's request on the repo id
+    // and released B's lock; B's request is still out, so the controls must stay locked.
+    await settle(() => first.resolve({ member: member('proj-a', 'studio-api') }));
+    expect(optionFor(section, 'studio-api')).toBeDisabled();
+    expect(optionFor(section, 'studio-api')).toHaveTextContent('… studio-api');
+    expect(onMembersChange).not.toHaveBeenCalled(); // A's result is not B's to apply
+
+    // B's own request lands: applied once, lock released.
+    await settle(() => second.resolve({ member: member('proj-b', 'studio-api') }));
+    expect(onMembersChange).toHaveBeenCalledTimes(1);
+    expect(onMembersChange.mock.calls[0]![0]([])).toEqual([member('proj-b', 'studio-api')]);
+    expect(optionFor(section, 'studio-api')).toBeEnabled();
+    expect(optionFor(section, 'studio-api')).toHaveTextContent('+ studio-api');
+  });
+
+  it('a navigation round trip (A → B → A) makes the request begun before it stale — same project id, different attempt', async () => {
+    const first = deferred<{ member: ProjectMember }>();
+    const second = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const onMembersChange = vi.fn();
+    const view = render(<ProjectRepositories projectId="proj-a" members={[]} onMembersChange={onMembersChange} />);
+    const section = screen.getByTestId('project-repos');
+
+    await openPickerAndAttach(section, 'studio-api');
+    view.rerender(<ProjectRepositories projectId="proj-b" members={[]} onMembersChange={onMembersChange} />);
+    view.rerender(<ProjectRepositories projectId="proj-a" members={[]} onMembersChange={onMembersChange} />);
+    await openPickerAndAttach(section, 'studio-api');
+    expect(attachProjectMember).toHaveBeenCalledTimes(2);
+
+    // The pre-round-trip request lands: the project id matches again, but the attempt does not.
+    await settle(() => first.resolve({ member: member('proj-a', 'studio-api') }));
+    expect(optionFor(section, 'studio-api')).toBeDisabled();
+    expect(onMembersChange).not.toHaveBeenCalled();
+
+    await settle(() => second.resolve({ member: member('proj-a', 'studio-api') }));
+    expect(onMembersChange).toHaveBeenCalledTimes(1);
+    expect(optionFor(section, 'studio-api')).toBeEnabled();
+  });
+
+  it('a stale attach FAILURE is dropped the same way — no error surfaces on the project that did not send it', async () => {
+    const first = deferred<{ member: ProjectMember }>();
+    const second = deferred<{ member: ProjectMember }>();
+    attachProjectMember.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const view = render(<ProjectRepositories projectId="proj-a" members={[]} onMembersChange={() => {}} />);
+    const section = screen.getByTestId('project-repos');
+
+    await openPickerAndAttach(section, 'studio-api');
+    view.rerender(<ProjectRepositories projectId="proj-b" members={[]} onMembersChange={() => {}} />);
+    await openPickerAndAttach(section, 'studio-api');
+
+    await settle(() => first.reject(new Error('A is gone')));
+    expect(within(section).queryByTestId('project-repo-error')).toBeNull();
+    expect(optionFor(section, 'studio-api')).toBeDisabled();
+
+    await settle(() => second.reject(new Error('B refused')));
+    expect(within(section).getByTestId('project-repo-error')).toHaveTextContent('attach failed: B refused');
+    expect(optionFor(section, 'studio-api')).toBeEnabled();
+  });
+
+  it('detach has the same guard: a stale detach never releases the lock of the detach begun after the round trip', async () => {
+    const first = deferred<{ ok: true }>();
+    const second = deferred<{ ok: true }>();
+    detachProjectMember.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const onMembersChange = vi.fn();
+    const members = [member('proj-a', 'studio-api')];
+    const view = render(<ProjectRepositories projectId="proj-a" members={members} onMembersChange={onMembersChange} />);
+    const section = screen.getByTestId('project-repos');
+
+    fireEvent.click(within(section).getByTestId('project-repo-detach'));
+    fireEvent.click(within(section).getByTestId('project-repo-detach-confirm'));
+    expect(detachProjectMember).toHaveBeenNthCalledWith(1, 'proj-a', 'proj-a:crew.repo:studio-api');
+
+    // Away and back: the effect abandons A's in-progress UI (confirm + lock); the operator asks again.
+    view.rerender(<ProjectRepositories projectId="proj-b" members={[]} onMembersChange={onMembersChange} />);
+    view.rerender(<ProjectRepositories projectId="proj-a" members={members} onMembersChange={onMembersChange} />);
+    fireEvent.click(within(section).getByTestId('project-repo-detach'));
+    fireEvent.click(within(section).getByTestId('project-repo-detach-confirm'));
+    expect(detachProjectMember).toHaveBeenCalledTimes(2);
+    expect(within(section).getByTestId('project-repo-detach-confirm')).toHaveTextContent('Detaching…');
+
+    await settle(() => first.resolve({ ok: true }));
+    expect(within(section).getByTestId('project-repo-detach-confirm')).toHaveTextContent('Detaching…');
+    expect(within(section).getByTestId('project-repo-detach-confirm')).toBeDisabled();
+    expect(onMembersChange).not.toHaveBeenCalled();
+
+    await settle(() => second.resolve({ ok: true }));
+    expect(onMembersChange).toHaveBeenCalledTimes(1);
+    expect(onMembersChange.mock.calls[0]![0](members)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #207.

## Problem

A UI-created project could never launch a project-scoped test: `NewProjectModal` sends name/description only, no surface ever called `api.attachProjectMember` with `kind: 'crew.repo'`, and crew's multiscope resolver 400s a project-only launch whose project holds zero repository members. The launch panel's own `testing-launch-project-empty` warning pointed at an action the product had no control for.

## Change

**New `ProjectRepositories` section** (`src/components/ProjectRepositories.tsx`), mounted on both project surfaces:

- **`ProjectDashboard` (`/p/:id`)** — the surface an operator actually lands on. `/projects/:id` is the legacy route that `useLegacyRedirect` (§1.5) replaces with `/p/:id` on mount, so a section only on `ProjectDetailPage` would have been dead UI. The dashboard's existing one membership read now keeps the `crew.repo` members as `ProjectMember[]`; the header's bound-repo chips (`dashboard-repos`, DES-FEEDBACK-002 §10.2 — contract unchanged) and the new section render from that one state, so an attach lights the chip with no second fetch.
- **`ProjectDetailPage` (`/projects/:id`, legacy)** — also mounted; its generic Members list now shows the non-repo members (the Repositories section owns the repo rows, no double-listing).

What the section does:

- Lists the project's `crew.repo` members (`project-repo-row[data-repo]`), name/path resolved from the session repo cache, raw ref when the registry lags.
- **Attach**: a registered-repo picker (`project-repo-search` / `project-repo-option`) over the ONE session repo cache (`fetchReposCached`, DES-FEEDBACK-002 §1.4) — fetched on the field's first focus, never on mount — excluding already-attached repos. Attach sends the pinned `AttachMemberBody`: `POST /projects/:id/members` `{ kind: 'crew.repo', ref: <repo id>, attachedBy: 'studio' }` — the same body `RepositoriesPanel`'s register flow sends.
- **Detach** (`project-repo-detach` → inline confirm `project-repo-detach-confirm` / `-cancel`): `DELETE /projects/:id/members/:mid` via the existing `api.detachProjectMember`.
- **One mutation at a time**: attach and detach share a single `busy` lock — both derive the next membership from the `members` they closed over, so two in flight together would report from a stale base and the later one would silently drop the earlier result. Every mutation control (picker options, Detach, confirm, cancel) is disabled while one is in flight.
- Empty state names the consequence ("a project-scoped test cannot launch until one is"); attach/detach failures surface in `project-repo-error`, never swallowed.
- **Omitted for the synthesized `default` project** (the wire rejects attach there and it has no stored members).

Not done: a repo picker inside `NewProjectModal`. Its 360×280 anatomy is design-pinned (DES-FEEDBACK-001 §1.3, asserted by `tests/NewProjectModal.test.tsx`) and the modal fetches nothing on open; the "Empty" start already lands on the project surface where the new section is the next step, so the create → attach journey is covered without reshaping the modal.

## Review follow-up (`c2b6b36`)

Both Copilot findings addressed:

- **Detach enabled mid-request** (`ProjectRepositories.tsx:239`) — the per-flag locks (`attaching`, `detaching`) became the one `busy` lock above; a second row's Detach can no longer re-point `confirming` while a detach is in flight, and the same lock closes the attach-vs-detach stale-closure race described above.
- **`Props.members` doc vs. dashboard usage** (`ProjectRepositories.tsx:107`) — the contract is now stated as it is: the parent hands in either every member (`ProjectDetailPage`) or just the `crew.repo` subset (`ProjectDashboard`); the section filters to `crew.repo` itself and `onMembersChange` returns the SAME array with only the repo change applied, so non-repo entries are never dropped. A test now pins that.

## Tests

- `tests/ProjectDetailPage.repos.test.tsx` (9): rows keyed by ref with other kinds excluded, empty-state copy, picker fetch-on-focus + exclusion of attached repos + the exact attach wire body + the new row/offer update, name narrowing + miss copy, failed attach surfaces and adds no row, detach cancel/confirm with the DELETE by member id, the single mutation lock (second row + picker disabled mid-detach, re-enabled after), non-repo members surviving attach and detach, omitted for `default`.
- `tests/ProjectDashboard.repos.test.tsx` (3): mounts from the dashboard's one membership read and an attach lights the header chip (still one membership read), detach retires the chip, omitted for `default`.
- `testid-inventory.json` regenerated: +11 static testids, none removed (unchanged by the follow-up; the drift test passes).

## Verification (at `c2b6b36`)

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 239 files, 2454 tests passed
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
