### PR TITLE
release: 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 
+## [0.5.5] — 2026-09-11
 ### Added
 - **Wave-2 consumers: the repo card renders the engine's findings, the Health rail renders
   `diagnostics.governance`, and New Chat carries a scope control** (#251, #246, #248 — pins
@@ -650,7 +651,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.1...v0.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.4",
+  "studioVersion": "0.5.5",
   "counts": {
     "files": 140,
     "occurrences": 1192,


### PR DESCRIPTION
Version PR for the operator-approved wave-2 release train (2026-09-11). On merge, `v0.5.5` is tagged on the merge commit and `release.yml` publishes to npm and creates the GitHub Release.

## Changes

- `package.json` 0.5.4 → 0.5.5; `package-lock.json` refreshed with `npm install --package-lock-only` — the two root `version` fields only, every dependency resolution unchanged.
- `testid-inventory.json` re-stamped with `npm run manifest:testids` — `studioVersion` 0.5.4 → 0.5.5 is the only change (1023 static · 59 dynamic · 7 computed testids across 140 files, exactly as #253 left it). TH-13 asserts the stamp equals the package version, so the bump alone fails `npm test`; the regenerated artifact rides in this PR as the inventory's own drift rule requires.
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.5] — 2026-09-11` (an empty `[Unreleased]` kept above) with the entries for the three PRs on `main` since 0.5.4 — #247 (`.codegraph/estate.db` untracked, #220), #252 (gate cards state the evaluator verdict / floor / denial remedy; the delivery strip stops counting non-delivering workflows as vacuous, #250) and #253 (wave-2 consumers: repo findings on the repo card, governance in the Health panel, scoped New Chat — #251 / #246 / #248) — plus the `[0.5.5]` link-ref, with the `[Unreleased]` compare base retargeted to `v0.5.5`. The entries themselves were authored in their PRs; this PR only cuts the heading and adds the link-refs.

## Contract pin — unchanged by this PR

`wicked-crew-api-types` stays `^0.32.0`, where #253 moved it once `api-types-v0.32.0` published from wicked-crew #518.

## Gates (fresh clone of `main` @ 79b9ada + this commit)

- `npm ci` — ok (installed `wicked-crew-api-types` 0.32.0)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 260 files, 2834 tests passed, 0 unhandled errors
- `npm run build` — ok (the pre-existing chunk-size warning); `dist/assets/index-*.js` carries the `0.5.5` version marker
- `npm run manifest:testids` re-run after the bump — byte-identical output (zero diff)
- `python3 scripts/changelog-section.py v0.5.5` — exit 0, a 66-line body, so the release workflow's GitHub Release step will find the section
- privacy scrub of the commit and this body — 0 hits beyond the repository-owner handle inside the compare-URL link-refs (the same handle every existing link-ref carries)

Follow-up after merge: tag `v0.5.5` on the merge commit → `release.yml` publishes `wicked-studio@0.5.5`; wicked-crew 0.7.29 then bumps its `wicked-studio` devDependency to `^0.5.5` so `build:with-studio` bundles this skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
