### PR TITLE
fix(gates): gate cards show the evaluator verdict, floor results and denial remedy; delivery strip ignores non-delivering workflows (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ npm publish dates. Every version listed here exists on
 ## [Unreleased]
 
 ### Fixed
+- **Gate cards state the evaluator verdict they are asking about** (#250, acceptance finding
+  F-3R2-006 — the UI half of wicked-core F-036/F-039). The verify pre-run gate ("Approve unit 4
+  before it runs") and the deliver gate showed only their prompt while the `fix` phase's PASS —
+  criterion, deterministic floor, the judge's reasoning — sat in the already-hydrated event log;
+  the DENIED gate said "Unit 4 verdict is NOT PASS — confirm to retry…" while the reason
+  (evaluator≠creator, the changed path, the restore command) was only in an expandable thread
+  line. `SteeringGate` now renders a `gate-verdict` block from the run's own `gateEvaluated` (the
+  last one at or below the gate's ord), with the F-039 `repoChecksEvaluated` floor per check
+  (name · exit code · duration · manifest source, plus what was skipped) and the F-036
+  `evaluatorMutatedWorktree` record (seat, phase, changed paths, tree ids) attached from the SAME
+  fold — a retry's verdict never inherits the previous attempt's evidence. A denial names the
+  layer (`denial.source`: worktree guard, repository checks, …) and quotes the engine's reason
+  verbatim, backticked commands rendered as copyable code. An ungated phase is labelled a
+  default-allow, never a pass (FINDING-025); no evaluation yet ⇒ no block, never a verdict
+  fabricated from the prompt. Zero new requests. `wicked-crew-api-types` 0.30.0 → 0.31.0
+  (purely additive: `UnitDenial`, `GateEvaluatedEvent.denial`, `RepoChecksEvaluatedEvent`,
+  `EvaluatorMutatedWorktreeEvent`). The judge SEAT is not on this wire, so the card claims none.
+- **The landing's delivery strip no longer counts onboarding runs as "Vacuous — needs retry"**
+  (#250, F-3R2-018). The daemon stamps `delivery: 'vacuous'` on every completed repo-scoped run
+  whose worktree is untouched — the DESIGNED outcome of `onboarding` and the other system
+  workflows — so a fresh install read "9 Vacuous — needs retry" and buried the one real signal.
+  `deliveryCounts` (shared by the strip and the KPI ribbon's Review tile) now licenses the
+  vacuous bucket with the Delivery section's own `canDeliver` rule — a deliver unit on the run, or
+  a workflow positively known not to be a system one (`is_system`, the one budgeted
+  `GET /workflows`) — and the cell reads "Vacuous — no change to deliver": the condition, not a
+  prescription. The licence can only withhold a count, never invent one.
 - **`.codegraph/estate.db` is no longer tracked** (#220). A fresh clone shipped the operator repo's code-graph
   identity, so onboarding the clone failed with `REPO COLLISION` (and an older wicked-core wrote into the
   tracked file); the graph is per-checkout, built by `wicked-estate index` under the daemon state home

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.30.0"
+        "wicked-crew-api-types": "0.31.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.30.0.tgz",
-      "integrity": "sha512-s0l2GtGMxkoAo8NG+OR65ocqFswMtot0PqXAup636JDaRGj32UJLva93WBdSsdwyP3ubSM5xyNK6eHG1QnjjIw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.31.0.tgz",
+      "integrity": "sha512-wlCLsbmUNkqAcfA6a5qUfS6xZ2cfAVCUbHu/wOtyr3gVg9G/mAuL3Dz+23jhvnGb1r1dmkXSLAbiuZ3iZoKfPA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.30.0"
+    "wicked-crew-api-types": "0.31.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/board/windowStats.ts
+++ b/src/board/windowStats.ts
@@ -1,4 +1,6 @@
 import type { SessionView, SessionWithDelivery } from '../api/types.js';
+import { canDeliver } from '../components/delivery.js';
+import type { IsSystemWorkflow } from '../components/runMode.js';
 import { outcomeOf } from './metrics.js';
 import { RANGE_LIMITS, rangeWord, type TimeRange } from '../hooks/useTimeRange.js';
 
@@ -243,20 +245,35 @@ export interface DeliveryCounts {
   delivered: number;
   /** `stranded` — completed work nobody lifted: needs review (recoverable). */
   stranded: number;
-  /** `vacuous` — completed with nothing liftable: needs a retry. */
+  /**
+   * `vacuous` — a run that was EXPECTED to deliver completed with no change to deliver. Counted
+   * only under {@link canDeliver}'s licence (a deliver unit on the run, or a workflow positively
+   * known not to be a system one): the daemon stamps `'vacuous'` on every completed repo-scoped
+   * run whose worktree is untouched, which is the DESIGNED outcome of `onboarding`, `survey-repo`
+   * and the other system workflows (wicked-studio#250, F-3R2-018 — nine onboarding runs read
+   * "9 Vacuous — needs retry" and buried the one real signal). Those are not a delivery finding
+   * and never count here.
+   */
   vacuous: number;
 }
 
-/** Count the three delivery outcomes across live runs — the deck's verified/needs-review strip and
- *  the ATTENTION "review" tile read the SAME fold, so they can never disagree. */
-export function deliveryCounts(runs: SessionView[]): DeliveryCounts {
+/**
+ * Count the three delivery outcomes across live runs — the deck's verified/needs-review strip and
+ * the ATTENTION "review" tile read the SAME fold, so they can never disagree.
+ *
+ * `isSystemWorkflow` is the app's `is_system` lookup (`store/workflowCache.useIsSystemWorkflow`),
+ * passed through to {@link canDeliver} for the `vacuous` licence. It can only ever WITHHOLD: with
+ * no lookup (or one that answers `undefined`, e.g. a materialised per-run def) a run with no
+ * deliver unit is not counted vacuous — the same trade the Delivery section makes, spelled once.
+ */
+export function deliveryCounts(runs: SessionView[], isSystemWorkflow?: IsSystemWorkflow): DeliveryCounts {
   const c: DeliveryCounts = { delivered: 0, stranded: 0, vacuous: 0 };
   for (const v of runs) {
     if (v.session.archived_at != null) continue;
     const d = wireDelivery(v);
     if (d === 'delivered') c.delivered += 1;
     else if (d === 'stranded') c.stranded += 1;
-    else if (d === 'vacuous') c.vacuous += 1;
+    else if (d === 'vacuous' && canDeliver(v, isSystemWorkflow)) c.vacuous += 1;
   }
   return c;
 }

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -61,6 +61,7 @@ export function ApprovalDock({
           runId={id}
           guidance={guidance}
           {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
+          {...(view !== undefined ? { units: view.units } : {})}
           onResolved={onResolved}
         />
       )}

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -45,6 +45,19 @@ export function ApprovalDock({
 
   const guidance = session === undefined ? undefined : sessionGuidance(session);
 
+  // The gate's ord, best-first: the cached gate record, else — the daemon-restarted fallback
+  // (§3.3: status says awaiting_human, the transient cache is empty) — derived from the run's own
+  // cursor the way `useRunModel.pendingGate` does: `unit_ix` is a 0-based INDEX and a gate's ord is
+  // the unit it sits before, so resolve it through the snapshot (`units[unit_ix].ord`, else
+  // `unit_ix + 1`). Trusted run state, never a guess — it keeps the card's verdict lookup BOUNDED
+  // when the prompt itself was lost (Copilot on #252). Undefined only with no run view at all.
+  const ord: number | undefined =
+    gate !== undefined
+      ? gate.ord
+      : view !== undefined
+        ? (view.units[view.session.unit_ix]?.ord ?? view.session.unit_ix + 1)
+        : undefined;
+
   return (
     <div
       data-testid="approval-dock"
@@ -60,7 +73,8 @@ export function ApprovalDock({
         <SteeringGate
           runId={id}
           guidance={guidance}
-          {...(gate ? { ord: gate.ord, prompt: gate.prompt } : {})}
+          {...(ord !== undefined ? { ord } : {})}
+          {...(gate ? { prompt: gate.prompt } : {})}
           {...(view !== undefined ? { units: view.units } : {})}
           onResolved={onResolved}
         />

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -49,13 +49,15 @@ export function ApprovalDock({
   // (§3.3: status says awaiting_human, the transient cache is empty) — derived from the run's own
   // cursor the way `useRunModel.pendingGate` does: `unit_ix` is a 0-based INDEX and a gate's ord is
   // the unit it sits before, so resolve it through the snapshot (`units[unit_ix].ord`, else
-  // `unit_ix + 1`). Trusted run state, never a guess — it keeps the card's verdict lookup BOUNDED
-  // when the prompt itself was lost (Copilot on #252). Undefined only with no run view at all.
+  // `unit_ix + 1`). The cursor indexes units in ORD order and the DTO's array is not guaranteed
+  // to arrive sorted, so sort first (the contract ChatPanel's render already states). Trusted run
+  // state, never a guess — it keeps the card's verdict lookup BOUNDED when the prompt itself was
+  // lost (Copilot on #252). Undefined only with no run view at all.
   const ord: number | undefined =
     gate !== undefined
       ? gate.ord
       : view !== undefined
-        ? (view.units[view.session.unit_ix]?.ord ?? view.session.unit_ix + 1)
+        ? ([...view.units].sort((a, b) => a.ord - b.ord)[view.session.unit_ix]?.ord ?? view.session.unit_ix + 1)
         : undefined;
 
   return (

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -990,14 +990,19 @@ export function CenterDashboard({
   // log, would be empty for an evaluation that is durably recorded (Copilot on #252). Bounded the
   // way `useBoardModel`'s failed-run backfill is: once per run id per mount, and only for runs
   // that currently hold a gate (a paused run has exactly one), so the list surface's request
-  // budget stays O(open gates), not O(rows). Degrades silently — an api surface without
-  // `getRunEvents`, a 503 (no event-log binding) or an empty history leaves the card promptless,
-  // never wrong; `hydrate` merges live frames by fingerprint, so nothing is double-counted.
+  // budget stays O(open gates), not O(rows). No "already has frames" shortcut: after a reconnect
+  // the live slice may hold only the new `awaitingHuman` while the `gateEvaluated` that opened it
+  // was recorded before the socket came up, so presence of a frame proves nothing about the
+  // history — the once-per-id guard alone bounds the requests, and `hydrate` merges live frames
+  // by fingerprint, so nothing is double-counted. Depends on `openGates` only (the store is read
+  // inside), so a busy dashboard does not rescan its gates on every structured frame. Degrades
+  // silently — an api surface without `getRunEvents`, a 503 (no event-log binding) or an empty
+  // history leaves the card promptless, never wrong.
   const gateBackfilled = useRef<Set<string>>(new Set());
   useEffect(() => {
     for (const g of openGates) {
       const id = g.runId;
-      if (gateBackfilled.current.has(id) || (byRun[id] ?? []).length > 0) continue;
+      if (gateBackfilled.current.has(id)) continue;
       gateBackfilled.current.add(id);
       try {
         api
@@ -1008,7 +1013,7 @@ export function CenterDashboard({
         /* an api surface without getRunEvents — nothing to backfill from */
       }
     }
-  }, [openGates, byRun]);
+  }, [openGates]);
 
   /** The last recorded `sessionFailed` message for a run, if the store holds one. */
   const failReasonOf = useCallback(

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -984,6 +984,32 @@ export function CenterDashboard({
     return all.filter((g) => mine.has(g.runId));
   }, [gates, projectId, scopedRuns]);
 
+  // Backfill the event log for OPEN-GATE runs whose frames are not in the store (a landing or
+  // project reload: `useRuns` restores the run list and the gate prompt, but only the run page's
+  // route hydrates `/runs/:id/events`) — else the inbox card's verdict block, which reads that
+  // log, would be empty for an evaluation that is durably recorded (Copilot on #252). Bounded the
+  // way `useBoardModel`'s failed-run backfill is: once per run id per mount, and only for runs
+  // that currently hold a gate (a paused run has exactly one), so the list surface's request
+  // budget stays O(open gates), not O(rows). Degrades silently — an api surface without
+  // `getRunEvents`, a 503 (no event-log binding) or an empty history leaves the card promptless,
+  // never wrong; `hydrate` merges live frames by fingerprint, so nothing is double-counted.
+  const gateBackfilled = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const g of openGates) {
+      const id = g.runId;
+      if (gateBackfilled.current.has(id) || (byRun[id] ?? []).length > 0) continue;
+      gateBackfilled.current.add(id);
+      try {
+        api
+          .getRunEvents(id)
+          .then(({ events }) => useRunEventStore.getState().hydrate(id, events))
+          .catch(() => { /* no event-log binding, or no persisted history — no backfill */ });
+      } catch {
+        /* an api surface without getRunEvents — nothing to backfill from */
+      }
+    }
+  }, [openGates, byRun]);
+
   /** The last recorded `sessionFailed` message for a run, if the store holds one. */
   const failReasonOf = useCallback(
     (runId: string): string | undefined => {

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -14,12 +14,14 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { SessionView } from '../api/types.js';
+import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
 import { unitsInFlight } from '../api/run-state.js';
 import { usageTotals, WINDOW_LABEL_STYLE } from '../board/metrics.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
+import { GateVerdict } from './GateVerdict.js';
+import { gateVerdict, phaseLabel } from './gateVerdictModel.js';
 import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { chroniclePath, modePath } from '../hooks/useRoute.js';
@@ -271,6 +273,9 @@ const FEED_META: Record<string, FeedMeta> = {
   },
 };
 
+const NO_EVENTS: CoreEvent[] = [];
+const NO_UNITS: WorkUnit[] = [];
+
 const DEFAULT_META: FeedMeta = {
   icon: '·',
   label: 'Event',
@@ -286,6 +291,11 @@ interface GateCardProps {
   ord: number | undefined;
   prompt: string | undefined;
   sessionLbl: string;
+  /** The run's structured event log (already subscribed by the dashboard) — the evaluator verdict
+   *  this gate is about is read from it (wicked-studio#250, F-3R2-006), exactly as `SteeringGate` does. */
+  events: readonly CoreEvent[];
+  /** The run's units (snapshot) — names the verdict's phase. */
+  units: readonly WorkUnit[];
   onApprove: (runId: string, amend?: string) => Promise<void>;
   onReject: (runId: string) => Promise<void>;
 }
@@ -295,12 +305,18 @@ function GateActionCard({
   ord,
   prompt,
   sessionLbl,
+  events,
+  units,
   onApprove,
   onReject,
 }: GateCardProps): React.ReactElement {
   const [amend, setAmend] = useState('');
   const [loading, setLoading] = useState(false);
   const [steerOpen, setSteerOpen] = useState(false);
+  // The same verdict block the run page's gate card renders (F-3R2-006): a gate answered from
+  // this inbox must show what it is approving too. Bounded on the gate's ord — with none known,
+  // no block, never an unbounded historical evaluation dressed as this gate's.
+  const verdict = useMemo(() => (typeof ord === 'number' ? gateVerdict(events, ord) : null), [events, ord]);
 
   const run = useCallback(
     async (action: () => Promise<void>): Promise<void> => {
@@ -394,6 +410,11 @@ function GateActionCard({
         >
           {prompt}
         </p>
+      )}
+
+      {/* The evaluator verdict this gate is about (F-3R2-006) — see SteeringGate. */}
+      {verdict !== null && (
+        <GateVerdict view={verdict} phase={phaseLabel(runId, units, verdict.ord)} />
       )}
 
       {/* Steer textarea — visible only when "Approve + steer" is toggled */}
@@ -1080,6 +1101,8 @@ export function CenterDashboard({
                     ord={gate.ord}
                     prompt={gate.prompt}
                     sessionLbl={lbl}
+                    events={byRun[gate.runId] ?? NO_EVENTS}
+                    units={v?.units ?? NO_UNITS}
                     onApprove={handleApprove}
                     onReject={handleReject}
                   />

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -276,6 +276,12 @@ const FEED_META: Record<string, FeedMeta> = {
 const NO_EVENTS: CoreEvent[] = [];
 const NO_UNITS: WorkUnit[] = [];
 
+/** One open gate as an INSTANCE: the same run can open several while the dashboard stays mounted
+ *  (a retry of the same ord included), and each must fetch and prove its own history. */
+function gateInstanceKey(g: { runId: string; ord: number; receivedAt: number }): string {
+  return `${g.runId}:${g.ord}:${g.receivedAt}`;
+}
+
 const DEFAULT_META: FeedMeta = {
   icon: '·',
   label: 'Event',
@@ -296,6 +302,11 @@ interface GateCardProps {
   events: readonly CoreEvent[];
   /** The run's units (snapshot) — names the verdict's phase. */
   units: readonly WorkUnit[];
+  /** True once THIS gate instance's durable history has been fetched and merged (see the
+   *  dashboard's backfill). Until then the block is withheld: the store may hold only an earlier
+   *  attempt's evaluation plus this gate's `awaitingHuman`, and a same-ord retry would otherwise
+   *  render the OLD verdict under the new gate — indefinitely, if the fetch returns nothing. */
+  ready: boolean;
   onApprove: (runId: string, amend?: string) => Promise<void>;
   onReject: (runId: string) => Promise<void>;
 }
@@ -307,6 +318,7 @@ function GateActionCard({
   sessionLbl,
   events,
   units,
+  ready,
   onApprove,
   onReject,
 }: GateCardProps): React.ReactElement {
@@ -315,8 +327,12 @@ function GateActionCard({
   const [steerOpen, setSteerOpen] = useState(false);
   // The same verdict block the run page's gate card renders (F-3R2-006): a gate answered from
   // this inbox must show what it is approving too. Bounded on the gate's ord — with none known,
-  // no block, never an unbounded historical evaluation dressed as this gate's.
-  const verdict = useMemo(() => (typeof ord === 'number' ? gateVerdict(events, ord) : null), [events, ord]);
+  // no block, never an unbounded historical evaluation dressed as this gate's — and only once
+  // this gate instance's history is KNOWN (`ready`): never the previous slice's verdict.
+  const verdict = useMemo(
+    () => (ready && typeof ord === 'number' ? gateVerdict(events, ord) : null),
+    [events, ord, ready],
+  );
 
   const run = useCallback(
     async (action: () => Promise<void>): Promise<void> => {
@@ -1001,20 +1017,32 @@ export function CenterDashboard({
   // is read inside), so a busy dashboard does not rescan its gates on every structured frame.
   // Degrades silently — an api surface without `getRunEvents`, a 503 (no event-log binding) or
   // an empty history leaves the card promptless, never wrong.
+  //
+  // READINESS (Copilot on #252): while an instance's fetch is pending the card renders NO verdict —
+  // the store's slice may be an earlier attempt's evaluation plus this gate's `awaitingHuman`, so
+  // on a same-ord retry after a reconnect "render from what we have" would show the OLD verdict
+  // under the new gate. An instance becomes ready only when its fetch resolves WITH history (the
+  // durable prefix merged); an empty history or a 503 leaves it un-ready for good — no block,
+  // never a stale one — which is the contract stated above.
   const gateBackfilled = useRef<Set<string>>(new Set());
+  const [gateReady, setGateReady] = useState<ReadonlySet<string>>(() => new Set());
   useEffect(() => {
     for (const g of openGates) {
       const id = g.runId;
-      const instance = `${id}:${g.ord}:${g.receivedAt}`;
+      const instance = gateInstanceKey(g);
       if (gateBackfilled.current.has(instance)) continue;
       gateBackfilled.current.add(instance);
       try {
         api
           .getRunEvents(id)
-          .then(({ events }) => useRunEventStore.getState().hydrate(id, events))
-          .catch(() => { /* no event-log binding, or no persisted history — no backfill */ });
+          .then(({ events }) => {
+            if (events.length === 0) return; // nothing known — stays un-ready, no block
+            useRunEventStore.getState().hydrate(id, events);
+            setGateReady((prev) => (prev.has(instance) ? prev : new Set(prev).add(instance)));
+          })
+          .catch(() => { /* no event-log binding, or the fetch failed — stays un-ready, no block */ });
       } catch {
-        /* an api surface without getRunEvents — nothing to backfill from */
+        /* an api surface without getRunEvents — nothing to backfill from; stays un-ready */
       }
     }
   }, [openGates]);
@@ -1138,6 +1166,7 @@ export function CenterDashboard({
                     sessionLbl={lbl}
                     events={byRun[gate.runId] ?? NO_EVENTS}
                     units={v?.units ?? NO_UNITS}
+                    ready={gateReady.has(gateInstanceKey(gate))}
                     onApprove={handleApprove}
                     onReject={handleReject}
                   />

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -988,22 +988,26 @@ export function CenterDashboard({
   // project reload: `useRuns` restores the run list and the gate prompt, but only the run page's
   // route hydrates `/runs/:id/events`) — else the inbox card's verdict block, which reads that
   // log, would be empty for an evaluation that is durably recorded (Copilot on #252). Bounded the
-  // way `useBoardModel`'s failed-run backfill is: once per run id per mount, and only for runs
-  // that currently hold a gate (a paused run has exactly one), so the list surface's request
-  // budget stays O(open gates), not O(rows). No "already has frames" shortcut: after a reconnect
-  // the live slice may hold only the new `awaitingHuman` while the `gateEvaluated` that opened it
-  // was recorded before the socket came up, so presence of a frame proves nothing about the
-  // history — the once-per-id guard alone bounds the requests, and `hydrate` merges live frames
-  // by fingerprint, so nothing is double-counted. Depends on `openGates` only (the store is read
-  // inside), so a busy dashboard does not rescan its gates on every structured frame. Degrades
-  // silently — an api surface without `getRunEvents`, a 503 (no event-log binding) or an empty
-  // history leaves the card promptless, never wrong.
+  // way `useBoardModel`'s failed-run backfill is: once per GATE INSTANCE (run id + ord + the
+  // moment it opened) per mount, and only for runs that currently hold a gate (a paused run has
+  // exactly one), so the list surface's request budget stays O(gates opened), not O(rows) — and a
+  // run that opens a second gate while the dashboard stays mounted (a retry of the same ord
+  // included) refreshes its durable prefix, so a reconnect gap between the two can never leave the
+  // earlier attempt's verdict standing under the new gate. No "already has frames" shortcut: after
+  // a reconnect the live slice may hold only the new `awaitingHuman` while the `gateEvaluated` that
+  // opened it was recorded before the socket came up, so presence of a frame proves nothing about
+  // the history — the per-instance guard alone bounds the requests, and `hydrate` merges live
+  // frames by fingerprint, so nothing is double-counted. Depends on `openGates` only (the store
+  // is read inside), so a busy dashboard does not rescan its gates on every structured frame.
+  // Degrades silently — an api surface without `getRunEvents`, a 503 (no event-log binding) or
+  // an empty history leaves the card promptless, never wrong.
   const gateBackfilled = useRef<Set<string>>(new Set());
   useEffect(() => {
     for (const g of openGates) {
       const id = g.runId;
-      if (gateBackfilled.current.has(id)) continue;
-      gateBackfilled.current.add(id);
+      const instance = `${id}:${g.ord}:${g.receivedAt}`;
+      if (gateBackfilled.current.has(instance)) continue;
+      gateBackfilled.current.add(instance);
       try {
         api
           .getRunEvents(id)

--- a/src/components/DeckKpiRibbon.tsx
+++ b/src/components/DeckKpiRibbon.tsx
@@ -4,6 +4,7 @@ import type { Navigate } from '../hooks/useRoute.js';
 import { governedRuns } from '../board/steeringUsage.js';
 import { observedSpend } from '../board/metrics.js';
 import { useRuntimeStore } from '../store/runtime.js';
+import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import {
   attachSeries,
   createdAtSeries,
@@ -51,6 +52,9 @@ interface Props {
 export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props): React.ReactElement {
   const at = now ?? Date.now();
   const logs = useRuntimeStore((s) => s.logs);
+  // The `is_system` lookup licenses the vacuous count (wicked-studio#250, F-3R2-018) — the same
+  // fold the strip below reads, so the Review tile and the strip can never disagree.
+  const isSystemWorkflow = useIsSystemWorkflow();
 
   const model = useMemo(() => {
     const live = runs.filter((v) => v.session.archived_at == null);
@@ -75,7 +79,7 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
     const successWord = counts.terminal === 0 ? '—' : `${Math.round((counts.done / counts.terminal) * 100)}%`;
 
     // Delivery outcomes across all live runs (the review-queue count + the strip below the feed).
-    const dc = deliveryCounts(live);
+    const dc = deliveryCounts(live, isSystemWorkflow);
     const reviewQueue = dc.stranded + dc.vacuous;
 
     // Rework: share of live runs that are a retry of another.
@@ -90,7 +94,7 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
       runsCurrent: current.length, runsDelta, failedDelta, counts, activeNow, spark,
       health, successWord, reviewQueue, reworkPct, governed, spend,
     };
-  }, [runs, claims, logs, at]);
+  }, [runs, claims, logs, at, isSystemWorkflow]);
 
   const go = (path: string) => (e: React.MouseEvent) => { e.preventDefault(); navigate(path); };
 

--- a/src/components/DeckVerifiedStrip.tsx
+++ b/src/components/DeckVerifiedStrip.tsx
@@ -2,18 +2,26 @@ import { useMemo } from 'react';
 import type { SessionView } from '../api/types.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { deliveryCounts } from '../board/windowStats.js';
+import { useIsSystemWorkflow } from '../store/workflowCache.js';
 
 /**
  * The verified-vs-needs-review strip (command-deck redesign) — the delivery outcomes pulled UP from
  * the run detail into the landing, so "what shipped vs what still needs me" reads at a glance. One
  * fold ({@link deliveryCounts}) shared with the ribbon's ATTENTION "review" tile, off the run DTO's
- * `delivery` field — nothing is fetched. Each cell is a door into the matching Work filter.
+ * `delivery` field — nothing is fetched per run. Each cell is a door into the matching Work filter.
+ *
+ * The `vacuous` cell counts only runs that were EXPECTED to deliver (wicked-studio#250,
+ * F-3R2-018): the fold takes the app's `is_system` lookup — the ONE `GET /workflows` the cache
+ * already budgets for the whole session — so onboarding and the other system workflows, which
+ * deliver nothing by design, no longer read as "9 Vacuous — needs retry" and bury the real signal.
+ * The label states the condition ("no change to deliver"), not a prescription.
  */
 export function DeckVerifiedStrip({ runs, navigate }: {
   runs: SessionView[];
   navigate: Navigate;
 }): React.ReactElement {
-  const c = useMemo(() => deliveryCounts(runs), [runs]);
+  const isSystemWorkflow = useIsSystemWorkflow();
+  const c = useMemo(() => deliveryCounts(runs, isSystemWorkflow), [runs, isSystemWorkflow]);
   const cell = (path: string) => (e: React.MouseEvent): void => { e.preventDefault(); navigate(path); };
   return (
     <div className="deck-vrbar" data-testid="home-delivery-strip" role="group" aria-label="Delivery outcomes">
@@ -27,7 +35,7 @@ export function DeckVerifiedStrip({ runs, navigate }: {
       </a>
       <a className="deck-vrcell" data-testid="delivery-vacuous" href="/work?filter=vacuous" onClick={cell('/work?filter=vacuous')}>
         <span className="deck-vn bad">{c.vacuous}</span>
-        <span className="deck-vl">Vacuous — needs retry</span>
+        <span className="deck-vl">Vacuous — no change to deliver</span>
       </a>
     </div>
   );

--- a/src/components/GateVerdict.tsx
+++ b/src/components/GateVerdict.tsx
@@ -1,0 +1,169 @@
+import {
+  checkOutcome,
+  denialSourceLabel,
+  formatDuration,
+  splitBackticks,
+  type GateVerdictView,
+} from './gateVerdictModel.js';
+
+/**
+ * The evaluator's verdict ON the gate card (wicked-studio#250, F-3R2-006): what the operator is
+ * really being asked to approve or reject. A pure view over {@link GateVerdictView} — the
+ * selection and narrowing live in `gateVerdictModel.ts`; this file only says it.
+ *
+ * States, by `data-verdict`:
+ *  - `pass`    — the floor (when one ran) and the judge passed; the criterion and the judge's
+ *                reasoning are stated so "approve" is an informed act, not a reflex.
+ *  - `fail`    — the winning denial: WHICH layer (`data-denial-source`), the engine's reason
+ *                VERBATIM (it carries the remedy — a quoted command renders as copyable code),
+ *                and for a worktree-guard denial the changed paths + seat + tree ids.
+ *  - `ungated` — nothing gated the phase (no floor, no judge, no evaluator policy): labelled as a
+ *                default-allow, never dressed as a pass (FINDING-025).
+ *
+ * The repo-checks floor (F-039) lists every check that ran — name, exit code, duration, the
+ * manifest line it came from — and what was skipped, so "checks passed" is the exit codes the
+ * engine observed, not the seat's account of them. The judge SEAT is not on the wire (api-types
+ * 0.31.0), so no line claims one.
+ *
+ * Own testids (`gate-verdict-*`): the run page's `verdict-detail` card keeps its selector.
+ */
+export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: string }): React.ReactElement {
+  const { outcome } = view;
+  const tone = outcome === 'fail' ? 'var(--status-fail)' : outcome === 'pass' ? 'var(--status-done)' : 'var(--ink-muted)';
+  const toneDim = outcome === 'fail' ? 'var(--status-fail-dim)' : outcome === 'pass' ? 'var(--status-done-dim)' : 'var(--surface-raised)';
+  const word = outcome === 'fail' ? 'DENIED' : outcome === 'pass' ? 'PASS' : 'UNGATED';
+  const vacuous = view.evaluatorPolicies.length === 0 && view.evaluatorPass === true;
+
+  return (
+    <div
+      data-testid="gate-verdict"
+      data-verdict={outcome}
+      {...(view.ord !== null ? { 'data-phase-ord': view.ord } : {})}
+      {...(view.denial !== null && view.denial.source !== null ? { 'data-denial-source': view.denial.source } : {})}
+      className="rounded-lg p-2.5 mb-3 flex flex-col gap-1 font-mono"
+      style={{ background: toneDim, border: `1px solid ${toneDim}` }}
+    >
+      <p className="text-xs font-semibold" style={{ color: tone }}>
+        Evaluator verdict — {phase} · {word}
+      </p>
+
+      {view.criterion !== null && (
+        <p className="text-[11px]" data-testid="gate-verdict-criterion" style={{ color: 'var(--ink-muted)' }}>
+          criterion: {view.criterion}
+        </p>
+      )}
+
+      {(view.agentVerdict !== null || view.agentReasoning !== null) && (
+        <p className="text-[11px]" data-testid="gate-verdict-judge" style={{ color: 'var(--ink-body)' }}>
+          {view.agentVerdict !== null && <span className="font-semibold">judge: {view.agentVerdict}</span>}
+          {view.agentVerdict !== null && view.agentReasoning !== null && ' — '}
+          {view.agentReasoning}
+        </p>
+      )}
+
+      {view.denial !== null && (
+        <p className="text-[11px]" data-testid="gate-verdict-denial" style={{ color: 'var(--status-fail)' }}>
+          <span className="font-semibold">denied by {denialSourceLabel(view.denial.source)}: </span>
+          {splitBackticks(view.denial.reason).map((part, i) =>
+            i % 2 === 1 ? (
+              <code key={i} className="px-1 rounded" style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)' }}>
+                {part}
+              </code>
+            ) : (
+              <span key={i}>{part}</span>
+            ),
+          )}
+          {view.denial.ruleIds.length > 0 && <span> · rules: {view.denial.ruleIds.join(', ')}</span>}
+          {view.denial.deniedTool !== null && <span> · tool: {view.denial.deniedTool}</span>}
+        </p>
+      )}
+
+      {view.mutation !== null && (
+        <p className="text-[11px]" data-testid="gate-verdict-mutation" style={{ color: 'var(--ink-body)' }}>
+          worktree changed by <span className="font-semibold">{view.mutation.cli || 'the seat'}</span>
+          {view.mutation.phase !== '' && <> during <span className="font-semibold">{view.mutation.phase}</span></>}
+          {': '}
+          {view.mutation.changed.length === 0
+            ? 'no path listed'
+            : view.mutation.changed.map((c) => `${c.status} ${c.path}`).join(', ')}
+          {view.mutation.beforeTree !== '' && view.mutation.afterTree !== '' && (
+            <span style={{ color: 'var(--ink-dim)' }}>
+              {' '}(tree {view.mutation.beforeTree.slice(0, 10)} → {view.mutation.afterTree.slice(0, 10)})
+            </span>
+          )}
+          {view.mutation.headMoved && ' · the run branch moved'}
+        </p>
+      )}
+
+      {view.floor !== null && (
+        <div
+          data-testid="gate-verdict-floor"
+          data-floor={view.floor.passed ? 'pass' : 'fail'}
+          className="text-[11px] flex flex-col gap-0.5"
+          style={{ color: 'var(--ink-body)' }}
+        >
+          <p>
+            <span className="font-semibold" style={{ color: view.floor.passed ? 'var(--status-done)' : 'var(--status-fail)' }}>
+              repository checks — {view.floor.passed ? 'pass' : 'fail'}
+            </span>
+            {view.floor.criterion !== '' && <span style={{ color: 'var(--ink-muted)' }}> · {view.floor.criterion}</span>}
+          </p>
+          {view.floor.checks.length === 0 ? (
+            <p style={{ color: 'var(--ink-muted)' }}>
+              {view.floor.passed
+                ? 'no detectable check in this repository — a disclosed vacuous pass, not a green suite'
+                : 'the floor failed before any check ran (no write boundary could be armed, or the manifest could not be trusted)'}
+            </p>
+          ) : (
+            <ul className="pl-3 list-disc">
+              {view.floor.checks.map((c) => {
+                const o = checkOutcome(c);
+                return (
+                  <li
+                    key={c.name}
+                    data-testid="gate-verdict-check"
+                    data-check={c.name}
+                    data-ok={o.ok ? 'true' : 'false'}
+                  >
+                    <span className="font-semibold">{c.name}</span>
+                    {' · '}
+                    <span style={{ color: o.ok ? 'var(--status-done)' : 'var(--status-fail)' }}>{o.word}</span>
+                    {' · '}
+                    {formatDuration(c.durationMs)}
+                    {c.source !== '' && <span style={{ color: 'var(--ink-dim)' }}> · {c.source}</span>}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {view.floor.skipped.length > 0 && (
+            <p data-testid="gate-verdict-skipped" style={{ color: 'var(--ink-muted)' }}>
+              skipped (an earlier check failed): {view.floor.skipped.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Which governance layers actually ran — the same never-overclaim line as VerdictDetail. */}
+      <p className="text-[10px]" data-testid="gate-verdict-layers" style={{ color: 'var(--ink-muted)' }}>
+        {view.hasDeterministicFloor
+          ? `deterministic floor: ${view.deterministicPass ? 'pass' : 'fail'}`
+          : 'no deterministic floor'}
+        {' · '}
+        {view.evaluatorPass === null
+          ? 'evaluator layer did not run'
+          : vacuous
+            ? 'evaluator: default-allow (no policy applied)'
+            : `evaluator: ${view.evaluatorPass ? 'pass' : 'fail'} (${view.evaluatorPolicies.length} ${
+                view.evaluatorPolicies.length === 1 ? 'policy' : 'policies'
+              })`}
+      </p>
+
+      {outcome === 'ungated' && (
+        <p className="text-[11px]" data-testid="gate-verdict-ungated" style={{ color: 'var(--ink-muted)' }}>
+          nothing gated this phase — it was approved by default, not verified
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/GateVerdict.tsx
+++ b/src/components/GateVerdict.tsx
@@ -62,7 +62,13 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
       )}
 
       {view.denial !== null && (
-        <p className="text-[11px]" data-testid="gate-verdict-denial" style={{ color: 'var(--status-fail)' }}>
+        <p
+          className="text-[11px]"
+          data-testid="gate-verdict-denial"
+          // The recorded remedy carries a 40-hex tree id inside one <code> span — an unbreakable
+          // token that overflows a narrow dock unless it may wrap anywhere.
+          style={{ color: 'var(--status-fail)', overflowWrap: 'anywhere' }}
+        >
           <span className="font-semibold">denied by {denialSourceLabel(view.denial.source)}: </span>
           {splitBackticks(view.denial.reason).map((part, i) =>
             i % 2 === 1 ? (

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { api, type GateDecision } from '../api/client.js';
-import type { CoverageReport } from '../api/types.js';
+import type { CoreEvent, CoverageReport, WorkUnit } from '../api/types.js';
 import { useGlobalShortcuts, type ShortcutEntry } from '../hooks/useGlobalShortcuts.js';
 import { useSteerPrefixes } from '../hooks/useSteerPrefixes.js';
 import { useAnnotationStore } from '../store/annotations.js';
+import { useRunEventStore } from '../store/events.js';
 import { durableGuidance, useGuidanceStore } from '../store/guidance.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
 import { GATE_HASH } from './GateChip.js';
+import { GateVerdict } from './GateVerdict.js';
+import { gateVerdict, phaseLabel } from './gateVerdictModel.js';
 
 interface Props {
   runId: string;
@@ -18,8 +21,14 @@ interface Props {
   guidance?: string | undefined;
   /** When present, fetches coverage stats for inline display at the gate card. */
   repoRef?: string;
+  /** The run's units (snapshot) — names the phase the evaluator verdict on the card is about
+   *  (wicked-studio#250, F-3R2-006). Absent ⇒ the verdict says `unit N`. */
+  units?: readonly WorkUnit[];
   onResolved?: () => void;
 }
+
+const EMPTY_EVENTS: CoreEvent[] = [];
+const EMPTY_UNITS: WorkUnit[] = [];
 
 /** Strip the bracketed architectural footnote from a workflow gate prompt. */
 function cleanPrompt(raw: string): { headline: string; footnote: string | null } {
@@ -38,9 +47,16 @@ function coverageLabel(r: CoverageReport): string {
   return `Coverage: ${pct} · ${r.behavior_bearing.toLocaleString()} nodes · ${r.unaccounted} unaccounted${resolvedPct}`;
 }
 
-export function SteeringGate({ runId, ord, prompt, guidance, repoRef, onResolved }: Props): React.ReactElement {
+export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onResolved }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
   const recordSteering = useSteeringStore((s) => s.record);
+  // The evaluator's record for THIS gate (wicked-studio#250, F-3R2-006): a pure view over the
+  // run's event log — already hydrated by the run page and fed live by /ws — so the card states
+  // what the operator is approving (the fix phase's verdict, criterion, the checks that ran) or
+  // rejecting (which layer denied, the engine's remedy) instead of the bare prompt. Zero fetches;
+  // an un-hydrated or evaluation-less log renders no block, never a verdict made up from the prompt.
+  const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
+  const verdict = useMemo(() => gateVerdict(events, ord), [events, ord]);
   // Slice BD (DES-UX-002 §4.3, EC51): gate arrival pre-populates the steer
   // textarea — the gate card MOUNTING is the arrival on this surface. Slice BE
   // added the durable layer (CREW-UX-7): pre-population order is the run DTO's
@@ -239,6 +255,14 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, onResolved
       >
         {headline}
       </p>
+
+      {/* The evaluator verdict this gate is about (F-3R2-006): pass/deny, criterion, the judge's
+          reasoning, the repo-checks floor per check, and on a denial the layer + the engine's
+          remedy verbatim. Rendered BETWEEN the question and the answer controls, so the decision
+          is informed on the card itself — not in an expandable thread line. */}
+      {verdict !== null && (
+        <GateVerdict view={verdict} phase={phaseLabel(runId, units ?? EMPTY_UNITS, verdict.ord)} />
+      )}
 
       {/* Coverage stats — shown when evaluator gate fails and we have repo coverage data */}
       {isCoverageFail && coverage && (

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -55,8 +55,12 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
   // what the operator is approving (the fix phase's verdict, criterion, the checks that ran) or
   // rejecting (which layer denied, the engine's remedy) instead of the bare prompt. Zero fetches;
   // an un-hydrated or evaluation-less log renders no block, never a verdict made up from the prompt.
+  // BOUNDED on the gate's ord, always: with no numeric ord in hand there is nothing to bound the
+  // lookup with, so no block — never an unbounded historical evaluation dressed as this gate's
+  // (Copilot on #252). Every caller has one: the gate record's, or ApprovalDock's derivation from
+  // the run's own cursor when the daemon-restart fallback lost the prompt.
   const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
-  const verdict = useMemo(() => gateVerdict(events, ord), [events, ord]);
+  const verdict = useMemo(() => (typeof ord === 'number' ? gateVerdict(events, ord) : null), [events, ord]);
   // Slice BD (DES-UX-002 §4.3, EC51): gate arrival pre-populates the steer
   // textarea — the gate card MOUNTING is the arrival on this surface. Slice BE
   // added the durable layer (CREW-UX-7): pre-population order is the run DTO's

--- a/src/components/VerdictDetail.tsx
+++ b/src/components/VerdictDetail.tsx
@@ -1,5 +1,6 @@
 import type { CoreEvent, WorkUnit } from '../api/types.js';
 import { useRunEventStore } from '../store/events.js';
+import { phaseLabel } from './gateVerdictModel.js';
 
 /**
  * The evaluator verdict card (DES-UX-001 §1.3-2, slice R).
@@ -75,14 +76,8 @@ export function decidingEval(events: readonly CoreEvent[]): GateEvalView | null 
   return denies[denies.length - 1] ?? evals[evals.length - 1] ?? null;
 }
 
-/** Phase name for an ord: the unit-key suffix for workflow units, the stage for free-text ones. */
-function phaseLabel(runId: string, units: readonly WorkUnit[], ord: number | null): string {
-  if (ord === null) return 'unknown phase';
-  const unit = units.find((u) => u.ord === ord);
-  if (unit === undefined) return `unit ${ord}`;
-  const key = unit.id.startsWith(`${runId}:`) ? unit.id.slice(runId.length + 1) : `u${unit.ord}`;
-  return /^u\d+$/.test(key) ? unit.stage : key;
-}
+// `phaseLabel` (the unit-key suffix for workflow units, the stage for free-text ones) is shared
+// with the gate card's verdict block — one spelling, `./gateVerdictModel.ts`.
 
 const EMPTY_EVENTS: CoreEvent[] = [];
 

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -105,13 +105,16 @@ const strings = (v: unknown): string[] =>
 function denialOf(ev: CoreEvent): GateDenialView | null {
   const raw = ev.denial;
   if (isRecord(raw) && typeof raw.reason === 'string') {
+    // Either casing survives the wire (api-types 0.31.0 spells it camelCase; earlier engines and
+    // the unit-record twin spell `claim_id` / `rule_ids` — the same tolerance `denialCopy.ts`
+    // already keeps), so a snake_case denial never drops its rule ids from the card.
     const d = raw as Partial<UnitDenial> & Record<string, unknown>;
     return {
       source: str(d.source),
       reason: d.reason as string,
-      claimId: str(d.claimId),
-      ruleIds: strings(d.ruleIds),
-      deniedTool: str(d.deniedTool),
+      claimId: str(d.claimId) ?? str(d['claim_id']),
+      ruleIds: strings(d.ruleIds ?? d['rule_ids']),
+      deniedTool: str(d.deniedTool) ?? str(d['denied_tool']),
       phase: str(d.phase),
     };
   }

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -188,7 +188,10 @@ export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): Gat
   for (let i = 0; i < events.length; i++) {
     const e = events[i]!;
     if (e.type !== 'gateEvaluated') continue;
-    if (gateOrd !== undefined && typeof e.ord === 'number' && e.ord > gateOrd) continue;
+    // A bounded lookup needs a numeric ordinal to bound: a frame with no `ord` cannot be shown to
+    // belong at or below this gate, so it is never the answer to one (Copilot on #252). Unbounded
+    // (no `gateOrd`) still takes the last evaluation whatever its shape.
+    if (gateOrd !== undefined && (typeof e.ord !== 'number' || e.ord > gateOrd)) continue;
     idx = i;
   }
   if (idx === -1) return null;

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -269,12 +269,19 @@ export function checkOutcome(c: GateFloorCheck): { word: string; ok: boolean } {
   return { word: c.exitCode === 0 ? 'exit 0' : `exit ${c.exitCode}`, ok: c.exitCode === 0 };
 }
 
-/** `6893` → `6.9s`, `79191` → `1m 19s`, `420` → `420ms`. */
+/**
+ * `6893` → `6.9s`, `79191` → `1m 19s`, `420` → `420ms`. Rounds to the UNIT it is about to print
+ * BEFORE choosing the format, so a boundary value never shows sixty of a smaller unit: 59,999 ms is
+ * `1m` (not `60.0s`), 119,500 ms is `2m` (not `1m 60s`), 999.6 ms is `1.0s` (Copilot on #252).
+ */
 export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
-  const m = Math.floor(ms / 60_000);
-  const s = Math.round((ms - m * 60_000) / 1000);
+  const wholeMs = Math.max(0, Math.round(ms));
+  if (wholeMs < 1000) return `${wholeMs}ms`;
+  const tenths = Math.round(ms / 100);
+  if (tenths < 600) return `${(tenths / 10).toFixed(1)}s`;
+  const totalSecs = Math.round(ms / 1000);
+  const m = Math.floor(totalSecs / 60);
+  const s = totalSecs % 60;
   return s === 0 ? `${m}m` : `${m}m ${s}s`;
 }
 

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -1,0 +1,287 @@
+import type { CoreEvent, RepoCheckRun, UnitDenial, WorkUnit, WorktreeChangedPath } from '../api/types.js';
+
+/**
+ * gateVerdict — the evaluator's record for the gate the operator is answering, read off the run's
+ * event log (wicked-studio#250, F-3R2-006 — the UI half of wicked-core F-036/F-039).
+ *
+ * The gate card asked "Approve unit 4 before it runs: verify" and, one denial later, "Unit 4
+ * verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run" — and nothing
+ * else. The verdict the operator was really answering (the `fix` phase PASSED its floor and its
+ * judge; the `verify` phase was DENIED because it changed the worktree it was reviewing, here is
+ * the path, here is the restore command) sat on the wire the whole time, in `gateEvaluated`,
+ * `evaluatorMutatedWorktree` and `repoChecksEvaluated` (wicked-crew-api-types 0.31.0), rendered
+ * only as an expandable thread line.
+ *
+ * This module is the pure half: pick the DECIDING evaluation and attach its evidence. Zero
+ * requests — the card is a view over the event log the run page already hydrates
+ * (`store/events.ts`), exactly as `VerdictDetail` reads it for a finished run.
+ *
+ * WHICH evaluation: the LAST `gateEvaluated` in the log whose `ord` does not exceed the gate's.
+ * Arrival order is the daemon's order, so at an open gate "last" is the verdict that opened it —
+ * for a pre-run gate "before unit #N" that is the phase that just finished (ord < N, the fix
+ * gate); for an escalated gate it is unit N's own denial. The `ord` bound is defensive: a frame
+ * for a later unit can never be the answer to an earlier gate. `null` when the log holds no
+ * evaluation yet (the very first gate) or is not hydrated — the card then renders NO verdict
+ * block, never one fabricated from the prompt.
+ *
+ * WHAT is attached, by ord and log order (the nearest frame BEFORE the chosen evaluation):
+ *  - `repoChecksEvaluated` — the F-039 floor: which repository checks ran, each exit code and
+ *    duration, what was skipped; the wire fires it once per fold just before `gateEvaluated`.
+ *  - `evaluatorMutatedWorktree` — the F-036 record: the paths an `executes_code: false` phase
+ *    changed, the seat that ran it, both tree ids.
+ *  - `denial` — the structured twin of `denialReason` (which layer denied, the engine's prose);
+ *    an older engine that sends only the prose still yields a denial view with `source: null`.
+ *
+ * Never overclaimed (FINDING-025): an evaluation with no floor, no judge verdict and no evaluator
+ * policy is `'ungated'` — a default-allow the card labels as "nothing gated this phase", not a
+ * pass. The judge SEAT is not on this wire (api-types 0.31.0 `gateEvaluated` carries no seat),
+ * so no view field exists for it — render nothing rather than infer one from `unitDispatched`.
+ */
+
+export type GateOutcome = 'pass' | 'fail' | 'ungated';
+
+/** One repository check the engine ran, narrowed off the wire's {@link RepoCheckRun}. */
+export interface GateFloorCheck {
+  name: string;
+  argv: string[];
+  source: string;
+  exitCode: number | null;
+  timedOut: boolean;
+  spawnError: string | null;
+  durationMs: number;
+}
+
+/** The F-039 floor as `repoChecksEvaluated` reported it. */
+export interface GateFloorView {
+  passed: boolean;
+  criterion: string;
+  attempt: number | null;
+  checks: GateFloorCheck[];
+  skipped: string[];
+}
+
+/** The F-036 record as `evaluatorMutatedWorktree` reported it. */
+export interface GateMutationView {
+  cli: string;
+  phase: string;
+  beforeTree: string;
+  afterTree: string;
+  headMoved: boolean;
+  changed: WorktreeChangedPath[];
+}
+
+/** The winning denial: structured when the wire carries `denial`, prose-only from an older engine. */
+export interface GateDenialView {
+  /** The denying layer (`worktree_guard`, `repo_checks`, …); `null` when only the prose survived. */
+  source: string | null;
+  /** The engine's prose, verbatim — it carries the remedy (the restore command, the def change). */
+  reason: string;
+  claimId: string | null;
+  ruleIds: string[];
+  deniedTool: string | null;
+  phase: string | null;
+}
+
+export interface GateVerdictView {
+  ord: number | null;
+  outcome: GateOutcome;
+  criterion: string | null;
+  hasDeterministicFloor: boolean;
+  deterministicPass: boolean;
+  agentVerdict: string | null;
+  agentReasoning: string | null;
+  evaluatorPass: boolean | null;
+  evaluatorPolicies: string[];
+  denial: GateDenialView | null;
+  floor: GateFloorView | null;
+  mutation: GateMutationView | null;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+const strings = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+function denialOf(ev: CoreEvent): GateDenialView | null {
+  const raw = ev.denial;
+  if (isRecord(raw) && typeof raw.reason === 'string') {
+    const d = raw as Partial<UnitDenial> & Record<string, unknown>;
+    return {
+      source: str(d.source),
+      reason: d.reason as string,
+      claimId: str(d.claimId),
+      ruleIds: strings(d.ruleIds),
+      deniedTool: str(d.deniedTool),
+      phase: str(d.phase),
+    };
+  }
+  const prose = str(ev.denialReason);
+  if (prose === null || prose === '') return null;
+  return { source: null, reason: prose, claimId: null, ruleIds: [], deniedTool: null, phase: null };
+}
+
+function checkOf(raw: unknown): GateFloorCheck | null {
+  if (!isRecord(raw) || typeof raw.name !== 'string') return null;
+  const c = raw as Partial<RepoCheckRun> & Record<string, unknown>;
+  return {
+    name: c.name as string,
+    argv: strings(c.argv),
+    source: str(c.source) ?? '',
+    exitCode: typeof c.exitCode === 'number' ? c.exitCode : null,
+    timedOut: c.timedOut === true,
+    spawnError: str(c.spawnError),
+    durationMs: typeof c.durationMs === 'number' ? c.durationMs : 0,
+  };
+}
+
+function floorOf(ev: CoreEvent): GateFloorView {
+  return {
+    passed: ev.passed === true,
+    criterion: str(ev.criterion) ?? '',
+    attempt: typeof ev.attempt === 'number' ? ev.attempt : null,
+    checks: Array.isArray(ev.checks) ? ev.checks.map(checkOf).filter((c): c is GateFloorCheck => c !== null) : [],
+    skipped: strings(ev.skipped),
+  };
+}
+
+function mutationOf(ev: CoreEvent): GateMutationView {
+  const changed = Array.isArray(ev.changed)
+    ? ev.changed.filter(
+        (p): p is WorktreeChangedPath => isRecord(p) && typeof p.path === 'string' && typeof p.status === 'string',
+      )
+    : [];
+  return {
+    cli: str(ev.cli) ?? '',
+    phase: str(ev.phase) ?? '',
+    beforeTree: str(ev.beforeTree) ?? '',
+    afterTree: str(ev.afterTree) ?? '',
+    headMoved: ev.headMoved === true,
+    changed,
+  };
+}
+
+/**
+ * The nearest frame of `type` for `ord` BEFORE index `before`, or `null` — searching back only as
+ * far as the previous `gateEvaluated` for the same ord. Evidence belongs to ONE fold: a retry's
+ * evaluation must not inherit the mutation record or the repo checks of the attempt it replaced
+ * (the ord-4 `verify` retry in the recording passed on its own floor; attempt 0's changed path is
+ * that attempt's story, and the previous verdict is the boundary between them).
+ */
+function nearestBefore(events: readonly CoreEvent[], before: number, type: string, ord: number | null): CoreEvent | null {
+  for (let i = before - 1; i >= 0; i--) {
+    const e = events[i]!;
+    if (e.type === 'gateEvaluated' && (ord === null || e.ord === ord)) return null;
+    if (e.type !== type) continue;
+    if (ord !== null && e.ord !== ord) continue;
+    return e;
+  }
+  return null;
+}
+
+/**
+ * The deciding evaluation for a gate on `gateOrd` (the card's `ord`; omit to take the last
+ * evaluation in the log), with its floor and mutation evidence attached. `null` when the log
+ * holds no qualifying `gateEvaluated`.
+ */
+export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): GateVerdictView | null {
+  let idx = -1;
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!;
+    if (e.type !== 'gateEvaluated') continue;
+    if (gateOrd !== undefined && typeof e.ord === 'number' && e.ord > gateOrd) continue;
+    idx = i;
+  }
+  if (idx === -1) return null;
+  const ev = events[idx]!;
+  const ord = typeof ev.ord === 'number' ? ev.ord : null;
+
+  const hasDeterministicFloor = ev.hasDeterministicFloor === true;
+  const agentVerdict = str(ev.agentVerdict);
+  const evaluatorPolicies = strings(ev.evaluatorPolicies);
+  const denial = denialOf(ev);
+  const combined = ev.combined === true;
+
+  const outcome: GateOutcome =
+    !combined || denial !== null
+      ? 'fail'
+      : !hasDeterministicFloor && agentVerdict === null && evaluatorPolicies.length === 0
+        ? 'ungated'
+        : 'pass';
+
+  const floorFrame = nearestBefore(events, idx, 'repoChecksEvaluated', ord);
+  const mutationFrame = nearestBefore(events, idx, 'evaluatorMutatedWorktree', ord);
+
+  return {
+    ord,
+    outcome,
+    criterion: str(ev.criterion),
+    hasDeterministicFloor,
+    deterministicPass: ev.deterministicPass === true,
+    agentVerdict,
+    agentReasoning: str(ev.agentReasoning),
+    evaluatorPass: typeof ev.evaluatorPass === 'boolean' ? ev.evaluatorPass : null,
+    evaluatorPolicies,
+    denial,
+    floor: floorFrame === null ? null : floorOf(floorFrame),
+    mutation: mutationFrame === null ? null : mutationOf(mutationFrame),
+  };
+}
+
+/**
+ * Phase name for an ord: the unit-key suffix for workflow units (`run:fix` → `fix`), the stage
+ * for free-text ones, `unit N` when the snapshot has no such unit. Shared with `VerdictDetail`.
+ */
+export function phaseLabel(runId: string, units: readonly WorkUnit[], ord: number | null): string {
+  if (ord === null) return 'unknown phase';
+  const unit = units.find((u) => u.ord === ord);
+  if (unit === undefined) return `unit ${ord}`;
+  const key = unit.id.startsWith(`${runId}:`) ? unit.id.slice(runId.length + 1) : `u${unit.ord}`;
+  return /^u\d+$/.test(key) ? unit.stage : key;
+}
+
+/**
+ * A person's name for the layer that denied (wicked-core `UnitDenial.source`). Unknown tokens —
+ * a newer engine's — are shown as they arrive rather than guessed at.
+ */
+export function denialSourceLabel(source: string | null): string {
+  switch (source) {
+    case 'worktree_guard': return 'worktree guard (evaluator ≠ creator)';
+    case 'repo_checks': return 'repository checks';
+    case 'pinned_validator': return 'pinned validator';
+    case 'agent_validator': return 'agent judge';
+    case 'evaluator': return 'evaluator second pass';
+    case 'governance': return 'governance gate';
+    case 'input_governance': return 'input governance';
+    case 'worker_failure': return 'worker failure';
+    case 'substance': return 'no reviewable substance';
+    case 'deliverables': return 'declared deliverables missing';
+    case 'elicitation': return 'elicitation ended';
+    case null: return 'the gate';
+    default: return source;
+  }
+}
+
+/** How one repository check ended, in a word or two. */
+export function checkOutcome(c: GateFloorCheck): { word: string; ok: boolean } {
+  if (c.spawnError !== null) return { word: `could not start: ${c.spawnError}`, ok: false };
+  if (c.timedOut) return { word: 'timed out', ok: false };
+  if (c.exitCode === null) return { word: 'no exit code', ok: false };
+  return { word: c.exitCode === 0 ? 'exit 0' : `exit ${c.exitCode}`, ok: c.exitCode === 0 };
+}
+
+/** `6893` → `6.9s`, `79191` → `1m 19s`, `420` → `420ms`. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.round((ms - m * 60_000) / 1000);
+  return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}
+
+/**
+ * Split prose on backticked spans so a quoted command (`git read-tree --reset -u …`) can render
+ * as code the operator can copy. Odd indices are the code spans.
+ */
+export function splitBackticks(text: string): string[] {
+  return text.split('`');
+}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.4",
   "counts": {
-    "files": 138,
-    "occurrences": 1154,
-    "static": 992,
+    "files": 139,
+    "occurrences": 1164,
+    "static": 1002,
     "dynamic": 57,
     "computed": 6
   },
@@ -1923,6 +1923,66 @@
       "testId": "gate-toast-overflow",
       "files": [
         "src/components/GateNotifications.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-check",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-criterion",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-denial",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-floor",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-judge",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-layers",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-mutation",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-skipped",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-ungated",
+      "files": [
+        "src/components/GateVerdict.tsx"
       ]
     },
     {

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -21,7 +21,7 @@ import {
 import { useGateStore } from '../src/store/gates.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { makeUnit, makeView } from './factories.js';
-import { G4_EVENTS, G4_GATE, GATE_RUN, GATE_UNITS } from './fixtures/gateEvidence.js';
+import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, GATE_RUN, GATE_UNITS, REPO_CHECKS_FAIL } from './fixtures/gateEvidence.js';
 import type { SessionView } from '../src/api/types.js';
 
 /** `GET /runs/:id/events`, swappable per test — the gate inbox backfills it for open-gate runs. */
@@ -188,8 +188,10 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     expect(inbox.textContent).toContain('migrate the tables');
   });
 
-  it('F-3R2-006: the inbox card states the evaluator verdict the gate is about — the same block as the run page', () => {
-    // The recorded G4 gate (before unit #4, verify): the fix phase's PASS is in the run's event log.
+  it('F-3R2-006: the inbox card states the evaluator verdict the gate is about — the same block as the run page', async () => {
+    // The recorded G4 gate (before unit #4, verify): the fix phase's PASS is in the run's event log
+    // (live in the store AND confirmed by the durable log — readiness needs the latter).
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G4_EVENTS : [] }));
     useGateStore.setState({
       gates: {
         [GATE_RUN]: { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
@@ -198,7 +200,7 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS } });
     dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
     const inbox = screen.getByTestId('gate-inbox');
-    const card = screen.getByTestId('gate-verdict');
+    const card = await screen.findByTestId('gate-verdict');
     expect(inbox.contains(card)).toBe(true);
     expect(card).toHaveAttribute('data-verdict', 'pass');
     expect(card).toHaveAttribute('data-phase-ord', '3');
@@ -269,6 +271,65 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     // more (a reconnect gap between the two gates can never leave the old verdict standing).
     act(() => useGateStore.setState({ gates: { [GATE_RUN]: { ...first, receivedAt: 2 } } }));
     expect(getRunEvents).toHaveBeenCalledTimes(2);
+    // …and the new instance proves its own history before its block renders.
+    expect(await screen.findByTestId('gate-verdict')).toHaveAttribute('data-verdict', 'pass');
+  });
+
+  /** The retry's OWN verdict — attempt 1 denied by the repo-checks floor (wire-declared shape). */
+  const RETRY_DENY = {
+    type: 'gateEvaluated', session: GATE_RUN, ord: 4, seq: 403, ts: 1789081879700,
+    criterion: "the repository's own checks pass in the run's worktree",
+    hasDeterministicFloor: true, deterministicPass: false, agentVerdict: 'pass', agentReasoning: null,
+    evaluatorPass: true, evaluatorPolicies: [] as string[],
+    denialReason: 'repository checks failed in the worktree: lint exited 1',
+    denial: { source: 'repo_checks', reason: 'repository checks failed in the worktree: lint exited 1', claimId: null, ruleIds: [], deniedTool: null, phase: 'unit-4' },
+    combined: false,
+  };
+  const RETRY_GATE = { runId: GATE_RUN, ord: 4, prompt: G5_GATE.prompt, lifecycle: 'open', receivedAt: 2 };
+
+  it('READINESS: on a same-ord retry after a reconnect the OLD attempt\'s verdict never renders — the block waits for this gate\'s own history (Copilot on #252)', async () => {
+    // The live slice: attempt 0's worktree-guard denial (the run's EARLIER ord-4 gate) — all the
+    // store knows when the retry's gate opens after a reconnect gap.
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: [...G5_EVENTS] } });
+    let landLog!: (v: { events: unknown[] }) => void;
+    getRunEvents.mockImplementation(() => new Promise<{ events: unknown[] }>((r) => { landLog = r; }));
+    useGateStore.setState({ gates: { [GATE_RUN]: RETRY_GATE } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+
+    // Pending: the inbox shows the gate, but NO verdict — the ord-4 evaluation in the store is
+    // attempt 0's, not this gate's.
+    expect(screen.getByTestId('gate-inbox')).toBeInTheDocument();
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+
+    // The durable log lands with the retry's own verdict: the block renders THAT one.
+    await act(async () => { landLog({ events: [...G5_EVENTS, REPO_CHECKS_FAIL, RETRY_DENY] }); });
+    const card = await screen.findByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'fail');
+    expect(card).toHaveAttribute('data-denial-source', 'repo_checks');
+    expect(card).not.toHaveTextContent('worktree guard');
+    expect(screen.getByTestId('gate-verdict-floor')).toHaveAttribute('data-floor', 'fail');
+  });
+
+  it('READINESS: an EMPTY durable history leaves the block withheld — never the stale slice', async () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: [...G5_EVENTS] } });
+    getRunEvents.mockImplementation(async () => ({ events: [] }));
+    useGateStore.setState({ gates: { [GATE_RUN]: RETRY_GATE } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    await act(async () => { await Promise.resolve(); });
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('gate-inbox')).toBeInTheDocument();
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+  });
+
+  it('READINESS: a failed fetch (503 / no event-log binding) leaves the block withheld — never the stale slice', async () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: [...G5_EVENTS] } });
+    getRunEvents.mockImplementation(async () => { throw new Error('503 no event-log binding'); });
+    useGateStore.setState({ gates: { [GATE_RUN]: RETRY_GATE } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    await act(async () => { await Promise.resolve(); });
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('gate-inbox')).toBeInTheDocument();
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
   });
 
   it('the inbox card renders NO verdict block when the run has no evaluation in its log yet', () => {

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -227,6 +227,31 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     expect(getRunEvents).toHaveBeenCalledWith(GATE_RUN);
   });
 
+  it('after a RECONNECT the live slice may hold only the new awaitingHuman — the backfill still runs, so the persisted verdict renders (Copilot on #252)', async () => {
+    // The socket came up after the gateEvaluated was recorded: the store has one live frame for
+    // the run (the gate itself) and none of the history. Presence of a frame proves nothing about
+    // the history, so the once-per-id guard alone bounds the fetch.
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G4_EVENTS : [] }));
+    // The live copy of the same emission: identical to the recorded frame minus `ts`/`seq` (the
+    // two fields only the durable log stamps) — which is exactly what the store's fingerprint
+    // merge de-duplicates on.
+    useRunEventStore.setState({
+      byRun: { [GATE_RUN]: [{ type: 'awaitingHuman', session: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, reviewingOrd: null }] },
+    });
+    useGateStore.setState({
+      gates: {
+        [GATE_RUN]: { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
+      },
+    });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    const card = await screen.findByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+    // The live frame that raced the backfill is still in the merged log exactly once (fingerprint merge).
+    const merged = useRunEventStore.getState().byRun[GATE_RUN] ?? [];
+    expect(merged.filter((e) => e.type === 'awaitingHuman' && e.ord === G4_GATE.ord)).toHaveLength(1);
+  });
+
   it('the inbox card renders NO verdict block when the run has no evaluation in its log yet', () => {
     useGateStore.setState({
       gates: { 'r-gate': { runId: 'r-gate', ord: 1, prompt: 'Approve unit 1 before it runs?', lifecycle: 'open', receivedAt: 1 } },

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -21,6 +21,7 @@ import {
 import { useGateStore } from '../src/store/gates.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { makeUnit, makeView } from './factories.js';
+import { G4_EVENTS, G4_GATE, GATE_RUN, GATE_UNITS } from './fixtures/gateEvidence.js';
 import type { SessionView } from '../src/api/types.js';
 
 vi.mock('../src/api/client.js', () => ({
@@ -179,6 +180,34 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     expect(inbox.textContent).toContain('Approve the plan?');
     // The gate card names the run by intent, not by workflow id.
     expect(inbox.textContent).toContain('migrate the tables');
+  });
+
+  it('F-3R2-006: the inbox card states the evaluator verdict the gate is about — the same block as the run page', () => {
+    // The recorded G4 gate (before unit #4, verify): the fix phase's PASS is in the run's event log.
+    useGateStore.setState({
+      gates: {
+        [GATE_RUN]: { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
+      },
+    });
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    const inbox = screen.getByTestId('gate-inbox');
+    const card = screen.getByTestId('gate-verdict');
+    expect(inbox.contains(card)).toBe(true);
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(card).toHaveAttribute('data-phase-ord', '3');
+    expect(card).toHaveTextContent('Evaluator verdict — fix · PASS');
+    expect(screen.getByTestId('gate-verdict-criterion')).toHaveTextContent('the run left a change in its worktree');
+    expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+  });
+
+  it('the inbox card renders NO verdict block when the run has no evaluation in its log yet', () => {
+    useGateStore.setState({
+      gates: { 'r-gate': { runId: 'r-gate', ord: 1, prompt: 'Approve unit 1 before it runs?', lifecycle: 'open', receivedAt: 1 } },
+    });
+    dash([makeView({ id: 'r-gate', problem: 'migrate the tables', status: 'awaiting_human' })]);
+    expect(screen.getByTestId('gate-inbox')).toBeInTheDocument();
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
   });
 });
 

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -24,10 +24,14 @@ import { makeUnit, makeView } from './factories.js';
 import { G4_EVENTS, G4_GATE, GATE_RUN, GATE_UNITS } from './fixtures/gateEvidence.js';
 import type { SessionView } from '../src/api/types.js';
 
+/** `GET /runs/:id/events`, swappable per test — the gate inbox backfills it for open-gate runs. */
+const getRunEvents = vi.hoisted(() => vi.fn<(id: string) => Promise<{ events: unknown[] }>>(async () => ({ events: [] })));
+
 vi.mock('../src/api/client.js', () => ({
   api: {
     confirmGate: vi.fn(async () => ({})),
     injectMessage: vi.fn(async () => ({})),
+    getRunEvents: (id: string) => getRunEvents(id),
   },
 }));
 
@@ -57,6 +61,8 @@ function units(done: number, total: number, sid = 'run-1') {
 beforeEach(() => {
   useGateStore.setState({ gates: {} });
   useRunEventStore.setState({ byRun: {} });
+  getRunEvents.mockReset();
+  getRunEvents.mockImplementation(async () => ({ events: [] }));
 });
 
 describe('the purpose statement (F7)', () => {
@@ -199,6 +205,26 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     expect(card).toHaveTextContent('Evaluator verdict — fix · PASS');
     expect(screen.getByTestId('gate-verdict-criterion')).toHaveTextContent('the run left a change in its worktree');
     expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+  });
+
+  it('after a reload the inbox backfills the open-gate run\'s event log ONCE, so a persisted verdict still renders (Copilot on #252)', async () => {
+    // Nothing in the store (a landing reload), the durable log holds the G4 frames.
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G4_EVENTS : [] }));
+    useGateStore.setState({
+      gates: {
+        [GATE_RUN]: { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
+      },
+    });
+    dash([
+      makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS),
+      // A run with no gate is never backfilled by this surface — the budget is O(open gates).
+      makeView({ id: 'r-quiet', problem: 'quiet work', status: 'executing' }),
+    ]);
+    const card = await screen.findByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(card).toHaveTextContent('Evaluator verdict — fix · PASS');
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+    expect(getRunEvents).toHaveBeenCalledWith(GATE_RUN);
   });
 
   it('the inbox card renders NO verdict block when the run has no evaluation in its log yet', () => {

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -11,7 +11,7 @@
  *   - the gate inbox appears only when a gate is pending (W4).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import {
   BUILD_PURPOSE,
   CenterDashboard,
@@ -250,6 +250,25 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     // The live frame that raced the backfill is still in the merged log exactly once (fingerprint merge).
     const merged = useRunEventStore.getState().byRun[GATE_RUN] ?? [];
     expect(merged.filter((e) => e.type === 'awaitingHuman' && e.ord === G4_GATE.ord)).toHaveLength(1);
+  });
+
+  it('the backfill is keyed by GATE INSTANCE: a second gate on the same run re-fetches once, a re-render of the same gate never (Copilot on #252)', async () => {
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G4_EVENTS : [] }));
+    const first = { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 };
+    useGateStore.setState({ gates: { [GATE_RUN]: first } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    await screen.findByTestId('gate-verdict');
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+
+    // The same gate, re-set (a store rebuild / a re-render): no second fetch.
+    act(() => useGateStore.setState({ gates: { [GATE_RUN]: { ...first } } }));
+    expect(getRunEvents).toHaveBeenCalledTimes(1);
+
+    // The run answers and opens ANOTHER gate — the retry of the same ord, later — while the
+    // dashboard stays mounted: a fresh instance, so the durable prefix is refreshed exactly once
+    // more (a reconnect gap between the two gates can never leave the old verdict standing).
+    act(() => useGateStore.setState({ gates: { [GATE_RUN]: { ...first, receivedAt: 2 } } }));
+    expect(getRunEvents).toHaveBeenCalledTimes(2);
   });
 
   it('the inbox card renders NO verdict block when the run has no evaluation in its log yet', () => {

--- a/tests/ChatPanel.dock.test.tsx
+++ b/tests/ChatPanel.dock.test.tsx
@@ -99,6 +99,18 @@ describe('ApprovalDock — pinned, never scrolls away', () => {
     expect(card).not.toHaveTextContent('stray');
   });
 
+  it('daemon-restart fallback: the cursor indexes units in ORD order, whatever order the DTO arrived in (Copilot on #252)', () => {
+    // The same paused run, its units array UNSORTED (build first): `unit_ix` 1 must still resolve
+    // to the unit with ord 2, not to whichever unit happens to sit at index 1.
+    renderPanel(
+      makeView({ status: 'awaiting_human', unit_ix: 1 }, [
+        makeUnit({ id: 'run-1:build', ord: 2, stage: 'build', status: 'distributed', assigned_cli: 'claude' }),
+        makeUnit({ id: 'run-1:survey', ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+      ]),
+    );
+    expect(screen.getByTestId('steering-gate')).toHaveTextContent('before unit #2');
+  });
+
   it('docks an open MCP elicitation the same way', () => {
     act(() => {
       useElicitationStore.getState().setElicitation({

--- a/tests/ChatPanel.dock.test.tsx
+++ b/tests/ChatPanel.dock.test.tsx
@@ -62,6 +62,41 @@ describe('ApprovalDock — pinned, never scrolls away', () => {
     expect(screen.getByTestId('steering-gate')).toBeInTheDocument();
     // SteeringGate's own id-only fallback copy renders (§3.3).
     expect(screen.getByTestId('steering-prompt')).toHaveTextContent(/prompt unavailable/i);
+    // The gate's ord is derived from the run's own cursor (`units[unit_ix].ord`, the same
+    // resolution `useRunModel.pendingGate` makes), so the card is still bound to a unit.
+    expect(screen.getByTestId('steering-gate')).toHaveTextContent('before unit #2');
+  });
+
+  it('daemon-restart fallback: the verdict lookup stays BOUNDED on the derived ord (Copilot on #252)', () => {
+    // The run paused before unit #2 (unit_ix 1 → units[1].ord = 2). Its log holds the survey
+    // phase's evaluation (ord 1) — the verdict this gate is about — and, appended later, a stray
+    // ord-9 frame that an UNBOUNDED "last evaluation" lookup would have shown instead.
+    act(() => {
+      useRunEventStore.setState({
+        byRun: {
+          'run-1': [
+            {
+              type: 'gateEvaluated', session: 'run-1', ord: 1,
+              criterion: 'the survey names every service', hasDeterministicFloor: true, deterministicPass: true,
+              agentVerdict: 'pass', agentReasoning: 'PASS — every service is named.', evaluatorPass: true,
+              evaluatorPolicies: [], denialReason: null, denial: null, combined: true,
+            },
+            {
+              type: 'gateEvaluated', session: 'run-1', ord: 9,
+              criterion: 'stray', hasDeterministicFloor: true, deterministicPass: false,
+              agentVerdict: 'deny', agentReasoning: null, evaluatorPass: true,
+              evaluatorPolicies: [], denialReason: 'stray denial', denial: null, combined: false,
+            },
+          ],
+        },
+      });
+    });
+    renderPanel(); // status awaiting_human, gate store empty → ord derived, prompt unavailable
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(card).toHaveAttribute('data-phase-ord', '1');
+    expect(card).toHaveTextContent('Evaluator verdict — survey · PASS');
+    expect(card).not.toHaveTextContent('stray');
   });
 
   it('docks an open MCP elicitation the same way', () => {

--- a/tests/DeckKpiRibbon.test.tsx
+++ b/tests/DeckKpiRibbon.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { DeckKpiRibbon } from '../src/components/DeckKpiRibbon.js';
-import { makeView } from './factories.js';
+import { makeUnit, makeView } from './factories.js';
 
 const NOW = 1_760_000_000_000;
 const DAY = 86_400_000;
@@ -45,7 +45,12 @@ describe('DeckKpiRibbon — real created_at windows', () => {
     ribbon([
       makeView({ id: 'a', status: 'completed', created_at: secs(NOW - DAY), delivery: 'delivered' }),
       makeView({ id: 'b', status: 'completed', created_at: secs(NOW - DAY), delivery: 'stranded' }),
-      makeView({ id: 'c', status: 'completed', created_at: secs(NOW - DAY), delivery: 'vacuous' }),
+      // A REAL vacuous run — its deliver phase ran and found nothing (F-3R2-018: the fold counts
+      // vacuous only for runs expected to deliver; a bare `vacuous` stamp on an unlicensed run is not one).
+      makeView(
+        { id: 'c', status: 'completed', created_at: secs(NOW - DAY), repo_ref: 'org/repo', delivery: 'vacuous' },
+        [makeUnit({ id: 'c:deliver', session_id: 'c', ord: 5, status: 'rejected', denial_reason: 'nothing to deliver' })],
+      ),
       makeView({ id: 'd', status: 'completed', created_at: secs(NOW - DAY), retry_of: 'a' }),
     ]);
     expect(screen.getByTestId('home-kpi-review')).toHaveAttribute('data-value', '2'); // stranded + vacuous

--- a/tests/DeckVerifiedStrip.test.tsx
+++ b/tests/DeckVerifiedStrip.test.tsx
@@ -1,12 +1,23 @@
 // The verified-vs-needs-review strip — the delivery split off the run DTO, one fold shared with the
-// ribbon's ATTENTION tile.
+// ribbon's ATTENTION tile. The vacuous cell counts only runs that were EXPECTED to deliver
+// (wicked-studio#250, F-3R2-018) and names the condition, not a prescription.
 
 import { render, screen, cleanup } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DeckVerifiedStrip } from '../src/components/DeckVerifiedStrip.js';
-import { makeView } from './factories.js';
+import { clearCachedWorkflows, setCachedWorkflows } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS } from './fixtures/workflows.js';
 
 afterEach(cleanup);
+beforeEach(() => clearCachedWorkflows());
+
+/** A completed repo-scoped run whose deliver phase ran and found nothing to lift — a REAL vacuous run. */
+const vacuousWithDeliverUnit = (id: string) =>
+  makeView(
+    { id, status: 'completed', repo_ref: 'org/repo', delivery: 'vacuous' },
+    [makeUnit({ id: `${id}:deliver`, session_id: id, ord: 5, status: 'rejected', denial_reason: 'nothing to deliver' })],
+  );
 
 describe('DeckVerifiedStrip', () => {
   it('counts delivered / stranded / vacuous off the wire, ignoring other states + archived runs', () => {
@@ -16,7 +27,7 @@ describe('DeckVerifiedStrip', () => {
           makeView({ id: 'a', delivery: 'delivered' }),
           makeView({ id: 'b', delivery: 'delivered' }),
           makeView({ id: 'c', delivery: 'stranded' }),
-          makeView({ id: 'd', delivery: 'vacuous' }),
+          vacuousWithDeliverUnit('d'),
           makeView({ id: 'e', delivery: 'none' }),
           makeView({ id: 'f', delivery: 'delivered', archived_at: 1 }), // archived → excluded
         ]}
@@ -40,5 +51,44 @@ describe('DeckVerifiedStrip', () => {
       />,
     );
     expect(screen.getByTestId('delivery-verified').textContent).toContain('2');
+  });
+
+  it('F-3R2-018: onboarding runs the daemon stamped vacuous are NOT "vacuous" — they deliver nothing by design', () => {
+    // The recorded landing: 2 delivered, 0 stranded, and NINE completed onboarding runs stamped
+    // `vacuous` on the wire (an untouched worktree is that workflow's designed outcome) — plus the
+    // one real signal, a bug run whose deliver phase found nothing.
+    setCachedWorkflows(LIVE_WORKFLOWS);
+    render(
+      <DeckVerifiedStrip
+        runs={[
+          makeView({ id: 'd1', workflow_id: 'bug', delivery: 'delivered' }),
+          makeView({ id: 'd2', workflow_id: 'bug', delivery: 'delivered' }),
+          ...Array.from({ length: 9 }, (_, i) =>
+            makeView({ id: `ob-${i}`, workflow_id: 'onboarding', status: 'completed', repo_ref: 'org/repo', delivery: 'vacuous' }),
+          ),
+          vacuousWithDeliverUnit('real'),
+        ]}
+        navigate={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('delivery-verified').textContent).toContain('2');
+    expect(screen.getByTestId('delivery-stranded').textContent).toContain('0');
+    const vacuous = screen.getByTestId('delivery-vacuous');
+    expect(vacuous.querySelector('.deck-vn')?.textContent).toBe('1');
+    // The label states the condition, not "needs retry".
+    expect(vacuous).toHaveTextContent('Vacuous — no change to deliver');
+    expect(vacuous).not.toHaveTextContent('needs retry');
+  });
+
+  it('the licence holds on a COLD catalog too: `onboarding` is denylisted, so the nine never flash as vacuous while defs load', () => {
+    render(
+      <DeckVerifiedStrip
+        runs={Array.from({ length: 9 }, (_, i) =>
+          makeView({ id: `ob-${i}`, workflow_id: 'onboarding', status: 'completed', repo_ref: 'org/repo', delivery: 'vacuous' }),
+        )}
+        navigate={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('delivery-vacuous').querySelector('.deck-vn')?.textContent).toBe('0');
   });
 });

--- a/tests/SteeringGate.verdict.test.tsx
+++ b/tests/SteeringGate.verdict.test.tsx
@@ -1,0 +1,201 @@
+// wicked-studio#250 / F-3R2-006 — the gate card states the evaluator verdict it is asking about.
+//
+// Recorded from the Phase 3 re-run (tests/fixtures/gateEvidence.ts): at G4 the card said only
+// "Approve unit 4 before it runs: verify — …" while the fix phase's PASS (criterion, floor, judge)
+// sat in the log; at G5 it said "Unit 4 verdict is NOT PASS — confirm to retry…" while the reason
+// (evaluator≠creator, the changed path, the restore command) was only in the thread; at G6 the
+// deliver gate never showed that the repo's own checks had run and passed. These pin the card:
+//
+//   1. G4 — `gate-verdict[data-verdict=pass]` names the fix phase, its criterion, the judge's
+//      reasoning and the floor line; no denial, no judge-seat claim.
+//   2. G5 — `data-verdict=fail` + `data-denial-source=worktree_guard`: the layer, the engine's
+//      reason verbatim with the restore command as <code>, and the changed path + seat + trees.
+//   3. G6 — the repo-checks floor: one row per check (name · exit · duration · manifest source).
+//   4. a failed floor (synthetic frame in the wire's declared shape): the failing check is marked,
+//      the skipped one named.
+//   5. no evaluation yet / no hydrated log ⇒ NO block — never a verdict made up from the prompt.
+//   6. ungated ⇒ labelled as a default-allow, not a pass.
+//   7. the existing card contract is untouched: `steering-prompt` still carries the headline and
+//      the `verdict-detail` selector (the run page's card) is not claimed by the gate card.
+
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as client from '../src/api/client.js';
+import { SteeringGate } from '../src/components/SteeringGate.js';
+import { useAnnotationStore } from '../src/store/annotations.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useGateStore } from '../src/store/gates.js';
+import {
+  G4_EVENTS,
+  G4_GATE,
+  G5_EVENTS,
+  G5_GATE,
+  G6_EVENTS,
+  G6_GATE,
+  GATE_RUN,
+  GATE_UNITS,
+  REPO_CHECKS_FAIL,
+  TREE_BEFORE,
+} from './fixtures/gateEvidence.js';
+
+describe('SteeringGate — the evaluator verdict on the card (F-3R2-006)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('G4 (before unit #4): renders the fix phase PASS — criterion, judge reasoning, floor line; no denial', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS } });
+    render(<SteeringGate runId={GATE_RUN} ord={G4_GATE.ord} prompt={G4_GATE.prompt} units={GATE_UNITS} />);
+
+    // The headline contract is untouched.
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Approve unit 4 before it runs: verify');
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(card).toHaveAttribute('data-phase-ord', '3');
+    expect(card).not.toHaveAttribute('data-denial-source');
+    expect(card).toHaveTextContent('Evaluator verdict — fix · PASS');
+    expect(screen.getByTestId('gate-verdict-criterion')).toHaveTextContent(
+      'criterion: the run left a change in its worktree (done is re-derived from the diff, never asserted)',
+    );
+    expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+    expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('multiple modified files and one new untracked test file');
+    expect(screen.getByTestId('gate-verdict-layers')).toHaveTextContent('deterministic floor: pass');
+    expect(screen.queryByTestId('gate-verdict-denial')).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-mutation')).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-floor')).toBeNull(); // no repoChecksEvaluated at G4
+    // The judge SEAT is not on this wire — the card must not claim one.
+    expect(card.textContent).not.toMatch(/judge seat|seat:/i);
+    // The run page's card keeps its selector.
+    expect(screen.queryByTestId('verdict-detail')).toBeNull();
+  });
+
+  it('G5 (escalated on unit #4): renders the worktree-guard denial — layer, verbatim reason with the restore command as code, changed path + seat', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G5_EVENTS } });
+    render(<SteeringGate runId={GATE_RUN} ord={G5_GATE.ord} prompt={G5_GATE.prompt} units={GATE_UNITS} />);
+
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Unit 4 verdict is NOT PASS');
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'fail');
+    expect(card).toHaveAttribute('data-phase-ord', '4');
+    expect(card).toHaveAttribute('data-denial-source', 'worktree_guard');
+    expect(card).toHaveTextContent('Evaluator verdict — verify · DENIED');
+
+    const denial = screen.getByTestId('gate-verdict-denial');
+    expect(denial).toHaveTextContent('denied by worktree guard (evaluator ≠ creator):');
+    expect(denial).toHaveTextContent('evaluator≠creator: phase verify declares executes_code: false but changed the worktree it was reviewing');
+    expect(denial).toHaveTextContent("Restore the creator's tree in the worktree with");
+    // The remedy command is copyable code, byte for byte.
+    const codes = within(denial).getAllByText((_, el) => el?.tagName === 'CODE' && (el.textContent ?? '').startsWith('git read-tree'));
+    expect(codes).toHaveLength(1);
+    expect(codes[0]).toHaveTextContent(`git read-tree --reset -u ${TREE_BEFORE}`);
+    // …and so is the def change the engine names as the other way out.
+    expect(denial).toHaveTextContent('a phase that must change code declares executes_code: true in the workflow def');
+
+    const mutation = screen.getByTestId('gate-verdict-mutation');
+    expect(mutation).toHaveTextContent('worktree changed by pi during verify: M src/App.tsx');
+    expect(mutation).toHaveTextContent(`(tree ${TREE_BEFORE.slice(0, 10)} →`);
+    expect(mutation).not.toHaveTextContent('run branch moved');
+
+    // The judge's own PASS is still stated — the denial is the guard's, and both are true.
+    expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+  });
+
+  it('G6 (before unit #5 deliver): renders the repo-checks floor per check — name, exit code, duration, manifest source', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G6_EVENTS } });
+    render(<SteeringGate runId={GATE_RUN} ord={G6_GATE.ord} prompt={G6_GATE.prompt} units={GATE_UNITS} />);
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'pass');
+    expect(card).toHaveTextContent('Evaluator verdict — verify · PASS');
+
+    const floor = screen.getByTestId('gate-verdict-floor');
+    expect(floor).toHaveAttribute('data-floor', 'pass');
+    expect(floor).toHaveTextContent('repository checks — pass');
+    expect(floor).toHaveTextContent("the repository's own checks pass in the run's worktree");
+
+    const rows = screen.getAllByTestId('gate-verdict-check');
+    expect(rows.map((r) => r.getAttribute('data-check'))).toEqual(['typecheck', 'lint', 'test']);
+    expect(rows.every((r) => r.getAttribute('data-ok') === 'true')).toBe(true);
+    expect(rows[0]).toHaveTextContent('typecheck · exit 0 · 6.9s · package.json scripts.typecheck');
+    expect(rows[1]).toHaveTextContent('lint · exit 0 · 6.1s · package.json scripts.lint');
+    expect(rows[2]).toHaveTextContent('test · exit 0 · 1m 19s · package.json scripts.test');
+    expect(screen.queryByTestId('gate-verdict-skipped')).toBeNull();
+    // The retry's PASS does not inherit attempt 0's mutation record.
+    expect(screen.queryByTestId('gate-verdict-mutation')).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-denial')).toBeNull();
+  });
+
+  it('a FAILED floor (wire-declared shape): the failing check is marked, the skipped check is named, the verdict is DENIED', () => {
+    const denied = {
+      ...G6_EVENTS[G6_EVENTS.length - 4]!, // the ord-4 attempt-1 gateEvaluated
+      seq: 403,
+      combined: false,
+      deterministicPass: false,
+      denialReason: 'repository checks failed in the worktree: lint exited 1',
+      denial: {
+        source: 'repo_checks',
+        reason: 'repository checks failed in the worktree: lint exited 1',
+        claimId: null,
+        ruleIds: [],
+        deniedTool: null,
+        phase: 'unit-4',
+      },
+    };
+    const events = [...G5_EVENTS, REPO_CHECKS_FAIL, denied, { type: 'gateDecided', session: GATE_RUN, ord: 4, allow: false }];
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: events } });
+    render(<SteeringGate runId={GATE_RUN} ord={4} prompt="Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run" units={GATE_UNITS} />);
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'fail');
+    expect(card).toHaveAttribute('data-denial-source', 'repo_checks');
+    expect(screen.getByTestId('gate-verdict-denial')).toHaveTextContent('denied by repository checks: repository checks failed in the worktree: lint exited 1');
+
+    const floor = screen.getByTestId('gate-verdict-floor');
+    expect(floor).toHaveAttribute('data-floor', 'fail');
+    const rows = screen.getAllByTestId('gate-verdict-check');
+    expect(rows.map((r) => [r.getAttribute('data-check'), r.getAttribute('data-ok')])).toEqual([
+      ['typecheck', 'true'],
+      ['lint', 'false'],
+    ]);
+    expect(rows[1]).toHaveTextContent('lint · exit 1 · 5.4s');
+    expect(screen.getByTestId('gate-verdict-skipped')).toHaveTextContent('skipped (an earlier check failed): test');
+    expect(screen.getByTestId('gate-verdict-layers')).toHaveTextContent('deterministic floor: fail');
+  });
+
+  it('the very first gate (no evaluation yet) and an un-hydrated log render NO verdict block', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS.slice(0, 1) } });
+    const { unmount } = render(<SteeringGate runId={GATE_RUN} ord={1} prompt="Approve unit 1 before it runs: triage" units={GATE_UNITS} />);
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Approve unit 1 before it runs: triage');
+    unmount();
+
+    // Nothing hydrated for this run at all (a gate reached from the chat surface, say).
+    render(<SteeringGate runId="run-elsewhere" ord={2} prompt="?" />);
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+  });
+
+  it('an UNGATED previous phase is labelled a default-allow — never dressed as a pass', () => {
+    // The gate before unit #2: the ord-1 triage evaluation had no floor, no judge, no policy.
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS.slice(0, 4) } });
+    render(<SteeringGate runId={GATE_RUN} ord={2} prompt="Approve unit 2 before it runs: reproduce" units={GATE_UNITS} />);
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'ungated');
+    expect(card).toHaveTextContent('Evaluator verdict — triage · UNGATED');
+    expect(screen.getByTestId('gate-verdict-ungated')).toHaveTextContent('nothing gated this phase — it was approved by default, not verified');
+    expect(screen.getByTestId('gate-verdict-layers')).toHaveTextContent('no deterministic floor · evaluator: default-allow (no policy applied)');
+    expect(screen.queryByTestId('gate-verdict-criterion')).toBeNull();
+  });
+
+  it('without `units` the phase is named by ord — the block still renders', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS } });
+    render(<SteeringGate runId={GATE_RUN} ord={G4_GATE.ord} prompt={G4_GATE.prompt} />);
+    expect(screen.getByTestId('gate-verdict')).toHaveTextContent('Evaluator verdict — unit 3 · PASS');
+  });
+});

--- a/tests/SteeringGate.verdict.test.tsx
+++ b/tests/SteeringGate.verdict.test.tsx
@@ -198,4 +198,11 @@ describe('SteeringGate — the evaluator verdict on the card (F-3R2-006)', () =>
     render(<SteeringGate runId={GATE_RUN} ord={G4_GATE.ord} prompt={G4_GATE.prompt} />);
     expect(screen.getByTestId('gate-verdict')).toHaveTextContent('Evaluator verdict — unit 3 · PASS');
   });
+
+  it('without a numeric `ord` there is nothing to bound the lookup with — NO block, even with a full log (Copilot on #252)', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G5_EVENTS } });
+    render(<SteeringGate runId={GATE_RUN} units={GATE_UNITS} />);
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent(/prompt unavailable/i);
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+  });
 });

--- a/tests/deliveryCounts.test.ts
+++ b/tests/deliveryCounts.test.ts
@@ -1,0 +1,84 @@
+// wicked-studio#250 / F-3R2-018 — the landing's delivery fold counts a run "vacuous" only when it
+// was EXPECTED to deliver. On the Phase 3 rig the strip read "2 Verified & delivered · 0 Stranded
+// — needs review · 9 Vacuous — needs retry": the nine were `onboarding` runs, which deliver
+// nothing by design. The fold now takes the app's `is_system` lookup and licenses the vacuous
+// bucket with the SAME rule the Delivery section uses (`canDeliver`: a deliver unit on the run,
+// or a workflow positively known not to be a system one) — one spelling, and it can only ever
+// WITHHOLD a count, never invent one.
+
+import { describe, expect, it } from 'vitest';
+import type { WorkflowDef } from '../src/api/types.js';
+import { deliveryCounts } from '../src/board/windowStats.js';
+import { isSystemWorkflowIn } from '../src/store/workflowCache.js';
+import { makeUnit, makeView } from './factories.js';
+import { LIVE_WORKFLOWS, materialised } from './fixtures/workflows.js';
+
+const lookupOver = (defs: WorkflowDef[] | null) => (id: string) => isSystemWorkflowIn(defs, id);
+const warm = lookupOver(LIVE_WORKFLOWS);
+const cold = lookupOver(null);
+
+/** A repo-scoped run the daemon stamped `vacuous`, on the given workflow, with/without a deliver unit. */
+function vacuousRun(id: string, workflow_id: string, withDeliverUnit: boolean) {
+  return makeView(
+    { id, workflow_id, status: 'completed', repo_ref: 'org/repo', delivery: 'vacuous' },
+    withDeliverUnit
+      ? [makeUnit({ id: `${id}:deliver`, session_id: id, ord: 5, status: 'rejected', denial_reason: 'nothing to deliver' })]
+      : [],
+  );
+}
+
+describe('deliveryCounts — the vacuous licence (F-3R2-018)', () => {
+  it('the recorded case: nine onboarding runs stamped vacuous do NOT count — warm or cold cache', () => {
+    const runs = [
+      ...Array.from({ length: 9 }, (_, i) => vacuousRun(`ob-${i}`, 'onboarding', false)),
+      makeView({ id: 'd1', delivery: 'delivered' }),
+      makeView({ id: 'd2', delivery: 'delivered' }),
+    ];
+    expect(deliveryCounts(runs, warm)).toEqual({ delivered: 2, stranded: 0, vacuous: 0 });
+    // `onboarding` is on the denylist too, so the answer holds before the catalog has loaded.
+    expect(deliveryCounts(runs, cold)).toEqual({ delivered: 2, stranded: 0, vacuous: 0 });
+    expect(deliveryCounts(runs)).toEqual({ delivered: 2, stranded: 0, vacuous: 0 });
+  });
+
+  it('a run WITH a deliver unit that produced nothing counts vacuous whatever its workflow id says (evidence first)', () => {
+    // A materialised per-run def is in no catalog — the lookup answers undefined — but the run's
+    // own units show the deliver phase ran and was denied for having nothing to lift.
+    const run = vacuousRun('r1', materialised('r1'), true);
+    expect(deliveryCounts([run], warm).vacuous).toBe(1);
+    expect(deliveryCounts([run], cold).vacuous).toBe(1);
+    expect(deliveryCounts([run]).vacuous).toBe(1);
+  });
+
+  it('a run on a POSITIVELY KNOWN build workflow (def in hand, no is_system flag) counts vacuous without a deliver unit', () => {
+    // `bug` launched with `deliver: 'none'` — it could have delivered and chose not to; it still
+    // completed with no change, which is the real vacuous signal.
+    const run = vacuousRun('b1', 'bug', false);
+    expect(deliveryCounts([run], warm).vacuous).toBe(1);
+  });
+
+  it('withholds when the classification is unknown: no deliver unit + a def the catalog does not serve, or no lookup at all', () => {
+    const run = vacuousRun('m1', materialised('m1'), false);
+    expect(deliveryCounts([run], warm).vacuous).toBe(0);
+    expect(deliveryCounts([run], cold).vacuous).toBe(0);
+    expect(deliveryCounts([run]).vacuous).toBe(0);
+    // A build id with a COLD cache is `undefined`, not `false` — still withheld (the same trade the
+    // Delivery section makes; the count appears when the one GET /workflows lands).
+    expect(deliveryCounts([vacuousRun('b2', 'bug', false)], cold).vacuous).toBe(0);
+  });
+
+  it('every other system workflow the catalog flags is excluded the same way (collab, interactive-*)', () => {
+    const runs = ['collab', 'interactive-draft', 'survey-repo', 'chat'].map((wf, i) => vacuousRun(`s-${i}`, wf, false));
+    expect(deliveryCounts(runs, warm).vacuous).toBe(0);
+  });
+
+  it('delivered and stranded are untouched by the licence, and archived runs stay excluded', () => {
+    const runs = [
+      makeView({ id: 'a', workflow_id: 'onboarding', delivery: 'delivered' }),
+      makeView({ id: 'b', workflow_id: 'onboarding', delivery: 'stranded' }),
+      makeView({ id: 'c', workflow_id: 'onboarding', delivery: 'none' }),
+      makeView({ id: 'd', workflow_id: 'bug', delivery: 'vacuous', archived_at: 1 }),
+      vacuousRun('e', 'bug', true),
+    ];
+    expect(deliveryCounts(runs, warm)).toEqual({ delivered: 1, stranded: 1, vacuous: 1 });
+  });
+});

--- a/tests/fixtures/gateEvidence.ts
+++ b/tests/fixtures/gateEvidence.ts
@@ -1,0 +1,294 @@
+import type { CoreEvent, WorkUnit } from '../../src/api/types.js';
+import { makeUnit } from '../factories.js';
+
+/**
+ * Recorded gate-evidence frames from the Phase 3 re-run of the acceptance program
+ * (wicked-studio#250 — findings F-3R2-006 / F-3R2-018): a governed `bug` run on a fresh
+ * wicked-crew 0.7.28 / core-ts 0.7.18 rig, captured off `GET /runs/:id/events` at three gates:
+ *
+ *  - G4 — the pre-run gate BEFORE unit #4 (`verify`): the operator is really answering the
+ *    `fix` phase's verdict, which the wire carried as the ord-3 `gateEvaluated`
+ *    (`hasDeterministicFloor: true`, `agentVerdict: "pass"`) and the card never rendered.
+ *  - G5 — the ESCALATED gate on unit #4: the `verify` phase (`executes_code: false`) changed the
+ *    worktree it was reviewing, so wicked-core's worktree guard (F-036) denied it —
+ *    `evaluatorMutatedWorktree` + a `gateEvaluated` whose `denial.source` is `worktree_guard`,
+ *    then `gateEscalated` / `awaitingHuman` ("verdict is NOT PASS"). The card said only the
+ *    prompt; the reason, the changed path and the restore command were in the thread.
+ *  - G6 — the pre-run gate BEFORE unit #5 (`deliver`) after the retry: the engine ran the repo's
+ *    own checks (F-039, `repoChecksEvaluated`: typecheck / lint / test, exit codes + durations)
+ *    and the ord-4 `gateEvaluated` passed on that floor.
+ *
+ * Shapes are the wire's, byte for byte in every field the surfaces read. Scrubbed: the run id,
+ * the operator's intent text, the rig's worktree paths and the test-runner tails (all replaced by
+ * short generic stand-ins), and the two git tree ids (synthetic hex of the same width — the
+ * denial prose that quotes them is kept in its exact wording so the card's copy is exercised on
+ * the engine's real sentence structure). `seq` values are the recording's.
+ */
+
+export const GATE_RUN = 'run-3r2';
+
+/** Synthetic stand-ins for the two tree ids the worktree guard compared (same width as git's). */
+export const TREE_BEFORE = 'a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0';
+export const TREE_AFTER = 'f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1';
+
+const INTENT = 'fix the reported issue';
+
+/** The five def-driven units of the `bug` workflow as the run's snapshot names them. */
+export const GATE_UNITS: WorkUnit[] = [
+  makeUnit({ id: `${GATE_RUN}:triage`, session_id: GATE_RUN, ord: 1, stage: 'recon', status: 'done' }),
+  makeUnit({ id: `${GATE_RUN}:reproduce`, session_id: GATE_RUN, ord: 2, stage: 'recon', status: 'done' }),
+  makeUnit({ id: `${GATE_RUN}:fix`, session_id: GATE_RUN, ord: 3, stage: 'build', status: 'done' }),
+  makeUnit({ id: `${GATE_RUN}:verify`, session_id: GATE_RUN, ord: 4, stage: 'test', status: 'pending' }),
+  makeUnit({
+    id: `${GATE_RUN}:deliver`,
+    session_id: GATE_RUN,
+    ord: 5,
+    stage: 'build',
+    status: 'pending',
+    tool_cmd: ['bash', '-lc', 'gh pr create --fill'],
+  }),
+];
+
+/** An UNGATED phase's evaluation (triage / reproduce): no floor, no judge, default-allow. */
+function ungated(ord: number, seq: number, ts: number): CoreEvent {
+  return {
+    type: 'gateEvaluated',
+    session: GATE_RUN,
+    ord,
+    seq,
+    ts,
+    criterion: null,
+    hasDeterministicFloor: false,
+    deterministicPass: true,
+    agentVerdict: null,
+    agentReasoning: null,
+    evaluatorPass: true,
+    evaluatorPolicies: [],
+    denialReason: null,
+    denial: null,
+    combined: true,
+  };
+}
+
+/** The run up to and including the G4 gate — the pre-run gate before unit #4 (`verify`). */
+export const G4_EVENTS: CoreEvent[] = [
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 1, seq: 33, ts: 1789079797015, prompt: `Approve unit 1 before it runs: triage — ${INTENT}`, reviewingOrd: null },
+  ungated(1, 43, 1789080137649),
+  { type: 'gateDecided', session: GATE_RUN, ord: 1, seq: 44, ts: 1789080137649, allow: true },
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 2, seq: 46, ts: 1789080137651, prompt: `Approve unit 2 before it runs: reproduce — ${INTENT}`, reviewingOrd: null },
+  ungated(2, 102, 1789080347132),
+  { type: 'gateDecided', session: GATE_RUN, ord: 2, seq: 103, ts: 1789080347132, allow: true },
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 3, seq: 105, ts: 1789080347133, prompt: `Approve unit 3 before it runs: fix — ${INTENT}`, reviewingOrd: null },
+  {
+    type: 'gateEvaluated',
+    session: GATE_RUN,
+    ord: 3,
+    seq: 197,
+    ts: 1789080925251,
+    criterion: 'the run left a change in its worktree (done is re-derived from the diff, never asserted)',
+    hasDeterministicFloor: true,
+    deterministicPass: true,
+    agentVerdict: 'pass',
+    agentReasoning:
+      'PASS — The worktree evidence shows multiple modified files and one new untracked test file, so the run left a change in its worktree. PASS',
+    evaluatorPass: true,
+    evaluatorPolicies: [],
+    denialReason: null,
+    denial: null,
+    combined: true,
+  },
+  { type: 'gateDecided', session: GATE_RUN, ord: 3, seq: 198, ts: 1789080925251, allow: true },
+  { type: 'unitDone', session: GATE_RUN, ord: 3, seq: 199, ts: 1789080925251 },
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 4, seq: 200, ts: 1789080925252, prompt: `Approve unit 4 before it runs: verify — ${INTENT}`, reviewingOrd: null },
+];
+
+/** The G4 gate as the gate store holds it. */
+export const G4_GATE = { ord: 4, prompt: `Approve unit 4 before it runs: verify — ${INTENT}` };
+
+/** The worktree guard's denial prose — the engine's exact sentence, tree ids substituted. */
+export const WORKTREE_GUARD_REASON =
+  'evaluator≠creator: phase `verify` declares `executes_code: false` but changed the worktree it was reviewing — ' +
+  `1 path(s): M src/App.tsx (tree ${TREE_BEFORE.slice(0, 10)} → ${TREE_AFTER.slice(0, 10)}). ` +
+  "The change under review is no longer the creator's, so this phase's verdict cannot certify it. " +
+  `Restore the creator's tree in the worktree with \`git read-tree --reset -u ${TREE_BEFORE}\`, or reject the run; ` +
+  'a phase that must change code declares `executes_code: true` in the workflow def.';
+
+/** The run up to and including the G5 gate — unit #4 (`verify`) denied by the worktree guard. */
+export const G5_EVENTS: CoreEvent[] = [
+  ...G4_EVENTS,
+  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 201, ts: 1789080930000, allow: true },
+  { type: 'resumed', session: GATE_RUN, seq: 202, ts: 1789080930001 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 203, ts: 1789080930002, cli: 'pi', attempt: 0 },
+  {
+    type: 'evaluatorMutatedWorktree',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 245,
+    ts: 1789081439093,
+    attempt: 0,
+    cli: 'pi',
+    phase: 'verify',
+    beforeTree: TREE_BEFORE,
+    afterTree: TREE_AFTER,
+    headMoved: false,
+    changed: [{ path: 'src/App.tsx', status: 'M' }],
+  },
+  {
+    type: 'gateEvaluated',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 246,
+    ts: 1789081439237,
+    criterion: 'the run left a change in its worktree (done is re-derived from the diff, never asserted)',
+    hasDeterministicFloor: true,
+    deterministicPass: true,
+    agentVerdict: 'pass',
+    agentReasoning:
+      'PASS — The worktree evidence shows multiple modified tracked files and one new untracked test file, directly satisfying the criterion that the run left a change in its worktree. PASS',
+    evaluatorPass: true,
+    evaluatorPolicies: [],
+    denialReason: WORKTREE_GUARD_REASON,
+    denial: {
+      source: 'worktree_guard',
+      reason: WORKTREE_GUARD_REASON,
+      claimId: null,
+      ruleIds: [],
+      deniedTool: null,
+      phase: 'unit-4',
+    },
+    combined: false,
+  },
+  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 247, ts: 1789081439237, allow: false },
+  { type: 'unitDenied', session: GATE_RUN, ord: 4, seq: 248, ts: 1789081439237 },
+  {
+    type: 'gateEscalated',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 249,
+    ts: 1789081439237,
+    condition: 'verdict_not_pass',
+    verdictSummary: WORKTREE_GUARD_REASON,
+  },
+  {
+    type: 'awaitingHuman',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 250,
+    ts: 1789081439238,
+    prompt: 'Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run',
+    reviewingOrd: 4,
+  },
+];
+
+/** The G5 gate as the gate store holds it. */
+export const G5_GATE = {
+  ord: 4,
+  prompt: 'Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run',
+};
+
+/** The repo-checks floor (F-039) as recorded on the retry — every detected check exited 0. */
+export const REPO_CHECKS_PASS: CoreEvent = {
+  type: 'repoChecksEvaluated',
+  session: GATE_RUN,
+  ord: 4,
+  seq: 302,
+  ts: 1789081879655,
+  attempt: 1,
+  passed: true,
+  criterion:
+    "the repository's own checks pass in the run's worktree (every detected check exits 0 — done is re-derived by running them, never asserted)",
+  checks: [
+    {
+      name: 'typecheck',
+      argv: ['npm', 'run', 'typecheck'],
+      source: 'package.json scripts.typecheck',
+      exitCode: 0,
+      timedOut: false,
+      spawnError: null,
+      durationMs: 6893,
+      stdoutTail: '\n> typecheck\n> tsc --noEmit\n\n',
+      stderrTail: '',
+    },
+    {
+      name: 'lint',
+      argv: ['npm', 'run', 'lint'],
+      source: 'package.json scripts.lint',
+      exitCode: 0,
+      timedOut: false,
+      spawnError: null,
+      durationMs: 6118,
+      stdoutTail: '\n> lint\n> eslint src tests\n\n',
+      stderrTail: '',
+    },
+    {
+      name: 'test',
+      argv: ['npm', 'run', 'test'],
+      source: 'package.json scripts.test',
+      exitCode: 0,
+      timedOut: false,
+      spawnError: null,
+      durationMs: 79191,
+      stdoutTail: ' Test Files  249 passed (249)\n      Tests  2675 passed (2675)\n',
+      stderrTail: '',
+    },
+  ],
+  skipped: [],
+};
+
+/**
+ * The run up to and including the G6 gate — the pre-run gate before unit #5 (`deliver`) after
+ * the operator approved the retry: the floor ran the repo's checks and the ord-4 verdict passed.
+ */
+export const G6_EVENTS: CoreEvent[] = [
+  ...G5_EVENTS,
+  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 251, ts: 1789081500000, allow: true },
+  { type: 'resumed', session: GATE_RUN, seq: 252, ts: 1789081500001 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 253, ts: 1789081500002, cli: 'claude', attempt: 1 },
+  REPO_CHECKS_PASS,
+  {
+    type: 'gateEvaluated',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 303,
+    ts: 1789081879700,
+    criterion:
+      "the repository's own checks pass in the run's worktree (every detected check exits 0 — done is re-derived by running them, never asserted)",
+    hasDeterministicFloor: true,
+    deterministicPass: true,
+    agentVerdict: 'pass',
+    agentReasoning: 'PASS — the verify phase reported the suite green and the engine observed every check exit 0. PASS',
+    evaluatorPass: true,
+    evaluatorPolicies: [],
+    denialReason: null,
+    denial: null,
+    combined: true,
+  },
+  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 304, ts: 1789081879700, allow: true },
+  { type: 'unitDone', session: GATE_RUN, ord: 4, seq: 305, ts: 1789081879700 },
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: 306, ts: 1789081879701, prompt: `Approve unit 5 before it runs: deliver — ${INTENT}`, reviewingOrd: null },
+];
+
+/** The G6 gate as the gate store holds it. */
+export const G6_GATE = { ord: 5, prompt: `Approve unit 5 before it runs: deliver — ${INTENT}` };
+
+/**
+ * SYNTHETIC (not recorded): the same floor with `lint` failing and `test` skipped — the shape the
+ * wire declares for a failed floor (`passed: false`, `skipped` names the detected check not run
+ * because an earlier one failed), so the fail rendering is pinned without waiting for a red run.
+ */
+export const REPO_CHECKS_FAIL: CoreEvent = {
+  ...REPO_CHECKS_PASS,
+  seq: 402,
+  passed: false,
+  checks: [
+    (REPO_CHECKS_PASS.checks as Array<Record<string, unknown>>)[0]!,
+    {
+      ...(REPO_CHECKS_PASS.checks as Array<Record<string, unknown>>)[1]!,
+      exitCode: 1,
+      durationMs: 5402,
+      stdoutTail: '',
+      stderrTail: 'src/App.tsx\n  12:7  error  Unexpected any  @typescript-eslint/no-explicit-any\n',
+    },
+  ],
+  skipped: ['test'],
+};

--- a/tests/fixtures/gateEvidence.ts
+++ b/tests/fixtures/gateEvidence.ts
@@ -18,11 +18,18 @@ import { makeUnit } from '../factories.js';
  *    own checks (F-039, `repoChecksEvaluated`: typecheck / lint / test, exit codes + durations)
  *    and the ord-4 `gateEvaluated` passed on that floor.
  *
- * Shapes are the wire's, byte for byte in every field the surfaces read. Scrubbed: the run id,
- * the operator's intent text, the rig's worktree paths and the test-runner tails (all replaced by
- * short generic stand-ins), and the two git tree ids (synthetic hex of the same width — the
- * denial prose that quotes them is kept in its exact wording so the card's copy is exercised on
- * the engine's real sentence structure). `seq` values are the recording's.
+ * The gate-relevant subset of the recording (`g4-events.json` / `g5-events.json` /
+ * `g6-events.json`): every `awaitingHuman`, `gateEvaluated`, `gateDecided`, `gateEscalated`,
+ * `unitDenied`, `unitDone`, `resumed`, `unitDispatched`, `unitExecuting`, `unitReworkAmended`,
+ * `evaluatorMutatedWorktree` and `repoChecksEvaluated` frame between the first gate and G6, with
+ * the recording's `seq` and `ts`; the high-volume frames between them (`unitOutputDelta`,
+ * `governanceHookFired`, council frames, `dataUsed`, `unitOutputCaptured`, …) are omitted. Every
+ * field the surfaces read is the wire's byte for byte — criterion, reasoning, verdicts, denial
+ * prose, check names / exit codes / durations / sources. Scrubbed: the run id, the operator's
+ * intent text (prompts, the retry amendment's re-stated description), the rig's worktree paths and
+ * the test-runner tails (replaced by short generic stand-ins), and the two git tree ids (synthetic
+ * hex of the same width — the denial prose and the amendment that quote them keep their exact
+ * wording). Only `REPO_CHECKS_FAIL` is synthetic, and says so.
  */
 
 export const GATE_RUN = 'run-3r2';
@@ -116,9 +123,9 @@ export const WORKTREE_GUARD_REASON =
 /** The run up to and including the G5 gate — unit #4 (`verify`) denied by the worktree guard. */
 export const G5_EVENTS: CoreEvent[] = [
   ...G4_EVENTS,
-  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 201, ts: 1789080930000, allow: true },
-  { type: 'resumed', session: GATE_RUN, seq: 202, ts: 1789080930001 },
-  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 203, ts: 1789080930002, cli: 'pi', attempt: 0 },
+  { type: 'resumed', session: GATE_RUN, ord: 4, seq: 201, ts: 1789081094441 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 202, ts: 1789081095027, attempt: 0 },
+  { type: 'unitExecuting', session: GATE_RUN, ord: 4, seq: 203, ts: 1789081095027 },
   {
     type: 'evaluatorMutatedWorktree',
     session: GATE_RUN,
@@ -241,31 +248,47 @@ export const REPO_CHECKS_PASS: CoreEvent = {
  */
 export const G6_EVENTS: CoreEvent[] = [
   ...G5_EVENTS,
-  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 251, ts: 1789081500000, allow: true },
-  { type: 'resumed', session: GATE_RUN, seq: 252, ts: 1789081500001 },
-  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 253, ts: 1789081500002, cli: 'claude', attempt: 1 },
+  {
+    // The operator approved the retry WITH a steer note (the recorded amendment, tree id
+    // substituted; the re-stated description is the scrubbed intent).
+    type: 'unitReworkAmended',
+    session: GATE_RUN,
+    ord: 4,
+    seq: 251,
+    ts: 1789081594674,
+    amendment:
+      `Operator restored the creator's tree (git read-tree --reset -u ${TREE_BEFORE.slice(0, 10)}...) before this retry. ` +
+      'Evaluator: you are READ-ONLY — do not edit, write, or format any file, and do not run npm run build (it writes dist/). ' +
+      'Run typecheck, lint and the test suite; review the diff against the acceptance criteria; report findings such as the stale comment at App.tsx:147 in your verdict text only — never fix them.',
+    updatedDescription: `verify — ${INTENT}`,
+  },
+  { type: 'resumed', session: GATE_RUN, ord: 4, seq: 252, ts: 1789081594676 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 253, ts: 1789081595299, attempt: 1 },
   REPO_CHECKS_PASS,
   {
+    // Recorded: the floor's criterion is JOINED onto the phase's own with `; `.
     type: 'gateEvaluated',
     session: GATE_RUN,
     ord: 4,
     seq: 303,
-    ts: 1789081879700,
+    ts: 1789081879672,
     criterion:
+      'the run left a change in its worktree (done is re-derived from the diff, never asserted); ' +
       "the repository's own checks pass in the run's worktree (every detected check exits 0 — done is re-derived by running them, never asserted)",
     hasDeterministicFloor: true,
     deterministicPass: true,
     agentVerdict: 'pass',
-    agentReasoning: 'PASS — the verify phase reported the suite green and the engine observed every check exit 0. PASS',
+    agentReasoning:
+      'PASS — The worktree evidence shows multiple modified files and one added test file, satisfying the criterion that the run left a change in its worktree. PASS',
     evaluatorPass: true,
     evaluatorPolicies: [],
     denialReason: null,
     denial: null,
     combined: true,
   },
-  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 304, ts: 1789081879700, allow: true },
-  { type: 'unitDone', session: GATE_RUN, ord: 4, seq: 305, ts: 1789081879700 },
-  { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: 306, ts: 1789081879701, prompt: `Approve unit 5 before it runs: deliver — ${INTENT}`, reviewingOrd: null },
+  { type: 'gateDecided', session: GATE_RUN, ord: 4, seq: 304, ts: 1789081879672, allow: true },
+  { type: 'unitDone', session: GATE_RUN, ord: 4, seq: 305, ts: 1789081879672 },
+  { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: 306, ts: 1789081879673, prompt: `Approve unit 5 before it runs: deliver — ${INTENT}`, reviewingOrd: null },
 ];
 
 /** The G6 gate as the gate store holds it. */

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -94,6 +94,20 @@ describe('gateVerdict — which evaluation answers the gate', () => {
     expect(v!.outcome).toBe('pass');
   });
 
+  it('a bounded lookup ignores a gateEvaluated with no numeric ord — it can never be shown to belong to this gate (Copilot on #252)', () => {
+    const ordless: CoreEvent = {
+      type: 'gateEvaluated', session: GATE_RUN, criterion: 'stray', hasDeterministicFloor: false,
+      deterministicPass: true, agentVerdict: null, agentReasoning: null, evaluatorPass: true,
+      evaluatorPolicies: [], denialReason: null, combined: true,
+    };
+    // Appended last, it would otherwise win "last at or below ord 4" and render an `unknown phase` card.
+    expect(gateVerdict([...G4_EVENTS, ordless], 4)!.ord).toBe(3);
+    // Alone in the log, a bounded gate sees no evaluation at all.
+    expect(gateVerdict([ordless], 4)).toBeNull();
+    // Unbounded still takes the last evaluation whatever its shape.
+    expect(gateVerdict([ordless])!.criterion).toBe('stray');
+  });
+
   it('no gateEvaluated yet (the very first gate) ⇒ null — the card renders no block', () => {
     const firstGate = G4_EVENTS.slice(0, 1); // just the ord-1 awaitingHuman
     expect(gateVerdict(firstGate, 1)).toBeNull();

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -138,6 +138,19 @@ describe('gateVerdict — which evaluation answers the gate', () => {
     });
   });
 
+  it('a structured denial spelled snake_case (claim_id / rule_ids / denied_tool) keeps its ids on the card (Copilot on #252)', () => {
+    const events: CoreEvent[] = [
+      {
+        type: 'gateEvaluated', session: GATE_RUN, ord: 2, combined: false,
+        denialReason: 'a steering rule fired',
+        denial: { source: 'governance', reason: 'a steering rule fired', claim_id: 'boundary-deny:unit-2', rule_ids: ['sec-001'], denied_tool: 'Bash', phase: 'unit-2' },
+      },
+    ];
+    expect(gateVerdict(events, 2)!.denial).toEqual({
+      source: 'governance', reason: 'a steering rule fired', claimId: 'boundary-deny:unit-2', ruleIds: ['sec-001'], deniedTool: 'Bash', phase: 'unit-2',
+    });
+  });
+
   it('malformed evidence frames are narrowed, never trusted: a check without a name is dropped, a non-array `changed` reads as none', () => {
     const events: CoreEvent[] = [
       { type: 'evaluatorMutatedWorktree', session: GATE_RUN, ord: 1, cli: 'pi', phase: 'verify', changed: 'nope' },

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -1,0 +1,180 @@
+// wicked-studio#250 / F-3R2-006 — the pure half of the gate card's evaluator verdict, pinned on
+// the recorded Phase 3 re-run frames (tests/fixtures/gateEvidence.ts): which `gateEvaluated` is
+// THE verdict for a gate, what evidence rides with it, and the never-overclaim classification.
+
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+import {
+  checkOutcome,
+  denialSourceLabel,
+  formatDuration,
+  gateVerdict,
+  phaseLabel,
+  splitBackticks,
+} from '../src/components/gateVerdictModel.js';
+import {
+  G4_EVENTS,
+  G5_EVENTS,
+  G6_EVENTS,
+  GATE_RUN,
+  GATE_UNITS,
+  REPO_CHECKS_FAIL,
+  TREE_AFTER,
+  TREE_BEFORE,
+  WORKTREE_GUARD_REASON,
+} from './fixtures/gateEvidence.js';
+
+describe('gateVerdict — which evaluation answers the gate', () => {
+  it('G4 (pre-run gate before unit #4): the verdict is the fix phase (ord 3) — a PASS with its floor and judge', () => {
+    const v = gateVerdict(G4_EVENTS, 4);
+    expect(v).not.toBeNull();
+    expect(v!.ord).toBe(3);
+    expect(v!.outcome).toBe('pass');
+    expect(v!.criterion).toBe('the run left a change in its worktree (done is re-derived from the diff, never asserted)');
+    expect(v!.hasDeterministicFloor).toBe(true);
+    expect(v!.deterministicPass).toBe(true);
+    expect(v!.agentVerdict).toBe('pass');
+    expect(v!.agentReasoning).toContain('the run left a change in its worktree');
+    expect(v!.denial).toBeNull();
+    expect(v!.floor).toBeNull(); // no repoChecksEvaluated preceded the ord-3 evaluation
+    expect(v!.mutation).toBeNull();
+  });
+
+  it('G5 (escalated gate on unit #4): the worktree-guard denial, structured, with the mutation record attached', () => {
+    const v = gateVerdict(G5_EVENTS, 4);
+    expect(v).not.toBeNull();
+    expect(v!.ord).toBe(4);
+    expect(v!.outcome).toBe('fail');
+    expect(v!.denial).toEqual({
+      source: 'worktree_guard',
+      reason: WORKTREE_GUARD_REASON,
+      claimId: null,
+      ruleIds: [],
+      deniedTool: null,
+      phase: 'unit-4',
+    });
+    expect(v!.mutation).toEqual({
+      cli: 'pi',
+      phase: 'verify',
+      beforeTree: TREE_BEFORE,
+      afterTree: TREE_AFTER,
+      headMoved: false,
+      changed: [{ path: 'src/App.tsx', status: 'M' }],
+    });
+    // The judge itself said PASS — the denial is the guard's, and the view keeps both facts.
+    expect(v!.agentVerdict).toBe('pass');
+  });
+
+  it('G6 (pre-run gate before unit #5 deliver): the verify retry PASSED on the repo-checks floor — per-check results attached', () => {
+    const v = gateVerdict(G6_EVENTS, 5);
+    expect(v).not.toBeNull();
+    expect(v!.ord).toBe(4);
+    expect(v!.outcome).toBe('pass');
+    expect(v!.denial).toBeNull();
+    // Evidence belongs to ONE fold: attempt 0's mutation record sits before the ord-4 DENY, which
+    // is the boundary — the retry's PASS must not inherit it (a PASS beside "worktree changed by
+    // pi" would be the stale story dressed as the current one).
+    expect(v!.mutation).toBeNull();
+    expect(v!.floor).not.toBeNull();
+    expect(v!.floor!.passed).toBe(true);
+    expect(v!.floor!.attempt).toBe(1);
+    expect(v!.floor!.skipped).toEqual([]);
+    expect(v!.floor!.checks.map((c) => [c.name, c.exitCode, c.durationMs])).toEqual([
+      ['typecheck', 0, 6893],
+      ['lint', 0, 6118],
+      ['test', 0, 79191],
+    ]);
+    expect(v!.floor!.checks[0]!.source).toBe('package.json scripts.typecheck');
+  });
+
+  it('the ord bound: a later unit\'s evaluation can never answer an earlier gate', () => {
+    // G6 holds ord-4 evaluations after the ord-3 one; a gate on ord 3 must still see ord ≤ 3.
+    const v = gateVerdict(G6_EVENTS, 3);
+    expect(v!.ord).toBe(3);
+    expect(v!.outcome).toBe('pass');
+  });
+
+  it('no gateEvaluated yet (the very first gate) ⇒ null — the card renders no block', () => {
+    const firstGate = G4_EVENTS.slice(0, 1); // just the ord-1 awaitingHuman
+    expect(gateVerdict(firstGate, 1)).toBeNull();
+    expect(gateVerdict([], 1)).toBeNull();
+  });
+
+  it('an UNGATED phase (no floor, no judge, no policy) classifies as ungated, never pass (FINDING-025)', () => {
+    // The gate before unit #2: the ord-1 triage evaluation is a default-allow.
+    const v = gateVerdict(G4_EVENTS.slice(0, 4), 2);
+    expect(v!.ord).toBe(1);
+    expect(v!.outcome).toBe('ungated');
+    expect(v!.criterion).toBeNull();
+    expect(v!.evaluatorPolicies).toEqual([]);
+  });
+
+  it('an older engine that sends only `denialReason` prose still yields a denial view (source null)', () => {
+    const legacy: CoreEvent[] = [
+      {
+        type: 'gateEvaluated', session: GATE_RUN, ord: 2, criterion: 'c', hasDeterministicFloor: true,
+        deterministicPass: false, agentVerdict: null, agentReasoning: null, evaluatorPass: null,
+        denialReason: 'pinned validator failed: exit 1', combined: false,
+      },
+    ];
+    const v = gateVerdict(legacy, 2);
+    expect(v!.outcome).toBe('fail');
+    expect(v!.denial).toEqual({
+      source: null, reason: 'pinned validator failed: exit 1', claimId: null, ruleIds: [], deniedTool: null, phase: null,
+    });
+  });
+
+  it('malformed evidence frames are narrowed, never trusted: a check without a name is dropped, a non-array `changed` reads as none', () => {
+    const events: CoreEvent[] = [
+      { type: 'evaluatorMutatedWorktree', session: GATE_RUN, ord: 1, cli: 'pi', phase: 'verify', changed: 'nope' },
+      { ...REPO_CHECKS_FAIL, ord: 1, checks: [{ name: 'lint', exitCode: 1, durationMs: 10 }, { exitCode: 0 }] },
+      { type: 'gateEvaluated', session: GATE_RUN, ord: 1, combined: false, denialReason: 'x' },
+    ];
+    const v = gateVerdict(events, 1)!;
+    expect(v.mutation!.changed).toEqual([]);
+    expect(v.floor!.checks.map((c) => c.name)).toEqual(['lint']);
+    expect(v.floor!.checks[0]!.argv).toEqual([]);
+  });
+});
+
+describe('gateVerdict helpers', () => {
+  it('phaseLabel: the unit-key suffix for workflow units, `unit N` when unknown', () => {
+    expect(phaseLabel(GATE_RUN, GATE_UNITS, 3)).toBe('fix');
+    expect(phaseLabel(GATE_RUN, GATE_UNITS, 4)).toBe('verify');
+    expect(phaseLabel(GATE_RUN, GATE_UNITS, 9)).toBe('unit 9');
+    expect(phaseLabel(GATE_RUN, [], null)).toBe('unknown phase');
+  });
+
+  it('denialSourceLabel: a person\'s name per wicked-core source token; unknown tokens pass through', () => {
+    expect(denialSourceLabel('worktree_guard')).toBe('worktree guard (evaluator ≠ creator)');
+    expect(denialSourceLabel('repo_checks')).toBe('repository checks');
+    expect(denialSourceLabel(null)).toBe('the gate');
+    expect(denialSourceLabel('some_future_layer')).toBe('some_future_layer');
+  });
+
+  it('checkOutcome: exit code, timeout and spawn error in that priority', () => {
+    const base = { name: 'test', argv: [], source: '', exitCode: 0, timedOut: false, spawnError: null, durationMs: 1 };
+    expect(checkOutcome(base)).toEqual({ word: 'exit 0', ok: true });
+    expect(checkOutcome({ ...base, exitCode: 1 })).toEqual({ word: 'exit 1', ok: false });
+    expect(checkOutcome({ ...base, exitCode: null, timedOut: true })).toEqual({ word: 'timed out', ok: false });
+    expect(checkOutcome({ ...base, exitCode: null, spawnError: 'ENOENT' })).toEqual({ word: 'could not start: ENOENT', ok: false });
+    expect(checkOutcome({ ...base, exitCode: null })).toEqual({ word: 'no exit code', ok: false });
+  });
+
+  it('formatDuration: ms under a second, one decimal under a minute, m/s above', () => {
+    expect(formatDuration(420)).toBe('420ms');
+    expect(formatDuration(6893)).toBe('6.9s');
+    expect(formatDuration(79191)).toBe('1m 19s');
+    expect(formatDuration(120000)).toBe('2m');
+  });
+
+  it('splitBackticks: odd indices are the quoted commands', () => {
+    const parts = splitBackticks(WORKTREE_GUARD_REASON);
+    expect(parts.filter((_, i) => i % 2 === 1)).toEqual([
+      'verify',
+      'executes_code: false',
+      `git read-tree --reset -u ${TREE_BEFORE}`,
+      'executes_code: true',
+    ]);
+  });
+});

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -168,6 +168,16 @@ describe('gateVerdict helpers', () => {
     expect(formatDuration(120000)).toBe('2m');
   });
 
+  it('formatDuration: rounds to the unit BEFORE choosing the format — never sixty of a smaller unit (Copilot on #252)', () => {
+    expect(formatDuration(59_999)).toBe('1m'); // not "60.0s"
+    expect(formatDuration(59_949)).toBe('59.9s');
+    expect(formatDuration(119_500)).toBe('2m'); // not "1m 60s"
+    expect(formatDuration(119_499)).toBe('1m 59s');
+    expect(formatDuration(999.6)).toBe('1.0s'); // not "1000ms"
+    expect(formatDuration(999.4)).toBe('999ms');
+    expect(formatDuration(-5)).toBe('0ms');
+  });
+
   it('splitBackticks: odd indices are the quoted commands', () => {
     const parts = splitBackticks(WORKTREE_GUARD_REASON);
     expect(parts.filter((_, i) => i % 2 === 1)).toEqual([


### PR DESCRIPTION
Closes #250

Fixes the two Phase 3 re-run findings that share the gate/delivery surface (wave 3 of the fix program, 2026-09-10). No version bump.

## F-3R2-006 — gate cards show the evaluator verdict, the floor results and the denial remedy

**Before.** The verify pre-run gate card read only "Approve unit 4 before it runs: verify — …" while the `fix` phase's PASS (criterion, deterministic floor, judge reasoning) sat in the already-hydrated event log; the DENIED gate read "Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run" while the reason (evaluator≠creator, the changed path, the restore command) was only in an expandable thread line; the deliver gate never showed that the repository's own checks had run.

**After.** `SteeringGate` renders a `gate-verdict` block between the question and the answer controls, from the run's own event log (`useRunEventStore` — the same source `VerdictDetail` reads; **zero new requests**):

- **Which evaluation:** the last `gateEvaluated` at or below the gate's `ord` — for a pre-run gate "before unit #N" that is the phase that just finished (the fix gate); for an escalated gate it is unit N's own denial. No evaluation yet ⇒ **no block**, never a verdict fabricated from the prompt.
- **Verdict + criterion + judge:** `PASS` / `DENIED` / `UNGATED` (an evaluation with no floor, no judge and no policy is labelled a default-allow, not a pass — FINDING-025), the `criterion`, `judge: <agentVerdict> — <agentReasoning>`, and the layers line (`deterministic floor: pass|fail · evaluator: …`).
- **Floor (F-039):** the `repoChecksEvaluated` frame from the same fold — one row per check: `typecheck · exit 0 · 6.9s · package.json scripts.typecheck`, timed-out / could-not-start spelled out, `skipped (an earlier check failed): test`, and the two `checks: []` cases disclosed ("no detectable check — a disclosed vacuous pass" vs "the floor failed before any check ran").
- **Denial:** `denied by <layer>: <engine reason verbatim>` from `GateEvaluatedEvent.denial` (`data-denial-source="worktree_guard"` etc.); backticked spans in the reason render as copyable `<code>`, so the remedy `git read-tree --reset -u <tree>` and the def change `executes_code: true` are right on the card. An older engine that sends only `denialReason` prose still gets a denial view (`source: null`).
- **Mutation record (F-036):** `worktree changed by pi during verify: M src/App.tsx (tree a1b2c3d4e5 → f0e1d2c3b4)`, plus "the run branch moved" when `headMoved`.
- **Evidence belongs to one fold:** the backward search for `repoChecksEvaluated` / `evaluatorMutatedWorktree` stops at the previous same-ord `gateEvaluated`, so a retry's PASS never inherits the replaced attempt's changed path (the recorded G6 case).
- **Every gate card, not just the run page's:** the project/landing gate inbox (`CenterDashboard`'s `GateActionCard`) renders the same `GateVerdict` block from the event log it already subscribes to (Copilot follow-up on this PR). `ApprovalDock` passes `view.units` so the phase is named (`fix`, `verify`); `phaseLabel` is now shared with `VerdictDetail` (moved, not duplicated). The e2e suites' selectors (`steering-gate`, `steering-prompt`, `verdict-detail`) are untouched — the new block has its own `gate-verdict-*` testids; inventory regenerated.
- **Always bounded (Copilot follow-ups):** the lookup requires a numeric gate ord — an ord-less `gateEvaluated` is never selected for a bounded gate, and a card with no ord renders no block rather than an unbounded "last evaluation". In the daemon-restart fallback (status `awaiting_human`, transient gate cache lost) `ApprovalDock` derives the ord from the run's own cursor exactly as `useRunModel.pendingGate` does (`units[unit_ix].ord`, else `unit_ix + 1`), so the run page's card stays bound even when the prompt was lost — and the cursor indexes units in ORD order, so the DTO's array is sorted before `unit_ix` is applied (the contract `ChatPanel`'s render already states). `formatDuration` rounds to the unit before choosing the format (no `60.0s` / `1m 60s`).
- **Persisted verdicts survive a reload (Copilot follow-up):** only the run page's route hydrates `/runs/:id/events`, so after a landing/project reload the inbox card would have had nothing to read. `CenterDashboard` now backfills the event log for OPEN-GATE runs only — once per GATE INSTANCE (`runId:ord:receivedAt`) per mount, so a run that opens a second gate while the dashboard stays mounted (a retry of the same ord included) refreshes its durable prefix and a reconnect gap between the two can never leave the earlier verdict standing under the new gate — the same bounded pattern `useBoardModel` uses for failed runs, so the list surface's request budget is O(open gates), not O(rows). No "already has frames" shortcut — after a reconnect the live slice may hold only the new `awaitingHuman` while the `gateEvaluated` was recorded before the socket came up, so the once-per-id guard alone bounds the fetch; the effect depends on `openGates` only (the store is read inside), so a busy dashboard does not rescan its gates on every structured frame. **Readiness per gate instance (Copilot follow-up):** while an instance's fetch is pending the inbox card renders NO verdict — the store's slice may be an earlier attempt's evaluation plus this gate's `awaitingHuman`, so on a same-ord retry after a reconnect "render what we have" would have shown the OLD verdict under the new gate; an instance becomes ready only when its fetch resolves with history, and an empty history or a 503 leaves it un-ready for good (no block, never a stale one). `hydrate` merges live frames by fingerprint so nothing double-counts.
- **Denial spellings (Copilot follow-up):** the structured denial is read in both casings — `claimId`/`claim_id`, `ruleIds`/`rule_ids`, `deniedTool`/`denied_tool` — the same tolerance `denialCopy.ts` already keeps, so a snake_case engine never drops its rule ids from the card.

**Wire contract:** `wicked-crew-api-types` **0.30.0 → 0.31.0** (devDependency, exact pin). Verified purely additive against the installed 0.30.0 `index.d.ts` (one doc-comment line changed, 151 lines added: `UnitDenialSource`, `UnitDenial`, `GateEvaluatedEvent.denial`/`evaluatorPolicies`, `WorktreeChangedPath`, `EvaluatorMutatedWorktreeEvent`, `RepoCheckRun`, `RepoChecksEvaluatedEvent`, `GateEvidenceEvent`); `tsc --noEmit` green on the bump alone before any source change. Every field the card renders is declared in 0.31.0; nothing is invented.

## F-3R2-018 — the delivery strip ignores non-delivering workflows

**Before.** "2 Verified & delivered · 0 Stranded — needs review · **9 Vacuous — needs retry**" — the nine were `onboarding` runs (verified against the rig's baseline: 9 × `onboarding`, 2 × `bug`), which the daemon stamps `delivery: 'vacuous'` because an untouched worktree is that workflow's designed outcome.

**After.** `deliveryCounts(runs, isSystemWorkflow?)` licenses the `vacuous` bucket with the Delivery section's existing `canDeliver` rule — a deliver unit on the run (evidence first: a materialised `wf-<id>` def whose deliver phase ran and found nothing still counts), or a workflow positively known not to be a system one (`is_system` from the ONE budgeted `GET /workflows`; `onboarding` is also on the denylist, so the count is right on a cold catalog too). Both consumers — `DeckVerifiedStrip` and the KPI ribbon's Review tile — pass the same lookup, so they cannot disagree. The cell reads **"Vacuous — no change to deliver"**: the condition, not a prescription. The licence can only withhold a count, never invent one (a bare `vacuous` stamp on an unclassifiable run is not shown — the same trade `canDeliver` already makes for the Delivery section).

## Tests

Recorded frames from the Phase 3 re-run (`GET /runs/:id/events` at G4 / G5 / G6 plus the `repoChecksEvaluated` capture) as a fixture, `tests/fixtures/gateEvidence.ts` — the gate-relevant subset of the recording with the recording's `seq`/`ts` and every rendered field byte-for-byte (the reviewer's W3S-252-01 is taken: the G6 ord-4 `gateEvaluated` now carries the recorded joined `criterion` and `agentReasoning`, and the connective frames between gates are the recorded `resumed` / `unitDispatched` / `unitExecuting` / `unitReworkAmended`, not invented ones). Scrubbed: run id, intent text (prompts and the amendment's re-stated description), worktree paths, test-runner tails, and the two git tree ids (synthetic hex of the same width, the denial prose and the amendment kept in their exact wording). One synthetic frame (`REPO_CHECKS_FAIL`, labelled) pins the failed-floor rendering in the wire's declared shape. W3S-252-02 is taken too: `overflow-wrap: anywhere` on `gate-verdict-denial`, so the 40-hex tree id inside one `<code>` span wraps in a narrow dock.

- `tests/gateVerdictModel.test.ts` (16) — which evaluation answers which gate, the ord bound (incl. ord-less frames), same-fold evidence, ungated classification, prose-only and snake_case denials, malformed-frame narrowing, helpers (incl. duration boundaries).
- `tests/SteeringGate.verdict.test.tsx` (8) — the card over G4 / G5 / G6 / failed floor / first gate / ungated / no units / no ord.
- `tests/CenterDashboard.build.test.tsx` (+8) — the gate inbox card renders the same verdict block (G4), none without an evaluation, after a reload it backfills the open-gate run's log exactly once (a gate-less run is never fetched), after a reconnect (only the live `awaitingHuman` in the store) the backfill still runs and the live frame is merged once, the guard is per gate instance (a re-set of the same gate fetches nothing, a second gate on the same run fetches exactly once more and proves its own history before its block renders), and the readiness rule is pinned three ways — a same-ord retry with a deferred fetch renders no block while pending and the retry's own `repo_checks` denial once the log lands (never attempt 0's worktree-guard denial), an empty history ⇒ no block, a 503 ⇒ no block; `tests/ChatPanel.dock.test.tsx` (+2, +1 assertion) — the daemon-restart fallback derives the ord (from an unsorted DTO too) and keeps the lookup bounded.
- `tests/deliveryCounts.test.ts` (6) — the recorded nine-onboarding case (warm, cold, no lookup), evidence-first deliver unit, positively-known build, withheld-when-unknown, other system workflows, delivered/stranded/archived untouched.
- `tests/DeckVerifiedStrip.test.tsx` (+2, existing fixture made a licensed vacuous run), `tests/DeckKpiRibbon.test.tsx` (fixture likewise).

`npm run lint` · `npm run typecheck` · `npm test` (256 files, 2781 tests) · `npm run build` — all green locally on the fresh clone. The `e2e/` suites are Python Playwright against a live daemon and were not run (no daemon may be touched from this wave); the selectors they key on are unchanged.

## Wire gaps (rendered what exists; listed rather than invented)

- **Judge seat** — `gateEvaluated` (api-types 0.31.0) carries no seat/CLI for the layer-2 judge; the brief asked for `judge: <seat>` when present. Not present ⇒ nothing rendered, and deliberately not inferred from `unitDispatched.cli` (that is the creator's seat, not the judge's). A `judgeCli?: string` on `GateEvaluatedEvent` would light this up with a one-line change.
- **`awaitingHuman.reviewingOrd`** — on the recorded wire (`null` for pre-run gates, `4` for the escalation) but not declared in api-types. Not needed: the card keys on the gate's `ord` and log order instead. Declaring it would let the card distinguish "before unit N" from "N's verdict escalated" without reading the prompt.
- **Fail-closed worktree-guard denials** carry no `evaluatorMutatedWorktree` (by design per the 0.31.0 docs); the card then shows the `denial.reason`, which names the cause. No gap in the card, noted for completeness.

## Declined / out of scope (with reason)

- The strip's `?filter=vacuous|stranded|delivered` doors land on `WorkPage`'s "All" tab — `routedFilter` honours only the five status tabs. Pre-existing and unrelated to either finding; left as is rather than growing this PR into a Work-page filter feature.
- `stranded` is not licensed the way `vacuous` now is: the daemon's `'stranded'` is its own positive worktree-carries-work check, and the finding is about the vacuous bucket only.
- No narrator line for `repoChecksEvaluated` / `evaluatorMutatedWorktree` — the finding is the gate card; the feed's existing "Checks ran on <phase> — pass|deny" line stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
