### PR TITLE
release: 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.5.4] — 2026-09-10
+
 ### Fixed
 - **Document thread — bare status frames file under the doc's MOUNTED thread (acceptance finding
   F-045, belt and braces).** Crew's own interactive seams narrated their governed runs with
@@ -580,7 +582,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.0...v0.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.3",
+  "studioVersion": "0.5.4",
   "counts": {
     "files": 138,
     "occurrences": 1154,


### PR DESCRIPTION
Version PR for the operator-approved release train (2026-09-10). On merge, `v0.5.4` is tagged on the merge commit and `release.yml` publishes to npm.

## Changes

- `package.json` 0.5.3 → 0.5.4; `package-lock.json` refreshed with `npm install --package-lock-only` — the two root `version` fields only, every dependency resolution unchanged.
- `testid-inventory.json` re-stamped with `npm run manifest:testids` — `studioVersion` 0.5.3 → 0.5.4 is the only change (992 static · 57 dynamic · 6 computed testids across 138 files, unchanged since #241). TH-13 asserts the stamp equals the package version, so the bump alone fails `npm test`; the regenerated artifact rides in this PR as the inventory's own drift rule requires.
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.4] — 2026-09-10` (an empty `[Unreleased]` kept above) with the entries for the one PR on `main` since 0.5.3 — #241: **F-045** bare document/demo status frames (a `document_id` with no project) file under the doc's MOUNTED thread — the composer claims a create-time pending binding under the bridge's canonical slug that the mounting thread adopts, held frames release exactly once onto the thread that binds, and Unfiled is reached only after a genuine 10 s with nothing bound; **F-046** `DocSubjectPicker` on both the Document and the Video launch composer — the project's `crew.repo` members as named toggles (`repo_refs`) and the bridge's four formats (`style`), with visible discovery loading / error / retry, an explicit no-grounding choice the thread records, and picks that reset when the launch context changes; the create body is typed from `wicked-crew-api-types` 0.30.0's `InteractiveDocCreateRequest` — plus the `[0.5.4]` link-ref, with the `[Unreleased]` compare base retargeted to `v0.5.4`. The entries themselves were authored in #241; this PR only cuts the heading and adds the link-refs.

## Contract pin — unchanged by this PR

`wicked-crew-api-types` stays `0.30.0` exactly, where #241 moved it (from `^0.25.0`) once the package published from wicked-crew #506 (`api-types-v0.30.0`). The skills wire mirror follow-up recorded in the 0.5.2 release (swap `src/api/skills-wire.ts` for `export type { … } from 'wicked-crew-api-types'`) can now proceed against the published declaration; it is not part of this release.

## Gates (fresh clone of `main` @ 1d10c09 + this commit)

- `npm ci` — ok
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 253 files, 2739 tests passed, 0 unhandled errors
- `npm run build` — ok (the pre-existing chunk-size warning)
- `python3 scripts/changelog-section.py v0.5.4` — exit 0, a 34-line body, so the release workflow's GitHub Release step will find the section
- privacy scrub of the commit and this body — 0 hits beyond the repository-owner handle inside the compare-URL link-refs (the same handle every existing link-ref carries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
