### PR TITLE
release: 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-09-10
+
 ### Fixed
 - **Launch composer: a multi-repo project must be told which repo a build run works in (F-028).**
   Choosing a project auto-attached every one of its repos as chips and the launch body took
@@ -542,7 +544,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/mikeparcewski/wicked-studio/compare/v0.4.15...v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.2",
+  "studioVersion": "0.5.3",
   "counts": {
     "files": 137,
     "occurrences": 1146,


### PR DESCRIPTION
Version PR for the operator-approved release train (2026-09-10). On merge, `v0.5.3` is tagged on the merge commit and `release.yml` publishes to npm.

## Changes

- `package.json` 0.5.2 → 0.5.3; `package-lock.json` refreshed with `npm install --package-lock-only` — the two root `version` fields only, every dependency resolution unchanged.
- `testid-inventory.json` re-stamped with `npm run manifest:testids` — `studioVersion` 0.5.2 → 0.5.3 is the only change (984 static · 57 dynamic · 6 computed testids across 137 files, unchanged since #240). TH-13 asserts the stamp equals the package version, so the bump alone fails `npm test`; the regenerated artifact rides in this PR as the inventory's own drift rule requires.
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.3] — 2026-09-10` (an empty `[Unreleased]` kept above) with the entries for the one PR on `main` since 0.5.2 — #240: **F-028** the launch composer derives one target repo through `resolveLaunchTarget` (Target-repo choice > explicit popover tick > the lone attached repo > ambiguous-with-no-default for build-kind work over several candidates; the operator's latest act stands), the deliver notice names the repo the PR lands on, and the `launch-confirm` step reads workflow / target repo / gate posture before Send; **F-029** a labelled `run-cancel` control on every non-terminal run, outside gates, with a confirm step and a `role="alert"` refusal — plus the `[0.5.3]` link-ref, with the `[Unreleased]` compare base retargeted to `v0.5.3`. The entries themselves were authored in #240; this PR only cuts the heading and adds the link-refs.

## Contract pin — unchanged by design

`wicked-crew-api-types` stays `^0.25.0`. #240 left the wire unchanged (`LaunchRunBody.repoRef` only), and the skills wire mirror follow-up recorded in the 0.5.2 release (swap `src/api/skills-wire.ts` for `export type { … } from 'wicked-crew-api-types'` once the pin can move to the published 0.28.0) still stands.

## Gates (fresh clone of `main` @ a502b0c + this commit)

- `npm ci` — ok
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 251 files, 2708 tests passed, 0 unhandled errors
- `npm run build` — ok (the pre-existing chunk-size warning)
- `python3 scripts/changelog-section.py v0.5.3` — exit 0, a 33-line body, so the release workflow's GitHub Release step will find the section
- privacy scrub of the commit and this body — 0 hits beyond the repository-owner handle inside the compare-URL link-refs (the same handle every existing link-ref carries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
