### PR TITLE
test(tests-feature): deterministic layer T1–T20/T24 + rename-consistency T30; fix 15 'Campaign' strings and the rail ＋ (#203)

### DIFF
--- a/docs/testing/tests-feature-test-plan.md
+++ b/docs/testing/tests-feature-test-plan.md
@@ -40,7 +40,9 @@ steps. Rename regression: wicked-studio#203 (15 rendered strings + the rail ＋ 
 - **Arrival intent (#203 fix).** `?new=test` / `?new=recon` on the landing
   (`testingLaunchPath`, `readLaunchIntent` in `src/api/testing.ts`) opens that panel on mount and
   is consumed with a `replace` navigation. The rail's ＋ ("New Test") and its "Run recon" row use
-  it — a create affordance creates.
+  it — a create affordance creates. The launch panel is keyed by intent + an arrival counter, so
+  each arrival (and each verb switch) mounts a fresh launch instance — a launched or errored panel
+  never carries over into the next ask.
 
 ## 2. Codex's REQUIRED CHANGES → what changed here
 
@@ -87,7 +89,7 @@ at the client boundary (`apiFetch` / `api.*`) or the fetch boundary; nothing tou
 | T19 | decisions | wire: four `POST /runs/:id/gate` bodies + bodyless cancel, content type only with a body, encoded id, refusal → typed error; panel: each button → its decision exactly once → resolved copy with working doors; cancel resolves; refused decision keeps the gate up | `tests/gateWire.test.ts`, `tests/TestingLaunch.test.tsx` |
 | T20 | named gap | `MULTI_SCOPE_UNSUPPORTED_COPY` rendered **verbatim** for multi-repo and project scopes on an old daemon; `/runs` never touched; form stays live | `tests/TestingLaunch.test.tsx` |
 | T24 | landing states | probing (line alone, one `GET /campaigns`, no verbs) → page; 404 → unsupported copy with verbs usable; 200 empty → "no tests yet" + CTA; 200 populated → KPIs + strip + grid | `tests/CampaignsPage.test.tsx` |
-| — | `?new=` intent | `campaign`/`recon` open the panel and consume the query with one `replace`; plain arrival opens nothing; honored on an unsupported daemon; toggles with the verb; rail ＋ → `?new=test`, "Run recon" row → `?new=recon`; `readLaunchIntent` rejects bare/foreign/backend-worded values | `tests/CampaignsPage.test.tsx`, `tests/LeftSidebar.rail.test.tsx`, `tests/testingRoutes.test.tsx` |
+| — | `?new=` intent | `campaign`/`recon` open the panel and consume the query with one `replace`; plain arrival opens nothing; honored on an unsupported daemon; toggles with the verb; rail ＋ → `?new=test`, "Run recon" row → `?new=recon`; `readLaunchIntent` rejects bare/foreign/backend-worded values; **every arrival is a fresh launch instance** — a second `?new=test` after a successful launch (or on a half-typed panel) remounts an empty panel that launches a second test, while consuming the query alone keeps the open instance; switching the verb after a launch is a fresh panel too | `tests/CampaignsPage.test.tsx`, `tests/TestingLaunch.test.tsx`, `tests/LeftSidebar.rail.test.tsx`, `tests/testingRoutes.test.tsx` |
 | T30 | rename consistency | every rendered string (text + `title`/`aria-label`/`placeholder`) on: the Test rail heading (title, ▦/＋ labels, Run recon row), the project-shell crumb, the chat group-attach chip, the scoreboard not-found / loading / attached-row tooltip, the panel's fan-out and resolved copy, the landing's probing / unsupported / nothing-matches / older-chip copy, the Needs-You row + verb, `TESTING_UNSUPPORTED_COPY` | `tests/renameConsistency.test.tsx`, `tests/renameGuard.ts`, `tests/needsYou.test.ts`, `tests/LeftSidebar.rail.test.tsx` |
 
 T30's guard (`expectTestVocabulary`) is scoped to product copy: fixture ids are chosen without the

--- a/docs/testing/tests-feature-test-plan.md
+++ b/docs/testing/tests-feature-test-plan.md
@@ -1,0 +1,211 @@
+# Tests feature — test plan (revised)
+
+The Test surfaces of wicked-studio: the `/testing/campaigns` landing (`CampaignsPage`), its two
+launch verbs (`TestingLaunchPanel` — "Run recon" / "New test"), the project-scoped view
+(`/p/:id/campaigns`, `ProjectCampaignsView`), the scoreboard (`CampaignScoreboard`), the Test
+rail section (`LeftSidebar`), and the wire below them (`src/api/testing.ts`, `src/api/errors.ts`).
+
+**Provenance.** Council recon run `1aba96f6-350d-4582-8491-21424c7073c3` (30 scenarios) →
+codex final review **REVISE** (7 HIGH / 11 MEDIUM, every finding file:line grounded) → adjudication
+ratified REVISE. This document is the plan with codex's REQUIRED CHANGES applied and the
+deterministic layer **executed** (vitest, `tests/`). The curl layer is repaired and left as
+documented next steps; the governed and Playwright layers are revised and left as documented next
+steps. Rename regression: wicked-studio#203 (15 rendered strings + the rail ＋ behavior).
+
+**Vocabulary rule.** The backend / route / store-key / testid vocabulary stays `campaign`
+(`/testing/campaigns`, `data-testid="campaign-*"`, `campaignId`, `POST /testing/recon`'s response
+`campaign` label). Every **rendered** word says Test. The guard for that is T30.
+
+## 1. What the surface actually does (recon, verified)
+
+- `TestingLaunchPanel` composes `TestingLaunchBody = {problem, projectId?, repoRefs?}` and calls
+  `launchTestingRun` (`src/api/testing.ts`), which POSTs the pinned `/testing/recon`. The
+  `problem` is `"<prefix>\n\n<trimmed brief>"`; the prefix is `RECON_PROBLEM_PREFIX` for "Run
+  recon" and `TEST_PROBLEM_PREFIX` for "New test" (`TestingLaunchPanel.tsx:43,49`).
+- **Presence gate.** Only the bare unknown-route 404 — body `'Not Found'` (Fastify headless) or
+  `'not found'` (crew's SPA-serving notFoundHandler), `isRouteAbsent` (`src/api/errors.ts`) — falls
+  back to the shipping `POST /runs` with the legacy single `repoRef`, and only when the scope fits
+  it (≤ 1 repo, no project). A scope that needs the pinned keys throws
+  `MultiScopeUnsupportedError` → `MULTI_SCOPE_UNSUPPORTED_COPY`. **Every other refusal is rethrown
+  untouched** (named 404, 400, 500, 501, transport) — never retried over `/runs`.
+- **Fan-out honesty.** `launchedRunIds` prefers a non-empty `runIds` over the legacy `runId`;
+  invalid entries are dropped. `ids.length > 1` renders the fan-out (buttons, one per run) and
+  **never** an inline gate; `ids.length === 1` watches the app's one gate fold (`useGateStore`,
+  fed by `awaitingHuman` frames on `/ws`) and renders the EXISTING `SteeringGate` card;
+  `ids.length === 0` is an error, not a silent no-op.
+- **Scope.** A launch needs a project OR ≥ 1 explicit repo, or the explicit "run unscoped"
+  opt-in. Selecting a project or attaching a repo resets that consent. A project's `crew.repo`
+  members render as locked "via project" chips (display only — the daemon re-resolves from
+  `projectId`); the picker excludes attached and project-carried repos and caps at 8.
+- **Arrival intent (#203 fix).** `?new=test` / `?new=recon` on the landing
+  (`testingLaunchPath`, `readLaunchIntent` in `src/api/testing.ts`) opens that panel on mount and
+  is consumed with a `replace` navigation. The rail's ＋ ("New Test") and its "Run recon" row use
+  it — a create affordance creates.
+
+## 2. Codex's REQUIRED CHANGES → what changed here
+
+| # | finding | resolution |
+|---|---|---|
+| 1 | T25 waits for `awaiting_human` and assumes the gate prompt starts with the launch prefix | Event is `awaitingHuman` (`src/store/gates.ts`). No prompt-prefix assumption anywhere: T17/T25 assert the prompt is rendered in-band via `steering-prompt`, whatever it says. |
+| 1 | T7's fixture is impossible through the picker | T7 attaches `r1` **before** selecting the project that carries it; asserts one locked chip while selected, the explicit chip (with a working remove) after clearing. |
+| 1 | T28 names the wrong close selector | "Add with chat" closes via `steering-author-close`; only the two launch panels use `testing-launch-close`. |
+| 1 | The rail ＋ only navigates | Fixed (＋ → `?new=test` with the panel open) and tested separately from the label (`LeftSidebar.rail.test.tsx`, `CampaignsPage.test.tsx`). |
+| 1 | T29's terminal URL is not guaranteed for project-filed runs | T29 asserts the canonical route (`/p/:projectId/build/:id` after `useLegacyRedirect`) or uses unfiled fixtures. |
+| 2 | T5 covers one scope shape with an unspecified prefix | T5 is a matrix: project-only / explicit-only / combined / unscoped × both prefixes, trimmed brief, attach-order `repoRefs`, no absent keys. |
+| 2 | T4 lacks the negative guarantee | T4 pins six real refusals (named 404, validation 400, strict-zod 400, 500, 501, transport) as rethrown after ONE call, both route-absent spellings, the unscoped `{problem}` fallback, and fallback-failure propagation. |
+| 3 | Gate coverage omits reject / steer / cancel / failure | T19 pins `{approve:true}`, `{approve:true,amend}`, `{approve:false}`, `{approve:false,amend}` and the bodyless `POST /runs/:id/cancel` — at the fetch boundary (`gateWire.test.ts`) and through the panel (`TestingLaunch.test.tsx`), plus the refused decision. T25/T26 carry execution-boundary evidence requirements (§5). |
+| 4 | Deterministic vs governed conflated; curl not executable | T22/T27/T29 split into deterministic assertions and labelled governed setup. T21–T23 rewritten as non-launching probes with captured bodies and the JSON content type (§4). |
+| 5 | Async scope / consent / boundaries / gate content missing | T6 (rapid switching, failed lookup), T9 (consent reset), T10 (whitespace brief, double submit, retry), T11 (loading → empty → fixed), T12 (unavailable `initialProjectId`), T14 (no inline gate with sibling gates), T16 (four no-id shapes, multi-request/one-answer), T17 (unrelated gate, gate-before-response). |
+| 6 | Rename inventory incomplete | 15 strings (§7), all fixed; T30 covers every listed surface state. |
+| 7 | Fixtures / dependencies | Every deterministic test initialises its own fixtures; T18 precedes T17; no scenario depends on another test's state. |
+
+## 3. Layer 1 — deterministic (vitest, executed)
+
+All of these run with `npm test`. Each test's name carries its scenario id. Fixtures are mocks
+at the client boundary (`apiFetch` / `api.*`) or the fetch boundary; nothing touches a daemon.
+
+| id | surface | what is pinned | file |
+|---|---|---|---|
+| T1 | `isRouteAbsent` | exactly the two route-absent bodies; named 404s, other statuses, non-wire errors → false | `tests/testingLaunch.wire.test.ts` |
+| T2 | `launchedRunIds` | non-empty `runIds` wins over `runId`; empty/invalid falls back; invalid entries dropped; `[]` when nothing usable | `tests/testingLaunch.wire.test.ts` |
+| T3 | `isMultiScopeUnsupported` | the typed error; strict-zod 400 naming `repoRefs`/`projectId`; other 400s / statuses → false | `tests/testingLaunch.wire.test.ts` |
+| T4 | `launchTestingRun` | (a) 200 verbatim, `/runs` untouched; (b) route absent + project → typed error, no `/runs`; (c) route absent + ≤1 repo → `POST /runs {problem, repoRef}` / `{problem}` (both spellings); (d) route absent + 2 repos → typed error; **negative:** six real refusals rethrown as-is after ONE call; fallback failure propagates verbatim | `tests/testingLaunch.wire.test.ts`, panel-level in `tests/TestingLaunch.test.tsx` |
+| T5 | wire body | matrix: project-only / explicit-only / combined / unscoped × recon & test prefixes; trimmed brief; attach-order `repoRefs`; no absent keys; landing-level cases (one repo, many repos, project alone, union, unscoped) | `tests/TestingLaunch.test.tsx` |
+| T6 | project selector | `crew.repo` members → locked chips (no remove), non-repo members ignored, `default`/archived projects not offered; rapid switching discards the stale answer; failed lookup → no chips, `projectId` still rides | `tests/TestingLaunch.test.tsx` |
+| T7 | explicit ∩ project | attach first → one locked chip while selected, picker excludes it, explicit chip + remove after clearing; wire: `repoRefs` alone when cleared, `projectId + repoRefs` while selected (union dedupes server-side) | `tests/TestingLaunch.test.tsx` |
+| T8 | picker | name OR id, case-insensitive, cap 8, miss/blank → no list; attached + project-carried excluded; picking clears the query | `tests/TestingLaunch.test.tsx` |
+| T9 | unscoped opt-in | visible iff unscoped; attaching / selecting hides it; removing / clearing brings it back UNCHECKED | `tests/TestingLaunch.test.tsx` |
+| T10 | submit gating | whitespace brief never launches; scope OR opt-in; consent lost with scope; double click → ONE POST, `onLaunched` once, "Launching…" disabled; failed launch → live form, retry clears the error | `tests/TestingLaunch.test.tsx` |
+| T11 | zero-repo project | absent while resolving, shown for no `crew.repo` member, cleared by an explicit attachment which rides the union | `tests/TestingLaunch.test.tsx` |
+| T12 | `initialProjectId` | pre-selected once the option loads, repos resolved, wire without a click; an inactive id still rides verbatim (daemon is the authority) | `tests/TestingLaunch.test.tsx`, `tests/ProjectCampaignsView.test.tsx` |
+| T13 | route wiring | `useRoute('/p/:id/campaigns')` → `{projectId, campaignsView:true, mode:null}`; `ProjectCampaignsView` frames the landing, crumb "Tests", back door, pre-selects the project | `tests/ProjectCampaignsView.test.tsx` |
+| T14 | fan-out | "N runs launched under <label>", one button per run, navigable; **no inline gate even when sibling gates arrive** | `tests/TestingLaunch.test.tsx` |
+| T15 | fan-out, no label | "— one per attached codebase, under one test", no label element; non-string label = absent | `tests/TestingLaunch.test.tsx` |
+| T16 | no run id | `{}`, `{runIds:[]}`, `{runId:''}`, `{runIds:[''],runId:''}` → error, `onLaunched` never fires, form live; multi-request answered with one id keeps the single-run flow | `tests/TestingLaunch.test.tsx` |
+| T17 | single-run gate | the ONE `SteeringGate` with `data-run-id`, prompt in-band; unrelated gate ignored; gate-before-response renders once the id is known | `tests/TestingLaunch.test.tsx` |
+| T18 | waiting | waiting line names the run (8-char prefix), no gate card | `tests/TestingLaunch.test.tsx` |
+| T19 | decisions | wire: four `POST /runs/:id/gate` bodies + bodyless cancel, content type only with a body, encoded id, refusal → typed error; panel: each button → its decision exactly once → resolved copy with working doors; cancel resolves; refused decision keeps the gate up | `tests/gateWire.test.ts`, `tests/TestingLaunch.test.tsx` |
+| T20 | named gap | `MULTI_SCOPE_UNSUPPORTED_COPY` rendered **verbatim** for multi-repo and project scopes on an old daemon; `/runs` never touched; form stays live | `tests/TestingLaunch.test.tsx` |
+| T24 | landing states | probing (line alone, one `GET /campaigns`, no verbs) → page; 404 → unsupported copy with verbs usable; 200 empty → "no tests yet" + CTA; 200 populated → KPIs + strip + grid | `tests/CampaignsPage.test.tsx` |
+| — | `?new=` intent | `campaign`/`recon` open the panel and consume the query with one `replace`; plain arrival opens nothing; honored on an unsupported daemon; toggles with the verb; rail ＋ → `?new=test`, "Run recon" row → `?new=recon`; `readLaunchIntent` rejects bare/foreign/backend-worded values | `tests/CampaignsPage.test.tsx`, `tests/LeftSidebar.rail.test.tsx`, `tests/testingRoutes.test.tsx` |
+| T30 | rename consistency | every rendered string (text + `title`/`aria-label`/`placeholder`) on: the Test rail heading (title, ▦/＋ labels, Run recon row), the project-shell crumb, the chat group-attach chip, the scoreboard not-found / loading / attached-row tooltip, the panel's fan-out and resolved copy, the landing's probing / unsupported / nothing-matches / older-chip copy, the Needs-You row + verb, `TESTING_UNSUPPORTED_COPY` | `tests/renameConsistency.test.tsx`, `tests/renameGuard.ts`, `tests/needsYou.test.ts`, `tests/LeftSidebar.rail.test.tsx` |
+
+T30's guard (`expectTestVocabulary`) is scoped to product copy: fixture ids are chosen without the
+word (`suite-1`, `r-1`), because a daemon-minted id or a user-authored title may legitimately say
+"campaign".
+
+## 4. Layer 2 — curl probes (documented next steps, non-launching)
+
+**Daemon fixtures.** Always a DISPOSABLE daemon on a free port with a temp data dir — never
+`:7701`, never `~/.wicked-crew`. `CURRENT` = the installed `wicked-crew` (0.7.25 at time of
+writing). `OLD` = any release predating `POST /testing/recon`; the T21 probe itself is the
+version check (you do not need to know the number in advance).
+
+**Why these bodies.** A launch POST with a *valid* body starts a governed run. Every probe below
+sends a body the route's zod **rejects** (or a GET), so a present route answers **400 naming the
+field** and an absent route answers the **bare 404** — presence is decided without launching
+anything.
+
+```bash
+HOST=http://127.0.0.1:$PORT   # the disposable daemon
+probe() {  # method path body → prints "<status>" then the captured body
+  local body; body=$(mktemp)
+  local code; code=$(curl -s -o "$body" -w '%{http_code}' -X "$1" "$HOST/api/v1$2" \
+    -H 'content-type: application/json' ${3:+-d "$3"})
+  echo "$code"; cat "$body"; echo; rm -f "$body"
+}
+```
+
+| id | command | OLD daemon | CURRENT daemon | proves |
+|---|---|---|---|---|
+| T21 | `probe POST /testing/recon '{}'` | `404` + `{"error":"Not Found"}` (headless) or `{"error":"not found"}` (bundled SPA handler) — the exact spellings `isRouteAbsent` matches | `400` naming `problem` (route present, zod refused, **nothing launched**) | the presence-gate discriminator, both spellings |
+| T22 | `probe POST /runs '{"problem":"x","repoRefs":["r"]}'` then `probe POST /runs '{"repoRef":1}'` | `400 Unrecognized key(s) … 'repoRefs'` and `400` on the `repoRef` type — the strict zod that *forces* the legacy spelling | same (the legacy route keeps its zod) | why the fallback composes `repoRef`, never the pinned keys. **The client fallback itself is proven by T4c**, not by curl. |
+| T23 | `probe GET /campaigns` | `404` bare | `200` with `campaigns: []`-or-rows; `groups` MAY be absent (the client normalises, `src/api/campaigns.ts`) | the `campaigns-unsupported` vs `campaigns-page` fork (T24's fixture is real) |
+
+Assert T23's shape with `python3 -c 'import json,sys; d=json.load(sys.stdin); assert isinstance(d["campaigns"], list); assert "groups" not in d or isinstance(d["groups"], list)'`.
+
+## 5. Layer 3 — governed runs (documented next steps; exactly ONE at a time)
+
+Each of these spawns a council. Serialize them; a disposable daemon needs a signed-in worker CLI
+or the run stalls — record that as skipped-with-reason, never as a pass.
+
+- **T25 — "Run recon" → intake gate.** From `/testing/campaigns`, "Run recon", attach 1 repo,
+  submit. Wait for the `awaitingHuman` frame for the returned run id on `/ws` (the store key,
+  `src/store/gates.ts`), **not** the `awaiting_human` session status. Assert: `steering-gate`
+  with that `data-run-id` inside `testing-launch-panel`; the prompt is rendered in `steering-prompt`
+  (if it contains `[`, the tail is in the collapsed disclosure — expand and check the plan text is
+  readable). **Do not assume the prompt starts with `RECON_PROBLEM_PREFIX`** — no contract says
+  so (crew#473: the recon gate is pre-execution; the plan may not be present at all — that is a
+  finding, not a test failure). Execution boundary evidence: `GET /runs/:id/units` shows no unit
+  past the gate before the decision; after **reject** (`{approve:false}`) the run reaches a
+  terminal status and spawns nothing further. Reject, do not approve, so no council executes.
+- **T26 — "New test" fan-out.** ≥ 2 registered repos, "New test", attach both, submit. Assert the
+  real `POST /testing/recon` response has `runIds.length === 2` (+ `campaign` label), the panel
+  renders T14's fan-out (buttons, not links), **no inline gate**. Then, per sibling: navigate to
+  `/runs/:id`, wait for its own `awaitingHuman`, correlate the gate's run id, reject it. The
+  campaign appears on the landing grid after `refresh`. Nothing is approved.
+- **T27 — project-scoped launch.** The deterministic half (pre-selection, via-project chips,
+  `projectId`-only body) is T12/T13. The governed half: from `/p/:id` → `dashboard-campaigns` →
+  "New test" → submit → the daemon resolves the project's repos server-side (the response's
+  `runIds` count equals the project's `crew.repo` member count). Reject at the gate.
+
+## 6. Layer 4 — Playwright (documented next steps)
+
+- **T28 — panel accordion.** `testing-recon-open` / `testing-author-open` /
+  `testing-campaign-open` are one-at-a-time (`aria-expanded`); the launch panels close via
+  `testing-launch-close`, "Add with chat" via **`steering-author-close`**. Also: arriving at
+  `/testing/campaigns?new=test` shows the New-test panel open and the address is `/testing/campaigns`
+  afterwards (consumed; Back does not re-open it).
+- **T29 — fan-out navigation.** Use the T26 run (governed setup, labelled) or a recorded
+  fixture. Click a `testing-launch-fanout-run` **button**; assert the run id in the URL and, for a
+  project-filed run, the **canonical** `/p/:projectId/build/:id` after `useLegacyRedirect` — not
+  the initial `/runs/:id`.
+
+## 7. Rename inventory (wicked-studio#203) — all fixed
+
+| # | where (before this change) | was | now |
+|---|---|---|---|
+| 1 | `LeftSidebar.tsx` `P_TEST.noun` → ＋ `aria-label`/`title` | New Campaign | New Test |
+| 2 | project-shell crumb (`App.tsx` → `ProjectCampaignsView.tsx`) | Campaigns | Tests |
+| 3 | `ChatInput.tsx` group-attach pill | Campaign: … | Test: … |
+| 4 | `board/needsYou.ts` row text | Campaign gaps — … | Test gaps — … |
+| 5 | `board/needsYou.ts` row action | Open campaign › | Open test › |
+| 6 | `CampaignScoreboard.tsx` not-found copy | No campaign is filed … a campaign appears … | No test is filed … a test appears … |
+| 7 | `CampaignScoreboard.tsx` not-found link | All campaigns | All tests |
+| 8 | `TestingLaunchPanel.tsx` fan-out footer | the campaign's progress | the test's progress |
+| 9 | `TestingLaunchPanel.tsx` resolved copy | the campaign's progress | the test's progress |
+| 10 | `TestingLaunchPanel.tsx` resolved link | Campaigns | Tests |
+| 11 | `CampaignsPage.tsx` probing | Checking this daemon for campaigns… | …for tests… |
+| 12 | `CampaignsPage.tsx` unsupported | no campaign surface … predates campaign grouping … effort's | no test surface … predates test grouping … test's |
+| 13 | `CampaignScoreboard.tsx` loading | Loading campaign … | Loading test … |
+| 14 | `CampaignScoreboard.tsx` attached-row tooltip | Filed onto this campaign … the campaign never … | Filed onto this test … the test never … |
+| 15 | `api/testing.ts` `TESTING_UNSUPPORTED_COPY` | The Campaigns surface still works. | The Test surface still works. |
+
+Also swept while T30 was written: `CampaignsPage.tsx` "+N older" chip title (`N campaign(s)` →
+`N test(s)`) and the "No campaigns match" line (→ "No tests match").
+
+**Rail ＋ behavior (separate finding).** The ＋ navigated to the landing with no panel open. It now
+lands on `/testing/campaigns?new=test` and the landing opens the New-test panel; the "Run recon"
+row lands on `?new=recon`. Testids unchanged except `project-campaigns-crumb` (new);
+`testid-inventory.json` regenerated.
+
+## 8. Dependencies
+
+T1–T3 (pure folds) → T4 (the gate) → T5, T14–T20 (panel-level launch). T6 → T7, T11. T12/T13
+→ T27. T18 → T17 → T19. The whole deterministic layer must be green before spending daemon time
+on T21–T23 (curl) or T25–T29 (governed / Playwright) — a governed failure is hard to attribute if
+the cheap checks are not.
+
+## 9. Open questions surfaced while executing (not asserted, filed as follow-ups)
+
+- **Panel state across intents.** `CampaignsPage` renders one unkeyed `TestingLaunchPanel` for
+  both verbs, so switching Run recon ↔ New test keeps the brief, scope, error and *launched* state
+  under the other title. Keying the panel by intent (`key={panel}`) would give a fresh panel per
+  verb. Product decision pending; no test pins either behavior.
+- **Failed member lookup wording.** When `listProjectMembers` fails, the panel shows the
+  zero-repo warning ("This project holds no repositories") — true for an empty project, misleading
+  for an unreachable lookup. T6 asserts the wire (`projectId` still rides) and deliberately does
+  not pin the warning.
+- **Inactive `initialProjectId`.** An archived/unknown project id from a shell still rides the
+  wire (T12 pins this as the honest behavior — the daemon's named 404 surfaces). The select shows
+  "no project" while the state is scoped; a visible "project unavailable" hint would be clearer.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ChatsPage } from './components/ChatsPage.js';
 import { GateNotifications } from './components/GateNotifications.js';
 import { HomeBoard } from './components/HomeBoard.js';
 import { MadeDashboard } from './components/MadeDashboard.js';
-import { CampaignsPage } from './components/CampaignsPage.js';
+import { ProjectCampaignsView } from './components/ProjectCampaignsView.js';
 import { LeftSidebar } from './components/LeftSidebar.js';
 import { DocumentCanvas } from './components/DocumentCanvas.js';
 import { DocumentThread } from './components/DocumentThread.js';
@@ -50,7 +50,7 @@ import { useRunEventStore } from './store/events.js';
 import { useDocThreadStore } from './store/docThread.js';
 import type { CoreEvent, RepoEntry } from './api/types.js';
 import { readSteeringTypeFilter } from './api/steering.js';
-import { isTestingSubPage } from './api/testing.js';
+import { isTestingSubPage, readLaunchIntent } from './api/testing.js';
 import { api } from './api/client.js';
 import { useAppearanceStore } from './theming/appearance.js';
 import { useNotifPrefsStore } from './store/notifPrefs.js';
@@ -460,41 +460,11 @@ export function App(): React.ReactElement {
         </ProjectShell>
       );
     }
-    // `/p/:projectId/campaigns` (nav-reorg): the project-scoped Campaigns surface — the
-    // campaign scoreboard/list re-homed under the project shell. A campaign is a DAG workload,
-    // not a project, so this is a project-scoped VIEW (mode stays null — the ModeSwitcher's
-    // four verbs are untouched), reached from the project dashboard. The campaign store is not
-    // project-partitioned on the wire yet, so the surface renders the full campaign command
-    // surface framed by the project context; true per-project scoping is a data-layer follow-up.
+    // `/p/:projectId/campaigns` (nav-reorg): the project-scoped Test surface — the test landing
+    // re-homed under the project shell as a project-scoped VIEW (mode stays null), reached from
+    // the project dashboard. See `ProjectCampaignsView` for the scoping caveats.
     if (projectId !== null && campaignsView) {
-      return (
-        <div className="flex-1 overflow-y-auto" data-testid="project-campaigns" data-project-id={projectId}>
-          <div
-            style={{
-              display: 'flex', alignItems: 'center', gap: '8px',
-              padding: '10px 24px 0', flexShrink: 0,
-            }}
-          >
-            <button
-              type="button"
-              data-testid="project-campaigns-back"
-              onClick={() => navigate(`/p/${encodeURIComponent(projectId)}`)}
-              title="Back to the project dashboard"
-              style={{
-                background: 'transparent', border: 'none', color: 'var(--ink-dim)', cursor: 'pointer',
-                fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', padding: 0,
-              }}
-            >
-              ‹ Project
-            </button>
-            <span aria-hidden style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}>›</span>
-            <span style={{ color: 'var(--ink-high)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)' }}>
-              Campaigns
-            </span>
-          </div>
-          <CampaignsPage runs={runs} navigate={navigate} projectId={projectId} />
-        </div>
-      );
+      return <ProjectCampaignsView projectId={projectId} runs={runs} navigate={navigate} />;
     }
     // `/p/:projectId` with NO mode segment is the PROJECT DASHBOARD (DES-FEEDBACK-001
     // §4.1, slice D) — context before actions, replacing the last-used-mode redirect.
@@ -629,6 +599,8 @@ export function App(): React.ReactElement {
             campaignId={campaignId}
             runs={runs}
             navigate={navigate}
+            // The landing's `?new=` arrival intent (the rail's ＋ / Run recon row — #203).
+            launchIntent={readLaunchIntent(search)}
           />
         </div>
       );

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -59,6 +59,36 @@ export function campaignPath(id: string): string {
   return `${testingPath('campaigns')}/${encodeURIComponent(id)}`;
 }
 
+// ── The landing's arrival intent (client route vocabulary, not a wire) ────────────────────────
+
+/** The two launch panels the Test landing serves — `recon` ("Run recon") and `campaign` ("New
+ *  test"; the key stays the backend's grouping noun, the display is Test). */
+export type LaunchIntent = 'recon' | 'campaign';
+
+/**
+ * `?new=<word>` on the Test landing opens that intent's launch panel on arrival — the rail's ＋
+ * ("New Test") and its "Run recon" row ride it, so a create affordance actually creates instead
+ * of landing on a page with nothing open (wicked-studio#203). The words are the USER-facing
+ * vocabulary (`test`, never the backend's `campaign`); the landing consumes the query once it
+ * has opened the panel, so a second click from the landing itself re-fires.
+ */
+const LAUNCH_INTENT_PARAM = 'new';
+const LAUNCH_INTENT_WORD: Record<LaunchIntent, string> = { campaign: 'test', recon: 'recon' };
+
+/** The Test landing's address with `intent`'s launch panel pre-opened. */
+export function testingLaunchPath(intent: LaunchIntent): string {
+  return `${testingPath('campaigns')}?${LAUNCH_INTENT_PARAM}=${LAUNCH_INTENT_WORD[intent]}`;
+}
+
+/** The launch intent a `location.search` string carries, or `null` — an absent, bare or
+ *  foreign `?new=` opens nothing (a mangled bookmark shows the landing, not a panel). */
+export function readLaunchIntent(search: string): LaunchIntent | null {
+  const raw = new URLSearchParams(search).get(LAUNCH_INTENT_PARAM);
+  if (raw === null) return null;
+  const hit = (Object.keys(LAUNCH_INTENT_WORD) as LaunchIntent[]).find((k) => LAUNCH_INTENT_WORD[k] === raw);
+  return hit ?? null;
+}
+
 // ── The testing/campaign LAUNCH wire (the multi-codebase pin) ─────────────────────────────────
 
 /**
@@ -314,4 +344,4 @@ export function isTestingUnsupported(e: unknown): boolean {
 
 /** The honest in-band copy for {@link isTestingUnsupported} refusals. */
 export const TESTING_UNSUPPORTED_COPY =
-  'This daemon cannot run steering evals — the embedded engine predates the eval bindings (requires core-ts 0.7.5). The Campaigns surface still works.';
+  'This daemon cannot run steering evals — the embedded engine predates the eval bindings (requires core-ts 0.7.5). The Test surface still works.';

--- a/src/board/needsYou.ts
+++ b/src/board/needsYou.ts
@@ -274,7 +274,7 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
       kind: 'campaign',
       severity: SEVERITY.campaign,
       subject: c.def.name !== '' ? c.def.name : c.id,
-      text: `Campaign gaps — ${bits.join(' · ')} (${surplus} beyond the list below)`,
+      text: `Test gaps — ${bits.join(' · ')} (${surplus} beyond the list below)`,
       tone: n.awaitingHuman > 0 ? 'gate' : 'fail',
       // The engine campaign carries no clocks — age unknown, said honestly.
       at: null,
@@ -282,7 +282,7 @@ export function needsYouRows(inputs: NeedsYouInputs): NeedRow[] {
       action: {
         kind: 'open',
         path: `/testing/campaigns/${encodeURIComponent(c.id)}`,
-        label: 'Open campaign ›',
+        label: 'Open test ›',
       },
     });
   }

