### PR TITLE
feat(wave-2 consumers): repo findings on the repo card, governance in the Health panel, scoped New Chat (#251, #246, #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,18 @@ npm publish dates. Every version listed here exists on
     (count as a floor when truncated, by type / by reason, the timestamp range, the outbox, the
     pre-fix HOME outbox) and every finding as a severity-styled row whose message carries the
     `wicked-crew governance replay …` recipe. A `store: null` boot and any error finding turn the
-    heart red (and show the collapsed-header dot); a warning degrades it to amber. A daemon without
-    the block, or without the route, reads "not reported by this daemon".
+    heart red (and show the collapsed-header dot) and degrade the home board's **Governed** tile
+    (fail-coloured, the reason underneath — never a clean percentage over evidence that is not
+    landing); a warning degrades the heart to amber. A daemon without the block, or without the
+    route, reads "not reported by this daemon".
   - *Scoped New Chat* (#248, crew#502 / F-067): the create window carries a **Scope** control —
     *All project repos* (the default once a project is bound: `projectId` alone rides the open and
     the daemon scopes to every `crew.repo` member), *Choose repos…* (a multi-select from
     `GET /repos`, loaded on that gesture; sends `repoRefs` by id) and *Unscoped* (an explicit click).
     An Unfiled chat with no choice does not open on send — the gap is stated on the row, nothing is
-    posted, the draft stays. The opened chat states `ChatOpenResponse.scope` under the header: the
+    posted, the draft stays. A scoped open with the default (untouched) seat chips omits `clis`, so
+    the daemon admits only governed seats and the 201 re-seeds the chips; an edited selection rides
+    as asked and refused seats say why. The opened chat states `ChatOpenResponse.scope` under the header: the
     repositories (names; paths on hover), read-only, whether a code graph grounds the seats and the
     daemon's reason when not, and any project member the registry no longer knows; a rejoin states
     `ChatDetailResponse.scope`, and a daemon that said nothing is reported as "not stated". The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+### Added
+- **Wave-2 consumers: the repo card renders the engine's findings, the Health rail renders
+  `diagnostics.governance`, and New Chat carries a scope control** (#251, #246, #248 — pins
+  `wicked-crew-api-types` 0.32.0, the wave-2 crew release).
+  - *Repo findings* (#251, wicked-core#406 via crew#517): `RepoEntry.findings[]` renders on the
+    Repositories fleet card, the repo detail header and the project page's repo rows — one labelled
+    row per finding with the engine's own message. An in-tree `.codegraph/` beside a live graph is a
+    tidy-up warning; an in-tree graph with NO live graph (the F-024 checkouts after the upgrade) is an
+    error whose row carries **Re-run onboarding**, wired to each surface's existing onboard trigger
+    (`POST /repos/:id/onboard`); `code_graph_root_unresolvable` is an error naming the daemon-
+    environment fault. Silent for a clean checkout and for a daemon that predates the field.
+  - *Governance in Health* (#246, crew#495 / F-022): expanding the rail's Health section also reads
+    `GET /diagnostics` and renders the `governance` block — the store path and which rule chose it,
+    the record counts (an honest "engine cannot count" for `null`, never 0), the dead-letter fold
+    (count as a floor when truncated, by type / by reason, the timestamp range, the outbox, the
+    pre-fix HOME outbox) and every finding as a severity-styled row whose message carries the
+    `wicked-crew governance replay …` recipe. A `store: null` boot and any error finding turn the
+    heart red (and show the collapsed-header dot); a warning degrades it to amber. A daemon without
+    the block, or without the route, reads "not reported by this daemon".
+  - *Scoped New Chat* (#248, crew#502 / F-067): the create window carries a **Scope** control —
+    *All project repos* (the default once a project is bound: `projectId` alone rides the open and
+    the daemon scopes to every `crew.repo` member), *Choose repos…* (a multi-select from
+    `GET /repos`, loaded on that gesture; sends `repoRefs` by id) and *Unscoped* (an explicit click).
+    An Unfiled chat with no choice does not open on send — the gap is stated on the row, nothing is
+    posted, the draft stays. The opened chat states `ChatOpenResponse.scope` under the header: the
+    repositories (names; paths on hover), read-only, whether a code graph grounds the seats and the
+    daemon's reason when not, and any project member the registry no longer knows; a rejoin states
+    `ChatDetailResponse.scope`, and a daemon that said nothing is reported as "not stated". The
+    route's refusals render as inline sentences by status — 404 (every missing ref named), 400
+    (an ambiguous name → name it by id), 409 (a daemon-side conflict), 501 (the engine predates chat
+    scope, with a **Continue unscoped** fallback that mints a fresh unscoped chat outside the shell).
+
 ### Fixed
 - **`.codegraph/estate.db` is no longer tracked** (#220). A fresh clone shipped the operator repo's code-graph
   identity, so onboarding the clone failed with `REPO COLLISION` (and an older wicked-core wrote into the

--- a/e2e/ux_fixJ42_test.py
+++ b/e2e/ux_fixJ42_test.py
@@ -176,6 +176,9 @@ with sync_playwright() as p:
           and mount_chat == [("GET", "/api/v1/roster")],
           storage_entries=storage, chips_bar=mount["chipsBar"], mount_chat_requests=mount_chat)
 
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill(MSG_COLD)
     page.keyboard.press("Enter")
     # The daemon ACCEPTS (strict contract): composer clears, replies land.
@@ -237,6 +240,9 @@ with sync_playwright() as p:
     # EC44: the failed MOUNT resolve renders as the bar's unresolved row —
     # no chip is painted, Send stays disabled, and Enter ships NOTHING.
     page2.locator('[data-testid="agent-chips-unresolved"]').wait_for(timeout=30000)
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").fill(MSG_DOWN)
     page2.keyboard.press("Enter")
     down = page2.evaluate(CENSUS)
@@ -260,6 +266,9 @@ with sync_playwright() as p:
     set_fixture(ORIGIN, roster_fail=False)
     page2.locator('[data-testid="agent-chips-retry"]').click()
     page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").click()
     page2.keyboard.press("Enter")
     page2.wait_for_function(
@@ -285,6 +294,9 @@ with sync_playwright() as p:
     page3.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page3.add_style_tag(content=HIDE_GATE_TOASTS)
 
+    _scope_none = page3.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page3.locator("textarea").fill(MSG_REJ)
     page3.keyboard.press("Enter")
     page3.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)

--- a/e2e/ux_fixJ43_test.py
+++ b/e2e/ux_fixJ43_test.py
@@ -232,6 +232,9 @@ with sync_playwright() as p:
     # no seat comes up red — the no-4-red-seats-by-default acceptance.
     displayed = page.evaluate(
         """() => [...document.querySelectorAll('[data-testid="agent-chip"]')].map((c) => c.dataset.agent)""")
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill(MSG_COLD)
     page.keyboard.press("Enter")
     page.wait_for_function(

--- a/e2e/ux_fixJ4J5_test.py
+++ b/e2e/ux_fixJ4J5_test.py
@@ -269,6 +269,9 @@ with sync_playwright() as p:
     page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").fill(MSG1)
     page2.keyboard.press("Enter")
     # 1 — the URL names the session the moment it exists.
@@ -318,6 +321,9 @@ with sync_playwright() as p:
           and rejoined["ready"] > 0 and not rejoined["firstrun"],
           **rejoined)
 
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").fill(MSG2)
     page2.keyboard.press("Enter")
     page2.wait_for_function(
@@ -350,6 +356,9 @@ with sync_playwright() as p:
     page2.screenshot(path=str(VSHOTS / "ux-fixJ4J5-ended.png"))
 
     # 3 — a send from the ended boundary starts a NEW session; the URL follows.
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").fill(MSG3)
     page2.keyboard.press("Enter")
     page2.wait_for_function(

--- a/e2e/ux_sliceAB_test.py
+++ b/e2e/ux_sliceAB_test.py
@@ -207,6 +207,9 @@ with sync_playwright() as p:
 
     # AC 1 — the send connects EXACTLY the displayed chips: the open names the
     # capable defaults + the explicit addition; no gesture-time roster fetch.
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill(MSG1)
     page.keyboard.press("Enter")
     page.wait_for_function(
@@ -232,6 +235,9 @@ with sync_playwright() as p:
 
     # AC 3 setup — turn 2 opens BEFORE turn 1's chunks arrive (chat_deltas
     # buffers them until the flush): the splice scenario, live.
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill(MSG2)
     page.keyboard.press("Enter")
     page.wait_for_function(
@@ -259,6 +265,9 @@ with sync_playwright() as p:
 
     # AC 2 — a refused fan-out keeps the draft and renders inline retry.
     set_fixture(ORIGIN, chat_send_fail=True)
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill(MSG3)
     page.keyboard.press("Enter")
     page.locator('[data-testid="chat-send-failed"]').wait_for(timeout=30000)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -255,6 +255,10 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #   chat_scope_501 — POST /chats answers crew's 501 "engine predates chat
          #                   scope" for any SCOPED open (default False).
          "repo_findings": False, "governance": None, "chat_scope": False, "chat_scope_501": False,
+         #   chat_admit_subset — with `clis` omitted on a scoped open the pre-filter admits ONLY
+         #                   claude (a strict subset of the chat-capable set), so a rig can prove
+         #                   the header shows exactly the admitted seats (W3S-253-09). Default False.
+         "chat_admit_subset": False,
          # Fix slice J4/J5 (BRIEF-UX-001 re-review): the outcome-partition
          # corpus — cancelled runs in AND out of the 24h window plus undatable
          # terminal runs (no attach clock anywhere), so a rig can prove
@@ -3152,6 +3156,7 @@ class W2Handler(SimpleHTTPRequestHandler):
             with state_lock:
                 scope_on = state["chat_scope"]
                 scope_501 = state["chat_scope_501"]
+                admit_subset = state["chat_admit_subset"]
                 repo_on = state["repo"]
                 repo_member_on = state["repo_member"]
             scope = None
@@ -3193,7 +3198,7 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # is passed through as asked. The fixture's stand-in for "governed" is the
                 # chat-capable set (the same seats chat_ensure admits).
                 if scope["kind"] != "none" and not body.get("clis"):
-                    clis = list(CHAT_CAPABLE_KEYS)
+                    clis = ["claude"] if admit_subset else list(CHAT_CAPABLE_KEYS)
             # Slice AB (§7.9-4): seats named by `chat_reject_seats` answer the
             # daemon's real per-seat shape — ok:false with an error the chip
             # must wear as failed-with-reason. Only accepted seats warm.

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -237,6 +237,24 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #               resolves), giving §4.4's runs-per-repo / failing-
          #               repos tiles something true to group. Default False.
          "chat_runs": False, "repo_refs": False,
+         # Wave-2 consumers (studio#251 / #246 / #248, api-types 0.32.0):
+         #   repo_findings — the studio-api RepoEntry carries the wicked-core#406
+         #                   `in_tree_code_graph_ignored` finding in its NO-LIVE-GRAPH
+         #                   form (the re-onboard remedy) and POST /repos/<id>/onboard
+         #                   answers {runId}. Default False.
+         #   governance    — GET /api/v1/diagnostics answers a body whose `governance`
+         #                   block is the F-022 dead-letter case (crew#495). Default
+         #                   None = the route is ABSENT (Fastify's unknown-route 404,
+         #                   a daemon predating diagnostics); "healthy" serves the
+         #                   clean block instead.
+         #   chat_scope    — POST /api/v1/chats resolves and STATES a scope (crew#502)
+         #                   from the body (repoRefs → repos; projectId → project;
+         #                   else none), 404s unknown refs naming every missing one,
+         #                   and GET /chats/<id> carries the recorded scope. Default
+         #                   False: the standing chat rigs see the pre-scope 201.
+         #   chat_scope_501 — POST /chats answers crew's 501 "engine predates chat
+         #                   scope" for any SCOPED open (default False).
+         "repo_findings": False, "governance": None, "chat_scope": False, "chat_scope_501": False,
          # Fix slice J4/J5 (BRIEF-UX-001 re-review): the outcome-partition
          # corpus — cancelled runs in AND out of the 24h window plus undatable
          # terminal runs (no attach clock anywhere), so a rig can prove
@@ -1339,6 +1357,76 @@ REPO_ENTRY = {
     "code_graph_db": "/tmp/w2/studio-api/.wicked-estate/code_graph.db",
 }
 
+# ── Wave 2 (studio#251 / #246 / #248) — the api-types 0.32.0 shapes ───────────
+STATE_HOME_GRAPH = "/tmp/w2/state/repo-graphs/studio-api-9c1e/estate.db"
+# wicked-core#406's finding, in its NO-LIVE-GRAPH form (core `repo.rs` sentence verbatim,
+# scrubbed paths) — the case whose remedy is the onboarding re-run.
+REPO_FINDING_NO_LIVE = {
+    "code": "in_tree_code_graph_ignored",
+    "message": ("/tmp/w2/studio-api/.codegraph exists in the checkout — a code graph an older wicked-core "
+                "indexed IN the working tree. It is ignored (no graph has been indexed under the state home yet "
+                f"— re-run onboarding (POST /repos/{REPO_ID}/onboard) to build {STATE_HOME_GRAPH}; never inside "
+                "the repository). Delete `.codegraph/` from the checkout — and `git rm --cached` it if the "
+                "repository tracks it — to clear this finding (core#406)."),
+    "path": "/tmp/w2/studio-api/.codegraph",
+}
+
+
+def repo_entry_wire(findings_on: bool) -> dict:
+    """The studio-api record as the wire carries it: with `repo_findings` the graph path moves
+    under the state home (core#406) and the finding rides along; otherwise the standing shape."""
+    if not findings_on:
+        return REPO_ENTRY
+    return {**REPO_ENTRY, "code_graph_db": STATE_HOME_GRAPH, "findings": [REPO_FINDING_NO_LIVE]}
+
+
+onboard_posts: list = []  # POST /repos/<id>/onboard receipts (studio#251's remedy, tapped by the rig)
+
+GOV_STORE = "/tmp/w2/state/core.db.governance/governance.db"
+GOV_OUTBOX = "/tmp/w2/state/core.db.governance/emit-outbox.ndjson"
+DIAGNOSTICS_BASE = {
+    "components": {"crew": "w2-fixture", "studioBundle": None, "coreTs": None, "engineBinaries": {}},
+    "daemon": {"uptimeMs": 60_000, "startedAt": NOW0 - 60 * SEC, "port": 7701},
+    "stores": [], "recentErrors": [], "acp": {"byCli": {}},
+}
+GOVERNANCE_BLOCKS = {
+    "healthy": {
+        "store": {"path": GOV_STORE, "source": "core-db-sidecar"},
+        "records": {"total": 412, "sinceBoot": 37},
+        "deadletters": {"path": GOV_OUTBOX, "count": 0, "byType": {}, "byReason": {}, "timestamped": 0,
+                        "untimestamped": 0, "oldestTs": None, "newestTs": None, "truncated": False,
+                        "legacyOutbox": None},
+        "findings": [],
+    },
+    # F-022: every governance event dead-lettered; the finding names the replay (crew#495).
+    "deadletters": {
+        "store": {"path": GOV_STORE, "source": "flag"},
+        "records": {"total": 0, "sinceBoot": 0},
+        "deadletters": {"path": GOV_OUTBOX, "count": 128,
+                        "byType": {"wicked.crew.governance.conformance_recorded": 96,
+                                   "wicked.crew.governance.decision_recorded": 32},
+                        "byReason": {"no shared store (WICKED_ESTATE_DB unset)": 128},
+                        "timestamped": 120, "untimestamped": 8,
+                        "oldestTs": NOW0 - 2 * HOUR, "newestTs": NOW0 - 5 * MIN, "truncated": True,
+                        "legacyOutbox": None},
+        "findings": [{"kind": "governance.deadletter", "severity": "error",
+                      "message": (f"128 governance event(s) dead-lettered to {GOV_OUTBOX} (at least — the fold "
+                                  "stopped at its size cap) — the store refused or was unset when they were emitted "
+                                  "(no shared store (WICKED_ESTATE_DB unset)); replay them with wicked-crew governance "
+                                  f"replay {GOV_OUTBOX} --governance-db {GOV_STORE}")}],
+    },
+}
+
+CHAT_SCRATCH = "/tmp/w2/wicked-crew-chats/4242-9f3a1c2b/{}"
+CHAT_SCOPE_501 = ("the installed wicked-core-ts predates chat scope (wicked-core#410): it cannot ground a scoped "
+                  "chat or hold its read roots read-only — upgrade the engine, or open the chat without "
+                  "projectId/repoRefs.")
+chat_scopes: dict = {}  # chatId → the ChatScope recorded at open (crew#502), under chat_state_lock
+
+
+def scope_repo(r: dict) -> dict:
+    return {"id": r["id"], "name": r["name"], "rootPath": r["root_path"]}
+
 
 def _graph_node(i: int, name: str, kind: str, file: str, lang: str,
                 in_deg: int, out_deg: int) -> dict:
@@ -2101,7 +2189,18 @@ class W2Handler(SimpleHTTPRequestHandler):
         if path == "/api/v1/repos":
             with state_lock:
                 repo_on = state["repo"]
-            self._json(200, {"repos": [REPO_ENTRY] if repo_on else []})
+                findings_on = state["repo_findings"]
+            self._json(200, {"repos": [repo_entry_wire(findings_on)] if repo_on else []})
+            return True
+        # Wave 2 (studio#246): GET /diagnostics — ABSENT (the unknown-route 404 a daemon
+        # predating the route answers) unless the `governance` switch names a block.
+        if path == "/api/v1/diagnostics":
+            with state_lock:
+                gov = state["governance"]
+            if gov is None:
+                self._json(404, {"error": "not found"})
+            else:
+                self._json(200, {**DIAGNOSTICS_BASE, "governance": GOVERNANCE_BLOCKS[gov]})
             return True
         # The slice-E repo profile reads (all real crew routes, switch-gated).
         m = re.match(r"^/api/v1/repos/([^/]+)/(graph|git-history|contributors)$", path)
@@ -2155,7 +2254,13 @@ class W2Handler(SimpleHTTPRequestHandler):
             with chat_state_lock:
                 seats = [k for k in chat_warm_seats.get(cid, [])
                          if k not in chat_dead_seats.get(cid, set())]
-            self._json(200, {"chatId": cid, "seats": seats})
+                scope = chat_scopes.get(cid)
+            with state_lock:
+                scope_on = state["chat_scope"]
+            detail = {"chatId": cid, "seats": seats}
+            if scope_on:
+                detail["scope"] = scope  # None = a chat this daemon did not open (crew#502)
+            self._json(200, detail)
             return True
         parts = path.split("/")
         # /api/v1/projects/<id>/members
@@ -3042,6 +3147,47 @@ class W2Handler(SimpleHTTPRequestHandler):
             clis = body.get("clis") or [s["key"] for s in ROSTER]
             chat_id = body.get("chatId") or "fixture-chat"
             known = {s["key"] for s in ROSTER}
+            # Wave 2 (studio#248, crew#502): resolve the scope BEFORE any seat warms —
+            # a refused scope warms nothing. Real status codes + sentences.
+            with state_lock:
+                scope_on = state["chat_scope"]
+                scope_501 = state["chat_scope_501"]
+                repo_on = state["repo"]
+                repo_member_on = state["repo_member"]
+            scope = None
+            if scope_on:
+                refs = ([body["repoRef"]] if body.get("repoRef") else []) + list(body.get("repoRefs") or [])
+                registry = [REPO_ENTRY] if repo_on else []
+                if refs:
+                    found = [r for r in registry if r["id"] in refs or r["name"] in refs]
+                    missing = [ref for ref in refs if not any(r["id"] == ref or r["name"] == ref for r in registry)]
+                    if missing:
+                        return self._json(404, {"error": "Repo " + ", ".join(f"'{m}'" for m in missing) + " not found",
+                                                "missing": missing})
+                    scope = {"kind": "repos", "repos": [scope_repo(r) for r in found], "cwd": CHAT_SCRATCH.format(chat_id),
+                             "graph": {"bound": False,
+                                       "reason": f"'{found[0]['name']}' has no resolvable code graph (not indexed yet); this chat gets none."},
+                             "dangling": []}
+                    if body.get("projectId"):
+                        scope["projectId"] = body["projectId"]
+                elif body.get("projectId"):
+                    pid = body["projectId"]
+                    members = [REPO_ENTRY] if (repo_on and repo_member_on and pid == "upload-endpoint") else []
+                    scope = {"kind": "project", "projectId": pid, "repos": [scope_repo(r) for r in members],
+                             "cwd": CHAT_SCRATCH.format(chat_id),
+                             "graph": ({"bound": True, "reason": f"bound to project '{pid}'s co-located code graph."}
+                                       if members else
+                                       {"bound": False, "reason": "the project graph has never been built. "
+                                                                  f"POST /api/v1/projects/{pid}/graph/refresh fixes it."}),
+                             "dangling": []}
+                else:
+                    scope = {"kind": "none", "repos": [], "cwd": CHAT_SCRATCH.format(chat_id),
+                             "graph": {"bound": False,
+                                       "reason": "the chat names no project and no repos, so its seats see only their own "
+                                                 "scratch root and no code graph; pass projectId or repoRefs to scope it."},
+                             "dangling": []}
+                if scope_501 and scope["kind"] != "none":
+                    return self._json(501, {"error": CHAT_SCOPE_501})
             # Slice AB (§7.9-4): seats named by `chat_reject_seats` answer the
             # daemon's real per-seat shape — ok:false with an error the chip
             # must wear as failed-with-reason. Only accepted seats warm.
@@ -3073,7 +3219,23 @@ class W2Handler(SimpleHTTPRequestHandler):
                             chat_warm_seats[chat_id].append(k)
                     chat_dead_seats.setdefault(chat_id, set())
                     chat_send_count.setdefault(chat_id, 0)
-            return self._json(201, {"chatId": chat_id, "seats": seats})
+                if scope is not None:
+                    chat_scopes[chat_id] = scope
+            opened = {"chatId": chat_id, "seats": seats}
+            if scope is not None:
+                opened["scope"] = scope
+            return self._json(201, opened)
+        # Wave 2 (studio#251): the re-onboard remedy's wire, POST /repos/<id>/onboard → {runId}.
+        m = re.match(r"^/api/v1/repos/([^/]+)/onboard$", path)
+        if m:
+            with state_lock:
+                findings_on = state["repo_findings"]
+            rid = urllib.parse.unquote(m.group(1))
+            if not findings_on or rid != REPO_ID:
+                return self._json(404, {"error": f"Repo {rid} not found"})
+            with chat_state_lock:
+                onboard_posts.append(rid)
+            return self._json(200, {"runId": "r-reonboard"})
         # POST /api/v1/chats/<id>/messages — accept the fan-out; replies would
         # stream over /ws, which this fixture leaves to the narration loop —
         # UNLESS the slice-K `chat_replies` switch is on: then each send queues

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -3188,6 +3188,12 @@ class W2Handler(SimpleHTTPRequestHandler):
                              "dangling": []}
                 if scope_501 and scope["kind"] != "none":
                     return self._json(501, {"error": CHAT_SCOPE_501})
+                # crew's admissibility pre-filter (routes.ts @ #518): with `clis` OMITTED on a
+                # SCOPED open the DEFAULT roster is filtered to governed seats; an explicit list
+                # is passed through as asked. The fixture's stand-in for "governed" is the
+                # chat-capable set (the same seats chat_ensure admits).
+                if scope["kind"] != "none" and not body.get("clis"):
+                    clis = list(CHAT_CAPABLE_KEYS)
             # Slice AB (§7.9-4): seats named by `chat_reject_seats` answer the
             # daemon's real per-seat shape — ok:false with an error the chip
             # must wear as failed-with-reason. Only accepted seats warm.

--- a/e2e/uxfix_slice4_test.py
+++ b/e2e/uxfix_slice4_test.py
@@ -243,6 +243,9 @@ with sync_playwright() as p:
     added_count = page.evaluate(
         """() => document.querySelector('[data-testid="agent-chips-bar"]')?.dataset.count ?? null""")
 
+    _scope_none = page.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page.locator("textarea").fill("warm the whole selection")
     page.keyboard.press("Enter")
     page.locator('[data-testid="chat-close"]').wait_for(timeout=30000)
@@ -282,6 +285,9 @@ with sync_playwright() as p:
     page2.locator('[data-testid="agent-chip"]').first.wait_for(timeout=30000)
     page2.add_style_tag(content=HIDE_GATE_TOASTS)
 
+    _scope_none = page2.locator('[data-testid="chat-scope-none"]')  # studio#248: an Unfiled chat opens only on an EXPLICIT unscoped choice
+    if _scope_none.count() and _scope_none.is_enabled():
+        _scope_none.click()
     page2.locator("textarea").fill("make me a deck")
     page2.keyboard.press("Enter")
     page2.locator('[data-testid="chat-close"]').wait_for(timeout=30000)

--- a/e2e/wave2_consumers_test.py
+++ b/e2e/wave2_consumers_test.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+wave2_consumers_test.py — the wave-2 consumers gate (studio#251 / #246 / #248,
+wicked-crew-api-types 0.32.0): the three surfaces render what wave 2 put on the wire.
+
+Runs against the shared frozen-NOW0 W2 fixture with the wave-2 switches on
+(`repo`, `repo_findings`, `governance="deadletters"`, `chat_scope`) — no crew
+daemon anywhere; the fixture answers the REAL contract shapes (RepoEntry.findings,
+DiagnosticsResponse.governance, ChatOpenResponse.scope and crew#502's 404/501).
+
+The DOM ACs, verbatim mapping:
+
+  1. REPO FINDINGS (#251): on /repos the studio-api card carries ONE finding row —
+     code in_tree_code_graph_ignored, severity error (no live graph), the engine's
+     message, and a "Re-run onboarding" button; clicking it POSTs
+     /api/v1/repos/studio-api/onboard (tapped off the fixture) and follows the
+     started run — never falling through to the card's own link (repo detail).
+     The repo detail header renders the same finding.
+     With `repo_findings` off the card renders NO findings block (silent).
+  2. GOVERNANCE (#246): expanding the rail's Health section renders the governance
+     group — store via flag + path, "0 records", dead letters 128+ with the by-type
+     / by-reason tallies, and the governance.deadletter ERROR row whose text carries
+     the `wicked-crew governance replay …` recipe; the heart reads unhealthy. With
+     the route ABSENT (older daemon) the group reads "not reported by this daemon"
+     (the heart's governance contribution is pinned in the unit suite — this roster's
+     inactive codex seat colours it on its own).
+  3. SCOPED NEW CHAT (#248): on /chat/new the Scope row is present; an Unfiled send
+     is BLOCKED (nothing POSTed, the gap stated, the draft kept); "Unscoped" then
+     opens with neither projectId nor repoRefs and the header states "unscoped".
+     A fresh /chat/new with "Choose repos…" lists the registry (GET /repos on that
+     gesture), picking studio-api sends repoRefs=["studio-api"], and the header
+     states the repo (path on hover) and the daemon's no-graph reason. With
+     `chat_scope_501` the scoped open renders the 501 sentence inline with the
+     "Continue unscoped" fallback.
+
+Captures (§12.0 contract: 1440x900, device_scale_factor=1) into e2e/shots/vision/:
+  wave2-repo-findings.png   the /repos card with the finding row + action
+  wave2-governance.png      the expanded Health rail with the F-022 rows
+  wave2-chat-scope.png      a scoped chat's header statement
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless SKIP_STUDIO_BUILD=1.
+Env knobs: FEEDBACK_PORT (default 4397), SKIP_STUDIO_BUILD. Prints a JSON report; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    REPO,
+    REPO_FINDING_NO_LIVE,
+    ensure_build,
+    onboard_posts,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4397"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the shared W2 fixture, wave-2 switches on ─────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, repo=True, repo_findings=True, governance="deadletters", chat_scope=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+TID = lambda t: f'[data-testid="{t}"]'  # noqa: E731
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    posts: list = []
+    page.on("request", lambda r: posts.append((r.method, r.url)) if r.method == "POST" else None)
+
+    # ── 2. #251 — the repo card + detail render the finding; the action posts the remedy ──
+    page.goto(f"{ORIGIN}/repos")
+    card = page.locator(TID("repo-card")).filter(has=page.locator('[data-repo-id="studio-api"]')).or_(
+        page.locator('[data-testid="repo-card"][data-repo-id="studio-api"]'))
+    card.first.wait_for(timeout=15000)
+    row = card.first.locator(TID("repo-card-findings-row"))
+    row.wait_for(timeout=10000)
+    check("repo_card_finding_row",
+          row.get_attribute("data-code") == "in_tree_code_graph_ignored"
+          and row.get_attribute("data-severity") == "error"
+          and row.get_attribute("data-reonboard") == "true"
+          and "re-run onboarding" in (row.inner_text() or "")
+          and card.first.locator(TID("repo-card-findings")).get_attribute("data-count") == "1",
+          code=row.get_attribute("data-code"), severity=row.get_attribute("data-severity"))
+    page.screenshot(path=str(VSHOTS / "wave2-repo-findings.png"))
+    row.locator(TID("repo-card-findings-reonboard")).click()
+    page.wait_for_timeout(500)
+    # The host's EXISTING onboard trigger follows the started run (as the card's own
+    # Onboard button does); what must NOT happen is the click falling through to the
+    # card's role=link and opening the repo detail instead.
+    check("repo_card_reonboard_posts_the_onboard_wire",
+          onboard_posts == ["studio-api"] and "/repo-detail/" not in page.url,
+          onboard_posts=list(onboard_posts), landed=page.url.replace(ORIGIN, ""))
+
+    page.goto(f"{ORIGIN}/repo-detail/studio-api")
+    detail_row = page.locator(TID("repo-findings-row"))
+    detail_row.wait_for(timeout=15000)
+    check("repo_detail_finding_row",
+          detail_row.get_attribute("data-code") == "in_tree_code_graph_ignored"
+          and REPO_FINDING_NO_LIVE["message"][:40] in (detail_row.inner_text() or "")
+          and detail_row.locator(TID("repo-findings-reonboard")).count() == 1)
+
+    # Silent when the record carries no findings (the switch off = the standing shape).
+    set_fixture(ORIGIN, repo_findings=False)
+    page.goto(f"{ORIGIN}/repos")
+    page.locator('[data-testid="repo-card"][data-repo-id="studio-api"]').wait_for(timeout=15000)
+    check("repo_card_silent_without_findings",
+          page.locator(TID("repo-card-findings")).count() == 0)
+    set_fixture(ORIGIN, repo_findings=True)
+
+    # ── 3. #246 — the Health rail renders diagnostics.governance ────────────────────
+    page.goto(f"{ORIGIN}/")
+    page.locator(TID("rail-health-toggle")).wait_for(timeout=15000)
+    page.locator(TID("rail-health-toggle")).click()
+    gov = page.locator(TID("rail-governance"))
+    gov.wait_for(timeout=10000)
+    gov_text = gov.inner_text()
+    finding = gov.locator(TID("rail-governance-finding"))
+    check("governance_rows",
+          gov.get_attribute("data-state") == "error"
+          and gov.get_attribute("data-deadletters") == "128"
+          and gov.get_attribute("data-store") == "flag"
+          and "via flag" in gov_text
+          and "0 records" in gov_text
+          and "128+" in gov_text
+          and "wicked.crew.governance.conformance_recorded ×96" in gov.locator(TID("rail-governance-by-type")).inner_text()
+          and "no shared store (WICKED_ESTATE_DB unset) ×128" in gov.locator(TID("rail-governance-by-reason")).inner_text()
+          and finding.get_attribute("data-kind") == "governance.deadletter"
+          and finding.get_attribute("data-severity") == "error"
+          and "wicked-crew governance replay" in finding.inner_text(),
+          state=gov.get_attribute("data-state"), deadletters=gov.get_attribute("data-deadletters"))
+    check("governance_heart_unhealthy",
+          page.locator(TID("rail-health-heart")).get_attribute("data-health") == "unhealthy"
+          and page.locator(TID("rail-health-summary-dot")).count() == 1)  # (codex is inactive on this roster too)
+    page.screenshot(path=str(VSHOTS / "wave2-governance.png"))
+
+    # An older daemon: no /diagnostics route at all → "not reported", heart healthy.
+    set_fixture(ORIGIN, governance=None)
+    page.goto(f"{ORIGIN}/")
+    page.locator(TID("rail-health-toggle")).wait_for(timeout=15000)
+    page.locator(TID("rail-health-toggle")).click()
+    gov = page.locator(TID("rail-governance"))
+    gov.wait_for(timeout=10000)
+    # (The heart's colour is not asserted here: the shared W2 roster carries an
+    # inactive codex seat, which reads unhealthy on its own — the governance
+    # contribution to the heart is pinned in HealthRailSection.governance.test.)
+    check("governance_absent_is_named",
+          gov.get_attribute("data-state") == "absent"
+          and gov.get_attribute("data-why") == "no-route"
+          and "not reported by this daemon" in gov.inner_text(),
+          state=gov.get_attribute("data-state"), why=gov.get_attribute("data-why"))
+    set_fixture(ORIGIN, governance="deadletters")
+
+    # ── 4. #248 — the scope control, the gate, the statement, the refusals ──────────
+    page.goto(f"{ORIGIN}/chat/new")
+    page.locator(TID("chat-scope-row")).wait_for(timeout=15000)
+    posts.clear()
+    composer = page.locator("textarea")
+    composer.fill("hello crew")
+    composer.press("Enter")
+    page.locator(TID("chat-scope-gap")).wait_for(timeout=5000)
+    check("unfiled_send_is_blocked",
+          page.locator(TID("chat-scope-row")).get_attribute("data-blocked") == "true"
+          and not [u for m, u in posts if "/api/v1/chats" in u]
+          and composer.input_value() == "hello crew",
+          gap=page.locator(TID("chat-scope-gap")).inner_text())
+    page.locator(TID("chat-scope-none")).click()
+    composer.press("Enter")
+    line = page.locator(TID("chat-scope"))
+    line.wait_for(timeout=10000)
+    chat_posts = [u for m, u in posts if u.endswith("/api/v1/chats")]
+    check("unscoped_opens_and_is_stated",
+          len(chat_posts) == 1 and line.get_attribute("data-kind") == "none"
+          and "unscoped" in line.inner_text(),
+          kind=line.get_attribute("data-kind"))
+
+    # A fresh chat, scoped to a picked repo.
+    page.locator(TID("chat-close")).click()
+    page.goto(f"{ORIGIN}/chat/new")
+    page.locator(TID("chat-scope-row")).wait_for(timeout=15000)
+    bodies: list = []
+    page.on("request", lambda r: bodies.append(r.post_data_json) if r.method == "POST" and r.url.endswith("/api/v1/chats") else None)
+    page.locator(TID("chat-scope-repos")).click()
+    option = page.locator('[data-testid="chat-scope-repo-option"][data-repo-id="studio-api"]')
+    option.wait_for(timeout=10000)
+    option.locator('input[type="checkbox"]').check()
+    composer = page.locator("textarea")
+    composer.fill("what does studio-api do?")
+    composer.press("Enter")
+    line = page.locator(TID("chat-scope"))
+    line.wait_for(timeout=10000)
+    repo_chip = line.locator(TID("chat-scope-repo"))
+    check("repo_scope_sends_repoRefs_and_is_stated",
+          len(bodies) == 1 and bodies[0].get("repoRefs") == ["studio-api"] and "projectId" not in bodies[0]
+          and line.get_attribute("data-kind") == "repos"
+          and repo_chip.count() == 1 and repo_chip.inner_text() == "studio-api"
+          and repo_chip.get_attribute("title") == "/tmp/w2/studio-api"
+          and line.get_attribute("data-graph-bound") == "false"
+          and "no code graph" in line.locator(TID("chat-scope-graph")).inner_text(),
+          body=bodies[0] if bodies else None, kind=line.get_attribute("data-kind"))
+    page.screenshot(path=str(VSHOTS / "wave2-chat-scope.png"))
+    page.locator(TID("chat-close")).click()
+
+    # crew#502's 501: the engine predates chat scope — stated inline, Unscoped offered.
+    set_fixture(ORIGIN, chat_scope_501=True)
+    page.goto(f"{ORIGIN}/chat/new")
+    page.locator(TID("chat-scope-row")).wait_for(timeout=15000)
+    page.locator(TID("chat-scope-repos")).click()
+    option = page.locator('[data-testid="chat-scope-repo-option"][data-repo-id="studio-api"]')
+    option.wait_for(timeout=10000)
+    option.locator('input[type="checkbox"]').check()
+    composer = page.locator("textarea")
+    composer.fill("scoped on an old engine")
+    composer.press("Enter")
+    err = page.locator(TID("chat-open-error"))
+    err.wait_for(timeout=10000)
+    check("scoped_open_501_is_stated_with_fallback",
+          err.get_attribute("data-status") == "501"
+          and "predates chat scope" in err.inner_text()
+          and err.locator(TID("chat-scope-fallback-none")).count() == 1
+          and "API 501" not in page.inner_text("body"),
+          text=err.inner_text()[:160])
+    set_fixture(ORIGIN, chat_scope_501=False)
+
+    browser.close()
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/wave2_consumers_test.py
+++ b/e2e/wave2_consumers_test.py
@@ -226,6 +226,33 @@ with sync_playwright() as p:
     page.screenshot(path=str(VSHOTS / "wave2-chat-scope.png"))
     page.locator(TID("chat-close")).click()
 
+    # W3S-253-09: the daemon admits a STRICT SUBSET of the default chips — the header shows
+    # exactly the admitted seats (no phantom `connecting` chip) and the now-bar is not stuck
+    # on "connecting" once the turn is out.
+    set_fixture(ORIGIN, chat_admit_subset=True)
+    page.goto(f"{ORIGIN}/chat/new")
+    page.locator(TID("chat-scope-row")).wait_for(timeout=15000)
+    page.locator(TID("chat-scope-repos")).click()
+    option = page.locator('[data-testid="chat-scope-repo-option"][data-repo-id="studio-api"]')
+    option.wait_for(timeout=10000)
+    option.locator('input[type="checkbox"]').check()
+    default_chips = page.locator(TID("agent-chip")).count()
+    composer = page.locator("textarea")
+    composer.fill("who is admitted?")
+    composer.press("Enter")
+    page.locator(TID("chat-scope")).wait_for(timeout=10000)
+    page.wait_for_timeout(2500)
+    chips = page.locator(TID("seat-chip"))
+    agents = [chips.nth(i).get_attribute("data-agent") for i in range(chips.count())]
+    states = [chips.nth(i).get_attribute("data-state") for i in range(chips.count())]
+    status = page.locator(TID("now-bar-status")).inner_text() if page.locator(TID("now-bar-status")).count() else ""
+    check("admitted_subset_renders_exactly_the_admitted_seats",
+          default_chips >= 2 and agents == ["claude"] and "connecting" not in states
+          and "connecting" not in status.lower(),
+          default_chips=default_chips, agents=agents, states=states, status=status)
+    page.locator(TID("chat-close")).click()
+    set_fixture(ORIGIN, chat_admit_subset=False)
+
     # crew#502's 501: the engine predates chat scope — stated inline, Unscoped offered.
     set_fixture(ORIGIN, chat_scope_501=True)
     page.goto(f"{ORIGIN}/chat/new")

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.30.0"
+        "wicked-crew-api-types": "^0.32.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.30.0.tgz",
-      "integrity": "sha512-s0l2GtGMxkoAo8NG+OR65ocqFswMtot0PqXAup636JDaRGj32UJLva93WBdSsdwyP3ubSM5xyNK6eHG1QnjjIw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.32.0.tgz",
+      "integrity": "sha512-Gs6MC/+VOXs5mDx8kt3VtIET88zXFi71tpEHin3B2gzlrexPCbaaUDO+ITDT+HBh29Ln1LXP6D/V7KWFhm3+YA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-studio",
   "version": "0.5.4",
-  "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
+  "description": "The coder-facing skin of the wicked experience plane \u2014 a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.30.0"
+    "wicked-crew-api-types": "^0.32.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,10 @@ import type {
   ActivityPage,
   AttachMemberBody,
   AuditPage,
+  ChatDetailResponse,
+  ChatListResponse,
+  ChatOpenBody,
+  ChatOpenResponse,
   CoreEvent,
   CreateProjectBody,
   DeliverRunResult,
@@ -228,9 +232,12 @@ export const api = {
   /** A unit's captured transcript (string, or `null`). Pass the unit key (the suffix after `<run>:`). */
   // ── Chat sessions (crew#165): warm seats + group fan-out ─────────────────
   /** `projectId` files the chat into a project at open time (`crew.chat`
-   *  membership, DES-PROJECT-001) — omitted = unfiled, the backend default. */
-  openChat: (body: { chatId?: string; clis?: string[]; repoRef?: string; projectId?: string }) =>
-    apiFetch<{ chatId: string; seats: { cliKey: string; ok: boolean; error?: string }[] }>(`/chats`, {
+   *  membership, DES-PROJECT-001) — omitted = unfiled, the backend default.
+   *  Since crew#502 (api-types 0.32.0) the body also SCOPES the chat: `repoRefs`
+   *  (ids or names) or the project's `crew.repo` members become the seats' read
+   *  roots, and the 201 states the resolved `scope` (studio#248). */
+  openChat: (body: ChatOpenBody) =>
+    apiFetch<ChatOpenResponse>(`/chats`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -243,11 +250,12 @@ export const api = {
     }),
   closeChat: (chatId: string) =>
     apiFetch<{ ok: boolean }>(`/chats/${encodeURIComponent(chatId)}`, { method: 'DELETE' }),
-  /** A chat's warm seats. Empty means the chat is gone — the daemon does not 404 an unknown id. */
+  /** A chat's warm seats (+ the scope recorded at open, `null` for a chat this daemon did not
+   *  open — crew#502). Empty seats mean the chat is gone — the daemon does not 404 an unknown id. */
   getChat: (chatId: string) =>
-    apiFetch<{ chatId: string; seats: string[] }>(`/chats/${encodeURIComponent(chatId)}`),
+    apiFetch<ChatDetailResponse>(`/chats/${encodeURIComponent(chatId)}`),
   /** Every live chat (FINDING-027). `idleSecs` is `number | null` — see the route's adapter. */
-  listChats: () => apiFetch<{ chats: { chatId: string; seats: string[]; idleSecs: number | null }[] }>(`/chats`),
+  listChats: () => apiFetch<ChatListResponse>(`/chats`),
 
   /**
    * A unit's stored transcript.

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -20,6 +20,7 @@ import { ApiError, isRouteAbsent } from './errors.js';
 // Through the Skills surface module (which re-exports the contract block), so the release swap of
 // the mirror for `wicked-crew-api-types` touches `skills.ts` alone.
 import type { DiagnosticsSkills } from './skills.js';
+import type { DiagnosticsGovernance } from './types.js';
 
 /** One CLI's ACP health, folded from the durable run event logs. */
 export interface DiagnosticsAcpCli {
@@ -66,6 +67,12 @@ export interface Diagnostics {
    *  whether the engine is being handed a verified snapshot (`state`), which one (`current`,
    *  `engineInput`) and, if not, why (`findings`). ABSENT on a daemon that predates the seam. */
   skills?: DiagnosticsSkills;
+  /** Whether the engine's governance evidence is LANDING (api-types 0.31.0, crew#495 / F-022):
+   *  the resolved store (`null` = a boot that resolved none — every emit dead-letters), the record
+   *  counts (`null` = the engine cannot count, never a fabricated 0), the folded dead-letter outbox
+   *  and the findings whose messages carry the `wicked-crew governance replay …` recipe. ABSENT on
+   *  a daemon predating crew#495 — the Health rail says so rather than inventing a healthy store. */
+  governance?: DiagnosticsGovernance;
 }
 
 /** `GET /diagnostics` — the daemon's self-description. Read-only. */

--- a/src/components/DeckKpiRibbon.tsx
+++ b/src/components/DeckKpiRibbon.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { GovernanceClaim, SessionView } from '../api/types.js';
+import type { DiagnosticsGovernance, GovernanceClaim, SessionView } from '../api/types.js';
 import type { Navigate } from '../hooks/useRoute.js';
 import { governedRuns } from '../board/steeringUsage.js';
 import { observedSpend } from '../board/metrics.js';
@@ -43,13 +43,17 @@ interface Props {
   runs: SessionView[];
   /** `GET /governance/claims`, or null when the daemon does not serve it. */
   claims: GovernanceClaim[] | null;
+  /** `GET /diagnostics`.governance (crew#495 / studio#246), or null/absent when not served: a boot
+   *  that resolved NO store, or any error finding (dead letters), means governance evidence is
+   *  NOT landing — the Governed tile must not read as a clean percentage over it. */
+  governance?: DiagnosticsGovernance | null | undefined;
   /** THE needs-you fold's count — the ribbon shows exactly what the feed lists. */
   needCount: number;
   navigate: Navigate;
   now?: number;
 }
 
-export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props): React.ReactElement {
+export function DeckKpiRibbon({ runs, claims, governance = null, needCount, navigate, now }: Props): React.ReactElement {
   const at = now ?? Date.now();
   const logs = useRuntimeStore((s) => s.logs);
   // The `is_system` lookup licenses the vacuous count (wicked-studio#250, F-3R2-018) — the same
@@ -98,6 +102,21 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
 
   const go = (path: string) => (e: React.MouseEvent) => { e.preventDefault(); navigate(path); };
 
+  // #246: the Governed tile degrades when the daemon says its governance evidence is not landing
+  // — the same signal the Health rail's heart reads (a null store, or an error finding such as
+  // `governance.deadletter`). The percentage stays (it is what the claims say), painted in the
+  // fail token with the reason underneath; nothing else about the tile changes.
+  const govError = governance !== null && (governance.store === null || governance.findings.some((f) => f.severity === 'error'));
+  const govWhy = governance === null
+    ? null
+    : governance.store === null
+      ? 'no governance store resolved — evidence is not landing (see Health)'
+      : governance.findings.find((f) => f.severity === 'error')?.kind === 'governance.deadletter'
+        ? `${governance.deadletters.count}${governance.deadletters.truncated ? '+' : ''} governance events dead-lettered (see Health)`
+        : governance.findings.some((f) => f.severity === 'error')
+          ? 'governance evidence is not landing (see Health)'
+          : null;
+
   return (
     <section className="deck-ribbon" data-testid="home-kpis" aria-label="Key metrics">
       {/* ── FLOW ── */}
@@ -141,9 +160,11 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
           <Tile testId="home-kpi-governed" lead label="Governed"
             value={model.governed !== null && model.governed.pct !== null ? String(model.governed.pct) : '—'}
             unit={model.governed !== null && model.governed.pct !== null ? '%' : ''}
+            valueColor={govError ? 'var(--status-fail)' : undefined}
+            state={govError ? 'governance-error' : undefined}
             href="/steering" onGo={go('/steering')}
             bar={model.governed?.pct ?? null}
-            sub={model.governed === null ? 'not served' : `${model.governed.governed}/${model.governed.total} runs`} />
+            sub={govError && govWhy !== null ? govWhy : model.governed === null ? 'not served' : `${model.governed.governed}/${model.governed.total} runs`} />
           <Tile testId="home-kpi-spend" label="Spend · session"
             value={model.spend.frames === 0 ? '—' : `$${model.spend.total.toFixed(2)}`}
             href="/work" onGo={go('/work')}
@@ -158,7 +179,7 @@ export function DeckKpiRibbon({ runs, claims, needCount, navigate, now }: Props)
 }
 
 /** One ribbon tile — the deck's luminous mono metric, delta pill, optional sparkline or bar. */
-function Tile({ testId, label, value, unit = '', delta, deltaBadUp, valueColor, sub, spark, bar, lead, href, onGo }: {
+function Tile({ testId, label, value, unit = '', delta, deltaBadUp, valueColor, state, sub, spark, bar, lead, href, onGo }: {
   testId: string;
   label: string;
   value: string;
@@ -166,6 +187,8 @@ function Tile({ testId, label, value, unit = '', delta, deltaBadUp, valueColor, 
   delta?: StatDelta;
   deltaBadUp?: boolean;
   valueColor?: string | undefined;
+  /** A named degraded state the tile is in (rendered as `data-state`), or undefined. */
+  state?: string | undefined;
   sub?: string;
   spark?: readonly number[];
   bar?: number | null;
@@ -187,6 +210,7 @@ function Tile({ testId, label, value, unit = '', delta, deltaBadUp, valueColor, 
       // (with its unit) and whether a real prior-window delta exists.
       data-value={`${value}${unit}`}
       data-delta={hasDelta ? dir : 'none'}
+      data-state={state}
       href={href}
       onClick={onGo}
     >

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -211,6 +211,9 @@ function clearStoredChatId(repoId?: string | null): void {
 /** The create-flow scope control's position. */
 export type ChatScopeMode = 'project' | 'repos' | 'none';
 
+/** `ChatOpenBody.repoRefs` takes 1–32 entries (api-types 0.32.0). */
+export const MAX_SCOPE_REPOS = 32;
+
 /**
  * Why a send may NOT open the chat yet — the scope it would resolve to is the
  * silent `none` (an Unfiled chat with no repos chosen and no explicit Unscoped),
@@ -484,7 +487,9 @@ export function GroupChat({
 
   function toggleScopeRepo(id: string): void {
     setScopeGap(null);
-    setScopeRepoIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    // The wire takes 1–32 `repoRefs`: the pick stops appending at the cap (removal stays open).
+    setScopeRepoIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : prev.length >= MAX_SCOPE_REPOS ? prev : [...prev, id]);
   }
 
   /** The project switcher's selection: a project makes `none` meaningless (the
@@ -927,10 +932,12 @@ export function GroupChat({
         }
         // The daemon STATES the scope it resolved (crew#502); an older daemon's
         // 201 carries none — said as "not stated", never invented.
-        const stated = (answer as { scope?: ChatScope }).scope;
+        const stated = (answer as { scope?: ChatScope | null }).scope;
         if (chatIdRef.current === id) {
+          // `null` is off-contract on a 201 (the field is non-null) — it reads like the pre-0.32
+          // omission: "not stated", never a guessed scope.
           setScope(stated ?? null);
-          setScopeUnstated(stated === undefined);
+          setScopeUnstated(stated == null);
         }
         // A repo switch mid-arm resets `chatIdRef` (the mount effect) — re-check
         // after the await so nothing is attributed to a repo we already left.
@@ -953,11 +960,20 @@ export function GroupChat({
               if (state === 'failed' && !opened.some((s) => s.cliKey === k)) delete next[k];
             }
           }
+          if (daemonPicksSeats) {
+            // The 201 IS the audience (review W3S-253-09): the optimistic pass painted every
+            // default chip `connecting`, but a seat the daemon's pre-filter did not admit was
+            // never warmed and will never answer — left in place it is a phantom amber chip and
+            // keeps `chatStatus` on "connecting" after the turn. Drop the unadmitted ones.
+            for (const [k, state] of Object.entries(prev)) {
+              if (state === 'connecting' && !opened.some((s) => s.cliKey === k)) delete next[k];
+            }
+          }
           return { ...next, ...st };
         });
         setSeatErrors((prev) => {
           const next = { ...prev };
-          if (ready.length > 0) {
+          if (ready.length > 0 || daemonPicksSeats) {
             for (const k of Object.keys(prev)) {
               if (!opened.some((s) => s.cliKey === k)) delete next[k];
             }
@@ -1762,17 +1778,19 @@ export function GroupChat({
                 ) : (
                   scopeRepos.map((r) => {
                     const checked = scopeRepoIds.includes(r.id);
+                    const atCap = !checked && scopeRepoIds.length >= MAX_SCOPE_REPOS;
                     return (
                       <label
                         key={r.id}
                         data-testid="chat-scope-repo-option"
                         data-repo-id={r.id}
                         data-checked={checked}
-                        title={r.root_path}
-                        className="flex items-center gap-2 text-[11px] font-mono cursor-pointer"
+                        data-at-cap={atCap}
+                        title={atCap ? `a chat scopes at most ${MAX_SCOPE_REPOS} repositories — remove one to add another` : r.root_path}
+                        className={`flex items-center gap-2 text-[11px] font-mono ${atCap ? 'opacity-50' : 'cursor-pointer'}`}
                         style={{ color: checked ? 'var(--ink-high)' : 'var(--ink-muted)' }}
                       >
-                        <input type="checkbox" checked={checked} onChange={() => toggleScopeRepo(r.id)} />
+                        <input type="checkbox" checked={checked} disabled={atCap} onChange={() => toggleScopeRepo(r.id)} />
                         <span>{r.name}</span>
                         <span className="truncate" style={{ color: 'var(--ink-dim)', minWidth: 0 }}>{r.root_path}</span>
                       </label>

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -158,6 +158,19 @@ const SEAT_DOT: Record<SeatState, string> = {
  */
 const CHAT_ID_KEY = (repoId?: string | null): string => `wicked.chat.${repoId ?? '_'}`;
 
+/**
+ * The per-surface storage key (Copilot on #253): a repo-entry chat is keyed by its repo, a
+ * PROJECT-SHELL chat by its project (`project:<id>`) — never the flat `_` key every shell would
+ * otherwise share, which let project B rejoin project A's chat (now a SCOPE leak, crew#502: no
+ * new POST rides a rejoin, so B's `projectId` was never applied). The flat `/chat/*` routes keep
+ * the historical `_` key.
+ */
+function chatStorageKey(repoId: string | null | undefined, projectId: string | null | undefined): string | null {
+  if (repoId) return repoId;
+  if (projectId) return `project:${projectId}`;
+  return null;
+}
+
 /** All three wrapped: sessionStorage throws in private-mode/blocked-cookie browsers, and a chat
  *  the operator cannot open is a worse outcome than a chat that leaks. Degrades to mint-per-mount,
  *  which is exactly the pre-fix behaviour — no new failure, just no improvement. */
@@ -247,6 +260,19 @@ export function describeChatOpenRefusal(status: number | null, wire: string | nu
   return fallback;
 }
 
+/**
+ * Whether a refused `POST /chats` is one the daemon answered BEFORE opening anything — crew#502's
+ * 400 (bad body / ambiguous name), 404 (missing refs), 409 (a conflict that opened nothing) and
+ * 501 (a scoped chat the engine cannot hold — closed again by the daemon). The one 409 that names
+ * a LIVE chat ("already open on this daemon") is excluded: that id exists and must not be dropped.
+ * Transport failures and 5xx (`status` null / ≥500) are unknown — the id is retained (FINDING-027).
+ */
+export function chatOpenedNothing(status: number | null, wire: string | null): boolean {
+  if (status === 400 || status === 404 || status === 501) return true;
+  if (status === 409) return !(wire !== null && /already open/i.test(wire));
+  return false;
+}
+
 interface Props {
   repoId?: string | null;
   onBack: () => void;
@@ -281,6 +307,8 @@ interface Props {
 export function GroupChat({
   repoId, onBack, projectId = null, navigate, routedChatId = null, reflectUrl = false,
 }: Props): React.ReactElement {
+  /** Where this surface remembers its live chat id — by repo, by project, or the flat `_` key. */
+  const storageKey = chatStorageKey(repoId, projectId);
   const [chatId, setChatId] = useState<string | null>(null);
   const [seats, setSeats] = useState<Record<string, SeatState>>({});
   const [seatErrors, setSeatErrors] = useState<Record<string, string>>({});
@@ -476,7 +504,7 @@ export function GroupChat({
     setOpenError(null);
     setOpenErrorStatus(null);
     setScopeGap(null);
-    clearStoredChatId(repoId);
+    clearStoredChatId(storageKey);
     setChatId(null);
     chatIdRef.current = null;
     setSeats({});
@@ -623,6 +651,13 @@ export function GroupChat({
     setRoutedGone(false);
     setScope(null);
     setScopeUnstated(false);
+    // The create-flow scope choice belongs to the surface it was made on (Copilot on
+    // #253): a repo pick made for one route must not ride the next route's open.
+    setScopeMode('project');
+    setScopeRepoIds([]);
+    setScopePickerOpen(false);
+    setScopeGap(null);
+    setOpenErrorStatus(null);
 
     // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
     // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
@@ -630,7 +665,7 @@ export function GroupChat({
     // Read SYNCHRONOUSLY, and park the opt-ins while the probe runs (see `resolving`).
     // J4: a URL-routed id WINS over the per-repo stored id — the operator asked
     // for THAT session by address; the stored id is only the tab's memory.
-    const stored = routedChatId ?? readStoredChatId(repoId);
+    const stored = routedChatId ?? readStoredChatId(storageKey);
     setResolving(stored !== null);
 
     void (async () => {
@@ -663,7 +698,7 @@ export function GroupChat({
         chatIdRef.current = stored;
         // A routed rejoin becomes THIS tab's session for the repo too — /chats
         // → row → send → navigate away → back must land on the same session.
-        writeStoredChatId(repoId, stored);
+        writeStoredChatId(storageKey, stored);
         // Warm seats only — the transcript is not persisted server-side, so a rejoined chat
         // starts with an empty log. The SESSIONS carry the conversation memory, which is the
         // expensive part; re-minting would have thrown that away as well as leaking it.
@@ -688,7 +723,7 @@ export function GroupChat({
       // ended (`routedGone`) — the honest boundary, never a wordless empty.
       // Either way warming stays the user's call and the next opt-in mints fresh.
       if (routedChatId !== null) setRoutedGone(true);
-      if (readStoredChatId(repoId) === stored) clearStoredChatId(repoId);
+      if (readStoredChatId(storageKey) === stored) clearStoredChatId(storageKey);
       setResolving(false);
       // (On the cancelled path `resolving` is deliberately left alone: the next effect
       // run has already set its own value for the new repo.)
@@ -699,7 +734,7 @@ export function GroupChat({
     };
     // (The exhaustive-deps suppression that used to sit here is gone: the effect closes over
     // nothing but `repoId`/`routedChatId` and module-scope helpers — the list is complete.)
-  }, [repoId, routedChatId]);
+  }, [repoId, routedChatId, projectId, storageKey]);
 
   // J4/C6 — the URL names the session the moment it exists. Mint, rejoin, or
   // routed: on the flat chat routes the live id is REFLECTED into `/chat/:id`
@@ -830,7 +865,7 @@ export function GroupChat({
         id = crypto.randomUUID();
         setChatId(id);
         chatIdRef.current = id;
-        writeStoredChatId(repoId, id);
+        writeStoredChatId(storageKey, id);
       }
       // Optimistic chips: each seat being warmed shows as connecting while the open is
       // in flight; ready/failed events (and the open response) correct them as truth arrives.
@@ -923,13 +958,26 @@ export function GroupChat({
         if (ready.length > 0) useLiveChatsStore.getState().upsert(id, ready);
         return { ready, failure: null };
       } catch (e: unknown) {
-        // The id stays stored on purpose: an open that failed at the HTTP layer may still have
-        // warmed seats server-side, and dropping the id here would orphan exactly what
-        // FINDING-027 exists to stop orphaning. The next mount re-checks it and clears it if dead.
-        const failure = describeChatOpenRefusal(apiStatus(e), apiWire(e), e instanceof Error ? e.message : String(e));
+        const status = apiStatus(e);
+        const failure = describeChatOpenRefusal(status, apiWire(e), e instanceof Error ? e.message : String(e));
         if (chatIdRef.current === id) {
           setOpenError(failure);
-          setOpenErrorStatus(apiStatus(e));
+          setOpenErrorStatus(status);
+          if (chatOpenedNothing(status, apiWire(e))) {
+            // A NAMED refusal (crew#502): the daemon validated the scope before any seat warmed
+            // and opened nothing — so the provisional id points at no chat, and keeping it would
+            // hide the create controls (the scope row) behind a failed pick the operator could
+            // not correct (Copilot on #253). Drop it; the next send mints fresh.
+            clearStoredChatId(storageKey);
+            setChatId(null);
+            chatIdRef.current = null;
+            setSeats({});
+            setSeatErrors({});
+          }
+          // Otherwise the id stays stored on purpose: an open that failed at the HTTP layer may
+          // still have warmed seats server-side, and dropping the id here would orphan exactly
+          // what FINDING-027 exists to stop orphaning. The next mount re-checks it and clears
+          // it if dead.
         }
         return { ready: [], failure };
       }
@@ -1078,7 +1126,13 @@ export function GroupChat({
     // Forget the id FIRST. If the DELETE fails we still must not rejoin a chat the operator has
     // ended — and the daemon's idle reaper will collect it either way. The reverse order would
     // leave a "live" id pointing at a chat the UI has already walked away from.
-    clearStoredChatId(repoId);
+    clearStoredChatId(storageKey);
+    // The next chat on this surface starts from the scope default, never from the
+    // closed chat's repo pick (Copilot on #253).
+    setScopeMode('project');
+    setScopeRepoIds([]);
+    setScopePickerOpen(false);
+    setScopeGap(null);
     if (chatId !== null) {
       useLiveChatsStore.getState().remove(chatId);
       try {
@@ -1407,7 +1461,7 @@ export function GroupChat({
             <span
               data-testid="chat-scope-dangling"
               title={scope.dangling.join(', ')}
-              style={{ color: 'var(--status-fail)' }}
+              style={{ color: 'var(--status-gate)' }}
             >
               {scope.dangling.length} project member{scope.dangling.length === 1 ? '' : 's'} not readable — no longer in the repo registry: {scope.dangling.join(', ')}
             </span>

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -246,7 +246,11 @@ export function chatScopeGap(input: {
  */
 export function describeChatOpenRefusal(status: number | null, wire: string | null, fallback: string): string {
   if (status === 404 && wire !== null) {
-    return `Scope refused — ${wire}. Name repositories that are registered (by id, or a name only one repo carries) and send again.`;
+    // Only a REPO 404 (`Repo 'x', 'y' not found` — chat-scope.ts) gets the repo remedy; the route
+    // also answers 404 `Project <id> not found` (routes.ts), which reads plain.
+    return /^Repo /.test(wire)
+      ? `Scope refused — ${wire}. Name repositories that are registered (by id, or a name only one repo carries) and send again.`
+      : wire;
   }
   if (status === 400 && wire !== null && /ambiguous/i.test(wire)) {
     return `Scope refused — ${wire}`;
@@ -900,11 +904,27 @@ export function GroupChat({
         if (scopeModeRef.current === 'repos' && scopeRepoIdsRef.current.length > 0) {
           body.repoRefs = [...scopeRepoIdsRef.current];
         }
-        // An empty selection omits `clis` — the daemon warms its own default
+        // Admissibility (crew#502 / review W3S-253-01): a SCOPED chat admits only governed seats
+        // — crew pre-filters its DEFAULT roster to seats with `acp_input_governance` / `os_sandbox`
+        // ONLY when `clis` is omitted; an explicit list is passed through and the engine refuses
+        // the inadmissible seats one by one (red chips with a sentence, no rule stated). So while
+        // the chips are UNTOUCHED (the default selection) and the scope is not `none`, the open
+        // omits `clis` and lets the daemon pick; the 201's `seats` then re-seed the chips so the
+        // audience shown is the audience the daemon admitted. An EDITED selection is the
+        // operator's word and rides as asked (refused seats say why); an unscoped open keeps the
+        // pre-existing rule (the displayed chips ARE the audience — EC44).
+        const scoped =
+          Boolean(repoId) || Boolean(boundProject) ||
+          (scopeModeRef.current === 'repos' && scopeRepoIdsRef.current.length > 0);
+        const daemonPicksSeats = scoped && !chipsTouchedRef.current;
+        // Otherwise an empty selection omits `clis` — the daemon warms its own default
         // roster (the pre-existing wire semantics for an absent array).
-        if (agents.length > 0) body.clis = agents;
+        if (!daemonPicksSeats && agents.length > 0) body.clis = agents;
         const answer = await api.openChat(body);
         const opened = answer.seats;
+        if (daemonPicksSeats && chatIdRef.current === id) {
+          setSelectedAgents(opened.map((s) => s.cliKey));
+        }
         // The daemon STATES the scope it resolved (crew#502); an older daemon's
         // 201 carries none — said as "not stated", never invented.
         const stated = (answer as { scope?: ChatScope }).scope;
@@ -1715,6 +1735,11 @@ export function GroupChat({
                 </>
               )}
             </div>
+            {(repoId || (scopeMode === 'repos' ? scopeRepoIds.length > 0 : boundProjectId !== null)) && (
+              <p data-testid="chat-scope-admission" className="text-[11px]" style={{ color: 'var(--ink-dim)', margin: 0 }}>
+                a scoped chat admits only governed seats — refused seats say why
+              </p>
+            )}
             {scopeGap !== null && (
               <p data-testid="chat-scope-gap" className="text-[11px] font-mono" style={{ color: 'var(--status-fail)', margin: 0 }}>
                 {scopeGap}

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -486,9 +486,19 @@ export function GroupChat({
   /** The project switcher's selection: a project makes `none` meaningless (the
    *  daemon scopes to the project whenever `projectId` rides the open). */
   function selectProject(id: string | null): void {
+    const changed = id !== selectedProjectRef.current;
     setSelectedProjectId(id);
     setScopeGap(null);
-    if (id !== null && scopeModeRef.current === 'none') setScopeMode('project');
+    if (changed) {
+      // A project change is a scope change: the previous project's repo pick and picker do not
+      // carry over (Copilot on #253) — the new project's default is "all its repos", and an
+      // Unfiled switch is back to the explicit-choice state.
+      setScopeMode('project');
+      setScopeRepoIds([]);
+      setScopePickerOpen(false);
+    } else if (id !== null && scopeModeRef.current === 'none') {
+      setScopeMode('project');
+    }
   }
 
   /**

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { Project, RosterSeat } from '../api/types.js';
+import { apiStatus, apiWire } from '../api/errors.js';
+import type { ChatOpenBody, ChatScope, Project, RepoEntry, RosterSeat } from '../api/types.js';
 import { useEventStream } from '../hooks/useEventStream.js';
 import { pinAwaiting } from '../store/awaitingPins.js';
+import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
 import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
 import { useLiveChatsStore } from '../store/liveChats.js';
 import { setRetryPrefill } from '../store/retryPrefill.js';
@@ -182,6 +184,69 @@ function clearStoredChatId(repoId?: string | null): void {
   }
 }
 
+// ── Scope (crew#502 / F-067, studio#248) ─────────────────────────────────────
+//
+// A chat is SCOPED by the daemon: its seats run in a private scratch root with the
+// scoped repositories as READ roots and, where a graph binds, a read-only estate
+// MCP over it. `POST /chats` decides the scope from the body — explicit `repoRefs`
+// win; else `projectId` means EVERY `crew.repo` member of the project; else NONE
+// (the seats see only their scratch root). The create flow therefore carries a
+// scope control, `kind: 'none'` is an EXPLICIT choice (never the silent default a
+// forgotten Unfiled field would produce), and the opened chat STATES the scope
+// the daemon resolved (`ChatOpenResponse.scope` / `ChatDetailResponse.scope`).
+
+/** The create-flow scope control's position. */
+export type ChatScopeMode = 'project' | 'repos' | 'none';
+
+/**
+ * Why a send may NOT open the chat yet — the scope it would resolve to is the
+ * silent `none` (an Unfiled chat with no repos chosen and no explicit Unscoped),
+ * or "repos" with nothing picked. `null` = the scope is a real choice; go.
+ * `repoId` (the repo-entry chat) is a scope of its own and never blocks.
+ */
+export function chatScopeGap(input: {
+  repoId: string | null | undefined;
+  mode: ChatScopeMode;
+  projectId: string | null;
+  repoIds: readonly string[];
+}): string | null {
+  if (input.repoId) return null;
+  if (input.mode === 'repos') {
+    return input.repoIds.length === 0
+      ? 'Pick at least one repository for the agents to read — or choose another scope.'
+      : null;
+  }
+  if (input.mode === 'none') return null;
+  return input.projectId !== null
+    ? null
+    : 'Unfiled chats give the agents nothing to read. Pick a project (all its repositories), choose repositories, or continue unscoped.';
+}
+
+/**
+ * The operator sentence for a refused `POST /chats` (crew#502's own status
+ * codes): 404 = a named ref is not registered (every missing one is in the
+ * daemon's sentence); 400 "ambiguous" = a NAME two checkouts share (name it by
+ * id); 409 = a daemon-side conflict (scratch-base overlap, an id still closing,
+ * an archived project); 501 = the installed engine cannot ground a scoped chat
+ * (predates chat scope) — the Unscoped fallback is offered beside it. Anything
+ * else keeps the translated message as-is.
+ */
+export function describeChatOpenRefusal(status: number | null, wire: string | null, fallback: string): string {
+  if (status === 404 && wire !== null) {
+    return `Scope refused — ${wire}. Name repositories that are registered (by id, or a name only one repo carries) and send again.`;
+  }
+  if (status === 400 && wire !== null && /ambiguous/i.test(wire)) {
+    return `Scope refused — ${wire}`;
+  }
+  if (status === 409 && wire !== null) {
+    return `The daemon refused to open this chat — ${wire}`;
+  }
+  if (status === 501 && wire !== null) {
+    return `This daemon cannot open a SCOPED chat — ${wire}`;
+  }
+  return fallback;
+}
+
 interface Props {
   repoId?: string | null;
   onBack: () => void;
@@ -222,6 +287,8 @@ export function GroupChat({
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState('');
   const [openError, setOpenError] = useState<string | null>(null);
+  /** The refused open's HTTP status (crew#502 refusals render by code); null when none / not a wire refusal. */
+  const [openErrorStatus, setOpenErrorStatus] = useState<number | null>(null);
   const [ended, setEnded] = useState(false);
   /** An arm (warm) in flight — guards the two opt-in paths against double fire. */
   const [arming, setArming] = useState(false);
@@ -339,6 +406,82 @@ export function GroupChat({
   const projectsRequested = useRef(false);
   const selectedProjectRef = useRef<string | null>(null);
   selectedProjectRef.current = selectedProjectId;
+
+  // ── Scope control (crew#502 / studio#248) ───────────────────────────────────
+  // `project` = every `crew.repo` member of the bound project (the daemon's own
+  // default when `projectId` rides the open); `repos` = an explicit `repoRefs`
+  // list picked from the registry; `none` = the EXPLICIT unscoped chat. The
+  // registry loads on the picker's first OPEN (a gesture — §2.4: zero on mount),
+  // through the ONE session repo cache the palette and rail share.
+  const [scopeMode, setScopeMode] = useState<ChatScopeMode>('project');
+  const scopeModeRef = useRef<ChatScopeMode>('project');
+  scopeModeRef.current = scopeMode;
+  const [scopeRepoIds, setScopeRepoIds] = useState<string[]>([]);
+  const scopeRepoIdsRef = useRef<string[]>([]);
+  scopeRepoIdsRef.current = scopeRepoIds;
+  const [scopeRepos, setScopeRepos] = useState<RepoEntry[] | null>(getCachedRepos);
+  const [scopeReposError, setScopeReposError] = useState<string | null>(null);
+  const [scopePickerOpen, setScopePickerOpen] = useState(false);
+  /** The blocked-send reason (`chatScopeGap`), shown on the scope row until a choice is made. */
+  const [scopeGap, setScopeGap] = useState<string | null>(null);
+  /** The scope the daemon RESOLVED for the live chat (the 201 / the rejoin probe). */
+  const [scope, setScope] = useState<ChatScope | null>(null);
+  /** The live chat answered WITHOUT a scope — a daemon predating crew#502, or a
+   *  chat this daemon did not open (restart). Stated, never guessed. */
+  const [scopeUnstated, setScopeUnstated] = useState(false);
+
+  function chooseScopeMode(mode: ChatScopeMode): void {
+    setScopeMode(mode);
+    setScopeGap(null);
+    if (mode !== 'repos') setScopePickerOpen(false);
+  }
+
+  /** "Choose repos…": the mode AND the picker; the registry loads on this gesture. */
+  function openScopePicker(): void {
+    setScopeMode('repos');
+    setScopeGap(null);
+    setScopePickerOpen((v) => !v || scopeModeRef.current !== 'repos');
+    if (scopeRepos !== null) return;
+    setScopeReposError(null);
+    // Through a resolved promise so a mocked/missing client throws as a rejection, not a render error.
+    Promise.resolve()
+      .then(() => fetchReposCached())
+      .then(setScopeRepos)
+      .catch((e: unknown) => setScopeReposError(e instanceof Error ? e.message : String(e)));
+  }
+
+  function toggleScopeRepo(id: string): void {
+    setScopeGap(null);
+    setScopeRepoIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  }
+
+  /** The project switcher's selection: a project makes `none` meaningless (the
+   *  daemon scopes to the project whenever `projectId` rides the open). */
+  function selectProject(id: string | null): void {
+    setSelectedProjectId(id);
+    setScopeGap(null);
+    if (id !== null && scopeModeRef.current === 'none') setScopeMode('project');
+  }
+
+  /**
+   * The 501 remedy the daemon names ("open the chat without projectId/repoRefs"):
+   * drop the scope, forget the refused id (the daemon parks it as closing — a
+   * reuse would 409), and let the next send mint an UNSCOPED chat. Only outside
+   * the project shell — there the context IS the project and cannot be dropped.
+   */
+  function fallbackUnscoped(): void {
+    setScopeMode('none');
+    setScopeRepoIds([]);
+    setSelectedProjectId(null);
+    setOpenError(null);
+    setOpenErrorStatus(null);
+    setScopeGap(null);
+    clearStoredChatId(repoId);
+    setChatId(null);
+    chatIdRef.current = null;
+    setSeats({});
+    setSeatErrors({});
+  }
 
   function loadProjects(): void {
     if (projectsRequested.current) return;
@@ -478,6 +621,8 @@ export function GroupChat({
     chatIdRef.current = null;
     setRejoined(false);
     setRoutedGone(false);
+    setScope(null);
+    setScopeUnstated(false);
 
     // A stored id is a claim, not a fact — the daemon reaps idle chats and enforces a pool cap,
     // so it may have reclaimed this one underneath us. Ask before trusting it. With nothing
@@ -497,7 +642,9 @@ export function GroupChat({
       // warm and burns the one id that could have reached it.
       const probe = await api
         .getChat(stored)
-        .then(({ seats }) => ({ seats }))
+        // `scope` is additive (crew#502): absent on an older daemon, `null` for a chat this
+        // daemon did not open — both read as "not stated", never as a guessed scope.
+        .then((detail) => ({ seats: detail.seats, scope: (detail as { scope?: ChatScope | null }).scope ?? null }))
         .catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
       if (cancelled) return;
 
@@ -523,6 +670,10 @@ export function GroupChat({
         // J4/C6: that boundary is STATED in the thread (`rejoined`), never a
         // silent blank pretending the conversation never happened.
         setSeats(Object.fromEntries(probe.seats.map((k) => [k, 'ready' as SeatState])));
+        // The rejoined chat STATES what its seats can see (studio#248) — or that
+        // the daemon did not say.
+        setScope(probe.scope);
+        setScopeUnstated(probe.scope === null);
         // The rejoined boundary note already covers these seats — mark them
         // announced so a trailing ready frame does not re-speak "joined".
         for (const k of probe.seats) announcedRef.current.set(k, 'ready');
@@ -669,6 +820,7 @@ export function GroupChat({
     // Each arm attempt is a fresh claim: a stale open-failure banner from the
     // previous attempt must not sit beside this one's outcome (J4 finding 3).
     setOpenError(null);
+    setOpenErrorStatus(null);
     try {
       // The chat id is minted CLIENT-side and set before the open call: seats warm
       // serially (~2-3s each), and their chatSessionReady events arrive BEFORE the
@@ -691,16 +843,30 @@ export function GroupChat({
         ),
       }));
       try {
-        const body: { chatId: string; repoRef?: string; clis?: string[]; projectId?: string } = { chatId: id };
+        const body: ChatOpenBody = { chatId: id };
         if (repoId) body.repoRef = repoId;
         // §5.1/§4.3: the binding rides the OPEN — shell context wins, then the
         // switcher's selection; Unfiled omits the key (the backend default).
         const boundProject = projectId ?? selectedProjectRef.current;
         if (boundProject) body.projectId = boundProject;
+        // studio#248: an explicit repo list narrows the scope (`repoRefs`, ids);
+        // `project` mode sends nothing extra — `projectId` alone scopes the chat
+        // to every member — and `none` is the explicit unscoped open.
+        if (scopeModeRef.current === 'repos' && scopeRepoIdsRef.current.length > 0) {
+          body.repoRefs = [...scopeRepoIdsRef.current];
+        }
         // An empty selection omits `clis` — the daemon warms its own default
         // roster (the pre-existing wire semantics for an absent array).
         if (agents.length > 0) body.clis = agents;
-        const { seats: opened } = await api.openChat(body);
+        const answer = await api.openChat(body);
+        const opened = answer.seats;
+        // The daemon STATES the scope it resolved (crew#502); an older daemon's
+        // 201 carries none — said as "not stated", never invented.
+        const stated = (answer as { scope?: ChatScope }).scope;
+        if (chatIdRef.current === id) {
+          setScope(stated ?? null);
+          setScopeUnstated(stated === undefined);
+        }
         // A repo switch mid-arm resets `chatIdRef` (the mount effect) — re-check
         // after the await so nothing is attributed to a repo we already left.
         if (chatIdRef.current !== id) return { ready: [], failure: null };
@@ -760,8 +926,11 @@ export function GroupChat({
         // The id stays stored on purpose: an open that failed at the HTTP layer may still have
         // warmed seats server-side, and dropping the id here would orphan exactly what
         // FINDING-027 exists to stop orphaning. The next mount re-checks it and clears it if dead.
-        const failure = e instanceof Error ? e.message : String(e);
-        if (chatIdRef.current === id) setOpenError(failure);
+        const failure = describeChatOpenRefusal(apiStatus(e), apiWire(e), e instanceof Error ? e.message : String(e));
+        if (chatIdRef.current === id) {
+          setOpenError(failure);
+          setOpenErrorStatus(apiStatus(e));
+        }
         return { ready: [], failure };
       }
     } finally {
@@ -778,6 +947,21 @@ export function GroupChat({
     // `resolving` waits out the rejoin probe: until it answers, "no chat id" does NOT
     // mean first-run, and treating it as one would mint over the stored id (FINDING-027).
     if (text === '' || ended || arming || resolving || sendingRef.current) return;
+    // studio#248: a chat is CREATED by its first send, and the scope is decided
+    // then. An Unfiled chat with no repos chosen would resolve to `kind: 'none'`
+    // silently — so the send waits for an explicit choice (Unscoped is one).
+    if (chatIdRef.current === null) {
+      const gap = chatScopeGap({
+        repoId,
+        mode: scopeModeRef.current,
+        projectId: projectId ?? selectedProjectRef.current,
+        repoIds: scopeRepoIdsRef.current,
+      });
+      if (gap !== null) {
+        setScopeGap(gap);
+        return;
+      }
+    }
     let warm = Object.entries(seats)
       .filter(([, st]) => WARM_STATES.has(st))
       .map(([k]) => k);
@@ -1032,6 +1216,14 @@ export function GroupChat({
   // in the shell the context IS the project (§4.3) and rides `projectId` silently.
   const showProjectField = projectId == null && chatId === null && !resolving && !ended;
   const currentProject = projects.find((p) => p.id === selectedProjectId) ?? null;
+  // studio#248: the scope control lives in the SAME create window as the project
+  // field (the scope is decided at open) — in the shell too, where it narrows the
+  // project default to a repo list.
+  const showScopeField = chatId === null && !resolving && !ended;
+  const boundProjectId = projectId ?? selectedProjectId;
+  const effectiveScopeMode: ChatScopeMode = repoId ? 'repos' : scopeMode;
+  // The scope STATEMENT: what the daemon said the live chat's seats can see.
+  const showScopeLine = chatId !== null && !ended && (scope !== null || scopeUnstated);
 
   // ── The §11.4 now-bar: what is happening RIGHT NOW, pinned above the thread.
   // The census wears the SAME display overlay as the chips (E4): a seat whose
@@ -1160,6 +1352,69 @@ export function GroupChat({
         )}
       </div>
 
+      {/* studio#248: the scope STATEMENT — what the daemon resolved for this chat
+          (`ChatOpenResponse.scope` / the rejoin's `ChatDetailResponse.scope`): the
+          repositories (names; paths on hover), read-only, whether a graph grounds
+          the seats and why not, and any project member the registry no longer
+          knows. A daemon that said nothing is reported as exactly that. */}
+      {showScopeLine && (
+        <div
+          data-testid="chat-scope"
+          data-kind={scope?.kind ?? 'unknown'}
+          data-graph-bound={scope === null ? 'unknown' : String(scope.graph.bound)}
+          data-dangling={scope?.dangling.length ?? 0}
+          className="px-6 py-1.5 border-b shrink-0 flex items-center gap-2 flex-wrap text-[11px] font-mono"
+          style={{ borderColor: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
+        >
+          <span className="uppercase tracking-widest text-[10px]" style={{ color: 'var(--ink-dim)' }}>Scope</span>
+          {scope === null ? (
+            <span data-testid="chat-scope-unstated" style={{ color: 'var(--status-gate)' }}>
+              not stated by the daemon — it predates chat scope, or this chat was opened before its
+              restart; what the agents can read is unknown
+            </span>
+          ) : scope.kind === 'none' ? (
+            <span>unscoped — the agents see only their private scratch root: no repositories, no code graph</span>
+          ) : (
+            <>
+              <span>
+                {scope.kind === 'project' ? 'project' : 'repos'} · {scope.repos.length} repositor{scope.repos.length === 1 ? 'y' : 'ies'} · read-only
+              </span>
+              {scope.repos.map((r) => (
+                <span
+                  key={r.id}
+                  data-testid="chat-scope-repo"
+                  data-repo-id={r.id}
+                  title={r.rootPath}
+                  className="rounded-full px-2"
+                  style={{ border: '1px solid var(--surface-overlay)', color: 'var(--ink-body)' }}
+                >
+                  {r.name}
+                </span>
+              ))}
+            </>
+          )}
+          {scope !== null && (
+            <span
+              data-testid="chat-scope-graph"
+              data-bound={scope.graph.bound}
+              title={scope.graph.reason}
+              style={{ color: scope.graph.bound ? 'var(--status-run)' : 'var(--status-gate)' }}
+            >
+              {scope.graph.bound ? 'code graph bound' : `no code graph — ${scope.graph.reason}`}
+            </span>
+          )}
+          {scope !== null && scope.dangling.length > 0 && (
+            <span
+              data-testid="chat-scope-dangling"
+              title={scope.dangling.join(', ')}
+              style={{ color: 'var(--status-fail)' }}
+            >
+              {scope.dangling.length} project member{scope.dangling.length === 1 ? '' : 's'} not readable — no longer in the repo registry: {scope.dangling.join(', ')}
+            </span>
+          )}
+        </div>
+      )}
+
       {/* The pinned now-bar (§11.4): what is happening RIGHT NOW — outside the
           scroll region, so it is visible by construction; "Latest ↓" jumps the
           thread to its live tail; the chip collects the artifacts replies name. */}
@@ -1180,7 +1435,22 @@ export function GroupChat({
         className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3"
       >
         {openError !== null && (
-          <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
+          <div data-testid="chat-open-error" data-status={openErrorStatus ?? 'none'} className="flex flex-col gap-1">
+            <p className="text-[12px] font-mono" style={{ color: 'var(--status-fail)' }}>Could not open chat: {openError}</p>
+            {/* crew#502's 501: the engine cannot hold a scoped chat — the daemon's own
+                remedy is an UNSCOPED open, offered here (outside the project shell). */}
+            {openErrorStatus === 501 && projectId == null && !repoId && (
+              <button
+                type="button"
+                data-testid="chat-scope-fallback-none"
+                onClick={fallbackUnscoped}
+                className="self-start text-[11px] px-2.5 py-1 rounded-lg"
+                style={{ background: 'var(--surface-raised)', color: 'var(--ink-high)', border: '1px solid var(--surface-overlay)' }}
+              >
+                Continue unscoped — the agents read no repositories
+              </button>
+            )}
+          </div>
         )}
         {/* J4/C6 — the honest boundary for a routed session that is gone: the
             daemon holds sessions only while they live, and transcripts are not
@@ -1227,6 +1497,13 @@ export function GroupChat({
             <p data-testid="chat-firstrun-instruction" style={{ fontSize: 'var(--text-sm)', color: 'var(--ink-body)', fontFamily: 'var(--font-sans)', margin: 0, maxWidth: '480px' }}>
               No run, no gates — just talk. Ask for a deck or some code and I’ll switch
               you to the right mode.
+            </p>
+            {/* studio#248: what the agents will be able to SEE is a choice made below,
+                before the first send — said here so the scope row reads as intended. */}
+            <p data-testid="chat-firstrun-scope" style={{ fontSize: 'var(--text-xs)', color: 'var(--ink-muted)', fontFamily: 'var(--font-sans)', margin: 0, maxWidth: '480px' }}>
+              The agents read only the repositories in scope — read-only, grounded on the
+              project’s code graph when one is indexed. Choose the scope below: a project
+              (all its repositories), a repo list, or unscoped.
             </p>
           </div>
         )}
@@ -1291,11 +1568,130 @@ export function GroupChat({
             <ProjectSwitcher
               current={currentProject}
               projects={projects}
-              onSelect={setSelectedProjectId}
+              onSelect={selectProject}
               onNewProject={() => setShowNewProject(true)}
               onOpen={loadProjects}
               dropUp
             />
+          </div>
+        )}
+        {/* studio#248: the scope control — decided at open, so it lives in the
+            create window with the project field. Three positions; `none` is an
+            explicit click (the send waits otherwise — `chatScopeGap`). */}
+        {showScopeField && (
+          <div
+            data-testid="chat-scope-row"
+            data-mode={effectiveScopeMode}
+            data-blocked={scopeGap !== null}
+            data-repo-count={effectiveScopeMode === 'repos' ? (repoId ? 1 : scopeRepoIds.length) : undefined}
+            className="flex flex-col gap-1.5 pb-2"
+          >
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'var(--ink-dim)' }}>
+                Scope
+              </span>
+              {repoId ? (
+                <span data-testid="chat-scope-fixed" className="text-[11px]" style={{ color: 'var(--ink-muted)' }}>
+                  this repository · read-only
+                </span>
+              ) : (
+                <>
+                  <div
+                    role="group"
+                    aria-label="What the agents can read"
+                    className="inline-flex items-center gap-0.5"
+                    style={{ border: '1px solid var(--surface-raised)', borderRadius: 'var(--radius-md)', padding: '1px' }}
+                  >
+                    {([
+                      ['project', 'chat-scope-project', boundProjectId !== null ? 'All project repos' : 'Project repos',
+                        boundProjectId !== null
+                          ? 'Every repository attached to the project, read-only, grounded on the project graph'
+                          : 'Pick a project first — its repositories become the scope'],
+                      ['repos', 'chat-scope-repos', `Choose repos…${scopeMode === 'repos' && scopeRepoIds.length > 0 ? ` ${scopeRepoIds.length}` : ''}`,
+                        'Name the repositories the agents may read (by registry id)'],
+                      ['none', 'chat-scope-none', 'Unscoped',
+                        boundProjectId !== null
+                          ? 'A chat filed into a project is scoped to it — unfile it (Unfiled) to chat unscoped'
+                          : 'No repositories, no code graph — the agents see only their private scratch root'],
+                    ] as const).map(([mode, tid, label, title]) => {
+                      const active = scopeMode === mode;
+                      const disabled = (mode === 'project' && boundProjectId === null) || (mode === 'none' && boundProjectId !== null);
+                      return (
+                        <button
+                          key={mode}
+                          type="button"
+                          data-testid={tid}
+                          aria-pressed={active}
+                          disabled={disabled}
+                          title={title}
+                          onClick={() => (mode === 'repos' ? openScopePicker() : chooseScopeMode(mode))}
+                          className="text-[11px] px-2 py-0.5 rounded disabled:opacity-40"
+                          style={{
+                            background: active ? 'var(--surface-raised)' : 'transparent',
+                            color: active ? 'var(--ink-high)' : 'var(--ink-muted)',
+                            border: 'none',
+                          }}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <span data-testid="chat-scope-summary" className="text-[11px]" style={{ color: scopeMode === 'project' && boundProjectId === null ? 'var(--status-gate)' : 'var(--ink-muted)' }}>
+                    {scopeMode === 'project'
+                      ? boundProjectId !== null
+                        ? 'every repository of the project · read-only · project graph when indexed'
+                        : 'no project selected — the agents would have nothing to read'
+                      : scopeMode === 'repos'
+                        ? scopeRepoIds.length === 0
+                          ? 'pick the repositories below'
+                          : `${scopeRepoIds.length} repositor${scopeRepoIds.length === 1 ? 'y' : 'ies'} · read-only${boundProjectId !== null ? ' · project graph when indexed' : scopeRepoIds.length === 1 ? ' · its own graph when indexed' : ' · no graph for several repos without a project'}`
+                        : 'unscoped — no repositories, no code graph; the agents see only their scratch root'}
+                  </span>
+                </>
+              )}
+            </div>
+            {scopeGap !== null && (
+              <p data-testid="chat-scope-gap" className="text-[11px] font-mono" style={{ color: 'var(--status-fail)', margin: 0 }}>
+                {scopeGap}
+              </p>
+            )}
+            {!repoId && scopeMode === 'repos' && scopePickerOpen && (
+              <div
+                data-testid="chat-scope-picker"
+                className="flex flex-col gap-1 rounded-lg px-3 py-2"
+                style={{ border: '1px solid var(--surface-raised)', maxHeight: '160px', overflowY: 'auto' }}
+              >
+                {scopeReposError !== null ? (
+                  <span data-testid="chat-scope-picker-error" className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
+                    registered repositories unreadable — {scopeReposError}
+                  </span>
+                ) : scopeRepos === null ? (
+                  <span data-testid="chat-scope-picker-loading" className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>loading registered repositories…</span>
+                ) : scopeRepos.length === 0 ? (
+                  <span data-testid="chat-scope-picker-empty" className="text-[11px] font-mono" style={{ color: 'var(--ink-dim)' }}>no repositories registered — register one on Repositories first</span>
+                ) : (
+                  scopeRepos.map((r) => {
+                    const checked = scopeRepoIds.includes(r.id);
+                    return (
+                      <label
+                        key={r.id}
+                        data-testid="chat-scope-repo-option"
+                        data-repo-id={r.id}
+                        data-checked={checked}
+                        title={r.root_path}
+                        className="flex items-center gap-2 text-[11px] font-mono cursor-pointer"
+                        style={{ color: checked ? 'var(--ink-high)' : 'var(--ink-muted)' }}
+                      >
+                        <input type="checkbox" checked={checked} onChange={() => toggleScopeRepo(r.id)} />
+                        <span>{r.name}</span>
+                        <span className="truncate" style={{ color: 'var(--ink-dim)', minWidth: 0 }}>{r.root_path}</span>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            )}
           </div>
         )}
         {showNewProject && (

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -151,10 +151,11 @@ function GovernanceRows({ read }: { read: GovernanceRead }): React.ReactElement 
   const dl = g.deadletters;
   const errors = g.findings.filter((f) => f.severity === 'error').length;
   const state = g.store === null || errors > 0 ? 'error' : g.findings.length > 0 ? 'warning' : 'ok';
-  const records =
-    g.records.total === null
-      ? 'engine cannot count'
-      : `${g.records.total} record${g.records.total === 1 ? '' : 's'}${g.records.sinceBoot === null ? '' : ` · ${g.records.sinceBoot} since boot`}`;
+  // `total` and `sinceBoot` are independently nullable — each field states itself.
+  const records = [
+    g.records.total === null ? 'total: engine cannot count' : `${g.records.total} record${g.records.total === 1 ? '' : 's'}`,
+    g.records.sinceBoot === null ? null : `${g.records.sinceBoot} since boot`,
+  ].filter((x): x is string => x !== null).join(' · ');
   const range =
     dl.oldestTs !== null && dl.newestTs !== null ? `${stamp(dl.oldestTs)} → ${stamp(dl.newestTs)}` : null;
   return (
@@ -167,7 +168,7 @@ function GovernanceRows({ read }: { read: GovernanceRead }): React.ReactElement 
           <DetailLine testId="rail-governance-store-path" label="path" value={g.store.path} />
         </>
       )}
-      <CheckRow label="records" ok={g.records.total === null ? null : true} detail={records} />
+      <CheckRow label="records" ok={g.records.total === null && g.records.sinceBoot === null ? null : true} detail={records} />
       <CheckRow
         label="dead letters"
         ok={dl.count === 0}

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import type { RosterSeat } from '../api/types.js';
+import { getDiagnostics, isDiagnosticsUnsupported } from '../api/diagnostics.js';
+import type { DiagnosticsGovernance, DiagnosticsGovernanceFinding, RosterSeat } from '../api/types.js';
 import { useConnectionStore } from '../store/connection.js';
 import { setCachedRoster } from '../store/rosterCache.js';
 
@@ -26,6 +27,19 @@ import { setCachedRoster } from '../store/rosterCache.js';
  * `health` is OPTIONAL on the wire (additive, absent on a daemon predating
  * crew#274): an absent `health` renders a dim `·` glyph and no message — never
  * a fabricated "active".
+ *
+ * GOVERNANCE (studio#246, crew#495 / F-022): the same expand also reads
+ * `GET /diagnostics` and renders its `governance` block as a third registry
+ * group — the store the engine's emit seam writes to (path + which rule chose
+ * it), the record counts (`null` = "engine cannot count", never 0), the folded
+ * dead-letter outbox (count, by type / by reason, the timestamp range,
+ * `truncated`, the pre-fix HOME outbox) and every finding as a severity-styled
+ * row whose message carries the `wicked-crew governance replay …` recipe.
+ * Null-safe by construction: a daemon predating the block (no `governance`
+ * key, or no `/diagnostics` at all) renders one honest "not reported" row; a
+ * daemon reporting `store: null` is NOT shown as governed — that is the
+ * `governance.store` error row. The header heart/dot fold the findings in:
+ * an error finding (or a null store) reads unhealthy, a warning degraded.
  */
 
 interface HealthInfo {
@@ -83,6 +97,116 @@ function SeatRow({ seat }: { seat: RosterSeat }): React.ReactElement {
   );
 }
 
+/** What the expand learned about governance (studio#246). */
+type GovernanceRead =
+  | { kind: 'loading' }
+  | { kind: 'absent'; why: 'no-route' | 'no-block' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ok'; governance: DiagnosticsGovernance };
+
+const FINDING_COLOR: Record<DiagnosticsGovernanceFinding['severity'], string> = {
+  error: 'var(--status-fail)',
+  warning: 'var(--status-gate)',
+};
+
+/** Sub-rows under a check row: `label · value`, dim mono. */
+function DetailLine({ label, value, color, testId }: { label: string; value: string; color?: string; testId?: string }): React.ReactElement {
+  return (
+    <div data-testid={testId} style={{ display: 'flex', gap: 'var(--space-2)', paddingLeft: '20px', marginBottom: '3px', minWidth: 0 }}>
+      <span style={{ fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{label}</span>
+      <span className="truncate" title={value} style={{ fontSize: 'var(--text-2xs)', color: color ?? 'var(--ink-muted)', fontFamily: 'var(--font-mono)', minWidth: 0 }}>{value}</span>
+    </div>
+  );
+}
+
+function tally(rec: Record<string, number>): string {
+  const entries = Object.entries(rec);
+  return entries.length === 0 ? 'none' : entries.map(([k, n]) => `${k} ×${n}`).join(' · ');
+}
+
+function stamp(ms: number): string {
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19) + 'Z';
+}
+
+/** The governance registry group — one CheckRow per question, the findings as banners. */
+function GovernanceRows({ read }: { read: GovernanceRead }): React.ReactElement {
+  if (read.kind === 'loading') return <CheckRow label="governance" ok={null} detail="checking…" />;
+  if (read.kind === 'error') return <CheckRow label="governance" ok={false} detail="unreachable" />;
+  if (read.kind === 'absent') {
+    return (
+      <div data-testid="rail-governance" data-state="absent" data-why={read.why}>
+        <CheckRow label="governance" ok={null} detail="not reported by this daemon" />
+        <DetailLine label="why" value={read.why === 'no-route' ? 'no /diagnostics route — upgrade wicked-crew' : 'no governance block on /diagnostics — upgrade wicked-crew to see where governance events land'} />
+      </div>
+    );
+  }
+  const g = read.governance;
+  const dl = g.deadletters;
+  const errors = g.findings.filter((f) => f.severity === 'error').length;
+  const state = g.store === null || errors > 0 ? 'error' : g.findings.length > 0 ? 'warning' : 'ok';
+  const records =
+    g.records.total === null
+      ? 'engine cannot count'
+      : `${g.records.total} record${g.records.total === 1 ? '' : 's'}${g.records.sinceBoot === null ? '' : ` · ${g.records.sinceBoot} since boot`}`;
+  const range =
+    dl.oldestTs !== null && dl.newestTs !== null ? `${stamp(dl.oldestTs)} → ${stamp(dl.newestTs)}` : null;
+  return (
+    <div data-testid="rail-governance" data-state={state} data-deadletters={dl.count} data-store={g.store === null ? 'none' : g.store.source}>
+      {g.store === null ? (
+        <CheckRow label="store" ok={false} detail="none resolved — emits dead-letter" />
+      ) : (
+        <>
+          <CheckRow label="store" ok detail={`via ${g.store.source}`} />
+          <DetailLine testId="rail-governance-store-path" label="path" value={g.store.path} />
+        </>
+      )}
+      <CheckRow label="records" ok={g.records.total === null ? null : true} detail={records} />
+      <CheckRow
+        label="dead letters"
+        ok={dl.count === 0}
+        detail={dl.count === 0 ? 'none' : `${dl.count}${dl.truncated ? '+' : ''}`}
+      />
+      {dl.count > 0 && (
+        <>
+          <DetailLine testId="rail-governance-by-type" label="by type" value={tally(dl.byType)} />
+          <DetailLine testId="rail-governance-by-reason" label="by reason" value={tally(dl.byReason)} />
+          <DetailLine
+            testId="rail-governance-range"
+            label="when"
+            value={
+              (range ?? 'no timestamps') +
+              (dl.untimestamped > 0 ? ` · ${dl.untimestamped} untimestamped` : '') +
+              (dl.truncated ? ' · fold truncated at its size cap — count is a floor' : '')
+            }
+          />
+          {dl.path !== null && <DetailLine testId="rail-governance-outbox" label="outbox" value={dl.path} />}
+        </>
+      )}
+      {dl.legacyOutbox !== null && (
+        <DetailLine testId="rail-governance-legacy" label="legacy outbox" value={`${dl.legacyOutbox.path} · ${dl.legacyOutbox.bytes} bytes`} color="var(--status-gate)" />
+      )}
+      {g.findings.map((f, i) => (
+        <p
+          key={`${f.kind}-${i}`}
+          data-testid="rail-governance-finding"
+          data-kind={f.kind}
+          data-severity={f.severity}
+          style={{
+            margin: '2px 0 5px', padding: '4px 8px', borderLeft: `2px solid ${FINDING_COLOR[f.severity]}`,
+            background: 'var(--surface-raised)', borderRadius: 'var(--radius-sm)',
+            fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-body)',
+            overflowWrap: 'anywhere', whiteSpace: 'pre-wrap',
+          }}
+        >
+          <span style={{ color: FINDING_COLOR[f.severity], fontWeight: 'var(--weight-bold)' }}>{f.severity} · {f.kind}</span>
+          {' — '}
+          {f.message}
+        </p>
+      ))}
+    </div>
+  );
+}
+
 interface Props {
   /** Controlled by the rail so the chrome dot can expand this section (§6.2). */
   open: boolean;
@@ -95,6 +219,7 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   const [healthError, setHealthError] = useState(false);
   const [roster, setRoster] = useState<RosterSeat[] | null>(null);
   const [rosterError, setRosterError] = useState(false);
+  const [governance, setGovernance] = useState<GovernanceRead>({ kind: 'loading' });
   const ref = useRef<HTMLDivElement>(null);
 
   // EC30: the expand IS the fetch gesture — one GET /health + one GET /roster
@@ -110,6 +235,16 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
     api.getRoster()
       .then(({ roster: seats }) => { setRoster(seats); setCachedRoster(seats); })
       .catch(() => setRosterError(true));
+    // studio#246: the same gesture reads the governance block. Absence is a
+    // named state (older daemon), never an invented healthy store.
+    setGovernance({ kind: 'loading' });
+    // Through a resolved promise so a client that cannot serve the read at all
+    // (a partial mock, a missing export) becomes the honest error row, not a throw.
+    Promise.resolve()
+      .then(() => getDiagnostics())
+      .then((d) => setGovernance(d.governance === undefined ? { kind: 'absent', why: 'no-block' } : { kind: 'ok', governance: d.governance }))
+      .catch((e: unknown) =>
+        setGovernance(isDiagnosticsUnsupported(e) ? { kind: 'absent', why: 'no-route' } : { kind: 'error', message: e instanceof Error ? e.message : String(e) }));
     // Opened from the chrome dot: bring the foot into view (§6.2).
     ref.current?.scrollIntoView({ block: 'nearest' });
   }, [open]);
@@ -118,13 +253,21 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   const pillLabel = wsStatus === 'connected' ? 'Connected' : wsStatus === 'connecting' ? 'Connecting' : 'Disconnected';
   // The passive header summary (§6.2): fail-red if any seat is inactive or the
   // socket is down — the rail's foot says "look inside" without being opened.
-  const sick = wsDown || (roster ?? []).some((s) => s.health?.status === 'inactive');
+  // studio#246: a null store or an error finding (dead letters, no store) is a
+  // health failure — the board must not read "Governed" over it.
+  const govErrors =
+    governance.kind === 'ok' &&
+    (governance.governance.store === null || governance.governance.findings.some((f) => f.severity === 'error'));
+  const govWarnings =
+    governance.kind === 'error' ||
+    (governance.kind === 'ok' && governance.governance.findings.some((f) => f.severity === 'warning'));
+  const sick = wsDown || govErrors || (roster ?? []).some((s) => s.health?.status === 'inactive');
   // The ♥ glyph is colored by health (nav-ui-tweaks): red when unhealthy (a
   // seat down or the socket gone), amber when degraded (socket still connecting,
   // a probe errored, or the API server not reporting ok), green otherwise. It
   // reads the same signals the section already computes — no new data source.
   const degraded =
-    wsStatus === 'connecting' || healthError || rosterError || (health !== null && health.status !== 'ok');
+    wsStatus === 'connecting' || healthError || rosterError || govWarnings || (health !== null && health.status !== 'ok');
   const heartState = sick ? 'unhealthy' : degraded ? 'degraded' : 'healthy';
   const heartColor = sick
     ? 'var(--status-fail)'
@@ -207,6 +350,14 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
           ) : (
             roster.map((seat) => <SeatRow key={seat.key} seat={seat} />)
           )}
+          <p
+            aria-hidden
+            className="select-none"
+            style={{ margin: '2px 0 5px', fontSize: 'var(--text-2xs)', color: 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+          >
+            ── governance ────────
+          </p>
+          <GovernanceRows read={governance} />
         </div>
       )}
     </div>

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -179,9 +179,9 @@ function GovernanceRows({ read }: { read: GovernanceRead }): React.ReactElement 
               (dl.truncated ? ' · fold truncated at its size cap — count is a floor' : '')
             }
           />
-          {dl.path !== null && <DetailLine testId="rail-governance-outbox" label="outbox" value={dl.path} />}
         </>
       )}
+      {dl.path !== null && <DetailLine testId="rail-governance-outbox" label="outbox" value={dl.path} />}
       {dl.legacyOutbox !== null && (
         <DetailLine testId="rail-governance-legacy" label="legacy outbox" value={`${dl.legacyOutbox.path} · ${dl.legacyOutbox.bytes} bytes`} color="var(--status-gate)" />
       )}
@@ -220,6 +220,9 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   const [roster, setRoster] = useState<RosterSeat[] | null>(null);
   const [rosterError, setRosterError] = useState(false);
   const [governance, setGovernance] = useState<GovernanceRead>({ kind: 'loading' });
+  /** The expand generation a diagnostics read belongs to — a completion from an earlier
+   *  expand must not overwrite a later one (the findings drive the heart and the dot). */
+  const governanceGen = useRef(0);
   const ref = useRef<HTMLDivElement>(null);
 
   // EC30: the expand IS the fetch gesture — one GET /health + one GET /roster
@@ -238,13 +241,21 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
     // studio#246: the same gesture reads the governance block. Absence is a
     // named state (older daemon), never an invented healthy store.
     setGovernance({ kind: 'loading' });
+    const gen = ++governanceGen.current;
     // Through a resolved promise so a client that cannot serve the read at all
     // (a partial mock, a missing export) becomes the honest error row, not a throw.
+    // Only the CURRENT expand's answer lands (Copilot on #253): a slow earlier read
+    // resolving after a re-expand would otherwise paint stale governance health.
     Promise.resolve()
       .then(() => getDiagnostics())
-      .then((d) => setGovernance(d.governance === undefined ? { kind: 'absent', why: 'no-block' } : { kind: 'ok', governance: d.governance }))
-      .catch((e: unknown) =>
-        setGovernance(isDiagnosticsUnsupported(e) ? { kind: 'absent', why: 'no-route' } : { kind: 'error', message: e instanceof Error ? e.message : String(e) }));
+      .then((d) => {
+        if (governanceGen.current !== gen) return;
+        setGovernance(d.governance === undefined ? { kind: 'absent', why: 'no-block' } : { kind: 'ok', governance: d.governance });
+      })
+      .catch((e: unknown) => {
+        if (governanceGen.current !== gen) return;
+        setGovernance(isDiagnosticsUnsupported(e) ? { kind: 'absent', why: 'no-route' } : { kind: 'error', message: e instanceof Error ? e.message : String(e) });
+      });
     // Opened from the chrome dot: bring the foot into view (§6.2).
     ref.current?.scrollIntoView({ block: 'nearest' });
   }, [open]);

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -131,7 +131,14 @@ function stamp(ms: number): string {
 /** The governance registry group — one CheckRow per question, the findings as banners. */
 function GovernanceRows({ read }: { read: GovernanceRead }): React.ReactElement {
   if (read.kind === 'loading') return <CheckRow label="governance" ok={null} detail="checking…" />;
-  if (read.kind === 'error') return <CheckRow label="governance" ok={false} detail="unreachable" />;
+  if (read.kind === 'error') {
+    return (
+      <div data-testid="rail-governance" data-state="error">
+        <CheckRow label="governance" ok={false} detail="unreachable" />
+        <DetailLine testId="rail-governance-error" label="why" value={read.message} color="var(--status-fail)" />
+      </div>
+    );
+  }
   if (read.kind === 'absent') {
     return (
       <div data-testid="rail-governance" data-state="absent" data-why={read.why}>

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -381,7 +381,7 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
           {/* ── The KPI ribbon: the hero, full-width — FLOW / ATTENTION / TRUST&SPEND on the real
                  created_at clock (the command-deck redesign). ── */}
           <div style={{ flexShrink: 0, padding: '0 var(--space-6)' }}>
-            <DeckKpiRibbon runs={runs} claims={wires.claims} needCount={needRows.length} navigate={navigate} now={now} />
+            <DeckKpiRibbon runs={runs} claims={wires.claims} governance={wires.diag?.governance ?? null} needCount={needRows.length} navigate={navigate} now={now} />
           </div>
 
           {/* ── The command center: the needs-you queue (spine, left) + the live-pulse column. ── */}

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { ProjectMember, RepoEntry } from '../api/types.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
+import { RepoFindings } from './RepoFindings.js';
 
 /**
  * The project's repositories — the one UI path that attaches a `crew.repo`
@@ -147,6 +148,10 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
   /** The last registry (picker) fetch failure, kept apart from the mutation error
    *  so the retry gesture clears exactly the one that just went stale. */
   const [registryError, setRegistryError] = useState<string | null>(null);
+  /** studio#251: the repo id whose onboarding re-run is in flight, or null. */
+  const [reonboarding, setReonboarding] = useState<string | null>(null);
+  /** studio#251: the outcome of the last re-run per repo id — the started run, or the refusal. */
+  const [reonboardNote, setReonboardNote] = useState<Record<string, { text: string; failed: boolean }>>({});
 
   /**
    * ONE mutation at a time. The lock keeps a second row's Detach from re-pointing
@@ -260,6 +265,27 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
     }
   }
 
+  /**
+   * studio#251: the "Re-run onboarding" remedy the engine names on an in-tree-ignored repo with no
+   * live graph — the EXISTING onboard wire (`POST /repos/:id/onboard`, what the Repositories page's
+   * Onboard button posts). This section has no run navigation, so the started run is STATED inline.
+   */
+  async function rerunOnboarding(repo: RepoEntry): Promise<void> {
+    if (reonboarding !== null) return;
+    const stillMine = beginMutation();
+    setReonboarding(repo.id);
+    try {
+      const { runId } = await api.rerunOnboarding(repo.id);
+      if (!stillMine()) return;
+      setReonboardNote((prev) => ({ ...prev, [repo.id]: { text: `onboarding run ${runId} started — the live graph is rebuilt when it completes`, failed: false } }));
+    } catch (e) {
+      if (!stillMine()) return;
+      setReonboardNote((prev) => ({ ...prev, [repo.id]: { text: `re-run refused: ${e instanceof Error ? e.message : String(e)}`, failed: true } }));
+    } finally {
+      if (stillMine()) setReonboarding(null);
+    }
+  }
+
   async function detach(member: ProjectMember): Promise<void> {
     if (busy) return;
     const forProject = projectId;
@@ -298,8 +324,10 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
             const repo = repoOf(m.member_ref, repos);
             const label = repo?.name ?? m.member_ref;
             const isConfirming = confirming === m.id;
+            const note = repo !== undefined ? reonboardNote[repo.id] : undefined;
             return (
-              <div key={m.id} data-testid="project-repo-row" data-repo={m.member_ref} style={CSS.row}>
+              <div key={m.id} style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+              <div data-testid="project-repo-row" data-repo={m.member_ref} style={CSS.row}>
                 <span aria-hidden style={{ color: 'var(--ink-dim)' }}>⬡</span>
                 <span style={CSS.repoName} title={m.member_ref}>{label}</span>
                 <span style={CSS.repoPath} title={repo?.root_path}>{repo?.root_path ?? ''}</span>
@@ -344,6 +372,26 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
                     </button>
                   </>
                 )}
+              </div>
+              {/* studio#251: the engine's checkout findings for this member (wicked-core#406) —
+                  known once the registry cache is warm (the picker's gesture), silent otherwise
+                  and silent for a clean checkout. */}
+              {repo !== undefined && (
+                <div style={{ padding: '0 10px 6px 30px', minWidth: 0 }}>
+                  <RepoFindings
+                    compact
+                    findings={repo.findings}
+                    onRerunOnboarding={() => void rerunOnboarding(repo)}
+                    rerunning={reonboarding === repo.id}
+                    testId="project-repo-findings"
+                  />
+                  {note !== undefined && (
+                    <p data-testid="project-repo-reonboard-note" data-failed={note.failed} style={note.failed ? CSS.error : CSS.hint}>
+                      {note.text}
+                    </p>
+                  )}
+                </div>
+              )}
               </div>
             );
           })}

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -158,7 +158,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
    * `confirming` while a detach is mid-request, and keeps the picker from
    * starting an attach on top of it.
    */
-  const busy = attaching !== null || detaching !== null;
+  const busy = attaching !== null || detaching !== null || reonboarding !== null;
 
   /**
    * The project this section shows RIGHT NOW — `null` once unmounted. Neither
@@ -195,6 +195,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
     setPickerOpen(false);
     setAttaching(null);
     setDetaching(null);
+    setReonboarding(null);
     return () => { liveProjectId.current = null; };
   }, [projectId]);
 
@@ -271,7 +272,9 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
    * Onboard button posts). This section has no run navigation, so the started run is STATED inline.
    */
   async function rerunOnboarding(repo: RepoEntry): Promise<void> {
-    if (reonboarding !== null) return;
+    // One mutation at a time, the SAME lock attach/detach hold (Copilot on #253): a concurrent
+    // mutation would take the token and this request's `finally` could never clear its flag.
+    if (busy) return;
     const stillMine = beginMutation();
     setReonboarding(repo.id);
     try {

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
 import type { ProjectMember, RepoEntry } from '../api/types.js';
 import { fetchReposCached, getCachedRepos } from '../store/repoCache.js';
-import { RepoFindings } from './RepoFindings.js';
+import { RepoFindings, repoFindings } from './RepoFindings.js';
 
 /**
  * The project's repositories — the one UI path that attaches a `crew.repo`
@@ -196,6 +196,7 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
     setAttaching(null);
     setDetaching(null);
     setReonboarding(null);
+    setReonboardNote({});
     return () => { liveProjectId.current = null; };
   }, [projectId]);
 
@@ -379,13 +380,14 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
               {/* studio#251: the engine's checkout findings for this member (wicked-core#406) —
                   known once the registry cache is warm (the picker's gesture), silent otherwise
                   and silent for a clean checkout. */}
-              {repo !== undefined && (
+              {repo !== undefined && (repoFindings(repo).length > 0 || note !== undefined) && (
                 <div style={{ padding: '0 10px 6px 30px', minWidth: 0 }}>
                   <RepoFindings
                     compact
                     findings={repo.findings}
                     onRerunOnboarding={() => void rerunOnboarding(repo)}
                     rerunning={reonboarding === repo.id}
+                    disabled={busy}
                     testId="project-repo-findings"
                   />
                   {note !== undefined && (

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -217,13 +217,15 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
             {/* studio#251: the engine's checkout findings (wicked-core#406) — an ignored in-tree
                 graph, a graph-less repo — with "Re-run onboarding" wired to THIS page's onboarding
                 trigger. Silent when the record carries none (or predates the field). */}
-            <div className="mt-2">
-              <RepoFindings
-                findings={repo.findings}
-                onRerunOnboarding={() => void startOnboarding()}
-                rerunning={onboarding}
-              />
-            </div>
+            {(repo.findings?.length ?? 0) > 0 && (
+              <div className="mt-2">
+                <RepoFindings
+                  findings={repo.findings}
+                  onRerunOnboarding={() => void startOnboarding()}
+                  rerunning={onboarding}
+                />
+              </div>
+            )}
             {repo.git_url && (
               /^https?:\/\//i.test(repo.git_url) ? (
                 <a

--- a/src/components/RepoDetailPage.tsx
+++ b/src/components/RepoDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api/client.js';
+import { RepoFindings } from './RepoFindings.js';
 import { CommitCadence } from './CommitCadence.js';
 import { HotspotsView } from './HotspotsView.js';
 import { LanguageBar } from './LanguageBar.js';
@@ -213,6 +214,16 @@ export function RepoDetailPage({ repoId, onSelectRun, navigate, onOpenGraph }: P
             <p className="text-xs font-mono mt-1 break-all" style={{ color: 'var(--ink-dim)' }}>
               {repo.root_path}
             </p>
+            {/* studio#251: the engine's checkout findings (wicked-core#406) — an ignored in-tree
+                graph, a graph-less repo — with "Re-run onboarding" wired to THIS page's onboarding
+                trigger. Silent when the record carries none (or predates the field). */}
+            <div className="mt-2">
+              <RepoFindings
+                findings={repo.findings}
+                onRerunOnboarding={() => void startOnboarding()}
+                rerunning={onboarding}
+              />
+            </div>
             {repo.git_url && (
               /^https?:\/\//i.test(repo.git_url) ? (
                 <a

--- a/src/components/RepoFindings.tsx
+++ b/src/components/RepoFindings.tsx
@@ -76,8 +76,11 @@ interface Props {
   /** The host surface's EXISTING onboarding trigger (`api.rerunOnboarding` + its own state);
    *  when omitted the re-onboard row states the remedy without a button. */
   onRerunOnboarding?: (() => void) | undefined;
-  /** The host's in-flight flag for that trigger (disables the button, "Starting…"). */
+  /** The host's in-flight flag for THIS repo's trigger (disables the button, "Starting…"). */
   rerunning?: boolean | undefined;
+  /** The host's shared mutation lock (another repo's re-run, an attach/detach): disables the
+   *  button without claiming this repo is starting. */
+  disabled?: boolean | undefined;
   /** Card dress: one-line rows, the message truncated with the full text on hover. */
   compact?: boolean | undefined;
   /** Test id root; per-finding rows are `<testId>-row`. */
@@ -85,7 +88,7 @@ interface Props {
 }
 
 export function RepoFindings({
-  findings, onRerunOnboarding, rerunning = false, compact = false, testId = 'repo-findings',
+  findings, onRerunOnboarding, rerunning = false, disabled = false, compact = false, testId = 'repo-findings',
 }: Props): React.ReactElement | null {
   if (findings === undefined || findings.length === 0) return null;
   return (
@@ -141,12 +144,12 @@ export function RepoFindings({
               <button
                 type="button"
                 data-testid={`${testId}-reonboard`}
-                disabled={rerunning}
+                disabled={rerunning || disabled}
                 title="Re-index this repo as a governed onboarding run (index → annotate) — builds the live graph under the daemon state home"
                 onClick={(e) => { e.stopPropagation(); onRerunOnboarding(); }}
                 className="disabled:opacity-50"
                 style={{
-                  flexShrink: 0, cursor: rerunning ? 'default' : 'pointer',
+                  flexShrink: 0, cursor: rerunning || disabled ? 'default' : 'pointer',
                   background: 'var(--accent)', color: 'var(--accent-fg)', border: 'none',
                   borderRadius: 'var(--radius-md)', padding: '2px 10px',
                   fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--weight-semi)',

--- a/src/components/RepoFindings.tsx
+++ b/src/components/RepoFindings.tsx
@@ -1,0 +1,163 @@
+import type { RepoEntry, RepoFinding } from '../api/types.js';
+
+/**
+ * The engine's per-repo findings (`RepoEntry.findings[]`, wicked-core#406 via crew#517 —
+ * api-types 0.32.0; studio#251), rendered wherever a repo card or detail header shows the repo:
+ * one labelled row per finding with the engine's own message, and — for the ONE case that has a
+ * UI remedy — the "Re-run onboarding" action wired to the existing onboarding trigger of the
+ * surface that hosts it (`POST /repos/:id/onboard`, the same call the Onboard buttons make).
+ *
+ * The codes the engine emits today, and how each reads here:
+ *
+ *  - `in_tree_code_graph_ignored` — the checkout carries a `.codegraph/` an older engine indexed IN
+ *    the working tree. It is ignored; the live graph lives under the daemon state home. Two
+ *    sub-states share the code and differ only in the engine's message (the wire carries no
+ *    machine-readable remedy field): "the live graph is <path>" (a graph exists — a tidy-up
+ *    warning) versus "re-run onboarding (POST /repos/<id>/onboard)" (no live graph has been
+ *    indexed yet — the repo is graph-less until it is onboarded again; F-024's upgraded
+ *    checkouts). {@link findingNeedsReonboard} keys on the engine's remedy sentence — the same
+ *    words core's own tests pin — and the row then carries the action.
+ *  - `code_graph_root_unresolvable` — no repo-graph root resolves for this daemon at all
+ *    (`code_graph_db` is empty); a daemon-environment fault the message names. No UI remedy.
+ *  - anything else — rendered verbatim as a warning (forward-additive: a newer engine may add codes).
+ *
+ * SILENT when `findings` is absent (a daemon predating the field) or empty (a clean checkout):
+ * the component renders nothing at all — no frame, no "no findings" copy.
+ */
+
+export const REPO_FINDING_IN_TREE_IGNORED = 'in_tree_code_graph_ignored';
+export const REPO_FINDING_ROOT_UNRESOLVABLE = 'code_graph_root_unresolvable';
+
+/** The engine's remedy sentence for an in-tree graph with NO live graph behind it (core `repo.rs`:
+ *  "no graph has been indexed under the state home yet — re-run onboarding (POST /repos/<id>/onboard)").
+ *  Matched on the words core's own tests pin, because the wire has no separate field for it. */
+const REONBOARD_REMEDY = /re-run onboarding/i;
+
+export type RepoFindingSeverity = 'warning' | 'error';
+
+/** Whether this finding's remedy is the onboarding re-run this UI can trigger. */
+export function findingNeedsReonboard(finding: RepoFinding): boolean {
+  return finding.code === REPO_FINDING_IN_TREE_IGNORED && REONBOARD_REMEDY.test(finding.message);
+}
+
+/** How loud a finding reads: a graph-less repo is an error (every graph surface is empty until it
+ *  is fixed); an ignored in-tree graph beside a live one is a tidy-up warning. */
+export function findingSeverity(finding: RepoFinding): RepoFindingSeverity {
+  if (finding.code === REPO_FINDING_ROOT_UNRESOLVABLE) return 'error';
+  if (findingNeedsReonboard(finding)) return 'error';
+  return 'warning';
+}
+
+/** The short operator label in front of the engine's message. */
+export function findingLabel(finding: RepoFinding): string {
+  switch (finding.code) {
+    case REPO_FINDING_IN_TREE_IGNORED:
+      return findingNeedsReonboard(finding) ? 'in-tree graph ignored · no live graph' : 'in-tree graph ignored';
+    case REPO_FINDING_ROOT_UNRESOLVABLE:
+      return 'no graph root';
+    default:
+      return finding.code.replace(/_/g, ' ');
+  }
+}
+
+/** The findings a repo record carries, or `[]` — absent and empty read the same (silent). */
+export function repoFindings(repo: Pick<RepoEntry, 'findings'> | null | undefined): RepoFinding[] {
+  return repo?.findings ?? [];
+}
+
+const SEVERITY_COLOR: Record<RepoFindingSeverity, string> = {
+  warning: 'var(--status-gate)',
+  error: 'var(--status-fail)',
+};
+
+interface Props {
+  /** `RepoEntry.findings` as the wire carries it — `undefined` on an older daemon. */
+  findings: RepoFinding[] | undefined;
+  /** The host surface's EXISTING onboarding trigger (`api.rerunOnboarding` + its own state);
+   *  when omitted the re-onboard row states the remedy without a button. */
+  onRerunOnboarding?: (() => void) | undefined;
+  /** The host's in-flight flag for that trigger (disables the button, "Starting…"). */
+  rerunning?: boolean | undefined;
+  /** Card dress: one-line rows, the message truncated with the full text on hover. */
+  compact?: boolean | undefined;
+  /** Test id root; per-finding rows are `<testId>-row`. */
+  testId?: string | undefined;
+}
+
+export function RepoFindings({
+  findings, onRerunOnboarding, rerunning = false, compact = false, testId = 'repo-findings',
+}: Props): React.ReactElement | null {
+  if (findings === undefined || findings.length === 0) return null;
+  return (
+    <div
+      data-testid={testId}
+      data-count={findings.length}
+      // Inside a clickable card (RepositoriesPanel's role=link) the action must not also navigate.
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      role="presentation"
+      style={{ display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 }}
+    >
+      {findings.map((f, i) => {
+        const severity = findingSeverity(f);
+        const reonboard = findingNeedsReonboard(f);
+        const color = SEVERITY_COLOR[severity];
+        return (
+          <div
+            key={`${f.code}-${i}`}
+            data-testid={`${testId}-row`}
+            data-code={f.code}
+            data-severity={severity}
+            data-reonboard={reonboard}
+            title={compact ? `${f.message}${f.path !== null ? `\n${f.path}` : ''}` : (f.path ?? undefined)}
+            style={{
+              display: 'flex', alignItems: compact ? 'center' : 'flex-start', gap: '8px', minWidth: 0,
+              padding: compact ? '2px 0' : '6px 10px',
+              borderLeft: compact ? undefined : `2px solid ${color}`,
+              background: compact ? 'transparent' : 'var(--surface-raised)',
+              borderRadius: compact ? undefined : 'var(--radius-md)',
+            }}
+          >
+            <span
+              style={{
+                flexShrink: 0, borderRadius: 'var(--radius-full)', padding: '1px 8px',
+                fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--weight-bold)',
+                color, border: `1px solid ${color}`, whiteSpace: 'nowrap',
+              }}
+            >
+              {findingLabel(f)}
+            </span>
+            <span
+              className={compact ? 'truncate' : undefined}
+              style={{
+                flex: 1, minWidth: 0, fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)',
+                color: 'var(--ink-muted)', margin: 0,
+                whiteSpace: compact ? 'nowrap' : 'normal', overflowWrap: compact ? undefined : 'anywhere',
+              }}
+            >
+              {f.message}
+            </span>
+            {reonboard && onRerunOnboarding !== undefined && (
+              <button
+                type="button"
+                data-testid={`${testId}-reonboard`}
+                disabled={rerunning}
+                title="Re-index this repo as a governed onboarding run (index → annotate) — builds the live graph under the daemon state home"
+                onClick={(e) => { e.stopPropagation(); onRerunOnboarding(); }}
+                className="disabled:opacity-50"
+                style={{
+                  flexShrink: 0, cursor: rerunning ? 'default' : 'pointer',
+                  background: 'var(--accent)', color: 'var(--accent-fg)', border: 'none',
+                  borderRadius: 'var(--radius-md)', padding: '2px 10px',
+                  fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--weight-semi)',
+                }}
+              >
+                {rerunning ? 'Starting…' : 'Re-run onboarding'}
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -772,6 +772,7 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                     findings={repo.findings}
                     onRerunOnboarding={() => void rerunOnboarding(repo.id)}
                     rerunning={isRerunning}
+                    disabled={capturing[repo.id] ?? false}
                     testId="repo-card-findings"
                   />
 

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { NewProjectModal } from './NewProjectModal.js';
 import { ago } from './ProjectCard.js';
 import { ProjectSwitcher } from './ProjectSwitcher.js';
+import { RepoFindings } from './RepoFindings.js';
 
 type SourceMode = 'local' | 'remote';
 
@@ -763,6 +764,16 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                   >
                     {graphStateWord(m, attachedAt, now)}
                   </p>
+
+                  {/* studio#251: the engine's checkout findings (wicked-core#406), compact —
+                      "Re-run onboarding" rides the card's EXISTING onboard wire. Silent when none. */}
+                  <RepoFindings
+                    compact
+                    findings={repo.findings}
+                    onRerunOnboarding={() => void rerunOnboarding(repo.id)}
+                    rerunning={isRerunning}
+                    testId="repo-card-findings"
+                  />
 
                   {/* Stats row — the window's counts, the honest clocks */}
                   <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.4",
   "counts": {
     "files": 140,
-    "occurrences": 1190,
-    "static": 1022,
+    "occurrences": 1192,
+    "static": 1023,
     "dynamic": 59,
     "computed": 7
   },
@@ -837,6 +837,12 @@
     },
     {
       "testId": "chat-scope",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-admission",
       "files": [
         "src/components/GroupChat.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,11 +10,11 @@
   "version": 1,
   "studioVersion": "0.5.4",
   "counts": {
-    "files": 138,
-    "occurrences": 1154,
-    "static": 992,
-    "dynamic": 57,
-    "computed": 6
+    "files": 139,
+    "occurrences": 1180,
+    "static": 1012,
+    "dynamic": 59,
+    "computed": 7
   },
   "static": [
     {
@@ -758,6 +758,12 @@
       ]
     },
     {
+      "testId": "chat-firstrun-scope",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
       "testId": "chat-layout-toggle",
       "files": [
         "src/components/GroupChat.tsx"
@@ -779,6 +785,12 @@
       "testId": "chat-needs-you",
       "files": [
         "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chat-open-error",
+      "files": [
+        "src/components/GroupChat.tsx"
       ]
     },
     {
@@ -821,6 +833,96 @@
       "testId": "chat-run-title",
       "files": [
         "src/components/ChatsPage.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-dangling",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-fallback-none",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-fixed",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-gap",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-graph",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-picker",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-picker-empty",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-picker-error",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-picker-loading",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-repo",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-repo-option",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-row",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-summary",
+      "files": [
+        "src/components/GroupChat.tsx"
+      ]
+    },
+    {
+      "testId": "chat-scope-unstated",
+      "files": [
+        "src/components/GroupChat.tsx"
       ]
     },
     {
@@ -3215,6 +3317,12 @@
       ]
     },
     {
+      "testId": "project-repo-reonboard-note",
+      "files": [
+        "src/components/ProjectRepositories.tsx"
+      ]
+    },
+    {
       "testId": "project-repo-row",
       "files": [
         "src/components/ProjectRepositories.tsx"
@@ -3470,6 +3578,18 @@
       "testId": "rail-evals-run",
       "files": [
         "src/components/LeftSidebar.tsx"
+      ]
+    },
+    {
+      "testId": "rail-governance",
+      "files": [
+        "src/components/HealthRailSection.tsx"
+      ]
+    },
+    {
+      "testId": "rail-governance-finding",
+      "files": [
+        "src/components/HealthRailSection.tsx"
       ]
     },
     {
@@ -6125,6 +6245,18 @@
       ]
     },
     {
+      "pattern": "*-reonboard",
+      "files": [
+        "src/components/RepoFindings.tsx"
+      ]
+    },
+    {
+      "pattern": "*-row",
+      "files": [
+        "src/components/RepoFindings.tsx"
+      ]
+    },
+    {
       "pattern": "*-search",
       "files": [
         "src/components/dashboardKit.tsx"
@@ -6369,9 +6501,11 @@
         "src/components/DashboardTiles.tsx",
         "src/components/DeckKpiRibbon.tsx",
         "src/components/FacetAutocomplete.tsx",
+        "src/components/HealthRailSection.tsx",
         "src/components/HomeCommand.tsx",
         "src/components/MetricTile.tsx",
         "src/components/ProvenanceLine.tsx",
+        "src/components/RepoFindings.tsx",
         "src/components/RunSparkline.tsx",
         "src/components/RunsBottomPanel.tsx",
         "src/components/SkillChips.tsx",
@@ -6393,6 +6527,12 @@
         "src/components/SteeringRuleDrawer.tsx",
         "src/components/SteeringRuleForm.tsx",
         "src/components/TestingPage.tsx"
+      ]
+    },
+    {
+      "expression": "tid",
+      "files": [
+        "src/components/GroupChat.tsx"
       ]
     },
     {

--- a/tests/DeckKpiRibbon.governance.test.tsx
+++ b/tests/DeckKpiRibbon.governance.test.tsx
@@ -1,0 +1,51 @@
+// #246 — the command deck's Governed tile degrades when the daemon says its governance
+// evidence is NOT landing (`GET /diagnostics`.governance: a null store, or an error finding such
+// as `governance.deadletter`) — the same signal the Health rail's heart reads. The claims-derived
+// percentage stays (it is what the claims say); it is painted in the fail token with the reason
+// underneath, and the tile carries `data-state="governance-error"`.
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DiagnosticsGovernance, GovernanceClaim } from '../src/api/types.js';
+import { DeckKpiRibbon } from '../src/components/DeckKpiRibbon.js';
+import { makeView } from './factories.js';
+import { GOVERNANCE_DEADLETTERS, GOVERNANCE_HEALTHY, GOVERNANCE_LEGACY_OUTBOX, GOVERNANCE_NO_STORE } from './fixtures/wave2.js';
+
+const NOW = 1_760_000_000_000;
+afterEach(cleanup);
+
+const RUNS = [makeView({ id: 'a', status: 'completed' }), makeView({ id: 'b', status: 'completed' })];
+// A claim's scope names its run (`runIdOfScope`: the id itself, or `wicked-agent/<id>`).
+const CLAIMS = [{ claim_id: 'c1', scope: 'wicked-agent/a', phase: 'build' }] as unknown as GovernanceClaim[];
+
+function ribbon(governance: DiagnosticsGovernance | null | undefined): HTMLElement {
+  render(<DeckKpiRibbon runs={RUNS} claims={CLAIMS} governance={governance} needCount={0} navigate={() => {}} now={NOW} />);
+  return screen.getByTestId('home-kpi-governed');
+}
+
+describe('DeckKpiRibbon — the Governed tile and diagnostics.governance (#246)', () => {
+  it('reads the claims percentage plainly when governance is healthy, absent, or only warning', () => {
+    for (const g of [GOVERNANCE_HEALTHY, GOVERNANCE_LEGACY_OUTBOX, null, undefined]) {
+      const tile = ribbon(g);
+      expect(tile).toHaveAttribute('data-value', '50%');
+      expect(tile).not.toHaveAttribute('data-state');
+      expect(tile.textContent).toContain('1/2 runs');
+      cleanup();
+    }
+  });
+
+  it('dead letters (the F-022 signal) degrade the tile: fail-coloured value, the count and a pointer to Health', () => {
+    const tile = ribbon(GOVERNANCE_DEADLETTERS);
+    expect(tile).toHaveAttribute('data-value', '50%'); // the claims still say 50 % — not rewritten
+    expect(tile).toHaveAttribute('data-state', 'governance-error');
+    expect(tile.querySelector('.deck-big')).toHaveStyle({ color: 'var(--status-fail)' });
+    expect(tile.textContent).toContain('128+ governance events dead-lettered (see Health)');
+    expect(tile.textContent).not.toContain('1/2 runs');
+  });
+
+  it('a boot that resolved NO store is never "Governed": the tile says evidence is not landing', () => {
+    const tile = ribbon(GOVERNANCE_NO_STORE);
+    expect(tile).toHaveAttribute('data-state', 'governance-error');
+    expect(tile.textContent).toContain('no governance store resolved — evidence is not landing (see Health)');
+  });
+});

--- a/tests/GroupChat.chips.test.tsx
+++ b/tests/GroupChat.chips.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat, chatCapable, defaultSelection, rosterSpeaksAcp } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
@@ -129,6 +129,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
       () => new Promise<{ roster: RosterSeat[] }>((res) => { release = res; }),
     );
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     // Before the resolve lands: the honest resolving state, ZERO chips —
     // never the writer/reviewer/planner trio dressed as seats.
@@ -163,6 +164,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
   it('WARM cache: chips render synchronously — roster-true, capability-filtered, zero requests', async () => {
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     expect(chipKeys()).toEqual(CAPABLE);
     expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '2');
@@ -177,6 +179,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     const user = userEvent.setup();
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     const displayed = chipKeys();
     await user.type(screen.getByRole('textbox'), 'hello seats');
@@ -191,6 +194,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     const user = userEvent.setup();
     getRoster.mockRejectedValueOnce(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     const failedRow = await screen.findByTestId('agent-chips-unresolved');
     expect(failedRow).toHaveTextContent(/couldn’t load the agent roster/);
@@ -211,6 +215,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     const user = userEvent.setup();
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await user.click(screen.getByRole('button', { name: 'Remove claude' }));
     expect(screen.getByTestId('agent-chips-bar')).toHaveAttribute('data-count', '1');
@@ -226,6 +231,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     const user = userEvent.setup();
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await user.click(screen.getByTestId('add-agent'));
     const options = await screen.findAllByTestId('agent-picker-option');
@@ -256,6 +262,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
     ] as unknown as RosterSeat[]);
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     expect(screen.queryAllByTestId('agent-chip')).toHaveLength(0);
     expect(screen.getByTestId('agent-chips-empty-note')).toHaveTextContent(/no agent has a chat \(ACP\) config/);
@@ -279,6 +286,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
       ] as unknown as RosterSeat[],
     });
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await waitFor(() => expect(screen.getAllByTestId('agent-chip').length).toBeGreaterThan(0));
     await user.click(screen.getByTestId('add-agent'));
 
@@ -309,6 +317,7 @@ describe('GroupChat — chips are truth (BRIEF-UX-001 C6/EC44)', () => {
       }),
     );
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     // The edit PINS the selection (§7.9-1) — no roster re-seed rides the send.
     await user.click(screen.getByRole('button', { name: 'Remove claude' }));

--- a/tests/GroupChat.firstrun.test.tsx
+++ b/tests/GroupChat.firstrun.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
@@ -75,6 +75,7 @@ beforeEach(() => {
 describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', () => {
   it('mounts cold: teaching state, NO painted chips (resolving row), the ONE named roster request, no Close — the AC verbatim', async () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     // The teaching state is on screen…
     const teach = screen.getByTestId('chat-firstrun');
@@ -106,6 +107,7 @@ describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', 
   it('the first send warms EXACTLY the displayed chips — typing is the opt-in, no hidden fan-out', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
 
     await user.type(screen.getByRole('textbox'), 'make me a deck');
@@ -133,6 +135,7 @@ describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', 
     const user = userEvent.setup();
     getRoster.mockRejectedValueOnce(new Error('daemon unreachable'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     const row = await screen.findByTestId('agent-chips-unresolved');
     expect(row).toHaveTextContent(/couldn’t load the agent roster/);
@@ -163,6 +166,7 @@ describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', 
   it('[+ Add] opens the roster picker and the addition joins the send', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await waitFor(() => expect(chipAgents()).toEqual(CAPABLE));
     expect(getRoster).toHaveBeenCalledTimes(1); // the mount resolve
 
@@ -191,6 +195,7 @@ describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', 
   it('a roster deposited by ANOTHER surface before the resolve lands seeds a PRISTINE selection — no duplicate fetch consumed', async () => {
     setCachedRoster(ROSTER);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     // Warm cache: chips render synchronously and the mount resolve is skipped.
     expect(chipAgents()).toEqual(CAPABLE);
     await waitFor(() => expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument());
@@ -205,6 +210,7 @@ describe('GroupChat — first-run teaches, nothing warms (§2.4 + §6 + EC44)', 
   it('Send is enabled by text alone once the roster is known — typing is the opt-in', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     const send = screen.getByRole('button', { name: 'Send' });
     expect(send).toBeDisabled();

--- a/tests/GroupChat.narrated.test.tsx
+++ b/tests/GroupChat.narrated.test.tsx
@@ -17,7 +17,7 @@
 //   - §11.6 the full transcript stays reachable behind the view toggle.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
@@ -96,6 +96,7 @@ describe('§11.1 — narration vs conversation in the DOM', () => {
   it('user turn stays a turn; a streaming worker output collapses to narration with the raw stream behind the expander', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'what needs fixing?');
 
     // The user's message is a first-class bubble.
@@ -124,6 +125,7 @@ describe('§11.1 — narration vs conversation in the DOM', () => {
   it('a short ok reply becomes a first-class conversational turn; an over-long one stays narration', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
 
     act(() => {
@@ -146,6 +148,7 @@ describe('§11.1 — narration vs conversation in the DOM', () => {
   it('a failed reply collapses to fail-tone narration', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'model refused', ok: false });
@@ -157,6 +160,7 @@ describe('§11.1 — narration vs conversation in the DOM', () => {
   it('seat lifecycle is narration: joined-the-chat lines carry the seat chip', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'hello');
     const seats = screen.getAllByTestId('chat-narration-seat').map((s) => s.textContent);
     expect(seats).toContain('claude');
@@ -169,6 +173,7 @@ describe('§11.2 — out-of-order arrival renders chronologically', () => {
   it('a turn-1 reply finalizing after turn 2 opened stays BEFORE the turn-2 user bubble', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'first ask');
     await user.type(screen.getByRole('textbox'), 'second ask');
     await user.keyboard('{Enter}');
@@ -192,6 +197,7 @@ describe('§11.4 — the pinned now-bar', () => {
   it('says working while a reply streams, your turn when the crew is done, and jumps to the tail', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
 
     expect(screen.getByTestId('now-bar-status')).toHaveTextContent('working');
@@ -214,6 +220,7 @@ describe('§11.4 — the pinned now-bar', () => {
   it('collects the artifacts replies name into the chip, and renders inline cards', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     act(() => {
       emit!({
@@ -232,6 +239,7 @@ describe('§11.5 — the pinned approval dock, answerable from the chat surface'
   it('a gate keyed by the chat session renders as a SIBLING of the scroll region, and reject carries the typed note', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
 
     act(() => {
@@ -265,6 +273,7 @@ describe('§11.5 — the pinned approval dock, answerable from the chat surface'
   it('an open elicitation docks the same way', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     act(() => {
       useElicitationStore.getState().setElicitation({
@@ -286,6 +295,7 @@ describe('§11.5 — the pinned approval dock, answerable from the chat surface'
     // run ids — swept gates[chatId], unmounting the dock mid-decision.
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
 
     act(() => {
@@ -333,6 +343,7 @@ describe('§11.5 — the pinned approval dock, answerable from the chat surface'
   it('renders no dock when nothing awaits the human', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     expect(screen.queryByTestId('approval-dock')).not.toBeInTheDocument();
   });
@@ -342,6 +353,7 @@ describe('§11.6 — the full transcript stays reachable', () => {
   it('the view toggle swaps narration for the old bubbles and back, zero requests', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'y'.repeat(3000), ok: true });
@@ -369,6 +381,7 @@ describe('§11.6 — the full transcript stays reachable', () => {
   it('picking a layout arrangement implies the full transcript', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'go');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'a', ok: true });

--- a/tests/GroupChat.project.test.tsx
+++ b/tests/GroupChat.project.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { setCachedRoster } from '../src/store/rosterCache.js';
@@ -79,6 +79,7 @@ describe('GroupChat — create-flow project binding (slice B)', () => {
   it('renders the Unfiled field, fetches nothing on mount, and opens the chat WITHOUT projectId', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     const field = screen.getByTestId('project-field');
     expect(field.textContent).toContain('Unfiled');
@@ -97,6 +98,7 @@ describe('GroupChat — create-flow project binding (slice B)', () => {
   it('loads projects on first open, and the selection binds the chat at creation', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await user.click(screen.getByTestId('project-field'));
     expect(listProjects).toHaveBeenCalledTimes(1);

--- a/tests/GroupChat.rejoin.test.tsx
+++ b/tests/GroupChat.rejoin.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 
@@ -357,6 +357,7 @@ describe('GroupChat — the routed session URL (J4/C6)', () => {
       <GroupChat repoId={null} onBack={() => undefined} routedChatId="gone-1" reflectUrl navigate={navigate} />,
     );
     await screen.findByTestId('chat-session-ended');
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await user.type(screen.getByRole('textbox'), 'start over');
     await user.keyboard('{Enter}');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
@@ -372,6 +373,7 @@ describe('GroupChat — the routed session URL (J4/C6)', () => {
     const user = userEvent.setup();
     const navigate = vi.fn();
     render(<GroupChat repoId={null} onBack={() => undefined} reflectUrl navigate={navigate} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const mintedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;
@@ -382,6 +384,7 @@ describe('GroupChat — the routed session URL (J4/C6)', () => {
   it('the reflection navigation does not reset the live transcript (routedChatId → own id)', async () => {
     const user = userEvent.setup();
     const view = render(<GroupChat repoId={null} onBack={() => undefined} reflectUrl />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await armViaFirstSend(user);
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     const mintedId = (openChat.mock.calls[0]?.[0] as { chatId: string }).chatId;

--- a/tests/GroupChat.repair.test.tsx
+++ b/tests/GroupChat.repair.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
@@ -87,6 +87,7 @@ describe('§7.9-2 — a failed send never clears the composer', () => {
     const user = userEvent.setup();
     sendChatMessage.mockRejectedValueOnce(new Error('daemon refused the fan-out'));
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await user.type(screen.getByRole('textbox'), 'first ask');
     await user.keyboard('{Enter}');
@@ -115,6 +116,7 @@ describe('§7.9-3 — chunk routing keys on seat+turn (per-seat FIFO)', () => {
   it('a still-streaming turn keeps its chunks when a second send opens the next turn — no mid-word splice', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await sendText(user, 'first ask');
     await user.type(screen.getByRole('textbox'), 'second ask');
@@ -145,6 +147,7 @@ describe('§7.9-3 — chunk routing keys on seat+turn (per-seat FIFO)', () => {
   it('an orphan chunk opens its own bubble — streamed text is never silently dropped', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'ask');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'done', ok: true });
@@ -160,6 +163,7 @@ describe('§7.9-4 / EC44 — explicit seat states', () => {
   it('working while a reply is pending, replied when it lands', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'ask');
 
     const chip = (agent: string): HTMLElement =>
@@ -187,6 +191,7 @@ describe('§7.9-4 / EC44 — explicit seat states', () => {
     );
     const user2 = user;
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user2, 'ask');
 
     const failed = document.querySelector('[data-testid="seat-chip"][data-agent="codex"]') as HTMLElement;
@@ -201,6 +206,7 @@ describe('the conversation→action bridge (§7.9)', () => {
     const user = userEvent.setup();
     const navigate = vi.fn();
     render(<GroupChat repoId={null} onBack={() => undefined} navigate={navigate} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'sketch the uploader');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'start with the seams', ok: true });

--- a/tests/GroupChat.scope.test.tsx
+++ b/tests/GroupChat.scope.test.tsx
@@ -126,6 +126,27 @@ describe('the scope choice belongs to the surface it was made on (review fix)', 
     expect('repoRefs' in lastBody(), 'the flat route\'s pick must not ride the shell\'s open').toBe(false);
   });
 
+  it('switching the Project field resets the pick — project B never inherits project A\'s repos', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT)));
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    fireEvent.click(within(options[0]!).getByRole('checkbox'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-repo-count', '1');
+    await user.click(screen.getByTestId('project-field'));
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBeGreaterThan(0));
+    await user.click(screen.getAllByTestId('project-switcher-option')[0]!);
+    const row = screen.getByTestId('chat-scope-row');
+    expect(row).toHaveAttribute('data-mode', 'project');
+    expect(row).not.toHaveAttribute('data-repo-count');
+    expect(screen.queryByTestId('chat-scope-picker')).toBeNull();
+    await typeAndSend('for the project');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().projectId).toBe('api-migration');
+    expect('repoRefs' in lastBody()).toBe(false);
+  });
+
   it('Close resets the pick too — the next chat on the surface starts from the default', async () => {
     openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_REPOS_NO_GRAPH)));
     render(<GroupChat repoId={null} onBack={() => undefined} />);

--- a/tests/GroupChat.scope.test.tsx
+++ b/tests/GroupChat.scope.test.tsx
@@ -51,7 +51,7 @@ vi.mock('../src/hooks/useEventStream.js', () => ({
 }));
 
 const { GroupChat } = await import('../src/components/GroupChat.js');
-const { chatScopeGap, describeChatOpenRefusal } = await import('../src/components/GroupChat.js');
+const { chatScopeGap, chatOpenedNothing, describeChatOpenRefusal } = await import('../src/components/GroupChat.js');
 const { clearRepoCache } = await import('../src/store/repoCache.js');
 
 const ROSTER = [{ key: 'claude', enabled_for_council: true }] as unknown as RosterSeat[];
@@ -106,6 +106,61 @@ describe('the gap rule (chatScopeGap)', () => {
     expect(describeChatOpenRefusal(501, CHAT_OPEN_REFUSALS.engine.body.error, 'x')).toMatch(/^This daemon cannot open a SCOPED chat — the installed wicked-core-ts predates chat scope/);
     expect(describeChatOpenRefusal(400, 'Invalid request body', 'the daemon refused this — Invalid request body')).toBe('the daemon refused this — Invalid request body');
     expect(describeChatOpenRefusal(null, null, 'boom')).toBe('boom');
+  });
+});
+
+describe('the scope choice belongs to the surface it was made on (review fix)', () => {
+  it('a route change resets the repo pick — the next open carries no stale repoRefs', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT)));
+    const view = render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    fireEvent.click(within(options[1]!).getByRole('checkbox'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-repo-count', '1');
+    // The App re-renders the SAME mount as a project shell (a different surface).
+    view.rerender(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-mode', 'project');
+    await typeAndSend('shell ask');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().projectId).toBe('api-migration');
+    expect('repoRefs' in lastBody(), 'the flat route\'s pick must not ride the shell\'s open').toBe(false);
+  });
+
+  it('Close resets the pick too — the next chat on the surface starts from the default', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_REPOS_NO_GRAPH)));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    fireEvent.click(within(options[1]!).getByRole('checkbox'));
+    await typeAndSend('first');
+    await screen.findByTestId('chat-scope');
+    fireEvent.click(screen.getByTestId('chat-close'));
+    await waitFor(() => expect(closeChat).toHaveBeenCalledTimes(1));
+    // (Close calls onBack; the surface itself is `ended`, so the assertion is on the stored pick
+    // through a fresh mount of the same surface.)
+    cleanup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-mode', 'project');
+    expect(getChat, 'the closed id was forgotten — no rejoin probe').not.toHaveBeenCalled();
+  });
+
+  it('project-shell sessions persist per PROJECT: project B never rejoins project A\'s chat', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT)));
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    await typeAndSend('for A');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const idA = lastBody().chatId!;
+    expect(sessionStorage.getItem('wicked.chat.project:api-migration')).toBe(idA);
+    expect(sessionStorage.getItem('wicked.chat._'), 'the flat key is not shared with the shell').toBeNull();
+    cleanup();
+    getChat.mockResolvedValue({ chatId: idA, seats: ['claude'], scope: SCOPE_PROJECT });
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="auth-refactor" />);
+    // Nothing stored for B: first-run, no probe of A's id.
+    expect(screen.getByTestId('chat-firstrun')).toBeInTheDocument();
+    expect(getChat).not.toHaveBeenCalled();
+    cleanup();
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    await waitFor(() => expect(getChat).toHaveBeenCalledWith(idA)); // A rejoins its own
   });
 });
 
@@ -262,7 +317,17 @@ describe('crew#502 refusals render as clear inline errors', () => {
     await typeAndSend('scoped');
   }
 
-  it('404 — every missing ref named, the remedy stated', async () => {
+  it('classifies which refusals opened nothing (chatOpenedNothing)', () => {
+    expect(chatOpenedNothing(404, "Repo 'x' not found")).toBe(true);
+    expect(chatOpenedNothing(400, 'ambiguous')).toBe(true);
+    expect(chatOpenedNothing(501, 'predates chat scope')).toBe(true);
+    expect(chatOpenedNothing(409, CHAT_OPEN_REFUSALS.overlap.body.error)).toBe(true);
+    expect(chatOpenedNothing(409, 'chat abc is already open on this daemon; DELETE /chats/abc first')).toBe(false);
+    expect(chatOpenedNothing(500, 'boom')).toBe(false);
+    expect(chatOpenedNothing(null, null)).toBe(false);
+  });
+
+  it('404 — every missing ref named, the remedy stated; the daemon opened nothing, so the create controls RETURN and the corrected pick mints fresh', async () => {
     refuse(CHAT_OPEN_REFUSALS.missing);
     render(<GroupChat repoId={null} onBack={() => undefined} />);
     await sendAsRepos();
@@ -271,6 +336,35 @@ describe('crew#502 refusals render as clear inline errors', () => {
     expect(err.textContent).toContain("Scope refused — Repo 'ghost', 'phantom' not found");
     expect(err.textContent).toContain('Name repositories that are registered');
     expect(screen.queryByTestId('chat-scope-fallback-none')).toBeNull();
+    const refusedId = lastBody().chatId;
+    // The provisional id points at no chat: it is forgotten and the scope row is back.
+    expect(sessionStorage.getItem('wicked.chat._')).toBeNull();
+    const row = screen.getByTestId('chat-scope-row');
+    expect(row).toHaveAttribute('data-mode', 'repos');
+    // Correct the pick (add the second repo) and send again: a FRESH id, the new refs.
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_REPOS_NO_GRAPH)));
+    // The picker (mode + the first pick) survives the refusal — only the dead id is dropped.
+    const options = screen.getAllByTestId('chat-scope-repo-option');
+    expect(options[0]).toHaveAttribute('data-checked', 'true');
+    fireEvent.click(within(options[1]!).getByRole('checkbox'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('textbox'));
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
+    expect(lastBody().chatId).not.toBe(refusedId);
+    expect(lastBody().repoRefs).toEqual(['studio-api', 'billing']);
+    expect(screen.queryByTestId('chat-open-error'), 'the refusal banner clears on the next attempt').toBeNull();
+  });
+
+  it('a TRANSPORT failure keeps the provisional id (FINDING-027) — the open may have warmed seats', async () => {
+    openChat.mockRejectedValue(new Error('Failed to fetch'));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none'));
+    await typeAndSend('hello');
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', 'none');
+    expect(sessionStorage.getItem('wicked.chat._')).toBe(lastBody().chatId!);
+    expect(screen.queryByTestId('chat-scope-row'), 'the chat may exist — the create controls stay hidden').toBeNull();
   });
 
   it('400 ambiguous name — the daemon\'s own "name the repo by id" sentence', async () => {

--- a/tests/GroupChat.scope.test.tsx
+++ b/tests/GroupChat.scope.test.tsx
@@ -275,6 +275,25 @@ describe('the create-flow scope control', () => {
     expect(graph).toHaveAttribute('title', SCOPE_REPOS_NO_GRAPH.graph.reason);
   });
 
+  it('the pick stops at the contract\'s 32 repoRefs — the 33rd option is disabled and titled with the cap; removal stays open', async () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ ...REPO_CLEAN, id: `r${i}`, name: `repo-${i}`, root_path: `/w2/repos/r${i}` }));
+    listRepos.mockResolvedValue({ repos: many });
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    expect(options).toHaveLength(40);
+    for (const o of options) fireEvent.click(within(o).getByRole('checkbox'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-repo-count', '32');
+    const capped = screen.getAllByTestId('chat-scope-repo-option').filter((o) => o.getAttribute('data-at-cap') === 'true');
+    expect(capped).toHaveLength(8);
+    expect(within(capped[0]!).getByRole('checkbox')).toBeDisabled();
+    expect(capped[0]!.getAttribute('title')).toContain('at most 32 repositories');
+    // Removing one re-opens a slot.
+    fireEvent.click(within(options[0]!).getByRole('checkbox'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-repo-count', '31');
+    expect(screen.getAllByTestId('chat-scope-repo-option').filter((o) => o.getAttribute('data-at-cap') === 'true')).toHaveLength(0);
+  });
+
   it('dangling project members are surfaced as a warning, never silently dropped', async () => {
     openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT_DANGLING)));
     render(<GroupChat repoId={null} onBack={() => undefined} projectId="auth-refactor" />);
@@ -331,6 +350,23 @@ describe('seat admissibility on a scoped open (review W3S-253-01)', () => {
     expect(byAgent['codex']!.textContent).toContain(REFUSED);
   });
 
+  it('the daemon admits a STRICT SUBSET of the default chips: exactly the admitted seats render, no phantom connecting chip, and the now-bar is not stuck on connecting (W3S-253-09)', async () => {
+    // Two chat-capable seats by default; the daemon's pre-filter admits only claude.
+    setCachedRoster([{ key: 'claude', enabled_for_council: true }, { key: 'pi', enabled_for_council: true }] as unknown as RosterSeat[]);
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT, ['claude'])));
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    expect(screen.getAllByTestId('agent-chip').map((c) => c.dataset['agent'])).toEqual(['claude', 'pi']);
+    await typeAndSend('subset');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect('clis' in lastBody()).toBe(false);
+    await waitFor(() => expect(screen.getAllByTestId('seat-chip').map((c) => c.dataset['agent'])).toEqual(['claude']));
+    // Give any late optimistic state a tick to surface — it must not.
+    await new Promise((r) => setTimeout(r, 50));
+    const states = screen.getAllByTestId('seat-chip').map((c) => c.dataset['state']);
+    expect(states).not.toContain('connecting');
+    expect(screen.getByTestId('now-bar-status').textContent).not.toBe('Connecting agents…');
+  });
+
   it('an EDITED selection is the operator\'s word — clis rides the scoped open as asked', async () => {
     openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT, body.clis ?? ['claude'])));
     const user = userEvent.setup();
@@ -364,6 +400,16 @@ describe('the scope statement on older daemons and rejoins', () => {
     const line = await screen.findByTestId('chat-scope');
     expect(line).toHaveAttribute('data-kind', 'unknown');
     expect(within(line).getByTestId('chat-scope-unstated').textContent).toContain('not stated by the daemon');
+  });
+
+  it('a 201 carrying `scope: null` (off-contract) reads like the omission — "not stated"', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve({ chatId: body.chatId, seats: [{ cliKey: 'claude', ok: true }], scope: null }));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none'));
+    await typeAndSend();
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'unknown');
+    expect(within(line).getByTestId('chat-scope-unstated')).toBeInTheDocument();
   });
 
   it('a rejoin states the ChatDetailResponse.scope; a null scope (chat this daemon did not open) is "not stated"', async () => {

--- a/tests/GroupChat.scope.test.tsx
+++ b/tests/GroupChat.scope.test.tsx
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiError } from '../src/api/errors.js';
+import type { ChatOpenBody, RosterSeat } from '../src/api/types.js';
+import { setCachedRoster } from '../src/store/rosterCache.js';
+import {
+  CHAT_OPEN_REFUSALS, REPO_CLEAN, REPO_INTREE_LIVE, SCOPE_NONE, SCOPE_PROJECT, SCOPE_PROJECT_DANGLING,
+  SCOPE_REPOS_NO_GRAPH, chatOpened,
+} from './fixtures/wave2.js';
+
+/**
+ * studio#248 (crew#502 / F-067, api-types 0.32.0) — New Chat carries a SCOPE control
+ * and the opened chat STATES its scope:
+ *   - project (default once a project is bound): `projectId` alone rides the open —
+ *     the daemon scopes to every `crew.repo` member; no `repoRefs`;
+ *   - repos: a multi-select from GET /repos (loaded on the picker's OPEN, never on
+ *     mount) → `repoRefs` (ids), with `projectId` when a project is bound (the union);
+ *   - none: an EXPLICIT click. An Unfiled chat with no choice does NOT open on send —
+ *     the gap is stated on the scope row, nothing is posted;
+ *   - the header states `ChatOpenResponse.scope`: repos (names, paths on hover),
+ *     read-only, the graph binding and its reason, dangling members; a rejoin states
+ *     `ChatDetailResponse.scope`, and a daemon that said nothing is reported as such;
+ *   - crew#502's refusals (404 missing refs, 400 ambiguous name, 409 conflict, 501
+ *     engine predates scope) render as inline sentences; the 501 offers Unscoped.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const listProjects = vi.fn();
+const listRepos = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+    listRepos: (...a: unknown[]) => listRepos(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({
+  useEventStream: () => undefined,
+}));
+
+const { GroupChat } = await import('../src/components/GroupChat.js');
+const { chatScopeGap, describeChatOpenRefusal } = await import('../src/components/GroupChat.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const ROSTER = [{ key: 'claude', enabled_for_council: true }] as unknown as RosterSeat[];
+const PROJECTS = [
+  { id: 'api-migration', name: 'api-migration', description: null, status: 'active', scope: 'project:api-migration', created_at: 1, updated_at: 5 },
+  { id: 'default', name: 'Unfiled', description: null, status: 'active', scope: '', created_at: 1, updated_at: 99 },
+];
+
+const lastBody = (): ChatOpenBody => openChat.mock.calls.at(-1)![0] as ChatOpenBody;
+
+async function typeAndSend(text = 'hello there'): Promise<void> {
+  const user = userEvent.setup();
+  await user.type(screen.getByRole('textbox'), text);
+  await user.keyboard('{Enter}');
+}
+
+beforeEach(() => {
+  openChat.mockReset();
+  getChat.mockReset();
+  closeChat.mockReset();
+  getRoster.mockReset();
+  sendChatMessage.mockReset();
+  listProjects.mockReset();
+  listRepos.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  listProjects.mockResolvedValue({ projects: PROJECTS });
+  listRepos.mockResolvedValue({ repos: [REPO_INTREE_LIVE, REPO_CLEAN] });
+  openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_NONE)));
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  closeChat.mockResolvedValue({ ok: true });
+  sessionStorage.clear();
+  localStorage.clear();
+  clearRepoCache();
+  setCachedRoster(ROSTER);
+});
+afterEach(() => cleanup());
+
+describe('the gap rule (chatScopeGap)', () => {
+  it('blocks the silent none and an empty repo pick; passes repo-entry, project, explicit none, and a filled pick', () => {
+    expect(chatScopeGap({ repoId: null, mode: 'project', projectId: null, repoIds: [] })).toMatch(/Unfiled chats give the agents nothing to read/);
+    expect(chatScopeGap({ repoId: null, mode: 'repos', projectId: null, repoIds: [] })).toMatch(/Pick at least one repository/);
+    expect(chatScopeGap({ repoId: 'r1', mode: 'project', projectId: null, repoIds: [] })).toBeNull();
+    expect(chatScopeGap({ repoId: null, mode: 'project', projectId: 'p', repoIds: [] })).toBeNull();
+    expect(chatScopeGap({ repoId: null, mode: 'none', projectId: null, repoIds: [] })).toBeNull();
+    expect(chatScopeGap({ repoId: null, mode: 'repos', projectId: null, repoIds: ['a'] })).toBeNull();
+  });
+
+  it('describes crew#502 refusals by status and leaves anything else as the translated message', () => {
+    expect(describeChatOpenRefusal(404, CHAT_OPEN_REFUSALS.missing.body.error, 'x')).toMatch(/^Scope refused — Repo 'ghost', 'phantom' not found\./);
+    expect(describeChatOpenRefusal(400, CHAT_OPEN_REFUSALS.ambiguous.body.error, 'x')).toMatch(/^Scope refused — repoRef 'api' is ambiguous/);
+    expect(describeChatOpenRefusal(409, CHAT_OPEN_REFUSALS.overlap.body.error, 'x')).toMatch(/^The daemon refused to open this chat — repo 'scratchpad'/);
+    expect(describeChatOpenRefusal(501, CHAT_OPEN_REFUSALS.engine.body.error, 'x')).toMatch(/^This daemon cannot open a SCOPED chat — the installed wicked-core-ts predates chat scope/);
+    expect(describeChatOpenRefusal(400, 'Invalid request body', 'the daemon refused this — Invalid request body')).toBe('the daemon refused this — Invalid request body');
+    expect(describeChatOpenRefusal(null, null, 'boom')).toBe('boom');
+  });
+});
+
+describe('the create-flow scope control', () => {
+  it('renders in the create window; with Unfiled a send is BLOCKED with the stated gap and posts nothing (zero requests on mount)', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const row = screen.getByTestId('chat-scope-row');
+    expect(row).toHaveAttribute('data-mode', 'project');
+    expect(screen.getByTestId('chat-scope-project')).toBeDisabled(); // no project bound yet
+    expect(screen.getByTestId('chat-scope-summary').textContent).toContain('no project selected');
+    expect(screen.getByTestId('chat-firstrun-scope').textContent).toContain('read only the repositories in scope');
+    expect(listRepos).not.toHaveBeenCalled();
+    await typeAndSend();
+    expect(openChat).not.toHaveBeenCalled();
+    expect(row).toHaveAttribute('data-blocked', 'true');
+    expect(screen.getByTestId('chat-scope-gap').textContent).toContain('continue unscoped');
+    // The draft is still in the composer — nothing was lost.
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('hello there');
+  });
+
+  it('an EXPLICIT Unscoped click lets the send open the chat with neither projectId nor repoRefs, and the header states "unscoped"', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-mode', 'none');
+    await typeAndSend();
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const body = lastBody();
+    expect('projectId' in body).toBe(false);
+    expect('repoRefs' in body).toBe(false);
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'none');
+    expect(line.textContent).toContain('unscoped — the agents see only their private scratch root');
+    // The create-window control is gone once the chat exists.
+    expect(screen.queryByTestId('chat-scope-row')).toBeNull();
+  });
+
+  it('a bound project defaults to "all project repos": projectId alone rides the open, no repoRefs; the 201 scope is stated with repo names, paths on hover, and the graph binding', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT)));
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await user.click(screen.getByTestId('project-field'));
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBeGreaterThan(0));
+    await user.click(screen.getAllByTestId('project-switcher-option')[0]!);
+    expect(screen.getByTestId('chat-scope-project')).not.toBeDisabled();
+    expect(screen.getByTestId('chat-scope-project')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('chat-scope-none'), 'a filed chat is scoped to its project — none is not an option').toBeDisabled();
+    expect(screen.getByTestId('chat-scope-summary').textContent).toContain('every repository of the project');
+    await typeAndSend('file me');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().projectId).toBe('api-migration');
+    expect('repoRefs' in lastBody()).toBe(false);
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'project');
+    expect(line).toHaveAttribute('data-graph-bound', 'true');
+    expect(line.textContent).toContain('2 repositories · read-only');
+    const repos = within(line).getAllByTestId('chat-scope-repo');
+    expect(repos.map((r) => r.textContent)).toEqual(['studio-api', 'billing']);
+    expect(repos[0]).toHaveAttribute('title', '/w2/repos/studio-api');
+    expect(within(line).getByTestId('chat-scope-graph')).toHaveTextContent('code graph bound');
+    expect(within(line).queryByTestId('chat-scope-dangling')).toBeNull();
+  });
+
+  it('"Choose repos…" loads GET /repos on THAT gesture, an empty pick blocks, a pick sends repoRefs (ids); the 201 states the unbound graph WITH its reason', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_REPOS_NO_GRAPH)));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    expect(listRepos).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    expect(options.map((o) => o.getAttribute('data-repo-id'))).toEqual(['studio-api', 'billing']);
+    expect(options[1]).toHaveAttribute('title', '/w2/repos/billing');
+    // Nothing picked yet: the send is blocked with the pick gap.
+    await typeAndSend('scoped ask');
+    expect(openChat).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-scope-gap').textContent).toContain('Pick at least one repository');
+    fireEvent.click(within(options[1]!).getByRole('checkbox'));
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-repo-count', '1');
+    expect(screen.getByTestId('chat-scope-summary').textContent).toContain('1 repository · read-only · its own graph when indexed');
+    const user = userEvent.setup();
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().repoRefs).toEqual(['billing']);
+    expect('projectId' in lastBody()).toBe(false);
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'repos');
+    expect(line).toHaveAttribute('data-graph-bound', 'false');
+    const graph = within(line).getByTestId('chat-scope-graph');
+    expect(graph.textContent).toContain('no code graph — \'billing\' has no resolvable code graph');
+    expect(graph).toHaveAttribute('title', SCOPE_REPOS_NO_GRAPH.graph.reason);
+  });
+
+  it('dangling project members are surfaced as a warning, never silently dropped', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT_DANGLING)));
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="auth-refactor" />);
+    // The project shell shows the scope control too (it can narrow the project default).
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-mode', 'project');
+    await typeAndSend('shell-bound');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-dangling', '1');
+    const dangling = within(line).getByTestId('chat-scope-dangling');
+    expect(dangling.textContent).toContain('1 project member not readable');
+    expect(dangling.textContent).toContain('old-auth-service');
+    expect(within(line).getByTestId('chat-scope-graph').textContent).toContain('the project graph has never been built');
+  });
+
+  it('a repo-entry chat (repoId) is its own scope: no control, no gap, repoRef rides the open as before', async () => {
+    render(<GroupChat repoId="studio-api" onBack={() => undefined} />);
+    expect(screen.getByTestId('chat-scope-fixed').textContent).toContain('this repository');
+    expect(screen.queryByTestId('chat-scope-none')).toBeNull();
+    await typeAndSend('repo ask');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().repoRef).toBe('studio-api');
+  });
+});
+
+describe('the scope statement on older daemons and rejoins', () => {
+  it('a 201 WITHOUT a scope (pre-0.32 daemon) is stated as "not stated", never guessed', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve({ chatId: body.chatId, seats: [{ cliKey: 'claude', ok: true }] }));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none'));
+    await typeAndSend();
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'unknown');
+    expect(within(line).getByTestId('chat-scope-unstated').textContent).toContain('not stated by the daemon');
+  });
+
+  it('a rejoin states the ChatDetailResponse.scope; a null scope (chat this daemon did not open) is "not stated"', async () => {
+    sessionStorage.setItem('wicked.chat._', 'live-1');
+    getChat.mockResolvedValue({ chatId: 'live-1', seats: ['claude'], scope: SCOPE_PROJECT });
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const line = await screen.findByTestId('chat-scope');
+    expect(line).toHaveAttribute('data-kind', 'project');
+    expect(within(line).getAllByTestId('chat-scope-repo')).toHaveLength(2);
+    cleanup();
+
+    sessionStorage.setItem('wicked.chat._', 'live-2');
+    getChat.mockResolvedValue({ chatId: 'live-2', seats: ['claude'], scope: null });
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    const unknown = await screen.findByTestId('chat-scope');
+    expect(unknown).toHaveAttribute('data-kind', 'unknown');
+  });
+});
+
+describe('crew#502 refusals render as clear inline errors', () => {
+  const refuse = (r: { status: number; body: { error: string } }): void => {
+    openChat.mockRejectedValue(new ApiError(r.status, r.body.error));
+  };
+
+  async function sendAsRepos(): Promise<void> {
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    fireEvent.click(within(options[0]!).getByRole('checkbox'));
+    await typeAndSend('scoped');
+  }
+
+  it('404 — every missing ref named, the remedy stated', async () => {
+    refuse(CHAT_OPEN_REFUSALS.missing);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendAsRepos();
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', '404');
+    expect(err.textContent).toContain("Scope refused — Repo 'ghost', 'phantom' not found");
+    expect(err.textContent).toContain('Name repositories that are registered');
+    expect(screen.queryByTestId('chat-scope-fallback-none')).toBeNull();
+  });
+
+  it('400 ambiguous name — the daemon\'s own "name the repo by id" sentence', async () => {
+    refuse(CHAT_OPEN_REFUSALS.ambiguous);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendAsRepos();
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', '400');
+    expect(err.textContent).toContain("repoRef 'api' is ambiguous");
+    expect(err.textContent).toContain('name the repo by id');
+  });
+
+  it('409 — the daemon\'s conflict sentence, whole', async () => {
+    refuse(CHAT_OPEN_REFUSALS.overlap);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendAsRepos();
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', '409');
+    expect(err.textContent).toContain('The daemon refused to open this chat — repo \'scratchpad\' is registered at');
+  });
+
+  it('501 — the engine predates chat scope: stated, and "Continue unscoped" re-arms a FRESH unscoped chat', async () => {
+    refuse(CHAT_OPEN_REFUSALS.engine);
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    await sendAsRepos();
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', '501');
+    expect(err.textContent).toContain('This daemon cannot open a SCOPED chat — the installed wicked-core-ts predates chat scope');
+    const refusedId = lastBody().chatId;
+    // The remedy the daemon names: an unscoped open. It must NOT reuse the refused
+    // id (the daemon parks it as closing — a reuse would 409).
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_NONE)));
+    fireEvent.click(screen.getByTestId('chat-scope-fallback-none'));
+    expect(screen.queryByTestId('chat-open-error')).toBeNull();
+    expect(screen.getByTestId('chat-scope-row')).toHaveAttribute('data-mode', 'none');
+    const user = userEvent.setup();
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(2));
+    const retry = lastBody();
+    expect(retry.chatId).not.toBe(refusedId);
+    expect('repoRefs' in retry).toBe(false);
+    expect('projectId' in retry).toBe(false);
+    expect(await screen.findByTestId('chat-scope')).toHaveAttribute('data-kind', 'none');
+  });
+
+  it('the 501 inside a project shell states the remedy but offers no fallback (the shell IS the project)', async () => {
+    refuse(CHAT_OPEN_REFUSALS.engine);
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    await typeAndSend('shell');
+    const err = await screen.findByTestId('chat-open-error');
+    expect(err).toHaveAttribute('data-status', '501');
+    expect(screen.queryByTestId('chat-scope-fallback-none')).toBeNull();
+  });
+});

--- a/tests/GroupChat.scope.test.tsx
+++ b/tests/GroupChat.scope.test.tsx
@@ -104,6 +104,8 @@ describe('the gap rule (chatScopeGap)', () => {
     expect(describeChatOpenRefusal(400, CHAT_OPEN_REFUSALS.ambiguous.body.error, 'x')).toMatch(/^Scope refused — repoRef 'api' is ambiguous/);
     expect(describeChatOpenRefusal(409, CHAT_OPEN_REFUSALS.overlap.body.error, 'x')).toMatch(/^The daemon refused to open this chat — repo 'scratchpad'/);
     expect(describeChatOpenRefusal(501, CHAT_OPEN_REFUSALS.engine.body.error, 'x')).toMatch(/^This daemon cannot open a SCOPED chat — the installed wicked-core-ts predates chat scope/);
+    // A 404 that is not a repo 404 (the route also answers `Project <id> not found`) reads plain.
+    expect(describeChatOpenRefusal(404, 'Project proj_9 not found', 'x')).toBe('Project proj_9 not found');
     expect(describeChatOpenRefusal(400, 'Invalid request body', 'the daemon refused this — Invalid request body')).toBe('the daemon refused this — Invalid request body');
     expect(describeChatOpenRefusal(null, null, 'boom')).toBe('boom');
   });
@@ -295,6 +297,61 @@ describe('the create-flow scope control', () => {
     await typeAndSend('repo ask');
     await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
     expect(lastBody().repoRef).toBe('studio-api');
+  });
+});
+
+describe('seat admissibility on a scoped open (review W3S-253-01)', () => {
+  const REFUSED = "seat 'codex' is not admissible for a scoped chat: no acp_input_governance and no os_sandbox";
+  const answerWithRefusal = (body: ChatOpenBody) =>
+    Promise.resolve({
+      chatId: body.chatId!,
+      seats: [{ cliKey: 'claude', ok: true }, { cliKey: 'codex', ok: false, error: REFUSED }],
+      scope: SCOPE_PROJECT,
+    });
+
+  it('untouched chips + a scope ⇒ the open OMITS clis (the daemon pre-filters), the 201 re-seeds the chips, and a refused seat says why', async () => {
+    openChat.mockImplementation(answerWithRefusal);
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    expect(screen.queryByTestId('chat-scope-admission'), 'no scope yet — no admission sentence').toBeNull();
+    await user.click(screen.getByTestId('project-field'));
+    await waitFor(() => expect(screen.getAllByTestId('project-switcher-option').length).toBeGreaterThan(0));
+    await user.click(screen.getAllByTestId('project-switcher-option')[0]!);
+    expect(screen.getByTestId('chat-scope-admission').textContent).toContain('a scoped chat admits only governed seats — refused seats say why');
+    await typeAndSend('scoped, default chips');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect('clis' in lastBody(), 'the daemon picks the admissible default seats').toBe(false);
+    expect(lastBody().projectId).toBe('api-migration');
+    // The header chips are the daemon's answer: claude ready, codex failed WITH the engine's sentence.
+    const chips = await screen.findAllByTestId('seat-chip');
+    const byAgent = Object.fromEntries(chips.map((c) => [c.getAttribute('data-agent'), c]));
+    // (claude is `working` the moment the first send fans out to it — either warm state is the point.)
+    expect(['ready', 'working']).toContain(byAgent['claude']!.getAttribute('data-state'));
+    expect(byAgent['codex']).toHaveAttribute('data-state', 'failed');
+    expect(byAgent['codex']!.textContent).toContain(REFUSED);
+  });
+
+  it('an EDITED selection is the operator\'s word — clis rides the scoped open as asked', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT, body.clis ?? ['claude'])));
+    const user = userEvent.setup();
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    // The roster here is one seat; removing it empties the selection, so re-add via the picker is
+    // out of scope — instead pin the edit through the Remove control on a two-seat roster.
+    setCachedRoster([{ key: 'claude', enabled_for_council: true }, { key: 'pi', enabled_for_council: true }] as unknown as RosterSeat[]);
+    cleanup();
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="api-migration" />);
+    await user.click(screen.getByRole('button', { name: 'Remove pi' }));
+    await typeAndSend('edited chips');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().clis).toEqual(['claude']);
+  });
+
+  it('an UNSCOPED open keeps the displayed chips as the audience (EC44) — clis is sent', async () => {
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none'));
+    await typeAndSend('unscoped');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(lastBody().clis).toEqual(['claude']);
   });
 });
 

--- a/tests/GroupChat.seatTruth.test.tsx
+++ b/tests/GroupChat.seatTruth.test.tsx
@@ -16,7 +16,7 @@
 //     message log the feed narrates from — so the two can never disagree.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { retainOnFinalize } from '../src/components/ChatThread.js';
@@ -90,6 +90,7 @@ describe('collapse retention — expanding restores every streamed byte', () => 
   it('a >collapse-threshold stream survives a SHORTER terminal reply; collapse → expand is byte-equal', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'plan it');
 
     // Stream well past CHAT_TURN_MAX_CHARS (1400) in several deltas — one line,
@@ -147,6 +148,7 @@ describe('one source for seat truth — the chip reads the feed’s own log', ()
   it('a not-ok reply shows FAILED on the header chip (with the turn’s reason), never "replied" (E4)', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'plan it');
 
     act(() => {
@@ -174,6 +176,7 @@ describe('one source for seat truth — the chip reads the feed’s own log', ()
   it('a seat streaming its next turn is WORKING again — the posture heals forward', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     await sendText(user, 'plan it');
     act(() => {
       emit!({ type: 'chatReply', chat: chatId(), cliKey: 'claude', text: 'nope', ok: false });

--- a/tests/GroupChat.tokens.test.tsx
+++ b/tests/GroupChat.tokens.test.tsx
@@ -20,7 +20,7 @@
  *     keep those pinned; this file is the visual-language contract only.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupChat } from '../src/components/GroupChat.js';
 import { setCachedRoster } from '../src/store/rosterCache.js';
@@ -73,6 +73,7 @@ beforeEach(() => {
 describe('GroupChat — the §5.3 visual language', () => {
   it('the first-run instruction reads sans / --ink-body', () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     const instruction = screen.getByTestId('chat-firstrun-instruction');
     expect(instruction.style.fontFamily).toBe('var(--font-sans)');
     expect(instruction.style.color).toBe('var(--ink-body)');
@@ -81,6 +82,7 @@ describe('GroupChat — the §5.3 visual language', () => {
 
   it('the composer: --surface-raised, --radius-xl, and the wk-composer focus-ring hook', () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     const composer = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(composer.className).toContain('wk-composer');
     expect(composer.style.background).toBe('var(--surface-raised)');
@@ -90,6 +92,7 @@ describe('GroupChat — the §5.3 visual language', () => {
 
   it('the default chips wear §6.3 anatomy in tokens; [+ Add] is dashed --ink-dim; Send is accent-filled', () => {
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
     const chip = screen.getAllByTestId('agent-chip')[0]!;
     expect(chip.style.background).toBe('var(--surface-raised)');
     expect(chip.style.borderRadius).toBe('var(--radius-full)');
@@ -120,6 +123,7 @@ describe('GroupChat — the §5.3 visual language', () => {
   it('user messages are transparent; agent bubbles sit on --surface-card; chips disclose with wk-disclose', async () => {
     const user = userEvent.setup();
     render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-none')); // studio#248: Unfiled = an EXPLICIT unscoped choice before the first send
 
     await user.type(screen.getByRole('textbox'), 'make me a deck');
     await user.keyboard('{Enter}');

--- a/tests/HealthRailSection.governance.test.tsx
+++ b/tests/HealthRailSection.governance.test.tsx
@@ -59,6 +59,29 @@ describe('the fetch rides the expand gesture (EC30)', () => {
   });
 });
 
+describe('only the CURRENT expand\'s answer lands', () => {
+  it('a slow read from an earlier expand cannot overwrite a later expand\'s governance block', async () => {
+    let releaseFirst: (v: unknown) => void = () => undefined;
+    let releaseSecond: (v: unknown) => void = () => undefined;
+    const answers = [
+      new Promise((resolve) => { releaseFirst = resolve; }),
+      new Promise((resolve) => { releaseSecond = resolve; }),
+    ];
+    diagnosticsAnswer = () => answers.shift()!;
+    const { rerender } = render(<HealthRailSection open onToggle={() => undefined} />);
+    rerender(<HealthRailSection open={false} onToggle={() => undefined} />);
+    rerender(<HealthRailSection open onToggle={() => undefined} />);
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    releaseSecond({ governance: GOVERNANCE_HEALTHY });
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'ok');
+    releaseFirst({ governance: GOVERNANCE_DEADLETTERS }); // the stale first read lands late
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.getByTestId('rail-governance')).toHaveAttribute('data-state', 'ok');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
+  });
+});
+
 describe('the healthy store', () => {
   it('names the store path + source, the record counts, zero dead letters, no findings; heart stays green', async () => {
     withGovernance(GOVERNANCE_HEALTHY);
@@ -70,6 +93,10 @@ describe('the healthy store', () => {
     expect(gov.textContent).toContain('via core-db-sidecar');
     expect(within(gov).getByTestId('rail-governance-store-path').textContent).toContain('/w2/state/core.db.governance/governance.db');
     expect(gov.textContent).toContain('412 records · 37 since boot');
+    // The outbox is part of the account even when it is empty — the operator can see where
+    // a dead letter WOULD land.
+    expect(within(gov).getByTestId('rail-governance-outbox').textContent).toContain('/w2/state/core.db.governance/emit-outbox.ndjson');
+    expect(within(gov).queryByTestId('rail-governance-by-type')).toBeNull();
     expect(within(gov).queryByTestId('rail-governance-finding')).toBeNull();
     expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
     expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();

--- a/tests/HealthRailSection.governance.test.tsx
+++ b/tests/HealthRailSection.governance.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { useState } from 'react';
 import { ApiError } from '../src/api/errors.js';
 import type { DiagnosticsGovernance } from '../src/api/types.js';

--- a/tests/HealthRailSection.governance.test.tsx
+++ b/tests/HealthRailSection.governance.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { useState } from 'react';
+import { ApiError } from '../src/api/errors.js';
+import type { DiagnosticsGovernance } from '../src/api/types.js';
+import { useConnectionStore } from '../src/store/connection.js';
+import {
+  GOVERNANCE_DEADLETTERS, GOVERNANCE_HEALTHY, GOVERNANCE_LEGACY_OUTBOX, GOVERNANCE_NO_STORE,
+} from './fixtures/wave2.js';
+
+/**
+ * studio#246 — the Health rail renders `GET /diagnostics`.governance (crew#495 / F-022,
+ * api-types 0.31.0+): the store + which rule chose it, the record counts (an honest
+ * "engine cannot count" for null), the dead-letter fold (count, by type / by reason,
+ * the timestamp range, truncated, the legacy HOME outbox) and every finding as a
+ * severity-styled row carrying the replay recipe. Null-safe: a daemon without the
+ * block (or without the route) says "not reported"; a null store is never "Governed"
+ * — it turns the heart red, as does an error finding; a warning finding degrades.
+ */
+
+let diagnosticsAnswer: () => Promise<unknown> = () => Promise.resolve({});
+const apiFetch = vi.fn((path: string) => (path === '/diagnostics' ? diagnosticsAnswer() : Promise.reject(new Error(`unexpected ${path}`))));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getHealth: () => Promise.resolve({ status: 'ok', version: '0.7.0', ping: 'pong' }),
+    getRoster: () => Promise.resolve({ roster: [] }),
+    listRepos: () => Promise.resolve({ repos: [] }),
+  },
+  apiFetch: (path: string) => apiFetch(path),
+}));
+
+const { HealthRailSection } = await import('../src/components/HealthRailSection.js');
+
+function Harness(): React.ReactElement {
+  const [open, setOpen] = useState(true);
+  return <HealthRailSection open={open} onToggle={() => setOpen((v) => !v)} />;
+}
+
+function withGovernance(g: DiagnosticsGovernance): void {
+  diagnosticsAnswer = () => Promise.resolve({ components: {}, daemon: {}, stores: [], recentErrors: [], acp: { byCli: {} }, governance: g });
+}
+
+beforeEach(() => {
+  apiFetch.mockClear();
+  useConnectionStore.setState({ status: 'connected' });
+});
+afterEach(() => cleanup());
+
+describe('the fetch rides the expand gesture (EC30)', () => {
+  it('fires ONE GET /diagnostics on expand, none before', async () => {
+    withGovernance(GOVERNANCE_HEALTHY);
+    const { rerender } = render(<HealthRailSection open={false} onToggle={() => undefined} />);
+    expect(apiFetch).not.toHaveBeenCalled();
+    rerender(<HealthRailSection open onToggle={() => undefined} />);
+    await screen.findByTestId('rail-governance');
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).toHaveBeenCalledWith('/diagnostics');
+  });
+});
+
+describe('the healthy store', () => {
+  it('names the store path + source, the record counts, zero dead letters, no findings; heart stays green', async () => {
+    withGovernance(GOVERNANCE_HEALTHY);
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'ok');
+    expect(gov).toHaveAttribute('data-store', 'core-db-sidecar');
+    expect(gov).toHaveAttribute('data-deadletters', '0');
+    expect(gov.textContent).toContain('via core-db-sidecar');
+    expect(within(gov).getByTestId('rail-governance-store-path').textContent).toContain('/w2/state/core.db.governance/governance.db');
+    expect(gov.textContent).toContain('412 records · 37 since boot');
+    expect(within(gov).queryByTestId('rail-governance-finding')).toBeNull();
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
+    expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
+  });
+});
+
+describe('the F-022 signal — dead letters', () => {
+  it('renders the count as a floor, the by-type / by-reason tallies, the range, the outbox, and the error finding with its replay recipe', async () => {
+    withGovernance(GOVERNANCE_DEADLETTERS);
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'error');
+    expect(gov).toHaveAttribute('data-deadletters', '128');
+    expect(gov.textContent).toContain('128+');
+    expect(within(gov).getByTestId('rail-governance-by-type').textContent).toContain('wicked.crew.governance.conformance_recorded ×96');
+    expect(within(gov).getByTestId('rail-governance-by-reason').textContent).toContain('no shared store (WICKED_ESTATE_DB unset) ×128');
+    const when = within(gov).getByTestId('rail-governance-range').textContent ?? '';
+    expect(when).toContain('2026-09-10 16:00:00Z → 2026-09-10 18:00:00Z');
+    expect(when).toContain('8 untimestamped');
+    expect(when).toContain('count is a floor');
+    expect(within(gov).getByTestId('rail-governance-outbox').textContent).toContain('/w2/state/core.db.governance/emit-outbox.ndjson');
+    const finding = within(gov).getByTestId('rail-governance-finding');
+    expect(finding).toHaveAttribute('data-kind', 'governance.deadletter');
+    expect(finding).toHaveAttribute('data-severity', 'error');
+    expect(finding.textContent).toContain('wicked-crew governance replay /w2/state/core.db.governance/emit-outbox.ndjson --governance-db');
+    // An error finding is a health failure: red heart + the collapsed-header dot.
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'unhealthy');
+    expect(screen.getByTestId('rail-health-summary-dot')).toBeInTheDocument();
+  });
+});
+
+describe('a boot that resolved NO store', () => {
+  it('is never shown as governed: the store row fails, records read "engine cannot count", the governance.store error renders, heart red', async () => {
+    withGovernance(GOVERNANCE_NO_STORE);
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'error');
+    expect(gov).toHaveAttribute('data-store', 'none');
+    expect(gov.textContent).toContain('none resolved — emits dead-letter');
+    expect(gov.textContent).toContain('engine cannot count');
+    expect(gov.textContent).not.toMatch(/\b0 records\b/);
+    expect(within(gov).getByTestId('rail-governance-finding')).toHaveAttribute('data-kind', 'governance.store');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'unhealthy');
+  });
+});
+
+describe('the pre-fix HOME outbox', () => {
+  it('renders the legacy outbox path + bytes and the warning finding; heart degrades to amber, no fail dot', async () => {
+    withGovernance(GOVERNANCE_LEGACY_OUTBOX);
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'warning');
+    expect(within(gov).getByTestId('rail-governance-legacy').textContent).toContain('/w2/home/.something-wicked/wicked-apps/emit-outbox.ndjson · 48213 bytes');
+    const finding = within(gov).getByTestId('rail-governance-finding');
+    expect(finding).toHaveAttribute('data-kind', 'governance.legacy-outbox');
+    expect(finding).toHaveAttribute('data-severity', 'warning');
+    // `sinceBoot: null` beside a counted total reads as the total alone — never an invented 0.
+    expect(gov.textContent).toContain('12 records');
+    expect(gov.textContent).not.toContain('since boot');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded');
+    expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
+  });
+});
+
+describe('older daemons — null-safe by construction', () => {
+  it('a /diagnostics WITHOUT a governance block says "not reported" and does not degrade', async () => {
+    diagnosticsAnswer = () => Promise.resolve({ components: {}, daemon: {}, stores: [], recentErrors: [], acp: { byCli: {} } });
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'absent');
+    expect(gov).toHaveAttribute('data-why', 'no-block');
+    expect(gov.textContent).toContain('not reported by this daemon');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
+  });
+
+  it('a daemon with NO /diagnostics route (unknown-route 404) says so too', async () => {
+    diagnosticsAnswer = () => Promise.reject(new ApiError(404, 'not found'));
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-why', 'no-route');
+    expect(gov.textContent).toContain('no /diagnostics route');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
+  });
+
+  it('a diagnostics read that FAILS (5xx) renders the unreachable row and degrades — never a guessed store', async () => {
+    diagnosticsAnswer = () => Promise.reject(new ApiError(500, 'boom'));
+    render(<Harness />);
+    await waitFor(() => expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded'));
+    expect(screen.queryByTestId('rail-governance')).toBeNull();
+    expect(screen.getByText('governance').parentElement?.textContent).toContain('unreachable');
+  });
+});

--- a/tests/HealthRailSection.governance.test.tsx
+++ b/tests/HealthRailSection.governance.test.tsx
@@ -181,11 +181,14 @@ describe('older daemons — null-safe by construction', () => {
     expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
   });
 
-  it('a diagnostics read that FAILS (5xx) renders the unreachable row and degrades — never a guessed store', async () => {
-    diagnosticsAnswer = () => Promise.reject(new ApiError(500, 'boom'));
+  it('a diagnostics read that FAILS (5xx) renders the unreachable row WITH its reason and degrades — never a guessed store', async () => {
+    diagnosticsAnswer = () => Promise.reject(new ApiError(500, 'governance fold crashed: ENOSPC'));
     render(<Harness />);
     await waitFor(() => expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded'));
-    expect(screen.queryByTestId('rail-governance')).toBeNull();
-    expect(screen.getByText('governance').parentElement?.textContent).toContain('unreachable');
+    const gov = screen.getByTestId('rail-governance');
+    expect(gov).toHaveAttribute('data-state', 'error');
+    expect(gov.textContent).toContain('unreachable');
+    // The daemon's own sentence rides the row (the translated ApiError message) — not dropped.
+    expect(within(gov).getByTestId('rail-governance-error').textContent).toContain('governance fold crashed: ENOSPC');
   });
 });

--- a/tests/HealthRailSection.governance.test.tsx
+++ b/tests/HealthRailSection.governance.test.tsx
@@ -143,6 +143,15 @@ describe('a boot that resolved NO store', () => {
   });
 });
 
+describe('records — the two counts state themselves independently', () => {
+  it('an uncountable total beside a counted sinceBoot shows both facts', async () => {
+    withGovernance({ ...GOVERNANCE_HEALTHY, records: { total: null, sinceBoot: 5 } });
+    render(<Harness />);
+    const gov = await screen.findByTestId('rail-governance');
+    expect(gov.textContent).toContain('total: engine cannot count · 5 since boot');
+  });
+});
+
 describe('the pre-fix HOME outbox', () => {
   it('renders the legacy outbox path + bytes and the warning finding; heart degrades to amber, no fail dot', async () => {
     withGovernance(GOVERNANCE_LEGACY_OUTBOX);

--- a/tests/HealthRailSection.test.tsx
+++ b/tests/HealthRailSection.test.tsx
@@ -16,12 +16,19 @@ const getHealth = vi.fn(() => Promise.resolve({ status: 'ok', version: '0.6.0', 
 let rosterAnswer: RosterSeat[] = [];
 const getRoster = vi.fn(() => Promise.resolve({ roster: rosterAnswer }));
 
+// `GET /diagnostics` rides the same expand (studio#246); this suite pins the seat
+// registry, so the daemon here answers a diagnostics body WITHOUT a governance
+// block (predates crew#495) — the honest "not reported" row, never degraded.
+// The governance rows themselves are pinned in HealthRailSection.governance.test.
+const apiFetch = vi.fn(() => Promise.resolve({}));
+
 vi.mock('../src/api/client.js', () => ({
   api: {
     getHealth: () => getHealth(),
     getRoster: () => getRoster(),
     listRepos: () => Promise.resolve({ repos: [] }),
   },
+  apiFetch: (...a: unknown[]) => apiFetch(...(a as [])),
 }));
 
 vi.mock('../src/hooks/useBoardModel.js', () => ({

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -20,7 +20,7 @@ const REPOS: RepoEntry[] = [REPO_CLEAN, REPO_PREDATES_FINDINGS, REPO_INTREE_LIVE
 
 const listRepos = vi.fn(() => Promise.resolve({ repos: REPOS }));
 const listRuns = vi.fn(() => Promise.resolve({ runs: [makeView({ id: 'r-1', repo_ref: 'billing', workflow_id: 'onboarding', status: 'completed' })] }));
-const rerunOnboarding = vi.fn(() => Promise.resolve({ runId: 'run-reonboard' }));
+const rerunOnboarding = vi.fn<(repoId: string) => Promise<{ runId: string }>>(() => Promise.resolve({ runId: 'run-reonboard' }));
 const getRepoGraph = vi.fn(() => Promise.resolve({ graph: null }));
 const getRepoGitHistory = vi.fn(() => Promise.resolve({ commits: [] }));
 const getRepoContributors = vi.fn(() => Promise.resolve({ contributors: [] }));

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -182,6 +182,20 @@ describe('the project page repo rows (ProjectRepositories)', () => {
     expect(note.textContent).toContain('onboarding run run-reonboard started');
   });
 
+  it('the re-run holds the section\'s ONE mutation lock: Detach is disabled while it is in flight and released after', async () => {
+    let release: (v: { runId: string }) => void = () => undefined;
+    rerunOnboarding.mockReturnValueOnce(new Promise((resolve) => { release = resolve; }));
+    await fetchReposCached();
+    render(<ProjectRepositories projectId="p-1" members={MEMBERS} onMembersChange={() => undefined} />);
+    fireEvent.click(screen.getByTestId('project-repo-findings-reonboard'));
+    await waitFor(() => expect(screen.getByTestId('project-repo-findings-reonboard')).toBeDisabled());
+    for (const b of screen.getAllByTestId('project-repo-detach')) expect(b).toBeDisabled();
+    release({ runId: 'run-late' });
+    await screen.findByTestId('project-repo-reonboard-note');
+    expect(screen.getByTestId('project-repo-findings-reonboard')).not.toBeDisabled();
+    for (const b of screen.getAllByTestId('project-repo-detach')) expect(b).not.toBeDisabled();
+  });
+
   it('a refused re-run is stated as a failure, not swallowed', async () => {
     rerunOnboarding.mockRejectedValueOnce(new Error('the daemon refused this — repo is already onboarding'));
     await fetchReposCached();

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -20,7 +20,7 @@ const REPOS: RepoEntry[] = [REPO_CLEAN, REPO_PREDATES_FINDINGS, REPO_INTREE_LIVE
 
 const listRepos = vi.fn(() => Promise.resolve({ repos: REPOS }));
 const listRuns = vi.fn(() => Promise.resolve({ runs: [makeView({ id: 'r-1', repo_ref: 'billing', workflow_id: 'onboarding', status: 'completed' })] }));
-const rerunOnboarding = vi.fn((_id: string) => Promise.resolve({ runId: 'run-reonboard' }));
+const rerunOnboarding = vi.fn(() => Promise.resolve({ runId: 'run-reonboard' }));
 const getRepoGraph = vi.fn(() => Promise.resolve({ graph: null }));
 const getRepoGitHistory = vi.fn(() => Promise.resolve({ commits: [] }));
 const getRepoContributors = vi.fn(() => Promise.resolve({ contributors: [] }));

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -72,6 +72,33 @@ describe('the finding rule (module functions)', () => {
     expect(findingLabel(unknown)).toBe('some new code');
   });
 
+  it('CONTRACT: the re-onboard rule keys on the sentence wicked-core pins in its own tests', () => {
+    // The wire has no machine-readable sub-state (both forms share `code: in_tree_code_graph_ignored`),
+    // so this UI keys on the remedy words core's `repo.rs` emits in `code_graph_db_and_findings` and
+    // pins in `the_record_publishes_the_root_path_and_reports_an_in_tree_graph` (asserts the no-live
+    // form `contains("re-run onboarding")` and NOT `"the live graph is"`) and
+    // `registration_ignores_an_in_tree_graph_and_reports_it`. If core rewords the remedy, this test
+    // fails here first — the row would otherwise silently downgrade from error + button to a warning.
+    const noLive = (repoId: string, db: string): string =>
+      `/w2/repos/${repoId}/.codegraph exists in the checkout — a code graph an older wicked-core indexed IN the ` +
+      'working tree. It is ignored (no graph has been indexed under the state home yet — re-run onboarding ' +
+      `(POST /repos/${repoId}/onboard) to build ${db}; never inside the repository). Delete \`.codegraph/\` from ` +
+      'the checkout — and `git rm --cached` it if the repository tracks it — to clear this finding (core#406).';
+    const live = (repoId: string, db: string): string =>
+      `/w2/repos/${repoId}/.codegraph exists in the checkout — a code graph an older wicked-core indexed IN the ` +
+      `working tree. It is ignored (the live graph is ${db}; never inside the repository). Delete \`.codegraph/\` ` +
+      'from the checkout — and `git rm --cached` it if the repository tracks it — to clear this finding (core#406).';
+    const unresolvedRoot =
+      'no live graph path resolves yet — see the `code_graph_root_unresolvable` finding; once one does it will be under the daemon state home';
+    const code = 'in_tree_code_graph_ignored';
+    expect(findingNeedsReonboard({ code, message: noLive('acme', '/w2/state/repo-graphs/acme-1/estate.db'), path: '/w2/repos/acme/.codegraph' })).toBe(true);
+    expect(findingNeedsReonboard({ code, message: live('acme', '/w2/state/repo-graphs/acme-1/estate.db'), path: '/w2/repos/acme/.codegraph' })).toBe(false);
+    // The third `live` sentence (no root resolves) names the OTHER finding, not the re-run remedy.
+    expect(findingNeedsReonboard({ code, message: `x exists in the checkout … It is ignored (${unresolvedRoot}; never inside the repository).`, path: null })).toBe(false);
+    // The rule is scoped to the in-tree code: the remedy words on any other code never grow a button.
+    expect(findingNeedsReonboard({ code: 'code_graph_root_unresolvable', message: 're-run onboarding', path: null })).toBe(false);
+  });
+
   it('renders NOTHING for an absent or empty findings array', () => {
     const { container } = render(
       <>

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -82,6 +82,13 @@ describe('the finding rule (module functions)', () => {
     expect(container.innerHTML).toBe('');
   });
 
+  it('the host\'s shared lock (`disabled`) disables the action WITHOUT claiming this repo is starting', () => {
+    render(<RepoFindings findings={REPO_INTREE_NO_LIVE.findings} onRerunOnboarding={() => undefined} disabled />);
+    const button = screen.getByTestId('repo-findings-reonboard');
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Re-run onboarding');
+  });
+
   it('states the remedy without a button when the host has no onboarding trigger', () => {
     render(<RepoFindings findings={REPO_INTREE_NO_LIVE.findings} />);
     const row = screen.getByTestId('repo-findings-row');
@@ -155,10 +162,11 @@ describe('the repo detail header (RepoDetailPage)', () => {
     await waitFor(() => expect(onSelectRun).toHaveBeenCalledWith('run-reonboard'));
   });
 
-  it('a clean record shows no findings block', async () => {
-    render(<RepoDetailPage repoId="billing" onSelectRun={() => undefined} navigate={() => undefined} onOpenGraph={() => undefined} />);
+  it('a clean record shows no findings block — and no empty spacer under the root path', async () => {
+    const { container } = render(<RepoDetailPage repoId="billing" onSelectRun={() => undefined} navigate={() => undefined} onOpenGraph={() => undefined} />);
     await screen.findByText('billing');
     expect(screen.queryByTestId('repo-findings')).toBeNull();
+    expect(container.querySelector('.mt-2:empty')).toBeNull();
   });
 });
 
@@ -175,6 +183,9 @@ describe('the project page repo rows (ProjectRepositories)', () => {
     expect(rows).toHaveLength(2);
     const blocks = screen.getAllByTestId('project-repo-findings');
     expect(blocks, 'billing is clean — only wicked-studio carries a block').toHaveLength(1);
+    // The clean member gets no padded wrapper either — silent means silent.
+    const billingRow = rows.find((r) => r.getAttribute('data-repo') === 'billing')!;
+    expect(billingRow.parentElement!.children).toHaveLength(1);
     fireEvent.click(within(blocks[0]!).getByTestId('project-repo-findings-reonboard'));
     await waitFor(() => expect(rerunOnboarding).toHaveBeenCalledWith('wicked-studio'));
     const note = await screen.findByTestId('project-repo-reonboard-note');

--- a/tests/RepoFindings.test.tsx
+++ b/tests/RepoFindings.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { RepoEntry } from '../src/api/types.js';
+import {
+  REPO_CLEAN, REPO_INTREE_LIVE, REPO_INTREE_NO_LIVE, REPO_PREDATES_FINDINGS, REPO_ROOT_UNRESOLVABLE,
+} from './fixtures/wave2.js';
+import { makeView } from './factories.js';
+
+/**
+ * studio#251 — `RepoEntry.findings[]` (wicked-core#406 via crew#517, api-types 0.32.0)
+ * rendered on the repo card (Repositories fleet), the repo detail header and the
+ * project page's repo rows. Pinned on the four recorded records: clean (silent),
+ * in-tree graph beside a LIVE graph (a warning chip, no action), in-tree graph with
+ * NO live graph (the error chip + "Re-run onboarding" wired to the surface's EXISTING
+ * onboard trigger), and the unresolvable root (an error chip, no action) — plus a
+ * record that predates the field (silent, never a fabricated "no findings").
+ */
+
+const REPOS: RepoEntry[] = [REPO_CLEAN, REPO_PREDATES_FINDINGS, REPO_INTREE_LIVE, REPO_INTREE_NO_LIVE, REPO_ROOT_UNRESOLVABLE];
+
+const listRepos = vi.fn(() => Promise.resolve({ repos: REPOS }));
+const listRuns = vi.fn(() => Promise.resolve({ runs: [makeView({ id: 'r-1', repo_ref: 'billing', workflow_id: 'onboarding', status: 'completed' })] }));
+const rerunOnboarding = vi.fn((_id: string) => Promise.resolve({ runId: 'run-reonboard' }));
+const getRepoGraph = vi.fn(() => Promise.resolve({ graph: null }));
+const getRepoGitHistory = vi.fn(() => Promise.resolve({ commits: [] }));
+const getRepoContributors = vi.fn(() => Promise.resolve({ contributors: [] }));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: () => listRepos(),
+    listRuns: () => listRuns(),
+    rerunOnboarding: (id: string) => rerunOnboarding(id),
+    getRepoGraph: () => getRepoGraph(),
+    getRepoGitHistory: () => getRepoGitHistory(),
+    getRepoContributors: () => getRepoContributors(),
+    listProjects: () => Promise.resolve({ projects: [] }),
+    attachProjectMember: () => Promise.reject(new Error('not in this suite')),
+    detachProjectMember: () => Promise.reject(new Error('not in this suite')),
+  },
+}));
+
+const { RepoFindings, findingNeedsReonboard, findingSeverity, findingLabel } = await import('../src/components/RepoFindings.js');
+const { RepositoriesPanel } = await import('../src/components/RepositoriesPanel.js');
+const { RepoDetailPage } = await import('../src/components/RepoDetailPage.js');
+const { ProjectRepositories } = await import('../src/components/ProjectRepositories.js');
+const { clearRepoCache, fetchReposCached } = await import('../src/store/repoCache.js');
+
+beforeEach(() => {
+  listRepos.mockClear();
+  rerunOnboarding.mockClear();
+  clearRepoCache();
+});
+afterEach(() => cleanup());
+
+describe('the finding rule (module functions)', () => {
+  it('classifies the three recorded codes: live in-tree = warning, no-live in-tree = error + re-onboard, unresolvable = error', () => {
+    const live = REPO_INTREE_LIVE.findings![0]!;
+    const noLive = REPO_INTREE_NO_LIVE.findings![0]!;
+    const root = REPO_ROOT_UNRESOLVABLE.findings![0]!;
+    expect(findingNeedsReonboard(live)).toBe(false);
+    expect(findingNeedsReonboard(noLive)).toBe(true);
+    expect(findingNeedsReonboard(root)).toBe(false);
+    expect(findingSeverity(live)).toBe('warning');
+    expect(findingSeverity(noLive)).toBe('error');
+    expect(findingSeverity(root)).toBe('error');
+    expect(findingLabel(live)).toBe('in-tree graph ignored');
+    expect(findingLabel(noLive)).toBe('in-tree graph ignored · no live graph');
+    expect(findingLabel(root)).toBe('no graph root');
+    // Forward-additive: an unknown code renders as a warning under its own name.
+    const unknown = { code: 'some_new_code', message: 'x', path: null };
+    expect(findingSeverity(unknown)).toBe('warning');
+    expect(findingLabel(unknown)).toBe('some new code');
+  });
+
+  it('renders NOTHING for an absent or empty findings array', () => {
+    const { container } = render(
+      <>
+        <RepoFindings findings={undefined} />
+        <RepoFindings findings={[]} />
+      </>,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('states the remedy without a button when the host has no onboarding trigger', () => {
+    render(<RepoFindings findings={REPO_INTREE_NO_LIVE.findings} />);
+    const row = screen.getByTestId('repo-findings-row');
+    expect(row).toHaveAttribute('data-reonboard', 'true');
+    expect(row.textContent).toContain('re-run onboarding');
+    expect(screen.queryByTestId('repo-findings-reonboard')).toBeNull();
+  });
+});
+
+describe('the repo card (RepositoriesPanel)', () => {
+  async function fleet(): Promise<HTMLElement[]> {
+    render(<RepositoriesPanel navigate={() => undefined} />);
+    await screen.findByTestId('repos-list');
+    return screen.getAllByTestId('repo-card');
+  }
+  const card = (cards: HTMLElement[], id: string): HTMLElement =>
+    cards.find((c) => c.getAttribute('data-repo-id') === id)!;
+
+  it('clean and predating records carry no findings block; the three finding records carry one each', async () => {
+    const cards = await fleet();
+    expect(within(card(cards, 'billing')).queryByTestId('repo-card-findings')).toBeNull();
+    expect(within(card(cards, 'legacy')).queryByTestId('repo-card-findings')).toBeNull();
+    for (const id of ['studio-api', 'wicked-studio', 'orphan']) {
+      expect(within(card(cards, id)).getByTestId('repo-card-findings')).toHaveAttribute('data-count', '1');
+    }
+  });
+
+  it('each finding row wears its code + severity and the engine message; only the no-live-graph case offers Re-run onboarding', async () => {
+    const cards = await fleet();
+    const live = within(card(cards, 'studio-api')).getByTestId('repo-card-findings-row');
+    expect(live).toHaveAttribute('data-code', 'in_tree_code_graph_ignored');
+    expect(live).toHaveAttribute('data-severity', 'warning');
+    expect(live.textContent).toContain('the live graph is /w2/state/repo-graphs/studio-api-9c1e/estate.db');
+    expect(within(live).queryByTestId('repo-card-findings-reonboard')).toBeNull();
+
+    const noLive = within(card(cards, 'wicked-studio')).getByTestId('repo-card-findings-row');
+    expect(noLive).toHaveAttribute('data-severity', 'error');
+    expect(within(noLive).getByTestId('repo-card-findings-reonboard')).toHaveTextContent('Re-run onboarding');
+
+    const root = within(card(cards, 'orphan')).getByTestId('repo-card-findings-row');
+    expect(root).toHaveAttribute('data-code', 'code_graph_root_unresolvable');
+    expect(root).toHaveAttribute('data-severity', 'error');
+    expect(root.textContent).toContain('no repo-graph root resolves for this daemon');
+    expect(within(root).queryByTestId('repo-card-findings-reonboard')).toBeNull();
+  });
+
+  it('Re-run onboarding posts the EXISTING onboard wire for that repo and does not navigate the card', async () => {
+    const navigate = vi.fn();
+    render(<RepositoriesPanel navigate={navigate} onSelectRun={() => undefined} />);
+    await screen.findByTestId('repos-list');
+    const cards = screen.getAllByTestId('repo-card');
+    fireEvent.click(within(card(cards, 'wicked-studio')).getByTestId('repo-card-findings-reonboard'));
+    await waitFor(() => expect(rerunOnboarding).toHaveBeenCalledWith('wicked-studio'));
+    expect(rerunOnboarding).toHaveBeenCalledTimes(1);
+    // The card is a role=link; the finding's action must not also open the detail.
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('the repo detail header (RepoDetailPage)', () => {
+  it('renders the finding under the root path and wires Re-run onboarding to the page trigger', async () => {
+    const onSelectRun = vi.fn();
+    render(<RepoDetailPage repoId="wicked-studio" onSelectRun={onSelectRun} navigate={() => undefined} onOpenGraph={() => undefined} />);
+    const block = await screen.findByTestId('repo-findings');
+    expect(block).toHaveAttribute('data-count', '1');
+    const row = within(block).getByTestId('repo-findings-row');
+    expect(row).toHaveAttribute('data-reonboard', 'true');
+    expect(row.textContent).toContain('re-run onboarding (POST /repos/wicked-studio/onboard)');
+    fireEvent.click(within(block).getByTestId('repo-findings-reonboard'));
+    await waitFor(() => expect(rerunOnboarding).toHaveBeenCalledWith('wicked-studio'));
+    await waitFor(() => expect(onSelectRun).toHaveBeenCalledWith('run-reonboard'));
+  });
+
+  it('a clean record shows no findings block', async () => {
+    render(<RepoDetailPage repoId="billing" onSelectRun={() => undefined} navigate={() => undefined} onOpenGraph={() => undefined} />);
+    await screen.findByText('billing');
+    expect(screen.queryByTestId('repo-findings')).toBeNull();
+  });
+});
+
+describe('the project page repo rows (ProjectRepositories)', () => {
+  const MEMBERS = [
+    { id: 'm-1', project_id: 'p-1', member_kind: 'crew.repo', member_ref: 'wicked-studio', attached_by: 'studio', attached_at: 1_757_500_000_000 },
+    { id: 'm-2', project_id: 'p-1', member_kind: 'crew.repo', member_ref: 'billing', attached_by: 'studio', attached_at: 1_757_500_000_000 },
+  ] as never[];
+
+  it('renders findings once the registry cache is warm, states the started run inline, and stays silent for a clean member', async () => {
+    await fetchReposCached(); // the palette / picker gesture warmed the ONE session cache
+    render(<ProjectRepositories projectId="p-1" members={MEMBERS} onMembersChange={() => undefined} />);
+    const rows = screen.getAllByTestId('project-repo-row');
+    expect(rows).toHaveLength(2);
+    const blocks = screen.getAllByTestId('project-repo-findings');
+    expect(blocks, 'billing is clean — only wicked-studio carries a block').toHaveLength(1);
+    fireEvent.click(within(blocks[0]!).getByTestId('project-repo-findings-reonboard'));
+    await waitFor(() => expect(rerunOnboarding).toHaveBeenCalledWith('wicked-studio'));
+    const note = await screen.findByTestId('project-repo-reonboard-note');
+    expect(note).toHaveAttribute('data-failed', 'false');
+    expect(note.textContent).toContain('onboarding run run-reonboard started');
+  });
+
+  it('a refused re-run is stated as a failure, not swallowed', async () => {
+    rerunOnboarding.mockRejectedValueOnce(new Error('the daemon refused this — repo is already onboarding'));
+    await fetchReposCached();
+    render(<ProjectRepositories projectId="p-1" members={MEMBERS} onMembersChange={() => undefined} />);
+    fireEvent.click(screen.getByTestId('project-repo-findings-reonboard'));
+    const note = await screen.findByTestId('project-repo-reonboard-note');
+    expect(note).toHaveAttribute('data-failed', 'true');
+    expect(note.textContent).toContain('re-run refused: the daemon refused this — repo is already onboarding');
+  });
+});

--- a/tests/fixtures/wave2.ts
+++ b/tests/fixtures/wave2.ts
@@ -1,0 +1,219 @@
+/**
+ * Recorded wire shapes for the wave-2 consumers (studio#251 / #246 / #248) —
+ * `wicked-crew-api-types` 0.32.0, privacy-scrubbed (paths under `/w2/…`).
+ *
+ *  - `RepoEntry.findings[]` (wicked-core#406 via crew#517): the messages are the
+ *    engine's own sentences from `wicked-core/src/repo.rs` `code_graph_db_and_findings`
+ *    — the in-tree graph beside a LIVE graph, the in-tree graph with NO live graph
+ *    (the re-onboard remedy), and the unresolvable root.
+ *  - `DiagnosticsGovernance` (crew#495 / F-022): the shapes `governance-health.ts`
+ *    folds — healthy, dead-lettered (the F-022 signal; the message carries the
+ *    `wicked-crew governance replay …` recipe), no store, and the legacy HOME outbox.
+ *  - `ChatScope` (crew#502 / F-067): a project scope with a bound graph, a repo scope
+ *    with no graph and the daemon's reason, an explicit `none`, and a project scope
+ *    with a dangling member.
+ */
+import type {
+  ChatOpenResponse,
+  ChatScope,
+  DiagnosticsGovernance,
+  RepoEntry,
+} from '../../src/api/types.js';
+
+// ── #251 — repo records ────────────────────────────────────────────────────────
+
+const STATE_HOME = '/w2/state/repo-graphs';
+
+export const REPO_CLEAN: RepoEntry = {
+  id: 'billing', name: 'billing', root_path: '/w2/repos/billing', default_branch: 'main',
+  registered_at: 1_757_500_000, code_graph_db: `${STATE_HOME}/billing-3f2a/estate.db`, findings: [],
+};
+
+/** An older daemon: no `findings` key at all (the field is optional in the TYPE only for this). */
+export const REPO_PREDATES_FINDINGS: RepoEntry = {
+  id: 'legacy', name: 'legacy', root_path: '/w2/repos/legacy', default_branch: 'main', registered_at: 1_757_400_000,
+};
+
+export const REPO_INTREE_LIVE: RepoEntry = {
+  id: 'studio-api', name: 'studio-api', root_path: '/w2/repos/studio-api', default_branch: 'main',
+  registered_at: 1_757_510_000, code_graph_db: `${STATE_HOME}/studio-api-9c1e/estate.db`,
+  findings: [{
+    code: 'in_tree_code_graph_ignored',
+    message:
+      '/w2/repos/studio-api/.codegraph exists in the checkout — a code graph an older wicked-core indexed IN the ' +
+      `working tree. It is ignored (the live graph is ${STATE_HOME}/studio-api-9c1e/estate.db; never inside the ` +
+      'repository). Delete `.codegraph/` from the checkout — and `git rm --cached` it if the repository tracks it — to ' +
+      'clear this finding (core#406).',
+    path: '/w2/repos/studio-api/.codegraph',
+  }],
+};
+
+export const REPO_INTREE_NO_LIVE: RepoEntry = {
+  id: 'wicked-studio', name: 'wicked-studio', root_path: '/w2/repos/wicked-studio', default_branch: 'main',
+  registered_at: 1_757_520_000, code_graph_db: `${STATE_HOME}/wicked-studio-77ab/estate.db`,
+  findings: [{
+    code: 'in_tree_code_graph_ignored',
+    message:
+      '/w2/repos/wicked-studio/.codegraph exists in the checkout — a code graph an older wicked-core indexed IN the ' +
+      'working tree. It is ignored (no graph has been indexed under the state home yet — re-run onboarding ' +
+      `(POST /repos/wicked-studio/onboard) to build ${STATE_HOME}/wicked-studio-77ab/estate.db; never inside the ` +
+      'repository). Delete `.codegraph/` from the checkout — and `git rm --cached` it if the repository tracks it — to ' +
+      'clear this finding (core#406).',
+    path: '/w2/repos/wicked-studio/.codegraph',
+  }],
+};
+
+export const REPO_ROOT_UNRESOLVABLE: RepoEntry = {
+  id: 'orphan', name: 'orphan', root_path: '/w2/repos/orphan', default_branch: 'main',
+  registered_at: 1_757_530_000, code_graph_db: '',
+  findings: [{
+    code: 'code_graph_root_unresolvable',
+    message:
+      'no repo-graph root resolves for this daemon (no WICKED_ESTATE_REPO_GRAPH_ROOT override, no state home, ' +
+      'no HOME / USERPROFILE): the repo has no code graph until one does',
+    path: null,
+  }],
+};
+
+// ── #246 — diagnostics.governance ─────────────────────────────────────────────
+
+const GOV_STORE = '/w2/state/core.db.governance/governance.db';
+const GOV_OUTBOX = '/w2/state/core.db.governance/emit-outbox.ndjson';
+const LEGACY_OUTBOX = '/w2/home/.something-wicked/wicked-apps/emit-outbox.ndjson';
+
+export const GOVERNANCE_HEALTHY: DiagnosticsGovernance = {
+  store: { path: GOV_STORE, source: 'core-db-sidecar' },
+  records: { total: 412, sinceBoot: 37 },
+  deadletters: {
+    path: GOV_OUTBOX, count: 0, byType: {}, byReason: {}, timestamped: 0, untimestamped: 0,
+    oldestTs: null, newestTs: null, truncated: false, legacyOutbox: null,
+  },
+  findings: [],
+};
+
+/** The F-022 signal: every governance event dead-lettered; the finding names the replay. */
+export const GOVERNANCE_DEADLETTERS: DiagnosticsGovernance = {
+  store: { path: GOV_STORE, source: 'flag' },
+  records: { total: 0, sinceBoot: 0 },
+  deadletters: {
+    path: GOV_OUTBOX, count: 128,
+    byType: { 'wicked.crew.governance.conformance_recorded': 96, 'wicked.crew.governance.decision_recorded': 32 },
+    byReason: { 'no shared store (WICKED_ESTATE_DB unset)': 128 },
+    timestamped: 120, untimestamped: 8, oldestTs: Date.UTC(2026, 8, 10, 16), newestTs: Date.UTC(2026, 8, 10, 18),
+    truncated: true, legacyOutbox: null,
+  },
+  findings: [{
+    kind: 'governance.deadletter', severity: 'error',
+    message:
+      `128 governance event(s) dead-lettered to ${GOV_OUTBOX} (at least — the fold stopped at its size cap), newest ` +
+      '2026-09-10T18:00:00.000Z — the store refused or was unset when they were emitted (no shared store ' +
+      `(WICKED_ESTATE_DB unset)); replay them with wicked-crew governance replay ${GOV_OUTBOX} --governance-db ${GOV_STORE}`,
+  }],
+};
+
+/** A boot that resolved NO store — must never read as "Governed". */
+export const GOVERNANCE_NO_STORE: DiagnosticsGovernance = {
+  store: null,
+  records: { total: null, sinceBoot: null },
+  deadletters: {
+    path: null, count: 0, byType: {}, byReason: {}, timestamped: 0, untimestamped: 0,
+    oldestTs: null, newestTs: null, truncated: false, legacyOutbox: null,
+  },
+  findings: [{
+    kind: 'governance.store', severity: 'error',
+    message:
+      'this daemon resolved no governance store — WICKED_ESTATE_DB is not exported to the engine, so every governance ' +
+      'event (conformance claims, phase transitions, rule lifecycle) dead-letters instead of landing; boot through ' +
+      '`wicked-crew serve` (which resolves <core db>.governance/governance.db) or pass --governance-db; inspect any ' +
+      'outbox meanwhile with wicked-crew governance replay <outbox.ndjson> --dry-run',
+  }],
+};
+
+/** Healthy store, but the pre-fix HOME outbox still holds events — a warning, not an error. */
+export const GOVERNANCE_LEGACY_OUTBOX: DiagnosticsGovernance = {
+  store: { path: GOV_STORE, source: 'env-estate' },
+  records: { total: 12, sinceBoot: null },
+  deadletters: {
+    path: GOV_OUTBOX, count: 0, byType: {}, byReason: {}, timestamped: 0, untimestamped: 0,
+    oldestTs: null, newestTs: null, truncated: false, legacyOutbox: { path: LEGACY_OUTBOX, bytes: 48_213 },
+  },
+  findings: [{
+    kind: 'governance.legacy-outbox', severity: 'warning',
+    message:
+      `a pre-fix dead-letter outbox exists under HOME at ${LEGACY_OUTBOX} (48213 bytes) — events every earlier daemon ` +
+      `on this host spooled there instead of storing; inspect it with wicked-crew governance replay ${LEGACY_OUTBOX} ` +
+      `--governance-db ${GOV_STORE} --dry-run, then replay it into this daemon's store with wicked-crew governance ` +
+      `replay ${LEGACY_OUTBOX} --governance-db ${GOV_STORE} (a replay appends the lines that fail to land back onto ` +
+      'that same file, so this warning persists until they are repaired)',
+  }],
+};
+
+// ── #248 — chat scope ─────────────────────────────────────────────────────────
+
+const CHAT_CWD = '/w2/tmp/wicked-crew-chats/4242-9f3a1c2b/chat-1';
+
+export const SCOPE_PROJECT: ChatScope = {
+  kind: 'project', projectId: 'api-migration',
+  repos: [
+    { id: 'studio-api', name: 'studio-api', rootPath: '/w2/repos/studio-api' },
+    { id: 'billing', name: 'billing', rootPath: '/w2/repos/billing' },
+  ],
+  cwd: CHAT_CWD,
+  graph: { bound: true, reason: "bound to project 'api-migration's co-located code graph." },
+  dangling: [],
+};
+
+export const SCOPE_REPOS_NO_GRAPH: ChatScope = {
+  kind: 'repos',
+  repos: [{ id: 'billing', name: 'billing', rootPath: '/w2/repos/billing' }],
+  cwd: CHAT_CWD,
+  graph: { bound: false, reason: "'billing' has no resolvable code graph (not indexed yet — onboard the repo); this chat gets none." },
+  dangling: [],
+};
+
+export const SCOPE_NONE: ChatScope = {
+  kind: 'none', repos: [], cwd: CHAT_CWD,
+  graph: {
+    bound: false,
+    reason: 'the chat names no project and no repos, so its seats see only their own scratch root and no code graph; pass projectId or repoRefs to scope it.',
+  },
+  dangling: [],
+};
+
+export const SCOPE_PROJECT_DANGLING: ChatScope = {
+  kind: 'project', projectId: 'auth-refactor',
+  repos: [{ id: 'studio-api', name: 'studio-api', rootPath: '/w2/repos/studio-api' }],
+  cwd: CHAT_CWD,
+  graph: { bound: false, reason: 'the project graph has never been built. POST /api/v1/projects/auth-refactor/graph/refresh fixes it.' },
+  dangling: ['old-auth-service'],
+};
+
+export function chatOpened(chatId: string, scope: ChatScope, seats: string[] = ['claude']): ChatOpenResponse {
+  return { chatId, seats: seats.map((cliKey) => ({ cliKey, ok: true })), scope };
+}
+
+/** crew#502's refusals as `POST /chats` answers them — `{status, body}` for a fetch stub. */
+export const CHAT_OPEN_REFUSALS = {
+  missing: { status: 404, body: { error: "Repo 'ghost', 'phantom' not found", missing: ['ghost', 'phantom'] } },
+  ambiguous: {
+    status: 400,
+    body: { error: "repoRef 'api' is ambiguous — 2 registered repos share that name ('api-1' at /w2/repos/api-1, 'api-2' at /w2/repos/api-2); name the repo by id." },
+  },
+  engine: {
+    status: 501,
+    body: {
+      error:
+        'the installed wicked-core-ts predates chat scope (wicked-core#410): it cannot ground a scoped chat or hold ' +
+        'its read roots read-only — upgrade the engine, or open the chat without projectId/repoRefs.',
+    },
+  },
+  overlap: {
+    status: 409,
+    body: {
+      error:
+        "repo 'scratchpad' is registered at /w2/tmp/wicked-crew-chats/scratchpad, which overlaps this daemon's chat " +
+        "scratch base /w2/tmp/wicked-crew-chats; a chat's scratch root can never sit inside a repository (nor a " +
+        'repository inside the scratch base) — register the repo elsewhere or set TMPDIR for the daemon.',
+    },
+  },
+} as const;


### PR DESCRIPTION
Closes #251, closes #246, closes #248.

Wave-2 consumer set (operator decision 2026-09-10: ships in this wave). Renders what crew #516 / #517 / #518 put on the wire — `wicked-crew-api-types` **0.32.0**.

## What changed

### #251 — repo card / detail render `RepoEntry.findings[]` (wicked-core#406 via crew#517)
- New `src/components/RepoFindings.tsx` — one labelled row per finding with the engine's own message; rendered on the Repositories fleet card (compact), the repo detail header, and the project page's repo rows (once the registry cache is warm — the picker gesture; zero-mount rule kept).
- `in_tree_code_graph_ignored` beside a **live** graph → warning chip, no action. The **no-live-graph** form (F-024 checkouts after the upgrade) → error chip + **Re-run onboarding**, wired to each surface's *existing* onboard trigger (`POST /repos/:id/onboard`). `code_graph_root_unresolvable` → error chip naming the daemon-environment fault. Unknown codes render as warnings under their own name.
- Silent when `findings` is absent (older daemon) or empty (clean checkout) — no frame, no "no findings" copy.
- The wire carries no machine-readable sub-state for "in-tree, no live graph"; the row keys on the engine's remedy sentence (`re-run onboarding`), the same words core's own tests pin. Listed under *wire gaps* below.

### #246 — Health rail renders `diagnostics.governance` (crew#495 / F-022)
- Expanding the rail's Health section now also reads `GET /diagnostics` (same gesture, EC30) and renders a `── governance ──` group: store path + `source`, record counts (`null` → "engine cannot count", never 0), the dead-letter fold (count as a floor when `truncated`, `byType` / `byReason` tallies, timestamp range, untimestamped count, the outbox, the pre-fix HOME `legacyOutbox`), and every finding as a severity-styled row whose text carries the `wicked-crew governance replay …` recipe.
- `store: null` or any **error** finding → heart red + the collapsed-header dot (never "Governed"); a **warning** → amber. A daemon without the block (`no-block`) or without the route (`no-route`, unknown-route 404 / 501) reads "not reported by this daemon" and does not degrade; a failed read (5xx) shows its reason under the row.
- **Home board `Governed` tile** (#246's second ask, landed after #252 merged): `DeckKpiRibbon` takes the `governance` block HomeBoard already fetches; a null store or an error finding paints the value in the fail token with the reason underneath (`data-state="governance-error"`) — the claims percentage itself is not rewritten.
- `src/api/diagnostics.ts` mirror gains `governance?: DiagnosticsGovernance` (typed off the contract package).

### #248 — New Chat: scope control + the chat states its scope (crew#502 / F-067)
- The create window carries a **Scope** row beside the Project field: **All project repos** (default once a project is bound — `projectId` alone rides the open, the daemon scopes to every `crew.repo` member; no `repoRefs`), **Choose repos…** (multi-select from `GET /repos`, loaded on that gesture through the session repo cache; sends `repoRefs` by id, with `projectId` when bound = the union), **Unscoped** (an explicit click; disabled while a project is bound, since a filed chat is scoped to it).
- `kind: 'none'` is never the silent default: an Unfiled chat with no choice does **not** open on send — the gap is stated on the row, nothing is POSTed, the draft stays in the composer. A repo-entry chat (`repoId`) is its own scope (unchanged `repoRef`).
- The opened chat states `ChatOpenResponse.scope` under the header (`data-testid="chat-scope"`): repositories (names; `rootPath` on hover), read-only, `graph.bound` / the daemon's `reason` when not, `dangling` members as a warning. A rejoin states `ChatDetailResponse.scope`; a daemon that said nothing (pre-0.32 201, or `scope: null`) is reported as "not stated", never guessed.
- Seat admissibility (review W3S-253-01): a scoped open with the default (untouched) chips **omits `clis`** so crew's pre-filter admits only governed seats (`acp_input_governance` / `os_sandbox`), and the 201's `seats` re-seed the chips; an edited selection rides as asked; the scope row states "a scoped chat admits only governed seats — refused seats say why". Unscoped opens keep EC44 (the displayed chips are the audience).
- Refusals render as inline sentences by status (`data-testid="chat-open-error" data-status`): **404** repo refs (every missing ref named + remedy; a `Project <id> not found` 404 reads plain), **400** ambiguous name (the daemon's "name the repo by id"), **409** (daemon-side conflict, sentence whole), **501** engine predates chat scope — with a **Continue unscoped** fallback outside the project shell. For these named refusals the daemon opened nothing, so the provisional chat id is dropped and the create controls return (the operator can correct the pick); retention of the id is kept only for unknown/transport failures (FINDING-027).
- Create-flow scope state resets on a repo / route / project change and after Close; project-shell sessions persist under a per-project storage key (`wicked.chat.project:<id>`), so project B never rejoins project A's scoped chat.
- First-run copy gains one sentence stating the scope rule (the pinned instruction text is unchanged).

### Shared-file hunks
- `src/api/client.ts`: `openChat` / `getChat` / `listChats` typed off `ChatOpenBody` / `ChatOpenResponse` / `ChatDetailResponse` / `ChatListResponse` (+4 type imports). Nothing else in the file.
- `src/api/diagnostics.ts`: one optional field + one type import.
- After #252 merged (merged into this branch, no rebase): `HomeBoard.tsx` one prop on the ribbon mount; `DeckKpiRibbon.tsx` the `governance` prop + a `data-state` on `Tile`. No gate-card component is touched.

## Tests
- **Unit (vitest, recorded fixtures in `tests/fixtures/wave2.ts`, privacy-scrubbed `/w2/…` paths, messages verbatim from core `repo.rs` / crew `governance-health.ts` / `chat-scope.ts`)**:
  - `tests/RepoFindings.test.tsx` — the four repo records (clean / in-tree+live / in-tree+no-live / root-unresolvable) + a record predating the field, across the fleet card, the detail header and the project rows; the action posts the existing onboard wire and does not fall through to the card link; the re-run holds the section's mutation lock.
  - `tests/HealthRailSection.governance.test.tsx` — healthy / dead-lettered (F-022) / no-store / legacy-outbox / no-block / no-route / 5xx, with the heart contribution.
  - `tests/GroupChat.scope.test.tsx` — the gap rule, project default, repo pick (GET /repos on gesture), explicit none, dangling, repo-entry, unstated (pre-0.32 201 and `scope: null` rejoin), the 404 / 400 / 409 / 501 refusals incl. the fallback and the returned create controls, scope reset across a route change / a project switch / Close, and the per-project session key.
  - Review follow-through (Copilot threads + suppressed remarks, all taken): the healthy governance case asserts the outbox path; a stale earlier expand cannot overwrite a later one; the finding action honours the section's shared lock; clean records render no empty wrapper/spacer.
  - Existing GroupChat suites: every Unfiled create-flow send now clicks **Unscoped** first (the explicit choice #248 asks for) — mechanical insertions, no assertion changed. `HealthRailSection.test.tsx`'s client mock gains `apiFetch` (a diagnostics body without governance).
  - Full run green; `npm run lint`, `npm run typecheck`, `npm run build` clean; `testid-inventory.json` regenerated.
- **Playwright (Python, against the shared W2 fixture — `e2e/wave2_consumers_test.py`)**: new fixture switches `repo_findings`, `governance` (`None` = route absent / `"healthy"` / `"deadletters"`), `chat_scope`, `chat_scope_501`; `POST /repos/:id/onboard` and `GET /diagnostics` routes; `POST /chats` resolves + states a scope with crew#502's real 404 / 501. 13 steps green: card + detail finding rows, the re-onboard POST (follows the run, never the card link), silence without findings, the governance rows + heart, the absent-route case, the blocked Unfiled send, the explicit unscoped open + statement, the repo pick → `repoRefs` + statement (name, path on hover, no-graph reason), the 501 with fallback. Screenshots: `e2e/shots/vision/wave2-{repo-findings,governance,chat-scope}.png` (gitignored).
- **Standing chat rigs** (`ux_sliceAB`, `ux_fixJ42`, `ux_fixJ43`, `ux_fixJ4J5`, `uxfix_slice4`) send on an Unfiled chat, which the #248 gate now blocks by design — each gains a guarded **Unscoped** click before its composer fill (a no-op where the scope row is absent/disabled). Verified: `ux_fixJ43` and `uxfix_slice4` pass end to end; `ux_sliceAB` and `ux_fixJ42` clear their chat scenes and then stop on `chats-dashboard-tiles`, `ux_fixJ4J5` stops earlier on `landing-lede` — both selectors have **zero** hits in `src/` on main (pre-existing drift; `feedback_sliceE` fails the same way on `narrative-band` without any chat involvement). Not touched here.

## Review follow-through
- Copilot threads (7): all taken and resolved on `d68a848` / `4c3c8c1` (see the threads and the summary comment).
- Independent review (verdict REVISE @ `d68a848`, W3S-253-01…06) + the coordinator's #246 completion — all taken in the bundled commit after merging #252: W3S-253-01 seat admissibility (above), -02 plain project 404, -03 governance error reason, -04 literal em dash restored, -05 **exact `0.32.0` pin** (the repo's convention; the earlier caret was the brief's wording — now aligned with the reviewer, Copilot's thread, and #248), -06 the remedy-sentence contract test naming core's `repo.rs` tests.

## Review follow-through, round 2 (`99b718f`)
- **W3S-253-09 (delta re-review, MEDIUM)** — with `clis` omitted, the optimistic pass painted every default chip `connecting` and the reconcile pruned only `failed` entries, so a seat the daemon's pre-filter did not admit stayed a phantom amber chip and kept `chatStatus` on "connecting". Fixed: when the daemon picked the seats, the post-201 reconcile drops `connecting` entries the 201 did not name (and their errors) — the 201 IS the audience. Unit test (two default seats, one admitted → exactly the admitted chip, none `connecting`, the now-bar not "Connecting agents…"); fixture switch `chat_admit_subset`; rig scene green (`agents: ['claude']`, `states: ['working']`).
- Copilot's four threads on `c6ec9a1` (previously deferred for the freeze) are now **taken** in the same commit: the fleet card's finding action honours `capturing[repo.id]`; the repo pick stops at the contract's 32 `repoRefs` (disabled + titled options at the cap, removal open); a 201 carrying `scope: null` reads "not stated"; the records row formats `total` / `sinceBoot` independently. Tests for the last three.

## Declined (with reason)
- Nothing outstanding.

## Wire gaps
- `RepoFinding` has no machine-readable remedy / sub-state for "in-tree graph, **no** live graph" vs "in-tree graph beside a live graph" — both share `code: in_tree_code_graph_ignored` and differ only in the message. Studio keys on the engine's remedy sentence. A `remedy?: 'reonboard' | …` (or a second code) on the contract would remove the string match.
- `ApiError` carries the daemon sentence, not the 404's `missing[]` array — the sentence names every missing ref, so nothing is lost for display, but a typed body would let the UI mark the picked chips individually.

## Notes
- No version bump (the release agent cuts studio 0.5.5). CHANGELOG `[Unreleased]` → *Added*.
- devDep `wicked-crew-api-types` → `^0.32.0`, installed from the registry (the lockfile resolves `registry.npmjs.org/…/wicked-crew-api-types-0.32.0.tgz`); the published `index.d.ts` was diffed against a local merge of crew main + #518 and is byte-identical. Developed against that local `npm pack` until 0.32.0 published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
