### PR TITLE
feat(skills): Skills section — rail heading before Steering, /skills file-manager page (CAS, publish, support files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+### Added
+- **Skills section (#209).** `/skills` — the file manager over the daemon's one effective
+  garden-shaped plugin root (the skills keystone, crew#480): the KPI band and catalog with
+  kind / provenance / core / claude-only / upgrade / conflict / unpublished badges, the enabled
+  switch through the daemon's guards, the drawer with the skill's own files and the root support
+  files under tabs, a textarea editor (Save → `PUT` → the daemon's findings, CAS on the revision
+  the content was read at), the read-only **Baseline side** of the open file (`?side=baseline`;
+  for a held-back name collision it names the upstream file actually read), Reset (typed
+  confirmation), Replace / Add (a pasted files map), Refresh baseline, Analyze (dry run) and
+  Publish. A "Skills" rail section sits before Steering. Every mutation answers the contract's
+  2xx `{verdict, findings, revision}` envelope (a `blocked` verdict is a normal answer with
+  nothing written); a 409 — exclusively a stale `expectedRevision` — freezes the page behind the
+  reload prompt.
+- **Engine line on `/skills`.** `GET /diagnostics` → `skills` (api-types 0.27.0) rendered under the
+  snapshot line: the state vocabulary `published | fallback | blocked | config-error | disabled`
+  with its findings — whether the engine is actually being handed a verified snapshot, and why not.
+
+### Fixed
+- **The Skills API layer speaks the real crew#480 wire (`wicked-crew-api-types` 0.27.0) — fix
+  pass 4 of #209.** Against the integrated bundle `/skills` rendered an error: studio's hand-mirrored
+  types expected a `manifest.support` map, string `revision`/`expectedRevision`, hash-carrying file
+  entries and a `SkillFileContent.hash`, none of which exist in the contract. Every declaration
+  is now a byte-for-byte MIRROR of the contract's skills block (`src/api/skills-wire.ts`, pinned
+  by `tests/skillsWire.test.ts` against a vendored fixture of the same line ranges), and every
+  reader/writer consumes it: numeric revisions, `manifest.files` records (support files are the
+  records no skill owns; the DEEPEST registered skill dir owns a file), `SkillFileTree` rows
+  `{path, size, record}`, `SkillReadResult {content|null, size, truncated, binary}` (Save disabled
+  on either flag), the `provenance` field as the wire's (no longer derived), `upgradeAvailable` /
+  `upstreamDir`, the `published` record and `current` snapshot, `SkillPublishResult.snapshot` and
+  `SkillRefreshResult`'s merge tallies in the notes. Every finding kind renders generically with
+  its skill, the skill it is against (core-marked), `file:line`, evidence and explanation. A
+  **503** (unseeded root / corrupt `current` / no seam) renders the named unavailable state with
+  the daemon's sentence — never an empty catalog; the bare 404 stays the "predates" state.
+  The package pin stays `^0.25.0` (0.27.0 is unpublished); swap the mirror for
+  `export type { … } from 'wicked-crew-api-types'` when it — or its re-minted successor after the
+  #475/#480 collision — publishes.
+
 ## [0.5.1] — 2026-09-08
 
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { RepositoriesPanel } from './components/RepositoriesPanel.js';
 import { RepoDetailPage } from './components/RepoDetailPage.js';
 import { RepoGraphModal } from './components/RepoGraphModal.js';
 import { RightPanel } from './components/RightPanel.js';
+import { SkillsPage } from './components/SkillsPage.js';
 import { SteeringPage } from './components/SteeringPage.js';
 import { MemoriesPanel } from './components/MemoriesPanel.js';
 import { GovernanceDashboard } from './components/GovernanceDashboard.js';
@@ -523,6 +524,18 @@ export function App(): React.ReactElement {
             search={search}
             runs={runs}
           />
+        </div>
+      );
+    }
+    // `/skills` — the skills file manager over the daemon's effective plugin root (the skills
+    // keystone): the catalog + KPI band, a drawer per skill (skill + support file trees, textarea
+    // editor, enable/disable, reset, replace), and the page-level Publish that writes the snapshot
+    // workers spawn with. `?skill=<name>` deep-links a drawer open. Same two-column shell as
+    // Steering — the page owns its own scrolling column, so no page-level scroll wrapper.
+    if (panel === 'skills') {
+      return (
+        <div className="flex flex-1 overflow-hidden">
+          <SkillsPage navigate={navigate} search={search} />
         </div>
       );
     }

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -17,7 +17,9 @@
 
 import { apiFetch } from './client.js';
 import { ApiError, isRouteAbsent } from './errors.js';
-import type { DiagnosticsSkills } from './skills-wire.js';
+// Through the Skills surface module (which re-exports the contract block), so the release swap of
+// the mirror for `wicked-crew-api-types` touches `skills.ts` alone.
+import type { DiagnosticsSkills } from './skills.js';
 
 /** One CLI's ACP health, folded from the durable run event logs. */
 export interface DiagnosticsAcpCli {

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -17,6 +17,7 @@
 
 import { apiFetch } from './client.js';
 import { ApiError, isRouteAbsent } from './errors.js';
+import type { DiagnosticsSkills } from './skills-wire.js';
 
 /** One CLI's ACP health, folded from the durable run event logs. */
 export interface DiagnosticsAcpCli {
@@ -59,6 +60,10 @@ export interface Diagnostics {
   /** Bounded tail, newest first. */
   recentErrors: DiagnosticsError[];
   acp: { byCli: Record<string, DiagnosticsAcpCli> };
+  /** The skills seam's last outcome (api-types 0.27.0, crew#480 — mirrored in `./skills-wire.ts`):
+   *  whether the engine is being handed a verified snapshot (`state`), which one (`current`,
+   *  `engineInput`) and, if not, why (`findings`). ABSENT on a daemon that predates the seam. */
+  skills?: DiagnosticsSkills;
 }
 
 /** `GET /diagnostics` — the daemon's self-description. Read-only. */

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -74,3 +74,17 @@ export function isRouteAbsent(e: unknown): boolean {
     e instanceof ApiError && e.status === 404 && (e.wire === 'Not Found' || e.wire === 'not found')
   );
 }
+
+/**
+ * The two-layer forward-compat signal every adoption seam folds: {@link isRouteAbsent}
+ * (the crew daemon predates the route) OR a **501** (the route exists but what stands
+ * behind it — the embedded engine's method, a store seam, the fold — does not yet).
+ * Both mean "nothing to manage here yet, upgrade wicked-crew" and render the named
+ * unsupported state; a NAMED 4xx/5xx from a daemon WITH the feature is a real answer
+ * and surfaces as one. The per-surface `is<Surface>Unsupported` helpers spell this
+ * same pair (diagnostics, steering, memory, proposals, testing, wiki); new seams
+ * should call this instead of restating it.
+ */
+export function isRouteUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}

--- a/src/api/skills-wire.ts
+++ b/src/api/skills-wire.ts
@@ -1,0 +1,436 @@
+/**
+ * MIRROR of wicked-crew-api-types 0.27.0 skills block (crew#480) — replace with imports from the
+ * published package at release.
+ *
+ * Studio's installed `wicked-crew-api-types` is 0.25.0 (the newest on npm); the skills contract
+ * ships in 0.27.0, which crew#480 mints but has not published. Until it lands, this module IS the
+ * contract: two regions copied VERBATIM from the crew worktree's `packages/crew-api-types/index.d.ts`
+ * (crew#480 @ 4cae105) — the skills block (`:1322-1685`) and the `diagnostics.skills` block
+ * (`:3262-3302`). Nothing in between the `>>> VERBATIM` / `<<< VERBATIM` markers is studio's
+ * wording, and nothing may be edited here: `tests/skillsWire.test.ts` pins each region
+ * byte-for-byte against the vendored fixture `tests/fixtures/api-types-0.27.0-skills.d.ts`
+ * (itself a byte copy of those line ranges), so any drift — a hand edit here, or a re-vendored
+ * fixture from a re-minted contract — fails the suite until both sides agree again.
+ *
+ * THE RELEASE SWAP: when 0.27.0 (or its re-minted successor — #475 and #480 both mint 0.27.0,
+ * whichever lands second re-mints) publishes, bump the `wicked-crew-api-types` devDependency,
+ * replace the body of this file with `export type { … } from 'wicked-crew-api-types';` for every
+ * name below, delete the fixture + pin test, and nothing else in studio moves: `./skills.ts` and
+ * every component import these names from here.
+ *
+ * Note the three wire rules the block spells out and every studio caller leans on: revisions are
+ * NUMBERS (`revision` / `expectedRevision`), every mutation answers a 2xx `{verdict, findings,
+ * revision}` envelope (a `blocked` verdict is a normal response with nothing written), and 409
+ * is EXCLUSIVELY a stale `expectedRevision`.
+ */
+
+// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:1322-1685 (crew#480 @ 4cae105) — the skills block
+// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.27.0) ──
+//
+// Skills are files (skills keystone, design v3 + amendments v3.1/v3.2). The daemon owns ONE
+// effective `wicked-garden`-shaped plugin root — `<state home>/skills/effective/`, the dependency
+// closure of the installed plugin: `.claude-plugin/{plugin.json,archetypes.json,components.json}`,
+// `skills/**` (nested layout verbatim), `scripts/**` minus CI + dev tools, `schemas/`,
+// `docs/examples/`, `pyproject.toml`, `uv.lock` — seeded from the LIVE installed plugin into a
+// content-addressed `baseline/<contentHash>/`. The operator edits files in place, replaces a
+// skill, adds one, disables one (manifest state — the files stay), resets one (content from the
+// baseline; never enablement). Nothing a worker runs is read from `effective/`: PUBLISHING
+// validates the whole tree and writes an IMMUTABLE, read-only `snapshots/<gen>/` (enabled skills
+// only, closure included, `snapshot.json`, and the generated delivery views —
+// `views/copilot/.github/skills/<name>/` holding the enabled PORTABLE skills, part of the content
+// hash), then flips `current -> snapshots/<gen>`; the engine receives the resolved snapshot path
+// as `WICKED_SKILLS_SNAPSHOT`. The daemon NEVER writes into the user's own CLI directories
+// (`~/.codex`, `~/.pi`, `~/.copilot`, `~/.config/opencode`, `~/.claude`): skills reach non-Claude
+// workers only through per-launch, wicked-owned delivery core performs from the snapshot (v3.2) —
+// a CLI without a lever (codex today) runs without wicked skills, and a unit on such a seat that
+// requires one is REFUSED at launch (no proceed-with-disclosure setting exists).
+// `/skills` is a file manager whose EVERY mutation is CAS-guarded (`expectedRevision`) and
+// answers 2xx `{verdict, findings[], revision}` — a `blocked` verdict is a normal response,
+// including a publish refused because one is in flight (`publish-in-flight`) or aborted because the
+// root changed under it (`root-changed`), neither of which wrote anything. 409 (`{error, revision}`)
+// is EXCLUSIVELY a stale `expectedRevision` (a CAS conflict).
+
+/** What a skill IS, from its frontmatter — fork-first: `context: fork` → fork worker (a subagent
+ *  body); else `user-invocable: true` → router (an operator-facing entry point); else module (a
+ *  nested reference skill routers/workers pull in). */
+export type SkillKind = 'router' | 'fork-worker' | 'module';
+
+/** `shipped` = every own file byte-identical to the baseline; `override` = a shipped skill with
+ *  edited/replaced files; `user-added` = no baseline (added through the API, or upstream dropped
+ *  it while the operator's edits were kept). */
+export type SkillProvenance = 'shipped' | 'override' | 'user-added';
+
+/** Where a baseline was captured from. `claude-plugin-cache` covers the marketplace cache AND the
+ *  hand-installed `plugins/wicked-garden` copy (both are "the installed plugin"); `checkout` is a
+ *  git working tree; `directory` any other explicit plugin-shaped directory. */
+export type SkillSourceKind = 'claude-plugin-cache' | 'checkout' | 'directory';
+
+/** The per-baseline `uv sync` state (`<baseline>/.venv`, provisioned once per content hash — the
+ *  publish that needs it AWAITS it — and shared read-only by every snapshot that links it):
+ *  `pending` until a successful publish records it, `synced` on success (the snapshot carries a
+ *  `.venv` link), `skipped` when the bundle carries no `pyproject.toml` (nothing to provision; no
+ *  link). `failed` (uv missing or a sync error) is BLOCKING for the publish (`venv-failed`) and is
+ *  therefore never the recorded state of a published baseline — the record keeps its previous
+ *  value; a later publish retries. */
+export type SkillVenvState = 'pending' | 'synced' | 'failed' | 'skipped';
+
+/** One captured baseline — keyed in `SkillManifest.baselines` by the content hash of its bundle
+ *  (sorted relative paths + sha256 digests), never by the version string alone: two installs of
+ *  "12.32.0" with different bytes are two baselines. */
+export interface SkillBaselineRecord {
+  /** `version` from the source's `.claude-plugin/plugin.json`. */
+  plugin_version: string;
+  source: { kind: SkillSourceKind; path: string };
+  /** HEAD sha for a `checkout` source; `null` otherwise (or when git could not answer). */
+  git_sha: string | null;
+  /** ISO-8601 instant the baseline was captured. */
+  captured_at: string;
+  venv: SkillVenvState;
+}
+
+export interface SkillEntry {
+  /** Plugin-relative directory, nested layout preserved (`skills/engineering/frontend`). Never
+   *  renamed — sibling `../` links depend on it. */
+  dir: string;
+  kind: SkillKind;
+  /** Core-by-reference: in the registered-reference closure — a `skill_ref` of a workflow the
+   *  daemon knows (core drop-ins, crew-generated, user-registered) or a skill one of those names in
+   *  its SKILL.md (repo-learn → search, mem). Disabling or renaming it is blocking. */
+  core: boolean;
+  /** `false` when the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a script relative to
+   *  the cwd (`python3 -u scripts/x.py`, `./scripts/x`, …), or link `../` — Claude-only by nature:
+   *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
+   *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
+  portable: boolean;
+  /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
+   *  excluded from the next published snapshot. Reset never flips it. */
+  enabled: boolean;
+  provenance: SkillProvenance;
+  /** ISO-8601 instant of the last edit/replace/add through the API; `null` when untouched. */
+  editedAt: string | null;
+  /** A refreshed baseline changed a file this skill overrides — the new side is readable as
+   *  `?side=baseline` for diffing; the operator's content is kept. */
+  upgradeAvailable: boolean;
+  /** `upgradeAvailable`, or the last refresh found a name collision (upstream now ships a skill
+   *  under this user-added name at another dir). Cleared by reset / a later refresh. */
+  conflict: boolean;
+  /** The held-back UPSTREAM skill's directory in the current baseline when the last refresh found a
+   *  name collision (upstream ships this name at another dir than the operator's skill); `null`
+   *  otherwise. `GET /skills/:name/files/*path?side=baseline` reads THIS directory for such a skill,
+   *  so the two sides of the collision are comparable — the answer's `path` names the file actually
+   *  read (api-types 0.27.0). Re-derived by every refresh. */
+  upstreamDir: string | null;
+}
+
+/** One managed file (plugin-relative path → hashes). `baselineHash` `null` = user-added file;
+ *  `effectiveHash` `null` = a baseline file absent from `effective/` (removed by a direct
+ *  filesystem edit — reset restores it; the skill reads `override` until then). */
+export interface SkillFileRecord {
+  baselineHash: string | null;
+  effectiveHash: string | null;
+  /** The hash this file had in the most recent published snapshot; `null` = never published. */
+  lastPublishedHash: string | null;
+  /** The last refresh saw BOTH sides change (kept the effective side). */
+  conflict: boolean;
+}
+
+/** The most recent publish. */
+export interface SkillPublishedRecord {
+  gen: number;
+  /** Hash over the snapshot's files (sorted relative paths + sha256 digests), `snapshot.json` excluded. */
+  contentHash: string;
+  /** ISO-8601 instant. */
+  at: string;
+  /** sha256 of the exact `snapshot.json` bytes publish wrote. `snapshot.json` is excluded from the
+   *  content hash, so the crew-owned manifest AUTHENTICATES it: `current` verifies only the
+   *  generation this record names, with metadata hashing to this value (api-types 0.27.0). */
+  snapshotHash: string;
+}
+
+/** `<skills root>/manifest.json` — the state of the daemon-owned root. (The v3 mirror ledger is
+ *  withdrawn with the mirror — design v3.2 §1: the daemon never writes into the user's CLI dirs.) */
+export interface SkillManifest {
+  version: 2;
+  /** Monotonic; bumped by EVERY mutation. Every mutating request carries it as `expectedRevision`. */
+  revision: number;
+  /** Content hash of the current baseline (`baseline/<hash>/`). */
+  baseline: string;
+  baselines: Record<string, SkillBaselineRecord>;
+  /** Keyed by frontmatter `name` (`wicked-garden-<dir segments joined by '-'>`). */
+  skills: Record<string, SkillEntry>;
+  /** Every managed file under `effective/`, plugin-relative. */
+  files: Record<string, SkillFileRecord>;
+  published: SkillPublishedRecord | null;
+}
+
+/** `GET /skills` 200 body. 503 when the root is not seeded (no installed plugin was found) or when
+ *  `current` exists but fails verification (realpath outside `snapshots/`, malformed
+ *  `snapshot.json`, content hash mismatch) — a corrupt root is a loud error, never an empty catalog. */
+export interface SkillsManifestResponse {
+  manifest: SkillManifest;
+  revision: number;
+  /** The resolved skills root on the daemon host (`<state home>/skills` by default). */
+  root: string;
+  /** The VERIFIED published snapshot `current` resolves to, or `null` before the first publish.
+   *  `path` is the absolute REAL path of `snapshots/<gen>` — byte-identical to the one input the
+   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). */
+  current: { gen: number; path: string } | null;
+}
+
+export interface SkillFileEntry {
+  /** POSIX path relative to the skill dir. */
+  path: string;
+  size: number;
+  sha256: string;
+  /** This file's manifest record (`null` for a file present on disk but not yet recorded). */
+  record: SkillFileRecord | null;
+}
+
+/** `GET /skills/:name/files` 200 body — the skill's OWN files (a nested skill's files are its own). */
+export interface SkillFileTree {
+  name: string;
+  dir: string;
+  enabled: boolean;
+  files: SkillFileEntry[];
+}
+
+/** `GET /skills/:name/files/*path` and `GET /skills/support/*path` 200 body — a typed, capped read.
+ *  Save is disabled on `truncated` or `binary`. `?side=baseline` reads the baseline copy instead
+ *  (the "new side" of a refresh conflict). */
+export interface SkillReadResult {
+  /** Plugin-relative path served. */
+  path: string;
+  /** UTF-8 text — the first 512 KB when `truncated`; `null` when `binary` (there is no text to show). */
+  content: string | null;
+  /** The file's FULL size in bytes. */
+  size: number;
+  truncated: boolean;
+  binary: boolean;
+}
+
+export type SkillFindingKind =
+  | 'name-invalid'
+  | 'name-collision'
+  | 'name-mismatch'
+  | 'frontmatter-invalid'
+  | 'missing-skill-md'
+  | 'unregistered-skill'
+  | 'nested-skill-create'
+  | 'core-disable'
+  | 'core-rename'
+  | 'core-missing'
+  | 'support-file-edit'
+  | 'non-portable'
+  /** A `${CLAUDE_PLUGIN_ROOT}/<p>` or `../<p>` reference in an enabled skill's files that does not
+   *  resolve inside the would-be snapshot. Severity follows the TARGET (design v3.4 §1): a reference
+   *  that ESCAPES the plugin root (`..` climbing out — it reaches whatever lies beside the snapshot on
+   *  the worker host) is `blocking`; one whose target is MISSING (it normalizes inside the root but
+   *  the snapshot does not carry it — a file the bundle omits, or a skill that is disabled) is a
+   *  `warning`: a content bug the skill's author owns, published as found — a publish with only
+   *  warnings answers `verdict: 'warnings'` with the findings AND a written snapshot (api-types
+   *  0.27.0). */
+  | 'unresolved-ref'
+  /** A path the store refuses BY NAME rather than reads through: a shape that could leave its root
+   *  (`..`, an absolute piece), a component that crosses a symlink, or — under `effective/`, where
+   *  every entry is classified — a symlink or a special node (socket, fifo, device) anywhere,
+   *  the contents of a pruned directory (`.venv`, `node_modules`, `__pycache__`) INCLUDED: such a
+   *  directory is never copied or hashed, but what it holds is still judged, and a link inside one
+   *  blocks with the reason (a provisioned environment lives under `baseline/`, not the editable
+   *  root). Blocking; `file` names the entry, `skill` its owning skill when it has one. */
+  | 'path-invalid'
+  | 'unknown-skill'
+  | 'no-baseline'
+  | 'fs-drift'
+  | 'refresh-conflict'
+  | 'empty-snapshot'
+  /** `.claude-plugin/plugin.json`, `archetypes.json` or `components.json` is absent from `effective/`
+   *  — the plugin manifest + the runtime catalogs are REQUIRED snapshot members (blocking at
+   *  publish; api-types 0.27.0). */
+  | 'missing-plugin-manifest'
+  /** The plugin manifest or a runtime catalog is present but not what its reader expects — does
+   *  not parse as JSON, is not a JSON object, or `archetypes.json` lacks its `archetypes`
+   *  collection (blocking at publish; api-types 0.27.0). A manifest without `name` is
+   *  `name-mismatch`. */
+  | 'catalog-invalid'
+  /** The baseline's shared read-only Python env could not be provisioned (uv missing, `uv sync`
+   *  failed, or the env could not be locked) while the bundle carries a `pyproject.toml` — the env
+   *  is REQUIRED, so the publish is blocked and nothing (the provisioning state included) is
+   *  persisted (api-types 0.27.0). */
+  | 'venv-failed'
+  /** A publish was refused because one is already running (one at a time) — nothing was written, so
+   *  it is a 2xx `blocked` envelope, not a 409 (409 is only a stale `expectedRevision`; api-types
+   *  0.27.0). Re-read `GET /skills` and retry against the revision it answers. */
+  | 'publish-in-flight'
+  /** A publish was aborted because the skills root changed under it — nothing was written to either
+   *  root; a 2xx `blocked` envelope (api-types 0.27.0). Re-read `GET /skills` and retry. */
+  | 'root-changed'
+  /** A path outside the bundle closure — the ONE allowlist of what the seed copies, what the support
+   *  API may address, and what a snapshot may carry: the five runtime catalogs under `.claude-plugin`
+   *  BY NAME (`plugin.json`, `archetypes.json`, `components.json`, `specialist.json`,
+   *  `stack-registry.json` — `marketplace.json`, a publish-time listing, is outside), everything under
+   *  `skills`, `schemas` and `docs/examples`, everything under `scripts` except the `ci` and `wg`
+   *  directories and any `wg-`-prefixed dev tooling, plus `pyproject.toml` and `uv.lock`. A support
+   *  add/PUT there is a 2xx `blocked` envelope (nothing written); a file found there under
+   *  `effective/` at publish/analyze (a direct filesystem edit) is a BLOCKING finding naming the path
+   *  — a snapshot never ships it (api-types 0.27.0). */
+  | 'outside-closure'
+  /** A content-addressed `baseline/<hash>` whose tree does not hash to its name (a bundle file
+   *  modified, planted or removed, or a symlink inside), or a baseline file whose bytes do not match
+   *  the hash the manifest recorded for it. Baselines are re-verified before EVERY reuse: a refresh
+   *  refuses to reuse it (2xx `blocked`, nothing copied), reset refuses to restore from it (nothing
+   *  written), publish/analyze report it blocking (before AND after the env was provisioned in it).
+   *  Read-only mode bits on the baseline are a guard, never the integrity boundary — the hash is
+   *  (api-types 0.27.0). */
+  | 'baseline-corrupt';
+
+export type SkillFindingSeverity = 'warning' | 'blocking';
+
+/** `blocked` = at least one blocking finding (nothing was written / published); `warnings` =
+ *  proceeded with warnings; `clear` = nothing to say. */
+export type SkillVerdict = 'clear' | 'warnings' | 'blocked';
+
+export interface SkillConflictFinding {
+  kind: SkillFindingKind;
+  severity: SkillFindingSeverity;
+  /** The skill this finding is about, or `null` for a catalog / support-file finding. */
+  skill: string | null;
+  /** Plugin-relative file the finding names, or `null`. */
+  file: string | null;
+  /** 1-based line in `file`, when the finding is anchored to one. */
+  line: number | null;
+  /** The OTHER catalog skill this finding is against (a collision, a core guard), or `null`. */
+  againstSkill: string | null;
+  againstIsCore: boolean;
+  /** The concrete fact (names, paths, the parse error). */
+  evidence: string;
+  /** Why it matters. */
+  explanation: string;
+}
+
+/** `POST /skills/analyze` 200 body (a PURE dry run of the publish validation: nothing persisted,
+ *  `revision` unchanged — drift it observes is reported, and recorded only by the publish that
+ *  ships it) — and the base of every mutation result. */
+export interface SkillAnalyzeResult {
+  verdict: SkillVerdict;
+  findings: SkillConflictFinding[];
+  revision: number;
+}
+
+/** Every `/skills` mutation's 200 body. `blocked` ⇒ nothing was written and `revision` is unchanged. */
+export interface SkillMutationResult extends SkillAnalyzeResult {
+  skill?: SkillEntry & { name: string };
+}
+
+/** `POST /skills/publish` 200 body. `snapshot` is `null` when the verdict is `blocked` — and then
+ *  `revision` is unchanged (a blocked publish persists nothing — not the drift it observed, not the
+ *  baseline's provisioning state). `path` is the absolute REAL path of the locked, read-only
+ *  generation; its `snapshot.json` carries the skill rows and the `views` block (`views.copilot`:
+ *  the `views/copilot` dir + the portable skills laid out in it). One publish runs at a time — a
+ *  concurrent one wrote nothing and answers a 2xx `blocked` `publish-in-flight` envelope
+ *  (`snapshot: null`), not a 409. */
+export interface SkillPublishResult extends SkillAnalyzeResult {
+  snapshot: { gen: number; path: string; contentHash: string; skills: number } | null;
+}
+
+/** `POST /skills/refresh-baseline` 200 body — the three-way merge per FILE (baseline_old /
+ *  baseline_new / effective): unchanged → take new; user-modified & upstream-unchanged → keep;
+ *  both changed → keep + `conflict` (new side readable as `?side=baseline`); user-DELETED &
+ *  upstream-changed → the deletion is kept + `conflict` (a deletion is a modification; reset
+ *  restores upstream); upstream-deleted & user-unmodified → remove; upstream-deleted &
+ *  user-modified → keep as user-added; a new upstream skill whose path-derived name is a
+ *  user-added skill's → conflict. 502 when no plugin is installed. */
+export interface SkillRefreshResult extends SkillAnalyzeResult {
+  previous_baseline: string;
+  baseline: string;
+  plugin_version: string;
+  /** Skills whose files were replaced from the new baseline. */
+  taken: string[];
+  /** Skills that kept operator content (upstream unchanged, or a flagged conflict). */
+  kept: string[];
+  added: string[];
+  removed: string[];
+  /** Skills flagged `conflict` by this refresh. */
+  conflicts: string[];
+}
+
+/** The 409 body of a `/skills` mutation whose `expectedRevision` is stale — a CAS conflict, the
+ *  ONLY thing that answers 409. A publish refused because another is in flight, or aborted because
+ *  the skills root changed under it, wrote nothing and instead answers a 2xx `blocked` findings
+ *  envelope (`publish-in-flight` / `root-changed`; api-types 0.27.0), never a 409. */
+export interface SkillRevisionConflict {
+  error: string;
+  /** The current revision — re-read `GET /skills` (or use this) and retry. */
+  revision: number;
+}
+
+/** The body of `POST /skills/:name/{enable,disable,reset}`, `POST /skills/publish` and
+ *  `POST /skills/refresh-baseline`. */
+export interface SkillRevisionBody {
+  expectedRevision: number;
+}
+
+/** `PUT /skills/:name/files/*path` and `PUT /skills/support/*path` body. `content` is UTF-8 text,
+ *  at most 512 KB. */
+export interface PutSkillFileBody {
+  content: string;
+  expectedRevision: number;
+}
+
+/** `POST /skills` body — add a user skill. `files` maps skill-relative POSIX paths to UTF-8 text
+ *  and must include `SKILL.md`; the skill lands at `skills/<name minus "wicked-garden-">`. */
+export interface AddSkillBody {
+  name: string;
+  files: Record<string, string>;
+  expectedRevision: number;
+}
+
+/** `POST /skills/:name/replace` body — replace the skill's OWN files wholesale (nested skills untouched). */
+export interface ReplaceSkillBody {
+  files: Record<string, string>;
+  expectedRevision: number;
+}
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:3262-3302 (crew#480 @ 4cae105) — the diagnostics skills block
+/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.27.0). */
+export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
+
+/** One finding the skills degradation ladder produced (design v3 §3). */
+export interface DiagnosticsSkillsFinding {
+  /** `skills.fallback` = no wicked-garden installed (engine input left unset / restored to the boot
+   *  value — the engine resolves the live cache itself); `skills.blocked` = the first publish is
+   *  blocked (engine input points at a non-existent refusal path — launches fail loudly until the
+   *  catalog is fixed); `skills.config` = the configured root is corrupt/unusable (same refusal;
+   *  `error`), or — as a `warning` on the `published` state — the root lies OUTSIDE the daemon
+   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch. */
+  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config';
+  severity: 'warning' | 'error';
+  message: string;
+}
+
+/**
+ * `GET /diagnostics` → `skills`: whether the engine is being handed a verified snapshot, and if not,
+ * why — the one read-only answer to "why do launches refuse the skills snapshot". `disabled` is a
+ * daemon booted without the seam (the manifest collector, some tests).
+ */
+export interface DiagnosticsSkills {
+  state: DiagnosticsSkillsState;
+  /** The resolved skills root on the daemon host; `null` when `disabled`. */
+  root: string | null;
+  /** The VERIFIED published snapshot (`current` realpath-contained, `snapshot.json` + content hash
+   *  checked), or `null`. `path` is the absolute REAL path of `snapshots/<gen>`. */
+  current: { gen: number; path: string } | null;
+  /** What `WICKED_SKILLS_SNAPSHOT` — the engine's ONE skills input (v3.1 §2, v3.4 §2;
+   *  `WICKED_SKILLS_CURRENT` is never set, `WICKED_CREW_STATE_HOME` is not exported) — is exported as
+   *  right now: the real snapshot path, a `<root>/refused/…` refusal path, `""` when the process
+   *  booted with an explicitly EMPTY value (preserved — a configuration error core refuses, state
+   *  `config-error`; design v3.5 §4), or `null` = unset. */
+  engineInput: string | null;
+  /** DIAGNOSTICS-ONLY: the canonical realpath of the daemon state home, reported for humans. It is
+   *  NOT an engine input — `WICKED_CREW_STATE_HOME` is retired (v3.4 §2): core reads only
+   *  `WICKED_SKILLS_SNAPSHOT` and derives the state home from its `<state home>/skills/snapshots/<gen>`
+   *  layout. `null` only when `disabled`. */
+  stateHome: string | null;
+  findings: DiagnosticsSkillsFinding[];
+}
+// <<< VERBATIM

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -1,0 +1,428 @@
+/**
+ * The skills wire — types and calls for the Skills surface (`/skills`): the file manager over the
+ * daemon's ONE effective garden-shaped plugin root (the skills keystone, design v3).
+ *
+ * ── INTEGRATION POINT (skills build, paired crew lane) ────────────────────────────────────────
+ * Skills are files. Crew owns the effective root under its state home (`skills/effective/`): the
+ * installed garden is captured as a content-hashed BASELINE, the operator edits any file in place
+ * (or replaces a skill dir), disable = excluded from the published snapshot, reset = restore the
+ * skill's content from the baseline. Nothing is live until PUBLISH validates the whole tree and
+ * writes an immutable snapshot generation that every worker spawn then receives.
+ *
+ * Every declaration here is TEMPORARY — hand-mirrored from the design's manifest + guard-envelope
+ * contract because the crew slice that serves it (`src/skills/`, built in a parallel lane) is not
+ * yet in studio's installed `wicked-crew-api-types`. **Delete the types in this module and
+ * re-export from `wicked-crew-api-types`** the moment studio bumps to the api-types version that
+ * carries the skills contract (the same stopgap `./steering.ts` wears, and the same exit).
+ *
+ * The three wire rules every caller leans on:
+ *  - CAS EVERYWHERE: every mutation sends `expectedRevision` (the catalog revision it was decided
+ *    against) and every 2xx answer is the guard envelope `{verdict, findings, revision}` — the new
+ *    revision is adopted by the page; a stale revision is a **409**, folded by
+ *    {@link isSkillsConflict} into the reload prompt.
+ *  - GUARD RESULTS ARE 2xx: `apiFetch` throws on any non-2xx, so a `blocked` verdict (the daemon
+ *    refused the change, the root is unchanged) arrives as a NORMAL answer, never an exception.
+ *  - READS ARE TYPED: a file read past the daemon's cap is `truncated`, a NUL-sniffed one `binary`
+ *    (content `""`) — Save stays disabled on either so the editor never clobbers what it cannot show.
+ *
+ * The support probe is the same two-layer adoption seam as the steering reads: a bare 404 means
+ * "this crew daemon predates the skills routes"; a 501 means "the route exists but the daemon has
+ * no skills root to serve". {@link isSkillsUnsupported} folds both so every caller renders the
+ * honest named state, never a raw refusal — and never a crash.
+ */
+
+import { apiFetch } from './client.js';
+import { ApiError, isRouteAbsent } from './errors.js';
+
+// ── Vocabulary ────────────────────────────────────────────────────────────────────────────────
+
+/** The three skill kinds, fork-first from frontmatter: `context: fork` → fork-worker; else
+ *  `user-invocable: true` → router; else module. */
+export const SKILL_KINDS = ['router', 'fork-worker', 'module'] as const;
+
+export type SkillKind = (typeof SKILL_KINDS)[number];
+
+export const SKILL_KIND_LABELS: Record<SkillKind, string> = {
+  router: 'router',
+  'fork-worker': 'fork worker',
+  module: 'module',
+};
+
+export function isSkillKind(s: string): s is SkillKind {
+  return (SKILL_KINDS as readonly string[]).includes(s);
+}
+
+/** Where a skill's effective content stands against the baseline — DERIVED from the hashes
+ *  ({@link provenanceOf}), never a wire field: no baseline → user-added; equal → shipped
+ *  untouched; different → an operator override. */
+export const SKILL_PROVENANCES = ['shipped', 'override', 'user-added'] as const;
+
+export type SkillProvenance = (typeof SKILL_PROVENANCES)[number];
+
+export const SKILL_PROVENANCE_LABELS: Record<SkillProvenance, string> = {
+  shipped: 'shipped',
+  override: 'overridden',
+  'user-added': 'user-added',
+};
+
+/** The guard verdict over one write/enable/publish. `blocked` = refused, nothing changed. */
+export type SkillVerdict = 'clear' | 'warnings' | 'blocked';
+
+// ── The catalog (`GET /skills` — manifest + revision) ─────────────────────────────────────────
+
+export interface SkillsBaselineSource {
+  kind: 'claude-plugin-cache' | 'checkout' | 'npm-pack';
+  path: string;
+  plugin_version: string;
+  git_sha: string | null;
+  captured_at: string;
+}
+
+/** A baseline is identified by the CONTENT HASH of the bundle it was captured from — never the
+ *  version string alone (two "12.32.0" captures can differ). */
+export interface SkillsBaseline {
+  contentHash: string;
+  source: SkillsBaselineSource;
+}
+
+export interface SkillManifestEntry {
+  /** `skills/<nested/path>` under the effective root — never renamed (sibling links depend on it). */
+  dir: string;
+  kind: SkillKind;
+  /** Core-by-reference: in the registered-reference closure (a workflow's `skill_ref`, or a
+   *  referenced skill's `mandates`) — disabling or renaming it is blocking. */
+  core: boolean;
+  /** `false` when the skill leans on `${CLAUDE_PLUGIN_ROOT}`, cwd-relative scripts or `../` links —
+   *  Claude-only by nature, excluded from the other CLIs' mirrors. */
+  portable: boolean;
+  /** Manifest state, orthogonal to content — reset restores content only and never flips this. */
+  enabled: boolean;
+  /** `null` for a user-added skill — there is no baseline to reset to. */
+  baselineHash: string | null;
+  effectiveHash: string;
+  /** The content hash the CURRENT snapshot carries for this skill; `null` when it has never been
+   *  published (a new skill, or no publish yet). */
+  lastPublishedHash: string | null;
+  editedAt: string | null;
+  /** The three-way refresh kept a user edit AND upstream changed the same skill — the new side is
+   *  stored for diff; reset takes it. */
+  conflict: boolean;
+}
+
+export interface SkillsManifest {
+  baseline: SkillsBaseline;
+  /** Keyed by frontmatter `name` (`wicked-garden-<path-joined-by-dashes>`). */
+  skills: Record<string, SkillManifestEntry>;
+  /** Root support files shared by every skill (`scripts/…`, `schemas/…`, `.claude-plugin/…`) →
+   *  effective content hash. */
+  support: Record<string, string>;
+  /** The snapshot generation `current` points at, or `null` before the first publish. */
+  currentGeneration: number | null;
+}
+
+/** `GET /skills`: the manifest plus the CAS revision every mutation is conditioned on. */
+export interface SkillsCatalog {
+  manifest: SkillsManifest;
+  revision: string;
+}
+
+/**
+ * The catalog read, shape-checked at the seam: a daemon that answers `/skills` with anything but
+ * `{manifest: {skills: …}, revision}` gets a NAMED error — never a page rendering zero skills
+ * against a daemon that answered something.
+ */
+export function readCatalogBody(body: unknown): SkillsCatalog {
+  if (typeof body === 'object' && body !== null) {
+    const { manifest, revision } = body as { manifest?: unknown; revision?: unknown };
+    if (
+      typeof manifest === 'object' && manifest !== null
+      && typeof (manifest as { skills?: unknown }).skills === 'object'
+      && (manifest as { skills?: unknown }).skills !== null
+      && typeof revision === 'string'
+    ) {
+      return { manifest: manifest as SkillsManifest, revision };
+    }
+  }
+  throw new Error('the daemon answered /skills with no catalog (expected {manifest: {skills}, revision})');
+}
+
+export async function getSkillsCatalog(): Promise<SkillsCatalog> {
+  return readCatalogBody(await apiFetch<unknown>('/skills'));
+}
+
+/** A manifest entry paired with its name and derived provenance — the row shape every list and
+ *  drawer renders. */
+export interface SkillRow extends SkillManifestEntry {
+  name: string;
+  provenance: SkillProvenance;
+}
+
+export function provenanceOf(entry: Pick<SkillManifestEntry, 'baselineHash' | 'effectiveHash'>): SkillProvenance {
+  if (entry.baselineHash === null) return 'user-added';
+  return entry.baselineHash === entry.effectiveHash ? 'shipped' : 'override';
+}
+
+/** True when the CURRENT snapshot does not carry this skill's effective content — a publish is
+ *  needed before any worker sees it. */
+export function isUnpublished(entry: Pick<SkillManifestEntry, 'effectiveHash' | 'lastPublishedHash'>): boolean {
+  return entry.lastPublishedHash !== entry.effectiveHash;
+}
+
+/** The manifest as rows, name-sorted (plain codepoint order — deterministic across locales). */
+export function skillRows(manifest: SkillsManifest): SkillRow[] {
+  return Object.entries(manifest.skills)
+    .map(([name, entry]) => ({ name, ...entry, provenance: provenanceOf(entry) }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+export interface SkillCounts {
+  total: number;
+  enabled: number;
+  overridden: number;
+  core: number;
+  portable: number;
+}
+
+/** The KPI fold over the manifest — pinned by test so the band agrees with the list. */
+export function skillCounts(rows: readonly SkillRow[]): SkillCounts {
+  const counts: SkillCounts = { total: rows.length, enabled: 0, overridden: 0, core: 0, portable: 0 };
+  for (const r of rows) {
+    if (r.enabled) counts.enabled += 1;
+    if (r.provenance === 'override') counts.overridden += 1;
+    if (r.core) counts.core += 1;
+    if (r.portable) counts.portable += 1;
+  }
+  return counts;
+}
+
+// ── Files: the tree and one file ──────────────────────────────────────────────────────────────
+
+export interface SkillFileEntry {
+  /** Relative to the skill dir (or the root, for support files), forward slashes. */
+  path: string;
+  hash: string;
+  /** Absent for a support file — the manifest's support map carries no sizes. */
+  size?: number;
+}
+
+/** File rows sorted by path with `SKILL.md` first — it IS the skill. */
+export function sortSkillFiles(files: readonly SkillFileEntry[]): SkillFileEntry[] {
+  return [...files].sort((a, b) => {
+    if (a.path === 'SKILL.md') return -1;
+    if (b.path === 'SKILL.md') return 1;
+    return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+  });
+}
+
+/** `GET /skills/:name/files` — the files the skill OWNS (a nested child skill's files belong to
+ *  the child; the daemon refuses to serve them through the parent). */
+export async function listSkillFiles(name: string): Promise<SkillFileEntry[]> {
+  const body = await apiFetch<{ files: SkillFileEntry[] }>(`/skills/${encodeURIComponent(name)}/files`);
+  return sortSkillFiles(body.files);
+}
+
+/** The root support files as tree rows, from the manifest's `support` map (there is no separate
+ *  list route — `GET|PUT /skills/support/*path` addresses one file). */
+export function supportFiles(manifest: SkillsManifest): SkillFileEntry[] {
+  return Object.entries(manifest.support)
+    .map(([path, hash]) => ({ path, hash }))
+    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/** A typed, capped file read: `truncated` past the daemon's cap (the head is served), `binary` on
+ *  a NUL sniff (content `""`). Save is disabled on either. */
+export interface SkillFileContent {
+  path: string;
+  content: string;
+  size: number;
+  hash: string;
+  truncated: boolean;
+  binary: boolean;
+}
+
+/** `*path` segments are encoded one by one so the slashes stay route separators. */
+function encodePath(path: string): string {
+  return path.split('/').map((s) => encodeURIComponent(s)).join('/');
+}
+
+function skillFileRoute(name: string, path: string): string {
+  return `/skills/${encodeURIComponent(name)}/files/${encodePath(path)}`;
+}
+
+function supportFileRoute(path: string): string {
+  return `/skills/support/${encodePath(path)}`;
+}
+
+export function readSkillFile(name: string, path: string): Promise<SkillFileContent> {
+  return apiFetch<SkillFileContent>(skillFileRoute(name, path));
+}
+
+export function readSupportFile(path: string): Promise<SkillFileContent> {
+  return apiFetch<SkillFileContent>(supportFileRoute(path));
+}
+
+// ── The guard envelope (every mutation answers with one, on 2xx) ──────────────────────────────
+
+/** `blocking` refuses the change (verdict `blocked`); `warning` lets it through, flagged. */
+export type SkillFindingSeverity = 'blocking' | 'warning';
+
+export interface SkillFinding {
+  /** The guard that fired (e.g. `name-collision`, `frontmatter-name`, `core-disable`,
+   *  `support-edit`, `unresolved-ref`). */
+  kind: string;
+  severity: SkillFindingSeverity;
+  /** The skill the finding is against, when there is one (a collision names the other skill). */
+  skill: string | null;
+  /** The file (relative to the effective root) and line the finding cites, when it cites one —
+   *  an unresolved `${CLAUDE_PLUGIN_ROOT}` reference names its `file:line`. */
+  file: string | null;
+  line: number | null;
+  explanation: string;
+}
+
+export interface SkillGuardResult {
+  verdict: SkillVerdict;
+  findings: SkillFinding[];
+  /** The catalog revision AFTER this call — the next mutation's `expectedRevision`. */
+  revision: string;
+}
+
+function post(path: string, body: Record<string, unknown>): Promise<SkillGuardResult> {
+  return apiFetch<SkillGuardResult>(path, { method: 'POST', body: JSON.stringify(body) });
+}
+
+/** `PUT /skills/:name/files/*path` — one file, atomic tmp+rename daemon-side. */
+export function writeSkillFile(name: string, path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
+  return apiFetch<SkillGuardResult>(skillFileRoute(name, path), {
+    method: 'PUT',
+    body: JSON.stringify({ content, expectedRevision }),
+  });
+}
+
+/** `PUT /skills/support/*path` — a root support file; the guards flag every such edit as a
+ *  warning (it is shared by every skill). */
+export function writeSupportFile(path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
+  return apiFetch<SkillGuardResult>(supportFileRoute(path), {
+    method: 'PUT',
+    body: JSON.stringify({ content, expectedRevision }),
+  });
+}
+
+/** `POST /skills/:name/{enable,disable}` — enablement is manifest state; the guards run on every
+ *  flip (disabling a core skill is blocking). */
+export function setSkillEnabled(name: string, enabled: boolean, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${encodeURIComponent(name)}/${enabled ? 'enable' : 'disable'}`, { expectedRevision });
+}
+
+/** `POST /skills/:name/reset` — restore the skill's OWN files from the baseline (a nested child's
+ *  overrides survive); never flips `enabled`. Refused for a user-added skill (no baseline). */
+export function resetSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${encodeURIComponent(name)}/reset`, { expectedRevision });
+}
+
+/** A whole skill dir as a files map — relative path → content. */
+export type SkillFilesMap = Record<string, string>;
+
+/** `POST /skills` — add a user-added skill from a files map. */
+export function addSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
+  return post('/skills', { name, files, expectedRevision });
+}
+
+/** `POST /skills/:name/replace` — replace the skill's own files wholesale from a files map. */
+export function replaceSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${encodeURIComponent(name)}/replace`, { files, expectedRevision });
+}
+
+/** `DELETE /skills/:name` — remove a USER-ADDED skill (a shipped skill is disabled or reset, never
+ *  deleted). The REST-natural spelling of the design's add/replace pair; the api-types
+ *  reconciliation confirms or renames it. */
+export function deleteSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
+  return apiFetch<SkillGuardResult>(`/skills/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+    body: JSON.stringify({ expectedRevision }),
+  });
+}
+
+/** `POST /skills/refresh-baseline` — capture the installed plugin as a new baseline and merge it
+ *  three-way per file (unchanged → take new; user-modified & upstream-unchanged → keep; both
+ *  changed → keep + `conflict`). Never clobbers an edit. */
+export function refreshSkillsBaseline(expectedRevision: string): Promise<SkillGuardResult> {
+  return post('/skills/refresh-baseline', { expectedRevision });
+}
+
+/** `POST /skills/publish` — validate the WHOLE tree (name uniqueness across the full catalog,
+ *  frontmatter names, the core closure, every `${CLAUDE_PLUGIN_ROOT}`/`../` reference resolving
+ *  inside the bundle), then write an immutable snapshot generation and flip `current`. A
+ *  `blocked` verdict writes nothing — workers keep the previous generation. */
+export function publishSkills(expectedRevision: string): Promise<SkillGuardResult> {
+  return post('/skills/publish', { expectedRevision });
+}
+
+/** `POST /skills/analyze` — the publish validation as a dry run: the same findings, nothing
+ *  written. Takes no `expectedRevision` — it mutates nothing. */
+export function analyzeSkills(): Promise<SkillGuardResult> {
+  return apiFetch<SkillGuardResult>('/skills/analyze', { method: 'POST' });
+}
+
+/**
+ * Parse a pasted files map for Add/Replace: a JSON object whose values are all strings. Returns
+ * the map, or the ONE issue to surface (the modal's Save stays disabled while there is one).
+ */
+export function parseFilesMap(text: string): { files: SkillFilesMap; issue: null } | { files: null; issue: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { files: null, issue: 'not valid JSON' };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { files: null, issue: 'the files map must be a JSON object of path → content' };
+  }
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.length === 0) return { files: null, issue: 'the files map is empty' };
+  for (const [path, content] of entries) {
+    if (typeof content !== 'string') return { files: null, issue: `"${path}" must be a string (file content)` };
+    if (path === '' || path.startsWith('/') || path.split('/').includes('..')) {
+      return { files: null, issue: `"${path}" must be a relative path with no ".." segment` };
+    }
+  }
+  if (!entries.some(([path]) => path === 'SKILL.md')) {
+    return { files: null, issue: 'the files map must include SKILL.md — it is the skill' };
+  }
+  return { files: parsed as SkillFilesMap, issue: null };
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────────────────────
+
+/** The Skills surface's route — bare for the catalog, `?skill=<name>` to deep-link one skill's
+ *  drawer open (the same `?rule=` idiom Steering uses; deep-linkable, back-button-correct). */
+export function skillsPath(name?: string | null): string {
+  return name == null ? '/skills' : `/skills?skill=${encodeURIComponent(name)}`;
+}
+
+/** The deep-linked skill name read from a `location.search` string, or `null`. */
+export function readSkillDeepLink(search: string): string | null {
+  const raw = new URLSearchParams(search).get('skill');
+  return raw !== null && raw !== '' ? raw : null;
+}
+
+// ── The adoption seam + the CAS seam ──────────────────────────────────────────────────────────
+
+/**
+ * True when this daemon cannot serve the skills catalog: a 501 (route present, no skills root
+ * behind it) or Fastify's bare unknown-route 404 (crew predates the `/skills` routes). A NAMED
+ * 404/4xx from a daemon WITH the routes ("unknown skill: …") is a real answer and surfaces as one.
+ */
+export function isSkillsUnsupported(e: unknown): boolean {
+  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+}
+
+/** The honest in-band copy for {@link isSkillsUnsupported} refusals. */
+export const SKILLS_UNSUPPORTED_COPY =
+  'This daemon predates the skills catalog (crew’s /skills routes) — there is nothing to manage here yet. Upgrade wicked-crew to browse, edit, enable, publish, and reset the skills its workers run.';
+
+/** A stale `expectedRevision`: the catalog changed under this page (another session, a direct
+ *  edit the daemon hashed, a refresh). The page reloads before anything else is written. */
+export function isSkillsConflict(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 409;
+}

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -254,23 +254,24 @@ export interface SkillFileContent {
 // rows, the support map) — untrusted until checked. `encodeURIComponent` preserves `.` and `..`,
 // and URL normalization collapses `/skills/<name>/files/../../support/x` into
 // `/skills/support/x` (or `/skills/support/../../settings` into `/settings`) BEFORE crew's
-// skill-scoped containment ever sees the request. So every segment is decoded (a percent-encoded
-// `..` is still `..`), refused when empty, dot-only (`.`, `..`, `…`), separator-bearing (`/`, `\`)
-// or NUL-bearing, and only then encoded. A refusal is a NAMED error and no request is built —
-// the callers below are `async` so it arrives as a rejection, like any other wire failure.
+// skill-scoped containment ever sees the request. So every segment is validated on its LITERAL
+// text — refused when empty, dot-only (`.`, `..`, `…`), separator-bearing (`/`, `\`) or
+// NUL-bearing — and then percent-encoded exactly once. A refusal is a NAMED error and no request
+// is built — the callers below are `async` so it arrives as a rejection, like any other wire
+// failure.
+//
+// The daemon's text IS the identity — it is never decoded first. A file literally named
+// `a%41.md` travels as `a%2541.md` and the daemon's one decode hands back `a%41.md`; decoding it
+// here would retarget every read and write onto `aA.md` while the drawer showed the requested name
+// (review round 2). A literal `%2e%2e` is by the same rule a file named `%2e%2e`, encoded to
+// `%252e%252e` — the route layer's single decode never turns it into `..`.
 
 /** One validated, encoded route segment; `what` names it in the refusal. */
 export function skillRouteSegment(raw: string, what: string): string {
-  let decoded = raw;
-  try {
-    decoded = decodeURIComponent(raw);
-  } catch {
-    // Not percent-encoded (a literal `%` in a name) — the raw text IS the segment.
-  }
-  if (decoded === '') throw new Error(`refusing ${what}: an empty segment`);
-  if (/^\.+$/.test(decoded)) throw new Error(`refusing ${what}: the dot-only segment "${raw}" would escape its route`);
-  if (/[/\\\0]/.test(decoded)) throw new Error(`refusing ${what}: the segment "${raw}" carries a path separator or NUL`);
-  return encodeURIComponent(decoded);
+  if (raw === '') throw new Error(`refusing ${what}: an empty segment`);
+  if (/^\.+$/.test(raw)) throw new Error(`refusing ${what}: the dot-only segment "${raw}" would escape its route`);
+  if (/[/\\\0]/.test(raw)) throw new Error(`refusing ${what}: the segment "${raw}" carries a path separator or NUL`);
+  return encodeURIComponent(raw);
 }
 
 /** A skill name as the ONE `:name` route segment. */

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -333,16 +333,6 @@ export function replaceSkill(name: string, files: SkillFilesMap, expectedRevisio
   return post(`/skills/${encodeURIComponent(name)}/replace`, { files, expectedRevision });
 }
 
-/** `DELETE /skills/:name` — remove a USER-ADDED skill (a shipped skill is disabled or reset, never
- *  deleted). The REST-natural spelling of the design's add/replace pair; the api-types
- *  reconciliation confirms or renames it. */
-export function deleteSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
-  return apiFetch<SkillGuardResult>(`/skills/${encodeURIComponent(name)}`, {
-    method: 'DELETE',
-    body: JSON.stringify({ expectedRevision }),
-  });
-}
-
 /** `POST /skills/refresh-baseline` — capture the installed plugin as a new baseline and merge it
  *  three-way per file (unchanged → take new; user-modified & upstream-unchanged → keep; both
  *  changed → keep + `conflict`). Never clobbers an edit. */

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -126,24 +126,32 @@ export interface SkillsCatalog {
   revision: string;
 }
 
+/** A plain object — the only shape a keyed map (`skills`, `support`) may arrive as. Arrays are
+ *  objects to `typeof` but `Object.entries` over one yields index keys, not skill names. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 /**
  * The catalog read, shape-checked at the seam: a daemon that answers `/skills` with anything but
- * `{manifest: {skills: …}, revision}` gets a NAMED error — never a page rendering zero skills
- * against a daemon that answered something.
+ * `{manifest: {skills: {…}, support: {…}}, revision}` gets a NAMED error — never a page rendering
+ * zero skills (or index-named rows, or a crash in `supportFiles`) against a daemon that answered
+ * something. `skills` and `support` must be PLAIN objects: an array, `null`, or a missing map is
+ * a mis-shaped answer.
  */
 export function readCatalogBody(body: unknown): SkillsCatalog {
-  if (typeof body === 'object' && body !== null) {
-    const { manifest, revision } = body as { manifest?: unknown; revision?: unknown };
+  if (isPlainObject(body)) {
+    const { manifest, revision } = body;
     if (
-      typeof manifest === 'object' && manifest !== null
-      && typeof (manifest as { skills?: unknown }).skills === 'object'
-      && (manifest as { skills?: unknown }).skills !== null
+      isPlainObject(manifest)
+      && isPlainObject(manifest.skills)
+      && isPlainObject(manifest.support)
       && typeof revision === 'string'
     ) {
-      return { manifest: manifest as SkillsManifest, revision };
+      return { manifest: manifest as unknown as SkillsManifest, revision };
     }
   }
-  throw new Error('the daemon answered /skills with no catalog (expected {manifest: {skills}, revision})');
+  throw new Error('the daemon answered /skills with no catalog (expected {manifest: {skills, support}, revision})');
 }
 
 export async function getSkillsCatalog(): Promise<SkillsCatalog> {
@@ -217,7 +225,7 @@ export function sortSkillFiles(files: readonly SkillFileEntry[]): SkillFileEntry
 /** `GET /skills/:name/files` — the files the skill OWNS (a nested child skill's files belong to
  *  the child; the daemon refuses to serve them through the parent). */
 export async function listSkillFiles(name: string): Promise<SkillFileEntry[]> {
-  const body = await apiFetch<{ files: SkillFileEntry[] }>(`/skills/${encodeURIComponent(name)}/files`);
+  const body = await apiFetch<{ files: SkillFileEntry[] }>(`/skills/${skillRouteName(name)}/files`);
   return sortSkillFiles(body.files);
 }
 
@@ -240,24 +248,60 @@ export interface SkillFileContent {
   binary: boolean;
 }
 
-/** `*path` segments are encoded one by one so the slashes stay route separators. */
-function encodePath(path: string): string {
-  return path.split('/').map((s) => encodeURIComponent(s)).join('/');
+// ── Route identity: every name and path is VALIDATED before it becomes a route ─────────────────
+//
+// Names and file paths reach this module from the daemon (manifest keys, `GET /skills/:name/files`
+// rows, the support map) — untrusted until checked. `encodeURIComponent` preserves `.` and `..`,
+// and URL normalization collapses `/skills/<name>/files/../../support/x` into
+// `/skills/support/x` (or `/skills/support/../../settings` into `/settings`) BEFORE crew's
+// skill-scoped containment ever sees the request. So every segment is decoded (a percent-encoded
+// `..` is still `..`), refused when empty, dot-only (`.`, `..`, `…`), separator-bearing (`/`, `\`)
+// or NUL-bearing, and only then encoded. A refusal is a NAMED error and no request is built —
+// the callers below are `async` so it arrives as a rejection, like any other wire failure.
+
+/** One validated, encoded route segment; `what` names it in the refusal. */
+export function skillRouteSegment(raw: string, what: string): string {
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    // Not percent-encoded (a literal `%` in a name) — the raw text IS the segment.
+  }
+  if (decoded === '') throw new Error(`refusing ${what}: an empty segment`);
+  if (/^\.+$/.test(decoded)) throw new Error(`refusing ${what}: the dot-only segment "${raw}" would escape its route`);
+  if (/[/\\\0]/.test(decoded)) throw new Error(`refusing ${what}: the segment "${raw}" carries a path separator or NUL`);
+  return encodeURIComponent(decoded);
+}
+
+/** A skill name as the ONE `:name` route segment. */
+export function skillRouteName(name: string): string {
+  return skillRouteSegment(name, `skill name "${name}"`);
+}
+
+/**
+ * A file path (relative to the skill dir, or to the root for a support file) as validated `*path`
+ * segments joined by `/`. Empty, absolute (`/x`), empty-segment (`a//b`, a trailing `/`), dot-only
+ * and separator-smuggling paths are refused before any request is built.
+ */
+export function skillRoutePath(path: string): string {
+  if (path === '') throw new Error('refusing an empty file path');
+  if (path.startsWith('/')) throw new Error(`refusing the absolute file path "${path}"`);
+  return path.split('/').map((s) => skillRouteSegment(s, `file path "${path}"`)).join('/');
 }
 
 function skillFileRoute(name: string, path: string): string {
-  return `/skills/${encodeURIComponent(name)}/files/${encodePath(path)}`;
+  return `/skills/${skillRouteName(name)}/files/${skillRoutePath(path)}`;
 }
 
 function supportFileRoute(path: string): string {
-  return `/skills/support/${encodePath(path)}`;
+  return `/skills/support/${skillRoutePath(path)}`;
 }
 
-export function readSkillFile(name: string, path: string): Promise<SkillFileContent> {
+export async function readSkillFile(name: string, path: string): Promise<SkillFileContent> {
   return apiFetch<SkillFileContent>(skillFileRoute(name, path));
 }
 
-export function readSupportFile(path: string): Promise<SkillFileContent> {
+export async function readSupportFile(path: string): Promise<SkillFileContent> {
   return apiFetch<SkillFileContent>(supportFileRoute(path));
 }
 
@@ -291,8 +335,10 @@ function post(path: string, body: Record<string, unknown>): Promise<SkillGuardRe
   return apiFetch<SkillGuardResult>(path, { method: 'POST', body: JSON.stringify(body) });
 }
 
-/** `PUT /skills/:name/files/*path` — one file, atomic tmp+rename daemon-side. */
-export function writeSkillFile(name: string, path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
+/** `PUT /skills/:name/files/*path` — one file, atomic tmp+rename daemon-side. The route is built
+ *  from the REQUESTED identity (the validated skill + path the caller opened), never from a path
+ *  the daemon echoed back. */
+export async function writeSkillFile(name: string, path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
   return apiFetch<SkillGuardResult>(skillFileRoute(name, path), {
     method: 'PUT',
     body: JSON.stringify({ content, expectedRevision }),
@@ -301,7 +347,7 @@ export function writeSkillFile(name: string, path: string, content: string, expe
 
 /** `PUT /skills/support/*path` — a root support file; the guards flag every such edit as a
  *  warning (it is shared by every skill). */
-export function writeSupportFile(path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
+export async function writeSupportFile(path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
   return apiFetch<SkillGuardResult>(supportFileRoute(path), {
     method: 'PUT',
     body: JSON.stringify({ content, expectedRevision }),
@@ -310,14 +356,14 @@ export function writeSupportFile(path: string, content: string, expectedRevision
 
 /** `POST /skills/:name/{enable,disable}` — enablement is manifest state; the guards run on every
  *  flip (disabling a core skill is blocking). */
-export function setSkillEnabled(name: string, enabled: boolean, expectedRevision: string): Promise<SkillGuardResult> {
-  return post(`/skills/${encodeURIComponent(name)}/${enabled ? 'enable' : 'disable'}`, { expectedRevision });
+export async function setSkillEnabled(name: string, enabled: boolean, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${skillRouteName(name)}/${enabled ? 'enable' : 'disable'}`, { expectedRevision });
 }
 
 /** `POST /skills/:name/reset` — restore the skill's OWN files from the baseline (a nested child's
  *  overrides survive); never flips `enabled`. Refused for a user-added skill (no baseline). */
-export function resetSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
-  return post(`/skills/${encodeURIComponent(name)}/reset`, { expectedRevision });
+export async function resetSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${skillRouteName(name)}/reset`, { expectedRevision });
 }
 
 /** A whole skill dir as a files map — relative path → content. */
@@ -329,8 +375,8 @@ export function addSkill(name: string, files: SkillFilesMap, expectedRevision: s
 }
 
 /** `POST /skills/:name/replace` — replace the skill's own files wholesale from a files map. */
-export function replaceSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
-  return post(`/skills/${encodeURIComponent(name)}/replace`, { files, expectedRevision });
+export async function replaceSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
+  return post(`/skills/${skillRouteName(name)}/replace`, { files, expectedRevision });
 }
 
 /** `POST /skills/refresh-baseline` — capture the installed plugin as a new baseline and merge it

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -28,15 +28,17 @@
  *    head is served), a NUL-sniffed one `binary` (`content: null`) — Save stays disabled on either
  *    so the editor never clobbers what it cannot show. `?side=baseline` reads the shipped copy.
  *
- * The adoption seam has two honest non-catalog states: a bare unknown-route 404 means "this crew
- * daemon predates the skills routes" ({@link isSkillsUnsupported}); a **503** means the route exists
- * but there is no catalog to serve — the root is unseeded (no installed plugin), `current` fails
- * verification, or the daemon booted without the seam ({@link isSkillsUnavailable}) — a LOUD error
- * with the daemon's sentence, never an empty catalog pretending.
+ * The adoption seam has two honest non-catalog states: the shared forward-compat signal — a bare
+ * unknown-route 404 (this crew daemon predates the skills routes) or a 501 (the route exists but
+ * nothing stands behind it yet) — is the NAMED unsupported state ({@link isSkillsUnsupported}, the
+ * same pair every other seam folds); a **503** means the route exists but there is no catalog to
+ * serve — the root is unseeded (no installed plugin), `current` fails verification, or the daemon
+ * booted without the seam ({@link isSkillsUnavailable}) — a LOUD error with the daemon's sentence,
+ * never an empty catalog pretending.
  */
 
 import { apiFetch } from './client.js';
-import { ApiError, isRouteAbsent } from './errors.js';
+import { ApiError, isRouteUnsupported } from './errors.js';
 import type {
   DiagnosticsSkillsState,
   SkillAnalyzeResult,
@@ -138,19 +140,23 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-function isRevision(v: unknown): v is number {
-  return typeof v === 'number' && Number.isInteger(v) && v >= 0;
+/** A non-negative SAFE integer — what the contract means by `revision: number` and by a snapshot
+ *  `gen`: a monotonic counter. `NaN`, `±Infinity`, a float, a negative or a string are none of it;
+ *  JSON cannot even spell the first two, so their arrival is a mis-shaped body, not a catalog. */
+function isCounter(v: unknown): v is number {
+  return typeof v === 'number' && Number.isSafeInteger(v) && v >= 0;
 }
 
-const CATALOG_SHAPE = '{manifest: {skills, files, …}, revision: number, root, current}';
+const CATALOG_SHAPE = '{manifest: {skills, files, …}, revision: number, root, current: {gen: number, path} | null}';
 
 /**
  * The catalog read, shape-checked at the seam: a daemon that answers `/skills` with anything but
  * `SkillsManifestResponse` gets a NAMED error — never a page rendering zero skills (or index-named
  * rows, or a crash in {@link supportFiles}) against a daemon that answered something. `skills` and
- * `files` must be PLAIN objects, `revision` a non-negative integer (0.27.0: revisions are numbers —
- * a string revision is a pre-contract daemon, not a catalog), `root` a string and `current` null or
- * `{gen, path}`.
+ * `files` must be PLAIN objects, `revision` a non-negative safe integer (0.27.0: revisions are
+ * numbers — a string revision is a pre-contract daemon, not a catalog), `root` a string and
+ * `current` null or `{gen, path}` with `gen` the same kind of counter (a `NaN` / `Infinity` / float
+ * generation would render as the snapshot line and be compared against `published.gen`).
  */
 export function readCatalogBody(body: unknown): SkillsCatalog {
   if (isPlainObject(body)) {
@@ -159,9 +165,9 @@ export function readCatalogBody(body: unknown): SkillsCatalog {
       isPlainObject(manifest)
       && isPlainObject(manifest.skills)
       && isPlainObject(manifest.files)
-      && isRevision(revision)
+      && isCounter(revision)
       && typeof root === 'string'
-      && (current === null || (isPlainObject(current) && typeof current.gen === 'number' && typeof current.path === 'string'))
+      && (current === null || (isPlainObject(current) && isCounter(current.gen) && typeof current.path === 'string'))
     ) {
       return { manifest: manifest as unknown as SkillManifest, revision, root, current: current as SkillsCatalog['current'] };
     }
@@ -515,12 +521,14 @@ export function readSkillDeepLink(search: string): string | null {
 // ── The adoption seam + the CAS seam ──────────────────────────────────────────────────────────
 
 /**
- * True when this daemon PREDATES the skills routes: Fastify's bare unknown-route 404. A NAMED
+ * True when this daemon cannot serve the skills routes YET — the shared two-layer forward-compat
+ * signal every adoption seam folds ({@link isRouteUnsupported}): Fastify's bare unknown-route 404
+ * (crew predates `/skills`) or a 501 (the route exists but nothing stands behind it yet). A NAMED
  * 404 from a daemon WITH the routes ("unknown skill: …", "no such file") is a real answer and
- * surfaces as one.
+ * surfaces as one; a 503 is {@link isSkillsUnavailable}, not this.
  */
 export function isSkillsUnsupported(e: unknown): boolean {
-  return isRouteAbsent(e);
+  return isRouteUnsupported(e);
 }
 
 /** The honest in-band copy for {@link isSkillsUnsupported} refusals. */

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -266,11 +266,18 @@ export interface SkillFileContent {
 // (review round 2). A literal `%2e%2e` is by the same rule a file named `%2e%2e`, encoded to
 // `%252e%252e` — the route layer's single decode never turns it into `..`.
 
+/** The ONE reason a route segment is refused (`null` when it is clean); `what` names it. */
+function segmentIssue(raw: string, what: string): string | null {
+  if (raw === '') return `refusing ${what}: an empty segment`;
+  if (/^\.+$/.test(raw)) return `refusing ${what}: the dot-only segment "${raw}" would escape its route`;
+  if (/[/\\\0]/.test(raw)) return `refusing ${what}: the segment "${raw}" carries a path separator or NUL`;
+  return null;
+}
+
 /** One validated, encoded route segment; `what` names it in the refusal. */
 export function skillRouteSegment(raw: string, what: string): string {
-  if (raw === '') throw new Error(`refusing ${what}: an empty segment`);
-  if (/^\.+$/.test(raw)) throw new Error(`refusing ${what}: the dot-only segment "${raw}" would escape its route`);
-  if (/[/\\\0]/.test(raw)) throw new Error(`refusing ${what}: the segment "${raw}" carries a path separator or NUL`);
+  const issue = segmentIssue(raw, what);
+  if (issue !== null) throw new Error(issue);
   return encodeURIComponent(raw);
 }
 
@@ -280,14 +287,30 @@ export function skillRouteName(name: string): string {
 }
 
 /**
- * A file path (relative to the skill dir, or to the root for a support file) as validated `*path`
- * segments joined by `/`. Empty, absolute (`/x`), empty-segment (`a//b`, a trailing `/`), dot-only
- * and separator-smuggling paths are refused before any request is built.
+ * The ONE reason a file path (relative to the skill dir, or to the root for a support file) is
+ * refused as a route — `null` when it is clean. Empty, absolute (`/x`), empty-segment (`a//b`, a
+ * trailing `/`), dot-only (`.`, `..`) and separator-smuggling (`\`, NUL) paths are refused, and
+ * the sentence names the offending path. Shared by the route builder ({@link skillRoutePath},
+ * which throws it) and the Add/Replace validation ({@link parseFilesMap}, which shows it), so the
+ * modal can never arm Save for a files map whose key the route layer — or the daemon's
+ * containment behind it — would refuse (review round 3).
  */
+export function skillFilePathIssue(path: string): string | null {
+  if (path === '') return 'refusing an empty file path';
+  if (path.startsWith('/')) return `refusing the absolute file path "${path}"`;
+  for (const s of path.split('/')) {
+    const issue = segmentIssue(s, `file path "${path}"`);
+    if (issue !== null) return issue;
+  }
+  return null;
+}
+
+/** A file path as validated `*path` segments joined by `/`, each encoded exactly once — refused
+ *  ({@link skillFilePathIssue}) before any request is built. */
 export function skillRoutePath(path: string): string {
-  if (path === '') throw new Error('refusing an empty file path');
-  if (path.startsWith('/')) throw new Error(`refusing the absolute file path "${path}"`);
-  return path.split('/').map((s) => skillRouteSegment(s, `file path "${path}"`)).join('/');
+  const issue = skillFilePathIssue(path);
+  if (issue !== null) throw new Error(issue);
+  return path.split('/').map((s) => encodeURIComponent(s)).join('/');
 }
 
 function skillFileRoute(name: string, path: string): string {
@@ -402,8 +425,12 @@ export function analyzeSkills(): Promise<SkillGuardResult> {
 }
 
 /**
- * Parse a pasted files map for Add/Replace: a JSON object whose values are all strings. Returns
- * the map, or the ONE issue to surface (the modal's Save stays disabled while there is one).
+ * Parse a pasted files map for Add/Replace: a JSON object whose values are all strings and whose
+ * keys are paths the route layer accepts — {@link skillFilePathIssue}, the SAME segment rules every
+ * `*path` route is built under (no empty / dot-only segment, no `//` or trailing `/`, no `\` or
+ * NUL, relative), so Save can never arm for a map the daemon would refuse. Returns the map, or the
+ * ONE issue to surface, naming the offending key (the modal's Save stays disabled while there is
+ * one).
  */
 export function parseFilesMap(text: string): { files: SkillFilesMap; issue: null } | { files: null; issue: string } {
   let parsed: unknown;
@@ -419,9 +446,8 @@ export function parseFilesMap(text: string): { files: SkillFilesMap; issue: null
   if (entries.length === 0) return { files: null, issue: 'the files map is empty' };
   for (const [path, content] of entries) {
     if (typeof content !== 'string') return { files: null, issue: `"${path}" must be a string (file content)` };
-    if (path === '' || path.startsWith('/') || path.split('/').includes('..')) {
-      return { files: null, issue: `"${path}" must be a relative path with no ".." segment` };
-    }
+    const pathIssue = skillFilePathIssue(path);
+    if (pathIssue !== null) return { files: null, issue: pathIssue };
   }
   if (!entries.some(([path]) => path === 'SKILL.md')) {
     return { files: null, issue: 'the files map must include SKILL.md — it is the skill' };

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -1,46 +1,97 @@
 /**
- * The skills wire — types and calls for the Skills surface (`/skills`): the file manager over the
- * daemon's ONE effective garden-shaped plugin root (the skills keystone, design v3).
+ * The skills wire — calls and folds for the Skills surface (`/skills`): the file manager over the
+ * daemon's ONE effective garden-shaped plugin root (the skills keystone, design v3 + v3.1–v3.5).
  *
- * ── INTEGRATION POINT (skills build, paired crew lane) ────────────────────────────────────────
  * Skills are files. Crew owns the effective root under its state home (`skills/effective/`): the
  * installed garden is captured as a content-hashed BASELINE, the operator edits any file in place
  * (or replaces a skill dir), disable = excluded from the published snapshot, reset = restore the
  * skill's content from the baseline. Nothing is live until PUBLISH validates the whole tree and
  * writes an immutable snapshot generation that every worker spawn then receives.
  *
- * Every declaration here is TEMPORARY — hand-mirrored from the design's manifest + guard-envelope
- * contract because the crew slice that serves it (`src/skills/`, built in a parallel lane) is not
- * yet in studio's installed `wicked-crew-api-types`. **Delete the types in this module and
- * re-export from `wicked-crew-api-types`** the moment studio bumps to the api-types version that
- * carries the skills contract (the same stopgap `./steering.ts` wears, and the same exit).
+ * THE TYPES ARE THE CONTRACT'S. Every wire shape here is imported from `./skills-wire.ts` — a
+ * byte-for-byte mirror of the `wicked-crew-api-types@0.27.0` skills block (crew#480), pinned by
+ * `tests/skillsWire.test.ts` against a vendored fixture until the package publishes and the mirror
+ * becomes a re-export. This module adds only what the UI folds from it (rows, counts, ownership,
+ * route identity, the adoption / CAS seams) — never a shape of its own for something the wire spells.
  *
- * The three wire rules every caller leans on:
- *  - CAS EVERYWHERE: every mutation sends `expectedRevision` (the catalog revision it was decided
- *    against) and every 2xx answer is the guard envelope `{verdict, findings, revision}` — the new
- *    revision is adopted by the page; a stale revision is a **409**, folded by
+ * The three wire rules every caller leans on (api-types 0.27.0):
+ *  - CAS EVERYWHERE, IN NUMBERS: every mutation sends `expectedRevision` (the catalog revision it
+ *    was decided against — a non-negative integer, `manifest.revision`) and every 2xx answer is the
+ *    envelope `{verdict, findings, revision}`; the answered revision is adopted by the page. A stale
+ *    revision is a **409** `{error, revision}` — the ONLY thing that answers 409 — folded by
  *    {@link isSkillsConflict} into the reload prompt.
  *  - GUARD RESULTS ARE 2xx: `apiFetch` throws on any non-2xx, so a `blocked` verdict (the daemon
- *    refused the change, the root is unchanged) arrives as a NORMAL answer, never an exception.
- *  - READS ARE TYPED: a file read past the daemon's cap is `truncated`, a NUL-sniffed one `binary`
- *    (content `""`) — Save stays disabled on either so the editor never clobbers what it cannot show.
+ *    refused the change, nothing was written — a core disable, a containment refusal, a publish
+ *    already in flight, the root changed under a publish) arrives as a NORMAL answer, never an
+ *    exception. `warnings` proceeded (a publish with only warnings WROTE its snapshot).
+ *  - READS ARE TYPED: `SkillReadResult` — a file past the daemon's 512 KB cap is `truncated` (the
+ *    head is served), a NUL-sniffed one `binary` (`content: null`) — Save stays disabled on either
+ *    so the editor never clobbers what it cannot show. `?side=baseline` reads the shipped copy.
  *
- * The support probe is the same two-layer adoption seam as the steering reads: a bare 404 means
- * "this crew daemon predates the skills routes"; a 501 means "the route exists but the daemon has
- * no skills root to serve". {@link isSkillsUnsupported} folds both so every caller renders the
- * honest named state, never a raw refusal — and never a crash.
+ * The adoption seam has two honest non-catalog states: a bare unknown-route 404 means "this crew
+ * daemon predates the skills routes" ({@link isSkillsUnsupported}); a **503** means the route exists
+ * but there is no catalog to serve — the root is unseeded (no installed plugin), `current` fails
+ * verification, or the daemon booted without the seam ({@link isSkillsUnavailable}) — a LOUD error
+ * with the daemon's sentence, never an empty catalog pretending.
  */
 
 import { apiFetch } from './client.js';
 import { ApiError, isRouteAbsent } from './errors.js';
+import type {
+  DiagnosticsSkillsState,
+  SkillAnalyzeResult,
+  SkillBaselineRecord,
+  SkillEntry,
+  SkillFileRecord,
+  SkillFileTree,
+  SkillKind,
+  SkillManifest,
+  SkillMutationResult,
+  SkillProvenance,
+  SkillPublishResult,
+  SkillReadResult,
+  SkillRefreshResult,
+  SkillsManifestResponse,
+} from './skills-wire.js';
+
+// The contract, re-exported for every component so the release swap touches ONE file.
+export type {
+  AddSkillBody,
+  DiagnosticsSkills,
+  DiagnosticsSkillsFinding,
+  DiagnosticsSkillsState,
+  PutSkillFileBody,
+  ReplaceSkillBody,
+  SkillAnalyzeResult,
+  SkillBaselineRecord,
+  SkillConflictFinding,
+  SkillEntry,
+  SkillFileEntry,
+  SkillFileRecord,
+  SkillFileTree,
+  SkillFindingKind,
+  SkillFindingSeverity,
+  SkillKind,
+  SkillManifest,
+  SkillMutationResult,
+  SkillProvenance,
+  SkillPublishedRecord,
+  SkillPublishResult,
+  SkillReadResult,
+  SkillRefreshResult,
+  SkillRevisionBody,
+  SkillRevisionConflict,
+  SkillSourceKind,
+  SkillsManifestResponse,
+  SkillVenvState,
+  SkillVerdict,
+} from './skills-wire.js';
 
 // ── Vocabulary ────────────────────────────────────────────────────────────────────────────────
 
 /** The three skill kinds, fork-first from frontmatter: `context: fork` → fork-worker; else
- *  `user-invocable: true` → router; else module. */
-export const SKILL_KINDS = ['router', 'fork-worker', 'module'] as const;
-
-export type SkillKind = (typeof SKILL_KINDS)[number];
+ *  `user-invocable: true` → router; else module (`SkillKind`, spelled out for the chips). */
+export const SKILL_KINDS: readonly SkillKind[] = ['router', 'fork-worker', 'module'];
 
 export const SKILL_KIND_LABELS: Record<SkillKind, string> = {
   router: 'router',
@@ -52,12 +103,9 @@ export function isSkillKind(s: string): s is SkillKind {
   return (SKILL_KINDS as readonly string[]).includes(s);
 }
 
-/** Where a skill's effective content stands against the baseline — DERIVED from the hashes
- *  ({@link provenanceOf}), never a wire field: no baseline → user-added; equal → shipped
- *  untouched; different → an operator override. */
-export const SKILL_PROVENANCES = ['shipped', 'override', 'user-added'] as const;
-
-export type SkillProvenance = (typeof SKILL_PROVENANCES)[number];
+/** `SkillProvenance` is a WIRE field (0.27.0): `shipped` = every own file byte-identical to the
+ *  baseline; `override` = a shipped skill with edited/replaced files; `user-added` = no baseline. */
+export const SKILL_PROVENANCES: readonly SkillProvenance[] = ['shipped', 'override', 'user-added'];
 
 export const SKILL_PROVENANCE_LABELS: Record<SkillProvenance, string> = {
   shipped: 'shipped',
@@ -65,121 +113,132 @@ export const SKILL_PROVENANCE_LABELS: Record<SkillProvenance, string> = {
   'user-added': 'user-added',
 };
 
-/** The guard verdict over one write/enable/publish. `blocked` = refused, nothing changed. */
-export type SkillVerdict = 'clear' | 'warnings' | 'blocked';
+/** The `diagnostics.skills.state` vocabulary (0.27.0), read as operator copy: whether the engine is
+ *  being handed a verified snapshot, and if not, why. */
+export const SKILLS_ENGINE_STATE_COPY: Record<DiagnosticsSkillsState, string> = {
+  published: 'published — the engine is handed the verified snapshot',
+  fallback: 'fallback — no wicked-garden is installed; the engine resolves the live plugin cache itself',
+  blocked: 'blocked — the first publish is blocked; launches refuse the skills snapshot until the catalog is fixed',
+  'config-error': 'config error — the skills root is corrupt or unusable; launches refuse the skills snapshot',
+  disabled: 'disabled — this daemon booted without the skills seam',
+};
 
-// ── The catalog (`GET /skills` — manifest + revision) ─────────────────────────────────────────
+// ── The catalog (`GET /skills` — manifest + revision + root + current) ────────────────────────
 
-export interface SkillsBaselineSource {
-  kind: 'claude-plugin-cache' | 'checkout' | 'npm-pack';
-  path: string;
-  plugin_version: string;
-  git_sha: string | null;
-  captured_at: string;
-}
+/** `GET /skills` 200 body — the contract's name, kept under the page's word for it. */
+export type SkillsCatalog = SkillsManifestResponse;
 
-/** A baseline is identified by the CONTENT HASH of the bundle it was captured from — never the
- *  version string alone (two "12.32.0" captures can differ). */
-export interface SkillsBaseline {
-  contentHash: string;
-  source: SkillsBaselineSource;
-}
+/** The envelope every mutation answers with on 2xx (`SkillAnalyzeResult` is the base of every
+ *  mutation result: `{verdict, findings, revision}`) — the shape every findings renderer takes. */
+export type SkillGuardResult = SkillAnalyzeResult;
 
-export interface SkillManifestEntry {
-  /** `skills/<nested/path>` under the effective root — never renamed (sibling links depend on it). */
-  dir: string;
-  kind: SkillKind;
-  /** Core-by-reference: in the registered-reference closure (a workflow's `skill_ref`, or a
-   *  referenced skill's `mandates`) — disabling or renaming it is blocking. */
-  core: boolean;
-  /** `false` when the skill leans on `${CLAUDE_PLUGIN_ROOT}`, cwd-relative scripts or `../` links —
-   *  Claude-only by nature, excluded from the other CLIs' mirrors. */
-  portable: boolean;
-  /** Manifest state, orthogonal to content — reset restores content only and never flips this. */
-  enabled: boolean;
-  /** `null` for a user-added skill — there is no baseline to reset to. */
-  baselineHash: string | null;
-  effectiveHash: string;
-  /** The content hash the CURRENT snapshot carries for this skill; `null` when it has never been
-   *  published (a new skill, or no publish yet). */
-  lastPublishedHash: string | null;
-  editedAt: string | null;
-  /** The three-way refresh kept a user edit AND upstream changed the same skill — the new side is
-   *  stored for diff; reset takes it. */
-  conflict: boolean;
-}
-
-export interface SkillsManifest {
-  baseline: SkillsBaseline;
-  /** Keyed by frontmatter `name` (`wicked-garden-<path-joined-by-dashes>`). */
-  skills: Record<string, SkillManifestEntry>;
-  /** Root support files shared by every skill (`scripts/…`, `schemas/…`, `.claude-plugin/…`) →
-   *  effective content hash. */
-  support: Record<string, string>;
-  /** The snapshot generation `current` points at, or `null` before the first publish. */
-  currentGeneration: number | null;
-}
-
-/** `GET /skills`: the manifest plus the CAS revision every mutation is conditioned on. */
-export interface SkillsCatalog {
-  manifest: SkillsManifest;
-  revision: string;
-}
-
-/** A plain object — the only shape a keyed map (`skills`, `support`) may arrive as. Arrays are
+/** A plain object — the only shape a keyed map (`skills`, `files`) may arrive as. Arrays are
  *  objects to `typeof` but `Object.entries` over one yields index keys, not skill names. */
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
+function isRevision(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0;
+}
+
+const CATALOG_SHAPE = '{manifest: {skills, files, …}, revision: number, root, current}';
+
 /**
  * The catalog read, shape-checked at the seam: a daemon that answers `/skills` with anything but
- * `{manifest: {skills: {…}, support: {…}}, revision}` gets a NAMED error — never a page rendering
- * zero skills (or index-named rows, or a crash in `supportFiles`) against a daemon that answered
- * something. `skills` and `support` must be PLAIN objects: an array, `null`, or a missing map is
- * a mis-shaped answer.
+ * `SkillsManifestResponse` gets a NAMED error — never a page rendering zero skills (or index-named
+ * rows, or a crash in {@link supportFiles}) against a daemon that answered something. `skills` and
+ * `files` must be PLAIN objects, `revision` a non-negative integer (0.27.0: revisions are numbers —
+ * a string revision is a pre-contract daemon, not a catalog), `root` a string and `current` null or
+ * `{gen, path}`.
  */
 export function readCatalogBody(body: unknown): SkillsCatalog {
   if (isPlainObject(body)) {
-    const { manifest, revision } = body;
+    const { manifest, revision, root, current } = body;
     if (
       isPlainObject(manifest)
       && isPlainObject(manifest.skills)
-      && isPlainObject(manifest.support)
-      && typeof revision === 'string'
+      && isPlainObject(manifest.files)
+      && isRevision(revision)
+      && typeof root === 'string'
+      && (current === null || (isPlainObject(current) && typeof current.gen === 'number' && typeof current.path === 'string'))
     ) {
-      return { manifest: manifest as unknown as SkillsManifest, revision };
+      return { manifest: manifest as unknown as SkillManifest, revision, root, current: current as SkillsCatalog['current'] };
     }
   }
-  throw new Error('the daemon answered /skills with no catalog (expected {manifest: {skills, support}, revision})');
+  throw new Error(`the daemon answered /skills with no catalog (expected ${CATALOG_SHAPE})`);
 }
 
 export async function getSkillsCatalog(): Promise<SkillsCatalog> {
   return readCatalogBody(await apiFetch<unknown>('/skills'));
 }
 
-/** A manifest entry paired with its name and derived provenance — the row shape every list and
- *  drawer renders. */
-export interface SkillRow extends SkillManifestEntry {
+/** The current baseline's record (keyed by content hash in `manifest.baselines`), or `null` when
+ *  the manifest names a hash it does not carry (a corrupt manifest the daemon would have refused). */
+export function currentBaseline(manifest: SkillManifest): (SkillBaselineRecord & { hash: string }) | null {
+  const record = manifest.baselines[manifest.baseline];
+  return record === undefined ? null : { ...record, hash: manifest.baseline };
+}
+
+// ── Ownership: which skill a managed file belongs to (the manifest's `files` map) ─────────────
+
+/** One file record with its plugin-relative path. */
+export interface OwnedFile {
+  path: string;
+  record: SkillFileRecord;
+}
+
+/** The manifest's `files` split by owner: each skill's OWN files (a nested skill's subtree is its
+ *  own — the DEEPEST registered skill dir on the path owns a file), and the root SUPPORT files no
+ *  skill owns (`.claude-plugin/`, `scripts/`, `schemas/`, `docs/examples/`, `pyproject.toml`,
+ *  `uv.lock`). Path-sorted. */
+export function fileOwnership(manifest: SkillManifest): { bySkill: Map<string, OwnedFile[]>; support: OwnedFile[] } {
+  const nameByDir = new Map<string, string>();
+  for (const [name, entry] of Object.entries(manifest.skills)) nameByDir.set(entry.dir, name);
+  const bySkill = new Map<string, OwnedFile[]>();
+  const support: OwnedFile[] = [];
+  const paths = Object.keys(manifest.files).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const path of paths) {
+    const record = manifest.files[path]!;
+    const segments = path.split('/');
+    let owner: string | undefined;
+    for (let depth = segments.length - 1; depth >= 1 && owner === undefined; depth -= 1) {
+      owner = nameByDir.get(segments.slice(0, depth).join('/'));
+    }
+    if (owner === undefined) {
+      support.push({ path, record });
+    } else {
+      const own = bySkill.get(owner);
+      if (own === undefined) bySkill.set(owner, [{ path, record }]);
+      else own.push({ path, record });
+    }
+  }
+  return { bySkill, support };
+}
+
+/**
+ * True when the CURRENT snapshot does not carry this skill's effective content — a publish is
+ * needed before any worker sees it: some own file's `effectiveHash` differs from the hash it had
+ * in the most recent publish (`lastPublishedHash`, `null` = never published). Publish records the
+ * hash only for files it SHIPS, so this is judged for ENABLED skills only — a disabled skill is
+ * left out of the next publish by its manifest state, which the switch already says.
+ */
+export function isUnpublished(entry: Pick<SkillEntry, 'enabled'>, own: readonly OwnedFile[]): boolean {
+  return entry.enabled && own.some(({ record }) => record.effectiveHash !== record.lastPublishedHash);
+}
+
+/** A manifest entry paired with its name and the derived publish state — the row shape every list
+ *  and drawer renders. `provenance` is the wire's. */
+export interface SkillRow extends SkillEntry {
   name: string;
-  provenance: SkillProvenance;
-}
-
-export function provenanceOf(entry: Pick<SkillManifestEntry, 'baselineHash' | 'effectiveHash'>): SkillProvenance {
-  if (entry.baselineHash === null) return 'user-added';
-  return entry.baselineHash === entry.effectiveHash ? 'shipped' : 'override';
-}
-
-/** True when the CURRENT snapshot does not carry this skill's effective content — a publish is
- *  needed before any worker sees it. */
-export function isUnpublished(entry: Pick<SkillManifestEntry, 'effectiveHash' | 'lastPublishedHash'>): boolean {
-  return entry.lastPublishedHash !== entry.effectiveHash;
+  unpublished: boolean;
 }
 
 /** The manifest as rows, name-sorted (plain codepoint order — deterministic across locales). */
-export function skillRows(manifest: SkillsManifest): SkillRow[] {
+export function skillRows(manifest: SkillManifest): SkillRow[] {
+  const { bySkill } = fileOwnership(manifest);
   return Object.entries(manifest.skills)
-    .map(([name, entry]) => ({ name, ...entry, provenance: provenanceOf(entry) }))
+    .map(([name, entry]) => ({ name, ...entry, unpublished: isUnpublished(entry, bySkill.get(name) ?? []) }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 }
 
@@ -203,18 +262,21 @@ export function skillCounts(rows: readonly SkillRow[]): SkillCounts {
   return counts;
 }
 
-// ── Files: the tree and one file ──────────────────────────────────────────────────────────────
+// ── Files: the two trees and one file ─────────────────────────────────────────────────────────
 
-export interface SkillFileEntry {
-  /** Relative to the skill dir (or the root, for support files), forward slashes. */
+/** One row of a file tree in the drawer: a skill's own file (`GET /skills/:name/files` —
+ *  `SkillFileEntry {path, size, sha256, record}`) or a root support file (from the manifest's
+ *  `files` map, which carries records but no sizes — `size: null`). `path` is relative to the
+ *  skill dir for the skill tree and to the plugin root for the support tree. */
+export interface SkillTreeRow {
   path: string;
-  hash: string;
-  /** Absent for a support file — the manifest's support map carries no sizes. */
-  size?: number;
+  size: number | null;
+  /** The manifest record (`null` for a file present on disk but not yet recorded). */
+  record: SkillFileRecord | null;
 }
 
 /** File rows sorted by path with `SKILL.md` first — it IS the skill. */
-export function sortSkillFiles(files: readonly SkillFileEntry[]): SkillFileEntry[] {
+export function sortSkillFiles(files: readonly SkillTreeRow[]): SkillTreeRow[] {
   return [...files].sort((a, b) => {
     if (a.path === 'SKILL.md') return -1;
     if (b.path === 'SKILL.md') return 1;
@@ -223,35 +285,31 @@ export function sortSkillFiles(files: readonly SkillFileEntry[]): SkillFileEntry
 }
 
 /** `GET /skills/:name/files` — the files the skill OWNS (a nested child skill's files belong to
- *  the child; the daemon refuses to serve them through the parent). */
-export async function listSkillFiles(name: string): Promise<SkillFileEntry[]> {
-  const body = await apiFetch<{ files: SkillFileEntry[] }>(`/skills/${skillRouteName(name)}/files`);
-  return sortSkillFiles(body.files);
+ *  the child; the daemon refuses to serve them through the parent). Shape-checked: a body without
+ *  a `files` array is a named error, never an empty tree. */
+export async function listSkillFiles(name: string): Promise<SkillTreeRow[]> {
+  const body = await apiFetch<unknown>(`/skills/${skillRouteName(name)}/files`);
+  if (!isPlainObject(body) || !Array.isArray(body.files)) {
+    throw new Error(`the daemon answered /skills/${name}/files with no file tree (expected {name, dir, enabled, files: [...]})`);
+  }
+  const tree = body as unknown as SkillFileTree;
+  return sortSkillFiles(tree.files.map((f) => ({ path: f.path, size: f.size, record: f.record })));
 }
 
-/** The root support files as tree rows, from the manifest's `support` map (there is no separate
- *  list route — `GET|PUT /skills/support/*path` addresses one file). */
-export function supportFiles(manifest: SkillsManifest): SkillFileEntry[] {
-  return Object.entries(manifest.support)
-    .map(([path, hash]) => ({ path, hash }))
-    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+/** The root support files as tree rows — the manifest `files` no skill owns (there is no list
+ *  route; `GET|PUT /skills/support/*path` addresses one file). Path-sorted, no sizes. */
+export function supportFiles(manifest: SkillManifest): SkillTreeRow[] {
+  return fileOwnership(manifest).support.map(({ path, record }) => ({ path, size: null, record }));
 }
 
-/** A typed, capped file read: `truncated` past the daemon's cap (the head is served), `binary` on
- *  a NUL sniff (content `""`). Save is disabled on either. */
-export interface SkillFileContent {
-  path: string;
-  content: string;
-  size: number;
-  hash: string;
-  truncated: boolean;
-  binary: boolean;
-}
+/** Which copy of a file to read: the effective root (the default) or the baseline — the "new side"
+ *  of a refresh conflict, or the held-back upstream skill of a name collision (`upstreamDir`). */
+export type SkillReadSide = 'effective' | 'baseline';
 
 // ── Route identity: every name and path is VALIDATED before it becomes a route ─────────────────
 //
 // Names and file paths reach this module from the daemon (manifest keys, `GET /skills/:name/files`
-// rows, the support map) — untrusted until checked. `encodeURIComponent` preserves `.` and `..`,
+// rows, the files map) — untrusted until checked. `encodeURIComponent` preserves `.` and `..`,
 // and URL normalization collapses `/skills/<name>/files/../../support/x` into
 // `/skills/support/x` (or `/skills/support/../../settings` into `/settings`) BEFORE crew's
 // skill-scoped containment ever sees the request. So every segment is validated on its LITERAL
@@ -321,107 +379,92 @@ function supportFileRoute(path: string): string {
   return `/skills/support/${skillRoutePath(path)}`;
 }
 
-export async function readSkillFile(name: string, path: string): Promise<SkillFileContent> {
-  return apiFetch<SkillFileContent>(skillFileRoute(name, path));
+/** `?side=baseline` when asked for the shipped copy; nothing for the effective root (the default). */
+function sideQuery(side: SkillReadSide): string {
+  return side === 'baseline' ? '?side=baseline' : '';
 }
 
-export async function readSupportFile(path: string): Promise<SkillFileContent> {
-  return apiFetch<SkillFileContent>(supportFileRoute(path));
+/** `GET /skills/:name/files/*path` — a typed, capped read (`SkillReadResult`). `side: 'baseline'`
+ *  reads the shipped copy; for a skill a refresh held back (`upstreamDir`), the answer's `path`
+ *  names the upstream file actually read. */
+export async function readSkillFile(name: string, path: string, side: SkillReadSide = 'effective'): Promise<SkillReadResult> {
+  return apiFetch<SkillReadResult>(`${skillFileRoute(name, path)}${sideQuery(side)}`);
+}
+
+/** `GET /skills/support/*path` — the same typed read for a root support file. */
+export async function readSupportFile(path: string, side: SkillReadSide = 'effective'): Promise<SkillReadResult> {
+  return apiFetch<SkillReadResult>(`${supportFileRoute(path)}${sideQuery(side)}`);
 }
 
 // ── The guard envelope (every mutation answers with one, on 2xx) ──────────────────────────────
 
-/** `blocking` refuses the change (verdict `blocked`); `warning` lets it through, flagged. */
-export type SkillFindingSeverity = 'blocking' | 'warning';
-
-export interface SkillFinding {
-  /** The guard that fired (e.g. `name-collision`, `frontmatter-name`, `core-disable`,
-   *  `support-edit`, `unresolved-ref`). */
-  kind: string;
-  severity: SkillFindingSeverity;
-  /** The skill the finding is against, when there is one (a collision names the other skill). */
-  skill: string | null;
-  /** The file (relative to the effective root) and line the finding cites, when it cites one —
-   *  an unresolved `${CLAUDE_PLUGIN_ROOT}` reference names its `file:line`. */
-  file: string | null;
-  line: number | null;
-  explanation: string;
-}
-
-export interface SkillGuardResult {
-  verdict: SkillVerdict;
-  findings: SkillFinding[];
-  /** The catalog revision AFTER this call — the next mutation's `expectedRevision`. */
-  revision: string;
-}
-
-function post(path: string, body: Record<string, unknown>): Promise<SkillGuardResult> {
-  return apiFetch<SkillGuardResult>(path, { method: 'POST', body: JSON.stringify(body) });
+function post<T extends SkillAnalyzeResult>(path: string, body: Record<string, unknown>): Promise<T> {
+  return apiFetch<T>(path, { method: 'POST', body: JSON.stringify(body) });
 }
 
 /** `PUT /skills/:name/files/*path` — one file, atomic tmp+rename daemon-side. The route is built
  *  from the REQUESTED identity (the validated skill + path the caller opened), never from a path
- *  the daemon echoed back. */
-export async function writeSkillFile(name: string, path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
-  return apiFetch<SkillGuardResult>(skillFileRoute(name, path), {
+ *  the daemon echoed back. Body `PutSkillFileBody {content, expectedRevision}`. */
+export async function writeSkillFile(name: string, path: string, content: string, expectedRevision: number): Promise<SkillMutationResult> {
+  return apiFetch<SkillMutationResult>(skillFileRoute(name, path), {
     method: 'PUT',
     body: JSON.stringify({ content, expectedRevision }),
   });
 }
 
-/** `PUT /skills/support/*path` — a root support file; the guards flag every such edit as a
- *  warning (it is shared by every skill). */
-export async function writeSupportFile(path: string, content: string, expectedRevision: string): Promise<SkillGuardResult> {
-  return apiFetch<SkillGuardResult>(supportFileRoute(path), {
+/** `PUT /skills/support/*path` — a root support file (shared by every skill; the guards flag the
+ *  edit, and a path outside the bundle closure is a 2xx `blocked` `outside-closure` envelope). */
+export async function writeSupportFile(path: string, content: string, expectedRevision: number): Promise<SkillMutationResult> {
+  return apiFetch<SkillMutationResult>(supportFileRoute(path), {
     method: 'PUT',
     body: JSON.stringify({ content, expectedRevision }),
   });
 }
 
 /** `POST /skills/:name/{enable,disable}` — enablement is manifest state; the guards run on every
- *  flip (disabling a core skill is blocking). */
-export async function setSkillEnabled(name: string, enabled: boolean, expectedRevision: string): Promise<SkillGuardResult> {
+ *  flip (disabling a core skill is `blocked`, `core-disable`). */
+export async function setSkillEnabled(name: string, enabled: boolean, expectedRevision: number): Promise<SkillMutationResult> {
   return post(`/skills/${skillRouteName(name)}/${enabled ? 'enable' : 'disable'}`, { expectedRevision });
 }
 
 /** `POST /skills/:name/reset` — restore the skill's OWN files from the baseline (a nested child's
  *  overrides survive); never flips `enabled`. Refused for a user-added skill (no baseline). */
-export async function resetSkill(name: string, expectedRevision: string): Promise<SkillGuardResult> {
+export async function resetSkill(name: string, expectedRevision: number): Promise<SkillMutationResult> {
   return post(`/skills/${skillRouteName(name)}/reset`, { expectedRevision });
 }
 
-/** A whole skill dir as a files map — relative path → content. */
+/** A whole skill dir as a files map — skill-relative POSIX path → UTF-8 content. */
 export type SkillFilesMap = Record<string, string>;
 
-/** `POST /skills` — add a user-added skill from a files map. */
-export function addSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
+/** `POST /skills` — add a user-added skill (`AddSkillBody`); it lands at
+ *  `skills/<name minus "wicked-garden-">`. */
+export function addSkill(name: string, files: SkillFilesMap, expectedRevision: number): Promise<SkillMutationResult> {
   return post('/skills', { name, files, expectedRevision });
 }
 
-/** `POST /skills/:name/replace` — replace the skill's own files wholesale from a files map. */
-export async function replaceSkill(name: string, files: SkillFilesMap, expectedRevision: string): Promise<SkillGuardResult> {
+/** `POST /skills/:name/replace` — replace the skill's own files wholesale (`ReplaceSkillBody`). */
+export async function replaceSkill(name: string, files: SkillFilesMap, expectedRevision: number): Promise<SkillMutationResult> {
   return post(`/skills/${skillRouteName(name)}/replace`, { files, expectedRevision });
 }
 
 /** `POST /skills/refresh-baseline` — capture the installed plugin as a new baseline and merge it
- *  three-way per file (unchanged → take new; user-modified & upstream-unchanged → keep; both
- *  changed → keep + `conflict`). Never clobbers an edit. */
-export function refreshSkillsBaseline(expectedRevision: string): Promise<SkillGuardResult> {
+ *  three-way per FILE (unchanged → take new; user-modified & upstream-unchanged → keep; both
+ *  changed → keep + `conflict`). Never clobbers an edit. Answers `SkillRefreshResult`. */
+export function refreshSkillsBaseline(expectedRevision: number): Promise<SkillRefreshResult> {
   return post('/skills/refresh-baseline', { expectedRevision });
 }
 
-/** `POST /skills/publish` — validate the WHOLE tree (name uniqueness across the full catalog,
- *  frontmatter names, the core closure, every `${CLAUDE_PLUGIN_ROOT}`/`../` reference resolving
- *  inside the bundle), then write an immutable snapshot generation and flip `current`. A
- *  `blocked` verdict writes nothing — workers keep the previous generation. */
-export function publishSkills(expectedRevision: string): Promise<SkillGuardResult> {
+/** `POST /skills/publish` — validate the WHOLE tree, then write an immutable snapshot generation
+ *  and flip `current`. `SkillPublishResult`: `snapshot` is `null` when `blocked` (nothing written,
+ *  `revision` unchanged — workers keep the previous generation); a `warnings` verdict WROTE it. */
+export function publishSkills(expectedRevision: number): Promise<SkillPublishResult> {
   return post('/skills/publish', { expectedRevision });
 }
 
-/** `POST /skills/analyze` — the publish validation as a dry run: the same findings, nothing
- *  written. Takes no `expectedRevision` — it mutates nothing. */
-export function analyzeSkills(): Promise<SkillGuardResult> {
-  return apiFetch<SkillGuardResult>('/skills/analyze', { method: 'POST' });
+/** `POST /skills/analyze` — the publish validation as a PURE dry run: the same findings, nothing
+ *  persisted, `revision` unchanged. Takes no body — it mutates nothing. */
+export function analyzeSkills(): Promise<SkillAnalyzeResult> {
+  return apiFetch<SkillAnalyzeResult>('/skills/analyze', { method: 'POST' });
 }
 
 /**
@@ -472,20 +515,32 @@ export function readSkillDeepLink(search: string): string | null {
 // ── The adoption seam + the CAS seam ──────────────────────────────────────────────────────────
 
 /**
- * True when this daemon cannot serve the skills catalog: a 501 (route present, no skills root
- * behind it) or Fastify's bare unknown-route 404 (crew predates the `/skills` routes). A NAMED
- * 404/4xx from a daemon WITH the routes ("unknown skill: …") is a real answer and surfaces as one.
+ * True when this daemon PREDATES the skills routes: Fastify's bare unknown-route 404. A NAMED
+ * 404 from a daemon WITH the routes ("unknown skill: …", "no such file") is a real answer and
+ * surfaces as one.
  */
 export function isSkillsUnsupported(e: unknown): boolean {
-  return (e instanceof ApiError && e.status === 501) || isRouteAbsent(e);
+  return isRouteAbsent(e);
 }
 
 /** The honest in-band copy for {@link isSkillsUnsupported} refusals. */
 export const SKILLS_UNSUPPORTED_COPY =
   'This daemon predates the skills catalog (crew’s /skills routes) — there is nothing to manage here yet. Upgrade wicked-crew to browse, edit, enable, publish, and reset the skills its workers run.';
 
-/** A stale `expectedRevision`: the catalog changed under this page (another session, a direct
- *  edit the daemon hashed, a refresh). The page reloads before anything else is written. */
+/**
+ * True when the route exists but there is NO catalog to serve — a **503** (0.27.0): the root is not
+ * seeded (no installed wicked-garden plugin was found), `current` exists but fails verification
+ * (a realpath outside `snapshots/`, malformed `snapshot.json`, a content-hash mismatch), the
+ * manifest is corrupt, or the daemon booted without the skills seam. The daemon's sentence says
+ * which; the page shows it as a LOUD named state — never an empty catalog.
+ */
+export function isSkillsUnavailable(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 503;
+}
+
+/** A stale `expectedRevision` (a CAS conflict — the ONLY thing that answers 409): the catalog
+ *  changed under this page (another session, a direct edit the daemon hashed, a refresh). The page
+ *  reloads before anything else is written. */
 export function isSkillsConflict(e: unknown): boolean {
   return e instanceof ApiError && e.status === 409;
 }

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -8,6 +8,7 @@ import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
 import { memoriesPath, policiesPath, steeringDashboardPath, STEERING_SECTIONS, STEERING_SECTION_LABELS, type SteeringSection } from '../api/steering.js';
+import { skillsPath } from '../api/skills.js';
 import { testingLaunchPath, testingPath } from '../api/testing.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
@@ -73,7 +74,7 @@ const S = {
 
 // ── The five paths (§2.1) ─────────────────────────────────────────────────────
 
-export type PathKey = 'projects' | 'execute' | 'test' | 'vibe' | 'demo' | 'chat' | 'repos' | 'testing' | 'steering' | 'settings';
+export type PathKey = 'projects' | 'execute' | 'test' | 'vibe' | 'demo' | 'chat' | 'repos' | 'testing' | 'skills' | 'steering' | 'settings';
 
 /** Heading word, collapsed-rail glyph (§3.2), ▦ target (§2.1; Settings' glyph
  *  links `/system` in the collapsed column — it has no dashboard). `noun` is
@@ -106,11 +107,16 @@ const P_TESTING: PathSpec  = { key: 'testing',  title: 'Evals',        noun: 'Ev
 // placed immediately BEFORE Settings. The nav-reorg moved its Dashboard from a sub-row to the
 // heading's ▦ (dash → the dashboard, same affordance Projects/Execute/Chat/Repos use); it keeps
 // NO ＋. Its accordion rows are the TWO management sub-sections (Policies / Memories).
+// Skills (the skills keystone): the file manager over the daemon's effective plugin root — the
+// skills its workers actually run. A SYSTEM section placed immediately BEFORE Steering, wearing the
+// Steering/Evals grammar: ▦ (the catalog) and NO ＋ — a skill is added from the page's own verb,
+// with the daemon's guards, never from a bare rail affordance.
+const P_SKILLS: PathSpec   = { key: 'skills',   title: 'Skills',       noun: 'Skill',      glyph: '◆', dash: skillsPath(), collapsedHref: skillsPath() };
 const P_STEERING: PathSpec = { key: 'steering', title: 'Steering',     noun: 'Rule',       glyph: '☸', dash: steeringDashboardPath(), collapsedHref: steeringDashboardPath() };
 const P_SETTINGS: PathSpec = { key: 'settings', title: 'Settings',     noun: 'Setting',    glyph: '⚙', dash: null,        collapsedHref: '/system' };
 // Order (nav-reorg): Execute / Vibe / Demo replace Make and sit before Evals; Chat / Repos /
-// Steering / Settings tail.
-const PATHS: PathSpec[] = [P_PROJECTS, P_EXECUTE, P_TEST, P_VIBE, P_DEMO, P_CHAT, P_REPOS, P_STEERING, P_TESTING, P_SETTINGS];
+// Skills / Steering / Settings tail.
+const PATHS: PathSpec[] = [P_PROJECTS, P_EXECUTE, P_TEST, P_VIBE, P_DEMO, P_CHAT, P_REPOS, P_SKILLS, P_STEERING, P_TESTING, P_SETTINGS];
 
 // `wiki`, `rules` and `policies` retired into Steering (they redirect to /steering); the
 // retired `coverage` and `domain` panels redirect to /system — kept mapped here so the rail
@@ -139,6 +145,8 @@ export function headingForPath(pathname: string): PathKey | null {
   // retired flat `/campaigns` addresses (which redirect onto `/testing/campaigns`) map to Test.
   if (first === 'campaigns') return 'test';
   if (first === 'testing') return second === 'campaigns' ? 'test' : 'testing';
+  // `/skills` (+ any sub-address) is the skills file manager — a system section beside Steering.
+  if (first === 'skills') return 'skills';
   // The retired `/wiki` + `/rules` + `/policies` panels AND the retired standalone `/proposals`
   // queue redirect into Steering (proposals now live inside its two sub-sections) — map them
   // there too, so the rail never flashes Settings open on the pre-redirect tick.
@@ -518,6 +526,27 @@ function TestRailRows({ navigate }: { navigate: (p: string) => void }): React.Re
   );
 }
 
+/** The Skills accordion's single shortcut row: Skills has no persistent per-item list worth
+ *  mirroring on the rail (the catalog is ~140 skills — a dashboard, not a shortcut list), so the
+ *  accordion is one "Browse skills" shortcut into the file manager (the ▦ links the same page).
+ *  Same grammar as {@link EvalsRailRows}. */
+function SkillsRailRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
+  return (
+    <div role="menu" className="flex flex-col pt-0.5">
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="rail-skills-browse"
+        onClick={() => navigate(skillsPath())}
+        className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
+        style={{ color: 'var(--ink-muted)' }}
+      >
+        Browse skills
+      </button>
+    </div>
+  );
+}
+
 /** The Steering accordion's rows: one per MANAGEMENT sub-section (Policies / Memories), each a
  *  navigate() shortcut to its page — the SettingsShortcutRows grammar. The nav-reorg moved the
  *  Dashboard from a sub-row to the heading's ▦ (same affordance Projects/Execute/Chat/Repos use),
@@ -868,6 +897,17 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
           {/* ── The work/system boundary (usability wave): a bar separating the work sections above
                  from the governance/system sections (Steering, Evals) below. ── */}
           <div aria-hidden data-testid="rail-divider" style={{ borderTop: '1px solid var(--surface-raised)', margin: '8px 12px' }} />
+
+          {/* ── Skills — the file manager over the daemon's effective plugin root (the skills its
+                workers run): browse, edit, enable/disable, reset. Sits before Steering. ── */}
+          <RailHeading
+            path={P_SKILLS}
+            open={openHeading === 'skills'}
+            onToggle={() => toggle('skills')}
+            navigate={navigate}
+          >
+            <SkillsRailRows navigate={navigate} />
+          </RailHeading>
 
           {/* ── Steering — the governed-knowledge home. Its three rows: Dashboard (the review-forward
                 home, on the ▦) + the Policies / Memories deep-dives. ─ */}

--- a/src/components/SkillChips.tsx
+++ b/src/components/SkillChips.tsx
@@ -1,5 +1,4 @@
 import {
-  isUnpublished,
   SKILL_KIND_LABELS,
   SKILL_PROVENANCE_LABELS,
   type SkillKind,
@@ -7,8 +6,9 @@ import {
   type SkillRow,
 } from '../api/skills.js';
 
-/** The Skills surface's shared chip grammar — kind, provenance, the core / Claude-only / conflict /
- *  unpublished badges and the enabled switch: one spelling for the catalog rows and the drawer. */
+/** The Skills surface's shared chip grammar — kind, provenance, the core / Claude-only / upgrade /
+ *  conflict / unpublished badges and the enabled switch: one spelling for the catalog rows and the
+ *  drawer. Every word here is the contract's (api-types 0.27.0 `SkillEntry`). */
 
 export const KIND_COLOR: Record<SkillKind, string> = {
   router: 'var(--accent)',
@@ -35,11 +35,18 @@ export function KindChip({ kind }: { kind: SkillKind }): React.ReactElement {
   );
 }
 
+/** `shipped` = every own file byte-identical to the baseline; `override` = edited/replaced files;
+ *  `user-added` = no baseline (added through the API, or upstream dropped it while the edits were kept). */
 export function ProvenanceChip({ provenance }: { provenance: SkillProvenance }): React.ReactElement {
   return (
     <span
       data-testid="skills-provenance-chip"
       data-provenance={provenance}
+      title={provenance === 'shipped'
+        ? 'shipped — every file byte-identical to the baseline'
+        : provenance === 'override'
+          ? 'overridden — a shipped skill with edited or replaced files (reset restores the baseline)'
+          : 'user-added — no baseline: added through the API, or upstream dropped it while your edits were kept'}
       className="inline-flex shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold font-mono uppercase"
       style={{ color: PROVENANCE_COLOR[provenance], border: `1px solid ${PROVENANCE_COLOR[provenance]}` }}
     >
@@ -50,14 +57,14 @@ export function ProvenanceChip({ provenance }: { provenance: SkillProvenance }):
 
 const BADGE = 'inline-flex shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold font-mono uppercase';
 
-/** Core-by-reference: a registered workflow's `skill_ref` (or a referenced skill's `mandates`)
- *  names this skill — disabling or renaming it is BLOCKING at the guards, so the badge says why
- *  the switch will refuse. */
+/** Core-by-reference: in the registered-reference closure — a `skill_ref` of a workflow the daemon
+ *  knows, or a skill one of those names in its SKILL.md — disabling or renaming it is BLOCKING at
+ *  the guards, so the badge says why the switch will refuse. */
 export function CoreBadge(): React.ReactElement {
   return (
     <span
       data-testid="skills-core-badge"
-      title="core — in the registered-reference closure (a workflow's skill_ref or a mandate); disabling or renaming it is blocked"
+      title="core — in the registered-reference closure (a workflow's skill_ref, or named by one of those skills); disabling or renaming it is blocked"
       className={BADGE}
       style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
     >
@@ -66,13 +73,14 @@ export function CoreBadge(): React.ReactElement {
   );
 }
 
-/** Not portable: leans on `${CLAUDE_PLUGIN_ROOT}`, cwd-relative scripts or `../` links —
- *  Claude-only by nature; excluded from the codex / pi / opencode / copilot mirrors. */
+/** Not portable: the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a cwd-relative script or
+ *  link `../` — Claude-only by nature; excluded from the snapshot's `views/copilot/` and from the
+ *  per-launch skill lists core builds for the other CLIs (design v3.2). */
 export function ClaudeOnlyBadge(): React.ReactElement {
   return (
     <span
       data-testid="skills-claude-only-badge"
-      title="not portable — depends on the plugin root, cwd-relative scripts or sibling links; Claude-only, excluded from the other CLIs' mirrors"
+      title="not portable — depends on the plugin root, cwd-relative scripts or sibling links; Claude-only, excluded from the snapshot's copilot view and the other CLIs' per-launch skill lists"
       className={BADGE}
       style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
     >
@@ -81,12 +89,28 @@ export function ClaudeOnlyBadge(): React.ReactElement {
   );
 }
 
-/** The three-way refresh kept a user edit AND upstream changed the same skill. */
+/** A refreshed baseline changed a file this skill overrides — the new side is readable as the
+ *  baseline copy for diffing; the operator's content is kept. */
+export function UpgradeBadge(): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-upgrade-badge"
+      title="upgrade available — the refreshed baseline changed a file you override; your content is kept, the new side is readable from the drawer (Baseline side)"
+      className={BADGE}
+      style={{ color: 'var(--status-run)', border: '1px solid var(--status-run)' }}
+    >
+      upgrade
+    </span>
+  );
+}
+
+/** `upgradeAvailable`, or the last refresh found a name collision (upstream now ships a skill
+ *  under this user-added name at another dir — `upstreamDir`). Cleared by reset / a later refresh. */
 export function ConflictBadge(): React.ReactElement {
   return (
     <span
       data-testid="skills-conflict-badge"
-      title="refresh conflict — your edit was kept and the new upstream side is stored for diff; reset takes the new baseline"
+      title="refresh conflict — your edit was kept while upstream changed the same file, or upstream now ships a skill under this name at another dir; the baseline side is readable from the drawer, reset takes it"
       className={BADGE}
       style={{ color: 'var(--status-gate)', border: '1px solid var(--status-gate)' }}
     >
@@ -101,7 +125,7 @@ export function UnpublishedBadge(): React.ReactElement {
   return (
     <span
       data-testid="skills-unpublished-badge"
-      title="unpublished — the current snapshot carries an older version (or none); Publish to hand this content to workers"
+      title="unpublished — the current snapshot carries an older version of a file this skill owns (or none); Publish to hand this content to workers"
       className={BADGE}
       style={{ color: 'var(--status-run)', border: '1px solid var(--status-run)' }}
     >
@@ -116,8 +140,9 @@ export function SkillFlags({ skill }: { skill: SkillRow }): React.ReactElement {
     <span className="inline-flex flex-wrap items-center gap-1">
       {skill.core && <CoreBadge />}
       {!skill.portable && <ClaudeOnlyBadge />}
+      {skill.upgradeAvailable && <UpgradeBadge />}
       {skill.conflict && <ConflictBadge />}
-      {isUnpublished(skill) && <UnpublishedBadge />}
+      {skill.unpublished && <UnpublishedBadge />}
     </span>
   );
 }
@@ -140,7 +165,7 @@ export function EnabledToggle({ name, enabled, busy, onToggle, testId }: {
       aria-checked={enabled}
       aria-label={`${enabled ? 'Disable' : 'Enable'} ${name}`}
       title={enabled
-        ? 'enabled — click to disable: the next publish leaves this skill out of the snapshot'
+        ? 'enabled — click to disable: the next publish leaves this skill out of the snapshot (its files stay)'
         : 'disabled — click to enable: the next publish carries this skill in the snapshot'}
       disabled={busy}
       onClick={onToggle}

--- a/src/components/SkillChips.tsx
+++ b/src/components/SkillChips.tsx
@@ -1,0 +1,162 @@
+import {
+  isUnpublished,
+  SKILL_KIND_LABELS,
+  SKILL_PROVENANCE_LABELS,
+  type SkillKind,
+  type SkillProvenance,
+  type SkillRow,
+} from '../api/skills.js';
+
+/** The Skills surface's shared chip grammar — kind, provenance, the core / Claude-only / conflict /
+ *  unpublished badges and the enabled switch: one spelling for the catalog rows and the drawer. */
+
+export const KIND_COLOR: Record<SkillKind, string> = {
+  router: 'var(--accent)',
+  'fork-worker': 'var(--status-run)',
+  module: 'var(--ink-muted)',
+};
+
+export const PROVENANCE_COLOR: Record<SkillProvenance, string> = {
+  shipped: 'var(--ink-muted)',
+  override: 'var(--status-gate)',
+  'user-added': 'var(--status-done)',
+};
+
+export function KindChip({ kind }: { kind: SkillKind }): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-kind-chip"
+      data-kind={kind}
+      className="inline-flex shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold font-mono"
+      style={{ background: 'var(--surface-raised)', color: KIND_COLOR[kind] }}
+    >
+      {SKILL_KIND_LABELS[kind]}
+    </span>
+  );
+}
+
+export function ProvenanceChip({ provenance }: { provenance: SkillProvenance }): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-provenance-chip"
+      data-provenance={provenance}
+      className="inline-flex shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold font-mono uppercase"
+      style={{ color: PROVENANCE_COLOR[provenance], border: `1px solid ${PROVENANCE_COLOR[provenance]}` }}
+    >
+      {SKILL_PROVENANCE_LABELS[provenance]}
+    </span>
+  );
+}
+
+const BADGE = 'inline-flex shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold font-mono uppercase';
+
+/** Core-by-reference: a registered workflow's `skill_ref` (or a referenced skill's `mandates`)
+ *  names this skill — disabling or renaming it is BLOCKING at the guards, so the badge says why
+ *  the switch will refuse. */
+export function CoreBadge(): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-core-badge"
+      title="core — in the registered-reference closure (a workflow's skill_ref or a mandate); disabling or renaming it is blocked"
+      className={BADGE}
+      style={{ background: 'var(--accent-subtle)', color: 'var(--accent)' }}
+    >
+      core
+    </span>
+  );
+}
+
+/** Not portable: leans on `${CLAUDE_PLUGIN_ROOT}`, cwd-relative scripts or `../` links —
+ *  Claude-only by nature; excluded from the codex / pi / opencode / copilot mirrors. */
+export function ClaudeOnlyBadge(): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-claude-only-badge"
+      title="not portable — depends on the plugin root, cwd-relative scripts or sibling links; Claude-only, excluded from the other CLIs' mirrors"
+      className={BADGE}
+      style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
+    >
+      claude-only
+    </span>
+  );
+}
+
+/** The three-way refresh kept a user edit AND upstream changed the same skill. */
+export function ConflictBadge(): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-conflict-badge"
+      title="refresh conflict — your edit was kept and the new upstream side is stored for diff; reset takes the new baseline"
+      className={BADGE}
+      style={{ color: 'var(--status-gate)', border: '1px solid var(--status-gate)' }}
+    >
+      conflict
+    </span>
+  );
+}
+
+/** The current snapshot does not carry this skill's effective content — publish to hand it to
+ *  workers. */
+export function UnpublishedBadge(): React.ReactElement {
+  return (
+    <span
+      data-testid="skills-unpublished-badge"
+      title="unpublished — the current snapshot carries an older version (or none); Publish to hand this content to workers"
+      className={BADGE}
+      style={{ color: 'var(--status-run)', border: '1px solid var(--status-run)' }}
+    >
+      unpublished
+    </span>
+  );
+}
+
+/** The flag badges one catalog row (and the drawer header) wears — one spelling for both. */
+export function SkillFlags({ skill }: { skill: SkillRow }): React.ReactElement {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {skill.core && <CoreBadge />}
+      {!skill.portable && <ClaudeOnlyBadge />}
+      {skill.conflict && <ConflictBadge />}
+      {isUnpublished(skill) && <UnpublishedBadge />}
+    </span>
+  );
+}
+
+/** The enabled switch — a real `role="switch"`; the daemon's guards decide the flip, so the
+ *  control shows the MANIFEST state, never an optimistic one. */
+export function EnabledToggle({ name, enabled, busy, onToggle, testId }: {
+  name: string;
+  enabled: boolean;
+  /** A write is in flight for this skill (or the catalog is frozen on a conflict) — the switch waits. */
+  busy: boolean;
+  onToggle: () => void;
+  testId: string;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      role="switch"
+      data-testid={testId}
+      aria-checked={enabled}
+      aria-label={`${enabled ? 'Disable' : 'Enable'} ${name}`}
+      title={enabled
+        ? 'enabled — click to disable: the next publish leaves this skill out of the snapshot'
+        : 'disabled — click to enable: the next publish carries this skill in the snapshot'}
+      disabled={busy}
+      onClick={onToggle}
+      className="inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors disabled:opacity-40 focus:outline-none focus-visible:ring-1"
+      style={{
+        background: enabled ? 'var(--accent)' : 'var(--surface-raised)',
+        border: '1px solid var(--surface-raised)',
+        justifyContent: enabled ? 'flex-end' : 'flex-start',
+        padding: '0 1px',
+      }}
+    >
+      <span
+        aria-hidden
+        className="block h-3 w-3 rounded-full"
+        style={{ background: enabled ? 'var(--accent-fg)' : 'var(--ink-dim)' }}
+      />
+    </button>
+  );
+}

--- a/src/components/SkillConfirmModal.tsx
+++ b/src/components/SkillConfirmModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { resetSkill, type SkillGuardResult, type SkillRow } from '../api/skills.js';
+import { resetSkill, type SkillMutationResult, type SkillRow } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
 import { SkillFindings } from './SkillFindings.js';
 import type { SkillsWriter } from './skillsWriter.js';
@@ -11,9 +11,10 @@ import type { SkillsWriter } from './skillsWriter.js';
  * state and is never flipped by a reset. A user-added skill has no baseline, so the drawer never
  * offers this for one (disable is its off switch; there is no delete verb on the wire).
  *
- * Runs through the page's CAS writer and answers with the daemon's guard envelope: `blocked` keeps
- * the modal open with the findings (nothing changed); anything else closes it through `onDone`; a
- * revision conflict closes it plain — the page's reload prompt owns that moment.
+ * Runs through the page's CAS writer and answers with the daemon's envelope
+ * (`SkillMutationResult`): `blocked` keeps the modal open with the findings (nothing changed — a
+ * corrupt baseline refuses to restore, `baseline-corrupt`); anything else closes it through
+ * `onDone`; a revision conflict closes it plain — the page's reload prompt owns that moment.
  */
 
 const BODY =
@@ -24,12 +25,12 @@ export function SkillConfirmModal({ skill, writer, onClose, onDone }: {
   writer: SkillsWriter;
   onClose: () => void;
   /** Fires after the wire answered with anything but `blocked`. */
-  onDone: (result: SkillGuardResult) => void;
+  onDone: (result: SkillMutationResult) => void;
 }): React.ReactElement {
   const [typed, setTyped] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
+  const [blocked, setBlocked] = useState<SkillMutationResult | null>(null);
   useModalEscape(onClose);
 
   const title = `Reset ${skill.name}`;

--- a/src/components/SkillConfirmModal.tsx
+++ b/src/components/SkillConfirmModal.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { deleteSkill, resetSkill, type SkillGuardResult, type SkillRow } from '../api/skills.js';
+import { useModalEscape } from './Modal.js';
+import { SkillFindings } from './SkillFindings.js';
+import type { SkillsWriter } from './skillsWriter.js';
+
+/**
+ * The typed-confirmation modal for the two destructive skill verbs — the SteeringRetireModal
+ * grammar (type the name to arm):
+ *  - RESET restores the skill's OWN files from the baseline, discarding every local edit (a nested
+ *    child skill's overrides survive); enablement is manifest state and is never flipped by a reset;
+ *  - DELETE removes a USER-ADDED skill from the effective root (a shipped skill is disabled or
+ *    reset, never deleted — the drawer offers Delete only for user-added).
+ * Both run through the page's CAS writer and answer with the daemon's guard envelope: `blocked`
+ * keeps the modal open with the findings (nothing changed); anything else closes it through
+ * `onDone`; a revision conflict closes it plain — the page's reload prompt owns that moment.
+ */
+
+const COPY = {
+  reset: {
+    title: (name: string) => `Reset ${name}`,
+    body: 'Restores every file this skill owns from the baseline and discards your local edits — the override becomes a shipped skill again. Enablement is manifest state and is NOT touched: a disabled skill stays disabled. Nothing reaches workers until the next Publish.',
+    verb: 'Reset skill',
+    busy: 'Resetting…',
+    color: 'var(--status-gate)',
+  },
+  delete: {
+    title: (name: string) => `Delete ${name}`,
+    body: 'Removes this user-added skill from the effective root. There is no baseline to restore it from — keep a copy of its files if you may want it back. The current snapshot keeps serving it until the next Publish.',
+    verb: 'Delete skill',
+    busy: 'Deleting…',
+    color: 'var(--status-fail)',
+  },
+} as const;
+
+export type SkillConfirmAction = keyof typeof COPY;
+
+export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
+  skill: SkillRow;
+  action: SkillConfirmAction;
+  writer: SkillsWriter;
+  onClose: () => void;
+  /** Fires after the wire answered with anything but `blocked`. */
+  onDone: (result: SkillGuardResult) => void;
+}): React.ReactElement {
+  const [typed, setTyped] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
+  useModalEscape(onClose);
+
+  const copy = COPY[action];
+  const armed = typed === skill.name && !busy;
+
+  const confirm = async (): Promise<void> => {
+    if (!armed) return;
+    setBusy(true);
+    setError(null);
+    setBlocked(null);
+    try {
+      const result = await writer.run((rev) => (action === 'reset' ? resetSkill(skill.name, rev) : deleteSkill(skill.name, rev)));
+      if (result === null) {
+        onClose();
+        return;
+      }
+      if (result.verdict === 'blocked') {
+        setBlocked(result);
+        setBusy(false);
+        return;
+      }
+      onDone(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
+      <div
+        data-testid="skills-confirm-modal"
+        data-action={action}
+        role="dialog"
+        aria-modal="true"
+        aria-label={copy.title(skill.name)}
+        className="flex w-[28rem] max-w-[92vw] flex-col gap-3 rounded-xl p-4 shadow-2xl"
+        style={{ background: 'var(--surface-card)', border: `1px solid ${copy.color}` }}
+      >
+        <h3 className="text-sm font-semibold" style={{ color: copy.color }}>{copy.title(skill.name)}</h3>
+        <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{copy.body}</p>
+        <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Type the skill name to confirm
+          <input
+            data-testid="skills-confirm-input"
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={skill.name}
+            spellCheck={false}
+            className="rounded px-2 py-1 font-mono text-[11px] focus:outline-none"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+        </label>
+        {error !== null && (
+          <p data-testid="skills-confirm-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+            {error}
+          </p>
+        )}
+        {blocked !== null && <SkillFindings verb={copy.verb} result={blocked} testId="skills-confirm-findings" />}
+        <div className="flex items-center justify-end gap-2">
+          <button
+            data-testid="skills-confirm-cancel"
+            type="button"
+            onClick={onClose}
+            className="rounded px-3 py-1 text-[11px]"
+            style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="skills-confirm"
+            type="button"
+            disabled={!armed}
+            onClick={() => void confirm()}
+            className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+            style={{ background: copy.color, color: 'var(--surface-base)' }}
+          >
+            {busy ? copy.busy : copy.verb}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SkillConfirmModal.tsx
+++ b/src/components/SkillConfirmModal.tsx
@@ -1,43 +1,26 @@
 import { useState } from 'react';
-import { deleteSkill, resetSkill, type SkillGuardResult, type SkillRow } from '../api/skills.js';
+import { resetSkill, type SkillGuardResult, type SkillRow } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
 import { SkillFindings } from './SkillFindings.js';
 import type { SkillsWriter } from './skillsWriter.js';
 
 /**
- * The typed-confirmation modal for the two destructive skill verbs — the SteeringRetireModal
- * grammar (type the name to arm):
- *  - RESET restores the skill's OWN files from the baseline, discarding every local edit (a nested
- *    child skill's overrides survive); enablement is manifest state and is never flipped by a reset;
- *  - DELETE removes a USER-ADDED skill from the effective root (a shipped skill is disabled or
- *    reset, never deleted — the drawer offers Delete only for user-added).
- * Both run through the page's CAS writer and answer with the daemon's guard envelope: `blocked`
- * keeps the modal open with the findings (nothing changed); anything else closes it through
- * `onDone`; a revision conflict closes it plain — the page's reload prompt owns that moment.
+ * The typed-confirmation modal for RESET — the one destructive skill verb (the SteeringRetireModal
+ * grammar: type the name to arm). Reset restores the skill's OWN files from the baseline,
+ * discarding every local edit (a nested child skill's overrides survive); enablement is manifest
+ * state and is never flipped by a reset. A user-added skill has no baseline, so the drawer never
+ * offers this for one (disable is its off switch; there is no delete verb on the wire).
+ *
+ * Runs through the page's CAS writer and answers with the daemon's guard envelope: `blocked` keeps
+ * the modal open with the findings (nothing changed); anything else closes it through `onDone`; a
+ * revision conflict closes it plain — the page's reload prompt owns that moment.
  */
 
-const COPY = {
-  reset: {
-    title: (name: string) => `Reset ${name}`,
-    body: 'Restores every file this skill owns from the baseline and discards your local edits — the override becomes a shipped skill again. Enablement is manifest state and is NOT touched: a disabled skill stays disabled. Nothing reaches workers until the next Publish.',
-    verb: 'Reset skill',
-    busy: 'Resetting…',
-    color: 'var(--status-gate)',
-  },
-  delete: {
-    title: (name: string) => `Delete ${name}`,
-    body: 'Removes this user-added skill from the effective root. There is no baseline to restore it from — keep a copy of its files if you may want it back. The current snapshot keeps serving it until the next Publish.',
-    verb: 'Delete skill',
-    busy: 'Deleting…',
-    color: 'var(--status-fail)',
-  },
-} as const;
+const BODY =
+  'Restores every file this skill owns from the baseline and discards your local edits — the override becomes a shipped skill again. Enablement is manifest state and is NOT touched: a disabled skill stays disabled. Nothing reaches workers until the next Publish.';
 
-export type SkillConfirmAction = keyof typeof COPY;
-
-export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
+export function SkillConfirmModal({ skill, writer, onClose, onDone }: {
   skill: SkillRow;
-  action: SkillConfirmAction;
   writer: SkillsWriter;
   onClose: () => void;
   /** Fires after the wire answered with anything but `blocked`. */
@@ -49,7 +32,7 @@ export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
   const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
   useModalEscape(onClose);
 
-  const copy = COPY[action];
+  const title = `Reset ${skill.name}`;
   const armed = typed === skill.name && !busy;
 
   const confirm = async (): Promise<void> => {
@@ -58,7 +41,7 @@ export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
     setError(null);
     setBlocked(null);
     try {
-      const result = await writer.run((rev) => (action === 'reset' ? resetSkill(skill.name, rev) : deleteSkill(skill.name, rev)));
+      const result = await writer.run((rev) => resetSkill(skill.name, rev));
       if (result === null) {
         onClose();
         return;
@@ -79,15 +62,14 @@ export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
       <div
         data-testid="skills-confirm-modal"
-        data-action={action}
         role="dialog"
         aria-modal="true"
-        aria-label={copy.title(skill.name)}
+        aria-label={title}
         className="flex w-[28rem] max-w-[92vw] flex-col gap-3 rounded-xl p-4 shadow-2xl"
-        style={{ background: 'var(--surface-card)', border: `1px solid ${copy.color}` }}
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--status-gate)' }}
       >
-        <h3 className="text-sm font-semibold" style={{ color: copy.color }}>{copy.title(skill.name)}</h3>
-        <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{copy.body}</p>
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--status-gate)' }}>{title}</h3>
+        <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{BODY}</p>
         <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
           Type the skill name to confirm
           <input
@@ -106,7 +88,7 @@ export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
             {error}
           </p>
         )}
-        {blocked !== null && <SkillFindings verb={copy.verb} result={blocked} testId="skills-confirm-findings" />}
+        {blocked !== null && <SkillFindings verb="Reset skill" result={blocked} testId="skills-confirm-findings" />}
         <div className="flex items-center justify-end gap-2">
           <button
             data-testid="skills-confirm-cancel"
@@ -123,9 +105,9 @@ export function SkillConfirmModal({ skill, action, writer, onClose, onDone }: {
             disabled={!armed}
             onClick={() => void confirm()}
             className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
-            style={{ background: copy.color, color: 'var(--surface-base)' }}
+            style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
           >
-            {busy ? copy.busy : copy.verb}
+            {busy ? 'Resetting…' : 'Reset skill'}
           </button>
         </div>
       </div>

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -1,0 +1,475 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  listSkillFiles,
+  readSkillFile,
+  readSupportFile,
+  writeSkillFile,
+  writeSupportFile,
+  type SkillFileContent,
+  type SkillFileEntry,
+  type SkillGuardResult,
+  type SkillRow,
+} from '../api/skills.js';
+import { useModalEscape } from './Modal.js';
+import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
+import { SkillConfirmModal, type SkillConfirmAction } from './SkillConfirmModal.js';
+import { SkillFilesMapModal } from './SkillFilesMapModal.js';
+import { SkillFindings } from './SkillFindings.js';
+import type { SkillsWriter } from './skillsWriter.js';
+
+/**
+ * The skill DRAWER — opened from a catalog row (the SteeringRuleDrawer idiom, widened for an
+ * editor). Two file trees under tabs: the skill's OWN files (`GET /skills/:name/files`) and the
+ * root SUPPORT files every skill shares (`scripts/`, `schemas/`, `.claude-plugin/`, from the
+ * manifest's support map — `GET|PUT /skills/support/*path`). A textarea editor over the selected
+ * file (v1 — studio has no code editor): Save → `PUT {content, expectedRevision}` through the
+ * page's CAS writer → the daemon's findings; a `blocked` verdict disables Save for that exact
+ * draft until it changes; a `truncated` or `binary` read is read-only (Save never clobbers what
+ * the editor cannot show). Plus the enabled switch and the dir-level verbs: Reset (from the
+ * baseline; disabled for a user-added skill, which has none), Replace (a pasted files map),
+ * Delete (user-added only).
+ *
+ * The page owns the catalog: the drawer reports every applied content write through `onChanged`
+ * so the page reloads (provenance flips, hashes move, `unpublished` lights up), and a delete
+ * through `onDeleted` so the page closes this drawer and says so.
+ */
+
+/** The two file trees the drawer edits. */
+type SkillDrawerTab = 'skill' | 'support';
+
+const TAB_LABEL: Record<SkillDrawerTab, string> = { skill: 'Skill files', support: 'Support files' };
+
+export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, onChanged, onDeleted }: {
+  skill: SkillRow;
+  /** The root support files (from the manifest), path-sorted. */
+  support: readonly SkillFileEntry[];
+  writer: SkillsWriter;
+  /** The page has a write in flight for this skill (or the catalog is frozen on a conflict) —
+   *  the drawer's verbs wait. */
+  busy: boolean;
+  onClose: () => void;
+  /** The page's guarded flip — it reloads the catalog and hands back the daemon's verdict
+   *  (`null` on a revision conflict: the page's prompt owns that moment). */
+  onToggle: (name: string, enabled: boolean) => Promise<SkillGuardResult | null>;
+  /** After any applied content write (save / reset / replace) — the page reloads the catalog. */
+  onChanged: () => void;
+  onDeleted: (name: string, result: SkillGuardResult) => void;
+}): React.ReactElement {
+  const [tab, setTab] = useState<SkillDrawerTab>('skill');
+  const [skillFiles, setSkillFiles] = useState<SkillFileEntry[] | null>(null);
+  const [filesError, setFilesError] = useState<string | null>(null);
+  const [file, setFile] = useState<SkillFileContent | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  /** The exact draft the daemon last BLOCKED — Save stays disabled until the text changes. */
+  const [blockedDraft, setBlockedDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [lastResult, setLastResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [modal, setModal] = useState<SkillConfirmAction | 'replace' | null>(null);
+  const [discardPrompt, setDiscardPrompt] = useState(false);
+
+  const dirty = file !== null && draft !== file.content;
+
+  // Closing with unsaved edits asks first — an Escape must never eat a draft silently.
+  const requestClose = useCallback((): void => {
+    if (dirty) setDiscardPrompt(true);
+    else onClose();
+  }, [dirty, onClose]);
+  useModalEscape(requestClose);
+
+  const loadSkillFiles = useCallback(async (): Promise<SkillFileEntry[]> => {
+    setFilesError(null);
+    try {
+      const rows = await listSkillFiles(skill.name);
+      setSkillFiles(rows);
+      return rows;
+    } catch (e) {
+      setSkillFiles([]);
+      setFilesError(e instanceof Error ? e.message : String(e));
+      return [];
+    }
+  }, [skill.name]);
+
+  const openFile = useCallback(async (scope: SkillDrawerTab, path: string): Promise<void> => {
+    setFileLoading(true);
+    setFileError(null);
+    setBlockedDraft(null);
+    try {
+      const f = scope === 'skill' ? await readSkillFile(skill.name, path) : await readSupportFile(path);
+      setFile(f);
+      setDraft(f.content);
+    } catch (e) {
+      setFile(null);
+      setFileError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setFileLoading(false);
+    }
+  }, [skill.name]);
+
+  // The page keys this drawer by skill name, so one mount = one skill: load the tree, open the
+  // first file (SKILL.md when present — the fold puts it first).
+  useEffect(() => {
+    void loadSkillFiles().then((rows) => {
+      const first = rows[0];
+      if (first !== undefined) void openFile('skill', first.path);
+    });
+  }, [loadSkillFiles, openFile]);
+
+  const files: readonly SkillFileEntry[] | null = tab === 'skill' ? skillFiles : support;
+
+  /** Switching trees opens the other tree's first file; locked while the open file is dirty or loading. */
+  const selectTab = (next: SkillDrawerTab): void => {
+    if (next === tab) return;
+    setTab(next);
+    setLastResult(null);
+    setFileError(null);
+    const rows = next === 'skill' ? skillFiles ?? [] : support;
+    const first = rows[0];
+    if (first !== undefined) void openFile(next, first.path);
+    else { setFile(null); setDraft(''); }
+  };
+
+  const readOnlyReason =
+    file === null ? null
+    : file.binary ? 'binary file — not editable here'
+    : file.truncated ? 'this file exceeds the daemon’s read cap and is shown truncated — saving would clobber it, so it is read-only here'
+    : null;
+
+  const canSave =
+    file !== null && !fileLoading && !saving && !busy && readOnlyReason === null && dirty && draft !== blockedDraft;
+
+  const save = async (): Promise<void> => {
+    if (file === null || !canSave) return;
+    const target = file;
+    setSaving(true);
+    setActionError(null);
+    try {
+      const result = await writer.run((rev) => (tab === 'skill'
+        ? writeSkillFile(skill.name, target.path, draft, rev)
+        : writeSupportFile(target.path, draft, rev)));
+      // A revision conflict: the page's prompt owns the moment; the draft is kept for after the reload.
+      if (result === null) return;
+      setLastResult({ verb: 'Save', result });
+      if (result.verdict === 'blocked') {
+        setBlockedDraft(draft);
+      } else {
+        setFile({ ...target, content: draft });
+        setBlockedDraft(null);
+        onChanged();
+      }
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const flip = (): void => {
+    setActionError(null);
+    void onToggle(skill.name, !skill.enabled)
+      .then((result) => {
+        if (result !== null) setLastResult({ verb: skill.enabled ? 'Disable' : 'Enable', result });
+      })
+      .catch((e: unknown) => setActionError(e instanceof Error ? e.message : String(e)));
+  };
+
+  /** After a dir-level write applied (reset / replace): the skill tree and the open file are
+   *  reloaded — the content on screen must be the daemon's, never this drawer's memory of it. */
+  const afterDirWrite = (verb: string, result: SkillGuardResult): void => {
+    setModal(null);
+    setLastResult({ verb, result });
+    onChanged();
+    const current = tab === 'skill' && file !== null ? file.path : null;
+    void loadSkillFiles().then((rows) => {
+      if (tab !== 'skill') return;
+      const target = current !== null && rows.some((r) => r.path === current) ? current : rows[0]?.path;
+      if (target !== undefined) void openFile('skill', target);
+      else { setFile(null); setDraft(''); }
+    });
+  };
+
+  const canReset = skill.baselineHash !== null;
+  const verbsDisabled = busy || saving;
+  const treeLocked = dirty || fileLoading;
+
+  return (
+    <aside
+      data-testid="skills-drawer"
+      data-skill={skill.name}
+      role="complementary"
+      aria-label={`Skill ${skill.name}`}
+      className="fixed inset-y-0 right-0 z-40 flex w-[44rem] max-w-[95vw] flex-col gap-3 overflow-y-auto p-4 shadow-2xl"
+      style={{ background: 'var(--surface-card)', borderLeft: '1px solid var(--surface-raised)' }}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>{skill.name}</span>
+        <KindChip kind={skill.kind} />
+        <ProvenanceChip provenance={skill.provenance} />
+        <SkillFlags skill={skill} />
+        <button
+          data-testid="skills-drawer-close"
+          type="button"
+          aria-label="Close skill"
+          onClick={requestClose}
+          className="ml-auto text-sm leading-none hover:opacity-70"
+          style={{ color: 'var(--ink-dim)' }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+        <span data-testid="skills-drawer-dir">{skill.dir}</span>
+        <span title="effective content hash">{skill.effectiveHash.slice(0, 12)}</span>
+        {skill.lastPublishedHash !== null && skill.lastPublishedHash !== skill.effectiveHash && (
+          <span title="the hash the current snapshot carries">published {skill.lastPublishedHash.slice(0, 12)}</span>
+        )}
+        {skill.editedAt !== null && <span>edited {skill.editedAt}</span>}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="inline-flex items-center gap-2 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          <EnabledToggle
+            testId="skills-drawer-toggle"
+            name={skill.name}
+            enabled={skill.enabled}
+            busy={verbsDisabled}
+            onToggle={flip}
+          />
+          {skill.enabled ? 'enabled' : 'disabled'}
+        </label>
+        <span className="flex-1" />
+        <button
+          data-testid="skills-reset-open"
+          type="button"
+          disabled={verbsDisabled || !canReset}
+          title={canReset ? 'Restore every file this skill owns from the baseline (typed confirmation)' : 'a user-added skill has no baseline to reset to'}
+          onClick={() => setModal('reset')}
+          className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-40"
+          style={{ color: 'var(--status-gate)', border: '1px solid var(--surface-raised)' }}
+        >
+          Reset…
+        </button>
+        <button
+          data-testid="skills-replace-open"
+          type="button"
+          disabled={verbsDisabled}
+          title="Replace every file this skill owns from a pasted files map"
+          onClick={() => setModal('replace')}
+          className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-40"
+          style={{ color: 'var(--accent)', border: '1px solid var(--surface-raised)' }}
+        >
+          Replace…
+        </button>
+        {skill.provenance === 'user-added' && (
+          <button
+            data-testid="skills-delete-open"
+            type="button"
+            disabled={verbsDisabled}
+            title="Remove this user-added skill from the effective root (typed confirmation)"
+            onClick={() => setModal('delete')}
+            className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-40"
+            style={{ color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
+          >
+            Delete…
+          </button>
+        )}
+      </div>
+
+      {discardPrompt && (
+        <div
+          data-testid="skills-discard-prompt"
+          role="alertdialog"
+          aria-label="Unsaved changes"
+          className="flex flex-wrap items-center gap-2 rounded px-3 py-2 text-[11px]"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--status-gate)', color: 'var(--ink-muted)' }}
+        >
+          <span>Unsaved edits to <span className="font-mono">{file?.path}</span>.</span>
+          <span className="flex-1" />
+          <button
+            data-testid="skills-keep-editing"
+            type="button"
+            onClick={() => setDiscardPrompt(false)}
+            className="rounded px-2 py-0.5 text-[10px]"
+            style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Keep editing
+          </button>
+          <button
+            data-testid="skills-discard"
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-0.5 text-[10px] font-semibold"
+            style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
+          >
+            Discard and close
+          </button>
+        </div>
+      )}
+
+      {/* The two trees' tabs — locked while the open file is dirty (save or discard first). */}
+      <div role="tablist" aria-label="File trees" className="flex items-center gap-1 text-[11px]">
+        {(['skill', 'support'] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            data-testid={`skills-tab-${t}`}
+            aria-selected={tab === t}
+            disabled={treeLocked && tab !== t}
+            title={treeLocked && tab !== t ? 'save or discard your edits first' : TAB_LABEL[t]}
+            onClick={() => selectTab(t)}
+            className="rounded px-2 py-1 font-semibold disabled:opacity-40"
+            style={{
+              color: tab === t ? 'var(--ink-high)' : 'var(--ink-muted)',
+              background: tab === t ? 'var(--surface-raised)' : 'transparent',
+            }}
+          >
+            {TAB_LABEL[t]}
+          </button>
+        ))}
+        {tab === 'support' && (
+          <span data-testid="skills-support-note" className="ml-2 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            shared by every skill — the guards flag each edit as a warning
+          </span>
+        )}
+      </div>
+
+      <div className="flex min-h-0 flex-1 gap-3">
+        {/* The file tree — flat, SKILL.md first; locked while the open file has unsaved edits. */}
+        <nav
+          data-testid="skills-file-tree"
+          data-tab={tab}
+          aria-label={TAB_LABEL[tab]}
+          className="flex w-48 shrink-0 flex-col gap-0.5 overflow-y-auto rounded p-1"
+          style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+        >
+          {files === null ? (
+            <p data-testid="skills-files-loading" className="px-2 py-1 text-[10px]" style={{ color: 'var(--ink-dim)' }}>Loading files…</p>
+          ) : tab === 'skill' && filesError !== null ? (
+            <p data-testid="skills-files-error" className="px-2 py-1 text-[10px]" style={{ color: 'var(--status-fail)' }}>{filesError}</p>
+          ) : files.length === 0 ? (
+            <p data-testid="skills-files-empty" className="px-2 py-1 text-[10px]" style={{ color: 'var(--ink-dim)' }}>No files.</p>
+          ) : (
+            files.map((f) => {
+              const active = file !== null && file.path === f.path;
+              return (
+                <button
+                  key={f.path}
+                  type="button"
+                  data-testid="skills-file"
+                  data-path={f.path}
+                  aria-current={active ? 'true' : undefined}
+                  disabled={treeLocked && !active}
+                  title={treeLocked && !active ? 'save or discard your edits first' : f.path}
+                  onClick={() => { setLastResult(null); void openFile(tab, f.path); }}
+                  className="truncate rounded px-2 py-1 text-left font-mono text-[10px] disabled:opacity-40 focus:outline-none focus-visible:ring-1"
+                  style={{
+                    background: active ? 'var(--accent-subtle)' : 'transparent',
+                    color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
+                  }}
+                >
+                  {f.path}
+                </button>
+              );
+            })
+          )}
+        </nav>
+
+        {/* The editor column. */}
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          {fileLoading && file === null ? (
+            <p data-testid="skills-file-loading" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Loading file…</p>
+          ) : fileError !== null ? (
+            <p data-testid="skills-file-error" className="rounded px-2 py-1 text-[11px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>{fileError}</p>
+          ) : file === null ? (
+            <p data-testid="skills-file-none" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Pick a file to edit.</p>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+                <span data-testid="skills-file-path" style={{ color: 'var(--ink-muted)' }}>{file.path}</span>
+                <span>{file.size} B</span>
+                {dirty && <span data-testid="skills-file-dirty" style={{ color: 'var(--status-gate)' }}>unsaved</span>}
+              </div>
+              {readOnlyReason !== null && (
+                <p data-testid="skills-file-readonly" className="text-[10px]" style={{ color: 'var(--status-gate)' }}>{readOnlyReason}</p>
+              )}
+              <textarea
+                data-testid="skills-editor"
+                aria-label={`${file.path} content`}
+                value={draft}
+                readOnly={readOnlyReason !== null}
+                spellCheck={false}
+                onChange={(e) => setDraft(e.target.value)}
+                className="min-h-[18rem] flex-1 resize-y rounded p-2 font-mono text-[11px] focus:outline-none"
+                style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)', lineHeight: 1.5 }}
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  data-testid="skills-save"
+                  type="button"
+                  disabled={!canSave}
+                  title={draft === blockedDraft && blockedDraft !== null ? 'the daemon blocked this exact content — change it to try again' : 'Save this file (the daemon runs its guards first)'}
+                  onClick={() => void save()}
+                  className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+                  style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+                >
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+                {dirty && (
+                  <button
+                    data-testid="skills-discard-edits"
+                    type="button"
+                    disabled={saving}
+                    onClick={() => { setDraft(file.content); setBlockedDraft(null); }}
+                    className="rounded px-2 py-1 text-[11px]"
+                    style={{ color: 'var(--ink-dim)', border: '1px solid var(--surface-raised)' }}
+                  >
+                    Discard edits
+                  </button>
+                )}
+              </div>
+            </>
+          )}
+
+          {actionError !== null && (
+            <p data-testid="skills-drawer-error" className="rounded px-2 py-1 text-[11px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+              {actionError}
+            </p>
+          )}
+          {lastResult !== null && (
+            <SkillFindings verb={lastResult.verb} result={lastResult.result} testId="skills-findings" />
+          )}
+        </div>
+      </div>
+
+      {(modal === 'reset' || modal === 'delete') && (
+        <SkillConfirmModal
+          skill={skill}
+          action={modal}
+          writer={writer}
+          onClose={() => setModal(null)}
+          onDone={(result) => {
+            if (modal === 'delete') {
+              setModal(null);
+              onDeleted(skill.name, result);
+            } else {
+              afterDirWrite('Reset', result);
+            }
+          }}
+        />
+      )}
+      {modal === 'replace' && (
+        <SkillFilesMapModal
+          mode="replace"
+          name={skill.name}
+          writer={writer}
+          onClose={() => setModal(null)}
+          onDone={(_name, result) => afterDirWrite('Replace', result)}
+        />
+      )}
+    </aside>
+  );
+}

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -12,7 +12,7 @@ import {
 } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
 import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
-import { SkillConfirmModal, type SkillConfirmAction } from './SkillConfirmModal.js';
+import { SkillConfirmModal } from './SkillConfirmModal.js';
 import { SkillFilesMapModal } from './SkillFilesMapModal.js';
 import { SkillFindings } from './SkillFindings.js';
 import type { SkillsWriter } from './skillsWriter.js';
@@ -26,12 +26,11 @@ import type { SkillsWriter } from './skillsWriter.js';
  * page's CAS writer → the daemon's findings; a `blocked` verdict disables Save for that exact
  * draft until it changes; a `truncated` or `binary` read is read-only (Save never clobbers what
  * the editor cannot show). Plus the enabled switch and the dir-level verbs: Reset (from the
- * baseline; disabled for a user-added skill, which has none), Replace (a pasted files map),
- * Delete (user-added only).
+ * baseline; disabled for a user-added skill, which has none — disable is its off switch) and
+ * Replace (a pasted files map).
  *
  * The page owns the catalog: the drawer reports every applied content write through `onChanged`
- * so the page reloads (provenance flips, hashes move, `unpublished` lights up), and a delete
- * through `onDeleted` so the page closes this drawer and says so.
+ * so the page reloads (provenance flips, hashes move, `unpublished` lights up).
  */
 
 /** The two file trees the drawer edits. */
@@ -39,7 +38,7 @@ type SkillDrawerTab = 'skill' | 'support';
 
 const TAB_LABEL: Record<SkillDrawerTab, string> = { skill: 'Skill files', support: 'Support files' };
 
-export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, onChanged, onDeleted }: {
+export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, onChanged }: {
   skill: SkillRow;
   /** The root support files (from the manifest), path-sorted. */
   support: readonly SkillFileEntry[];
@@ -53,7 +52,6 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
   onToggle: (name: string, enabled: boolean) => Promise<SkillGuardResult | null>;
   /** After any applied content write (save / reset / replace) — the page reloads the catalog. */
   onChanged: () => void;
-  onDeleted: (name: string, result: SkillGuardResult) => void;
 }): React.ReactElement {
   const [tab, setTab] = useState<SkillDrawerTab>('skill');
   const [skillFiles, setSkillFiles] = useState<SkillFileEntry[] | null>(null);
@@ -67,7 +65,7 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
   const [saving, setSaving] = useState(false);
   const [lastResult, setLastResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [modal, setModal] = useState<SkillConfirmAction | 'replace' | null>(null);
+  const [modal, setModal] = useState<'reset' | 'replace' | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
 
   const dirty = file !== null && draft !== file.content;
@@ -263,19 +261,6 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
         >
           Replace…
         </button>
-        {skill.provenance === 'user-added' && (
-          <button
-            data-testid="skills-delete-open"
-            type="button"
-            disabled={verbsDisabled}
-            title="Remove this user-added skill from the effective root (typed confirmation)"
-            onClick={() => setModal('delete')}
-            className="rounded px-2 py-1 text-[10px] font-semibold disabled:opacity-40"
-            style={{ color: 'var(--status-fail)', border: '1px solid var(--status-fail-dim)' }}
-          >
-            Delete…
-          </button>
-        )}
       </div>
 
       {discardPrompt && (
@@ -445,20 +430,12 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
         </div>
       </div>
 
-      {(modal === 'reset' || modal === 'delete') && (
+      {modal === 'reset' && (
         <SkillConfirmModal
           skill={skill}
-          action={modal}
           writer={writer}
           onClose={() => setModal(null)}
-          onDone={(result) => {
-            if (modal === 'delete') {
-              setModal(null);
-              onDeleted(skill.name, result);
-            } else {
-              afterDirWrite('Reset', result);
-            }
-          }}
+          onDone={(result) => afterDirWrite('Reset', result)}
         />
       )}
       {modal === 'replace' && (

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -43,9 +43,13 @@ import type { SkillsWriter } from './skillsWriter.js';
  *    CAS stays the backstop for whatever the re-read did not see.
  *  - **Late answers are ignored.** Every read carries an intent token; a file list or a file that
  *    answers after the operator switched tabs, picked another file, or saved is dropped — the
- *    Support editor is never swapped for a skill file by a slow list. And a read never lands over
- *    typing: the editor is read-only while a file is loading, and if text reached the draft after
- *    the request left anyway, the answer is set aside as a STALE read (the draft stays, named).
+ *    Support editor is never swapped for a skill file by a slow list. The skill tree with its list
+ *    still loading is a first-class PENDING state (the mount, or a switch back to it before the
+ *    list landed): the loading state shows, nothing is selected, and the file last open there
+ *    (else the first) opens ONCE — the moment the list arrives, and only if the operator is still
+ *    on that tree. And a read never lands over typing: the editor is read-only while a file is
+ *    loading, and if text reached the draft after the request left anyway, the answer is set
+ *    aside as a STALE read (the draft stays, named).
  *
  * The page owns the catalog: the drawer reports every applied content write through `onChanged`
  * so the page reloads (provenance flips, hashes move, `unpublished` lights up) — and every dirty
@@ -58,6 +62,12 @@ import type { SkillsWriter } from './skillsWriter.js';
 type SkillDrawerTab = 'skill' | 'support';
 
 const TAB_LABEL: Record<SkillDrawerTab, string> = { skill: 'Skill files', support: 'Support files' };
+
+/** The file a tree (re)opens: the one last open there when it is still listed, else the first
+ *  (SKILL.md for the skill tree — the fold puts it first); `undefined` for an empty tree. */
+function reopenTarget(last: string | null, rows: readonly SkillFileEntry[]): string | undefined {
+  return last !== null && rows.some((r) => r.path === last) ? last : rows[0]?.path;
+}
 
 /** The open file: the daemon's typed read bound to the REQUESTED scope + path, stamped with the
  *  catalog revision the page held as the request left — what Save is conditioned on. */
@@ -112,12 +122,18 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
   const [actionError, setActionError] = useState<string | null>(null);
   const [modal, setModal] = useState<'reset' | 'replace' | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
+  /** The skill tree wants a file open but its list has not landed yet (the mount; a switch back
+   *  to it while the list is pending): the loading state shows, and the open runs ONCE when the
+   *  list arrives — cleared by any move away, so a late list is never an instruction to open. */
+  const [openOnList, setOpenOnList] = useState(true);
 
   /** The intent token: every operator move that changes WHICH content is on screen (a pick, a tab
    *  switch, a save, a dir write) bumps it; an async answer applies only if it is still current. */
   const intent = useRef(0);
   const fileRef = useRef<OpenFile | null>(null);
   const draftRef = useRef('');
+  /** The file last OPENED on each tree — what a switch back to that tree re-selects. */
+  const lastOpened = useRef<Record<SkillDrawerTab, string | null>>({ skill: null, support: null });
   useEffect(() => { fileRef.current = file; }, [file]);
   useEffect(() => { draftRef.current = draft; }, [draft]);
 
@@ -193,6 +209,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
         setStaleRead(path);
         return;
       }
+      lastOpened.current[scope] = path;
       setFile(f);
       setDraft(f.content);
     } catch (e) {
@@ -204,17 +221,23 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     }
   }, [readFile]);
 
-  // The page keys this drawer by skill name, so one mount = one skill: load the tree, open the
-  // first file (SKILL.md when present — the fold puts it first). A list that answers after the
-  // operator already moved (to Support, say) is data for the tree, not an instruction to open.
+  // The page keys this drawer by skill name, so one mount = one skill: load the tree. The open
+  // that follows is the pending-list effect below (`openOnList` starts true).
   useEffect(() => {
-    const seq = ++intent.current;
-    void loadSkillFiles().then((rows) => {
-      if (seq !== intent.current) return;
-      const first = rows[0];
-      if (first !== undefined) void openFile('skill', first.path);
-    });
-  }, [loadSkillFiles, openFile]);
+    void loadSkillFiles();
+  }, [loadSkillFiles]);
+
+  // The skill tree asked for a file before its list was here (the mount, or a switch back while
+  // the list was still loading): the moment the list lands, open the file last open there (else
+  // the first — SKILL.md) exactly once. `openOnList` is cleared by every move away, so a list that
+  // answers after the operator already moved (to Support, say) is data for the tree, not an
+  // instruction to open; and `openFile` bumps the intent token, so nothing older lands after it.
+  useEffect(() => {
+    if (!openOnList || skillFiles === null) return;
+    setOpenOnList(false);
+    const target = reopenTarget(lastOpened.current.skill, skillFiles);
+    if (target !== undefined) void openFile('skill', target);
+  }, [openOnList, skillFiles, openFile]);
 
   // Every successful catalog read re-reads the open file (content + hash): the page's revision
   // moved (a Refresh, a toggle, a publish, another session's write) and the content on screen must
@@ -252,24 +275,37 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
 
   const files: readonly SkillFileEntry[] | null = tab === 'skill' ? skillFiles : support;
 
-  /** Switching trees opens the other tree's first file; locked while the open file is dirty or loading. */
+  /** No file on screen: a new intent (an in-flight read for the previous tree is void), the
+   *  editor and its per-file state cleared. */
+  const clearEditor = (): void => {
+    intent.current += 1;
+    setFile(null);
+    setDraft('');
+    setIntervening(null);
+    setStaleRead(null);
+    setBlockedDraft(null);
+    setFileLoading(false);
+  };
+
+  /** Switching trees re-opens the file last open on the other tree (else its first); locked while
+   *  the open file is dirty or loading. The skill tree with its list still PENDING is not "no
+   *  files": the editor clears to the loading state and the open waits for the list
+   *  (`openOnList`) — never a stray or duplicate open, never the other tree's file left on screen. */
   const selectTab = (next: SkillDrawerTab): void => {
     if (next === tab) return;
     setTab(next);
     setLastResult(null);
     setFileError(null);
-    const rows = next === 'skill' ? skillFiles ?? [] : support;
-    const first = rows[0];
-    if (first !== undefined) {
-      void openFile(next, first.path);
-    } else {
-      intent.current += 1;
-      setFile(null);
-      setDraft('');
-      setIntervening(null);
-      setStaleRead(null);
-      setFileLoading(false);
+    const rows = next === 'skill' ? skillFiles : support;
+    if (rows === null) {
+      clearEditor();
+      setOpenOnList(true);
+      return;
     }
+    setOpenOnList(false);
+    const target = reopenTarget(lastOpened.current[next], rows);
+    if (target !== undefined) void openFile(next, target);
+    else clearEditor();
   };
 
   const readOnlyReason =
@@ -552,9 +588,10 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
           )}
         </nav>
 
-        {/* The editor column. */}
+        {/* The editor column. A file is loading, or one is about to (the skill list is pending):
+            the loading state — never "pick a file" over a tree that has nothing to pick yet. */}
         <div className="flex min-w-0 flex-1 flex-col gap-2">
-          {fileLoading && file === null ? (
+          {(fileLoading || openOnList) && file === null ? (
             <p data-testid="skills-file-loading" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Loading file…</p>
           ) : fileError !== null ? (
             <p data-testid="skills-file-error" className="rounded px-2 py-1 text-[11px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>{fileError}</p>

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -43,10 +43,15 @@ import type { SkillsWriter } from './skillsWriter.js';
  *    CAS stays the backstop for whatever the re-read did not see.
  *  - **Late answers are ignored.** Every read carries an intent token; a file list or a file that
  *    answers after the operator switched tabs, picked another file, or saved is dropped — the
- *    Support editor is never swapped for a skill file by a slow list.
+ *    Support editor is never swapped for a skill file by a slow list. And a read never lands over
+ *    typing: the editor is read-only while a file is loading, and if text reached the draft after
+ *    the request left anyway, the answer is set aside as a STALE read (the draft stays, named).
  *
  * The page owns the catalog: the drawer reports every applied content write through `onChanged`
- * so the page reloads (provenance flips, hashes move, `unpublished` lights up).
+ * so the page reloads (provenance flips, hashes move, `unpublished` lights up) — and every dirty
+ * flip through `onDirtyChange`, so a row click on another skill comes back as `leaveTo` and goes
+ * through the same discard confirmation a close does; the page swaps the drawer only on
+ * `onLeave(true)`.
  */
 
 /** The two file trees the drawer edits. */
@@ -61,7 +66,7 @@ interface OpenFile extends SkillFileContent {
   readAt: string | null;
 }
 
-export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClose, onToggle, onChanged }: {
+export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveTo, onClose, onLeave, onDirtyChange, onToggle, onChanged }: {
   skill: SkillRow;
   /** The root support files (from the manifest), path-sorted. */
   support: readonly SkillFileEntry[];
@@ -71,7 +76,16 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
   /** The page has a write in flight (or the catalog is frozen on a conflict / stale) — the
    *  drawer's verbs wait. */
   busy: boolean;
+  /** The page was asked to open ANOTHER skill while this drawer is dirty: its name. The drawer
+   *  raises its discard confirmation and answers through `onLeave`; the page swaps the drawer
+   *  (its `key`) only after the operator discards. */
+  leaveTo: string | null;
   onClose: () => void;
+  /** The answer to `leaveTo`: `true` discards the draft and opens it, `false` keeps editing. */
+  onLeave: (proceed: boolean) => void;
+  /** Every dirty flip (and a clean slate when the drawer unmounts) — the page routes a row click
+   *  through the confirmation instead of unmounting a draft. */
+  onDirtyChange: (dirty: boolean) => void;
   /** The page's guarded flip — it reloads the catalog and hands back the daemon's verdict
    *  (`null` on a revision conflict: the page's prompt owns that moment). */
   onToggle: (name: string, enabled: boolean) => Promise<SkillGuardResult | null>;
@@ -90,6 +104,9 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
   const [intervening, setIntervening] = useState<OpenFile | null>(null);
   /** The exact draft the daemon last BLOCKED — Save stays disabled until the text changes. */
   const [blockedDraft, setBlockedDraft] = useState<string | null>(null);
+  /** A file whose read answered AFTER text reached the draft — set aside, never applied over the
+   *  typing; names the path so the operator knows what did not open. */
+  const [staleRead, setStaleRead] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [lastResult, setLastResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -106,12 +123,32 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
 
   const dirty = file !== null && draft !== file.content;
 
+  // The page hears every dirty flip — and a clean slate when this drawer goes — so a row click on
+  // another skill is routed through the discard confirmation instead of unmounting the draft.
+  useEffect(() => {
+    onDirtyChange(dirty);
+    return () => onDirtyChange(false);
+  }, [dirty, onDirtyChange]);
+
   // Closing with unsaved edits asks first — an Escape must never eat a draft silently.
   const requestClose = useCallback((): void => {
     if (dirty) setDiscardPrompt(true);
     else onClose();
   }, [dirty, onClose]);
   useModalEscape(requestClose);
+
+  // ONE discard confirmation for both ways out: a close (Escape / ✕) and the page's request to
+  // open another skill (`leaveTo`). Keep editing answers the page `false`; Discard closes, or
+  // answers `true` and the page navigates — the drawer's key never changes under a draft.
+  const leavePrompt = discardPrompt || leaveTo !== null;
+  const keepEditing = (): void => {
+    setDiscardPrompt(false);
+    if (leaveTo !== null) onLeave(false);
+  };
+  const discardAndLeave = (): void => {
+    if (leaveTo !== null) onLeave(true);
+    else onClose();
+  };
 
   const loadSkillFiles = useCallback(async (): Promise<SkillFileEntry[]> => {
     setFilesError(null);
@@ -134,16 +171,28 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
     return { ...f, path, scope, readAt };
   }, [skill.name, writer]);
 
-  /** The operator opens a file: a new intent; a late answer to an older one is dropped. */
+  /** The operator opens a file: a new intent; a late answer to an older one is dropped, and an
+   *  answer that would land over text typed since the request left is set aside as stale. */
   const openFile = useCallback(async (scope: SkillDrawerTab, path: string): Promise<void> => {
     const seq = ++intent.current;
+    const draftAtRequest = draftRef.current;
     setFileLoading(true);
     setFileError(null);
     setBlockedDraft(null);
     setIntervening(null);
+    setStaleRead(null);
     try {
       const f = await readFile(scope, path);
       if (seq !== intent.current) return;
+      // The editor is read-only while this read is in flight, but nothing upstream is trusted: text
+      // that reached the draft after the request left is never overwritten by its answer. The read
+      // is set aside — the draft stays, dirty against the file it was typed into, and the tree
+      // stays locked until it is saved or discarded.
+      const typed = draftRef.current;
+      if (typed !== draftAtRequest && typed !== '') {
+        setStaleRead(path);
+        return;
+      }
       setFile(f);
       setDraft(f.content);
     } catch (e) {
@@ -218,6 +267,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
       setFile(null);
       setDraft('');
       setIntervening(null);
+      setStaleRead(null);
       setFileLoading(false);
     }
   };
@@ -295,6 +345,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
     }
     setDraft(file.content);
     setBlockedDraft(null);
+    setStaleRead(null);
   };
 
   const flip = (): void => {
@@ -398,9 +449,10 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
         </button>
       </div>
 
-      {discardPrompt && (
+      {leavePrompt && (
         <div
           data-testid="skills-discard-prompt"
+          data-leave-to={leaveTo ?? undefined}
           role="alertdialog"
           aria-label="Unsaved changes"
           className="flex flex-wrap items-center gap-2 rounded px-3 py-2 text-[11px]"
@@ -411,7 +463,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
           <button
             data-testid="skills-keep-editing"
             type="button"
-            onClick={() => setDiscardPrompt(false)}
+            onClick={keepEditing}
             className="rounded px-2 py-0.5 text-[10px]"
             style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
           >
@@ -420,11 +472,11 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
           <button
             data-testid="skills-discard"
             type="button"
-            onClick={onClose}
+            onClick={discardAndLeave}
             className="rounded px-2 py-0.5 text-[10px] font-semibold"
             style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
           >
-            Discard and close
+            {leaveTo !== null ? <>Discard and open <span className="font-mono">{leaveTo}</span></> : 'Discard and close'}
           </button>
         </div>
       )}
@@ -514,9 +566,15 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
                 <span data-testid="skills-file-path" data-scope={file.scope} style={{ color: 'var(--ink-muted)' }}>{file.path}</span>
                 <span>{file.size} B</span>
                 {dirty && <span data-testid="skills-file-dirty" style={{ color: 'var(--status-gate)' }}>unsaved</span>}
+                {fileLoading && <span data-testid="skills-file-loading">loading…</span>}
               </div>
               {readOnlyReason !== null && (
                 <p data-testid="skills-file-readonly" className="text-[10px]" style={{ color: 'var(--status-gate)' }}>{readOnlyReason}</p>
+              )}
+              {staleRead !== null && (
+                <p data-testid="skills-file-stale-read" data-path={staleRead} role="status" className="text-[10px]" style={{ color: 'var(--status-gate)' }}>
+                  <span className="font-mono">{staleRead}</span> finished loading while you were typing — its content was not applied over your text. Save or discard your edits, then open it again.
+                </p>
               )}
               {intervening !== null && (
                 <div
@@ -555,7 +613,8 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClos
                 data-testid="skills-editor"
                 aria-label={`${file.path} content`}
                 value={draft}
-                readOnly={readOnlyReason !== null}
+                readOnly={readOnlyReason !== null || fileLoading}
+                aria-busy={fileLoading}
                 spellCheck={false}
                 onChange={(e) => setDraft(e.target.value)}
                 className="min-h-[18rem] flex-1 resize-y rounded p-2 font-mono text-[11px] focus:outline-none"

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -5,10 +5,10 @@ import {
   readSupportFile,
   writeSkillFile,
   writeSupportFile,
-  type SkillFileContent,
-  type SkillFileEntry,
-  type SkillGuardResult,
+  type SkillMutationResult,
+  type SkillReadResult,
   type SkillRow,
+  type SkillTreeRow,
 } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
 import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
@@ -19,15 +19,19 @@ import type { SkillsWriter } from './skillsWriter.js';
 
 /**
  * The skill DRAWER — opened from a catalog row (the SteeringRuleDrawer idiom, widened for an
- * editor). Two file trees under tabs: the skill's OWN files (`GET /skills/:name/files`) and the
- * root SUPPORT files every skill shares (`scripts/`, `schemas/`, `.claude-plugin/`, from the
- * manifest's support map — `GET|PUT /skills/support/*path`). A textarea editor over the selected
- * file (v1 — studio has no code editor): Save → `PUT {content, expectedRevision}` through the
- * page's CAS writer → the daemon's findings; a `blocked` verdict disables Save for that exact
- * draft until it changes; a `truncated` or `binary` read is read-only (Save never clobbers what
- * the editor cannot show). Plus the enabled switch and the dir-level verbs: Reset (from the
- * baseline; disabled for a user-added skill, which has none — disable is its off switch) and
- * Replace (a pasted files map).
+ * editor). Two file trees under tabs: the skill's OWN files (`GET /skills/:name/files` —
+ * `SkillFileTree`, a nested skill's files are its own) and the root SUPPORT files every skill
+ * shares (`.claude-plugin/`, `scripts/`, `schemas/`, `docs/examples/` … — the manifest `files` no
+ * skill owns; `GET|PUT /skills/support/*path`). A textarea editor over the selected file (v1 —
+ * studio has no code editor): Save → `PUT {content, expectedRevision}` through the page's CAS
+ * writer → the daemon's `SkillMutationResult`; a `blocked` verdict disables Save for that exact
+ * draft until it changes; a `truncated` or `binary` read (`SkillReadResult`, api-types 0.27.0) is
+ * read-only — Save never clobbers what the editor cannot show. Plus the enabled switch, the
+ * dir-level verbs — Reset (from the baseline; disabled for a user-added skill, which has none —
+ * disable is its off switch) and Replace (a pasted files map) — and the BASELINE SIDE: a read-only
+ * view of the shipped copy of the open file (`?side=baseline`), the "new side" of a refresh
+ * conflict or, for a skill a refresh held back under a name collision (`upstreamDir`), the upstream
+ * file actually read (the answer's `path` names it).
  *
  * Three invariants keep the editor honest about WHAT it is editing:
  *
@@ -52,7 +56,7 @@ import type { SkillsWriter } from './skillsWriter.js';
  *    aside as a STALE read (the draft stays, named).
  *
  * The page owns the catalog: the drawer reports every applied content write through `onChanged`
- * so the page reloads (provenance flips, hashes move, `unpublished` lights up) — and every dirty
+ * so the page reloads (provenance flips, records move, `unpublished` lights up) — and every dirty
  * flip through `onDirtyChange`, so a row click on another skill comes back as `leaveTo` and goes
  * through the same discard confirmation a close does; the page swaps the drawer only on
  * `onLeave(true)`.
@@ -65,21 +69,26 @@ const TAB_LABEL: Record<SkillDrawerTab, string> = { skill: 'Skill files', suppor
 
 /** The file a tree (re)opens: the one last open there when it is still listed, else the first
  *  (SKILL.md for the skill tree — the fold puts it first); `undefined` for an empty tree. */
-function reopenTarget(last: string | null, rows: readonly SkillFileEntry[]): string | undefined {
+function reopenTarget(last: string | null, rows: readonly SkillTreeRow[]): string | undefined {
   return last !== null && rows.some((r) => r.path === last) ? last : rows[0]?.path;
 }
 
 /** The open file: the daemon's typed read bound to the REQUESTED scope + path, stamped with the
  *  catalog revision the page held as the request left — what Save is conditioned on. */
-interface OpenFile extends SkillFileContent {
+interface OpenFile extends SkillReadResult {
   scope: SkillDrawerTab;
-  readAt: string | null;
+  readAt: number | null;
+}
+
+/** The editor's text for a read: `content` is `null` only when `binary` (there is no text to show). */
+function textOf(f: SkillReadResult): string {
+  return f.content ?? '';
 }
 
 export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveTo, onClose, onLeave, onDirtyChange, onToggle, onChanged }: {
   skill: SkillRow;
-  /** The root support files (from the manifest), path-sorted. */
-  support: readonly SkillFileEntry[];
+  /** The root support files (from the manifest's `files`, no owning skill), path-sorted. */
+  support: readonly SkillTreeRow[];
   writer: SkillsWriter;
   /** Bumped by the page on every SUCCESSFUL catalog read — the open file is re-read against it. */
   catalogEpoch: number;
@@ -98,12 +107,12 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
   onDirtyChange: (dirty: boolean) => void;
   /** The page's guarded flip — it reloads the catalog and hands back the daemon's verdict
    *  (`null` on a revision conflict: the page's prompt owns that moment). */
-  onToggle: (name: string, enabled: boolean) => Promise<SkillGuardResult | null>;
+  onToggle: (name: string, enabled: boolean) => Promise<SkillMutationResult | null>;
   /** After any applied content write (save / reset / replace) — the page reloads the catalog. */
   onChanged: () => void;
 }): React.ReactElement {
   const [tab, setTab] = useState<SkillDrawerTab>('skill');
-  const [skillFiles, setSkillFiles] = useState<SkillFileEntry[] | null>(null);
+  const [skillFiles, setSkillFiles] = useState<SkillTreeRow[] | null>(null);
   const [filesError, setFilesError] = useState<string | null>(null);
   const [file, setFile] = useState<OpenFile | null>(null);
   const [fileLoading, setFileLoading] = useState(false);
@@ -118,7 +127,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
    *  typing; names the path so the operator knows what did not open. */
   const [staleRead, setStaleRead] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [lastResult, setLastResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
+  const [lastResult, setLastResult] = useState<{ verb: string; result: SkillMutationResult } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [modal, setModal] = useState<'reset' | 'replace' | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
@@ -126,6 +135,8 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
    *  to it while the list is pending): the loading state shows, and the open runs ONCE when the
    *  list arrives — cleared by any move away, so a late list is never an instruction to open. */
   const [openOnList, setOpenOnList] = useState(true);
+  /** The BASELINE SIDE of the open file (`?side=baseline`), read-only: the read, or its refusal. */
+  const [baseline, setBaseline] = useState<{ result: SkillReadResult } | { error: string } | 'loading' | null>(null);
 
   /** The intent token: every operator move that changes WHICH content is on screen (a pick, a tab
    *  switch, a save, a dir write) bumps it; an async answer applies only if it is still current. */
@@ -137,7 +148,8 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
   useEffect(() => { fileRef.current = file; }, [file]);
   useEffect(() => { draftRef.current = draft; }, [draft]);
 
-  const dirty = file !== null && draft !== file.content;
+  // A binary read has no text (`content: null`): nothing to be dirty against.
+  const dirty = file !== null && file.content !== null && draft !== file.content;
 
   // The page hears every dirty flip — and a clean slate when this drawer goes — so a row click on
   // another skill is routed through the discard confirmation instead of unmounting the draft.
@@ -166,7 +178,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     else onClose();
   };
 
-  const loadSkillFiles = useCallback(async (): Promise<SkillFileEntry[]> => {
+  const loadSkillFiles = useCallback(async (): Promise<SkillTreeRow[]> => {
     setFilesError(null);
     try {
       const rows = await listSkillFiles(skill.name);
@@ -197,6 +209,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     setBlockedDraft(null);
     setIntervening(null);
     setStaleRead(null);
+    setBaseline(null);
     try {
       const f = await readFile(scope, path);
       if (seq !== intent.current) return;
@@ -211,7 +224,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
       }
       lastOpened.current[scope] = path;
       setFile(f);
-      setDraft(f.content);
+      setDraft(textOf(f));
     } catch (e) {
       if (seq !== intent.current) return;
       setFile(null);
@@ -239,12 +252,12 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     if (target !== undefined) void openFile('skill', target);
   }, [openOnList, skillFiles, openFile]);
 
-  // Every successful catalog read re-reads the open file (content + hash): the page's revision
-  // moved (a Refresh, a toggle, a publish, another session's write) and the content on screen must
-  // be reconciled with it BEFORE any Save rides the new revision. Same bytes → they stand at the
-  // new revision; changed + pristine → adopt the daemon's version; changed + dirty → keep the
-  // draft, surface the intervening change. Not a user intent: it applies only while the file it
-  // reconciled is still the one on screen.
+  // Every successful catalog read re-reads the open file: the page's revision moved (a Refresh, a
+  // toggle, a publish, another session's write) and the content on screen must be reconciled with
+  // it BEFORE any Save rides the new revision. Same bytes → they stand at the new revision;
+  // changed + pristine → adopt the daemon's version; changed + dirty → keep the draft, surface the
+  // intervening change. Not a user intent: it applies only while the file it reconciled is still
+  // the one on screen.
   useEffect(() => {
     const base = fileRef.current;
     if (base === null) return;
@@ -257,9 +270,9 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
           setIntervening(null);
           return;
         }
-        if (draftRef.current === base.content) {
+        if (draftRef.current === textOf(base)) {
           setFile(incoming);
-          setDraft(incoming.content);
+          setDraft(textOf(incoming));
           setIntervening(null);
           return;
         }
@@ -273,7 +286,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
       });
   }, [catalogEpoch, readFile]);
 
-  const files: readonly SkillFileEntry[] | null = tab === 'skill' ? skillFiles : support;
+  const files: readonly SkillTreeRow[] | null = tab === 'skill' ? skillFiles : support;
 
   /** No file on screen: a new intent (an in-flight read for the previous tree is void), the
    *  editor and its per-file state cleared. */
@@ -284,6 +297,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     setIntervening(null);
     setStaleRead(null);
     setBlockedDraft(null);
+    setBaseline(null);
     setFileLoading(false);
   };
 
@@ -311,7 +325,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
   const readOnlyReason =
     file === null ? null
     : file.binary ? 'binary file — not editable here'
-    : file.truncated ? 'this file exceeds the daemon’s read cap and is shown truncated — saving would clobber it, so it is read-only here'
+    : file.truncated ? 'this file exceeds the daemon’s 512 KB read cap and is shown truncated — saving would clobber it, so it is read-only here'
     : null;
 
   const canSave =
@@ -342,7 +356,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
       } else {
         // The base moved: a re-read in flight against the old base is void.
         intent.current += 1;
-        setFile({ ...target, content, readAt: result.revision });
+        setFile({ ...target, content, size: new TextEncoder().encode(content).byteLength, readAt: result.revision });
         setBlockedDraft(null);
         onChanged();
       }
@@ -358,7 +372,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     if (intervening === null) return;
     intent.current += 1;
     setFile(intervening);
-    setDraft(intervening.content);
+    setDraft(textOf(intervening));
     setIntervening(null);
     setBlockedDraft(null);
   };
@@ -379,7 +393,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
       takeIntervening();
       return;
     }
-    setDraft(file.content);
+    setDraft(textOf(file));
     setBlockedDraft(null);
     setStaleRead(null);
   };
@@ -395,10 +409,11 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
 
   /** After a dir-level write applied (reset / replace): the skill tree and the open file are
    *  reloaded — the content on screen must be the daemon's, never this drawer's memory of it. */
-  const afterDirWrite = (verb: string, result: SkillGuardResult): void => {
+  const afterDirWrite = (verb: string, result: SkillMutationResult): void => {
     setModal(null);
     setLastResult({ verb, result });
     setIntervening(null);
+    setBaseline(null);
     onChanged();
     const current = file !== null && file.scope === 'skill' ? file.path : null;
     const seq = ++intent.current;
@@ -410,7 +425,32 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
     });
   };
 
-  const canReset = skill.baselineHash !== null;
+  /** The BASELINE SIDE of the open file — `?side=baseline`, read-only, bound to the same requested
+   *  identity. The answer's `path` is shown: for a skill a refresh held back (`upstreamDir`) it names
+   *  the upstream file actually read, so the two sides of the collision are comparable. */
+  const toggleBaseline = async (): Promise<void> => {
+    if (file === null) return;
+    if (baseline !== null) { setBaseline(null); return; }
+    const target = file;
+    const seq = intent.current;
+    setBaseline('loading');
+    try {
+      const result = target.scope === 'skill'
+        ? await readSkillFile(skill.name, target.path, 'baseline')
+        : await readSupportFile(target.path, 'baseline');
+      if (seq !== intent.current || fileRef.current !== target) return;
+      setBaseline({ result });
+    } catch (e) {
+      if (seq !== intent.current || fileRef.current !== target) return;
+      setBaseline({ error: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  // A user-added skill has no baseline: nothing to reset to — and no shipped side to read, UNLESS a
+  // refresh held back an upstream skill under its name (`upstreamDir`): then `?side=baseline` reads
+  // that upstream directory, so the two sides of the collision are comparable (reset stays refused).
+  const canReset = skill.provenance !== 'user-added';
+  const hasBaseline = canReset || skill.upstreamDir !== null;
   const verbsDisabled = busy || saving;
   const treeLocked = dirty || fileLoading;
 
@@ -441,12 +481,13 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
       </div>
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
-        <span data-testid="skills-drawer-dir">{skill.dir}</span>
-        <span title="effective content hash">{skill.effectiveHash.slice(0, 12)}</span>
-        {skill.lastPublishedHash !== null && skill.lastPublishedHash !== skill.effectiveHash && (
-          <span title="the hash the current snapshot carries">published {skill.lastPublishedHash.slice(0, 12)}</span>
+        <span data-testid="skills-drawer-dir" title="plugin-relative directory (never renamed — sibling links depend on it)">{skill.dir}</span>
+        {skill.editedAt !== null && <span data-testid="skills-drawer-edited">edited {skill.editedAt}</span>}
+        {skill.upstreamDir !== null && (
+          <span data-testid="skills-drawer-upstream" style={{ color: 'var(--status-gate)' }} title="the last refresh found a name collision: upstream ships a skill under this name at another dir; Baseline side reads that directory">
+            upstream ships this name at {skill.upstreamDir}
+          </span>
         )}
-        {skill.editedAt !== null && <span>edited {skill.editedAt}</span>}
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -540,7 +581,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
         ))}
         {tab === 'support' && (
           <span data-testid="skills-support-note" className="ml-2 text-[10px]" style={{ color: 'var(--ink-dim)' }}>
-            shared by every skill — the guards flag each edit as a warning
+            shared by every skill — the guards flag each edit; a path outside the bundle closure is refused
           </span>
         )}
       </div>
@@ -565,23 +606,28 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
           ) : (
             files.map((f) => {
               const active = file !== null && file.scope === tab && file.path === f.path;
+              const conflict = f.record?.conflict === true;
               return (
                 <button
                   key={f.path}
                   type="button"
                   data-testid="skills-file"
                   data-path={f.path}
+                  data-conflict={conflict ? 'true' : undefined}
                   aria-current={active ? 'true' : undefined}
                   disabled={treeLocked}
-                  title={treeLocked ? (dirty ? 'save or discard your edits first' : 'loading…') : f.path}
+                  title={treeLocked
+                    ? (dirty ? 'save or discard your edits first' : 'loading…')
+                    : `${f.path}${f.size !== null ? ` · ${f.size} B` : ''}${conflict ? ' · refresh conflict: both sides changed (the effective side was kept)' : ''}`}
                   onClick={() => { setLastResult(null); void openFile(tab, f.path); }}
-                  className="truncate rounded px-2 py-1 text-left font-mono text-[10px] disabled:opacity-40 focus:outline-none focus-visible:ring-1"
+                  className="flex items-center gap-1 truncate rounded px-2 py-1 text-left font-mono text-[10px] disabled:opacity-40 focus:outline-none focus-visible:ring-1"
                   style={{
                     background: active ? 'var(--accent-subtle)' : 'transparent',
                     color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
                   }}
                 >
-                  {f.path}
+                  <span className="truncate">{f.path}</span>
+                  {conflict && <span aria-hidden className="shrink-0" style={{ color: 'var(--status-gate)' }}>⚑</span>}
                 </button>
               );
             })
@@ -599,11 +645,28 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
             <p data-testid="skills-file-none" className="text-[11px]" style={{ color: 'var(--ink-dim)' }}>Pick a file to edit.</p>
           ) : (
             <>
-              <div className="flex items-center gap-2 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+              <div className="flex flex-wrap items-center gap-2 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
                 <span data-testid="skills-file-path" data-scope={file.scope} style={{ color: 'var(--ink-muted)' }}>{file.path}</span>
-                <span>{file.size} B</span>
+                <span data-testid="skills-file-size" title="the file's full size in bytes">{file.size} B</span>
                 {dirty && <span data-testid="skills-file-dirty" style={{ color: 'var(--status-gate)' }}>unsaved</span>}
                 {fileLoading && <span data-testid="skills-file-loading">loading…</span>}
+                <span className="flex-1" />
+                {hasBaseline && (
+                  <button
+                    data-testid="skills-baseline-open"
+                    type="button"
+                    aria-pressed={baseline !== null}
+                    disabled={fileLoading}
+                    title={baseline === null
+                      ? 'Read the shipped copy of this file (the baseline side) — the new side of a refresh conflict, or the upstream file a name collision held back'
+                      : 'Hide the baseline side'}
+                    onClick={() => void toggleBaseline()}
+                    className="rounded px-1.5 py-0.5 text-[10px] disabled:opacity-40"
+                    style={{ color: 'var(--accent)', border: '1px solid var(--surface-raised)' }}
+                  >
+                    {baseline === null ? 'Baseline side' : 'Hide baseline'}
+                  </button>
+                )}
               </div>
               {readOnlyReason !== null && (
                 <p data-testid="skills-file-readonly" className="text-[10px]" style={{ color: 'var(--status-gate)' }}>{readOnlyReason}</p>
@@ -622,8 +685,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
                 >
                   <span className="font-semibold" style={{ color: 'var(--status-gate)' }}>This file changed on the daemon while you were editing.</span>
                   <span>
-                    <span className="font-mono">{file.path}</span> is now <span className="font-mono">{intervening.hash.slice(0, 12)}</span>
-                    {' '}(you started from <span className="font-mono">{file.hash.slice(0, 12)}</span>). Your draft is kept; Save waits until you pick a side.
+                    <span className="font-mono">{file.path}</span> is now {intervening.size} B on the daemon (you started from {file.size} B, catalog revision {file.readAt ?? '?'}). Your draft is kept; Save waits until you pick a side.
                   </span>
                   <span className="flex-1" />
                   <button
@@ -657,6 +719,39 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
                 className="min-h-[18rem] flex-1 resize-y rounded p-2 font-mono text-[11px] focus:outline-none"
                 style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)', lineHeight: 1.5 }}
               />
+              {baseline !== null && (
+                <div
+                  data-testid="skills-baseline-view"
+                  className="flex flex-col gap-1 rounded p-2 text-[10px]"
+                  style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+                >
+                  {baseline === 'loading' ? (
+                    <span data-testid="skills-baseline-loading">Loading the baseline side…</span>
+                  ) : 'error' in baseline ? (
+                    <span data-testid="skills-baseline-error" style={{ color: 'var(--status-fail)' }}>{baseline.error}</span>
+                  ) : (
+                    <>
+                      <span className="flex flex-wrap items-center gap-2 font-mono" style={{ color: 'var(--ink-dim)' }}>
+                        <span>baseline side ·</span>
+                        <span data-testid="skills-baseline-path" style={{ color: 'var(--ink-muted)' }} title="the plugin-relative path the daemon actually read (an upstream skill's dir for a held-back collision)">{baseline.result.path}</span>
+                        <span>{baseline.result.size} B</span>
+                        {baseline.result.truncated && <span style={{ color: 'var(--status-gate)' }}>truncated</span>}
+                        {baseline.result.binary && <span style={{ color: 'var(--status-gate)' }}>binary</span>}
+                        <span className="ml-auto">read-only</span>
+                      </span>
+                      <textarea
+                        data-testid="skills-baseline-content"
+                        aria-label={`${baseline.result.path} baseline content`}
+                        value={textOf(baseline.result)}
+                        readOnly
+                        spellCheck={false}
+                        className="min-h-[10rem] resize-y rounded p-2 font-mono text-[11px] focus:outline-none"
+                        style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)', lineHeight: 1.5 }}
+                      />
+                    </>
+                  )}
+                </div>
+              )}
               <div className="flex items-center gap-2">
                 <button
                   data-testid="skills-save"

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listSkillFiles,
   readSkillFile,
@@ -29,6 +29,22 @@ import type { SkillsWriter } from './skillsWriter.js';
  * baseline; disabled for a user-added skill, which has none — disable is its off switch) and
  * Replace (a pasted files map).
  *
+ * Three invariants keep the editor honest about WHAT it is editing:
+ *
+ *  - **The open file is the REQUESTED identity.** Its scope (skill vs support) and its validated
+ *    path travel with the content from the moment it is asked for; Save's endpoint follows the
+ *    file, never the current tab, and never a `path` the daemon echoed back.
+ *  - **Save is conditioned on the revision the CONTENT was read at** (`readAt`), not the page's
+ *    latest. Every successful catalog read (`catalogEpoch`) re-reads the open file: same bytes →
+ *    they now stand at the new revision; changed + pristine → the daemon's version is adopted;
+ *    changed + unsaved edits → the draft is KEPT and the intervening change surfaces — Save waits
+ *    for the operator to load the daemon's version or keep the draft (an explicit replace). A
+ *    Refresh can therefore never turn an old-content edit into a silent overwrite; the daemon's
+ *    CAS stays the backstop for whatever the re-read did not see.
+ *  - **Late answers are ignored.** Every read carries an intent token; a file list or a file that
+ *    answers after the operator switched tabs, picked another file, or saved is dropped — the
+ *    Support editor is never swapped for a skill file by a slow list.
+ *
  * The page owns the catalog: the drawer reports every applied content write through `onChanged`
  * so the page reloads (provenance flips, hashes move, `unpublished` lights up).
  */
@@ -38,13 +54,22 @@ type SkillDrawerTab = 'skill' | 'support';
 
 const TAB_LABEL: Record<SkillDrawerTab, string> = { skill: 'Skill files', support: 'Support files' };
 
-export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, onChanged }: {
+/** The open file: the daemon's typed read bound to the REQUESTED scope + path, stamped with the
+ *  catalog revision the page held as the request left — what Save is conditioned on. */
+interface OpenFile extends SkillFileContent {
+  scope: SkillDrawerTab;
+  readAt: string | null;
+}
+
+export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, onClose, onToggle, onChanged }: {
   skill: SkillRow;
   /** The root support files (from the manifest), path-sorted. */
   support: readonly SkillFileEntry[];
   writer: SkillsWriter;
-  /** The page has a write in flight for this skill (or the catalog is frozen on a conflict) —
-   *  the drawer's verbs wait. */
+  /** Bumped by the page on every SUCCESSFUL catalog read — the open file is re-read against it. */
+  catalogEpoch: number;
+  /** The page has a write in flight (or the catalog is frozen on a conflict / stale) — the
+   *  drawer's verbs wait. */
   busy: boolean;
   onClose: () => void;
   /** The page's guarded flip — it reloads the catalog and hands back the daemon's verdict
@@ -56,10 +81,13 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
   const [tab, setTab] = useState<SkillDrawerTab>('skill');
   const [skillFiles, setSkillFiles] = useState<SkillFileEntry[] | null>(null);
   const [filesError, setFilesError] = useState<string | null>(null);
-  const [file, setFile] = useState<SkillFileContent | null>(null);
+  const [file, setFile] = useState<OpenFile | null>(null);
   const [fileLoading, setFileLoading] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
+  /** The daemon's CURRENT version of the open file when it differs from the base the draft was
+   *  edited against — surfaced, never silently adopted over unsaved edits. Save waits. */
+  const [intervening, setIntervening] = useState<OpenFile | null>(null);
   /** The exact draft the daemon last BLOCKED — Save stays disabled until the text changes. */
   const [blockedDraft, setBlockedDraft] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -67,6 +95,14 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
   const [actionError, setActionError] = useState<string | null>(null);
   const [modal, setModal] = useState<'reset' | 'replace' | null>(null);
   const [discardPrompt, setDiscardPrompt] = useState(false);
+
+  /** The intent token: every operator move that changes WHICH content is on screen (a pick, a tab
+   *  switch, a save, a dir write) bumps it; an async answer applies only if it is still current. */
+  const intent = useRef(0);
+  const fileRef = useRef<OpenFile | null>(null);
+  const draftRef = useRef('');
+  useEffect(() => { fileRef.current = file; }, [file]);
+  useEffect(() => { draftRef.current = draft; }, [draft]);
 
   const dirty = file !== null && draft !== file.content;
 
@@ -90,30 +126,80 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
     }
   }, [skill.name]);
 
+  /** One typed read, bound to the REQUESTED identity (scope + validated path — never the
+   *  response's `path`) and stamped with the revision the page holds as the request leaves. */
+  const readFile = useCallback(async (scope: SkillDrawerTab, path: string): Promise<OpenFile> => {
+    const readAt = writer.revision();
+    const f = scope === 'skill' ? await readSkillFile(skill.name, path) : await readSupportFile(path);
+    return { ...f, path, scope, readAt };
+  }, [skill.name, writer]);
+
+  /** The operator opens a file: a new intent; a late answer to an older one is dropped. */
   const openFile = useCallback(async (scope: SkillDrawerTab, path: string): Promise<void> => {
+    const seq = ++intent.current;
     setFileLoading(true);
     setFileError(null);
     setBlockedDraft(null);
+    setIntervening(null);
     try {
-      const f = scope === 'skill' ? await readSkillFile(skill.name, path) : await readSupportFile(path);
+      const f = await readFile(scope, path);
+      if (seq !== intent.current) return;
       setFile(f);
       setDraft(f.content);
     } catch (e) {
+      if (seq !== intent.current) return;
       setFile(null);
       setFileError(e instanceof Error ? e.message : String(e));
     } finally {
-      setFileLoading(false);
+      if (seq === intent.current) setFileLoading(false);
     }
-  }, [skill.name]);
+  }, [readFile]);
 
   // The page keys this drawer by skill name, so one mount = one skill: load the tree, open the
-  // first file (SKILL.md when present — the fold puts it first).
+  // first file (SKILL.md when present — the fold puts it first). A list that answers after the
+  // operator already moved (to Support, say) is data for the tree, not an instruction to open.
   useEffect(() => {
+    const seq = ++intent.current;
     void loadSkillFiles().then((rows) => {
+      if (seq !== intent.current) return;
       const first = rows[0];
       if (first !== undefined) void openFile('skill', first.path);
     });
   }, [loadSkillFiles, openFile]);
+
+  // Every successful catalog read re-reads the open file (content + hash): the page's revision
+  // moved (a Refresh, a toggle, a publish, another session's write) and the content on screen must
+  // be reconciled with it BEFORE any Save rides the new revision. Same bytes → they stand at the
+  // new revision; changed + pristine → adopt the daemon's version; changed + dirty → keep the
+  // draft, surface the intervening change. Not a user intent: it applies only while the file it
+  // reconciled is still the one on screen.
+  useEffect(() => {
+    const base = fileRef.current;
+    if (base === null) return;
+    const seq = intent.current;
+    void readFile(base.scope, base.path)
+      .then((incoming) => {
+        if (seq !== intent.current || fileRef.current !== base) return;
+        if (incoming.content === base.content) {
+          setFile(incoming);
+          setIntervening(null);
+          return;
+        }
+        if (draftRef.current === base.content) {
+          setFile(incoming);
+          setDraft(incoming.content);
+          setIntervening(null);
+          return;
+        }
+        setIntervening(incoming);
+      })
+      .catch((e: unknown) => {
+        if (seq !== intent.current || fileRef.current !== base) return;
+        // The file stays as read; Save still carries the revision it was read at, so the daemon's
+        // CAS is the backstop. The editor stays visible — a draft is never hidden behind an error.
+        setActionError(`could not re-read ${base.path} after the catalog reload — ${e instanceof Error ? e.message : String(e)}`);
+      });
+  }, [catalogEpoch, readFile]);
 
   const files: readonly SkillFileEntry[] | null = tab === 'skill' ? skillFiles : support;
 
@@ -125,8 +211,15 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
     setFileError(null);
     const rows = next === 'skill' ? skillFiles ?? [] : support;
     const first = rows[0];
-    if (first !== undefined) void openFile(next, first.path);
-    else { setFile(null); setDraft(''); }
+    if (first !== undefined) {
+      void openFile(next, first.path);
+    } else {
+      intent.current += 1;
+      setFile(null);
+      setDraft('');
+      setIntervening(null);
+      setFileLoading(false);
+    }
   };
 
   const readOnlyReason =
@@ -136,24 +229,34 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
     : null;
 
   const canSave =
-    file !== null && !fileLoading && !saving && !busy && readOnlyReason === null && dirty && draft !== blockedDraft;
+    file !== null && file.readAt !== null && intervening === null
+    && !fileLoading && !saving && !busy && readOnlyReason === null && dirty && draft !== blockedDraft;
 
   const save = async (): Promise<void> => {
-    if (file === null || !canSave) return;
+    if (file === null || file.readAt === null || !canSave) return;
     const target = file;
+    const readAt = file.readAt;
+    const content = draft;
     setSaving(true);
     setActionError(null);
     try {
-      const result = await writer.run((rev) => (tab === 'skill'
-        ? writeSkillFile(skill.name, target.path, draft, rev)
-        : writeSupportFile(target.path, draft, rev)));
+      // The endpoint follows the FILE's scope and requested path; the revision is the one its
+      // content was read at — never the page's latest.
+      const result = await writer.run(
+        (rev) => (target.scope === 'skill'
+          ? writeSkillFile(skill.name, target.path, content, rev)
+          : writeSupportFile(target.path, content, rev)),
+        { expectedRevision: readAt },
+      );
       // A revision conflict: the page's prompt owns the moment; the draft is kept for after the reload.
       if (result === null) return;
       setLastResult({ verb: 'Save', result });
       if (result.verdict === 'blocked') {
-        setBlockedDraft(draft);
+        setBlockedDraft(content);
       } else {
-        setFile({ ...target, content: draft });
+        // The base moved: a re-read in flight against the old base is void.
+        intent.current += 1;
+        setFile({ ...target, content, readAt: result.revision });
         setBlockedDraft(null);
         onChanged();
       }
@@ -162,6 +265,36 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
     } finally {
       setSaving(false);
     }
+  };
+
+  /** The intervening change, resolved the daemon's way: its version replaces the draft. */
+  const takeIntervening = (): void => {
+    if (intervening === null) return;
+    intent.current += 1;
+    setFile(intervening);
+    setDraft(intervening.content);
+    setIntervening(null);
+    setBlockedDraft(null);
+  };
+
+  /** …or the operator's way: the draft stays and, on Save, replaces the daemon's version — an
+   *  explicit overwrite conditioned on the revision the daemon's version was read at. */
+  const keepDraftOverIntervening = (): void => {
+    if (intervening === null) return;
+    intent.current += 1;
+    setFile(intervening);
+    setIntervening(null);
+    setBlockedDraft(null);
+  };
+
+  const discardEdits = (): void => {
+    if (file === null) return;
+    if (intervening !== null) {
+      takeIntervening();
+      return;
+    }
+    setDraft(file.content);
+    setBlockedDraft(null);
   };
 
   const flip = (): void => {
@@ -178,10 +311,12 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
   const afterDirWrite = (verb: string, result: SkillGuardResult): void => {
     setModal(null);
     setLastResult({ verb, result });
+    setIntervening(null);
     onChanged();
-    const current = tab === 'skill' && file !== null ? file.path : null;
+    const current = file !== null && file.scope === 'skill' ? file.path : null;
+    const seq = ++intent.current;
     void loadSkillFiles().then((rows) => {
-      if (tab !== 'skill') return;
+      if (seq !== intent.current || tab !== 'skill') return;
       const target = current !== null && rows.some((r) => r.path === current) ? current : rows[0]?.path;
       if (target !== undefined) void openFile('skill', target);
       else { setFile(null); setDraft(''); }
@@ -323,7 +458,9 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
       </div>
 
       <div className="flex min-h-0 flex-1 gap-3">
-        {/* The file tree — flat, SKILL.md first; locked while the open file has unsaved edits. */}
+        {/* The file tree — flat, SKILL.md first; EVERY row locks while the open file has unsaved
+            edits or is loading — the active one too, since re-opening it would reload the content
+            over the draft. */}
         <nav
           data-testid="skills-file-tree"
           data-tab={tab}
@@ -339,7 +476,7 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
             <p data-testid="skills-files-empty" className="px-2 py-1 text-[10px]" style={{ color: 'var(--ink-dim)' }}>No files.</p>
           ) : (
             files.map((f) => {
-              const active = file !== null && file.path === f.path;
+              const active = file !== null && file.scope === tab && file.path === f.path;
               return (
                 <button
                   key={f.path}
@@ -347,8 +484,8 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
                   data-testid="skills-file"
                   data-path={f.path}
                   aria-current={active ? 'true' : undefined}
-                  disabled={treeLocked && !active}
-                  title={treeLocked && !active ? 'save or discard your edits first' : f.path}
+                  disabled={treeLocked}
+                  title={treeLocked ? (dirty ? 'save or discard your edits first' : 'loading…') : f.path}
                   onClick={() => { setLastResult(null); void openFile(tab, f.path); }}
                   className="truncate rounded px-2 py-1 text-left font-mono text-[10px] disabled:opacity-40 focus:outline-none focus-visible:ring-1"
                   style={{
@@ -374,12 +511,45 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
           ) : (
             <>
               <div className="flex items-center gap-2 text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
-                <span data-testid="skills-file-path" style={{ color: 'var(--ink-muted)' }}>{file.path}</span>
+                <span data-testid="skills-file-path" data-scope={file.scope} style={{ color: 'var(--ink-muted)' }}>{file.path}</span>
                 <span>{file.size} B</span>
                 {dirty && <span data-testid="skills-file-dirty" style={{ color: 'var(--status-gate)' }}>unsaved</span>}
               </div>
               {readOnlyReason !== null && (
                 <p data-testid="skills-file-readonly" className="text-[10px]" style={{ color: 'var(--status-gate)' }}>{readOnlyReason}</p>
+              )}
+              {intervening !== null && (
+                <div
+                  data-testid="skills-file-conflict"
+                  role="alert"
+                  className="flex flex-wrap items-center gap-2 rounded px-3 py-2 text-[11px]"
+                  style={{ background: 'var(--surface-rail)', border: '1px solid var(--status-gate)', color: 'var(--ink-muted)' }}
+                >
+                  <span className="font-semibold" style={{ color: 'var(--status-gate)' }}>This file changed on the daemon while you were editing.</span>
+                  <span>
+                    <span className="font-mono">{file.path}</span> is now <span className="font-mono">{intervening.hash.slice(0, 12)}</span>
+                    {' '}(you started from <span className="font-mono">{file.hash.slice(0, 12)}</span>). Your draft is kept; Save waits until you pick a side.
+                  </span>
+                  <span className="flex-1" />
+                  <button
+                    data-testid="skills-file-conflict-take"
+                    type="button"
+                    onClick={takeIntervening}
+                    className="rounded px-2 py-0.5 text-[10px] font-semibold"
+                    style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
+                  >
+                    Load the daemon’s version (discard my edits)
+                  </button>
+                  <button
+                    data-testid="skills-file-conflict-keep"
+                    type="button"
+                    onClick={keepDraftOverIntervening}
+                    className="rounded px-2 py-0.5 text-[10px]"
+                    style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+                  >
+                    Keep my draft — it replaces the daemon’s version on Save
+                  </button>
+                </div>
               )}
               <textarea
                 data-testid="skills-editor"
@@ -396,7 +566,11 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
                   data-testid="skills-save"
                   type="button"
                   disabled={!canSave}
-                  title={draft === blockedDraft && blockedDraft !== null ? 'the daemon blocked this exact content — change it to try again' : 'Save this file (the daemon runs its guards first)'}
+                  title={
+                    intervening !== null ? 'this file changed on the daemon — load its version or keep your draft first'
+                    : draft === blockedDraft && blockedDraft !== null ? 'the daemon blocked this exact content — change it to try again'
+                    : 'Save this file (the daemon runs its guards first)'
+                  }
                   onClick={() => void save()}
                   className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
                   style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
@@ -408,7 +582,7 @@ export function SkillDrawer({ skill, support, writer, busy, onClose, onToggle, o
                     data-testid="skills-discard-edits"
                     type="button"
                     disabled={saving}
-                    onClick={() => { setDraft(file.content); setBlockedDraft(null); }}
+                    onClick={discardEdits}
                     className="rounded px-2 py-1 text-[11px]"
                     style={{ color: 'var(--ink-dim)', border: '1px solid var(--surface-raised)' }}
                   >

--- a/src/components/SkillFilesMapModal.tsx
+++ b/src/components/SkillFilesMapModal.tsx
@@ -10,8 +10,11 @@ import type { SkillsWriter } from './skillsWriter.js';
  * operator pastes a JSON files map (`{"SKILL.md": "...", "refs/x.md": "..."}`), validated live
  * ({@link parseFilesMap}: an object of string contents, relative paths, `SKILL.md` present). The
  * write runs through the page's CAS writer; the daemon's guards answer: `blocked` keeps the modal
- * open with the findings (nothing changed); anything else closes it through `onDone`; a revision
- * conflict closes it plain — the page's reload prompt owns that moment.
+ * open with the findings (nothing changed); anything else closes it through `onDone`. A revision
+ * conflict (409) keeps the modal MOUNTED — the name and the pasted files map are the operator's
+ * work and are never dropped for a stale revision: the banner names the conflict, the catalog is
+ * re-read through the writer, and the same map is retried against the revision it adopts
+ * (review round 2).
  */
 
 /** The frontmatter-name charset, echoed client-side; the daemon is the authority. */
@@ -33,6 +36,9 @@ export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
+  /** The last write hit a revision conflict: nothing was written, the draft is kept, the catalog
+   *  is (being) re-read — the operator retries the same map against the new revision. */
+  const [conflict, setConflict] = useState(false);
   useModalEscape(onClose);
 
   const target = mode === 'add' ? newName.trim() : name ?? '';
@@ -49,10 +55,15 @@ export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
     setBusy(true);
     setError(null);
     setBlocked(null);
+    setConflict(false);
     try {
       const result = await writer.run((rev) => (mode === 'add' ? addSkill(target, files, rev) : replaceSkill(target, files, rev)));
       if (result === null) {
-        onClose();
+        // A stale revision: the daemon wrote nothing. The name + files map stay exactly as pasted;
+        // the catalog is re-read here so the retry rides the current revision.
+        setConflict(true);
+        await writer.reload();
+        setBusy(false);
         return;
       }
       if (result.verdict === 'blocked') {
@@ -126,6 +137,20 @@ export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
           </p>
         )}
         {blocked !== null && <SkillFindings verb={verb} result={blocked} testId="skills-files-findings" />}
+        {conflict && (
+          <p
+            data-testid="skills-files-conflict"
+            role="alert"
+            className="rounded px-2 py-1 text-[10px]"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--status-gate)', color: 'var(--ink-muted)' }}
+          >
+            <span className="font-semibold" style={{ color: 'var(--status-gate)' }}>The skills catalog changed under this page — nothing was written.</span>
+            {' '}
+            {busy
+              ? 'Reloading the catalog…'
+              : `Your ${mode === 'add' ? 'name and files map are' : 'files map is'} kept and the catalog was reloaded — ${verb} again to write against the current revision.`}
+          </p>
+        )}
         <div className="flex items-center justify-end gap-2">
           <button
             data-testid="skills-files-cancel"
@@ -144,7 +169,7 @@ export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
             className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
             style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
           >
-            {busy ? 'Writing…' : verb}
+            {busy ? (conflict ? 'Reloading…' : 'Writing…') : verb}
           </button>
         </div>
       </div>

--- a/src/components/SkillFilesMapModal.tsx
+++ b/src/components/SkillFilesMapModal.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { addSkill, parseFilesMap, replaceSkill, type SkillGuardResult } from '../api/skills.js';
+import { useModalEscape } from './Modal.js';
+import { SkillFindings } from './SkillFindings.js';
+import type { SkillsWriter } from './skillsWriter.js';
+
+/**
+ * The files-map modal behind two verbs: ADD a user-added skill (`POST /skills`) and REPLACE a
+ * skill's own files wholesale (`POST /skills/:name/replace`). v1 has no multi-file picker — the
+ * operator pastes a JSON files map (`{"SKILL.md": "...", "refs/x.md": "..."}`), validated live
+ * ({@link parseFilesMap}: an object of string contents, relative paths, `SKILL.md` present). The
+ * write runs through the page's CAS writer; the daemon's guards answer: `blocked` keeps the modal
+ * open with the findings (nothing changed); anything else closes it through `onDone`; a revision
+ * conflict closes it plain — the page's reload prompt owns that moment.
+ */
+
+/** The frontmatter-name charset, echoed client-side; the daemon is the authority. */
+const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+const PLACEHOLDER = '{\n  "SKILL.md": "---\\nname: my-skill\\n---\\n…"\n}';
+
+export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
+  mode: 'add' | 'replace';
+  /** The skill being replaced; ignored in `add` mode (the operator names the new skill). */
+  name: string | null;
+  writer: SkillsWriter;
+  onClose: () => void;
+  /** Fires after the wire answered with anything but `blocked`, with the skill's name. */
+  onDone: (name: string, result: SkillGuardResult) => void;
+}): React.ReactElement {
+  const [newName, setNewName] = useState('');
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
+  useModalEscape(onClose);
+
+  const target = mode === 'add' ? newName.trim() : name ?? '';
+  const nameIssue = mode === 'add' && target !== '' && !NAME_RE.test(target)
+    ? 'name: letters, digits, "-" and "_" only, starting with a letter or digit'
+    : null;
+  const parsed = text.trim() === '' ? null : parseFilesMap(text);
+  const issue = nameIssue ?? (parsed === null ? null : parsed.issue);
+  const armed = !busy && target !== '' && parsed !== null && parsed.files !== null && nameIssue === null;
+
+  const submit = async (): Promise<void> => {
+    if (!armed || parsed === null || parsed.files === null) return;
+    const files = parsed.files;
+    setBusy(true);
+    setError(null);
+    setBlocked(null);
+    try {
+      const result = await writer.run((rev) => (mode === 'add' ? addSkill(target, files, rev) : replaceSkill(target, files, rev)));
+      if (result === null) {
+        onClose();
+        return;
+      }
+      if (result.verdict === 'blocked') {
+        setBlocked(result);
+        setBusy(false);
+        return;
+      }
+      onDone(target, result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  const title = mode === 'add' ? 'Add a skill' : `Replace ${name ?? ''}`;
+  const verb = mode === 'add' ? 'Add skill' : 'Replace files';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'var(--scrim)' }}>
+      <div
+        data-testid="skills-files-modal"
+        data-mode={mode}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="flex w-[36rem] max-w-[92vw] flex-col gap-3 rounded-xl p-4 shadow-2xl"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)' }}
+      >
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>{title}</h3>
+        <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          {mode === 'add'
+            ? 'A user-added skill: a new dir under the effective root, carried in the snapshot once enabled and published. Paste its files as a JSON map of relative path → content; SKILL.md is required.'
+            : 'Replaces every file this skill owns with the map below — files not in the map are removed (a nested child skill keeps its own). Paste a JSON map of relative path → content; SKILL.md is required.'}
+          {' '}The daemon runs its guards (name uniqueness across the whole catalog, frontmatter name = path-derived name, core protection) before anything is written.
+        </p>
+        {mode === 'add' && (
+          <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+            Skill name
+            <input
+              data-testid="skills-files-name"
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="my-team-skill"
+              spellCheck={false}
+              aria-invalid={nameIssue !== null}
+              className="rounded px-2 py-1 font-mono text-[11px] focus:outline-none"
+              style={{ background: 'var(--surface-base)', border: `1px solid ${nameIssue === null ? 'var(--surface-raised)' : 'var(--status-fail)'}`, color: 'var(--ink-high)' }}
+            />
+          </label>
+        )}
+        <label className="flex flex-col gap-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+          Files map (JSON)
+          <textarea
+            data-testid="skills-files-map"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={PLACEHOLDER}
+            spellCheck={false}
+            aria-invalid={parsed !== null && parsed.issue !== null}
+            className="min-h-[12rem] resize-y rounded px-2 py-1 font-mono text-[11px] focus:outline-none"
+            style={{ background: 'var(--surface-base)', border: '1px solid var(--surface-raised)', color: 'var(--ink-high)' }}
+          />
+        </label>
+        {issue !== null && (
+          <p data-testid="skills-files-issue" className="text-[10px]" style={{ color: 'var(--status-fail)' }}>{issue}</p>
+        )}
+        {error !== null && (
+          <p data-testid="skills-files-error" className="rounded px-2 py-1 text-[10px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+            {error}
+          </p>
+        )}
+        {blocked !== null && <SkillFindings verb={verb} result={blocked} testId="skills-files-findings" />}
+        <div className="flex items-center justify-end gap-2">
+          <button
+            data-testid="skills-files-cancel"
+            type="button"
+            onClick={onClose}
+            className="rounded px-3 py-1 text-[11px]"
+            style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="skills-files-save"
+            type="button"
+            disabled={!armed}
+            onClick={() => void submit()}
+            className="rounded px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+            style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+          >
+            {busy ? 'Writing…' : verb}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SkillFilesMapModal.tsx
+++ b/src/components/SkillFilesMapModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { addSkill, parseFilesMap, replaceSkill, type SkillGuardResult } from '../api/skills.js';
+import { addSkill, parseFilesMap, replaceSkill, type SkillMutationResult } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
 import { SkillFindings } from './SkillFindings.js';
 import type { SkillsWriter } from './skillsWriter.js';
@@ -9,9 +9,11 @@ import type { SkillsWriter } from './skillsWriter.js';
  * skill's own files wholesale (`POST /skills/:name/replace`). v1 has no multi-file picker — the
  * operator pastes a JSON files map (`{"SKILL.md": "...", "refs/x.md": "..."}`), validated live
  * ({@link parseFilesMap}: an object of string contents, relative paths, `SKILL.md` present). The
- * write runs through the page's CAS writer; the daemon's guards answer: `blocked` keeps the modal
- * open with the findings (nothing changed); anything else closes it through `onDone`. A revision
- * conflict (409) keeps the modal MOUNTED — the name and the pasted files map are the operator's
+ * write runs through the page's CAS writer; the daemon's guards answer (`SkillMutationResult`,
+ * api-types 0.27.0): `blocked` keeps the modal open with the findings (nothing changed — a name
+ * collision, a core rename, an `outside-closure` path); anything else closes it through `onDone`.
+ * A revision conflict (409 — a stale `expectedRevision`, the only thing that answers 409) keeps the
+ * modal MOUNTED — the name and the pasted files map are the operator's
  * work and are never dropped for a stale revision: the banner names the conflict, the catalog is
  * re-read through the writer, and the same map is retried against the revision it adopts
  * (review round 2).
@@ -29,13 +31,13 @@ export function SkillFilesMapModal({ mode, name, writer, onClose, onDone }: {
   writer: SkillsWriter;
   onClose: () => void;
   /** Fires after the wire answered with anything but `blocked`, with the skill's name. */
-  onDone: (name: string, result: SkillGuardResult) => void;
+  onDone: (name: string, result: SkillMutationResult) => void;
 }): React.ReactElement {
   const [newName, setNewName] = useState('');
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [blocked, setBlocked] = useState<SkillGuardResult | null>(null);
+  const [blocked, setBlocked] = useState<SkillMutationResult | null>(null);
   /** The last write hit a revision conflict: nothing was written, the draft is kept, the catalog
    *  is (being) re-read — the operator retries the same map against the new revision. */
   const [conflict, setConflict] = useState(false);

--- a/src/components/SkillFindings.tsx
+++ b/src/components/SkillFindings.tsx
@@ -1,0 +1,81 @@
+import type { SkillFinding, SkillGuardResult, SkillVerdict } from '../api/skills.js';
+
+/**
+ * The guard envelope of ONE write / enable / publish / analyze, rendered honestly: the verdict
+ * line names the verb and the outcome (`clear` — no findings; `warnings` — passed, read them;
+ * `blocked` — REFUSED, nothing was written), then every finding with the guard that fired, its
+ * severity, the skill it is against, and the `file:line` the daemon cited.
+ */
+
+export const VERDICT_COLOR: Record<SkillVerdict, string> = {
+  clear: 'var(--status-done)',
+  warnings: 'var(--status-gate)',
+  blocked: 'var(--status-fail)',
+};
+
+function verdictLine(verb: string, result: SkillGuardResult): string {
+  const n = result.findings.length;
+  const plural = n === 1 ? 'finding' : 'findings';
+  if (result.verdict === 'blocked') return `${verb} blocked — nothing was written (${n} ${plural}).`;
+  if (result.verdict === 'warnings') return `${verb} passed with ${n} ${plural} to read.`;
+  return n === 0 ? `${verb} clear — no findings.` : `${verb} clear (${n} ${plural}).`;
+}
+
+/** `file` alone, or `file:line` when the daemon cited a line. */
+export function findingLocation(f: SkillFinding): string | null {
+  if (f.file === null) return null;
+  return f.line === null ? f.file : `${f.file}:${f.line}`;
+}
+
+export function SkillFindings({ verb, result, testId }: {
+  /** The verb the result answers — "Save", "Enable", "Reset", "Publish"… */
+  verb: string;
+  result: SkillGuardResult;
+  testId: string;
+}): React.ReactElement {
+  const color = VERDICT_COLOR[result.verdict];
+  return (
+    <div
+      data-testid={testId}
+      data-verdict={result.verdict}
+      role="status"
+      className="flex flex-col gap-1.5 rounded px-3 py-2 text-[11px]"
+      style={{ background: 'var(--surface-rail)', border: `1px solid ${color}` }}
+    >
+      <p className="font-semibold" style={{ color }}>{verdictLine(verb, result)}</p>
+      {result.findings.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {result.findings.map((f, i) => {
+            const location = findingLocation(f);
+            return (
+              <li
+                key={`${f.kind}-${i}`}
+                data-testid="skills-finding"
+                data-kind={f.kind}
+                data-severity={f.severity}
+                className="flex flex-col gap-0.5"
+                style={{ color: 'var(--ink-muted)' }}
+              >
+                <span className="inline-flex flex-wrap items-center gap-1.5">
+                  <span className="rounded px-1.5 text-[10px] font-mono" style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}>
+                    {f.kind}
+                  </span>
+                  <span className="text-[10px] font-mono uppercase" style={{ color: f.severity === 'blocking' ? 'var(--status-fail)' : 'var(--ink-dim)' }}>
+                    {f.severity}
+                  </span>
+                  {f.skill !== null && (
+                    <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>against {f.skill}</span>
+                  )}
+                  {location !== null && (
+                    <code data-testid="skills-finding-location" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{location}</code>
+                  )}
+                </span>
+                <span>{f.explanation}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/SkillFindings.tsx
+++ b/src/components/SkillFindings.tsx
@@ -1,10 +1,14 @@
-import type { SkillFinding, SkillGuardResult, SkillVerdict } from '../api/skills.js';
+import type { SkillConflictFinding, SkillGuardResult, SkillVerdict } from '../api/skills.js';
 
 /**
- * The guard envelope of ONE write / enable / publish / analyze, rendered honestly: the verdict
- * line names the verb and the outcome (`clear` — no findings; `warnings` — passed, read them;
- * `blocked` — REFUSED, nothing was written), then every finding with the guard that fired, its
- * severity, the skill it is against, and the `file:line` the daemon cited.
+ * The guard envelope of ONE write / enable / publish / analyze (`{verdict, findings, revision}` —
+ * api-types 0.27.0 `SkillAnalyzeResult`, the base of every mutation result), rendered honestly:
+ * the verdict line names the verb and the outcome (`clear` — no findings; `warnings` — proceeded,
+ * read them; `blocked` — REFUSED, nothing was written), then every finding GENERICALLY — whatever
+ * its `kind` (the contract's `SkillFindingKind` grows; nothing here enumerates it): the guard that
+ * fired, its severity, the skill it is about, the OTHER skill it is against (a collision, a core
+ * guard — marked when that one is core), the `file:line` the daemon cited, the concrete EVIDENCE
+ * (names, paths, the parse error) and the explanation of why it matters.
  */
 
 export const VERDICT_COLOR: Record<SkillVerdict, string> = {
@@ -22,7 +26,7 @@ function verdictLine(verb: string, result: SkillGuardResult): string {
 }
 
 /** `file` alone, or `file:line` when the daemon cited a line. */
-export function findingLocation(f: SkillFinding): string | null {
+export function findingLocation(f: Pick<SkillConflictFinding, 'file' | 'line'>): string | null {
   if (f.file === null) return null;
   return f.line === null ? f.file : `${f.file}:${f.line}`;
 }
@@ -34,15 +38,26 @@ export function SkillFindings({ verb, result, testId }: {
   testId: string;
 }): React.ReactElement {
   const color = VERDICT_COLOR[result.verdict];
+  const blocking = result.findings.filter((f) => f.severity === 'blocking').length;
+  const warnings = result.findings.length - blocking;
   return (
     <div
       data-testid={testId}
       data-verdict={result.verdict}
+      data-revision={result.revision}
       role="status"
       className="flex flex-col gap-1.5 rounded px-3 py-2 text-[11px]"
       style={{ background: 'var(--surface-rail)', border: `1px solid ${color}` }}
     >
-      <p className="font-semibold" style={{ color }}>{verdictLine(verb, result)}</p>
+      <p className="flex flex-wrap items-baseline gap-2">
+        <span className="font-semibold" style={{ color }}>{verdictLine(verb, result)}</span>
+        {result.findings.length > 0 && (
+          <span data-testid="skills-findings-tally" className="font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+            {blocking} blocking · {warnings} {warnings === 1 ? 'warning' : 'warnings'}
+          </span>
+        )}
+        <span className="ml-auto font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }} title="the catalog revision after this call">rev {result.revision}</span>
+      </p>
       {result.findings.length > 0 && (
         <ul className="flex flex-col gap-1">
           {result.findings.map((f, i) => {
@@ -60,16 +75,24 @@ export function SkillFindings({ verb, result, testId }: {
                   <span className="rounded px-1.5 text-[10px] font-mono" style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)' }}>
                     {f.kind}
                   </span>
-                  <span className="text-[10px] font-mono uppercase" style={{ color: f.severity === 'blocking' ? 'var(--status-fail)' : 'var(--ink-dim)' }}>
+                  <span className="text-[10px] font-mono uppercase" style={{ color: f.severity === 'blocking' ? 'var(--status-fail)' : 'var(--status-gate)' }}>
                     {f.severity}
                   </span>
                   {f.skill !== null && (
-                    <span className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>against {f.skill}</span>
+                    <span data-testid="skills-finding-skill" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{f.skill}</span>
+                  )}
+                  {f.againstSkill !== null && (
+                    <span data-testid="skills-finding-against" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>
+                      against {f.againstSkill}{f.againstIsCore ? ' (core)' : ''}
+                    </span>
                   )}
                   {location !== null && (
                     <code data-testid="skills-finding-location" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{location}</code>
                   )}
                 </span>
+                {f.evidence !== '' && (
+                  <code data-testid="skills-finding-evidence" className="break-all text-[10px] font-mono" style={{ color: 'var(--ink-high)' }}>{f.evidence}</code>
+                )}
                 <span>{f.explanation}</span>
               </li>
             );

--- a/src/components/SkillsGrid.tsx
+++ b/src/components/SkillsGrid.tsx
@@ -105,7 +105,11 @@ export function SkillsGrid({ rows, facets, onFacets, selectedName, busyName, fro
                     data-testid="skills-row"
                     data-skill={r.name}
                     data-enabled={r.enabled}
-                    aria-selected={selected}
+                    // A plain <table> row is not a selectable ARIA widget (`aria-selected` belongs to
+                    // option/gridcell/tab); `aria-current` is the global attribute for "the one the
+                    // drawer is open on", and `data-selected` is the styling/test hook.
+                    aria-current={selected ? 'true' : undefined}
+                    data-selected={selected}
                     onClick={() => onSelect(r.name)}
                     className="cursor-pointer align-middle transition-colors"
                     style={{

--- a/src/components/SkillsGrid.tsx
+++ b/src/components/SkillsGrid.tsx
@@ -59,7 +59,8 @@ export function SkillsGrid({ rows, facets, onFacets, selectedName, busyName, fro
   selectedName: string | null;
   /** The skill with a write in flight — its switch waits. */
   busyName: string | null;
-  /** The catalog changed under the page (a revision conflict) — every switch waits for the reload. */
+  /** Writes are frozen page-wide (a revision conflict, a stale catalog, a write or page verb in
+   *  flight) — every switch waits. */
   frozen: boolean;
   onSelect: (name: string) => void;
   onToggle: (row: SkillRow) => void;

--- a/src/components/SkillsGrid.tsx
+++ b/src/components/SkillsGrid.tsx
@@ -1,0 +1,151 @@
+import { SKILL_KINDS, isSkillKind, type SkillRow } from '../api/skills.js';
+import { FilterStrip } from './dashboardKit.js';
+import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
+
+/**
+ * The skills CATALOG — one row per skill in the manifest: name · kind · provenance · flags (core /
+ * claude-only / conflict / unpublished) · the enabled switch. A row click opens the drawer (the
+ * SteeringGrid row/drawer-open idiom); the switch is the ONE inline write — it flips through the
+ * daemon's guards and the row shows the manifest's answer, never an optimistic one.
+ *
+ * Facets stay client-side over the one manifest fetch (FilterStrip: search + ONE chip — every
+ * kind, plus the state cuts the KPI tiles open). NOT virtualized on purpose: the catalog is ~140
+ * rows.
+ */
+
+/** The facet chips — the three kinds plus the state cuts the KPI tiles are doors into. */
+export const SKILL_CHIPS = ['all', ...SKILL_KINDS, 'enabled', 'disabled', 'overridden', 'core', 'portable', 'claude-only'] as const;
+
+export type SkillChip = (typeof SKILL_CHIPS)[number];
+
+export interface SkillsFacets {
+  query: string;
+  chip: SkillChip;
+}
+
+export const SKILLS_FACETS_DEFAULT: SkillsFacets = { query: '', chip: 'all' };
+
+/** The facet predicate over the manifest rows — pinned by unit test so the chip counts, the
+ *  KPI tiles and the table agree. */
+export function filterSkills(rows: readonly SkillRow[], f: SkillsFacets): SkillRow[] {
+  const q = f.query.trim().toLowerCase();
+  return rows.filter((r) => {
+    if (isSkillKind(f.chip) && r.kind !== f.chip) return false;
+    if (f.chip === 'enabled' && !r.enabled) return false;
+    if (f.chip === 'disabled' && r.enabled) return false;
+    if (f.chip === 'overridden' && r.provenance !== 'override') return false;
+    if (f.chip === 'core' && !r.core) return false;
+    if (f.chip === 'portable' && !r.portable) return false;
+    if (f.chip === 'claude-only' && r.portable) return false;
+    if (q !== '' && !r.name.toLowerCase().includes(q) && !r.dir.toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
+
+const TH: React.CSSProperties = {
+  color: 'var(--ink-dim)',
+  fontSize: '10px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 'var(--weight-semi)',
+  textAlign: 'left',
+};
+
+export function SkillsGrid({ rows, facets, onFacets, selectedName, busyName, frozen, onSelect, onToggle }: {
+  rows: readonly SkillRow[];
+  facets: SkillsFacets;
+  onFacets: (next: SkillsFacets) => void;
+  /** The skill whose drawer is open — its row reads selected. */
+  selectedName: string | null;
+  /** The skill with a write in flight — its switch waits. */
+  busyName: string | null;
+  /** The catalog changed under the page (a revision conflict) — every switch waits for the reload. */
+  frozen: boolean;
+  onSelect: (name: string) => void;
+  onToggle: (row: SkillRow) => void;
+}): React.ReactElement {
+  const shown = filterSkills(rows, facets);
+  const count = (chip: SkillChip): number => filterSkills(rows, { query: facets.query, chip }).length;
+
+  return (
+    <div data-testid="skills-grid" className="flex min-w-0 flex-col gap-2">
+      <FilterStrip
+        testId="skills-filter"
+        query={facets.query}
+        onQuery={(q) => onFacets({ ...facets, query: q })}
+        placeholder="Search skill name or dir…"
+        chips={SKILL_CHIPS.map((c) => ({ id: c, label: c, count: count(c) }))}
+        active={facets.chip}
+        onChip={(id) => onFacets({ ...facets, chip: id as SkillChip })}
+      />
+
+      {shown.length === 0 ? (
+        <p data-testid="skills-grid-empty" className="text-xs" style={{ color: 'var(--ink-dim)' }}>
+          {rows.length === 0 ? 'The manifest lists no skills.' : 'No skills match these filters.'}
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded" style={{ border: '1px solid var(--surface-raised)' }}>
+          <table className="w-full border-collapse" style={{ minWidth: '40rem' }}>
+            <thead>
+              <tr style={{ background: 'var(--surface-rail)' }}>
+                <th className="px-2 py-1.5" style={TH}>Skill</th>
+                <th className="px-2 py-1.5" style={TH}>Kind</th>
+                <th className="px-2 py-1.5" style={TH}>Provenance</th>
+                <th className="px-2 py-1.5" style={TH}>Flags</th>
+                <th className="px-2 py-1.5" style={{ ...TH, textAlign: 'right' }}>Enabled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((r) => {
+                const selected = r.name === selectedName;
+                return (
+                  <tr
+                    key={r.name}
+                    data-testid="skills-row"
+                    data-skill={r.name}
+                    data-enabled={r.enabled}
+                    aria-selected={selected}
+                    onClick={() => onSelect(r.name)}
+                    className="cursor-pointer align-middle transition-colors"
+                    style={{
+                      borderTop: '1px solid var(--surface-raised)',
+                      background: selected ? 'var(--accent-subtle)' : 'transparent',
+                      opacity: r.enabled ? 1 : 0.6,
+                    }}
+                  >
+                    <td className="px-2 py-1.5">
+                      <button
+                        type="button"
+                        data-testid="skills-row-name"
+                        aria-label={`Open ${r.name}`}
+                        onClick={(e) => { e.stopPropagation(); onSelect(r.name); }}
+                        className="block max-w-[28rem] truncate text-left font-mono text-[11px] hover:underline focus:outline-none focus-visible:ring-1"
+                        style={{ color: 'var(--ink-high)', background: 'transparent' }}
+                        title={r.dir}
+                      >
+                        {r.name}
+                      </button>
+                      <span className="block truncate font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>{r.dir}</span>
+                    </td>
+                    <td className="px-2 py-1.5"><KindChip kind={r.kind} /></td>
+                    <td className="px-2 py-1.5"><ProvenanceChip provenance={r.provenance} /></td>
+                    <td className="px-2 py-1.5"><SkillFlags skill={r} /></td>
+                    <td className="px-2 py-1.5 text-right" onClick={(e) => e.stopPropagation()}>
+                      <EnabledToggle
+                        testId="skills-toggle"
+                        name={r.name}
+                        enabled={r.enabled}
+                        busy={frozen || busyName === r.name}
+                        onToggle={() => onToggle(r)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -1,0 +1,438 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { apiWire } from '../api/errors.js';
+import {
+  analyzeSkills,
+  getSkillsCatalog,
+  isSkillsConflict,
+  isSkillsUnsupported,
+  isUnpublished,
+  publishSkills,
+  readSkillDeepLink,
+  refreshSkillsBaseline,
+  setSkillEnabled,
+  skillCounts,
+  skillRows,
+  skillsPath,
+  SKILLS_UNSUPPORTED_COPY,
+  supportFiles,
+  type SkillGuardResult,
+  type SkillRow,
+  type SkillsCatalog,
+} from '../api/skills.js';
+import { KpiBand, KpiGroup, StatTile } from './dashboardKit.js';
+import { SkillDrawer } from './SkillDrawer.js';
+import { SkillFilesMapModal } from './SkillFilesMapModal.js';
+import { SkillFindings } from './SkillFindings.js';
+import { SkillsGrid, SKILLS_FACETS_DEFAULT, type SkillsFacets } from './SkillsGrid.js';
+import type { SkillsWriter } from './skillsWriter.js';
+
+/**
+ * The Skills surface (`/skills`, the skills keystone) — a FILE MANAGER over the daemon's one
+ * effective garden-shaped plugin root, the skills every governed worker runs:
+ *
+ *  - the KPI band (total · enabled · overridden · core · portable) over the manifest, each tile a
+ *    door into the matching catalog filter;
+ *  - the CATALOG (SkillsGrid): one row per skill with kind / provenance / flags and the enabled
+ *    switch — the one inline write, through the daemon's guards;
+ *  - the DRAWER (SkillDrawer) a row opens: skill files + support files under tabs, the textarea
+ *    editor (Save → PUT → findings), reset / replace / delete. `?skill=<name>` is the drawer's
+ *    address — selecting a row is a real navigation (deep-linkable, back-button-correct);
+ *  - the page verbs: Add (a pasted files map), Refresh baseline (the three-way upgrade), Analyze
+ *    (the publish validation as a dry run) and PUBLISH — validate the whole tree and write the
+ *    immutable snapshot generation workers spawn with. Nothing here is live until published.
+ *
+ * CAS: the page holds the catalog `revision`; every write goes through {@link SkillsWriter}
+ * (`expectedRevision` out, the answered `revision` adopted). A **409** freezes the page behind the
+ * reload prompt — nothing else is written until the catalog is re-read.
+ *
+ * A daemon without the `/skills` routes renders the NAMED unsupported state — never a crash and
+ * never an empty catalog pretending. Every write goes through crew's API (the guarded operator
+ * path); nothing here touches the root directly.
+ */
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'loaded' }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; message: string };
+
+type PageVerb = 'refresh' | 'analyze' | 'publish';
+
+const PAGE_VERB_LABEL: Record<PageVerb, string> = {
+  refresh: 'Refresh baseline',
+  analyze: 'Analyze',
+  publish: 'Publish',
+};
+
+export function SkillsPage({ navigate, search = '' }: {
+  navigate: (path: string) => void;
+  /** The URL search string — `?skill=<name>` addresses one skill's drawer. */
+  search?: string;
+}): React.ReactElement {
+  const [catalog, setCatalog] = useState<SkillsCatalog | null>(null);
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [facets, setFacets] = useState<SkillsFacets>(SKILLS_FACETS_DEFAULT);
+  /** The skill with a write in flight from this page (a row toggle) — its switch waits. */
+  const [busyName, setBusyName] = useState<string | null>(null);
+  /** The page verb in flight — its button waits. */
+  const [verbBusy, setVerbBusy] = useState<PageVerb | null>(null);
+  /** The last page-level guard result worth reading (a toggle's warnings, a publish's findings). */
+  const [pageResult, setPageResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  /** A 409 — the catalog changed under this page. The daemon's sentence, for the prompt. */
+  const [conflict, setConflict] = useState<string | null>(null);
+  /** The revision every mutation is conditioned on — a ref so chained writes read the latest. */
+  const revisionRef = useRef<string | null>(null);
+
+  const load = useCallback(async (): Promise<SkillsCatalog | null> => {
+    try {
+      const c = await getSkillsCatalog();
+      revisionRef.current = c.revision;
+      setCatalog(c);
+      setState({ kind: 'loaded' });
+      return c;
+    } catch (e) {
+      if (isSkillsUnsupported(e)) setState({ kind: 'unsupported' });
+      else setState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  /** The ONE CAS seam: expectedRevision out, the answered revision adopted, a 409 → the prompt. */
+  const run = useCallback(async (mutation: (expectedRevision: string) => Promise<SkillGuardResult>): Promise<SkillGuardResult | null> => {
+    const expected = revisionRef.current;
+    if (expected === null) throw new Error('the skills catalog has not loaded — nothing to write against');
+    try {
+      const result = await mutation(expected);
+      revisionRef.current = result.revision;
+      return result;
+    } catch (e) {
+      if (isSkillsConflict(e)) {
+        setConflict(apiWire(e) ?? '');
+        return null;
+      }
+      throw e;
+    }
+  }, []);
+  const writer = useMemo<SkillsWriter>(() => ({ run }), [run]);
+
+  const reloadAfterConflict = (): void => {
+    setConflict(null);
+    setPageResult(null);
+    void load();
+  };
+
+  const rows: SkillRow[] = catalog === null ? [] : skillRows(catalog.manifest);
+  const counts = skillCounts(rows);
+  const unpublished = rows.filter(isUnpublished).length;
+  const support = useMemo(() => (catalog === null ? [] : supportFiles(catalog.manifest)), [catalog]);
+
+  // The drawer's address: `?skill=<name>`. A name the manifest does not carry renders a note,
+  // never a silent swap onto the bare catalog (the dead-address contract, review #4).
+  const linked = readSkillDeepLink(search);
+  const selected = linked === null ? null : rows.find((r) => r.name === linked) ?? null;
+  const linkedMissing = linked !== null && catalog !== null && selected === null;
+
+  /** The ONE guarded flip: the catalog reloaded on anything but `blocked`, the verdict handed back. */
+  const toggle = useCallback(async (name: string, enabled: boolean): Promise<SkillGuardResult | null> => {
+    setBusyName(name);
+    try {
+      const result = await run((rev) => setSkillEnabled(name, enabled, rev));
+      if (result !== null && result.verdict !== 'blocked') await load();
+      return result;
+    } finally {
+      setBusyName(null);
+    }
+  }, [run, load]);
+
+  const onRowToggle = (row: SkillRow): void => {
+    setPageError(null);
+    setPageResult(null);
+    void toggle(row.name, !row.enabled)
+      .then((result) => {
+        // A clear flip needs no banner — the row's switch IS the answer; warnings and refusals do.
+        if (result !== null && (result.verdict !== 'clear' || result.findings.length > 0)) {
+          setPageResult({ verb: `${row.enabled ? 'Disable' : 'Enable'} ${row.name}`, result });
+        }
+      })
+      .catch((e: unknown) => setPageError(e instanceof Error ? e.message : String(e)));
+  };
+
+  /** The three page verbs share one shape: run, show the envelope, reload on an applied write. */
+  const pageVerb = async (verb: PageVerb): Promise<void> => {
+    setVerbBusy(verb);
+    setPageError(null);
+    setPageResult(null);
+    setNote(null);
+    try {
+      const result = verb === 'analyze'
+        ? await analyzeSkills()
+        : await run((rev) => (verb === 'publish' ? publishSkills(rev) : refreshSkillsBaseline(rev)));
+      if (result === null) return;
+      setPageResult({ verb: PAGE_VERB_LABEL[verb], result });
+      if (verb === 'analyze' || result.verdict === 'blocked') return;
+      const next = await load();
+      if (next === null) return;
+      const m = next.manifest;
+      setNote(verb === 'publish'
+        ? `Published — snapshot generation ${m.currentGeneration ?? '?'} is current; workers spawn with it from now on.`
+        : `Baseline refreshed — ${m.baseline.source.plugin_version} (${m.baseline.contentHash.slice(0, 12)}), ${Object.keys(m.skills).length} skills. Your edits were kept; conflicts are flagged.`);
+    } catch (e) {
+      setPageError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setVerbBusy(null);
+    }
+  };
+
+  const onAdded = (name: string, result: SkillGuardResult): void => {
+    setAddOpen(false);
+    setNote(`Added ${name} — publish to hand it to workers.`);
+    setPageResult(result.findings.length > 0 ? { verb: `Add ${name}`, result } : null);
+    void load().then(() => navigate(skillsPath(name)));
+  };
+
+  const onDeleted = (name: string, result: SkillGuardResult): void => {
+    setNote(`Deleted ${name} — removed from the effective root; the current snapshot keeps it until the next publish.`);
+    setPageResult(result.findings.length > 0 ? { verb: `Delete ${name}`, result } : null);
+    navigate(skillsPath());
+    void load();
+  };
+
+  const baseline = catalog?.manifest.baseline ?? null;
+  const generation = catalog?.manifest.currentGeneration ?? null;
+  const frozen = conflict !== null;
+
+  const verbButton = (verb: PageVerb, testId: string, title: string, primary: boolean): React.ReactElement => (
+    <button
+      type="button"
+      data-testid={testId}
+      disabled={frozen || verbBusy !== null}
+      title={title}
+      onClick={() => void pageVerb(verb)}
+      className="rounded px-2 py-1 text-[11px] font-semibold disabled:opacity-40"
+      style={primary
+        ? { background: 'var(--accent)', color: 'var(--accent-fg)' }
+        : { color: 'var(--accent)', border: '1px solid var(--surface-raised)' }}
+    >
+      {verbBusy === verb ? `${PAGE_VERB_LABEL[verb]}…` : PAGE_VERB_LABEL[verb]}
+    </button>
+  );
+
+  return (
+    <div data-testid="skills-page" className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden">
+      <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Skills</h2>
+            <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+              The skills every governed worker runs — one effective plugin root the daemon publishes
+              as immutable snapshots. Edit any file in place, enable or disable, reset to the baseline;
+              the daemon guards every write, and nothing reaches a worker until you publish.
+            </p>
+            {baseline !== null && (
+              <p data-testid="skills-source" className="mt-1 font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>
+                baseline {baseline.source.plugin_version} · {baseline.source.kind} · {baseline.contentHash.slice(0, 12)}
+                {baseline.source.git_sha !== null && ` · ${baseline.source.git_sha.slice(0, 10)}`}
+                {` · captured ${baseline.source.captured_at}`}
+              </p>
+            )}
+            {catalog !== null && (
+              <p data-testid="skills-snapshot" data-generation={generation ?? 'none'} data-unpublished={unpublished} className="mt-0.5 font-mono text-[10px]" style={{ color: unpublished > 0 ? 'var(--status-run)' : 'var(--ink-dim)' }}>
+                {generation === null ? 'never published — workers fall back to the installed plugin' : `snapshot generation ${generation} is current`}
+                {unpublished > 0 && ` · ${unpublished} unpublished ${unpublished === 1 ? 'skill' : 'skills'}`}
+              </p>
+            )}
+          </div>
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {state.kind === 'loaded' && (
+              <>
+                <button
+                  type="button"
+                  data-testid="skills-add-open"
+                  disabled={frozen}
+                  onClick={() => setAddOpen(true)}
+                  className="rounded px-2 py-1 text-[11px] font-semibold disabled:opacity-40"
+                  style={{ color: 'var(--accent)', border: '1px solid var(--surface-raised)' }}
+                >
+                  Add skill…
+                </button>
+                {verbButton('refresh', 'skills-refresh', 'Capture the installed plugin as a new baseline and merge it three-way per file: untouched skills take the new version, your edits are kept and conflicts flagged — never clobbered', false)}
+                {verbButton('analyze', 'skills-analyze', 'Dry-run the publish validation over the whole tree — the same findings, nothing written', false)}
+                {verbButton('publish', 'skills-publish', 'Validate the whole tree and write the immutable snapshot generation workers spawn with (enabled skills only)', true)}
+              </>
+            )}
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="text-[10px] hover:underline"
+              style={{ color: 'var(--ink-dim)' }}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {state.kind === 'loading' ? (
+          <p data-testid="skills-loading" className="text-xs" style={{ color: 'var(--ink-dim)' }}>Loading skills…</p>
+        ) : state.kind === 'unsupported' ? (
+          <div
+            data-testid="skills-unsupported"
+            className="flex flex-col gap-2 rounded p-4"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)' }}
+          >
+            <p className="text-xs font-semibold" style={{ color: 'var(--ink-high)' }}>Skills are not served by this daemon.</p>
+            <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{SKILLS_UNSUPPORTED_COPY}</p>
+          </div>
+        ) : state.kind === 'failed' ? (
+          <p data-testid="skills-error" className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+            {state.message}
+          </p>
+        ) : (
+          <>
+            <KpiBand testId="skills-kpis">
+              <KpiGroup label="Catalog" grow={2}>
+                <StatTile
+                  testId="skills-kpi-total"
+                  label="Skills"
+                  value={counts.total}
+                  context={baseline === null ? undefined : `baseline ${baseline.source.plugin_version}`}
+                  onOpen={() => setFacets({ ...facets, chip: 'all' })}
+                />
+                <StatTile
+                  testId="skills-kpi-enabled"
+                  label="Enabled"
+                  value={counts.enabled}
+                  context={`${counts.total - counts.enabled} disabled`}
+                  onOpen={() => setFacets({ ...facets, chip: 'enabled' })}
+                />
+              </KpiGroup>
+              <KpiGroup label="Provenance" grow={2}>
+                <StatTile
+                  testId="skills-kpi-overridden"
+                  label="Overridden"
+                  value={counts.overridden}
+                  context="edited from the baseline"
+                  valueColor={counts.overridden > 0 ? 'var(--status-gate)' : undefined}
+                  onOpen={() => setFacets({ ...facets, chip: 'overridden' })}
+                />
+                <StatTile
+                  testId="skills-kpi-core"
+                  label="Core"
+                  value={counts.core}
+                  context="in the workflow reference closure"
+                  onOpen={() => setFacets({ ...facets, chip: 'core' })}
+                />
+              </KpiGroup>
+              <KpiGroup label="Reach">
+                <StatTile
+                  testId="skills-kpi-portable"
+                  label="Portable"
+                  value={counts.portable}
+                  context={`${counts.total - counts.portable} claude-only`}
+                  onOpen={() => setFacets({ ...facets, chip: 'portable' })}
+                />
+              </KpiGroup>
+            </KpiBand>
+
+            {note !== null && (
+              <p
+                data-testid="skills-note"
+                className="rounded px-3 py-2 text-[11px]"
+                style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+              >
+                {note}
+              </p>
+            )}
+            {pageError !== null && (
+              <p data-testid="skills-page-error" className="rounded px-3 py-2 text-[11px]" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
+                {pageError}
+              </p>
+            )}
+            {pageResult !== null && (
+              <SkillFindings verb={pageResult.verb} result={pageResult.result} testId="skills-page-findings" />
+            )}
+            {linkedMissing && (
+              <p
+                data-testid="skills-deep-link-missing"
+                className="rounded px-3 py-2 text-[11px]"
+                style={{ background: 'var(--surface-rail)', border: '1px solid var(--surface-raised)', color: 'var(--ink-muted)' }}
+              >
+                No skill named <span className="font-mono">{linked}</span> in this catalog — showing every skill.
+              </p>
+            )}
+
+            <SkillsGrid
+              rows={rows}
+              facets={facets}
+              onFacets={setFacets}
+              selectedName={selected?.name ?? null}
+              busyName={busyName}
+              frozen={frozen}
+              onSelect={(name) => navigate(skillsPath(name))}
+              onToggle={onRowToggle}
+            />
+          </>
+        )}
+      </div>
+
+      {selected !== null && (
+        <SkillDrawer
+          key={selected.name}
+          skill={selected}
+          support={support}
+          writer={writer}
+          busy={frozen || busyName === selected.name}
+          onClose={() => navigate(skillsPath())}
+          onToggle={toggle}
+          onChanged={() => void load()}
+          onDeleted={onDeleted}
+        />
+      )}
+
+      {addOpen && (
+        <SkillFilesMapModal
+          mode="add"
+          name={null}
+          writer={writer}
+          onClose={() => setAddOpen(false)}
+          onDone={onAdded}
+        />
+      )}
+
+      {/* The revision-conflict prompt: above every layer (the drawer is z-40, modals z-50) so the
+          operator sees it wherever the stale write came from. Reload is the only way forward —
+          nothing else is written while it shows. Drafts in the drawer are kept. */}
+      {conflict !== null && (
+        <div
+          data-testid="skills-conflict"
+          role="alertdialog"
+          aria-label="The skills catalog changed"
+          className="fixed inset-x-0 top-3 z-[60] mx-auto flex w-[36rem] max-w-[92vw] flex-wrap items-center gap-2 rounded-lg px-4 py-3 text-[11px] shadow-2xl"
+          style={{ background: 'var(--surface-card)', border: '1px solid var(--status-gate)', color: 'var(--ink-muted)' }}
+        >
+          <span className="font-semibold" style={{ color: 'var(--status-gate)' }}>The skills catalog changed under this page.</span>
+          <span>
+            Nothing was written{conflict !== '' ? ` — ${conflict}` : ''}. Reload to pick up the current revision;
+            unsaved edits in the drawer are kept as drafts.
+          </span>
+          <span className="flex-1" />
+          <button
+            data-testid="skills-conflict-reload"
+            type="button"
+            onClick={reloadAfterConflict}
+            className="rounded px-3 py-1 text-[11px] font-semibold"
+            style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
+          >
+            Reload catalog
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -43,7 +43,8 @@ import type { SkillsWriter } from './skillsWriter.js';
  *
  * CAS: the page holds the catalog `revision`; every write goes through {@link SkillsWriter}
  * (`expectedRevision` out, the answered `revision` adopted). A **409** freezes the page behind the
- * reload prompt — nothing else is written until the catalog is re-read. Every write also freezes
+ * reload prompt — nothing else is written until the catalog is re-read (the Add/Replace modal
+ * re-reads through the writer itself and keeps its files map for the retry). Every write also freezes
  * the others while it is in flight (they all share the one revision — overlapping writes could
  * only 409), and a catalog re-read that FAILS marks the page stale: the rows stay readable, every
  * write waits until a re-read succeeds. Each successful re-read bumps `catalogEpoch`, which the
@@ -97,6 +98,11 @@ export function SkillsPage({ navigate, search = '' }: {
   const [inFlight, setInFlight] = useState(0);
   /** The revision every mutation is conditioned on — a ref so chained writes read the latest. */
   const revisionRef = useRef<string | null>(null);
+  /** The open drawer has unsaved edits (it reports every flip). A row click on ANOTHER skill then
+   *  parks its name in `pendingSelect` and the drawer asks first — its `key` swaps only after the
+   *  operator discards, never under a draft (review round 2). */
+  const [drawerDirty, setDrawerDirty] = useState(false);
+  const [pendingSelect, setPendingSelect] = useState<string | null>(null);
 
   const load = useCallback(async (): Promise<SkillsCatalog | null> => {
     try {
@@ -145,13 +151,17 @@ export function SkillsPage({ navigate, search = '' }: {
       setInFlight((n) => n - 1);
     }
   }, []);
-  const writer = useMemo<SkillsWriter>(() => ({ run, revision: () => revisionRef.current }), [run]);
-
-  const reloadAfterConflict = (): void => {
+  /** After a 409: the prompt clears and the catalog is re-read. Also the writer's `reload` — the
+   *  Add/Replace modal calls it with its files map intact and retries against the revision it adopts. */
+  const reloadAfterConflict = useCallback(async (): Promise<void> => {
     setConflict(null);
     setPageResult(null);
-    void load();
-  };
+    await load();
+  }, [load]);
+  const writer = useMemo<SkillsWriter>(
+    () => ({ run, revision: () => revisionRef.current, reload: reloadAfterConflict }),
+    [run, reloadAfterConflict],
+  );
 
   const rows: SkillRow[] = catalog === null ? [] : skillRows(catalog.manifest);
   const counts = skillCounts(rows);
@@ -163,6 +173,31 @@ export function SkillsPage({ navigate, search = '' }: {
   const linked = readSkillDeepLink(search);
   const selected = linked === null ? null : rows.find((r) => r.name === linked) ?? null;
   const linkedMissing = linked !== null && catalog !== null && selected === null;
+  const selectedName = selected?.name ?? null;
+
+  // A parked selection belongs to the drawer it was asked from: when that drawer goes (a close, a
+  // discard, a skill that left the catalog) the request goes with it — a later drawer never
+  // inherits a stale "open X?" prompt.
+  useEffect(() => {
+    setPendingSelect(null);
+  }, [selectedName]);
+
+  /** A row click is a navigation to `?skill=<name>` — unless the open drawer is dirty and the click
+   *  names another skill: then the drawer's discard confirmation asks first, and the navigation
+   *  runs only when the operator answers `onLeave(true)`. */
+  const selectSkill = (name: string): void => {
+    if (selectedName !== null && name !== selectedName && drawerDirty) {
+      setPendingSelect(name);
+      return;
+    }
+    navigate(skillsPath(name));
+  };
+
+  const onLeave = (proceed: boolean): void => {
+    const to = pendingSelect;
+    setPendingSelect(null);
+    if (proceed && to !== null) navigate(skillsPath(to));
+  };
 
   /** The ONE guarded flip: the catalog reloaded on anything but `blocked`, the verdict handed back. */
   const toggle = useCallback(async (name: string, enabled: boolean): Promise<SkillGuardResult | null> => {
@@ -417,7 +452,7 @@ export function SkillsPage({ navigate, search = '' }: {
               selectedName={selected?.name ?? null}
               busyName={busyName}
               frozen={frozen}
-              onSelect={(name) => navigate(skillsPath(name))}
+              onSelect={selectSkill}
               onToggle={onRowToggle}
             />
           </>
@@ -432,7 +467,10 @@ export function SkillsPage({ navigate, search = '' }: {
           writer={writer}
           catalogEpoch={catalogEpoch}
           busy={frozen || busyName === selected.name}
+          leaveTo={pendingSelect}
           onClose={() => navigate(skillsPath())}
+          onLeave={onLeave}
+          onDirtyChange={setDrawerDirty}
           onToggle={toggle}
           onChanged={() => void load()}
         />
@@ -468,7 +506,7 @@ export function SkillsPage({ navigate, search = '' }: {
           <button
             data-testid="skills-conflict-reload"
             type="button"
-            onClick={reloadAfterConflict}
+            onClick={() => void reloadAfterConflict()}
             className="rounded px-3 py-1 text-[11px] font-semibold"
             style={{ background: 'var(--status-gate)', color: 'var(--surface-base)' }}
           >

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -35,7 +35,7 @@ import type { SkillsWriter } from './skillsWriter.js';
  *  - the CATALOG (SkillsGrid): one row per skill with kind / provenance / flags and the enabled
  *    switch — the one inline write, through the daemon's guards;
  *  - the DRAWER (SkillDrawer) a row opens: skill files + support files under tabs, the textarea
- *    editor (Save → PUT → findings), reset / replace / delete. `?skill=<name>` is the drawer's
+ *    editor (Save → PUT → findings), reset / replace. `?skill=<name>` is the drawer's
  *    address — selecting a row is a real navigation (deep-linkable, back-button-correct);
  *  - the page verbs: Add (a pasted files map), Refresh baseline (the three-way upgrade), Analyze
  *    (the publish validation as a dry run) and PUBLISH — validate the whole tree and write the
@@ -195,13 +195,6 @@ export function SkillsPage({ navigate, search = '' }: {
     setNote(`Added ${name} — publish to hand it to workers.`);
     setPageResult(result.findings.length > 0 ? { verb: `Add ${name}`, result } : null);
     void load().then(() => navigate(skillsPath(name)));
-  };
-
-  const onDeleted = (name: string, result: SkillGuardResult): void => {
-    setNote(`Deleted ${name} — removed from the effective root; the current snapshot keeps it until the next publish.`);
-    setPageResult(result.findings.length > 0 ? { verb: `Delete ${name}`, result } : null);
-    navigate(skillsPath());
-    void load();
   };
 
   const baseline = catalog?.manifest.baseline ?? null;
@@ -391,7 +384,6 @@ export function SkillsPage({ navigate, search = '' }: {
           onClose={() => navigate(skillsPath())}
           onToggle={toggle}
           onChanged={() => void load()}
-          onDeleted={onDeleted}
         />
       )}
 

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getDiagnostics } from '../api/diagnostics.js';
 import { apiWire } from '../api/errors.js';
 import {
   analyzeSkills,
+  currentBaseline,
   getSkillsCatalog,
   isSkillsConflict,
+  isSkillsUnavailable,
   isSkillsUnsupported,
-  isUnpublished,
   publishSkills,
   readSkillDeepLink,
   refreshSkillsBaseline,
@@ -13,9 +15,13 @@ import {
   skillCounts,
   skillRows,
   skillsPath,
+  SKILLS_ENGINE_STATE_COPY,
   SKILLS_UNSUPPORTED_COPY,
   supportFiles,
+  type DiagnosticsSkills,
+  type SkillAnalyzeResult,
   type SkillGuardResult,
+  type SkillMutationResult,
   type SkillRow,
   type SkillsCatalog,
 } from '../api/skills.js';
@@ -28,38 +34,50 @@ import type { SkillsWriter } from './skillsWriter.js';
 
 /**
  * The Skills surface (`/skills`, the skills keystone) — a FILE MANAGER over the daemon's one
- * effective garden-shaped plugin root, the skills every governed worker runs:
+ * effective garden-shaped plugin root, the skills every governed worker runs (api-types 0.27.0,
+ * crew#480):
  *
  *  - the KPI band (total · enabled · overridden · core · portable) over the manifest, each tile a
  *    door into the matching catalog filter;
  *  - the CATALOG (SkillsGrid): one row per skill with kind / provenance / flags and the enabled
  *    switch — the one inline write, through the daemon's guards;
  *  - the DRAWER (SkillDrawer) a row opens: skill files + support files under tabs, the textarea
- *    editor (Save → PUT → findings), reset / replace. `?skill=<name>` is the drawer's
- *    address — selecting a row is a real navigation (deep-linkable, back-button-correct);
+ *    editor (Save → PUT → findings), the baseline side, reset / replace. `?skill=<name>` is the
+ *    drawer's address — selecting a row is a real navigation (deep-linkable, back-button-correct);
  *  - the page verbs: Add (a pasted files map), Refresh baseline (the three-way upgrade), Analyze
- *    (the publish validation as a dry run) and PUBLISH — validate the whole tree and write the
- *    immutable snapshot generation workers spawn with. Nothing here is live until published.
+ *    (the publish validation as a pure dry run) and PUBLISH — validate the whole tree and write the
+ *    immutable snapshot generation workers spawn with. Nothing here is live until published;
+ *  - the ENGINE line (`GET /diagnostics` → `skills`, read-only): whether the engine is actually
+ *    being handed a verified snapshot (`published`), or why not (`fallback` / `blocked` /
+ *    `config-error` / `disabled`) — the one answer to "why do launches refuse the skills snapshot".
  *
- * CAS: the page holds the catalog `revision`; every write goes through {@link SkillsWriter}
- * (`expectedRevision` out, the answered `revision` adopted). A **409** freezes the page behind the
- * reload prompt — nothing else is written until the catalog is re-read (the Add/Replace modal
- * re-reads through the writer itself and keeps its files map for the retry). Every write also freezes
- * the others while it is in flight (they all share the one revision — overlapping writes could
- * only 409), and a catalog re-read that FAILS marks the page stale: the rows stay readable, every
- * write waits until a re-read succeeds. Each successful re-read bumps `catalogEpoch`, which the
- * drawer reconciles its open file against — a Refresh never advances the write revision past
- * content the editor read earlier.
+ * CAS: the page holds the catalog `revision` (a number, bumped by every mutation); every write
+ * goes through {@link SkillsWriter} (`expectedRevision` out, the answered `revision` adopted). A
+ * **409** — exclusively a stale `expectedRevision` — freezes the page behind the reload prompt;
+ * nothing else is written until the catalog is re-read (the Add/Replace modal re-reads through the
+ * writer itself and keeps its files map for the retry). Every write also freezes the others while
+ * it is in flight (they all share the one revision — overlapping writes could only 409), and a
+ * catalog re-read that FAILS marks the page stale: the rows stay readable, every write waits until
+ * a re-read succeeds. Each successful re-read bumps `catalogEpoch`, which the drawer reconciles its
+ * open file against — a Refresh never advances the write revision past content the editor read
+ * earlier.
  *
- * A daemon without the `/skills` routes renders the NAMED unsupported state — never a crash and
- * never an empty catalog pretending. Every write goes through crew's API (the guarded operator
- * path); nothing here touches the root directly.
+ * Every 2xx mutation answer is an envelope `{verdict, findings, revision}`: `blocked` = the daemon
+ * refused and wrote nothing (a normal answer, rendered as the findings — never an exception);
+ * `warnings` = it proceeded (a publish WROTE its snapshot) and the findings are worth reading.
+ *
+ * The honest non-catalog states: a daemon WITHOUT the `/skills` routes (bare 404) renders the
+ * named unsupported state; a daemon whose route answers **503** — an unseeded root (no installed
+ * plugin), a `current` that fails verification, no skills seam — renders the daemon's sentence as
+ * the named UNAVAILABLE state. Never a crash and never an empty catalog pretending. Every write
+ * goes through crew's API (the guarded operator path); nothing here touches the root directly.
  */
 
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'loaded' }
   | { kind: 'unsupported' }
+  | { kind: 'unavailable'; message: string }
   | { kind: 'failed'; message: string };
 
 type PageVerb = 'refresh' | 'analyze' | 'publish';
@@ -68,6 +86,15 @@ const PAGE_VERB_LABEL: Record<PageVerb, string> = {
   refresh: 'Refresh baseline',
   analyze: 'Analyze',
   publish: 'Publish',
+};
+
+/** The engine line's color by `diagnostics.skills.state`. */
+const ENGINE_STATE_COLOR: Record<DiagnosticsSkills['state'], string> = {
+  published: 'var(--status-done)',
+  fallback: 'var(--status-gate)',
+  blocked: 'var(--status-fail)',
+  'config-error': 'var(--status-fail)',
+  disabled: 'var(--ink-dim)',
 };
 
 export function SkillsPage({ navigate, search = '' }: {
@@ -82,7 +109,7 @@ export function SkillsPage({ navigate, search = '' }: {
   const [busyName, setBusyName] = useState<string | null>(null);
   /** The page verb in flight — its button waits. */
   const [verbBusy, setVerbBusy] = useState<PageVerb | null>(null);
-  /** The last page-level guard result worth reading (a toggle's warnings, a publish's findings). */
+  /** The last page-level envelope worth reading (a toggle's warnings, a publish's findings). */
   const [pageResult, setPageResult] = useState<{ verb: string; result: SkillGuardResult } | null>(null);
   const [pageError, setPageError] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
@@ -97,12 +124,26 @@ export function SkillsPage({ navigate, search = '' }: {
   /** Writes in flight through the CAS seam — while any is, every other write affordance waits. */
   const [inFlight, setInFlight] = useState(0);
   /** The revision every mutation is conditioned on — a ref so chained writes read the latest. */
-  const revisionRef = useRef<string | null>(null);
+  const revisionRef = useRef<number | null>(null);
+  /** `GET /diagnostics` → `skills`: what the engine is being handed. `null` until read, or when
+   *  this daemon's diagnostics predate the seam / could not be read (never blocks the page). */
+  const [engine, setEngine] = useState<DiagnosticsSkills | null>(null);
   /** The open drawer has unsaved edits (it reports every flip). A row click on ANOTHER skill then
    *  parks its name in `pendingSelect` and the drawer asks first — its `key` swaps only after the
    *  operator discards, never under a draft (review round 2). */
   const [drawerDirty, setDrawerDirty] = useState(false);
   const [pendingSelect, setPendingSelect] = useState<string | null>(null);
+
+  /** The engine line is read-only telemetry beside the catalog: a failure (an older daemon, a
+   *  transient error) leaves it blank — it never fails the page. */
+  const loadEngine = useCallback(async (): Promise<void> => {
+    try {
+      const d = await getDiagnostics();
+      setEngine(d.skills ?? null);
+    } catch {
+      setEngine(null);
+    }
+  }, []);
 
   const load = useCallback(async (): Promise<SkillsCatalog | null> => {
     try {
@@ -112,6 +153,7 @@ export function SkillsPage({ navigate, search = '' }: {
       setStale(null);
       setState({ kind: 'loaded' });
       setCatalogEpoch((n) => n + 1);
+      void loadEngine();
       return c;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -120,12 +162,15 @@ export function SkillsPage({ navigate, search = '' }: {
         setStale(isSkillsUnsupported(e) ? 'the daemon no longer serves the skills catalog' : message);
       } else if (isSkillsUnsupported(e)) {
         setState({ kind: 'unsupported' });
+      } else if (isSkillsUnavailable(e)) {
+        setState({ kind: 'unavailable', message: apiWire(e) ?? message });
+        void loadEngine();
       } else {
         setState({ kind: 'failed', message });
       }
       return null;
     }
-  }, []);
+  }, [loadEngine]);
 
   useEffect(() => {
     void load();
@@ -163,9 +208,9 @@ export function SkillsPage({ navigate, search = '' }: {
     [run, reloadAfterConflict],
   );
 
-  const rows: SkillRow[] = catalog === null ? [] : skillRows(catalog.manifest);
+  const rows: SkillRow[] = useMemo(() => (catalog === null ? [] : skillRows(catalog.manifest)), [catalog]);
   const counts = skillCounts(rows);
-  const unpublished = rows.filter(isUnpublished).length;
+  const unpublished = rows.filter((r) => r.unpublished).length;
   const support = useMemo(() => (catalog === null ? [] : supportFiles(catalog.manifest)), [catalog]);
 
   // The drawer's address: `?skill=<name>`. A name the manifest does not carry renders a note,
@@ -200,7 +245,7 @@ export function SkillsPage({ navigate, search = '' }: {
   };
 
   /** The ONE guarded flip: the catalog reloaded on anything but `blocked`, the verdict handed back. */
-  const toggle = useCallback(async (name: string, enabled: boolean): Promise<SkillGuardResult | null> => {
+  const toggle = useCallback(async (name: string, enabled: boolean): Promise<SkillMutationResult | null> => {
     setBusyName(name);
     try {
       const result = await run((rev) => setSkillEnabled(name, enabled, rev));
@@ -224,25 +269,38 @@ export function SkillsPage({ navigate, search = '' }: {
       .catch((e: unknown) => setPageError(e instanceof Error ? e.message : String(e)));
   };
 
-  /** The three page verbs share one shape: run, show the envelope, reload on an applied write. */
+  /** The three page verbs share one shape: run, show the envelope, reload on an applied write.
+   *  Each answers its own result type; the note reads the fields that type carries. */
   const pageVerb = async (verb: PageVerb): Promise<void> => {
     setVerbBusy(verb);
     setPageError(null);
     setPageResult(null);
     setNote(null);
     try {
-      const result = verb === 'analyze'
-        ? await analyzeSkills()
-        : await run((rev) => (verb === 'publish' ? publishSkills(rev) : refreshSkillsBaseline(rev)));
+      let result: SkillAnalyzeResult | null;
+      let applied: string | null = null;
+      if (verb === 'analyze') {
+        result = await analyzeSkills();
+      } else if (verb === 'publish') {
+        const r = await run((rev) => publishSkills(rev));
+        result = r;
+        // `snapshot` is null exactly when the publish was blocked (nothing written, revision unchanged).
+        if (r !== null && r.snapshot !== null) {
+          applied = `Published — snapshot generation ${r.snapshot.gen} is current (${r.snapshot.skills} skills, ${r.snapshot.contentHash.slice(0, 12)}); workers spawn with it from now on.`;
+        }
+      } else {
+        const r = await run((rev) => refreshSkillsBaseline(rev));
+        result = r;
+        if (r !== null && r.verdict !== 'blocked') {
+          applied = `Baseline refreshed — ${r.plugin_version} (${r.baseline.slice(0, 12)}): ${r.taken.length} taken · ${r.kept.length} kept · ${r.added.length} added · ${r.removed.length} removed · ${r.conflicts.length} ${r.conflicts.length === 1 ? 'conflict' : 'conflicts'}. Your edits were kept; conflicts are flagged.`;
+        }
+      }
       if (result === null) return;
       setPageResult({ verb: PAGE_VERB_LABEL[verb], result });
       if (verb === 'analyze' || result.verdict === 'blocked') return;
       const next = await load();
       if (next === null) return;
-      const m = next.manifest;
-      setNote(verb === 'publish'
-        ? `Published — snapshot generation ${m.currentGeneration ?? '?'} is current; workers spawn with it from now on.`
-        : `Baseline refreshed — ${m.baseline.source.plugin_version} (${m.baseline.contentHash.slice(0, 12)}), ${Object.keys(m.skills).length} skills. Your edits were kept; conflicts are flagged.`);
+      setNote(applied);
     } catch (e) {
       setPageError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -254,7 +312,7 @@ export function SkillsPage({ navigate, search = '' }: {
    *  skill's drawer (`?skill=<name>`) opens only once that re-read SUCCEEDS. A failed re-read has
    *  already raised the stale banner (the rows stay, writes wait); navigating anyway would render
    *  "No skill named … in this catalog" over a skill the daemon DID write (review round 3). */
-  const onAdded = (name: string, result: SkillGuardResult): void => {
+  const onAdded = (name: string, result: SkillMutationResult): void => {
     setAddOpen(false);
     setNote(`Added ${name} — publish to hand it to workers.`);
     setPageResult(result.findings.length > 0 ? { verb: `Add ${name}`, result } : null);
@@ -263,8 +321,9 @@ export function SkillsPage({ navigate, search = '' }: {
     });
   };
 
-  const baseline = catalog?.manifest.baseline ?? null;
-  const generation = catalog?.manifest.currentGeneration ?? null;
+  const baseline = catalog === null ? null : currentBaseline(catalog.manifest);
+  const current = catalog?.current ?? null;
+  const published = catalog?.manifest.published ?? null;
   /** Every write affordance waits while: a 409 is up, the catalog is stale, a write is in flight,
    *  or a page verb is running — they all share the one revision. */
   const frozen = conflict !== null || stale !== null || inFlight > 0 || verbBusy !== null;
@@ -296,17 +355,56 @@ export function SkillsPage({ navigate, search = '' }: {
               as immutable snapshots. Edit any file in place, enable or disable, reset to the baseline;
               the daemon guards every write, and nothing reaches a worker until you publish.
             </p>
+            {catalog !== null && (
+              <p data-testid="skills-root" className="mt-1 font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }} title="the resolved skills root on the daemon host (<state home>/skills — not configurable)">
+                root {catalog.root}
+              </p>
+            )}
             {baseline !== null && (
-              <p data-testid="skills-source" className="mt-1 font-mono text-[10px]" style={{ color: 'var(--ink-dim)' }}>
-                baseline {baseline.source.plugin_version} · {baseline.source.kind} · {baseline.contentHash.slice(0, 12)}
-                {baseline.source.git_sha !== null && ` · ${baseline.source.git_sha.slice(0, 10)}`}
-                {` · captured ${baseline.source.captured_at}`}
+              <p
+                data-testid="skills-source"
+                data-venv={baseline.venv}
+                className="mt-0.5 font-mono text-[10px]"
+                style={{ color: 'var(--ink-dim)' }}
+                title={`captured from ${baseline.source.path}`}
+              >
+                baseline {baseline.plugin_version} · {baseline.source.kind} · {baseline.hash.slice(0, 12)}
+                {baseline.git_sha !== null && ` · ${baseline.git_sha.slice(0, 10)}`}
+                {` · venv ${baseline.venv}`}
+                {` · captured ${baseline.captured_at}`}
               </p>
             )}
             {catalog !== null && (
-              <p data-testid="skills-snapshot" data-generation={generation ?? 'none'} data-unpublished={unpublished} className="mt-0.5 font-mono text-[10px]" style={{ color: unpublished > 0 ? 'var(--status-run)' : 'var(--ink-dim)' }}>
-                {generation === null ? 'never published — workers fall back to the installed plugin' : `snapshot generation ${generation} is current`}
+              <p
+                data-testid="skills-snapshot"
+                data-generation={current?.gen ?? 'none'}
+                data-unpublished={unpublished}
+                className="mt-0.5 font-mono text-[10px]"
+                style={{ color: unpublished > 0 ? 'var(--status-run)' : 'var(--ink-dim)' }}
+                title={current === null ? undefined : current.path}
+              >
+                {current === null
+                  ? 'never published — no snapshot to hand to workers yet'
+                  : `snapshot generation ${current.gen} is current`}
+                {published !== null && ` · published ${published.at} · ${published.contentHash.slice(0, 12)}`}
                 {unpublished > 0 && ` · ${unpublished} unpublished ${unpublished === 1 ? 'skill' : 'skills'}`}
+              </p>
+            )}
+            {engine !== null && (
+              <p
+                data-testid="skills-engine"
+                data-state={engine.state}
+                className="mt-0.5 font-mono text-[10px]"
+                style={{ color: ENGINE_STATE_COLOR[engine.state] }}
+                title={engine.engineInput === null ? 'WICKED_SKILLS_SNAPSHOT is unset' : `WICKED_SKILLS_SNAPSHOT=${engine.engineInput}`}
+              >
+                engine {SKILLS_ENGINE_STATE_COPY[engine.state]}
+                {engine.current !== null && ` · gen ${engine.current.gen}`}
+                {engine.findings.map((f, i) => (
+                  <span key={`${f.kind}-${i}`} data-testid="skills-engine-finding" data-kind={f.kind} data-severity={f.severity} className="block">
+                    {f.kind} · {f.severity} · {f.message}
+                  </span>
+                ))}
               </p>
             )}
           </div>
@@ -324,8 +422,8 @@ export function SkillsPage({ navigate, search = '' }: {
                   Add skill…
                 </button>
                 {verbButton('refresh', 'skills-refresh', 'Capture the installed plugin as a new baseline and merge it three-way per file: untouched skills take the new version, your edits are kept and conflicts flagged — never clobbered', false)}
-                {verbButton('analyze', 'skills-analyze', 'Dry-run the publish validation over the whole tree — the same findings, nothing written', false)}
-                {verbButton('publish', 'skills-publish', 'Validate the whole tree and write the immutable snapshot generation workers spawn with (enabled skills only)', true)}
+                {verbButton('analyze', 'skills-analyze', 'Dry-run the publish validation over the whole tree — the same findings, nothing written, the revision unchanged', false)}
+                {verbButton('publish', 'skills-publish', 'Validate the whole tree and write the immutable snapshot generation workers spawn with (enabled skills only); a publish with only warnings still writes it', true)}
               </>
             )}
             <button
@@ -352,6 +450,21 @@ export function SkillsPage({ navigate, search = '' }: {
             <p className="text-xs font-semibold" style={{ color: 'var(--ink-high)' }}>Skills are not served by this daemon.</p>
             <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>{SKILLS_UNSUPPORTED_COPY}</p>
           </div>
+        ) : state.kind === 'unavailable' ? (
+          <div
+            data-testid="skills-unavailable"
+            role="alert"
+            className="flex flex-col gap-2 rounded p-4"
+            style={{ background: 'var(--surface-rail)', border: '1px solid var(--status-fail)' }}
+          >
+            <p className="text-xs font-semibold" style={{ color: 'var(--status-fail)' }}>The daemon has no skills catalog to serve.</p>
+            <p className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+              The `/skills` routes are here but answered 503 — the root is not seeded (no installed wicked-garden plugin was found),
+              the published snapshot fails verification, or the daemon booted without the skills seam. Nothing is shown as an
+              empty catalog. The daemon says:
+            </p>
+            <p className="font-mono text-[11px]" style={{ color: 'var(--ink-high)' }}>{state.message}</p>
+          </div>
         ) : state.kind === 'failed' ? (
           <p data-testid="skills-error" className="rounded px-2 py-1 text-xs" style={{ background: 'var(--status-fail-dim)', color: 'var(--status-fail)' }}>
             {state.message}
@@ -364,7 +477,7 @@ export function SkillsPage({ navigate, search = '' }: {
                   testId="skills-kpi-total"
                   label="Skills"
                   value={counts.total}
-                  context={baseline === null ? undefined : `baseline ${baseline.source.plugin_version}`}
+                  context={baseline === null ? undefined : `baseline ${baseline.plugin_version}`}
                   onOpen={() => setFacets({ ...facets, chip: 'all' })}
                 />
                 <StatTile

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -43,7 +43,12 @@ import type { SkillsWriter } from './skillsWriter.js';
  *
  * CAS: the page holds the catalog `revision`; every write goes through {@link SkillsWriter}
  * (`expectedRevision` out, the answered `revision` adopted). A **409** freezes the page behind the
- * reload prompt — nothing else is written until the catalog is re-read.
+ * reload prompt — nothing else is written until the catalog is re-read. Every write also freezes
+ * the others while it is in flight (they all share the one revision — overlapping writes could
+ * only 409), and a catalog re-read that FAILS marks the page stale: the rows stay readable, every
+ * write waits until a re-read succeeds. Each successful re-read bumps `catalogEpoch`, which the
+ * drawer reconciles its open file against — a Refresh never advances the write revision past
+ * content the editor read earlier.
  *
  * A daemon without the `/skills` routes renders the NAMED unsupported state — never a crash and
  * never an empty catalog pretending. Every write goes through crew's API (the guarded operator
@@ -83,6 +88,13 @@ export function SkillsPage({ navigate, search = '' }: {
   const [addOpen, setAddOpen] = useState(false);
   /** A 409 — the catalog changed under this page. The daemon's sentence, for the prompt. */
   const [conflict, setConflict] = useState<string | null>(null);
+  /** A catalog RE-READ failed after a successful load — the rows on screen may be behind the
+   *  daemon, so every write waits until a re-read succeeds. The failure's sentence, for the banner. */
+  const [stale, setStale] = useState<string | null>(null);
+  /** Bumped on every SUCCESSFUL catalog read — the drawer re-reads its open file on each. */
+  const [catalogEpoch, setCatalogEpoch] = useState(0);
+  /** Writes in flight through the CAS seam — while any is, every other write affordance waits. */
+  const [inFlight, setInFlight] = useState(0);
   /** The revision every mutation is conditioned on — a ref so chained writes read the latest. */
   const revisionRef = useRef<string | null>(null);
 
@@ -91,11 +103,20 @@ export function SkillsPage({ navigate, search = '' }: {
       const c = await getSkillsCatalog();
       revisionRef.current = c.revision;
       setCatalog(c);
+      setStale(null);
       setState({ kind: 'loaded' });
+      setCatalogEpoch((n) => n + 1);
       return c;
     } catch (e) {
-      if (isSkillsUnsupported(e)) setState({ kind: 'unsupported' });
-      else setState({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+      const message = e instanceof Error ? e.message : String(e);
+      if (revisionRef.current !== null) {
+        // A re-read after a successful load: keep the rows readable, mark them stale, freeze writes.
+        setStale(isSkillsUnsupported(e) ? 'the daemon no longer serves the skills catalog' : message);
+      } else if (isSkillsUnsupported(e)) {
+        setState({ kind: 'unsupported' });
+      } else {
+        setState({ kind: 'failed', message });
+      }
       return null;
     }
   }, []);
@@ -104,10 +125,12 @@ export function SkillsPage({ navigate, search = '' }: {
     void load();
   }, [load]);
 
-  /** The ONE CAS seam: expectedRevision out, the answered revision adopted, a 409 → the prompt. */
-  const run = useCallback(async (mutation: (expectedRevision: string) => Promise<SkillGuardResult>): Promise<SkillGuardResult | null> => {
-    const expected = revisionRef.current;
+  /** The ONE CAS seam: expectedRevision out (the page's latest, or the revision the caller's
+   *  content was read at), the answered revision adopted, a 409 → the prompt. */
+  const run = useCallback<SkillsWriter['run']>(async (mutation, opts) => {
+    const expected = opts?.expectedRevision ?? revisionRef.current;
     if (expected === null) throw new Error('the skills catalog has not loaded — nothing to write against');
+    setInFlight((n) => n + 1);
     try {
       const result = await mutation(expected);
       revisionRef.current = result.revision;
@@ -118,9 +141,11 @@ export function SkillsPage({ navigate, search = '' }: {
         return null;
       }
       throw e;
+    } finally {
+      setInFlight((n) => n - 1);
     }
   }, []);
-  const writer = useMemo<SkillsWriter>(() => ({ run }), [run]);
+  const writer = useMemo<SkillsWriter>(() => ({ run, revision: () => revisionRef.current }), [run]);
 
   const reloadAfterConflict = (): void => {
     setConflict(null);
@@ -199,7 +224,9 @@ export function SkillsPage({ navigate, search = '' }: {
 
   const baseline = catalog?.manifest.baseline ?? null;
   const generation = catalog?.manifest.currentGeneration ?? null;
-  const frozen = conflict !== null;
+  /** Every write affordance waits while: a 409 is up, the catalog is stale, a write is in flight,
+   *  or a page verb is running — they all share the one revision. */
+  const frozen = conflict !== null || stale !== null || inFlight > 0 || verbBusy !== null;
 
   const verbButton = (verb: PageVerb, testId: string, title: string, primary: boolean): React.ReactElement => (
     <button
@@ -262,6 +289,8 @@ export function SkillsPage({ navigate, search = '' }: {
             )}
             <button
               type="button"
+              data-testid="skills-reload"
+              title="Re-read the catalog (the drawer re-reads its open file against it)"
               onClick={() => void load()}
               className="text-[10px] hover:underline"
               style={{ color: 'var(--ink-dim)' }}
@@ -333,6 +362,27 @@ export function SkillsPage({ navigate, search = '' }: {
               </KpiGroup>
             </KpiBand>
 
+            {stale !== null && (
+              <div
+                data-testid="skills-stale"
+                role="alert"
+                className="flex flex-wrap items-center gap-2 rounded px-3 py-2 text-[11px]"
+                style={{ background: 'var(--surface-rail)', border: '1px solid var(--status-gate)', color: 'var(--ink-muted)' }}
+              >
+                <span className="font-semibold" style={{ color: 'var(--status-gate)' }}>The catalog could not be re-read.</span>
+                <span>{stale} — what is shown may be behind the daemon; writes wait until a re-read succeeds.</span>
+                <span className="flex-1" />
+                <button
+                  data-testid="skills-stale-retry"
+                  type="button"
+                  onClick={() => void load()}
+                  className="rounded px-2 py-0.5 text-[10px] font-semibold"
+                  style={{ color: 'var(--status-gate)', border: '1px solid var(--status-gate)' }}
+                >
+                  Retry
+                </button>
+              </div>
+            )}
             {note !== null && (
               <p
                 data-testid="skills-note"
@@ -380,6 +430,7 @@ export function SkillsPage({ navigate, search = '' }: {
           skill={selected}
           support={support}
           writer={writer}
+          catalogEpoch={catalogEpoch}
           busy={frozen || busyName === selected.name}
           onClose={() => navigate(skillsPath())}
           onToggle={toggle}

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -250,11 +250,17 @@ export function SkillsPage({ navigate, search = '' }: {
     }
   };
 
+  /** After an applied Add: the modal closes, the note stands, and the catalog is re-read — the new
+   *  skill's drawer (`?skill=<name>`) opens only once that re-read SUCCEEDS. A failed re-read has
+   *  already raised the stale banner (the rows stay, writes wait); navigating anyway would render
+   *  "No skill named … in this catalog" over a skill the daemon DID write (review round 3). */
   const onAdded = (name: string, result: SkillGuardResult): void => {
     setAddOpen(false);
     setNote(`Added ${name} — publish to hand it to workers.`);
     setPageResult(result.findings.length > 0 ? { verb: `Add ${name}`, result } : null);
-    void load().then(() => navigate(skillsPath(name)));
+    void load().then((next) => {
+      if (next !== null) navigate(skillsPath(name));
+    });
   };
 
   const baseline = catalog?.manifest.baseline ?? null;

--- a/src/components/skillsWriter.ts
+++ b/src/components/skillsWriter.ts
@@ -1,15 +1,19 @@
-import type { SkillGuardResult } from '../api/skills.js';
+import type { SkillAnalyzeResult } from '../api/skills.js';
 
 /**
  * The Skills page's CAS seam, handed to every component that writes (the drawer, the confirm and
- * files-map modals). The page holds the catalog revision; a writer runs ONE mutation conditioned
- * on it and adopts the revision the daemon answers with, so consecutive writes chain correctly
- * without every component tracking revisions itself.
+ * files-map modals). The page holds the catalog revision (a non-negative integer — api-types
+ * 0.27.0 `SkillManifest.revision`, bumped by EVERY mutation); a writer runs ONE mutation
+ * conditioned on it and adopts the revision the daemon answers with, so consecutive writes chain
+ * correctly without every component tracking revisions itself.
  *
- * `run` resolves the daemon's guard envelope, or `null` when the daemon answered **409** — the
- * revision was stale (another session, a hashed direct edit, a refresh). On `null` the PAGE owns
- * the moment (it raises the reload prompt) and the caller changes nothing: no findings, no state
- * flip, the draft kept. Every other failure throws, for the caller's own error line.
+ * `run` resolves the daemon's envelope — typed as whatever the mutation answers (`SkillMutationResult`,
+ * `SkillPublishResult`, `SkillRefreshResult`; every one extends `SkillAnalyzeResult`
+ * `{verdict, findings, revision}`) — or `null` when the daemon answered **409** — the revision was
+ * stale (another session, a hashed direct edit, a refresh; 409 is EXCLUSIVELY that). On `null` the
+ * PAGE owns the moment (it raises the reload prompt) and the caller changes nothing: no findings, no
+ * state flip, the draft kept. Every other failure throws, for the caller's own error line. A
+ * `blocked` verdict is NOT a failure: it resolves normally with `revision` unchanged.
  *
  * A file EDIT is the one write that must not ride the page's latest revision blindly: the page
  * may have re-read the catalog (a Refresh, a toggle, a publish) after the editor read its content,
@@ -20,16 +24,16 @@ import type { SkillGuardResult } from '../api/skills.js';
  */
 export interface SkillsWriter {
   /** The catalog revision the page holds right now (`null` before the first load). */
-  revision(): string | null;
+  revision(): number | null;
   /** After a `null` (409): clear the page's prompt and re-read the catalog, adopting the current
    *  revision. A caller that holds a draft (the Add/Replace files map) KEEPS it across this and
    *  retries the same write once it resolves — nothing is retyped after a conflict. */
   reload(): Promise<void>;
-  run(
-    mutation: (expectedRevision: string) => Promise<SkillGuardResult>,
+  run<T extends SkillAnalyzeResult>(
+    mutation: (expectedRevision: number) => Promise<T>,
     opts?: {
       /** Condition this write on the revision its CONTENT was read at, not the page's latest. */
-      expectedRevision?: string;
+      expectedRevision?: number;
     },
-  ): Promise<SkillGuardResult | null>;
+  ): Promise<T | null>;
 }

--- a/src/components/skillsWriter.ts
+++ b/src/components/skillsWriter.ts
@@ -10,7 +10,22 @@ import type { SkillGuardResult } from '../api/skills.js';
  * revision was stale (another session, a hashed direct edit, a refresh). On `null` the PAGE owns
  * the moment (it raises the reload prompt) and the caller changes nothing: no findings, no state
  * flip, the draft kept. Every other failure throws, for the caller's own error line.
+ *
+ * A file EDIT is the one write that must not ride the page's latest revision blindly: the page
+ * may have re-read the catalog (a Refresh, a toggle, a publish) after the editor read its content,
+ * and adopting that newer revision would let an old-content edit overwrite an intervening change
+ * the daemon's CAS exists to catch. So a read records `revision()` as the revision its content
+ * stands at, and Save passes it back as `expectedRevision` — the daemon compares against what the
+ * editor actually shows, not against what the page last heard.
  */
 export interface SkillsWriter {
-  run(mutation: (expectedRevision: string) => Promise<SkillGuardResult>): Promise<SkillGuardResult | null>;
+  /** The catalog revision the page holds right now (`null` before the first load). */
+  revision(): string | null;
+  run(
+    mutation: (expectedRevision: string) => Promise<SkillGuardResult>,
+    opts?: {
+      /** Condition this write on the revision its CONTENT was read at, not the page's latest. */
+      expectedRevision?: string;
+    },
+  ): Promise<SkillGuardResult | null>;
 }

--- a/src/components/skillsWriter.ts
+++ b/src/components/skillsWriter.ts
@@ -21,6 +21,10 @@ import type { SkillGuardResult } from '../api/skills.js';
 export interface SkillsWriter {
   /** The catalog revision the page holds right now (`null` before the first load). */
   revision(): string | null;
+  /** After a `null` (409): clear the page's prompt and re-read the catalog, adopting the current
+   *  revision. A caller that holds a draft (the Add/Replace files map) KEEPS it across this and
+   *  retries the same write once it resolves — nothing is retyped after a conflict. */
+  reload(): Promise<void>;
   run(
     mutation: (expectedRevision: string) => Promise<SkillGuardResult>,
     opts?: {

--- a/src/components/skillsWriter.ts
+++ b/src/components/skillsWriter.ts
@@ -1,0 +1,16 @@
+import type { SkillGuardResult } from '../api/skills.js';
+
+/**
+ * The Skills page's CAS seam, handed to every component that writes (the drawer, the confirm and
+ * files-map modals). The page holds the catalog revision; a writer runs ONE mutation conditioned
+ * on it and adopts the revision the daemon answers with, so consecutive writes chain correctly
+ * without every component tracking revisions itself.
+ *
+ * `run` resolves the daemon's guard envelope, or `null` when the daemon answered **409** — the
+ * revision was stale (another session, a hashed direct edit, a refresh). On `null` the PAGE owns
+ * the moment (it raises the reload prompt) and the caller changes nothing: no findings, no state
+ * flip, the draft kept. Every other failure throws, for the caller's own error line.
+ */
+export interface SkillsWriter {
+  run(mutation: (expectedRevision: string) => Promise<SkillGuardResult>): Promise<SkillGuardResult | null>;
+}

--- a/src/hooks/useRoute.ts
+++ b/src/hooks/useRoute.ts
@@ -35,9 +35,12 @@ import { isTestingSubPage } from '../api/testing.js';
 // surface): policy proposals live under `/steering/policies`, memory proposals under
 // `/steering/memories`. Its old `/proposals` address (and `?type=memory` deep link) fold into
 // those sub-sections via `useSteeringRedirect`.
-export type Panel = 'home' | 'runs' | 'workflows' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'execute' | 'vibe' | 'demo' | 'not-found';
+// `skills` is the Skills file manager (`/skills`, the skills keystone) — the catalog of the
+// daemon's effective plugin root. A flat panel with no sub-routes: the one skill a deep link
+// opens rides `?skill=<name>` in `search` (read via `readSkillDeepLink`), never a path segment.
+export type Panel = 'home' | 'runs' | 'workflows' | 'skills' | 'steering' | 'testing' | 'repos' | 'system' | 'theme' | 'chats' | 'work' | 'repo-detail' | 'projects' | 'project-detail' | 'execute' | 'vibe' | 'demo' | 'not-found';
 
-const PANELS: Panel[] = ['runs', 'workflows', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'execute', 'vibe', 'demo'];
+const PANELS: Panel[] = ['runs', 'workflows', 'skills', 'repos', 'system', 'theme', 'chats', 'work', 'repo-detail', 'projects', 'project-detail', 'execute', 'vibe', 'demo'];
 
 /**
  * The four verbs on a project (DES-MERGE-001 §1.3). Mode is a ROUTE SEGMENT, not

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.1",
   "counts": {
     "files": 137,
-    "occurrences": 1113,
-    "static": 952,
+    "occurrences": 1116,
+    "static": 954,
     "dynamic": 57,
     "computed": 6
   },
@@ -4066,6 +4066,12 @@
       ]
     },
     {
+      "testId": "skills-file-stale-read",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-file-tree",
       "files": [
         "src/components/SkillDrawer.tsx"
@@ -4073,6 +4079,12 @@
     },
     {
       "testId": "skills-files-cancel",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-conflict",
       "files": [
         "src/components/SkillFilesMapModal.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,10 +10,10 @@
   "version": 1,
   "studioVersion": "0.5.1",
   "counts": {
-    "files": 130,
-    "occurrences": 1042,
-    "static": 886,
-    "dynamic": 56,
+    "files": 137,
+    "occurrences": 1108,
+    "static": 947,
+    "dynamic": 57,
     "computed": 6
   },
   "static": [
@@ -3462,6 +3462,12 @@
       ]
     },
     {
+      "testId": "rail-skills-browse",
+      "files": [
+        "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
       "testId": "rail-steering-section",
       "files": [
         "src/components/LeftSidebar.tsx"
@@ -3871,6 +3877,367 @@
       "testId": "site-name-input",
       "files": [
         "src/components/AppearanceSettings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-add-open",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-claude-only-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-confirm",
+      "files": [
+        "src/components/SkillConfirmModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-confirm-cancel",
+      "files": [
+        "src/components/SkillConfirmModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-confirm-error",
+      "files": [
+        "src/components/SkillConfirmModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-confirm-input",
+      "files": [
+        "src/components/SkillConfirmModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-confirm-modal",
+      "files": [
+        "src/components/SkillConfirmModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-conflict",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-conflict-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-conflict-reload",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-core-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-deep-link-missing",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-delete-open",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-discard",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-discard-edits",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-discard-prompt",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-close",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-dir",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-error",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-editor",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-error",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-dirty",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-error",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-loading",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-none",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-path",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-readonly",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-tree",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-cancel",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-empty",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-error",
+      "files": [
+        "src/components/SkillDrawer.tsx",
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-issue",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-loading",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-map",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-modal",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-name",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-files-save",
+      "files": [
+        "src/components/SkillFilesMapModal.tsx"
+      ]
+    },
+    {
+      "testId": "skills-finding",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-finding-location",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-grid",
+      "files": [
+        "src/components/SkillsGrid.tsx"
+      ]
+    },
+    {
+      "testId": "skills-grid-empty",
+      "files": [
+        "src/components/SkillsGrid.tsx"
+      ]
+    },
+    {
+      "testId": "skills-keep-editing",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-kind-chip",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-loading",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-note",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-page",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-page-error",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-provenance-chip",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-replace-open",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-reset-open",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-row",
+      "files": [
+        "src/components/SkillsGrid.tsx"
+      ]
+    },
+    {
+      "testId": "skills-row-name",
+      "files": [
+        "src/components/SkillsGrid.tsx"
+      ]
+    },
+    {
+      "testId": "skills-save",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-snapshot",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-source",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-support-note",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-unpublished-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-unsupported",
+      "files": [
+        "src/components/SkillsPage.tsx"
       ]
     },
     {
@@ -5675,6 +6042,12 @@
       ]
     },
     {
+      "pattern": "skills-tab-*",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "pattern": "stepper-phase-*",
       "files": [
         "src/components/ChatPanel.tsx"
@@ -5731,6 +6104,9 @@
         "src/components/ProvenanceLine.tsx",
         "src/components/RunSparkline.tsx",
         "src/components/RunsBottomPanel.tsx",
+        "src/components/SkillChips.tsx",
+        "src/components/SkillFindings.tsx",
+        "src/components/SkillsPage.tsx",
         "src/components/dashboardKit.tsx"
       ]
     },

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.1",
   "counts": {
     "files": 137,
-    "occurrences": 1107,
-    "static": 946,
+    "occurrences": 1113,
+    "static": 952,
     "dynamic": 57,
     "computed": 6
   },
@@ -4012,6 +4012,24 @@
       ]
     },
     {
+      "testId": "skills-file-conflict",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-conflict-keep",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-conflict-take",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-file-dirty",
       "files": [
         "src/components/SkillDrawer.tsx"
@@ -4175,6 +4193,12 @@
       ]
     },
     {
+      "testId": "skills-reload",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
       "testId": "skills-replace-open",
       "files": [
         "src/components/SkillDrawer.tsx"
@@ -4212,6 +4236,18 @@
     },
     {
       "testId": "skills-source",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-stale",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-stale-retry",
       "files": [
         "src/components/SkillsPage.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.1",
   "counts": {
     "files": 137,
-    "occurrences": 1108,
-    "static": 947,
+    "occurrences": 1107,
+    "static": 946,
     "dynamic": 57,
     "computed": 6
   },
@@ -3949,12 +3949,6 @@
       "testId": "skills-deep-link-missing",
       "files": [
         "src/components/SkillsPage.tsx"
-      ]
-    },
-    {
-      "testId": "skills-delete-open",
-      "files": [
-        "src/components/SkillDrawer.tsx"
       ]
     },
     {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.1",
   "counts": {
     "files": 137,
-    "occurrences": 1116,
-    "static": 954,
+    "occurrences": 1134,
+    "static": 972,
     "dynamic": 57,
     "computed": 6
   },
@@ -3886,6 +3886,42 @@
       ]
     },
     {
+      "testId": "skills-baseline-content",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-baseline-error",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-baseline-loading",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-baseline-open",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-baseline-path",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-baseline-view",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-claude-only-badge",
       "files": [
         "src/components/SkillChips.tsx"
@@ -3988,7 +4024,19 @@
       ]
     },
     {
+      "testId": "skills-drawer-edited",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-drawer-error",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-upstream",
       "files": [
         "src/components/SkillDrawer.tsx"
       ]
@@ -3997,6 +4045,18 @@
       "testId": "skills-editor",
       "files": [
         "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-engine",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-engine-finding",
+      "files": [
+        "src/components/SkillsPage.tsx"
       ]
     },
     {
@@ -4061,6 +4121,12 @@
     },
     {
       "testId": "skills-file-readonly",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-file-size",
       "files": [
         "src/components/SkillDrawer.tsx"
       ]
@@ -4145,7 +4211,31 @@
       ]
     },
     {
+      "testId": "skills-finding-against",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-finding-evidence",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
       "testId": "skills-finding-location",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-finding-skill",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-findings-tally",
       "files": [
         "src/components/SkillFindings.tsx"
       ]
@@ -4223,6 +4313,12 @@
       ]
     },
     {
+      "testId": "skills-root",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
       "testId": "skills-row",
       "files": [
         "src/components/SkillsGrid.tsx"
@@ -4271,6 +4367,12 @@
       ]
     },
     {
+      "testId": "skills-unavailable",
+      "files": [
+        "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
       "testId": "skills-unpublished-badge",
       "files": [
         "src/components/SkillChips.tsx"
@@ -4280,6 +4382,12 @@
       "testId": "skills-unsupported",
       "files": [
         "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-upgrade-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
       ]
     },
     {

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -57,7 +57,8 @@ const W2_ORDERED = [
   bp('scratch', 'quiet', 0),
 ];
 
-const HEADING_KEYS = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'steering', 'testing', 'settings'] as const;
+// Skills (the skills keystone) joined the system block BEFORE Steering — eleven headings.
+const HEADING_KEYS = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'skills', 'steering', 'testing', 'settings'] as const;
 
 function rail(props: Partial<{ pathname: string; navigate: (p: string) => void; runs: ReturnType<typeof makeView>[] }> = {}): ReturnType<typeof render> {
   return render(
@@ -118,14 +119,19 @@ describe('the route→heading map (§3.2)', () => {
     for (const p of ['/testing', '/testing/harness', '/testing/evals']) {
       expect(headingForPath(p)).toBe('testing');
     }
+    // Skills owns `/skills` and any sub-address (the file manager is one flat page; a skill's
+    // drawer rides `?skill=`), and it is its OWN heading — never Steering's.
+    for (const p of ['/skills', '/skills/', '/skills/wicked-garden-repo-learn']) {
+      expect(headingForPath(p)).toBe('skills');
+    }
     expect(headingForPath('/')).toBeNull();
     expect(headingForPath('/runs')).toBeNull();
     expect(headingForPath('/runs/r-1')).toBeNull();
   });
 });
 
-describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
-  it('renders all ten headings; Settings is icon-less, Steering carries ▦ only, the rest carry ▦ and ＋', async () => {
+describe('the eleven heading rows (§3.1 + nav-reorg + usability wave + skills)', () => {
+  it('renders all eleven headings; Settings is icon-less, Skills/Steering/Evals carry ▦ only, the rest carry ▦ and ＋', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
@@ -140,9 +146,10 @@ describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
       expect(within(h).queryByTestId('heading-dashboard')).toBeNull();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
     }
-    // Steering AND Evals carry ▦ (the Dashboard) but NO ＋ — system sections, not create surfaces
-    // (usability wave: Evals lost its ＋, it only opens its dashboard).
-    for (const k of ['steering', 'testing']) {
+    // Skills, Steering AND Evals carry ▦ (the Dashboard) but NO ＋ — system sections, not create
+    // surfaces (usability wave: Evals lost its ＋, it only opens its dashboard; Skills adds from its
+    // own page verb, behind the daemon's guards).
+    for (const k of ['skills', 'steering', 'testing']) {
       const h = screen.getByTestId(`rail-heading-${k}`);
       expect(within(h).getByTestId('heading-dashboard')).toBeInTheDocument();
       expect(within(h).queryByTestId('heading-new')).toBeNull();
@@ -155,22 +162,27 @@ describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
     }
   });
 
-  it('order: Projects → Execute → Test → Vibe → Demo → Chat → Repos ┃ Steering → Evals ┃ Settings', async () => {
+  it('order: Projects → Execute → Test → Vibe → Demo → Chat → Repos ┃ Skills → Steering → Evals ┃ Settings', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     const el = (k: string): HTMLElement => screen.getByTestId(`rail-heading-${k}`);
-    // Dividers now sit between the work sections, Steering/Evals and Settings, so check DOCUMENT
-    // order (compareDocumentPosition) rather than nextElementSibling — Test below Execute, Evals
-    // beside Steering.
-    const order = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'steering', 'testing', 'settings'];
+    // Dividers now sit between the work sections, Skills/Steering/Evals and Settings, so check
+    // DOCUMENT order (compareDocumentPosition) rather than nextElementSibling — Test below
+    // Execute, Skills before Steering, Evals beside Steering.
+    const order = ['projects', 'execute', 'test', 'vibe', 'demo', 'chat', 'repos', 'skills', 'steering', 'testing', 'settings'];
     for (let i = 0; i < order.length - 1; i += 1) {
       const rel = el(order[i]!).compareDocumentPosition(el(order[i + 1]!));
       expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     }
-    // Evals sits AFTER Steering (moved there), and Test sits AFTER Execute.
+    // Skills sits BEFORE Steering (the keystone's placement), Evals AFTER Steering (moved there),
+    // and Test AFTER Execute.
+    expect(el('skills').compareDocumentPosition(el('steering')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(el('steering').compareDocumentPosition(el('testing')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(el('execute').compareDocumentPosition(el('test')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Skills is in the SYSTEM block: the first divider precedes it.
+    const [workDivider] = screen.getAllByTestId('rail-divider');
+    expect(workDivider!.compareDocumentPosition(el('skills')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('the promoted headings are labelled Execute / Vibe / Demo, and the Test section is labelled Evals', async () => {
@@ -201,6 +213,7 @@ describe('the ten heading rows (§3.1 + nav-reorg + usability wave)', () => {
     expect(hrefOf('testing')).toBe('/testing/evals');
     expect(hrefOf('chat')).toBe('/chats');
     expect(hrefOf('repos')).toBe('/repos');
+    expect(hrefOf('skills')).toBe('/skills');
     expect(hrefOf('steering')).toBe('/steering/dashboard');
 
     fireEvent.click(within(screen.getByTestId('rail-heading-execute')).getByTestId('heading-dashboard'));
@@ -466,6 +479,25 @@ describe('accordion contents (§3.3)', () => {
     expect(navigate).toHaveBeenCalledWith('/steering/memories');
   });
 
+  it('Skills expands to the one "Browse skills" shortcut row, navigating to the file manager; the route expands it', async () => {
+    const navigate = vi.fn();
+    rail({ pathname: '/skills', navigate });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+
+    const skills = screen.getByTestId('rail-heading-skills');
+    expect(skills.getAttribute('aria-expanded')).toBe('true');
+    expect(within(skills).getByTestId('rail-title-skills')).toHaveTextContent('Skills');
+    // Exactly one row — the catalog is a dashboard, not a shortcut list — and no `+` inside.
+    expect(within(skills).getAllByRole('menuitem')).toHaveLength(1);
+    const browse = within(skills).getByTestId('rail-skills-browse');
+    expect(browse).toHaveTextContent('Browse skills');
+    expect(browse.textContent).not.toContain('+');
+    fireEvent.click(browse);
+    expect(navigate).toHaveBeenCalledWith('/skills');
+    // Opening Skills leaves Steering closed (the one-open accordion).
+    expect(expandedKeys()).toEqual(['skills']);
+  });
+
   it('Evals expands to the "Run evals" shortcut row, navigating to the runner; the route expands it', async () => {
     const navigate = vi.fn();
     rail({ pathname: '/testing/evals', navigate });
@@ -482,16 +514,20 @@ describe('accordion contents (§3.3)', () => {
 });
 
 describe('the collapsed rail (§3.2)', () => {
-  it('shows exactly ten glyph links (Evals → its runner, Steering → its Dashboard, Settings → /system)', async () => {
+  it('shows exactly eleven glyph links (Skills → /skills, Evals → its runner, Steering → its Dashboard, Settings → /system)', async () => {
     rail();
     await screen.findByRole('button', { name: 'wicked-studio' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
     const glyphs = screen.getAllByTestId('rail-collapsed-glyph');
-    expect(glyphs).toHaveLength(10);
+    expect(glyphs).toHaveLength(11);
     expect(glyphs.map((g) => g.getAttribute('href'))).toEqual([
-      '/projects', '/execute', '/testing/campaigns', '/vibe', '/demo', '/chats', '/repos', '/steering/dashboard', '/testing/evals', '/system',
+      '/projects', '/execute', '/testing/campaigns', '/vibe', '/demo', '/chats', '/repos', '/skills', '/steering/dashboard', '/testing/evals', '/system',
     ]);
+    // The Skills glyph is ◆, labelled for the icon-only column.
+    const skillsGlyph = glyphs[7]!;
+    expect(skillsGlyph).toHaveAttribute('aria-label', 'Skills');
+    expect(skillsGlyph).toHaveTextContent('◆');
     expect(screen.queryByTestId('rail-heading-projects')).toBeNull();
   });
 });

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -31,7 +31,13 @@ import type { SkillFileEntry, SkillGuardResult, SkillManifestEntry, SkillsCatalo
  *    unsaved edits surfaces as the file conflict, never a silent overwrite; Save's endpoint
  *    follows the file's scope + requested path (never the tab, never the daemon's echoed `path`);
  *    a file list answering after a tab switch is ignored; the active file locks while dirty;
- *    a failed re-read marks the page stale and freezes writes; a write in flight freezes the rest.
+ *    a failed re-read marks the page stale and freezes writes; a write in flight freezes the rest;
+ *  - drafts survive every way out (review round 2): a row click on ANOTHER skill while the drawer
+ *    is dirty goes through the discard confirmation (the drawer's `key` swaps only on Discard);
+ *    an Add/Replace 409 keeps the modal with its name + files map, reloads the catalog and retries
+ *    the same payload against the new revision; the editor is read-only while a file loads, a read
+ *    answering for a file no longer selected is dropped, and one that would land over text typed
+ *    since the request left is set aside as a stale read — the draft stays.
  */
 
 const apiFetch = vi.fn();
@@ -1282,5 +1288,251 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
     await screen.findAllByTestId('skills-row');
     fireEvent.click(screen.getByTestId('skills-publish'));
     expect(await screen.findByTestId('skills-page-error')).toHaveTextContent('snapshot write failed: ENOSPC');
+  });
+});
+
+describe('SkillsPage — review round 2: a draft survives a skill switch, a modal 409, and a read that lands mid-typing', () => {
+  const mineHandlers: Record<string, Handler> = {
+    [`GET /skills/${MINE}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+    [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
+  };
+
+  it('selecting ANOTHER skill while the drawer is dirty asks first: Keep editing keeps the draft (no navigation, no key swap); Discard opens the other skill', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN), ...mineHandlers });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft for A' } });
+    navigate.mockClear();
+
+    fireEvent.click(row(MINE));
+    // Nothing navigated, the drawer is still A's with the draft intact, and the prompt names B.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('skills-drawer').dataset.skill).toBe(REPO_LEARN);
+    const prompt = within(drawer).getByTestId('skills-discard-prompt');
+    expect(prompt.dataset.leaveTo).toBe(MINE);
+    expect(within(prompt).getByTestId('skills-discard')).toHaveTextContent(`Discard and open ${MINE}`);
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft for A');
+    expect(calls('GET', `/skills/${MINE}/files`)).toBe(0);
+
+    fireEvent.click(within(prompt).getByTestId('skills-keep-editing'));
+    expect(within(drawer).queryByTestId('skills-discard-prompt')).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('skills-drawer').dataset.skill).toBe(REPO_LEARN);
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft for A');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+
+    // Escape still closes through the same confirmation, worded for a close (no skill to open).
+    fireEvent.keyDown(document, { key: 'Escape' });
+    const closePrompt = within(drawer).getByTestId('skills-discard-prompt');
+    expect(closePrompt.dataset.leaveTo).toBeUndefined();
+    expect(within(closePrompt).getByTestId('skills-discard')).toHaveTextContent('Discard and close');
+    fireEvent.click(within(closePrompt).getByTestId('skills-keep-editing'));
+    expect(within(drawer).queryByTestId('skills-discard-prompt')).toBeNull();
+
+    // Asked again and discarded: NOW the navigation runs and B's drawer mounts, prompt-free.
+    fireEvent.click(row(MINE));
+    fireEvent.click(within(within(drawer).getByTestId('skills-discard-prompt')).getByTestId('skills-discard'));
+    expect(navigate).toHaveBeenCalledWith(`/skills?skill=${MINE}`);
+    await waitFor(() => expect(screen.getByTestId('skills-drawer').dataset.skill).toBe(MINE));
+    const next = screen.getByTestId('skills-drawer');
+    await waitFor(() => expect(within(next).getByTestId('skills-editor')).toHaveValue('mine'));
+    expect(within(next).queryByTestId('skills-discard-prompt')).toBeNull();
+    expect(within(next).queryByTestId('skills-file-dirty')).toBeNull();
+  });
+
+  it('a PRISTINE drawer switches skills on a row click at once — the confirmation is only ever for a draft', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN), ...mineHandlers });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(row(MINE));
+    expect(navigate).toHaveBeenCalledWith(`/skills?skill=${MINE}`);
+    await waitFor(() => expect(screen.getByTestId('skills-drawer').dataset.skill).toBe(MINE));
+    expect(screen.queryByTestId('skills-discard-prompt')).toBeNull();
+    await waitFor(() => expect(within(screen.getByTestId('skills-drawer')).getByTestId('skills-editor')).toHaveValue('mine'));
+  });
+
+  it('Add → 409 keeps the modal with the name + files map intact, shows the conflict banner, reloads the catalog, and the retry posts the SAME payload against the new revision', async () => {
+    const posts: unknown[] = [];
+    let revision = REV_1;
+    let added = false;
+    wire({
+      'GET /skills': () => Promise.resolve(added
+        ? catalog({ revision, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+        : catalog({ revision })),
+      'POST /skills': (init) => {
+        const b = body(init) as { expectedRevision: string };
+        posts.push(b);
+        if (b.expectedRevision !== revision) return Promise.reject(new ApiError(409, `expected revision ${b.expectedRevision}, catalog is at ${revision}`));
+        added = true;
+        revision = REV_3;
+        return Promise.resolve(clear(REV_3));
+      },
+      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-add-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    fireEvent.change(within(modal).getByTestId('skills-files-name'), { target: { value: 'new-skill' } });
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: '{"SKILL.md": "new"}' } });
+
+    // Another session moved the catalog to r2 after this page loaded it at r1.
+    revision = REV_2;
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+
+    const banner = await within(modal).findByTestId('skills-files-conflict');
+    expect(banner).toHaveTextContent('The skills catalog changed under this page — nothing was written.');
+    // Still mounted, intact; the catalog was re-read (r2 adopted) and Save is re-armed.
+    await waitFor(() => expect(calls('GET', '/skills')).toBe(2));
+    await waitFor(() => expect(within(modal).getByTestId('skills-files-save')).toBeEnabled());
+    expect(screen.getByTestId('skills-files-modal')).toBe(modal);
+    expect(within(modal).getByTestId('skills-files-name')).toHaveValue('new-skill');
+    expect(within(modal).getByTestId('skills-files-map')).toHaveValue('{"SKILL.md": "new"}');
+    expect(banner).toHaveTextContent('Your name and files map are kept and the catalog was reloaded — Add skill again');
+    expect(within(modal).getByTestId('skills-files-save')).toHaveTextContent('Add skill');
+    // The modal owns this conflict: no page prompt, no error, no "Added" note, nothing navigated.
+    expect(screen.queryByTestId('skills-conflict')).toBeNull();
+    expect(within(modal).queryByTestId('skills-files-error')).toBeNull();
+    expect(screen.queryByTestId('skills-note')).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(posts).toEqual([{ name: 'new-skill', files: { 'SKILL.md': 'new' }, expectedRevision: REV_1 }]);
+
+    // The retry: the same payload, now conditioned on r2 → applied; the modal closes; the new skill opens.
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+    await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
+    expect(posts).toEqual([
+      { name: 'new-skill', files: { 'SKILL.md': 'new' }, expectedRevision: REV_1 },
+      { name: 'new-skill', files: { 'SKILL.md': 'new' }, expectedRevision: REV_2 },
+    ]);
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Added new-skill');
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/skills?skill=new-skill'));
+    expect((await screen.findByTestId('skills-drawer')).dataset.skill).toBe('new-skill');
+  });
+
+  it('Replace → 409 shares the branch: the files map is kept, the catalog reloaded, and the retry rides the new revision', async () => {
+    const posts: unknown[] = [];
+    let revision = REV_1;
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({ revision })),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${REPO_LEARN}/replace`]: (init) => {
+        const b = body(init) as { expectedRevision: string };
+        posts.push(b);
+        if (b.expectedRevision !== revision) return Promise.reject(new ApiError(409, 'stale'));
+        return Promise.resolve(clear(REV_3));
+      },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(within(drawer).getByTestId('skills-replace-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    const map = '{"SKILL.md": "---\\nname: x\\n---"}';
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: map } });
+
+    revision = REV_2;
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+    const banner = await within(modal).findByTestId('skills-files-conflict');
+    await waitFor(() => expect(within(modal).getByTestId('skills-files-save')).toBeEnabled());
+    expect(banner).toHaveTextContent('Your files map is kept and the catalog was reloaded — Replace files again');
+    expect(within(modal).getByTestId('skills-files-map')).toHaveValue(map);
+    expect(calls('GET', '/skills')).toBe(2);
+    expect(screen.queryByTestId('skills-conflict')).toBeNull();
+
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+    await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
+    expect(posts.map((p) => (p as { expectedRevision: string }).expectedRevision)).toEqual([REV_1, REV_2]);
+    expect((await within(drawer).findByTestId('skills-findings')).dataset.verdict).toBe('clear');
+  });
+
+  it('the editor is read-only while a file loads; text that reaches the draft anyway is NOT overwritten by the answer — the read is set aside as stale, the draft stays', async () => {
+    let resolveNotes: (v: unknown) => void = () => {};
+    const deferred = new Promise<unknown>((r) => { resolveNotes = r; });
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`GET /skills/${REPO_LEARN}/files/refs/notes.md`]: () => deferred,
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    expect(editor).toHaveValue(SKILL_MD);
+    expect(editor).not.toHaveAttribute('readonly');
+
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    // Loading: the previous content is still on screen, but the editor is read-only and says so.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveAttribute('readonly');
+    expect(within(drawer).getByTestId('skills-editor')).toHaveAttribute('aria-busy', 'true');
+    expect(within(drawer).getByTestId('skills-file-loading')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('SKILL.md');
+    for (const f of within(drawer).getAllByTestId('skills-file')) expect(f).toBeDisabled();
+
+    // Belt and braces: a change that reaches the draft anyway (nothing upstream is trusted).
+    fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: `${SKILL_MD} typed while loading` } });
+    await act(async () => {
+      resolveNotes(fileRead('refs/notes.md', 'notes'));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // The answer did NOT land over the typing: the draft stays, dirty against SKILL.md; the stale read is named.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue(`${SKILL_MD} typed while loading`);
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('SKILL.md');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    const stale = within(drawer).getByTestId('skills-file-stale-read');
+    expect(stale.dataset.path).toBe('refs/notes.md');
+    expect(stale).toHaveTextContent('refs/notes.md finished loading while you were typing — its content was not applied over your text.');
+    expect(within(drawer).getByTestId('skills-editor')).not.toHaveAttribute('readonly');
+    expect(within(drawer).queryByTestId('skills-file-loading')).toBeNull();
+    // Save would write the typed text to the file it was typed INTO (SKILL.md) — never to refs/notes.md.
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+    expect(within(drawer).getAllByTestId('skills-file')[0]).toHaveAttribute('aria-current', 'true');
+
+    // Discarding clears the draft and the marker; the tree unlocks and refs/notes.md opens on a fresh read.
+    fireEvent.click(within(drawer).getByTestId('skills-discard-edits'));
+    expect(within(drawer).queryByTestId('skills-file-stale-read')).toBeNull();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD);
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('notes'));
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('refs/notes.md');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/refs/notes.md`)).toBe(2);
+  });
+
+  it('a read for a file that is NO LONGER selected is dropped: a Reset re-opens SKILL.md while refs/notes.md is still loading, and the late answer never lands', async () => {
+    let resolveNotes: (v: unknown) => void = () => {};
+    const deferred = new Promise<unknown>((r) => { resolveNotes = r; });
+    let content = SKILL_MD;
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', content)),
+      [`GET /skills/${REPO_LEARN}/files/refs/notes.md`]: () => deferred,
+      [`POST /skills/${REPO_LEARN}/reset`]: () => { content = 'baseline body'; return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    expect(within(drawer).getByTestId('skills-editor')).toHaveAttribute('readonly');
+
+    // A Reset while the pick is in flight: the tree and SKILL.md (the file still on screen) reload.
+    fireEvent.click(within(drawer).getByTestId('skills-reset-open'));
+    const modal = screen.getByTestId('skills-confirm-modal');
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: REPO_LEARN } });
+    fireEvent.click(within(modal).getByTestId('skills-confirm'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('baseline body'));
+    expect(within(drawer).getByTestId('skills-editor')).not.toHaveAttribute('readonly');
+
+    // The stale pick answers late: dropped — SKILL.md stays, pristine; nothing flips to refs/notes.md.
+    await act(async () => {
+      resolveNotes(fileRead('refs/notes.md', 'notes'));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('baseline body');
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('SKILL.md');
+    expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-file-stale-read')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-file-loading')).toBeNull();
   });
 });

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -386,6 +386,17 @@ describe('SkillsPage — the honest non-catalog states', () => {
     expect(screen.queryByTestId('skills-analyze')).toBeNull();
   });
 
+  it('a 501 (route present, nothing behind it yet) is the same named unsupported state — the forward-compat pair every adoption seam folds', async () => {
+    wire({ 'GET /skills': () => Promise.reject(new ApiError(501, 'skills store not implemented by this engine')) });
+    render(<Harness />);
+    const state = await screen.findByTestId('skills-unsupported');
+    expect(state).toHaveTextContent(/predates the skills catalog/);
+    expect(screen.queryByTestId('skills-unavailable')).toBeNull();
+    expect(screen.queryByTestId('skills-error')).toBeNull();
+    expect(screen.queryByTestId('skills-kpis')).toBeNull();
+    expect(screen.queryByTestId('skills-publish')).toBeNull();
+  });
+
   it('a 503 (route present, no catalog to serve: unseeded / corrupt current / no seam) renders the NAMED unavailable state with the daemon’s sentence', async () => {
     wire({ 'GET /skills': () => Promise.reject(new ApiError(503, 'the skills root is not seeded: no installed wicked-garden plugin was found')) });
     render(<Harness />);
@@ -415,7 +426,13 @@ describe('SkillsPage — the honest non-catalog states', () => {
     // A STRING revision is a pre-0.27.0 daemon (or a hand-mirrored shape) — not the contract.
     wire({ 'GET /skills': () => Promise.resolve({ ...catalog(), revision: 'rev-0001' }) });
     render(<Harness />);
-    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog \(expected \{manifest: \{skills, files, …\}, revision: number, root, current\}\)/);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog \(expected \{manifest: \{skills, files, …\}, revision: number, root, current: \{gen: number, path\} \| null\}\)/);
+    cleanup();
+
+    // A `current.gen` that is not a counter (NaN cannot even travel as JSON; a float / negative can) — refused at the seam.
+    wire({ 'GET /skills': () => Promise.resolve({ ...catalog(), current: { gen: 2.5, path: SNAPSHOT_PATH } }) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog/);
     cleanup();
 
     // A manifest without the `files` map (the old `support` map instead) is not the contract either.

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -1536,3 +1536,188 @@ describe('SkillsPage — review round 2: a draft survives a skill switch, a moda
     expect(within(drawer).queryByTestId('skills-file-loading')).toBeNull();
   });
 });
+
+describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a failed post-add re-read, the skill tree while its list is pending', () => {
+  const SUPPORT_HANDLERS: Record<string, Handler> = {
+    'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', '{"name":"wicked-garden"}')),
+    'GET /skills/support/scripts/_python.sh': () => Promise.resolve(fileRead('scripts/_python.sh', '#!/bin/sh')),
+  };
+
+  it('the Add modal refuses a files-map key the route layer would refuse (`a//b`, `a/./b`, `a/`, `a\\b`): the issue names the key, Save stays disabled, nothing is posted', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()) });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-add-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    fireEvent.change(within(modal).getByTestId('skills-files-name'), { target: { value: 'new-skill' } });
+
+    const refused: Array<[string, RegExp]> = [
+      ['a//b', /an empty segment/],
+      ['a/./b', /dot-only segment "\."/],
+      ['a/', /an empty segment/],
+      ['a\\b', /path separator/],
+    ];
+    for (const [key, reason] of refused) {
+      fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: JSON.stringify({ 'SKILL.md': 'new', [key]: 'y' }) } });
+      const issue = within(modal).getByTestId('skills-files-issue');
+      expect(issue).toHaveTextContent(`"${key}"`);
+      expect(issue).toHaveTextContent(reason);
+      expect(within(modal).getByTestId('skills-files-map')).toHaveAttribute('aria-invalid', 'true');
+      expect(within(modal).getByTestId('skills-files-save')).toBeDisabled();
+    }
+    // A clean nested key arms Save again.
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: JSON.stringify({ 'SKILL.md': 'new', 'refs/a.md': 'y' }) } });
+    expect(within(modal).queryByTestId('skills-files-issue')).toBeNull();
+    expect(within(modal).getByTestId('skills-files-save')).toBeEnabled();
+    expect(calls('POST', '/skills')).toBe(0);
+  });
+
+  it('Add applied but the post-add catalog re-read FAILS: the modal closes, the "Added" note stands, the stale banner shows, and the page does NOT navigate to ?skill=<name> (no "No skill named…" over a skill the daemon wrote)', async () => {
+    let added = false;
+    let fail = false;
+    wire({
+      'GET /skills': () => {
+        if (fail) return Promise.reject(new ApiError(500, 'store busy'));
+        return Promise.resolve(added
+          ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+          : catalog());
+      },
+      // The write lands — and the daemon's very next catalog read fails.
+      'POST /skills': () => { added = true; fail = true; return Promise.resolve(clear()); },
+      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-add-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    fireEvent.change(within(modal).getByTestId('skills-files-name'), { target: { value: 'new-skill' } });
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: '{"SKILL.md": "new"}' } });
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+
+    await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Added new-skill — publish to hand it to workers.');
+    const stale = await screen.findByTestId('skills-stale');
+    expect(stale).toHaveTextContent('The catalog could not be re-read.');
+    expect(stale).toHaveTextContent('store busy');
+    expect(calls('GET', '/skills')).toBe(2);
+    // No navigation, no dead-address note, no drawer: the rows on screen are the pre-add catalog, marked stale.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('skills-deep-link-missing')).toBeNull();
+    expect(screen.queryByTestId('skills-drawer')).toBeNull();
+    expect(screen.getAllByTestId('skills-row')).toHaveLength(4);
+    expect(screen.getByTestId('skills-add-open')).toBeDisabled();
+
+    // Retry: the re-read succeeds, the new skill is in the catalog, the note survived; the row is the door.
+    fail = false;
+    fireEvent.click(within(stale).getByTestId('skills-stale-retry'));
+    await waitFor(() => expect(screen.queryByTestId('skills-stale')).toBeNull());
+    expect(screen.getByTestId('skills-kpi-total').dataset.value).toBe('5');
+    expect(screen.getByTestId('skills-note')).toHaveTextContent('Added new-skill');
+    expect(navigate).not.toHaveBeenCalled();
+    fireEvent.click(row('new-skill'));
+    expect(navigate).toHaveBeenCalledWith('/skills?skill=new-skill');
+    expect((await screen.findByTestId('skills-drawer')).dataset.skill).toBe('new-skill');
+  });
+
+  it('switching BACK to Skill files while the list is still loading shows the loading state (nothing selected, no stray open, the Support tab still available); when the list lands, SKILL.md opens exactly once', async () => {
+    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
+    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => deferred,
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', SKILL_MD)),
+      [`GET /skills/${REPO_LEARN}/files/refs/notes.md`]: () => Promise.resolve(fileRead('refs/notes.md', 'notes')),
+      ...SUPPORT_HANDLERS,
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    // The mount, list pending: the tree AND the editor say a file is coming — not "pick a file" over nothing.
+    expect(within(drawer).getByTestId('skills-files-loading')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-file-loading')).toBeInTheDocument();
+    expect(within(drawer).queryByTestId('skills-file-none')).toBeNull();
+
+    // Slow list, fast support read: to Support…
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('support');
+
+    // …and quickly back to Skill while the list is still pending.
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    expect(within(drawer).getByTestId('skills-tab-skill')).toHaveAttribute('aria-selected', 'true');
+    expect(within(drawer).getByTestId('skills-file-tree').dataset.tab).toBe('skill');
+    expect(within(drawer).getByTestId('skills-files-loading')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-file-loading')).toBeInTheDocument();
+    expect(within(drawer).queryByTestId('skills-file-none')).toBeNull();
+    // Nothing selected, nothing opened, and the support file is NOT left on screen under the skill tab.
+    expect(within(drawer).queryByTestId('skills-editor')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-file-path')).toBeNull();
+    expect(within(drawer).queryAllByTestId('skills-file')).toHaveLength(0);
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(0);
+    // Not a trap: the operator can still leave for Support while the list is pending.
+    expect(within(drawer).getByTestId('skills-tab-support')).toBeEnabled();
+
+    await act(async () => {
+      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // The list landed on the tree that asked for it: SKILL.md opens — once, through the skill route.
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD));
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('skill');
+    const files = within(drawer).getAllByTestId('skills-file');
+    expect(files.map((f) => f.dataset.path)).toEqual(['SKILL.md', 'refs/notes.md']);
+    expect(files[0]).toHaveAttribute('aria-current', 'true');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(1);
+    // The in-flight list was waited for, not re-requested.
+    expect(calls('GET', `/skills/${REPO_LEARN}/files`)).toBe(1);
+    expect(within(drawer).queryByTestId('skills-files-loading')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-file-loading')).toBeNull();
+  });
+
+  it('…but a list that lands after the operator moved on AGAIN (Skill pending → Support) opens nothing; and a switch back re-selects the file last open on that tree, not always the first', async () => {
+    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
+    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => deferred,
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', SKILL_MD)),
+      [`GET /skills/${REPO_LEARN}/files/refs/notes.md`]: () => Promise.resolve(fileRead('refs/notes.md', 'notes')),
+      ...SUPPORT_HANDLERS,
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    expect(within(drawer).getByTestId('skills-file-loading')).toBeInTheDocument();
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    expect(calls('GET', '/skills/support/.claude-plugin/plugin.json')).toBe(2);
+
+    // The late list is data for the skill tree, not an instruction to open: the support editor stays.
+    await act(async () => {
+      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}');
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('support');
+    expect(within(drawer).getByTestId('skills-file-tree').dataset.tab).toBe('support');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(0);
+
+    // Back on Skill (the list is here): SKILL.md opens (nothing was open there yet); pick refs/notes.md…
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD));
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('notes'));
+    // …go to Support and come back: refs/notes.md is re-selected — the previous file, not SKILL.md again.
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('notes'));
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('refs/notes.md');
+    expect(within(drawer).getAllByTestId('skills-file')[1]).toHaveAttribute('aria-current', 'true');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(1);
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/refs/notes.md`)).toBe(2);
+  });
+});

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { SkillsPage } from '../src/components/SkillsPage.js';
 import { ApiError } from '../src/api/errors.js';
-import type { SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src/api/skills.js';
+import type { SkillFileEntry, SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src/api/skills.js';
 
 /**
  * The Skills file manager (`/skills`, the skills keystone — design v3) over a MOCKED `/skills`
@@ -25,7 +25,13 @@ import type { SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src
  *  - the page verbs: Publish (`POST /skills/publish`, findings shown, the snapshot line moves),
  *    Analyze (`POST /skills/analyze`, a dry run — no body, no reload), Refresh baseline;
  *  - a daemon WITHOUT the routes (bare 404 / 501) renders the NAMED unsupported state — never a
- *    crash, never an empty catalog pretending; a mis-shaped answer is a named error.
+ *    crash, never an empty catalog pretending; a mis-shaped answer is a named error;
+ *  - the editor's honesty (review round 1): Save is conditioned on the revision its CONTENT was
+ *    read at and every catalog re-read re-reads the open file — an intervening change under
+ *    unsaved edits surfaces as the file conflict, never a silent overwrite; Save's endpoint
+ *    follows the file's scope + requested path (never the tab, never the daemon's echoed `path`);
+ *    a file list answering after a tab switch is ignored; the active file locks while dirty;
+ *    a failed re-read marks the page stale and freezes writes; a write in flight freezes the rest.
  */
 
 const apiFetch = vi.fn();
@@ -413,10 +419,20 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
       revision: REV_2,
       findings: [{ kind: 'frontmatter-description', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'description is empty' }],
     };
+    // The daemon keeps what it was handed — the post-save re-read must find the saved text.
+    let content = SKILL_MD;
+    let revision = REV_1;
     wire({
-      'GET /skills': () => Promise.resolve(catalog()),
+      'GET /skills': () => Promise.resolve(catalog({ revision })),
       ...fileHandlers(REPO_LEARN),
-      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: (init) => { puts.push(body(init)); return Promise.resolve(warnings); },
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', content)),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: (init) => {
+        const b = body(init) as { content: string };
+        puts.push(b);
+        content = b.content;
+        revision = REV_2;
+        return Promise.resolve(warnings);
+      },
     });
     render(<Harness />);
     const drawer = await openDrawer(REPO_LEARN);
@@ -550,6 +566,51 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
     expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
   });
 
+  it('Save binds to the REQUESTED identity — a daemon echoing a different `path` in the read cannot redirect the write', async () => {
+    const puts: string[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+      // The body claims a path that would normalize onto the support route.
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('../../support/scripts/a.sh', 'body')),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => { puts.push('skill'); return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    // The editor names the file it was ASKED for, not the one the daemon claims.
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('SKILL.md');
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('skill');
+    fireEvent.change(editor, { target: { value: 'body edited' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+    await waitFor(() => expect(puts).toEqual(['skill']));
+    expect(apiFetch.mock.calls.some(([p, init]) => (init as Init)?.method === 'PUT' && String(p).includes('..'))).toBe(false);
+  });
+
+  it('clicking the ACTIVE file with unsaved edits never reloads it — the whole tree locks while dirty, the draft stays', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    const [active, other] = within(drawer).getAllByTestId('skills-file');
+    expect(active).toHaveAttribute('aria-current', 'true');
+    expect(active).toBeEnabled();
+
+    fireEvent.change(editor, { target: { value: 'UNSAVED' } });
+    expect(active).toBeDisabled();
+    expect(other).toBeDisabled();
+    expect(active).toHaveAttribute('title', 'save or discard your edits first');
+    fireEvent.click(active!);
+    // Nothing re-read, nothing discarded.
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(1);
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('UNSAVED');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+
+    // Discarding unlocks the tree again.
+    fireEvent.click(within(drawer).getByTestId('skills-discard-edits'));
+    expect(within(drawer).getAllByTestId('skills-file')[0]).toBeEnabled();
+  });
+
   it('closing with unsaved edits asks first; Escape does not eat the draft', async () => {
     wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
     render(<Harness />);
@@ -570,6 +631,281 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
   });
 });
 
+describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision its content was read at', () => {
+  /** A daemon whose one skill file can change under the editor: `content`/`hash` are what the
+   *  file read answers, `revision` what the catalog answers. */
+  function movingDaemon() {
+    const d = { content: SKILL_MD, hash: 'h-1', revision: REV_1, puts: [] as unknown[] };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({ revision: d.revision })),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: d.hash, size: d.content.length }] }),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve({ ...fileRead('SKILL.md', d.content), hash: d.hash }),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: (init) => { d.puts.push(body(init)); return Promise.resolve(clear(REV_3)); },
+    });
+    return d;
+  }
+
+  const externalChange = (d: ReturnType<typeof movingDaemon>): void => {
+    d.content = `${SKILL_MD}\n\nChanged by another session.`;
+    d.hash = 'h-2';
+    d.revision = REV_2;
+  };
+
+  it('load at r1 → external change to r2 → Refresh → Save: the file is RE-READ, the draft kept, the intervening change surfaces, nothing is written', async () => {
+    const d = movingDaemon();
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    expect(editor).toHaveValue(SKILL_MD);
+    fireEvent.change(editor, { target: { value: 'mine' } });
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+
+    externalChange(d);
+    fireEvent.click(screen.getByTestId('skills-reload'));
+    await waitFor(() => expect(calls('GET', '/skills')).toBe(2));
+
+    // The refresh re-read the open file and found it changed under a dirty editor.
+    const conflict = await within(drawer).findByTestId('skills-file-conflict');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(2);
+    expect(conflict).toHaveTextContent('This file changed on the daemon while you were editing.');
+    expect(conflict).toHaveTextContent('is now h-2');
+    expect(conflict).toHaveTextContent('you started from h-1');
+    // The draft is preserved and Save waits — the codex probe's silent `expectedRevision: r2` overwrite cannot happen.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('mine');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    const save = within(drawer).getByTestId('skills-save');
+    expect(save).toBeDisabled();
+    expect(save).toHaveAttribute('title', expect.stringMatching(/changed on the daemon/));
+    fireEvent.click(save);
+    expect(d.puts).toEqual([]);
+    expect(screen.queryByTestId('skills-conflict')).toBeNull();
+
+    // Loading the daemon's version discards the draft: the editor shows r2's bytes, pristine.
+    fireEvent.click(within(conflict).getByTestId('skills-file-conflict-take'));
+    expect(within(drawer).queryByTestId('skills-file-conflict')).toBeNull();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue(d.content);
+    expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(d.puts).toEqual([]);
+  });
+
+  it('…or the operator keeps the draft: Save then sends the revision the daemon’s version was read at — an explicit replace, never a silent one', async () => {
+    const d = movingDaemon();
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'mine' } });
+
+    externalChange(d);
+    fireEvent.click(screen.getByTestId('skills-reload'));
+    const conflict = await within(drawer).findByTestId('skills-file-conflict');
+    fireEvent.click(within(conflict).getByTestId('skills-file-conflict-keep'));
+    expect(within(drawer).queryByTestId('skills-file-conflict')).toBeNull();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('mine');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    const save = within(drawer).getByTestId('skills-save');
+    expect(save).toBeEnabled();
+    fireEvent.click(save);
+    await waitFor(() => expect(d.puts).toHaveLength(1));
+    expect(d.puts).toEqual([{ content: 'mine', expectedRevision: REV_2 }]);
+  });
+
+  it('a PRISTINE editor adopts the daemon’s version on Refresh, and a later Save is conditioned on the revision that content was read at (r2, not r1)', async () => {
+    const d = movingDaemon();
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+
+    externalChange(d);
+    fireEvent.click(screen.getByTestId('skills-reload'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue(d.content));
+    expect(within(drawer).queryByTestId('skills-file-conflict')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull();
+
+    fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: `${d.content}\nmine` } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+    await waitFor(() => expect(d.puts).toHaveLength(1));
+    expect((d.puts[0] as { expectedRevision: string }).expectedRevision).toBe(REV_2);
+  });
+
+  it('a row toggle that advances the revision re-reads the open file, so the drawer’s Save rides the revision its (unchanged) content now stands at', async () => {
+    const d = movingDaemon();
+    apiFetch.mockImplementation((path: unknown, init?: Init) => {
+      if (String(path) === `/skills/${A11Y}/enable` && init?.method === 'POST') { d.revision = REV_2; return Promise.resolve(clear(REV_2)); }
+      const key = `${init?.method ?? 'GET'} ${String(path)}`;
+      if (key === 'GET /skills') return Promise.resolve(catalog({ revision: d.revision }));
+      if (key === `GET /skills/${REPO_LEARN}/files`) return Promise.resolve({ files: [{ path: 'SKILL.md', hash: d.hash, size: 1 }] });
+      if (key === `GET /skills/${REPO_LEARN}/files/SKILL.md`) return Promise.resolve({ ...fileRead('SKILL.md', d.content), hash: d.hash });
+      if (key === `PUT /skills/${REPO_LEARN}/files/SKILL.md`) { d.puts.push(body(init)); return Promise.resolve(clear(REV_3)); }
+      return Promise.reject(new ApiError(404, 'Not Found'));
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(1);
+
+    fireEvent.click(within(row(A11Y)).getByTestId('skills-toggle'));
+    await waitFor(() => expect(calls('GET', '/skills')).toBe(2));
+    await waitFor(() => expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(2));
+    expect(within(drawer).queryByTestId('skills-file-conflict')).toBeNull();
+
+    fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: 'after the toggle' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+    await waitFor(() => expect(d.puts).toHaveLength(1));
+    expect(d.puts).toEqual([{ content: 'after the toggle', expectedRevision: REV_2 }]);
+  });
+});
+
+describe('SkillsPage — late answers are ignored; the file’s scope travels with it', () => {
+  it('a file list that answers AFTER the operator switched to Support does not swap the editor onto SKILL.md; Save follows the support file', async () => {
+    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
+    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    const puts: string[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => deferred,
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', SKILL_MD)),
+      'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', '{"name":"wicked-garden"}')),
+      'GET /skills/support/scripts/_python.sh': () => Promise.resolve(fileRead('scripts/_python.sh', '#!/bin/sh')),
+      'PUT /skills/support/.claude-plugin/plugin.json': () => { puts.push('support'); return Promise.resolve(clear()); },
+      'PUT /skills/support/SKILL.md': () => { puts.push('WRONG: support route for a skill file'); return Promise.resolve(clear()); },
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => { puts.push('WRONG: skill route'); return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    expect(within(drawer).getByTestId('skills-files-loading')).toBeInTheDocument();
+
+    // The operator moves to Support before the skill list answers.
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('support');
+
+    // The list lands late: data for the skill tree, NOT an instruction to open SKILL.md.
+    await act(async () => {
+      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}');
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('.claude-plugin/plugin.json');
+    expect(within(drawer).getByTestId('skills-file-tree').dataset.tab).toBe('support');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(0);
+
+    fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: '{"name":"wicked-garden","v":2}' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+    await waitFor(() => expect(puts).toEqual(['support']));
+    // The save settled (the file is the saved text again) before the tree is touched.
+    await waitFor(() => expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull());
+    await waitFor(() => expect(calls('GET', '/skills')).toBe(2));
+
+    // Back on the skill tree the late list is there, and SKILL.md opens through the skill route.
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD));
+    expect(within(drawer).getAllByTestId('skills-file').map((f) => f.dataset.path)).toEqual(['SKILL.md', 'refs/notes.md']);
+    expect(within(drawer).getByTestId('skills-file-path').dataset.scope).toBe('skill');
+  });
+});
+
+describe('SkillsPage — stale catalog and in-flight writes freeze every write affordance', () => {
+  it('a FAILED catalog re-read marks the page stale: the rows stay readable, every write (rows, verbs, Add, the drawer’s Save) waits until a re-read succeeds', async () => {
+    let fail = false;
+    wire({
+      'GET /skills': () => (fail ? Promise.reject(new ApiError(500, 'store busy')) : Promise.resolve(catalog())),
+      ...fileHandlers(REPO_LEARN),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft' } });
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+
+    fail = true;
+    fireEvent.click(screen.getByTestId('skills-reload'));
+    const stale = await screen.findByTestId('skills-stale');
+    expect(stale).toHaveTextContent('The catalog could not be re-read.');
+    expect(stale).toHaveTextContent('store busy');
+    // Not the first-load failure state: the catalog on screen stays.
+    expect(screen.queryByTestId('skills-error')).toBeNull();
+    expect(screen.getAllByTestId('skills-row')).toHaveLength(4);
+    for (const r of screen.getAllByTestId('skills-row')) expect(within(r).getByTestId('skills-toggle')).toBeDisabled();
+    expect(screen.getByTestId('skills-publish')).toBeDisabled();
+    expect(screen.getByTestId('skills-refresh')).toBeDisabled();
+    expect(screen.getByTestId('skills-add-open')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-drawer-toggle')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-reset-open')).toBeDisabled();
+    // The draft is untouched.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft');
+
+    fail = false;
+    fireEvent.click(within(stale).getByTestId('skills-stale-retry'));
+    await waitFor(() => expect(screen.queryByTestId('skills-stale')).toBeNull());
+    expect(within(row(MINE)).getByTestId('skills-toggle')).toBeEnabled();
+    expect(screen.getByTestId('skills-publish')).toBeEnabled();
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+  });
+
+  it('a page verb in flight (Publish) freezes the row switches, Add, the other verbs and the drawer’s Save until it answers', async () => {
+    let resolvePublish: (v: SkillGuardResult) => void = () => {};
+    const deferred = new Promise<SkillGuardResult>((r) => { resolvePublish = r; });
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      'POST /skills/publish': () => deferred,
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft' } });
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+    expect(within(row(MINE)).getByTestId('skills-toggle')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('skills-publish'));
+    expect(screen.getByTestId('skills-publish')).toHaveTextContent('Publish…');
+    for (const r of screen.getAllByTestId('skills-row')) expect(within(r).getByTestId('skills-toggle')).toBeDisabled();
+    expect(screen.getByTestId('skills-add-open')).toBeDisabled();
+    expect(screen.getByTestId('skills-refresh')).toBeDisabled();
+    expect(screen.getByTestId('skills-analyze')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-drawer-toggle')).toBeDisabled();
+
+    await act(async () => {
+      resolvePublish(clear(REV_2));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await screen.findByTestId('skills-page-findings');
+    await waitFor(() => expect(within(row(MINE)).getByTestId('skills-toggle')).toBeEnabled());
+    expect(screen.getByTestId('skills-add-open')).toBeEnabled();
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft');
+  });
+
+  it('a row switch in flight freezes the other rows and the drawer too — writes share one revision', async () => {
+    let resolveFlip: (v: SkillGuardResult) => void = () => {};
+    const deferred = new Promise<SkillGuardResult>((r) => { resolveFlip = r; });
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${MINE}/disable`]: () => deferred,
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft' } });
+
+    fireEvent.click(within(row(MINE)).getByTestId('skills-toggle'));
+    for (const r of screen.getAllByTestId('skills-row')) expect(within(r).getByTestId('skills-toggle')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(screen.getByTestId('skills-publish')).toBeDisabled();
+
+    await act(async () => {
+      resolveFlip(clear(REV_2));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(within(row(A11Y)).getByTestId('skills-toggle')).toBeEnabled());
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+  });
+});
+
 describe('SkillsPage — the Support tab (root support files)', () => {
   it('lists the manifest’s support files path-sorted, opens the first, and Save PUTs /skills/support/*path with {content, expectedRevision}', async () => {
     const puts: unknown[] = [];
@@ -578,12 +914,18 @@ describe('SkillsPage — the Support tab (root support files)', () => {
       revision: REV_2,
       findings: [{ kind: 'support-edit', severity: 'warning', skill: null, file: '.claude-plugin/plugin.json', line: null, explanation: 'a support file is shared by every skill' }],
     };
+    let pluginJson = '{"name":"wicked-garden"}';
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       ...fileHandlers(REPO_LEARN),
-      'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', '{"name":"wicked-garden"}')),
+      'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', pluginJson)),
       'GET /skills/support/scripts/_python.sh': () => Promise.resolve(fileRead('scripts/_python.sh', '#!/bin/sh')),
-      'PUT /skills/support/.claude-plugin/plugin.json': (init) => { puts.push(body(init)); return Promise.resolve(supportWarning); },
+      'PUT /skills/support/.claude-plugin/plugin.json': (init) => {
+        const b = body(init) as { content: string };
+        puts.push(b);
+        pluginJson = b.content;
+        return Promise.resolve(supportWarning);
+      },
     });
     render(<Harness />);
     const drawer = await openDrawer(REPO_LEARN);

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -1,0 +1,958 @@
+import { useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { SkillsPage } from '../src/components/SkillsPage.js';
+import { ApiError } from '../src/api/errors.js';
+import type { SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src/api/skills.js';
+
+/**
+ * The Skills file manager (`/skills`, the skills keystone — design v3) over a MOCKED `/skills`
+ * wire:
+ *  - the catalog renders as the KPI band (total · enabled · overridden · core · portable) + one
+ *    row per skill with kind / provenance chips and the core / claude-only / conflict / unpublished
+ *    badges; the source and snapshot lines name the baseline and the current generation;
+ *  - CAS: every mutation sends `expectedRevision` (the catalog revision) and the answered
+ *    `revision` is adopted for the next one; a 409 raises the `skills-conflict` reload prompt and
+ *    freezes every write until the catalog is re-read;
+ *  - the row switch POSTs `/skills/:name/{enable,disable}` and the catalog reloads for the
+ *    manifest's answer; a `blocked` refusal renders the findings and reloads nothing;
+ *  - a row click is a NAVIGATION to `?skill=<name>`; the drawer lists the skill's files
+ *    (SKILL.md first) and — under the Support tab — the root support files; Save PUTs
+ *    `{content, expectedRevision}`, the findings render, a `blocked` verdict disables Save for
+ *    that exact draft, a `truncated` or `binary` read disables Save outright;
+ *  - Reset is a typed confirmation over `POST /skills/:name/reset` (disabled for a user-added
+ *    skill); Delete (user-added only) over `DELETE /skills/:name`; Replace / Add post files maps;
+ *  - the page verbs: Publish (`POST /skills/publish`, findings shown, the snapshot line moves),
+ *    Analyze (`POST /skills/analyze`, a dry run — no body, no reload), Refresh baseline;
+ *  - a daemon WITHOUT the routes (bare 404 / 501) renders the NAMED unsupported state — never a
+ *    crash, never an empty catalog pretending; a mis-shaped answer is a named error.
+ */
+
+const apiFetch = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  apiFetch: (...a: unknown[]) => apiFetch(...a),
+}));
+
+function entry(over: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+  return {
+    dir: 'skills/x',
+    kind: 'module',
+    core: false,
+    portable: true,
+    enabled: true,
+    baselineHash: 'a'.repeat(8),
+    effectiveHash: 'a'.repeat(8),
+    lastPublishedHash: 'a'.repeat(8),
+    editedAt: null,
+    conflict: false,
+    ...over,
+  };
+}
+
+const REPO_LEARN = 'wicked-garden-repo-learn';
+const EXTRACTOR = 'wicked-garden-domain-extractor';
+const A11Y = 'wicked-garden-qe-a11y-test-engineer';
+const MINE = 'my-team-skill';
+
+const REV_1 = 'rev-0001';
+const REV_2 = 'rev-0002';
+const REV_3 = 'rev-0003';
+
+function catalog(opts: { skills?: Record<string, SkillManifestEntry>; revision?: string; plugin_version?: string; generation?: number | null } = {}): SkillsCatalog {
+  return {
+    manifest: {
+      baseline: {
+        contentHash: 'b'.repeat(16),
+        source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0', plugin_version: opts.plugin_version ?? '12.32.0', git_sha: 'abcdef0123456789', captured_at: '2026-09-08T00:00:00Z' },
+      },
+      skills: {
+        [REPO_LEARN]: entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
+        // An override (effective ≠ baseline), Claude-only, in refresh conflict, not yet published.
+        [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, effectiveHash: 'c'.repeat(8), conflict: true, editedAt: '2026-09-07T10:00:00Z' }),
+        [A11Y]: entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
+        // User-added: no baseline, never published.
+        [MINE]: entry({ dir: `skills/${MINE}`, baselineHash: null, lastPublishedHash: null }),
+        ...opts.skills,
+      },
+      support: { 'scripts/_python.sh': 'd'.repeat(8), '.claude-plugin/plugin.json': 'e'.repeat(8) },
+      currentGeneration: opts.generation === undefined ? 3 : opts.generation,
+    },
+    revision: opts.revision ?? REV_1,
+  };
+}
+
+function clear(revision = REV_2): SkillGuardResult {
+  return { verdict: 'clear', findings: [], revision };
+}
+
+type Init = { method?: string; body?: string } | undefined;
+type Handler = (init: Init) => Promise<unknown>;
+
+/** Wire handlers keyed by `METHOD /path`; everything else is the bare unknown-route 404. */
+function wire(handlers: Record<string, Handler>): void {
+  apiFetch.mockImplementation((path: unknown, init?: Init) => {
+    const h = handlers[`${init?.method ?? 'GET'} ${String(path)}`];
+    if (h !== undefined) return h(init);
+    return Promise.reject(new ApiError(404, 'Not Found'));
+  });
+}
+
+/** How many times a `METHOD /path` was asked for. */
+function calls(method: string, path: string): number {
+  return apiFetch.mock.calls.filter(([p, init]) => String(p) === path && ((init as Init)?.method ?? 'GET') === method).length;
+}
+
+function body(init: Init): unknown {
+  return JSON.parse(init!.body!);
+}
+
+const SKILL_MD = `---\nname: ${REPO_LEARN}\n---\nLearn the repo.`;
+
+function fileRead(path: string, content: string, over: Partial<{ truncated: boolean; binary: boolean }> = {}) {
+  return { path, content, size: content.length, hash: 'f'.repeat(8), truncated: false, binary: false, ...over };
+}
+
+function fileHandlers(name: string): Record<string, Handler> {
+  return {
+    [`GET /skills/${name}/files`]: () => Promise.resolve({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] }),
+    [`GET /skills/${name}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', SKILL_MD)),
+    [`GET /skills/${name}/files/refs/notes.md`]: () => Promise.resolve(fileRead('refs/notes.md', 'notes')),
+  };
+}
+
+const navigate = vi.fn();
+
+/** The page under its real address contract: `navigate` updates the `search` the page reads. */
+function Harness({ initialSearch = '' }: { initialSearch?: string }): React.ReactElement {
+  const [search, setSearch] = useState(initialSearch);
+  return (
+    <SkillsPage
+      navigate={(p) => { navigate(p); setSearch(new URL(p, 'http://studio.test').search); }}
+      search={search}
+    />
+  );
+}
+
+function row(name: string): HTMLElement {
+  return screen.getAllByTestId('skills-row').find((r) => r.dataset.skill === name)!;
+}
+
+async function openDrawer(name: string): Promise<HTMLElement> {
+  await screen.findAllByTestId('skills-row');
+  fireEvent.click(row(name));
+  expect(navigate).toHaveBeenCalledWith(`/skills?skill=${name}`);
+  const drawer = await screen.findByTestId('skills-drawer');
+  expect(drawer.dataset.skill).toBe(name);
+  return drawer;
+}
+
+beforeEach(() => {
+  cleanup();
+  apiFetch.mockReset();
+  navigate.mockReset();
+});
+
+describe('SkillsPage — the catalog from the manifest', () => {
+  it('renders the five KPIs, the source + snapshot lines, and one row per skill with chips + badges', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()) });
+    render(<Harness />);
+
+    expect(await screen.findByTestId('skills-kpis')).toBeInTheDocument();
+    expect(screen.getByTestId('skills-kpi-total').dataset.value).toBe('4');
+    expect(screen.getByTestId('skills-kpi-enabled').dataset.value).toBe('3');
+    expect(screen.getByTestId('skills-kpi-overridden').dataset.value).toBe('1');
+    expect(screen.getByTestId('skills-kpi-core').dataset.value).toBe('2');
+    expect(screen.getByTestId('skills-kpi-portable').dataset.value).toBe('3');
+    expect(screen.getByTestId('skills-source')).toHaveTextContent('baseline 12.32.0 · claude-plugin-cache · bbbbbbbbbbbb · abcdef0123');
+    const snapshot = screen.getByTestId('skills-snapshot');
+    expect(snapshot).toHaveTextContent('snapshot generation 3 is current · 2 unpublished skills');
+    expect(snapshot.dataset.generation).toBe('3');
+    expect(snapshot.dataset.unpublished).toBe('2');
+
+    const rows = screen.getAllByTestId('skills-row');
+    expect(rows.map((r) => r.dataset.skill)).toEqual([MINE, EXTRACTOR, A11Y, REPO_LEARN]);
+
+    const extractor = row(EXTRACTOR);
+    expect(within(extractor).getByTestId('skills-kind-chip').dataset.kind).toBe('fork-worker');
+    expect(within(extractor).getByTestId('skills-provenance-chip').dataset.provenance).toBe('override');
+    expect(within(extractor).getByTestId('skills-core-badge')).toBeInTheDocument();
+    expect(within(extractor).getByTestId('skills-claude-only-badge')).toBeInTheDocument();
+    expect(within(extractor).getByTestId('skills-conflict-badge')).toBeInTheDocument();
+    expect(within(extractor).getByTestId('skills-unpublished-badge')).toBeInTheDocument();
+    expect(within(extractor).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'true');
+
+    const mine = row(MINE);
+    expect(within(mine).getByTestId('skills-provenance-chip').dataset.provenance).toBe('user-added');
+    expect(within(mine).getByTestId('skills-unpublished-badge')).toBeInTheDocument();
+    expect(within(mine).queryByTestId('skills-core-badge')).toBeNull();
+    expect(within(mine).queryByTestId('skills-claude-only-badge')).toBeNull();
+    expect(within(mine).queryByTestId('skills-conflict-badge')).toBeNull();
+
+    const learn = row(REPO_LEARN);
+    expect(within(learn).getByTestId('skills-provenance-chip').dataset.provenance).toBe('shipped');
+    expect(within(learn).queryByTestId('skills-unpublished-badge')).toBeNull();
+
+    expect(within(row(A11Y)).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'false');
+    expect(row(A11Y).dataset.enabled).toBe('false');
+    expect(screen.queryByTestId('skills-drawer')).toBeNull();
+    expect(screen.queryByTestId('skills-conflict')).toBeNull();
+  });
+
+  it('a never-published root says so on the snapshot line', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog({ generation: null })) });
+    render(<Harness />);
+    const snapshot = await screen.findByTestId('skills-snapshot');
+    expect(snapshot).toHaveTextContent(/never published/);
+    expect(snapshot.dataset.generation).toBe('none');
+  });
+
+  it('the KPI tiles are doors into the matching filter chip', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()) });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    fireEvent.click(screen.getByTestId('skills-kpi-overridden'));
+    expect(screen.getByTestId('skills-filter').dataset.filter).toBe('overridden');
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([EXTRACTOR]);
+
+    fireEvent.click(screen.getByTestId('skills-kpi-core'));
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([EXTRACTOR, REPO_LEARN]);
+
+    fireEvent.click(screen.getByTestId('skills-kpi-portable'));
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([MINE, A11Y, REPO_LEARN]);
+
+    fireEvent.click(screen.getByTestId('skills-kpi-enabled'));
+    expect(screen.getAllByTestId('skills-row')).toHaveLength(3);
+
+    fireEvent.click(screen.getByTestId('skills-kpi-total'));
+    expect(screen.getAllByTestId('skills-row')).toHaveLength(4);
+  });
+});
+
+describe('SkillsPage — the honest non-catalog states', () => {
+  it('a daemon without the routes (bare 404) renders the NAMED unsupported state — no crash, no empty catalog', async () => {
+    wire({});
+    render(<Harness />);
+    const state = await screen.findByTestId('skills-unsupported');
+    expect(state).toHaveTextContent(/predates the skills catalog/);
+    expect(screen.queryByTestId('skills-kpis')).toBeNull();
+    expect(screen.queryByTestId('skills-grid')).toBeNull();
+    expect(screen.queryByTestId('skills-error')).toBeNull();
+    // The write verbs are not offered against a daemon that cannot serve them.
+    expect(screen.queryByTestId('skills-add-open')).toBeNull();
+    expect(screen.queryByTestId('skills-publish')).toBeNull();
+    expect(screen.queryByTestId('skills-refresh')).toBeNull();
+    expect(screen.queryByTestId('skills-analyze')).toBeNull();
+  });
+
+  it('a 501 (route present, no skills root) is the same named state', async () => {
+    wire({ 'GET /skills': () => Promise.reject(new ApiError(501, 'no skills root configured')) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-unsupported')).toBeInTheDocument();
+  });
+
+  it('a real refusal renders the translated error, and a mis-shaped answer a named one', async () => {
+    wire({ 'GET /skills': () => Promise.reject(new ApiError(500, 'skills store corrupt')) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent('the daemon refused this — skills store corrupt');
+    cleanup();
+
+    // A bare manifest with no revision is NOT the v3 catalog — a named error, never zero skills.
+    wire({ 'GET /skills': () => Promise.resolve(catalog().manifest) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog/);
+  });
+
+  it('a ?skill= deep link the manifest does not carry says so and shows every skill', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()) });
+    render(<Harness initialSearch="?skill=nope" />);
+    expect(await screen.findByTestId('skills-deep-link-missing')).toHaveTextContent('nope');
+    expect(screen.getAllByTestId('skills-row')).toHaveLength(4);
+    expect(screen.queryByTestId('skills-drawer')).toBeNull();
+  });
+});
+
+describe('SkillsPage — the row switch (enable/disable through the guards, CAS)', () => {
+  it('POSTs /skills/:name/enable with {expectedRevision}, reloads, and chains the answered revision into the next write', async () => {
+    let enabled = false;
+    let revision = REV_1;
+    const bodies: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({ revision, skills: { [A11Y]: entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled }) } })),
+      [`POST /skills/${A11Y}/enable`]: (init) => { bodies.push(body(init)); enabled = true; revision = REV_2; return Promise.resolve(clear(REV_2)); },
+      [`POST /skills/${A11Y}/disable`]: (init) => { bodies.push(body(init)); enabled = false; revision = REV_3; return Promise.resolve(clear(REV_3)); },
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    fireEvent.click(within(row(A11Y)).getByTestId('skills-toggle'));
+    await waitFor(() => expect(within(row(A11Y)).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'true'));
+    expect(calls('POST', `/skills/${A11Y}/enable`)).toBe(1);
+    expect(calls('GET', '/skills')).toBe(2);
+    expect(screen.getByTestId('skills-kpi-enabled').dataset.value).toBe('4');
+    // A clear flip needs no banner — the switch is the answer.
+    expect(screen.queryByTestId('skills-page-findings')).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+
+    // The second write is conditioned on the revision the first one answered with.
+    fireEvent.click(within(row(A11Y)).getByTestId('skills-toggle'));
+    await waitFor(() => expect(within(row(A11Y)).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'false'));
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }, { expectedRevision: REV_2 }]);
+  });
+
+  it('a blocked disable (a core skill) renders the findings and reloads nothing — the switch stays on', async () => {
+    const blocked: SkillGuardResult = {
+      verdict: 'blocked',
+      revision: REV_1,
+      findings: [{ kind: 'core-disable', severity: 'blocking', skill: REPO_LEARN, file: 'workflows/repo-learn.json', line: null, explanation: 'a registered workflow names this skill by skill_ref' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`POST /skills/${REPO_LEARN}/disable`]: () => Promise.resolve(blocked),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    fireEvent.click(within(row(REPO_LEARN)).getByTestId('skills-toggle'));
+    const findings = await screen.findByTestId('skills-page-findings');
+    expect(findings.dataset.verdict).toBe('blocked');
+    expect(findings).toHaveTextContent(`Disable ${REPO_LEARN} blocked — nothing was written (1 finding).`);
+    const finding = within(findings).getByTestId('skills-finding');
+    expect(finding.dataset.kind).toBe('core-disable');
+    expect(finding.dataset.severity).toBe('blocking');
+    expect(finding).toHaveTextContent(`against ${REPO_LEARN}`);
+    expect(within(finding).getByTestId('skills-finding-location')).toHaveTextContent('workflows/repo-learn.json');
+    expect(calls('GET', '/skills')).toBe(1);
+    expect(within(row(REPO_LEARN)).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('a wire failure on the flip surfaces as the page error', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`POST /skills/${MINE}/disable`]: () => Promise.reject(new ApiError(500, 'disk full')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(within(row(MINE)).getByTestId('skills-toggle'));
+    expect(await screen.findByTestId('skills-page-error')).toHaveTextContent('disk full');
+  });
+
+  it('a 409 raises the reload prompt with the daemon’s sentence, freezes every write, and Reload re-reads the catalog', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`POST /skills/${MINE}/disable`]: () => Promise.reject(new ApiError(409, 'expected revision rev-0001, catalog is at rev-0002')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    fireEvent.click(within(row(MINE)).getByTestId('skills-toggle'));
+    const prompt = await screen.findByTestId('skills-conflict');
+    expect(prompt).toHaveTextContent('The skills catalog changed under this page.');
+    expect(prompt).toHaveTextContent('expected revision rev-0001, catalog is at rev-0002');
+    // Not an error banner, not a findings banner — a named state.
+    expect(screen.queryByTestId('skills-page-error')).toBeNull();
+    expect(screen.queryByTestId('skills-page-findings')).toBeNull();
+    // Frozen: every switch and page verb waits for the reload.
+    for (const r of screen.getAllByTestId('skills-row')) expect(within(r).getByTestId('skills-toggle')).toBeDisabled();
+    expect(screen.getByTestId('skills-publish')).toBeDisabled();
+    expect(screen.getByTestId('skills-add-open')).toBeDisabled();
+    expect(calls('GET', '/skills')).toBe(1);
+
+    fireEvent.click(within(prompt).getByTestId('skills-conflict-reload'));
+    await waitFor(() => expect(calls('GET', '/skills')).toBe(2));
+    await waitFor(() => expect(screen.queryByTestId('skills-conflict')).toBeNull());
+    expect(within(row(MINE)).getByTestId('skills-toggle')).toBeEnabled();
+    expect(screen.getByTestId('skills-publish')).toBeEnabled();
+  });
+});
+
+describe('SkillsPage — the drawer: files, the textarea editor, Save → findings', () => {
+  it('a row click navigates to ?skill=<name>; the drawer lists files SKILL.md-first and loads it into the editor', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+
+    const files = await within(drawer).findAllByTestId('skills-file');
+    expect(files.map((f) => f.dataset.path)).toEqual(['SKILL.md', 'refs/notes.md']);
+    const tree = within(drawer).getByTestId('skills-file-tree');
+    expect(tree.dataset.tab).toBe('skill');
+    expect(within(tree).getAllByTestId('skills-file')).toHaveLength(2);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    expect(editor).toHaveValue(SKILL_MD);
+    expect(files[0]).toHaveAttribute('aria-current', 'true');
+    expect(within(drawer).getByTestId('skills-drawer-dir')).toHaveTextContent('skills/repo-learn');
+    expect(within(drawer).getByTestId('skills-core-badge')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-tab-skill')).toHaveAttribute('aria-selected', 'true');
+    expect(within(drawer).getByTestId('skills-tab-support')).toHaveAttribute('aria-selected', 'false');
+    // Pristine: Save is disabled, nothing is dirty.
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull();
+    // The row reads selected.
+    expect(row(REPO_LEARN)).toHaveAttribute('aria-selected', 'true');
+
+    // Picking the other file loads it.
+    fireEvent.click(files[1]!);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('notes'));
+  });
+
+  it('the ?skill= deep link opens the drawer directly; close returns to the bare catalog', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
+    render(<Harness initialSearch={`?skill=${REPO_LEARN}`} />);
+    const drawer = await screen.findByTestId('skills-drawer');
+    expect(drawer.dataset.skill).toBe(REPO_LEARN);
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-close'));
+    expect(navigate).toHaveBeenCalledWith('/skills');
+    await waitFor(() => expect(screen.queryByTestId('skills-drawer')).toBeNull());
+  });
+
+  it('Save PUTs {content, expectedRevision}; the findings render, the file is the saved text, the catalog reloads', async () => {
+    const puts: unknown[] = [];
+    const warnings: SkillGuardResult = {
+      verdict: 'warnings',
+      revision: REV_2,
+      findings: [{ kind: 'frontmatter-description', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'description is empty' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: (init) => { puts.push(body(init)); return Promise.resolve(warnings); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+
+    const next = `${SKILL_MD}\n\nAlso: learn faster.`;
+    fireEvent.change(editor, { target: { value: next } });
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    // Other files AND the other tree lock while this one is dirty.
+    expect(within(drawer).getAllByTestId('skills-file')[1]).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-tab-support')).toBeDisabled();
+    const save = within(drawer).getByTestId('skills-save');
+    expect(save).toBeEnabled();
+    fireEvent.click(save);
+
+    const findings = await within(drawer).findByTestId('skills-findings');
+    expect(findings.dataset.verdict).toBe('warnings');
+    expect(findings).toHaveTextContent('Save passed with 1 finding to read.');
+    expect(within(findings).getByTestId('skills-finding')).toHaveTextContent('description is empty');
+    expect(puts).toEqual([{ content: next, expectedRevision: REV_1 }]);
+    // Saved: no longer dirty, Save disabled again, catalog reloaded (provenance may have moved).
+    await waitFor(() => expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull());
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue(next);
+    expect(within(drawer).getByTestId('skills-tab-support')).toBeEnabled();
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+
+  it('a blocked Save renders the refusal and disables Save for that exact draft until it changes', async () => {
+    const blocked: SkillGuardResult = {
+      verdict: 'blocked',
+      revision: REV_1,
+      findings: [{ kind: 'frontmatter-name', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 2, explanation: 'frontmatter name must equal the path-derived name' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(blocked),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+
+    fireEvent.change(editor, { target: { value: '---\nname: other\n---' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+
+    const findings = await within(drawer).findByTestId('skills-findings');
+    expect(findings.dataset.verdict).toBe('blocked');
+    expect(findings).toHaveTextContent('Save blocked — nothing was written (1 finding).');
+    expect(within(findings).getByTestId('skills-finding-location')).toHaveTextContent('skills/repo-learn/SKILL.md:2');
+    // Still dirty (the daemon wrote nothing) but Save is OFF for this exact content…
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    // …and back ON once the draft changes.
+    fireEvent.change(editor, { target: { value: `---\nname: ${REPO_LEARN}\n---` } });
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+    // Nothing was reloaded: the refusal changed no state.
+    expect(calls('GET', '/skills')).toBe(1);
+  });
+
+  it('a wire failure on Save is the drawer error, the draft kept', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.reject(new ApiError(403, 'path escapes the skill dir')),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'x' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+    expect(await within(drawer).findByTestId('skills-drawer-error')).toHaveTextContent('path escapes the skill dir');
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('x');
+  });
+
+  it('a 409 on Save raises the page’s reload prompt; no findings, the draft kept, Save frozen until the reload', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.reject(new ApiError(409, 'stale revision')),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft' } });
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+
+    const prompt = await screen.findByTestId('skills-conflict');
+    expect(prompt).toHaveTextContent('stale revision');
+    expect(within(drawer).queryByTestId('skills-findings')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-drawer-error')).toBeNull();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft');
+    expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+    expect(within(drawer).getByTestId('skills-drawer-toggle')).toBeDisabled();
+
+    fireEvent.click(within(prompt).getByTestId('skills-conflict-reload'));
+    await waitFor(() => expect(screen.queryByTestId('skills-conflict')).toBeNull());
+    // The draft survived the reload and can be saved against the fresh revision.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft');
+    expect(within(drawer).getByTestId('skills-save')).toBeEnabled();
+  });
+
+  it('a truncated file is read-only — Save never clobbers what the editor cannot show', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'big.md', hash: 'h1', size: 900000 }, { path: 'SKILL.md', hash: 'h2', size: 900000 }] }),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'head…', { truncated: true })),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    expect(within(drawer).getByTestId('skills-file-readonly')).toHaveTextContent(/truncated/);
+    expect(editor).toHaveAttribute('readonly');
+    fireEvent.change(editor, { target: { value: 'head… more' } });
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+  });
+
+  it('a binary file is read-only too', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h2', size: 12 }] }),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', '', { binary: true })),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    expect(within(drawer).getByTestId('skills-file-readonly')).toHaveTextContent(/binary/);
+    expect(editor).toHaveAttribute('readonly');
+    fireEvent.change(editor, { target: { value: 'text over bytes' } });
+    expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
+  });
+
+  it('closing with unsaved edits asks first; Escape does not eat the draft', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    const editor = await within(drawer).findByTestId('skills-editor');
+    fireEvent.change(editor, { target: { value: 'draft' } });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.getByTestId('skills-drawer')).toBeInTheDocument();
+    const prompt = within(drawer).getByTestId('skills-discard-prompt');
+    fireEvent.click(within(prompt).getByTestId('skills-keep-editing'));
+    expect(within(drawer).queryByTestId('skills-discard-prompt')).toBeNull();
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue('draft');
+
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-close'));
+    fireEvent.click(within(drawer).getByTestId('skills-discard'));
+    expect(navigate).toHaveBeenCalledWith('/skills');
+  });
+});
+
+describe('SkillsPage — the Support tab (root support files)', () => {
+  it('lists the manifest’s support files path-sorted, opens the first, and Save PUTs /skills/support/*path with {content, expectedRevision}', async () => {
+    const puts: unknown[] = [];
+    const supportWarning: SkillGuardResult = {
+      verdict: 'warnings',
+      revision: REV_2,
+      findings: [{ kind: 'support-edit', severity: 'warning', skill: null, file: '.claude-plugin/plugin.json', line: null, explanation: 'a support file is shared by every skill' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', '{"name":"wicked-garden"}')),
+      'GET /skills/support/scripts/_python.sh': () => Promise.resolve(fileRead('scripts/_python.sh', '#!/bin/sh')),
+      'PUT /skills/support/.claude-plugin/plugin.json': (init) => { puts.push(body(init)); return Promise.resolve(supportWarning); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    expect(within(drawer).getByTestId('skills-tab-support')).toHaveAttribute('aria-selected', 'true');
+    expect(within(drawer).getByTestId('skills-support-note')).toHaveTextContent(/shared by every skill/);
+    const tree = within(drawer).getByTestId('skills-file-tree');
+    expect(tree.dataset.tab).toBe('support');
+    expect(within(tree).getAllByTestId('skills-file').map((f) => f.dataset.path)).toEqual(['.claude-plugin/plugin.json', 'scripts/_python.sh']);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}'));
+    expect(within(drawer).getByTestId('skills-file-path')).toHaveTextContent('.claude-plugin/plugin.json');
+
+    fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: '{"name":"wicked-garden","version":"x"}' } });
+    // The skill tree locks while a support file is dirty.
+    expect(within(drawer).getByTestId('skills-tab-skill')).toBeDisabled();
+    fireEvent.click(within(drawer).getByTestId('skills-save'));
+
+    const findings = await within(drawer).findByTestId('skills-findings');
+    expect(findings.dataset.verdict).toBe('warnings');
+    expect(within(findings).getByTestId('skills-finding').dataset.kind).toBe('support-edit');
+    expect(puts).toEqual([{ content: '{"name":"wicked-garden","version":"x"}', expectedRevision: REV_1 }]);
+    expect(calls('GET', '/skills')).toBe(2);
+
+    // Back to the skill tree: SKILL.md re-opens.
+    fireEvent.click(within(drawer).getByTestId('skills-tab-skill'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD));
+    expect(within(drawer).getByTestId('skills-file-tree').dataset.tab).toBe('skill');
+  });
+
+  it('picking another support file reads it through the support route', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      'GET /skills/support/.claude-plugin/plugin.json': () => Promise.resolve(fileRead('.claude-plugin/plugin.json', '{}')),
+      'GET /skills/support/scripts/_python.sh': () => Promise.resolve(fileRead('scripts/_python.sh', '#!/bin/sh')),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(within(drawer).getByTestId('skills-tab-support'));
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{}'));
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('#!/bin/sh'));
+    expect(calls('GET', '/skills/support/scripts/_python.sh')).toBe(1);
+  });
+});
+
+describe('SkillsPage — the drawer verbs: switch, Reset, Replace, Delete', () => {
+  it('the drawer switch flips through the same guarded wire (expectedRevision) and renders the verdict in the drawer', async () => {
+    let enabled = true;
+    const bodies: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({ skills: { [REPO_LEARN]: entry({ dir: 'skills/repo-learn', kind: 'router', core: true, enabled }) } })),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${REPO_LEARN}/disable`]: (init) => {
+        bodies.push(body(init));
+        enabled = false;
+        return Promise.resolve({ verdict: 'warnings', revision: REV_2, findings: [{ kind: 'core-disable', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'a workflow names this skill' }] });
+      },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-toggle'));
+    const findings = await within(drawer).findByTestId('skills-findings');
+    expect(findings.dataset.verdict).toBe('warnings');
+    expect(findings).toHaveTextContent('Disable passed with 1 finding');
+    await waitFor(() => expect(within(screen.getByTestId('skills-drawer')).getByTestId('skills-drawer-toggle')).toHaveAttribute('aria-checked', 'false'));
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+
+  it('Reset is a typed confirmation over POST /skills/:name/reset {expectedRevision}; the tree + file reload after', async () => {
+    let content = 'edited body';
+    const bodies: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${EXTRACTOR}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 1 }] }),
+      [`GET /skills/${EXTRACTOR}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', content)),
+      [`POST /skills/${EXTRACTOR}/reset`]: (init) => {
+        bodies.push(body(init));
+        content = 'baseline body';
+        return Promise.resolve(clear());
+      },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(EXTRACTOR);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('edited body'));
+
+    fireEvent.click(within(drawer).getByTestId('skills-reset-open'));
+    const modal = screen.getByTestId('skills-confirm-modal');
+    expect(modal.dataset.action).toBe('reset');
+    expect(modal).toHaveTextContent(`Reset ${EXTRACTOR}`);
+    expect(modal).toHaveTextContent(/stays disabled/);
+    const confirm = within(modal).getByTestId('skills-confirm');
+    expect(confirm).toBeDisabled();
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: 'wrong-name' } });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: EXTRACTOR } });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(screen.queryByTestId('skills-confirm-modal')).toBeNull());
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
+    const findings = await within(drawer).findByTestId('skills-findings');
+    expect(findings.dataset.verdict).toBe('clear');
+    expect(findings).toHaveTextContent('Reset clear — no findings.');
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('baseline body'));
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+
+  it('a user-added skill cannot Reset (no baseline) but can Delete — typed confirmation over DELETE /skills/:name {expectedRevision}', async () => {
+    const bodies: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      [`GET /skills/${MINE}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+      [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
+      [`DELETE /skills/${MINE}`]: (init) => { bodies.push(body(init)); return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(MINE);
+    await within(drawer).findByTestId('skills-editor');
+
+    expect(within(drawer).getByTestId('skills-reset-open')).toBeDisabled();
+    fireEvent.click(within(drawer).getByTestId('skills-delete-open'));
+    const modal = screen.getByTestId('skills-confirm-modal');
+    expect(modal.dataset.action).toBe('delete');
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: MINE } });
+    fireEvent.click(within(modal).getByTestId('skills-confirm'));
+
+    await waitFor(() => expect(calls('DELETE', `/skills/${MINE}`)).toBe(1));
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
+    expect(navigate).toHaveBeenLastCalledWith('/skills');
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent(`Deleted ${MINE}`);
+    await waitFor(() => expect(screen.queryByTestId('skills-drawer')).toBeNull());
+  });
+
+  it('a shipped skill offers no Delete', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    expect(within(drawer).queryByTestId('skills-delete-open')).toBeNull();
+    expect(within(drawer).getByTestId('skills-reset-open')).toBeEnabled();
+  });
+
+  it('a blocked Reset keeps the modal open with the findings; nothing reloads', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${REPO_LEARN}/reset`]: () => Promise.resolve({ verdict: 'blocked', revision: REV_1, findings: [{ kind: 'baseline-missing', severity: 'blocking', skill: REPO_LEARN, file: null, line: null, explanation: 'no baseline for this version' }] }),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(within(drawer).getByTestId('skills-reset-open'));
+    const modal = screen.getByTestId('skills-confirm-modal');
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: REPO_LEARN } });
+    fireEvent.click(within(modal).getByTestId('skills-confirm'));
+    const findings = await within(modal).findByTestId('skills-confirm-findings');
+    expect(findings.dataset.verdict).toBe('blocked');
+    expect(screen.getByTestId('skills-confirm-modal')).toBeInTheDocument();
+    expect(calls('GET', '/skills')).toBe(1);
+  });
+
+  it('a 409 on Reset closes the modal plain and raises the page prompt', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${REPO_LEARN}/reset`]: () => Promise.reject(new ApiError(409, 'stale')),
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    fireEvent.click(within(drawer).getByTestId('skills-reset-open'));
+    const modal = screen.getByTestId('skills-confirm-modal');
+    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: REPO_LEARN } });
+    fireEvent.click(within(modal).getByTestId('skills-confirm'));
+    await screen.findByTestId('skills-conflict');
+    expect(screen.queryByTestId('skills-confirm-modal')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-findings')).toBeNull();
+  });
+
+  it('Replace posts {files, expectedRevision}; the modal validates the pasted map live', async () => {
+    const posts: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      ...fileHandlers(REPO_LEARN),
+      [`POST /skills/${REPO_LEARN}/replace`]: (init) => { posts.push(body(init)); return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    const drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+
+    fireEvent.click(within(drawer).getByTestId('skills-replace-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    expect(modal.dataset.mode).toBe('replace');
+    const save = within(modal).getByTestId('skills-files-save');
+    expect(save).toBeDisabled();
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: '{"refs/a.md": "x"}' } });
+    expect(within(modal).getByTestId('skills-files-issue')).toHaveTextContent(/SKILL\.md/);
+    expect(save).toBeDisabled();
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: '{"SKILL.md": "---\\nname: x\\n---"}' } });
+    expect(within(modal).queryByTestId('skills-files-issue')).toBeNull();
+    fireEvent.click(save);
+
+    await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
+    expect(posts).toEqual([{ files: { 'SKILL.md': '---\nname: x\n---' }, expectedRevision: REV_1 }]);
+    expect((await within(drawer).findByTestId('skills-findings')).dataset.verdict).toBe('clear');
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+});
+
+describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish', () => {
+  it('Add posts {name, files, expectedRevision} to /skills, reloads, and opens the new skill', async () => {
+    const posts: unknown[] = [];
+    let added = false;
+    wire({
+      'GET /skills': () => Promise.resolve(added
+        ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+        : catalog()),
+      'POST /skills': (init) => { posts.push(body(init)); added = true; return Promise.resolve(clear()); },
+      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    fireEvent.click(screen.getByTestId('skills-add-open'));
+    const modal = screen.getByTestId('skills-files-modal');
+    expect(modal.dataset.mode).toBe('add');
+    fireEvent.change(within(modal).getByTestId('skills-files-name'), { target: { value: 'bad name!' } });
+    fireEvent.change(within(modal).getByTestId('skills-files-map'), { target: { value: '{"SKILL.md": "new"}' } });
+    expect(within(modal).getByTestId('skills-files-issue')).toHaveTextContent(/name:/);
+    expect(within(modal).getByTestId('skills-files-save')).toBeDisabled();
+    fireEvent.change(within(modal).getByTestId('skills-files-name'), { target: { value: 'new-skill' } });
+    fireEvent.click(within(modal).getByTestId('skills-files-save'));
+
+    await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
+    expect(posts).toEqual([{ name: 'new-skill', files: { 'SKILL.md': 'new' }, expectedRevision: REV_1 }]);
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Added new-skill');
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/skills?skill=new-skill'));
+    expect((await screen.findByTestId('skills-drawer')).dataset.skill).toBe('new-skill');
+    expect(screen.getByTestId('skills-kpi-total').dataset.value).toBe('5');
+  });
+
+  it('Refresh baseline posts {expectedRevision}, renders the merge findings, reloads, and the note names the new baseline', async () => {
+    let refreshed = false;
+    const bodies: unknown[] = [];
+    const merged: SkillGuardResult = {
+      verdict: 'warnings',
+      revision: REV_2,
+      findings: [{ kind: 'refresh-conflict', severity: 'warning', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: null, explanation: 'both sides changed — your edit was kept, the new side stored for diff' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(refreshed ? catalog({ revision: REV_2, plugin_version: '12.33.0' }) : catalog()),
+      'POST /skills/refresh-baseline': (init) => { bodies.push(body(init)); refreshed = true; return Promise.resolve(merged); },
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-refresh'));
+
+    const findings = await screen.findByTestId('skills-page-findings');
+    expect(findings.dataset.verdict).toBe('warnings');
+    expect(findings).toHaveTextContent('Refresh baseline passed with 1 finding to read.');
+    expect(within(findings).getByTestId('skills-finding').dataset.kind).toBe('refresh-conflict');
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Baseline refreshed — 12.33.0 (bbbbbbbbbbbb), 4 skills.');
+    expect(screen.getByTestId('skills-source')).toHaveTextContent('baseline 12.33.0');
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+
+  it('Analyze posts /skills/analyze with NO body (a dry run), renders the findings, reloads nothing', async () => {
+    const analysis: SkillGuardResult = {
+      verdict: 'blocked',
+      revision: REV_1,
+      findings: [{ kind: 'unresolved-ref', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 49, explanation: '../search/refs/hotspots.md does not resolve inside the bundle' }],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      'POST /skills/analyze': (init) => { expect(init?.body).toBeUndefined(); return Promise.resolve(analysis); },
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-analyze'));
+
+    const findings = await screen.findByTestId('skills-page-findings');
+    expect(findings.dataset.verdict).toBe('blocked');
+    expect(findings).toHaveTextContent('Analyze blocked — nothing was written (1 finding).');
+    expect(within(findings).getByTestId('skills-finding-location')).toHaveTextContent('skills/repo-learn/SKILL.md:49');
+    expect(calls('POST', '/skills/analyze')).toBe(1);
+    expect(calls('GET', '/skills')).toBe(1);
+    expect(screen.queryByTestId('skills-note')).toBeNull();
+  });
+
+  it('Publish posts {expectedRevision}; a clear verdict reloads and the snapshot line moves to the new generation', async () => {
+    let published = false;
+    const bodies: unknown[] = [];
+    wire({
+      'GET /skills': () => Promise.resolve(published ? catalog({ revision: REV_2, generation: 4 }) : catalog()),
+      'POST /skills/publish': (init) => { bodies.push(body(init)); published = true; return Promise.resolve(clear()); },
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    expect(screen.getByTestId('skills-snapshot').dataset.generation).toBe('3');
+
+    fireEvent.click(screen.getByTestId('skills-publish'));
+    const findings = await screen.findByTestId('skills-page-findings');
+    expect(findings.dataset.verdict).toBe('clear');
+    expect(findings).toHaveTextContent('Publish clear — no findings.');
+    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Published — snapshot generation 4 is current');
+    await waitFor(() => expect(screen.getByTestId('skills-snapshot').dataset.generation).toBe('4'));
+    expect(calls('GET', '/skills')).toBe(2);
+  });
+
+  it('a blocked Publish renders the findings with their file:line and reloads nothing — the old generation stays current', async () => {
+    const blocked: SkillGuardResult = {
+      verdict: 'blocked',
+      revision: REV_1,
+      findings: [
+        { kind: 'unresolved-ref', severity: 'blocking', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: 42, explanation: '${CLAUDE_PLUGIN_ROOT}/scripts/domain/extract_loop.py does not resolve inside the bundle' },
+        { kind: 'name-collision', severity: 'blocking', skill: MINE, file: null, line: null, explanation: 'frontmatter name collides with a disabled skill' },
+      ],
+    };
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      'POST /skills/publish': () => Promise.resolve(blocked),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-publish'));
+
+    const findings = await screen.findByTestId('skills-page-findings');
+    expect(findings.dataset.verdict).toBe('blocked');
+    expect(findings).toHaveTextContent('Publish blocked — nothing was written (2 findings).');
+    const rows = within(findings).getAllByTestId('skills-finding');
+    expect(rows.map((r) => r.dataset.kind)).toEqual(['unresolved-ref', 'name-collision']);
+    expect(within(rows[0]!).getByTestId('skills-finding-location')).toHaveTextContent('skills/domain/extractor/SKILL.md:42');
+    expect(within(rows[1]!).queryByTestId('skills-finding-location')).toBeNull();
+    expect(calls('GET', '/skills')).toBe(1);
+    expect(screen.queryByTestId('skills-note')).toBeNull();
+    expect(screen.getByTestId('skills-snapshot').dataset.generation).toBe('3');
+  });
+
+  it('a 409 on Publish raises the reload prompt', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      'POST /skills/publish': () => Promise.reject(new ApiError(409, 'expected revision rev-0001')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-publish'));
+    expect(await screen.findByTestId('skills-conflict')).toHaveTextContent('expected revision rev-0001');
+    expect(screen.queryByTestId('skills-page-findings')).toBeNull();
+    expect(screen.queryByTestId('skills-page-error')).toBeNull();
+  });
+
+  it('a wire failure on Publish is the page error', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog()),
+      'POST /skills/publish': () => Promise.reject(new ApiError(500, 'snapshot write failed: ENOSPC')),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    fireEvent.click(screen.getByTestId('skills-publish'));
+    expect(await screen.findByTestId('skills-page-error')).toHaveTextContent('snapshot write failed: ENOSPC');
+  });
+});

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -21,7 +21,7 @@ import type { SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src
  *    `{content, expectedRevision}`, the findings render, a `blocked` verdict disables Save for
  *    that exact draft, a `truncated` or `binary` read disables Save outright;
  *  - Reset is a typed confirmation over `POST /skills/:name/reset` (disabled for a user-added
- *    skill); Delete (user-added only) over `DELETE /skills/:name`; Replace / Add post files maps;
+ *    skill — no baseline, and no delete verb on the wire); Replace / Add post files maps;
  *  - the page verbs: Publish (`POST /skills/publish`, findings shown, the snapshot line moves),
  *    Analyze (`POST /skills/analyze`, a dry run — no body, no reload), Refresh baseline;
  *  - a daemon WITHOUT the routes (bare 404 / 501) renders the NAMED unsupported state — never a
@@ -633,7 +633,7 @@ describe('SkillsPage — the Support tab (root support files)', () => {
   });
 });
 
-describe('SkillsPage — the drawer verbs: switch, Reset, Replace, Delete', () => {
+describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
   it('the drawer switch flips through the same guarded wire (expectedRevision) and renders the verdict in the drawer', async () => {
     let enabled = true;
     const bodies: unknown[] = [];
@@ -678,7 +678,6 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace, Delete', () =
 
     fireEvent.click(within(drawer).getByTestId('skills-reset-open'));
     const modal = screen.getByTestId('skills-confirm-modal');
-    expect(modal.dataset.action).toBe('reset');
     expect(modal).toHaveTextContent(`Reset ${EXTRACTOR}`);
     expect(modal).toHaveTextContent(/stays disabled/);
     const confirm = within(modal).getByTestId('skills-confirm');
@@ -698,38 +697,25 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace, Delete', () =
     expect(calls('GET', '/skills')).toBe(2);
   });
 
-  it('a user-added skill cannot Reset (no baseline) but can Delete — typed confirmation over DELETE /skills/:name {expectedRevision}', async () => {
-    const bodies: unknown[] = [];
+  it('a user-added skill cannot Reset (no baseline to restore from) — a shipped one can', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       [`GET /skills/${MINE}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
       [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
-      [`DELETE /skills/${MINE}`]: (init) => { bodies.push(body(init)); return Promise.resolve(clear()); },
+      ...fileHandlers(REPO_LEARN),
     });
     render(<Harness />);
-    const drawer = await openDrawer(MINE);
+    let drawer = await openDrawer(MINE);
     await within(drawer).findByTestId('skills-editor');
+    const reset = within(drawer).getByTestId('skills-reset-open');
+    expect(reset).toBeDisabled();
+    expect(reset).toHaveAttribute('title', expect.stringMatching(/no baseline/));
+    // Replace stays available — the way to change a user-added skill wholesale.
+    expect(within(drawer).getByTestId('skills-replace-open')).toBeEnabled();
 
-    expect(within(drawer).getByTestId('skills-reset-open')).toBeDisabled();
-    fireEvent.click(within(drawer).getByTestId('skills-delete-open'));
-    const modal = screen.getByTestId('skills-confirm-modal');
-    expect(modal.dataset.action).toBe('delete');
-    fireEvent.change(within(modal).getByTestId('skills-confirm-input'), { target: { value: MINE } });
-    fireEvent.click(within(modal).getByTestId('skills-confirm'));
-
-    await waitFor(() => expect(calls('DELETE', `/skills/${MINE}`)).toBe(1));
-    expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
-    expect(navigate).toHaveBeenLastCalledWith('/skills');
-    expect(await screen.findByTestId('skills-note')).toHaveTextContent(`Deleted ${MINE}`);
-    await waitFor(() => expect(screen.queryByTestId('skills-drawer')).toBeNull());
-  });
-
-  it('a shipped skill offers no Delete', async () => {
-    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(REPO_LEARN) });
-    render(<Harness />);
-    const drawer = await openDrawer(REPO_LEARN);
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-close'));
+    drawer = await openDrawer(REPO_LEARN);
     await within(drawer).findByTestId('skills-editor');
-    expect(within(drawer).queryByTestId('skills-delete-open')).toBeNull();
     expect(within(drawer).getByTestId('skills-reset-open')).toBeEnabled();
   });
 

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -3,11 +3,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { SkillsPage } from '../src/components/SkillsPage.js';
 import { ApiError } from '../src/api/errors.js';
-import type { SkillFileEntry, SkillGuardResult, SkillManifestEntry, SkillsCatalog } from '../src/api/skills.js';
+import type {
+  SkillAnalyzeResult,
+  SkillConflictFinding,
+  SkillEntry,
+  SkillFileEntry,
+  SkillFileRecord,
+  SkillFileTree,
+  SkillMutationResult,
+  SkillPublishResult,
+  SkillReadResult,
+  SkillRefreshResult,
+  SkillsCatalog,
+} from '../src/api/skills.js';
 
 /**
  * The Skills file manager (`/skills`, the skills keystone — design v3) over a MOCKED `/skills`
- * wire:
+ * wire shaped EXACTLY like crew#480's (api-types 0.27.0: `SkillsManifestResponse` with a numeric
+ * `revision`, `manifest.files` records instead of a support map, `SkillFileTree` rows
+ * `{path, size, sha256, record}`, `SkillReadResult {content|null, size, truncated, binary}`,
+ * `SkillMutationResult` / `SkillPublishResult` / `SkillRefreshResult` envelopes, 409 only on a
+ * stale `expectedRevision`, 503 = no catalog to serve):
  *  - the catalog renders as the KPI band (total · enabled · overridden · core · portable) + one
  *    row per skill with kind / provenance chips and the core / claude-only / conflict / unpublished
  *    badges; the source and snapshot lines name the baseline and the current generation;
@@ -24,8 +40,10 @@ import type { SkillFileEntry, SkillGuardResult, SkillManifestEntry, SkillsCatalo
  *    skill — no baseline, and no delete verb on the wire); Replace / Add post files maps;
  *  - the page verbs: Publish (`POST /skills/publish`, findings shown, the snapshot line moves),
  *    Analyze (`POST /skills/analyze`, a dry run — no body, no reload), Refresh baseline;
- *  - a daemon WITHOUT the routes (bare 404 / 501) renders the NAMED unsupported state — never a
- *    crash, never an empty catalog pretending; a mis-shaped answer is a named error;
+ *  - a daemon WITHOUT the routes (bare 404) renders the NAMED unsupported state, one whose route
+ *    answers 503 (unseeded root / corrupt current / no seam) the NAMED unavailable state with the
+ *    daemon's sentence — never a crash, never an empty catalog pretending; a mis-shaped answer
+ *    (a string revision, no `files` map) is a named error;
  *  - the editor's honesty (review round 1): Save is conditioned on the revision its CONTENT was
  *    read at and every catalog re-read re-reads the open file — an intervening change under
  *    unsaved edits surfaces as the file conflict, never a silent overwrite; Save's endpoint
@@ -46,20 +64,25 @@ vi.mock('../src/api/client.js', () => ({
   apiFetch: (...a: unknown[]) => apiFetch(...a),
 }));
 
-function entry(over: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+function entry(over: Partial<SkillEntry> = {}): SkillEntry {
   return {
     dir: 'skills/x',
     kind: 'module',
     core: false,
     portable: true,
     enabled: true,
-    baselineHash: 'a'.repeat(8),
-    effectiveHash: 'a'.repeat(8),
-    lastPublishedHash: 'a'.repeat(8),
+    provenance: 'shipped',
     editedAt: null,
+    upgradeAvailable: false,
     conflict: false,
+    upstreamDir: null,
     ...over,
   };
+}
+
+/** One `manifest.files` record: shipped + published by default. */
+function record(over: Partial<SkillFileRecord> = {}): SkillFileRecord {
+  return { baselineHash: 'a'.repeat(8), effectiveHash: 'a'.repeat(8), lastPublishedHash: 'a'.repeat(8), conflict: false, ...over };
 }
 
 const REPO_LEARN = 'wicked-garden-repo-learn';
@@ -67,35 +90,83 @@ const EXTRACTOR = 'wicked-garden-domain-extractor';
 const A11Y = 'wicked-garden-qe-a11y-test-engineer';
 const MINE = 'my-team-skill';
 
-const REV_1 = 'rev-0001';
-const REV_2 = 'rev-0002';
-const REV_3 = 'rev-0003';
+// Revisions are NUMBERS on the wire (`SkillManifest.revision`, bumped by every mutation).
+const REV_1 = 1;
+const REV_2 = 2;
+const REV_3 = 3;
 
-function catalog(opts: { skills?: Record<string, SkillManifestEntry>; revision?: string; plugin_version?: string; generation?: number | null } = {}): SkillsCatalog {
+const BASELINE = 'b'.repeat(16);
+const SNAPSHOT_PATH = '/state/skills/snapshots/000003';
+
+/** The four-skill manifest: a core router (shipped, published), a core Claude-only fork worker
+ *  (an OVERRIDE whose SKILL.md is not yet published, in refresh conflict), a disabled fork worker,
+ *  and a user-added module (no baseline, never published) — plus two root support files. */
+function catalog(opts: {
+  skills?: Record<string, SkillEntry>;
+  files?: Record<string, SkillFileRecord>;
+  revision?: number;
+  plugin_version?: string;
+  /** The verified published snapshot `current` resolves to; `null` before the first publish. */
+  current?: { gen: number; path: string } | null;
+} = {}): SkillsCatalog {
+  const revision = opts.revision ?? REV_1;
+  const current = opts.current === undefined ? { gen: 3, path: SNAPSHOT_PATH } : opts.current;
   return {
     manifest: {
-      baseline: {
-        contentHash: 'b'.repeat(16),
-        source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0', plugin_version: opts.plugin_version ?? '12.32.0', git_sha: 'abcdef0123456789', captured_at: '2026-09-08T00:00:00Z' },
+      version: 2,
+      revision,
+      baseline: BASELINE,
+      baselines: {
+        [BASELINE]: {
+          plugin_version: opts.plugin_version ?? '12.32.0',
+          source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0' },
+          git_sha: 'abcdef0123456789',
+          captured_at: '2026-09-08T00:00:00Z',
+          venv: 'synced',
+        },
       },
       skills: {
         [REPO_LEARN]: entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
-        // An override (effective ≠ baseline), Claude-only, in refresh conflict, not yet published.
-        [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, effectiveHash: 'c'.repeat(8), conflict: true, editedAt: '2026-09-07T10:00:00Z' }),
+        // An override (edited files), Claude-only, in refresh conflict + upgrade available, not yet published.
+        [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', upgradeAvailable: true, conflict: true, editedAt: '2026-09-07T10:00:00Z' }),
         [A11Y]: entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
         // User-added: no baseline, never published.
-        [MINE]: entry({ dir: `skills/${MINE}`, baselineHash: null, lastPublishedHash: null }),
+        [MINE]: entry({ dir: `skills/${MINE}`, provenance: 'user-added' }),
         ...opts.skills,
       },
-      support: { 'scripts/_python.sh': 'd'.repeat(8), '.claude-plugin/plugin.json': 'e'.repeat(8) },
-      currentGeneration: opts.generation === undefined ? 3 : opts.generation,
+      files: {
+        'skills/repo-learn/SKILL.md': record(),
+        'skills/repo-learn/refs/notes.md': record(),
+        // The parent skill `domain` is not in this catalog; the extractor's own file is edited (c) over baseline (a),
+        // published at (a) → unpublished; the last refresh saw both sides change.
+        'skills/domain/extractor/SKILL.md': record({ effectiveHash: 'c'.repeat(8), conflict: true }),
+        'skills/qe/a11y-test-engineer/SKILL.md': record(),
+        [`skills/${MINE}/SKILL.md`]: record({ baselineHash: null, effectiveHash: 'm'.repeat(8), lastPublishedHash: null }),
+        // Root support files: no owning skill.
+        'scripts/_python.sh': record(),
+        '.claude-plugin/plugin.json': record(),
+        ...opts.files,
+      },
+      published: current === null ? null : { gen: current.gen, contentHash: 'p'.repeat(16), at: '2026-09-08T00:00:00Z', snapshotHash: 's'.repeat(16) },
     },
-    revision: opts.revision ?? REV_1,
+    revision,
+    root: '/state/skills',
+    current,
   };
 }
 
-function clear(revision = REV_2): SkillGuardResult {
+function clear(revision = REV_2): SkillMutationResult {
   return { verdict: 'clear', findings: [], revision };
+}
+
+/** A `SkillPublishResult` that WROTE generation `gen`. */
+function publishedAt(gen: number, revision = REV_2, skills = 4): SkillPublishResult {
+  return { verdict: 'clear', findings: [], revision, snapshot: { gen, path: `/state/skills/snapshots/00000${gen}`, contentHash: 'n'.repeat(16), skills } };
+}
+
+/** One `SkillConflictFinding`, every contract field present. */
+function finding(over: Partial<SkillConflictFinding> & Pick<SkillConflictFinding, 'kind' | 'severity'>): SkillConflictFinding {
+  return { skill: null, file: null, line: null, againstSkill: null, againstIsCore: false, evidence: '', explanation: '', ...over };
 }
 
 type Init = { method?: string; body?: string } | undefined;
@@ -121,13 +192,25 @@ function body(init: Init): unknown {
 
 const SKILL_MD = `---\nname: ${REPO_LEARN}\n---\nLearn the repo.`;
 
-function fileRead(path: string, content: string, over: Partial<{ truncated: boolean; binary: boolean }> = {}) {
-  return { path, content, size: content.length, hash: 'f'.repeat(8), truncated: false, binary: false, ...over };
+/** A `SkillReadResult`: the typed, capped read (`content` is `null` only when `binary`). */
+function fileRead(path: string, content: string, over: Partial<Pick<SkillReadResult, 'truncated' | 'binary'>> = {}): SkillReadResult {
+  const binary = over.binary === true;
+  return { path, content: binary ? null : content, size: content.length, truncated: false, binary: false, ...over, ...(binary ? { content: null } : {}) };
+}
+
+/** One `SkillFileTree` row. */
+function treeFile(path: string, size: number): SkillFileEntry {
+  return { path, size, sha256: 'f'.repeat(64), record: record() };
+}
+
+/** A `GET /skills/:name/files` body. */
+function tree(files: SkillFileEntry[], name = REPO_LEARN): SkillFileTree {
+  return { name, dir: `skills/${name.replace(/^wicked-garden-/, '')}`, enabled: true, files };
 }
 
 function fileHandlers(name: string): Record<string, Handler> {
   return {
-    [`GET /skills/${name}/files`]: () => Promise.resolve({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] }),
+    [`GET /skills/${name}/files`]: () => Promise.resolve(tree([treeFile('refs/notes.md', 5), treeFile('SKILL.md', SKILL_MD.length)], name)),
     [`GET /skills/${name}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', SKILL_MD)),
     [`GET /skills/${name}/files/refs/notes.md`]: () => Promise.resolve(fileRead('refs/notes.md', 'notes')),
   };
@@ -176,11 +259,16 @@ describe('SkillsPage — the catalog from the manifest', () => {
     expect(screen.getByTestId('skills-kpi-overridden').dataset.value).toBe('1');
     expect(screen.getByTestId('skills-kpi-core').dataset.value).toBe('2');
     expect(screen.getByTestId('skills-kpi-portable').dataset.value).toBe('3');
-    expect(screen.getByTestId('skills-source')).toHaveTextContent('baseline 12.32.0 · claude-plugin-cache · bbbbbbbbbbbb · abcdef0123');
+    expect(screen.getByTestId('skills-root')).toHaveTextContent('root /state/skills');
+    const source = screen.getByTestId('skills-source');
+    expect(source).toHaveTextContent('baseline 12.32.0 · claude-plugin-cache · bbbbbbbbbbbb · abcdef0123 · venv synced · captured 2026-09-08T00:00:00Z');
+    expect(source.dataset.venv).toBe('synced');
     const snapshot = screen.getByTestId('skills-snapshot');
-    expect(snapshot).toHaveTextContent('snapshot generation 3 is current · 2 unpublished skills');
+    expect(snapshot).toHaveTextContent('snapshot generation 3 is current · published 2026-09-08T00:00:00Z · pppppppppppp · 2 unpublished skills');
     expect(snapshot.dataset.generation).toBe('3');
     expect(snapshot.dataset.unpublished).toBe('2');
+    // No engine line: this daemon's /diagnostics is the bare 404 (predates the seam) — never an error.
+    expect(screen.queryByTestId('skills-engine')).toBeNull();
 
     const rows = screen.getAllByTestId('skills-row');
     expect(rows.map((r) => r.dataset.skill)).toEqual([MINE, EXTRACTOR, A11Y, REPO_LEARN]);
@@ -190,6 +278,7 @@ describe('SkillsPage — the catalog from the manifest', () => {
     expect(within(extractor).getByTestId('skills-provenance-chip').dataset.provenance).toBe('override');
     expect(within(extractor).getByTestId('skills-core-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-claude-only-badge')).toBeInTheDocument();
+    expect(within(extractor).getByTestId('skills-upgrade-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-conflict-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-unpublished-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'true');
@@ -200,6 +289,7 @@ describe('SkillsPage — the catalog from the manifest', () => {
     expect(within(mine).queryByTestId('skills-core-badge')).toBeNull();
     expect(within(mine).queryByTestId('skills-claude-only-badge')).toBeNull();
     expect(within(mine).queryByTestId('skills-conflict-badge')).toBeNull();
+    expect(within(mine).queryByTestId('skills-upgrade-badge')).toBeNull();
 
     const learn = row(REPO_LEARN);
     expect(within(learn).getByTestId('skills-provenance-chip').dataset.provenance).toBe('shipped');
@@ -212,11 +302,49 @@ describe('SkillsPage — the catalog from the manifest', () => {
   });
 
   it('a never-published root says so on the snapshot line', async () => {
-    wire({ 'GET /skills': () => Promise.resolve(catalog({ generation: null })) });
+    wire({ 'GET /skills': () => Promise.resolve(catalog({ current: null })) });
     render(<Harness />);
     const snapshot = await screen.findByTestId('skills-snapshot');
     expect(snapshot).toHaveTextContent(/never published/);
+    expect(snapshot).not.toHaveTextContent(/published 2026/);
     expect(snapshot.dataset.generation).toBe('none');
+  });
+
+  it('the engine line reads diagnostics.skills (0.27.0) — state vocabulary, generation, findings', async () => {
+    const diagnostics = (state: string, findings: unknown[] = []) => ({
+      components: { crew: '0.7.25', studioBundle: null, coreTs: null, engineBinaries: {} },
+      daemon: { uptimeMs: 1, startedAt: 1, port: 7701 },
+      stores: [], recentErrors: [], acp: { byCli: {} },
+      skills: { state, root: '/state/skills', current: state === 'published' ? { gen: 3, path: SNAPSHOT_PATH } : null, engineInput: state === 'published' ? SNAPSHOT_PATH : null, stateHome: '/state', findings },
+    });
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), 'GET /diagnostics': () => Promise.resolve(diagnostics('published')) });
+    render(<Harness />);
+    const engine = await screen.findByTestId('skills-engine');
+    expect(engine.dataset.state).toBe('published');
+    expect(engine).toHaveTextContent('engine published — the engine is handed the verified snapshot · gen 3');
+    expect(engine).toHaveAttribute('title', `WICKED_SKILLS_SNAPSHOT=${SNAPSHOT_PATH}`);
+    cleanup();
+
+    // Every other state renders its own honest copy — and the ladder's findings under it.
+    for (const [state, copy] of [
+      ['fallback', 'fallback — no wicked-garden is installed'],
+      ['blocked', 'blocked — the first publish is blocked'],
+      ['config-error', 'config error — the skills root is corrupt or unusable'],
+      ['disabled', 'disabled — this daemon booted without the skills seam'],
+    ] as const) {
+      wire({
+        'GET /skills': () => Promise.resolve(catalog()),
+        'GET /diagnostics': () => Promise.resolve(diagnostics(state, [{ kind: 'skills.fallback', severity: 'warning', message: `why ${state}` }])),
+      });
+      render(<Harness />);
+      const line = await screen.findByTestId('skills-engine');
+      expect(line.dataset.state).toBe(state);
+      expect(line).toHaveTextContent(copy);
+      const f = within(line).getByTestId('skills-engine-finding');
+      expect(f.dataset.kind).toBe('skills.fallback');
+      expect(f).toHaveTextContent(`skills.fallback · warning · why ${state}`);
+      cleanup();
+    }
   });
 
   it('the KPI tiles are doors into the matching filter chip', async () => {
@@ -258,10 +386,18 @@ describe('SkillsPage — the honest non-catalog states', () => {
     expect(screen.queryByTestId('skills-analyze')).toBeNull();
   });
 
-  it('a 501 (route present, no skills root) is the same named state', async () => {
-    wire({ 'GET /skills': () => Promise.reject(new ApiError(501, 'no skills root configured')) });
+  it('a 503 (route present, no catalog to serve: unseeded / corrupt current / no seam) renders the NAMED unavailable state with the daemon’s sentence', async () => {
+    wire({ 'GET /skills': () => Promise.reject(new ApiError(503, 'the skills root is not seeded: no installed wicked-garden plugin was found')) });
     render(<Harness />);
-    expect(await screen.findByTestId('skills-unsupported')).toBeInTheDocument();
+    const state = await screen.findByTestId('skills-unavailable');
+    expect(state).toHaveTextContent('The daemon has no skills catalog to serve.');
+    expect(state).toHaveTextContent('the skills root is not seeded: no installed wicked-garden plugin was found');
+    // Not the "predates" state, not a raw error, no write verbs, no empty catalog.
+    expect(screen.queryByTestId('skills-unsupported')).toBeNull();
+    expect(screen.queryByTestId('skills-error')).toBeNull();
+    expect(screen.queryByTestId('skills-kpis')).toBeNull();
+    expect(screen.queryByTestId('skills-grid')).toBeNull();
+    expect(screen.queryByTestId('skills-publish')).toBeNull();
   });
 
   it('a real refusal renders the translated error, and a mis-shaped answer a named one', async () => {
@@ -270,8 +406,23 @@ describe('SkillsPage — the honest non-catalog states', () => {
     expect(await screen.findByTestId('skills-error')).toHaveTextContent('the daemon refused this — skills store corrupt');
     cleanup();
 
-    // A bare manifest with no revision is NOT the v3 catalog — a named error, never zero skills.
+    // A bare manifest with no revision is NOT the catalog — a named error, never zero skills.
     wire({ 'GET /skills': () => Promise.resolve(catalog().manifest) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog/);
+    cleanup();
+
+    // A STRING revision is a pre-0.27.0 daemon (or a hand-mirrored shape) — not the contract.
+    wire({ 'GET /skills': () => Promise.resolve({ ...catalog(), revision: 'rev-0001' }) });
+    render(<Harness />);
+    expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog \(expected \{manifest: \{skills, files, …\}, revision: number, root, current\}\)/);
+    cleanup();
+
+    // A manifest without the `files` map (the old `support` map instead) is not the contract either.
+    const c = catalog();
+    const { files: _files, ...noFiles } = c.manifest;
+    void _files;
+    wire({ 'GET /skills': () => Promise.resolve({ ...c, manifest: { ...noFiles, support: {} } }) });
     render(<Harness />);
     expect(await screen.findByTestId('skills-error')).toHaveTextContent(/no catalog/);
   });
@@ -314,10 +465,10 @@ describe('SkillsPage — the row switch (enable/disable through the guards, CAS)
   });
 
   it('a blocked disable (a core skill) renders the findings and reloads nothing — the switch stays on', async () => {
-    const blocked: SkillGuardResult = {
+    const blocked: SkillMutationResult = {
       verdict: 'blocked',
       revision: REV_1,
-      findings: [{ kind: 'core-disable', severity: 'blocking', skill: REPO_LEARN, file: 'workflows/repo-learn.json', line: null, explanation: 'a registered workflow names this skill by skill_ref' }],
+      findings: [finding({ kind: 'core-disable', severity: 'blocking', skill: REPO_LEARN, file: 'workflows/repo-learn.json', line: null, againstSkill: REPO_LEARN, againstIsCore: true, evidence: `${REPO_LEARN} is core-by-reference`, explanation: 'a registered workflow dispatches phases to this skill by name (skill_ref)' })],
     };
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
@@ -330,11 +481,17 @@ describe('SkillsPage — the row switch (enable/disable through the guards, CAS)
     const findings = await screen.findByTestId('skills-page-findings');
     expect(findings.dataset.verdict).toBe('blocked');
     expect(findings).toHaveTextContent(`Disable ${REPO_LEARN} blocked — nothing was written (1 finding).`);
-    const finding = within(findings).getByTestId('skills-finding');
-    expect(finding.dataset.kind).toBe('core-disable');
-    expect(finding.dataset.severity).toBe('blocking');
-    expect(finding).toHaveTextContent(`against ${REPO_LEARN}`);
-    expect(within(finding).getByTestId('skills-finding-location')).toHaveTextContent('workflows/repo-learn.json');
+    expect(within(findings).getByTestId('skills-findings-tally')).toHaveTextContent('1 blocking · 0 warnings');
+    expect(findings.dataset.revision).toBe(String(REV_1));
+    const item = within(findings).getByTestId('skills-finding');
+    expect(item.dataset.kind).toBe('core-disable');
+    expect(item.dataset.severity).toBe('blocking');
+    // Every contract field, generically: the skill, the OTHER skill it is against (core-marked), the cite, the evidence.
+    expect(within(item).getByTestId('skills-finding-skill')).toHaveTextContent(REPO_LEARN);
+    expect(within(item).getByTestId('skills-finding-against')).toHaveTextContent(`against ${REPO_LEARN} (core)`);
+    expect(within(item).getByTestId('skills-finding-location')).toHaveTextContent('workflows/repo-learn.json');
+    expect(within(item).getByTestId('skills-finding-evidence')).toHaveTextContent(`${REPO_LEARN} is core-by-reference`);
+    expect(item).toHaveTextContent('a registered workflow dispatches phases to this skill by name (skill_ref)');
     expect(calls('GET', '/skills')).toBe(1);
     expect(within(row(REPO_LEARN)).getByTestId('skills-toggle')).toHaveAttribute('aria-checked', 'true');
   });
@@ -353,7 +510,7 @@ describe('SkillsPage — the row switch (enable/disable through the guards, CAS)
   it('a 409 raises the reload prompt with the daemon’s sentence, freezes every write, and Reload re-reads the catalog', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`POST /skills/${MINE}/disable`]: () => Promise.reject(new ApiError(409, 'expected revision rev-0001, catalog is at rev-0002')),
+      [`POST /skills/${MINE}/disable`]: () => Promise.reject(new ApiError(409, 'revision mismatch: expected 1, the manifest is at 2 — re-read GET /skills and retry')),
     });
     render(<Harness />);
     await screen.findAllByTestId('skills-row');
@@ -361,7 +518,7 @@ describe('SkillsPage — the row switch (enable/disable through the guards, CAS)
     fireEvent.click(within(row(MINE)).getByTestId('skills-toggle'));
     const prompt = await screen.findByTestId('skills-conflict');
     expect(prompt).toHaveTextContent('The skills catalog changed under this page.');
-    expect(prompt).toHaveTextContent('expected revision rev-0001, catalog is at rev-0002');
+    expect(prompt).toHaveTextContent('revision mismatch: expected 1, the manifest is at 2 — re-read GET /skills and retry');
     // Not an error banner, not a findings banner — a named state.
     expect(screen.queryByTestId('skills-page-error')).toBeNull();
     expect(screen.queryByTestId('skills-page-findings')).toBeNull();
@@ -420,10 +577,10 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
 
   it('Save PUTs {content, expectedRevision}; the findings render, the file is the saved text, the catalog reloads', async () => {
     const puts: unknown[] = [];
-    const warnings: SkillGuardResult = {
+    const warnings: SkillMutationResult = {
       verdict: 'warnings',
       revision: REV_2,
-      findings: [{ kind: 'frontmatter-description', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'description is empty' }],
+      findings: [finding({ kind: 'frontmatter-invalid', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'description is empty' })],
     };
     // The daemon keeps what it was handed — the post-save re-read must find the saved text.
     let content = SKILL_MD;
@@ -468,10 +625,10 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
   });
 
   it('a blocked Save renders the refusal and disables Save for that exact draft until it changes', async () => {
-    const blocked: SkillGuardResult = {
+    const blocked: SkillMutationResult = {
       verdict: 'blocked',
       revision: REV_1,
-      findings: [{ kind: 'frontmatter-name', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 2, explanation: 'frontmatter name must equal the path-derived name' }],
+      findings: [finding({ kind: 'name-mismatch', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 2, explanation: 'frontmatter name must equal the path-derived name' })],
     };
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
@@ -545,7 +702,7 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
   it('a truncated file is read-only — Save never clobbers what the editor cannot show', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'big.md', hash: 'h1', size: 900000 }, { path: 'SKILL.md', hash: 'h2', size: 900000 }] }),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve(tree([treeFile('big.md', 900000), treeFile('SKILL.md', 900000)])),
       [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'head…', { truncated: true })),
     });
     render(<Harness />);
@@ -560,7 +717,7 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
   it('a binary file is read-only too', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h2', size: 12 }] }),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 12)])),
       [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', '', { binary: true })),
     });
     render(<Harness />);
@@ -576,7 +733,7 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
     const puts: string[] = [];
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 4)])),
       // The body claims a path that would normalize onto the support route.
       [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('../../support/scripts/a.sh', 'body')),
       [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: () => { puts.push('skill'); return Promise.resolve(clear()); },
@@ -641,11 +798,11 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
   /** A daemon whose one skill file can change under the editor: `content`/`hash` are what the
    *  file read answers, `revision` what the catalog answers. */
   function movingDaemon() {
-    const d = { content: SKILL_MD, hash: 'h-1', revision: REV_1, puts: [] as unknown[] };
+    const d = { content: SKILL_MD, revision: REV_1, puts: [] as unknown[] };
     wire({
       'GET /skills': () => Promise.resolve(catalog({ revision: d.revision })),
-      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: d.hash, size: d.content.length }] }),
-      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve({ ...fileRead('SKILL.md', d.content), hash: d.hash }),
+      [`GET /skills/${REPO_LEARN}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', d.content.length)])),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', d.content)),
       [`PUT /skills/${REPO_LEARN}/files/SKILL.md`]: (init) => { d.puts.push(body(init)); return Promise.resolve(clear(REV_3)); },
     });
     return d;
@@ -653,7 +810,6 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
 
   const externalChange = (d: ReturnType<typeof movingDaemon>): void => {
     d.content = `${SKILL_MD}\n\nChanged by another session.`;
-    d.hash = 'h-2';
     d.revision = REV_2;
   };
 
@@ -674,8 +830,7 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
     const conflict = await within(drawer).findByTestId('skills-file-conflict');
     expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(2);
     expect(conflict).toHaveTextContent('This file changed on the daemon while you were editing.');
-    expect(conflict).toHaveTextContent('is now h-2');
-    expect(conflict).toHaveTextContent('you started from h-1');
+    expect(conflict).toHaveTextContent(`SKILL.md is now ${d.content.length} B on the daemon (you started from ${SKILL_MD.length} B, catalog revision ${REV_1})`);
     // The draft is preserved and Save waits — the codex probe's silent `expectedRevision: r2` overwrite cannot happen.
     expect(within(drawer).getByTestId('skills-editor')).toHaveValue('mine');
     expect(within(drawer).getByTestId('skills-file-dirty')).toBeInTheDocument();
@@ -731,7 +886,7 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
     fireEvent.change(within(drawer).getByTestId('skills-editor'), { target: { value: `${d.content}\nmine` } });
     fireEvent.click(within(drawer).getByTestId('skills-save'));
     await waitFor(() => expect(d.puts).toHaveLength(1));
-    expect((d.puts[0] as { expectedRevision: string }).expectedRevision).toBe(REV_2);
+    expect((d.puts[0] as { expectedRevision: number }).expectedRevision).toBe(REV_2);
   });
 
   it('a row toggle that advances the revision re-reads the open file, so the drawer’s Save rides the revision its (unchanged) content now stands at', async () => {
@@ -740,8 +895,8 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
       if (String(path) === `/skills/${A11Y}/enable` && init?.method === 'POST') { d.revision = REV_2; return Promise.resolve(clear(REV_2)); }
       const key = `${init?.method ?? 'GET'} ${String(path)}`;
       if (key === 'GET /skills') return Promise.resolve(catalog({ revision: d.revision }));
-      if (key === `GET /skills/${REPO_LEARN}/files`) return Promise.resolve({ files: [{ path: 'SKILL.md', hash: d.hash, size: 1 }] });
-      if (key === `GET /skills/${REPO_LEARN}/files/SKILL.md`) return Promise.resolve({ ...fileRead('SKILL.md', d.content), hash: d.hash });
+      if (key === `GET /skills/${REPO_LEARN}/files`) return Promise.resolve(tree([treeFile('SKILL.md', 1)]));
+      if (key === `GET /skills/${REPO_LEARN}/files/SKILL.md`) return Promise.resolve(fileRead('SKILL.md', d.content));
       if (key === `PUT /skills/${REPO_LEARN}/files/SKILL.md`) { d.puts.push(body(init)); return Promise.resolve(clear(REV_3)); }
       return Promise.reject(new ApiError(404, 'Not Found'));
     });
@@ -764,8 +919,8 @@ describe('SkillsPage — the editor’s CAS: Save is conditioned on the revision
 
 describe('SkillsPage — late answers are ignored; the file’s scope travels with it', () => {
   it('a file list that answers AFTER the operator switched to Support does not swap the editor onto SKILL.md; Save follows the support file', async () => {
-    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
-    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    let resolveList: (v: SkillFileTree) => void = () => {};
+    const deferred = new Promise<SkillFileTree>((r) => { resolveList = r; });
     const puts: string[] = [];
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
@@ -788,7 +943,7 @@ describe('SkillsPage — late answers are ignored; the file’s scope travels wi
 
     // The list lands late: data for the skill tree, NOT an instruction to open SKILL.md.
     await act(async () => {
-      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      resolveList(tree([treeFile('refs/notes.md', 5), treeFile('SKILL.md', SKILL_MD.length)]));
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}');
@@ -851,8 +1006,8 @@ describe('SkillsPage — stale catalog and in-flight writes freeze every write a
   });
 
   it('a page verb in flight (Publish) freezes the row switches, Add, the other verbs and the drawer’s Save until it answers', async () => {
-    let resolvePublish: (v: SkillGuardResult) => void = () => {};
-    const deferred = new Promise<SkillGuardResult>((r) => { resolvePublish = r; });
+    let resolvePublish: (v: SkillPublishResult) => void = () => {};
+    const deferred = new Promise<SkillPublishResult>((r) => { resolvePublish = r; });
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       ...fileHandlers(REPO_LEARN),
@@ -875,7 +1030,7 @@ describe('SkillsPage — stale catalog and in-flight writes freeze every write a
     expect(within(drawer).getByTestId('skills-drawer-toggle')).toBeDisabled();
 
     await act(async () => {
-      resolvePublish(clear(REV_2));
+      resolvePublish(publishedAt(3));
       await new Promise((r) => setTimeout(r, 0));
     });
     await screen.findByTestId('skills-page-findings');
@@ -886,8 +1041,8 @@ describe('SkillsPage — stale catalog and in-flight writes freeze every write a
   });
 
   it('a row switch in flight freezes the other rows and the drawer too — writes share one revision', async () => {
-    let resolveFlip: (v: SkillGuardResult) => void = () => {};
-    const deferred = new Promise<SkillGuardResult>((r) => { resolveFlip = r; });
+    let resolveFlip: (v: SkillMutationResult) => void = () => {};
+    const deferred = new Promise<SkillMutationResult>((r) => { resolveFlip = r; });
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       ...fileHandlers(REPO_LEARN),
@@ -915,10 +1070,10 @@ describe('SkillsPage — stale catalog and in-flight writes freeze every write a
 describe('SkillsPage — the Support tab (root support files)', () => {
   it('lists the manifest’s support files path-sorted, opens the first, and Save PUTs /skills/support/*path with {content, expectedRevision}', async () => {
     const puts: unknown[] = [];
-    const supportWarning: SkillGuardResult = {
+    const supportWarning: SkillMutationResult = {
       verdict: 'warnings',
       revision: REV_2,
-      findings: [{ kind: 'support-edit', severity: 'warning', skill: null, file: '.claude-plugin/plugin.json', line: null, explanation: 'a support file is shared by every skill' }],
+      findings: [finding({ kind: 'support-file-edit', severity: 'warning', skill: null, file: '.claude-plugin/plugin.json', line: null, explanation: 'a support file is shared by every skill' })],
     };
     let pluginJson = '{"name":"wicked-garden"}';
     wire({
@@ -953,7 +1108,7 @@ describe('SkillsPage — the Support tab (root support files)', () => {
 
     const findings = await within(drawer).findByTestId('skills-findings');
     expect(findings.dataset.verdict).toBe('warnings');
-    expect(within(findings).getByTestId('skills-finding').dataset.kind).toBe('support-edit');
+    expect(within(findings).getByTestId('skills-finding').dataset.kind).toBe('support-file-edit');
     expect(puts).toEqual([{ content: '{"name":"wicked-garden","version":"x"}', expectedRevision: REV_1 }]);
     expect(calls('GET', '/skills')).toBe(2);
 
@@ -991,7 +1146,7 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
       [`POST /skills/${REPO_LEARN}/disable`]: (init) => {
         bodies.push(body(init));
         enabled = false;
-        return Promise.resolve({ verdict: 'warnings', revision: REV_2, findings: [{ kind: 'core-disable', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'a workflow names this skill' }] });
+        return Promise.resolve({ verdict: 'warnings', revision: REV_2, findings: [finding({ kind: 'core-disable', severity: 'warning', skill: REPO_LEARN, file: null, line: null, explanation: 'a workflow names this skill' })] });
       },
     });
     render(<Harness />);
@@ -1012,7 +1167,7 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
     const bodies: unknown[] = [];
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`GET /skills/${EXTRACTOR}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 1 }] }),
+      [`GET /skills/${EXTRACTOR}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 1)])),
       [`GET /skills/${EXTRACTOR}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', content)),
       [`POST /skills/${EXTRACTOR}/reset`]: (init) => {
         bodies.push(body(init));
@@ -1048,7 +1203,7 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
   it('a user-added skill cannot Reset (no baseline to restore from) — a shipped one can', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      [`GET /skills/${MINE}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+      [`GET /skills/${MINE}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 4)])),
       [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
       ...fileHandlers(REPO_LEARN),
     });
@@ -1071,7 +1226,7 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       ...fileHandlers(REPO_LEARN),
-      [`POST /skills/${REPO_LEARN}/reset`]: () => Promise.resolve({ verdict: 'blocked', revision: REV_1, findings: [{ kind: 'baseline-missing', severity: 'blocking', skill: REPO_LEARN, file: null, line: null, explanation: 'no baseline for this version' }] }),
+      [`POST /skills/${REPO_LEARN}/reset`]: () => Promise.resolve({ verdict: 'blocked', revision: REV_1, findings: [finding({ kind: 'baseline-corrupt', severity: 'blocking', skill: REPO_LEARN, file: null, line: null, explanation: 'no baseline for this version' })] }),
     });
     render(<Harness />);
     const drawer = await openDrawer(REPO_LEARN);
@@ -1102,6 +1257,66 @@ describe('SkillsPage — the drawer verbs: switch, Reset, Replace', () => {
     await screen.findByTestId('skills-conflict');
     expect(screen.queryByTestId('skills-confirm-modal')).toBeNull();
     expect(within(drawer).queryByTestId('skills-findings')).toBeNull();
+  });
+
+  it('Baseline side reads `?side=baseline` for the OPEN file, read-only, and shows the path the daemon actually read; a held-back collision (`upstreamDir`) offers it on a user-added skill, a plain user-added skill does not', async () => {
+    const HELD = 'wicked-garden-held';
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [HELD]: entry({ dir: 'skills/held', provenance: 'user-added', conflict: true, upstreamDir: 'skills/upstream/held' }) },
+        files: { 'skills/held/SKILL.md': record({ baselineHash: null, lastPublishedHash: null }) },
+      })),
+      ...fileHandlers(REPO_LEARN),
+      [`GET /skills/${REPO_LEARN}/files/SKILL.md?side=baseline`]: () => Promise.resolve(fileRead('skills/repo-learn/SKILL.md', 'shipped body')),
+      [`GET /skills/${HELD}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 4)], HELD)),
+      [`GET /skills/${HELD}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
+      // The upstream skill's file is what the baseline side of a held-back collision reads — the answer's `path` names it.
+      [`GET /skills/${HELD}/files/SKILL.md?side=baseline`]: () => Promise.resolve(fileRead('skills/upstream/held/SKILL.md', 'upstream body')),
+      [`GET /skills/${MINE}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 4)], MINE)),
+      [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
+    });
+    render(<Harness />);
+    let drawer = await openDrawer(REPO_LEARN);
+    await within(drawer).findByTestId('skills-editor');
+    expect(within(drawer).queryByTestId('skills-drawer-upstream')).toBeNull();
+    const open = within(drawer).getByTestId('skills-baseline-open');
+    expect(open).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(open);
+    const view = await within(drawer).findByTestId('skills-baseline-view');
+    await waitFor(() => expect(within(view).getByTestId('skills-baseline-content')).toHaveValue('shipped body'));
+    expect(within(view).getByTestId('skills-baseline-content')).toHaveAttribute('readonly');
+    expect(within(view).getByTestId('skills-baseline-path')).toHaveTextContent('skills/repo-learn/SKILL.md');
+    expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md?side=baseline`)).toBe(1);
+    // The editor is untouched: the baseline side is a second, read-only pane — never the draft.
+    expect(within(drawer).getByTestId('skills-editor')).toHaveValue(SKILL_MD);
+    expect(within(drawer).getByTestId('skills-baseline-open')).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(within(drawer).getByTestId('skills-baseline-open'));
+    expect(within(drawer).queryByTestId('skills-baseline-view')).toBeNull();
+    // Opening it and then picking another file clears it (it belongs to the file it was read for).
+    fireEvent.click(within(drawer).getByTestId('skills-baseline-open'));
+    await within(drawer).findByTestId('skills-baseline-view');
+    fireEvent.click(within(drawer).getAllByTestId('skills-file')[1]!);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('notes'));
+    expect(within(drawer).queryByTestId('skills-baseline-view')).toBeNull();
+
+    // A user-added skill a refresh HELD BACK: the header names the upstream dir and the baseline side reads it.
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-close'));
+    drawer = await openDrawer(HELD);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('mine'));
+    expect(within(drawer).getByTestId('skills-drawer-upstream')).toHaveTextContent('upstream ships this name at skills/upstream/held');
+    expect(within(drawer).getByTestId('skills-conflict-badge')).toBeInTheDocument();
+    expect(within(drawer).getByTestId('skills-reset-open')).toBeDisabled();
+    fireEvent.click(within(drawer).getByTestId('skills-baseline-open'));
+    const held = await within(drawer).findByTestId('skills-baseline-view');
+    await waitFor(() => expect(within(held).getByTestId('skills-baseline-content')).toHaveValue('upstream body'));
+    expect(within(held).getByTestId('skills-baseline-path')).toHaveTextContent('skills/upstream/held/SKILL.md');
+
+    // A plain user-added skill has no baseline side to offer.
+    fireEvent.click(within(drawer).getByTestId('skills-drawer-close'));
+    drawer = await openDrawer(MINE);
+    await waitFor(() => expect(within(drawer).getByTestId('skills-editor')).toHaveValue('mine'));
+    expect(within(drawer).queryByTestId('skills-baseline-open')).toBeNull();
+    expect(within(drawer).queryByTestId('skills-drawer-upstream')).toBeNull();
   });
 
   it('Replace posts {files, expectedRevision}; the modal validates the pasted map live', async () => {
@@ -1140,10 +1355,10 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
     let added = false;
     wire({
       'GET /skills': () => Promise.resolve(added
-        ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+        ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', provenance: 'user-added' }) } })
         : catalog()),
       'POST /skills': (init) => { posts.push(body(init)); added = true; return Promise.resolve(clear()); },
-      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files': () => Promise.resolve(tree([treeFile('SKILL.md', 3)])),
       'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
     });
     render(<Harness />);
@@ -1170,10 +1385,18 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
   it('Refresh baseline posts {expectedRevision}, renders the merge findings, reloads, and the note names the new baseline', async () => {
     let refreshed = false;
     const bodies: unknown[] = [];
-    const merged: SkillGuardResult = {
+    const merged: SkillRefreshResult = {
       verdict: 'warnings',
       revision: REV_2,
-      findings: [{ kind: 'refresh-conflict', severity: 'warning', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: null, explanation: 'both sides changed — your edit was kept, the new side stored for diff' }],
+      findings: [finding({ kind: 'refresh-conflict', severity: 'warning', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: null, explanation: 'both sides changed — your edit was kept, the new side stored for diff' })],
+      previous_baseline: BASELINE,
+      baseline: 'c'.repeat(16),
+      plugin_version: '12.33.0',
+      taken: [REPO_LEARN, A11Y],
+      kept: [EXTRACTOR, MINE],
+      added: [],
+      removed: [],
+      conflicts: [EXTRACTOR],
     };
     wire({
       'GET /skills': () => Promise.resolve(refreshed ? catalog({ revision: REV_2, plugin_version: '12.33.0' }) : catalog()),
@@ -1188,16 +1411,16 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
     expect(findings).toHaveTextContent('Refresh baseline passed with 1 finding to read.');
     expect(within(findings).getByTestId('skills-finding').dataset.kind).toBe('refresh-conflict');
     expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
-    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Baseline refreshed — 12.33.0 (bbbbbbbbbbbb), 4 skills.');
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Baseline refreshed — 12.33.0 (cccccccccccc): 2 taken · 2 kept · 0 added · 0 removed · 1 conflict. Your edits were kept; conflicts are flagged.');
     expect(screen.getByTestId('skills-source')).toHaveTextContent('baseline 12.33.0');
     expect(calls('GET', '/skills')).toBe(2);
   });
 
   it('Analyze posts /skills/analyze with NO body (a dry run), renders the findings, reloads nothing', async () => {
-    const analysis: SkillGuardResult = {
+    const analysis: SkillAnalyzeResult = {
       verdict: 'blocked',
       revision: REV_1,
-      findings: [{ kind: 'unresolved-ref', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 49, explanation: '../search/refs/hotspots.md does not resolve inside the bundle' }],
+      findings: [finding({ kind: 'unresolved-ref', severity: 'blocking', skill: REPO_LEARN, file: 'skills/repo-learn/SKILL.md', line: 49, explanation: '../search/refs/hotspots.md does not resolve inside the bundle' })],
     };
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
@@ -1220,8 +1443,8 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
     let published = false;
     const bodies: unknown[] = [];
     wire({
-      'GET /skills': () => Promise.resolve(published ? catalog({ revision: REV_2, generation: 4 }) : catalog()),
-      'POST /skills/publish': (init) => { bodies.push(body(init)); published = true; return Promise.resolve(clear()); },
+      'GET /skills': () => Promise.resolve(published ? catalog({ revision: REV_2, current: { gen: 4, path: '/state/skills/snapshots/000004' } }) : catalog()),
+      'POST /skills/publish': (init) => { bodies.push(body(init)); published = true; return Promise.resolve(publishedAt(4)); },
     });
     render(<Harness />);
     await screen.findAllByTestId('skills-row');
@@ -1232,18 +1455,19 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
     expect(findings.dataset.verdict).toBe('clear');
     expect(findings).toHaveTextContent('Publish clear — no findings.');
     expect(bodies).toEqual([{ expectedRevision: REV_1 }]);
-    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Published — snapshot generation 4 is current');
+    expect(await screen.findByTestId('skills-note')).toHaveTextContent('Published — snapshot generation 4 is current (4 skills, nnnnnnnnnnnn); workers spawn with it from now on.');
     await waitFor(() => expect(screen.getByTestId('skills-snapshot').dataset.generation).toBe('4'));
     expect(calls('GET', '/skills')).toBe(2);
   });
 
   it('a blocked Publish renders the findings with their file:line and reloads nothing — the old generation stays current', async () => {
-    const blocked: SkillGuardResult = {
+    const blocked: SkillPublishResult = {
       verdict: 'blocked',
       revision: REV_1,
+      snapshot: null,
       findings: [
-        { kind: 'unresolved-ref', severity: 'blocking', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: 42, explanation: '${CLAUDE_PLUGIN_ROOT}/scripts/domain/extract_loop.py does not resolve inside the bundle' },
-        { kind: 'name-collision', severity: 'blocking', skill: MINE, file: null, line: null, explanation: 'frontmatter name collides with a disabled skill' },
+        finding({ kind: 'unresolved-ref', severity: 'blocking', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: 42, explanation: '${CLAUDE_PLUGIN_ROOT}/scripts/domain/extract_loop.py escapes the plugin root' }),
+        finding({ kind: 'name-collision', severity: 'blocking', skill: MINE, againstSkill: A11Y, explanation: 'frontmatter name collides with a disabled skill' }),
       ],
     };
     wire({
@@ -1269,12 +1493,12 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
   it('a 409 on Publish raises the reload prompt', async () => {
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
-      'POST /skills/publish': () => Promise.reject(new ApiError(409, 'expected revision rev-0001')),
+      'POST /skills/publish': () => Promise.reject(new ApiError(409, 'revision mismatch: expected 1, the manifest is at 2')),
     });
     render(<Harness />);
     await screen.findAllByTestId('skills-row');
     fireEvent.click(screen.getByTestId('skills-publish'));
-    expect(await screen.findByTestId('skills-conflict')).toHaveTextContent('expected revision rev-0001');
+    expect(await screen.findByTestId('skills-conflict')).toHaveTextContent('revision mismatch: expected 1, the manifest is at 2');
     expect(screen.queryByTestId('skills-page-findings')).toBeNull();
     expect(screen.queryByTestId('skills-page-error')).toBeNull();
   });
@@ -1293,7 +1517,7 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
 
 describe('SkillsPage — review round 2: a draft survives a skill switch, a modal 409, and a read that lands mid-typing', () => {
   const mineHandlers: Record<string, Handler> = {
-    [`GET /skills/${MINE}/files`]: () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 4 }] }),
+    [`GET /skills/${MINE}/files`]: () => Promise.resolve(tree([treeFile('SKILL.md', 4)])),
     [`GET /skills/${MINE}/files/SKILL.md`]: () => Promise.resolve(fileRead('SKILL.md', 'mine')),
   };
 
@@ -1359,17 +1583,17 @@ describe('SkillsPage — review round 2: a draft survives a skill switch, a moda
     let added = false;
     wire({
       'GET /skills': () => Promise.resolve(added
-        ? catalog({ revision, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+        ? catalog({ revision, skills: { 'new-skill': entry({ dir: 'skills/new-skill', provenance: 'user-added' }) } })
         : catalog({ revision })),
       'POST /skills': (init) => {
-        const b = body(init) as { expectedRevision: string };
+        const b = body(init) as { expectedRevision: number };
         posts.push(b);
-        if (b.expectedRevision !== revision) return Promise.reject(new ApiError(409, `expected revision ${b.expectedRevision}, catalog is at ${revision}`));
+        if (b.expectedRevision !== revision) return Promise.reject(new ApiError(409, `revision mismatch: expected ${b.expectedRevision}, the manifest is at ${revision}`));
         added = true;
         revision = REV_3;
         return Promise.resolve(clear(REV_3));
       },
-      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files': () => Promise.resolve(tree([treeFile('SKILL.md', 3)])),
       'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
     });
     render(<Harness />);
@@ -1419,7 +1643,7 @@ describe('SkillsPage — review round 2: a draft survives a skill switch, a moda
       'GET /skills': () => Promise.resolve(catalog({ revision })),
       ...fileHandlers(REPO_LEARN),
       [`POST /skills/${REPO_LEARN}/replace`]: (init) => {
-        const b = body(init) as { expectedRevision: string };
+        const b = body(init) as { expectedRevision: number };
         posts.push(b);
         if (b.expectedRevision !== revision) return Promise.reject(new ApiError(409, 'stale'));
         return Promise.resolve(clear(REV_3));
@@ -1444,7 +1668,7 @@ describe('SkillsPage — review round 2: a draft survives a skill switch, a moda
 
     fireEvent.click(within(modal).getByTestId('skills-files-save'));
     await waitFor(() => expect(screen.queryByTestId('skills-files-modal')).toBeNull());
-    expect(posts.map((p) => (p as { expectedRevision: string }).expectedRevision)).toEqual([REV_1, REV_2]);
+    expect(posts.map((p) => (p as { expectedRevision: number }).expectedRevision)).toEqual([REV_1, REV_2]);
     expect((await within(drawer).findByTestId('skills-findings')).dataset.verdict).toBe('clear');
   });
 
@@ -1579,12 +1803,12 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
       'GET /skills': () => {
         if (fail) return Promise.reject(new ApiError(500, 'store busy'));
         return Promise.resolve(added
-          ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', baselineHash: null, lastPublishedHash: null }) } })
+          ? catalog({ revision: REV_2, skills: { 'new-skill': entry({ dir: 'skills/new-skill', provenance: 'user-added' }) } })
           : catalog());
       },
       // The write lands — and the daemon's very next catalog read fails.
       'POST /skills': () => { added = true; fail = true; return Promise.resolve(clear()); },
-      'GET /skills/new-skill/files': () => Promise.resolve({ files: [{ path: 'SKILL.md', hash: 'h', size: 3 }] }),
+      'GET /skills/new-skill/files': () => Promise.resolve(tree([treeFile('SKILL.md', 3)])),
       'GET /skills/new-skill/files/SKILL.md': () => Promise.resolve(fileRead('SKILL.md', 'new')),
     });
     render(<Harness />);
@@ -1621,8 +1845,8 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
   });
 
   it('switching BACK to Skill files while the list is still loading shows the loading state (nothing selected, no stray open, the Support tab still available); when the list lands, SKILL.md opens exactly once', async () => {
-    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
-    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    let resolveList: (v: SkillFileTree) => void = () => {};
+    const deferred = new Promise<SkillFileTree>((r) => { resolveList = r; });
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       [`GET /skills/${REPO_LEARN}/files`]: () => deferred,
@@ -1658,7 +1882,7 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
     expect(within(drawer).getByTestId('skills-tab-support')).toBeEnabled();
 
     await act(async () => {
-      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      resolveList(tree([treeFile('refs/notes.md', 5), treeFile('SKILL.md', SKILL_MD.length)]));
       await new Promise((r) => setTimeout(r, 0));
     });
     // The list landed on the tree that asked for it: SKILL.md opens — once, through the skill route.
@@ -1675,8 +1899,8 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
   });
 
   it('…but a list that lands after the operator moved on AGAIN (Skill pending → Support) opens nothing; and a switch back re-selects the file last open on that tree, not always the first', async () => {
-    let resolveList: (v: { files: SkillFileEntry[] }) => void = () => {};
-    const deferred = new Promise<{ files: SkillFileEntry[] }>((r) => { resolveList = r; });
+    let resolveList: (v: SkillFileTree) => void = () => {};
+    const deferred = new Promise<SkillFileTree>((r) => { resolveList = r; });
     wire({
       'GET /skills': () => Promise.resolve(catalog()),
       [`GET /skills/${REPO_LEARN}/files`]: () => deferred,
@@ -1697,7 +1921,7 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
 
     // The late list is data for the skill tree, not an instruction to open: the support editor stays.
     await act(async () => {
-      resolveList({ files: [{ path: 'refs/notes.md', hash: 'h1', size: 5 }, { path: 'SKILL.md', hash: 'h2', size: SKILL_MD.length }] });
+      resolveList(tree([treeFile('refs/notes.md', 5), treeFile('SKILL.md', SKILL_MD.length)]));
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(within(drawer).getByTestId('skills-editor')).toHaveValue('{"name":"wicked-garden"}');

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -574,8 +574,10 @@ describe('SkillsPage — the drawer: files, the textarea editor, Save → findin
     // Pristine: Save is disabled, nothing is dirty.
     expect(within(drawer).getByTestId('skills-save')).toBeDisabled();
     expect(within(drawer).queryByTestId('skills-file-dirty')).toBeNull();
-    // The row reads selected.
-    expect(row(REPO_LEARN)).toHaveAttribute('aria-selected', 'true');
+    // The row reads as the current one (`aria-current`, not `aria-selected` — a plain table row is
+    // no ARIA option) and carries the `data-selected` styling hook.
+    expect(row(REPO_LEARN)).toHaveAttribute('aria-current', 'true');
+    expect(row(REPO_LEARN)).toHaveAttribute('data-selected', 'true');
 
     // Picking the other file loads it.
     fireEvent.click(files[1]!);

--- a/tests/fixtures/api-types-0.27.0-skills.d.ts
+++ b/tests/fixtures/api-types-0.27.0-skills.d.ts
@@ -1,0 +1,410 @@
+// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:1322-1685 (crew#480 @ 4cae105) — the skills block
+// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.27.0) ──
+//
+// Skills are files (skills keystone, design v3 + amendments v3.1/v3.2). The daemon owns ONE
+// effective `wicked-garden`-shaped plugin root — `<state home>/skills/effective/`, the dependency
+// closure of the installed plugin: `.claude-plugin/{plugin.json,archetypes.json,components.json}`,
+// `skills/**` (nested layout verbatim), `scripts/**` minus CI + dev tools, `schemas/`,
+// `docs/examples/`, `pyproject.toml`, `uv.lock` — seeded from the LIVE installed plugin into a
+// content-addressed `baseline/<contentHash>/`. The operator edits files in place, replaces a
+// skill, adds one, disables one (manifest state — the files stay), resets one (content from the
+// baseline; never enablement). Nothing a worker runs is read from `effective/`: PUBLISHING
+// validates the whole tree and writes an IMMUTABLE, read-only `snapshots/<gen>/` (enabled skills
+// only, closure included, `snapshot.json`, and the generated delivery views —
+// `views/copilot/.github/skills/<name>/` holding the enabled PORTABLE skills, part of the content
+// hash), then flips `current -> snapshots/<gen>`; the engine receives the resolved snapshot path
+// as `WICKED_SKILLS_SNAPSHOT`. The daemon NEVER writes into the user's own CLI directories
+// (`~/.codex`, `~/.pi`, `~/.copilot`, `~/.config/opencode`, `~/.claude`): skills reach non-Claude
+// workers only through per-launch, wicked-owned delivery core performs from the snapshot (v3.2) —
+// a CLI without a lever (codex today) runs without wicked skills, and a unit on such a seat that
+// requires one is REFUSED at launch (no proceed-with-disclosure setting exists).
+// `/skills` is a file manager whose EVERY mutation is CAS-guarded (`expectedRevision`) and
+// answers 2xx `{verdict, findings[], revision}` — a `blocked` verdict is a normal response,
+// including a publish refused because one is in flight (`publish-in-flight`) or aborted because the
+// root changed under it (`root-changed`), neither of which wrote anything. 409 (`{error, revision}`)
+// is EXCLUSIVELY a stale `expectedRevision` (a CAS conflict).
+
+/** What a skill IS, from its frontmatter — fork-first: `context: fork` → fork worker (a subagent
+ *  body); else `user-invocable: true` → router (an operator-facing entry point); else module (a
+ *  nested reference skill routers/workers pull in). */
+export type SkillKind = 'router' | 'fork-worker' | 'module';
+
+/** `shipped` = every own file byte-identical to the baseline; `override` = a shipped skill with
+ *  edited/replaced files; `user-added` = no baseline (added through the API, or upstream dropped
+ *  it while the operator's edits were kept). */
+export type SkillProvenance = 'shipped' | 'override' | 'user-added';
+
+/** Where a baseline was captured from. `claude-plugin-cache` covers the marketplace cache AND the
+ *  hand-installed `plugins/wicked-garden` copy (both are "the installed plugin"); `checkout` is a
+ *  git working tree; `directory` any other explicit plugin-shaped directory. */
+export type SkillSourceKind = 'claude-plugin-cache' | 'checkout' | 'directory';
+
+/** The per-baseline `uv sync` state (`<baseline>/.venv`, provisioned once per content hash — the
+ *  publish that needs it AWAITS it — and shared read-only by every snapshot that links it):
+ *  `pending` until a successful publish records it, `synced` on success (the snapshot carries a
+ *  `.venv` link), `skipped` when the bundle carries no `pyproject.toml` (nothing to provision; no
+ *  link). `failed` (uv missing or a sync error) is BLOCKING for the publish (`venv-failed`) and is
+ *  therefore never the recorded state of a published baseline — the record keeps its previous
+ *  value; a later publish retries. */
+export type SkillVenvState = 'pending' | 'synced' | 'failed' | 'skipped';
+
+/** One captured baseline — keyed in `SkillManifest.baselines` by the content hash of its bundle
+ *  (sorted relative paths + sha256 digests), never by the version string alone: two installs of
+ *  "12.32.0" with different bytes are two baselines. */
+export interface SkillBaselineRecord {
+  /** `version` from the source's `.claude-plugin/plugin.json`. */
+  plugin_version: string;
+  source: { kind: SkillSourceKind; path: string };
+  /** HEAD sha for a `checkout` source; `null` otherwise (or when git could not answer). */
+  git_sha: string | null;
+  /** ISO-8601 instant the baseline was captured. */
+  captured_at: string;
+  venv: SkillVenvState;
+}
+
+export interface SkillEntry {
+  /** Plugin-relative directory, nested layout preserved (`skills/engineering/frontend`). Never
+   *  renamed — sibling `../` links depend on it. */
+  dir: string;
+  kind: SkillKind;
+  /** Core-by-reference: in the registered-reference closure — a `skill_ref` of a workflow the
+   *  daemon knows (core drop-ins, crew-generated, user-registered) or a skill one of those names in
+   *  its SKILL.md (repo-learn → search, mem). Disabling or renaming it is blocking. */
+  core: boolean;
+  /** `false` when the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a script relative to
+   *  the cwd (`python3 -u scripts/x.py`, `./scripts/x`, …), or link `../` — Claude-only by nature:
+   *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
+   *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
+  portable: boolean;
+  /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
+   *  excluded from the next published snapshot. Reset never flips it. */
+  enabled: boolean;
+  provenance: SkillProvenance;
+  /** ISO-8601 instant of the last edit/replace/add through the API; `null` when untouched. */
+  editedAt: string | null;
+  /** A refreshed baseline changed a file this skill overrides — the new side is readable as
+   *  `?side=baseline` for diffing; the operator's content is kept. */
+  upgradeAvailable: boolean;
+  /** `upgradeAvailable`, or the last refresh found a name collision (upstream now ships a skill
+   *  under this user-added name at another dir). Cleared by reset / a later refresh. */
+  conflict: boolean;
+  /** The held-back UPSTREAM skill's directory in the current baseline when the last refresh found a
+   *  name collision (upstream ships this name at another dir than the operator's skill); `null`
+   *  otherwise. `GET /skills/:name/files/*path?side=baseline` reads THIS directory for such a skill,
+   *  so the two sides of the collision are comparable — the answer's `path` names the file actually
+   *  read (api-types 0.27.0). Re-derived by every refresh. */
+  upstreamDir: string | null;
+}
+
+/** One managed file (plugin-relative path → hashes). `baselineHash` `null` = user-added file;
+ *  `effectiveHash` `null` = a baseline file absent from `effective/` (removed by a direct
+ *  filesystem edit — reset restores it; the skill reads `override` until then). */
+export interface SkillFileRecord {
+  baselineHash: string | null;
+  effectiveHash: string | null;
+  /** The hash this file had in the most recent published snapshot; `null` = never published. */
+  lastPublishedHash: string | null;
+  /** The last refresh saw BOTH sides change (kept the effective side). */
+  conflict: boolean;
+}
+
+/** The most recent publish. */
+export interface SkillPublishedRecord {
+  gen: number;
+  /** Hash over the snapshot's files (sorted relative paths + sha256 digests), `snapshot.json` excluded. */
+  contentHash: string;
+  /** ISO-8601 instant. */
+  at: string;
+  /** sha256 of the exact `snapshot.json` bytes publish wrote. `snapshot.json` is excluded from the
+   *  content hash, so the crew-owned manifest AUTHENTICATES it: `current` verifies only the
+   *  generation this record names, with metadata hashing to this value (api-types 0.27.0). */
+  snapshotHash: string;
+}
+
+/** `<skills root>/manifest.json` — the state of the daemon-owned root. (The v3 mirror ledger is
+ *  withdrawn with the mirror — design v3.2 §1: the daemon never writes into the user's CLI dirs.) */
+export interface SkillManifest {
+  version: 2;
+  /** Monotonic; bumped by EVERY mutation. Every mutating request carries it as `expectedRevision`. */
+  revision: number;
+  /** Content hash of the current baseline (`baseline/<hash>/`). */
+  baseline: string;
+  baselines: Record<string, SkillBaselineRecord>;
+  /** Keyed by frontmatter `name` (`wicked-garden-<dir segments joined by '-'>`). */
+  skills: Record<string, SkillEntry>;
+  /** Every managed file under `effective/`, plugin-relative. */
+  files: Record<string, SkillFileRecord>;
+  published: SkillPublishedRecord | null;
+}
+
+/** `GET /skills` 200 body. 503 when the root is not seeded (no installed plugin was found) or when
+ *  `current` exists but fails verification (realpath outside `snapshots/`, malformed
+ *  `snapshot.json`, content hash mismatch) — a corrupt root is a loud error, never an empty catalog. */
+export interface SkillsManifestResponse {
+  manifest: SkillManifest;
+  revision: number;
+  /** The resolved skills root on the daemon host (`<state home>/skills` by default). */
+  root: string;
+  /** The VERIFIED published snapshot `current` resolves to, or `null` before the first publish.
+   *  `path` is the absolute REAL path of `snapshots/<gen>` — byte-identical to the one input the
+   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). */
+  current: { gen: number; path: string } | null;
+}
+
+export interface SkillFileEntry {
+  /** POSIX path relative to the skill dir. */
+  path: string;
+  size: number;
+  sha256: string;
+  /** This file's manifest record (`null` for a file present on disk but not yet recorded). */
+  record: SkillFileRecord | null;
+}
+
+/** `GET /skills/:name/files` 200 body — the skill's OWN files (a nested skill's files are its own). */
+export interface SkillFileTree {
+  name: string;
+  dir: string;
+  enabled: boolean;
+  files: SkillFileEntry[];
+}
+
+/** `GET /skills/:name/files/*path` and `GET /skills/support/*path` 200 body — a typed, capped read.
+ *  Save is disabled on `truncated` or `binary`. `?side=baseline` reads the baseline copy instead
+ *  (the "new side" of a refresh conflict). */
+export interface SkillReadResult {
+  /** Plugin-relative path served. */
+  path: string;
+  /** UTF-8 text — the first 512 KB when `truncated`; `null` when `binary` (there is no text to show). */
+  content: string | null;
+  /** The file's FULL size in bytes. */
+  size: number;
+  truncated: boolean;
+  binary: boolean;
+}
+
+export type SkillFindingKind =
+  | 'name-invalid'
+  | 'name-collision'
+  | 'name-mismatch'
+  | 'frontmatter-invalid'
+  | 'missing-skill-md'
+  | 'unregistered-skill'
+  | 'nested-skill-create'
+  | 'core-disable'
+  | 'core-rename'
+  | 'core-missing'
+  | 'support-file-edit'
+  | 'non-portable'
+  /** A `${CLAUDE_PLUGIN_ROOT}/<p>` or `../<p>` reference in an enabled skill's files that does not
+   *  resolve inside the would-be snapshot. Severity follows the TARGET (design v3.4 §1): a reference
+   *  that ESCAPES the plugin root (`..` climbing out — it reaches whatever lies beside the snapshot on
+   *  the worker host) is `blocking`; one whose target is MISSING (it normalizes inside the root but
+   *  the snapshot does not carry it — a file the bundle omits, or a skill that is disabled) is a
+   *  `warning`: a content bug the skill's author owns, published as found — a publish with only
+   *  warnings answers `verdict: 'warnings'` with the findings AND a written snapshot (api-types
+   *  0.27.0). */
+  | 'unresolved-ref'
+  /** A path the store refuses BY NAME rather than reads through: a shape that could leave its root
+   *  (`..`, an absolute piece), a component that crosses a symlink, or — under `effective/`, where
+   *  every entry is classified — a symlink or a special node (socket, fifo, device) anywhere,
+   *  the contents of a pruned directory (`.venv`, `node_modules`, `__pycache__`) INCLUDED: such a
+   *  directory is never copied or hashed, but what it holds is still judged, and a link inside one
+   *  blocks with the reason (a provisioned environment lives under `baseline/`, not the editable
+   *  root). Blocking; `file` names the entry, `skill` its owning skill when it has one. */
+  | 'path-invalid'
+  | 'unknown-skill'
+  | 'no-baseline'
+  | 'fs-drift'
+  | 'refresh-conflict'
+  | 'empty-snapshot'
+  /** `.claude-plugin/plugin.json`, `archetypes.json` or `components.json` is absent from `effective/`
+   *  — the plugin manifest + the runtime catalogs are REQUIRED snapshot members (blocking at
+   *  publish; api-types 0.27.0). */
+  | 'missing-plugin-manifest'
+  /** The plugin manifest or a runtime catalog is present but not what its reader expects — does
+   *  not parse as JSON, is not a JSON object, or `archetypes.json` lacks its `archetypes`
+   *  collection (blocking at publish; api-types 0.27.0). A manifest without `name` is
+   *  `name-mismatch`. */
+  | 'catalog-invalid'
+  /** The baseline's shared read-only Python env could not be provisioned (uv missing, `uv sync`
+   *  failed, or the env could not be locked) while the bundle carries a `pyproject.toml` — the env
+   *  is REQUIRED, so the publish is blocked and nothing (the provisioning state included) is
+   *  persisted (api-types 0.27.0). */
+  | 'venv-failed'
+  /** A publish was refused because one is already running (one at a time) — nothing was written, so
+   *  it is a 2xx `blocked` envelope, not a 409 (409 is only a stale `expectedRevision`; api-types
+   *  0.27.0). Re-read `GET /skills` and retry against the revision it answers. */
+  | 'publish-in-flight'
+  /** A publish was aborted because the skills root changed under it — nothing was written to either
+   *  root; a 2xx `blocked` envelope (api-types 0.27.0). Re-read `GET /skills` and retry. */
+  | 'root-changed'
+  /** A path outside the bundle closure — the ONE allowlist of what the seed copies, what the support
+   *  API may address, and what a snapshot may carry: the five runtime catalogs under `.claude-plugin`
+   *  BY NAME (`plugin.json`, `archetypes.json`, `components.json`, `specialist.json`,
+   *  `stack-registry.json` — `marketplace.json`, a publish-time listing, is outside), everything under
+   *  `skills`, `schemas` and `docs/examples`, everything under `scripts` except the `ci` and `wg`
+   *  directories and any `wg-`-prefixed dev tooling, plus `pyproject.toml` and `uv.lock`. A support
+   *  add/PUT there is a 2xx `blocked` envelope (nothing written); a file found there under
+   *  `effective/` at publish/analyze (a direct filesystem edit) is a BLOCKING finding naming the path
+   *  — a snapshot never ships it (api-types 0.27.0). */
+  | 'outside-closure'
+  /** A content-addressed `baseline/<hash>` whose tree does not hash to its name (a bundle file
+   *  modified, planted or removed, or a symlink inside), or a baseline file whose bytes do not match
+   *  the hash the manifest recorded for it. Baselines are re-verified before EVERY reuse: a refresh
+   *  refuses to reuse it (2xx `blocked`, nothing copied), reset refuses to restore from it (nothing
+   *  written), publish/analyze report it blocking (before AND after the env was provisioned in it).
+   *  Read-only mode bits on the baseline are a guard, never the integrity boundary — the hash is
+   *  (api-types 0.27.0). */
+  | 'baseline-corrupt';
+
+export type SkillFindingSeverity = 'warning' | 'blocking';
+
+/** `blocked` = at least one blocking finding (nothing was written / published); `warnings` =
+ *  proceeded with warnings; `clear` = nothing to say. */
+export type SkillVerdict = 'clear' | 'warnings' | 'blocked';
+
+export interface SkillConflictFinding {
+  kind: SkillFindingKind;
+  severity: SkillFindingSeverity;
+  /** The skill this finding is about, or `null` for a catalog / support-file finding. */
+  skill: string | null;
+  /** Plugin-relative file the finding names, or `null`. */
+  file: string | null;
+  /** 1-based line in `file`, when the finding is anchored to one. */
+  line: number | null;
+  /** The OTHER catalog skill this finding is against (a collision, a core guard), or `null`. */
+  againstSkill: string | null;
+  againstIsCore: boolean;
+  /** The concrete fact (names, paths, the parse error). */
+  evidence: string;
+  /** Why it matters. */
+  explanation: string;
+}
+
+/** `POST /skills/analyze` 200 body (a PURE dry run of the publish validation: nothing persisted,
+ *  `revision` unchanged — drift it observes is reported, and recorded only by the publish that
+ *  ships it) — and the base of every mutation result. */
+export interface SkillAnalyzeResult {
+  verdict: SkillVerdict;
+  findings: SkillConflictFinding[];
+  revision: number;
+}
+
+/** Every `/skills` mutation's 200 body. `blocked` ⇒ nothing was written and `revision` is unchanged. */
+export interface SkillMutationResult extends SkillAnalyzeResult {
+  skill?: SkillEntry & { name: string };
+}
+
+/** `POST /skills/publish` 200 body. `snapshot` is `null` when the verdict is `blocked` — and then
+ *  `revision` is unchanged (a blocked publish persists nothing — not the drift it observed, not the
+ *  baseline's provisioning state). `path` is the absolute REAL path of the locked, read-only
+ *  generation; its `snapshot.json` carries the skill rows and the `views` block (`views.copilot`:
+ *  the `views/copilot` dir + the portable skills laid out in it). One publish runs at a time — a
+ *  concurrent one wrote nothing and answers a 2xx `blocked` `publish-in-flight` envelope
+ *  (`snapshot: null`), not a 409. */
+export interface SkillPublishResult extends SkillAnalyzeResult {
+  snapshot: { gen: number; path: string; contentHash: string; skills: number } | null;
+}
+
+/** `POST /skills/refresh-baseline` 200 body — the three-way merge per FILE (baseline_old /
+ *  baseline_new / effective): unchanged → take new; user-modified & upstream-unchanged → keep;
+ *  both changed → keep + `conflict` (new side readable as `?side=baseline`); user-DELETED &
+ *  upstream-changed → the deletion is kept + `conflict` (a deletion is a modification; reset
+ *  restores upstream); upstream-deleted & user-unmodified → remove; upstream-deleted &
+ *  user-modified → keep as user-added; a new upstream skill whose path-derived name is a
+ *  user-added skill's → conflict. 502 when no plugin is installed. */
+export interface SkillRefreshResult extends SkillAnalyzeResult {
+  previous_baseline: string;
+  baseline: string;
+  plugin_version: string;
+  /** Skills whose files were replaced from the new baseline. */
+  taken: string[];
+  /** Skills that kept operator content (upstream unchanged, or a flagged conflict). */
+  kept: string[];
+  added: string[];
+  removed: string[];
+  /** Skills flagged `conflict` by this refresh. */
+  conflicts: string[];
+}
+
+/** The 409 body of a `/skills` mutation whose `expectedRevision` is stale — a CAS conflict, the
+ *  ONLY thing that answers 409. A publish refused because another is in flight, or aborted because
+ *  the skills root changed under it, wrote nothing and instead answers a 2xx `blocked` findings
+ *  envelope (`publish-in-flight` / `root-changed`; api-types 0.27.0), never a 409. */
+export interface SkillRevisionConflict {
+  error: string;
+  /** The current revision — re-read `GET /skills` (or use this) and retry. */
+  revision: number;
+}
+
+/** The body of `POST /skills/:name/{enable,disable,reset}`, `POST /skills/publish` and
+ *  `POST /skills/refresh-baseline`. */
+export interface SkillRevisionBody {
+  expectedRevision: number;
+}
+
+/** `PUT /skills/:name/files/*path` and `PUT /skills/support/*path` body. `content` is UTF-8 text,
+ *  at most 512 KB. */
+export interface PutSkillFileBody {
+  content: string;
+  expectedRevision: number;
+}
+
+/** `POST /skills` body — add a user skill. `files` maps skill-relative POSIX paths to UTF-8 text
+ *  and must include `SKILL.md`; the skill lands at `skills/<name minus "wicked-garden-">`. */
+export interface AddSkillBody {
+  name: string;
+  files: Record<string, string>;
+  expectedRevision: number;
+}
+
+/** `POST /skills/:name/replace` body — replace the skill's OWN files wholesale (nested skills untouched). */
+export interface ReplaceSkillBody {
+  files: Record<string, string>;
+  expectedRevision: number;
+}
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:3262-3302 (crew#480 @ 4cae105) — the diagnostics skills block
+/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.27.0). */
+export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
+
+/** One finding the skills degradation ladder produced (design v3 §3). */
+export interface DiagnosticsSkillsFinding {
+  /** `skills.fallback` = no wicked-garden installed (engine input left unset / restored to the boot
+   *  value — the engine resolves the live cache itself); `skills.blocked` = the first publish is
+   *  blocked (engine input points at a non-existent refusal path — launches fail loudly until the
+   *  catalog is fixed); `skills.config` = the configured root is corrupt/unusable (same refusal;
+   *  `error`), or — as a `warning` on the `published` state — the root lies OUTSIDE the daemon
+   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch. */
+  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config';
+  severity: 'warning' | 'error';
+  message: string;
+}
+
+/**
+ * `GET /diagnostics` → `skills`: whether the engine is being handed a verified snapshot, and if not,
+ * why — the one read-only answer to "why do launches refuse the skills snapshot". `disabled` is a
+ * daemon booted without the seam (the manifest collector, some tests).
+ */
+export interface DiagnosticsSkills {
+  state: DiagnosticsSkillsState;
+  /** The resolved skills root on the daemon host; `null` when `disabled`. */
+  root: string | null;
+  /** The VERIFIED published snapshot (`current` realpath-contained, `snapshot.json` + content hash
+   *  checked), or `null`. `path` is the absolute REAL path of `snapshots/<gen>`. */
+  current: { gen: number; path: string } | null;
+  /** What `WICKED_SKILLS_SNAPSHOT` — the engine's ONE skills input (v3.1 §2, v3.4 §2;
+   *  `WICKED_SKILLS_CURRENT` is never set, `WICKED_CREW_STATE_HOME` is not exported) — is exported as
+   *  right now: the real snapshot path, a `<root>/refused/…` refusal path, `""` when the process
+   *  booted with an explicitly EMPTY value (preserved — a configuration error core refuses, state
+   *  `config-error`; design v3.5 §4), or `null` = unset. */
+  engineInput: string | null;
+  /** DIAGNOSTICS-ONLY: the canonical realpath of the daemon state home, reported for humans. It is
+   *  NOT an engine input — `WICKED_CREW_STATE_HOME` is retired (v3.4 §2): core reads only
+   *  `WICKED_SKILLS_SNAPSHOT` and derives the state home from its `<state home>/skills/snapshots/<gen>`
+   *  layout. `null` only when `disabled`. */
+  stateHome: string | null;
+  findings: DiagnosticsSkillsFinding[];
+}
+// <<< VERBATIM

--- a/tests/notFoundRoute.test.tsx
+++ b/tests/notFoundRoute.test.tsx
@@ -54,6 +54,7 @@ describe('useRoute — dead addresses parse to the not-found panel', () => {
     expect(routeAt('/demo').current.panel).toBe('demo');
     expect(routeAt('/steering').current.panel).toBe('steering');
     expect(routeAt('/steering/security').current.panel).toBe('steering');
+    expect(routeAt('/skills').current.panel).toBe('skills');
     expect(routeAt('/testing/harness').current.panel).toBe('testing');
     expect(routeAt('/runs/r-1').current).toMatchObject({ panel: 'runs', runId: 'r-1' });
     expect(routeAt('/runs/new').current).toMatchObject({ panel: 'runs', showLaunch: true });

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -35,9 +35,11 @@ vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
  *  - `readCatalogBody` accepts exactly `{manifest: {skills: {…}, support: {…}}, revision}` with
  *    PLAIN objects for the two maps; anything else (an array, a missing map) throws a NAMED error
  *    (never a silent empty catalog against a daemon that answered something);
- *  - route identity: every name / path segment is decoded, refused when empty, dot-only or
- *    separator-bearing, then encoded — a daemon-supplied `..` can never normalize a skill-file
- *    request onto `/skills/support/…` or a support PUT onto `/settings` (the codex probes);
+ *  - route identity: every name / path segment is validated on its LITERAL text (refused when
+ *    empty, dot-only or separator/NUL-bearing) and then encoded exactly once — a daemon-supplied
+ *    `..` can never normalize a skill-file request onto `/skills/support/…` or a support PUT onto
+ *    `/settings` (the round-1 probes), and a literal `%` filename keeps its identity on the wire
+ *    (`refs/a%41.md` → `refs/a%2541.md`, never `refs/aA.md` — the round-2 probe);
  *  - `provenanceOf` DERIVES shipped / override / user-added from the hashes — no wire field;
  *  - `isUnpublished` compares the effective hash with what the current snapshot carries;
  *  - `sortSkillFiles` puts SKILL.md first; `supportFiles` folds the manifest's support map;
@@ -116,36 +118,45 @@ describe('route identity — every name and path is validated before it becomes 
     fetchMock.mockResolvedValue({ files: [], verdict: 'clear', findings: [], revision: 'r' });
   });
 
-  it('segments: decoded, then refused when empty, dot-only, or carrying a separator; encoded otherwise', () => {
+  it('segments: validated on the LITERAL text — refused when empty, dot-only, or carrying a separator / NUL; encoded exactly once otherwise', () => {
     expect(skillRouteSegment('SKILL.md', 'x')).toBe('SKILL.md');
     expect(skillRouteSegment('.claude-plugin', 'x')).toBe('.claude-plugin');
     expect(skillRouteSegment('a b#c', 'x')).toBe('a%20b%23c');
-    // A literal `%` that is not an escape is the segment's own text.
+    // A `%` is the segment's own text, never an escape to resolve here: the daemon's ONE decode
+    // hands the literal back. (Round 2: decoding `a%41.md` first retargeted every read and write
+    // onto `aA.md` while the drawer showed the requested name.)
     expect(skillRouteSegment('100%.md', 'x')).toBe('100%25.md');
+    expect(skillRouteSegment('a%41.md', 'x')).toBe('a%2541.md');
+    expect(decodeURIComponent(skillRouteSegment('a%41.md', 'x'))).toBe('a%41.md');
+    // Percent-encoded dots are a file literally NAMED `%2e%2e`: encoded once, the route layer's
+    // single decode yields `%2e%2e` again — never `..`. Same for an encoded slash or NUL.
+    expect(skillRouteSegment('%2e%2e', 'x')).toBe('%252e%252e');
+    expect(skillRouteSegment('a%2Fb', 'x')).toBe('a%252Fb');
+    expect(skillRouteSegment('a%00b', 'x')).toBe('a%2500b');
     expect(() => skillRouteSegment('', 'x')).toThrow(/refusing x: an empty segment/);
     expect(() => skillRouteSegment('.', 'x')).toThrow(/dot-only/);
     expect(() => skillRouteSegment('..', 'x')).toThrow(/dot-only/);
     expect(() => skillRouteSegment('...', 'x')).toThrow(/dot-only/);
-    // Percent-encoded dots are still dots once the route layer decodes them.
-    expect(() => skillRouteSegment('%2e%2e', 'x')).toThrow(/dot-only/);
-    expect(() => skillRouteSegment('%2E.', 'x')).toThrow(/dot-only/);
-    expect(() => skillRouteSegment('a%2Fb', 'x')).toThrow(/path separator/);
+    expect(() => skillRouteSegment('a/b', 'x')).toThrow(/path separator/);
     expect(() => skillRouteSegment('a\\b', 'x')).toThrow(/path separator/);
-    expect(() => skillRouteSegment('a%00b', 'x')).toThrow(/path separator/);
+    expect(() => skillRouteSegment('a\0b', 'x')).toThrow(/path separator/);
   });
 
-  it('paths: relative, no empty / dot-only / separator-smuggling segment; each segment encoded, slashes kept', () => {
+  it('paths: relative, no empty / dot-only / separator-smuggling segment; each segment encoded once, slashes kept', () => {
     expect(skillRoutePath('SKILL.md')).toBe('SKILL.md');
     expect(skillRoutePath('refs/notes.md')).toBe('refs/notes.md');
     expect(skillRoutePath('.claude-plugin/plugin.json')).toBe('.claude-plugin/plugin.json');
     expect(skillRoutePath('docs/a b#c.md')).toBe('docs/a%20b%23c.md');
+    expect(skillRoutePath('refs/a%41.md')).toBe('refs/a%2541.md');
+    // A literal `%2e%2e` dir is not a traversal once encoded exactly once — nothing normalizes.
+    expect(skillRoutePath('%2e%2e/%2e%2e/settings')).toBe('%252e%252e/%252e%252e/settings');
     expect(() => skillRoutePath('')).toThrow(/empty file path/);
     expect(() => skillRoutePath('/etc/passwd')).toThrow(/absolute/);
     expect(() => skillRoutePath('a//b')).toThrow(/empty segment/);
     expect(() => skillRoutePath('a/')).toThrow(/empty segment/);
     expect(() => skillRoutePath('a/./b')).toThrow(/dot-only/);
     expect(() => skillRoutePath('../../support/scripts/a.sh')).toThrow(/dot-only/);
-    expect(() => skillRoutePath('%2e%2e/%2e%2e/settings')).toThrow(/dot-only/);
+    expect(() => skillRoutePath('refs/../SKILL.md')).toThrow(/dot-only/);
     expect(() => skillRoutePath('a\\..\\b')).toThrow(/path separator/);
   });
 
@@ -160,7 +171,27 @@ describe('route identity — every name and path is validated before it becomes 
   it('codex probe 1: a skill-file path that would normalize onto /skills/support/… is refused client-side — no request is built', async () => {
     await expect(readSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh')).rejects.toThrow(/refusing file path/);
     await expect(writeSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh', 'x', 'r-1')).rejects.toThrow(/refusing file path/);
-    await expect(readSkillFile('wicked-garden-repo-learn', '%2e%2e/%2e%2e/support/scripts/a.sh')).rejects.toThrow(/refusing file path/);
+    await expect(readSkillFile('wicked-garden-repo-learn', 'refs/../SKILL.md')).rejects.toThrow(/refusing file path/);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // A LITERAL `%2e%2e` dir is a file identity, not a traversal: encoded once it cannot normalize —
+    // the request names `%252e%252e`, which the daemon's single decode returns as `%2e%2e`.
+    await readSkillFile('wicked-garden-repo-learn', '%2e%2e/%2e%2e/support/scripts/a.sh');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/%252e%252e/%252e%252e/support/scripts/a.sh');
+  });
+
+  it('codex round 2: a literal `%` filename keeps its identity — `refs/a%41.md` travels as `refs/a%2541.md` (never `refs/aA.md`) on GET and PUT; a `..` segment is refused with no request', async () => {
+    await readSkillFile('wicked-garden-repo-learn', 'refs/a%41.md');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/a%2541.md');
+    await writeSkillFile('wicked-garden-repo-learn', 'refs/a%41.md', 'x', 'r-1');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/a%2541.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 'r-1' }) });
+    await readSupportFile('scripts/a%41.sh');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/a%2541.sh');
+    // The round trip: the daemon decodes once and gets the literal name back; nothing was retargeted.
+    expect(decodeURIComponent('/skills/wicked-garden-repo-learn/files/refs/a%2541.md')).toBe('/skills/wicked-garden-repo-learn/files/refs/a%41.md');
+    expect(fetchMock.mock.calls.some(([p]) => String(p).includes('aA.md'))).toBe(false);
+    fetchMock.mockClear();
+    await expect(readSkillFile('wicked-garden-repo-learn', 'refs/../a%41.md')).rejects.toThrow(/dot-only/);
+    await expect(writeSkillFile('wicked-garden-repo-learn', '../a%41.md', 'x', 'r-1')).rejects.toThrow(/dot-only/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -2,15 +2,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../src/api/errors.js';
 import { apiFetch } from '../src/api/client.js';
 import {
+  addSkill,
+  analyzeSkills,
+  currentBaseline,
+  fileOwnership,
   isSkillsConflict,
+  isSkillsUnavailable,
   isSkillsUnsupported,
   isUnpublished,
   listSkillFiles,
   parseFilesMap,
-  provenanceOf,
+  publishSkills,
   readCatalogBody,
   readSkillFile,
   readSupportFile,
+  refreshSkillsBaseline,
+  replaceSkill,
+  resetSkill,
   setSkillEnabled,
   skillCounts,
   skillFilePathIssue,
@@ -18,12 +26,19 @@ import {
   skillRoutePath,
   skillRouteSegment,
   skillRows,
+  SKILLS_ENGINE_STATE_COPY,
   sortSkillFiles,
   supportFiles,
   writeSkillFile,
   writeSupportFile,
-  type SkillManifestEntry,
-  type SkillsManifest,
+  type SkillEntry,
+  type SkillFileRecord,
+  type SkillFileTree,
+  type SkillManifest,
+  type SkillMutationResult,
+  type SkillPublishResult,
+  type SkillReadResult,
+  type SkillsManifestResponse,
 } from '../src/api/skills.js';
 import { findingLocation } from '../src/components/SkillFindings.js';
 import { filterSkills, SKILL_CHIPS, SKILLS_FACETS_DEFAULT } from '../src/components/SkillsGrid.js';
@@ -31,86 +46,158 @@ import { filterSkills, SKILL_CHIPS, SKILLS_FACETS_DEFAULT } from '../src/compone
 vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
 
 /**
- * The skills wire's pure folds (src/api/skills.ts, design v3) — the seams the page's numbers,
- * filters and honest states hang on, pinned so they cannot drift:
- *  - `readCatalogBody` accepts exactly `{manifest: {skills: {…}, support: {…}}, revision}` with
- *    PLAIN objects for the two maps; anything else (an array, a missing map) throws a NAMED error
- *    (never a silent empty catalog against a daemon that answered something);
+ * The skills wire's pure folds (src/api/skills.ts) against responses shaped EXACTLY like crew#480's
+ * (api-types 0.27.0 — the mirror in src/api/skills-wire.ts), pinned so they cannot drift:
+ *  - `readCatalogBody` accepts exactly `SkillsManifestResponse` — `{manifest: {skills: {…}, files: {…},
+ *    …}, revision: number, root, current}` with PLAIN objects for the two maps and a non-negative
+ *    INTEGER revision; anything else (an array, a missing `files` map, a string revision, the old
+ *    `support` map) throws a NAMED error — never a silent empty catalog against a daemon that
+ *    answered something;
  *  - route identity: every name / path segment is validated on its LITERAL text (refused when
  *    empty, dot-only or separator/NUL-bearing) and then encoded exactly once — a daemon-supplied
  *    `..` can never normalize a skill-file request onto `/skills/support/…` or a support PUT onto
  *    `/settings` (the round-1 probes), and a literal `%` filename keeps its identity on the wire
- *    (`refs/a%41.md` → `refs/a%2541.md`, never `refs/aA.md` — the round-2 probe);
- *  - `provenanceOf` DERIVES shipped / override / user-added from the hashes — no wire field;
- *  - `isUnpublished` compares the effective hash with what the current snapshot carries;
- *  - `sortSkillFiles` puts SKILL.md first; `supportFiles` folds the manifest's support map;
- *  - `isSkillsUnsupported` folds a 501 and the bare unknown-route 404 (a named 404 is an answer);
- *    `isSkillsConflict` is the CAS 409 and nothing else;
+ *    (`refs/a%41.md` → `refs/a%2541.md`, never `refs/aA.md` — the round-2 probe); `?side=baseline`
+ *    reads the shipped copy;
+ *  - every mutation sends `expectedRevision` as a NUMBER and answers its contract result type
+ *    (`SkillMutationResult` / `SkillPublishResult` / `SkillRefreshResult`; analyze has no body);
+ *  - `fileOwnership` splits `manifest.files` by the DEEPEST registered skill dir (a nested skill's
+ *    subtree is its own) and the rest are the root support files; `isUnpublished` compares each own
+ *    file's `effectiveHash` with `lastPublishedHash` (enabled skills only); `provenance` is the wire's;
+ *  - `sortSkillFiles` puts SKILL.md first; `listSkillFiles` folds `SkillFileTree` rows;
+ *  - `isSkillsUnsupported` is the bare unknown-route 404 (a named 404 is an answer);
+ *    `isSkillsUnavailable` is the 503 (no catalog to serve); `isSkillsConflict` is the CAS 409 and
+ *    nothing else;
  *  - `skillCounts` is the five-tile KPI fold; `filterSkills` the catalog predicate the chips count with;
  *  - `parseFilesMap` is the Add/Replace modal's live validation — every key under the ROUTE
  *    BUILDER's segment rules (`skillFilePathIssue`, one rule for both); `findingLocation` the
- *    `file:line` cite.
+ *    `file:line` cite; `SKILLS_ENGINE_STATE_COPY` spells every `DiagnosticsSkillsState`.
  */
 
-function entry(over: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+function entry(over: Partial<SkillEntry> = {}): SkillEntry {
   return {
     dir: 'skills/x',
     kind: 'module',
     core: false,
     portable: true,
     enabled: true,
-    baselineHash: 'a'.repeat(8),
-    effectiveHash: 'a'.repeat(8),
-    lastPublishedHash: 'a'.repeat(8),
+    provenance: 'shipped',
     editedAt: null,
+    upgradeAvailable: false,
     conflict: false,
+    upstreamDir: null,
     ...over,
   };
 }
 
-const MANIFEST: SkillsManifest = {
-  baseline: {
-    contentHash: 'b'.repeat(16),
-    source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0', plugin_version: '12.32.0', git_sha: null, captured_at: '2026-09-08T00:00:00Z' },
+function record(over: Partial<SkillFileRecord> = {}): SkillFileRecord {
+  return { baselineHash: 'a'.repeat(8), effectiveHash: 'a'.repeat(8), lastPublishedHash: 'a'.repeat(8), conflict: false, ...over };
+}
+
+const BASELINE = 'b'.repeat(16);
+
+const MANIFEST: SkillManifest = {
+  version: 2,
+  revision: 7,
+  baseline: BASELINE,
+  baselines: {
+    [BASELINE]: {
+      plugin_version: '12.32.0',
+      source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0' },
+      git_sha: null,
+      captured_at: '2026-09-08T00:00:00Z',
+      venv: 'synced',
+    },
   },
   skills: {
     'wicked-garden-repo-learn': entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
-    'wicked-garden-domain-extractor': entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, effectiveHash: 'c'.repeat(8), conflict: true }),
+    // A PARENT skill with a nested child: the parent owns `vendor/`, the child owns its own subtree.
+    'wicked-garden-domain': entry({ dir: 'skills/domain', kind: 'router', core: true, portable: false }),
+    'wicked-garden-domain-extractor': entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', conflict: true, upgradeAvailable: true }),
     'wicked-garden-qe-a11y-test-engineer': entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
-    'my-team-skill': entry({ dir: 'skills/my-team-skill', baselineHash: null, lastPublishedHash: null }),
+    'my-team-skill': entry({ dir: 'skills/my-team-skill', provenance: 'user-added', upstreamDir: 'skills/team-skill' }),
   },
-  support: { 'scripts/_python.sh': 'd'.repeat(8), '.claude-plugin/plugin.json': 'e'.repeat(8) },
-  currentGeneration: 3,
+  files: {
+    'skills/repo-learn/SKILL.md': record(),
+    'skills/domain/SKILL.md': record(),
+    'skills/domain/vendor/README.md': record(),
+    // The extractor's own file: edited (c) over baseline (a), last published at (a) → unpublished.
+    'skills/domain/extractor/SKILL.md': record({ effectiveHash: 'c'.repeat(8), conflict: true }),
+    'skills/domain/extractor/refs/loop.md': record(),
+    // Disabled, and its file was edited: NOT counted as unpublished (publish records only what it ships).
+    'skills/qe/a11y-test-engineer/SKILL.md': record({ effectiveHash: 'd'.repeat(8) }),
+    // User-added, never published.
+    'skills/my-team-skill/SKILL.md': record({ baselineHash: null, effectiveHash: 'm'.repeat(8), lastPublishedHash: null }),
+    // Root support files — no skill owns them.
+    'scripts/_python.sh': record(),
+    '.claude-plugin/plugin.json': record(),
+    'schemas/domain-model.json': record(),
+    'pyproject.toml': record(),
+  },
+  published: { gen: 3, contentHash: 'p'.repeat(16), at: '2026-09-08T00:00:00Z', snapshotHash: 's'.repeat(16) },
 };
 
-describe('readCatalogBody — exactly {manifest, revision}, never a silent empty catalog', () => {
-  it('accepts the catalog envelope and hands the manifest through untouched', () => {
-    const c = readCatalogBody({ manifest: MANIFEST, revision: 'r-1' });
+const CATALOG: SkillsManifestResponse = {
+  manifest: MANIFEST,
+  revision: 7,
+  root: '/state/skills',
+  current: { gen: 3, path: '/state/skills/snapshots/000003' },
+};
+
+describe('readCatalogBody — exactly SkillsManifestResponse, never a silent empty catalog', () => {
+  it('accepts the 0.27.0 envelope and hands the manifest through untouched', () => {
+    const c = readCatalogBody(CATALOG);
     expect(c.manifest).toBe(MANIFEST);
-    expect(c.revision).toBe('r-1');
+    expect(c.revision).toBe(7);
+    expect(c.root).toBe('/state/skills');
+    expect(c.current).toEqual({ gen: 3, path: '/state/skills/snapshots/000003' });
+    // Before the first publish `current` is null — still a catalog.
+    expect(readCatalogBody({ ...CATALOG, current: null }).current).toBeNull();
+    // Revision 0 is a valid (fresh) revision.
+    expect(readCatalogBody({ ...CATALOG, revision: 0 }).revision).toBe(0);
   });
 
-  it('throws a NAMED error on a bare manifest (no revision), a missing skills map, or non-objects', () => {
+  it('throws a NAMED error on a bare manifest (no revision), a missing skills/files map, or non-objects', () => {
     expect(() => readCatalogBody(MANIFEST)).toThrow(/no catalog/);
     expect(() => readCatalogBody({ manifest: MANIFEST })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { support: {} }, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { skills: null, support: {} }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { files: {} } })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { skills: null, files: {} } })).toThrow(/no catalog/);
     expect(() => readCatalogBody({ nonsense: true })).toThrow(/no catalog/);
     expect(() => readCatalogBody(null)).toThrow(/no catalog/);
     expect(() => readCatalogBody('catalog')).toThrow(/no catalog/);
+    expect(() => readCatalogBody([CATALOG])).toThrow(/no catalog/);
   });
 
-  it('requires PLAIN objects for `skills` and `support` — an array or a missing map is a mis-shaped answer, not weird rows', () => {
-    expect(() => readCatalogBody({ manifest: { ...MANIFEST, skills: [] }, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { ...MANIFEST, skills: [MANIFEST.skills['my-team-skill']] }, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { ...MANIFEST, support: [] }, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { ...MANIFEST, support: null }, revision: 'r' })).toThrow(/no catalog/);
-    const { support: _dropped, ...noSupport } = MANIFEST;
+  it('revisions are NUMBERS (0.27.0): a string, a float, a negative or a missing revision is a mis-shaped answer', () => {
+    expect(() => readCatalogBody({ ...CATALOG, revision: 'rev-0007' })).toThrow(/expected \{manifest: \{skills, files, …\}, revision: number, root, current\}/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: 1.5 })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: -1 })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: undefined })).toThrow(/no catalog/);
+  });
+
+  it('requires PLAIN objects for `skills` and `files` — an array, null, or the OLD `support` map instead of `files` is a mis-shaped answer, not weird rows', () => {
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { ...MANIFEST, skills: [] } })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { ...MANIFEST, skills: [MANIFEST.skills['my-team-skill']] } })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { ...MANIFEST, files: [] } })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { ...MANIFEST, files: null } })).toThrow(/no catalog/);
+    const { files: _dropped, ...noFiles } = MANIFEST;
     void _dropped;
-    expect(() => readCatalogBody({ manifest: noSupport, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody([MANIFEST])).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, manifest: { ...noFiles, support: { 'scripts/x': 'h' } } })).toThrow(/no catalog/);
     // Empty maps are plain objects — a daemon with no skills yet is a real (empty) catalog.
-    expect(readCatalogBody({ manifest: { ...MANIFEST, skills: {}, support: {} }, revision: 'r' }).revision).toBe('r');
+    expect(readCatalogBody({ ...CATALOG, manifest: { ...MANIFEST, skills: {}, files: {} } }).revision).toBe(7);
+  });
+
+  it('root must be a string and current null or {gen, path}', () => {
+    expect(() => readCatalogBody({ ...CATALOG, root: undefined })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, current: { gen: '3' } })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, current: undefined })).toThrow(/no catalog/);
+  });
+});
+
+describe('currentBaseline — the baseline record keyed by the manifest’s content hash', () => {
+  it('pairs the record with its hash; null when the manifest names a hash it does not carry', () => {
+    expect(currentBaseline(MANIFEST)).toEqual({ ...MANIFEST.baselines[BASELINE], hash: BASELINE });
+    expect(currentBaseline({ ...MANIFEST, baseline: 'z'.repeat(16) })).toBeNull();
   });
 });
 
@@ -118,7 +205,7 @@ describe('route identity — every name and path is validated before it becomes 
   const fetchMock = vi.mocked(apiFetch);
   beforeEach(() => {
     fetchMock.mockReset();
-    fetchMock.mockResolvedValue({ files: [], verdict: 'clear', findings: [], revision: 'r' });
+    fetchMock.mockResolvedValue({ name: 'x', dir: 'skills/x', enabled: true, files: [], verdict: 'clear', findings: [], revision: 8 });
   });
 
   it('segments: validated on the LITERAL text — refused when empty, dot-only, or carrying a separator / NUL; encoded exactly once otherwise', () => {
@@ -173,7 +260,7 @@ describe('route identity — every name and path is validated before it becomes 
 
   it('codex probe 1: a skill-file path that would normalize onto /skills/support/… is refused client-side — no request is built', async () => {
     await expect(readSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh')).rejects.toThrow(/refusing file path/);
-    await expect(writeSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh', 'x', 'r-1')).rejects.toThrow(/refusing file path/);
+    await expect(writeSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh', 'x', 7)).rejects.toThrow(/refusing file path/);
     await expect(readSkillFile('wicked-garden-repo-learn', 'refs/../SKILL.md')).rejects.toThrow(/refusing file path/);
     expect(fetchMock).not.toHaveBeenCalled();
     // A LITERAL `%2e%2e` dir is a file identity, not a traversal: encoded once it cannot normalize —
@@ -185,8 +272,8 @@ describe('route identity — every name and path is validated before it becomes 
   it('codex round 2: a literal `%` filename keeps its identity — `refs/a%41.md` travels as `refs/a%2541.md` (never `refs/aA.md`) on GET and PUT; a `..` segment is refused with no request', async () => {
     await readSkillFile('wicked-garden-repo-learn', 'refs/a%41.md');
     expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/a%2541.md');
-    await writeSkillFile('wicked-garden-repo-learn', 'refs/a%41.md', 'x', 'r-1');
-    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/a%2541.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 'r-1' }) });
+    await writeSkillFile('wicked-garden-repo-learn', 'refs/a%41.md', 'x', 7);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/a%2541.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 7 }) });
     await readSupportFile('scripts/a%41.sh');
     expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/a%2541.sh');
     // The round trip: the daemon decodes once and gets the literal name back; nothing was retargeted.
@@ -194,99 +281,201 @@ describe('route identity — every name and path is validated before it becomes 
     expect(fetchMock.mock.calls.some(([p]) => String(p).includes('aA.md'))).toBe(false);
     fetchMock.mockClear();
     await expect(readSkillFile('wicked-garden-repo-learn', 'refs/../a%41.md')).rejects.toThrow(/dot-only/);
-    await expect(writeSkillFile('wicked-garden-repo-learn', '../a%41.md', 'x', 'r-1')).rejects.toThrow(/dot-only/);
+    await expect(writeSkillFile('wicked-garden-repo-learn', '../a%41.md', 'x', 7)).rejects.toThrow(/dot-only/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('codex probe 2: a support PUT that would normalize onto /settings is refused client-side — no request is built', async () => {
-    await expect(writeSupportFile('../../settings', '{}', 'r-1')).rejects.toThrow(/refusing file path/);
+    await expect(writeSupportFile('../../settings', '{}', 7)).rejects.toThrow(/refusing file path/);
     await expect(readSupportFile('../../settings')).rejects.toThrow(/refusing file path/);
-    await expect(writeSupportFile('/settings', '{}', 'r-1')).rejects.toThrow(/absolute/);
+    await expect(writeSupportFile('/settings', '{}', 7)).rejects.toThrow(/absolute/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('a traversal in the skill NAME is refused on every name-bearing route', async () => {
     await expect(listSkillFiles('../support')).rejects.toThrow(/refusing skill name/);
-    await expect(setSkillEnabled('..', true, 'r-1')).rejects.toThrow(/refusing skill name/);
+    await expect(setSkillEnabled('..', true, 7)).rejects.toThrow(/refusing skill name/);
     await expect(readSkillFile('a/b', 'SKILL.md')).rejects.toThrow(/refusing skill name/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('legitimate identities build the expected routes, segment-encoded', async () => {
+  it('legitimate identities build the expected routes, segment-encoded; `?side=baseline` reads the shipped copy', async () => {
     await readSkillFile('wicked-garden-repo-learn', 'refs/notes.md');
     expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/notes.md');
-    await writeSkillFile('my team', 'docs/a b.md', 'x', 'r-1');
-    expect(fetchMock).toHaveBeenLastCalledWith('/skills/my%20team/files/docs/a%20b.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 'r-1' }) });
+    await readSkillFile('wicked-garden-repo-learn', 'refs/notes.md', 'baseline');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/notes.md?side=baseline');
+    await readSupportFile('scripts/_python.sh', 'baseline');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/_python.sh?side=baseline');
+    await writeSkillFile('my team', 'docs/a b.md', 'x', 7);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/my%20team/files/docs/a%20b.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 7 }) });
     await readSupportFile('.claude-plugin/plugin.json');
     expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/.claude-plugin/plugin.json');
-    await writeSupportFile('scripts/_python.sh', '#!/bin/sh', 'r-1');
-    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/_python.sh', { method: 'PUT', body: JSON.stringify({ content: '#!/bin/sh', expectedRevision: 'r-1' }) });
+    await writeSupportFile('scripts/_python.sh', '#!/bin/sh', 7);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/_python.sh', { method: 'PUT', body: JSON.stringify({ content: '#!/bin/sh', expectedRevision: 7 }) });
     await listSkillFiles('wicked-garden-repo-learn');
     expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files');
   });
-});
 
-describe('provenanceOf / isUnpublished — derived from the hashes', () => {
-  it('no baseline → user-added; equal hashes → shipped; different → override', () => {
-    expect(provenanceOf({ baselineHash: null, effectiveHash: 'x' })).toBe('user-added');
-    expect(provenanceOf({ baselineHash: 'x', effectiveHash: 'x' })).toBe('shipped');
-    expect(provenanceOf({ baselineHash: 'x', effectiveHash: 'y' })).toBe('override');
+  it('every mutation posts `expectedRevision` as a NUMBER in the contract body; analyze posts NO body', async () => {
+    await setSkillEnabled('wicked-garden-repo-learn', false, 7);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/disable', { method: 'POST', body: JSON.stringify({ expectedRevision: 7 }) });
+    await setSkillEnabled('wicked-garden-repo-learn', true, 8);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/enable', { method: 'POST', body: JSON.stringify({ expectedRevision: 8 }) });
+    await resetSkill('wicked-garden-repo-learn', 9);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/reset', { method: 'POST', body: JSON.stringify({ expectedRevision: 9 }) });
+    await addSkill('new-skill', { 'SKILL.md': 'x' }, 10);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills', { method: 'POST', body: JSON.stringify({ name: 'new-skill', files: { 'SKILL.md': 'x' }, expectedRevision: 10 }) });
+    await replaceSkill('new-skill', { 'SKILL.md': 'y' }, 11);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/new-skill/replace', { method: 'POST', body: JSON.stringify({ files: { 'SKILL.md': 'y' }, expectedRevision: 11 }) });
+    await refreshSkillsBaseline(12);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/refresh-baseline', { method: 'POST', body: JSON.stringify({ expectedRevision: 12 }) });
+    await publishSkills(13);
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/publish', { method: 'POST', body: JSON.stringify({ expectedRevision: 13 }) });
+    await analyzeSkills();
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/analyze', { method: 'POST' });
+    // Every body is the contract's: the revision is a JSON number, never a string.
+    for (const [, init] of fetchMock.mock.calls) {
+      const b = (init as { body?: string } | undefined)?.body;
+      if (b === undefined) continue;
+      const parsed = JSON.parse(b) as { expectedRevision: unknown };
+      expect(typeof parsed.expectedRevision).toBe('number');
+    }
   });
 
-  it('unpublished when the snapshot carries a different hash, or none', () => {
-    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: 'x' })).toBe(false);
-    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: 'y' })).toBe(true);
-    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: null })).toBe(true);
+  it('the envelopes come back typed as the contract answers them (a 2xx `blocked` is a normal answer)', async () => {
+    const blocked: SkillPublishResult = {
+      verdict: 'blocked',
+      revision: 7,
+      snapshot: null,
+      findings: [{ kind: 'publish-in-flight', severity: 'blocking', skill: null, file: null, line: null, againstSkill: null, againstIsCore: false, evidence: 'publish #1 running', explanation: 'a publish is already running (one at a time); nothing was written' }],
+    };
+    fetchMock.mockResolvedValueOnce(blocked);
+    await expect(publishSkills(7)).resolves.toEqual(blocked);
+    const mutation: SkillMutationResult = { verdict: 'clear', findings: [], revision: 8, skill: { name: 'wicked-garden-repo-learn', ...entry({ dir: 'skills/repo-learn', provenance: 'override', editedAt: '2026-09-09T00:00:00Z' }) } };
+    fetchMock.mockResolvedValueOnce(mutation);
+    await expect(writeSkillFile('wicked-garden-repo-learn', 'SKILL.md', 'x', 7)).resolves.toEqual(mutation);
+  });
+});
+
+describe('fileOwnership / isUnpublished — the manifest’s files map, split by the deepest skill dir', () => {
+  it('the deepest registered skill dir owns a file; a parent keeps what its nested child does not claim; the rest is support', () => {
+    const { bySkill, support } = fileOwnership(MANIFEST);
+    expect(bySkill.get('wicked-garden-domain')?.map((f) => f.path)).toEqual(['skills/domain/SKILL.md', 'skills/domain/vendor/README.md']);
+    expect(bySkill.get('wicked-garden-domain-extractor')?.map((f) => f.path)).toEqual(['skills/domain/extractor/SKILL.md', 'skills/domain/extractor/refs/loop.md']);
+    expect(bySkill.get('wicked-garden-repo-learn')?.map((f) => f.path)).toEqual(['skills/repo-learn/SKILL.md']);
+    expect(bySkill.get('my-team-skill')?.map((f) => f.path)).toEqual(['skills/my-team-skill/SKILL.md']);
+    expect(support.map((f) => f.path)).toEqual(['.claude-plugin/plugin.json', 'pyproject.toml', 'schemas/domain-model.json', 'scripts/_python.sh']);
+    expect(support[0]!.record).toEqual(record());
+  });
+
+  it('unpublished = an ENABLED skill with an own file whose effectiveHash ≠ lastPublishedHash (never-published = null); disabled skills are not judged', () => {
+    const { bySkill } = fileOwnership(MANIFEST);
+    expect(isUnpublished(MANIFEST.skills['wicked-garden-repo-learn']!, bySkill.get('wicked-garden-repo-learn')!)).toBe(false);
+    expect(isUnpublished(MANIFEST.skills['wicked-garden-domain-extractor']!, bySkill.get('wicked-garden-domain-extractor')!)).toBe(true);
+    expect(isUnpublished(MANIFEST.skills['my-team-skill']!, bySkill.get('my-team-skill')!)).toBe(true);
+    // Edited but disabled: the switch already says it is left out; publish records nothing for it.
+    expect(isUnpublished(MANIFEST.skills['wicked-garden-qe-a11y-test-engineer']!, bySkill.get('wicked-garden-qe-a11y-test-engineer')!)).toBe(false);
+    // A baseline file removed from effective/ (effectiveHash null) differs from what was published.
+    expect(isUnpublished({ enabled: true }, [{ path: 'skills/x/SKILL.md', record: record({ effectiveHash: null }) }])).toBe(true);
+    expect(isUnpublished({ enabled: true }, [])).toBe(false);
   });
 });
 
 describe('skillRows / skillCounts — the KPI fold agrees with the catalog', () => {
-  it('rows are name-sorted by codepoint, carry their name and derived provenance', () => {
+  it('rows are name-sorted by codepoint, carry their name, the WIRE provenance and the derived unpublished flag', () => {
     const rows = skillRows(MANIFEST);
     expect(rows.map((r) => r.name)).toEqual([
-      'my-team-skill', 'wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn',
+      'my-team-skill', 'wicked-garden-domain', 'wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn',
     ]);
-    expect(rows.map((r) => r.provenance)).toEqual(['user-added', 'override', 'shipped', 'shipped']);
+    expect(rows.map((r) => r.provenance)).toEqual(['user-added', 'shipped', 'override', 'shipped', 'shipped']);
+    expect(rows.map((r) => r.unpublished)).toEqual([true, false, true, false, false]);
+    expect(rows[0]!.upstreamDir).toBe('skills/team-skill');
+    expect(rows[2]!.upgradeAvailable).toBe(true);
   });
 
   it('counts total · enabled · overridden · core · portable', () => {
-    expect(skillCounts(skillRows(MANIFEST))).toEqual({ total: 4, enabled: 3, overridden: 1, core: 2, portable: 3 });
+    expect(skillCounts(skillRows(MANIFEST))).toEqual({ total: 5, enabled: 4, overridden: 1, core: 3, portable: 3 });
     expect(skillCounts([])).toEqual({ total: 0, enabled: 0, overridden: 0, core: 0, portable: 0 });
   });
 });
 
-describe('sortSkillFiles / supportFiles — the two trees', () => {
+describe('sortSkillFiles / listSkillFiles / supportFiles — the two trees', () => {
+  const fetchMock = vi.mocked(apiFetch);
+  beforeEach(() => fetchMock.mockReset());
+
   it('sorts by path with SKILL.md first, rows intact', () => {
-    const rows = sortSkillFiles([{ path: 'refs/z.md', hash: 'h1', size: 3 }, { path: 'SKILL.md', hash: 'h2', size: 9 }, { path: 'refs/a.md', hash: 'h3', size: 1 }]);
+    const rows = sortSkillFiles([{ path: 'refs/z.md', size: 3, record: null }, { path: 'SKILL.md', size: 9, record: record() }, { path: 'refs/a.md', size: 1, record: null }]);
     expect(rows.map((r) => r.path)).toEqual(['SKILL.md', 'refs/a.md', 'refs/z.md']);
-    expect(rows[0]).toEqual({ path: 'SKILL.md', hash: 'h2', size: 9 });
+    expect(rows[0]).toEqual({ path: 'SKILL.md', size: 9, record: record() });
   });
 
-  it('folds the manifest support map into path-sorted rows carrying the hash (no size)', () => {
-    expect(supportFiles(MANIFEST)).toEqual([
-      { path: '.claude-plugin/plugin.json', hash: 'e'.repeat(8) },
-      { path: 'scripts/_python.sh', hash: 'd'.repeat(8) },
+  it('listSkillFiles folds a SkillFileTree into rows {path, size, record}, SKILL.md first; a body without `files` is a named error', async () => {
+    const tree: SkillFileTree = {
+      name: 'wicked-garden-repo-learn',
+      dir: 'skills/repo-learn',
+      enabled: true,
+      files: [
+        { path: 'refs/notes.md', size: 5, sha256: 'x'.repeat(64), record: null },
+        { path: 'SKILL.md', size: 6030, sha256: 'y'.repeat(64), record: record() },
+      ],
+    };
+    fetchMock.mockResolvedValueOnce(tree);
+    await expect(listSkillFiles('wicked-garden-repo-learn')).resolves.toEqual([
+      { path: 'SKILL.md', size: 6030, record: record() },
+      { path: 'refs/notes.md', size: 5, record: null },
     ]);
+    fetchMock.mockResolvedValueOnce({ files: 'nope' });
+    await expect(listSkillFiles('wicked-garden-repo-learn')).rejects.toThrow(/no file tree/);
+    fetchMock.mockResolvedValueOnce([]);
+    await expect(listSkillFiles('wicked-garden-repo-learn')).rejects.toThrow(/no file tree/);
+  });
+
+  it('supportFiles are the manifest files no skill owns, path-sorted, carrying the record (no size — the manifest has none)', () => {
+    expect(supportFiles(MANIFEST)).toEqual([
+      { path: '.claude-plugin/plugin.json', size: null, record: record() },
+      { path: 'pyproject.toml', size: null, record: record() },
+      { path: 'schemas/domain-model.json', size: null, record: record() },
+      { path: 'scripts/_python.sh', size: null, record: record() },
+    ]);
+  });
+
+  it('a SkillReadResult is passed through as the contract spells it (content null only when binary)', async () => {
+    const read: SkillReadResult = { path: 'skills/repo-learn/SKILL.md', content: 'body', size: 4, truncated: false, binary: false };
+    fetchMock.mockResolvedValueOnce(read);
+    await expect(readSkillFile('wicked-garden-repo-learn', 'SKILL.md')).resolves.toEqual(read);
+    const binary: SkillReadResult = { path: 'scripts/x.bin', content: null, size: 4096, truncated: false, binary: true };
+    fetchMock.mockResolvedValueOnce(binary);
+    await expect(readSupportFile('scripts/x.bin')).resolves.toEqual(binary);
   });
 });
 
-describe('isSkillsUnsupported / isSkillsConflict — the adoption seam and the CAS seam', () => {
-  it('unsupported folds a 501 and the bare unknown-route 404 (both Fastify and SPA spellings)', () => {
-    expect(isSkillsUnsupported(new ApiError(501, 'no skills root configured'))).toBe(true);
+describe('isSkillsUnsupported / isSkillsUnavailable / isSkillsConflict — the adoption seam and the CAS seam', () => {
+  it('unsupported is the bare unknown-route 404 (both Fastify and SPA spellings) — the daemon predates the routes', () => {
     expect(isSkillsUnsupported(new ApiError(404, 'Not Found'))).toBe(true);
     expect(isSkillsUnsupported(new ApiError(404, 'not found'))).toBe(true);
   });
 
-  it('a NAMED 404, any other status, and a non-wire error are real answers', () => {
+  it('a NAMED 404, a 501, a 503, any other status, and a non-wire error are NOT "predates"', () => {
     expect(isSkillsUnsupported(new ApiError(404, 'unknown skill: nope'))).toBe(false);
+    expect(isSkillsUnsupported(new ApiError(501, 'not implemented'))).toBe(false);
+    expect(isSkillsUnsupported(new ApiError(503, 'the skills root is not seeded'))).toBe(false);
     expect(isSkillsUnsupported(new ApiError(500, 'boom'))).toBe(false);
     expect(isSkillsUnsupported(new ApiError(409, 'stale revision'))).toBe(false);
     expect(isSkillsUnsupported(new Error('Not Found'))).toBe(false);
   });
 
+  it('unavailable is the 503 — the route exists but there is no catalog to serve (unseeded / corrupt current / no seam)', () => {
+    expect(isSkillsUnavailable(new ApiError(503, 'the skills root is not seeded: no installed wicked-garden plugin was found'))).toBe(true);
+    expect(isSkillsUnavailable(new ApiError(503, 'the daemon booted without a skills store (no state home seam) — /skills is unavailable'))).toBe(true);
+    expect(isSkillsUnavailable(new ApiError(404, 'Not Found'))).toBe(false);
+    expect(isSkillsUnavailable(new ApiError(500, 'boom'))).toBe(false);
+    expect(isSkillsUnavailable(new Error('503'))).toBe(false);
+  });
+
   it('a conflict is the 409 and nothing else', () => {
-    expect(isSkillsConflict(new ApiError(409, 'expected revision r-1, catalog is at r-2'))).toBe(true);
+    expect(isSkillsConflict(new ApiError(409, 'revision mismatch: expected 2, the manifest is at 3 — re-read GET /skills and retry'))).toBe(true);
     expect(isSkillsConflict(new ApiError(404, 'Not Found'))).toBe(false);
+    expect(isSkillsConflict(new ApiError(503, 'unseeded'))).toBe(false);
     expect(isSkillsConflict(new ApiError(500, 'boom'))).toBe(false);
     expect(isSkillsConflict(new Error('409'))).toBe(false);
   });
@@ -298,16 +487,16 @@ describe('filterSkills — the chip predicate', () => {
     filterSkills(rows, { query, chip }).map((r) => r.name);
 
   it('all shows everything; kinds, enabled/disabled, overridden, core, portable and claude-only cut it', () => {
-    expect(names('all')).toHaveLength(4);
-    expect(names('router')).toEqual(['wicked-garden-repo-learn']);
+    expect(names('all')).toHaveLength(5);
+    expect(names('router')).toEqual(['wicked-garden-domain', 'wicked-garden-repo-learn']);
     expect(names('fork-worker')).toEqual(['wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer']);
     expect(names('module')).toEqual(['my-team-skill']);
-    expect(names('enabled')).toHaveLength(3);
+    expect(names('enabled')).toHaveLength(4);
     expect(names('disabled')).toEqual(['wicked-garden-qe-a11y-test-engineer']);
     expect(names('overridden')).toEqual(['wicked-garden-domain-extractor']);
-    expect(names('core')).toEqual(['wicked-garden-domain-extractor', 'wicked-garden-repo-learn']);
+    expect(names('core')).toEqual(['wicked-garden-domain', 'wicked-garden-domain-extractor', 'wicked-garden-repo-learn']);
     expect(names('portable')).toEqual(['my-team-skill', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn']);
-    expect(names('claude-only')).toEqual(['wicked-garden-domain-extractor']);
+    expect(names('claude-only')).toEqual(['wicked-garden-domain', 'wicked-garden-domain-extractor']);
   });
 
   it('the query matches name OR dir, case-insensitively, and composes with the chip', () => {
@@ -318,7 +507,7 @@ describe('filterSkills — the chip predicate', () => {
   });
 
   it('the default facets are the whole catalog', () => {
-    expect(filterSkills(rows, SKILLS_FACETS_DEFAULT)).toHaveLength(4);
+    expect(filterSkills(rows, SKILLS_FACETS_DEFAULT)).toHaveLength(5);
   });
 });
 
@@ -370,11 +559,18 @@ describe('parseFilesMap — the Add/Replace validation', () => {
 });
 
 describe('findingLocation — the file:line cite', () => {
-  const base = { kind: 'unresolved-ref', severity: 'blocking' as const, skill: null, explanation: 'x' };
   it('null without a file; the file alone without a line; file:line with both', () => {
-    expect(findingLocation({ ...base, file: null, line: null })).toBeNull();
-    expect(findingLocation({ ...base, file: null, line: 3 })).toBeNull();
-    expect(findingLocation({ ...base, file: 'skills/repo-learn/SKILL.md', line: null })).toBe('skills/repo-learn/SKILL.md');
-    expect(findingLocation({ ...base, file: 'skills/repo-learn/SKILL.md', line: 49 })).toBe('skills/repo-learn/SKILL.md:49');
+    expect(findingLocation({ file: null, line: null })).toBeNull();
+    expect(findingLocation({ file: null, line: 3 })).toBeNull();
+    expect(findingLocation({ file: 'skills/repo-learn/SKILL.md', line: null })).toBe('skills/repo-learn/SKILL.md');
+    expect(findingLocation({ file: 'skills/repo-learn/SKILL.md', line: 49 })).toBe('skills/repo-learn/SKILL.md:49');
+  });
+});
+
+describe('SKILLS_ENGINE_STATE_COPY — every DiagnosticsSkillsState has operator copy', () => {
+  it('spells the five states', () => {
+    expect(Object.keys(SKILLS_ENGINE_STATE_COPY).sort()).toEqual(['blocked', 'config-error', 'disabled', 'fallback', 'published']);
+    expect(SKILLS_ENGINE_STATE_COPY.published).toMatch(/^published — /);
+    expect(SKILLS_ENGINE_STATE_COPY['config-error']).toMatch(/^config error — /);
   });
 });

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError } from '../src/api/errors.js';
+import { ApiError, isRouteUnsupported } from '../src/api/errors.js';
 import { apiFetch } from '../src/api/client.js';
 import {
   addSkill,
@@ -168,11 +168,31 @@ describe('readCatalogBody — exactly SkillsManifestResponse, never a silent emp
     expect(() => readCatalogBody([CATALOG])).toThrow(/no catalog/);
   });
 
-  it('revisions are NUMBERS (0.27.0): a string, a float, a negative or a missing revision is a mis-shaped answer', () => {
-    expect(() => readCatalogBody({ ...CATALOG, revision: 'rev-0007' })).toThrow(/expected \{manifest: \{skills, files, …\}, revision: number, root, current\}/);
+  it('revisions are NUMBERS (0.27.0): a string, a float, a negative, NaN, ±Infinity, an unsafe integer or a missing revision is a mis-shaped answer', () => {
+    expect(() => readCatalogBody({ ...CATALOG, revision: 'rev-0007' })).toThrow(/expected \{manifest: \{skills, files, …\}, revision: number, root, current: \{gen: number, path\} \| null\}/);
     expect(() => readCatalogBody({ ...CATALOG, revision: 1.5 })).toThrow(/no catalog/);
     expect(() => readCatalogBody({ ...CATALOG, revision: -1 })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: Number.NaN })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: Number.POSITIVE_INFINITY })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: Number.NEGATIVE_INFINITY })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ ...CATALOG, revision: Number.MAX_SAFE_INTEGER + 1 })).toThrow(/no catalog/);
     expect(() => readCatalogBody({ ...CATALOG, revision: undefined })).toThrow(/no catalog/);
+    expect(readCatalogBody({ ...CATALOG, revision: Number.MAX_SAFE_INTEGER }).revision).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('current.gen is the same kind of counter (Copilot, fix pass 4): NaN / ±Infinity / a float / a negative / a string / an unsafe integer is a mis-shaped answer; 0 and safe integers pass', () => {
+    const at = (gen: unknown) => ({ ...CATALOG, current: { gen, path: '/state/skills/snapshots/000003' } });
+    expect(() => readCatalogBody(at(Number.NaN))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(Number.POSITIVE_INFINITY))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(Number.NEGATIVE_INFINITY))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(2.5))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(-1))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at('3'))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(Number.MAX_SAFE_INTEGER + 1))).toThrow(/no catalog/);
+    expect(() => readCatalogBody(at(undefined))).toThrow(/no catalog/);
+    expect(readCatalogBody(at(0)).current).toEqual({ gen: 0, path: '/state/skills/snapshots/000003' });
+    expect(readCatalogBody(at(3)).current).toEqual({ gen: 3, path: '/state/skills/snapshots/000003' });
+    expect(readCatalogBody(at(Number.MAX_SAFE_INTEGER)).current?.gen).toBe(Number.MAX_SAFE_INTEGER);
   });
 
   it('requires PLAIN objects for `skills` and `files` — an array, null, or the OLD `support` map instead of `files` is a mis-shaped answer, not weird rows', () => {
@@ -450,23 +470,29 @@ describe('sortSkillFiles / listSkillFiles / supportFiles — the two trees', () 
 });
 
 describe('isSkillsUnsupported / isSkillsUnavailable / isSkillsConflict — the adoption seam and the CAS seam', () => {
-  it('unsupported is the bare unknown-route 404 (both Fastify and SPA spellings) — the daemon predates the routes', () => {
+  it('unsupported is the shared forward-compat pair — the bare unknown-route 404 (both Fastify and SPA spellings) OR a 501 — the same signal every other adoption seam folds', () => {
     expect(isSkillsUnsupported(new ApiError(404, 'Not Found'))).toBe(true);
     expect(isSkillsUnsupported(new ApiError(404, 'not found'))).toBe(true);
+    expect(isSkillsUnsupported(new ApiError(501, 'not implemented'))).toBe(true);
+    expect(isSkillsUnsupported(new ApiError(501, ''))).toBe(true);
+    // ONE spelling: the shared helper in errors.ts is what this seam answers.
+    for (const e of [new ApiError(404, 'Not Found'), new ApiError(501, 'x'), new ApiError(404, 'unknown skill: nope'), new ApiError(503, 'unseeded'), new Error('Not Found')]) {
+      expect(isSkillsUnsupported(e)).toBe(isRouteUnsupported(e));
+    }
   });
 
-  it('a NAMED 404, a 501, a 503, any other status, and a non-wire error are NOT "predates"', () => {
+  it('a NAMED 404, a 503, any other status, and a non-wire error are NOT "unsupported"', () => {
     expect(isSkillsUnsupported(new ApiError(404, 'unknown skill: nope'))).toBe(false);
-    expect(isSkillsUnsupported(new ApiError(501, 'not implemented'))).toBe(false);
     expect(isSkillsUnsupported(new ApiError(503, 'the skills root is not seeded'))).toBe(false);
     expect(isSkillsUnsupported(new ApiError(500, 'boom'))).toBe(false);
     expect(isSkillsUnsupported(new ApiError(409, 'stale revision'))).toBe(false);
     expect(isSkillsUnsupported(new Error('Not Found'))).toBe(false);
   });
 
-  it('unavailable is the 503 — the route exists but there is no catalog to serve (unseeded / corrupt current / no seam)', () => {
+  it('unavailable is the 503 — the route exists but there is no catalog to serve (unseeded / corrupt current / no seam); never the 501', () => {
     expect(isSkillsUnavailable(new ApiError(503, 'the skills root is not seeded: no installed wicked-garden plugin was found'))).toBe(true);
     expect(isSkillsUnavailable(new ApiError(503, 'the daemon booted without a skills store (no state home seam) — /skills is unavailable'))).toBe(true);
+    expect(isSkillsUnavailable(new ApiError(501, 'not implemented'))).toBe(false);
     expect(isSkillsUnavailable(new ApiError(404, 'Not Found'))).toBe(false);
     expect(isSkillsUnavailable(new ApiError(500, 'boom'))).toBe(false);
     expect(isSkillsUnavailable(new Error('503'))).toBe(false);

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../src/api/errors.js';
+import {
+  isSkillsConflict,
+  isSkillsUnsupported,
+  isUnpublished,
+  parseFilesMap,
+  provenanceOf,
+  readCatalogBody,
+  skillCounts,
+  skillRows,
+  sortSkillFiles,
+  supportFiles,
+  type SkillManifestEntry,
+  type SkillsManifest,
+} from '../src/api/skills.js';
+import { findingLocation } from '../src/components/SkillFindings.js';
+import { filterSkills, SKILL_CHIPS, SKILLS_FACETS_DEFAULT } from '../src/components/SkillsGrid.js';
+
+/**
+ * The skills wire's pure folds (src/api/skills.ts, design v3) — the seams the page's numbers,
+ * filters and honest states hang on, pinned so they cannot drift:
+ *  - `readCatalogBody` accepts exactly `{manifest: {skills}, revision}`; anything else throws a
+ *    NAMED error (never a silent empty catalog against a daemon that answered something);
+ *  - `provenanceOf` DERIVES shipped / override / user-added from the hashes — no wire field;
+ *  - `isUnpublished` compares the effective hash with what the current snapshot carries;
+ *  - `sortSkillFiles` puts SKILL.md first; `supportFiles` folds the manifest's support map;
+ *  - `isSkillsUnsupported` folds a 501 and the bare unknown-route 404 (a named 404 is an answer);
+ *    `isSkillsConflict` is the CAS 409 and nothing else;
+ *  - `skillCounts` is the five-tile KPI fold; `filterSkills` the catalog predicate the chips count with;
+ *  - `parseFilesMap` is the Add/Replace modal's live validation; `findingLocation` the `file:line` cite.
+ */
+
+function entry(over: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+  return {
+    dir: 'skills/x',
+    kind: 'module',
+    core: false,
+    portable: true,
+    enabled: true,
+    baselineHash: 'a'.repeat(8),
+    effectiveHash: 'a'.repeat(8),
+    lastPublishedHash: 'a'.repeat(8),
+    editedAt: null,
+    conflict: false,
+    ...over,
+  };
+}
+
+const MANIFEST: SkillsManifest = {
+  baseline: {
+    contentHash: 'b'.repeat(16),
+    source: { kind: 'claude-plugin-cache', path: '/cache/wicked-garden/12.32.0', plugin_version: '12.32.0', git_sha: null, captured_at: '2026-09-08T00:00:00Z' },
+  },
+  skills: {
+    'wicked-garden-repo-learn': entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
+    'wicked-garden-domain-extractor': entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, effectiveHash: 'c'.repeat(8), conflict: true }),
+    'wicked-garden-qe-a11y-test-engineer': entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
+    'my-team-skill': entry({ dir: 'skills/my-team-skill', baselineHash: null, lastPublishedHash: null }),
+  },
+  support: { 'scripts/_python.sh': 'd'.repeat(8), '.claude-plugin/plugin.json': 'e'.repeat(8) },
+  currentGeneration: 3,
+};
+
+describe('readCatalogBody — exactly {manifest, revision}, never a silent empty catalog', () => {
+  it('accepts the catalog envelope and hands the manifest through untouched', () => {
+    const c = readCatalogBody({ manifest: MANIFEST, revision: 'r-1' });
+    expect(c.manifest).toBe(MANIFEST);
+    expect(c.revision).toBe('r-1');
+  });
+
+  it('throws a NAMED error on a bare manifest (no revision), a missing skills map, or non-objects', () => {
+    expect(() => readCatalogBody(MANIFEST)).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: MANIFEST })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { support: {} }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { skills: null }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ nonsense: true })).toThrow(/no catalog/);
+    expect(() => readCatalogBody(null)).toThrow(/no catalog/);
+    expect(() => readCatalogBody('catalog')).toThrow(/no catalog/);
+  });
+});
+
+describe('provenanceOf / isUnpublished — derived from the hashes', () => {
+  it('no baseline → user-added; equal hashes → shipped; different → override', () => {
+    expect(provenanceOf({ baselineHash: null, effectiveHash: 'x' })).toBe('user-added');
+    expect(provenanceOf({ baselineHash: 'x', effectiveHash: 'x' })).toBe('shipped');
+    expect(provenanceOf({ baselineHash: 'x', effectiveHash: 'y' })).toBe('override');
+  });
+
+  it('unpublished when the snapshot carries a different hash, or none', () => {
+    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: 'x' })).toBe(false);
+    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: 'y' })).toBe(true);
+    expect(isUnpublished({ effectiveHash: 'x', lastPublishedHash: null })).toBe(true);
+  });
+});
+
+describe('skillRows / skillCounts — the KPI fold agrees with the catalog', () => {
+  it('rows are name-sorted by codepoint, carry their name and derived provenance', () => {
+    const rows = skillRows(MANIFEST);
+    expect(rows.map((r) => r.name)).toEqual([
+      'my-team-skill', 'wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn',
+    ]);
+    expect(rows.map((r) => r.provenance)).toEqual(['user-added', 'override', 'shipped', 'shipped']);
+  });
+
+  it('counts total · enabled · overridden · core · portable', () => {
+    expect(skillCounts(skillRows(MANIFEST))).toEqual({ total: 4, enabled: 3, overridden: 1, core: 2, portable: 3 });
+    expect(skillCounts([])).toEqual({ total: 0, enabled: 0, overridden: 0, core: 0, portable: 0 });
+  });
+});
+
+describe('sortSkillFiles / supportFiles — the two trees', () => {
+  it('sorts by path with SKILL.md first, rows intact', () => {
+    const rows = sortSkillFiles([{ path: 'refs/z.md', hash: 'h1', size: 3 }, { path: 'SKILL.md', hash: 'h2', size: 9 }, { path: 'refs/a.md', hash: 'h3', size: 1 }]);
+    expect(rows.map((r) => r.path)).toEqual(['SKILL.md', 'refs/a.md', 'refs/z.md']);
+    expect(rows[0]).toEqual({ path: 'SKILL.md', hash: 'h2', size: 9 });
+  });
+
+  it('folds the manifest support map into path-sorted rows carrying the hash (no size)', () => {
+    expect(supportFiles(MANIFEST)).toEqual([
+      { path: '.claude-plugin/plugin.json', hash: 'e'.repeat(8) },
+      { path: 'scripts/_python.sh', hash: 'd'.repeat(8) },
+    ]);
+  });
+});
+
+describe('isSkillsUnsupported / isSkillsConflict — the adoption seam and the CAS seam', () => {
+  it('unsupported folds a 501 and the bare unknown-route 404 (both Fastify and SPA spellings)', () => {
+    expect(isSkillsUnsupported(new ApiError(501, 'no skills root configured'))).toBe(true);
+    expect(isSkillsUnsupported(new ApiError(404, 'Not Found'))).toBe(true);
+    expect(isSkillsUnsupported(new ApiError(404, 'not found'))).toBe(true);
+  });
+
+  it('a NAMED 404, any other status, and a non-wire error are real answers', () => {
+    expect(isSkillsUnsupported(new ApiError(404, 'unknown skill: nope'))).toBe(false);
+    expect(isSkillsUnsupported(new ApiError(500, 'boom'))).toBe(false);
+    expect(isSkillsUnsupported(new ApiError(409, 'stale revision'))).toBe(false);
+    expect(isSkillsUnsupported(new Error('Not Found'))).toBe(false);
+  });
+
+  it('a conflict is the 409 and nothing else', () => {
+    expect(isSkillsConflict(new ApiError(409, 'expected revision r-1, catalog is at r-2'))).toBe(true);
+    expect(isSkillsConflict(new ApiError(404, 'Not Found'))).toBe(false);
+    expect(isSkillsConflict(new ApiError(500, 'boom'))).toBe(false);
+    expect(isSkillsConflict(new Error('409'))).toBe(false);
+  });
+});
+
+describe('filterSkills — the chip predicate', () => {
+  const rows = skillRows(MANIFEST);
+  const names = (chip: (typeof SKILL_CHIPS)[number], query = ''): string[] =>
+    filterSkills(rows, { query, chip }).map((r) => r.name);
+
+  it('all shows everything; kinds, enabled/disabled, overridden, core, portable and claude-only cut it', () => {
+    expect(names('all')).toHaveLength(4);
+    expect(names('router')).toEqual(['wicked-garden-repo-learn']);
+    expect(names('fork-worker')).toEqual(['wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer']);
+    expect(names('module')).toEqual(['my-team-skill']);
+    expect(names('enabled')).toHaveLength(3);
+    expect(names('disabled')).toEqual(['wicked-garden-qe-a11y-test-engineer']);
+    expect(names('overridden')).toEqual(['wicked-garden-domain-extractor']);
+    expect(names('core')).toEqual(['wicked-garden-domain-extractor', 'wicked-garden-repo-learn']);
+    expect(names('portable')).toEqual(['my-team-skill', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn']);
+    expect(names('claude-only')).toEqual(['wicked-garden-domain-extractor']);
+  });
+
+  it('the query matches name OR dir, case-insensitively, and composes with the chip', () => {
+    expect(names('all', 'QE/')).toEqual(['wicked-garden-qe-a11y-test-engineer']);
+    expect(names('all', 'team')).toEqual(['my-team-skill']);
+    expect(names('core', 'extractor')).toEqual(['wicked-garden-domain-extractor']);
+    expect(names('module', 'extractor')).toEqual([]);
+  });
+
+  it('the default facets are the whole catalog', () => {
+    expect(filterSkills(rows, SKILLS_FACETS_DEFAULT)).toHaveLength(4);
+  });
+});
+
+describe('parseFilesMap — the Add/Replace validation', () => {
+  it('accepts an object of relative path → string content that includes SKILL.md', () => {
+    const r = parseFilesMap('{"SKILL.md": "---\\nname: x\\n---", "refs/a.md": "notes"}');
+    expect(r.issue).toBeNull();
+    expect(r.files).toEqual({ 'SKILL.md': '---\nname: x\n---', 'refs/a.md': 'notes' });
+  });
+
+  it('names the ONE issue: invalid JSON, non-object, empty, non-string content, unsafe path, missing SKILL.md', () => {
+    expect(parseFilesMap('{nope').issue).toBe('not valid JSON');
+    expect(parseFilesMap('[1]').issue).toMatch(/JSON object/);
+    expect(parseFilesMap('{}').issue).toMatch(/empty/);
+    expect(parseFilesMap('{"SKILL.md": 3}').issue).toMatch(/must be a string/);
+    expect(parseFilesMap('{"SKILL.md": "x", "/etc/passwd": "y"}').issue).toMatch(/relative path/);
+    expect(parseFilesMap('{"SKILL.md": "x", "a/../b": "y"}').issue).toMatch(/relative path/);
+    expect(parseFilesMap('{"refs/a.md": "x"}').issue).toMatch(/SKILL\.md/);
+    expect(parseFilesMap('{"refs/a.md": "x"}').files).toBeNull();
+  });
+});
+
+describe('findingLocation — the file:line cite', () => {
+  const base = { kind: 'unresolved-ref', severity: 'blocking' as const, skill: null, explanation: 'x' };
+  it('null without a file; the file alone without a line; file:line with both', () => {
+    expect(findingLocation({ ...base, file: null, line: null })).toBeNull();
+    expect(findingLocation({ ...base, file: null, line: 3 })).toBeNull();
+    expect(findingLocation({ ...base, file: 'skills/repo-learn/SKILL.md', line: null })).toBe('skills/repo-learn/SKILL.md');
+    expect(findingLocation({ ...base, file: 'skills/repo-learn/SKILL.md', line: 49 })).toBe('skills/repo-learn/SKILL.md:49');
+  });
+});

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -1,27 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../src/api/errors.js';
+import { apiFetch } from '../src/api/client.js';
 import {
   isSkillsConflict,
   isSkillsUnsupported,
   isUnpublished,
+  listSkillFiles,
   parseFilesMap,
   provenanceOf,
   readCatalogBody,
+  readSkillFile,
+  readSupportFile,
+  setSkillEnabled,
   skillCounts,
+  skillRouteName,
+  skillRoutePath,
+  skillRouteSegment,
   skillRows,
   sortSkillFiles,
   supportFiles,
+  writeSkillFile,
+  writeSupportFile,
   type SkillManifestEntry,
   type SkillsManifest,
 } from '../src/api/skills.js';
 import { findingLocation } from '../src/components/SkillFindings.js';
 import { filterSkills, SKILL_CHIPS, SKILLS_FACETS_DEFAULT } from '../src/components/SkillsGrid.js';
 
+vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
+
 /**
  * The skills wire's pure folds (src/api/skills.ts, design v3) — the seams the page's numbers,
  * filters and honest states hang on, pinned so they cannot drift:
- *  - `readCatalogBody` accepts exactly `{manifest: {skills}, revision}`; anything else throws a
- *    NAMED error (never a silent empty catalog against a daemon that answered something);
+ *  - `readCatalogBody` accepts exactly `{manifest: {skills: {…}, support: {…}}, revision}` with
+ *    PLAIN objects for the two maps; anything else (an array, a missing map) throws a NAMED error
+ *    (never a silent empty catalog against a daemon that answered something);
+ *  - route identity: every name / path segment is decoded, refused when empty, dot-only or
+ *    separator-bearing, then encoded — a daemon-supplied `..` can never normalize a skill-file
+ *    request onto `/skills/support/…` or a support PUT onto `/settings` (the codex probes);
  *  - `provenanceOf` DERIVES shipped / override / user-added from the hashes — no wire field;
  *  - `isUnpublished` compares the effective hash with what the current snapshot carries;
  *  - `sortSkillFiles` puts SKILL.md first; `supportFiles` folds the manifest's support map;
@@ -73,10 +89,106 @@ describe('readCatalogBody — exactly {manifest, revision}, never a silent empty
     expect(() => readCatalogBody(MANIFEST)).toThrow(/no catalog/);
     expect(() => readCatalogBody({ manifest: MANIFEST })).toThrow(/no catalog/);
     expect(() => readCatalogBody({ manifest: { support: {} }, revision: 'r' })).toThrow(/no catalog/);
-    expect(() => readCatalogBody({ manifest: { skills: null }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { skills: null, support: {} }, revision: 'r' })).toThrow(/no catalog/);
     expect(() => readCatalogBody({ nonsense: true })).toThrow(/no catalog/);
     expect(() => readCatalogBody(null)).toThrow(/no catalog/);
     expect(() => readCatalogBody('catalog')).toThrow(/no catalog/);
+  });
+
+  it('requires PLAIN objects for `skills` and `support` — an array or a missing map is a mis-shaped answer, not weird rows', () => {
+    expect(() => readCatalogBody({ manifest: { ...MANIFEST, skills: [] }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { ...MANIFEST, skills: [MANIFEST.skills['my-team-skill']] }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { ...MANIFEST, support: [] }, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody({ manifest: { ...MANIFEST, support: null }, revision: 'r' })).toThrow(/no catalog/);
+    const { support: _dropped, ...noSupport } = MANIFEST;
+    void _dropped;
+    expect(() => readCatalogBody({ manifest: noSupport, revision: 'r' })).toThrow(/no catalog/);
+    expect(() => readCatalogBody([MANIFEST])).toThrow(/no catalog/);
+    // Empty maps are plain objects — a daemon with no skills yet is a real (empty) catalog.
+    expect(readCatalogBody({ manifest: { ...MANIFEST, skills: {}, support: {} }, revision: 'r' }).revision).toBe('r');
+  });
+});
+
+describe('route identity — every name and path is validated before it becomes a route', () => {
+  const fetchMock = vi.mocked(apiFetch);
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ files: [], verdict: 'clear', findings: [], revision: 'r' });
+  });
+
+  it('segments: decoded, then refused when empty, dot-only, or carrying a separator; encoded otherwise', () => {
+    expect(skillRouteSegment('SKILL.md', 'x')).toBe('SKILL.md');
+    expect(skillRouteSegment('.claude-plugin', 'x')).toBe('.claude-plugin');
+    expect(skillRouteSegment('a b#c', 'x')).toBe('a%20b%23c');
+    // A literal `%` that is not an escape is the segment's own text.
+    expect(skillRouteSegment('100%.md', 'x')).toBe('100%25.md');
+    expect(() => skillRouteSegment('', 'x')).toThrow(/refusing x: an empty segment/);
+    expect(() => skillRouteSegment('.', 'x')).toThrow(/dot-only/);
+    expect(() => skillRouteSegment('..', 'x')).toThrow(/dot-only/);
+    expect(() => skillRouteSegment('...', 'x')).toThrow(/dot-only/);
+    // Percent-encoded dots are still dots once the route layer decodes them.
+    expect(() => skillRouteSegment('%2e%2e', 'x')).toThrow(/dot-only/);
+    expect(() => skillRouteSegment('%2E.', 'x')).toThrow(/dot-only/);
+    expect(() => skillRouteSegment('a%2Fb', 'x')).toThrow(/path separator/);
+    expect(() => skillRouteSegment('a\\b', 'x')).toThrow(/path separator/);
+    expect(() => skillRouteSegment('a%00b', 'x')).toThrow(/path separator/);
+  });
+
+  it('paths: relative, no empty / dot-only / separator-smuggling segment; each segment encoded, slashes kept', () => {
+    expect(skillRoutePath('SKILL.md')).toBe('SKILL.md');
+    expect(skillRoutePath('refs/notes.md')).toBe('refs/notes.md');
+    expect(skillRoutePath('.claude-plugin/plugin.json')).toBe('.claude-plugin/plugin.json');
+    expect(skillRoutePath('docs/a b#c.md')).toBe('docs/a%20b%23c.md');
+    expect(() => skillRoutePath('')).toThrow(/empty file path/);
+    expect(() => skillRoutePath('/etc/passwd')).toThrow(/absolute/);
+    expect(() => skillRoutePath('a//b')).toThrow(/empty segment/);
+    expect(() => skillRoutePath('a/')).toThrow(/empty segment/);
+    expect(() => skillRoutePath('a/./b')).toThrow(/dot-only/);
+    expect(() => skillRoutePath('../../support/scripts/a.sh')).toThrow(/dot-only/);
+    expect(() => skillRoutePath('%2e%2e/%2e%2e/settings')).toThrow(/dot-only/);
+    expect(() => skillRoutePath('a\\..\\b')).toThrow(/path separator/);
+  });
+
+  it('names: one segment — a traversal or a slash in a manifest key is refused', () => {
+    expect(skillRouteName('wicked-garden-repo-learn')).toBe('wicked-garden-repo-learn');
+    expect(skillRouteName('my team')).toBe('my%20team');
+    expect(() => skillRouteName('..')).toThrow(/skill name/);
+    expect(() => skillRouteName('../support')).toThrow(/path separator/);
+    expect(() => skillRouteName('')).toThrow(/empty segment/);
+  });
+
+  it('codex probe 1: a skill-file path that would normalize onto /skills/support/… is refused client-side — no request is built', async () => {
+    await expect(readSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh')).rejects.toThrow(/refusing file path/);
+    await expect(writeSkillFile('wicked-garden-repo-learn', '../../support/scripts/a.sh', 'x', 'r-1')).rejects.toThrow(/refusing file path/);
+    await expect(readSkillFile('wicked-garden-repo-learn', '%2e%2e/%2e%2e/support/scripts/a.sh')).rejects.toThrow(/refusing file path/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('codex probe 2: a support PUT that would normalize onto /settings is refused client-side — no request is built', async () => {
+    await expect(writeSupportFile('../../settings', '{}', 'r-1')).rejects.toThrow(/refusing file path/);
+    await expect(readSupportFile('../../settings')).rejects.toThrow(/refusing file path/);
+    await expect(writeSupportFile('/settings', '{}', 'r-1')).rejects.toThrow(/absolute/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('a traversal in the skill NAME is refused on every name-bearing route', async () => {
+    await expect(listSkillFiles('../support')).rejects.toThrow(/refusing skill name/);
+    await expect(setSkillEnabled('..', true, 'r-1')).rejects.toThrow(/refusing skill name/);
+    await expect(readSkillFile('a/b', 'SKILL.md')).rejects.toThrow(/refusing skill name/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('legitimate identities build the expected routes, segment-encoded', async () => {
+    await readSkillFile('wicked-garden-repo-learn', 'refs/notes.md');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files/refs/notes.md');
+    await writeSkillFile('my team', 'docs/a b.md', 'x', 'r-1');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/my%20team/files/docs/a%20b.md', { method: 'PUT', body: JSON.stringify({ content: 'x', expectedRevision: 'r-1' }) });
+    await readSupportFile('.claude-plugin/plugin.json');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/.claude-plugin/plugin.json');
+    await writeSupportFile('scripts/_python.sh', '#!/bin/sh', 'r-1');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/support/scripts/_python.sh', { method: 'PUT', body: JSON.stringify({ content: '#!/bin/sh', expectedRevision: 'r-1' }) });
+    await listSkillFiles('wicked-garden-repo-learn');
+    expect(fetchMock).toHaveBeenLastCalledWith('/skills/wicked-garden-repo-learn/files');
   });
 });
 

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -13,6 +13,7 @@ import {
   readSupportFile,
   setSkillEnabled,
   skillCounts,
+  skillFilePathIssue,
   skillRouteName,
   skillRoutePath,
   skillRouteSegment,
@@ -46,7 +47,9 @@ vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
  *  - `isSkillsUnsupported` folds a 501 and the bare unknown-route 404 (a named 404 is an answer);
  *    `isSkillsConflict` is the CAS 409 and nothing else;
  *  - `skillCounts` is the five-tile KPI fold; `filterSkills` the catalog predicate the chips count with;
- *  - `parseFilesMap` is the Add/Replace modal's live validation; `findingLocation` the `file:line` cite.
+ *  - `parseFilesMap` is the Add/Replace modal's live validation — every key under the ROUTE
+ *    BUILDER's segment rules (`skillFilePathIssue`, one rule for both); `findingLocation` the
+ *    `file:line` cite.
  */
 
 function entry(over: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
@@ -331,10 +334,38 @@ describe('parseFilesMap — the Add/Replace validation', () => {
     expect(parseFilesMap('[1]').issue).toMatch(/JSON object/);
     expect(parseFilesMap('{}').issue).toMatch(/empty/);
     expect(parseFilesMap('{"SKILL.md": 3}').issue).toMatch(/must be a string/);
-    expect(parseFilesMap('{"SKILL.md": "x", "/etc/passwd": "y"}').issue).toMatch(/relative path/);
-    expect(parseFilesMap('{"SKILL.md": "x", "a/../b": "y"}').issue).toMatch(/relative path/);
+    expect(parseFilesMap('{"SKILL.md": "x", "/etc/passwd": "y"}').issue).toMatch(/absolute file path "\/etc\/passwd"/);
+    expect(parseFilesMap('{"SKILL.md": "x", "a/../b": "y"}').issue).toMatch(/file path "a\/\.\.\/b": the dot-only segment "\.\."/);
     expect(parseFilesMap('{"refs/a.md": "x"}').issue).toMatch(/SKILL\.md/);
     expect(parseFilesMap('{"refs/a.md": "x"}').files).toBeNull();
+  });
+
+  it('review round 3: every key is validated with the ROUTE BUILDER’s segment rules — `a/./b`, `a//b`, `a/`, `a\\b` (and `..`, absolute, empty) are refused, the issue names the offending key, and `skillRoutePath` refuses the same key with the same sentence', () => {
+    const refused: Array<[string, RegExp]> = [
+      ['a/./b', /dot-only segment "\."/],
+      ['a//b', /an empty segment/],
+      ['a/', /an empty segment/],
+      ['a\\b', /path separator/],
+      ['a/../b', /dot-only segment "\.\."/],
+      ['/etc/passwd', /absolute file path/],
+      ['', /empty file path/],
+    ];
+    for (const [key, reason] of refused) {
+      const r = parseFilesMap(JSON.stringify({ 'SKILL.md': 'x', [key]: 'y' }));
+      expect(r.files).toBeNull();
+      expect(r.issue).toMatch(reason);
+      if (key !== '') expect(r.issue).toContain(`"${key}"`);
+      // ONE rule: the modal's refusal IS the route layer's refusal, sentence for sentence — Save can
+      // never arm for a map whose key `PUT /skills/:name/files/*path` would later refuse.
+      expect(skillFilePathIssue(key)).toBe(r.issue);
+      expect(() => skillRoutePath(key)).toThrow(r.issue!);
+    }
+    // And what the route layer accepts, the modal accepts: nested dirs, dotfiles, spaces, a literal `%`.
+    for (const key of ['refs/notes.md', '.claude-plugin/plugin.json', 'docs/a b#c.md', 'refs/a%41.md', 'SKILL.md']) {
+      expect(parseFilesMap(JSON.stringify({ 'SKILL.md': 'x', [key]: 'y' })).issue).toBeNull();
+      expect(skillFilePathIssue(key)).toBeNull();
+      expect(() => skillRoutePath(key)).not.toThrow();
+    }
   });
 });
 

--- a/tests/skillsRoutes.test.tsx
+++ b/tests/skillsRoutes.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRoute } from '../src/hooks/useRoute.js';
+import { readSkillDeepLink, skillsPath } from '../src/api/skills.js';
+
+/**
+ * The Skills surface's route (the skills keystone): `/skills` is ONE flat panel — the file
+ * manager over the daemon's effective plugin root.
+ *  - `/skills` parses to the `skills` panel with no run/project machinery armed;
+ *  - the one skill a link opens rides `?skill=<name>` in `search` (never a path segment) —
+ *    `skillsPath(name)` spells it, `readSkillDeepLink(search)` reads it back;
+ *  - a sub-address (`/skills/<anything>`) parses to the same panel — the generic panel arm, the
+ *    same contract every flat panel (`/work/...`) has; the rail's heading map agrees.
+ */
+
+function routeAt(path: string) {
+  window.history.replaceState(null, '', path);
+  return renderHook(() => useRoute()).result;
+}
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+describe('useRoute — /skills', () => {
+  it('parses /skills to the skills panel with nothing else armed', () => {
+    const r = routeAt('/skills').current;
+    expect(r.panel).toBe('skills');
+    expect(r.runId).toBeNull();
+    expect(r.projectId).toBeNull();
+    expect(r.showLaunch).toBe(false);
+    expect(r.steeringSection).toBeNull();
+    expect(r.testingPage).toBeNull();
+  });
+
+  it('carries the ?skill= deep link in `search`, not in the panel parse', () => {
+    const r = routeAt('/skills?skill=wicked-garden-repo-learn').current;
+    expect(r.panel).toBe('skills');
+    expect(r.search).toBe('?skill=wicked-garden-repo-learn');
+    expect(readSkillDeepLink(r.search)).toBe('wicked-garden-repo-learn');
+  });
+
+  it('a sub-address parses to the same flat panel (the generic panel arm)', () => {
+    expect(routeAt('/skills/').current.panel).toBe('skills');
+    expect(routeAt('/skills/wicked-garden-repo-learn').current.panel).toBe('skills');
+  });
+
+  it('panelPath spells the skills panel as /skills', () => {
+    expect(routeAt('/').current.panelPath('skills')).toBe('/skills');
+  });
+});
+
+describe('skillsPath / readSkillDeepLink — the one spelling of the drawer address', () => {
+  it('bare for the catalog, ?skill=<name> (encoded) for one skill', () => {
+    expect(skillsPath()).toBe('/skills');
+    expect(skillsPath(null)).toBe('/skills');
+    expect(skillsPath('wicked-garden-repo-learn')).toBe('/skills?skill=wicked-garden-repo-learn');
+    expect(skillsPath('a b/c')).toBe('/skills?skill=a%20b%2Fc');
+  });
+
+  it('reads the name back, decoded; absent or empty is null (the bare catalog)', () => {
+    expect(readSkillDeepLink('?skill=a%20b%2Fc')).toBe('a b/c');
+    expect(readSkillDeepLink('')).toBeNull();
+    expect(readSkillDeepLink('?skill=')).toBeNull();
+    expect(readSkillDeepLink('?type=security')).toBeNull();
+  });
+});

--- a/tests/skillsWire.test.ts
+++ b/tests/skillsWire.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.27.0 contract.
+ *
+ * `src/api/skills-wire.ts` carries the skills block of `wicked-crew-api-types@0.27.0` (crew#480 @
+ * 4cae105, unpublished) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM` markers, and
+ * `tests/fixtures/api-types-0.27.0-skills.d.ts` is a byte copy of the same line ranges taken
+ * straight from the crew worktree. This test compares every marked region of the two files: a
+ * hand edit to the mirror, or a re-vendored fixture from a re-minted contract, fails here until
+ * both agree again — the mirror can never quietly drift from the wire crew serves.
+ *
+ * Delete this test (and the fixture) at the release swap, when the mirror becomes
+ * `export type { … } from 'wicked-crew-api-types'`.
+ *
+ * @vitest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
+const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.27.0-skills.d.ts', import.meta.url));
+
+const BEGIN = /^\/\/ >>> VERBATIM (.+)$/;
+const END = '// <<< VERBATIM';
+
+/** The marked regions of a file: `{ label, body }` per `>>> … <<<` pair, in order. */
+function regions(path: string): Array<{ label: string; body: string }> {
+  const out: Array<{ label: string; body: string }> = [];
+  let open: { label: string; lines: string[] } | null = null;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const begin = BEGIN.exec(line);
+    if (begin !== null) {
+      if (open !== null) throw new Error(`${path}: a VERBATIM region opens inside another (${open.label})`);
+      open = { label: begin[1]!, lines: [] };
+      continue;
+    }
+    if (line === END) {
+      if (open === null) throw new Error(`${path}: a VERBATIM region closes with none open`);
+      out.push({ label: open.label, body: open.lines.join('\n') });
+      open = null;
+      continue;
+    }
+    if (open !== null) open.lines.push(line);
+  }
+  if (open !== null) throw new Error(`${path}: the VERBATIM region ${open.label} never closes`);
+  return out;
+}
+
+describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.27.0 skills contract', () => {
+  it('carries the MIRROR header naming the contract, the PR, and the release swap', () => {
+    const head = readFileSync(MIRROR, 'utf8').slice(0, 400);
+    expect(head).toContain('MIRROR of wicked-crew-api-types 0.27.0 skills block (crew#480) — replace with imports from the');
+    expect(head).toContain('published package at release.');
+  });
+
+  it('every marked region equals the vendored fixture region, label and body, in order', () => {
+    const mirror = regions(MIRROR);
+    const fixture = regions(FIXTURE);
+    expect(mirror.map((r) => r.label)).toEqual(fixture.map((r) => r.label));
+    expect(mirror.length).toBe(2);
+    for (let i = 0; i < mirror.length; i += 1) {
+      // Same bytes, named by region so a drift report says WHICH block moved.
+      expect(mirror[i]!.body, mirror[i]!.label).toBe(fixture[i]!.body);
+    }
+  });
+
+  it('the two regions are the skills block and the diagnostics.skills block of 0.27.0', () => {
+    const labels = regions(FIXTURE).map((r) => r.label);
+    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.27\.0 index\.d\.ts:1322-1685 /);
+    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.27\.0 index\.d\.ts:3262-3302 /);
+    const [skills, diagnostics] = regions(FIXTURE).map((r) => r.body);
+    // The declarations studio consumes are all in the block — a re-mint that drops one fails here.
+    for (const name of [
+      'export type SkillKind', 'export type SkillProvenance', 'export type SkillVerdict', 'export type SkillFindingKind',
+      'export interface SkillEntry', 'export interface SkillFileRecord', 'export interface SkillPublishedRecord',
+      'export interface SkillManifest', 'export interface SkillsManifestResponse', 'export interface SkillFileEntry',
+      'export interface SkillFileTree', 'export interface SkillReadResult', 'export interface SkillConflictFinding',
+      'export interface SkillAnalyzeResult', 'export interface SkillMutationResult', 'export interface SkillPublishResult',
+      'export interface SkillRefreshResult', 'export interface SkillRevisionConflict', 'export interface SkillRevisionBody',
+      'export interface PutSkillFileBody', 'export interface AddSkillBody', 'export interface ReplaceSkillBody',
+    ]) {
+      expect(skills, name).toContain(name);
+    }
+    expect(diagnostics).toContain("export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';");
+    expect(diagnostics).toContain('export interface DiagnosticsSkills {');
+    // The three wire rules the mirror header restates come from the block itself.
+    expect(skills).toContain('revision: number;');
+    expect(skills).toContain('expectedRevision: number;');
+    expect(skills).toContain("export type SkillVerdict = 'clear' | 'warnings' | 'blocked';");
+  });
+});


### PR DESCRIPTION
## Summary

Studio's slice of the skills keystone (design v3): a **Skills** section in the rail — heading before Steering, ▦ only — and the `/skills` file-manager page over crew's ONE effective garden-shaped plugin root. Studio speaks only crew's `/api/v1`; crew's `/skills` routes are being built in parallel, so the wire types here are LOCAL and marked TEMPORARY.

- **Rail** (`LeftSidebar.tsx`): `P_SKILLS` (`◆`, `/skills`) inserted before `P_STEERING`; `headingForPath('/skills…') → 'skills'`; a `RailHeading` with one "Browse skills" row between the work divider and Steering; collapsed glyph column 10 → 11.
- **Route** (`useRoute.ts`, `App.tsx`): `Panel` gains `skills`; `/skills` (and any sub-address) parses to it via the generic panel arm; `?skill=<name>` deep-links a drawer. `renderCenter` clones the Steering branch.
- **`src/api/skills.ts`** — LOCAL wire types marked TEMPORARY (delete + re-export from `wicked-crew-api-types` once it publishes the skills contract; the `steering.ts` stopgap pattern, same exit): the catalog (`GET /skills` → `{manifest, revision}`), skill files + support files (`GET|PUT /skills/:name/files/*`, `GET|PUT /skills/support/*`), enable / disable / reset / replace / add, refresh-baseline, publish, analyze — exactly the design's route table. **CAS everywhere**: every mutation sends `expectedRevision`, every 2xx is the `{verdict, findings, revision}` envelope (a `blocked` verdict is a normal answer); a 409 is `isSkillsConflict`; a daemon without the routes is `isSkillsUnsupported` (`isRouteAbsent` + 501) → the named unsupported state.
- **`SkillsPage`**: KPI band (total · enabled · overridden · core · portable), rows (`skills-row[data-skill]`) with kind / provenance chips + core / claude-only / conflict / unpublished badges and the enabled toggle (`skills-toggle`), source + snapshot-generation lines; page verbs Add · Refresh baseline (`skills-refresh`) · Analyze (`skills-analyze`, dry run) · **Publish** (`skills-publish`). A `SkillsWriter` seam holds the catalog revision and adopts the answered one so chained writes condition correctly; a 409 raises `skills-conflict` (reload prompt, above every layer) and freezes every write until the catalog is re-read.
- **`SkillDrawer`**: skill-files / **support-files** tabs (`skills-file-tree[data-tab]`, `skills-file[data-path]`), a `<textarea>` editor (`skills-editor` — no code editor exists), Save (`skills-save`) disabled on `truncated` / `binary` reads and for a `blocked` draft until it changes, findings inline (`skills-findings`, `file:line` cites), Reset (typed confirm; disabled for user-added — no baseline), Replace (pasted files map).
- Clones, originals untouched: `SkillsGrid` ← SteeringGrid, `SkillDrawer` ← SteeringRuleDrawer, `SkillConfirmModal` ← SteeringRetireModal (the reset-only typed confirmation), `SkillChips` ← SteeringChips; the type filter is the grid's `FilterStrip` chips. Reused as-is: `dashboardKit`, `useModalEscape`. `FileViewer` / `api.openPath` deliberately not used.

## Design notes
- Provenance (shipped / override / user-added) is DERIVED from `baselineHash` vs `effectiveHash` — no extra wire field to reconcile later.
- `unpublished` = `effectiveHash ≠ lastPublishedHash` (design §7 per-file hashes); the snapshot line counts them so the operator sees a Publish is due.
- `POST /skills/analyze` sends no `expectedRevision` — it mutates nothing.
- No delete verb: `DELETE /skills/:name` is not in the design's route table, so studio offers none — a user-added skill is disabled (its off switch) or replaced. The second commit removes the earlier attempt's invented route end-to-end.

## Tests
- `tests/SkillsPage.test.tsx` (35): catalog render + the five KPIs; toggle wire body incl. `expectedRevision` and revision chaining across two writes; blocked → findings + no reload; **409 → conflict prompt, frozen writes, Reload re-reads**; Save → findings; blocked / truncated / binary disable Save; 409 on Save keeps the draft; Support tab list / read / write; Reset (typed confirm, blocked keeps the modal, 409) / Replace / Add bodies; user-added cannot Reset; Refresh / Analyze / Publish (clear → generation moves, blocked with `file:line`, 409, wire failure); unsupported (404 / 501), mis-shaped catalog, dead deep link.
- `tests/skillsApi.test.ts` (17): `readCatalogBody`, `provenanceOf`, `isUnpublished`, `skillRows` / `skillCounts`, `sortSkillFiles` / `supportFiles`, the adoption + CAS seams, `filterSkills`, `parseFilesMap`, `findingLocation`.
- Rail / route tests extended: ten → eleven headings, Skills in the ▦-only loop, order (Skills before Steering, after the work divider), hrefs, collapsed 10 → 11, `notFoundRoute` insertion, `skillsRoutes` (`/skills`, `?skill=`, sub-address, `panelPath`).
- `testid-inventory.json` regenerated (`npm run manifest:testids`).

## Verification (real results, second commit)
`npm run typecheck` ✓ · `npm run lint` ✓ · `npm test` ✓ 240 files / 2501 tests · `npm run build` ✓

Integration order per the design: api-types publish → studio swaps the TEMPORARY types for re-exports; core-ts → crew; crew bundles the released studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