--- a/src/components/CampaignScoreboard.tsx
+++ b/src/components/CampaignScoreboard.tsx
@@ -191,8 +191,8 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
     return (
       <div data-testid="campaign-notfound" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
         <p style={{ marginBottom: '12px' }}>
-          No campaign is filed under <b style={{ color: 'var(--ink-high)' }}>{campaignId}</b> on
-          this daemon — a campaign appears with its first run, so this label either never
+          No test is filed under <b style={{ color: 'var(--ink-high)' }}>{campaignId}</b> on
+          this daemon — a test appears with its first run, so this label either never
           launched one or lives on another daemon.
         </p>
         <button
@@ -200,7 +200,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
           onClick={() => navigate(testingPath('campaigns'))}
           style={{ color: 'var(--status-run)', textDecoration: 'underline' }}
         >
-          All campaigns
+          All tests
         </button>
       </div>
     );
@@ -215,7 +215,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
   if (campaign === null) {
     return (
       <div data-testid="campaign-loading" style={{ padding: '32px', color: 'var(--ink-muted)' }}>
-        Loading campaign {campaignId}…
+        Loading test {campaignId}…
       </div>
     );
   }
@@ -409,7 +409,7 @@ export function CampaignScoreboard({ campaignId, runs, navigate }: Props): React
                     {row.kind === 'attached' && (
                       <span
                         style={{ marginLeft: '8px', color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}
-                        title="Filed onto this campaign at launch — not a DAG node; the campaign never schedules, gates or cancels it."
+                        title="Filed onto this test at launch — not a DAG node; the test never schedules, gates or cancels it."
                       >
                         attached
                       </span>

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { campaignPath } from '../api/testing.js';
+import { campaignPath, testingPath, type LaunchIntent } from '../api/testing.js';
 import type { SessionView } from '../api/types.js';
 import {
   campaignCards, campaignTotals, deliveryRollupWord, matchesCampaignChip, memberRunIdSet,
@@ -9,6 +9,7 @@ import {
 import { recentActivity } from '../board/homeActivity.js';
 import { outcomeOf } from '../board/metrics.js';
 import { healthColor, windowBuckets, windowDelta, deltaWord } from '../board/windowStats.js';
+import type { Navigate } from '../hooks/useRoute.js';
 import { rangeWord, useTimeRange } from '../hooks/useTimeRange.js';
 import { useCampaignsStore } from '../store/campaigns.js';
 import { useRunEventStore } from '../store/events.js';
@@ -25,7 +26,8 @@ import { TestingLaunchPanel } from './TestingLaunchPanel.js';
  * `/testing/campaigns` — THE Testing landing (the testing-UX wave), a COMMAND SURFACE with
  * the section-dashboard kit (`dashboardKit`, zero forks — the /projects //make grammar): a
  * KPI band under the three operator questions, the creation verbs in the header (Run recon /
- * New campaign / Add with chat — one panel open at a time), then a filterable grid where
+ * New test / Add with chat — one panel open at a time; a `?new=` arrival intent pre-opens one,
+ * see `readLaunchIntent`), then a filterable grid where
  * engine campaigns AND ad-hoc label groups (wicked-studio#27, api-types 0.19.0) render as one
  * sorted set of cards — needs-you first, attention routing before navigation.
  *
@@ -300,12 +302,15 @@ function CampaignCard({ m, narration, navigate }: {
 interface Props {
   /** The board's live run list — KPI windows, gate jumps and narration read it, zero extra fetches. */
   runs: SessionView[];
-  navigate: (path: string) => void;
+  navigate: Navigate;
   /** When rendered inside a project shell (`/p/:id/campaigns`), the project a new test auto-scopes to. */
   projectId?: string | null;
+  /** The `?new=` arrival intent (`readLaunchIntent`) — the rail's ＋ / "Run recon" row land here
+   *  with that launch panel OPEN. `null` = a plain arrival, nothing opens. */
+  launchIntent?: LaunchIntent | null;
 }
 
-export function CampaignsPage({ runs, navigate, projectId = null }: Props): React.ReactElement {
+export function CampaignsPage({ runs, navigate, projectId = null, launchIntent = null }: Props): React.ReactElement {
   const support = useCampaignsStore((s) => s.support);
   const campaigns = useCampaignsStore((s) => s.campaigns);
   const groups = useCampaignsStore((s) => s.groups);
@@ -323,6 +328,15 @@ export function CampaignsPage({ runs, navigate, projectId = null }: Props): Reac
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // The arrival intent (wicked-studio#203): a create affordance that lands here must land with
+  // its panel OPEN. Open it, then CONSUME the query — replace, so Back never re-opens the panel
+  // and a second ＋ click from this very page changes the address again and re-fires.
+  useEffect(() => {
+    if (launchIntent === null) return;
+    setPanel(launchIntent);
+    navigate(testingPath('campaigns'), { replace: true });
+  }, [launchIntent, navigate]);
 
   // ── The window (Work page idiom, over the CAMPAIGN/GROUP-member runs) ────────
   const runsById = useMemo(() => {
@@ -465,7 +479,7 @@ export function CampaignsPage({ runs, navigate, projectId = null }: Props): Reac
   if (support === 'unknown') {
     return (
       <div data-testid="campaigns-probing" style={{ padding: '24px', color: 'var(--ink-muted)' }}>
-        Checking this daemon for campaigns…
+        Checking this daemon for tests…
       </div>
     );
   }
@@ -477,9 +491,9 @@ export function CampaignsPage({ runs, navigate, projectId = null }: Props): Reac
       <div data-testid="campaigns-page" style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
         {header}
         <div data-testid="campaigns-unsupported" style={{ color: 'var(--ink-muted)', maxWidth: '640px' }}>
-          This daemon has no campaign surface — `GET /campaigns` is not served, which means the
-          connected wicked-crew predates campaign grouping. Launches still work; upgrade the
-          daemon to group a multi-run effort&rsquo;s sibling runs here.
+          This daemon has no test surface — `GET /campaigns` is not served, which means the
+          connected wicked-crew predates test grouping. Launches still work; upgrade the
+          daemon to group a multi-run test&rsquo;s sibling runs here.
         </div>
       </div>
     );
@@ -580,7 +594,7 @@ export function CampaignsPage({ runs, navigate, projectId = null }: Props): Reac
             type="button"
             data-testid="campaigns-show-older"
             onClick={() => setRange('all')}
-            title={`${hiddenByWindow} campaign${hiddenByWindow === 1 ? '' : 's'} with no run in the ${rangeWord(range)} window`}
+            title={`${hiddenByWindow} test${hiddenByWindow === 1 ? '' : 's'} with no run in the ${rangeWord(range)} window`}
             style={{
               borderRadius: 'var(--radius-full)', padding: '3px 10px',
               fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', cursor: 'pointer',
@@ -620,7 +634,7 @@ export function CampaignsPage({ runs, navigate, projectId = null }: Props): Reac
         </div>
       ) : visible.length === 0 ? (
         <p data-testid="campaigns-empty-filter" style={{ fontSize: '13px', color: S.faint, margin: 0 }}>
-          No campaigns match —{' '}
+          No tests match —{' '}
           <button
             type="button"
             onClick={() => { setChip('all'); setQuery(''); setRange('all'); }}

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -320,6 +320,11 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
 
   const [panel, setPanel] = useState<PanelKind>(null);
   const openPanel = (p: Exclude<PanelKind, null>): void => setPanel((cur) => (cur === p ? null : p));
+  // Counts `?new=` ARRIVALS (not intents): part of the launch panel's `key`, so a re-arrival on
+  // an already-open panel remounts a FRESH launch instance instead of `setPanel(same)` no-op-ing
+  // onto one that has already launched (or errored) — the rail's ＋ after a successful launch
+  // must start a second test, not re-show the first one's "launched" state (#210 review).
+  const [arrival, setArrival] = useState(0);
 
   const [query, setQuery] = useState('');
   const [chip, setChip] = useState<CampaignChip>('all');
@@ -332,9 +337,12 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
   // The arrival intent (wicked-studio#203): a create affordance that lands here must land with
   // its panel OPEN. Open it, then CONSUME the query — replace, so Back never re-opens the panel
   // and a second ＋ click from this very page changes the address again and re-fires.
+  // Consuming is also what makes EVERY ＋ click a distinct arrival (`null → intent → null`), so
+  // repeated same-intent arrivals each bump `arrival` and each get a fresh panel.
   useEffect(() => {
     if (launchIntent === null) return;
     setPanel(launchIntent);
+    setArrival((n) => n + 1);
     navigate(testingPath('campaigns'), { replace: true });
   }, [launchIntent, navigate]);
 
@@ -461,8 +469,11 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
         </button>
       </div>
 
+      {/* Keyed by intent AND arrival: a new `?new=` arrival, or switching the verb (recon ⇄ test),
+          is a NEW launch instance — a launched/errored panel never carries over into the next ask. */}
       {(panel === 'recon' || panel === 'campaign') && (
         <TestingLaunchPanel
+          key={`${panel}:${arrival}`}
           intent={panel}
           navigate={navigate}
           onClose={() => setPanel(null)}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -903,7 +903,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   if (groupAttach.campaignId !== undefined || groupAttach.groupLabel !== undefined) {
     activePills.push({
       label: groupAttach.campaignId !== undefined
-        ? `Campaign: ${groupAttach.campaignId}`
+        ? `Test: ${groupAttach.campaignId}`
         : `Group: ${groupAttach.groupLabel!}`,
       onClear: () => { setGroupChoice(''); setNewGroupLabel(''); },
       attrs: { 'data-testid': 'group-pill' },

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -8,7 +8,7 @@ import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { useProjectsStore } from '../store/projects.js';
 import { memoriesPath, policiesPath, steeringDashboardPath, STEERING_SECTIONS, STEERING_SECTION_LABELS, type SteeringSection } from '../api/steering.js';
-import { testingPath } from '../api/testing.js';
+import { testingLaunchPath, testingPath } from '../api/testing.js';
 import { AppChrome } from './AppChrome.js';
 import { isChatRun } from './ChatsPage.js';
 import { HealthRailSection } from './HealthRailSection.js';
@@ -98,7 +98,8 @@ const P_REPOS: PathSpec    = { key: 'repos',    title: 'Repositories', noun: 'Re
 // Test — the campaign/recon testing capability as a standalone WORK section (usability wave):
 // project-optional (recon takes an optional project), placed right below Execute. Routes to the
 // existing `/testing/campaigns` page; the rail split (headingForPath) keeps it distinct from Evals.
-const P_TEST: PathSpec      = { key: 'test',     title: 'Test',         noun: 'Campaign',   glyph: '✓', dash: testingPath('campaigns'), collapsedHref: testingPath('campaigns') };
+// The noun is the DISPLAY word (＋ = "New Test", #203) — the route keeps the backend's `campaigns`.
+const P_TEST: PathSpec      = { key: 'test',     title: 'Test',         noun: 'Test',       glyph: '✓', dash: testingPath('campaigns'), collapsedHref: testingPath('campaigns') };
 // Evals — steering-rule evals, moved beside Steering (a SYSTEM concept, not a work one). Glyph ◈.
 const P_TESTING: PathSpec  = { key: 'testing',  title: 'Evals',        noun: 'Eval',       glyph: '◈', dash: testingPath('evals'), collapsedHref: testingPath('evals') };
 // Steering (DES-MEM-FACETED-001, unified surface): the governed-knowledge home, a PRIMARY path
@@ -495,10 +496,11 @@ function EvalsRailRows({ navigate }: { navigate: (p: string) => void }): React.R
   );
 }
 
-/** The Test accordion's shortcut row (usability wave): a "Run recon" launcher into the campaigns
- *  landing — Test works WITHOUT a project (recon takes an optional one), so it lives here as a
- *  standalone work section. The ▦ links the campaigns dashboard; this row is the create verb's
- *  sibling. Same grammar as {@link EvalsRailRows}. */
+/** The Test accordion's shortcut row (usability wave): a "Run recon" launcher into the test
+ *  landing WITH the recon panel open (`?new=recon` — a launcher launches, #203) — Test works
+ *  WITHOUT a project (recon takes an optional one), so it lives here as a standalone work
+ *  section. The ▦ links the test dashboard; this row is the create verb's sibling. Same grammar
+ *  as {@link EvalsRailRows}. */
 function TestRailRows({ navigate }: { navigate: (p: string) => void }): React.ReactElement {
   return (
     <div role="menu" className="flex flex-col pt-0.5">
@@ -506,7 +508,7 @@ function TestRailRows({ navigate }: { navigate: (p: string) => void }): React.Re
         type="button"
         role="menuitem"
         data-testid="rail-test-recon"
-        onClick={() => navigate(testingPath('campaigns'))}
+        onClick={() => navigate(testingLaunchPath('recon'))}
         className="w-full text-left px-6 py-1.5 rounded text-xs font-mono transition-colors hover:bg-surface-raised hover:text-ink-body focus-visible:outline-none focus-visible:bg-surface-raised focus-visible:text-ink-body"
         style={{ color: 'var(--ink-muted)' }}
       >
@@ -719,13 +721,14 @@ export function LeftSidebar({ runs, navigate, pathname, runPath = flatRunPath, i
             <ViewAll href="/execute" navigate={navigate} />
           </RailHeading>
 
-          {/* ── Test — campaigns/recon as a standalone work section (usability wave): below Execute,
-                 works with or without a project. ＋ launches a recon into the campaigns landing. ── */}
+          {/* ── Test — tests/recon as a standalone work section (usability wave): below Execute,
+                 works with or without a project. ＋ ("New Test") lands on the test landing with the
+                 New-test panel OPEN (`?new=test`, #203) — a create affordance creates. ── */}
           <RailHeading
             path={P_TEST}
             open={openHeading === 'test'}
             onToggle={() => toggle('test')}
-            onNew={() => navigate(testingPath('campaigns'))}
+            onNew={() => navigate(testingLaunchPath('campaign'))}
             navigate={navigate}
           >
             <TestRailRows navigate={navigate} />

--- a/src/components/NeedsYouQueue.tsx
+++ b/src/components/NeedsYouQueue.tsx
@@ -14,7 +14,7 @@ import { humanTitle } from './runIdentity.js';
  *   gate         → Open gate › (the run's approval dock — `…#gate`)
  *   failed run   → Retry › (Retry-as-prefill: deposits, navigates, POSTS NOTHING)
  *   repo graph   → Re-index › (the same prefill idiom) / Open repo ›
- *   campaign     → Open campaign ›
+ *   campaign     → Open test › (the engine campaign, rendered in Test vocabulary — #203)
  *   stalled chat → Open chat ›
  *
  * THE CONTRADICTION GUARD IS STRUCTURAL: this component receives the fold's

--- a/src/components/ProjectCampaignsView.tsx
+++ b/src/components/ProjectCampaignsView.tsx
@@ -1,0 +1,53 @@
+import type { SessionView } from '../api/types.js';
+import type { Navigate } from '../hooks/useRoute.js';
+import { CampaignsPage } from './CampaignsPage.js';
+
+/**
+ * `/p/:projectId/campaigns` (nav-reorg): the project-scoped Test surface — the test landing
+ * re-homed under the project shell. A test (an engine campaign) is a DAG workload, not a
+ * project, so this is a project-scoped VIEW (mode stays null — the ModeSwitcher's four verbs are
+ * untouched), reached from the project dashboard's "Test" door. The campaign store is not
+ * project-partitioned on the wire yet, so the surface renders the full test command surface
+ * framed by the project context; true per-project scoping is a data-layer follow-up. What the
+ * project DOES scope today is creation: `CampaignsPage` pre-selects it in the launch panel.
+ *
+ * The route and testids keep the backend's `campaigns` vocabulary; every rendered word says
+ * Test (wicked-studio#203).
+ */
+export function ProjectCampaignsView({ projectId, runs, navigate }: {
+  projectId: string;
+  runs: SessionView[];
+  navigate: Navigate;
+}): React.ReactElement {
+  return (
+    <div className="flex-1 overflow-y-auto" data-testid="project-campaigns" data-project-id={projectId}>
+      <div
+        style={{
+          display: 'flex', alignItems: 'center', gap: '8px',
+          padding: '10px 24px 0', flexShrink: 0,
+        }}
+      >
+        <button
+          type="button"
+          data-testid="project-campaigns-back"
+          onClick={() => navigate(`/p/${encodeURIComponent(projectId)}`)}
+          title="Back to the project dashboard"
+          style={{
+            background: 'transparent', border: 'none', color: 'var(--ink-dim)', cursor: 'pointer',
+            fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)', padding: 0,
+          }}
+        >
+          ‹ Project
+        </button>
+        <span aria-hidden style={{ color: 'var(--ink-dim)', fontSize: 'var(--text-xs)' }}>›</span>
+        <span
+          data-testid="project-campaigns-crumb"
+          style={{ color: 'var(--ink-high)', fontSize: 'var(--text-xs)', fontFamily: 'var(--font-sans)' }}
+        >
+          Tests
+        </span>
+      </div>
+      <CampaignsPage runs={runs} navigate={navigate} projectId={projectId} />
+    </div>
+  );
+}

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -6,6 +6,7 @@ import {
   launchedRunIds,
   MULTI_SCOPE_UNSUPPORTED_COPY,
   testingPath,
+  type LaunchIntent,
   type TestingLaunchBody,
   type TestingLaunchResult,
 } from '../api/testing.js';
@@ -51,7 +52,9 @@ export const TEST_PROBLEM_PREFIX =
   'approved plan as governed sibling runs under one test. Present the plan at the ' +
   'intake gate and launch nothing until it is approved.';
 
-export type LaunchIntent = 'recon' | 'campaign';
+// The intent vocabulary lives with the route helpers (`testingLaunchPath` / `readLaunchIntent`
+// in `../api/testing.ts`); re-exported here so the panel's callers read one name.
+export type { LaunchIntent };
 
 const INTENT_COPY: Record<LaunchIntent, { title: string; blurb: string; cta: string; prefix: string }> = {
   recon: {
@@ -423,12 +426,12 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
           </div>
           <p className="text-[10px]" style={{ color: 'var(--ink-muted)' }}>
             Each sibling stops at its own intake gate — gates surface everywhere gates do, and
-            the campaign&rsquo;s progress lands on this page.
+            the test&rsquo;s progress lands on this page.
           </p>
         </div>
       ) : resolved ? (
         <p data-testid="testing-launch-resolved" className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
-          Intake gate answered — the campaign&rsquo;s progress lands on{' '}
+          Intake gate answered — the test&rsquo;s progress lands on{' '}
           <button
             type="button"
             data-testid="testing-launch-to-campaigns"
@@ -436,7 +439,7 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
             className="underline"
             style={{ color: 'var(--accent)' }}
           >
-            Campaigns
+            Tests
           </button>
           , and the run itself is at{' '}
           <button
@@ -456,7 +459,7 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
         </p>
       ) : (
         // The intake gate — the EXISTING gate card, reused verbatim. Approving (optionally
-        // with steer text) is what launches the proposed campaign; rejecting launches nothing.
+        // with steer text) is what launches the proposed test; rejecting launches nothing.
         <SteeringGate
           runId={gateRunId!}
           ord={gate.ord}

--- a/src/components/TestingPage.tsx
+++ b/src/components/TestingPage.tsx
@@ -11,8 +11,10 @@ import {
   type EvalReport,
   type EvalResult,
   type EvalSample,
+  type LaunchIntent,
   type TestingSubPage,
 } from '../api/testing.js';
+import type { Navigate } from '../hooks/useRoute.js';
 import { useEvalReportStore } from '../store/evalReport.js';
 import { CampaignScoreboard } from './CampaignScoreboard.js';
 import { CampaignsPage } from './CampaignsPage.js';
@@ -473,13 +475,15 @@ function EvalsPage({ navigate }: { navigate: (path: string) => void }): React.Re
 
 // ── The page ──────────────────────────────────────────────────────────────────────────────────
 
-export function TestingPage({ page, campaignId, runs, navigate }: {
+export function TestingPage({ page, campaignId, runs, navigate, launchIntent = null }: {
   page: TestingSubPage;
   /** Non-null only on `/testing/campaigns/:id` — renders that campaign's scoreboard. */
   campaignId: string | null;
   /** The board's live run list — the campaign landing + scoreboard read live status from it. */
   runs: SessionView[];
-  navigate: (path: string) => void;
+  navigate: Navigate;
+  /** The landing's `?new=` arrival intent (`readLaunchIntent(search)`) — opens that launch panel. */
+  launchIntent?: LaunchIntent | null;
 }): React.ReactElement {
   return (
     <div data-testid="testing-page" data-testing-page={page} className="flex flex-col">
@@ -497,7 +501,7 @@ export function TestingPage({ page, campaignId, runs, navigate }: {
         campaignId !== null ? (
           <CampaignScoreboard campaignId={campaignId} runs={runs} navigate={navigate} />
         ) : (
-          <CampaignsPage runs={runs} navigate={navigate} />
+          <CampaignsPage runs={runs} navigate={navigate} launchIntent={launchIntent} />
         )
       ) : (
         <div className="max-w-5xl px-6 py-4">

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.1",
   "counts": {
-    "files": 129,
-    "occurrences": 1041,
-    "static": 885,
+    "files": 130,
+    "occurrences": 1042,
+    "static": 886,
     "dynamic": 56,
     "computed": 6
   },
@@ -3018,13 +3018,19 @@
     {
       "testId": "project-campaigns",
       "files": [
-        "src/App.tsx"
+        "src/components/ProjectCampaignsView.tsx"
       ]
     },
     {
       "testId": "project-campaigns-back",
       "files": [
-        "src/App.tsx"
+        "src/components/ProjectCampaignsView.tsx"
+      ]
+    },
+    {
+      "testId": "project-campaigns-crumb",
+      "files": [
+        "src/components/ProjectCampaignsView.tsx"
       ]
     },
     {

--- a/tests/CampaignScoreboard.test.tsx
+++ b/tests/CampaignScoreboard.test.tsx
@@ -242,7 +242,7 @@ describe('honest degradation', () => {
     const navigate = vi.fn();
     board([], navigate);
     await waitFor(() => expect(screen.getByTestId('campaign-notfound')).toBeInTheDocument());
-    fireEvent.click(screen.getByText('All campaigns'));
+    fireEvent.click(screen.getByText('All tests'));
     expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
   });
 

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -143,6 +143,29 @@ describe('the ?new= arrival intent (#203) — a create affordance lands with its
     expect(screen.getByTestId('testing-launch-panel')).toHaveAttribute('data-intent', 'campaign');
   });
 
+  it('a REPEATED same-intent arrival remounts a fresh panel (typed text gone, query consumed again) — while consuming the query alone keeps the open instance', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+    const navigate = vi.fn();
+    const { rerender } = render(<CampaignsPage runs={[]} navigate={navigate} launchIntent="campaign" />);
+    const first = await screen.findByTestId('testing-launch-panel');
+    expect(navigate).toHaveBeenCalledTimes(1);
+
+    // The App re-renders with the consumed (null) intent — same instance, the operator's typing survives.
+    rerender(<CampaignsPage runs={[]} navigate={navigate} launchIntent={null} />);
+    expect(screen.getByTestId('testing-launch-panel')).toBe(first);
+    fireEvent.change(within(first).getByTestId('testing-launch-instructions'), { target: { value: 'half-typed' } });
+    expect(within(first).getByTestId('testing-launch-instructions')).toHaveValue('half-typed');
+
+    // The rail ＋ again (`null → campaign`): a NEW arrival = a NEW launch instance, consumed once more.
+    rerender(<CampaignsPage runs={[]} navigate={navigate} launchIntent="campaign" />);
+    const fresh = await screen.findByTestId('testing-launch-panel');
+    expect(fresh).not.toBe(first);
+    expect(fresh).toHaveAttribute('data-intent', 'campaign');
+    expect(within(fresh).getByTestId('testing-launch-instructions')).toHaveValue('');
+    expect(navigate).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenLastCalledWith('/testing/campaigns', { replace: true });
+  });
+
   it('the intent-opened panel is the same one the verb toggles — clicking "New test" again closes it', async () => {
     listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     render(<CampaignsPage runs={[]} navigate={vi.fn()} launchIntent="campaign" />);

--- a/tests/CampaignsPage.test.tsx
+++ b/tests/CampaignsPage.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { SessionView } from '../src/api/types.js';
 import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
+import { deferred } from './deferred.js';
 import { makeView } from './factories.js';
 
 /**
@@ -61,24 +62,94 @@ beforeEach(() => {
 });
 afterEach(() => cleanup());
 
-describe('the §1.5 probe states', () => {
-  it('404 renders the honest "daemon predates campaigns" copy — and the creation verbs STAY usable', async () => {
+describe('T24 — the §1.5 probe states', () => {
+  it('T24 — while probing: the probing line ALONE (no verbs, no grid), ONE GET /campaigns on mount; the answer swaps it for the page', async () => {
+    const probe = deferred<unknown>();
+    listCampaigns.mockReturnValue(probe.promise);
+    page();
+    expect(screen.getByTestId('campaigns-probing')).toBeInTheDocument();
+    expect(screen.queryByTestId('campaigns-page')).toBeNull();
+    expect(screen.queryByTestId('testing-campaign-open')).toBeNull();
+    expect(listCampaigns).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      probe.resolve({ campaigns: [], groups: [] });
+      await probe.promise;
+    });
+    await screen.findByTestId('campaigns-page');
+    expect(screen.queryByTestId('campaigns-probing')).toBeNull();
+    expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument();
+    // Mount probes once — the store's in-flight guard, not a second fetch.
+    expect(listCampaigns).toHaveBeenCalledTimes(1);
+  });
+
+  it('T24 — 404 renders the honest "daemon predates tests" copy — and the creation verbs STAY usable', async () => {
     listCampaigns.mockRejectedValue(new ApiError(404, 'Not Found'));
     page();
     await waitFor(() => expect(screen.getByTestId('campaigns-unsupported')).toBeInTheDocument());
-    expect(screen.getByTestId('campaigns-unsupported').textContent).toContain('predates campaign grouping');
+    expect(screen.getByTestId('campaigns-unsupported').textContent).toContain('predates test grouping');
     expect(screen.getByTestId('testing-recon-open')).toBeInTheDocument();
     expect(screen.getByTestId('testing-campaign-open')).toBeInTheDocument();
     expect(screen.getByTestId('testing-author-open')).toBeInTheDocument();
   });
 
-  it('200 with empty lists is the "no tests yet" answer, with a CTA that opens the New test flow', async () => {
+  it('T24 — 200 with empty lists is the "no tests yet" answer, with a CTA that opens the New test flow', async () => {
     listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     page();
     await waitFor(() => expect(screen.getByTestId('campaigns-empty')).toBeInTheDocument());
     expect(screen.getByTestId('campaigns-empty').textContent).toContain('run recon over a codebase');
     fireEvent.click(screen.getByTestId('campaigns-empty-cta'));
     expect(await screen.findByTestId('testing-launch-panel')).toHaveAttribute('data-intent', 'campaign');
+  });
+
+  it('T24 — 200 with tests renders the full command surface: the KPI band, the filter strip and the grid', async () => {
+    listCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign('alpha', [{ status: 'completed', runId: 'run-1' }])],
+      groups: [],
+    });
+    page(() => {}, [view('run-1', 'completed')]);
+    await screen.findByTestId('campaigns-kpis');
+    expect(screen.getByTestId('stat-campaigns')).toHaveAttribute('data-value', '1');
+    expect(screen.getAllByTestId('campaigns-filter-chip').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('campaign-card')).toHaveLength(1);
+    expect(screen.queryByTestId('campaigns-empty')).toBeNull();
+    expect(screen.queryByTestId('campaigns-unsupported')).toBeNull();
+  });
+});
+
+describe('the ?new= arrival intent (#203) — a create affordance lands with its panel OPEN', () => {
+  it.each(['campaign', 'recon'] as const)('launchIntent=%s opens that launch panel on arrival and CONSUMES the query with ONE replace navigation', async (intent) => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+    const navigate = vi.fn();
+    render(<CampaignsPage runs={[]} navigate={navigate} launchIntent={intent} />);
+    expect(await screen.findByTestId('testing-launch-panel')).toHaveAttribute('data-intent', intent);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns', { replace: true });
+  });
+
+  it('a plain arrival (no intent) opens nothing and navigates nowhere', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+    const navigate = vi.fn();
+    render(<CampaignsPage runs={[]} navigate={navigate} />);
+    await screen.findByTestId('campaigns-page');
+    expect(screen.queryByTestId('testing-launch-panel')).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('the intent is honored on a daemon WITHOUT the campaign surface too — the creation verbs stay usable there (§1.5)', async () => {
+    listCampaigns.mockRejectedValue(new ApiError(404, 'Not Found'));
+    render(<CampaignsPage runs={[]} navigate={vi.fn()} launchIntent="campaign" />);
+    await screen.findByTestId('campaigns-unsupported');
+    expect(screen.getByTestId('testing-launch-panel')).toHaveAttribute('data-intent', 'campaign');
+  });
+
+  it('the intent-opened panel is the same one the verb toggles — clicking "New test" again closes it', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+    render(<CampaignsPage runs={[]} navigate={vi.fn()} launchIntent="campaign" />);
+    await screen.findByTestId('testing-launch-panel');
+    expect(screen.getByTestId('testing-campaign-open')).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(screen.getByTestId('testing-campaign-open'));
+    expect(screen.queryByTestId('testing-launch-panel')).toBeNull();
   });
 });
 

--- a/tests/ChatInput.group.test.tsx
+++ b/tests/ChatInput.group.test.tsx
@@ -73,7 +73,8 @@ describe('ChatInput launch form — ad-hoc grouping (#27)', () => {
     const user = userEvent.setup();
     render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
     await user.selectOptions(screen.getByTestId('group-attach'), 'c:camp-1');
-    expect(screen.getByTestId('group-pill').textContent).toContain('Campaign: camp-1');
+    // The pill speaks the Test vocabulary (#203) — the wire key stays `campaignId`.
+    expect(screen.getByTestId('group-pill').textContent).toContain('Test: camp-1');
     const body = await typeAndLaunch(user);
     expect(body.campaignId).toBe('camp-1');
     expect('groupLabel' in body).toBe(false);

--- a/tests/LeftSidebar.rail.test.tsx
+++ b/tests/LeftSidebar.rail.test.tsx
@@ -298,11 +298,30 @@ describe('the ＋ create actions (§2.1/§3.4)', () => {
     expect(navigate).toHaveBeenCalledWith('/chat/new');
     fireEvent.click(within(screen.getByTestId('rail-heading-repos')).getByTestId('heading-new'));
     expect(navigate).toHaveBeenCalledWith('/repos/new');
-    // Test ＋ → the campaigns/recon landing (project-optional).
+    // Test ＋ → the test landing WITH the New-test panel open (`?new=test`, #203) — a create
+    // affordance creates; it never lands on a page with nothing open.
     fireEvent.click(within(screen.getByTestId('rail-heading-test')).getByTestId('heading-new'));
-    expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns?new=test');
     // Evals is a system section now — dashboard only, no ＋.
     expect(within(screen.getByTestId('rail-heading-testing')).queryByTestId('heading-new')).toBeNull();
+  });
+
+  it('T30 — the Test ＋ is labelled "New Test" (aria-label + title), never "New Campaign" (#203)', async () => {
+    rail();
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    const plus = within(screen.getByTestId('rail-heading-test')).getByTestId('heading-new');
+    expect(plus).toHaveAttribute('aria-label', 'New Test');
+    expect(plus).toHaveAttribute('title', 'New Test');
+  });
+
+  it('the Test accordion\'s "Run recon" row lands on the test landing with the recon panel open (`?new=recon`)', async () => {
+    const navigate = vi.fn();
+    rail({ pathname: '/testing/campaigns', navigate });
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    const test = screen.getByTestId('rail-heading-test');
+    expect(test.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(within(test).getByTestId('rail-test-recon'));
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns?new=recon');
   });
 
   it('Vibe ＋ opens a project-picker locked to Document; Demo ＋ one locked to Video', async () => {

--- a/tests/ProjectCampaignsView.test.tsx
+++ b/tests/ProjectCampaignsView.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, renderHook, screen, within } from '@testing-library/react';
+import { useRoute } from '../src/hooks/useRoute.js';
+import { expectTestVocabulary } from './renameGuard.js';
+
+/**
+ * T13 — the project-shell route wiring for the project-scoped Test surface (`/p/:id/campaigns`):
+ * `useRoute` parses the address to `{projectId, campaignsView: true}` with NO mode (a project-scoped
+ * VIEW, not a fifth verb), and `ProjectCampaignsView` — what App renders for that route — frames
+ * `CampaignsPage` with the project, so a "New test" there pre-selects it (T12's contract, reached
+ * through the route). The breadcrumb speaks Test (#203); the route + testids keep the backend's
+ * `campaigns` vocabulary.
+ */
+
+const listCampaigns = vi.fn();
+vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/campaigns.js')>()),
+  listCampaigns: () => listCampaigns() as Promise<unknown>,
+}));
+
+const listProjectMembers = vi.fn();
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: () => Promise.resolve({ repos: [] }),
+    listProjects: () => Promise.resolve({
+      projects: [{
+        id: 'proj-1', name: 'Merge the skins', description: null, status: 'active',
+        scope: 'project:proj-1', created_at: 1, updated_at: 1,
+      }],
+    }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+  },
+  apiFetch: () => Promise.reject(new Error('not wired in this suite')),
+}));
+
+const { ProjectCampaignsView } = await import('../src/components/ProjectCampaignsView.js');
+const { useCampaignsStore } = await import('../src/store/campaigns.js');
+
+function routeAt(path: string): ReturnType<typeof useRoute> {
+  window.history.replaceState(null, '', path);
+  return renderHook(() => useRoute()).result.current;
+}
+
+beforeEach(() => {
+  listCampaigns.mockReset();
+  listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+  listProjectMembers.mockReset();
+  listProjectMembers.mockResolvedValue({
+    members: [{ id: 1, project_id: 'proj-1', member_kind: 'crew.repo', member_ref: 'r-1' }],
+  });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
+});
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('T13 — useRoute: /p/:projectId/campaigns', () => {
+  it('T13 — parses to the project with campaignsView and NO mode/run — the flag selects the surface', () => {
+    expect(routeAt('/p/proj-1/campaigns')).toMatchObject({
+      projectId: 'proj-1', campaignsView: true, mode: null, runId: null, artifactId: null, showLaunch: false,
+    });
+  });
+
+  it('T13 — decodes the project id; a mode route and the top-level landing never claim campaignsView', () => {
+    expect(routeAt('/p/my%20proj/campaigns')).toMatchObject({ projectId: 'my proj', campaignsView: true });
+    expect(routeAt('/p/proj-1/build')).toMatchObject({ projectId: 'proj-1', campaignsView: false, mode: 'build' });
+    expect(routeAt('/testing/campaigns')).toMatchObject({ panel: 'testing', projectId: null, campaignsView: false });
+  });
+});
+
+describe('T13 — ProjectCampaignsView: the project frames the test landing', () => {
+  it('T13 — renders the project-campaigns container for the project, a "Tests" crumb, and a back door to the dashboard', async () => {
+    const navigate = vi.fn();
+    render(<ProjectCampaignsView projectId="proj-1" runs={[]} navigate={navigate} />);
+    expect(screen.getByTestId('project-campaigns')).toHaveAttribute('data-project-id', 'proj-1');
+    expect(screen.getByTestId('project-campaigns-crumb')).toHaveTextContent('Tests');
+    fireEvent.click(screen.getByTestId('project-campaigns-back'));
+    expect(navigate).toHaveBeenCalledWith('/p/proj-1');
+    // The landing mounts inside it — its probe runs and the page renders.
+    await screen.findByTestId('campaigns-page');
+  });
+
+  it('T13 → T12 — "New test" from the project shell pre-selects THIS project and resolves its repos as via-project chips', async () => {
+    render(<ProjectCampaignsView projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await screen.findByTestId('campaigns-page');
+    fireEvent.click(screen.getByTestId('testing-campaign-open'));
+    const panel = await screen.findByTestId('testing-launch-panel');
+    const select = within(panel).getByTestId('testing-launch-project') as HTMLSelectElement;
+    await within(select).findByRole('option', { name: 'Merge the skins' });
+    expect(select.value).toBe('proj-1');
+    expect(listProjectMembers).toHaveBeenCalledWith('proj-1');
+    const chips = await within(panel).findAllByTestId('testing-launch-chip');
+    expect(chips.map((c) => c.dataset.repo)).toEqual(['r-1']);
+    expect(chips[0]!.dataset.source).toBe('project');
+  });
+
+  it('T30 — nothing rendered in the project frame says "Campaign" (the route + testids keep the word; the copy does not)', async () => {
+    render(<ProjectCampaignsView projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await screen.findByTestId('campaigns-page');
+    expectTestVocabulary(screen.getByTestId('project-campaigns'));
+  });
+});

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -1132,9 +1132,14 @@ describe('the landing header verbs — the Harness, folded in', () => {
     await user.click(within(fresh).getByTestId('testing-launch-unscoped'));
     await user.click(within(fresh).getByTestId('testing-launch-submit'));
     expect(await screen.findByTestId('testing-launch-waiting')).toHaveTextContent(/run-seco/);
-    expect(bodySentTo('/testing/recon')).toMatchObject({ problem: `${TEST_PROBLEM_PREFIX}\n\nFirst pass` });
-    const bodies = apiFetch.mock.calls.filter(([p]) => p === '/testing/recon');
+    // Two launches, two bodies, IN ORDER: each shortcut arrival sent its own brief. (Asserting
+    // only the first body here would pass even if the second panel re-sent the first brief.)
+    const bodies = apiFetch.mock.calls
+      .filter(([p]) => p === '/testing/recon')
+      .map(([, init]) => JSON.parse((init as { body?: string }).body ?? 'null') as { problem: string });
     expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toMatchObject({ problem: `${TEST_PROBLEM_PREFIX}\n\nFirst pass` });
+    expect(bodies[1]).toMatchObject({ problem: `${TEST_PROBLEM_PREFIX}\n\nSecond pass` });
   });
 
   it('switching the verb after a launch (recon launched → "New test") is a fresh test panel, never a launched recon wearing the test title', async () => {

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ApiError } from '../src/api/errors.js';
 import { useGateStore } from '../src/store/gates.js';
+import { deferred } from './deferred.js';
 
 /**
  * The testing LAUNCH flow (the testing-UX wave) — the Harness folded into the Campaigns
@@ -22,6 +23,9 @@ import { useGateStore } from '../src/store/gates.js';
  *
  * NEVER submits against a live daemon — every wire here is a mock, and the assertions pin the
  * BODY the client sends, byte-for-byte as parsed JSON.
+ *
+ * Scenario ids (T5–T12, T14–T20) refer to the Tests-feature plan's deterministic layer
+ * (docs/testing/tests-feature-test-plan.md); T1–T4 live in testingLaunch.wire.test.ts.
  */
 
 const launchRun = vi.fn();
@@ -45,9 +49,39 @@ vi.mock('../src/api/client.js', () => ({
 }));
 
 const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
-const { RECON_PROBLEM_PREFIX, TEST_PROBLEM_PREFIX } = await import('../src/components/TestingLaunchPanel.js');
-const { MULTI_SCOPE_UNSUPPORTED_COPY, launchedRunIds, isMultiScopeUnsupported } = await import('../src/api/testing.js');
+const { RECON_PROBLEM_PREFIX, TEST_PROBLEM_PREFIX, TestingLaunchPanel } = await import('../src/components/TestingLaunchPanel.js');
+const { MULTI_SCOPE_UNSUPPORTED_COPY, isMultiScopeUnsupported } = await import('../src/api/testing.js');
 const { useCampaignsStore } = await import('../src/store/campaigns.js');
+
+type User = ReturnType<typeof userEvent.setup>;
+
+/** The one crew.repo member the project fixtures carry, unless a case says otherwise. */
+const MEMBER_R1 = { members: [{ id: 1, project_id: 'proj-a', member_kind: 'crew.repo', member_ref: 'r-1' }] };
+
+/** Attach one registered repo through the picker: search by name, click its one option. */
+async function attach(user: User, panel: HTMLElement, name: string): Promise<void> {
+  await user.type(within(panel).getByTestId('testing-launch-repo-search'), name);
+  await user.click(await within(panel).findByTestId('testing-launch-repo-option'));
+}
+
+/** Pick a project once its option has loaded (`''` clears the selection). */
+async function pick(user: User, panel: HTMLElement, id: string, optionName: string): Promise<void> {
+  const select = within(panel).getByTestId('testing-launch-project');
+  await within(select).findByRole('option', { name: optionName });
+  await user.selectOptions(select, id);
+}
+
+/** The panel on its own (no landing around it) — for the onLaunched / intake-gate contracts. */
+function panelOnly(over: Partial<Parameters<typeof TestingLaunchPanel>[0]> = {}): void {
+  render(<TestingLaunchPanel intent="campaign" navigate={() => {}} onClose={() => {}} {...over} />);
+}
+
+/** An awaitingHuman frame for `runId` lands on the app's one /ws fold. */
+function gateArrives(runId: string, prompt = 'Proposed plan: 3 scenarios — approve to launch'): void {
+  act(() => {
+    useGateStore.getState().ingest({ type: 'awaitingHuman', session: runId, ord: 1, prompt } as never);
+  });
+}
 
 /** The POST body sent to `path`, parsed — the pinned-body assertions read this. */
 function bodySentTo(path: string): unknown {
@@ -127,7 +161,7 @@ async function openPanel(user: ReturnType<typeof userEvent.setup>, verb: string)
 }
 
 describe('the launch wire — the pinned body on POST /testing/recon, exactly', () => {
-  it('recon + ONE explicit repo sends the PINNED repoRefs (the strict recon zod knows no bare repoRef)', async () => {
+  it('T5 — recon + ONE explicit repo sends the PINNED repoRefs (the strict recon zod knows no bare repoRef)', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-recon-1', runIds: ['run-recon-1'], campaign: 'recon-abc' });
     landing();
@@ -146,7 +180,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     });
   });
 
-  it('multiple explicit repos send the PINNED repoRefs (deduped, no repoRef, no projectId)', async () => {
+  it('T5 — multiple explicit repos send the PINNED repoRefs (deduped, no repoRef, no projectId)', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-1', runIds: ['run-1', 'run-2'] });
     landing();
@@ -167,7 +201,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     });
   });
 
-  it('the project selector resolves the project’s repos as locked via-project chips and sends projectId ALONE (crew resolves server-side)', async () => {
+  it('T5/T6 — the project selector resolves the project’s repos as locked via-project chips and sends projectId ALONE (crew resolves server-side)', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-p' });
     listProjectMembers.mockResolvedValue({
@@ -204,7 +238,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     });
   });
 
-  it('a project-scoped page PRE-SELECTS that project in the launch panel — create a test from a project (usability wave)', async () => {
+  it('T12 — a project-scoped page PRE-SELECTS that project in the launch panel — create a test from a project (usability wave)', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-scoped' });
     render(<CampaignsPage runs={[]} navigate={() => {}} projectId="proj-a" />);
@@ -215,7 +249,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     expect(select.value).toBe('proj-a');
   });
 
-  it('project + extra explicit repos = the UNION body {problem, projectId, repoRefs} exactly', async () => {
+  it('T5 — project + extra explicit repos = the UNION body {problem, projectId, repoRefs} exactly', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-u', runIds: ['run-u', 'run-v', 'run-w'] });
     listProjectMembers.mockResolvedValue({
@@ -243,7 +277,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
     });
   });
 
-  it('unscoped is EXPLICIT: the button gates on scope until the operator opts out, then NEITHER field rides', async () => {
+  it('T5/T10 — unscoped is EXPLICIT: the button gates on scope until the operator opts out, then NEITHER field rides', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'run-un' });
     landing();
@@ -261,7 +295,7 @@ describe('the launch wire — the pinned body on POST /testing/recon, exactly', 
 });
 
 describe('fan-out honesty — runIds is the source of truth', () => {
-  it('a multi-repo launch renders "N runs launched under <label>" with a real link per run', async () => {
+  it('T14 — a multi-repo launch renders "N runs launched under <label>" with a real link per run', async () => {
     const user = userEvent.setup();
     const navigate = vi.fn();
     wireUp({ runId: 'run-a', runIds: ['run-a', 'run-b', 'run-c'], campaign: 'checkout-hardening' });
@@ -283,17 +317,11 @@ describe('fan-out honesty — runIds is the source of truth', () => {
     await user.click(links[1]!);
     expect(navigate).toHaveBeenCalledWith('/runs/run-b');
   });
-
-  it('launchedRunIds folds both spellings: runIds ≥ 1 wins; else the legacy runId; else nothing', () => {
-    expect(launchedRunIds({ runId: 'a', runIds: ['x', 'y'] })).toEqual(['x', 'y']);
-    expect(launchedRunIds({ runId: 'a', runIds: [] })).toEqual(['a']);
-    expect(launchedRunIds({ runId: 'a' })).toEqual(['a']);
-    expect(launchedRunIds({})).toEqual([]);
-  });
+  // T2 (`launchedRunIds`, the fold itself) is pinned in testingLaunch.wire.test.ts.
 });
 
 describe('the presence-gate — an older crew (no POST /testing/recon) keeps today’s flow working', () => {
-  it('a ONE-repo launch falls back to the shipping POST /runs with the legacy repoRef spelling, and the {runId}-only old-crew answer lands in the intake-gate flow, no crash', async () => {
+  it('T4c/T17/T19 — a ONE-repo launch falls back to the shipping POST /runs with the legacy repoRef spelling, and the {runId}-only old-crew answer lands in the intake-gate flow, no crash', async () => {
     const user = userEvent.setup();
     // The BUNDLED daemon's unknown-route shape: crew's SPA-serving notFoundHandler answers
     // `{error: 'not found'}` (lowercase) — the production old-crew wire, pinned here so the
@@ -330,10 +358,10 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
     expect(gate).toHaveAttribute('data-run-id', 'run-old-1');
     await user.click(within(gate).getByTestId('steering-approve'));
     await waitFor(() => expect(confirmGate).toHaveBeenCalledWith('run-old-1', { approve: true }));
-    expect(await screen.findByTestId('testing-launch-resolved')).toHaveTextContent(/Campaigns/);
+    expect(await screen.findByTestId('testing-launch-resolved')).toHaveTextContent(/Tests/);
   });
 
-  it('an UNSCOPED launch falls back too — the legacy body carries no repoRef at all', async () => {
+  it('T4c — an UNSCOPED launch falls back too — the legacy body carries no repoRef at all', async () => {
     const user = userEvent.setup();
     wireUpOldCrew({ runId: 'run-old-2' });
     landing();
@@ -347,7 +375,7 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
     expect(bodySentTo('/runs')).toEqual({ problem: `${RECON_PROBLEM_PREFIX}\n\nSurvey it all` });
   });
 
-  it('a MULTI-CODEBASE scope on the old daemon renders the honest named gap — and never launches half a scope over /runs', async () => {
+  it('T4d/T20 — a MULTI-CODEBASE scope on the old daemon renders the honest named gap — and never launches half a scope over /runs', async () => {
     const user = userEvent.setup();
     wireUpOldCrew({ runId: 'never-launched' });
     landing();
@@ -360,14 +388,15 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
     }
     await user.click(within(panel).getByTestId('testing-launch-submit'));
 
-    expect(await screen.findByTestId('testing-launch-error')).toHaveTextContent(/predates multi-codebase launches/);
+    // T20: the pinned copy, VERBATIM — the surface renders the constant, never a paraphrase.
+    expect((await screen.findByTestId('testing-launch-error')).textContent).toBe(MULTI_SCOPE_UNSUPPORTED_COPY);
     // Fail-closed: a silently narrowed one-repo launch is exactly what the pin forbids.
     expect(apiFetch.mock.calls.some(([p]) => p === '/runs')).toBe(false);
     // The form stays live — retrying with a single repo is the way through.
     expect(within(panel).getByTestId('testing-launch-submit')).toBeEnabled();
   });
 
-  it('a PROJECT scope on the old daemon is the same named gap (POST /runs projectId means filing, not repo resolution)', async () => {
+  it('T4b/T20 — a PROJECT scope on the old daemon is the same named gap (POST /runs projectId means filing, not repo resolution)', async () => {
     const user = userEvent.setup();
     wireUpOldCrew({ runId: 'never-launched' });
     listProjectMembers.mockResolvedValue({
@@ -386,7 +415,7 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
     expect(apiFetch.mock.calls.some(([p]) => p === '/runs')).toBe(false);
   });
 
-  it('a NAMED 400 from a daemon WITH the route (a bad ref) surfaces verbatim — a real answer, not a gap', async () => {
+  it('T3/T4 — a NAMED 400 from a daemon WITH the route (a bad ref) surfaces verbatim — a real answer, not a gap', async () => {
     const user = userEvent.setup();
     wireUp(new ApiError(400, "repoRefs: 'r-2' does not name a registered repo — register it first"));
     landing();
@@ -405,7 +434,7 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
     expect(MULTI_SCOPE_UNSUPPORTED_COPY).toMatch(/one repository per launch/);
   });
 
-  it('a NAMED 404 from the recon route ("unknown project") is a real answer — never mistaken for route absence, never retried over /runs', async () => {
+  it('T4 — a NAMED 404 from the recon route ("unknown project") is a real answer — never mistaken for route absence, never retried over /runs', async () => {
     const user = userEvent.setup();
     wireUp(new ApiError(404, 'unknown project: proj-a'));
     listProjectMembers.mockResolvedValue({
@@ -422,6 +451,615 @@ describe('the presence-gate — an older crew (no POST /testing/recon) keeps tod
 
     expect(await screen.findByTestId('testing-launch-error')).toHaveTextContent(/unknown project: proj-a/);
     expect(apiFetch.mock.calls.some(([p]) => p === '/runs')).toBe(false);
+  });
+});
+
+// ── The panel alone: the scope matrix, the picker, the consent, the response boundaries ───────
+
+const INTENTS = ['recon', 'campaign'] as const;
+const PREFIX_OF = { recon: RECON_PROBLEM_PREFIX, campaign: TEST_PROBLEM_PREFIX } as const;
+
+/** `[repo, source]` per chip, in render order. */
+function chipsOf(panel: HTMLElement): string[][] {
+  return within(panel).getAllByTestId('testing-launch-chip').map((c) => [c.dataset.repo ?? '', c.dataset.source ?? '']);
+}
+
+/** The picker's option repo ids, in render order. */
+function optionIds(panel: HTMLElement): string[] {
+  return within(panel).getAllByTestId('testing-launch-repo-option').map((o) => o.dataset.repo ?? '');
+}
+
+/** Type the brief, opt into unscoped when nothing is attached, submit. */
+async function brief(user: User, panel: HTMLElement, text: string, { unscoped = false } = {}): Promise<void> {
+  await user.type(within(panel).getByTestId('testing-launch-instructions'), text);
+  if (unscoped) await user.click(within(panel).getByTestId('testing-launch-unscoped'));
+  await user.click(within(panel).getByTestId('testing-launch-submit'));
+}
+
+/** A launch whose HTTP answer the test settles (the standalone panel needs no `/campaigns`). */
+function wireUpDeferred(): ReturnType<typeof deferred<unknown>> {
+  const d = deferred<unknown>();
+  apiFetch.mockImplementation((path: unknown) =>
+    String(path) === '/testing/recon' ? d.promise : Promise.reject(new ApiError(404, 'Not Found')));
+  return d;
+}
+
+describe('T5 — the wire-body matrix: every scope shape × both intents, exact keys, trimmed brief', () => {
+  it.each(INTENTS)('T5 — %s + project ONLY → {problem, projectId}: no repoRefs key rides', async (intent) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-5', runIds: ['run-5'] });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly({ intent });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await pick(user, panel, 'proj-a', 'alpha');
+    await within(panel).findAllByTestId('testing-launch-chip');
+    await brief(user, panel, 'Project only');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${PREFIX_OF[intent]}\n\nProject only`, projectId: 'proj-a' });
+  });
+
+  it.each(INTENTS)('T5 — %s + explicit repos ONLY → {problem, repoRefs} in attach order: no projectId key rides', async (intent) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-5', runIds: ['run-5'] });
+    panelOnly({ intent });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await attach(user, panel, 'repo-two');
+    await attach(user, panel, 'repo-one');
+    await brief(user, panel, 'Explicit only');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${PREFIX_OF[intent]}\n\nExplicit only`, repoRefs: ['r-2', 'r-1'] });
+  });
+
+  it.each(INTENTS)('T5 — %s + project AND an extra repo → the UNION {problem, projectId, repoRefs}; repoRefs holds only the extras (the picker never offers the project\'s own repo)', async (intent) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-5', runIds: ['run-5'] });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly({ intent });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await pick(user, panel, 'proj-a', 'alpha');
+    await within(panel).findAllByTestId('testing-launch-chip');
+    await attach(user, panel, 'repo-two');
+    await brief(user, panel, 'Union');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${PREFIX_OF[intent]}\n\nUnion`, projectId: 'proj-a', repoRefs: ['r-2'] });
+  });
+
+  it.each(INTENTS)('T5 — %s unscoped (the explicit opt-in) → {problem} alone', async (intent) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-5', runIds: ['run-5'] });
+    panelOnly({ intent });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Everything', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${PREFIX_OF[intent]}\n\nEverything` });
+  });
+
+  it.each(INTENTS)('T5 — %s: the brief is TRIMMED and framed "<prefix>\\n\\n<brief>" — surrounding whitespace never rides', async (intent) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-5', runIds: ['run-5'] });
+    panelOnly({ intent });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, '   Trim me   ', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${PREFIX_OF[intent]}\n\nTrim me` });
+  });
+});
+
+describe('T7 — an explicit attachment the project ALSO carries (attached FIRST, then the project picked)', () => {
+  it('T7 — folds into the ONE locked via-project chip while the project is selected, resurfaces as a removable explicit chip when the project is cleared, and rides repoRefs alone then', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-7' });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+
+    await attach(user, panel, 'repo-one');
+    expect(chipsOf(panel)).toEqual([['r-1', 'explicit']]);
+    expect(within(panel).getByTestId('testing-launch-chip-remove')).toHaveAttribute('data-repo', 'r-1');
+
+    await pick(user, panel, 'proj-a', 'alpha');
+    // ONE chip, locked — no explicit twin, no remove button.
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['r-1', 'project']]));
+    expect(within(panel).queryByTestId('testing-launch-chip-remove')).toBeNull();
+    // The picker will not offer it again — it is in scope through the project.
+    await user.type(within(panel).getByTestId('testing-launch-repo-search'), 'repo-one');
+    expect(within(panel).queryByTestId('testing-launch-repo-option')).toBeNull();
+    await user.clear(within(panel).getByTestId('testing-launch-repo-search'));
+
+    await pick(user, panel, '', 'no project');
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['r-1', 'explicit']]));
+    expect(within(panel).getByTestId('testing-launch-chip-remove')).toHaveAttribute('data-repo', 'r-1');
+
+    await brief(user, panel, 'Seven');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nSeven`, repoRefs: ['r-1'] });
+  });
+
+  it('T7 — while the project is selected the redundant explicit ref STILL rides repoRefs — the daemon\'s union dedupes; the client never silently drops an operator\'s attachment', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-7' });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await attach(user, panel, 'repo-one');
+    await pick(user, panel, 'proj-a', 'alpha');
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['r-1', 'project']]));
+    await brief(user, panel, 'Seven again');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nSeven again`, projectId: 'proj-a', repoRefs: ['r-1'] });
+  });
+});
+
+describe('T8 — the multi-repo picker search', () => {
+  const MANY = {
+    repos: Array.from({ length: 10 }, (_, i) => ({
+      id: `m-${i}`, name: `many-${i}`, root_path: `/tmp/m${i}`, default_branch: 'main', registered_at: i + 1,
+    })),
+  };
+
+  it('T8 — matches name OR id case-insensitively, capped at 8 options; a miss or a blank query renders NO matches list', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'never-sent' });
+    listRepos.mockResolvedValue(MANY);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    const search = within(panel).getByTestId('testing-launch-repo-search');
+    expect(within(panel).queryByTestId('testing-launch-repo-matches')).toBeNull();
+
+    await user.type(search, 'MANY');
+    await waitFor(() => expect(optionIds(panel)).toHaveLength(8));
+    expect(optionIds(panel)).toEqual(['m-0', 'm-1', 'm-2', 'm-3', 'm-4', 'm-5', 'm-6', 'm-7']);
+
+    await user.clear(search);
+    await user.type(search, 'm-3');
+    expect(optionIds(panel)).toEqual(['m-3']);
+
+    await user.clear(search);
+    await user.type(search, 'zzz');
+    expect(within(panel).queryByTestId('testing-launch-repo-matches')).toBeNull();
+
+    await user.clear(search);
+    await user.type(search, '   ');
+    expect(within(panel).queryByTestId('testing-launch-repo-matches')).toBeNull();
+  });
+
+  it('T8 — attached and project-carried repos are excluded from the options; picking one clears the query', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'never-sent' });
+    listRepos.mockResolvedValue(MANY);
+    listProjectMembers.mockResolvedValue({
+      members: [{ id: 1, project_id: 'proj-a', member_kind: 'crew.repo', member_ref: 'm-1' }],
+    });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    const search = within(panel).getByTestId('testing-launch-repo-search');
+
+    await attach(user, panel, 'many-0');
+    expect(search).toHaveValue('');
+    expect(chipsOf(panel)).toEqual([['m-0', 'explicit']]);
+    await pick(user, panel, 'proj-a', 'alpha');
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['m-1', 'project'], ['m-0', 'explicit']]));
+
+    await user.type(search, 'many');
+    // m-0 (attached) and m-1 (via project) are gone; the cap still holds over the rest.
+    expect(optionIds(panel)).toEqual(['m-2', 'm-3', 'm-4', 'm-5', 'm-6', 'm-7', 'm-8', 'm-9']);
+  });
+});
+
+describe('T9 — the unscoped opt-in shows exactly while the launch is unscoped', () => {
+  it('T9 — attaching a repo hides it; removing the last repo brings it back UNCHECKED (attaching reset the consent)', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'never-sent' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    const box = (): HTMLElement | null => within(panel).queryByTestId('testing-launch-unscoped');
+
+    expect(box()).toBeInTheDocument();
+    await user.click(box()!);
+    expect(box()).toBeChecked();
+
+    await attach(user, panel, 'repo-one');
+    expect(box()).toBeNull();
+
+    await user.click(within(panel).getByTestId('testing-launch-chip-remove'));
+    expect(box()).toBeInTheDocument();
+    expect(box()).not.toBeChecked();
+  });
+
+  it('T9 — selecting a project hides it; clearing the project brings it back UNCHECKED', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'never-sent' });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    const box = (): HTMLElement | null => within(panel).queryByTestId('testing-launch-unscoped');
+
+    await user.click(box()!);
+    expect(box()).toBeChecked();
+    await pick(user, panel, 'proj-a', 'alpha');
+    expect(box()).toBeNull();
+    await pick(user, panel, '', 'no project');
+    expect(box()).toBeInTheDocument();
+    expect(box()).not.toBeChecked();
+  });
+});
+
+describe('T10 — submit gating and the launch boundaries', () => {
+  it('T10 — a whitespace-only brief never launches; a real brief needs a scope OR the opt-in; dropping the scope drops the consent too', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'never-sent' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    const submit = (): HTMLElement => within(panel).getByTestId('testing-launch-submit');
+    const instructions = within(panel).getByTestId('testing-launch-instructions');
+
+    expect(submit()).toBeDisabled();
+    await user.type(instructions, '   ');
+    await user.click(within(panel).getByTestId('testing-launch-unscoped'));
+    expect(submit()).toBeDisabled();
+
+    await user.clear(instructions);
+    await user.type(instructions, 'Real brief');
+    expect(submit()).toBeEnabled();
+
+    await attach(user, panel, 'repo-one');
+    expect(submit()).toBeEnabled();
+    // Attaching reset the consent — removing the repo leaves neither scope nor opt-in.
+    await user.click(within(panel).getByTestId('testing-launch-chip-remove'));
+    expect(submit()).toBeDisabled();
+    expect(within(panel).getByTestId('testing-launch-unscoped')).not.toBeChecked();
+    expect(apiFetch.mock.calls.some(([p]) => p === '/testing/recon')).toBe(false);
+  });
+
+  it('T10 — a double click sends ONE launch and onLaunched fires exactly once; the button reads "Launching…" and is disabled in flight', async () => {
+    const user = userEvent.setup();
+    const d = wireUpDeferred();
+    const onLaunched = vi.fn();
+    panelOnly({ onLaunched });
+    const panel = screen.getByTestId('testing-launch-panel');
+    const submit = within(panel).getByTestId('testing-launch-submit');
+
+    await brief(user, panel, 'Once', { unscoped: true });
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveTextContent('Launching…');
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    expect(apiFetch.mock.calls.filter(([p]) => p === '/testing/recon')).toHaveLength(1);
+
+    await act(async () => {
+      d.resolve({ runId: 'run-once' });
+      await d.promise;
+    });
+    await screen.findByTestId('testing-launch-waiting');
+    expect(onLaunched).toHaveBeenCalledTimes(1);
+    expect(onLaunched).toHaveBeenCalledWith(['run-once']);
+    expect(apiFetch.mock.calls.filter(([p]) => p === '/testing/recon')).toHaveLength(1);
+  });
+
+  it('T10 — a failed launch leaves the form live with the daemon\'s sentence; the retry clears it and launches', async () => {
+    const user = userEvent.setup();
+    let attempts = 0;
+    apiFetch.mockImplementation((path: unknown) => {
+      if (String(path) !== '/testing/recon') return Promise.reject(new ApiError(404, 'Not Found'));
+      attempts += 1;
+      return attempts === 1
+        ? Promise.reject(new ApiError(500, 'internal error'))
+        : Promise.resolve({ runId: 'run-retry' });
+    });
+    const onLaunched = vi.fn();
+    panelOnly({ onLaunched });
+    const panel = screen.getByTestId('testing-launch-panel');
+
+    await brief(user, panel, 'Retry me', { unscoped: true });
+    expect(await screen.findByTestId('testing-launch-error')).toHaveTextContent('internal error');
+    expect(onLaunched).not.toHaveBeenCalled();
+    const submit = within(panel).getByTestId('testing-launch-submit');
+    expect(submit).toBeEnabled();
+
+    await user.click(submit);
+    await screen.findByTestId('testing-launch-waiting');
+    expect(within(panel).queryByTestId('testing-launch-error')).toBeNull();
+    expect(onLaunched).toHaveBeenCalledTimes(1);
+    expect(attempts).toBe(2);
+  });
+});
+
+describe('T11 — the zero-repo project warning', () => {
+  it('T11 — absent while the members resolve, shown for a project with no crew.repo member (a run member does not count), cleared by an explicit attachment — which then rides the union', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-11' });
+    const members = deferred<unknown>();
+    listProjectMembers.mockReturnValue(members.promise);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+
+    await pick(user, panel, 'proj-a', 'alpha');
+    expect(within(panel).getByTestId('testing-launch-chips')).toHaveTextContent('resolving project repos…');
+    expect(within(panel).queryByTestId('testing-launch-project-empty')).toBeNull();
+
+    await act(async () => {
+      members.resolve({ members: [{ id: 9, project_id: 'proj-a', member_kind: 'crew.run', member_ref: 'run-x' }] });
+      await members.promise;
+    });
+    expect(await within(panel).findByTestId('testing-launch-project-empty')).toHaveTextContent('holds no repositories');
+    expect(within(panel).queryByTestId('testing-launch-chip')).toBeNull();
+    expect(within(panel).queryByText('resolving project repos…')).toBeNull();
+
+    await attach(user, panel, 'repo-two');
+    expect(within(panel).queryByTestId('testing-launch-project-empty')).toBeNull();
+
+    await brief(user, panel, 'Eleven');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nEleven`, projectId: 'proj-a', repoRefs: ['r-2'] });
+  });
+});
+
+describe('T12/T6 — initialProjectId and the asynchronous project scope', () => {
+  it('T12 — initialProjectId pre-selects the project once its option loads, resolves its repos, and rides the wire with no click', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-12' });
+    listProjectMembers.mockResolvedValue(MEMBER_R1);
+    panelOnly({ initialProjectId: 'proj-a' });
+    const panel = screen.getByTestId('testing-launch-panel');
+    const select = within(panel).getByTestId('testing-launch-project') as HTMLSelectElement;
+    await within(select).findByRole('option', { name: 'alpha' });
+    expect(select.value).toBe('proj-a');
+    expect(listProjectMembers).toHaveBeenCalledWith('proj-a');
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['r-1', 'project']]));
+    expect(within(panel).queryByTestId('testing-launch-unscoped')).toBeNull();
+
+    await brief(user, panel, 'From the shell');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nFrom the shell`, projectId: 'proj-a' });
+  });
+
+  it('T12 — an initialProjectId that is not an active project still names it on the wire — the daemon is the authority (its named 404 surfaces verbatim); the client never silently unscopes', async () => {
+    const user = userEvent.setup();
+    wireUp(new ApiError(404, 'unknown project: proj-z'));
+    panelOnly({ initialProjectId: 'proj-z' });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('proj-z'));
+    expect(within(panel).queryByTestId('testing-launch-unscoped')).toBeNull();
+
+    await brief(user, panel, 'Stale shell');
+    expect(await screen.findByTestId('testing-launch-error')).toHaveTextContent('unknown project: proj-z');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nStale shell`, projectId: 'proj-z' });
+  });
+
+  it('T6 — rapid switching: a late members answer for the PREVIOUS project is discarded; the wire carries the current one', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-6' });
+    listProjects.mockResolvedValue({
+      projects: [
+        { id: 'proj-a', name: 'alpha', description: null, status: 'active', scope: 'project:proj-a', created_at: 1, updated_at: 1 },
+        { id: 'proj-b', name: 'beta', description: null, status: 'active', scope: 'project:proj-b', created_at: 1, updated_at: 1 },
+      ],
+    });
+    const late = deferred<unknown>();
+    listProjectMembers.mockImplementation((id: unknown) =>
+      id === 'proj-a'
+        ? late.promise
+        : Promise.resolve({ members: [{ id: 2, project_id: 'proj-b', member_kind: 'crew.repo', member_ref: 'r-2' }] }));
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+
+    await pick(user, panel, 'proj-a', 'alpha');
+    await pick(user, panel, 'proj-b', 'beta');
+    await waitFor(() => expect(chipsOf(panel)).toEqual([['r-2', 'project']]));
+    await act(async () => {
+      late.resolve({ members: [{ id: 1, project_id: 'proj-a', member_kind: 'crew.repo', member_ref: 'r-1' }] });
+      await late.promise;
+    });
+    expect(chipsOf(panel)).toEqual([['r-2', 'project']]);
+
+    await brief(user, panel, 'Switched');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nSwitched`, projectId: 'proj-b' });
+  });
+
+  it('T6 — a failed member lookup leaves no chips and no "resolving" line; the launch still rides projectId (the chips were only ever a preview — the daemon resolves the scope)', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-6f' });
+    listProjectMembers.mockRejectedValue(new ApiError(500, 'members store unavailable'));
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+
+    await pick(user, panel, 'proj-a', 'alpha');
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('proj-a'));
+    await waitFor(() => expect(within(panel).queryByText('resolving project repos…')).toBeNull());
+    expect(within(panel).queryByTestId('testing-launch-chip')).toBeNull();
+
+    await brief(user, panel, 'Blind project');
+    await screen.findByTestId('testing-launch-waiting');
+    expect(launchBody()).toEqual({ problem: `${TEST_PROBLEM_PREFIX}\n\nBlind project`, projectId: 'proj-a' });
+  });
+});
+
+describe('T14–T16 — fan-out and response honesty (the answer decides, never the request)', () => {
+  it('T14 — a fan-out NEVER renders an inline gate, even as sibling gates arrive — each shows where gates show', async () => {
+    const user = userEvent.setup();
+    wireUp({ runIds: ['run-a', 'run-b'], campaign: 'suite-1' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await attach(user, panel, 'repo-one');
+    await attach(user, panel, 'repo-two');
+    await brief(user, panel, 'Fan out');
+    const fanout = await screen.findByTestId('testing-launch-fanout');
+
+    gateArrives('run-a');
+    gateArrives('run-b');
+    expect(within(panel).queryByTestId('steering-gate')).toBeNull();
+    expect(within(panel).queryByTestId('testing-launch-waiting')).toBeNull();
+    expect(fanout).toBeInTheDocument();
+    // The app's one gate fold DID take them — this panel just is not where they render.
+    expect(useGateStore.getState().gates['run-a']).toBeDefined();
+    expect(useGateStore.getState().gates['run-b']).toBeDefined();
+  });
+
+  it.each([
+    ['no campaign field', { runIds: ['run-a', 'run-b'] }],
+    ['a non-string campaign field', { runIds: ['run-a', 'run-b'], campaign: 7 }],
+  ])('T15 — a fan-out with %s says so plainly and never fabricates a label', async (_label, answer) => {
+    const user = userEvent.setup();
+    wireUp(answer);
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await attach(user, panel, 'repo-one');
+    await attach(user, panel, 'repo-two');
+    await brief(user, panel, 'Unlabelled');
+    const fanout = await screen.findByTestId('testing-launch-fanout');
+    expect(fanout).toHaveTextContent('2 runs launched — one per attached codebase, under one test.');
+    expect(within(fanout).queryByTestId('testing-launch-fanout-label')).toBeNull();
+    expect(within(fanout).getAllByTestId('testing-launch-fanout-run').map((l) => l.dataset.runId)).toEqual(['run-a', 'run-b']);
+  });
+
+  it.each([
+    ['{}', {}],
+    ['{runIds: []}', { runIds: [] }],
+    ['{runId: ""}', { runId: '' }],
+    ['{runIds: [""], runId: ""}', { runIds: [''], runId: '' }],
+  ])('T16 — a 200 answering %s is an ERROR, not a silent no-op: onLaunched never fires, the form stays live', async (_label, answer) => {
+    const user = userEvent.setup();
+    wireUp(answer);
+    const onLaunched = vi.fn();
+    panelOnly({ onLaunched });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'No id', { unscoped: true });
+
+    expect(await screen.findByTestId('testing-launch-error')).toHaveTextContent('answered without a run id');
+    expect(onLaunched).not.toHaveBeenCalled();
+    expect(within(panel).queryByTestId('testing-launch-waiting')).toBeNull();
+    expect(within(panel).queryByTestId('testing-launch-fanout')).toBeNull();
+    expect(within(panel).getByTestId('testing-launch-submit')).toBeEnabled();
+  });
+
+  it('T16 — a multi-repo REQUEST answered with ONE id keeps the single-run intake-gate flow', async () => {
+    const user = userEvent.setup();
+    wireUp({ runIds: ['run-solo'] });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await attach(user, panel, 'repo-one');
+    await attach(user, panel, 'repo-two');
+    await brief(user, panel, 'Two asked, one answered');
+    expect(await screen.findByTestId('testing-launch-waiting')).toHaveTextContent('run-solo');
+    expect(within(panel).queryByTestId('testing-launch-fanout')).toBeNull();
+  });
+});
+
+describe('T17–T19 — the single-run intake gate: the EXISTING SteeringGate card, reused', () => {
+  it('T18 — before the gate arrives: the waiting line names the run; no gate card yet', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-1234567890' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Wait', { unscoped: true });
+    const waiting = await screen.findByTestId('testing-launch-waiting');
+    expect(waiting).toHaveTextContent('run-1234');
+    expect(waiting).toHaveTextContent('intake gate will appear here');
+    expect(within(panel).queryByTestId('steering-gate')).toBeNull();
+  });
+
+  it('T17 — the awaitingHuman frame for THIS run swaps the waiting line for the ONE SteeringGate (prompt in-band); a frame for another run changes nothing', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-1' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Gate me', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+
+    gateArrives('run-other');
+    expect(within(panel).queryByTestId('steering-gate')).toBeNull();
+    expect(within(panel).getByTestId('testing-launch-waiting')).toBeInTheDocument();
+
+    gateArrives('run-1', 'Proposed plan: 3 scenarios — approve to launch');
+    const gates = await within(panel).findAllByTestId('steering-gate');
+    expect(gates).toHaveLength(1);
+    expect(gates[0]).toHaveAttribute('data-run-id', 'run-1');
+    expect(within(gates[0]!).getByTestId('steering-prompt')).toHaveTextContent('Proposed plan: 3 scenarios');
+    expect(within(panel).queryByTestId('testing-launch-waiting')).toBeNull();
+  });
+
+  it('T17 — a gate that lands BEFORE the launch response resolves renders the moment the run id is known', async () => {
+    const user = userEvent.setup();
+    const d = wireUpDeferred();
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Early gate', { unscoped: true });
+    gateArrives('run-early');
+    await act(async () => {
+      d.resolve({ runId: 'run-early' });
+      await d.promise;
+    });
+    expect(await within(panel).findByTestId('steering-gate')).toHaveAttribute('data-run-id', 'run-early');
+    expect(within(panel).queryByTestId('testing-launch-waiting')).toBeNull();
+  });
+
+  const DECISIONS: Array<[label: string, button: string, amend: string | undefined, decision: Record<string, unknown>]> = [
+    ['approve', 'steering-approve', undefined, { approve: true }],
+    ['approve + steer', 'steering-approve-steer', 'focus on the checkout flow', { approve: true, amend: 'focus on the checkout flow' }],
+    ['reject', 'steering-reject', undefined, { approve: false }],
+    ['reject + note', 'steering-reject', 'the proposed plan is too broad', { approve: false, amend: 'the proposed plan is too broad' }],
+  ];
+
+  it.each(DECISIONS)('T19 — %s → confirmGate(runId, %j) exactly once, then the resolved copy with working doors to the Tests landing and the run', async (_label, button, amend, decision) => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-1' });
+    confirmGate.mockResolvedValue({ status: 'ok' });
+    const navigate = vi.fn();
+    panelOnly({ navigate });
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Decide', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+    gateArrives('run-1');
+    const gate = await within(panel).findByTestId('steering-gate');
+    if (amend !== undefined) await user.type(within(gate).getByTestId('steering-amend'), amend);
+    await user.click(within(gate).getByTestId(button));
+
+    await waitFor(() => expect(confirmGate).toHaveBeenCalledWith('run-1', decision));
+    expect(confirmGate).toHaveBeenCalledTimes(1);
+    expect(cancelRun).not.toHaveBeenCalled();
+    const resolved = await within(panel).findByTestId('testing-launch-resolved');
+    expect(within(panel).queryByTestId('steering-gate')).toBeNull();
+    const [toTests, toRun] = within(resolved).getAllByRole('button');
+    expect(toTests).toHaveTextContent('Tests');
+    await user.click(toTests!);
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns');
+    await user.click(toRun!);
+    expect(navigate).toHaveBeenCalledWith('/runs/run-1');
+  });
+
+  it('T19 — Cancel run is the BODYLESS POST /runs/:id/cancel (no gate decision), and resolves the panel too', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-1' });
+    cancelRun.mockResolvedValue({ status: 'cancelled' });
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Cancel', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+    gateArrives('run-1');
+    await user.click(within(await within(panel).findByTestId('steering-gate')).getByTestId('steering-cancel'));
+
+    await waitFor(() => expect(cancelRun).toHaveBeenCalledWith('run-1'));
+    expect(cancelRun.mock.calls[0]).toHaveLength(1);
+    expect(confirmGate).not.toHaveBeenCalled();
+    await within(panel).findByTestId('testing-launch-resolved');
+  });
+
+  it('T19 — a refused decision keeps the gate up with the daemon\'s sentence — nothing resolves', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-1' });
+    confirmGate.mockRejectedValue(new ApiError(409, 'gate already decided'));
+    panelOnly();
+    const panel = screen.getByTestId('testing-launch-panel');
+    await brief(user, panel, 'Refused', { unscoped: true });
+    await screen.findByTestId('testing-launch-waiting');
+    gateArrives('run-1');
+    const gate = await within(panel).findByTestId('steering-gate');
+    await user.click(within(gate).getByTestId('steering-approve'));
+
+    expect(await within(gate).findByTestId('steering-error')).toHaveTextContent('gate already decided');
+    expect(within(panel).getByTestId('steering-gate')).toBeInTheDocument();
+    expect(within(panel).queryByTestId('testing-launch-resolved')).toBeNull();
   });
 });
 

--- a/tests/TestingLaunch.test.tsx
+++ b/tests/TestingLaunch.test.tsx
@@ -1094,6 +1094,68 @@ describe('the landing header verbs — the Harness, folded in', () => {
     });
   });
 
+  it('a second ?new=test after a SUCCESSFUL launch is a FRESH panel — the rail ＋ starts a second test (#210 review)', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-first', runIds: ['run-first'] });
+    const navigate = vi.fn();
+    // The App's real prop flow: the ＋ lands `?new=test` → the landing opens the panel and
+    // consumes the query with ONE replace → the App re-renders the landing with a null intent.
+    const { rerender } = render(<CampaignsPage runs={[]} navigate={navigate} launchIntent="campaign" />);
+    const first = await screen.findByTestId('testing-launch-panel');
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/testing/campaigns', { replace: true });
+    rerender(<CampaignsPage runs={[]} navigate={navigate} launchIntent={null} />);
+    // Consuming the query keeps the SAME open instance — no flicker, no reset mid-typing.
+    expect(screen.getByTestId('testing-launch-panel')).toBe(first);
+
+    await user.type(within(first).getByTestId('testing-launch-instructions'), 'First pass');
+    await user.click(within(first).getByTestId('testing-launch-unscoped'));
+    await user.click(within(first).getByTestId('testing-launch-submit'));
+    expect(await screen.findByTestId('testing-launch-waiting')).toHaveTextContent(/run-firs/);
+
+    // The rail ＋ again: `?new=test` re-arrives on the landing whose panel is ALREADY open and
+    // sitting in its launched state. Before the fix `setPanel('campaign')` was a no-op and the
+    // unkeyed panel kept `launched` — no second test could start from the shortcut.
+    rerender(<CampaignsPage runs={[]} navigate={navigate} launchIntent="campaign" />);
+    const fresh = await screen.findByTestId('testing-launch-panel');
+    expect(fresh).not.toBe(first);
+    expect(fresh).toHaveAttribute('data-intent', 'campaign');
+    expect(screen.queryByTestId('testing-launch-waiting')).toBeNull();
+    expect(within(fresh).getByTestId('testing-launch-instructions')).toHaveValue('');
+    expect(within(fresh).getByTestId('testing-launch-submit')).toBeDisabled();
+    // Consumed again — exactly one replace per arrival.
+    expect(navigate).toHaveBeenCalledTimes(2);
+
+    // …and the fresh panel LAUNCHES: the second test from the shortcut, its own run.
+    wireUp({ runId: 'run-second', runIds: ['run-second'] });
+    await user.type(within(fresh).getByTestId('testing-launch-instructions'), 'Second pass');
+    await user.click(within(fresh).getByTestId('testing-launch-unscoped'));
+    await user.click(within(fresh).getByTestId('testing-launch-submit'));
+    expect(await screen.findByTestId('testing-launch-waiting')).toHaveTextContent(/run-seco/);
+    expect(bodySentTo('/testing/recon')).toMatchObject({ problem: `${TEST_PROBLEM_PREFIX}\n\nFirst pass` });
+    const bodies = apiFetch.mock.calls.filter(([p]) => p === '/testing/recon');
+    expect(bodies).toHaveLength(2);
+  });
+
+  it('switching the verb after a launch (recon launched → "New test") is a fresh test panel, never a launched recon wearing the test title', async () => {
+    const user = userEvent.setup();
+    wireUp({ runId: 'run-recon', runIds: ['run-recon'] });
+    landing();
+
+    const recon = await openPanel(user, 'testing-recon-open');
+    await user.type(within(recon).getByTestId('testing-launch-instructions'), 'Survey the estate');
+    await user.click(within(recon).getByTestId('testing-launch-unscoped'));
+    await user.click(within(recon).getByTestId('testing-launch-submit'));
+    expect(await screen.findByTestId('testing-launch-waiting')).toHaveTextContent(/run-reco/);
+
+    await user.click(screen.getByTestId('testing-campaign-open'));
+    const test = screen.getByTestId('testing-launch-panel');
+    expect(test).not.toBe(recon);
+    expect(test).toHaveAttribute('data-intent', 'campaign');
+    expect(screen.queryByTestId('testing-launch-waiting')).toBeNull();
+    expect(within(test).getByTestId('testing-launch-instructions')).toHaveValue('');
+  });
+
   it('the three panels are one-at-a-time, the management-bar grammar', async () => {
     const user = userEvent.setup();
     wireUp({ runId: 'never-sent' });

--- a/tests/deferred.ts
+++ b/tests/deferred.ts
@@ -1,0 +1,22 @@
+/**
+ * A promise whose settlement the TEST controls — for pinning what a surface renders while a
+ * wire is still pending (a probe, a member lookup, a launch in flight), then settling it inside
+ * `act` so the resolved state is asserted on the same render tree. Every deferred a test hands
+ * to a module-level in-flight guard (the campaign store's `refresh`) MUST be settled before the
+ * test ends, or the next test's refresh returns the stale pending promise.
+ */
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+export function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/tests/gateWire.test.ts
+++ b/tests/gateWire.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api, type GateDecision } from '../src/api/client.js';
+
+/**
+ * T19 (the wire half) — the intake gate's decisions as HTTP, pinned at the fetch boundary: the
+ * four `POST /runs/:id/gate` bodies the gate card speaks (`SteeringGate.tsx`) and the BODYLESS
+ * `POST /runs/:id/cancel`. Fastify v5 refuses an empty body that advertises JSON, so the content
+ * type may ride ONLY with a body — the guard `apiFetch` carries for every bodyless POST. The panel
+ * half (which button sends which decision) lives in TestingLaunch.test.tsx.
+ */
+
+const fetchSpy = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+
+function answer(status: number, body: unknown): void {
+  fetchSpy.mockResolvedValue(new Response(JSON.stringify(body), { status }));
+}
+
+function sent(): { url: string; init: RequestInit } {
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [input, init] = fetchSpy.mock.calls[0]!;
+  return { url: String(input), init: init ?? {} };
+}
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal('fetch', fetchSpy);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const DECISIONS: Array<[string, GateDecision]> = [
+  ['approve', { approve: true }],
+  ['approve + steer', { approve: true, amend: 'focus on the checkout flow' }],
+  ['reject', { approve: false }],
+  ['reject + note', { approve: false, amend: 'the proposed plan is too broad' }],
+];
+
+describe('T19 — POST /runs/:id/gate: the four decision bodies, exactly', () => {
+  it.each(DECISIONS)('%s → JSON %j with Content-Type application/json, the run id encoded', async (_label, decision) => {
+    answer(200, { status: 'ok' });
+    await expect(api.confirmGate('run 1', decision)).resolves.toEqual({ status: 'ok' });
+    const { url, init } = sent();
+    expect(url.endsWith('/api/v1/runs/run%201/gate')).toBe(true);
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('content-type')).toBe('application/json');
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body).toEqual(decision);
+    // No extra key rides — the daemon's zod is strict.
+    expect(Object.keys(body)).toEqual(Object.keys(decision));
+  });
+
+  it('a refused decision throws the typed ApiError — status + the daemon\'s verbatim sentence on the fields', async () => {
+    answer(409, { error: 'gate already decided' });
+    await expect(api.confirmGate('r1', { approve: true })).rejects.toMatchObject({
+      status: 409,
+      wire: 'gate already decided',
+    });
+  });
+});
+
+describe('T19 — POST /runs/:id/cancel is BODYLESS', () => {
+  it('sends no body and no Content-Type (an empty JSON body would 400 on Fastify v5)', async () => {
+    answer(200, { status: 'cancelled' });
+    await api.cancelRun('r1');
+    const { url, init } = sent();
+    expect(url.endsWith('/api/v1/runs/r1/cancel')).toBe(true);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+    expect(new Headers(init.headers).has('content-type')).toBe(false);
+  });
+});

--- a/tests/needsYou.test.ts
+++ b/tests/needsYou.test.ts
@@ -168,7 +168,7 @@ describe('needsYouRows — dedupe', () => {
     expect(rows.map((r) => r.key)).toEqual(['fail:r-member']);
   });
 
-  it('campaign counts the live list cannot see produce ONE campaign row', () => {
+  it('campaign counts the live list cannot see produce ONE campaign row — spoken in Test words (T30, #203)', () => {
     const rows = needsYouRows(inputs({
       runs: [makeView({ id: 'r-member', status: 'failed' })],
       // 3 failed on the server; only one member is in the live list.
@@ -176,8 +176,12 @@ describe('needsYouRows — dedupe', () => {
     }));
     expect(rows.map((r) => r.key)).toEqual(['fail:r-member', 'campaign:camp-1']);
     expect(rows[1]!.text).toContain('3 runs failed');
+    // The row's rendered line and verb are product copy: Test vocabulary, never "Campaign".
+    expect(rows[1]!.text).toMatch(/^Test gaps — /);
+    expect(rows[1]!.text).not.toMatch(/campaign/i);
+    expect(rows[1]!.action.label).not.toMatch(/campaign/i);
     expect(rows[1]!.action).toEqual({
-      kind: 'open', path: '/testing/campaigns/camp-1', label: 'Open campaign ›',
+      kind: 'open', path: '/testing/campaigns/camp-1', label: 'Open test ›',
     });
   });
 

--- a/tests/renameConsistency.test.tsx
+++ b/tests/renameConsistency.test.tsx
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as client from '../src/api/client.js';
+import { ApiError } from '../src/api/errors.js';
+import { TESTING_UNSUPPORTED_COPY } from '../src/api/testing.js';
+import { CampaignScoreboard } from '../src/components/CampaignScoreboard.js';
+import { CampaignsPage } from '../src/components/CampaignsPage.js';
+import { ChatInput } from '../src/components/ChatInput.js';
+import { LeftSidebar } from '../src/components/LeftSidebar.js';
+import { ProjectCampaignsView } from '../src/components/ProjectCampaignsView.js';
+import { TestingLaunchPanel } from '../src/components/TestingLaunchPanel.js';
+import { useCampaignsStore } from '../src/store/campaigns.js';
+import { useGateStore } from '../src/store/gates.js';
+import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
+import { deferred } from './deferred.js';
+import { expectTestVocabulary } from './renameGuard.js';
+
+/**
+ * T30 — rename consistency (wicked-studio#203): the Campaign→Test rename covers EVERY rendered
+ * word on the Test surfaces, not just the panel titles. Each case renders a real surface into the
+ * state that shows the copy #203 listed — the rail heading (title, ▦/＋ labels, the Run recon row),
+ * the project-shell breadcrumb, the chat composer's group-attach chip, the scoreboard's not-found /
+ * loading / attached-row copy, the launch panel's fan-out and resolved copy, the landing's probing /
+ * unsupported / nothing-matches / older-window copy — and runs the guard over text AND the
+ * attributes a reader sees. The backend/route/testid vocabulary stays `campaign` by design and is
+ * out of the guard's scope; fixture ids (`suite-1`, `r1`) carry no forbidden word themselves.
+ */
+
+vi.mock('../src/hooks/useBoardModel.js', () => ({
+  useBoardModel: () => ({ items: [], unfiled: [], loading: false, error: null }),
+}));
+
+const getCampaign = vi.fn();
+const listCampaigns = vi.fn();
+vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/campaigns.js')>()),
+  getCampaign: (id: string) => getCampaign(id) as Promise<unknown>,
+  listCampaigns: () => listCampaigns() as Promise<unknown>,
+}));
+
+/** What `POST /testing/recon` answers through the REAL client (the launch panel's wire). */
+let reconAnswer: unknown = { runId: 'r1', runIds: ['r1'] };
+
+const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+  const url = String(input);
+  if (url.endsWith('/api/v1/testing/recon')) {
+    return Promise.resolve(new Response(JSON.stringify(reconAnswer), { status: 200 }));
+  }
+  return Promise.resolve(new Response(JSON.stringify({ error: 'not found' }), { status: 404 }));
+});
+
+const REPOS = {
+  repos: [{ id: 'r-1', name: 'repo-one', root_path: '/tmp/r1', default_branch: 'main', registered_at: 1 }],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal('fetch', fetchSpy);
+  fetchSpy.mockClear();
+  reconAnswer = { runId: 'r1', runIds: ['r1'] };
+  getCampaign.mockReset();
+  listCampaigns.mockReset();
+  listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+  vi.spyOn(client.api, 'getHealth').mockResolvedValue({ status: 'ok', version: '0.5.1', ping: 'pong' } as never);
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue(REPOS as never);
+  vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] } as never);
+  vi.spyOn(client.api, 'listProjectMembers').mockResolvedValue({ members: [] } as never);
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] } as never);
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({
+    roster: [{ key: 'claude', display_name: 'claude', binary: 'claude', enabled_for_council: true }],
+  } as never);
+  vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' } as never);
+  vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  window.localStorage.clear();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function launchUnscoped(user: ReturnType<typeof userEvent.setup>, brief: string): Promise<void> {
+  await user.type(screen.getByTestId('testing-launch-instructions'), brief);
+  await user.click(screen.getByTestId('testing-launch-unscoped'));
+  await user.click(screen.getByTestId('testing-launch-submit'));
+}
+
+describe('T30 — every rendered word on the Test surfaces says Test (#203)', () => {
+  it('T30 — the Test rail heading: its title, the ▦/＋ labels, and the Run recon row', async () => {
+    render(<LeftSidebar runs={[]} navigate={() => {}} pathname="/testing/campaigns" />);
+    await screen.findByRole('button', { name: 'wicked-studio' });
+    const heading = screen.getByTestId('rail-heading-test');
+    expect(heading.getAttribute('aria-expanded')).toBe('true');
+    expect(within(heading).getByTestId('rail-title-test')).toHaveTextContent('Test');
+    const plus = within(heading).getByTestId('heading-new');
+    expect(plus).toHaveAttribute('aria-label', 'New Test');
+    expect(plus).toHaveAttribute('title', 'New Test');
+    expect(within(heading).getByTestId('rail-test-recon')).toHaveTextContent('Run recon');
+    expectTestVocabulary(heading);
+  });
+
+  it('T30 — the project-shell breadcrumb', async () => {
+    render(<ProjectCampaignsView projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await screen.findByTestId('campaigns-page');
+    expect(screen.getByTestId('project-campaigns-crumb')).toHaveTextContent('Tests');
+    expectTestVocabulary(screen.getByTestId('project-campaigns'));
+  });
+
+  it('T30 — the chat composer\'s group-attach chip', async () => {
+    const user = userEvent.setup();
+    // The composer refreshes the store on mount — answer the SAME fixture on the wire so the
+    // list it renders is this one. Never override the store's `refresh` here: zustand merges,
+    // so a no-op would stick for every later test in this file and pin them on "probing".
+    const fixture = {
+      campaigns: [makeCampaign('suite-1', [{ status: 'running', runId: 'r1' }])],
+      groups: [makeGroup('perf-sweep', [attachedRun('g-1')])],
+    };
+    listCampaigns.mockResolvedValue(fixture);
+    useCampaignsStore.setState({ support: 'supported', ...fixture, live: {} });
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await user.selectOptions(screen.getByTestId('group-attach'), 'c:suite-1');
+    const pill = screen.getByTestId('group-pill');
+    expect(pill).toHaveTextContent('Test: suite-1');
+    expectTestVocabulary(pill);
+  });
+
+  it('T30 — the scoreboard\'s not-found copy and its way out', async () => {
+    // The DAEMON's sentence is not rendered here — the surface renders its own not-found copy.
+    getCampaign.mockRejectedValue(new ApiError(404, 'Unknown campaign'));
+    render(<CampaignScoreboard campaignId="suite-1" runs={[]} navigate={() => {}} />);
+    const notFound = await screen.findByTestId('campaign-notfound');
+    expect(notFound).toHaveTextContent('No test is filed under suite-1');
+    expect(within(notFound).getByRole('button')).toHaveTextContent('All tests');
+    expectTestVocabulary(notFound);
+  });
+
+  it('T30 — the scoreboard\'s loading line', async () => {
+    const d = deferred<unknown>();
+    getCampaign.mockReturnValue(d.promise);
+    render(<CampaignScoreboard campaignId="suite-1" runs={[]} navigate={() => {}} />);
+    const loading = screen.getByTestId('campaign-loading');
+    expect(loading).toHaveTextContent('Loading test suite-1');
+    expectTestVocabulary(loading);
+    await act(async () => {
+      d.resolve(makeCampaign('suite-1', [{ id: 'n-api', status: 'completed', runId: 'r1' }]));
+      await d.promise;
+    });
+  });
+
+  it('T30 — the scoreboard ladder, the attached-row tooltip included', async () => {
+    getCampaign.mockResolvedValue(makeCampaign(
+      'suite-1',
+      [{ id: 'n-api', status: 'completed', runId: 'r1' }],
+      { attached_runs: [attachedRun('r-adhoc')] },
+    ));
+    render(<CampaignScoreboard campaignId="suite-1" runs={[]} navigate={() => {}} />);
+    const board = await screen.findByTestId('campaign-scoreboard');
+    expect(within(board).getByTitle(/^Filed onto this test at launch/)).toBeInTheDocument();
+    expectTestVocabulary(board);
+  });
+
+  it('T30 — the launch panel\'s fan-out copy (the no-label arm)', async () => {
+    const user = userEvent.setup();
+    reconAnswer = { runIds: ['r1', 'r2'] };
+    render(<TestingLaunchPanel intent="campaign" navigate={() => {}} onClose={() => {}} />);
+    await launchUnscoped(user, 'Smoke it');
+    const fanout = await screen.findByTestId('testing-launch-fanout');
+    expect(fanout).toHaveTextContent('2 runs launched — one per attached codebase, under one test');
+    expectTestVocabulary(screen.getByTestId('testing-launch-panel'));
+  });
+
+  it('T30 — the launch panel\'s resolved copy once the intake gate is answered', async () => {
+    const user = userEvent.setup();
+    render(<TestingLaunchPanel intent="recon" navigate={() => {}} onClose={() => {}} />);
+    await launchUnscoped(user, 'Survey it');
+    await screen.findByTestId('testing-launch-waiting');
+    act(() => {
+      useGateStore.getState().ingest({
+        type: 'awaitingHuman', session: 'r1', ord: 1, prompt: 'Proposed plan: 3 scenarios — approve to launch',
+      } as never);
+    });
+    await user.click(within(await screen.findByTestId('steering-gate')).getByTestId('steering-approve'));
+    const resolved = await screen.findByTestId('testing-launch-resolved');
+    expect(within(resolved).getByTestId('testing-launch-to-campaigns')).toHaveTextContent('Tests');
+    expectTestVocabulary(screen.getByTestId('testing-launch-panel'));
+  });
+
+  it('T30 — the landing while probing', async () => {
+    const d = deferred<unknown>();
+    listCampaigns.mockReturnValue(d.promise);
+    render(<CampaignsPage runs={[]} navigate={() => {}} />);
+    const probing = screen.getByTestId('campaigns-probing');
+    expect(probing).toHaveTextContent('Checking this daemon for tests');
+    expectTestVocabulary(probing);
+    // Settle the store's in-flight refresh so the next test's refresh is its own.
+    await act(async () => {
+      d.resolve({ campaigns: [], groups: [] });
+      await d.promise;
+    });
+  });
+
+  it('T30 — the landing on a daemon without the surface', async () => {
+    listCampaigns.mockRejectedValue(new ApiError(404, 'Not Found'));
+    render(<CampaignsPage runs={[]} navigate={() => {}} />);
+    const page = await screen.findByTestId('campaigns-page');
+    expect(screen.getByTestId('campaigns-unsupported')).toHaveTextContent('This daemon has no test surface');
+    expectTestVocabulary(page);
+  });
+
+  it('T30 — the landing\'s "nothing matches" line and the "+N older" chip', async () => {
+    // A test whose only member run is outside the live list sits outside the recency window:
+    // the grid says nothing matches and the older chip names what is hidden — in Test words.
+    listCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign('suite-1', [{ status: 'completed', runId: 'r-gone' }])],
+      groups: [],
+    });
+    render(<CampaignsPage runs={[]} navigate={() => {}} />);
+    const page = await screen.findByTestId('campaigns-page');
+    expect(await screen.findByTestId('campaigns-empty-filter')).toHaveTextContent('No tests match');
+    expect(screen.getByTestId('campaigns-show-older').getAttribute('title')).toMatch(/^1 test with no run in the .+ window$/);
+    expectTestVocabulary(page);
+  });
+
+  it('T30 — the shared evals-unsupported note names the Test surface', () => {
+    expect(TESTING_UNSUPPORTED_COPY).toContain('The Test surface still works.');
+    expect(TESTING_UNSUPPORTED_COPY).not.toMatch(/campaign/i);
+  });
+});

--- a/tests/renameGuard.ts
+++ b/tests/renameGuard.ts
@@ -1,0 +1,39 @@
+import { expect } from 'vitest';
+
+/**
+ * The rename-consistency guard (T30, wicked-studio#203): every RENDERED word on a Test surface
+ * says Test — the text nodes and the attributes a reader is shown (`title`, `aria-label`,
+ * `placeholder`). The backend/route/testid vocabulary (`data-testid="campaign-…"`,
+ * `/testing/campaigns`, `data-campaign-id`) is intentionally OUT of scope: it is a wire and
+ * selector contract, not copy. Fixtures handed to a guarded surface must not carry the word
+ * themselves — a user-authored title or a daemon-minted id may legitimately say "campaign", and
+ * the guard is about product copy, so choose ids like `suite-1`.
+ *
+ * Copy MAY name a route literally (the unsupported state says "`GET /campaigns` is not served"
+ * — the exact wire fact, which is the honest thing to say). A route path is the backend's
+ * vocabulary, so `/campaigns` path tokens are stripped before the copy is judged; the word
+ * anywhere else in a rendered string is still a rename miss.
+ */
+const FORBIDDEN = /campaign/i;
+const ROUTE_TOKEN = /\/campaigns\b/g;
+const READ_ATTRS = ['title', 'aria-label', 'placeholder'] as const;
+
+/** Every string a reader can see inside `root`, located for a legible failure. */
+export function renderedStrings(root: HTMLElement): Array<{ where: string; text: string }> {
+  const out: Array<{ where: string; text: string }> = [{ where: 'text', text: root.textContent ?? '' }];
+  for (const el of [root, ...Array.from(root.querySelectorAll('*'))]) {
+    for (const attr of READ_ATTRS) {
+      const v = el.getAttribute(attr);
+      if (v !== null && v !== '') out.push({ where: `${el.tagName.toLowerCase()}[${attr}]`, text: v });
+    }
+  }
+  return out;
+}
+
+/** Fails on the first rendered "Campaign" under `root`, naming where it was found. */
+export function expectTestVocabulary(root: HTMLElement): void {
+  for (const { where, text } of renderedStrings(root)) {
+    const copy = text.replace(ROUTE_TOKEN, '');
+    expect(copy, `rendered copy at ${where} still says Campaign (#203): ${JSON.stringify(text)}`).not.toMatch(FORBIDDEN);
+  }
+}

--- a/tests/testingLaunch.wire.test.ts
+++ b/tests/testingLaunch.wire.test.ts
@@ -31,7 +31,10 @@ function bodySentTo(path: string): Record<string, unknown> {
   expect(calls).toHaveLength(1);
   const init = calls[0]![1] as { method?: string; body?: string };
   expect(init.method).toBe('POST');
-  return JSON.parse(init.body ?? 'null') as Record<string, unknown>;
+  // A POST without a body is a regression in its own right — name it here, rather than letting
+  // `JSON.parse(null)` surface later as an opaque TypeError on the parsed object.
+  expect(init.body, `${path} was POSTed without a body`).toBeTypeOf('string');
+  return JSON.parse(init.body!) as Record<string, unknown>;
 }
 
 /** An old-crew wire: `/testing/recon` is absent (spelled `wire`), `/runs` answers `runsAnswer`. */

--- a/tests/testingLaunch.wire.test.ts
+++ b/tests/testingLaunch.wire.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, isRouteAbsent } from '../src/api/errors.js';
+
+/**
+ * The testing LAUNCH wire, below the panel — T1–T4 of the Tests-feature plan
+ * (docs/testing/tests-feature-test-plan.md): the pure folds and the presence gate of
+ * `launchTestingRun`, with `apiFetch` mocked at the client boundary.
+ *
+ * T4's point is the NEGATIVE guarantee: a REAL refusal — a named 404, a validation 400, a 500 or
+ * 501, a transport failure — is rethrown untouched and NEVER retried over `POST /runs`. Only the
+ * bare unknown-route 404 (both spellings) falls back, and only for a scope that fits the legacy
+ * single-`repoRef` wire; a scope that needs the pinned fields is the honest named gap.
+ */
+
+const apiFetch = vi.fn();
+vi.mock('../src/api/client.js', () => ({ apiFetch: (...a: unknown[]) => apiFetch(...a) }));
+
+const {
+  isMultiScopeUnsupported, launchTestingRun, launchedRunIds, MultiScopeUnsupportedError,
+} = await import('../src/api/testing.js');
+
+/** Fastify's headless default and crew's SPA-serving notFoundHandler — the two route-absent bodies. */
+const ROUTE_ABSENT_SPELLINGS = ['Not Found', 'not found'] as const;
+
+/** The paths `apiFetch` was asked for, in call order. */
+const paths = (): string[] => apiFetch.mock.calls.map(([p]) => String(p));
+
+/** The parsed JSON body of the ONE POST to `path`. */
+function bodySentTo(path: string): Record<string, unknown> {
+  const calls = apiFetch.mock.calls.filter(([p]) => String(p) === path);
+  expect(calls).toHaveLength(1);
+  const init = calls[0]![1] as { method?: string; body?: string };
+  expect(init.method).toBe('POST');
+  return JSON.parse(init.body ?? 'null') as Record<string, unknown>;
+}
+
+/** An old-crew wire: `/testing/recon` is absent (spelled `wire`), `/runs` answers `runsAnswer`. */
+function oldCrew(wire: string, runsAnswer: unknown | Error): void {
+  apiFetch.mockImplementation((path: unknown) => {
+    if (String(path) === '/runs') {
+      return runsAnswer instanceof Error ? Promise.reject(runsAnswer) : Promise.resolve(runsAnswer);
+    }
+    return Promise.reject(new ApiError(404, wire));
+  });
+}
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+describe('T1 — isRouteAbsent: the bare unknown-route 404, both spellings, nothing else', () => {
+  it('T1 — matches exactly the two route-absent bodies', () => {
+    for (const wire of ROUTE_ABSENT_SPELLINGS) {
+      expect(isRouteAbsent(new ApiError(404, wire))).toBe(true);
+    }
+  });
+
+  it('T1 — a NAMED 404 is a real answer from a daemon WITH the route', () => {
+    expect(isRouteAbsent(new ApiError(404, 'unknown campaign: x'))).toBe(false);
+    expect(isRouteAbsent(new ApiError(404, 'unknown project: proj-a'))).toBe(false);
+  });
+
+  it('T1 — the spelling is exact, the status must be 404, and non-wire errors never match', () => {
+    expect(isRouteAbsent(new ApiError(404, 'NOT FOUND'))).toBe(false);
+    expect(isRouteAbsent(new ApiError(404, ''))).toBe(false);
+    expect(isRouteAbsent(new ApiError(500, ''))).toBe(false);
+    expect(isRouteAbsent(new ApiError(400, 'Not Found'))).toBe(false);
+    expect(isRouteAbsent(new Error('Not Found'))).toBe(false);
+    expect(isRouteAbsent(undefined)).toBe(false);
+  });
+});
+
+describe('T2 — launchedRunIds: runIds (≥ 1 non-empty string) wins; else the legacy runId; else nothing', () => {
+  it('T2 — the recon answer: runIds is the source of truth even when runId disagrees', () => {
+    expect(launchedRunIds({ runIds: ['a', 'b'] })).toEqual(['a', 'b']);
+    expect(launchedRunIds({ runId: 'z', runIds: ['a', 'b'], campaign: 'suite-1' })).toEqual(['a', 'b']);
+  });
+
+  it('T2 — an empty or all-invalid runIds falls back to runId; nothing usable is []', () => {
+    expect(launchedRunIds({ runIds: [], runId: 'a' })).toEqual(['a']);
+    expect(launchedRunIds({ runIds: ['', ''], runId: 'a' })).toEqual(['a']);
+    expect(launchedRunIds({ runId: 'a' })).toEqual(['a']);
+    expect(launchedRunIds({ runIds: [] })).toEqual([]);
+    expect(launchedRunIds({ runId: '' })).toEqual([]);
+    expect(launchedRunIds({})).toEqual([]);
+  });
+
+  it('T2 — invalid entries are dropped, never rendered as links', () => {
+    expect(launchedRunIds({ runIds: ['', 3, null, 'ok'] } as never)).toEqual(['ok']);
+    expect(launchedRunIds({ runIds: 'a' } as never)).toEqual([]);
+    expect(launchedRunIds({ runId: 3 } as never)).toEqual([]);
+  });
+});
+
+describe('T3 — isMultiScopeUnsupported: THIS daemon cannot serve a multi-codebase launch', () => {
+  it('T3 — the primary signal is the fold\'s own MultiScopeUnsupportedError', () => {
+    expect(isMultiScopeUnsupported(new MultiScopeUnsupportedError())).toBe(true);
+  });
+
+  it('T3 — belt-and-braces: a strict launch zod refusing the pinned keys BY NAME (400)', () => {
+    expect(isMultiScopeUnsupported(new ApiError(400, "Unrecognized key(s) in object: 'repoRefs'"))).toBe(true);
+    expect(isMultiScopeUnsupported(new ApiError(400, 'unrecognized key projectId'))).toBe(true);
+  });
+
+  it('T3 — a named 400 about anything else is a REAL answer; other statuses and non-wire errors never match', () => {
+    expect(isMultiScopeUnsupported(new ApiError(400, 'project proj-a holds zero repos — attach one first'))).toBe(false);
+    expect(isMultiScopeUnsupported(new ApiError(400, "repoRefs: 'r-9' does not name a registered repo"))).toBe(false);
+    // Route absence is the launch fold's business (it throws the typed error above), not this predicate's.
+    expect(isMultiScopeUnsupported(new ApiError(404, 'Not Found'))).toBe(false);
+    expect(isMultiScopeUnsupported(new ApiError(500, 'unrecognized key'))).toBe(false);
+    expect(isMultiScopeUnsupported(new Error('unrecognized key repoRefs'))).toBe(false);
+  });
+});
+
+describe('T4 — launchTestingRun: the presence gate on POST /testing/recon', () => {
+  it('T4a — 200 on the pinned route answers verbatim; /runs is never touched', async () => {
+    const answer = { runId: 'a', runIds: ['a', 'b'], campaign: 'suite-1', extra: 'passes through untouched' };
+    apiFetch.mockResolvedValue(answer);
+    const body = { problem: 'p', projectId: 'proj-a', repoRefs: ['r-1'] };
+
+    await expect(launchTestingRun(body)).resolves.toEqual(answer);
+    expect(paths()).toEqual(['/testing/recon']);
+    expect(bodySentTo('/testing/recon')).toEqual(body);
+  });
+
+  it.each(ROUTE_ABSENT_SPELLINGS)(
+    'T4b — route absent (%j) + a PROJECT scope → MultiScopeUnsupportedError; /runs is never tried',
+    async (wire) => {
+      oldCrew(wire, { runId: 'never-launched' });
+      await expect(launchTestingRun({ problem: 'p', projectId: 'proj-a' })).rejects.toBeInstanceOf(MultiScopeUnsupportedError);
+      expect(paths()).toEqual(['/testing/recon']);
+    },
+  );
+
+  it.each(ROUTE_ABSENT_SPELLINGS)(
+    'T4c — route absent (%j) + ONE repo → POST /runs {problem, repoRef}: the legacy spelling, no pinned key',
+    async (wire) => {
+      oldCrew(wire, { runId: 'run-old' });
+      await expect(launchTestingRun({ problem: 'p', repoRefs: ['r-1'] })).resolves.toEqual({ runId: 'run-old' });
+      expect(paths()).toEqual(['/testing/recon', '/runs']);
+      const legacy = bodySentTo('/runs');
+      expect(legacy).toEqual({ problem: 'p', repoRef: 'r-1' });
+      // The old strict zod 400s on `repoRefs`/`projectId` — neither may ride the fallback.
+      expect(Object.keys(legacy)).toEqual(['problem', 'repoRef']);
+    },
+  );
+
+  it('T4c — route absent + UNSCOPED (absent or empty repoRefs) → POST /runs {problem} alone', async () => {
+    oldCrew('not found', { runId: 'run-old' });
+    await launchTestingRun({ problem: 'p' });
+    expect(bodySentTo('/runs')).toEqual({ problem: 'p' });
+
+    apiFetch.mockClear();
+    oldCrew('not found', { runId: 'run-old' });
+    await launchTestingRun({ problem: 'p', repoRefs: [] });
+    expect(bodySentTo('/runs')).toEqual({ problem: 'p' });
+  });
+
+  it('T4d — route absent + TWO repos → MultiScopeUnsupportedError; never half a scope over /runs', async () => {
+    oldCrew('Not Found', { runId: 'never-launched' });
+    await expect(launchTestingRun({ problem: 'p', repoRefs: ['r-1', 'r-2'] })).rejects.toBeInstanceOf(MultiScopeUnsupportedError);
+    expect(paths()).toEqual(['/testing/recon']);
+  });
+
+  const REFUSALS: Array<[string, unknown]> = [
+    ['a NAMED 404 (unknown project)', new ApiError(404, 'unknown project: proj-a')],
+    ['a validation 400 (bad ref)', new ApiError(400, "repoRefs: 'r-9' does not name a registered repo")],
+    ['a strict-zod 400 (unrecognized key)', new ApiError(400, "Unrecognized key(s) in object: 'repoRefs'")],
+    ['a 500', new ApiError(500, 'internal error')],
+    ['a 501 (route present, engine absent)', new ApiError(501, 'the embedded engine predates recon')],
+    ['a transport failure', new TypeError('Failed to fetch')],
+  ];
+
+  it.each(REFUSALS)(
+    'T4 negative — %s is rethrown AS-IS after one call; /runs is never a fallback for a real answer',
+    async (_label, refusal) => {
+      apiFetch.mockRejectedValue(refusal);
+      // A one-repo scope — the one that WOULD fall back on route absence — proves the gate
+      // discriminates on the refusal, not on the scope.
+      await expect(launchTestingRun({ problem: 'p', repoRefs: ['r-1'] })).rejects.toBe(refusal);
+      expect(paths()).toEqual(['/testing/recon']);
+    },
+  );
+
+  it('T4 — a fallback that itself fails propagates THAT refusal verbatim, never re-read as route absence', async () => {
+    const refusal = new ApiError(400, 'problem: must not be empty');
+    oldCrew('Not Found', refusal);
+    await expect(launchTestingRun({ problem: '', repoRefs: ['r-1'] })).rejects.toBe(refusal);
+    expect(paths()).toEqual(['/testing/recon', '/runs']);
+  });
+});

--- a/tests/testingRoutes.test.tsx
+++ b/tests/testingRoutes.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useRoute } from '../src/hooks/useRoute.js';
 import { useTestingRedirect } from '../src/hooks/useLegacyRedirect.js';
-import { TESTING_PAGES } from '../src/api/testing.js';
+import { readLaunchIntent, TESTING_PAGES, testingLaunchPath, testingPath } from '../src/api/testing.js';
 
 /**
  * The Testing routes (the testing wave; landing re-aimed by the testing-UX wave):
@@ -108,5 +108,26 @@ describe('useTestingRedirect', () => {
     renderHook(() => useTestingRedirect('testing', 'campaigns', '/testing/campaigns/c-42', navigate));
     renderHook(() => useTestingRedirect('steering', null, '/steering', navigate));
     expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('the landing\'s ?new= arrival intent (#203) — testingLaunchPath / readLaunchIntent', () => {
+  it('spells the two intents in USER words on the landing\'s route: ?new=test and ?new=recon', () => {
+    expect(testingLaunchPath('campaign')).toBe(`${testingPath('campaigns')}?new=test`);
+    expect(testingLaunchPath('recon')).toBe(`${testingPath('campaigns')}?new=recon`);
+  });
+
+  it('reads back exactly what it spells — and the route parse still lands on the landing', () => {
+    for (const intent of ['campaign', 'recon'] as const) {
+      const url = new URL(testingLaunchPath(intent), 'http://studio.test');
+      expect(readLaunchIntent(url.search)).toBe(intent);
+      expect(routeAt(url.pathname).current).toMatchObject({ panel: 'testing', testingPage: 'campaigns', campaignId: null });
+    }
+  });
+
+  it('an absent, bare, foreign or backend-worded ?new= opens NOTHING — a mangled bookmark shows the landing', () => {
+    for (const search of ['', '?v=2', '?new=', '?new=bogus', '?new=campaign', '?new=Test']) {
+      expect(readLaunchIntent(search)).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## What

Executes the deterministic layer of the Tests-feature test plan (council run `1aba96f6`, codex review REVISE with its REQUIRED CHANGES applied), closes the Campaign→Test rename regression (#203), and ships the revised plan in-repo.

### Fixes (#203)
- **15 rendered "Campaign" strings → Test vocabulary.** Rail ＋ label (`P_TEST.noun`), project-shell crumb, chat group-attach pill, Needs-You row text + verb, scoreboard not-found / loading / attached-tooltip, launch panel fan-out + resolved copy + link, landing probing / unsupported copy, `TESTING_UNSUPPORTED_COPY`. Also the "+N older" chip title and "No tests match" line. Backend / route / store-key / testid vocabulary stays `campaign` by design.
- **The Test rail ＋ now creates.** It landed on the Tests page with nothing open. New `?new=test` / `?new=recon` arrival intent (`testingLaunchPath` / `readLaunchIntent` in `src/api/testing.ts`): `CampaignsPage` opens that panel on mount and consumes the query with one `replace` navigation. The rail's "Run recon" row rides `?new=recon`.
- The project-scoped view moved out of `App.tsx` into `ProjectCampaignsView.tsx` (crumb gets `project-campaigns-crumb`); `testid-inventory.json` regenerated.

### Tests (scenario ids in every test name)
- `tests/testingLaunch.wire.test.ts` — **T1–T4**: `isRouteAbsent`, `launchedRunIds`, `isMultiScopeUnsupported`, and the presence gate incl. the negative guarantee (named 404 / 400 / strict-zod 400 / 500 / 501 / transport rethrown after ONE call, never retried over `/runs`), both route-absent spellings, fallback-failure propagation.
- `tests/gateWire.test.ts` — **T19 (wire)**: the four `POST /runs/:id/gate` bodies, bodyless `/runs/:id/cancel`, content type only with a body, encoded id.
- `tests/TestingLaunch.test.tsx` — **T5** matrix (project-only / explicit-only / combined / unscoped × both prefixes, trimmed brief), **T6** (locked chips, rapid switching discards the stale answer, failed lookup), **T7** (attach-first fixture per codex), **T8** (picker: name/id, cap 8, exclusions), **T9** (consent visibility + reset), **T10** (whitespace brief, double-submit → one POST / one `onLaunched`, retry after failure), **T11**, **T12** (incl. inactive `initialProjectId`), **T14** (fan-out never renders an inline gate even as sibling gates arrive), **T15**, **T16** (four no-id shapes), **T17/T18** (unrelated gate ignored, gate-before-response), **T19** (panel half: each decision → resolved copy with working doors; cancel; refused decision), **T20** (copy verbatim).
- `tests/CampaignsPage.test.tsx` — **T24** (probing → page with one `GET /campaigns`, 404, empty, populated) + the `?new=` intent (opens, consumes once, plain arrival opens nothing, honored on an unsupported daemon, toggles with the verb).
- `tests/ProjectCampaignsView.test.tsx` — **T13** route wiring + T12 through the shell.
- `tests/renameConsistency.test.tsx` + `tests/renameGuard.ts` — **T30**: every rendered string (text + `title`/`aria-label`/`placeholder`) on the Test rail heading, crumb, chat chip, scoreboard states, panel fan-out/resolved, landing states; route-path tokens are wire vocabulary and are stripped before judging. Also T30 assertions in `LeftSidebar.rail.test.tsx` and `needsYou.test.ts`.
- `docs/testing/tests-feature-test-plan.md` — the REVISED plan: codex changes applied, T21–T23 rewritten as **non-launching** curl probes (invalid bodies → 400 on a present route vs bare 404, captured bodies, JSON content type), T25–T29 governed/Playwright revised and left as documented next steps, open questions listed.

## Verification (real results)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 241 files, 2540 tests passed
- `npm run build` — ok (pre-existing chunk-size warning)

## Notes
- One pre-existing test hazard fixed along the way: a T30 case overrode the campaign store's `refresh` via `setState`, which zustand merges and so stuck every later test in the file on "probing". It now answers the same fixture on the wire instead.
- Open product questions (not asserted, in the plan §9): the unkeyed launch panel keeps state across Run recon ↔ New test; a failed member lookup shows the zero-repo warning; an inactive `initialProjectId` rides the wire honestly but the select shows "no project".

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
